### PR TITLE
Add roadmap autopilot and review gates

### DIFF
--- a/ROADMAP.yaml
+++ b/ROADMAP.yaml
@@ -1,0 +1,16 @@
+roadmap_id: vnx-roadmap-autopilot
+title: VNX Multi-Feature Roadmap
+
+features:
+  - feature_id: roadmap-autopilot
+    title: Roadmap Autopilot, Auto-Next Feature Loading, and Multi-Reviewer Gates
+    plan_path: roadmap/features/roadmap-autopilot/FEATURE_PLAN.md
+    branch_name: feature/roadmap-autopilot-review-gates
+    risk_class: high
+    merge_policy: human
+    review_stack:
+      - gemini_review
+      - codex_gate
+      - claude_github_optional
+    depends_on: []
+    status: planned

--- a/bin/vnx
+++ b/bin/vnx
@@ -165,6 +165,7 @@ Worktree commands:
 
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
+  roadmap <sub>       Roadmap orchestration and auto-next feature loading
 
 Process commands (visibility and control):
   status             Show session, terminals, queue, and open-item summary
@@ -1838,6 +1839,9 @@ main() {
       ;;
     gate-check)
       python3 "$VNX_HOME/scripts/pre_merge_gate.py" "$@"
+      ;;
+    roadmap)
+      cmd_roadmap "$@"
       ;;
     status)
       python3 "$VNX_HOME/scripts/vnx_process_ux.py" status "$@"

--- a/roadmap/features/README.md
+++ b/roadmap/features/README.md
@@ -1,0 +1,10 @@
+# VNX Feature Catalog
+
+Each feature in this catalog is pre-authored and may be loaded into the active
+root `FEATURE_PLAN.md` and `PR_QUEUE.md` by `vnx roadmap load <feature_id>`.
+
+Rules:
+- one active feature at a time
+- roadmap entries live in `ROADMAP.yaml`
+- inserted fix-up features are runtime-generated under `.vnx-data/state/roadmap_generated_features/`
+- roadmap transitions are governance events, not product PRs

