### PR TITLE
feat(adapter): stream-json event parsing + --resume support (F28 PR-3)

### DIFF
--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -10,10 +10,16 @@ BILLING SAFETY: Only calls subprocess.Popen(["claude", ...]). No Anthropic SDK.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 import signal
 import subprocess
-from typing import Any, Dict, List, Optional
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from adapter_types import (
     CAPABILITY_DELIVER,
@@ -29,6 +35,21 @@ from adapter_types import (
     SpawnResult,
     StopResult,
 )
+
+
+
+# ---------------------------------------------------------------------------
+# StreamEvent dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StreamEvent:
+    """A single parsed event from --output-format stream-json stdout."""
+    type: str          # init, thinking, tool_use, tool_result, text, result, error
+    data: Dict[str, Any]
+    timestamp: float = field(default_factory=time.time)
+    session_id: Optional[str] = None  # extracted from init event
+
 
 SUBPROCESS_CAPABILITIES = frozenset({
     CAPABILITY_SPAWN,
@@ -58,6 +79,8 @@ class SubprocessAdapter:
         self._processes: Dict[str, subprocess.Popen] = {}
         # terminal_id -> spawn config (preserved for re-spawn if needed)
         self._configs: Dict[str, Dict[str, Any]] = {}
+        # terminal_id -> session_id extracted from init event
+        self._session_ids: Dict[str, str] = {}
 
     def adapter_type(self) -> str:
         return "subprocess"
@@ -115,6 +138,7 @@ class SubprocessAdapter:
         *,
         instruction: Optional[str] = None,
         model: Optional[str] = None,
+        resume_session: Optional[str] = None,
         **kwargs: Any,
     ) -> DeliveryResult:
         """Spawn a claude subprocess with the dispatch instruction.
@@ -122,6 +146,9 @@ class SubprocessAdapter:
         instruction and model can be passed directly or pulled from the stored
         config registered via spawn(). dispatch_id is always appended to the
         instruction so the subprocess can identify its work.
+
+        resume_session: if provided, adds --resume <session_id> to the CLI
+        command for session continuity.
         """
         config = self._configs.get(terminal_id, {})
         effective_instruction = instruction or config.get("instruction", dispatch_id)
@@ -132,8 +159,10 @@ class SubprocessAdapter:
             "-p",
             "--output-format", "stream-json",
             "--model", effective_model,
-            effective_instruction,
         ]
+        if resume_session:
+            cmd.extend(["--resume", resume_session])
+        cmd.append(effective_instruction)
 
         try:
             process = subprocess.Popen(
@@ -170,6 +199,58 @@ class SubprocessAdapter:
             pane_id=None,
             path_used="subprocess",
         )
+
+    # ------------------------------------------------------------------
+    # Stream event parsing
+    # ------------------------------------------------------------------
+
+    def read_events(self, terminal_id: str) -> Iterator[StreamEvent]:
+        """Yield parsed StreamEvents from subprocess stdout line-by-line.
+
+        Reads until EOF (process exited or pipe closed). Malformed NDJSON lines
+        are logged as warnings and skipped — they do not raise.
+
+        The first `init` event's session_id is stored and retrievable via
+        get_session_id().
+        """
+        process = self._processes.get(terminal_id)
+        if process is None or process.stdout is None:
+            return
+
+        for raw_line in process.stdout:
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\n")
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "subprocess_adapter: malformed NDJSON line for %s (skipped): %r",
+                    terminal_id,
+                    line[:200],
+                )
+                continue
+
+            event_type = payload.get("type", "")
+            session_id: Optional[str] = payload.get("session_id")
+
+            # Extract session_id from first init event
+            if event_type == "init" and session_id and terminal_id not in self._session_ids:
+                self._session_ids[terminal_id] = session_id
+
+            yield StreamEvent(
+                type=event_type,
+                data=payload,
+                session_id=session_id,
+            )
+
+    def get_session_id(self, terminal_id: str) -> Optional[str]:
+        """Return session_id extracted from the init event, or None.
+
+        Will be None if read_events() has not yet yielded the init event for
+        this terminal_id.
+        """
+        return self._session_ids.get(terminal_id)
 
     # ------------------------------------------------------------------
     # Observe

