### PR TITLE
fix(subprocess): wire event pipeline + stream archive

### DIFF
--- a/docs/internal/plans/HEADLESS_BURNIN_TEST_PLAN.md
+++ b/docs/internal/plans/HEADLESS_BURNIN_TEST_PLAN.md
@@ -580,12 +580,15 @@ for t in tools: print(f'  - {t}')
 8. **Long-running stability** (Scenario 5): 50+ events captured without gaps
 9. **Dashboard renders**: Agent-stream page shows events color-coded by type
 10. **tmux parity** (Scenario 6): Subprocess produces functionally equivalent results
+11. **Model variations** (Scenario 7): haiku, opus, and sonnet all produce valid streams
+12. **Session resume** (Scenario 8): `--resume` flag produces context-aware continuation
 
 ### Informational (Observed but Not Blocking)
 
-11. Session JSONL cross-reference: EventStore event count as expected fraction of JSONL lines
-12. Event file size stays under 10 MB for all scenarios
-13. SSE latency: Events appear in dashboard within 1 second of generation
+13. Session JSONL cross-reference: EventStore event count as expected fraction of JSONL lines
+14. Event file size stays under 10 MB for all scenarios
+15. SSE latency: Events appear in dashboard within 1 second of generation
+16. Shell routing (Scenario 9): `VNX_ADAPTER_T{n}` variable correctly routes through dispatcher
 
 ---
 
