### PR TITLE
fix(ci): remove forbidden path literal from sync_skills_registry

### DIFF
--- a/scripts/sync_skills_registry.py
+++ b/scripts/sync_skills_registry.py
@@ -265,8 +265,8 @@ def main() -> int:
 
     # Auto-detect paths relative to this script's location
     script_dir = Path(__file__).resolve().parent
-    vnx_system_dir = script_dir.parent  # .claude/vnx-system/
-    claude_dir = vnx_system_dir.parent  # .claude/
+    vnx_system_dir = script_dir.parent  # scripts -> vnx-system
+    claude_dir = vnx_system_dir.parent  # vnx-system -> .claude
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else claude_dir / "skills"
     registry_path = Path(args.registry) if args.registry else claude_dir / "skills" / "skills.yaml"


### PR DESCRIPTION
## Summary
- Removes `.claude/vnx-system/` literal from inline comment on line 268
- vnx doctor CI gate flags this as a forbidden path reference

## Fix
```diff
-    vnx_system_dir = script_dir.parent  # .claude/vnx-system/
-    claude_dir = vnx_system_dir.parent  # .claude/
+    vnx_system_dir = script_dir.parent  # scripts -> vnx-system
+    claude_dir = vnx_system_dir.parent  # vnx-system -> .claude
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)