### PR TITLE
feat: add sync_skills_registry.py

### DIFF
--- a/scripts/sync_skills_registry.py
+++ b/scripts/sync_skills_registry.py
@@ -269,7 +269,7 @@ def main() -> int:
     claude_dir = vnx_system_dir.parent  # .claude/
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else claude_dir / "skills"
-    registry_path = Path(args.registry) if args.registry else vnx_system_dir / "skills" / "skills.yaml"
+    registry_path = Path(args.registry) if args.registry else claude_dir / "skills" / "skills.yaml"
 
     return sync(skills_dir, registry_path, dry_run=args.dry_run)
 


### PR DESCRIPTION
## Summary
- Adds `scripts/sync_skills_registry.py` for auto-syncing skill directories to `skills.yaml`
- Scans `.claude/skills/` for subdirectories with `SKILL.md`, parses frontmatter, infers type, appends missing entries
- Supports `--dry-run` and custom paths
- Ensures new VNX project installations get automatic skill registration

## Why
Script was created in SEOcrawler but never committed to vnx-orchestration. New projects (like linkedin_engine) were missing it, requiring manual skills.yaml editing.

## Test plan
- [ ] `python3 scripts/sync_skills_registry.py --dry-run` shows correct output
- [ ] `python3 scripts/sync_skills_registry.py` adds new entries to skills.yaml
- [ ] Existing entries are preserved (not duplicated)
- [ ] Protected skills (vnx-manager, t0-orchestrator) are never removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)