### PR TITLE
test(dashboard): Playwright E2E suite for operator dashboard

### DIFF
--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -1,0 +1,154 @@
+# T0 - VNX Master Orchestrator
+
+You are T0. You orchestrate work and governance. You do not implement code.
+You are the BRAIN, not the HANDS.
+
+## Mandatory Startup
+
+Before any orchestration action, load `@t0-orchestrator`.
+Do not run orchestration from memory; follow the skill workflow.
+
+For the next 4-feature hardening lane, operate in full autonomous mode:
+- no routine user checkpoints
+- no pause requests unless a true chain-breaking blocker prevents safe continuation
+- after each feature: close -> merge -> verify merge -> create next branch/worktree from post-merge `main`
+- do not end the chain with unresolved chain-created open items
+
+## Crash Recovery Startup
+
+After any system crash or tmux session restart, before normal orchestration:
+
+1. Validate runtime schema: `python3 scripts/runtime_coordination_init.py`
+2. Check stale leases:
+   ```bash
+   for T in T1 T2 T3; do
+     python3 scripts/runtime_core_cli.py check-terminal --terminal $T --dispatch-id recovery-check
+   done
+   ```
+   Release any `lease_expired_not_cleaned` via `release-on-failure`.
+3. Reconcile queue: `python3 scripts/reconcile_queue_state.py --json`
+4. Check for orphaned dispatches (active dispatch without completion receipt):
+   ```bash
+   ls .vnx-data/dispatches/active/
+   ```
+   If any exist: read the dispatch, check if worker has uncommitted changes, decide re-dispatch or resume.
+5. Verify pane IDs match live tmux:
+   ```bash
+   tmux list-panes -a -F "#{pane_id} #{pane_current_path}"
+   ```
+   Update `.vnx-data/state/panes.json` if pane IDs changed.
+6. Check for unresolved incidents:
+   ```bash
+   sqlite3 .vnx-data/state/runtime_coordination.db \
+     "SELECT COUNT(*) FROM incident_log WHERE resolved_at IS NULL AND severity='blocking';"
+   ```
+
+## Runtime Policy
+
+- T0 runtime is Claude Opus only.
+- `T1` and `T2` are manually Sonnet-pinned; do not assume runtime `/model` switching works.
+- `T3` is a Claude review/certification terminal and must be treated as modal-sensitive after `/clear`.
+- Tri-file support (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) applies to worker terminals.
+- T0 orchestration uses `CLAUDE.md` only.
+
+## Permissions and Hard Guardrails
+
+- ALLOWED: `Read`, `Grep`, `Glob`
+- ALLOWED: `Bash` only for orchestration/state commands
+- DENIED: `Write`, `Edit`, `Task`, and implementation execution
+- OUTPUT: promote staged dispatches only; do NOT print dispatch instructions to terminal
+- Manager blocks to terminal are ONLY for accidental dispatches (no staged dispatch exists) or operator-requested manual delivery
+- Promoting from staging IS the delivery mechanism — smart tap picks up from pending/ automatically
+
+## Core Responsibilities
+
+1. Review receipts critically, not blindly.
+2. Evaluate quality advisory before deciding next action.
+3. Check open items and close only evidence-backed items.
+4. Complete PRs only after blocker/warn criteria are resolved.
+5. Promote staged dispatches before crafting manual dispatches.
+6. Open new open items when new out-of-scope risks/issues are discovered.
+7. Dispatch one block at a time and keep queue state consistent.
+8. Request required headless review gates and verify their report + receipt evidence before closure.
+
+## Core Decision Rules
+
+1. Never auto-complete PRs from receipt status alone.
+2. Never guess state; verify via CLI and state files.
+3. If any terminal is busy or queue is active: WAIT.
+4. If dependencies are unmet: WAIT.
+5. If evidence is incomplete or contradictory: DO NOT approve.
+6. If the review stack requires Gemini or Codex evidence, do not approve until both a gate result and a normalized headless report exist.
+7. If a dispatch targets a Claude terminal, do not rely on implicit clear-context before payload delivery.
+8. `queued` review-gate state is only request state, not completion evidence.
+9. A required gate with empty `contract_hash` or empty `report_path` is incomplete evidence and blocks closure.
+
+## Headless Review Enforcement
+
+When a PR or feature policy requires a headless review gate:
+
+1. T0 must trigger the gate through the review-gate flow.
+2. T0 must actively start execution unless a proven automatic runner exists in the repo.
+3. T0 must verify the request record exists under `.vnx-data/state/review_gates/requests/`.
+4. T0 must verify the result record exists under `.vnx-data/state/review_gates/results/`.
+5. T0 must verify the result links to the active review contract via `contract_hash`.
+6. T0 must verify `contract_hash` is non-empty.
+7. T0 must verify `report_path` is non-empty.
+8. T0 must verify an operator-readable markdown report exists under `$VNX_DATA_DIR/unified_reports/`.
+9. T0 must block PR completion and closure-ready claims if any of those surfaces are missing, contradictory, or ambiguous.
+
+When result JSON and normalized report content disagree:
+- treat that as evidence failure, not as a soft warning
+- do not close the PR until the contradiction is dispositioned or corrected
+
+When a required gate remains only `queued` or `requested`:
+- do not passively treat it as running
+- do not close the PR
+- either start execution, dispatch execution, or classify the missing runner path as a blocker
+
+## Doubt Escalation Policy
+
+When uncertain, use this order:
+
+1. Request a second review (another terminal/person) for the same deliverable.
+2. Present clear options and tradeoffs to the user and ask for decision.
+3. Do not dispatch or close critical items until ambiguity is resolved.
+
+## Stale Lease Cleanup (Required Before First Dispatch)
+
+Before the first promote of any new feature chain, check all target terminals for stale leases in runtime_coordination.db. The dispatcher fails closed on expired-but-uncleaned leases.
+
+```bash
+export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+# Check each terminal
+for T in T1 T2 T3; do
+  python3 scripts/runtime_core_cli.py check-terminal --terminal $T --dispatch-id <new-dispatch-id>
+done
+# If any shows lease_expired_not_cleaned, find generation and release:
+sqlite3 .vnx-data/state/runtime_coordination.db "SELECT * FROM terminal_leases WHERE terminal_id='<T>';"
+python3 scripts/runtime_core_cli.py release-on-failure --terminal <T> --dispatch-id <old-dispatch> --generation <gen> --reason "stale_lease_cleanup"
+```
+
+## Quick Commands
+
+```bash
+python3 scripts/pr_queue_manager.py status
+python3 scripts/open_items_manager.py digest
+python3 scripts/validate_skill.py --list
+```
+
+## Read-Only State Sources
+
+- `.vnx-data/state/t0_brief.json`
+- `.vnx-data/state/t0_recommendations.json`
+- `.vnx-data/state/open_items_digest.json`
+- `.vnx-data/state/pr_queue_state.yaml`
+- `.vnx-data/state/review_gates/requests/`
+- `.vnx-data/state/review_gates/results/`
+- `$VNX_DATA_DIR/unified_reports/`
+
+## Feature Plan Path
+
+Use `FEATURE_PLAN.md` in repo root.
+
+Remember: Receipt -> Review -> Decide -> Dispatch (or WAIT).