--- a/tests/test_subprocess_adapter_pr3.py
+++ b/tests/test_subprocess_adapter_pr3.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Tests for F28 PR-3: StreamEvent parsing and --resume support.
+
+Tests use mock subprocesses with NDJSON fixture data — no external processes
+are spawned. Covers all 7 event types, session_id extraction, --resume flag
+construction, malformed line handling, and read_events() iteration.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import sys
+import unittest
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+# Add scripts/lib to path so imports work without install
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "lib"))
+
+from subprocess_adapter import StreamEvent, SubprocessAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# NDJSON fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURE_INIT = {"type": "init", "session_id": "ses_abc123", "model": "claude-sonnet-4-6"}
+FIXTURE_THINKING = {"type": "thinking", "thinking": "Let me analyze this..."}
+FIXTURE_TOOL_USE = {"type": "tool_use", "name": "Read", "input": {"file_path": "/tmp/foo"}}
+FIXTURE_TOOL_RESULT = {"type": "tool_result", "content": "file contents here"}
+FIXTURE_TEXT = {"type": "text", "text": "Here is the answer."}
+FIXTURE_RESULT = {"type": "result", "result": "Task completed.", "session_id": "ses_abc123"}
+FIXTURE_ERROR = {"type": "error", "error": "Something went wrong"}
+
+ALL_FIXTURE_EVENTS = [
+    FIXTURE_INIT,
+    FIXTURE_THINKING,
+    FIXTURE_TOOL_USE,
+    FIXTURE_TOOL_RESULT,
+    FIXTURE_TEXT,
+    FIXTURE_RESULT,
+    FIXTURE_ERROR,
+]
+
+
+def make_ndjson_bytes(events: List[Dict[str, Any]]) -> bytes:
+    """Encode a list of dicts as NDJSON bytes."""
+    return b"\n".join(json.dumps(e).encode() for e in events) + b"\n"
+
+
+def make_mock_process(stdout_bytes: bytes, returncode: int = 0) -> MagicMock:
+    """Return a mock Popen-like object with a readable stdout pipe."""
+    mock = MagicMock()
+    mock.stdout = io.BytesIO(stdout_bytes)
+    mock.poll.return_value = returncode
+    mock.pid = 12345
+    mock.returncode = returncode
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# StreamEvent dataclass tests
+# ---------------------------------------------------------------------------
+
+class TestStreamEventDataclass(unittest.TestCase):
+    def test_required_fields(self):
+        evt = StreamEvent(type="text", data={"text": "hi"})
+        self.assertEqual(evt.type, "text")
+        self.assertEqual(evt.data, {"text": "hi"})
+        self.assertIsNone(evt.session_id)
+        self.assertIsInstance(evt.timestamp, float)
+        self.assertGreater(evt.timestamp, 0)
+
+    def test_session_id_field(self):
+        evt = StreamEvent(type="init", data={}, session_id="ses_xyz")
+        self.assertEqual(evt.session_id, "ses_xyz")
+
+    def test_all_event_types_constructible(self):
+        for etype in ("init", "thinking", "tool_use", "tool_result", "text", "result", "error"):
+            evt = StreamEvent(type=etype, data={"type": etype})
+            self.assertEqual(evt.type, etype)
+
+
+# ---------------------------------------------------------------------------
+# read_events() tests
+# ---------------------------------------------------------------------------
+
+class TestReadEvents(unittest.TestCase):
+    def _adapter_with_fixture(self, events: List[Dict]) -> SubprocessAdapter:
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(make_ndjson_bytes(events))
+        return adapter
+
+    def test_all_seven_event_types_parsed(self):
+        adapter = self._adapter_with_fixture(ALL_FIXTURE_EVENTS)
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(len(events), 7)
+        types = [e.type for e in events]
+        self.assertEqual(types, ["init", "thinking", "tool_use", "tool_result", "text", "result", "error"])
+
+    def test_init_event_fields(self):
+        adapter = self._adapter_with_fixture([FIXTURE_INIT])
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(len(events), 1)
+        evt = events[0]
+        self.assertEqual(evt.type, "init")
+        self.assertEqual(evt.session_id, "ses_abc123")
+        self.assertEqual(evt.data["model"], "claude-sonnet-4-6")
+
+    def test_text_event_fields(self):
+        adapter = self._adapter_with_fixture([FIXTURE_TEXT])
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(events[0].type, "text")
+        self.assertEqual(events[0].data["text"], "Here is the answer.")
+        self.assertIsNone(events[0].session_id)
+
+    def test_tool_use_event_fields(self):
+        adapter = self._adapter_with_fixture([FIXTURE_TOOL_USE])
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(events[0].type, "tool_use")
+        self.assertEqual(events[0].data["name"], "Read")
+
+    def test_error_event_fields(self):
+        adapter = self._adapter_with_fixture([FIXTURE_ERROR])
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(events[0].type, "error")
+        self.assertEqual(events[0].data["error"], "Something went wrong")
+
+    def test_empty_stdout_yields_nothing(self):
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(b"")
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(events, [])
+
+    def test_no_process_yields_nothing(self):
+        adapter = SubprocessAdapter()
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(events, [])
+
+    def test_blank_lines_skipped(self):
+        ndjson = b"\n\n" + json.dumps(FIXTURE_TEXT).encode() + b"\n\n"
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(ndjson)
+        events = list(adapter.read_events("T1"))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].type, "text")
+
+    def test_malformed_line_skipped_no_raise(self):
+        good = json.dumps(FIXTURE_TEXT).encode()
+        bad = b"NOT JSON {{{broken"
+        ndjson = bad + b"\n" + good + b"\n"
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(ndjson)
+        with self.assertLogs("subprocess_adapter", level="WARNING") as cm:
+            events = list(adapter.read_events("T1"))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].type, "text")
+        self.assertTrue(any("malformed" in msg for msg in cm.output))
+
+    def test_multiple_malformed_lines_all_skipped(self):
+        lines = b"garbage\n{bad json\n" + json.dumps(FIXTURE_RESULT).encode() + b"\n"
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(lines)
+        with self.assertLogs("subprocess_adapter", level="WARNING"):
+            events = list(adapter.read_events("T1"))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].type, "result")
+
+
+# ---------------------------------------------------------------------------
+# get_session_id() tests
+# ---------------------------------------------------------------------------
+
+class TestGetSessionId(unittest.TestCase):
+    def test_returns_none_before_read(self):
+        adapter = SubprocessAdapter()
+        self.assertIsNone(adapter.get_session_id("T1"))
+
+    def test_extracted_from_init_event(self):
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(make_ndjson_bytes([FIXTURE_INIT]))
+        list(adapter.read_events("T1"))  # consume iterator
+        self.assertEqual(adapter.get_session_id("T1"), "ses_abc123")
+
+    def test_extracted_from_first_init_only(self):
+        second_init = {"type": "init", "session_id": "ses_other", "model": "x"}
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(
+            make_ndjson_bytes([FIXTURE_INIT, second_init])
+        )
+        list(adapter.read_events("T1"))
+        # First init wins
+        self.assertEqual(adapter.get_session_id("T1"), "ses_abc123")
+
+    def test_no_session_id_if_no_init_event(self):
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(make_ndjson_bytes([FIXTURE_TEXT]))
+        list(adapter.read_events("T1"))
+        self.assertIsNone(adapter.get_session_id("T1"))
+
+    def test_init_without_session_id_field(self):
+        init_no_sid = {"type": "init", "model": "claude-sonnet-4-6"}
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(make_ndjson_bytes([init_no_sid]))
+        list(adapter.read_events("T1"))
+        self.assertIsNone(adapter.get_session_id("T1"))
+
+    def test_session_ids_isolated_per_terminal(self):
+        adapter = SubprocessAdapter()
+        adapter._processes["T1"] = make_mock_process(make_ndjson_bytes([FIXTURE_INIT]))
+        adapter._processes["T2"] = make_mock_process(
+            make_ndjson_bytes([{"type": "init", "session_id": "ses_t2_xyz"}])
+        )
+        list(adapter.read_events("T1"))
+        list(adapter.read_events("T2"))
+        self.assertEqual(adapter.get_session_id("T1"), "ses_abc123")
+        self.assertEqual(adapter.get_session_id("T2"), "ses_t2_xyz")
+
+
+# ---------------------------------------------------------------------------
+# --resume flag in deliver() tests
+# ---------------------------------------------------------------------------
+
+class TestDeliverResumeFlag(unittest.TestCase):
+    def _captured_cmd(self, **deliver_kwargs) -> List[str]:
+        """Run deliver() with a mocked Popen and return the cmd list it was called with."""
+        adapter = SubprocessAdapter()
+        adapter.spawn("T1", {})
+        captured = {}
+
+        def mock_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            mock = MagicMock()
+            mock.poll.return_value = None
+            mock.pid = 99
+            mock.returncode = None
+            mock.stdout = io.BytesIO(b"")
+            mock.stderr = io.BytesIO(b"")
+            return mock
+
+        with patch("subprocess_adapter.subprocess.Popen", side_effect=mock_popen):
+            adapter.deliver("T1", "dispatch-001", **deliver_kwargs)
+
+        return captured.get("cmd", [])
+
+    def test_no_resume_session_no_resume_flag(self):
+        cmd = self._captured_cmd(instruction="do work", model="sonnet")
+        self.assertNotIn("--resume", cmd)
+
+    def test_resume_session_adds_resume_flag(self):
+        cmd = self._captured_cmd(instruction="do work", model="sonnet", resume_session="ses_abc123")
+        self.assertIn("--resume", cmd)
+        idx = cmd.index("--resume")
+        self.assertEqual(cmd[idx + 1], "ses_abc123")
+
+    def test_resume_session_position_before_instruction(self):
+        cmd = self._captured_cmd(instruction="do work", model="sonnet", resume_session="ses_abc123")
+        resume_idx = cmd.index("--resume")
+        instruction_idx = cmd.index("do work")
+        self.assertLess(resume_idx, instruction_idx)
+
+    def test_resume_none_omits_flag(self):
+        cmd = self._captured_cmd(instruction="do work", model="sonnet", resume_session=None)
+        self.assertNotIn("--resume", cmd)
+
+    def test_output_format_stream_json_always_present(self):
+        cmd = self._captured_cmd(instruction="do work", resume_session="ses_abc123")
+        self.assertIn("--output-format", cmd)
+        idx = cmd.index("--output-format")
+        self.assertEqual(cmd[idx + 1], "stream-json")
+
+    def test_model_flag_always_present(self):
+        cmd = self._captured_cmd(instruction="do work", model="opus", resume_session="ses_abc123")
+        self.assertIn("--model", cmd)
+        idx = cmd.index("--model")
+        self.assertEqual(cmd[idx + 1], "opus")
+
+    def test_deliver_returns_success_with_resume(self):
+        adapter = SubprocessAdapter()
+        adapter.spawn("T1", {})
+
+        def mock_popen(cmd, **kwargs):
+            mock = MagicMock()
+            mock.poll.return_value = None
+            mock.pid = 99
+            mock.returncode = None
+            mock.stdout = io.BytesIO(b"")
+            mock.stderr = io.BytesIO(b"")
+            return mock
+
+        with patch("subprocess_adapter.subprocess.Popen", side_effect=mock_popen):
+            result = adapter.deliver(
+                "T1", "dispatch-001",
+                instruction="do work",
+                resume_session="ses_abc123",
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.path_used, "subprocess")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- StreamEvent dataclass for typed NDJSON event access
- read_events() iterator parsing subprocess stdout
- --resume session_id support in deliver()
- get_session_id() extraction from init events
- 307L tests, billing audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)