### PR TITLE
feat(adapter): RuntimeFacade adapter factory with per-terminal env vars (F28 PR-1)

### DIFF
--- a/scripts/lib/runtime_facade.py
+++ b/scripts/lib/runtime_facade.py
@@ -15,6 +15,7 @@ The facade:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -28,6 +29,7 @@ from adapter_types import (
     CAPABILITY_SESSION_HEALTH,
     CAPABILITY_SPAWN,
     CAPABILITY_STOP,
+    RuntimeAdapter,
     UnsupportedCapability,
 )
 from result_contract import Result, result_error, result_ok
@@ -47,6 +49,49 @@ class RuntimeOutcome:
 CANONICAL_TERMINALS = ("T0", "T1", "T2", "T3")
 
 
+def _resolve_state_dir() -> str:
+    """Return the VNX state directory from env, falling back to a sensible default."""
+    state_dir = os.environ.get("VNX_STATE_DIR", "")
+    if state_dir:
+        return state_dir
+    # Derive from VNX_DATA_DIR when VNX_STATE_DIR is absent.
+    data_dir = os.environ.get("VNX_DATA_DIR", "")
+    if data_dir:
+        return str(Path(data_dir) / "state")
+    # Last-resort: repo-relative default (matches vnx_paths.py convention).
+    return str(Path(__file__).parent.parent.parent / ".vnx-data" / "state")
+
+
+def get_adapter(terminal: str) -> RuntimeAdapter:
+    """Factory: select adapter for terminal based on VNX_ADAPTER_{terminal} env var.
+
+    Values: ``tmux`` (default) | ``subprocess``
+
+    The tmux adapter is constructed with the state directory resolved from
+    ``VNX_STATE_DIR`` → ``VNX_DATA_DIR/state`` → repo-relative default.
+
+    Raises:
+        NotImplementedError: when value is ``subprocess`` (placeholder — SubprocessAdapter
+            not yet implemented).
+        ValueError: when value is set to an unrecognised string.
+    """
+    env_key = f"VNX_ADAPTER_{terminal.upper()}"
+    value = os.environ.get(env_key, "tmux").lower()
+    if value == "tmux":
+        return TmuxAdapter(_resolve_state_dir())
+    if value == "subprocess":
+        # SubprocessAdapter does not exist yet; import is deferred so that the
+        # module loads without error on standard paths.
+        raise NotImplementedError(
+            f"SubprocessAdapter is not yet implemented. "
+            f"Set {env_key}=tmux or leave unset."
+        )
+    raise ValueError(
+        f"Unknown adapter value {value!r} for {env_key}. "
+        f"Valid values: tmux, subprocess."
+    )
+
+
 class RuntimeFacade:
     """Adapter-backed runtime boundary for orchestration and dashboard.
 
@@ -55,7 +100,7 @@ class RuntimeFacade:
     owns canonical state (leases, dispatches, receipts).
     """
 
-    def __init__(self, adapter: TmuxAdapter) -> None:
+    def __init__(self, adapter: RuntimeAdapter) -> None:
         self._adapter = adapter
 
     @property

--- a/tests/test_runtime_facade.py
+++ b/tests/test_runtime_facade.py
@@ -25,7 +25,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from runtime_facade import CANONICAL_TERMINALS, RuntimeFacade, RuntimeOutcome
+from runtime_facade import CANONICAL_TERMINALS, RuntimeFacade, RuntimeOutcome, get_adapter
 from tmux_adapter import TmuxAdapter
 
 
@@ -266,3 +266,39 @@ class TestFacadeStop:
             outcome = f.stop("T9")
             assert outcome.success is True
             assert outcome.details["was_running"] is False
+
+
+# ---------------------------------------------------------------------------
+# 9. get_adapter factory
+# ---------------------------------------------------------------------------
+
+class TestGetAdapterFactory:
+
+    def test_default_selects_tmux_adapter(self, tmp_path: Path) -> None:
+        """No env var set — must return TmuxAdapter."""
+        env = {"VNX_STATE_DIR": str(tmp_path)}
+        # Ensure VNX_ADAPTER_T1 is absent so the default path is exercised.
+        with patch.dict("os.environ", env):
+            with patch.dict("os.environ", {}, clear=False):
+                import os as _os
+                _os.environ.pop("VNX_ADAPTER_T1", None)
+                adapter = get_adapter("T1")
+        assert isinstance(adapter, TmuxAdapter)
+
+    def test_explicit_tmux_selects_tmux_adapter(self, tmp_path: Path) -> None:
+        """VNX_ADAPTER_T1=tmux — must return TmuxAdapter."""
+        with patch.dict("os.environ", {"VNX_ADAPTER_T1": "tmux", "VNX_STATE_DIR": str(tmp_path)}):
+            adapter = get_adapter("T1")
+        assert isinstance(adapter, TmuxAdapter)
+
+    def test_subprocess_raises_not_implemented(self) -> None:
+        """VNX_ADAPTER_T1=subprocess — must raise NotImplementedError (placeholder)."""
+        with patch.dict("os.environ", {"VNX_ADAPTER_T1": "subprocess"}):
+            with pytest.raises(NotImplementedError, match="SubprocessAdapter"):
+                get_adapter("T1")
+
+    def test_invalid_value_raises_value_error(self) -> None:
+        """Unrecognised value raises ValueError with the offending key."""
+        with patch.dict("os.environ", {"VNX_ADAPTER_T1": "docker"}):
+            with pytest.raises(ValueError, match="VNX_ADAPTER_T1"):
+                get_adapter("T1")


### PR DESCRIPTION
## Summary
- Add get_adapter() factory with VNX_ADAPTER_{terminal} env var selection
- Default: TmuxAdapter. subprocess: NotImplementedError placeholder
- Factory tests for all selection paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)