--- a/dashboard/token-dashboard/e2e/governance-digest.spec.ts
+++ b/dashboard/token-dashboard/e2e/governance-digest.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Governance digest page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/operator/governance');
+  });
+
+  test('page loads without errors', async ({ page }) => {
+    await expect(page).not.toHaveTitle(/error/i);
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await page.waitForLoadState('networkidle');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('digest content renders or shows no-data message', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    // Either digest content is shown or a "no data" / empty-state message
+    const hasContent = await page.locator('h2, h3, [data-testid="digest-content"]').count() > 0;
+    const hasNoData = await page.getByText(/no data|no digest|empty|nothing/i).count() > 0;
+    expect(hasContent || hasNoData).toBe(true);
+  });
+});

--- a/dashboard/token-dashboard/e2e/health.spec.ts
+++ b/dashboard/token-dashboard/e2e/health.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('API health endpoints', () => {
+  test('GET /api/health returns 200 with valid JSON', async ({ request }) => {
+    const response = await request.get('/api/health');
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toBeDefined();
+    expect(typeof body).toBe('object');
+  });
+
+  test('GET /api/operator/kanban returns valid JSON array', async ({ request }) => {
+    const response = await request.get('/api/operator/kanban');
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+});

--- a/dashboard/token-dashboard/e2e/kanban.spec.ts
+++ b/dashboard/token-dashboard/e2e/kanban.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+const KANBAN_COLUMNS = ['staging', 'pending', 'active', 'review', 'done'];
+
+test.describe('Kanban board page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/operator/kanban');
+  });
+
+  test('page loads without errors', async ({ page }) => {
+    await expect(page).not.toHaveTitle(/error/i);
+    // No unhandled JS errors
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await page.waitForLoadState('networkidle');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('5 kanban columns are visible', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    for (const col of KANBAN_COLUMNS) {
+      const column = page.getByText(new RegExp(col, 'i')).first();
+      await expect(column).toBeVisible();
+    }
+  });
+});

