### PR TITLE
feat(sse): agent stream SSE endpoint (F29 PR-2)

### DIFF
--- a/dashboard/api_agent_stream.py
+++ b/dashboard/api_agent_stream.py
@@ -1,0 +1,99 @@
+"""Agent stream SSE endpoint handlers.
+
+Provides Server-Sent Events streaming from EventStore NDJSON files
+and a status endpoint listing terminals with available events.
+
+BILLING SAFETY: No Anthropic SDK imports. Local filesystem only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from http import HTTPStatus
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from http.server import BaseHTTPRequestHandler
+
+# Make scripts/lib importable for EventStore
+_SCRIPTS_LIB = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, _SCRIPTS_LIB)
+
+from event_store import EventStore
+
+_store = EventStore()
+
+VALID_TERMINALS = frozenset({"T0", "T1", "T2", "T3"})
+
+_POLL_INTERVAL = 0.5  # seconds between polls for new events
+
+
+def handle_agent_stream(handler: BaseHTTPRequestHandler, terminal: str, since: str | None) -> None:
+    """Stream events for a terminal as SSE.
+
+    Keeps the connection open, polling every 500ms for new events.
+    Stops when the client disconnects (BrokenPipeError / ConnectionResetError).
+    """
+    if terminal not in VALID_TERMINALS:
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+        return
+
+    if _store.event_count(terminal) == 0:
+        _send_json(handler, HTTPStatus.NOT_FOUND, {"error": f"No events for terminal {terminal}"})
+        return
+
+    # Send SSE headers
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("Connection", "keep-alive")
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.end_headers()
+
+    last_timestamp = since
+
+    try:
+        while True:
+            events = list(_store.tail(terminal, since=last_timestamp))
+            for event in events:
+                line = f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
+                handler.wfile.write(line.encode("utf-8"))
+                ts = event.get("timestamp")
+                if ts:
+                    last_timestamp = ts
+
+            handler.wfile.flush()
+            time.sleep(_POLL_INTERVAL)
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        # Client disconnected — clean exit
+        pass
+
+
+def handle_agent_stream_status(handler: BaseHTTPRequestHandler) -> None:
+    """Return JSON listing terminals with event data."""
+    terminals = {}
+    for tid in sorted(VALID_TERMINALS):
+        count = _store.event_count(tid)
+        if count > 0:
+            last = _store.last_event(tid)
+            terminals[tid] = {
+                "event_count": count,
+                "last_timestamp": last.get("timestamp") if last else None,
+            }
+
+    _send_json(handler, HTTPStatus.OK, {"terminals": terminals})
+
+
+def _send_json(handler: BaseHTTPRequestHandler, status: HTTPStatus, payload: dict) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.end_headers()
+    handler.wfile.write(body)

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -137,6 +137,11 @@ from api_operator import (  # noqa: E402
     _unlock_terminal,
 )
 
+from api_agent_stream import (  # noqa: E402
+    handle_agent_stream,
+    handle_agent_stream_status,
+)
+
 
 def _json_response(handler: "DashboardHandler", status: HTTPStatus, payload_obj: dict) -> None:
     payload = json.dumps(payload_obj).encode("utf-8")
@@ -250,6 +255,17 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/system-health":
             _json_response(self, HTTPStatus.OK, _operator_get_system_health())
+            return
+
+        # Agent stream SSE endpoints
+        if path == "/api/agent-stream/status":
+            handle_agent_stream_status(self)
+            return
+
+        if path.startswith("/api/agent-stream/"):
+            terminal = path[len("/api/agent-stream/"):]
+            since = params.get("since", [None])[0]
+            handle_agent_stream(self, terminal, since)
             return
 
         # Return JSON 404 for unrecognised /api/* paths so callers get

--- a/tests/test_agent_stream_sse.py
+++ b/tests/test_agent_stream_sse.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Tests for agent stream SSE endpoint (F29 PR-2).
+
+Tests SSE response format, since-parameter reconnection, status endpoint,
+and client disconnect handling.
+"""
+
+import io
+import json
+import os
+import sys
+import threading
+import time
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add dashboard and scripts/lib to path
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+from event_store import EventStore
+from api_agent_stream import handle_agent_stream, handle_agent_stream_status, _store
+
+
+@pytest.fixture
+def tmp_events_dir(tmp_path):
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    return events_dir
+
+
+@pytest.fixture
+def store(tmp_events_dir):
+    return EventStore(events_dir=tmp_events_dir)
+
+
+def _make_handler(wfile=None):
+    """Build a mock HTTP handler with response tracking."""
+    handler = MagicMock()
+    handler.wfile = wfile or io.BytesIO()
+    headers_sent = {}
+
+    def send_header(name, value):
+        headers_sent[name] = value
+
+    handler.send_header = MagicMock(side_effect=send_header)
+    handler._headers_sent = headers_sent
+    return handler
+
+
+class TestSSEResponseFormat:
+    def test_returns_event_stream_content_type(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {"session_id": "abc"}})
+        handler = _make_handler()
+
+        # Stop the loop after first flush by raising on second flush
+        flush_count = 0
+
+        def limited_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count > 1:
+                raise BrokenPipeError("client disconnected")
+
+        handler.wfile.flush = limited_flush
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "T1", None)
+
+        handler.send_response.assert_called_with(HTTPStatus.OK)
+        handler.send_header.assert_any_call("Content-Type", "text/event-stream")
+        handler.send_header.assert_any_call("Cache-Control", "no-cache")
+        handler.send_header.assert_any_call("Access-Control-Allow-Origin", "*")
+
+    def test_events_formatted_as_sse_data_lines(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {"session_id": "abc"}})
+        store.append("T1", {"type": "result", "data": {"text": "hello"}})
+
+        handler = _make_handler()
+        flush_count = 0
+
+        def limited_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count > 1:
+                raise BrokenPipeError()
+
+        handler.wfile.flush = limited_flush
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "T1", None)
+
+        output = handler.wfile.getvalue().decode("utf-8")
+        lines = [l for l in output.split("\n") if l.startswith("data: ")]
+        assert len(lines) == 2
+
+        for line in lines:
+            payload = json.loads(line[len("data: "):])
+            assert "type" in payload
+            assert "timestamp" in payload
+            assert "terminal" in payload
+
+    def test_returns_404_for_empty_terminal(self, store, tmp_events_dir):
+        handler = _make_handler()
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "T2", None)
+
+        handler.send_response.assert_called_with(HTTPStatus.NOT_FOUND)
+
+    def test_returns_400_for_invalid_terminal(self, store, tmp_events_dir):
+        handler = _make_handler()
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "INVALID", None)
+
+        handler.send_response.assert_called_with(HTTPStatus.BAD_REQUEST)
+
+
+class TestSinceReconnection:
+    def test_since_filters_older_events(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}})
+        time.sleep(0.01)
+
+        # Get timestamp of first event to use as since
+        events = list(store.tail("T1"))
+        first_ts = events[0]["timestamp"]
+
+        time.sleep(0.01)
+        store.append("T1", {"type": "result", "data": {"text": "new"}})
+
+        handler = _make_handler()
+        flush_count = 0
+
+        def limited_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count > 1:
+                raise BrokenPipeError()
+
+        handler.wfile.flush = limited_flush
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "T1", since=first_ts)
+
+        output = handler.wfile.getvalue().decode("utf-8")
+        lines = [l for l in output.split("\n") if l.startswith("data: ")]
+        assert len(lines) == 1
+
+        payload = json.loads(lines[0][len("data: "):])
+        assert payload["type"] == "result"
+
+
+class TestStatusEndpoint:
+    def test_status_lists_terminals_with_events(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}})
+        store.append("T3", {"type": "init", "data": {}})
+
+        handler = _make_handler()
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream_status(handler)
+
+        handler.send_response.assert_called_with(HTTPStatus.OK)
+        body = handler.wfile.getvalue().decode("utf-8")
+        result = json.loads(body)
+
+        assert "T1" in result["terminals"]
+        assert "T3" in result["terminals"]
+        assert "T0" not in result["terminals"]
+        assert "T2" not in result["terminals"]
+
+        for tid in ("T1", "T3"):
+            info = result["terminals"][tid]
+            assert info["event_count"] > 0
+            assert "last_timestamp" in info
+
+    def test_status_empty_when_no_events(self, store, tmp_events_dir):
+        handler = _make_handler()
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream_status(handler)
+
+        body = handler.wfile.getvalue().decode("utf-8")
+        result = json.loads(body)
+        assert result["terminals"] == {}
+
+
+class TestClientDisconnect:
+    def test_broken_pipe_stops_cleanly(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}})
+
+        handler = _make_handler()
+
+        def raise_on_write(data):
+            raise BrokenPipeError("client gone")
+
+        handler.wfile.write = raise_on_write
+
+        with patch("api_agent_stream._store", store):
+            # Should not raise — disconnect handled gracefully
+            handle_agent_stream(handler, "T1", None)
+
+    def test_connection_reset_stops_cleanly(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}})
+
+        handler = _make_handler()
+
+        def raise_on_write(data):
+            raise ConnectionResetError("reset")
+
+        handler.wfile.write = raise_on_write
+
+        with patch("api_agent_stream._store", store):
+            handle_agent_stream(handler, "T1", None)


### PR DESCRIPTION
## Summary
- Add `GET /api/agent-stream/{terminal}` SSE endpoint that streams events from EventStore with 500ms polling interval
- Add `GET /api/agent-stream/status` JSON endpoint listing terminals with available event data (event_count + last_timestamp)
- Handle client disconnection gracefully (BrokenPipeError/ConnectionResetError)
- Support `since` query parameter for reconnection without duplicate events

## Test plan
- [x] SSE response Content-Type is `text/event-stream`
- [x] Events formatted as SSE `data:` lines with valid JSON
- [x] 404 returned for terminals with no events
- [x] 400 returned for invalid terminal names
- [x] `since` parameter filters older events correctly
- [x] Status endpoint lists terminals with events and omits empty ones
- [x] BrokenPipeError handled cleanly (no resource leak)
- [x] ConnectionResetError handled cleanly
- [x] All 9 tests pass (`pytest tests/test_agent_stream_sse.py`)
- [ ] Manual curl validation: `curl localhost:4173/api/agent-stream/T1`

Dispatch-ID: 20260406-270001-f29-pr2-sse-endpoint-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)