### PR TITLE
feat(governance): add T0 Advisory and Open Items Delta to CQS

### DIFF
--- a/docs/core/10_JSON_DISPATCH_FORMAT.md
+++ b/docs/core/10_JSON_DISPATCH_FORMAT.md
@@ -77,6 +77,7 @@ Smart Tap V7 introduces comprehensive JSON dispatch support with automatic Markd
 - **gate** (optional): Current gate ("planning", "implementation", "review", "testing", "validation")
 - **phase** (optional): Sprint phase identifier (e.g., "sprint.3.2")
 - **cognition** (optional): Processing type ("normal", "focused", "deep")
+- **target_open_items** (optional): JSON array of OI-IDs this dispatch targets for resolution (e.g., `["OI-042", "OI-043"]`). Auto-extracted from instruction text via `OI-\d{3,}` regex by the dispatcher. Used by CQS OI Delta scoring to detect unresolved targets.
 
 ### content (required)
 - **title** (required): Brief task description

--- a/docs/core/technical/INTELLIGENCE_SYSTEM.md
+++ b/docs/core/technical/INTELLIGENCE_SYSTEM.md
@@ -1,10 +1,10 @@
 # VNX Intelligence System - Technical Reference
-**Last Updated**: 2026-03-02
+**Last Updated**: 2026-03-07
 **Owner**: T-MANAGER
 **Purpose**: Documentation for VNX Intelligence System - Technical Reference.
 
-**Version**: 3.0.0
-**Date**: 2026-03-02
+**Version**: 4.0.0
+**Date**: 2026-03-07
 **Status**: Active
 **Maintainer**: T-MANAGER
 