--- a/dashboard/token-dashboard/e2e/open-items.spec.ts
+++ b/dashboard/token-dashboard/e2e/open-items.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Open Items page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/operator/open-items');
+  });
+
+  test('page loads without errors', async ({ page }) => {
+    await expect(page).not.toHaveTitle(/error/i);
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await page.waitForLoadState('networkidle');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('severity filter chips are visible', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    // Expect severity filter chips: blocker, warn, info
+    const blockerChip = page.getByText(/blocker/i).first();
+    await expect(blockerChip).toBeVisible();
+
+    const warnChip = page.getByText(/warn/i).first();
+    await expect(warnChip).toBeVisible();
+
+    const infoChip = page.getByText(/info/i).first();
+    await expect(infoChip).toBeVisible();
+  });
+});

--- a/dashboard/token-dashboard/e2e/session-control.spec.ts
+++ b/dashboard/token-dashboard/e2e/session-control.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Session control', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('main page loads without errors', async ({ page }) => {
+    await expect(page).not.toHaveTitle(/error/i);
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await page.waitForLoadState('networkidle');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('session control buttons are visible', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    // Start, Stop, and Attach buttons are present in the operator project cards.
+    // At least one session control action button must be visible.
+    const startBtn = page.getByTestId('btn-start');
+    const stopBtn = page.getByTestId('btn-stop');
+    const attachBtn = page.getByTestId('btn-attach');
+
+    const startCount = await startBtn.count();
+    const stopCount = await stopBtn.count();
+    const attachCount = await attachBtn.count();
+
+    expect(startCount + stopCount + attachCount).toBeGreaterThan(0);
+  });
+
+  test('start or stop button exists in DOM', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    const startOrStop = await page
+      .locator('[data-testid="btn-start"], [data-testid="btn-stop"]')
+      .count();
+    expect(startOrStop).toBeGreaterThan(0);
+  });
+});

--- a/dashboard/token-dashboard/package-lock.json
+++ b/dashboard/token-dashboard/package-lock.json
@@ -17,6 +17,7 @@
         "swr": "^2.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1922,6 +1923,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6100,6 +6117,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/dashboard/token-dashboard/package.json
+++ b/dashboard/token-dashboard/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --port 3100",
     "build": "next build",
     "start": "next start --port 3100",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -18,6 +19,7 @@
     "swr": "^2.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/dashboard/token-dashboard/playwright.config.ts
