### PR TITLE
feat(headless): T1 as headless backend-developer (F32)

### DIFF
--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -135,6 +135,17 @@ sqlite3 .vnx-data/state/runtime_coordination.db "SELECT * FROM terminal_leases W
 python3 scripts/runtime_core_cli.py release-on-failure --terminal <T> --dispatch-id <old-dispatch> --generation <gen> --reason "stale_lease_cleanup"
 ```
 
+## Headless T1 Dispatch
+
+T1 is a headless backend-developer. Dispatch via:
+- Set VNX_ADAPTER_T1=subprocess in the dispatcher environment (default since F32)
+- Or call directly: `python3 scripts/lib/subprocess_dispatch.py --terminal-id T1 --dispatch-id <id> --model sonnet --instruction "<task>"`
+
+T1 dispatches do NOT go through tmux send-keys.
+T1 receipts arrive in t0_receipts.ndjson with source="subprocess".
+T1 events stream to .vnx-data/events/T1.ndjson and are visible via SSE.
+The subprocess automatically loads T1's CLAUDE.md as skill context (injected by subprocess_dispatch.py).
+
 ## Quick Commands
 
 ```bash

--- a/.claude/terminals/T1/CLAUDE.md
+++ b/.claude/terminals/T1/CLAUDE.md
@@ -1,49 +1,46 @@
-# T1 Worker Terminal (Track A)
+# T1 — Backend Developer Agent
 
-Purpose: implementation-heavy tasks. For this feature, expect concrete Python/runtime changes that make headless runs inspectable.
+You are a backend developer. You implement features, fix bugs, and write tests.
 
-## Startup
-1. Your dispatch arrives in this conversation. Execute only the scoped work in that dispatch.
-2. Write your report to `$VNX_DATA_DIR/unified_reports/` using the absolute runtime path from environment.
+## Your Capabilities
+- Python, TypeScript, shell scripting
+- Read, Write, Edit, Bash, Grep, Glob tools
+- Git operations (commit, push, branch)
+- pytest for testing
 
-## load-dispatch Activation
-When your first message is `load-dispatch <dispatch-id>`, read the dispatch bundle from disk:
-```bash
-python scripts/load_dispatch.py --dispatch-id <dispatch-id>
-```
-This prints the skill command and full prompt. Execute those instructions as your task.
+## Your Workflow
+1. Read the dispatch instruction carefully
+2. Read relevant code files before making changes
+3. Implement the changes
+4. Write/update tests
+5. Run tests to verify
+6. Commit with conventional commit format
+7. Push to the branch
+8. Create GitHub PR if instructed
+9. Write a completion report to .vnx-data/unified_reports/
 
-## Required Report Discipline
+## Rules
+- No TODO comments — complete all implementations
+- No mock objects or placeholder data
+- Run all existing tests before committing
+- Follow established project patterns and conventions
+- All shell changes must pass `bash -n`
+- Backward compatibility with existing commands is mandatory unless dispatch says otherwise
+- Path handling must work in both main repo and worktree contexts
 
-Your report must always include:
-
-- what changed
-- exact commands you ran
-- exact test files and totals you ran
-- whether you tested PTY-backed, non-PTY, or synthetic paths
-- known limitations or unresolved runtime gaps
+## Report Discipline
+Your report must include:
+- What changed (files modified)
+- Exact commands you ran
+- Exact test files and totals you ran
+- Known limitations or unresolved runtime gaps
 - `## Open Items` section, even when empty
 
 Do NOT:
+- Invent totals
+- Say "tests passed" without naming the command
+- Say "done" if you left follow-up work or ambiguity
+- Claim a PR or feature is closure-ready; only T0 can declare governance completion
 
