### PR TITLE
feat(runtime): worker state machine and heartbeat persistence

### DIFF
--- a/schemas/runtime_coordination_v9.sql
+++ b/schemas/runtime_coordination_v9.sql
@@ -1,0 +1,47 @@
+-- VNX Runtime Coordination Schema — Migration v9 (Feature 12, PR-1)
+-- Purpose: Add worker_states table for canonical worker lifecycle tracking.
+-- Contract: docs/core/130_RUNTIME_STATE_MACHINE_CONTRACT.md §8.1
+-- Applies on top of: v8 (Headless Observability PR-1) — headless run registry
+--
+-- Design:
+--   - Single row per terminal (PK on terminal_id) — only one active worker per terminal.
+--   - state_entered_at tracks when the current state was entered (independent of heartbeat).
+--   - last_output_at tracks most recent output event (independent of heartbeat).
+--   - stall_count accumulates across stall episodes within one dispatch lifecycle.
+--   - Foreign keys enforce referential integrity against terminal_leases and dispatches.
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+-- ============================================================================
+-- WORKER STATES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS worker_states (
+    terminal_id      TEXT    NOT NULL,
+    dispatch_id      TEXT    NOT NULL,
+    state            TEXT    NOT NULL DEFAULT 'initializing',
+    last_output_at   TEXT,
+    state_entered_at TEXT    NOT NULL,
+    stall_count      INTEGER NOT NULL DEFAULT 0,
+    blocked_reason   TEXT,
+    metadata_json    TEXT,
+    created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+
+    PRIMARY KEY (terminal_id),
+    FOREIGN KEY (terminal_id) REFERENCES terminal_leases(terminal_id),
+    FOREIGN KEY (dispatch_id) REFERENCES dispatches(dispatch_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_state
+    ON worker_states (state);
+CREATE INDEX IF NOT EXISTS idx_worker_dispatch
+    ON worker_states (dispatch_id);
+
+-- ============================================================================
+-- SCHEMA VERSION
+-- ============================================================================
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (9, 'Feature 12 PR-1: worker_states table — canonical worker lifecycle and heartbeat persistence');

--- a/scripts/lib/worker_state_manager.py
+++ b/scripts/lib/worker_state_manager.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""
+VNX Worker State Manager — Canonical worker lifecycle state machine.
+
+Implements the worker layer from the Runtime State Machine Contract
+(docs/core/130_RUNTIME_STATE_MACHINE_CONTRACT.md):
+
+  - Canonical worker states with deterministic transitions (§3)
+  - Heartbeat freshness classification (§4)
+  - last_output_at tracking (§4.1)
+  - Coordination events for every state change (§8.2)
+  - T0-readable state surface without terminal scraping (§6)
+
+The worker layer sits between lease acquisition and lease release,
+providing runtime observability that the lease layer cannot.
+
+Key invariant: worker state is only valid while a lease is leased.
+If the lease is idle, no worker state exists.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from runtime_coordination import (
+    InvalidTransitionError,
+    get_connection,
+    init_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical worker states (§3.1)
+# ---------------------------------------------------------------------------
+
+WORKER_STATES = frozenset({
+    "initializing",
+    "working",
+    "idle_between_tasks",
+    "stalled",
+    "blocked",
+    "awaiting_input",
+    "exited_clean",
+    "exited_bad",
+    "resume_unsafe",
+})
+
+TERMINAL_WORKER_STATES = frozenset({
+    "exited_clean",
+    "exited_bad",
+    "resume_unsafe",
+})
+
+ACTIVE_WORKER_STATES = WORKER_STATES - TERMINAL_WORKER_STATES
+
+# ---------------------------------------------------------------------------
+# State transition matrix (§3.2)
+# ---------------------------------------------------------------------------
+
+WORKER_TRANSITIONS: Dict[str, frozenset] = {
+    "initializing":       frozenset({"working", "stalled", "blocked", "exited_clean", "exited_bad", "resume_unsafe"}),
+    "working":            frozenset({"idle_between_tasks", "stalled", "blocked", "awaiting_input", "exited_clean", "exited_bad", "resume_unsafe"}),
+    "idle_between_tasks": frozenset({"working", "stalled", "exited_clean", "exited_bad", "resume_unsafe"}),
+    "stalled":            frozenset({"working", "exited_bad", "resume_unsafe"}),
+    "blocked":            frozenset({"working", "exited_bad", "resume_unsafe"}),
+    "awaiting_input":     frozenset({"working", "exited_bad", "resume_unsafe"}),
+    "exited_clean":       frozenset(),
+    "exited_bad":         frozenset(),
+    "resume_unsafe":      frozenset(),
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat thresholds (§4.3, Appendix B)
+# ---------------------------------------------------------------------------
+
+DEFAULT_HEARTBEAT_INTERVAL = 30
+DEFAULT_HEARTBEAT_STALE_THRESHOLD = 90
+DEFAULT_HEARTBEAT_DEAD_THRESHOLD = 300
+DEFAULT_STARTUP_GRACE_PERIOD = 120
+DEFAULT_STALL_THRESHOLD = 180
+DEFAULT_IDLE_BETWEEN_TASKS_GRACE = 120
+DEFAULT_INTERACTIVE_STALL_MULTIPLIER = 1.5
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class InvalidWorkerStateError(ValueError):
+    """Raised when a worker state value is not in the canonical set."""
+
+
+class InvalidWorkerTransitionError(InvalidTransitionError):
+    """Raised when a worker state transition is not permitted."""
+
+
+def validate_worker_state(state: str) -> None:
+    if state not in WORKER_STATES:
+        raise InvalidWorkerStateError(
+            f"Unknown worker state: {state!r}. Valid: {sorted(WORKER_STATES)}"
+        )
+
+
+def validate_worker_transition(from_state: str, to_state: str) -> None:
+    validate_worker_state(from_state)
+    validate_worker_state(to_state)
+    allowed = WORKER_TRANSITIONS.get(from_state, frozenset())
+    if to_state not in allowed:
+        raise InvalidWorkerTransitionError(
+            f"Worker transition {from_state!r} -> {to_state!r} is not permitted. "
+            f"Allowed from {from_state!r}: {sorted(allowed) or 'none (terminal state)'}"
+        )
+
+
+def is_terminal_worker_state(state: str) -> bool:
+    return state in TERMINAL_WORKER_STATES
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat classification (§4.2)
+# ---------------------------------------------------------------------------
+
+def classify_heartbeat(
+    last_heartbeat_at: Optional[str],
+    *,
+    now: Optional[datetime] = None,
+    stale_threshold: int = DEFAULT_HEARTBEAT_STALE_THRESHOLD,
+    dead_threshold: int = DEFAULT_HEARTBEAT_DEAD_THRESHOLD,
+) -> str:
+    """Classify heartbeat freshness as 'fresh', 'stale', or 'dead'.
+
+    Returns 'dead' if last_heartbeat_at is None (no heartbeat ever received).
+    """
+    if last_heartbeat_at is None:
+        return "dead"
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    try:
+        hb = datetime.fromisoformat(last_heartbeat_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return "dead"
+
+    age = (now - hb).total_seconds()
+    if age < stale_threshold:
+        return "fresh"
+    elif age < dead_threshold:
+        return "stale"
+    else:
+        return "dead"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WorkerStateResult:
+    """Returned by worker state operations."""
+    terminal_id: str
+    dispatch_id: str
+    state: str
+    last_output_at: Optional[str]
+    state_entered_at: str
+    stall_count: int
+    blocked_reason: Optional[str]
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "WorkerStateResult":
+        return cls(
+            terminal_id=row["terminal_id"],
+            dispatch_id=row["dispatch_id"],
+            state=row["state"],
+            last_output_at=row.get("last_output_at"),
+            state_entered_at=row["state_entered_at"],
+            stall_count=row["stall_count"],
+            blocked_reason=row.get("blocked_reason"),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _new_event_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _dump(obj: Any) -> str:
+    return json.dumps(obj) if obj is not None else "{}"
+
+
+def _append_worker_event(
+    conn,
+    *,
+    event_type: str,
+    terminal_id: str,
+    from_state: Optional[str] = None,
+    to_state: Optional[str] = None,
+    actor: str = "worker_supervisor",
+    reason: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Append a worker state coordination event. Returns the event_id."""
+    event_id = _new_event_id()
+    conn.execute(
+        """
+        INSERT INTO coordination_events
+            (event_id, event_type, entity_type, entity_id,
+             from_state, to_state, actor, reason, metadata_json, occurred_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            event_type,
+            "worker",
+            terminal_id,
+            from_state,
+            to_state,
+            actor,
+            reason,
+            _dump(metadata),
+            _now_utc(),
+        ),
+    )
+    return event_id
+
+
+# ---------------------------------------------------------------------------
+# WorkerStateManager
+# ---------------------------------------------------------------------------
+
+class WorkerStateManager:
+    """High-level facade for worker state lifecycle operations.
+
+    Usage::
+
+        mgr = WorkerStateManager(state_dir)
+
+        # On lease acquisition (§8.3 step 1):
+        result = mgr.initialize("T1", dispatch_id="d-001")
+
+        # On first output detection:
+        result = mgr.transition("T1", "working", reason="first stdout output")
+
+        # Record output events:
+        mgr.record_output("T1")
+
+        # On clean exit:
+        result = mgr.transition("T1", "exited_clean", reason="exit code 0")
+
+        # On lease release (§8.3 step 4):
+        mgr.cleanup("T1")
+
+        # T0 reads state:
+        state = mgr.get("T1")
+        summary = mgr.get_all_states()
+    """
+
+    def __init__(self, state_dir: str | Path, *, auto_init: bool = True) -> None:
+        self.state_dir = Path(state_dir)
+        self._auto_init = auto_init
+        self._initialized = False
+
+    def _ensure_init(self) -> None:
+        if not self._initialized and self._auto_init:
+            init_schema(self.state_dir)
+            self._initialized = True
+
+    # -----------------------------------------------------------------------
+    # Lifecycle operations (§8.3)
+    # -----------------------------------------------------------------------
+
+    def initialize(
+        self,
+        terminal_id: str,
+        dispatch_id: str,
+        *,
+        actor: str = "worker_supervisor",
+        reason: Optional[str] = None,
+    ) -> WorkerStateResult:
+        """Create worker state row in 'initializing' for a newly leased terminal.
+
+        If a row already exists for this terminal, it is replaced (new dispatch
+        overwrites previous worker state — §8.1 design: single row per terminal).
+        """
+        self._ensure_init()
+        now = _now_utc()
+
+        with get_connection(self.state_dir) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO worker_states
+                    (terminal_id, dispatch_id, state, last_output_at,
+                     state_entered_at, stall_count, blocked_reason,
+                     metadata_json, created_at, updated_at)
+                VALUES (?, ?, 'initializing', NULL, ?, 0, NULL, NULL, ?, ?)
+                """,
+                (terminal_id, dispatch_id, now, now, now),
+            )
+
+            _append_worker_event(
+                conn,
+                event_type="worker_state_changed",
+                terminal_id=terminal_id,
+                from_state=None,
+                to_state="initializing",
+                actor=actor,
+                reason=reason or f"worker initialized for dispatch {dispatch_id}",
+                metadata={"dispatch_id": dispatch_id},
+            )
+            conn.commit()
+
+            row = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+        return WorkerStateResult.from_row(dict(row))
+
+    def transition(
+        self,
+        terminal_id: str,
+        to_state: str,
+        *,
+        actor: str = "worker_supervisor",
+        reason: Optional[str] = None,
+        blocked_reason: Optional[str] = None,
+    ) -> WorkerStateResult:
+        """Transition worker to a new state with validation against §3.2.
+
+        For 'blocked' transitions, blocked_reason should describe the obstacle.
+        Transitions to 'stalled' auto-increment stall_count.
+        """
+        self._ensure_init()
+        validate_worker_state(to_state)
+
+        with get_connection(self.state_dir) as conn:
+            row = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+            if row is None:
+                raise KeyError(
+                    f"No worker state for terminal {terminal_id!r}. "
+                    "Was initialize() called after lease acquisition?"
+                )
+
+            current = dict(row)
+            from_state = current["state"]
+            validate_worker_transition(from_state, to_state)
+
+            now = _now_utc()
+            stall_count = current["stall_count"]
+            if to_state == "stalled":
+                stall_count += 1
+
+            new_blocked_reason = blocked_reason if to_state == "blocked" else None
+
+            conn.execute(
+                """
+                UPDATE worker_states
+                SET state = ?, state_entered_at = ?, stall_count = ?,
+                    blocked_reason = ?, updated_at = ?
+                WHERE terminal_id = ?
+                """,
+                (to_state, now, stall_count, new_blocked_reason, now, terminal_id),
+            )
+
+            event_type = _event_type_for_transition(from_state, to_state)
+            _append_worker_event(
+                conn,
+                event_type=event_type,
+                terminal_id=terminal_id,
+                from_state=from_state,
+                to_state=to_state,
+                actor=actor,
+                reason=reason,
+                metadata={
+                    "dispatch_id": current["dispatch_id"],
+                    "stall_count": stall_count,
+                    "blocked_reason": new_blocked_reason,
+                },
+            )
+            conn.commit()
+
+            updated = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+        return WorkerStateResult.from_row(dict(updated))
+
+    def record_output(
+        self,
+        terminal_id: str,
+        *,
+        actor: str = "output_monitor",
+    ) -> WorkerStateResult:
+        """Record an output event — updates last_output_at timestamp.
+
+        Per §4.1 H-2: output events update last_output_at independently of
+        heartbeat. Heartbeat proves liveness; output proves progress.
+        """
+        self._ensure_init()
+        now = _now_utc()
+
+        with get_connection(self.state_dir) as conn:
+            row = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+            if row is None:
+                raise KeyError(f"No worker state for terminal {terminal_id!r}.")
+
+            conn.execute(
+                """
+                UPDATE worker_states
+                SET last_output_at = ?, updated_at = ?
+                WHERE terminal_id = ?
+                """,
+                (now, now, terminal_id),
+            )
+
+            _append_worker_event(
+                conn,
+                event_type="worker_output_detected",
+                terminal_id=terminal_id,
+                from_state=row["state"],
+                to_state=row["state"],
+                actor=actor,
+                reason="output event detected",
+                metadata={
+                    "dispatch_id": row["dispatch_id"],
+                    "last_output_at": now,
+                },
+            )
+            conn.commit()
+
+            updated = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+        return WorkerStateResult.from_row(dict(updated))
+
+    def cleanup(
+        self,
+        terminal_id: str,
+        *,
+        actor: str = "worker_supervisor",
+        reason: Optional[str] = None,
+    ) -> None:
+        """Remove worker state row on lease release (§8.3 step 4).
+
+        The worker state row is deleted so the terminal can accept a new dispatch.
+        A coordination event is appended for audit trail.
+        """
+        self._ensure_init()
+
+        with get_connection(self.state_dir) as conn:
+            row = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+
+            if row is None:
+                return
+
+            current = dict(row)
+            conn.execute(
+                "DELETE FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            )
+
+            _append_worker_event(
+                conn,
+                event_type="worker_state_cleaned",
+                terminal_id=terminal_id,
+                from_state=current["state"],
+                to_state=None,
+                actor=actor,
+                reason=reason or "lease released, worker state cleaned up",
+                metadata={
+                    "dispatch_id": current["dispatch_id"],
+                    "final_state": current["state"],
+                    "stall_count": current["stall_count"],
+                },
+            )
+            conn.commit()
+
+    # -----------------------------------------------------------------------
+    # Query helpers — T0-readable state surface (§6)
+    # -----------------------------------------------------------------------
+
+    def get(self, terminal_id: str) -> Optional[WorkerStateResult]:
+        """Return current worker state for a terminal, or None if no active worker."""
+        self._ensure_init()
+        with get_connection(self.state_dir) as conn:
+            row = conn.execute(
+                "SELECT * FROM worker_states WHERE terminal_id = ?",
+                (terminal_id,),
+            ).fetchone()
+        return WorkerStateResult.from_row(dict(row)) if row else None
+
+    def get_all_states(self) -> List[WorkerStateResult]:
+        """Return worker state for all terminals with active workers."""
+        self._ensure_init()
+        with get_connection(self.state_dir) as conn:
+            rows = conn.execute(
+                "SELECT * FROM worker_states ORDER BY terminal_id"
+            ).fetchall()
+        return [WorkerStateResult.from_row(dict(r)) for r in rows]
+
+    def get_state_summary(self) -> Dict[str, Any]:
+        """Return T0-readable summary of all worker states with heartbeat classification.
+
+        This is the canonical read-model surface for T0 and downstream consumers.
+        No terminal scraping required.
+        """
+        self._ensure_init()
+        with get_connection(self.state_dir) as conn:
+            workers = conn.execute(
+                "SELECT * FROM worker_states ORDER BY terminal_id"
+            ).fetchall()
+            leases = conn.execute(
+                "SELECT terminal_id, last_heartbeat_at FROM terminal_leases"
+            ).fetchall()
+
+        heartbeat_map = {r["terminal_id"]: r["last_heartbeat_at"] for r in leases}
+        now = datetime.now(timezone.utc)
+
+        terminals: Dict[str, Any] = {}
+        for row in workers:
+            r = dict(row)
+            tid = r["terminal_id"]
+            hb = heartbeat_map.get(tid)
+            hb_class = classify_heartbeat(hb, now=now)
+
+            terminals[tid] = {
+                "terminal_id": tid,
+                "dispatch_id": r["dispatch_id"],
+                "worker_state": r["state"],
+                "state_entered_at": r["state_entered_at"],
+                "last_output_at": r["last_output_at"],
+                "last_heartbeat_at": hb,
+                "heartbeat_classification": hb_class,
+                "stall_count": r["stall_count"],
+                "blocked_reason": r["blocked_reason"],
+                "is_terminal": is_terminal_worker_state(r["state"]),
+            }
+
+        return {"terminals": terminals}
+
+
+# ---------------------------------------------------------------------------
+# Event type mapping (§8.2)
+# ---------------------------------------------------------------------------
+
+def _event_type_for_transition(from_state: str, to_state: str) -> str:
+    """Map a state transition to its coordination event type per §8.2."""
+    if to_state == "stalled":
+        return "worker_stall_detected"
+    if to_state == "working" and from_state in ("stalled", "initializing", "blocked", "awaiting_input"):
+        return "worker_output_detected"
+    if to_state == "blocked":
+        return "worker_blocked"
+    if to_state in TERMINAL_WORKER_STATES:
+        return "worker_exited"
+    return "worker_state_changed"
+
+
+# ---------------------------------------------------------------------------
+# Module-level factory
+# ---------------------------------------------------------------------------
+
+def load_manager(state_dir: str | Path) -> WorkerStateManager:
+    """Return a WorkerStateManager for state_dir, auto-initializing the schema."""
+    return WorkerStateManager(state_dir, auto_init=True)

--- a/tests/test_worker_state_machine.py
+++ b/tests/test_worker_state_machine.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""
+Tests for worker_state_manager.py (Feature 12, PR-1)
+
+Quality gate coverage (gate_pr1_state_machine_and_heartbeat):
+  - All runtime state machine and heartbeat tests pass
+  - Launch, output, clean exit, bad exit, and interruption transitions are explicit
+  - Heartbeat and last-output timestamps persist in canonical runtime state
+  - T0-readable state surface exists without scraping terminal behavior
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from runtime_coordination import (
+    get_connection,
+    get_events,
+    init_schema,
+    register_dispatch,
+    acquire_lease,
+)
+from worker_state_manager import (
+    WORKER_STATES,
+    WORKER_TRANSITIONS,
+    TERMINAL_WORKER_STATES,
+    ACTIVE_WORKER_STATES,
+    DEFAULT_HEARTBEAT_STALE_THRESHOLD,
+    DEFAULT_HEARTBEAT_DEAD_THRESHOLD,
+    WorkerStateManager,
+    WorkerStateResult,
+    InvalidWorkerStateError,
+    InvalidWorkerTransitionError,
+    classify_heartbeat,
+    validate_worker_state,
+    validate_worker_transition,
+    is_terminal_worker_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _setup_state_dir(tmp_path: str) -> str:
+    """Initialize schema and return state_dir."""
+    state_dir = os.path.join(tmp_path, "state")
+    os.makedirs(state_dir, exist_ok=True)
+    init_schema(state_dir)
+    return state_dir
+
+
+def _register_and_lease(state_dir: str, terminal_id: str = "T1", dispatch_id: str = "d-001"):
+    """Register a dispatch and acquire a lease — prerequisites for worker state."""
+    with get_connection(state_dir) as conn:
+        register_dispatch(conn, dispatch_id=dispatch_id, terminal_id=terminal_id, track="B")
+        acquire_lease(conn, terminal_id=terminal_id, dispatch_id=dispatch_id)
+        conn.commit()
+
+
+# ===========================================================================
+# Test: State validation
+# ===========================================================================
+
+class TestWorkerStateValidation(unittest.TestCase):
+
+    def test_all_states_defined(self):
+        expected = {
+            "initializing", "working", "idle_between_tasks", "stalled",
+            "blocked", "awaiting_input", "exited_clean", "exited_bad",
+            "resume_unsafe",
+        }
+        self.assertEqual(WORKER_STATES, expected)
+
+    def test_terminal_states(self):
+        self.assertEqual(TERMINAL_WORKER_STATES, {"exited_clean", "exited_bad", "resume_unsafe"})
+
+    def test_active_states(self):
+        self.assertEqual(ACTIVE_WORKER_STATES, WORKER_STATES - TERMINAL_WORKER_STATES)
+
+    def test_validate_valid_state(self):
+        for state in WORKER_STATES:
+            validate_worker_state(state)
+
+    def test_validate_invalid_state_raises(self):
+        with self.assertRaises(InvalidWorkerStateError):
+            validate_worker_state("nonexistent")
+
+    def test_is_terminal(self):
+        for state in TERMINAL_WORKER_STATES:
+            self.assertTrue(is_terminal_worker_state(state))
+        for state in ACTIVE_WORKER_STATES:
+            self.assertFalse(is_terminal_worker_state(state))
+
+
+# ===========================================================================
+# Test: Transition matrix (§3.2)
+# ===========================================================================
+
+class TestTransitionMatrix(unittest.TestCase):
+
+    def test_terminal_states_have_no_outgoing(self):
+        """W-T1: Terminal states have no outgoing transitions."""
+        for state in TERMINAL_WORKER_STATES:
+            self.assertEqual(WORKER_TRANSITIONS[state], frozenset())
+
+    def test_initializing_cannot_reach_idle_between_tasks(self):
+        """W-T4: initializing cannot reach idle_between_tasks."""
+        self.assertNotIn("idle_between_tasks", WORKER_TRANSITIONS["initializing"])
+
+    def test_initializing_cannot_reach_awaiting_input(self):
+        """W-T4: initializing cannot reach awaiting_input."""
+        self.assertNotIn("awaiting_input", WORKER_TRANSITIONS["initializing"])
+
+    def test_stalled_cannot_reach_idle_between_tasks(self):
+        """W-T2: stalled can only recover to working or exit."""
+        allowed = WORKER_TRANSITIONS["stalled"]
+        self.assertNotIn("idle_between_tasks", allowed)
+        self.assertIn("working", allowed)
+
+    def test_blocked_cannot_reach_idle_between_tasks(self):
+        """W-T3: blocked can only recover to working or exit."""
+        self.assertNotIn("idle_between_tasks", WORKER_TRANSITIONS["blocked"])
+
+    def test_awaiting_input_cannot_reach_idle_between_tasks(self):
+        """W-T3: awaiting_input can only recover to working or exit."""
+        self.assertNotIn("idle_between_tasks", WORKER_TRANSITIONS["awaiting_input"])
+
+    def test_valid_transition_passes(self):
+        validate_worker_transition("initializing", "working")
+        validate_worker_transition("working", "exited_clean")
+
+    def test_invalid_transition_raises(self):
+        with self.assertRaises(InvalidWorkerTransitionError):
+            validate_worker_transition("exited_clean", "working")
+
+    def test_all_transitions_reference_valid_states(self):
+        for from_state, to_states in WORKER_TRANSITIONS.items():
+            self.assertIn(from_state, WORKER_STATES)
+            for to_state in to_states:
+                self.assertIn(to_state, WORKER_STATES)
+
+
+# ===========================================================================
+# Test: Worker state lifecycle
+# ===========================================================================
+
+class TestWorkerStateLifecycle(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    # -- Initialize --
+
+    def test_initialize_creates_worker_state(self):
+        result = self.mgr.initialize("T1", "d-001")
+        self.assertEqual(result.terminal_id, "T1")
+        self.assertEqual(result.dispatch_id, "d-001")
+        self.assertEqual(result.state, "initializing")
+        self.assertIsNone(result.last_output_at)
+        self.assertEqual(result.stall_count, 0)
+        self.assertIsNone(result.blocked_reason)
+
+    def test_initialize_replaces_existing(self):
+        self.mgr.initialize("T1", "d-001")
+        _register_and_lease_second(self.state_dir)
+        result = self.mgr.initialize("T1", "d-002")
+        self.assertEqual(result.dispatch_id, "d-002")
+        self.assertEqual(result.state, "initializing")
+
+    # -- Launch → Working (first output) --
+
+    def test_launch_to_working(self):
+        self.mgr.initialize("T1", "d-001")
+        result = self.mgr.transition("T1", "working", reason="first stdout output")
+        self.assertEqual(result.state, "working")
+
+    # -- Working → Clean exit --
+
+    def test_working_to_exited_clean(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition("T1", "exited_clean", reason="exit code 0")
+        self.assertEqual(result.state, "exited_clean")
+
+    # -- Working → Bad exit --
+
+    def test_working_to_exited_bad(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition("T1", "exited_bad", reason="exit code 1")
+        self.assertEqual(result.state, "exited_bad")
+
+    # -- Interruption → resume_unsafe --
+
+    def test_working_to_resume_unsafe(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition("T1", "resume_unsafe", reason="forced termination")
+        self.assertEqual(result.state, "resume_unsafe")
+
+    def test_stalled_to_resume_unsafe(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "stalled")
+        result = self.mgr.transition("T1", "resume_unsafe", reason="TTL expiry during stall")
+        self.assertEqual(result.state, "resume_unsafe")
+
+    # -- Working → idle_between_tasks → working --
+
+    def test_idle_between_tasks_cycle(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition("T1", "idle_between_tasks", reason="sub-task boundary")
+        self.assertEqual(result.state, "idle_between_tasks")
+        result = self.mgr.transition("T1", "working", reason="next sub-task started")
+        self.assertEqual(result.state, "working")
+
+    # -- Blocked --
+
+    def test_blocked_with_reason(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition(
+            "T1", "blocked",
+            blocked_reason="MCP tool timeout: brave_web_search",
+        )
+        self.assertEqual(result.state, "blocked")
+        self.assertEqual(result.blocked_reason, "MCP tool timeout: brave_web_search")
+
+    def test_blocked_to_working_clears_reason(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "blocked", blocked_reason="test")
+        result = self.mgr.transition("T1", "working", reason="unblocked")
+        self.assertIsNone(result.blocked_reason)
+
+    # -- Awaiting input --
+
+    def test_awaiting_input_from_working(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.transition("T1", "awaiting_input")
+        self.assertEqual(result.state, "awaiting_input")
+
+    # -- Stall count --
+
+    def test_stall_count_increments(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        r1 = self.mgr.transition("T1", "stalled")
+        self.assertEqual(r1.stall_count, 1)
+        self.mgr.transition("T1", "working")
+        r2 = self.mgr.transition("T1", "stalled")
+        self.assertEqual(r2.stall_count, 2)
+
+    # -- Terminal states block further transitions --
+
+    def test_terminal_state_blocks_transition(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "exited_clean")
+        with self.assertRaises(InvalidWorkerTransitionError):
+            self.mgr.transition("T1", "working")
+
+    # -- Missing worker state --
+
+    def test_transition_without_initialize_raises(self):
+        with self.assertRaises(KeyError):
+            self.mgr.transition("T1", "working")
+
+    # -- Illegal transitions --
+
+    def test_initializing_to_idle_between_tasks_raises(self):
+        self.mgr.initialize("T1", "d-001")
+        with self.assertRaises(InvalidWorkerTransitionError):
+            self.mgr.transition("T1", "idle_between_tasks")
+
+    def test_initializing_to_awaiting_input_raises(self):
+        self.mgr.initialize("T1", "d-001")
+        with self.assertRaises(InvalidWorkerTransitionError):
+            self.mgr.transition("T1", "awaiting_input")
+
+    def test_stalled_to_idle_between_tasks_raises(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "stalled")
+        with self.assertRaises(InvalidWorkerTransitionError):
+            self.mgr.transition("T1", "idle_between_tasks")
+
+
+# ===========================================================================
+# Test: Output tracking and heartbeat persistence
+# ===========================================================================
+
+class TestOutputAndHeartbeatPersistence(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_record_output_updates_last_output_at(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.record_output("T1")
+        self.assertIsNotNone(result.last_output_at)
+
+    def test_record_output_does_not_change_state(self):
+        """H-2: output events update last_output_at, not heartbeat or state."""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        result = self.mgr.record_output("T1")
+        self.assertEqual(result.state, "working")
+
+    def test_last_output_at_persists_across_reads(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.record_output("T1")
+        state = self.mgr.get("T1")
+        self.assertIsNotNone(state.last_output_at)
+
+    def test_state_entered_at_updates_on_transition(self):
+        self.mgr.initialize("T1", "d-001")
+        r1 = self.mgr.get("T1")
+        entered_init = r1.state_entered_at
+        r2 = self.mgr.transition("T1", "working")
+        self.assertNotEqual(r2.state_entered_at, entered_init)
+
+    def test_heartbeat_in_lease_persists(self):
+        """Heartbeat is tracked in terminal_leases.last_heartbeat_at (existing)."""
+        with get_connection(self.state_dir) as conn:
+            row = conn.execute(
+                "SELECT last_heartbeat_at FROM terminal_leases WHERE terminal_id = 'T1'"
+            ).fetchone()
+        self.assertIsNotNone(row["last_heartbeat_at"])
+
+
+# ===========================================================================
+# Test: Heartbeat classification (§4.2)
+# ===========================================================================
+
+class TestHeartbeatClassification(unittest.TestCase):
+
+    def _ts(self, seconds_ago: float) -> str:
+        ts = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return ts.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+    def test_fresh(self):
+        self.assertEqual(classify_heartbeat(self._ts(10)), "fresh")
+
+    def test_stale(self):
+        self.assertEqual(classify_heartbeat(self._ts(100)), "stale")
+
+    def test_dead(self):
+        self.assertEqual(classify_heartbeat(self._ts(400)), "dead")
+
+    def test_none_is_dead(self):
+        self.assertEqual(classify_heartbeat(None), "dead")
+
+    def test_boundary_fresh_stale(self):
+        self.assertEqual(classify_heartbeat(self._ts(89)), "fresh")
+        self.assertEqual(classify_heartbeat(self._ts(91)), "stale")
+
+    def test_boundary_stale_dead(self):
+        self.assertEqual(classify_heartbeat(self._ts(299)), "stale")
+        self.assertEqual(classify_heartbeat(self._ts(301)), "dead")
+
+    def test_custom_thresholds(self):
+        result = classify_heartbeat(
+            self._ts(50),
+            stale_threshold=30,
+            dead_threshold=60,
+        )
+        self.assertEqual(result, "stale")
+
+
+# ===========================================================================
+# Test: Cleanup (§8.3 step 4)
+# ===========================================================================
+
+class TestCleanup(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_cleanup_removes_worker_state(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.cleanup("T1")
+        self.assertIsNone(self.mgr.get("T1"))
+
+    def test_cleanup_noop_for_missing(self):
+        self.mgr.cleanup("T1")  # no error
+
+    def test_cleanup_emits_event(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.cleanup("T1")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(
+                conn, entity_id="T1", event_type="worker_state_cleaned"
+            )
+        self.assertGreaterEqual(len(events), 1)
+
+
+# ===========================================================================
+# Test: T0-readable state surface (§6)
+# ===========================================================================
+
+class TestStateSurface(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_get_returns_none_for_uninitialized(self):
+        self.assertIsNone(self.mgr.get("T1"))
+
+    def test_get_returns_state(self):
+        self.mgr.initialize("T1", "d-001")
+        result = self.mgr.get("T1")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.state, "initializing")
+
+    def test_get_all_states(self):
+        self.mgr.initialize("T1", "d-001")
+        states = self.mgr.get_all_states()
+        self.assertEqual(len(states), 1)
+        self.assertEqual(states[0].terminal_id, "T1")
+
+    def test_get_state_summary(self):
+        self.mgr.initialize("T1", "d-001")
+        summary = self.mgr.get_state_summary()
+        self.assertIn("T1", summary["terminals"])
+        t1 = summary["terminals"]["T1"]
+        self.assertEqual(t1["worker_state"], "initializing")
+        self.assertIn("heartbeat_classification", t1)
+        self.assertIn("is_terminal", t1)
+        self.assertFalse(t1["is_terminal"])
+
+    def test_summary_shows_terminal_state(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "exited_clean")
+        summary = self.mgr.get_state_summary()
+        self.assertTrue(summary["terminals"]["T1"]["is_terminal"])
+
+
+# ===========================================================================
+# Test: Coordination events (§8.2)
+# ===========================================================================
+
+class TestCoordinationEvents(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_initialize_emits_event(self):
+        self.mgr.initialize("T1", "d-001")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id="T1", entity_type="worker")
+        state_events = [e for e in events if e["event_type"] == "worker_state_changed"]
+        self.assertGreaterEqual(len(state_events), 1)
+        self.assertEqual(state_events[0]["to_state"], "initializing")
+
+    def test_stall_detection_event_type(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "stalled")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id="T1", event_type="worker_stall_detected")
+        self.assertGreaterEqual(len(events), 1)
+
+    def test_exit_event_type(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "exited_bad")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id="T1", event_type="worker_exited")
+        self.assertGreaterEqual(len(events), 1)
+
+    def test_blocked_event_type(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "blocked", blocked_reason="test")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id="T1", event_type="worker_blocked")
+        self.assertGreaterEqual(len(events), 1)
+
+    def test_output_detected_event(self):
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.record_output("T1")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id="T1", event_type="worker_output_detected")
+        self.assertGreaterEqual(len(events), 1)
+
+
+# ===========================================================================
+# Test: Full lifecycle scenarios
+# ===========================================================================
+
+class TestFullLifecycleScenarios(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state_dir(self._tmp.name)
+        _register_and_lease(self.state_dir)
+        self.mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_happy_path_clean_exit(self):
+        """initializing → working → exited_clean → cleanup"""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working", reason="first output")
+        self.mgr.record_output("T1")
+        self.mgr.transition("T1", "exited_clean", reason="exit code 0")
+        self.mgr.cleanup("T1")
+        self.assertIsNone(self.mgr.get("T1"))
+
+    def test_bad_exit_from_initializing(self):
+        """initializing → exited_bad (crash during startup)"""
+        self.mgr.initialize("T1", "d-001")
+        result = self.mgr.transition("T1", "exited_bad", reason="crash during context load")
+        self.assertEqual(result.state, "exited_bad")
+
+    def test_stall_recovery_path(self):
+        """working → stalled → working → exited_clean"""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "stalled", reason="no output for 180s")
+        self.mgr.transition("T1", "working", reason="output resumed")
+        result = self.mgr.transition("T1", "exited_clean")
+        self.assertEqual(result.state, "exited_clean")
+        self.assertEqual(result.stall_count, 1)
+
+    def test_blocked_recovery_path(self):
+        """working → blocked → working → exited_clean"""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "blocked", blocked_reason="MCP timeout")
+        self.mgr.transition("T1", "working", reason="unblocked")
+        result = self.mgr.transition("T1", "exited_clean")
+        self.assertEqual(result.state, "exited_clean")
+
+    def test_forced_termination_from_blocked(self):
+        """working → blocked → resume_unsafe"""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "blocked", blocked_reason="resource unavailable")
+        result = self.mgr.transition("T1", "resume_unsafe", reason="operator kill")
+        self.assertEqual(result.state, "resume_unsafe")
+
+    def test_idle_between_tasks_stall(self):
+        """working → idle_between_tasks → stalled → exited_bad"""
+        self.mgr.initialize("T1", "d-001")
+        self.mgr.transition("T1", "working")
+        self.mgr.transition("T1", "idle_between_tasks")
+        self.mgr.transition("T1", "stalled", reason="idle grace exceeded")
+        result = self.mgr.transition("T1", "exited_bad", reason="dead heartbeat")
+        self.assertEqual(result.state, "exited_bad")
+
+
+# ---------------------------------------------------------------------------
+# Helper for multi-dispatch tests
+# ---------------------------------------------------------------------------
+
+def _register_and_lease_second(state_dir: str):
+    """Register a second dispatch and re-lease T1 (simulates new dispatch after release)."""
+    with get_connection(state_dir) as conn:
+        register_dispatch(conn, dispatch_id="d-002", terminal_id="T1", track="B")
+        # Release current lease first
+        row = conn.execute(
+            "SELECT generation FROM terminal_leases WHERE terminal_id = 'T1'"
+        ).fetchone()
+        gen = row["generation"]
+        conn.execute(
+            """UPDATE terminal_leases
+               SET state = 'idle', dispatch_id = NULL, expires_at = NULL,
+                   released_at = datetime('now')
+               WHERE terminal_id = 'T1'"""
+        )
+        acquire_lease(conn, terminal_id="T1", dispatch_id="d-002")
+        conn.commit()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implements canonical worker state machine per Runtime State Machine Contract (§3-§8)
- Adds `worker_states` table (schema v9) with heartbeat classification and stall tracking
- 63 tests covering all 9 states, transition matrix, heartbeat classification, coordination events

## PR-1 of Feature 12: Autonomous Runtime State Machine And Stall Supervision

## Test plan
- [x] 63 unit tests pass (`python -m pytest tests/test_worker_state_machine.py`)
- [x] All gate criteria verified against contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)