+++ b/dashboard/token-dashboard/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3100',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/docs/internal/OPERATOR_FEEDBACK_ARCHITECTURE.md
+++ b/docs/internal/OPERATOR_FEEDBACK_ARCHITECTURE.md
@@ -1,0 +1,97 @@
+# Operator Feedback Architecture
+
+## Overview
+
+VNX operator feedback flows through 4 channels, each serving a distinct latency and audience need.
+
+## Feedback Channels
+
+### Channel 1: Real-Time Dashboard
+- **Latency**: <5s (WebSocket/polling)
+- **Source**: `dashboard_status.json` written by intelligence daemon
+- **Content**: Terminal status, active dispatches, queue depth, health indicators
+- **Consumer**: Operator during active development sessions
+
+### Channel 2: Governance Digest (Automated)
+- **Latency**: 5-min cadence
+- **Source**: `governance_digest.json` written by `GovernanceDigestRunner`
+- **Content**: Gate pass/fail signals, queue anomalies, defect family recurrence, advisory recommendations
+- **Consumer**: T0 orchestrator for dispatch planning decisions
+
+### Channel 3: Retrospective Digest (Daily)
+- **Latency**: Daily at 18:00 (configurable via `daily_hygiene_hour`)
+- **Source**: Learning loop output from `intelligence_daemon.py` daily hygiene
+- **Content**: Pattern recurrence trends, quality intelligence refresh, tag auto-refresh, candidate guardrails
+- **Consumer**: Operator for weekly planning; T0 for long-term pattern adjustment
+
+### Channel 4: Session Analytics (Nightly)
+- **Latency**: Nightly batch
+- **Source**: `conversation_analyzer.py` parsing JSONL session logs
+- **Content**: Token usage, tool call distribution, session cost, model utilization
+- **Consumer**: Operator for cost monitoring and capacity planning
+- **Limitation**: Metadata only — does not analyze output quality or correctness
+
+## Signal Flow
+
+```
+Terminal Output (T1/T2/T3)
+    |
+    v
++-------------------+     +------------------------+
+| Unified Reports   |---->| Governance Signal       |
+| (markdown)        |     | Extractor (5-min)       |
++-------------------+     +------------------------+
+    |                              |
+    v                              v
++-------------------+     +------------------------+
+| Receipt Processor |     | Retrospective Digest    |
+| (NDJSON)          |---->| Builder (daily)         |
++-------------------+     +------------------------+
+    |                              |
+    v                              v
++-------------------+     +------------------------+
+| T0 Receipt Review |     | Optional LLM Hook       |
+| (manual gate)     |     | (candidate guardrails)  |
++-------------------+     +------------------------+
+                                   |
+                                   v
+                          +------------------------+
+                          | Governance Digest JSON  |
+                          | (T0 + Dashboard)        |
+                          +------------------------+
+```
+
+## Missing Channel: Terminal Quality Analysis
+
+Currently absent — the gap between "what did the worker produce?" (Channel 2/3) and "how well did the worker work?" (not captured). See `TERMINAL_QUALITY_ANALYSIS_ARCHITECTURE.md` for the proposed design.
+
+## Email Digest Activation
+
+The intelligence daemon supports email digest delivery via environment variables:
+
+```bash
+# Enable email digest (requires SMTP configuration)
+export VNX_EMAIL_DIGEST_ENABLED=1
+export VNX_EMAIL_SMTP_HOST=smtp.example.com
+export VNX_EMAIL_SMTP_PORT=587
+export VNX_EMAIL_RECIPIENT=operator@example.com
+
+# Digest schedule (default: daily at 18:00 with hygiene cycle)
+export VNX_DIGEST_EMAIL_HOUR=18
+```
+
+**Current status**: Email delivery is not yet implemented. The digest infrastructure (`governance_digest.json`) is the structured data source that an email renderer would consume. Implementation would involve:
+1. A `DigestEmailRenderer` that reads `governance_digest.json`
+2. Template-based HTML email with recurring pattern highlights
+3. Triggered from `IntelligenceDaemon.daily_hygiene()` after digest generation
+4. Opt-in only — never auto-enabled
+
+## Configuration Reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VNX_DIGEST_INTERVAL` | 300 | Governance digest cycle (seconds) |
+| `VNX_DAILY_INTEL_REFRESH` | 1 | Enable daily quality intelligence refresh |
+| `VNX_INTELLIGENCE_DASHBOARD_WRITE` | 0 | Enable dashboard status file writes |
+| `VNX_ANALYZER_LLM` | auto | Conversation analyzer LLM strategy |
+| `VNX_OLLAMA_MODEL` | qwen2.5-coder:14b | Local model for deep analysis |

