### PR TITLE
fix(dashboard): live testing fixes — kanban cards, staleness, PROJECT_ROOT

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -24,7 +24,7 @@ except ImportError:
 
 # Compute paths locally to avoid circular imports with serve_dashboard.
 VNX_DIR = Path(__file__).resolve().parents[1]
-PROJECT_ROOT = VNX_DIR.parents[1]
+PROJECT_ROOT = VNX_DIR
 SCRIPTS_DIR = VNX_DIR / "scripts"
 CANONICAL_STATE_DIR = Path(os.environ.get("VNX_STATE_DIR", str(PROJECT_ROOT / ".vnx-data" / "state")))
 _VNX_DATA_DIR = CANONICAL_STATE_DIR.parent

--- a/dashboard/token-dashboard/app/operator/kanban/page.tsx
+++ b/dashboard/token-dashboard/app/operator/kanban/page.tsx
@@ -301,8 +301,8 @@ function KanbanColumn({
         ) : cards.length === 0 ? (
           <EmptyColumn stage={colKey} />
         ) : (
-          cards.map((card) => (
-            <DispatchCard key={card.id} card={card} />
+          cards.map((card, idx) => (
+            <DispatchCard key={`${card.id}-${idx}`} card={card} />
           ))
         )}
       </div>

--- a/dashboard/token-dashboard/app/operator/kanban/page.tsx
+++ b/dashboard/token-dashboard/app/operator/kanban/page.tsx
@@ -96,23 +96,24 @@ function DispatchCard({ card }: { card: KanbanCard }) {
         transition: 'border-color 0.2s ease',
       }}
     >
-      {/* Top row: PR-id + track badge */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      {/* Top row: dispatch ID + track badge */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
         <span
-          data-testid="card-pr-id"
+          data-testid="card-id"
           style={{
-            fontSize: 12,
+            fontSize: 11,
             fontWeight: 700,
             color: 'var(--color-foreground)',
             letterSpacing: '-0.01em',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
-            maxWidth: 140,
+            flex: 1,
+            minWidth: 0,
           }}
-          title={card.pr_id}
+          title={card.id}
         >
-          {card.pr_id || '—'}
+          {card.id || card.pr_id || '—'}
         </span>
         {track && track !== '—' && (
           <span
@@ -134,7 +135,27 @@ function DispatchCard({ card }: { card: KanbanCard }) {
         )}
       </div>
 
-      {/* Middle: terminal + gate */}
+      {/* Reason / description */}
+      {card.reason && (
+        <p
+          data-testid="card-reason"
+          style={{
+            fontSize: 11,
+            color: 'var(--color-muted)',
+            margin: 0,
+            lineHeight: 1.4,
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+          title={card.reason}
+        >
+          {card.reason}
+        </p>
+      )}
+
+      {/* Meta row: terminal + gate + PR */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
         {card.terminal && card.terminal !== '—' && (
           <span
@@ -160,11 +181,27 @@ function DispatchCard({ card }: { card: KanbanCard }) {
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              maxWidth: 130,
+              maxWidth: 100,
             }}
             title={card.gate}
           >
             {card.gate}
+          </span>
+        )}
+        {card.pr_id && card.pr_id !== 'none' && card.pr_id !== '—' && (
+          <span
+            data-testid="card-pr-id"
+            style={{
+              fontSize: 10,
+              padding: '2px 7px',
+              borderRadius: 5,
+              background: 'rgba(249,115,22,0.10)',
+              border: '1px solid rgba(249,115,22,0.25)',
+              color: 'var(--color-accent)',
+              fontWeight: 600,
+            }}
+          >
+            {card.pr_id}
           </span>
         )}
       </div>

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -246,6 +246,7 @@ export interface KanbanCard {
   gate: string;
   priority: string;
   status: string;
+  reason?: string;
   stage: string;
   duration_secs: number;
   duration_label: string;

--- a/scripts/lib/dashboard_read_model.py
+++ b/scripts/lib/dashboard_read_model.py
@@ -433,7 +433,10 @@ class OpenItemsView:
         oi_path = self.state_dir / "open_items.json"
         oi_mtime = _file_mtime_iso(oi_path)
         sources = {"open_items.json": oi_mtime}
-        staleness, degraded, reasons = _compute_freshness(sources, now)
+        staleness, degraded, reasons = _compute_freshness(
+            sources, now,
+            threshold_overrides={"open_items.json": REGISTRY_AGING_THRESHOLD},
+        )
 
         raw = _load_json(oi_path)
         if raw is None:
@@ -538,7 +541,10 @@ class AggregateOpenItemsView:
             )
 
         _sort_by_severity(all_items)
-        staleness, degraded, fresh_reasons = _compute_freshness(sources, now)
+        oi_overrides = {k: REGISTRY_AGING_THRESHOLD for k in sources if k.endswith("open_items.json")}
+        staleness, degraded, fresh_reasons = _compute_freshness(
+            sources, now, threshold_overrides=oi_overrides,
+        )
         degraded_reasons.extend(fresh_reasons)
 
         total_summary = {
@@ -595,7 +601,13 @@ class SessionView:
             "progress_state.yaml": _file_mtime_iso(progress_path),
             "runtime_coordination.db": _file_mtime_iso(db_path),
         }
-        staleness, degraded, reasons = _compute_freshness(sources, now)
+        staleness, degraded, reasons = _compute_freshness(
+            sources, now,
+            threshold_overrides={
+                "pr_queue_state.json": REGISTRY_AGING_THRESHOLD,
+                "progress_state.yaml": REGISTRY_AGING_THRESHOLD,
+            },
+        )
 
         queue_data = _load_json(queue_path)
         progress_data = _load_yaml(progress_path)

--- a/scripts/lib/dashboard_read_model.py
+++ b/scripts/lib/dashboard_read_model.py
@@ -87,8 +87,10 @@ def _staleness(mtime_iso: Optional[str], now: datetime) -> Optional[float]:
         return None
     try:
         ts = datetime.fromisoformat(mtime_iso.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
         return (now - ts).total_seconds()
-    except (ValueError, AttributeError):
+    except (ValueError, AttributeError, TypeError):
         return None
 
 

--- a/scripts/lib/dashboard_read_model.py
+++ b/scripts/lib/dashboard_read_model.py
@@ -37,6 +37,7 @@ except ImportError:
 
 FRESH_THRESHOLD = 60
 AGING_THRESHOLD = 300
+REGISTRY_AGING_THRESHOLD = 86400  # 24h — registry files change infrequently
 
 
 @dataclass
@@ -117,6 +118,8 @@ def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
 def _compute_freshness(
     sources: Dict[str, Optional[str]],
     now: datetime,
+    *,
+    threshold_overrides: Optional[Dict[str, float]] = None,
 ) -> tuple[float, bool, List[str]]:
     """Compute max staleness and degraded state from source freshness map.
 
@@ -125,6 +128,7 @@ def _compute_freshness(
     max_staleness = 0.0
     degraded = False
     reasons: List[str] = []
+    overrides = threshold_overrides or {}
 
     for name, mtime in sources.items():
         if mtime is None:
@@ -138,7 +142,8 @@ def _compute_freshness(
             continue
         if age > max_staleness:
             max_staleness = age
-        if age > AGING_THRESHOLD:
+        threshold = overrides.get(name, AGING_THRESHOLD)
+        if age > threshold:
             degraded = True
             reasons.append(f"{name}: stale ({age:.0f}s)")
 
@@ -708,7 +713,10 @@ class ProjectsView:
 
             results.append(entry)
 
-        staleness, degraded, reasons = _compute_freshness(sources, now)
+        staleness, degraded, reasons = _compute_freshness(
+            sources, now,
+            threshold_overrides={"projects.json": REGISTRY_AGING_THRESHOLD},
+        )
 
         return FreshnessEnvelope(
             view="ProjectsView",


### PR DESCRIPTION
Dashboard fixes from T2 live testing: kanban dispatch cards, 24h staleness threshold, PROJECT_ROOT resolution, naive datetime crash.