### PR TITLE
fix(supervisor): stop unbound variable crash and infinite alert stall

### DIFF
--- a/scripts/pane_manager_v2.sh
+++ b/scripts/pane_manager_v2.sh
@@ -32,7 +32,7 @@ _pm_log() {
 # Method 1: Discover pane by title
 discover_pane_by_title() {
     local terminal="$1"
-    local pane_id
+    local pane_id=""
 
     # Scope to own session when PROJECT_ROOT is set (prevents cross-project matches)
     local vnx_session=""

--- a/scripts/vnx_supervisor_simple.sh
+++ b/scripts/vnx_supervisor_simple.sh
@@ -392,8 +392,6 @@ monitor() {
                     fi
                 else
                     log "🚨 ALERT: $name has crashed $MAX_RESTART_ATTEMPTS times - waiting ${RESTART_COOLDOWN}s before retry"
-                    # Still track time for cooldown
-                    echo "$restart_count|$current_time" > "$tracking_file"
                 fi
             else
                 # Process is running - reset restart counter


### PR DESCRIPTION
## Summary

- **`pane_manager_v2.sh`**: `local pane_id` was uninitialized in `discover_pane_by_title()`. With `set -u` active, accessing it before assignment threw `pane_id: unbound variable`, crashing subshells on every pane lookup when tmux was unavailable. Fixed by initializing to empty string.
- **`vnx_supervisor_simple.sh`**: The alert branch wrote `restart_count|now` to the tracking file on every 5-second loop iteration, continuously refreshing `last_restart`. This prevented the `RESTART_COOLDOWN` window from ever expiring, causing the supervisor to stall indefinitely instead of retrying after 30s. Fixed by removing the tracking file write from the alert branch.

## Root cause (observed incident)

After a tmux session restart, the dispatcher's lock fingerprint no longer matched. Three successive restart attempts all exited immediately via the singleton enforcer, incrementing the crash counter to 3. The supervisor then entered the alert loop — which, due to bug #2, never resolved. Two dispatches sat stuck in `pending/` until the tracking file was manually deleted.

## Test plan

- [ ] Simulate tmux restart: kill session, recreate, verify dispatcher restarts within one cooldown window (≤35s)
- [ ] Verify `discover_pane_by_title()` no longer emits `pane_id: unbound variable` when tmux is unavailable
- [ ] Verify supervisor retries dispatcher after `RESTART_COOLDOWN` (30s) following 3 crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)