--- a/docs/internal/TERMINAL_QUALITY_ANALYSIS_ARCHITECTURE.md
+++ b/docs/internal/TERMINAL_QUALITY_ANALYSIS_ARCHITECTURE.md
@@ -1,0 +1,165 @@
+# Terminal Quality Analysis Architecture
+
+## 1. Current State
+
+### Self-Learning Pipeline (Feature 18)
+
+The F18 pipeline has three layers, orchestrated by `scripts/intelligence_daemon.py`:
+
+**Layer 1: Signal Extraction** (`scripts/lib/governance_signal_extractor.py`)
+Extracts 7 signal types from governance artifacts:
+- `session_failure` — headless session_failed or session_timed_out
+- `session_artifact` — artifact_materialized (execution evidence)
+- `gate_failure` — quality gate did not pass
+- `gate_success` — quality gate passed
+- `queue_anomaly` — delivery failure, reconcile error, dead letter, queue stall
+- `open_item_transition` — open-item status change (new/escalated/resolved)
+- `defect_family` — normalized recurring defect pattern (N occurrences)
+
+Signals carry full correlation context: feature_id, pr_id, session_id, dispatch_id, provider_id, terminal_id, branch.
+
+**Layer 2: Recurrence Detection & Digest** (`scripts/lib/retrospective_digest.py`)
+- Groups signals by `defect_family` key (MD5 of normalized content)
+- Produces `RecurrenceRecord` for families with count >= 2
+- Generates advisory-only `Recommendation` objects (4 categories: review_required, runtime_fix, policy_change, prompt_tuning)
+- Assembles `RetroDigest` for T0 consumption
+
+**Layer 3: Optional LLM Hook** (`scripts/lib/retrospective_model_hook.py`)
+- Protocol-based: `LocalModelHook.analyze()` receives digest, returns `RetroAnalysisSummary`
+- Always non-authoritative (`authoritative=False` enforced)
+- Fallback: rule-based summary when no model configured
+- Proposes candidate guardrails; T0 decides
+
+**Orchestration** (`scripts/intelligence_daemon.py`)
+- `GovernanceDigestRunner`: 5-min cadence, reads gate results + queue anomalies from `t0_receipts.ndjson`, writes `governance_digest.json`
+- `IntelligenceDaemon`: hourly extraction, daily hygiene at 18:00, learning cycle
+
+### Conversation Analyzer (`scripts/conversation_analyzer.py`)
+- Parses Claude Code JSONL session logs for token/tool/message metrics
+- Heuristic pattern detection (token thresholds, tool counts)
+- Optional LLM deep analysis for high-cost sessions
+- Stores in `session_analytics` table
+- **Limitation**: Analyzes session metadata only, NOT output quality or correctness
+
+## 2. Gap Analysis
+
+| Aspect | Current Coverage | Missing |
+|--------|-----------------|---------|
+| Gate pass/fail | Signals extracted | No root-cause from output |
+| Session failures | Timeout/crash detected | No thinking-loop or stall detection |
+| Code quality | Not analyzed | Function/file size violations introduced by worker |
+| Instruction adherence | Not analyzed | Deviation from dispatch instructions |
+| Search efficiency | Not analyzed | Excessive grep/glob before finding target |
+| Rework patterns | Not analyzed | Multiple commits on same file in one dispatch |
+| Test outcomes | Not analyzed | Worker code failing tests |
+| Output correctness | Not analyzed | Wrong instructions, hallucinated paths |
+
+The pipeline knows WHAT happened (pass/fail) but not WHY. Terminal output is the missing link between dispatch instructions and outcomes.
+
+## 3. Proposed Signal Types
+
+Six new signal types for `governance_signal_extractor.py`:
+
+### `terminal_rework`
+- **Extraction**: Parse git log for dispatch branch — count commits touching same file >2 times
+- **Source**: Git history on dispatch branch
+- **Severity**: warn (3+ touches), info (2 touches)
+- **Correlation**: dispatch_id, terminal_id, file paths
+
+### `terminal_timeout`
+- **Extraction**: Worker ran out of context window without producing final report
+- **Source**: Unified reports directory — dispatch_id present in receipt but no corresponding report file
+- **Severity**: blocker
+- **Correlation**: dispatch_id, terminal_id, provider_id
+
+### `terminal_search_excessive`
+- **Extraction**: Count Grep/Glob/Read tool calls before first Edit/Write in stream-json events
+- **Source**: F28 stream-json event stream (future), or conversation JSONL (current)
+- **Severity**: warn (>10 search ops), info (>5)
+- **Correlation**: dispatch_id, terminal_id, session_id
+
+### `terminal_test_failure`
+- **Extraction**: Detect test runner exit codes != 0 in Bash tool results
+- **Source**: Stream-json events or unified reports with test evidence
+- **Severity**: warn (flaky), blocker (consistent failure)
+- **Correlation**: dispatch_id, terminal_id, test file paths
+
+### `terminal_code_quality`
+- **Extraction**: Post-commit static analysis — function length >50 lines, file >500 lines introduced by worker
+- **Source**: Git diff on dispatch branch + simple line-count heuristic
+- **Severity**: info (function >50L), warn (file >500L)
+- **Correlation**: dispatch_id, terminal_id, file paths
+
+### `terminal_instruction_mismatch`
+- **Extraction**: Compare dispatch instruction scope (files mentioned, task type) vs actual files modified
+- **Source**: Dispatch JSON + git diff
+- **Severity**: warn (modified files not in scope), blocker (no overlap with scope)
+- **Correlation**: dispatch_id, terminal_id
+
+## 4. Integration with Existing Pipeline
+
+### Extraction Phase
+New extractors plug into `collect_governance_signals()` via additional keyword arguments:
+
+```python
+def collect_governance_signals(
+    *,
+    # existing sources
+    session_timeline=None,
+    gate_results=None,
+    queue_anomalies=None,
+    open_item_transitions=None,
+    # new terminal quality sources
+    terminal_quality_events=None,   # List[Dict] from git/report analysis
+    stream_json_events=None,        # List[Dict] from F28 subprocess streams
+    correlation=None,
+    ...
+)
+```
+
+### Digest Phase
+`retrospective_digest.py` needs no changes — `detect_recurrences()` and `generate_recommendations()` operate on any signal with a `defect_family` key. New signal types will naturally cluster into families.
+
+### New recommendation category
+Add `worker_coaching` to `RECOMMENDATION_CATEGORIES`:
+- Triggered by recurring `terminal_search_excessive` or `terminal_rework`
+- Advisory: "Worker on T1 repeatedly exceeds 10 search operations. Consider providing more specific file paths in dispatch instructions."
+
+## 5. F28/F29 Streaming Analysis Design
+
+### Stream-JSON Event Model (F28)
+When `SubprocessAdapter` emits `--output-format stream-json`, each event contains:
+- `type`: tool_use, tool_result, text, error, system
+- `tool`: tool name (Read, Grep, Edit, Bash, etc.)
+- `timestamp`: event time
+- `content`: truncated output
+
+### Real-Time Analysis Hooks
+A `StreamAnalyzer` class processes the event stream in-flight:
+
+1. **Thinking loop detector**: If >5 consecutive text events without tool_use, flag as potential reasoning loop
+2. **Search spiral detector**: Count sequential Grep/Glob/Read without Edit — threshold at 10
+3. **Stall detector**: No events for >60s while process still alive
+4. **Error cascade detector**: >3 consecutive tool_result with error status
+
+### Integration Point
+`StreamAnalyzer` emits `terminal_quality_events` in real-time, which the `GovernanceDigestRunner` can pick up on its next 5-min cycle. For dashboard integration, events also write to a ring buffer file (`stream_quality_events.ndjson`, max 1000 lines).
+
+### Dashboard Panel (F29)
+- New panel: "Worker Quality" showing per-terminal quality scores
+- Metrics: search efficiency ratio, rework rate, test pass rate
+- Sourced from `governance_digest.json` terminal quality section
+
+## 6. Recommendation
+
+**Do NOT bundle with F28.** Terminal quality analysis should be a separate feature (F30 or similar) because:
+
+1. F28 SubprocessAdapter is infrastructure — it should ship lean
+2. Quality signals from git/reports work TODAY without stream-json
+3. Stream-json analysis is an incremental enhancement once F28 lands
+4. Separate feature allows independent testing and rollback
+
+**Phased delivery**:
+- Phase 1 (now): Git-based signals (rework, code quality, instruction mismatch) — no F28 dependency
+- Phase 2 (post-F28): Stream-json signals (search excessive, thinking loops, stall detection)
+- Phase 3 (post-F29): Dashboard integration with quality scoring panel

