### PR TITLE
refactor(adapter): extract shared types to adapter_types.py (F28 PR-0)

### DIFF
--- a/scripts/lib/adapter_protocol.py
+++ b/scripts/lib/adapter_protocol.py
@@ -1,63 +1,32 @@
 #!/usr/bin/env python3
 """RuntimeAdapter protocol and shared types for transport abstraction.
 
-Defines the protocol that all adapter implementations (TmuxAdapter,
-HeadlessAdapter, LocalSessionAdapter) must satisfy. Shared result
-types are imported from tmux_adapter.py where they were first defined.
-
-Required capabilities: SPAWN, STOP, DELIVER, OBSERVE, HEALTH, SESSION_HEALTH.
-Optional capabilities: ATTACH, INSPECT, REHEAL.
+Backward-compatibility shim: all types now live in adapter_types.py.
+This module re-exports them so existing imports continue to work.
 """
 
-from __future__ import annotations
-
-from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
-
-from tmux_adapter import (
+from adapter_types import (  # noqa: F401
+    CAPABILITY_ATTACH,
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
+    CAPABILITY_INSPECT,
     CAPABILITY_OBSERVE,
+    CAPABILITY_REHEAL,
     CAPABILITY_SESSION_HEALTH,
     CAPABILITY_SPAWN,
     CAPABILITY_STOP,
+    REQUIRED_CAPABILITIES,
     AttachResult,
     DeliveryResult,
     HealthResult,
     InspectionResult,
     ObservationResult,
     RehealResult,
+    RuntimeAdapter,
+    RuntimeAdapterError,
     SessionHealthResult,
     SpawnResult,
     StopResult,
     UnsupportedCapability,
+    validate_required_capabilities,
 )
-
-REQUIRED_CAPABILITIES = frozenset({
-    CAPABILITY_SPAWN, CAPABILITY_STOP, CAPABILITY_DELIVER,
-    CAPABILITY_OBSERVE, CAPABILITY_HEALTH, CAPABILITY_SESSION_HEALTH,
-})
-
-
-@runtime_checkable
-class RuntimeAdapter(Protocol):
-    """Protocol defining the canonical runtime adapter interface."""
-
-    def adapter_type(self) -> str: ...
-    def capabilities(self) -> frozenset: ...
-    def spawn(self, terminal_id: str, config: Dict[str, Any]) -> SpawnResult: ...
-    def stop(self, terminal_id: str) -> StopResult: ...
-    def deliver(self, terminal_id: str, dispatch_id: str,
-                attempt_id: Optional[str] = None, **kwargs: Any) -> DeliveryResult: ...
-    def attach(self, terminal_id: str) -> AttachResult: ...
-    def observe(self, terminal_id: str) -> ObservationResult: ...
-    def inspect(self, terminal_id: str) -> InspectionResult: ...
-    def health(self, terminal_id: str) -> HealthResult: ...
-    def session_health(self, terminal_ids: List[str]) -> SessionHealthResult: ...
-    def reheal(self, terminal_id: str) -> RehealResult: ...
-    def shutdown(self, graceful: bool = True) -> None: ...
-
-
-def validate_required_capabilities(adapter: RuntimeAdapter) -> List[str]:
-    """Return list of missing required capabilities, empty if all present."""
-    caps = adapter.capabilities()
-    return [c for c in REQUIRED_CAPABILITIES if c not in caps]

--- a/scripts/lib/adapter_types.py
+++ b/scripts/lib/adapter_types.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Shared types for VNX RuntimeAdapter abstraction layer.
+
+Contains all result dataclasses, capability constants, exception hierarchy,
+and the RuntimeAdapter Protocol. Canonical source of truth for adapter types —
+all adapters and consumers import from here.
+
+Extracted from tmux_adapter.py and adapter_protocol.py as part of F28 PR-0
+to decouple shared types from the tmux transport implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+# ---------------------------------------------------------------------------
+# Capability constants
+# ---------------------------------------------------------------------------
+
+CAPABILITY_SPAWN = "SPAWN"
+CAPABILITY_STOP = "STOP"
+CAPABILITY_DELIVER = "DELIVER"
+CAPABILITY_ATTACH = "ATTACH"
+CAPABILITY_OBSERVE = "OBSERVE"
+CAPABILITY_INSPECT = "INSPECT"
+CAPABILITY_HEALTH = "HEALTH"
+CAPABILITY_SESSION_HEALTH = "SESSION_HEALTH"
+CAPABILITY_REHEAL = "REHEAL"
+
+REQUIRED_CAPABILITIES = frozenset({
+    CAPABILITY_SPAWN, CAPABILITY_STOP, CAPABILITY_DELIVER,
+    CAPABILITY_OBSERVE, CAPABILITY_HEALTH, CAPABILITY_SESSION_HEALTH,
+})
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SpawnResult:
+    """Result of spawning an execution surface."""
+    success: bool
+    transport_ref: str = ""
+    error: Optional[str] = None
+
+
+@dataclass
+class StopResult:
+    """Result of stopping an execution surface."""
+    success: bool
+    was_running: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class DeliveryResult:
+    """Result of a single delivery attempt."""
+    success: bool
+    terminal_id: str
+    dispatch_id: str
+    pane_id: Optional[str]
+    path_used: str          # "primary" | "legacy" | "none"
+    failure_reason: Optional[str] = None
+    tmux_returncode: Optional[int] = None
+
+
+@dataclass
+class AttachResult:
+    """Result of switching operator focus."""
+    success: bool
+    error: Optional[str] = None
+
+
+@dataclass
+class ObservationResult:
+    """Read-only state probe result."""
+    exists: bool
+    responsive: bool = False
+    transport_state: Dict[str, Any] = field(default_factory=dict)
+    last_output_fragment: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class InspectionResult:
+    """Deep diagnostic inspection result."""
+    exists: bool
+    transport_ref: str = ""
+    transport_details: Dict[str, Any] = field(default_factory=dict)
+    pane_content: Optional[str] = None
+    environment: Optional[Dict[str, str]] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class HealthResult:
+    """Fast health check result."""
+    healthy: bool
+    surface_exists: bool = False
+    process_alive: bool = False
+    details: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+@dataclass
+class SessionHealthResult:
+    """Aggregate health check result."""
+    session_exists: bool
+    terminals: Dict[str, HealthResult] = field(default_factory=dict)
+    degraded_terminals: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@dataclass
+class RehealResult:
+    """Transport drift recovery result."""
+    rehealed: bool
+    old_ref: Optional[str] = None
+    new_ref: Optional[str] = None
+    strategy: str = ""
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+class RuntimeAdapterError(Exception):
+    """Base error for all runtime adapter failures."""
+    def __init__(self, message: str, adapter_type: str = "tmux", operation: str = ""):
+        self.adapter_type = adapter_type
+        self.operation = operation
+        super().__init__(message)
+
+
+class UnsupportedCapability(RuntimeAdapterError):
+    """Raised when an operation is invoked on an adapter that does not support it."""
+    def __init__(self, operation: str, adapter_type: str = "tmux", reason: str = ""):
+        self.reason = reason or f"{adapter_type} adapter does not support {operation}"
+        super().__init__(self.reason, adapter_type=adapter_type, operation=operation)
+
+
+# ---------------------------------------------------------------------------
+# RuntimeAdapter Protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class RuntimeAdapter(Protocol):
+    """Protocol defining the canonical runtime adapter interface."""
+
+    def adapter_type(self) -> str: ...
+    def capabilities(self) -> frozenset: ...
+    def spawn(self, terminal_id: str, config: Dict[str, Any]) -> SpawnResult: ...
+    def stop(self, terminal_id: str) -> StopResult: ...
+    def deliver(self, terminal_id: str, dispatch_id: str,
+                attempt_id: Optional[str] = None, **kwargs: Any) -> DeliveryResult: ...
+    def attach(self, terminal_id: str) -> AttachResult: ...
+    def observe(self, terminal_id: str) -> ObservationResult: ...
+    def inspect(self, terminal_id: str) -> InspectionResult: ...
+    def health(self, terminal_id: str) -> HealthResult: ...
+    def session_health(self, terminal_ids: List[str]) -> SessionHealthResult: ...
+    def reheal(self, terminal_id: str) -> RehealResult: ...
+    def shutdown(self, graceful: bool = True) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_required_capabilities(adapter: RuntimeAdapter) -> List[str]:
+    """Return list of missing required capabilities, empty if all present."""
+    caps = adapter.capabilities()
+    return [c for c in REQUIRED_CAPABILITIES if c not in caps]

--- a/scripts/lib/headless_transport_adapter.py
+++ b/scripts/lib/headless_transport_adapter.py
@@ -21,7 +21,7 @@ import shlex
 import subprocess
 from typing import Any, Dict, List, Optional
 
-from tmux_adapter import (
+from adapter_types import (
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
     CAPABILITY_INSPECT,

--- a/scripts/lib/local_session_adapter.py
+++ b/scripts/lib/local_session_adapter.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from tmux_adapter import (
+from adapter_types import (
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
     CAPABILITY_INSPECT,

--- a/scripts/lib/runtime_facade.py
+++ b/scripts/lib/runtime_facade.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from result_contract import Result, result_error, result_ok
-from tmux_adapter import (
+from adapter_types import (
     CAPABILITY_ATTACH,
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
@@ -29,9 +28,10 @@ from tmux_adapter import (
     CAPABILITY_SESSION_HEALTH,
     CAPABILITY_SPAWN,
     CAPABILITY_STOP,
-    TmuxAdapter,
     UnsupportedCapability,
 )
+from result_contract import Result, result_error, result_ok
+from tmux_adapter import TmuxAdapter
 
 
 @dataclass

--- a/scripts/lib/tmux_adapter.py
+++ b/scripts/lib/tmux_adapter.py
@@ -17,6 +17,28 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from adapter_types import (
+    CAPABILITY_ATTACH,
+    CAPABILITY_DELIVER,
+    CAPABILITY_HEALTH,
+    CAPABILITY_INSPECT,
+    CAPABILITY_OBSERVE,
+    CAPABILITY_REHEAL,
+    CAPABILITY_SESSION_HEALTH,
+    CAPABILITY_SPAWN,
+    CAPABILITY_STOP,
+    AttachResult,
+    DeliveryResult,
+    HealthResult,
+    InspectionResult,
+    ObservationResult,
+    RehealResult,
+    RuntimeAdapterError,
+    SessionHealthResult,
+    SpawnResult,
+    StopResult,
+    UnsupportedCapability,
+)
 from runtime_coordination import _append_event, get_connection, get_lease
 
 
@@ -46,115 +68,12 @@ class PaneTarget:
     provider: str = "claude_code"
 
 
-@dataclass
-class DeliveryResult:
-    """Result of a single delivery attempt."""
-    success: bool
-    terminal_id: str
-    dispatch_id: str
-    pane_id: Optional[str]
-    path_used: str          # "primary" | "legacy" | "none"
-    failure_reason: Optional[str] = None
-    tmux_returncode: Optional[int] = None
-
-
-@dataclass
-class SpawnResult:
-    """Result of spawning an execution surface."""
-    success: bool
-    transport_ref: str = ""
-    error: Optional[str] = None
-
-
-@dataclass
-class StopResult:
-    """Result of stopping an execution surface."""
-    success: bool
-    was_running: bool = False
-    error: Optional[str] = None
-
-
-@dataclass
-class AttachResult:
-    """Result of switching operator focus."""
-    success: bool
-    error: Optional[str] = None
-
-
-@dataclass
-class ObservationResult:
-    """Read-only state probe result."""
-    exists: bool
-    responsive: bool = False
-    transport_state: Dict[str, Any] = field(default_factory=dict)
-    last_output_fragment: Optional[str] = None
-    error: Optional[str] = None
-
-
-@dataclass
-class InspectionResult:
-    """Deep diagnostic inspection result."""
-    exists: bool
-    transport_ref: str = ""
-    transport_details: Dict[str, Any] = field(default_factory=dict)
-    pane_content: Optional[str] = None
-    environment: Optional[Dict[str, str]] = None
-    error: Optional[str] = None
-
-
-@dataclass
-class HealthResult:
-    """Fast health check result."""
-    healthy: bool
-    surface_exists: bool = False
-    process_alive: bool = False
-    details: Dict[str, Any] = field(default_factory=dict)
-    error: Optional[str] = None
-
-
-@dataclass
-class SessionHealthResult:
-    """Aggregate health check result."""
-    session_exists: bool
-    terminals: Dict[str, HealthResult] = field(default_factory=dict)
-    degraded_terminals: List[str] = field(default_factory=list)
-    error: Optional[str] = None
-
-
-@dataclass
-class RehealResult:
-    """Transport drift recovery result."""
-    rehealed: bool
-    old_ref: Optional[str] = None
-    new_ref: Optional[str] = None
-    strategy: str = ""
-    error: Optional[str] = None
-
-
-# Capability constants
-CAPABILITY_SPAWN = "SPAWN"
-CAPABILITY_STOP = "STOP"
-CAPABILITY_DELIVER = "DELIVER"
-CAPABILITY_ATTACH = "ATTACH"
-CAPABILITY_OBSERVE = "OBSERVE"
-CAPABILITY_INSPECT = "INSPECT"
-CAPABILITY_HEALTH = "HEALTH"
-CAPABILITY_SESSION_HEALTH = "SESSION_HEALTH"
-CAPABILITY_REHEAL = "REHEAL"
 
 TMUX_CAPABILITIES = frozenset({
     CAPABILITY_SPAWN, CAPABILITY_STOP, CAPABILITY_DELIVER, CAPABILITY_ATTACH,
     CAPABILITY_OBSERVE, CAPABILITY_INSPECT, CAPABILITY_HEALTH,
     CAPABILITY_SESSION_HEALTH, CAPABILITY_REHEAL,
 })
-
-
-class RuntimeAdapterError(Exception):
-    """Base error for all runtime adapter failures."""
-    def __init__(self, message: str, adapter_type: str = "tmux", operation: str = ""):
-        self.adapter_type = adapter_type
-        self.operation = operation
-        super().__init__(message)
 
 
 class AdapterError(RuntimeAdapterError):
@@ -170,13 +89,6 @@ class AdapterTransportError(RuntimeAdapterError):
     def __init__(self, message: str, transport_detail: str = "", **kwargs: Any):
         self.transport_detail = transport_detail
         super().__init__(message, **kwargs)
-
-
-class UnsupportedCapability(RuntimeAdapterError):
-    """Raised when an operation is invoked on an adapter that does not support it."""
-    def __init__(self, operation: str, adapter_type: str = "tmux", reason: str = ""):
-        self.reason = reason or f"{adapter_type} adapter does not support {operation}"
-        super().__init__(self.reason, adapter_type=adapter_type, operation=operation)
 
 
 class AdapterDisabledError(AdapterError):

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -25,9 +25,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from adapter_protocol import (
+from adapter_types import (
+    CAPABILITY_ATTACH,
+    CAPABILITY_REHEAL,
     REQUIRED_CAPABILITIES,
     RuntimeAdapter,
+    UnsupportedCapability,
     validate_required_capabilities,
 )
 from headless_transport_adapter import (
@@ -35,11 +38,8 @@ from headless_transport_adapter import (
     HeadlessAdapter,
 )
 from tmux_adapter import (
-    CAPABILITY_ATTACH,
-    CAPABILITY_REHEAL,
     TMUX_CAPABILITIES,
     TmuxAdapter,
-    UnsupportedCapability,
 )
 
 
@@ -182,7 +182,7 @@ class TestCapabilityDeclarationAccuracy:
 
     def test_headless_inspect_declared(self, headless_adapter: HeadlessAdapter) -> None:
         """HeadlessAdapter declares INSPECT (partial support)."""
-        from tmux_adapter import CAPABILITY_INSPECT
+        from adapter_types import CAPABILITY_INSPECT
         assert CAPABILITY_INSPECT in headless_adapter.capabilities()
 
     def test_headless_inspect_returns_result(self, headless_adapter: HeadlessAdapter) -> None:

--- a/tests/test_local_session_adapter.py
+++ b/tests/test_local_session_adapter.py
@@ -21,9 +21,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from adapter_protocol import RuntimeAdapter, validate_required_capabilities
+from adapter_types import RuntimeAdapter, UnsupportedCapability, validate_required_capabilities
 from local_session_adapter import LocalSessionAdapter, SessionAttempt
-from tmux_adapter import UnsupportedCapability
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rich_headless_certification.py
+++ b/tests/test_rich_headless_certification.py
@@ -19,7 +19,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from adapter_protocol import RuntimeAdapter, REQUIRED_CAPABILITIES, validate_required_capabilities
+from adapter_types import REQUIRED_CAPABILITIES, RuntimeAdapter, UnsupportedCapability, validate_required_capabilities
 from headless_event_stream import (
     CANONICAL_ORDER,
     TERMINAL_EVENT_TYPES,
@@ -41,7 +41,7 @@ from provider_observability import (
     get_provider_capabilities,
     is_provider_known,
 )
-from tmux_adapter import UnsupportedCapability
+
 
 
 # ===================================================================

--- a/tests/test_runtime_adapter_certification.py
+++ b/tests/test_runtime_adapter_certification.py
@@ -24,13 +24,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from adapter_protocol import (
-    REQUIRED_CAPABILITIES,
-    RuntimeAdapter,
-    validate_required_capabilities,
-)
-from headless_transport_adapter import HEADLESS_CAPABILITIES, HeadlessAdapter
-from tmux_adapter import (
+from adapter_types import (
     CAPABILITY_ATTACH,
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
@@ -40,18 +34,24 @@ from tmux_adapter import (
     CAPABILITY_SESSION_HEALTH,
     CAPABILITY_SPAWN,
     CAPABILITY_STOP,
-    TMUX_CAPABILITIES,
-    TmuxAdapter,
-    UnsupportedCapability,
+    REQUIRED_CAPABILITIES,
+    AttachResult,
+    DeliveryResult,
+    HealthResult,
+    InspectionResult,
+    ObservationResult,
+    RehealResult,
+    RuntimeAdapter,
+    SessionHealthResult,
     SpawnResult,
     StopResult,
-    DeliveryResult,
-    AttachResult,
-    ObservationResult,
-    InspectionResult,
-    HealthResult,
-    SessionHealthResult,
-    RehealResult,
+    UnsupportedCapability,
+    validate_required_capabilities,
+)
+from headless_transport_adapter import HEADLESS_CAPABILITIES, HeadlessAdapter
+from tmux_adapter import (
+    TMUX_CAPABILITIES,
+    TmuxAdapter,
 )
 
 LIB_DIR = Path(__file__).parent.parent / "scripts" / "lib"

--- a/tests/test_tmux_adapter.py
+++ b/tests/test_tmux_adapter.py
@@ -32,9 +32,9 @@ from runtime_coordination import (
     init_schema,
     register_dispatch,
 )
+from adapter_types import DeliveryResult
 from tmux_adapter import (
     AdapterDisabledError,
-    DeliveryResult,
     LeaseNotActiveError,
     PaneNotFoundError,
     PaneTarget,

--- a/tests/test_tmux_adapter_interface.py
+++ b/tests/test_tmux_adapter_interface.py
@@ -24,7 +24,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from tmux_adapter import (
+from adapter_types import (
     CAPABILITY_ATTACH,
     CAPABILITY_DELIVER,
     CAPABILITY_HEALTH,
@@ -34,9 +34,6 @@ from tmux_adapter import (
     CAPABILITY_SESSION_HEALTH,
     CAPABILITY_SPAWN,
     CAPABILITY_STOP,
-    TMUX_CAPABILITIES,
-    AdapterConfigError,
-    AdapterTransportError,
     AttachResult,
     HealthResult,
     InspectionResult,
@@ -46,8 +43,13 @@ from tmux_adapter import (
     SessionHealthResult,
     SpawnResult,
     StopResult,
-    TmuxAdapter,
     UnsupportedCapability,
+)
+from tmux_adapter import (
+    TMUX_CAPABILITIES,
+    AdapterConfigError,
+    AdapterTransportError,
+    TmuxAdapter,
 )
 
 


### PR DESCRIPTION
## Summary
- Extract RuntimeAdapter Protocol + all result types from tmux_adapter.py to standalone adapter_types.py (176L)
- adapter_protocol.py reduced to backward-compat re-export shim
- 12 files updated with new imports, 266 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)