### PR TITLE
feat(dashboard): read-model projection layer for operator dashboard

### DIFF
--- a/scripts/lib/dashboard_read_model.py
+++ b/scripts/lib/dashboard_read_model.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""
+VNX Dashboard Read Model — Projection layer for the Coding Operator Dashboard.
+
+Implements the read-model views from the Dashboard Contract
+(docs/core/140_DASHBOARD_READ_MODEL_CONTRACT.md):
+
+  - ProjectsView (§2.2, §3.1): cross-project overview with attention model
+  - SessionView (§2.3): per-project session detail with PR progress
+  - TerminalView (§2.4): per-terminal health with heartbeat and output recency
+  - OpenItemsView (§2.5): per-project open items with severity summary
+  - AggregateOpenItemsView (§2.6, §7): cross-project open item aggregation
+
+Every view response includes a freshness envelope (§3.4) and handles
+degraded, stale, missing, and contradictory source states (§5.1).
+
+The dashboard UI queries ONLY these views — never raw files (§6.1).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Freshness envelope (§3.4)
+# ---------------------------------------------------------------------------
+
+FRESH_THRESHOLD = 60
+AGING_THRESHOLD = 300
+
+
+@dataclass
+class FreshnessEnvelope:
+    """Wraps every read-model response with source freshness tracking."""
+    view: str
+    queried_at: str
+    source_freshness: Dict[str, Optional[str]]
+    staleness_seconds: float
+    degraded: bool
+    degraded_reasons: List[str] = field(default_factory=list)
+    data: Any = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = {
+            "view": self.view,
+            "queried_at": self.queried_at,
+            "source_freshness": self.source_freshness,
+            "staleness_seconds": round(self.staleness_seconds, 1),
+            "degraded": self.degraded,
+            "data": self.data,
+        }
+        if self.degraded_reasons:
+            result["degraded_reasons"] = self.degraded_reasons
+        return result
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now_utc().isoformat()
+
+
+def _file_mtime_iso(path: Path) -> Optional[str]:
+    """Return file mtime as ISO string, or None if file doesn't exist."""
+    try:
+        mt = path.stat().st_mtime
+        return datetime.fromtimestamp(mt, tz=timezone.utc).isoformat()
+    except (OSError, ValueError):
+        return None
+
+
+def _staleness(mtime_iso: Optional[str], now: datetime) -> Optional[float]:
+    """Return age in seconds from an ISO timestamp, or None."""
+    if not mtime_iso:
+        return None
+    try:
+        ts = datetime.fromisoformat(mtime_iso.replace("Z", "+00:00"))
+        return (now - ts).total_seconds()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _load_json(path: Path) -> Optional[Dict[str, Any]]:
+    """Load JSON file, returning None if missing or invalid."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
+    """Load YAML file, returning None if missing, invalid, or yaml unavailable."""
+    if yaml is None:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except (OSError, Exception):
+        return None
+
+
+def _compute_freshness(
+    sources: Dict[str, Optional[str]],
+    now: datetime,
+) -> tuple[float, bool, List[str]]:
+    """Compute max staleness and degraded state from source freshness map.
+
+    Returns (staleness_seconds, degraded, reasons).
+    """
+    max_staleness = 0.0
+    degraded = False
+    reasons: List[str] = []
+
+    for name, mtime in sources.items():
+        if mtime is None:
+            degraded = True
+            reasons.append(f"{name}: unavailable")
+            continue
+        age = _staleness(mtime, now)
+        if age is None:
+            degraded = True
+            reasons.append(f"{name}: unparseable timestamp")
+            continue
+        if age > max_staleness:
+            max_staleness = age
+        if age > AGING_THRESHOLD:
+            degraded = True
+            reasons.append(f"{name}: stale ({age:.0f}s)")
+
+    return max_staleness, degraded, reasons
+
+
+# ---------------------------------------------------------------------------
+# Project Registry (§3.2)
+# ---------------------------------------------------------------------------
+
+DEFAULT_REGISTRY_PATH = Path.home() / ".vnx" / "projects.json"
+
+
+def load_project_registry(
+    registry_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Load the project registry. Returns empty registry if missing."""
+    path = registry_path or DEFAULT_REGISTRY_PATH
+    data = _load_json(path)
+    if data and "projects" in data:
+        return data
+    return {"schema_version": 1, "projects": []}
+
+
+def register_project(
+    name: str,
+    project_path: str,
+    *,
+    vnx_data_dir: str = ".vnx-data",
+    registry_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Register a project in the registry. Idempotent — skips if path exists."""
+    path = registry_path or DEFAULT_REGISTRY_PATH
+    data = load_project_registry(path)
+    for proj in data["projects"]:
+        if proj["path"] == project_path:
+            return proj
+    entry = {
+        "name": name,
+        "path": project_path,
+        "vnx_data_dir": vnx_data_dir,
+        "registered_at": _now_iso(),
+        "active": True,
+    }
+    data["projects"].append(entry)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# TerminalView (§2.4)
+# ---------------------------------------------------------------------------
+
+class TerminalView:
+    """Per-terminal health with heartbeat and output recency from runtime DB."""
+
+    def __init__(self, state_dir: str | Path) -> None:
+        self.state_dir = Path(state_dir)
+
+    def get_terminal(self, terminal_id: str) -> FreshnessEnvelope:
+        now = _now_utc()
+        db_path = self.state_dir / "runtime_coordination.db"
+        db_mtime = _file_mtime_iso(db_path)
+
+        ctx_path = self.state_dir / f"context_window_{terminal_id}.json"
+        ctx_mtime = _file_mtime_iso(ctx_path)
+
+        sources = {
+            "runtime_coordination.db": db_mtime,
+            f"context_window_{terminal_id}.json": ctx_mtime,
+        }
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+
+        terminal_data = self._read_terminal(terminal_id, ctx_path)
+        if terminal_data is None:
+            degraded = True
+            reasons.append(f"terminal {terminal_id}: no data in runtime DB")
+            terminal_data = {"terminal_id": terminal_id, "status": "unknown"}
+
+        return FreshnessEnvelope(
+            view="TerminalView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded,
+            degraded_reasons=reasons,
+            data=terminal_data,
+        )
+
+    def get_all_terminals(self) -> FreshnessEnvelope:
+        now = _now_utc()
+        db_path = self.state_dir / "runtime_coordination.db"
+        db_mtime = _file_mtime_iso(db_path)
+        sources = {"runtime_coordination.db": db_mtime}
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+
+        terminals = self._read_all_terminals()
+
+        return FreshnessEnvelope(
+            view="TerminalView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded,
+            degraded_reasons=reasons,
+            data=terminals,
+        )
+
+    def _read_terminal(self, terminal_id: str, ctx_path: Path) -> Optional[Dict[str, Any]]:
+        try:
+            from runtime_coordination import get_connection
+            from worker_state_manager import classify_heartbeat, is_terminal_worker_state
+        except ImportError:
+            return None
+
+        try:
+            with get_connection(self.state_dir) as conn:
+                lease = conn.execute(
+                    "SELECT * FROM terminal_leases WHERE terminal_id = ?",
+                    (terminal_id,),
+                ).fetchone()
+                if lease is None:
+                    return None
+                lease = dict(lease)
+
+                worker = conn.execute(
+                    "SELECT * FROM worker_states WHERE terminal_id = ?",
+                    (terminal_id,),
+                ).fetchone()
+                worker = dict(worker) if worker else None
+        except Exception:
+            return None
+
+        now = _now_utc()
+        hb_class = classify_heartbeat(lease.get("last_heartbeat_at"), now=now)
+
+        result: Dict[str, Any] = {
+            "terminal_id": terminal_id,
+            "lease_state": lease["state"],
+            "dispatch_id": lease.get("dispatch_id"),
+            "heartbeat_classification": hb_class,
+            "last_heartbeat_at": lease.get("last_heartbeat_at"),
+        }
+
+        if worker:
+            result["worker_state"] = worker["state"]
+            result["last_output_at"] = worker.get("last_output_at")
+            result["state_entered_at"] = worker["state_entered_at"]
+            result["stall_count"] = worker["stall_count"]
+            result["blocked_reason"] = worker.get("blocked_reason")
+            result["is_terminal"] = is_terminal_worker_state(worker["state"])
+            # Derive display status from worker state
+            result["status"] = worker["state"]
+        else:
+            result["worker_state"] = None
+            result["status"] = "idle" if lease["state"] == "idle" else lease["state"]
+
+        # Context pressure
+        ctx_data = _load_json(ctx_path)
+        if ctx_data and "remaining_pct" in ctx_data:
+            result["context_pressure"] = {
+                "remaining_pct": ctx_data["remaining_pct"],
+                "warning": ctx_data["remaining_pct"] < 25,
+            }
+
+        return result
+
+    def _read_all_terminals(self) -> List[Dict[str, Any]]:
+        try:
+            from runtime_coordination import get_connection
+            from worker_state_manager import classify_heartbeat, is_terminal_worker_state
+        except ImportError:
+            return []
+
+        try:
+            with get_connection(self.state_dir) as conn:
+                leases = conn.execute("SELECT * FROM terminal_leases ORDER BY terminal_id").fetchall()
+                workers = conn.execute("SELECT * FROM worker_states").fetchall()
+        except Exception:
+            return []
+
+        worker_map = {dict(w)["terminal_id"]: dict(w) for w in workers}
+        now = _now_utc()
+        terminals = []
+
+        for lease_row in leases:
+            lease = dict(lease_row)
+            tid = lease["terminal_id"]
+            worker = worker_map.get(tid)
+            hb_class = classify_heartbeat(lease.get("last_heartbeat_at"), now=now)
+
+            entry: Dict[str, Any] = {
+                "terminal_id": tid,
+                "lease_state": lease["state"],
+                "dispatch_id": lease.get("dispatch_id"),
+                "heartbeat_classification": hb_class,
+                "last_heartbeat_at": lease.get("last_heartbeat_at"),
+            }
+            if worker:
+                entry["worker_state"] = worker["state"]
+                entry["last_output_at"] = worker.get("last_output_at")
+                entry["stall_count"] = worker["stall_count"]
+                entry["status"] = worker["state"]
+                entry["is_terminal"] = is_terminal_worker_state(worker["state"])
+            else:
+                entry["worker_state"] = None
+                entry["status"] = "idle" if lease["state"] == "idle" else lease["state"]
+
+            terminals.append(entry)
+
+        return terminals
+
+
+# ---------------------------------------------------------------------------
+# OpenItemsView (§2.5)
+# ---------------------------------------------------------------------------
+
+class OpenItemsView:
+    """Per-project open items with severity summary."""
+
+    def __init__(self, state_dir: str | Path) -> None:
+        self.state_dir = Path(state_dir)
+
+    def get_items(
+        self,
+        *,
+        severity: Optional[str] = None,
+        status: Optional[str] = None,
+        include_resolved: bool = False,
+    ) -> FreshnessEnvelope:
+        now = _now_utc()
+        oi_path = self.state_dir / "open_items.json"
+        oi_mtime = _file_mtime_iso(oi_path)
+        sources = {"open_items.json": oi_mtime}
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+
+        raw = _load_json(oi_path)
+        if raw is None:
+            degraded = True
+            reasons.append("open_items.json: unavailable")
+            return FreshnessEnvelope(
+                view="OpenItemsView",
+                queried_at=_now_iso(),
+                source_freshness=sources,
+                staleness_seconds=staleness,
+                degraded=degraded,
+                degraded_reasons=reasons,
+                data={"items": [], "summary": {"blocker_count": 0, "warn_count": 0, "info_count": 0}},
+            )
+
+        items = raw.get("items", [])
+
+        # Filter
+        if not include_resolved:
+            items = [i for i in items if i.get("status", "open") == "open"
+                     and i.get("resolved_at") is None
+                     and i.get("closed_at") is None]
+        if severity:
+            items = [i for i in items if i.get("severity") == severity]
+        if status:
+            items = [i for i in items if i.get("status") == status]
+
+        # Sort: blocker > warn > info, then oldest first
+        severity_order = {"blocker": 0, "blocking": 0, "warn": 1, "warning": 1, "info": 2}
+        items.sort(key=lambda x: (
+            severity_order.get(x.get("severity", "info"), 3),
+            x.get("created_at", ""),
+        ))
+
+        # Enrich with age
+        for item in items:
+            created = item.get("created_at") or item.get("detected_at")
+            age = _staleness(created, now)
+            item["age_seconds"] = round(age, 0) if age is not None else None
+
+        # Summary
+        open_items = [i for i in items if i.get("status", "open") == "open"
+                      and i.get("resolved_at") is None
+                      and i.get("closed_at") is None]
+        summary = {
+            "blocker_count": sum(1 for i in open_items if i.get("severity") in ("blocker", "blocking")),
+            "warn_count": sum(1 for i in open_items if i.get("severity") in ("warn", "warning")),
+            "info_count": sum(1 for i in open_items if i.get("severity") == "info"),
+        }
+
+        return FreshnessEnvelope(
+            view="OpenItemsView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded,
+            degraded_reasons=reasons,
+            data={"items": items, "summary": summary},
+        )
+
+
+# ---------------------------------------------------------------------------
+# AggregateOpenItemsView (§2.6, §7)
+# ---------------------------------------------------------------------------
+
+class AggregateOpenItemsView:
+    """Cross-project open item aggregation from project registry."""
+
+    def __init__(self, registry_path: Optional[Path] = None) -> None:
+        self.registry_path = registry_path or DEFAULT_REGISTRY_PATH
+
+    def get_aggregate(
+        self,
+        *,
+        project_filter: Optional[str] = None,
+    ) -> FreshnessEnvelope:
+        now = _now_utc()
+        registry = load_project_registry(self.registry_path)
+        projects = [p for p in registry.get("projects", []) if p.get("active", True)]
+
+        if project_filter:
+            projects = [p for p in projects if p["name"] == project_filter]
+
+        all_items: List[Dict[str, Any]] = []
+        per_project: Dict[str, Dict[str, Any]] = {}
+        sources: Dict[str, Optional[str]] = {}
+        degraded_reasons: List[str] = []
+
+        for proj in projects:
+            proj_path = Path(proj["path"])
+            data_dir = proj.get("vnx_data_dir", ".vnx-data")
+            state_dir = proj_path / data_dir / "state"
+            oi_path = state_dir / "open_items.json"
+            source_key = f"{proj['name']}/open_items.json"
+            oi_mtime = _file_mtime_iso(oi_path)
+            sources[source_key] = oi_mtime
+
+            raw = _load_json(oi_path)
+            if raw is None:
+                per_project[proj["name"]] = {
+                    "status": "unavailable",
+                    "blocker_count": 0, "warn_count": 0, "info_count": 0,
+                }
+                degraded_reasons.append(f"{proj['name']}: open_items.json unavailable")
+                continue
+
+            items = raw.get("items", [])
+            open_items = [i for i in items
+                          if i.get("status", "open") == "open"
+                          and i.get("resolved_at") is None
+                          and i.get("closed_at") is None]
+
+            for item in open_items:
+                item["_project_name"] = proj["name"]
+                created = item.get("created_at") or item.get("detected_at")
+                age = _staleness(created, now)
+                item["age_seconds"] = round(age, 0) if age is not None else None
+                all_items.append(item)
+
+            per_project[proj["name"]] = {
+                "status": "available",
+                "blocker_count": sum(1 for i in open_items if i.get("severity") in ("blocker", "blocking")),
+                "warn_count": sum(1 for i in open_items if i.get("severity") in ("warn", "warning")),
+                "info_count": sum(1 for i in open_items if i.get("severity") == "info"),
+            }
+
+        # Sort all items: severity then age
+        severity_order = {"blocker": 0, "blocking": 0, "warn": 1, "warning": 1, "info": 2}
+        all_items.sort(key=lambda x: (
+            severity_order.get(x.get("severity", "info"), 3),
+            x.get("created_at", ""),
+        ))
+
+        staleness, degraded, fresh_reasons = _compute_freshness(sources, now)
+        degraded_reasons.extend(fresh_reasons)
+
+        total_summary = {
+            "blocker_count": sum(p.get("blocker_count", 0) for p in per_project.values()),
+            "warn_count": sum(p.get("warn_count", 0) for p in per_project.values()),
+            "info_count": sum(p.get("info_count", 0) for p in per_project.values()),
+        }
+
+        return FreshnessEnvelope(
+            view="AggregateOpenItemsView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded or bool(degraded_reasons),
+            degraded_reasons=degraded_reasons,
+            data={
+                "items": all_items,
+                "per_project_subtotals": per_project,
+                "total_summary": total_summary,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# SessionView (§2.3)
+# ---------------------------------------------------------------------------
+
+class SessionView:
+    """Per-project session detail with PR progress and terminal summary."""
+
+    def __init__(self, state_dir: str | Path) -> None:
+        self.state_dir = Path(state_dir)
+
+    def get_session(self) -> FreshnessEnvelope:
+        now = _now_utc()
+        queue_path = self.state_dir / "pr_queue_state.json"
+        progress_path = self.state_dir / "progress_state.yaml"
+        db_path = self.state_dir / "runtime_coordination.db"
+
+        sources = {
+            "pr_queue_state.json": _file_mtime_iso(queue_path),
+            "progress_state.yaml": _file_mtime_iso(progress_path),
+            "runtime_coordination.db": _file_mtime_iso(db_path),
+        }
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+
+        queue_data = _load_json(queue_path)
+        progress_data = _load_yaml(progress_path)
+
+        session: Dict[str, Any] = {}
+
+        # Feature info from queue
+        if queue_data:
+            session["feature_name"] = queue_data.get("feature")
+            prs = queue_data.get("prs", [])
+            session["pr_progress"] = [
+                {"id": p.get("id"), "title": p.get("title"), "status": p.get("status"),
+                 "track": p.get("track"), "gate": p.get("gate")}
+                for p in prs
+            ]
+        else:
+            session["feature_name"] = None
+            session["pr_progress"] = []
+            degraded = True
+            reasons.append("pr_queue_state.json: unavailable")
+
+        # Track status from progress
+        if progress_data and "tracks" in progress_data:
+            tracks = progress_data["tracks"]
+            session["track_status"] = {}
+            for track_id, track_data in tracks.items():
+                session["track_status"][track_id] = {
+                    "current_gate": track_data.get("current_gate"),
+                    "status": track_data.get("status"),
+                    "active_dispatch_id": track_data.get("active_dispatch_id"),
+                }
+        else:
+            session["track_status"] = {}
+
+        # Terminal summary
+        tv = TerminalView(self.state_dir)
+        terminal_env = tv.get_all_terminals()
+        session["terminal_states"] = terminal_env.data if terminal_env.data else []
+
+        # Last activity: most recent heartbeat or output across terminals
+        last_activity = None
+        for t in session.get("terminal_states", []):
+            for ts_field in ("last_heartbeat_at", "last_output_at"):
+                val = t.get(ts_field)
+                if val and (last_activity is None or val > last_activity):
+                    last_activity = val
+        session["last_activity"] = last_activity
+
+        # Open item summary
+        oi = OpenItemsView(self.state_dir)
+        oi_env = oi.get_items()
+        session["open_item_summary"] = oi_env.data.get("summary", {}) if oi_env.data else {}
+
+        return FreshnessEnvelope(
+            view="SessionView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded,
+            degraded_reasons=reasons,
+            data=session,
+        )
+
+
+# ---------------------------------------------------------------------------
+# ProjectsView (§2.2)
+# ---------------------------------------------------------------------------
+
+class ProjectsView:
+    """Cross-project overview with attention model."""
+
+    def __init__(self, registry_path: Optional[Path] = None) -> None:
+        self.registry_path = registry_path or DEFAULT_REGISTRY_PATH
+
+    def list_projects(self) -> FreshnessEnvelope:
+        now = _now_utc()
+        reg_mtime = _file_mtime_iso(self.registry_path)
+        sources = {"projects.json": reg_mtime}
+
+        registry = load_project_registry(self.registry_path)
+        projects = registry.get("projects", [])
+
+        results: List[Dict[str, Any]] = []
+
+        for proj in projects:
+            if not proj.get("active", True):
+                continue
+            proj_path = Path(proj["path"])
+            data_dir = proj.get("vnx_data_dir", ".vnx-data")
+            state_dir = proj_path / data_dir / "state"
+
+            entry: Dict[str, Any] = {
+                "name": proj["name"],
+                "path": proj["path"],
+                "registered_at": proj.get("registered_at"),
+            }
+
+            # Session active check
+            session_profile = state_dir / "session_profile.json"
+            entry["session_active"] = session_profile.exists()
+
+            # Feature name
+            queue = _load_json(state_dir / "pr_queue_state.json")
+            entry["active_feature"] = queue.get("feature") if queue else None
+
+            # Open items summary
+            oi_raw = _load_json(state_dir / "open_items.json")
+            if oi_raw:
+                open_items = [i for i in oi_raw.get("items", [])
+                              if i.get("status", "open") == "open"
+                              and i.get("resolved_at") is None
+                              and i.get("closed_at") is None]
+                blocker_count = sum(1 for i in open_items if i.get("severity") in ("blocker", "blocking"))
+                warn_count = sum(1 for i in open_items if i.get("severity") in ("warn", "warning"))
+                entry["open_blocker_count"] = blocker_count
+                entry["open_warn_count"] = warn_count
+            else:
+                entry["open_blocker_count"] = 0
+                entry["open_warn_count"] = 0
+
+            # Attention model (§7.3)
+            entry["attention_level"] = self._compute_attention(entry)
+
+            results.append(entry)
+
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+
+        return FreshnessEnvelope(
+            view="ProjectsView",
+            queried_at=_now_iso(),
+            source_freshness=sources,
+            staleness_seconds=staleness,
+            degraded=degraded,
+            degraded_reasons=reasons,
+            data=results,
+        )
+
+    @staticmethod
+    def _compute_attention(proj: Dict[str, Any]) -> str:
+        """Compute attention level per §7.3."""
+        if proj.get("open_blocker_count", 0) > 0:
+            return "critical"
+        if proj.get("open_warn_count", 0) > 0:
+            return "warning"
+        return "clear"

--- a/tests/test_dashboard_read_model.py
+++ b/tests/test_dashboard_read_model.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""
+Tests for dashboard_read_model.py (Feature 13, PR-1)
+
+Quality gate coverage (gate_pr1_dashboard_read_model):
+  - All dashboard read-model projection tests pass
+  - Project session, terminal runtime, and open-item projections are queryable
+  - Aggregate open-item projection across projects is available under test
+  - Degraded or mismatched projection states produce operator-readable diagnostics
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from runtime_coordination import (
+    get_connection,
+    init_schema,
+    register_dispatch,
+    acquire_lease,
+)
+from worker_state_manager import WorkerStateManager
+
+from dashboard_read_model import (
+    FRESH_THRESHOLD,
+    AGING_THRESHOLD,
+    FreshnessEnvelope,
+    TerminalView,
+    OpenItemsView,
+    AggregateOpenItemsView,
+    SessionView,
+    ProjectsView,
+    load_project_registry,
+    register_project,
+    _compute_freshness,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _setup_state(tmp: str) -> str:
+    """Initialize runtime DB in state_dir and return state_dir path."""
+    state_dir = os.path.join(tmp, "state")
+    os.makedirs(state_dir, exist_ok=True)
+    init_schema(state_dir)
+    return state_dir
+
+
+def _write_json(path: Path, data: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _make_open_items(items: list) -> dict:
+    return {"schema_version": "1.0", "items": items, "next_id": len(items) + 1}
+
+
+def _open_item(severity="warn", status="open", title="test", **kwargs):
+    item = {
+        "id": f"OI-{id(title) % 1000:03d}",
+        "status": status,
+        "severity": severity,
+        "title": title,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "details": "",
+        "origin_dispatch_id": "d-test",
+    }
+    item.update(kwargs)
+    return item
+
+
+def _setup_project_tree(base: str, name: str, *, open_items=None, queue=None):
+    """Create a minimal project directory structure."""
+    proj_dir = os.path.join(base, name)
+    state_dir = os.path.join(proj_dir, ".vnx-data", "state")
+    os.makedirs(state_dir, exist_ok=True)
+    if open_items is not None:
+        _write_json(Path(state_dir) / "open_items.json", open_items)
+    if queue is not None:
+        _write_json(Path(state_dir) / "pr_queue_state.json", queue)
+    return proj_dir
+
+
+# ===========================================================================
+# Test: Freshness envelope (§3.4)
+# ===========================================================================
+
+class TestFreshnessEnvelope(unittest.TestCase):
+
+    def test_fresh_sources(self):
+        now = datetime.now(timezone.utc)
+        sources = {"a.json": now.isoformat()}
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+        self.assertLess(staleness, 1)
+        self.assertFalse(degraded)
+        self.assertEqual(reasons, [])
+
+    def test_stale_source_degrades(self):
+        now = datetime.now(timezone.utc)
+        old = (now - timedelta(seconds=400)).isoformat()
+        sources = {"a.json": old}
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+        self.assertTrue(degraded)
+        self.assertIn("a.json: stale", reasons[0])
+
+    def test_missing_source_degrades(self):
+        now = datetime.now(timezone.utc)
+        sources = {"a.json": None}
+        staleness, degraded, reasons = _compute_freshness(sources, now)
+        self.assertTrue(degraded)
+        self.assertIn("unavailable", reasons[0])
+
+    def test_envelope_to_dict(self):
+        env = FreshnessEnvelope(
+            view="TestView",
+            queried_at="2026-04-01T20:00:00Z",
+            source_freshness={"a": "2026-04-01T20:00:00Z"},
+            staleness_seconds=1.5,
+            degraded=False,
+            data={"key": "value"},
+        )
+        d = env.to_dict()
+        self.assertEqual(d["view"], "TestView")
+        self.assertEqual(d["data"]["key"], "value")
+        self.assertFalse(d["degraded"])
+
+
+# ===========================================================================
+# Test: Project Registry (§3.2)
+# ===========================================================================
+
+class TestProjectRegistry(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.reg_path = Path(self._tmp.name) / "projects.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_empty_registry(self):
+        data = load_project_registry(self.reg_path)
+        self.assertEqual(data["projects"], [])
+
+    def test_register_project(self):
+        entry = register_project("test-project", "/tmp/test", registry_path=self.reg_path)
+        self.assertEqual(entry["name"], "test-project")
+        self.assertTrue(entry["active"])
+
+        data = load_project_registry(self.reg_path)
+        self.assertEqual(len(data["projects"]), 1)
+
+    def test_idempotent_registration(self):
+        register_project("test-project", "/tmp/test", registry_path=self.reg_path)
+        register_project("test-project", "/tmp/test", registry_path=self.reg_path)
+        data = load_project_registry(self.reg_path)
+        self.assertEqual(len(data["projects"]), 1)
+
+
+# ===========================================================================
+# Test: TerminalView (§2.4)
+# ===========================================================================
+
+class TestTerminalView(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_idle_terminal(self):
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T1")
+        self.assertEqual(env.view, "TerminalView")
+        self.assertIn("queried_at", env.to_dict())
+        data = env.data
+        self.assertEqual(data["terminal_id"], "T1")
+        self.assertEqual(data["lease_state"], "idle")
+        self.assertEqual(data["status"], "idle")
+
+    def test_working_terminal(self):
+        with get_connection(self.state_dir) as conn:
+            register_dispatch(conn, dispatch_id="d-001", terminal_id="T1", track="B")
+            acquire_lease(conn, terminal_id="T1", dispatch_id="d-001")
+            conn.commit()
+        mgr = WorkerStateManager(self.state_dir, auto_init=False)
+        mgr.initialize("T1", "d-001")
+        mgr.transition("T1", "working")
+
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T1")
+        self.assertEqual(env.data["worker_state"], "working")
+        self.assertEqual(env.data["status"], "working")
+        self.assertEqual(env.data["dispatch_id"], "d-001")
+
+    def test_all_terminals(self):
+        tv = TerminalView(self.state_dir)
+        env = tv.get_all_terminals()
+        self.assertIsInstance(env.data, list)
+        self.assertEqual(len(env.data), 3)  # T1, T2, T3
+        tids = [t["terminal_id"] for t in env.data]
+        self.assertIn("T1", tids)
+
+    def test_context_pressure(self):
+        # Write context window file
+        ctx_path = Path(self.state_dir) / "context_window_T1.json"
+        _write_json(ctx_path, {"remaining_pct": 15, "tokens_used": 85000})
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T1")
+        self.assertIn("context_pressure", env.data)
+        self.assertTrue(env.data["context_pressure"]["warning"])
+
+    def test_missing_terminal(self):
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T99")
+        self.assertTrue(env.degraded)
+        self.assertEqual(env.data["status"], "unknown")
+
+    def test_freshness_envelope_present(self):
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T1")
+        d = env.to_dict()
+        self.assertIn("source_freshness", d)
+        self.assertIn("staleness_seconds", d)
+        self.assertIn("degraded", d)
+
+
+# ===========================================================================
+# Test: OpenItemsView (§2.5)
+# ===========================================================================
+
+class TestOpenItemsView(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = os.path.join(self._tmp.name, "state")
+        os.makedirs(self.state_dir, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_empty_open_items(self):
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items([]))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertEqual(len(env.data["items"]), 0)
+        self.assertEqual(env.data["summary"]["blocker_count"], 0)
+
+    def test_severity_summary(self):
+        items = [
+            _open_item(severity="blocker", title="b1"),
+            _open_item(severity="blocker", title="b2"),
+            _open_item(severity="warn", title="w1"),
+            _open_item(severity="info", title="i1"),
+        ]
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items(items))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertEqual(env.data["summary"]["blocker_count"], 2)
+        self.assertEqual(env.data["summary"]["warn_count"], 1)
+        self.assertEqual(env.data["summary"]["info_count"], 1)
+
+    def test_severity_sort_order(self):
+        """Blockers first, then warnings, then info."""
+        items = [
+            _open_item(severity="info", title="i1"),
+            _open_item(severity="blocker", title="b1"),
+            _open_item(severity="warn", title="w1"),
+        ]
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items(items))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        severities = [i["severity"] for i in env.data["items"]]
+        self.assertEqual(severities, ["blocker", "warn", "info"])
+
+    def test_resolved_items_excluded(self):
+        items = [
+            _open_item(severity="blocker", title="resolved", status="done",
+                       closed_at="2026-04-01T12:00:00Z"),
+            _open_item(severity="warn", title="still open"),
+        ]
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items(items))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertEqual(len(env.data["items"]), 1)
+        self.assertEqual(env.data["items"][0]["title"], "still open")
+
+    def test_missing_file_degrades(self):
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertTrue(env.degraded)
+        self.assertIn("unavailable", env.degraded_reasons[0])
+
+    def test_age_enrichment(self):
+        items = [_open_item(severity="warn", title="aged")]
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items(items))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertIn("age_seconds", env.data["items"][0])
+
+    def test_severity_filter(self):
+        items = [
+            _open_item(severity="blocker", title="b1"),
+            _open_item(severity="warn", title="w1"),
+        ]
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items(items))
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items(severity="blocker")
+        self.assertEqual(len(env.data["items"]), 1)
+
+
+# ===========================================================================
+# Test: AggregateOpenItemsView (§2.6, §7)
+# ===========================================================================
+
+class TestAggregateOpenItemsView(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = self._tmp.name
+        self.reg_path = Path(self.base) / "projects.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_aggregate_across_projects(self):
+        """V-1: Every registered project contributes to aggregate."""
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="blocker", title="p1-blocker"),
+        ]))
+        p2 = _setup_project_tree(self.base, "proj-b", open_items=_make_open_items([
+            _open_item(severity="warn", title="p2-warn"),
+            _open_item(severity="info", title="p2-info"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+        register_project("proj-b", p2, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate()
+        self.assertEqual(env.data["total_summary"]["blocker_count"], 1)
+        self.assertEqual(env.data["total_summary"]["warn_count"], 1)
+        self.assertEqual(env.data["total_summary"]["info_count"], 1)
+        self.assertEqual(len(env.data["items"]), 3)
+
+    def test_per_project_subtotals(self):
+        """V-5: Aggregate shows per-project subtotals."""
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="blocker", title="b1"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate()
+        self.assertIn("proj-a", env.data["per_project_subtotals"])
+        self.assertEqual(env.data["per_project_subtotals"]["proj-a"]["blocker_count"], 1)
+
+    def test_unavailable_project_shows_status(self):
+        """V-6: Unavailable project shows 'data unavailable', not zero."""
+        p1 = os.path.join(self.base, "missing-proj")
+        os.makedirs(p1, exist_ok=True)
+        register_project("missing", p1, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate()
+        self.assertEqual(env.data["per_project_subtotals"]["missing"]["status"], "unavailable")
+        self.assertTrue(env.degraded)
+
+    def test_project_filter(self):
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="blocker", title="b1"),
+        ]))
+        p2 = _setup_project_tree(self.base, "proj-b", open_items=_make_open_items([
+            _open_item(severity="warn", title="w1"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+        register_project("proj-b", p2, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate(project_filter="proj-a")
+        self.assertEqual(len(env.data["items"]), 1)
+        self.assertEqual(env.data["items"][0]["title"], "b1")
+
+    def test_sort_by_severity_then_age(self):
+        """V-2: Items sorted blocker > warn > info, then oldest first."""
+        old = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        new = datetime.now(timezone.utc).isoformat()
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="info", title="new-info", created_at=new),
+            _open_item(severity="blocker", title="old-blocker", created_at=old),
+            _open_item(severity="blocker", title="new-blocker", created_at=new),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate()
+        titles = [i["title"] for i in env.data["items"]]
+        # Blockers first (old before new), then info
+        self.assertEqual(titles[0], "old-blocker")
+        self.assertEqual(titles[1], "new-blocker")
+        self.assertEqual(titles[2], "new-info")
+
+    def test_items_carry_project_name(self):
+        """V-3: Each item shows its project name."""
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="warn", title="test"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        agg = AggregateOpenItemsView(self.reg_path)
+        env = agg.get_aggregate()
+        self.assertEqual(env.data["items"][0]["_project_name"], "proj-a")
+
+
+# ===========================================================================
+# Test: SessionView (§2.3)
+# ===========================================================================
+
+class TestSessionView(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = _setup_state(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_session_with_queue_data(self):
+        queue = {"feature": "Test Feature", "prs": [
+            {"id": "PR-0", "title": "Contract", "status": "completed", "track": "C", "gate": "g0"},
+            {"id": "PR-1", "title": "Impl", "status": "in_progress", "track": "B", "gate": "g1"},
+        ]}
+        _write_json(Path(self.state_dir) / "pr_queue_state.json", queue)
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items([]))
+
+        sv = SessionView(self.state_dir)
+        env = sv.get_session()
+        self.assertEqual(env.data["feature_name"], "Test Feature")
+        self.assertEqual(len(env.data["pr_progress"]), 2)
+
+    def test_session_includes_terminals(self):
+        _write_json(Path(self.state_dir) / "pr_queue_state.json", {"feature": "F", "prs": []})
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items([]))
+
+        sv = SessionView(self.state_dir)
+        env = sv.get_session()
+        self.assertIn("terminal_states", env.data)
+        self.assertEqual(len(env.data["terminal_states"]), 3)
+
+    def test_session_missing_queue_degrades(self):
+        sv = SessionView(self.state_dir)
+        env = sv.get_session()
+        self.assertTrue(env.degraded)
+        self.assertIsNone(env.data["feature_name"])
+
+    def test_session_includes_open_item_summary(self):
+        _write_json(Path(self.state_dir) / "pr_queue_state.json", {"feature": "F", "prs": []})
+        _write_json(Path(self.state_dir) / "open_items.json", _make_open_items([
+            _open_item(severity="blocker", title="b1"),
+        ]))
+        sv = SessionView(self.state_dir)
+        env = sv.get_session()
+        self.assertEqual(env.data["open_item_summary"]["blocker_count"], 1)
+
+
+# ===========================================================================
+# Test: ProjectsView (§2.2)
+# ===========================================================================
+
+class TestProjectsView(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = self._tmp.name
+        self.reg_path = Path(self.base) / "projects.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_empty_registry(self):
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        self.assertEqual(env.data, [])
+
+    def test_project_with_attention(self):
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="blocker", title="b1"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        self.assertEqual(len(env.data), 1)
+        self.assertEqual(env.data[0]["attention_level"], "critical")
+        self.assertEqual(env.data[0]["open_blocker_count"], 1)
+
+    def test_clear_attention(self):
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        self.assertEqual(env.data[0]["attention_level"], "clear")
+
+    def test_warning_attention(self):
+        p1 = _setup_project_tree(self.base, "proj-a", open_items=_make_open_items([
+            _open_item(severity="warn", title="w1"),
+        ]))
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        self.assertEqual(env.data[0]["attention_level"], "warning")
+
+    def test_feature_name_from_queue(self):
+        p1 = _setup_project_tree(self.base, "proj-a",
+                                  open_items=_make_open_items([]),
+                                  queue={"feature": "Feature 13", "prs": []})
+        register_project("proj-a", p1, registry_path=self.reg_path)
+
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        self.assertEqual(env.data[0]["active_feature"], "Feature 13")
+
+    def test_freshness_envelope_on_projects(self):
+        pv = ProjectsView(self.reg_path)
+        env = pv.list_projects()
+        d = env.to_dict()
+        self.assertIn("source_freshness", d)
+        self.assertIn("staleness_seconds", d)
+
+
+# ===========================================================================
+# Test: Degraded state diagnostics (§5.1)
+# ===========================================================================
+
+class TestDegradedDiagnostics(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.state_dir = os.path.join(self._tmp.name, "state")
+        os.makedirs(self.state_dir, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_missing_db_degrades_terminal_view(self):
+        """DS-1: Missing data rendered as explicitly missing, not empty."""
+        tv = TerminalView(self.state_dir)
+        env = tv.get_terminal("T1")
+        self.assertTrue(env.degraded)
+        self.assertEqual(env.data["status"], "unknown")
+
+    def test_degraded_reasons_are_operator_readable(self):
+        """DS-2: Degraded reasons are human-readable strings."""
+        oi = OpenItemsView(self.state_dir)
+        env = oi.get_items()
+        self.assertTrue(env.degraded)
+        for reason in env.degraded_reasons:
+            self.assertIsInstance(reason, str)
+            self.assertGreater(len(reason), 5)
+
+    def test_stale_source_includes_age(self):
+        now = datetime.now(timezone.utc)
+        old = (now - timedelta(seconds=400)).isoformat()
+        sources = {"test.json": old}
+        _, degraded, reasons = _compute_freshness(sources, now)
+        self.assertTrue(degraded)
+        self.assertIn("400", reasons[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implements all 5 dashboard read-model views per Contract §2-§3, §5, §7
- FreshnessEnvelope with staleness tracking on every response
- Cross-project open-item aggregation with attention model
- 39 tests covering all gate criteria

## PR-1 of Feature 13: Coding Operator Dashboard And Session Control

## Test plan
- [x] 39 unit tests pass (`python -m pytest tests/test_dashboard_read_model.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)