--- a/skills/t0-orchestrator/SKILL.md
+++ b/skills/t0-orchestrator/SKILL.md
@@ -105,7 +105,61 @@ When uncertain, use this sequence:
 3. Keep safety-first default.
 - If ambiguity remains on blocker/warn criteria, do not complete PR.
 
-## 6. Open Items Lifecycle
+## 6. Startup Reconciliation
+
+Run this sequence on every session start. For post-crash starts, run all steps. For normal starts, steps 1 and 3 are sufficient.
+
+### 6.1 Normal Startup
+
+```bash
+python3 scripts/runtime_coordination_init.py
+python3 scripts/reconcile_queue_state.py --json
+```
+
+### 6.2 Post-Crash Startup
+
+```bash
+# Step 1: Validate runtime schema
+python3 scripts/runtime_coordination_init.py
+
+# Step 2: Check for stale leases
+for T in T1 T2 T3; do
+  python3 scripts/runtime_core_cli.py check-terminal --terminal $T --dispatch-id recovery-check
+done
+# If lease_expired_not_cleaned: release via release-on-failure
+
+# Step 3: Reconcile queue truth
+python3 scripts/reconcile_queue_state.py --json
+
+# Step 4: Terminal state reconciliation
+python3 scripts/reconcile_terminal_state.py --no-tmux-probe
+
+# Step 5: Review incident log
+sqlite3 .vnx-data/state/runtime_coordination.db \
+  "SELECT COUNT(*), severity FROM incident_log WHERE resolved_at IS NULL GROUP BY severity;"
+
+# Step 6: Check active and pending dispatches
+ls -la .vnx-data/dispatches/active/ 2>/dev/null
+ls -la .vnx-data/dispatches/pending/ 2>/dev/null
+```
+
+### 6.3 Orphaned Dispatch Handling
+
+If `active/` contains dispatches after crash: read dispatch, check worker state, decide re-dispatch or resume.
+
+```bash
+python3 scripts/reconcile_queue_state.py --json 2>/dev/null | \
+  jq '.prs[] | select(.state == "active") | {pr_id, provenance}'
+```
+
+### 6.4 Recovery Engine
+
+```bash
+python3 scripts/lib/vnx_recover_runtime.py --dry-run   # preview
+python3 scripts/lib/vnx_recover_runtime.py             # execute
+```
+
+## 7. Open Items Lifecycle
 
 ### 6.1 Inspect
 
