### PR TITLE
fix: backfill popup cmd on existing sessions for multi-project support

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -727,6 +727,24 @@ TSJSON
     # Store per-session so Ctrl+G resolves the correct project at runtime.
     tmux set-option -t "$session_name" @vnx_popup_cmd "$popup_full_cmd" 2>/dev/null
 
+    # Backfill: ensure all other VNX sessions also have @vnx_popup_cmd set.
+    # Without this, old sessions (started before the resolver existed) have no
+    # popup cmd and Ctrl+G shows "No VNX popup configured" instead of the queue.
+    for _other_session in $(tmux list-sessions -F '#{session_name}' 2>/dev/null); do
+      [ "$_other_session" = "$session_name" ] && continue
+      # Skip sessions that already have a popup cmd
+      _existing_cmd=$(tmux show-option -t "$_other_session" -v @vnx_popup_cmd 2>/dev/null || true)
+      [ -n "$_existing_cmd" ] && continue
+      # Detect project root from pane paths in that session
+      _other_root=$(tmux list-panes -t "$_other_session" -F '#{pane_current_path}' 2>/dev/null \
+        | head -1 | sed 's|/\.claude/terminals/.*||' || true)
+      if [ -n "$_other_root" ] && [ -d "$_other_root/.claude/vnx-system" ]; then
+        _other_cmd="unset PROJECT_ROOT VNX_HOME VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_LOGS_DIR VNX_SKILLS_DIR VNX_PIDS_DIR VNX_LOCKS_DIR VNX_REPORTS_DIR VNX_DB_DIR; export PROJECT_ROOT='$_other_root' VNX_HOME='$_other_root/.claude/vnx-system' VNX_DATA_DIR='$_other_root/.vnx-data'; bash '$_other_root/.claude/vnx-system/scripts/queue_ui_enhanced.sh'"
+        tmux set-option -t "$_other_session" @vnx_popup_cmd "$_other_cmd" 2>/dev/null || true
+        log "Backfilled @vnx_popup_cmd on session: $_other_session (project: $_other_root)"
+      fi
+    done
+
     # Create resolver script that reads @vnx_popup_cmd from the current client session.
     # Falls back to scanning all sessions by pane path if the current session has no cmd set.
     # Keep this compatible with tmux variants that do not support `run-shell -F`.


### PR DESCRIPTION
## Summary
- When `vnx start` launches a second project, it now scans all existing tmux sessions
- Any VNX session missing `@vnx_popup_cmd` gets backfilled automatically
- Prevents "No VNX popup configured for session" error on older sessions

## Root cause
Ctrl+G keybinding is global (tmux server-wide). The resolver reads `@vnx_popup_cmd` per-session, but sessions started before the resolver system existed had no cmd set.

## Test plan
- [x] Start SEOcrawler VNX session
- [x] Start linkedin_engine VNX session
- [x] Ctrl+G works in both sessions, pointing to correct project queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)