### PR TITLE
fix: activate pending→active→completed dispatch lifecycle

### DIFF
--- a/hooks/vnx_rotate.sh
+++ b/hooks/vnx_rotate.sh
@@ -134,15 +134,22 @@ tmux paste-buffer -t "$PANE_ID"
 sleep 1
 tmux send-keys -t "$PANE_ID" Enter
 
-# Update terminal state to "working" so T0 sees correct status after rotation
+# Update terminal state to "working" ONLY if dispatch is still in active/.
+# If receipt_processor already moved it to completed/ (task_complete arrived
+# during the rotation window), don't clobber the idle state.
 if [[ -n "$DISPATCH_ID" && "$DISPATCH_ID" != "unknown" ]]; then
-  python3 "$SCRIPT_DIR/../scripts/terminal_state_shadow.py" \
-    --terminal-id "$TERMINAL" \
-    --status "working" \
-    --claimed-by "$DISPATCH_ID" \
-    --last-activity "$(date -u +%Y-%m-%dT%H:%M:%SZ)" 2>/dev/null || \
-    log "WARNING: Failed to update terminal state after rotation"
-  log "Terminal state updated: $TERMINAL -> working (dispatch=$DISPATCH_ID)"
+  ACTIVE_CHECK=$(ls "$VNX_DATA_DIR/dispatches/active/${DISPATCH_ID}"*.md 2>/dev/null | head -1)
+  if [[ -n "$ACTIVE_CHECK" ]]; then
+    python3 "$SCRIPT_DIR/../scripts/terminal_state_shadow.py" \
+      --terminal-id "$TERMINAL" \
+      --status "working" \
+      --claimed-by "$DISPATCH_ID" \
+      --last-activity "$(date -u +%Y-%m-%dT%H:%M:%SZ)" 2>/dev/null || \
+      log "WARNING: Failed to update terminal state after rotation"
+    log "Terminal state updated: $TERMINAL -> working (dispatch=$DISPATCH_ID)"
+  else
+    log "Dispatch $DISPATCH_ID not in active/ — task already completed, skipping state update"
+  fi
 fi
 
 # Emit continuation receipt for context-rot research

--- a/scripts/dispatcher_v8_minimal.sh
+++ b/scripts/dispatcher_v8_minimal.sh
@@ -1095,10 +1095,10 @@ $receipt_footer"
         log "V8 WARNING: Failed to notify heartbeat ACK monitor (non-fatal)"
     }
 
-    # Move dispatch to completed
-    mv "$dispatch_file" "$COMPLETED_DIR/$filename"
+    # Move dispatch to active (receipt_processor moves to completed on task_complete)
+    mv "$dispatch_file" "$ACTIVE_DIR/$filename"
 
-    log "V8 DISPATCH: Complete - moved to $COMPLETED_DIR/$filename"
+    log "V8 DISPATCH: Activated - moved to $ACTIVE_DIR/$filename"
     return 0
 }
 

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -434,6 +434,21 @@ update_receipt_shadow_state() {
     shadow_update_terminal_state "$terminal" "$completion_status" "$_rf_dispatch_id" "$_rf_timestamp" "$clear_claim" "$lease_seconds"
 }
 
+# Section C2: Move dispatch from active/ to completed/ on task finish.
+# Reads _rf_* variables. Non-fatal.
+_move_dispatch_to_completed() {
+    if [ "$_rf_event_type" != "task_complete" ] && [ "$_rf_event_type" != "task_failed" ] && [ "$_rf_event_type" != "task_timeout" ]; then
+        return 0
+    fi
+    [ -z "$_rf_dispatch_id" ] && return 0
+    local src
+    src=$(ls "$VNX_DISPATCH_DIR/active/${_rf_dispatch_id}"*.md 2>/dev/null | head -1)
+    [ -z "$src" ] && return 0
+    mv "$src" "$VNX_DISPATCH_DIR/completed/" 2>/dev/null && \
+        log "DEBUG" "Dispatch moved: active → completed ($_rf_dispatch_id)" || \
+        log "WARN" "Failed to move dispatch to completed: $_rf_dispatch_id"
+}
+
 # Section D: Extract PR ID (3-tier) and attach evidence to open items.
 # Reads _rf_* variables. Non-fatal.
 attach_pr_evidence() {
@@ -741,6 +756,9 @@ process_single_report() {
 
     # C. Shadow write terminal state (non-fatal)
     update_receipt_shadow_state "$terminal"
+
+    # C2. Move dispatch from active/ → completed/ on task finish (non-fatal)
+    _move_dispatch_to_completed
 
     # D. Attach PR evidence on success (non-fatal)
     attach_pr_evidence "$receipt_json" "$report_path"


### PR DESCRIPTION
## Summary
- Dispatcher now moves dispatches to `active/` (not `completed/`) when sent to a terminal
- Receipt processor moves `active/` → `completed/` on task_complete/failed/timeout
- `vnx_rotate.sh` only sets terminal to "working" if dispatch is still in `active/`
- Fixes race condition where rotation overwrote completion state (T1 stuck on "working")
- Enables T0 intelligence: `generate_t0_brief.sh` + `generate_t0_recommendations.py` already read `active/` but it was always empty

## Files changed
| File | Change |
|------|--------|
| `scripts/dispatcher_v8_minimal.sh` | mv target: `completed/` → `active/` (2 lines) |
| `scripts/receipt_processor_v4.sh` | New `_move_dispatch_to_completed()` + call site (17 lines) |
| `hooks/vnx_rotate.sh` | Guard state update with `active/` check (12 lines) |

## Test plan
- [x] `bash -n` syntax check on all 3 files
- [x] T1 + T3 reset to idle, pending dispatch should now be picked up
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)