@@ -146,7 +200,7 @@ python .claude/vnx-system/scripts/open_items_manager.py add \
 
 If CLI signature differs in your branch, use `--help` and map fields accordingly.
 
-## 7. PR Queue Lifecycle
+## 8. PR Queue Lifecycle
 
 ### 7.1 Read state
 
@@ -173,7 +227,7 @@ python .claude/vnx-system/scripts/pr_queue_manager.py complete PR-X
 
 Only after blocker/warn obligations are satisfied.
 
-## 8. Dispatch Guard and Provider Awareness
+## 9. Dispatch Guard and Provider Awareness
 
 Before dispatching:
 
@@ -188,7 +242,25 @@ bash .claude/skills/t0-orchestrator/scripts/provider_capabilities.sh current
 
 See full matrix in `references/provider-matrix.md`.
 
-## 9. Manager Block Quality Standard
+### 9.1 Pre-Dispatch Pane Verification
+
+Before the first dispatch of any session or after a tmux restart:
+
+```bash
+# Verify all terminal panes are reachable
+tmux list-panes -a -F "#{pane_id} #{pane_current_path}"
+
+for T in T0 T1 T2 T3; do
+  tmux list-panes -a -F "#{pane_id} #{pane_current_path}" | \
+    grep "$(pwd)/.claude/terminals/$T" && echo "$T: OK" || echo "$T: MISSING"
+done
+```
+
+**Pane discovery tiers (fallback order):** Cache → panes.json → path-based → interactive.
+Path-based discovery survives tmux restart — always works as long as pane exists.
+If any pane is missing, escalate before dispatching.
+
+## 10. Manager Block Quality Standard
 
 Every dispatch must include:
 