--- a/roadmap/features/roadmap-autopilot/FEATURE_PLAN.md
+++ b/roadmap/features/roadmap-autopilot/FEATURE_PLAN.md
@@ -1,0 +1,140 @@
+# Feature: VNX Roadmap Autopilot, Auto-Next Feature Loading, And Multi-Reviewer Gates
+
+**Status**: Draft
+**Priority**: P0
+**Branch**: `feature/roadmap-autopilot-review-gates`
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+
+Primary objective:
+Enable multi-feature roadmap orchestration with automatic feature handoff after merged + verified closure.
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+PR-0 -> PR-1
+PR-0 -> PR-2
+PR-1, PR-2 -> PR-3
+```
+
+## PR-0: Roadmap Registry And Materialization
+**Track**: C
+**Priority**: P0
+**Complexity**: High
+**Risk**: High
+**Skill**: @architect
+**Requires-Model**: opus
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Estimated Time**: 1 day
+**Dependencies**: []
+
+### Description
+Introduce the roadmap registry, active feature materialization, and roadmap state tracking.
+
+### Scope
+- roadmap registry
+- active feature materialization
+- roadmap state file
+
+### Success Criteria
+- roadmap can initialize and load one active feature
+- root FEATURE_PLAN.md and PR_QUEUE.md represent only the active feature
+
+### Quality Gate
+`gate_pr0_roadmap_registry`:
+- [ ] Roadmap registry initializes cleanly
+- [ ] Feature materialization is deterministic
+
+## PR-1: Review Gate Stack
+**Track**: B
+**Priority**: P0
+**Complexity**: Medium
+**Risk**: Medium
+**Skill**: @backend-developer
+**Requires-Model**: sonnet
+**Risk-Class**: medium
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Estimated Time**: 1 day
+**Dependencies**: [PR-0]
+
+### Description
+Add Gemini, Codex, and optional Claude GitHub review gate adapters.
+
+### Scope
+- review request manager
+- review result persistence
+- governance receipts for review events
+
+### Success Criteria
+- review requests and results are tracked durably
+- optional Claude GitHub path skips cleanly when not configured
+
+### Quality Gate
+`gate_pr1_review_stack`:
+- [ ] Review requests are emitted deterministically
+- [ ] Result recording produces durable evidence
+
+## PR-2: Closure Verifier And Auto-Merge Policy
+**Track**: C
+**Priority**: P0
+**Complexity**: High
+**Risk**: High
+**Skill**: @quality-engineer
+**Requires-Model**: opus
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Estimated Time**: 1 day
+**Dependencies**: [PR-0]
+
+### Description
+Add executable closure verification and conditional auto-merge policy evaluation.
+
+### Scope
+- closure verifier
+- metadata sync checks
+- GitHub merge-state verification
+- conditional auto-merge evaluator
+
+### Success Criteria
+- T0 closure-ready claims become executable
+- low-risk conditional auto-merge is policy-evaluable
+
+### Quality Gate
+`gate_pr2_closure_policy`:
+- [ ] Closure verifier blocks inconsistent merge claims
+- [ ] Auto-merge policy blocks high-risk paths
+
+## PR-3: Auto-Advance And Drift Fix-up Insertion
+**Track**: C
+**Priority**: P0
+**Complexity**: High
+**Risk**: High
+**Skill**: @architect
+**Requires-Model**: opus
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Estimated Time**: 1 day
+**Dependencies**: [PR-1, PR-2]
+
+### Description
+Advance the roadmap only after merged + verified closure, and insert blocking fix-up features when drift is detected.
+
+### Scope
+- roadmap reconcile
+- roadmap advance
+- fix-up feature insertion
+
+### Success Criteria
+- next feature loads automatically only after verified merge
+- blocking drift inserts a fix-up before roadmap advancement
+
+### Quality Gate
+`gate_pr3_auto_advance`:
+- [ ] Auto-next only occurs after merged + verified closure
+- [ ] Blocking drift produces a fix-up feature instead of silent advancement

--- a/scripts/auto_merge_policy.py
+++ b/scripts/auto_merge_policy.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Conditional auto-merge policy evaluator for VNX governance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+HIGH_RISK_PATH_MARKERS = (
+    "scripts/dispatcher",
+    "scripts/receipt_processor",
+    "scripts/pr_queue_manager",
+    "scripts/pre_merge_gate",
+    "scripts/closure_verifier",
+    "scripts/review_gate_manager",
+    "scripts/roadmap_manager",
+    "scripts/lib/vnx_paths",
+    "scripts/commands/start.sh",
+    "scripts/commands/stop.sh",
+    "scripts/commands/doctor.sh",
+    "schemas/",
+    ".github/workflows/",
+)
+
+
+@dataclass(frozen=True)
+class AutoMergeDecision:
+    allowed: bool
+    reason: str
+    blockers: List[str]
+
+
+def _normalize_paths(changed_files: Iterable[str]) -> List[str]:
+    normalized: List[str] = []
+    for path in changed_files:
+        p = str(path).strip()
+        if not p:
+            continue
+        normalized.append(Path(p).as_posix())
+    return normalized
+
+
+def codex_final_gate_required(changed_files: Iterable[str]) -> bool:
+    for path in _normalize_paths(changed_files):
+        if any(marker in path for marker in HIGH_RISK_PATH_MARKERS):
+            return True
+        if path.endswith(".sql"):
+            return True
+    return False
+
+
+def evaluate_auto_merge_policy(
+    *,
+    risk_class: str,
+    merge_policy: str,
+    changed_files: Sequence[str],
+    gemini_review_passed: bool,
+    codex_gate_passed: bool,
+    required_checks_passed: bool,
+    closure_verifier_passed: bool,
+) -> AutoMergeDecision:
+    blockers: List[str] = []
+    risk = (risk_class or "").strip().lower()
+    policy = (merge_policy or "").strip().lower()
+
+    if policy != "conditional_auto":
+        blockers.append("merge_policy_not_conditional_auto")
+    if risk != "low":
+        blockers.append("risk_class_not_low")
+    if codex_final_gate_required(changed_files):
+        blockers.append("high_risk_change_scope")
+    if not gemini_review_passed:
+        blockers.append("gemini_review_not_passed")
+    if not codex_gate_passed:
+        blockers.append("codex_gate_not_passed")
+    if not required_checks_passed:
+        blockers.append("required_checks_not_passed")
+    if not closure_verifier_passed:
+        blockers.append("closure_verifier_not_passed")
+
+    if blockers:
+        return AutoMergeDecision(
+            allowed=False,
+            reason="conditional auto-merge denied",
+            blockers=blockers,
+        )
+
+    return AutoMergeDecision(
+        allowed=True,
+        reason="conditional auto-merge allowed",
+        blockers=[],
+    )
+
+
+__all__ = [
+    "AutoMergeDecision",
+    "codex_final_gate_required",
+    "evaluate_auto_merge_policy",
+]

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Governance closure verification for VNX feature branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from vnx_paths import ensure_env
+from governance_receipts import emit_governance_receipt
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+
+
+def _run(cmd: Sequence[str], *, cwd: Optional[Path] = None, timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(cmd),
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_feature_plan(path: Path) -> Dict[str, Any]:
+    content = _read_text(path)
+    title_match = re.search(r"^#\s*Feature:\s*(.+)$", content, re.MULTILINE)
+    status_match = re.search(r"^\*\*Status\*\*:\s*(.+)$", content, re.MULTILINE)
+    deps_match = re.search(r"^## Dependency Flow\s*```text\s*(.+?)```", content, re.MULTILINE | re.DOTALL)
+    pr_ids = re.findall(r"^##\s+(PR-\d+):", content, re.MULTILINE)
+    return {
+        "title": title_match.group(1).strip() if title_match else "",
+        "status": status_match.group(1).strip() if status_match else "",
+        "dependency_flow": deps_match.group(1).strip() if deps_match else "",
+        "pr_ids": pr_ids,
+    }
+
+
+def _parse_pr_queue(path: Path) -> Dict[str, Any]:
+    content = _read_text(path)
+    title_match = re.search(r"^# PR Queue(?:\s*-\s*Feature:|\s*—\s*FP\d+:\s*)(.+)$", content, re.MULTILINE)
+    overview_match = re.search(
+        r"Total:\s*(\d+)\s+PRs\s*\|\s*Complete:\s*(\d+)\s*\|\s*Active:\s*(\d+)\s*\|\s*Queued:\s*(\d+)\s*\|\s*Blocked:\s*(\d+)",
+        content,
+    )
+    deps_match = re.search(r"## Dependency Flow(?: \(executed\))?\s*```\s*(.+?)```", content, re.DOTALL)
+    return {
+        "title": title_match.group(1).strip() if title_match else "",
+        "overview": tuple(int(x) for x in overview_match.groups()) if overview_match else None,
+        "dependency_flow": deps_match.group(1).strip() if deps_match else "",
+    }
+
+
+def _find_branch_pr(branch: str) -> Optional[Dict[str, Any]]:
+    result = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "all",
+            "--json",
+            "number,url,state,mergeStateStatus,mergeCommit,statusCheckRollup,headRefName,baseRefName",
+        ]
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    return payload[0] if payload else None
+
+
+def _remote_branch_exists(branch: str, project_root: Path) -> bool:
+    result = _run(["git", "ls-remote", "--heads", "origin", branch], cwd=project_root)
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _merge_commit_on_main(oid: str, project_root: Path) -> bool:
+    _run(["git", "fetch", "origin", "main", "--quiet"], cwd=project_root)
+    result = _run(["git", "merge-base", "--is-ancestor", oid, "origin/main"], cwd=project_root)
+    return result.returncode == 0
+
+
+def _load_claim_file(path: Optional[Path]) -> Dict[str, Any]:
+    if not path or not path.exists():
+        return {}
+    try:
+        return json.loads(_read_text(path))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _validate_test_claims(claims: Dict[str, Any], project_root: Path) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    test_files = claims.get("test_files") or []
+    test_command = (claims.get("test_command") or "").strip()
+    trusted_result = claims.get("trusted_test_result")
+
+    if not test_files:
+        results.append(CheckResult("test_files", "FAIL", "no claimed test files provided"))
+    else:
+        missing = []
+        for rel in test_files:
+            path = Path(rel)
+            if not path.is_absolute():
+                path = project_root / rel
+            if not path.exists():
+                missing.append(str(rel))
+        if missing:
+            results.append(CheckResult("test_files", "FAIL", f"missing claimed test files: {', '.join(missing)}"))
+        else:
+            results.append(CheckResult("test_files", "PASS", f"{len(test_files)} claimed test file(s) exist"))
+
+    if test_command:
+        results.append(CheckResult("test_command", "PASS", "claimed test command present"))
+    elif trusted_result:
+        results.append(CheckResult("test_command", "PASS", "trusted test result recorded"))
+    else:
+        results.append(CheckResult("test_command", "FAIL", "no test command or trusted test result provided"))
+
+    parallel_assignments = claims.get("parallel_assignments") or []
+    if parallel_assignments:
+        terminals = [str(entry.get("terminal")).strip() for entry in parallel_assignments if entry.get("terminal")]
+        duplicates = sorted({terminal for terminal in terminals if terminals.count(terminal) > 1})
+        if duplicates:
+            results.append(
+                CheckResult(
+                    "parallelism",
+                    "FAIL",
+                    f"same terminal reported for parallel work: {', '.join(duplicates)}",
+                )
+            )
+        else:
+            results.append(CheckResult("parallelism", "PASS", "parallel assignments use distinct terminals"))
+
+    commit_map = claims.get("commit_pr_map") or {}
+    if commit_map:
+        bad = []
+        for sha in commit_map.keys():
+            result = _run(["git", "rev-parse", "--verify", f"{sha}^{{commit}}"], cwd=project_root)
+            if result.returncode != 0:
+                bad.append(sha)
+        if bad:
+            results.append(CheckResult("commit_mapping", "FAIL", f"unknown commit(s): {', '.join(bad)}"))
+        else:
+            results.append(CheckResult("commit_mapping", "PASS", "commit-to-PR mapping references known commits"))
+
+    return results
+
+
+def _check_stale_staging(paths: Dict[str, str], active_pr_ids: Iterable[str]) -> CheckResult:
+    staging_dir = Path(paths["VNX_DISPATCH_DIR"]) / "staging"
+    if not staging_dir.exists():
+        return CheckResult("stale_staging", "PASS", "no staging directory")
+
+    active_set = set(active_pr_ids)
+    stale: List[str] = []
+    for dispatch in staging_dir.glob("*.md"):
+        content = _read_text(dispatch)
+        match = re.search(r"^PR-ID:\s*(.+)$", content, re.MULTILINE)
+        pr_id = match.group(1).strip() if match else ""
+        if pr_id and pr_id not in active_set:
+            stale.append(dispatch.name)
+
+    if stale:
+        return CheckResult("stale_staging", "FAIL", f"stale staging dispatches present: {', '.join(sorted(stale))}")
+    return CheckResult("stale_staging", "PASS", "no stale staging dispatches")
+
+
+def verify_closure(
+    *,
+    project_root: Path,
+    feature_plan: Path,
+    pr_queue: Path,
+    branch: str,
+    mode: str,
+    claim_file: Optional[Path] = None,
+) -> Dict[str, Any]:
+    feature = _parse_feature_plan(feature_plan)
+    queue = _parse_pr_queue(pr_queue)
+    claims = _load_claim_file(claim_file)
+    paths = ensure_env()
+
+    checks: List[CheckResult] = []
+
+    checks.append(
+        CheckResult(
+            "feature_plan_status",
+            "PASS" if feature["status"].lower() == "complete" else "FAIL",
+            f"FEATURE_PLAN status is {feature['status'] or 'missing'}",
+        )
+    )
+
+    queue_match = queue["overview"] is not None and queue["overview"][0] == queue["overview"][1]
+    checks.append(
+        CheckResult(
+            "pr_queue_complete",
+            "PASS" if queue_match else "FAIL",
+            "PR queue is fully complete" if queue_match else "PR queue totals are not fully complete",
+        )
+    )
+
+    checks.append(
+        CheckResult(
+            "metadata_sync",
+            "PASS" if feature["title"] and feature["title"] == queue["title"] and feature["dependency_flow"] == queue["dependency_flow"] else "FAIL",
+            "FEATURE_PLAN and PR_QUEUE titles/dependency flow match"
+            if feature["title"] and feature["title"] == queue["title"] and feature["dependency_flow"] == queue["dependency_flow"]
+            else "FEATURE_PLAN and PR_QUEUE drift detected",
+        )
+    )
+
+    branch_exists = _remote_branch_exists(branch, project_root)
+    checks.append(
+        CheckResult(
+            "branch_pushed",
+            "PASS" if branch_exists else "FAIL",
+            f"remote branch {'found' if branch_exists else 'missing'}: {branch}",
+        )
+    )
+
+    pr = _find_branch_pr(branch)
+    checks.append(
+        CheckResult(
+            "pr_exists",
+            "PASS" if pr else "FAIL",
+            f"PR {'found' if pr else 'missing'} for branch {branch}",
+        )
+    )
+
+    if pr:
+        if mode == "pre_merge":
+            clean = str(pr.get("mergeStateStatus") or "").upper() == "CLEAN" and str(pr.get("state") or "").upper() == "OPEN"
+            checks.append(
+                CheckResult(
+                    "merge_state",
+                    "PASS" if clean else "FAIL",
+                    f"PR state={pr.get('state')} mergeStateStatus={pr.get('mergeStateStatus')}",
+                )
+            )
+            rollup = pr.get("statusCheckRollup") or []
+            all_green = bool(rollup) and all(
+                item.get("status") == "COMPLETED" and item.get("conclusion") == "SUCCESS"
+                for item in rollup
+                if item.get("__typename") == "CheckRun"
+            )
+            checks.append(
+                CheckResult(
+                    "github_checks",
+                    "PASS" if all_green else "FAIL",
+                    "all required GitHub checks green" if all_green else "GitHub checks incomplete or failing",
+                )
+            )
+        else:
+            merged = str(pr.get("state") or "").upper() == "MERGED"
+            checks.append(
+                CheckResult(
+                    "pr_merged",
+                    "PASS" if merged else "FAIL",
+                    f"PR state={pr.get('state')}",
+                )
+            )
+            merge_commit = ((pr.get("mergeCommit") or {}) if isinstance(pr.get("mergeCommit"), dict) else {}) or {}
+            oid = merge_commit.get("oid")
+            on_main = bool(oid) and _merge_commit_on_main(oid, project_root)
+            checks.append(
+                CheckResult(
+                    "merge_commit_on_main",
+                    "PASS" if on_main else "FAIL",
+                    f"merge commit {'present on origin/main' if on_main else 'missing from origin/main'}",
+                )
+            )
+
+    checks.extend(_validate_test_claims(claims, project_root))
+    checks.append(_check_stale_staging(paths, feature["pr_ids"]))
+
+    verdict = "pass" if all(check.status == "PASS" for check in checks) else "fail"
+    payload = {
+        "verdict": verdict,
+        "mode": mode,
+        "branch": branch,
+        "feature_title": feature["title"],
+        "checks": [check.__dict__ for check in checks],
+        "pr": pr,
+        "claim_file": str(claim_file) if claim_file else None,
+    }
+    return payload
+
+
+def _default_claim_file(paths: Dict[str, str]) -> Path:
+    return Path(paths["VNX_STATE_DIR"]) / "closure_claim.json"
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="VNX closure verifier")
+    parser.add_argument("--feature-plan", default="FEATURE_PLAN.md")
+    parser.add_argument("--pr-queue", default="PR_QUEUE.md")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--mode", choices=("pre_merge", "post_merge"), default="pre_merge")
+    parser.add_argument("--claim-file", default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--emit-receipt", action="store_true")
+    args = parser.parse_args(argv)
+
+    paths = ensure_env()
+    project_root = Path(paths["PROJECT_ROOT"]).resolve()
+    branch = args.branch or _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=project_root).stdout.strip()
+    claim_file = Path(args.claim_file) if args.claim_file else _default_claim_file(paths)
+
+    result = verify_closure(
+        project_root=project_root,
+        feature_plan=(project_root / args.feature_plan if not Path(args.feature_plan).is_absolute() else Path(args.feature_plan)),
+        pr_queue=(project_root / args.pr_queue if not Path(args.pr_queue).is_absolute() else Path(args.pr_queue)),
+        branch=branch,
+        mode=args.mode,
+        claim_file=claim_file if claim_file.exists() else None,
+    )
+
+    if args.emit_receipt:
+        emit_governance_receipt(
+            "closure_verification_result",
+            status="success" if result["verdict"] == "pass" else "blocked",
+            branch=branch,
+            verification_mode=args.mode,
+            feature_title=result.get("feature_title"),
+            verifier="closure_verifier.py",
+            checks=result["checks"],
+        )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Closure verifier: {result['verdict'].upper()}")
+        for check in result["checks"]:
+            print(f"- [{check['status']}] {check['name']}: {check['detail']}")
+
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/commands/roadmap.sh
+++ b/scripts/commands/roadmap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# VNX command: roadmap
+
+cmd_roadmap() {
+  if [ "$#" -eq 0 ]; then
+    cat <<'HELP'
+Usage: vnx roadmap <init|status|load|reconcile|advance> [args]
+
+Commands:
+  init <ROADMAP.yaml>    Initialize roadmap registry state
+  status                 Show current roadmap status
+  load <feature_id>      Materialize one feature into root FEATURE_PLAN.md + PR_QUEUE.md
+  reconcile              Verify closure truth and detect blocking drift
+  advance                Auto-load next feature after merged + verified closure
+HELP
+    return 0
+  fi
+
+  python3 "$VNX_HOME/scripts/roadmap_manager.py" "$@"
+}

--- a/scripts/lib/dispatch_metadata.sh
+++ b/scripts/lib/dispatch_metadata.sh
@@ -120,6 +120,27 @@ vnx_dispatch_extract_requires_model() {
     echo "${model:-}"
 }
 
+vnx_dispatch_extract_risk_class() {
+    local file="$1"
+    local risk_class
+    risk_class=$(sed -n 's/^Risk-Class:[[:space:]]*//Ip' "$file" 2>/dev/null | sed 's/#.*//' | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+    echo "${risk_class:-medium}"
+}
+
+vnx_dispatch_extract_merge_policy() {
+    local file="$1"
+    local merge_policy
+    merge_policy=$(sed -n 's/^Merge-Policy:[[:space:]]*//Ip' "$file" 2>/dev/null | sed 's/#.*//' | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+    echo "${merge_policy:-human}"
+}
+
+vnx_dispatch_extract_review_stack() {
+    local file="$1"
+    local review_stack
+    review_stack=$(sed -n 's/^Review-Stack:[[:space:]]*//Ip' "$file" 2>/dev/null | sed 's/#.*//')
+    echo "${review_stack:-none}"
+}
+
 vnx_dispatch_extract_requires_mcp() {
     local file="$1"
     local mcp

--- a/scripts/lib/governance_receipts.py
+++ b/scripts/lib/governance_receipts.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Helpers for governance/runtime receipts outside the report pipeline."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Optional
+
+from append_receipt import AppendReceiptError, append_receipt_payload
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def emit_governance_receipt(
+    event_type: str,
+    *,
+    status: str = "info",
+    terminal: str = "T0",
+    source: str = "vnx_governance",
+    receipts_file: Optional[str] = None,
+    **fields: Any,
+) -> Dict[str, Any]:
+    """Append a governance event into canonical receipts."""
+    receipt: Dict[str, Any] = {
+        "timestamp": utc_now_iso(),
+        "event_type": event_type,
+        "status": status,
+        "terminal": terminal,
+        "source": source,
+    }
+    receipt.update(fields)
+    result = append_receipt_payload(receipt, receipts_file=receipts_file)
+    receipt["append_status"] = result.status
+    receipt["idempotency_key"] = result.idempotency_key
+    return receipt
+
+
+__all__ = ["emit_governance_receipt", "utc_now_iso", "AppendReceiptError"]

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -51,6 +51,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "intelligence-import", "init-feature", "bootstrap-skills",
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings",
     "patch-agent-files", "register", "list-projects", "unregister",
+    "roadmap",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",
     "init-db",
 })

--- a/scripts/pr_queue_manager.py
+++ b/scripts/pr_queue_manager.py
@@ -90,7 +90,6 @@ class PRQueueManager:
                 file=sys.stderr,
             )
 
-        self.queue_file = "PR_QUEUE.md"
         # Store state in project's VNX_STATE_DIR (not script-relative) to prevent
         # cross-project contamination when multiple projects share the same vnx-system.
         self.state_file = self.vnx_state_dir / "pr_queue_state.json"
@@ -98,6 +97,7 @@ class PRQueueManager:
         self.vnx_state_file = self.vnx_state_dir / "pr_queue_state.yaml"
         self.vnx_queue_json = self.vnx_state_dir / "pr_queue.json"
         self.project_root = project_root
+        self.queue_file = self.project_root / "PR_QUEUE.md"
         self.state = {}
         self.load_queue()
 
@@ -129,10 +129,25 @@ class PRQueueManager:
             self.state['active'] = [self.state['active']] if self.state['active'] else []
         elif self.state.get('active') is None:
             self.state['active'] = []
+        self.state.setdefault('feature_metadata', {})
+
+    @staticmethod
+    def _fresh_state(feature_name: Optional[str] = None, feature_metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return {
+            "feature": feature_name,
+            "feature_metadata": feature_metadata or {},
+            "prs": [],
+            "completed": [],
+            "active": [],
+            "blocked": [],
+            "created_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+        }
 
     def save_state(self):
         """Save current state to JSON file"""
         self.state["updated_at"] = datetime.now().isoformat()
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
         with open(self.state_file, 'w') as f:
             json.dump(self.state, f, indent=2)
 
@@ -293,14 +308,27 @@ class PRQueueManager:
         percent = int(complete / total * 100) if total > 0 else 0
         progress_bar = '█' * int(percent / 10) + '░' * (10 - int(percent / 10))
 
+        feature_metadata = self.state.get('feature_metadata') or {}
         content = f"""# PR Queue - Feature: {self.state.get('feature', 'Unknown')}
 
 ## Progress Overview
 Total: {total} PRs | Complete: {complete} | Active: {active} | Queued: {queued} | Blocked: {blocked}
 Progress: {progress_bar} {percent}%
 
+"""
+        if feature_metadata:
+            review_stack = feature_metadata.get("review_stack") or []
+            if isinstance(review_stack, list):
+                review_stack = ",".join(review_stack)
+            content += f"""## Governance Metadata
+Risk-Class: {feature_metadata.get('risk_class', 'unknown')}
+Merge-Policy: {feature_metadata.get('merge_policy', 'human')}
+Review-Stack: {review_stack or 'none'}
+
 ## Status
 """
+        else:
+            content += "## Status\n"
 
         # Completed PRs
         if self.state['completed']:
@@ -317,7 +345,11 @@ Progress: {progress_bar} {percent}%
                 pr = next((p for p in self.state['prs'] if p['id'] == active_id), None)
                 if pr:
                     track = pr.get('track', '?')
-                    content += f"- {pr['id']}: {pr['title']} (Track {track}, skill: {pr['skill']})\n"
+                    content += (
+                        f"- {pr['id']}: {pr['title']} "
+                        f"(Track {track}, skill: {pr['skill']}, risk: {pr.get('risk_class', 'unknown')}, "
+                        f"merge: {pr.get('merge_policy', 'human')})\n"
+                    )
 
         # Queued PRs
         queued_prs = [pr for pr in self.state['prs'] if pr['status'] == 'queued']
@@ -325,7 +357,11 @@ Progress: {progress_bar} {percent}%
             content += "\n### ⏳ Queued PRs\n"
             for pr in queued_prs:
                 deps = f" (dependencies: {', '.join(pr['dependencies'])})" if pr.get('dependencies') else " (dependencies: none)"
-                content += f"- {pr['id']}: {pr['title']}{deps}\n"
+                content += (
+                    f"- {pr['id']}: {pr['title']}{deps} "
+                    f"[risk={pr.get('risk_class', 'unknown')}, merge={pr.get('merge_policy', 'human')}, "
+                    f"review={','.join(pr.get('review_stack', [])) or 'none'}]\n"
+                )
 
         # Blocked PRs
         if self.state.get('blocked'):
@@ -357,17 +393,27 @@ Progress: {progress_bar} {percent}%
 
     def clear_queue(self):
         """Clear the queue and start fresh"""
-        self.state = {
-            "feature": None,
-            "prs": [],
-            "completed": [],
-            "active": [],
-            "blocked": [],
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat()
-        }
+        self.state = self._fresh_state()
         self.save_state()
         self.update_markdown()
+
+    def _parse_feature_metadata(self, content: str) -> Dict[str, Any]:
+        def extract(name: str, default: str = "") -> str:
+            match = re.search(rf'^\*\*{re.escape(name)}\*\*:\s*(.+)$', content, re.MULTILINE)
+            if match:
+                return match.group(1).strip()
+            match = re.search(rf'^{re.escape(name)}:\s*(.+)$', content, re.MULTILINE)
+            if match:
+                return match.group(1).strip()
+            return default
+
+        review_stack_raw = extract("Review-Stack", "")
+        review_stack = [item.strip() for item in review_stack_raw.split(",") if item.strip()]
+        return {
+            "risk_class": extract("Risk-Class", "medium").lower(),
+            "merge_policy": extract("Merge-Policy", "human").lower(),
+            "review_stack": review_stack,
+        }
 
     def get_status_summary(self) -> Dict:
         """Get a summary of the current queue status"""
@@ -578,6 +624,7 @@ Progress: {progress_bar} {percent}%
         """
         # Try multiple paths to find FEATURE_PLAN.md
         possible_paths = [
+            self.project_root / "FEATURE_PLAN.md",
             Path(__file__).parent.parent.parent / "FEATURE_PLAN.md",  # From scripts/
             Path.cwd() / "FEATURE_PLAN.md",  # From current working directory
             Path.cwd() / ".." / "FEATURE_PLAN.md"  # One level up
@@ -615,6 +662,9 @@ Progress: {progress_bar} {percent}%
                 'complexity': 'Medium',  # default
                 'cognition': 'normal',  # default
                 'requires_model': None,  # default
+                'risk_class': 'medium',
+                'merge_policy': 'human',
+                'review_stack': [],
                 'dependencies': [],  # default
                 'description': '',
                 'scope': '',
@@ -658,6 +708,20 @@ Progress: {progress_bar} {percent}%
                 model_match = re.match(r'\*\*Requires-Model\*\*:\s*(.+)', line, re.IGNORECASE)
                 if model_match:
                     details['requires_model'] = model_match.group(1).strip()
+
+                risk_class_match = re.match(r'\*\*Risk-Class\*\*:\s*(.+)', line, re.IGNORECASE)
+                if risk_class_match:
+                    details['risk_class'] = risk_class_match.group(1).strip().lower()
+
+                merge_policy_match = re.match(r'\*\*Merge-Policy\*\*:\s*(.+)', line, re.IGNORECASE)
+                if merge_policy_match:
+                    details['merge_policy'] = merge_policy_match.group(1).strip().lower()
+
+                review_stack_match = re.match(r'\*\*Review-Stack\*\*:\s*(.+)', line, re.IGNORECASE)
+                if review_stack_match:
+                    details['review_stack'] = [
+                        item.strip() for item in review_stack_match.group(1).split(',') if item.strip()
+                    ]
 
             # SPRINT 2: Derive cognition from complexity
             complexity_lower = details['complexity'].lower()
@@ -789,6 +853,13 @@ Progress: {progress_bar} {percent}%
                 'risk': extract_field('Risk', 'Medium'),
                 'skill': extract_field('Skill', 'backend-developer'),
                 'estimated_time': extract_field('Estimated Time', 'unknown'),
+                'risk_class': extract_field('Risk-Class', 'medium').lower(),
+                'merge_policy': extract_field('Merge-Policy', 'human').lower(),
+                'review_stack': [
+                    item.strip()
+                    for item in str(extract_field('Review-Stack', '') or '').split(',')
+                    if item.strip()
+                ],
                 'dependencies': deps,
                 'gate': gate,
             }
@@ -844,6 +915,9 @@ Progress: {progress_bar} {percent}%
         priority = (pr_details.get('priority') if pr_details else None) or pr.get('priority', 'P1')
         cognition = (pr_details.get('cognition') if pr_details else None) or 'normal'
         requires_model = (pr_details.get('requires_model') if pr_details else None) or None
+        risk_class = (pr_details.get('risk_class') if pr_details else None) or pr.get('risk_class', 'medium')
+        merge_policy = (pr_details.get('merge_policy') if pr_details else None) or pr.get('merge_policy', 'human')
+        review_stack = (pr_details.get('review_stack') if pr_details else None) or pr.get('review_stack', [])
 
         # Generate dispatch ID
         timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
@@ -859,13 +933,12 @@ Progress: {progress_bar} {percent}%
 
         if pr_details:
             # Extract full PR section from FEATURE_PLAN.md for complete context
-            feature_plan_path = Path(__file__).parent.parent.parent / "FEATURE_PLAN.md"
-            for path in [feature_plan_path, Path.cwd() / "FEATURE_PLAN.md"]:
+            feature_plan_path = self.project_root / "FEATURE_PLAN.md"
+            for path in [feature_plan_path, Path(__file__).parent.parent.parent / "FEATURE_PLAN.md", Path.cwd() / "FEATURE_PLAN.md"]:
                 if path.exists():
                     with open(path, 'r') as f:
                         content = f.read()
                     # Find full PR section
-                    import re
                     pr_pattern = f'## {pr_id}:(.+?)(?=\n##\\s+PR-|$)'
                     match = re.search(pr_pattern, content, re.DOTALL)
                     if match:
@@ -887,7 +960,10 @@ Track: {track}
 Terminal: {terminal}
 Gate: {pr.get('gate', 'implementation')}
 Priority: {priority}
-Cognition: {cognition}"""
+Cognition: {cognition}
+Risk-Class: {risk_class}
+Merge-Policy: {merge_policy}
+Review-Stack: {','.join(review_stack) if review_stack else 'none'}"""
 
         # SPRINT 2: Add Requires-Model if specified
         if requires_model:
@@ -1114,6 +1190,18 @@ Size Estimate: {pr.get('size', 'unknown')} lines
             if priority_match:
                 metadata['priority'] = priority_match.group(1).strip()
 
+            risk_class_match = re.search(r'Risk-Class:\s*(.+)', content)
+            if risk_class_match:
+                metadata['risk_class'] = risk_class_match.group(1).strip()
+
+            merge_policy_match = re.search(r'Merge-Policy:\s*(.+)', content)
+            if merge_policy_match:
+                metadata['merge_policy'] = merge_policy_match.group(1).strip()
+
+            review_stack_match = re.search(r'Review-Stack:\s*(.+)', content)
+            if review_stack_match:
+                metadata['review_stack'] = review_stack_match.group(1).strip()
+
             return metadata
 
         except Exception as e:
@@ -1160,6 +1248,9 @@ Size Estimate: {pr.get('size', 'unknown')} lines
             print(f"   Track: {metadata.get('track', 'N/A')}")
             print(f"   Gate: {metadata.get('gate', 'N/A')}")
             print(f"   Priority: {metadata.get('priority', 'N/A')}")
+            print(f"   Risk-Class: {metadata.get('risk_class', 'N/A')}")
+            print(f"   Merge-Policy: {metadata.get('merge_policy', 'N/A')}")
+            print(f"   Review-Stack: {metadata.get('review_stack', 'N/A')}")
 
             # Show first 30 lines of content
             lines = content.split('\n')
@@ -1358,6 +1449,7 @@ Size Estimate: {pr.get('size', 'unknown')} lines
             # Parse feature name
             feature_match = re.search(r'#\s*Feature:\s*(.+?)(?:\n|$)', content)
             feature_name = feature_match.group(1).strip() if feature_match else "Unknown Feature"
+            feature_metadata = self._parse_feature_metadata(content)
 
             # Parse ALL PR metadata directly from plan content
             parsed_prs = self._parse_all_prs_from_plan(content)
@@ -1376,15 +1468,7 @@ Size Estimate: {pr.get('size', 'unknown')} lines
             print(f"🎯 Generating batch dispatches to staging/\n")
 
             # Reset internal state with new feature data
-            self.state = {
-                "feature": feature_name,
-                "prs": [],
-                "completed": [],
-                "active": [],
-                "blocked": [],
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat()
-            }
+            self.state = self._fresh_state(feature_name=feature_name, feature_metadata=feature_metadata)
 
             for pr_data in parsed_prs:
                 self.state['prs'].append({
@@ -1397,6 +1481,9 @@ Size Estimate: {pr.get('size', 'unknown')} lines
                     'track': pr_data['track'],
                     'priority': pr_data['priority'],
                     'gate': pr_data['gate'],
+                    'risk_class': pr_data.get('risk_class', feature_metadata.get('risk_class', 'medium')),
+                    'merge_policy': pr_data.get('merge_policy', feature_metadata.get('merge_policy', 'human')),
+                    'review_stack': pr_data.get('review_stack', feature_metadata.get('review_stack', [])),
                 })
 
             self.save_state()
@@ -1454,6 +1541,9 @@ Terminal: {terminal}
 Gate: {pr_data['gate']}
 Priority: {pr_data['priority']}
 Cognition: {cognition}
+Risk-Class: {pr_data.get('risk_class', feature_metadata.get('risk_class', 'medium'))}
+Merge-Policy: {pr_data.get('merge_policy', feature_metadata.get('merge_policy', 'human'))}
+Review-Stack: {','.join(pr_data.get('review_stack', feature_metadata.get('review_stack', []))) or 'none'}
 Dispatch-ID: {dispatch_id}
 PR-ID: {pr_id}
 Parent-Dispatch: none
@@ -1479,6 +1569,11 @@ Size Estimate: {pr_data['estimated_time']}
                 print(f"✅ Created {pr_id}: {dispatch_id}")
                 print(f"   Role: {skill} | Track: {track} | Terminal: {terminal}")
                 print(f"   Priority: {pr_data['priority']} | Cognition: {cognition}")
+                print(
+                    f"   Risk: {pr_data.get('risk_class', feature_metadata.get('risk_class', 'medium'))} | "
+                    f"Merge: {pr_data.get('merge_policy', feature_metadata.get('merge_policy', 'human'))} | "
+                    f"Review: {','.join(pr_data.get('review_stack', feature_metadata.get('review_stack', []))) or 'none'}"
+                )
                 print(f"   Dependencies: {deps_str}")
                 created += 1
 
@@ -1522,6 +1617,52 @@ Size Estimate: {pr_data['estimated_time']}
             print(f"❌ Batch generation failed: {e}")
             import traceback
             traceback.print_exc()
+            return False, 0
+
+    def load_feature_plan(self, feature_plan_path: str) -> tuple[bool, int]:
+        """
+        Materialize one feature plan into active root FEATURE_PLAN.md/PR_QUEUE.md state
+        without generating dispatches.
+        """
+        valid, error = self.validate_feature_plan(feature_plan_path)
+        if not valid:
+            print(f"❌ Invalid feature plan: {error}")
+            return False, 0
+
+        try:
+            content = Path(feature_plan_path).read_text(encoding="utf-8")
+            feature_match = re.search(r'#\s*Feature:\s*(.+?)(?:\n|$)', content)
+            feature_name = feature_match.group(1).strip() if feature_match else "Unknown Feature"
+            feature_metadata = self._parse_feature_metadata(content)
+            parsed_prs = self._parse_all_prs_from_plan(content)
+            if not parsed_prs:
+                print("❌ No PRs found in feature plan")
+                return False, 0
+
+            self.state = self._fresh_state(feature_name=feature_name, feature_metadata=feature_metadata)
+            for pr_data in parsed_prs:
+                self.state["prs"].append(
+                    {
+                        "id": pr_data["id"],
+                        "title": pr_data["title_from_header"],
+                        "size": pr_data.get("estimated_time", "unknown"),
+                        "dependencies": pr_data["dependencies"],
+                        "skill": pr_data["skill"],
+                        "status": "queued",
+                        "track": pr_data["track"],
+                        "priority": pr_data["priority"],
+                        "gate": pr_data["gate"],
+                        "risk_class": pr_data.get("risk_class", feature_metadata.get("risk_class", "medium")),
+                        "merge_policy": pr_data.get("merge_policy", feature_metadata.get("merge_policy", "human")),
+                        "review_stack": pr_data.get("review_stack", feature_metadata.get("review_stack", [])),
+                    }
+                )
+
+            self.save_state()
+            self.update_markdown()
+            return True, len(parsed_prs)
+        except Exception as e:
+            print(f"❌ Failed to load feature plan: {e}")
             return False, 0
 
     def list_staging_dispatches(self) -> None:

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Review gate orchestration for Gemini, Codex, and optional Claude GitHub review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from vnx_paths import ensure_env
+from governance_receipts import emit_governance_receipt
+from auto_merge_policy import codex_final_gate_required
+
+
+DEFAULT_REVIEW_STACK = ["gemini_review", "codex_gate", "claude_github_optional"]
+
+
+def _utc_now() -> str:
+    from governance_receipts import utc_now_iso
+    return utc_now_iso()
+
+
+class ReviewGateManager:
+    def __init__(self) -> None:
+        self.paths = ensure_env()
+        self.state_dir = Path(self.paths["VNX_STATE_DIR"])
+        self.requests_dir = self.state_dir / "review_gates" / "requests"
+        self.results_dir = self.state_dir / "review_gates" / "results"
+        self.requests_dir.mkdir(parents=True, exist_ok=True)
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.requests_dir / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.results_dir / f"pr-{pr_number}-{gate}.json"
+
+    def _gemini_available(self) -> bool:
+        return os.environ.get("VNX_GEMINI_REVIEW_ENABLED", "1") != "0" and shutil.which("gemini") is not None
+
+    def _codex_headless_available(self) -> bool:
+        return os.environ.get("VNX_CODEX_HEADLESS_ENABLED", "0") == "1" and shutil.which("codex") is not None
+
+    def _claude_github_configured(self) -> bool:
+        return os.environ.get("VNX_CLAUDE_GITHUB_REVIEW_ENABLED", "0") == "1" and shutil.which("gh") is not None
+
+    def request_reviews(
+        self,
+        *,
+        pr_number: int,
+        branch: str,
+        review_stack: Optional[Iterable[str]] = None,
+        risk_class: str,
+        changed_files: Iterable[str],
+        mode: str,
+    ) -> Dict[str, Any]:
+        review_stack_list = [item.strip() for item in (review_stack or DEFAULT_REVIEW_STACK) if str(item).strip()]
+        changed_files = [str(path).strip() for path in changed_files if str(path).strip()]
+        requested: List[Dict[str, Any]] = []
+
+        for gate in review_stack_list:
+            if gate == "gemini_review":
+                payload = self._request_gemini(pr_number, branch, risk_class, changed_files, mode)
+            elif gate == "codex_gate":
+                payload = self._request_codex(pr_number, branch, risk_class, changed_files, mode)
+            elif gate == "claude_github_optional":
+                payload = self._request_claude_github(pr_number, branch, risk_class, changed_files, mode)
+            else:
+                payload = {
+                    "gate": gate,
+                    "status": "blocked",
+                    "reason": "unknown_review_gate",
+                }
+
+            requested.append(payload)
+            emit_governance_receipt(
+                "review_gate_request",
+                status=payload["status"],
+                terminal="T0",
+                pr_number=pr_number,
+                branch=branch,
+                gate=payload["gate"],
+                review_mode=mode,
+                risk_class=risk_class,
+                changed_files=changed_files,
+                request=payload,
+            )
+
+        return {
+            "pr_number": pr_number,
+            "branch": branch,
+            "requested": requested,
+        }
+
+    def _request_gemini(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str
+    ) -> Dict[str, Any]:
+        available = self._gemini_available()
+        payload = {
+            "gate": "gemini_review",
+            "status": "queued" if available else "blocked",
+            "provider": "gemini_cli",
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": _utc_now(),
+        }
+        if not available:
+            payload["reason"] = "gemini_not_available"
+        self._request_path("gemini_review", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _request_codex(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str
+    ) -> Dict[str, Any]:
+        required = mode == "final" or codex_final_gate_required(changed_files)
+        available = self._codex_headless_available()
+        model = os.environ.get("VNX_CODEX_HEADLESS_MODEL") or os.environ.get("VNX_CODEX_MODEL") or "gpt-5.2-codex"
+        payload = {
+            "gate": "codex_gate",
+            "status": "queued" if available else ("blocked" if required else "not_configured"),
+            "provider": "codex_headless",
+            "model": model,
+            "required": required,
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": _utc_now(),
+        }
+        if not available:
+            payload["reason"] = "codex_headless_not_available"
+        self._request_path("codex_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _request_claude_github(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str
+    ) -> Dict[str, Any]:
+        configured = self._claude_github_configured()
+        payload = {
+            "gate": "claude_github_optional",
+            "status": "not_configured",
+            "provider": "claude_github",
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": _utc_now(),
+        }
+        if configured:
+            payload["status"] = "queued"
+            if os.environ.get("VNX_CLAUDE_GITHUB_REVIEW_TRIGGER", "0") == "1":
+                comment = os.environ.get("VNX_CLAUDE_GITHUB_REVIEW_COMMENT", "@claude review")
+                proc = subprocess.run(
+                    ["gh", "pr", "comment", str(pr_number), "--body", comment],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if proc.returncode == 0:
+                    payload["status"] = "requested"
+                else:
+                    payload["status"] = "blocked"
+                    payload["reason"] = "claude_github_trigger_failed"
+                    payload["stderr"] = proc.stderr.strip()
+            else:
+                payload["status"] = "configured_dry_run"
+        self._request_path("claude_github_optional", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def record_result(
+        self,
+        *,
+        gate: str,
+        pr_number: int,
+        branch: str,
+        status: str,
+        summary: str,
+        findings: Optional[List[Dict[str, Any]]] = None,
+        residual_risk: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "gate": gate,
+            "pr_number": pr_number,
+            "branch": branch,
+            "status": status,
+            "summary": summary,
+            "findings": findings or [],
+            "residual_risk": residual_risk,
+            "recorded_at": _utc_now(),
+        }
+        self._result_path(gate, pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        emit_governance_receipt(
+            "review_gate_result",
+            status=status,
+            terminal="T0",
+            pr_number=pr_number,
+            branch=branch,
+            gate=gate,
+            summary=summary,
+            findings=payload["findings"],
+            residual_risk=residual_risk,
+        )
+        return payload
+
+    def status(self, pr_number: int) -> Dict[str, Any]:
+        results = []
+        for path in sorted(self.results_dir.glob(f"pr-{pr_number}-*.json")):
+            results.append(json.loads(path.read_text(encoding="utf-8")))
+        requests = []
+        for path in sorted(self.requests_dir.glob(f"pr-{pr_number}-*.json")):
+            requests.append(json.loads(path.read_text(encoding="utf-8")))
+        return {"pr_number": pr_number, "requests": requests, "results": results}
+
+
+def _parse_changed_files(value: str) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="VNX review gate manager")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    request_parser = sub.add_parser("request")
+    request_parser.add_argument("--pr", type=int, required=True)
+    request_parser.add_argument("--branch", required=True)
+    request_parser.add_argument("--review-stack", default=",".join(DEFAULT_REVIEW_STACK))
+    request_parser.add_argument("--risk-class", default="medium")
+    request_parser.add_argument("--changed-files", default="")
+    request_parser.add_argument("--mode", choices=("per_pr", "final"), default="per_pr")
+    request_parser.add_argument("--json", action="store_true")
+
+    result_parser = sub.add_parser("record-result")
+    result_parser.add_argument("--gate", required=True)
+    result_parser.add_argument("--pr", type=int, required=True)
+    result_parser.add_argument("--branch", required=True)
+    result_parser.add_argument("--status", required=True)
+    result_parser.add_argument("--summary", required=True)
+    result_parser.add_argument("--findings-file", default=None)
+    result_parser.add_argument("--residual-risk", default=None)
+    result_parser.add_argument("--json", action="store_true")
+
+    status_parser = sub.add_parser("status")
+    status_parser.add_argument("--pr", type=int, required=True)
+    status_parser.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+    manager = ReviewGateManager()
+
+    if args.command == "request":
+        result = manager.request_reviews(
+            pr_number=args.pr,
+            branch=args.branch,
+            review_stack=[item.strip() for item in args.review_stack.split(",") if item.strip()],
+            risk_class=args.risk_class,
+            changed_files=_parse_changed_files(args.changed_files),
+            mode=args.mode,
+        )
+        print(json.dumps(result, indent=2) if args.json else json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "record-result":
+        findings = []
+        if args.findings_file:
+            findings = json.loads(Path(args.findings_file).read_text(encoding="utf-8"))
+        result = manager.record_result(
+            gate=args.gate,
+            pr_number=args.pr,
+            branch=args.branch,
+            status=args.status,
+            summary=args.summary,
+            findings=findings,
+            residual_risk=args.residual_risk,
+        )
+        print(json.dumps(result, indent=2) if args.json else json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "status":
+        result = manager.status(args.pr)
+        print(json.dumps(result, indent=2) if args.json else json.dumps(result, indent=2))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Roadmap orchestration and auto-next feature loading for VNX."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from vnx_paths import ensure_env
+from governance_receipts import emit_governance_receipt, utc_now_iso
+from pr_queue_manager import PRQueueManager
+from closure_verifier import verify_closure
+
+
+ALLOWED_DRIFT_CATEGORIES = {"bugfix", "post_cleanup", "governance_gap", "path/runtime regression"}
+
+
+def _root_file(project_root: Path, name: str) -> Path:
+    return project_root / name
+
+
+@dataclass
+class RoadmapPaths:
+    project_root: Path
+    state_dir: Path
+    state_file: Path
+    generated_dir: Path
+
+
+class RoadmapManager:
+    def __init__(self) -> None:
+        paths = ensure_env()
+        self.project_root = Path(paths["PROJECT_ROOT"]).resolve()
+        self.state_dir = Path(paths["VNX_STATE_DIR"]).resolve()
+        self.paths = RoadmapPaths(
+            project_root=self.project_root,
+            state_dir=self.state_dir,
+            state_file=self.state_dir / "roadmap_state.json",
+            generated_dir=self.state_dir / "roadmap_generated_features",
+        )
+        self.paths.generated_dir.mkdir(parents=True, exist_ok=True)
+
+    def _load_yaml(self, path: Path) -> Dict[str, Any]:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+    def _save_state(self, state: Dict[str, Any]) -> None:
+        self.paths.state_file.parent.mkdir(parents=True, exist_ok=True)
+        self.paths.state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    def load_state(self) -> Dict[str, Any]:
+        if not self.paths.state_file.exists():
+            return {
+                "roadmap_file": None,
+                "current_active_feature": None,
+                "features": [],
+                "inserted_fixups": [],
+                "merged_features": [],
+                "last_verified_merge_commit": None,
+                "last_closure_verification_result": None,
+                "blocked_reason": None,
+                "updated_at": utc_now_iso(),
+            }
+        return json.loads(self.paths.state_file.read_text(encoding="utf-8"))
+
+    def _normalize_feature(self, raw: Dict[str, Any]) -> Dict[str, Any]:
+        review_stack = raw.get("review_stack") or []
+        if isinstance(review_stack, str):
+            review_stack = [item.strip() for item in review_stack.split(",") if item.strip()]
+        depends_on = raw.get("depends_on") or []
+        return {
+            "feature_id": raw["feature_id"],
+            "title": raw["title"],
+            "plan_path": raw["plan_path"],
+            "branch_name": raw["branch_name"],
+            "risk_class": raw.get("risk_class", "medium"),
+            "merge_policy": raw.get("merge_policy", "human"),
+            "review_stack": review_stack,
+            "depends_on": depends_on,
+            "status": raw.get("status", "planned"),
+            "inserted": bool(raw.get("inserted", False)),
+        }
+
+    def _load_roadmap(self, roadmap_file: Path) -> List[Dict[str, Any]]:
+        data = self._load_yaml(roadmap_file)
+        features = data.get("features") or []
+        normalized = [self._normalize_feature(feature) for feature in features]
+        ids = [feature["feature_id"] for feature in normalized]
+        if len(ids) != len(set(ids)):
+            raise ValueError("ROADMAP.yaml contains duplicate feature_id values")
+        return normalized
+
+    def init_roadmap(self, roadmap_file: Path) -> Dict[str, Any]:
+        features = self._load_roadmap(roadmap_file)
+        state = self.load_state()
+        state.update(
+            {
+                "roadmap_file": str(roadmap_file.resolve()),
+                "features": features,
+                "current_active_feature": None,
+                "inserted_fixups": [],
+                "merged_features": [],
+                "last_verified_merge_commit": None,
+                "last_closure_verification_result": None,
+                "blocked_reason": None,
+                "updated_at": utc_now_iso(),
+            }
+        )
+        self._save_state(state)
+        emit_governance_receipt(
+            "roadmap_transition",
+            status="success",
+            action="init",
+            roadmap_file=str(roadmap_file.resolve()),
+            feature_count=len(features),
+        )
+        return state
+
+    def _materialize_plan(self, plan_path: Path) -> None:
+        shutil.copy2(plan_path, _root_file(self.project_root, "FEATURE_PLAN.md"))
+        manager = PRQueueManager()
+        manager.load_feature_plan(str(_root_file(self.project_root, "FEATURE_PLAN.md")))
+
+    def load_feature(self, feature_id: str) -> Dict[str, Any]:
+        state = self.load_state()
+        features = state.get("features") or []
+        feature = next((item for item in features if item["feature_id"] == feature_id), None)
+        if not feature:
+            raise ValueError(f"Unknown feature_id: {feature_id}")
+
+        plan_path = Path(feature["plan_path"])
+        if not plan_path.is_absolute():
+            plan_path = self.project_root / plan_path
+        if not plan_path.exists():
+            raise FileNotFoundError(f"Feature plan not found: {plan_path}")
+
+        self._materialize_plan(plan_path)
+
+        for item in features:
+            if item["feature_id"] == feature_id:
+                item["status"] = "active"
+            elif item["status"] == "active":
+                item["status"] = "planned"
+
+        state["current_active_feature"] = feature_id
+        state["blocked_reason"] = None
+        state["updated_at"] = utc_now_iso()
+        self._save_state(state)
+        emit_governance_receipt(
+            "roadmap_transition",
+            status="success",
+            action="load_feature",
+            feature_id=feature_id,
+            title=feature["title"],
+            branch_name=feature["branch_name"],
+            risk_class=feature["risk_class"],
+            merge_policy=feature["merge_policy"],
+            review_stack=feature["review_stack"],
+        )
+        return state
+
+    def _detect_blocking_drift(self) -> List[Dict[str, Any]]:
+        drift_path = self.paths.state_dir / "post_feature_drift.json"
+        items: List[Dict[str, Any]] = []
+        if drift_path.exists():
+            try:
+                payload = json.loads(drift_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                payload = {}
+            for item in payload.get("items", []):
+                category = str(item.get("category", "")).strip()
+                if item.get("blocking") and category in ALLOWED_DRIFT_CATEGORIES:
+                    items.append(item)
+
+        open_items_path = self.paths.state_dir / "open_items.json"
+        if open_items_path.exists():
+            try:
+                payload = json.loads(open_items_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                payload = {}
+            for item in payload.get("items", []):
+                category = str(item.get("category", "")).strip()
+                if item.get("status") == "open" and item.get("severity") == "blocker" and category in ALLOWED_DRIFT_CATEGORIES:
+                    items.append(item)
+
+        seen = set()
+        deduped = []
+        for item in items:
+            key = (item.get("id"), item.get("title"), item.get("category"))
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(item)
+        return deduped
+
+    def _insert_fixup_feature(self, state: Dict[str, Any], drift_items: List[Dict[str, Any]]) -> Dict[str, Any]:
+        fixup_id = f"fixup-{utc_now_iso().replace(':', '').replace('-', '').lower()}"
+        plan_dir = self.paths.generated_dir / fixup_id
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = plan_dir / "FEATURE_PLAN.md"
+        bullet_list = "\n".join(f"- {item.get('title') or item.get('id') or item.get('category')}" for item in drift_items)
+        plan_path.write_text(
+            f"""# Feature: Runtime Fix-up — {fixup_id}
+
+**Status**: Draft
+**Priority**: P0
+**Branch**: `feature/{fixup_id}`
+**Risk-Class**: medium
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+
+Primary objective:
+Close the blocking post-feature drift discovered during roadmap reconciliation.
+
+## Blocking Drift
+{bullet_list}
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: Blocking Runtime Fix-up
+**Track**: C
+**Priority**: P0
+**Complexity**: Medium
+**Risk**: Medium
+**Skill**: @architect
+**Requires-Model**: opus
+**Risk-Class**: medium
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Estimated Time**: 2-6 hours
+**Dependencies**: []
+
+### Description
+Implement the minimum blocking fix required before the roadmap may advance.
+
+### Scope
+{bullet_list}
+
+### Success Criteria
+- blocking drift is resolved
+- no unrelated roadmap scope is added
+- closure verifier passes after the fix-up merges
+
+### Quality Gate
+`gate_fixup_blocking_drift`:
+- [ ] Blocking drift is fully addressed
+- [ ] No unrelated feature work was folded into the fix-up
+- [ ] Verification evidence exists for the addressed issue
+""",
+            encoding="utf-8",
+        )
+
+        feature = {
+            "feature_id": fixup_id,
+            "title": f"Runtime Fix-up — {fixup_id}",
+            "plan_path": str(plan_path),
+            "branch_name": f"feature/{fixup_id}",
+            "risk_class": "medium",
+            "merge_policy": "human",
+            "review_stack": ["gemini_review", "codex_gate", "claude_github_optional"],
+            "depends_on": [],
+            "status": "planned",
+            "inserted": True,
+        }
+
+        current_id = state.get("current_active_feature")
+        features = state.get("features") or []
+        insert_at = next((idx + 1 for idx, item in enumerate(features) if item["feature_id"] == current_id), len(features))
+        features.insert(insert_at, feature)
+        state["features"] = features
+        state.setdefault("inserted_fixups", []).append(
+            {"feature_id": fixup_id, "items": drift_items, "plan_path": str(plan_path), "inserted_at": utc_now_iso()}
+        )
+        state["updated_at"] = utc_now_iso()
+        state["blocked_reason"] = "blocking_drift_fixup_inserted"
+        self._save_state(state)
+
+        emit_governance_receipt(
+            "drift_fixup_inserted",
+            status="success",
+            feature_id=fixup_id,
+            plan_path=str(plan_path),
+            drift_items=drift_items,
+        )
+        return state
+
+    def reconcile(self) -> Dict[str, Any]:
+        state = self.load_state()
+        current_id = state.get("current_active_feature")
+        if not current_id:
+            result = {"verdict": "idle", "reason": "no_active_feature", "state": state}
+            state["last_closure_verification_result"] = result
+            state["updated_at"] = utc_now_iso()
+            self._save_state(state)
+            return result
+
+        feature = next((item for item in state.get("features", []) if item["feature_id"] == current_id), None)
+        if not feature:
+            raise ValueError(f"Active feature missing from roadmap state: {current_id}")
+
+        verification = verify_closure(
+            project_root=self.project_root,
+            feature_plan=_root_file(self.project_root, "FEATURE_PLAN.md"),
+            pr_queue=_root_file(self.project_root, "PR_QUEUE.md"),
+            branch=feature["branch_name"],
+            mode="post_merge",
+            claim_file=(self.paths.state_dir / "closure_claim.json") if (self.paths.state_dir / "closure_claim.json").exists() else None,
+        )
+        drift_items = self._detect_blocking_drift() if verification["verdict"] == "pass" else []
+        result = {
+            "verdict": "pass" if verification["verdict"] == "pass" and not drift_items else ("drift_blocked" if drift_items else "blocked"),
+            "feature_id": current_id,
+            "closure_verification": verification,
+            "drift_items": drift_items,
+        }
+        state["last_closure_verification_result"] = result
+        state["last_verified_merge_commit"] = (((verification.get("pr") or {}).get("mergeCommit") or {}).get("oid"))
+        state["blocked_reason"] = "blocking_drift_detected" if drift_items else (None if verification["verdict"] == "pass" else "closure_verification_failed")
+        state["updated_at"] = utc_now_iso()
+        self._save_state(state)
+        emit_governance_receipt(
+            "closure_verification_result",
+            status="success" if result["verdict"] == "pass" else "blocked",
+            feature_id=current_id,
+            verifier_result=result,
+        )
+        return result
+
+    def advance(self) -> Dict[str, Any]:
+        state = self.load_state()
+        reconcile_result = self.reconcile()
+        if reconcile_result["verdict"] == "blocked":
+            return {"advanced": False, "reason": "closure_verification_failed", "reconcile": reconcile_result}
+
+        if reconcile_result["verdict"] == "drift_blocked":
+            state = self.load_state()
+            state = self._insert_fixup_feature(state, reconcile_result["drift_items"])
+            fixup_id = state["inserted_fixups"][-1]["feature_id"]
+            self.load_feature(fixup_id)
+            return {"advanced": True, "reason": "blocking_fixup_inserted", "next_feature": fixup_id}
+
+        state = self.load_state()
+        current_id = state.get("current_active_feature")
+        if current_id and current_id not in state.get("merged_features", []):
+            state.setdefault("merged_features", []).append(current_id)
+            for item in state.get("features", []):
+                if item["feature_id"] == current_id:
+                    item["status"] = "merged"
+            self._save_state(state)
+
+        merged = set(state.get("merged_features", []))
+        next_feature = None
+        for feature in state.get("features", []):
+            if feature["status"] not in {"planned", "blocked"}:
+                continue
+            if all(dep in merged for dep in feature.get("depends_on", [])):
+                next_feature = feature
+                break
+
+        if not next_feature:
+            state["current_active_feature"] = None
+            state["blocked_reason"] = None
+            state["updated_at"] = utc_now_iso()
+            self._save_state(state)
+            emit_governance_receipt("roadmap_transition", status="success", action="advance_complete", merged_features=sorted(merged))
+            return {"advanced": False, "reason": "no_remaining_features"}
+
+        self.load_feature(next_feature["feature_id"])
+        return {"advanced": True, "reason": "loaded_next_feature", "next_feature": next_feature["feature_id"]}
+
+    def status(self) -> Dict[str, Any]:
+        state = self.load_state()
+        return {
+            "roadmap_file": state.get("roadmap_file"),
+            "current_active_feature": state.get("current_active_feature"),
+            "merged_features": state.get("merged_features", []),
+            "inserted_fixups": state.get("inserted_fixups", []),
+            "blocked_reason": state.get("blocked_reason"),
+            "features": state.get("features", []),
+            "last_closure_verification_result": state.get("last_closure_verification_result"),
+        }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="VNX roadmap manager")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = sub.add_parser("init")
+    init_parser.add_argument("roadmap_file")
+    init_parser.add_argument("--json", action="store_true")
+
+    status_parser = sub.add_parser("status")
+    status_parser.add_argument("--json", action="store_true")
+
+    load_parser = sub.add_parser("load")
+    load_parser.add_argument("feature_id")
+    load_parser.add_argument("--json", action="store_true")
+
+    reconcile_parser = sub.add_parser("reconcile")
+    reconcile_parser.add_argument("--json", action="store_true")
+
+    advance_parser = sub.add_parser("advance")
+    advance_parser.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+    manager = RoadmapManager()
+
+    if args.command == "init":
+        result = manager.init_roadmap(Path(args.roadmap_file))
+    elif args.command == "status":
+        result = manager.status()
+    elif args.command == "load":
+        result = manager.load_feature(args.feature_id)
+    elif args.command == "reconcile":
+        result = manager.reconcile()
+    elif args.command == "advance":
+        result = manager.advance()
+    else:
+        raise AssertionError("unreachable")
+
+    print(json.dumps(result, indent=2) if getattr(args, "json", False) else json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/t0-orchestrator/template.md
+++ b/skills/t0-orchestrator/template.md
@@ -19,6 +19,9 @@ Terminal: <T1|T2|T3>
 Priority: <P0|P1|P2>
 Cognition: <normal|deep>
 Requires-Model: <opus|sonnet>
+Risk-Class: <low|medium|high>
+Merge-Policy: <human|conditional_auto>
+Review-Stack: <gemini_review,codex_gate,claude_github_optional>
 Dispatch-ID: <YYYYMMDD-HHMMSS-descriptor-track>
 Parent-Dispatch: <dispatch-id or "none">
 PR-ID: <PR-X or "none">
@@ -126,6 +129,9 @@ Every Manager Block MUST have:
 ### Optional Fields (Use When Needed)
 - `Gate`: investigation, planning, implementation, review, testing, integration (mode selection only)
 - `Requires-Model`: opus or sonnet (force specific model)
+- `Risk-Class`: low, medium, or high
+- `Merge-Policy`: human or conditional_auto
+- `Review-Stack`: comma-separated reviewer gates
 - `Mode`: planning, thinking, normal (terminal mode)
 - `ClearContext`: true/false (default: true)
 - `ForceNormalMode`: true/false (reset mode first)
@@ -162,6 +168,9 @@ Terminal: T1
 Priority: P1
 Cognition: normal
 Requires-Model: sonnet
+Risk-Class: medium
+Merge-Policy: human
+Review-Stack: gemini_review,codex_gate,claude_github_optional
 Dispatch-ID: 20260203-153000-storage-fix-A
 Parent-Dispatch: none
 PR-ID: PR-4
@@ -201,3 +210,4 @@ Check `.claude/skills/skills.yaml` for current list. Common skills:
 6. **V8 UPDATE**: Dispatcher uses skills from `.claude/skills/`, not agent templates
 7. **Required Fields**: All V2 fields must be present (Role, Dispatch-ID, Parent-Dispatch, PR-ID, Reason)
 8. **Context Format**: Use `[[@path]]` format for context files
+9. **Governance Metadata**: Set Risk-Class, Merge-Policy, and Review-Stack explicitly for any PR-backed dispatch

--- a/tests/test_auto_merge_policy.py
+++ b/tests/test_auto_merge_policy.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from auto_merge_policy import codex_final_gate_required, evaluate_auto_merge_policy
+
+
+def test_conditional_auto_merge_allowed_for_low_risk_docs_change():
+    decision = evaluate_auto_merge_policy(
+        risk_class="low",
+        merge_policy="conditional_auto",
+        changed_files=["docs/quickstart.md", "README.md"],
+        gemini_review_passed=True,
+        codex_gate_passed=True,
+        required_checks_passed=True,
+        closure_verifier_passed=True,
+    )
+
+    assert decision.allowed is True
+    assert decision.blockers == []
+
+
+def test_conditional_auto_merge_blocked_for_high_risk_runtime_scope():
+    decision = evaluate_auto_merge_policy(
+        risk_class="low",
+        merge_policy="conditional_auto",
+        changed_files=["scripts/dispatcher_v8_minimal.sh"],
+        gemini_review_passed=True,
+        codex_gate_passed=True,
+        required_checks_passed=True,
+        closure_verifier_passed=True,
+    )
+
+    assert decision.allowed is False
+    assert "high_risk_change_scope" in decision.blockers
+    assert codex_final_gate_required(["scripts/dispatcher_v8_minimal.sh"]) is True
+
+
+def test_conditional_auto_merge_blocked_when_risk_not_low():
+    decision = evaluate_auto_merge_policy(
+        risk_class="medium",
+        merge_policy="conditional_auto",
+        changed_files=["docs/ops.md"],
+        gemini_review_passed=True,
+        codex_gate_passed=True,
+        required_checks_passed=True,
+        closure_verifier_passed=True,
+    )
+
+    assert decision.allowed is False
+    assert "risk_class_not_low" in decision.blockers

--- a/tests/test_closure_verifier.py
+++ b/tests/test_closure_verifier.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import closure_verifier as cv
+
+
+@pytest.fixture
+def verifier_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "repo"
+    project_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=project_root, check=True, capture_output=True)
+    (project_root / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=project_root, check=True, capture_output=True)
+
+    data_dir = project_root / ".vnx-data"
+    dispatch_dir = data_dir / "dispatches"
+    (dispatch_dir / "staging").mkdir(parents=True, exist_ok=True)
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+
+    feature_plan = project_root / "FEATURE_PLAN.md"
+    feature_plan.write_text(
+        """# Feature: Demo Feature
+
+**Status**: Complete
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: Demo PR
+**Track**: C
+**Priority**: P1
+**Complexity**: Medium
+**Skill**: @architect
+**Dependencies**: []
+""",
+        encoding="utf-8",
+    )
+    pr_queue = project_root / "PR_QUEUE.md"
+    pr_queue.write_text(
+        """# PR Queue - Feature: Demo Feature
+
+## Progress Overview
+Total: 1 PRs | Complete: 1 | Active: 0 | Queued: 0 | Blocked: 0
+Progress: ██████████ 100%
+
+## Status
+
+## Dependency Flow
+```
+PR-0 (no dependencies)
+```
+""",
+        encoding="utf-8",
+    )
+    claim_file = state_dir / "closure_claim.json"
+    claim_file.write_text(
+        json.dumps(
+            {
+                "test_files": ["FEATURE_PLAN.md"],
+                "test_command": "python3 -m pytest tests/test_demo.py",
+                "parallel_assignments": [{"terminal": "T1"}, {"terminal": "T2"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    return {
+        "project_root": project_root,
+        "feature_plan": feature_plan,
+        "pr_queue": pr_queue,
+        "claim_file": claim_file,
+        "dispatch_dir": dispatch_dir,
+    }
+
+
+def _good_pr_payload(state="OPEN", merge_state="CLEAN"):
+    return {
+        "number": 45,
+        "url": "https://example.test/pr/45",
+        "state": state,
+        "mergeStateStatus": merge_state,
+        "statusCheckRollup": [
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ],
+        "mergeCommit": {"oid": "abc123"},
+    }
+
+
+def test_verify_closure_fails_when_pr_missing(verifier_env, monkeypatch):
+    monkeypatch.setattr(cv, "_remote_branch_exists", lambda branch, project_root: True)
+    monkeypatch.setattr(cv, "_find_branch_pr", lambda branch: None)
+
+    result = cv.verify_closure(
+        project_root=verifier_env["project_root"],
+        feature_plan=verifier_env["feature_plan"],
+        pr_queue=verifier_env["pr_queue"],
+        branch="feature/demo",
+        mode="pre_merge",
+        claim_file=verifier_env["claim_file"],
+    )
+
+    assert result["verdict"] == "fail"
+    failed = {check["name"] for check in result["checks"] if check["status"] == "FAIL"}
+    assert "pr_exists" in failed
+
+
+def test_verify_closure_fails_on_metadata_drift(verifier_env, monkeypatch):
+    verifier_env["pr_queue"].write_text(
+        """# PR Queue - Feature: Wrong Feature
+
+## Progress Overview
+Total: 1 PRs | Complete: 1 | Active: 0 | Queued: 0 | Blocked: 0
+Progress: ██████████ 100%
+
+## Status
+
+## Dependency Flow
+```
+PR-0 -> PR-1
+```
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cv, "_remote_branch_exists", lambda branch, project_root: True)
+    monkeypatch.setattr(cv, "_find_branch_pr", lambda branch: _good_pr_payload())
+
+    result = cv.verify_closure(
+        project_root=verifier_env["project_root"],
+        feature_plan=verifier_env["feature_plan"],
+        pr_queue=verifier_env["pr_queue"],
+        branch="feature/demo",
+        mode="pre_merge",
+        claim_file=verifier_env["claim_file"],
+    )
+
+    failed = {check["name"] for check in result["checks"] if check["status"] == "FAIL"}
+    assert "metadata_sync" in failed
+
+
+def test_verify_closure_fails_when_stale_staging_dispatches_present(verifier_env, monkeypatch):
+    stale_dispatch = verifier_env["dispatch_dir"] / "staging" / "stale.md"
+    stale_dispatch.write_text("PR-ID: PR-999\n", encoding="utf-8")
+    monkeypatch.setattr(cv, "_remote_branch_exists", lambda branch, project_root: True)
+    monkeypatch.setattr(cv, "_find_branch_pr", lambda branch: _good_pr_payload())
+
+    result = cv.verify_closure(
+        project_root=verifier_env["project_root"],
+        feature_plan=verifier_env["feature_plan"],
+        pr_queue=verifier_env["pr_queue"],
+        branch="feature/demo",
+        mode="pre_merge",
+        claim_file=verifier_env["claim_file"],
+    )
+
+    failed = {check["name"] for check in result["checks"] if check["status"] == "FAIL"}
+    assert "stale_staging" in failed
+
+
+def test_verify_closure_passes_for_valid_post_merge_state(verifier_env, monkeypatch):
+    monkeypatch.setattr(cv, "_remote_branch_exists", lambda branch, project_root: True)
+    monkeypatch.setattr(cv, "_find_branch_pr", lambda branch: _good_pr_payload(state="MERGED"))
+    monkeypatch.setattr(cv, "_merge_commit_on_main", lambda oid, project_root: True)
+
+    result = cv.verify_closure(
+        project_root=verifier_env["project_root"],
+        feature_plan=verifier_env["feature_plan"],
+        pr_queue=verifier_env["pr_queue"],
+        branch="feature/demo",
+        mode="post_merge",
+        claim_file=verifier_env["claim_file"],
+    )
+
+    assert result["verdict"] == "pass"

--- a/tests/test_pr_queue_roadmap_metadata.py
+++ b/tests/test_pr_queue_roadmap_metadata.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from pr_queue_manager import PRQueueManager
+
+
+@pytest.fixture
+def queue_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    fake_vnx_home = project_root / ".claude" / "vnx-system"
+    fake_vnx_home.mkdir(parents=True, exist_ok=True)
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    dispatch_dir = data_dir / "dispatches"
+    (dispatch_dir / "staging").mkdir(parents=True, exist_ok=True)
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(fake_vnx_home))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    monkeypatch.chdir(project_root)
+    return project_root
+
+
+def test_load_feature_plan_captures_feature_metadata(queue_env):
+    feature_plan = queue_env / "FEATURE_PLAN.md"
+    feature_plan.write_text(
+        """# Feature: Governance Feature
+
+**Status**: Draft
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: Queue Metadata
+**Track**: C
+**Priority**: P0
+**Complexity**: High
+**Skill**: @architect
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate,claude_github_optional
+**Dependencies**: []
+""",
+        encoding="utf-8",
+    )
+
+    manager = PRQueueManager()
+    success, count = manager.load_feature_plan(str(feature_plan))
+
+    assert success is True
+    assert count == 1
+    assert manager.state["feature_metadata"]["risk_class"] == "high"
+    assert manager.state["prs"][0]["risk_class"] == "high"
+    assert manager.state["prs"][0]["review_stack"] == [
+        "gemini_review",
+        "codex_gate",
+        "claude_github_optional",
+    ]
+    pr_queue = (queue_env / "PR_QUEUE.md").read_text(encoding="utf-8")
+    assert "Risk-Class: high" in pr_queue
+    assert "Review-Stack: gemini_review,codex_gate,claude_github_optional" in pr_queue
+
+
+def test_init_feature_batch_writes_governance_metadata_to_dispatch(queue_env):
+    feature_plan = queue_env / "FEATURE_PLAN.md"
+    feature_plan.write_text(
+        """# Feature: Dispatch Governance
+
+**Status**: Draft
+**Risk-Class**: low
+**Merge-Policy**: conditional_auto
+**Review-Stack**: gemini_review,codex_gate
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: Dispatch Metadata
+**Track**: B
+**Priority**: P1
+**Complexity**: Medium
+**Skill**: @backend-developer
+**Risk-Class**: low
+**Merge-Policy**: conditional_auto
+**Review-Stack**: gemini_review,codex_gate
+**Estimated Time**: 2h
+**Dependencies**: []
+""",
+        encoding="utf-8",
+    )
+
+    manager = PRQueueManager()
+    success, created = manager.init_feature_batch(str(feature_plan))
+
+    assert success is True
+    assert created == 1
+    dispatch_files = list((queue_env / ".vnx-data" / "dispatches" / "staging").glob("*.md"))
+    assert len(dispatch_files) == 1
+    content = dispatch_files[0].read_text(encoding="utf-8")
+    assert "Risk-Class: low" in content
+    assert "Merge-Policy: conditional_auto" in content
+    assert "Review-Stack: gemini_review,codex_gate" in content

--- a/tests/test_review_gate_manager.py
+++ b/tests/test_review_gate_manager.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import review_gate_manager as rgm
+
+
+@pytest.fixture
+def review_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return project_root
+
+
+def test_request_reviews_queues_gemini_and_skips_unconfigured_optional(review_env, monkeypatch):
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rgm.shutil, "which", lambda tool: "/usr/bin/fake" if tool == "gemini" else None)
+    monkeypatch.setenv("VNX_GEMINI_REVIEW_ENABLED", "1")
+    monkeypatch.setenv("VNX_CODEX_HEADLESS_ENABLED", "0")
+    monkeypatch.setenv("VNX_CLAUDE_GITHUB_REVIEW_ENABLED", "0")
+
+    manager = rgm.ReviewGateManager()
+    result = manager.request_reviews(
+        pr_number=12,
+        branch="feature/demo",
+        review_stack=["gemini_review", "claude_github_optional"],
+        risk_class="medium",
+        changed_files=["docs/guide.md"],
+        mode="per_pr",
+    )
+
+    requested = {item["gate"]: item for item in result["requested"]}
+    assert requested["gemini_review"]["status"] == "queued"
+    assert requested["claude_github_optional"]["status"] == "not_configured"
+    assert (manager.requests_dir / "pr-12-gemini_review.json").exists()
+
+
+def test_codex_final_gate_blocks_when_required_but_not_available(review_env, monkeypatch):
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rgm.shutil, "which", lambda tool: None)
+    monkeypatch.setenv("VNX_CODEX_HEADLESS_ENABLED", "0")
+
+    manager = rgm.ReviewGateManager()
+    result = manager.request_reviews(
+        pr_number=44,
+        branch="feature/runtime-core",
+        review_stack=["codex_gate"],
+        risk_class="high",
+        changed_files=["scripts/pr_queue_manager.py"],
+        mode="final",
+    )
+
+    gate = result["requested"][0]
+    assert gate["gate"] == "codex_gate"
+    assert gate["status"] == "blocked"
+    assert gate["required"] is True
+
+
+def test_record_result_persists_structured_review_output(review_env, monkeypatch):
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+    manager = rgm.ReviewGateManager()
+
+    payload = manager.record_result(
+        gate="gemini_review",
+        pr_number=8,
+        branch="feature/docs",
+        status="pass",
+        summary="No blocking findings",
+        findings=[{"severity": "info", "title": "Minor wording"}],
+        residual_risk="low",
+    )
+
+    result_path = manager.results_dir / "pr-8-gemini_review.json"
+    assert result_path.exists()
+    saved = json.loads(result_path.read_text(encoding="utf-8"))
+    assert saved["status"] == "pass"
+    assert saved["findings"][0]["title"] == "Minor wording"
+    assert payload["residual_risk"] == "low"

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import roadmap_manager as rm
+
+
+@pytest.fixture
+def roadmap_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    fake_vnx_home = project_root / ".claude" / "vnx-system"
+    fake_vnx_home.mkdir(parents=True, exist_ok=True)
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    dispatch_dir = data_dir / "dispatches"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(fake_vnx_home))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    monkeypatch.setattr(rm, "emit_governance_receipt", lambda *args, **kwargs: None)
+
+    roadmap_dir = project_root / "roadmap" / "features"
+    (roadmap_dir / "feature-a").mkdir(parents=True, exist_ok=True)
+    (roadmap_dir / "feature-b").mkdir(parents=True, exist_ok=True)
+    feature_a = roadmap_dir / "feature-a" / "FEATURE_PLAN.md"
+    feature_b = roadmap_dir / "feature-b" / "FEATURE_PLAN.md"
+    for path, title, branch in [
+        (feature_a, "Feature A", "feature/a"),
+        (feature_b, "Feature B", "feature/b"),
+    ]:
+        path.write_text(
+            f"""# Feature: {title}
+
+**Status**: Draft
+**Risk-Class**: low
+**Merge-Policy**: conditional_auto
+**Review-Stack**: gemini_review,codex_gate
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: {title} PR
+**Track**: C
+**Priority**: P1
+**Complexity**: Medium
+**Skill**: @architect
+**Risk-Class**: low
+**Merge-Policy**: conditional_auto
+**Review-Stack**: gemini_review,codex_gate
+**Dependencies**: []
+""",
+            encoding="utf-8",
+        )
+
+    roadmap_file = project_root / "ROADMAP.yaml"
+    roadmap_file.write_text(
+        """features:
+  - feature_id: feature-a
+    title: Feature A
+    plan_path: roadmap/features/feature-a/FEATURE_PLAN.md
+    branch_name: feature/a
+    risk_class: low
+    merge_policy: conditional_auto
+    review_stack: [gemini_review, codex_gate]
+    depends_on: []
+    status: planned
+  - feature_id: feature-b
+    title: Feature B
+    plan_path: roadmap/features/feature-b/FEATURE_PLAN.md
+    branch_name: feature/b
+    risk_class: medium
+    merge_policy: human
+    review_stack: [gemini_review, codex_gate]
+    depends_on: [feature-a]
+    status: planned
+""",
+        encoding="utf-8",
+    )
+
+    return {"project_root": project_root, "roadmap_file": roadmap_file, "state_dir": state_dir}
+
+
+def test_load_feature_materializes_active_plan_and_queue(roadmap_env):
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    state = manager.load_feature("feature-a")
+
+    assert state["current_active_feature"] == "feature-a"
+    feature_plan = roadmap_env["project_root"] / "FEATURE_PLAN.md"
+    pr_queue = roadmap_env["project_root"] / "PR_QUEUE.md"
+    assert feature_plan.exists()
+    assert pr_queue.exists()
+    assert "Feature A" in feature_plan.read_text(encoding="utf-8")
+    assert "Risk-Class: low" in pr_queue.read_text(encoding="utf-8")
+
+
+def test_advance_loads_next_feature_after_verified_merge(roadmap_env, monkeypatch):
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm,
+        "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    result = manager.advance()
+    state = manager.load_state()
+
+    assert result["advanced"] is True
+    assert result["reason"] == "loaded_next_feature"
+    assert result["next_feature"] == "feature-b"
+    assert state["current_active_feature"] == "feature-b"
+    assert "feature-a" in state["merged_features"]
+
+
+def test_advance_inserts_fixup_when_blocking_drift_detected(roadmap_env, monkeypatch):
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm,
+        "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    (roadmap_env["state_dir"] / "post_feature_drift.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "id": "oi-1",
+                        "title": "Fix runtime regression",
+                        "category": "path/runtime regression",
+                        "blocking": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = manager.advance()
+    state = manager.load_state()
+
+    assert result["advanced"] is True
+    assert result["reason"] == "blocking_fixup_inserted"
+    assert state["current_active_feature"].startswith("fixup-")
+    assert state["inserted_fixups"]


### PR DESCRIPTION
## Summary
- add roadmap registry, active feature materialization, reconcile/advance commands, and drift fix-up insertion
- add closure verifier, review gate manager, and conditional auto-merge policy evaluation
- extend PR queue/dispatch metadata plus T0 template and add targeted governance tests

## Testing
- python3 -m pytest -q tests/test_auto_merge_policy.py tests/test_review_gate_manager.py tests/test_closure_verifier.py tests/test_roadmap_manager.py tests/test_pr_queue_roadmap_metadata.py tests/test_pr_queue_integration.py
- bash -n bin/vnx scripts/commands/roadmap.sh scripts/lib/dispatch_metadata.sh
- python3 -m py_compile scripts/auto_merge_policy.py scripts/closure_verifier.py scripts/review_gate_manager.py scripts/roadmap_manager.py scripts/pr_queue_manager.py scripts/lib/governance_receipts.py