@@ -623,3 +626,162 @@ cp .vnx-data/events/T1.ndjson .vnx-data/events/burnin-snapshot-scenario-N.ndjson
 ```
 
 This preserves evidence until the archive proposal (Section 4) is implemented.
+
+---
+
+## 8. CLI Flag Variation Scenarios
+
+`SubprocessAdapter.deliver()` builds the command: `claude -p --output-format stream-json --model <model> [--resume <session_id>] <instruction>`. These scenarios validate the flag combinations that the dispatcher can produce.
+
+### Scenario 7: Model Variations
+
+**Goal**: Verify all model values the dispatcher might pass produce valid streams.
+
+#### 7a: Explicit Haiku (cheapest — good for burn-in volume)
+
+```bash
+export VNX_ADAPTER_T1=subprocess
+
+python3 scripts/lib/subprocess_dispatch.py \
+  --terminal-id T1 \
+  --instruction "Say the word 'haiku-ok'." \
+  --model haiku \
+  --dispatch-id burnin-007a-model-haiku
+```
+
+**Validation**:
+- [ ] Process exits 0, `result` event contains "haiku-ok" or equivalent
+- [ ] `init` event `data` field shows the haiku model was used
+
+#### 7b: Explicit Opus
+
+```bash
+python3 scripts/lib/subprocess_dispatch.py \
+  --terminal-id T1 \
+  --instruction "Say the word 'opus-ok'." \
+  --model opus \
+  --dispatch-id burnin-007b-model-opus
+```
+
+**Validation**:
+- [ ] Process exits 0, `result` event present
+- [ ] Note: dispatcher normalizes "opus" → "default" for `/model` command in tmux path; verify `subprocess_adapter.py` passes "opus" raw to CLI (it does — no normalization in SubprocessAdapter)
+
+#### 7c: Default model (sonnet — omitted is same as sonnet)
+
+```bash
+python3 scripts/lib/subprocess_dispatch.py \
+  --terminal-id T1 \
+  --instruction "Say the word 'sonnet-ok'." \
+  --model sonnet \
+  --dispatch-id burnin-007c-model-sonnet
+```
+
+**Validation**:
+- [ ] Process exits 0
+- [ ] This is the baseline — should behave identically to S1
+
+### Scenario 8: Session Resume via --resume
+
+**Goal**: Verify `--resume <session_id>` flag produces a valid continuation stream.
+
+`SubprocessAdapter.deliver()` accepts `resume_session` which adds `--resume <session_id>` to the CLI command. This is used for session continuity (e.g., retrying a failed dispatch against the same conversation).
+
+**Note**: `subprocess_dispatch.py` CLI does not currently expose `--resume`. This scenario requires direct Python invocation.
+
+```bash
+export VNX_ADAPTER_T1=subprocess
+
+# Step 1: Run initial dispatch, capture session_id from init event
+python3 -c "
+import sys
+sys.path.insert(0, 'scripts/lib')
+from subprocess_adapter import SubprocessAdapter
+
+adapter = SubprocessAdapter()
+adapter.deliver('T1', 'burnin-008a-resume-init', instruction='Say hello and tell me your session ID.', model='haiku')
+
+session_id = None
+for event in adapter.read_events('T1'):
+    if event.type == 'init' and event.session_id:
+        session_id = event.session_id
+        print(f'Captured session_id: {session_id}')
+
+# Save for step 2
+if session_id:
+    with open('/tmp/burnin-008-session-id.txt', 'w') as f:
+        f.write(session_id)
+    print(f'Session ID saved: {session_id}')
+else:
+    print('WARNING: No session_id captured from init event')
+    sys.exit(1)
+"
+
+# Step 2: Resume the same session
+SESSION_ID=$(cat /tmp/burnin-008-session-id.txt)
+echo "Resuming session: $SESSION_ID"
+
+python3 -c "
+import sys
+sys.path.insert(0, 'scripts/lib')
+from subprocess_adapter import SubprocessAdapter
+
+adapter = SubprocessAdapter()
+adapter.deliver('T1', 'burnin-008b-resume-continue',
+    instruction='What was the first thing I asked you?',
+    model='haiku',
+    resume_session='$SESSION_ID')
+
+for event in adapter.read_events('T1'):
+    if event.type in ('text', 'result'):
+        print(f'[{event.type}] {event.data}')
+"
+```
+
+**Validation Checklist**:
+- [ ] Step 1 produces events with a valid `session_id` in the `init` event
+- [ ] Step 2 process exits 0 (session resume accepted by CLI)
+- [ ] Step 2 `init` event has the same `session_id` as Step 1
+- [ ] Step 2 response references the prior conversation (proves context continuity)
+- [ ] Step 2 events have `dispatch_id: burnin-008b-resume-continue` (not the Step 1 ID)
+- [ ] `clear()` was called between Step 1 and Step 2 (Step 2 events start at sequence 1)
+
+### Scenario 9: Dispatch-Level Flag Integration Test
+
+**Goal**: Verify the full dispatcher shell path correctly passes `VNX_ADAPTER_T{n}=subprocess` flag through `dispatch_deliver.sh` → `subprocess_dispatch.py`.
+
+This is not a direct Python call — it tests the actual shell routing.
+
+```bash
+export VNX_ADAPTER_T1=subprocess
+
+# Create a minimal dispatch file for testing
+DISPATCH_ID="burnin-009-shell-route"
+DISPATCH_FILE=".vnx-data/dispatches/pending/${DISPATCH_ID}.md"
+mkdir -p .vnx-data/dispatches/pending
+
+cat > "$DISPATCH_FILE" << 'DISPATCH'
+---
+dispatch-id: burnin-009-shell-route
+track: A
+agent-role: architect
+pr: HEADLESS-BURNIN
+gate: planning
+---
+
+Say 'shell-route-ok' and nothing else.
+DISPATCH
+
+# Verify the dispatcher would route to subprocess
+# (dry-run: check adapter var resolution)
+bash -c '
+  terminal_id="T1"
+  adapter_var="VNX_ADAPTER_${terminal_id}"
+  echo "Adapter for $terminal_id: ${!adapter_var:-tmux}"
+'
+```
+
+**Validation**:
+- [ ] Shell variable resolution correctly yields "subprocess"
+- [ ] If running a full dispatch cycle: events appear in T1.ndjson
+- [ ] dispatch_deliver.sh `_ddt_subprocess_delivery` path is exercised (check dispatcher logs)

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -15,6 +15,7 @@ import fcntl
 import json
 import logging
 import os
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
@@ -120,11 +121,38 @@ class EventStore:
             finally:
                 fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
-    def clear(self, terminal: str) -> None:
+    def archive_dir(self, terminal: str) -> Path:
+        """Return the archive directory for a terminal."""
+        return self._events_dir / "archive" / terminal
+
+    def archive(self, terminal: str, dispatch_id: str) -> Optional[Path]:
+        """Copy current event file to archive before clearing.
+
+        Returns the archive path on success, None if nothing to archive.
+        """
+        event_file = self._terminal_path(terminal)
+        if not event_file.exists() or event_file.stat().st_size == 0:
+            return None
+
+        archive_path = self.archive_dir(terminal)
+        archive_path.mkdir(parents=True, exist_ok=True)
+        dest = archive_path / f"{dispatch_id}.ndjson"
+        shutil.copy2(str(event_file), str(dest))
+        logger.info("event_store: archived %s -> %s", event_file, dest)
+        return dest
+
+    def clear(self, terminal: str, archive_dispatch_id: Optional[str] = None) -> None:
         """Truncate the event file for a terminal (new dispatch clears old events).
+
+        If archive_dispatch_id is provided and the file has content, the events
+        are archived to .vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson
+        before truncation.
 
         Also resets the sequence counter.
         """
+        if archive_dispatch_id:
+            self.archive(terminal, archive_dispatch_id)
+
         path = self._terminal_path(terminal)
         self._sequences.pop(terminal, None)
 

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -207,10 +207,12 @@ class SubprocessAdapter:
 
         self._processes[terminal_id] = process
 
-        # Clear event store for new dispatch (per retention policy)
+        # Archive previous dispatch events, then clear for new dispatch
         es = self._get_event_store()
         if es is not None:
-            es.clear(terminal_id)
+            last = es.last_event(terminal_id)
+            prev_dispatch_id = last.get("dispatch_id") if last else None
+            es.clear(terminal_id, archive_dispatch_id=prev_dispatch_id or None)
 
         return DeliveryResult(
             success=True,

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -24,6 +24,9 @@ def deliver_via_subprocess(
 ) -> bool:
     """Deliver a dispatch instruction to terminal_id via SubprocessAdapter.
 
+    Blocks until the subprocess exits, consuming all stream events.
+    Events are persisted to EventStore via read_events() internally.
+
     Returns True on success, False on failure.
     """
     adapter = SubprocessAdapter()
@@ -33,7 +36,13 @@ def deliver_via_subprocess(
         instruction=instruction,
         model=model,
     )
-    return result.success
+    if not result.success:
+        return False
+    # Consume all events — blocks until subprocess exits.
+    # read_events() internally calls EventStore.append() for each event.
+    for _event in adapter.read_events(terminal_id):
+        pass
+    return True
 
 
 if __name__ == "__main__":

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -179,6 +179,57 @@ class TestConcurrentWrites:
             assert "sequence" in event
 
 
+class TestArchive:
+    def test_clear_with_archive_creates_archive_file(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}}, dispatch_id="d-100")
+        store.append("T1", {"type": "result", "data": {}}, dispatch_id="d-100")
+        assert store.event_count("T1") == 2
+
+        store.clear("T1", archive_dispatch_id="d-100")
+        assert store.event_count("T1") == 0
+
+        archive_path = tmp_events_dir / "archive" / "T1" / "d-100.ndjson"
+        assert archive_path.exists()
+        lines = [l for l in archive_path.read_text().strip().split("\n") if l]
+        assert len(lines) == 2
+        for line in lines:
+            event = json.loads(line)
+            assert event["dispatch_id"] == "d-100"
+
+    def test_clear_without_archive_does_not_create_archive(self, store, tmp_events_dir):
+        store.append("T1", {"type": "init", "data": {}})
+        store.clear("T1")
+        archive_dir = tmp_events_dir / "archive" / "T1"
+        assert not archive_dir.exists()
+
+    def test_archive_empty_file_returns_none(self, store, tmp_events_dir):
+        # Create empty file
+        path = tmp_events_dir / "T1.ndjson"
+        path.touch()
+        result = store.archive("T1", "d-200")
+        assert result is None
+
+    def test_archive_nonexistent_file_returns_none(self, store):
+        result = store.archive("T1", "d-300")
+        assert result is None
+
+    def test_archive_preserves_content(self, store, tmp_events_dir):
+        for i in range(5):
+            store.append("T1", {"type": "text", "data": {"i": i}}, dispatch_id="d-400")
+        store.clear("T1", archive_dispatch_id="d-400")
+
+        archive_path = tmp_events_dir / "archive" / "T1" / "d-400.ndjson"
+        lines = [l for l in archive_path.read_text().strip().split("\n") if l]
+        assert len(lines) == 5
+        for i, line in enumerate(lines):
+            event = json.loads(line)
+            assert event["sequence"] == i + 1
+
+    def test_archive_dir_property(self, store, tmp_events_dir):
+        expected = tmp_events_dir / "archive" / "T1"
+        assert store.archive_dir("T1") == expected
+
+
 class TestEventCount:
     def test_event_count_zero(self, store):
         assert store.event_count("T1") == 0

--- a/tests/test_subprocess_dispatch.py
+++ b/tests/test_subprocess_dispatch.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Tests for subprocess_dispatch — event pipeline wiring."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from subprocess_dispatch import deliver_via_subprocess
+
+
+@pytest.fixture
+def mock_adapter():
+    """Patch SubprocessAdapter and return the mock instance."""
+    with patch("subprocess_dispatch.SubprocessAdapter") as cls:
+        instance = MagicMock()
+        cls.return_value = instance
+        yield instance
+
+
+class TestDeliverViaSubprocess:
+    def test_success_consumes_all_events(self, mock_adapter):
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events.return_value = iter([
+            MagicMock(type="init"),
+            MagicMock(type="text"),
+            MagicMock(type="result"),
+        ])
+
+        result = deliver_via_subprocess("T1", "do stuff", "sonnet", "d-001")
+
+        assert result is True
+        mock_adapter.deliver.assert_called_once_with(
+            "T1", "d-001", instruction="do stuff", model="sonnet",
+        )
+        mock_adapter.read_events.assert_called_once_with("T1")
+
+    def test_failure_returns_false_without_reading(self, mock_adapter):
+        mock_adapter.deliver.return_value = MagicMock(success=False)
+
+        result = deliver_via_subprocess("T1", "do stuff", "sonnet", "d-002")
+
+        assert result is False
+        mock_adapter.read_events.assert_not_called()
+
+    def test_empty_event_stream_succeeds(self, mock_adapter):
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events.return_value = iter([])
+
+        result = deliver_via_subprocess("T1", "do stuff", "sonnet", "d-003")
+
+        assert result is True
+        mock_adapter.read_events.assert_called_once_with("T1")


### PR DESCRIPTION
## Summary
- **Event pipeline wired**: `deliver_via_subprocess()` now blocks on `read_events()` until the subprocess exits, ensuring all NDJSON events are persisted to EventStore. Previously, stdout was never consumed.
- **Stream archive**: `EventStore.clear()` accepts optional `archive_dispatch_id` — when provided, events are copied to `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson` before truncation, preserving audit trail across dispatch boundaries.
- **Adapter integration**: `SubprocessAdapter.deliver()` reads the previous dispatch_id from the last event and passes it to `clear()` for automatic archiving.

## Test plan
- [x] `pytest tests/test_event_store.py -v` — 25 tests pass (6 new archive tests)
- [x] `pytest tests/test_subprocess_dispatch.py -v` — 3 tests pass (new file, mock-based)
- [x] `pytest tests/test_agent_stream_sse.py -v` — 9 tests pass (regression check)
- [ ] Burn-in scenarios 1-5 from `docs/internal/plans/HEADLESS_BURNIN_TEST_PLAN.md`

Dispatch-ID: 20260406-300001-subprocess-event-pipeline-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)