@@ -213,7 +285,7 @@ Validate role names when uncertain:
 python .claude/vnx-system/scripts/validate_skill.py --list
 ```
 
-## 10. Recommended Script Toolbox
+## 11. Recommended Script Toolbox
 
 1. `scripts/queue_status.sh`
 - queue/staging/terminal summary
@@ -233,7 +305,7 @@ python .claude/vnx-system/scripts/validate_skill.py --list
 6. `scripts/intelligence.sh`
 - intelligence read helpers
 
-## 11. Decision Outputs
+## 12. Decision Outputs
 
 When not dispatching, provide explicit status to user:
 
@@ -241,7 +313,7 @@ When not dispatching, provide explicit status to user:
 2. `ESCALATE`: explain ambiguity and propose options.
 3. `PROCEED`: show why criteria are met.
 
-## 12. References
+## 13. References
 
 1. `references/dispatch-patterns.md`
 2. `references/example-workflows.md`
@@ -250,6 +322,47 @@ When not dispatching, provide explicit status to user:
 5. `template.md`
 
 Final rule: if evidence is weak or contradictory, do not approve by default.
+
+---
+
+## 14. Session Resume After Crash
+
+When T0 or a worker terminal crashes and conversation context is lost:
+
+### 14.1 Find the Session ID
+
+```bash
+# Query Claude Code's conversation index
+sqlite3 ~/.claude/conversation-index.db \
+  "SELECT session_id, cwd, last_message \
+   FROM conversations \
+   WHERE cwd LIKE '$(pwd)/.claude/terminals/T%' \
+   ORDER BY last_message DESC LIMIT 5;"
+```
+
+Path containment invariant: `session.cwd` in `<PROJECT_ROOT>/.claude/terminals/T{N}` → session belongs to this worktree.
+
+### 14.2 Resume
+
+```bash
+cd $PROJECT_ROOT/.claude/terminals/<TERMINAL>
+claude --resume <session_id>
+```
+
+Pick the session with the most recent `last_message` if multiple exist.
+
+### 14.3 Worker Resume via Dispatch
+
+Worker terminals (T1/T2/T3) should resume via new dispatch, not manual session resume:
+1. Run startup reconciliation (section 6.2) to assess damage.
+2. Check orphaned dispatches in `active/` (section 6.3).
+3. Re-dispatch to affected worker with remaining task scope.
+
+### 14.4 Limitations
+
+- `--resume` restores **message history only** — not in-flight dispatch context or queued actions.
+- A resumed T0 session is read-only history. Re-run startup reconciliation before new orchestration actions.
+- `--fork-session` creates a new session_id from the old history — use to avoid reattaching to original.
 
 ---
 


### PR DESCRIPTION
## Summary
- Set up Playwright with Chromium for Next.js dashboard E2E testing
- 5 test specs: health, kanban, open-items, governance-digest, session-control
- Configured against localhost:3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)