### PR TITLE
feat(dashboard): agent stream page + F29 closeout (F29 PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to VNX are documented here.
 
+## v0.5.2 — Dashboard Agent Stream (Feature 29)
+
+Released: 2026-04-06
+
+Highlights:
+- EventStore NDJSON persistence for agent stream events with atomic append and file locking (PR-1)
+- Open-item auto-close on dispatch completion and SubprocessAdapter integration (PR-1)
+- SSE endpoint `GET /api/agent-stream/{terminal}` for real-time event streaming with `since` reconnection (PR-2)
+- Stream status endpoint `GET /api/agent-stream/status` listing terminals with active event data (PR-2)
+- Dashboard Agent Stream page with terminal selector, color-coded event rendering, auto-scroll, and auto-reconnect (PR-3)
+- Sidebar "Agent Stream" link under Operator section (PR-3)
+
 ## v0.5.1 — Terminal Startup And Session Control (Feature 26)
 
 Released: 2026-04-04

--- a/dashboard/token-dashboard/app/agent-stream/page.tsx
+++ b/dashboard/token-dashboard/app/agent-stream/page.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Activity, Circle, Pause, Play } from 'lucide-react';
+
+const TERMINALS = ['T1', 'T2', 'T3'] as const;
+type Terminal = (typeof TERMINALS)[number];
+
+interface StreamEvent {
+  type: string;
+  timestamp: string;
+  terminal: string;
+  sequence: number;
+  dispatch_id: string;
+  data: Record<string, unknown>;
+}
+
+interface TerminalStatus {
+  event_count: number;
+  last_timestamp: string | null;
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  thinking: 'rgba(160, 170, 190, 0.85)',
+  tool_use: '#6B8AE6',
+  tool_result: '#50fa7b',
+  text: 'var(--color-foreground)',
+  result: 'var(--color-foreground)',
+  error: '#ff6b6b',
+  init: 'var(--color-accent)',
+};
+
+const EVENT_BG: Record<string, string> = {
+  thinking: 'rgba(160, 170, 190, 0.05)',
+  tool_use: 'rgba(107, 138, 230, 0.08)',
+  tool_result: 'rgba(80, 250, 123, 0.06)',
+  error: 'rgba(255, 107, 107, 0.08)',
+  init: 'rgba(249, 115, 22, 0.08)',
+};
+
+function EventBadge({ type }: { type: string }) {
+  const color = EVENT_COLORS[type] ?? 'var(--color-muted)';
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color,
+        background: EVENT_BG[type] ?? 'rgba(255,255,255,0.04)',
+        padding: '2px 8px',
+        borderRadius: 4,
+        border: `1px solid ${color}33`,
+        flexShrink: 0,
+      }}
+    >
+      {type}
+    </span>
+  );
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch {
+    return iso;
+  }
+}
+
+function renderEventContent(event: StreamEvent): string {
+  const d = event.data;
+  if (event.type === 'text' || event.type === 'result') {
+    return String(d?.text ?? d?.content ?? JSON.stringify(d));
+  }
+  if (event.type === 'thinking') {
+    return String(d?.thinking ?? d?.text ?? JSON.stringify(d));
+  }
+  if (event.type === 'tool_use') {
+    const name = String(d?.name ?? d?.tool ?? '');
+    return name ? `${name}(...)` : JSON.stringify(d);
+  }
+  if (event.type === 'tool_result') {
+    const content = String(d?.content ?? d?.output ?? d?.text ?? '');
+    return content.length > 300 ? content.slice(0, 300) + '...' : content || JSON.stringify(d);
+  }
+  if (event.type === 'error') {
+    return String(d?.error ?? d?.message ?? JSON.stringify(d));
+  }
+  if (event.type === 'init') {
+    return `Session started: ${d?.session_id ?? d?.dispatch_id ?? ''}`;
+  }
+  return JSON.stringify(d);
+}
+
+function EventRow({ event }: { event: StreamEvent }) {
+  const color = EVENT_COLORS[event.type] ?? 'var(--color-muted)';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 12,
+        alignItems: 'flex-start',
+        padding: '8px 12px',
+        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        fontSize: 13,
+        lineHeight: '1.5',
+      }}
+    >
+      <span style={{ color: 'var(--color-muted)', fontSize: 11, flexShrink: 0, marginTop: 2, fontFamily: 'monospace' }}>
+        {formatTime(event.timestamp)}
+      </span>
+      <EventBadge type={event.type} />
+      <span
+        style={{
+          color,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          fontFamily: event.type === 'thinking' ? 'inherit' : 'monospace',
+          fontStyle: event.type === 'thinking' ? 'italic' : 'normal',
+          flex: 1,
+        }}
+      >
+        {renderEventContent(event)}
+      </span>
+    </div>
+  );
+}
+
+export default function AgentStreamPage() {
+  const [terminal, setTerminal] = useState<Terminal>('T1');
+  const [events, setEvents] = useState<StreamEvent[]>([]);
+  const [status, setStatus] = useState<Record<string, TerminalStatus>>({});
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paused, setPaused] = useState(false);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const lastTimestampRef = useRef<string | null>(null);
+  const pausedRef = useRef(false);
+
+  // Keep ref in sync with state for use in EventSource callbacks
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  // Fetch status endpoint
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchStatus() {
+      try {
+        const res = await fetch('/api/agent-stream/status');
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setStatus(data.terminals ?? {});
+        }
+      } catch {
+        // non-critical
+      }
+    }
+    fetchStatus();
+    const iv = setInterval(fetchStatus, 5000);
+    return () => { cancelled = true; clearInterval(iv); };
+  }, []);
+
+  // Connect to SSE
+  const connect = useCallback((term: Terminal, since: string | null) => {
+    // Close existing connection
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+
+    let url = `/api/agent-stream/${term}`;
+    if (since) url += `?since=${encodeURIComponent(since)}`;
+
+    const es = new EventSource(url);
+    eventSourceRef.current = es;
+
+    es.onopen = () => {
+      setConnected(true);
+      setError(null);
+    };
+
+    es.onmessage = (msg) => {
+      try {
+        const event: StreamEvent = JSON.parse(msg.data);
+        if (event.timestamp) {
+          lastTimestampRef.current = event.timestamp;
+        }
+        if (!pausedRef.current) {
+          setEvents((prev) => [...prev, event]);
+        }
+      } catch {
+        // skip malformed
+      }
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      es.close();
+      eventSourceRef.current = null;
+      // Auto-reconnect after 2s
+      setTimeout(() => {
+        connect(term, lastTimestampRef.current);
+      }, 2000);
+    };
+  }, []);
+
+  // Connect when terminal changes
+  useEffect(() => {
+    setEvents([]);
+    setError(null);
+    lastTimestampRef.current = null;
+    connect(terminal, null);
+
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      setConnected(false);
+    };
+  }, [terminal, connect]);
+
+  // Auto-scroll
+  useEffect(() => {
+    if (!paused && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [events, paused]);
+
+  const terminalStatus = status[terminal];
+
+  return (
+    <div>
+      {/* Page header */}
+      <div className="flex items-center justify-between" style={{ marginBottom: 24 }}>
+        <div className="flex items-center gap-3">
+          <div style={{ height: 28, width: 4, borderRadius: 2, background: 'var(--color-accent)' }} />
+          <div>
+            <h2
+              style={{
+                fontSize: '1.5rem',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                color: 'var(--color-foreground)',
+              }}
+            >
+              Agent Stream
+            </h2>
+            <p style={{ fontSize: 12, color: 'var(--color-muted)', marginTop: 2 }}>
+              Real-time event stream from worker terminals
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* Connection status */}
+          <div className="flex items-center gap-2" style={{ fontSize: 12, color: connected ? '#50fa7b' : 'var(--color-muted)' }}>
+            <Circle size={8} fill={connected ? '#50fa7b' : 'var(--color-muted)'} />
+            {connected ? 'Connected' : 'Disconnected'}
+          </div>
+
+          {/* Pause/Resume */}
+          <button
+            onClick={() => setPaused(!paused)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '7px 14px',
+              borderRadius: 8,
+              background: paused ? 'rgba(249, 115, 22, 0.15)' : 'rgba(255,255,255,0.05)',
+              border: `1px solid ${paused ? 'rgba(249, 115, 22, 0.3)' : 'rgba(255,255,255,0.1)'}`,
+              cursor: 'pointer',
+              fontSize: 12,
+              color: paused ? 'var(--color-accent)' : 'var(--color-muted)',
+            }}
+          >
+            {paused ? <Play size={13} /> : <Pause size={13} />}
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+
+          {/* Terminal selector */}
+          <div style={{ display: 'flex', gap: 4 }}>
+            {TERMINALS.map((t) => {
+              const active = t === terminal;
+              const hasEvents = !!status[t];
+              return (
+                <button
+                  key={t}
+                  onClick={() => setTerminal(t)}
+                  style={{
+                    padding: '7px 16px',
+                    borderRadius: 8,
+                    background: active ? 'rgba(249, 115, 22, 0.15)' : 'rgba(255,255,255,0.05)',
+                    border: `1px solid ${active ? 'rgba(249, 115, 22, 0.3)' : 'rgba(255,255,255,0.1)'}`,
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    fontWeight: active ? 600 : 400,
+                    color: active ? 'var(--color-accent)' : 'var(--color-muted)',
+                    position: 'relative',
+                  }}
+                >
+                  {t}
+                  {hasEvents && (
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 4,
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        background: '#50fa7b',
+                      }}
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      {terminalStatus && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 24,
+            padding: '10px 16px',
+            marginBottom: 16,
+            background: 'rgba(255,255,255,0.02)',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.06)',
+            fontSize: 12,
+            color: 'var(--color-muted)',
+          }}
+        >
+          <span>Events: <strong style={{ color: 'var(--color-foreground)' }}>{terminalStatus.event_count}</strong></span>
+          <span>Displayed: <strong style={{ color: 'var(--color-foreground)' }}>{events.length}</strong></span>
+          {terminalStatus.last_timestamp && (
+            <span>Last: <strong style={{ color: 'var(--color-foreground)' }}>{formatTime(terminalStatus.last_timestamp)}</strong></span>
+          )}
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div
+          style={{
+            padding: '12px 16px',
+            marginBottom: 16,
+            background: 'rgba(255, 107, 107, 0.08)',
+            borderRadius: 8,
+            border: '1px solid rgba(255, 107, 107, 0.2)',
+            color: '#ff6b6b',
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Event stream */}
+      <div
+        ref={scrollRef}
+        style={{
+          background: 'var(--color-card)',
+          borderRadius: 12,
+          border: '1px solid var(--color-card-border)',
+          height: 'calc(100vh - 240px)',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+        }}
+      >
+        {events.length === 0 ? (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+              gap: 12,
+              color: 'var(--color-muted)',
+            }}
+          >
+            <Activity size={32} strokeWidth={1.5} />
+            <span style={{ fontSize: 13 }}>
+              {connected ? 'Waiting for events...' : `No events for ${terminal}`}
+            </span>
+          </div>
+        ) : (
+          events.map((ev, i) => <EventRow key={`${ev.terminal}-${ev.sequence}-${i}`} event={ev} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -3,13 +3,14 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity } from 'lucide-react';
 
 const OPERATOR_NAV = [
   { href: '/operator', label: 'Control Surface', icon: Radio },
   { href: '/operator/open-items', label: 'Open Items', icon: AlertTriangle },
   { href: '/operator/kanban', label: 'Kanban Board', icon: Kanban },
   { href: '/operator/governance', label: 'Governance', icon: ShieldAlert },
+  { href: '/agent-stream', label: 'Agent Stream', icon: Activity },
 ];
 
 const NAV_ITEMS = [


### PR DESCRIPTION
## Summary
- Add agent stream page at `/agent-stream` with real-time SSE event rendering, terminal selector (T1/T2/T3), color-coded event types, auto-scroll, pause/resume, and auto-reconnect with `since` parameter
- Add "Agent Stream" link to sidebar under Operator section with Activity icon
- Update CHANGELOG.md with F29 v0.5.2 closeout summary

## Test plan
- [x] `next build` compiles successfully (pre-existing type error in open-items/page.tsx is unrelated)
- [x] Page renders at `/agent-stream` route
- [x] Terminal selector buttons switch streams
- [x] Event types color-coded: thinking (gray), tool_use (blue), tool_result (green), text/result (white), error (red), init (orange)
- [x] Auto-scroll follows latest events
- [x] Pause/Resume button stops/resumes auto-scroll and event append
- [x] Connection status indicator shows connected/disconnected
- [x] SSE reconnection with `since` parameter on disconnect
- [x] Status endpoint polled every 5s for terminal activity indicators
- [x] Sidebar shows "Agent Stream" link with Activity icon
- [ ] End-to-end: dispatch → subprocess → event store → SSE → browser render

Dispatch-ID: 20260406-280001-f29-pr3-dashboard-stream-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)