-- invent totals
-- say "tests passed" without naming the command
-- say "done" if you left follow-up work or ambiguity
-- claim a PR or feature is closure-ready; only T0 can declare governance completion
-- claim headless behavior is operationally proven if you only exercised unit paths
-
-## Project Rules
-
-- This project modifies VNX itself
-- Main CLI: `bin/vnx`
-- All shell changes must pass `bash -n`
-- Backward compatibility with existing commands is mandatory unless dispatch says otherwise
-- Path handling must work in both main repo and worktree contexts where relevant
-
-## Evidence Standard
-
-- If you changed code, say which files changed
-- If you ran tests, include the exact command
-- If you could not run something, say that explicitly
-- If headless logging, heartbeat, or exit classification is involved, say exactly which evidence path you verified
-- Distinguish clearly between local verification and any remote GitHub/CI checks you did not perform
+## BILLING SAFETY
+No Anthropic SDK imports. No api.anthropic.com calls. CLI-only.

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -511,8 +511,12 @@ deliver_dispatch_to_terminal() {
     local complete_prompt="$8" skill_command="$9"
 
     # Resolve per-terminal adapter: VNX_ADAPTER_T1, VNX_ADAPTER_T2, etc.
+    # T1 defaults to subprocess (headless backend-developer) since F32.
     local adapter_var="VNX_ADAPTER_${terminal_id}"
     local adapter_type="${!adapter_var:-tmux}"
+    if [[ "$terminal_id" == "T1" && "$adapter_type" == "tmux" && -z "${!adapter_var:-}" ]]; then
+        adapter_type="subprocess"
+    fi
 
     if [[ "$adapter_type" == "subprocess" ]]; then
         local model="${_CTM_REQUIRES_MODEL:-sonnet}"

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -24,6 +24,25 @@ from subprocess_adapter import SubprocessAdapter
 logger = logging.getLogger(__name__)
 
 
+def _inject_skill_context(terminal_id: str, instruction: str) -> str:
+    """Prepend terminal CLAUDE.md content to instruction for context.
+
+    The CLAUDE.md file acts as the agent's skill context when running
+    headless — it replaces the interactive /skill loading that tmux
+    terminals use.
+
+    Returns the instruction unchanged if no CLAUDE.md exists.
+    """
+    claude_md_path = (
+        Path(__file__).resolve().parents[2]
+        / ".claude" / "terminals" / terminal_id / "CLAUDE.md"
+    )
+    if claude_md_path.exists():
+        context = claude_md_path.read_text()
+        return f"{context}\n\n---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
+    return instruction
+
+
 def _default_state_dir() -> Path:
     """Resolve VNX state directory from environment."""
     env = os.environ.get("VNX_STATE_DIR", "")
@@ -75,6 +94,9 @@ def deliver_via_subprocess(
 
     Returns True on success, False on failure.
     """
+    # Inject terminal CLAUDE.md as skill context for headless agents
+    instruction = _inject_skill_context(terminal_id, instruction)
+
     adapter = SubprocessAdapter()
     result = adapter.deliver(
         terminal_id,

--- a/tests/test_skill_context_injection.py
+++ b/tests/test_skill_context_injection.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for _inject_skill_context() in subprocess_dispatch.py (F32)."""
+
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from subprocess_dispatch import _inject_skill_context
+
+
+class TestInjectSkillContext:
+    """Tests for CLAUDE.md skill context injection."""
+
+    def test_prepends_claude_md_when_exists(self, tmp_path):
+        """When CLAUDE.md exists for a terminal, it is prepended to the instruction."""
+        terminal_id = "T1"
+        claude_md_dir = tmp_path / ".claude" / "terminals" / terminal_id
+        claude_md_dir.mkdir(parents=True)
+        claude_md = claude_md_dir / "CLAUDE.md"
+        claude_md.write_text("# Agent Context\nYou are a backend developer.")
+
+        instruction = "Implement feature X"
+
+        with patch(
+            "subprocess_dispatch.Path.__file__",
+            create=True,
+        ):
+            # Patch the path resolution to point at our tmp_path
+            fake_file = tmp_path / "scripts" / "lib" / "subprocess_dispatch.py"
+            fake_file.parent.mkdir(parents=True, exist_ok=True)
+            fake_file.touch()
+
+            with patch("subprocess_dispatch.Path") as MockPath:
+                # Make Path(__file__).resolve().parents[2] return tmp_path
+                mock_resolved = MockPath.return_value.resolve.return_value
+                mock_resolved.parents.__getitem__ = lambda self, idx: tmp_path if idx == 2 else None
+                # But we also need Path / ".claude" / "terminals" / ... to work
+                # Simpler: just patch at function level
+                pass
+
+        # Direct approach: call function with patched __file__ location
+        result = _call_with_fake_root(tmp_path, terminal_id, instruction)
+
+        assert result.startswith("# Agent Context")
+        assert "You are a backend developer." in result
+        assert "---\n\nDISPATCH INSTRUCTION:\n\n" in result
+        assert result.endswith(instruction)
+
+    def test_returns_unchanged_when_no_claude_md(self, tmp_path):
+        """When no CLAUDE.md exists, instruction is returned unchanged."""
+        instruction = "Implement feature Y"
+        result = _call_with_fake_root(tmp_path, "T99", instruction)
+        assert result == instruction
+
+    def test_returns_unchanged_for_empty_terminal_dir(self, tmp_path):
+        """When terminal directory exists but CLAUDE.md does not, instruction unchanged."""
+        terminal_dir = tmp_path / ".claude" / "terminals" / "T1"
+        terminal_dir.mkdir(parents=True)
+        # No CLAUDE.md file created
+        instruction = "Do something"
+        result = _call_with_fake_root(tmp_path, "T1", instruction)
+        assert result == instruction
+
+    def test_context_separator_format(self, tmp_path):
+        """Verify the separator between context and instruction."""
+        terminal_id = "T1"
+        claude_md_dir = tmp_path / ".claude" / "terminals" / terminal_id
+        claude_md_dir.mkdir(parents=True)
+        (claude_md_dir / "CLAUDE.md").write_text("Context here")
+
+        result = _call_with_fake_root(tmp_path, terminal_id, "Task")
+        parts = result.split("\n\n---\n\nDISPATCH INSTRUCTION:\n\n")
+        assert len(parts) == 2
+        assert parts[0] == "Context here"
+        assert parts[1] == "Task"
+
+
+def _call_with_fake_root(fake_root: Path, terminal_id: str, instruction: str) -> str:
+    """Call _inject_skill_context with a patched repo root path."""
+    import subprocess_dispatch
+
+    original_file = subprocess_dispatch.__file__
+    fake_file = fake_root / "scripts" / "lib" / "subprocess_dispatch.py"
+    fake_file.parent.mkdir(parents=True, exist_ok=True)
+    fake_file.touch()
+
+    with patch.object(subprocess_dispatch, "__file__", str(fake_file)):
+        return _inject_skill_context(terminal_id, instruction)


### PR DESCRIPTION
## Summary
- Rewrites T1 CLAUDE.md as pure backend-developer agent context — no tmux, no /skill loading, no interactive assumptions
- Adds `_inject_skill_context()` to `subprocess_dispatch.py` — automatically prepends terminal CLAUDE.md to subprocess instructions
- Defaults T1 to subprocess adapter in `dispatch_deliver.sh` (overrideable via `VNX_ADAPTER_T1=tmux`)
- Documents headless T1 dispatch workflow in T0 CLAUDE.md

## Test plan
- [x] 4 new tests for `_inject_skill_context()` — all pass
- [x] 66 existing headless system tests — all pass
- [x] `bash -n` validation on `dispatch_deliver.sh` — pass
- [ ] Live headless dispatch test (requires claude CLI availability)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)