@@ -17,10 +17,11 @@
 6. [Prevention Rules](#prevention-rules)
 7. [Tag Intelligence](#tag-intelligence)
 8. [Learning Loop](#learning-loop)
-9. [Performance & Caching](#performance--caching)
-10. [Integration](#integration)
-11. [Operations](#operations)
-12. [Testing](#testing)
+9. [Governance Measurement](#governance-measurement)
+10. [Performance & Caching](#performance--caching)
+11. [Integration](#integration)
+12. [Operations](#operations)
+13. [Testing](#testing)
 
 ---
 
@@ -932,6 +933,117 @@ REPORT_CACHE_TTL = 1800    # 30 min
 
 ---
 
+## Governance Measurement
+
+### Purpose
+
+Replaces self-reported terminal status with objective, calculated quality scores. Detects anomalies using Statistical Process Control (SPC) and makes rework visible through First-Pass Yield measurement.
+
+### Implementation
+
+**Version**: 1.1 (2026-03-07)
+**Schema**: 8.2.0-cqs-advisory-oi
+**Files**: `cqs_calculator.py`, `governance_aggregator.py`, `governance_weekly_report.py`, `open_items_manager.py`
+**Full Reference**: `docs/intelligence/GOVERNANCE_MEASUREMENT.md`
+
+### Why This Exists
+
+Analysis of dispatch data revealed three fundamental measurement problems:
+
+1. **166 unique self-reported status values** — no standardization, terminals define own success
+2. **Rework invisible** — re-dispatched "successful" tasks counted as multiple successes
+3. **System timeouts pollute metrics** — 30% of dispatches timeout (receipt processing issue), inflating failure rates
+
+### Composite Quality Score (CQS)
+
+Weighted 0-100 score computed from 7 independent signals:
+
+```
+CQS = Status(25%) + Completion(20%) + Effort(15%) + ErrorDensity(10%)
+    + Rework(10%) + T0Advisory(10%) + OIDelta(10%)
+
+Status:       166 raw values -> 5 categories (success=100, partial=60, failure=0)
+              timeout/unknown -> excluded from all metrics
+
+Completion:   Has report? + PR merged? + Gate passed? -> 0-100
+
+Effort:       Tokens used / median for same role
+              <= 0.5x = 100, 1x = 80, 2x = 20, >2x = 0
+
+ErrorDensity: Error messages / total messages ratio
+              0% = 100, <5% = 80, <15% = 50, <30% = 25, >30% = 0
+
+Rework:       Same gate+pr_id dispatched before?
+              First attempt = 100, rework = 0
+
+T0Advisory:   quality_advisory.t0_recommendation decision + risk_score
+              approve=100, followup=60, hold=0 (70/30 blend with inverse risk)
+
+OIDelta:      Open items created vs resolved balance
+              +15/resolved (cap 30), -10/created (cap 30), -20/unresolved target (cap 20)
+              No OI involvement = 50 (neutral)
+```
+
+### SPC Control Charts
+
+Statistical Process Control from manufacturing quality (Toyota/Six Sigma):
+
+```
+UCL = X-bar + 3*sigma     Upper Control Limit
+CL  = X-bar               Center Line (mean)
+LCL = max(0, X-bar - 3*sigma)  Lower Control Limit
+```
+
+Recomputed nightly from 30-day rolling baseline. Point beyond limits has 0.27% probability of occurring by chance.
+
+### Western Electric Anomaly Rules
+
+| Rule | Condition | Severity |
+|------|-----------|----------|
+| Out of control | Point beyond UCL/LCL | Critical |
+| Trend | 7+ consecutive increasing/decreasing | Warning |
+| Shift | 8+ points on same side of center | Warning |
+| Run | 2 of 3 beyond 2-sigma | Info |
+
+### Nightly Aggregation Metrics
+
+Computed per scope (system/terminal/role/gate/model):
+
+| Metric | Formula | Standard |
+|--------|---------|----------|
+| First-Pass Yield | Unique tasks succeeded first / total unique | Toyota TPS |
+| Rework Rate | Total dispatches / unique gate+pr_id | Six Sigma |
+| Gate Velocity | Hours from first dispatch to gate pass | DORA lead time |
+| Mean CQS | Average composite quality score | Composite index |
+| OI Resolution Rate | resolved / (created + resolved) | Quality debt velocity |
+
+### Database
+
+```sql
+-- CQS columns on dispatch_metadata
+cqs REAL, normalized_status TEXT, cqs_components TEXT
+target_open_items TEXT,       -- JSON array ["OI-042"]
+open_items_created INTEGER DEFAULT 0,
+open_items_resolved INTEGER DEFAULT 0
+
+-- Aggregated metrics
+governance_metrics (period, scope, metric_name, value, sample_size)
+
+-- Control limits
+spc_control_limits (metric, scope, center_line, ucl, lcl, sigma)
+
+-- Anomaly alerts
+spc_alerts (alert_type, metric, scope, observed, limit, severity)
+```
+
+### Integration
+
+- **Receipt-time**: CQS computed in `append_receipt.py` and `receipt_processor_v4.sh` (C3b)
+- **Nightly**: Phase 2.5 in `conversation_analyzer_nightly.sh`
+- **Weekly**: `governance_weekly_report.py` -> `docs/governance/week_YYYY_WW.md`
+
+---
+
 ## Performance & Caching
 
 ### Purpose
@@ -1397,7 +1509,7 @@ python3 tests/test_intelligence_integration.py
 
 ---
 
-**Document Version**: 3.0.0
-**Last Updated**: 2026-03-02
+**Document Version**: 4.0.0
+**Last Updated**: 2026-03-07
 **Maintained by**: T-MANAGER
 **Status**: Production Active

--- a/docs/intelligence/GOVERNANCE_MEASUREMENT.md
+++ b/docs/intelligence/GOVERNANCE_MEASUREMENT.md
@@ -1,0 +1,541 @@
+# Governance Measurement System
+
+**Version**: 1.1.0
+**Added**: 2026-03-07
+**Updated**: 2026-03-07
+**Owner**: T-MANAGER
+**Schema**: 8.2.0-cqs-advisory-oi
+
+## Overview
+
+The Governance Measurement System replaces self-reported status with objective, calculated quality scores. It addresses three fundamental measurement problems that undermined the reliability of VNX quality data:
+
+| Problem | Impact | Solution |
+|---------|--------|----------|
+| Self-reported status | 166 unique status values, no standardization | Normalized to 5 categories + weighted CQS |
+| Success != done | `task_complete` = terminal says done, not verified | Composite score from multiple objective signals |
+| Timeout != failure | 30% receipt timeouts pollute quality metrics | Timeouts excluded from quality calculations |
+
+### Industry Context
+
+The system applies **Statistical Process Control (SPC)** — the same methodology used in manufacturing quality (Toyota Production System, Six Sigma) and modern software delivery (DORA metrics, Accelerate). SPC provides:
+
+- **Control charts** with statistically-derived limits (X-bar +/- 3 sigma) that distinguish normal variation from anomalies
+- **Western Electric rules** for early detection of trends, shifts, and runs before they become critical
+- **First-Pass Yield (FPY)** — the percentage of work completed correctly on the first attempt, the single most important quality metric in both manufacturing and software delivery
+
+These are not arbitrary thresholds. A 3-sigma control limit means a point outside it has only a 0.27% probability of occurring by chance — making false alarms rare while catching real problems early.
+
+## Architecture: 3-Layer Governance
+
+```
+                    VNX Intelligence Feedback Loop
+                    ==============================
+
+ DISPATCH                    EXECUTION                    RECEIPT
+ --------                    ---------                    -------
+   T0 dispatches task         Terminal executes            Receipt arrives
+   with intelligence          with patterns +              with status +
+   context + patterns         prevention rules             report path
+        |                          |                           |
+        v                          v                           v
+ +--------------+          +---------------+          +----------------+
+ | Intelligence |          |  Session Log  |          | Receipt        |
+ | Injection    |          |  (JSONL)      |          | Enrichment     |
+ | - patterns   |          |  - tokens     |          | - quality      |
+ | - prevention |          |  - errors     |          |   advisory     |
+ | - tags       |          |  - tool calls |          | - git          |
+ | - model hint |          |  - model      |          |   provenance   |
+ +--------------+          +---------------+          +----------------+
+        |                          |                           |
+        |                          |                           |
+        +------------+-------------+---------------------------+
+                     |
+                     v
+        +---------------------------+
+        |   Layer 1: CQS Calculator |  <-- Real-time, per dispatch
+        |   (receipt-time scoring)   |
+        |                           |
+        |   Inputs:                 |
+        |   - normalized_status     |
+        |   - completion signals    |
+        |   - token efficiency      |
+        |   - error density         |
+        |   - rework detection      |
+        |                           |
+        |   Output: CQS 0-100      |
+        +---------------------------+
+                     |
+                     | stored in dispatch_metadata
+                     v
+        +---------------------------+
+        |  Layer 2: Nightly         |  <-- Aggregated, statistical
+        |  Governance Aggregator    |
+        |                           |
+        |  Computes per scope:      |
+        |  - First-Pass Yield       |
+        |  - Rework Rate            |
+        |  - Gate Velocity          |
+        |  - Mean CQS              |
+        |                           |
+        |  SPC Control Charts:      |
+        |  - X-bar +/- 3 sigma      |
+        |  - Western Electric rules |
+        |  - Anomaly alerts         |
+        +---------------------------+
+                     |
+                     | governance_metrics + spc_alerts
+                     v
+        +---------------------------+
+        |  Layer 3: Weekly Report   |  <-- Comparative, actionable
+        |                           |
+        |  - System FPY trend       |
+        |  - Model comparison       |
+        |    (controlled for role)  |
+        |  - Role effectiveness     |
+        |  - Gate bottlenecks       |
+        |  - Top 5 actions          |
+        +---------------------------+
+                     |
+                     | feeds back into
+                     v
+        +---------------------------+
+        |  Intelligence Loop        |
+        |  - Pattern confidence     |
+        |    adjustment             |
+        |  - Model routing hints    |
+        |  - Suggested edits        |
+        |  - Prevention rules       |
+        +---------------------------+
+                     |
+                     | next dispatch cycle
+                     v
+                  DISPATCH
+                  (improved)
+```
+
+## Intelligence Feedback Loop: Complete Data Flow
+
+The governance system closes the loop between dispatch quality measurement and future dispatch improvement. Here is the complete closed-loop architecture showing how conversational logs, receipts, and statistical analysis feed back into the intelligence system:
+
+```
++=====================================================================+
+|                    CLOSED-LOOP INTELLIGENCE SYSTEM                   |
++=====================================================================+
+
+  1. DISPATCH ENRICHMENT (real-time)
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  gather_intelligence.py
+       |
+       +-- Agent validation (skills.yaml registry)
+       +-- Pattern matching (FTS5, top 5 by relevance)
+       +-- Prevention rules (tag-based, 1-4 per task)
+       +-- Model routing hints (from t0_session_brief.json)   <----+
+       +-- Quality context injection                                |
+       |                                                            |
+       v                                                            |
+  2. EXECUTION + LOGGING                                            |
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~                                        |
+  Claude Code terminal session                                      |
+       |                                                            |
+       +-- JSONL session log (tokens, tools, errors, model)         |
+       +-- Report generation (markdown)                             |
+       +-- Git provenance (commits, branch, diff)                   |
+       |                                                            |
+       v                                                            |
+  3. RECEIPT PROCESSING (real-time)                                  |
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                  |
+  receipt_processor_v4.sh + append_receipt.py                        |
+       |                                                            |
+       +-- Quality advisory (code checks on changed files)          |
+       +-- Terminal snapshot                                        |
+       +-- Dispatch metadata update (outcome_status)                |
+       +-- CQS calculation + persistence  <-- NEW                   |
+       |        |                                                   |
+       |        +-- Status normalization (166 -> 5 categories)      |
+       |        +-- Completion signal scoring                       |
+       |        +-- Effort efficiency (vs role median)              |
+       |        +-- Error density analysis                          |
+       |        +-- Rework detection (same gate+pr_id)              |
+       |                                                            |
+       v                                                            |
+  4. NIGHTLY ANALYSIS PIPELINE                                      |
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                   |
+  conversation_analyzer_nightly.sh                                   |
+       |                                                            |
+       +-- Phase 1: Session parsing                                 |
+       |   conversation_analyzer.py                                 |
+       |   - Parse JSONL -> session_analytics DB                    |
+       |   - Extract model, tokens, tools, errors                   |
+       |   - Deep analysis (heuristic + LLM)                       |
+       |                                                            |
+       +-- Phase 1.5: Session-dispatch linkage                      |
+       |   link_sessions_dispatches.py                              |
+       |   - Cross-reference sessions with dispatches               |
+       |   - Enable per-dispatch token analysis                     |
+       |                                                            |
+       +-- Phase 2: T0 session brief                                |
+       |   generate_t0_session_brief.py                             |
+       |   - Model performance aggregation (7-day window)           |
+       |   - Model routing hints generation  ---------------------->+
+       |   - Active concerns detection                              |
+       |                                                            |
+       +-- Phase 2.5: Governance aggregation  <-- NEW               |
+       |   governance_aggregator.py                                 |
+       |   - CQS backfill for unscored dispatches                  |
+       |   - FPY, rework rate, gate velocity per scope              |
+       |   - SPC control limit computation                          |
+       |   - Anomaly detection (Western Electric rules)             |
+       |                                                            |
+       +-- Phase 3: Suggested edits                                 |
+       |   generate_suggested_edits.py                              |
+       |   - Pattern-based system tuning suggestions -------------->+
+       |   - Human-in-the-loop review workflow                      |
+       |                                                            |
+       +-- Phase 4: Email digest (opt-in)                           |
+       |   - Model performance + routing hints                      |
+       |   - Pending suggested edits                                |
+       |   - SPC alerts summary                                     |
+       |                                                            |
+       v                                                            |
+  5. LEARNING LOOP (daily 18:00)                                    |
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                   |
+  learning_loop.py + intelligence_daemon.py                          |
+       |                                                            |
+       +-- Pattern confidence adjustment                            |
+       |   - Used patterns: +10% (cap 2.0)                         |
+       |   - Ignored patterns: -5% (floor 0.1)                     |
+       |   - Success patterns: +15%                                 |
+       |   - Failure patterns: -10%                                 |
+       |                                                            |
+       +-- Pattern archival (unused 30+ days)                       |
+       +-- Prevention rule generation (from tag combinations)       |
+       +-- Cache invalidation and preloading                        |
+       |                                                            |
+       +-------> Feeds back to step 1 (next dispatch) ------------>+
+
+  6. WEEKLY GOVERNANCE REPORT (Sunday 03:00 or manual)
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  governance_weekly_report.py
+       |
+       +-- System FPY trend (4 weeks)
+       +-- Model comparison (controlled for role/complexity)
+       +-- Role effectiveness ranking
+       +-- Gate bottleneck identification
+       +-- Top 5 actionable items from SPC data
+       |
+       v
+  docs/governance/week_YYYY_WW.md
+```
+
+### Key Insight: Why Self-Reported Status is Insufficient
+
+The VNX system previously relied on terminals reporting their own success. Analysis revealed:
+
+- **166 unique status strings** across all dispatches — no standardization
+- **100% Sonnet success rate** according to self-reported data — statistically implausible
+- **30% of dispatches** receive `no_confirmation` (receipt timeout), which is a system issue, not a task failure
+- **Rework is invisible**: When a "successful" task requires re-dispatch to the same gate, the original dispatch still shows as successful
+
+The CQS replaces this with objective measurement from multiple independent signals.
+
+## Layer 1: Composite Quality Score (CQS)
+
+### Calculation
+
+CQS is a weighted 0-100 score computed per dispatch from 7 independent signals:
+
+| Component | Weight | Source | Calculation |
+|-----------|--------|--------|-------------|
+| Status | 25% | receipt.status | 166 raw statuses mapped to 5 categories |
+| Completion | 20% | receipt | Has report? PR merged? Gate passed? |
+| Effort | 15% | session_analytics | Token usage vs median for same role |
+| Error density | 10% | session JSONL | Error/fail message ratio |
+| Rework | 10% | dispatch_metadata | Same gate+pr_id dispatched before? |
+| T0 Advisory | 10% | quality_advisory | T0 decision (approve/followup/hold) blended with risk_score |
+| OI Delta | 10% | open_items.json | Open items created vs resolved balance |
+
+### Status Normalization
+
+Raw status values are mapped to 5 normalized categories:
+
+| Category | Score | Example Raw Values |
+|----------|-------|--------------------|
+| `success` | 100 | task_complete, success, merged, done, approved, gate_passed |
+| `partial` | 60 | partial, needs_review, in_progress, pending_review |
+| `failure` | 0 | task_failed, error, rejected, failed, blocked |
+| `timeout` | excluded | no_confirmation, timeout, receipt_timeout |
+| `unknown` | excluded | anything not in the mapping |
+
+**Critical design decision**: `timeout` and `unknown` statuses are excluded from all quality metrics. This prevents system-level issues (receipt processing delays) from contaminating quality data. Only dispatches with a definitive quality outcome (success/partial/failure) receive a CQS score.
+
+### Effort Efficiency Scoring
+
+Token usage is compared against the median for the same role:
+
+| Ratio (actual/median) | Score | Interpretation |
+|------------------------|-------|----------------|
+| <= 0.5x | 100 | Highly efficient |
+| 0.5x - 1.0x | 80-100 | Normal efficiency |
+| 1.0x - 2.0x | 20-80 | Below average |
+| > 2.0x | 0-20 | Significant overhead |
+
+### Rework Detection
+
+A dispatch is flagged as rework if another dispatch exists with the same `gate` and `pr_id` combination. First attempts score 100, rework attempts score 0. This makes rework visible in the aggregate metrics.
+
+### T0 Advisory Scoring
+
+The T0 quality advisory produces a decision (`approve`, `approve_with_followup`, `hold`) and a risk score (0-100). CQS blends these with 70/30 weighting:
+
+| Decision | Decision Score |
+|----------|---------------|
+| `approve` | 100 |
+| `approve_with_followup` | 60 |
+| `hold` | 0 |
+
+```
+T0 Advisory Score = decision_score * 0.7 + (100 - risk_score) * 0.3
+```
+
+When no advisory data exists (historical dispatches), the component scores **50.0 (neutral)**.
+
+### Open Items Delta Scoring
+
+Measures the quality debt impact of a dispatch — were quality issues created or resolved?
+
+| Signal | Effect |
+|--------|--------|
+| Each item resolved | +15 points (cap 30) |
+| Each item created | -10 points (cap 30) |
+| Targeted items unresolved | -20 per unresolved (cap 20) |
+| No OI involvement | 50.0 (neutral) |
+
+Dispatches can reference target open items via `OI-NNN` patterns in instructions. When a dispatch targets an OI but doesn't resolve it, the penalty makes this measurable.
+
+### target_open_items Dispatch Enrichment
+
+Open item references are captured at dispatch time through two mechanisms:
+
+1. **Formal**: `--target-open-items` argument to `log_dispatch_metadata.py` (JSON array or comma-separated)
+2. **Fallback**: Regex scan of dispatch instructions for `OI-\d{3,}` patterns in `dispatcher_v8_minimal.sh`
+
+Resolution is tracked via `closed_by_dispatch_id` on open items when they are closed.
+
+### Example CQS Calculation
+
+```
+Dispatch: gate_pr4_excel_quality, role=backend-developer, model=claude-opus
+
+Status:       task_complete -> success -> 100 * 0.25 = 25.0
+Completion:   report=yes, pr=no, gate=yes -> 66.7 * 0.20 = 13.3
+Effort:       48K tokens vs 52K median -> ratio 0.92 -> 84 * 0.15 = 12.6
+Error density: 2 errors / 45 messages -> 4.4% -> 80 * 0.10 = 8.0
+Rework:       first attempt -> 100 * 0.10 = 10.0
+T0 Advisory:  approve, risk_score=10 -> 97 * 0.10 = 9.7
+OI Delta:     0 created, 1 resolved -> 65 * 0.10 = 6.5
+                                                    --------
+CQS = 85.1
+```
+
+### Database Schema
+
+Six columns on `dispatch_metadata` (3 original CQS + 3 OI delta):
+
+```sql
+ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL;
+ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT;
+ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT;  -- JSON breakdown
+ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT;       -- JSON array ["OI-042"]
+ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0;
+ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0;
+```
+
+### Integration Points
+
+CQS is computed at two points for reliability:
+
+1. **Receipt enrichment** (`append_receipt.py`): Computed during quality advisory enrichment and persisted immediately
+2. **Receipt processing** (`receipt_processor_v4.sh` section C3b): Standalone update via `update_dispatch_cqs.py` as fallback
+
+## Layer 2: Nightly Governance Aggregation
+
+### Metrics
+
+Six metrics are computed per scope (system/terminal/role/gate/model):
+
+| Metric | Formula | Industry Standard |
+|--------|---------|-------------------|
+| **First-Pass Yield (FPY)** | Unique tasks succeeded first try / total unique tasks | Toyota Production System, Six Sigma |
+| **Rework Rate** | Total dispatches / unique (gate, pr_id) combos | Manufacturing quality, DORA change failure rate |
+| **Gate Velocity** | Hours from first dispatch to successful gate completion | DORA lead time for changes |
+| **Mean CQS** | AVG(cqs) WHERE cqs IS NOT NULL | Composite quality index |
+| **Dispatch Count** | Total dispatches in period | Volume/throughput metric |
+| **OI Resolution Rate** | SUM(resolved) / (SUM(created) + SUM(resolved)) | Quality debt velocity |
+
+#### First-Pass Yield (FPY)
+
+FPY is the gold standard quality metric in lean manufacturing and increasingly in software delivery. It measures the percentage of work items that pass through a process correctly the first time, without requiring rework, correction, or re-dispatch.
+
+**Why FPY matters more than success rate**: A gate with 90% success rate sounds good, but if it takes 3 attempts to reach success, the true FPY is only 33%. FPY exposes the hidden cost of rework.
+
+**Chain Reliability**: For multi-gate features, overall reliability is the product of individual FPY rates:
+
+```
+Feature FPY = FPY_gate1 * FPY_gate2 * FPY_gate3
+Example:     0.80      * 0.75      * 0.85       = 0.51 (51%)
+```
+
+This explains why features with many gates often have long delivery times — even individually high FPY rates compound to poor overall throughput.
+
+### SPC Control Charts
+
+Statistical Process Control uses control limits derived from the data itself (not arbitrary thresholds):
+
+```
+UCL = X-bar + 3 * sigma    (Upper Control Limit)
+CL  = X-bar                (Center Line / Mean)
+LCL = X-bar - 3 * sigma    (Lower Control Limit, floor at 0)
+```
+
+These are recomputed nightly from a 30-day rolling baseline. A point outside the control limits has a 0.27% probability of occurring by chance — making it a statistically significant signal.
+
+### Anomaly Detection (Western Electric Rules)
+
+Four rules from the Western Electric Handbook (1956), still the standard in SPC:
+
+| Rule | Condition | Severity | Signal |
+|------|-----------|----------|--------|
+| **Out of control** | Point beyond UCL or LCL | Critical | Process has shifted |
+| **Trend** | 7+ consecutive points increasing or decreasing | Warning | Drift in progress |
+| **Shift** | 8+ consecutive points on same side of center line | Warning | Mean has shifted |
+| **Run** | 2 of 3 points beyond 2-sigma | Info | Increased variability |
+
+These rules detect problems early — a trend of 7 points is caught before it reaches the control limits.
+
+### Database Schema
+
+```sql
+-- Aggregated metrics per scope and period
+CREATE TABLE governance_metrics (
+    period_start DATE, period_end DATE,
+    scope_type TEXT,    -- 'system'|'terminal'|'role'|'gate'|'model'
+    scope_value TEXT,
+    metric_name TEXT,   -- 'fpy'|'rework_rate'|'gate_velocity_hours'|'mean_cqs'|'dispatch_count'
+    metric_value REAL,
+    sample_size INTEGER
+);
+
+-- SPC control limits (UPSERT on recalculation)
+CREATE TABLE spc_control_limits (
+    metric_name TEXT, scope_type TEXT, scope_value TEXT,
+    center_line REAL, ucl REAL, lcl REAL, sigma REAL,
+    sample_count INTEGER, baseline_start DATE, baseline_end DATE,
+    UNIQUE(metric_name, scope_type, scope_value)
+);
+
+-- Anomaly alerts from Western Electric rules
+CREATE TABLE spc_alerts (
+    alert_type TEXT,    -- 'out_of_control'|'trend'|'shift'|'run'
+    metric_name TEXT, scope_type TEXT, scope_value TEXT,
+    observed_value REAL, control_limit REAL,
+    description TEXT, severity TEXT
+);
+```
+
+## Layer 3: Weekly Governance Report
+
+Generated weekly (manual or cron). Produces `docs/governance/week_YYYY_WW.md` with:
+
+1. **System Health**: FPY trend (4 weeks), rework trend, active SPC alerts
+2. **Model Comparison**: Mean CQS and FPY per model, controlled for role mix
+3. **Role Effectiveness**: FPY and rework rate per role
+4. **Gate Bottlenecks**: Slowest gates, highest rework gates
+5. **Top Actions**: Data-driven improvement suggestions from SPC alerts and metric outliers
+
+### Model Comparison: Controlling for Confounders
+
+Raw model comparison (Opus vs Sonnet) is misleading when models handle different task types. The report only compares models on the same role mix, ensuring the comparison reflects model capability rather than task difficulty.
+
+## Pipeline Integration
+
+### Nightly Pipeline (conversation_analyzer_nightly.sh)
+
+```
+Phase 0:   DB schema migrations (quality_db_init.py)
+Phase 1:   Session parsing (conversation_analyzer.py)
+Phase 1.5: Session-dispatch linkage (link_sessions_dispatches.py)
+Phase 2:   T0 session brief (generate_t0_session_brief.py)
+Phase 2.5: Governance aggregation + SPC  <-- NEW
+Phase 3:   Suggested edits (generate_suggested_edits.py)
+Phase 4:   Email digest (send_digest_email.py)
+```
+
+Phase 2.5 includes automatic CQS backfill for any dispatches that were completed before the governance system was installed.
+
+### Receipt Processing Pipeline
+
+```
+Receipt arrives
+  -> A. Enrichment (append_receipt.py)
+       -> Quality advisory
+       -> CQS calculation + DB persist  <-- NEW
+  -> B. Terminal state update
+  -> C. Dispatch metadata update
+       -> C3: outcome_status + completed_at
+       -> C3b: CQS update (fallback)    <-- NEW
+  -> D. PR evidence
+  -> E. Progress state
+  -> F. Send to T0
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/lib/cqs_calculator.py` | CQS calculation engine + status normalization |
+| `scripts/update_dispatch_cqs.py` | Standalone CQS update CLI |
+| `scripts/governance_aggregator.py` | Nightly FPY/rework/SPC computation |
+| `scripts/governance_weekly_report.py` | Weekly markdown governance report |
+| `schemas/quality_intelligence.sql` | Schema v8.2.0 with governance tables + OI delta columns |
+| `scripts/open_items_manager.py` | Resolution tracking (closed_by_dispatch_id) + programmatic close |
+| `scripts/quality_db_init.py` | Migration for CQS columns + governance tables |
+| `scripts/append_receipt.py` | CQS integration at receipt enrichment |
+| `scripts/receipt_processor_v4.sh` | CQS fallback update in section C3b |
+| `scripts/conversation_analyzer_nightly.sh` | Phase 2.5 governance pipeline |
+
+## Operations
+
+```bash
+# Verify governance tables exist
+python3 scripts/quality_db_init.py
+
+# Backfill CQS for all existing dispatches (dry-run)
+python3 scripts/governance_aggregator.py --dry-run --backfill
+
+# Run governance aggregation (production)
+python3 scripts/governance_aggregator.py --backfill
+
+# Generate weekly report
+python3 scripts/governance_weekly_report.py
+
+# Query CQS distribution
+sqlite3 $VNX_STATE_DIR/quality_intelligence.db \
+  "SELECT normalized_status, COUNT(*), ROUND(AVG(cqs),1) FROM dispatch_metadata WHERE normalized_status IS NOT NULL GROUP BY normalized_status"
+
+# Check SPC alerts
+sqlite3 $VNX_STATE_DIR/quality_intelligence.db \
+  "SELECT severity, alert_type, description FROM spc_alerts WHERE acknowledged_at IS NULL ORDER BY detected_at DESC LIMIT 10"
+
+# View governance metrics for a scope
+sqlite3 $VNX_STATE_DIR/quality_intelligence.db \
+  "SELECT metric_name, metric_value, sample_size FROM governance_metrics WHERE scope_type='system' AND scope_value='all' ORDER BY period_start DESC LIMIT 20"
+```
+
+## References
+
+- Wheeler, D.J. & Chambers, D.S. (1992). *Understanding Statistical Process Control*. SPC Press.
+- Western Electric Company (1956). *Statistical Quality Control Handbook*. Western Electric.
+- Forsgren, N., Humble, J., & Kim, G. (2018). *Accelerate: The Science of Lean Software and DevOps*. IT Revolution Press.
+- Toyota Production System — Shingo, S. (1989). *A Study of the Toyota Production System*. Productivity Press.
+- DORA Metrics — State of DevOps Reports (2018-2024). Google Cloud / DORA Team.

--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -508,3 +508,148 @@ VALUES ('8.0.4-conversation-mining', 'Add session_analytics, improvement_suggest
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES ('8.0.5-session-model', 'Add session_model column to session_analytics for model-based performance tracking');
+
+-- ============================================================================
+-- DISPATCH METADATA (Dispatch Analytics Persistence)
+-- ============================================================================
+
+-- Full dispatch lifecycle tracking: dispatch → session → report → receipt
+CREATE TABLE IF NOT EXISTS dispatch_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL UNIQUE,
+    terminal TEXT NOT NULL,
+    track TEXT NOT NULL,
+    role TEXT,
+    skill_name TEXT,
+    gate TEXT,
+    cognition TEXT DEFAULT 'normal',
+    priority TEXT DEFAULT 'P1',
+    pr_id TEXT,
+    parent_dispatch TEXT,
+    pattern_count INTEGER DEFAULT 0,
+    prevention_rule_count INTEGER DEFAULT 0,
+    intelligence_json TEXT,
+    instruction_char_count INTEGER DEFAULT 0,
+    context_file_count INTEGER DEFAULT 0,
+    dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME,
+    outcome_status TEXT,
+    outcome_report_path TEXT,
+    session_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_id ON dispatch_metadata (dispatch_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_terminal ON dispatch_metadata (terminal);
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_role ON dispatch_metadata (role);
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_gate ON dispatch_metadata (gate);
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_outcome ON dispatch_metadata (outcome_status);
+CREATE INDEX IF NOT EXISTS idx_dispatch_meta_dispatched ON dispatch_metadata (dispatched_at DESC);
+
+-- Analytics views for dispatch correlation
+
+CREATE VIEW IF NOT EXISTS dispatch_success_by_role AS
+SELECT
+    role,
+    COUNT(*) as total_dispatches,
+    SUM(CASE WHEN outcome_status = 'success' THEN 1 ELSE 0 END) as successes,
+    ROUND(AVG(CASE WHEN outcome_status = 'success' THEN 1.0 ELSE 0.0 END), 3) as success_rate,
+    AVG(pattern_count) as avg_patterns,
+    AVG(prevention_rule_count) as avg_rules,
+    AVG(instruction_char_count) as avg_instruction_chars
+FROM dispatch_metadata
+WHERE outcome_status IS NOT NULL
+GROUP BY role
+ORDER BY total_dispatches DESC;
+
+CREATE VIEW IF NOT EXISTS intelligence_effectiveness AS
+SELECT
+    CASE WHEN intelligence_json IS NOT NULL AND intelligence_json != '' THEN 'with_intelligence' ELSE 'without_intelligence' END as intelligence_used,
+    COUNT(*) as total,
+    SUM(CASE WHEN outcome_status = 'success' THEN 1 ELSE 0 END) as successes,
+    ROUND(AVG(CASE WHEN outcome_status = 'success' THEN 1.0 ELSE 0.0 END), 3) as success_rate,
+    AVG(pattern_count) as avg_patterns
+FROM dispatch_metadata
+WHERE outcome_status IS NOT NULL
+GROUP BY intelligence_used;
+
+CREATE VIEW IF NOT EXISTS cost_per_dispatch AS
+SELECT
+    dm.dispatch_id,
+    dm.terminal,
+    dm.role,
+    dm.gate,
+    dm.outcome_status,
+    sa.session_model,
+    sa.total_input_tokens,
+    sa.total_output_tokens,
+    sa.tool_calls_total,
+    sa.duration_minutes,
+    dm.pattern_count,
+    dm.instruction_char_count
+FROM dispatch_metadata dm
+LEFT JOIN session_analytics sa ON sa.dispatch_id = dm.dispatch_id
+WHERE dm.outcome_status IS NOT NULL;
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.0.6-dispatch-analytics', 'Add dispatch_metadata table, dispatch_id columns, and analytics views');
+
+-- ============================================================================
+-- GOVERNANCE MEASUREMENT (Objective Quality Scoring + SPC)
+-- ============================================================================
+
+-- Governance metrics aggregated nightly per scope
+CREATE TABLE IF NOT EXISTS governance_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    period_start DATE NOT NULL,
+    period_end DATE NOT NULL,
+    scope_type TEXT NOT NULL,     -- 'system'|'terminal'|'role'|'gate'|'model'
+    scope_value TEXT NOT NULL,
+    metric_name TEXT NOT NULL,    -- 'fpy'|'rework_rate'|'gate_velocity_hours'|'mean_cqs'|'dispatch_count'
+    metric_value REAL NOT NULL,
+    sample_size INTEGER NOT NULL,
+    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup
+    ON governance_metrics (period_start, scope_type, metric_name);
+
+-- SPC control limits (X-bar +/- 3 sigma)
+CREATE TABLE IF NOT EXISTS spc_control_limits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    metric_name TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    scope_value TEXT NOT NULL,
+    center_line REAL NOT NULL,    -- X-bar (mean)
+    ucl REAL NOT NULL,            -- Upper Control Limit (X-bar + 3 sigma)
+    lcl REAL NOT NULL,            -- Lower Control Limit (X-bar - 3 sigma)
+    sigma REAL NOT NULL,
+    sample_count INTEGER NOT NULL,
+    baseline_start DATE,
+    baseline_end DATE,
+    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(metric_name, scope_type, scope_value)
+);
+
+-- SPC anomaly alerts
+CREATE TABLE IF NOT EXISTS spc_alerts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    alert_type TEXT NOT NULL,     -- 'out_of_control'|'trend'|'shift'|'run'
+    metric_name TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    scope_value TEXT NOT NULL,
+    observed_value REAL NOT NULL,
+    control_limit REAL,
+    description TEXT,
+    severity TEXT DEFAULT 'warning', -- 'info'|'warning'|'critical'
+    detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    acknowledged_at DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup
+    ON spc_alerts (detected_at DESC, severity);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.1.0-governance', 'Add governance_metrics, spc_control_limits, spc_alerts tables and CQS columns on dispatch_metadata');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.2.0-cqs-advisory-oi', 'Add target_open_items, open_items_created, open_items_resolved columns to dispatch_metadata for T0 advisory and OI delta CQS components');

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -24,6 +24,7 @@ try:
     from vnx_paths import ensure_env
     from quality_advisory import generate_quality_advisory, get_changed_files
     from terminal_snapshot import collect_terminal_snapshot
+    from cqs_calculator import calculate_cqs
 except Exception as exc:  # pragma: no cover - hard fail on bootstrap issue
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
@@ -581,6 +582,61 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
             "error": str(exc),
         }
 
+    # Enrich with open items delta for CQS (best-effort)
+    try:
+        dispatch_id_for_oi = enriched.get("dispatch_id") or enriched.get("metadata", {}).get("dispatch_id")
+        if dispatch_id_for_oi:
+            oim = _get_open_items_manager()
+            resolved_count = oim.count_items_closed_by_dispatch(dispatch_id_for_oi)
+            enriched["open_items_resolved"] = resolved_count
+
+            # Load target_open_items from dispatch_metadata
+            db_path_oi = state_dir / "quality_intelligence.db"
+            if db_path_oi.exists():
+                import sqlite3 as _sqlite3_oi
+                conn_oi = _sqlite3_oi.connect(str(db_path_oi))
+                row = conn_oi.execute(
+                    "SELECT target_open_items FROM dispatch_metadata WHERE dispatch_id=?",
+                    (dispatch_id_for_oi,),
+                ).fetchone()
+                conn_oi.close()
+                if row and row[0]:
+                    try:
+                        enriched["target_open_items"] = json.loads(row[0])
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+    except Exception as exc:
+        _emit("WARN", "oi_delta_enrichment_failed", error=str(exc))
+
+    # Compute CQS and persist to dispatch_metadata (best-effort)
+    try:
+        db_path = state_dir / "quality_intelligence.db"
+        if db_path.exists():
+            dispatch_id = enriched.get("dispatch_id") or enriched.get("metadata", {}).get("dispatch_id")
+            if dispatch_id:
+                cqs_result = calculate_cqs(enriched, None, db_path, dispatch_id)
+                enriched["cqs"] = cqs_result
+                import sqlite3
+                conn = sqlite3.connect(str(db_path))
+                conn.execute(
+                    """UPDATE dispatch_metadata
+                       SET cqs=?, normalized_status=?, cqs_components=?,
+                           open_items_created=?, open_items_resolved=?
+                       WHERE dispatch_id=?""",
+                    (
+                        cqs_result["cqs"],
+                        cqs_result["normalized_status"],
+                        json.dumps(cqs_result["components"]),
+                        enriched.get("open_items_created", 0),
+                        enriched.get("open_items_resolved", 0),
+                        dispatch_id,
+                    ),
+                )
+                conn.commit()
+                conn.close()
+    except Exception as exc:
+        _emit("WARN", "cqs_calculation_failed", error=str(exc))
+
     return enriched
 
 
@@ -653,21 +709,24 @@ _SEVERITY_MAP = {
 }
 
 
-def _register_quality_open_items(receipt: Dict[str, Any]) -> None:
+def _register_quality_open_items(receipt: Dict[str, Any]) -> int:
     """Best-effort: register quality advisory violations as tracked open items.
 
     Reads t0_recommendation.open_items[] from the enriched receipt, creates
     open items with dedup keys, and ALWAYS writes a sidecar summary for the
     receipt processor to include in T0 notifications (even when clean).
+
+    Returns:
+        Count of newly created open items.
     """
     try:
         advisory = receipt.get("quality_advisory")
         if not isinstance(advisory, dict):
-            return
+            return 0
 
         rec = advisory.get("t0_recommendation")
         if not isinstance(rec, dict):
-            return
+            return 0
 
         dispatch_id = str(receipt.get("dispatch_id") or "unknown")
         report_path = str(receipt.get("report_path") or "")
@@ -752,8 +811,11 @@ def _register_quality_open_items(receipt: Dict[str, Any]) -> None:
         except Exception as exc:
             _emit("WARN", "quality_sidecar_write_failed", error=str(exc))
 
+        return len(new_ids)
+
     except Exception as exc:
         _emit("WARN", "quality_oi_registration_failed", error=str(exc))
+        return 0
 
 
 def append_receipt_payload(
@@ -819,7 +881,8 @@ def append_receipt_payload(
     # Best-effort: register quality advisory violations as tracked open items
     # (outside flock to avoid holding the receipt lock during OI registration)
     if result is not None and result.status == "appended":
-        _register_quality_open_items(receipt)
+        created_count = _register_quality_open_items(receipt)
+        receipt["open_items_created"] = created_count
 
     return result
 

--- a/scripts/dispatcher_v8_minimal.sh
+++ b/scripts/dispatcher_v8_minimal.sh
@@ -1106,6 +1106,34 @@ $receipt_footer"
         log "V8 WARNING: Failed to notify heartbeat ACK monitor (non-fatal)"
     }
 
+    # Log dispatch metadata to quality_intelligence.db (non-fatal)
+    local _dm_cognition _dm_priority _dm_pattern_count _dm_rule_count _dm_instr_chars
+    _dm_cognition=$(vnx_dispatch_extract_cognition "$dispatch_file" 2>/dev/null || echo "normal")
+    _dm_priority=$(vnx_dispatch_extract_priority "$dispatch_file" 2>/dev/null || echo "P1")
+    _dm_pattern_count=$(echo "$intelligence_data" | grep -o '"pattern_count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+    _dm_rule_count=$(echo "$intelligence_data" | grep -o '"prevention_rule_count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+    _dm_instr_chars=${#instruction_content}
+    # Extract OI-NNN references from dispatch instructions for target tracking
+    local _dm_target_oi=""
+    _dm_target_oi=$(echo "$instruction_content" | grep -oE 'OI-[0-9]{3,}' | sort -u | paste -sd ',' - 2>/dev/null || echo "")
+    python3 "$VNX_DIR/scripts/log_dispatch_metadata.py" \
+        --dispatch-id "$dispatch_id" \
+        --terminal "$terminal_id" \
+        --track "$track" \
+        --role "$agent_role" \
+        --skill-name "$agent_role" \
+        --gate "$gate" \
+        --cognition "$_dm_cognition" \
+        --priority "$_dm_priority" \
+        --pr-id "${pr_id:-}" \
+        --pattern-count "${_dm_pattern_count:-0}" \
+        --prevention-rule-count "${_dm_rule_count:-0}" \
+        --intelligence-json "$intelligence_data" \
+        --instruction-char-count "${_dm_instr_chars:-0}" \
+        --target-open-items "${_dm_target_oi:-}" 2>/dev/null || {
+        log "V8 WARNING: Failed to log dispatch metadata (non-fatal)"
+    }
+
     # Move dispatch to active (receipt_processor moves to completed on task_complete)
     mv "$dispatch_file" "$ACTIVE_DIR/$filename"
 

--- a/scripts/governance_aggregator.py
+++ b/scripts/governance_aggregator.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Nightly Governance Aggregator (Layer 2).
+
+Computes FPY, rework rate, gate velocity, mean CQS per scope,
+updates SPC control limits, and detects anomalies via Western Electric rules.
+
+Usage:
+    python3 governance_aggregator.py [--dry-run] [--backfill] [--baseline-days 30]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import statistics
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from vnx_paths import ensure_env
+from cqs_calculator import calculate_cqs
+
+
+def get_db(paths: Dict[str, str]) -> Path:
+    return Path(paths["VNX_STATE_DIR"]) / "quality_intelligence.db"
+
+
+def ensure_governance_schema(conn: sqlite3.Connection) -> None:
+    """Create governance tables if they don't exist (idempotent)."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS governance_metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            period_start DATE NOT NULL,
+            period_end DATE NOT NULL,
+            scope_type TEXT NOT NULL,
+            scope_value TEXT NOT NULL,
+            metric_name TEXT NOT NULL,
+            metric_value REAL NOT NULL,
+            sample_size INTEGER NOT NULL,
+            computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup
+            ON governance_metrics (period_start, scope_type, metric_name);
+
+        CREATE TABLE IF NOT EXISTS spc_control_limits (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            metric_name TEXT NOT NULL,
+            scope_type TEXT NOT NULL,
+            scope_value TEXT NOT NULL,
+            center_line REAL NOT NULL,
+            ucl REAL NOT NULL,
+            lcl REAL NOT NULL,
+            sigma REAL NOT NULL,
+            sample_count INTEGER NOT NULL,
+            baseline_start DATE,
+            baseline_end DATE,
+            computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(metric_name, scope_type, scope_value)
+        );
+
+        CREATE TABLE IF NOT EXISTS spc_alerts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            alert_type TEXT NOT NULL,
+            metric_name TEXT NOT NULL,
+            scope_type TEXT NOT NULL,
+            scope_value TEXT NOT NULL,
+            observed_value REAL NOT NULL,
+            control_limit REAL,
+            description TEXT,
+            severity TEXT DEFAULT 'warning',
+            detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            acknowledged_at DATETIME
+        );
+        CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup
+            ON spc_alerts (detected_at DESC, severity);
+    """)
+
+
+def ensure_cqs_columns(conn: sqlite3.Connection) -> None:
+    """Add CQS columns to dispatch_metadata if missing."""
+    cursor = conn.execute("PRAGMA table_info(dispatch_metadata)")
+    cols = {row[1] for row in cursor.fetchall()}
+    if "cqs" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
+    if "normalized_status" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
+    if "cqs_components" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
+    if "target_open_items" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
+    if "open_items_created" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0")
+    if "open_items_resolved" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0")
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Backfill: compute CQS for all dispatches with outcome but no CQS
+# ---------------------------------------------------------------------------
+
+
+def backfill_cqs(conn: sqlite3.Connection, db_path: Path, dry_run: bool = False) -> int:
+    """Retroactively compute CQS for dispatches missing it."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM dispatch_metadata WHERE outcome_status IS NOT NULL AND cqs IS NULL"
+    ).fetchall()
+
+    count = 0
+    for row in rows:
+        receipt = {
+            "status": row["outcome_status"],
+            "report_path": row["outcome_report_path"],
+            "role": row["role"],
+            "gate": row["gate"],
+            "pr_id": row["pr_id"],
+        }
+        session = None
+        sa = conn.execute(
+            "SELECT * FROM session_analytics WHERE dispatch_id = ?", (row["dispatch_id"],)
+        ).fetchone()
+        if sa:
+            session = dict(sa)
+
+        result = calculate_cqs(receipt, session, db_path, row["dispatch_id"])
+
+        if not dry_run:
+            conn.execute(
+                "UPDATE dispatch_metadata SET cqs=?, normalized_status=?, cqs_components=? WHERE dispatch_id=?",
+                (result["cqs"], result["normalized_status"], json.dumps(result["components"]), row["dispatch_id"]),
+            )
+        count += 1
+        if dry_run:
+            print(f"  [dry-run] {row['dispatch_id']}: CQS={result['cqs']} status={result['normalized_status']}")
+
+    if not dry_run:
+        conn.commit()
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+
+def compute_metrics(conn: sqlite3.Connection, period_start: date, period_end: date) -> List[Dict[str, Any]]:
+    """Compute all governance metrics for a period."""
+    metrics: List[Dict[str, Any]] = []
+
+    scopes = _get_scopes(conn, period_start, period_end)
+
+    for scope_type, scope_value in scopes:
+        where, params = _scope_filter(scope_type, scope_value, period_start, period_end)
+
+        # Mean CQS
+        row = conn.execute(
+            f"SELECT AVG(cqs), COUNT(*) FROM dispatch_metadata WHERE cqs IS NOT NULL AND {where}", params
+        ).fetchone()
+        if row and row[1] > 0:
+            metrics.append(_metric(period_start, period_end, scope_type, scope_value, "mean_cqs", row[0], row[1]))
+
+        # Dispatch count
+        total = conn.execute(
+            f"SELECT COUNT(*) FROM dispatch_metadata WHERE {where}", params
+        ).fetchone()[0]
+        if total > 0:
+            metrics.append(_metric(period_start, period_end, scope_type, scope_value, "dispatch_count", total, total))
+
+        # FPY (First-Pass Yield)
+        fpy_data = _compute_fpy(conn, where, params)
+        if fpy_data:
+            metrics.append(_metric(period_start, period_end, scope_type, scope_value, "fpy", fpy_data[0], fpy_data[1]))
+
+        # Rework rate
+        rework = _compute_rework_rate(conn, where, params)
+        if rework:
+            metrics.append(_metric(period_start, period_end, scope_type, scope_value, "rework_rate", rework[0], rework[1]))
+
+        # OI resolution rate
+        oi_row = conn.execute(
+            f"""SELECT SUM(COALESCE(open_items_resolved, 0)),
+                       SUM(COALESCE(open_items_created, 0)) + SUM(COALESCE(open_items_resolved, 0))
+                FROM dispatch_metadata WHERE {where}""",
+            params,
+        ).fetchone()
+        if oi_row and oi_row[1] and oi_row[1] > 0:
+            oi_rate = oi_row[0] / oi_row[1] * 100
+            metrics.append(_metric(period_start, period_end, scope_type, scope_value, "oi_resolution_rate", oi_rate, int(oi_row[1])))
+
+        # Gate velocity (only for gate scope)
+        if scope_type == "gate":
+            velocity = _compute_gate_velocity(conn, scope_value, period_start, period_end)
+            if velocity:
+                metrics.append(_metric(period_start, period_end, scope_type, scope_value, "gate_velocity_hours", velocity[0], velocity[1]))
+
+    return metrics
+
+
+def _get_scopes(conn: sqlite3.Connection, start: date, end: date) -> List[Tuple[str, str]]:
+    """Get all scope (type, value) pairs for the period."""
+    scopes = [("system", "all")]
+    start_s, end_s = str(start), str(end)
+
+    for col, stype in [("terminal", "terminal"), ("role", "role"), ("gate", "gate")]:
+        rows = conn.execute(
+            f"SELECT DISTINCT {col} FROM dispatch_metadata WHERE {col} IS NOT NULL AND date(dispatched_at) BETWEEN ? AND ?",
+            (start_s, end_s),
+        ).fetchall()
+        scopes.extend((stype, r[0]) for r in rows if r[0])
+
+    # Model scope from session_analytics
+    rows = conn.execute(
+        """SELECT DISTINCT sa.session_model FROM session_analytics sa
+           JOIN dispatch_metadata dm ON sa.dispatch_id = dm.dispatch_id
+           WHERE sa.session_model IS NOT NULL AND date(dm.dispatched_at) BETWEEN ? AND ?""",
+        (start_s, end_s),
+    ).fetchall()
+    scopes.extend(("model", r[0]) for r in rows if r[0] and r[0] != "unknown")
+
+    return scopes
+
+
+def _scope_filter(scope_type: str, scope_value: str, start: date, end: date) -> Tuple[str, tuple]:
+    """Build WHERE clause and params for scope filtering."""
+    base = "date(dispatched_at) BETWEEN ? AND ?"
+    params: list = [str(start), str(end)]
+
+    if scope_type == "system":
+        return base, tuple(params)
+    elif scope_type == "model":
+        return (
+            f"{base} AND dispatch_id IN (SELECT dispatch_id FROM session_analytics WHERE session_model = ?)",
+            tuple(params + [scope_value]),
+        )
+    else:
+        return f"{base} AND {scope_type} = ?", tuple(params + [scope_value])
+
+
+def _compute_fpy(conn: sqlite3.Connection, where: str, params: tuple) -> Optional[Tuple[float, int]]:
+    """First-Pass Yield: ratio of unique gate+pr_id combos that succeeded on first try."""
+    rows = conn.execute(
+        f"""SELECT gate, pr_id, MIN(dispatched_at) as first_at, normalized_status
+            FROM dispatch_metadata
+            WHERE normalized_status IS NOT NULL AND normalized_status != 'timeout' AND normalized_status != 'unknown'
+            AND gate IS NOT NULL AND {where}
+            GROUP BY gate, pr_id
+            HAVING dispatched_at = first_at""",
+        params,
+    ).fetchall()
+    if not rows:
+        return None
+    success = sum(1 for r in rows if r[3] == "success")
+    return (success / len(rows) * 100, len(rows))
+
+
+def _compute_rework_rate(conn: sqlite3.Connection, where: str, params: tuple) -> Optional[Tuple[float, int]]:
+    """Rework rate: total dispatches / unique (gate, pr_id) combos."""
+    total = conn.execute(
+        f"SELECT COUNT(*) FROM dispatch_metadata WHERE gate IS NOT NULL AND {where}", params
+    ).fetchone()[0]
+    unique = conn.execute(
+        f"SELECT COUNT(DISTINCT gate || '|' || COALESCE(pr_id, '')) FROM dispatch_metadata WHERE gate IS NOT NULL AND {where}",
+        params,
+    ).fetchone()[0]
+    if unique == 0:
+        return None
+    return (total / unique, total)
+
+
+def _compute_gate_velocity(conn: sqlite3.Connection, gate: str, start: date, end: date) -> Optional[Tuple[float, int]]:
+    """Hours from first dispatch to gate completion for a specific gate."""
+    rows = conn.execute(
+        """SELECT pr_id,
+                  MIN(dispatched_at) as first_dispatch,
+                  MAX(completed_at) as last_complete
+           FROM dispatch_metadata
+           WHERE gate = ? AND date(dispatched_at) BETWEEN ? AND ?
+           AND completed_at IS NOT NULL AND normalized_status = 'success'
+           GROUP BY pr_id""",
+        (gate, str(start), str(end)),
+    ).fetchall()
+    if not rows:
+        return None
+    hours = []
+    for r in rows:
+        try:
+            t_start = datetime.fromisoformat(r[1])
+            t_end = datetime.fromisoformat(r[2])
+            hours.append((t_end - t_start).total_seconds() / 3600)
+        except (ValueError, TypeError):
+            continue
+    if not hours:
+        return None
+    return (statistics.mean(hours), len(hours))
+
+
+def _metric(start: date, end: date, scope_type: str, scope_value: str, name: str, value: float, sample: int) -> Dict[str, Any]:
+    return {
+        "period_start": str(start),
+        "period_end": str(end),
+        "scope_type": scope_type,
+        "scope_value": scope_value,
+        "metric_name": name,
+        "metric_value": round(value, 4),
+        "sample_size": sample,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SPC Control Limits
+# ---------------------------------------------------------------------------
+
+
+def update_control_limits(conn: sqlite3.Connection, baseline_days: int = 30) -> int:
+    """Recompute control limits from recent governance_metrics data."""
+    end = date.today()
+    start = end - timedelta(days=baseline_days)
+
+    rows = conn.execute(
+        """SELECT DISTINCT metric_name, scope_type, scope_value
+           FROM governance_metrics
+           WHERE period_start >= ?""",
+        (str(start),),
+    ).fetchall()
+
+    updated = 0
+    for metric_name, scope_type, scope_value in rows:
+        values = [
+            r[0]
+            for r in conn.execute(
+                """SELECT metric_value FROM governance_metrics
+                   WHERE metric_name=? AND scope_type=? AND scope_value=?
+                   AND period_start >= ? ORDER BY period_start""",
+                (metric_name, scope_type, scope_value, str(start)),
+            ).fetchall()
+        ]
+        if len(values) < 3:
+            continue
+
+        mean = statistics.mean(values)
+        sigma = statistics.stdev(values)
+        ucl = mean + 3 * sigma
+        lcl = max(0, mean - 3 * sigma)
+
+        conn.execute(
+            """INSERT INTO spc_control_limits (metric_name, scope_type, scope_value, center_line, ucl, lcl, sigma, sample_count, baseline_start, baseline_end)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(metric_name, scope_type, scope_value)
+               DO UPDATE SET center_line=excluded.center_line, ucl=excluded.ucl, lcl=excluded.lcl,
+                             sigma=excluded.sigma, sample_count=excluded.sample_count,
+                             baseline_start=excluded.baseline_start, baseline_end=excluded.baseline_end,
+                             computed_at=CURRENT_TIMESTAMP""",
+            (metric_name, scope_type, scope_value, mean, ucl, lcl, sigma, len(values), str(start), str(end)),
+        )
+        updated += 1
+
+    conn.commit()
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Anomaly Detection (Western Electric Rules)
+# ---------------------------------------------------------------------------
+
+
+def detect_anomalies(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
+    """Detect SPC anomalies using Western Electric rules."""
+    alerts: List[Dict[str, Any]] = []
+
+    limits = conn.execute("SELECT * FROM spc_control_limits").fetchall()
+    col_names = [d[0] for d in conn.execute("SELECT * FROM spc_control_limits LIMIT 0").description]
+
+    for limit_row in limits:
+        limit = dict(zip(col_names, limit_row))
+        values = [
+            r[0]
+            for r in conn.execute(
+                """SELECT metric_value FROM governance_metrics
+                   WHERE metric_name=? AND scope_type=? AND scope_value=?
+                   ORDER BY period_start DESC LIMIT 20""",
+                (limit["metric_name"], limit["scope_type"], limit["scope_value"]),
+            ).fetchall()
+        ]
+        if not values:
+            continue
+
+        latest = values[0]
+        center = limit["center_line"]
+        ucl = limit["ucl"]
+        lcl = limit["lcl"]
+        sigma = limit["sigma"]
+
+        # Rule 1: Out of control — point beyond UCL/LCL
+        if latest > ucl or latest < lcl:
+            violated = "UCL" if latest > ucl else "LCL"
+            alerts.append({
+                "alert_type": "out_of_control",
+                "metric_name": limit["metric_name"],
+                "scope_type": limit["scope_type"],
+                "scope_value": limit["scope_value"],
+                "observed_value": latest,
+                "control_limit": ucl if latest > ucl else lcl,
+                "description": f"{limit['metric_name']} = {latest:.2f} beyond {violated} ({ucl:.2f}/{lcl:.2f})",
+                "severity": "critical",
+            })
+
+        # Rule 2: Trend — 7+ consecutive increasing or decreasing
+        if len(values) >= 7:
+            recent7 = list(reversed(values[:7]))
+            if all(recent7[i] < recent7[i + 1] for i in range(6)):
+                alerts.append({
+                    "alert_type": "trend",
+                    "metric_name": limit["metric_name"],
+                    "scope_type": limit["scope_type"],
+                    "scope_value": limit["scope_value"],
+                    "observed_value": latest,
+                    "control_limit": None,
+                    "description": f"7-point increasing trend detected for {limit['metric_name']}",
+                    "severity": "warning",
+                })
+            elif all(recent7[i] > recent7[i + 1] for i in range(6)):
+                alerts.append({
+                    "alert_type": "trend",
+                    "metric_name": limit["metric_name"],
+                    "scope_type": limit["scope_type"],
+                    "scope_value": limit["scope_value"],
+                    "observed_value": latest,
+                    "control_limit": None,
+                    "description": f"7-point decreasing trend detected for {limit['metric_name']}",
+                    "severity": "warning",
+                })
+
+        # Rule 3: Shift — 8+ consecutive on same side of center line
+        if len(values) >= 8:
+            recent8 = values[:8]
+            above = all(v > center for v in recent8)
+            below = all(v < center for v in recent8)
+            if above or below:
+                side = "above" if above else "below"
+                alerts.append({
+                    "alert_type": "shift",
+                    "metric_name": limit["metric_name"],
+                    "scope_type": limit["scope_type"],
+                    "scope_value": limit["scope_value"],
+                    "observed_value": latest,
+                    "control_limit": center,
+                    "description": f"8-point shift {side} center line for {limit['metric_name']}",
+                    "severity": "warning",
+                })
+
+        # Rule 4: Run — 2 of 3 beyond 2 sigma
+        if len(values) >= 3 and sigma > 0:
+            two_sigma_high = center + 2 * sigma
+            two_sigma_low = center - 2 * sigma
+            recent3 = values[:3]
+            beyond_2s = sum(1 for v in recent3 if v > two_sigma_high or v < two_sigma_low)
+            if beyond_2s >= 2:
+                alerts.append({
+                    "alert_type": "run",
+                    "metric_name": limit["metric_name"],
+                    "scope_type": limit["scope_type"],
+                    "scope_value": limit["scope_value"],
+                    "observed_value": latest,
+                    "control_limit": two_sigma_high,
+                    "description": f"2-of-3 points beyond 2-sigma for {limit['metric_name']}",
+                    "severity": "info",
+                })
+
+    return alerts
+
+
+def store_metrics(conn: sqlite3.Connection, metrics: List[Dict[str, Any]]) -> None:
+    """Insert computed metrics into governance_metrics table."""
+    for m in metrics:
+        conn.execute(
+            """INSERT INTO governance_metrics (period_start, period_end, scope_type, scope_value, metric_name, metric_value, sample_size)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (m["period_start"], m["period_end"], m["scope_type"], m["scope_value"],
+             m["metric_name"], m["metric_value"], m["sample_size"]),
+        )
+    conn.commit()
+
+
+def store_alerts(conn: sqlite3.Connection, alerts: List[Dict[str, Any]]) -> None:
+    """Insert SPC alerts into spc_alerts table."""
+    for a in alerts:
+        conn.execute(
+            """INSERT INTO spc_alerts (alert_type, metric_name, scope_type, scope_value, observed_value, control_limit, description, severity)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (a["alert_type"], a["metric_name"], a["scope_type"], a["scope_value"],
+             a["observed_value"], a.get("control_limit"), a["description"], a["severity"]),
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Nightly governance metrics aggregator")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing to DB")
+    parser.add_argument("--backfill", action="store_true", help="Backfill CQS for existing dispatches")
+    parser.add_argument("--baseline-days", type=int, default=30, help="SPC baseline window in days")
+    parser.add_argument("--period-days", type=int, default=1, help="Aggregation period in days")
+    args = parser.parse_args()
+
+    paths = ensure_env()
+    db_path = get_db(paths)
+    if not db_path.exists():
+        print("No quality_intelligence.db found, skipping governance aggregation")
+        return 0
+
+    conn = sqlite3.connect(str(db_path))
+
+    # Ensure schema exists
+    ensure_governance_schema(conn)
+    ensure_cqs_columns(conn)
+
+    # Backfill CQS if requested
+    if args.backfill:
+        count = backfill_cqs(conn, db_path, dry_run=args.dry_run)
+        print(f"Backfilled CQS for {count} dispatches")
+
+    # Compute metrics for the period
+    period_end = date.today() - timedelta(days=1)  # yesterday
+    period_start = period_end - timedelta(days=args.period_days - 1)
+
+    print(f"Computing governance metrics for {period_start} to {period_end}...")
+    metrics = compute_metrics(conn, period_start, period_end)
+
+    if args.dry_run:
+        print(f"\n[dry-run] {len(metrics)} metrics computed:")
+        for m in metrics:
+            print(f"  {m['scope_type']}/{m['scope_value']}: {m['metric_name']}={m['metric_value']:.4f} (n={m['sample_size']})")
+    else:
+        store_metrics(conn, metrics)
+        print(f"Stored {len(metrics)} governance metrics")
+
+    # Update SPC control limits
+    if not args.dry_run:
+        updated = update_control_limits(conn, args.baseline_days)
+        print(f"Updated {updated} SPC control limits")
+
+    # Detect anomalies
+    alerts = detect_anomalies(conn)
+    if alerts:
+        if args.dry_run:
+            print(f"\n[dry-run] {len(alerts)} SPC alerts detected:")
+            for a in alerts:
+                print(f"  [{a['severity']}] {a['alert_type']}: {a['description']}")
+        else:
+            store_alerts(conn, alerts)
+            print(f"Stored {len(alerts)} SPC alerts")
+            for a in alerts:
+                if a["severity"] == "critical":
+                    print(f"  CRITICAL: {a['description']}")
+    else:
+        print("No SPC anomalies detected")
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/cqs_calculator.py
+++ b/scripts/lib/cqs_calculator.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Composite Quality Score (CQS) calculator for VNX dispatches.
+
+Computes an objective 0-100 quality score per dispatch from receipt signals,
+replacing self-reported status with measurable indicators.
+
+Scoring components (weighted, 7 total):
+  - Status normalization (25%): Maps raw status to 5 categories
+  - Completion signals (20%): Report path, PR merge, gate passed
+  - Effort efficiency (15%): Token usage vs median for role
+  - Error density (10%): Error/fail messages ratio in JSONL
+  - Rework indicator (10%): Same gate+pr_id dispatched before?
+  - T0 Advisory (10%): quality_advisory.t0_recommendation decision + risk_score
+  - Open Items Delta (10%): Created vs resolved open items balance
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Normalize the ~166 unique status values into 5 categories
+STATUS_MAP: Dict[str, str] = {
+    # success (score contribution: 100)
+    "task_complete": "success",
+    "success": "success",
+    "merged": "success",
+    "completed": "success",
+    "done": "success",
+    "approved": "success",
+    "gate_passed": "success",
+    # partial (score contribution: 60)
+    "partial": "partial",
+    "needs_review": "partial",
+    "partial_success": "partial",
+    "in_progress": "partial",
+    "pending_review": "partial",
+    # failure (score contribution: 0)
+    "task_failed": "failure",
+    "error": "failure",
+    "rejected": "failure",
+    "failed": "failure",
+    "blocked": "failure",
+    # timeout (excluded from quality metrics)
+    "no_confirmation": "timeout",
+    "timeout": "timeout",
+    "receipt_timeout": "timeout",
+}
+
+STATUS_SCORES = {"success": 100, "partial": 60, "failure": 0}
+
+
+def normalize_status(raw_status: str | None) -> str:
+    """Map raw status string to normalized category."""
+    if not raw_status:
+        return "unknown"
+    key = raw_status.strip().lower().replace(" ", "_").replace("-", "_")
+    return STATUS_MAP.get(key, "unknown")
+
+
+def _score_status(normalized: str) -> float | None:
+    """Score for status component. None = exclude from CQS."""
+    return STATUS_SCORES.get(normalized)
+
+
+def _score_completion(receipt: Dict[str, Any]) -> float:
+    """Score based on completion signals (0-100)."""
+    score = 0.0
+    signals = 0
+    total = 3
+
+    if receipt.get("report_path"):
+        score += 100
+        signals += 1
+
+    pr_merged = receipt.get("pr_merged") or receipt.get("provenance", {}).get("pr_merged")
+    if pr_merged:
+        score += 100
+        signals += 1
+
+    gate = receipt.get("gate_passed") or receipt.get("quality_advisory", {}).get("t0_recommendation", {}).get("decision") == "approve"
+    if gate:
+        score += 100
+        signals += 1
+
+    return (score / total) if total > 0 else 0.0
+
+
+def _score_effort(session: Dict[str, Any] | None, db_path: Path | None = None, role: str | None = None) -> float:
+    """Score based on token efficiency vs median for same role (0-100)."""
+    if not session:
+        return 50.0  # neutral when no session data
+
+    total_tokens = (session.get("total_input_tokens") or 0) + (session.get("total_output_tokens") or 0)
+    if total_tokens == 0:
+        return 50.0
+
+    median_tokens = _get_role_median_tokens(db_path, role)
+    if median_tokens is None or median_tokens == 0:
+        return 50.0
+
+    ratio = total_tokens / median_tokens
+    if ratio <= 0.5:
+        return 100.0
+    elif ratio <= 1.0:
+        return 80.0 + (1.0 - ratio) * 40
+    elif ratio <= 2.0:
+        return 80.0 - (ratio - 1.0) * 60
+    else:
+        return max(0.0, 20.0 - (ratio - 2.0) * 10)
+
+
+def _get_role_median_tokens(db_path: Path | None, role: str | None) -> float | None:
+    """Get median total tokens for a role from session_analytics."""
+    if not db_path or not role or not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            """SELECT total_input_tokens + total_output_tokens as total
+               FROM session_analytics sa
+               JOIN dispatch_metadata dm ON sa.dispatch_id = dm.dispatch_id
+               WHERE dm.role = ?
+               AND sa.total_input_tokens IS NOT NULL
+               ORDER BY total""",
+            (role,),
+        ).fetchall()
+        conn.close()
+        if not rows:
+            return None
+        mid = len(rows) // 2
+        return rows[mid][0]
+    except Exception:
+        return None
+
+
+def _score_error_density(session: Dict[str, Any] | None) -> float:
+    """Score based on error message density (0-100). Lower density = higher score."""
+    if not session:
+        return 50.0
+
+    error_count = session.get("error_count") or 0
+    total_messages = session.get("total_messages") or session.get("tool_calls_total") or 1
+
+    if total_messages == 0:
+        return 50.0
+
+    ratio = error_count / total_messages
+    if ratio == 0:
+        return 100.0
+    elif ratio < 0.05:
+        return 80.0
+    elif ratio < 0.15:
+        return 50.0
+    elif ratio < 0.30:
+        return 25.0
+    else:
+        return 0.0
+
+
+def _score_rework(dispatch_id: str, gate: str | None, pr_id: str | None, db_path: Path | None) -> float:
+    """Score based on rework detection (0-100). First attempt = 100, rework = 0."""
+    if not db_path or not db_path.exists() or not gate:
+        return 100.0  # no data = assume first attempt
+    try:
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute(
+            """SELECT COUNT(*) FROM dispatch_metadata
+               WHERE gate = ? AND (pr_id = ? OR (pr_id IS NULL AND ? IS NULL))
+               AND dispatch_id != ? AND dispatched_at IS NOT NULL""",
+            (gate, pr_id, pr_id, dispatch_id),
+        ).fetchone()[0]
+        conn.close()
+        return 0.0 if count > 0 else 100.0
+    except Exception:
+        return 100.0
+
+
+def _score_t0_advisory(receipt: Dict[str, Any]) -> float:
+    """Score from quality_advisory.t0_recommendation (0-100)."""
+    advisory = receipt.get("quality_advisory")
+    if not isinstance(advisory, dict):
+        return 50.0  # neutral
+
+    rec = advisory.get("t0_recommendation")
+    if not isinstance(rec, dict):
+        return 50.0
+
+    decision = rec.get("decision", "approve")
+    risk_score = advisory.get("summary", {}).get("risk_score", 0)
+
+    decision_scores = {"approve": 100.0, "approve_with_followup": 60.0, "hold": 0.0}
+    decision_score = decision_scores.get(decision, 50.0)
+
+    # Blend: 70% decision weight, 30% inverse risk score
+    return decision_score * 0.7 + max(0, 100 - risk_score) * 0.3
+
+
+def _score_open_items_delta(receipt: Dict[str, Any]) -> float:
+    """Score based on open items created vs resolved (0-100)."""
+    created = receipt.get("open_items_created", 0) or 0
+    resolved = receipt.get("open_items_resolved", 0) or 0
+    targeted = len(receipt.get("target_open_items") or [])
+
+    if not created and not resolved and not targeted:
+        return 50.0  # neutral — dispatch unrelated to open items
+
+    score = 50.0
+    score += min(30, resolved * 15)        # bonus per resolved item
+    score -= min(30, created * 10)          # penalty per created item
+    if targeted and resolved < targeted:    # penalty for unresolved targets
+        score -= min(20, (targeted - resolved) * 20)
+
+    return max(0, min(100, score))
+
+
+def calculate_cqs(
+    receipt: Dict[str, Any],
+    session: Dict[str, Any] | None,
+    db_path: Path | None = None,
+    dispatch_id: str | None = None,
+) -> Dict[str, Any]:
+    """Calculate Composite Quality Score for a dispatch.
+
+    Args:
+        receipt: Receipt data with status, report_path, etc.
+        session: Session analytics data (tokens, errors, etc.) or None.
+        db_path: Path to quality_intelligence.db for median lookups.
+        dispatch_id: Dispatch ID for rework detection.
+
+    Returns:
+        {cqs: float|None, normalized_status: str, components: dict}
+        cqs is None when status is timeout/unknown (excluded from metrics).
+    """
+    raw_status = receipt.get("status") or receipt.get("outcome_status") or ""
+    normalized = normalize_status(raw_status)
+
+    status_score = _score_status(normalized)
+    if status_score is None:
+        return {
+            "cqs": None,
+            "normalized_status": normalized,
+            "components": {"excluded_reason": f"status={normalized} excluded from quality metrics"},
+        }
+
+    role = receipt.get("role")
+    gate = receipt.get("gate")
+    pr_id = receipt.get("pr_id")
+
+    completion = _score_completion(receipt)
+    effort = _score_effort(session, db_path, role)
+    error_density = _score_error_density(session)
+    rework = _score_rework(dispatch_id or "", gate, pr_id, db_path)
+    t0_advisory = _score_t0_advisory(receipt)
+    oi_delta = _score_open_items_delta(receipt)
+
+    # Weighted composite (7 components)
+    cqs = (
+        status_score * 0.25
+        + completion * 0.20
+        + effort * 0.15
+        + error_density * 0.10
+        + rework * 0.10
+        + t0_advisory * 0.10
+        + oi_delta * 0.10
+    )
+
+    components = {
+        "status": round(status_score, 1),
+        "completion": round(completion, 1),
+        "effort": round(effort, 1),
+        "error_density": round(error_density, 1),
+        "rework": round(rework, 1),
+        "t0_advisory": round(t0_advisory, 1),
+        "oi_delta": round(oi_delta, 1),
+        "weights": {
+            "status": 0.25, "completion": 0.20, "effort": 0.15,
+            "error_density": 0.10, "rework": 0.10,
+            "t0_advisory": 0.10, "oi_delta": 0.10,
+        },
+    }
+
+    return {
+        "cqs": round(cqs, 2),
+        "normalized_status": normalized,
+        "components": components,
+    }

--- a/scripts/log_dispatch_metadata.py
+++ b/scripts/log_dispatch_metadata.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Log dispatch metadata to quality_intelligence.db after successful dispatch.
+
+Called non-fatally from dispatcher_v8_minimal.sh after each successful dispatch.
+Inserts a row into dispatch_metadata with all available context.
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+try:
+    from vnx_paths import ensure_env
+except Exception as exc:
+    raise SystemExit(f"Failed to load vnx_paths: {exc}")
+
+PATHS = ensure_env()
+DB_PATH = Path(PATHS["VNX_STATE_DIR"]) / "quality_intelligence.db"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Log dispatch metadata to DB")
+    parser.add_argument("--dispatch-id", required=True)
+    parser.add_argument("--terminal", required=True)
+    parser.add_argument("--track", required=True)
+    parser.add_argument("--role", default="")
+    parser.add_argument("--skill-name", default="")
+    parser.add_argument("--gate", default="")
+    parser.add_argument("--cognition", default="normal")
+    parser.add_argument("--priority", default="P1")
+    parser.add_argument("--pr-id", default="")
+    parser.add_argument("--pattern-count", type=int, default=0)
+    parser.add_argument("--prevention-rule-count", type=int, default=0)
+    parser.add_argument("--intelligence-json", default="")
+    parser.add_argument("--instruction-char-count", type=int, default=0)
+    parser.add_argument("--context-file-count", type=int, default=0)
+    parser.add_argument("--target-open-items", default="", help="JSON array or comma-separated OI-IDs targeted by this dispatch")
+    args = parser.parse_args()
+
+    # Normalize target_open_items to JSON array string
+    raw_toi = args.target_open_items.strip()
+    if raw_toi and not raw_toi.startswith("["):
+        # comma-separated OI-IDs → JSON array
+        raw_toi = json.dumps([x.strip() for x in raw_toi.split(",") if x.strip()])
+    args.target_open_items = raw_toi or None
+
+    if not DB_PATH.exists():
+        print(f"WARNING: DB not found: {DB_PATH}", file=sys.stderr)
+        return 1
+
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    cur.execute("""
+        INSERT OR REPLACE INTO dispatch_metadata (
+            dispatch_id, terminal, track, role, skill_name, gate,
+            cognition, priority, pr_id,
+            pattern_count, prevention_rule_count, intelligence_json,
+            instruction_char_count, context_file_count, target_open_items, dispatched_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, (
+        args.dispatch_id,
+        args.terminal,
+        args.track,
+        args.role or None,
+        args.skill_name or None,
+        args.gate or None,
+        args.cognition,
+        args.priority,
+        args.pr_id or None,
+        args.pattern_count,
+        args.prevention_rule_count,
+        args.intelligence_json or None,
+        args.instruction_char_count,
+        args.context_file_count,
+        args.target_open_items,
+        datetime.utcnow().isoformat(),
+    ))
+    conn.commit()
+    conn.close()
+    print(f"Logged dispatch metadata: {args.dispatch_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -228,6 +228,8 @@ def close_item(args):
     old_status = item["status"]
     item["status"] = args.status
     item["closed_reason"] = args.reason
+    item["closed_by_dispatch_id"] = getattr(args, 'dispatch_id', None)
+    item["closed_at"] = datetime.now().isoformat()
     item["updated_at"] = datetime.now().isoformat()
 
     save_items(data)
@@ -485,6 +487,78 @@ def generate_markdown(data: dict, digest: dict):
     with open(MARKDOWN_FILE, 'w') as f:
         f.write('\n'.join(lines))
 
+def close_item_programmatic(
+    *,
+    item_id: str,
+    status: str = "done",
+    reason: str = "",
+    dispatch_id: str = "",
+) -> bool:
+    """Thread-safe programmatic API for closing open items.
+
+    Uses fcntl.flock on a dedicated lock file for concurrent terminal safety.
+
+    Returns:
+        True if item was closed, False if not found or already closed.
+    """
+    lock_path = STATE_DIR / "open_items.lock"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            data = load_items()
+
+            item = None
+            for i in data["items"]:
+                if i["id"] == item_id:
+                    item = i
+                    break
+
+            if not item or item["status"] != "open":
+                return False
+
+            item["status"] = status
+            item["closed_reason"] = reason
+            item["closed_by_dispatch_id"] = dispatch_id or None
+            item["closed_at"] = datetime.now().isoformat()
+            item["updated_at"] = datetime.now().isoformat()
+
+            save_items(data)
+
+            audit_log_entry(
+                "close",
+                item_id=item_id,
+                from_status="open",
+                to_status=status,
+                reason=reason,
+                dispatch_id=dispatch_id,
+            )
+
+            generate_digest()
+            return True
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+def get_items_by_origin_dispatch(dispatch_id: str) -> List[dict]:
+    """Items created by this dispatch (origin_dispatch_id matches)."""
+    data = load_items()
+    return [
+        item for item in data["items"]
+        if item.get("origin_dispatch_id") == dispatch_id
+    ]
+
+
+def count_items_closed_by_dispatch(dispatch_id: str) -> int:
+    """Count items where closed_by_dispatch_id matches."""
+    data = load_items()
+    return sum(
+        1 for item in data["items"]
+        if item.get("closed_by_dispatch_id") == dispatch_id
+    )
+
+
 def main():
     if _rollback_mode_enabled():
         print(
@@ -516,16 +590,19 @@ def main():
     close_parser.add_argument('--status', default='done',
                              choices=['done'], help='Close status')
     close_parser.add_argument('--reason', required=True, help='Closure reason')
+    close_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID that resolved this item')
 
     # Defer command
     defer_parser = subparsers.add_parser('defer', help='Defer item')
     defer_parser.add_argument('item_id', help='Item ID to defer')
     defer_parser.add_argument('--reason', required=True, help='Deferral reason')
+    defer_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID that deferred this item')
 
     # Wontfix command
     wontfix_parser = subparsers.add_parser('wontfix', help='Mark as wontfix')
     wontfix_parser.add_argument('item_id', help='Item ID to mark wontfix')
     wontfix_parser.add_argument('--reason', required=True, help='Wontfix reason')
+    wontfix_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID that marked this wontfix')
 
     # Attach evidence command
     evidence_parser = subparsers.add_parser('attach-evidence', help='Attach report evidence to PR open items')

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -145,6 +145,7 @@ def initialize_database() -> bool:
                     duration_minutes REAL,
                     has_error_recovery BOOLEAN DEFAULT FALSE,
                     has_context_reset BOOLEAN DEFAULT FALSE,
+                    context_reset_count INTEGER DEFAULT 0,
                     has_large_refactor BOOLEAN DEFAULT FALSE,
                     has_test_cycle BOOLEAN DEFAULT FALSE,
                     primary_activity TEXT,
@@ -201,6 +202,96 @@ def initialize_database() -> bool:
             conn.commit()
             log('INFO', 'Migrated session_analytics: added session_model column + index')
 
+        # Migration: add dispatch_id column to session_analytics if missing
+        cursor.execute("PRAGMA table_info(session_analytics)")
+        sa_cols = {row[1] for row in cursor.fetchall()}
+        if "dispatch_id" not in sa_cols:
+            cursor.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_session_dispatch_id ON session_analytics (dispatch_id)")
+            conn.commit()
+            log('INFO', 'Migrated session_analytics: added dispatch_id column + index')
+
+        # Migration: add dispatch_id column to report_findings if missing
+        cursor.execute("PRAGMA table_info(report_findings)")
+        rf_cols = {row[1] for row in cursor.fetchall()}
+        if "dispatch_id" not in rf_cols:
+            cursor.execute("ALTER TABLE report_findings ADD COLUMN dispatch_id TEXT")
+            conn.commit()
+            log('INFO', 'Migrated report_findings: added dispatch_id column')
+
+        # Migration: add CQS columns to dispatch_metadata if missing
+        cursor.execute("PRAGMA table_info(dispatch_metadata)")
+        dm_cols = {row[1] for row in cursor.fetchall()}
+        if "cqs" not in dm_cols:
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
+            conn.commit()
+            log('INFO', 'Migrated dispatch_metadata: added cqs, normalized_status, cqs_components columns')
+
+        # Migration: create governance tables if missing
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='governance_metrics'")
+        if not cursor.fetchone():
+            cursor.executescript("""
+                CREATE TABLE IF NOT EXISTS governance_metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    period_start DATE NOT NULL,
+                    period_end DATE NOT NULL,
+                    scope_type TEXT NOT NULL,
+                    scope_value TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    metric_value REAL NOT NULL,
+                    sample_size INTEGER NOT NULL,
+                    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup
+                    ON governance_metrics (period_start, scope_type, metric_name);
+
+                CREATE TABLE IF NOT EXISTS spc_control_limits (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    metric_name TEXT NOT NULL,
+                    scope_type TEXT NOT NULL,
+                    scope_value TEXT NOT NULL,
+                    center_line REAL NOT NULL,
+                    ucl REAL NOT NULL,
+                    lcl REAL NOT NULL,
+                    sigma REAL NOT NULL,
+                    sample_count INTEGER NOT NULL,
+                    baseline_start DATE,
+                    baseline_end DATE,
+                    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(metric_name, scope_type, scope_value)
+                );
+
+                CREATE TABLE IF NOT EXISTS spc_alerts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    alert_type TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    scope_type TEXT NOT NULL,
+                    scope_value TEXT NOT NULL,
+                    observed_value REAL NOT NULL,
+                    control_limit REAL,
+                    description TEXT,
+                    severity TEXT DEFAULT 'warning',
+                    detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    acknowledged_at DATETIME
+                );
+                CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup
+                    ON spc_alerts (detected_at DESC, severity);
+            """)
+            conn.commit()
+            log('INFO', 'Migrated: created governance_metrics, spc_control_limits, spc_alerts tables')
+
+        # Migration: add CQS enhancement columns (T0 advisory + OI delta) if missing
+        cursor.execute("PRAGMA table_info(dispatch_metadata)")
+        dm_cols_v2 = {row[1] for row in cursor.fetchall()}
+        if "target_open_items" not in dm_cols_v2:
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0")
+            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0")
+            conn.commit()
+            log('INFO', 'Migrated dispatch_metadata: added target_open_items, open_items_created, open_items_resolved columns')
+
         log('SUCCESS', 'Database schema initialized successfully')
 
         # Close connection
@@ -238,14 +329,21 @@ def verify_database_structure() -> bool:
             'prevention_rules',
             'session_analytics',
             'improvement_suggestions',
-            'nightly_digests'
+            'nightly_digests',
+            'dispatch_metadata',
+            'governance_metrics',
+            'spc_control_limits',
+            'spc_alerts'
         ]
 
         # Expected views
         expected_views = [
             'high_quality_snippets',
             'files_needing_attention',
-            'open_alerts_summary'
+            'open_alerts_summary',
+            'dispatch_success_by_role',
+            'intelligence_effectiveness',
+            'cost_per_dispatch'
         ]
 
         # Check tables

--- a/tests/test_cqs_calculator.py
+++ b/tests/test_cqs_calculator.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for CQS calculator — 7-component scoring with T0 Advisory and OI Delta."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure lib is importable
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from cqs_calculator import (
+    _score_t0_advisory,
+    _score_open_items_delta,
+    calculate_cqs,
+    normalize_status,
+)
+
+
+# ── T0 Advisory scoring ──
+
+
+def test_score_t0_advisory_approve():
+    receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "approve"},
+            "summary": {"risk_score": 0},
+        }
+    }
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(100.0)
+
+
+def test_score_t0_advisory_hold():
+    receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "hold"},
+            "summary": {"risk_score": 100},
+        }
+    }
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(0.0)
+
+
+def test_score_t0_advisory_followup_blended():
+    receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "approve_with_followup"},
+            "summary": {"risk_score": 40},
+        }
+    }
+    # 60 * 0.7 + (100-40) * 0.3 = 42 + 18 = 60
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(60.0)
+
+
+def test_score_t0_advisory_missing():
+    score = _score_t0_advisory({})
+    assert score == pytest.approx(50.0)
+
+
+def test_score_t0_advisory_unavailable():
+    receipt = {"quality_advisory": {"status": "unavailable"}}
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(50.0)
+
+
+# ── Open Items Delta scoring ──
+
+
+def test_score_oi_delta_resolved_bonus():
+    receipt = {"open_items_resolved": 2, "open_items_created": 0}
+    score = _score_open_items_delta(receipt)
+    # 50 + min(30, 2*15) = 50 + 30 = 80
+    assert score == pytest.approx(80.0)
+
+
+def test_score_oi_delta_created_penalty():
+    receipt = {"open_items_created": 3, "open_items_resolved": 0}
+    score = _score_open_items_delta(receipt)
+    # 50 - min(30, 3*10) = 50 - 30 = 20
+    assert score == pytest.approx(20.0)
+
+
+def test_score_oi_delta_targeted_unresolved():
+    receipt = {
+        "target_open_items": ["OI-042", "OI-043"],
+        "open_items_resolved": 0,
+        "open_items_created": 0,
+    }
+    score = _score_open_items_delta(receipt)
+    # 50 - min(20, 2*20) = 50 - 20 = 30 (unresolved targets)
+    # Note: targeted=2, resolved=0 → (2-0)*20 = 40 capped at 20
+    assert score == pytest.approx(30.0)
+
+
+def test_score_oi_delta_neutral():
+    score = _score_open_items_delta({})
+    assert score == pytest.approx(50.0)
+
+
+# ── Weights validation ──
+
+
+def test_weights_sum_to_1():
+    receipt = {"status": "task_complete"}
+    result = calculate_cqs(receipt, None)
+    weights = result["components"]["weights"]
+    assert sum(weights.values()) == pytest.approx(1.0)
+    assert len(weights) == 7
+
+
+# ── Timeout exclusion ──
+
+
+def test_backward_compat_timeout_excluded():
+    receipt = {"status": "timeout"}
+    result = calculate_cqs(receipt, None)
+    assert result["cqs"] is None
+    assert result["normalized_status"] == "timeout"
+
+
+# ── Full 7-component CQS ──
+
+
+@patch("cqs_calculator._get_role_median_tokens", return_value=None)
+def test_full_cqs_7_components(mock_median):
+    receipt = {
+        "status": "task_complete",
+        "report_path": "/some/report.md",
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "approve"},
+            "summary": {"risk_score": 10},
+        },
+        "open_items_created": 0,
+        "open_items_resolved": 1,
+    }
+    result = calculate_cqs(receipt, None)
+    assert result["cqs"] is not None
+    assert 0 <= result["cqs"] <= 100
+    assert result["normalized_status"] == "success"
+
+    components = result["components"]
+    assert "t0_advisory" in components
+    assert "oi_delta" in components
+    assert components["t0_advisory"] > 50  # approve with low risk
+    assert components["oi_delta"] > 50  # resolved 1, created 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- **CQS expanded from 5 to 7 components** with T0 Advisory (10%) and Open Items Delta (10%) scoring
- **Weight rebalancing**: Status 25%, Completion 20%, Effort 15%, Error Density 10%, Rework 10%, T0 Advisory 10%, OI Delta 10%
- **Resolution tracking**: `closed_by_dispatch_id` on open items, `target_open_items` on dispatches
- **Backward compatible**: Historical dispatches score neutral 50.0 for both new components

### Files changed (12)
- `scripts/lib/cqs_calculator.py` — 2 new scoring functions + rebalanced weights
- `scripts/open_items_manager.py` — Resolution tracking, programmatic close, query helpers
- `scripts/append_receipt.py` — OI delta enrichment into CQS pipeline
- `scripts/log_dispatch_metadata.py` — `--target-open-items` argument
- `scripts/dispatcher_v8_minimal.sh` — OI-NNN regex extraction from instructions
- `scripts/governance_aggregator.py` — New columns + `oi_resolution_rate` metric
- `scripts/quality_db_init.py` — Migration for 3 new dispatch_metadata columns
- `schemas/quality_intelligence.sql` — Schema v8.2.0
- `docs/intelligence/GOVERNANCE_MEASUREMENT.md` — 7-component CQS documentation
- `docs/core/10_JSON_DISPATCH_FORMAT.md` — target_open_items field
- `docs/core/technical/INTELLIGENCE_SYSTEM.md` — Updated governance section
- `tests/test_cqs_calculator.py` — 12 tests (all pass)

### Proof
- approve dispatch CQS=70.37 vs hold dispatch CQS=50.1 (20.3pt delta)
- Legacy backward compat: neutral 50.0 for both new components
- Weights sum to exactly 1.00
- 12/13 CI tests pass (1 pre-existing failure unrelated to this PR)

## Test plan
- [x] 12 new CQS unit tests pass
- [x] CI suite passes (12/13, 1 pre-existing)
- [x] Live CQS calculation proves scoring differentiation
- [x] Backward compatibility verified
- [ ] Run `governance_aggregator.py --backfill` after merge to recompute historical scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)