### PR TITLE
feat(F37): Auto-Report Pipeline — stop hook, extraction, assembler, haiku classification

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/stop_report_hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.x — F37 Auto-Report Pipeline (2026-04-08)
+
+### Features
+- **F37 PR-5**: Receipt processor integration and end-to-end tests — 39 tests covering auto-generated report validation, tag flow integrity, manual report backward compatibility, subprocess trigger path, and end-to-end fixture through `ReportParser`
+- **F37 PR-5**: Fix `render_markdown()` to include `**Terminal**` field required for receipt processor terminal detection
+
 ## v0.6.0 — Headless Pipeline + Post-Chain Refactoring (2026-04-07)
 
 ### Features

--- a/scripts/hooks/stop_report_hook.sh
+++ b/scripts/hooks/stop_report_hook.sh
@@ -158,9 +158,10 @@ ASSEMBLER_OUTPUT=""
 ASSEMBLER_EXIT=0
 
 if [ -f "$ASSEMBLER" ] && command -v python3 &>/dev/null; then
+    mkdir -p "$VNX_DATA/logs"
     ASSEMBLER_OUTPUT=$(
         VNX_DATA_DIR="$VNX_DATA" \
-        python3 "$ASSEMBLER" "$TRIGGER_FILE" 2>/dev/null
+        python3 "$ASSEMBLER" "$TRIGGER_FILE" 2>>"$VNX_DATA/logs/report_pipeline.log"
     ) || ASSEMBLER_EXIT=$?
 fi
 

--- a/scripts/hooks/stop_report_hook.sh
+++ b/scripts/hooks/stop_report_hook.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# VNX Stop Hook — Auto-Report Pipeline Entry Point
+#
+# Claude Code calls this script when a worker session ends (Stop hook).
+# Receives hook JSON on stdin, writes an extraction trigger file to
+# .vnx-data/state/report_pipeline/ for the next pipeline stage.
+#
+# Gate: VNX_AUTO_REPORT=1 must be set; otherwise no-op.
+# Non-blocking: must complete in < 5s.
+# Exit 0 always (never block the session stop).
+
+set -euo pipefail
+
+# ── Env-var gate ─────────────────────────────────────────────────────────────
+if [ "${VNX_AUTO_REPORT:-0}" != "1" ]; then
+    # Disabled — emit skipped output and exit silently
+    printf '{"skipped":true,"skip_reason":"VNX_AUTO_REPORT not set"}\n'
+    exit 0
+fi
+
+# ── Read and parse stdin JSON ─────────────────────────────────────────────────
+STDIN_JSON=$(cat)
+
+if ! command -v jq &>/dev/null; then
+    printf '{"skipped":true,"skip_reason":"jq not available"}\n' >&2
+    exit 0
+fi
+
+SESSION_ID=$(echo "$STDIN_JSON" | jq -r '.session_id // ""')
+TRANSCRIPT_PATH=$(echo "$STDIN_JSON" | jq -r '.transcript_path // ""')
+CWD=$(echo "$STDIN_JSON" | jq -r '.cwd // ""')
+
+if [ -z "$SESSION_ID" ] || [ -z "$CWD" ]; then
+    printf '{"skipped":true,"skip_reason":"missing session_id or cwd in hook input"}\n' >&2
+    exit 0
+fi
+
+# ── Detect terminal identity from cwd ────────────────────────────────────────
+# Matches .claude/terminals/T1, T2, or T3 in the cwd path
+TERMINAL=""
+case "$CWD" in
+    */.claude/terminals/T1*|*/terminals/T1)
+        TERMINAL="T1" ;;
+    */.claude/terminals/T2*|*/terminals/T2)
+        TERMINAL="T2" ;;
+    */.claude/terminals/T3*|*/terminals/T3)
+        TERMINAL="T3" ;;
+    *)
+        # Not a worker terminal (T0 or non-VNX session) — skip silently
+        printf '{"skipped":true,"skip_reason":"not a worker terminal","cwd":"%s"}\n' "$CWD"
+        exit 0
+        ;;
+esac
+
+# ── Resolve project root from cwd ────────────────────────────────────────────
+# Walk up from CWD to find directory containing .vnx-data/
+PROJECT_ROOT=""
+SEARCH_DIR="$CWD"
+for _ in 1 2 3 4 5 6; do
+    if [ -d "$SEARCH_DIR/.vnx-data" ]; then
+        PROJECT_ROOT="$SEARCH_DIR"
+        break
+    fi
+    PARENT="$(dirname "$SEARCH_DIR")"
+    if [ "$PARENT" = "$SEARCH_DIR" ]; then
+        break
+    fi
+    SEARCH_DIR="$PARENT"
+done
+
+if [ -z "$PROJECT_ROOT" ]; then
+    # Use VNX_DATA_DIR env var as fallback
+    if [ -n "${VNX_DATA_DIR:-}" ]; then
+        PROJECT_ROOT="$(dirname "$VNX_DATA_DIR")"
+    else
+        printf '{"skipped":true,"skip_reason":"could not resolve project root from cwd"}\n' >&2
+        exit 0
+    fi
+fi
+
+VNX_DATA="${VNX_DATA_DIR:-$PROJECT_ROOT/.vnx-data}"
+
+# ── Detect active dispatch ────────────────────────────────────────────────────
+ACTIVE_DIR="$VNX_DATA/dispatches/active"
+DISPATCH_ID=""
+DISPATCH_GATE=""
+DISPATCH_TRACK=""
+PR_ID=""
+
+if [ -d "$ACTIVE_DIR" ]; then
+    # Find dispatch file matching this terminal's track
+    TRACK_SUFFIX=""
+    case "$TERMINAL" in
+        T1) TRACK_SUFFIX="-A" ;;
+        T2) TRACK_SUFFIX="-B" ;;
+        T3) TRACK_SUFFIX="-C" ;;
+    esac
+
+    # Match active dispatch files by track suffix
+    for dispatch_file in "$ACTIVE_DIR"/*"${TRACK_SUFFIX}.md" "$ACTIVE_DIR"/*"${TRACK_SUFFIX}.json"; do
+        if [ -f "$dispatch_file" ]; then
+            BASENAME="$(basename "$dispatch_file")"
+            # Extract dispatch ID from filename (strip extension)
+            CANDIDATE="${BASENAME%.*}"
+            # Read gate and PR from dispatch file header (Manager Block format)
+            DISPATCH_GATE=$(grep -m1 '^Gate:' "$dispatch_file" 2>/dev/null | awk '{print $2}' || echo "")
+            DISPATCH_TRACK=$(grep -m1 '^Track:' "$dispatch_file" 2>/dev/null | awk '{print $2}' || echo "")
+            PR_ID=$(grep -m1 '^PR-ID:' "$dispatch_file" 2>/dev/null | awk '{print $2}' || echo "")
+            DISPATCH_ID="$CANDIDATE"
+            break
+        fi
+    done
+fi
+
+if [ -z "$DISPATCH_ID" ]; then
+    # No active dispatch — write partial trigger (extraction can still attempt git-based extraction)
+    DISPATCH_ID="unknown-${TERMINAL}-$(date +%s)"
+fi
+
+# ── Write extraction trigger file ─────────────────────────────────────────────
+PIPELINE_DIR="$VNX_DATA/state/report_pipeline"
+mkdir -p "$PIPELINE_DIR"
+
+TRIGGER_FILE="$PIPELINE_DIR/${DISPATCH_ID}.trigger.json"
+TRIGGER_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+jq -n \
+    --arg trigger_time "$TRIGGER_TIME" \
+    --arg dispatch_id "$DISPATCH_ID" \
+    --arg terminal "$TERMINAL" \
+    --arg track "${DISPATCH_TRACK:-}" \
+    --arg gate "${DISPATCH_GATE:-}" \
+    --arg pr_id "${PR_ID:-}" \
+    --arg session_id "$SESSION_ID" \
+    --arg transcript_path "$TRANSCRIPT_PATH" \
+    --arg cwd "$CWD" \
+    --arg project_root "$PROJECT_ROOT" \
+    --arg source "stop_hook" \
+    '{
+        trigger_time: $trigger_time,
+        dispatch_id: $dispatch_id,
+        terminal: $terminal,
+        track: $track,
+        gate: $gate,
+        pr_id: $pr_id,
+        session_id: $session_id,
+        transcript_path: $transcript_path,
+        cwd: $cwd,
+        project_root: $project_root,
+        source: $source
+    }' > "$TRIGGER_FILE"
+
+# ── Emit structured output ────────────────────────────────────────────────────
+jq -n \
+    --arg dispatch_id "$DISPATCH_ID" \
+    --arg terminal "$TERMINAL" \
+    --arg trigger_file "$TRIGGER_FILE" \
+    '{
+        auto_report_path: $trigger_file,
+        dispatch_id: $dispatch_id,
+        terminal: $terminal,
+        skipped: false
+    }'
+
+exit 0

--- a/scripts/hooks/stop_report_hook.sh
+++ b/scripts/hooks/stop_report_hook.sh
@@ -150,15 +150,42 @@ jq -n \
         source: $source
     }' > "$TRIGGER_FILE"
 
+# ── Invoke report assembler ───────────────────────────────────────────────────
+# Runs report_assembler.py CLI which reads the trigger file, runs extraction,
+# assembles AutoReport JSON + markdown, and writes both to .vnx-data/.
+ASSEMBLER="$PROJECT_ROOT/scripts/lib/report_assembler.py"
+ASSEMBLER_OUTPUT=""
+ASSEMBLER_EXIT=0
+
+if [ -f "$ASSEMBLER" ] && command -v python3 &>/dev/null; then
+    ASSEMBLER_OUTPUT=$(
+        VNX_DATA_DIR="$VNX_DATA" \
+        python3 "$ASSEMBLER" "$TRIGGER_FILE" 2>/dev/null
+    ) || ASSEMBLER_EXIT=$?
+fi
+
 # ── Emit structured output ────────────────────────────────────────────────────
+MD_PATH=""
+JSON_PATH=""
+if [ -n "$ASSEMBLER_OUTPUT" ] && echo "$ASSEMBLER_OUTPUT" | jq -e . &>/dev/null; then
+    MD_PATH=$(echo "$ASSEMBLER_OUTPUT" | jq -r '.md_path // ""')
+    JSON_PATH=$(echo "$ASSEMBLER_OUTPUT" | jq -r '.json_path // ""')
+fi
+
 jq -n \
     --arg dispatch_id "$DISPATCH_ID" \
     --arg terminal "$TERMINAL" \
     --arg trigger_file "$TRIGGER_FILE" \
+    --arg md_path "$MD_PATH" \
+    --arg json_path "$JSON_PATH" \
+    --argjson assembler_exit "$ASSEMBLER_EXIT" \
     '{
         auto_report_path: $trigger_file,
         dispatch_id: $dispatch_id,
         terminal: $terminal,
+        md_path: $md_path,
+        json_path: $json_path,
+        assembler_exit: $assembler_exit,
         skipped: false
     }'
 

--- a/scripts/hooks/stop_report_hook.sh
+++ b/scripts/hooks/stop_report_hook.sh
@@ -3,7 +3,7 @@
 #
 # Claude Code calls this script when a worker session ends (Stop hook).
 # Receives hook JSON on stdin, writes an extraction trigger file to
-# .vnx-data/state/report_pipeline/ for the next pipeline stage.
+# the report_pipeline state directory for the next pipeline stage.
 #
 # Gate: VNX_AUTO_REPORT=1 must be set; otherwise no-op.
 # Non-blocking: must complete in < 5s.
@@ -118,7 +118,7 @@ if [ -z "$DISPATCH_ID" ]; then
 fi
 
 # ── Write extraction trigger file ─────────────────────────────────────────────
-PIPELINE_DIR="$VNX_DATA/state/report_pipeline"
+PIPELINE_DIR="${VNX_STATE_DIR:-$VNX_DATA/state}/report_pipeline"
 mkdir -p "$PIPELINE_DIR"
 
 TRIGGER_FILE="$PIPELINE_DIR/${DISPATCH_ID}.trigger.json"

--- a/scripts/lib/auto_report_contract.py
+++ b/scripts/lib/auto_report_contract.py
@@ -1,0 +1,836 @@
+"""Auto-Report Pipeline Contract — PR-0 Schema Definition.
+
+This module defines all schemas, contracts, and taxonomies for the F37
+auto-report pipeline. It governs how stop hooks, deterministic extraction,
+haiku classification, and report assembly interact.
+
+Architecture:
+    Stop hook fires → deterministic extraction → haiku classification →
+    report assembly → receipt processor integration
+
+All schemas are frozen dataclasses for immutability. Validation is strict:
+construction raises ValueError on invalid input.
+
+Non-Goals (V1):
+    - No dashboard changes (auto-reports render via existing report viewer)
+    - No receipt format breaking changes (auto-reports produce standard receipts)
+    - No embedding/vector infrastructure (tag-based retrieval only)
+    - No autonomous policy changes (intelligence is advisory-only)
+    - No open-ended tag extensibility (taxonomy is closed in V1)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ─── Schema Version ──────────────────────────────────────────────────────────
+
+SCHEMA_VERSION = "1.0.0"
+
+
+# ─── Closed Tag Taxonomy ─────────────────────────────────────────────────────
+#
+# V1 taxonomy is CLOSED. No free-form tags. All values must be from these enums.
+# Extension requires a schema version bump.
+
+class DispatchType(str, Enum):
+    """Set by T0 at dispatch creation."""
+    IMPLEMENTATION = "implementation"
+    TEST = "test"
+    REVIEW = "review"
+    REFACTOR = "refactor"
+    DOCS = "docs"
+    CONFIG = "config"
+    PLANNING = "planning"
+
+
+class RiskLevel(str, Enum):
+    """Set by T0 at dispatch creation; may be overridden by blast radius."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class Scope(str, Enum):
+    """Set by T0 at dispatch creation."""
+    SINGLE_FILE = "single_file"
+    MULTI_FILE = "multi_file"
+    CROSS_MODULE = "cross_module"
+    INFRASTRUCTURE = "infrastructure"
+
+
+class ContentType(str, Enum):
+    """Set by haiku classification or rule-based fallback."""
+    IMPLEMENTATION = "implementation"
+    TEST = "test"
+    REFACTOR = "refactor"
+    DOCS = "docs"
+    REVIEW = "review"
+    CONFIG = "config"
+    PLANNING = "planning"
+    MIXED = "mixed"
+
+
+class Complexity(str, Enum):
+    """Set by haiku classification or rule-based fallback."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class OutcomeStatus(str, Enum):
+    """Final dispatch outcome."""
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL = "partial"
+    CRASHED = "crashed"
+    NO_EXECUTION = "no_execution"
+
+
+# ─── Stop Hook Contract ──────────────────────────────────────────────────────
+#
+# Claude Code delivers this JSON on stdin to the Stop hook.
+# See: https://docs.anthropic.com/en/docs/claude-code/hooks
+#
+# Exit codes:
+#   0  — success (allow stop, optional JSON on stdout)
+#   2  — blocking error (prevent stop, stderr fed back to Claude)
+#   other — non-blocking error (logged, stop proceeds)
+
+@dataclass(frozen=True)
+class StopHookInput:
+    """JSON delivered on stdin by Claude Code when the Stop hook fires.
+
+    The hook fires once per assistant turn when Claude finishes all work.
+    It does NOT fire on user interrupts or API errors.
+    """
+    session_id: str
+    transcript_path: str
+    cwd: str
+    hook_event_name: str = "Stop"
+    permission_mode: str = "default"
+
+    @classmethod
+    def from_stdin(cls, raw: str) -> StopHookInput:
+        """Parse JSON from stdin into StopHookInput."""
+        data = json.loads(raw)
+        return cls(
+            session_id=data["session_id"],
+            transcript_path=data["transcript_path"],
+            cwd=data["cwd"],
+            hook_event_name=data.get("hook_event_name", "Stop"),
+            permission_mode=data.get("permission_mode", "default"),
+        )
+
+    def detect_terminal(self) -> Optional[str]:
+        """Detect VNX terminal ID from cwd path.
+
+        Returns T1, T2, or T3 if cwd matches .claude/terminals/T{N}.
+        Returns None for T0 or non-terminal paths.
+        """
+        match = re.search(r"\.claude/terminals/(T[1-3])\b", self.cwd)
+        return match.group(1) if match else None
+
+
+@dataclass(frozen=True)
+class StopHookOutput:
+    """JSON written to stdout by the stop hook on success (exit 0).
+
+    If the hook needs to block the stop (exit 2), write reason to stderr instead.
+    """
+    auto_report_path: Optional[str] = None
+    dispatch_id: Optional[str] = None
+    terminal: Optional[str] = None
+    skipped: bool = False
+    skip_reason: Optional[str] = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"))
+
+
+# ─── Dispatch Tags ────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class DispatchTags:
+    """Tags set by T0 at dispatch creation. Stored in bundle.json."""
+    dispatch_type: DispatchType
+    risk: RiskLevel
+    scope: Scope
+    expected_ois: int = 0
+    depends_on: tuple = ()  # Upstream dispatch IDs (tuple for frozen)
+
+    def __post_init__(self) -> None:
+        if self.expected_ois < 0:
+            raise ValueError(f"expected_ois must be >= 0, got {self.expected_ois}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dispatch_type": self.dispatch_type.value,
+            "risk": self.risk.value,
+            "scope": self.scope.value,
+            "expected_ois": self.expected_ois,
+            "depends_on": list(self.depends_on),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> DispatchTags:
+        return cls(
+            dispatch_type=DispatchType(data["dispatch_type"]),
+            risk=RiskLevel(data["risk"]),
+            scope=Scope(data["scope"]),
+            expected_ois=data.get("expected_ois", 0),
+            depends_on=tuple(data.get("depends_on", ())),
+        )
+
+
+# ─── Extraction Results ──────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TestResults:
+    """Parsed from pytest output in event stream or Bash tool results."""
+    passed: int = 0
+    failed: int = 0
+    errors: int = 0
+    skipped: int = 0
+    duration_seconds: float = 0.0
+    raw_output: str = ""  # Truncated to 500 chars max
+
+    @property
+    def total(self) -> int:
+        return self.passed + self.failed + self.errors + self.skipped
+
+    @property
+    def all_passed(self) -> bool:
+        return self.failed == 0 and self.errors == 0 and self.total > 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> TestResults:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass(frozen=True)
+class SyntaxCheck:
+    """Result of py_compile or bash -n on a changed file."""
+    file_path: str
+    language: str  # "python" or "shell"
+    valid: bool
+    error_message: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GitProvenance:
+    """Git state captured at extraction time."""
+    commit_hash: str = ""
+    commit_message: str = ""
+    branch: str = ""
+    files_changed: tuple = ()  # Tuple of file paths (frozen)
+    insertions: int = 0
+    deletions: int = 0
+    is_dirty: bool = False
+
+    @property
+    def line_delta(self) -> int:
+        return self.insertions - self.deletions
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["files_changed"] = list(self.files_changed)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> GitProvenance:
+        data = dict(data)
+        data["files_changed"] = tuple(data.get("files_changed", ()))
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass(frozen=True)
+class EventMetrics:
+    """Aggregated metrics from the subprocess event stream."""
+    tool_use_count: int = 0
+    text_block_count: int = 0
+    thinking_block_count: int = 0
+    error_count: int = 0
+    session_duration_seconds: int = 0
+    model_used: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Output of deterministic extraction (Phase 1). No LLM calls.
+
+    Assembled from: git diff, event stream, pytest output, syntax checks,
+    and dispatch metadata.
+    """
+    dispatch_id: str
+    terminal: str  # T1, T2, T3
+    track: str  # A, B, C
+    gate: str
+    git: GitProvenance = field(default_factory=GitProvenance)
+    tests: Optional[TestResults] = None
+    syntax_checks: tuple = ()  # Tuple[SyntaxCheck, ...]
+    events: EventMetrics = field(default_factory=EventMetrics)
+    exit_summary: str = ""  # Last text block from worker, ≤200 chars
+    extracted_at: str = ""
+
+    def __post_init__(self) -> None:
+        if self.terminal not in ("T1", "T2", "T3"):
+            raise ValueError(f"terminal must be T1/T2/T3, got {self.terminal}")
+        if self.track not in ("A", "B", "C"):
+            raise ValueError(f"track must be A/B/C, got {self.track}")
+
+    @property
+    def has_test_failures(self) -> bool:
+        return self.tests is not None and not self.tests.all_passed
+
+    @property
+    def has_syntax_errors(self) -> bool:
+        return any(not sc.valid for sc in self.syntax_checks)
+
+    @property
+    def all_syntax_valid(self) -> bool:
+        return all(sc.valid for sc in self.syntax_checks)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "dispatch_id": self.dispatch_id,
+            "terminal": self.terminal,
+            "track": self.track,
+            "gate": self.gate,
+            "git": self.git.to_dict(),
+            "tests": self.tests.to_dict() if self.tests else None,
+            "syntax_checks": [sc.to_dict() for sc in self.syntax_checks],
+            "events": self.events.to_dict(),
+            "exit_summary": self.exit_summary,
+            "extracted_at": self.extracted_at,
+        }
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ExtractionResult:
+        return cls(
+            dispatch_id=data["dispatch_id"],
+            terminal=data["terminal"],
+            track=data["track"],
+            gate=data["gate"],
+            git=GitProvenance.from_dict(data.get("git", {})),
+            tests=TestResults.from_dict(data["tests"]) if data.get("tests") else None,
+            syntax_checks=tuple(
+                SyntaxCheck(**sc) for sc in data.get("syntax_checks", ())
+            ),
+            events=EventMetrics(**data.get("events", {})),
+            exit_summary=data.get("exit_summary", ""),
+            extracted_at=data.get("extracted_at", ""),
+        )
+
+
+# ─── Auto-Derived Tags ───────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class AutoDerivedTags:
+    """Tags derived deterministically from ExtractionResult. No LLM."""
+    file_count: int = 0
+    test_count: int = 0
+    line_delta_add: int = 0
+    line_delta_del: int = 0
+    duration_seconds: int = 0
+    model_used: str = ""
+    has_commit: bool = False
+    syntax_valid: bool = True
+    tests_passed: bool = True
+    tool_use_count: int = 0
+    error_count: int = 0
+
+    @classmethod
+    def from_extraction(cls, ex: ExtractionResult) -> AutoDerivedTags:
+        return cls(
+            file_count=len(ex.git.files_changed),
+            test_count=ex.tests.total if ex.tests else 0,
+            line_delta_add=ex.git.insertions,
+            line_delta_del=ex.git.deletions,
+            duration_seconds=ex.events.session_duration_seconds,
+            model_used=ex.events.model_used,
+            has_commit=bool(ex.git.commit_hash),
+            syntax_valid=ex.all_syntax_valid,
+            tests_passed=ex.tests.all_passed if ex.tests else True,
+            tool_use_count=ex.events.tool_use_count,
+            error_count=ex.events.error_count,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ─── Haiku Classification ────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class HaikuClassification:
+    """Output of haiku semantic classification (Phase 2).
+
+    Only runs when:
+    - VNX_HAIKU_CLASSIFY=1 env var is set
+    - No blocking syntax errors in extraction
+    - Extraction produced non-empty results
+
+    Falls back to rule-based classification when haiku is disabled or fails.
+    """
+    content_type: ContentType
+    quality_score: int  # 1-5
+    complexity: Complexity
+    consistency_score: float  # 0.0-1.0 (exit summary vs git diff alignment)
+    summary: str  # ≤100 tokens semantic summary
+    classified_by: str  # "haiku" or "rule_based"
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.quality_score <= 5:
+            raise ValueError(f"quality_score must be 1-5, got {self.quality_score}")
+        if not 0.0 <= self.consistency_score <= 1.0:
+            raise ValueError(
+                f"consistency_score must be 0.0-1.0, got {self.consistency_score}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "content_type": self.content_type.value,
+            "quality_score": self.quality_score,
+            "complexity": self.complexity.value,
+            "consistency_score": self.consistency_score,
+            "summary": self.summary,
+            "classified_by": self.classified_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> HaikuClassification:
+        return cls(
+            content_type=ContentType(data["content_type"]),
+            quality_score=data["quality_score"],
+            complexity=Complexity(data["complexity"]),
+            consistency_score=data["consistency_score"],
+            summary=data["summary"],
+            classified_by=data["classified_by"],
+        )
+
+    @classmethod
+    def rule_based(cls, extraction: ExtractionResult) -> HaikuClassification:
+        """Deterministic fallback when haiku is unavailable.
+
+        Maps extraction data to classification without LLM.
+        """
+        # Content type from file extensions and test results
+        files = [f.lower() for f in extraction.git.files_changed]
+        has_tests = any("test" in f for f in files)
+        has_py = any(f.endswith(".py") for f in files)
+        has_sh = any(f.endswith(".sh") for f in files)
+        has_md = any(f.endswith(".md") for f in files)
+
+        if has_tests and not any(f for f in files if "test" not in f):
+            content_type = ContentType.TEST
+        elif has_md and not has_py and not has_sh:
+            content_type = ContentType.DOCS
+        elif has_py or has_sh:
+            content_type = ContentType.IMPLEMENTATION
+        else:
+            content_type = ContentType.MIXED
+
+        # Complexity from file count and line delta
+        total_lines = extraction.git.insertions + extraction.git.deletions
+        file_count = len(extraction.git.files_changed)
+        if total_lines > 300 or file_count > 5:
+            complexity = Complexity.HIGH
+        elif total_lines > 100 or file_count > 2:
+            complexity = Complexity.MEDIUM
+        else:
+            complexity = Complexity.LOW
+
+        # Quality score from test results and syntax
+        score = 3  # baseline
+        if extraction.tests and extraction.tests.all_passed:
+            score += 1
+        if extraction.has_test_failures:
+            score -= 1
+        if extraction.has_syntax_errors:
+            score -= 1
+        if extraction.git.commit_hash:
+            score += 1
+        score = max(1, min(5, score))
+
+        return cls(
+            content_type=content_type,
+            quality_score=score,
+            complexity=complexity,
+            consistency_score=1.0 if extraction.git.commit_hash else 0.5,
+            summary=extraction.exit_summary[:200] or "Rule-based classification",
+            classified_by="rule_based",
+        )
+
+
+# ─── Classified Tags ─────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ClassifiedTags:
+    """Tags from haiku classification. Separate from auto-derived."""
+    content_type: str  # ContentType.value
+    quality_score: int  # 1-5
+    complexity: str  # Complexity.value
+    consistency_score: float  # 0.0-1.0
+    classified_by: str  # "haiku" or "rule_based"
+
+    @classmethod
+    def from_classification(cls, c: HaikuClassification) -> ClassifiedTags:
+        return cls(
+            content_type=c.content_type.value,
+            quality_score=c.quality_score,
+            complexity=c.complexity.value,
+            consistency_score=c.consistency_score,
+            classified_by=c.classified_by,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ─── Unified Tag Set ──────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class UnifiedTagSet:
+    """Complete tag set for a dispatch execution.
+
+    Three stages, each additive:
+        1. dispatch_tags — set by T0 at creation (from bundle.json)
+        2. auto_derived — deterministic from extraction (git, tests, events)
+        3. classified — from haiku or rule-based fallback
+
+    The tag chain is immutable: later stages never modify earlier stages.
+    """
+    dispatch_tags: Optional[DispatchTags] = None
+    auto_derived: Optional[AutoDerivedTags] = None
+    classified: Optional[ClassifiedTags] = None
+    outcome: OutcomeStatus = OutcomeStatus.SUCCESS
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dispatch_tags": self.dispatch_tags.to_dict() if self.dispatch_tags else None,
+            "auto_derived": self.auto_derived.to_dict() if self.auto_derived else None,
+            "classified": self.classified.to_dict() if self.classified else None,
+            "outcome": self.outcome.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> UnifiedTagSet:
+        return cls(
+            dispatch_tags=DispatchTags.from_dict(data["dispatch_tags"])
+            if data.get("dispatch_tags")
+            else None,
+            auto_derived=AutoDerivedTags(**data["auto_derived"])
+            if data.get("auto_derived")
+            else None,
+            classified=ClassifiedTags(**data["classified"])
+            if data.get("classified")
+            else None,
+            outcome=OutcomeStatus(data.get("outcome", "success")),
+        )
+
+
+# ─── Auto Report ─────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class AutoReportMetadata:
+    """Report identity and provenance."""
+    dispatch_id: str
+    pr_id: str
+    terminal: str
+    track: str
+    gate: str
+    status: str  # "success", "failure", etc. — for receipt processor compatibility
+    auto_generated: bool = True
+    schema_version: str = SCHEMA_VERSION
+    assembled_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AutoReport:
+    """The complete auto-assembled report.
+
+    This is the final output of the auto-report pipeline, containing:
+    - metadata: dispatch identity and provenance
+    - extraction: deterministic data from git, tests, events
+    - classification: haiku or rule-based semantic tags
+    - tags: unified tag set across all three stages
+    - quality_checks: deterministic quality advisory results
+
+    The JSON form is written to .vnx-data/state/report_pipeline/{dispatch_id}.json.
+    A markdown rendering is written to .vnx-data/unified_reports/ for the receipt
+    processor.
+    """
+    metadata: AutoReportMetadata
+    extraction: ExtractionResult
+    classification: Optional[HaikuClassification] = None
+    tags: UnifiedTagSet = field(default_factory=UnifiedTagSet)
+    quality_checks: tuple = ()  # Tuple of QualityCheck-compatible dicts
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "metadata": self.metadata.to_dict(),
+            "extraction": self.extraction.to_dict(),
+            "classification": self.classification.to_dict()
+            if self.classification
+            else None,
+            "tags": self.tags.to_dict(),
+            "quality_checks": list(self.quality_checks),
+            "schema_version": SCHEMA_VERSION,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AutoReport:
+        return cls(
+            metadata=AutoReportMetadata(**data["metadata"]),
+            extraction=ExtractionResult.from_dict(data["extraction"]),
+            classification=HaikuClassification.from_dict(data["classification"])
+            if data.get("classification")
+            else None,
+            tags=UnifiedTagSet.from_dict(data.get("tags", {})),
+            quality_checks=tuple(data.get("quality_checks", ())),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> AutoReport:
+        return cls.from_dict(json.loads(raw))
+
+
+# ─── Receipt Processor Integration Contract ──────────────────────────────────
+#
+# The auto-report pipeline produces a markdown file in unified_reports/ that
+# receipt_processor_v4.sh can parse identically to manual reports. The contract:
+#
+# 1. FILENAME: {YYYYMMDD}-{HHMMSS}-{track}-auto-{short_title}.md
+#    The "auto-" prefix distinguishes auto-generated reports.
+#
+# 2. METADATA BLOCK (required by receipt processor):
+#    The markdown MUST contain these fields parseable by report_parser.py:
+#
+#    **Dispatch ID**: {dispatch_id}
+#    **PR**: {pr_id}
+#    **Track**: {track}
+#    **Gate**: {gate}
+#    **Status**: {status}
+#
+# 3. ADDITIONAL FIELD:
+#    **Auto-Generated**: true
+#    This field marks the report for audit trail purposes. The receipt
+#    processor does not require it but it enables filtering.
+#
+# 4. SECTIONS (all optional, included when data is available):
+#    ## Summary           — exit_summary or haiku summary
+#    ## Files Modified    — from git extraction
+#    ## Test Results      — from pytest extraction
+#    ## Quality Checks    — from deterministic checks
+#    ## Tags              — unified tag set
+#    ## Open Items        — always present, even when empty
+#
+# 5. JSON SIDECAR:
+#    Written to .vnx-data/state/report_pipeline/{dispatch_id}.json
+#    Contains the full AutoReport JSON for downstream processing
+#    (intelligence persistence, governance signal extraction).
+#
+# 6. RECEIPT ENRICHMENT:
+#    append_receipt.py adds git_provenance and idempotency_key.
+#    The auto-report pipeline does NOT call append_receipt.py directly.
+#    The receipt processor handles receipt creation from the markdown file.
+#
+# 7. BACKWARD COMPATIBILITY:
+#    Manual reports (written by workers directly) continue to work unchanged.
+#    The receipt processor treats auto-generated and manual reports identically.
+#    The "auto-" filename prefix is cosmetic, not functional.
+
+RECEIPT_REQUIRED_FIELDS = frozenset({
+    "dispatch_id", "pr_id", "track", "gate", "status",
+})
+
+MARKDOWN_TEMPLATE = """\
+# Auto-Report: {title}
+
+**Dispatch ID**: {dispatch_id}
+**PR**: {pr_id}
+**Track**: {track}
+**Gate**: {gate}
+**Status**: {status}
+**Auto-Generated**: true
+
+## Summary
+
+{summary}
+
+## Files Modified
+
+{files_section}
+
+## Test Results
+
+{tests_section}
+
+## Quality Checks
+
+{quality_section}
+
+## Tags
+
+{tags_section}
+
+## Open Items
+
+{open_items_section}
+"""
+
+
+def render_markdown(report: AutoReport) -> str:
+    """Render an AutoReport as markdown compatible with receipt_processor_v4.sh."""
+    meta = report.metadata
+    ext = report.extraction
+
+    # Summary
+    if report.classification and report.classification.summary:
+        summary = report.classification.summary
+    elif ext.exit_summary:
+        summary = ext.exit_summary
+    else:
+        summary = "No summary available."
+
+    # Files
+    if ext.git.files_changed:
+        files_lines = [f"- `{f}`" for f in ext.git.files_changed]
+        files_lines.append(
+            f"\n**Delta**: +{ext.git.insertions}/-{ext.git.deletions} lines "
+            f"across {len(ext.git.files_changed)} file(s)"
+        )
+        if ext.git.commit_hash:
+            files_lines.append(f"**Commit**: `{ext.git.commit_hash[:12]}`")
+        files_section = "\n".join(files_lines)
+    else:
+        files_section = "No file changes detected."
+
+    # Tests
+    if ext.tests and ext.tests.total > 0:
+        t = ext.tests
+        tests_section = (
+            f"**Passed**: {t.passed} | **Failed**: {t.failed} | "
+            f"**Errors**: {t.errors} | **Skipped**: {t.skipped}\n"
+            f"**Duration**: {t.duration_seconds:.1f}s"
+        )
+    else:
+        tests_section = "No test results captured."
+
+    # Quality checks
+    if report.quality_checks:
+        qc_lines = []
+        for check in report.quality_checks:
+            sev = check.get("severity", "info")
+            msg = check.get("message", "")
+            qc_lines.append(f"- **[{sev}]** {msg}")
+        quality_section = "\n".join(qc_lines)
+    else:
+        quality_section = "No quality issues detected."
+
+    # Tags
+    tags_parts = []
+    if report.tags.dispatch_tags:
+        dt = report.tags.dispatch_tags
+        tags_parts.append(
+            f"**Dispatch**: type={dt.dispatch_type.value}, "
+            f"risk={dt.risk.value}, scope={dt.scope.value}"
+        )
+    if report.tags.classified:
+        ct = report.tags.classified
+        tags_parts.append(
+            f"**Classified**: content={ct.content_type}, "
+            f"quality={ct.quality_score}/5, complexity={ct.complexity}, "
+            f"by={ct.classified_by}"
+        )
+    if report.tags.auto_derived:
+        ad = report.tags.auto_derived
+        tags_parts.append(
+            f"**Auto-derived**: files={ad.file_count}, tests={ad.test_count}, "
+            f"+{ad.line_delta_add}/-{ad.line_delta_del} lines, "
+            f"duration={ad.duration_seconds}s"
+        )
+    tags_section = "\n".join(tags_parts) if tags_parts else "No tags."
+
+    # Title
+    title = summary[:60].replace("\n", " ") if summary else meta.dispatch_id
+
+    return MARKDOWN_TEMPLATE.format(
+        title=title,
+        dispatch_id=meta.dispatch_id,
+        pr_id=meta.pr_id,
+        track=meta.track,
+        gate=meta.gate,
+        status=meta.status,
+        summary=summary,
+        files_section=files_section,
+        tests_section=tests_section,
+        quality_section=quality_section,
+        tags_section=tags_section,
+        open_items_section="No open items.",
+    )
+
+
+# ─── Validation ──────────────────────────────────────────────────────────────
+
+def validate_auto_report(report: AutoReport) -> List[str]:
+    """Validate an AutoReport for receipt processor compatibility.
+
+    Returns a list of error strings. Empty list means valid.
+    """
+    errors: List[str] = []
+    meta = report.metadata
+
+    if not meta.dispatch_id:
+        errors.append("metadata.dispatch_id is required")
+    if not meta.pr_id:
+        errors.append("metadata.pr_id is required")
+    if not meta.track:
+        errors.append("metadata.track is required")
+    if not meta.gate:
+        errors.append("metadata.gate is required")
+    if not meta.status:
+        errors.append("metadata.status is required")
+
+    # Extraction consistency
+    if report.extraction.dispatch_id != meta.dispatch_id:
+        errors.append(
+            f"extraction.dispatch_id ({report.extraction.dispatch_id}) "
+            f"does not match metadata.dispatch_id ({meta.dispatch_id})"
+        )
+
+    # Classification validation (if present)
+    if report.classification:
+        c = report.classification
+        if c.quality_score < 1 or c.quality_score > 5:
+            errors.append(f"classification.quality_score out of range: {c.quality_score}")
+        if c.consistency_score < 0.0 or c.consistency_score > 1.0:
+            errors.append(
+                f"classification.consistency_score out of range: {c.consistency_score}"
+            )
+
+    return errors

--- a/scripts/lib/auto_report_contract.py
+++ b/scripts/lib/auto_report_contract.py
@@ -674,6 +674,7 @@ MARKDOWN_TEMPLATE = """\
 **Dispatch ID**: {dispatch_id}
 **PR**: {pr_id}
 **Track**: {track}
+**Terminal**: {terminal}
 **Gate**: {gate}
 **Status**: {status}
 **Auto-Generated**: true
@@ -784,6 +785,7 @@ def render_markdown(report: AutoReport) -> str:
         dispatch_id=meta.dispatch_id,
         pr_id=meta.pr_id,
         track=meta.track,
+        terminal=meta.terminal,
         gate=meta.gate,
         status=meta.status,
         summary=summary,

--- a/scripts/lib/auto_report_contract.py
+++ b/scripts/lib/auto_report_contract.py
@@ -577,7 +577,7 @@ class AutoReport:
     - tags: unified tag set across all three stages
     - quality_checks: deterministic quality advisory results
 
-    The JSON form is written to .vnx-data/state/report_pipeline/{dispatch_id}.json.
+    The JSON form is written to $VNX_STATE_DIR/report_pipeline/{dispatch_id}.json.
     A markdown rendering is written to .vnx-data/unified_reports/ for the receipt
     processor.
     """
@@ -650,7 +650,7 @@ class AutoReport:
 #    ## Open Items        — always present, even when empty
 #
 # 5. JSON SIDECAR:
-#    Written to .vnx-data/state/report_pipeline/{dispatch_id}.json
+#    Written to $VNX_STATE_DIR/report_pipeline/{dispatch_id}.json
 #    Contains the full AutoReport JSON for downstream processing
 #    (intelligence persistence, governance signal extraction).
 #

--- a/scripts/lib/report_assembler.py
+++ b/scripts/lib/report_assembler.py
@@ -50,6 +50,7 @@ from auto_report_contract import (
     validate_auto_report,
 )
 from report_extraction import run_extraction
+from report_classifier import classify_report
 
 
 # ─── Assembly Result ──────────────────────────────────────────────────────────
@@ -247,8 +248,8 @@ def assemble(
     # Auto-derived tags
     auto_derived = AutoDerivedTags.from_extraction(extraction)
 
-    # Rule-based classification (haiku is PR-4)
-    classification = HaikuClassification.rule_based(extraction)
+    # Semantic classification: haiku when VNX_HAIKU_CLASSIFY=1, else rule-based
+    classification = classify_report(extraction)
     classified_tags = ClassifiedTags.from_classification(classification)
 
     # Unified tag set

--- a/scripts/lib/report_assembler.py
+++ b/scripts/lib/report_assembler.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Auto-Report Assembler — PR-3 (F37 Auto-Report Pipeline).
+
+Combines extraction results with dispatch metadata to produce structured
+JSON and readable markdown reports compatible with receipt_processor_v4.sh.
+
+Public API:
+    assemble_from_trigger(trigger_path)  → AssemblyResult
+    assemble(dispatch_id, ...)           → AssemblyResult
+    write_report(result, vnx_data_dir)  → (json_path, md_path)
+
+All functions return results on partial data — never raise on missing input.
+
+BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ── PR-0 / PR-2 imports ───────────────────────────────────────────────────────
+import sys as _sys
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in _sys.path:
+    _sys.path.insert(0, _LIB)
+
+from auto_report_contract import (
+    AutoDerivedTags,
+    AutoReport,
+    AutoReportMetadata,
+    ClassifiedTags,
+    DispatchTags,
+    DispatchType,
+    ExtractionResult,
+    HaikuClassification,
+    OutcomeStatus,
+    RiskLevel,
+    Scope,
+    UnifiedTagSet,
+    render_markdown,
+    validate_auto_report,
+)
+from report_extraction import run_extraction
+
+
+# ─── Assembly Result ──────────────────────────────────────────────────────────
+
+@dataclass
+class AssemblyResult:
+    """Output of the assembler. Carries the report and write paths."""
+    report: AutoReport
+    json_path: Optional[Path] = None
+    md_path: Optional[Path] = None
+    errors: tuple = ()  # Validation errors (empty = valid)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+# ─── Dispatch Metadata Parser ─────────────────────────────────────────────────
+
+def _parse_dispatch_file(dispatch_path: Path) -> dict:
+    """Parse Manager Block fields from an active dispatch .md file.
+
+    Returns a dict with lowercase underscore keys (e.g. 'dispatch_id').
+    Returns empty dict when the file is missing or unparseable.
+    """
+    if not dispatch_path or not dispatch_path.exists():
+        return {}
+
+    try:
+        content = dispatch_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("_parse_dispatch_file: cannot read %s: %s", dispatch_path, exc)
+        return {}
+
+    meta: dict = {}
+    # Parse "Key: Value" lines in the Manager Block header
+    for line in content.splitlines()[:40]:
+        line = line.strip()
+        if ":" not in line or line.startswith("#"):
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower().replace("-", "_")
+        value = value.strip()
+        if key and value:
+            meta[key] = value
+    return meta
+
+
+def _resolve_dispatch_metadata(
+    dispatch_id: str,
+    terminal: str,
+    track: str,
+    gate: str,
+    pr_id: str,
+    active_dir: Optional[Path],
+) -> Tuple[str, str, str, str]:
+    """Resolve (track, gate, pr_id, terminal) from dispatch file when not provided.
+
+    Falls back to provided values when dispatch file is unavailable.
+    """
+    if active_dir and (not track or not gate or not pr_id):
+        # Try exact filename match first
+        for suffix in (".md", ".json"):
+            candidate = active_dir / f"{dispatch_id}{suffix}"
+            parsed = _parse_dispatch_file(candidate)
+            if parsed:
+                track = track or parsed.get("track", "")
+                gate = gate or parsed.get("gate", "")
+                pr_id = pr_id or parsed.get("pr_id", "") or parsed.get("pr-id", "")
+                terminal = terminal or parsed.get("terminal", "")
+                break
+
+    return track or "A", gate or "", pr_id or "", terminal or "T1"
+
+
+def _load_dispatch_tags(dispatch_id: str, active_dir: Optional[Path]) -> Optional[DispatchTags]:
+    """Attempt to load DispatchTags from a bundle.json next to the dispatch file.
+
+    Returns None when no bundle is found — assembler continues without dispatch tags.
+    """
+    if not active_dir:
+        return None
+
+    bundle_path = active_dir / f"{dispatch_id}.bundle.json"
+    if not bundle_path.exists():
+        # Try the dispatch subdir format
+        subdir = active_dir / dispatch_id / "bundle.json"
+        if subdir.exists():
+            bundle_path = subdir
+        else:
+            return None
+
+    try:
+        data = json.loads(bundle_path.read_text(encoding="utf-8"))
+        tags_data = data.get("tags") or data
+        return DispatchTags.from_dict(tags_data)
+    except Exception as exc:
+        logger.debug("_load_dispatch_tags: cannot parse bundle %s: %s", bundle_path, exc)
+        return None
+
+
+# ─── Outcome Status Derivation ────────────────────────────────────────────────
+
+def _derive_outcome(extraction: ExtractionResult, status_override: str = "") -> OutcomeStatus:
+    """Derive OutcomeStatus from extraction data.
+
+    Priority:
+    1. status_override (from trigger file or caller)
+    2. test failures → FAILURE
+    3. syntax errors → FAILURE
+    4. no commit → PARTIAL
+    5. default → SUCCESS
+    """
+    _map = {
+        "success": OutcomeStatus.SUCCESS,
+        "failure": OutcomeStatus.FAILURE,
+        "partial": OutcomeStatus.PARTIAL,
+        "crashed": OutcomeStatus.CRASHED,
+        "no_execution": OutcomeStatus.NO_EXECUTION,
+    }
+    if status_override and status_override.lower() in _map:
+        return _map[status_override.lower()]
+
+    if extraction.has_test_failures or extraction.has_syntax_errors:
+        return OutcomeStatus.FAILURE
+    if not extraction.git.commit_hash:
+        return OutcomeStatus.PARTIAL
+    return OutcomeStatus.SUCCESS
+
+
+# ─── Core Assembly ────────────────────────────────────────────────────────────
+
+def assemble(
+    dispatch_id: str,
+    terminal: str,
+    track: str,
+    gate: str,
+    pr_id: str,
+    repo_path: Optional[Path] = None,
+    events_path: Optional[Path] = None,
+    exit_summary: str = "",
+    status_override: str = "",
+    vnx_data_dir: Optional[Path] = None,
+    active_dir: Optional[Path] = None,
+) -> AssemblyResult:
+    """Assemble an AutoReport from extraction + dispatch metadata.
+
+    Args:
+        dispatch_id:    Dispatch identifier string.
+        terminal:       Worker terminal (T1, T2, T3).
+        track:          Track letter (A, B, C).
+        gate:           Quality gate name.
+        pr_id:          PR identifier (e.g. PR-3).
+        repo_path:      Repository root for git extraction.
+        events_path:    NDJSON event stream path.
+        exit_summary:   Override for exit summary text.
+        status_override: Force a specific outcome status.
+        vnx_data_dir:   Base .vnx-data directory (used for path resolution).
+        active_dir:     Active dispatches directory (for dispatch metadata).
+
+    Returns:
+        AssemblyResult with populated AutoReport.
+    """
+    # Resolve vnx_data_dir from env when not provided
+    if vnx_data_dir is None:
+        env_dir = os.environ.get("VNX_DATA_DIR")
+        if env_dir:
+            vnx_data_dir = Path(env_dir)
+
+    if active_dir is None and vnx_data_dir:
+        active_dir = vnx_data_dir / "dispatches" / "active"
+
+    # Resolve missing metadata from dispatch file
+    track, gate, pr_id, terminal = _resolve_dispatch_metadata(
+        dispatch_id, terminal, track, gate, pr_id, active_dir
+    )
+
+    # Load dispatch tags (optional — pipeline continues without them)
+    dispatch_tags = _load_dispatch_tags(dispatch_id, active_dir)
+
+    # Run deterministic extraction
+    extraction = run_extraction(
+        dispatch_id=dispatch_id,
+        terminal=terminal,
+        track=track,
+        gate=gate,
+        repo_path=repo_path,
+        events_path=events_path,
+        exit_summary=exit_summary,
+    )
+
+    # Derive outcome status
+    outcome = _derive_outcome(extraction, status_override)
+
+    # Auto-derived tags
+    auto_derived = AutoDerivedTags.from_extraction(extraction)
+
+    # Rule-based classification (haiku is PR-4)
+    classification = HaikuClassification.rule_based(extraction)
+    classified_tags = ClassifiedTags.from_classification(classification)
+
+    # Unified tag set
+    tags = UnifiedTagSet(
+        dispatch_tags=dispatch_tags,
+        auto_derived=auto_derived,
+        classified=classified_tags,
+        outcome=outcome,
+    )
+
+    # Assemble metadata
+    assembled_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    status_str = outcome.value
+    metadata = AutoReportMetadata(
+        dispatch_id=dispatch_id,
+        pr_id=pr_id,
+        terminal=terminal,
+        track=track,
+        gate=gate,
+        status=status_str,
+        auto_generated=True,
+        assembled_at=assembled_at,
+    )
+
+    report = AutoReport(
+        metadata=metadata,
+        extraction=extraction,
+        classification=classification,
+        tags=tags,
+        quality_checks=(),
+    )
+
+    errors = tuple(validate_auto_report(report))
+    return AssemblyResult(report=report, errors=errors)
+
+
+# ─── Trigger File Entry Point ─────────────────────────────────────────────────
+
+def assemble_from_trigger(trigger_path: Path, repo_path: Optional[Path] = None) -> AssemblyResult:
+    """Assemble a report from a stop-hook trigger file.
+
+    The trigger file is a JSON written by stop_report_hook.sh or
+    SubprocessAdapter.trigger_report_pipeline(). It contains dispatch_id,
+    terminal, track, gate, pr_id, and project_root.
+
+    Args:
+        trigger_path: Path to the .trigger.json file.
+        repo_path:    Override repository root (defaults to trigger's project_root).
+
+    Returns:
+        AssemblyResult, possibly with errors if input was partial.
+    """
+    try:
+        trigger = json.loads(Path(trigger_path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.error("assemble_from_trigger: cannot read %s: %s", trigger_path, exc)
+        # Return a minimal failed report so the pipeline can record the failure
+        return _minimal_failed_result(str(trigger_path))
+
+    dispatch_id = trigger.get("dispatch_id", "")
+    terminal = trigger.get("terminal", "T1")
+    track = trigger.get("track", "")
+    gate = trigger.get("gate", "")
+    pr_id = trigger.get("pr_id", "") or trigger.get("pr-id", "")
+    project_root = trigger.get("project_root", "")
+    session_id = trigger.get("session_id", "")
+
+    # Validate minimum fields
+    if not dispatch_id or dispatch_id.startswith("unknown-"):
+        logger.warning("assemble_from_trigger: dispatch_id is unknown/empty: %s", dispatch_id)
+
+    # Resolve paths
+    if repo_path is None and project_root:
+        repo_path = Path(project_root)
+
+    vnx_data_dir: Optional[Path] = None
+    env_dir = os.environ.get("VNX_DATA_DIR")
+    if env_dir:
+        vnx_data_dir = Path(env_dir)
+    elif project_root:
+        vnx_data_dir = Path(project_root) / ".vnx-data"
+
+    events_path: Optional[Path] = None
+    if vnx_data_dir and terminal:
+        candidate = vnx_data_dir / "events" / f"{terminal}.ndjson"
+        if candidate.exists():
+            events_path = candidate
+
+    return assemble(
+        dispatch_id=dispatch_id,
+        terminal=terminal,
+        track=track,
+        gate=gate,
+        pr_id=pr_id,
+        repo_path=repo_path,
+        events_path=events_path,
+        vnx_data_dir=vnx_data_dir,
+    )
+
+
+def _minimal_failed_result(label: str) -> AssemblyResult:
+    """Return a placeholder AssemblyResult for unreadable trigger files."""
+    from auto_report_contract import GitProvenance, EventMetrics
+
+    extraction = ExtractionResult(
+        dispatch_id=label,
+        terminal="T1",
+        track="A",
+        gate="",
+        exit_summary="Assembler could not read trigger file.",
+    )
+    metadata = AutoReportMetadata(
+        dispatch_id=label,
+        pr_id="",
+        terminal="T1",
+        track="A",
+        gate="",
+        status=OutcomeStatus.CRASHED.value,
+        assembled_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+    report = AutoReport(metadata=metadata, extraction=extraction)
+    return AssemblyResult(report=report, errors=("unreadable trigger file",))
+
+
+# ─── File Writers ─────────────────────────────────────────────────────────────
+
+def write_report(
+    result: AssemblyResult,
+    vnx_data_dir: Optional[Path] = None,
+) -> Tuple[Optional[Path], Optional[Path]]:
+    """Write JSON sidecar and markdown report to disk.
+
+    Args:
+        result:       The AssemblyResult to write.
+        vnx_data_dir: Base .vnx-data directory. Resolved from VNX_DATA_DIR env
+                      when not provided.
+
+    Returns:
+        (json_path, md_path) — paths of written files, or (None, None) on failure.
+    """
+    if vnx_data_dir is None:
+        env_dir = os.environ.get("VNX_DATA_DIR")
+        if env_dir:
+            vnx_data_dir = Path(env_dir)
+
+    if vnx_data_dir is None:
+        logger.error("write_report: VNX_DATA_DIR not set and no vnx_data_dir provided")
+        return None, None
+
+    report = result.report
+    meta = report.metadata
+    dispatch_id = meta.dispatch_id
+
+    # ── JSON sidecar ──────────────────────────────────────────────────────────
+    pipeline_dir = vnx_data_dir / "state" / "report_pipeline"
+    pipeline_dir.mkdir(parents=True, exist_ok=True)
+    json_path = pipeline_dir / f"{dispatch_id}.json"
+
+    try:
+        json_path.write_text(report.to_json(indent=2), encoding="utf-8")
+        result.json_path = json_path
+    except OSError as exc:
+        logger.error("write_report: cannot write JSON to %s: %s", json_path, exc)
+        json_path = None
+
+    # ── Markdown report ───────────────────────────────────────────────────────
+    unified_dir = vnx_data_dir / "unified_reports"
+    unified_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    # Short title: first 30 chars of dispatch_id after the datestamp prefix
+    # e.g. "20260408-110915-auto-report-assembler-A" → "auto-report-assembler"
+    short_title = _short_title_from_dispatch_id(dispatch_id)
+    md_filename = f"{timestamp}-{meta.track}-auto-{short_title}.md"
+    md_path = unified_dir / md_filename
+
+    try:
+        markdown = render_markdown(report)
+        md_path.write_text(markdown, encoding="utf-8")
+        result.md_path = md_path
+    except OSError as exc:
+        logger.error("write_report: cannot write markdown to %s: %s", md_path, exc)
+        md_path = None
+
+    return json_path, md_path
+
+
+def _short_title_from_dispatch_id(dispatch_id: str) -> str:
+    """Extract a short slug from dispatch_id for use in filenames.
+
+    '20260408-110915-auto-report-assembler-A' → 'auto-report-assembler'
+    Falls back to the last 20 chars when pattern doesn't match.
+    """
+    # Strip leading timestamp (YYYYMMDD-HHMMSS-) and trailing track letter (-A/-B/-C)
+    m = re.match(r"^\d{8}-\d{6}-(.+)-[ABC]$", dispatch_id)
+    if m:
+        slug = m.group(1)
+        # Truncate to 30 chars to keep filenames manageable
+        return slug[:30]
+    # Fallback: use last segment, up to 30 chars
+    return dispatch_id[-30:] if len(dispatch_id) > 30 else dispatch_id
+
+
+# ─── CLI Entry Point ──────────────────────────────────────────────────────────
+
+def main() -> int:
+    """CLI: assemble_report.py <trigger_file> [--output-dir <dir>]
+
+    Reads a trigger JSON file and assembles + writes the auto-report.
+    Exit code: 0 = success, 1 = assembly error, 2 = write error.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Assemble auto-report from trigger file")
+    parser.add_argument("trigger", help="Path to .trigger.json file")
+    parser.add_argument("--output-dir", help="Override VNX_DATA_DIR for output")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    trigger_path = Path(args.trigger)
+    if not trigger_path.exists():
+        print(f"ERROR: trigger file not found: {trigger_path}", file=_sys.stderr)
+        return 1
+
+    vnx_data_dir = Path(args.output_dir) if args.output_dir else None
+
+    result = assemble_from_trigger(trigger_path)
+
+    if result.errors:
+        print(f"WARN: report has validation errors: {result.errors}", file=_sys.stderr)
+
+    json_path, md_path = write_report(result, vnx_data_dir)
+
+    if json_path is None and md_path is None:
+        print("ERROR: failed to write report files", file=_sys.stderr)
+        return 2
+
+    # Emit structured output for stop hook chaining
+    output = {
+        "dispatch_id": result.report.metadata.dispatch_id,
+        "status": result.report.metadata.status,
+        "json_path": str(json_path) if json_path else None,
+        "md_path": str(md_path) if md_path else None,
+        "errors": list(result.errors),
+    }
+    print(json.dumps(output, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    _sys.exit(main())

--- a/scripts/lib/report_classifier.py
+++ b/scripts/lib/report_classifier.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Haiku Semantic Classifier — PR-4 (F37 Auto-Report Pipeline).
+
+Adds semantic classification to assembled reports using claude-haiku via CLI
+subprocess. Deterministic checks run first (ExtractionResult is already complete);
+haiku only adds semantic judgment.
+
+Public API:
+    classify_report(extraction)  → HaikuClassification
+
+Gated by VNX_HAIKU_CLASSIFY=1. Falls back to rule-based classification when:
+- VNX_HAIKU_CLASSIFY is unset or != "1"
+- haiku subprocess fails or times out
+- haiku returns unparseable output
+
+Classification enriches the AutoReport with:
+    content_type, quality_score (1-5), complexity (low/medium/high),
+    consistency_score (0.0-1.0), summary (≤200 chars), classified_by
+
+BILLING SAFETY: No Anthropic SDK imports. CLI subprocess only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+import sys as _sys
+_LIB = str(__file__).rsplit("/", 1)[0] if "/" in __file__ else "."
+if _LIB not in _sys.path:
+    _sys.path.insert(0, _LIB)
+
+from auto_report_contract import (
+    Complexity,
+    ContentType,
+    ExtractionResult,
+    HaikuClassification,
+)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+_HAIKU_MODEL = "claude-haiku-4-5-20251001"
+_HAIKU_TIMEOUT = 30  # seconds — haiku is fast; fail-fast on hang
+
+_VALID_CONTENT_TYPES = {e.value for e in ContentType}
+_VALID_COMPLEXITIES = {e.value for e in Complexity}
+
+_PROMPT_TEMPLATE = """\
+You are a code review classifier. Analyze this dispatch execution report and \
+classify it. Respond ONLY with a JSON object — no markdown, no explanation.
+
+Required JSON fields:
+  "content_type": one of: implementation, test, refactor, docs, review, config, planning, mixed
+  "quality_score": integer 1-5 (1=poor, 3=adequate, 5=excellent)
+  "complexity": one of: low, medium, high
+  "consistency_score": float 0.0-1.0 (how well exit summary matches the actual changes)
+  "summary": string, 1-2 sentences describing what was accomplished (max 200 chars)
+
+Dispatch execution data:
+{report_context}
+
+Respond with only the JSON object.
+"""
+
+
+# ─── Prompt Builder ───────────────────────────────────────────────────────────
+
+def _build_prompt(extraction: ExtractionResult) -> str:
+    """Serialize key extraction data as a compact context block for haiku."""
+    ctx: dict = {
+        "dispatch_id": extraction.dispatch_id,
+        "track": extraction.track,
+        "gate": extraction.gate,
+        "exit_summary": extraction.exit_summary or "(none)",
+        "files_changed": list(extraction.git.files_changed),
+        "insertions": extraction.git.insertions,
+        "deletions": extraction.git.deletions,
+        "commit_hash": extraction.git.commit_hash or "(none)",
+        "commit_message": extraction.git.commit_message or "(none)",
+        "has_commit": bool(extraction.git.commit_hash),
+        "test_passed": extraction.tests.passed if extraction.tests else 0,
+        "test_failed": extraction.tests.failed if extraction.tests else 0,
+        "test_errors": extraction.tests.errors if extraction.tests else 0,
+        "has_syntax_errors": extraction.has_syntax_errors,
+        "tool_use_count": extraction.events.tool_use_count,
+        "error_events": extraction.events.error_count,
+        "session_duration_s": extraction.events.session_duration_seconds,
+    }
+    report_context = json.dumps(ctx, indent=2)
+    return _PROMPT_TEMPLATE.format(report_context=report_context)
+
+
+# ─── Haiku Subprocess ─────────────────────────────────────────────────────────
+
+def _call_haiku(prompt: str) -> Optional[str]:
+    """Invoke claude -p --model haiku with prompt on stdin.
+
+    Returns the raw text output, or None on any failure (timeout, non-zero
+    exit, empty output).
+    """
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--model", _HAIKU_MODEL],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=_HAIKU_TIMEOUT,
+        )
+    except FileNotFoundError:
+        logger.debug("_call_haiku: 'claude' binary not found in PATH")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("_call_haiku: timed out after %ds", _HAIKU_TIMEOUT)
+        return None
+    except OSError as exc:
+        logger.debug("_call_haiku: subprocess error: %s", exc)
+        return None
+
+    if result.returncode != 0:
+        logger.debug(
+            "_call_haiku: non-zero exit %d; stderr=%s",
+            result.returncode,
+            result.stderr[:200] if result.stderr else "",
+        )
+        return None
+
+    text = result.stdout.strip()
+    if not text:
+        logger.debug("_call_haiku: empty output")
+        return None
+
+    return text
+
+
+# ─── Response Parser ──────────────────────────────────────────────────────────
+
+def _parse_haiku_response(text: str) -> Optional[dict]:
+    """Extract a JSON object from haiku's text response.
+
+    Handles:
+    - Clean JSON output (most common)
+    - JSON wrapped in a markdown code fence (```json ... ```)
+    - Trailing/leading whitespace
+
+    Returns None when no valid JSON object is found.
+    """
+    if not text:
+        return None
+
+    # Strip markdown code fences if present
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1)
+
+    # Try direct parse first
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    # Try to extract a JSON object from somewhere in the text
+    obj_match = re.search(r"\{[^{}]*\}", text, re.DOTALL)
+    if obj_match:
+        try:
+            data = json.loads(obj_match.group(0))
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            pass
+
+    logger.debug("_parse_haiku_response: no JSON object found in: %s", text[:200])
+    return None
+
+
+def _validate_parsed(data: dict) -> Optional[dict]:
+    """Validate and normalise the parsed haiku response dict.
+
+    Returns a clean dict with all required fields, or None if any required
+    field is missing or invalid.
+    """
+    content_type = str(data.get("content_type", "")).lower().strip()
+    if content_type not in _VALID_CONTENT_TYPES:
+        logger.debug("_validate_parsed: invalid content_type=%r", content_type)
+        return None
+
+    try:
+        quality_score = int(data.get("quality_score", 0))
+    except (TypeError, ValueError):
+        logger.debug("_validate_parsed: invalid quality_score=%r", data.get("quality_score"))
+        return None
+    if not 1 <= quality_score <= 5:
+        logger.debug("_validate_parsed: quality_score %d out of range", quality_score)
+        return None
+
+    complexity = str(data.get("complexity", "")).lower().strip()
+    if complexity not in _VALID_COMPLEXITIES:
+        logger.debug("_validate_parsed: invalid complexity=%r", complexity)
+        return None
+
+    try:
+        consistency_score = float(data.get("consistency_score", 0.5))
+    except (TypeError, ValueError):
+        consistency_score = 0.5
+    consistency_score = max(0.0, min(1.0, consistency_score))
+
+    summary = str(data.get("summary", "")).strip()
+    summary = summary[:200]  # enforce contract limit
+
+    return {
+        "content_type": content_type,
+        "quality_score": quality_score,
+        "complexity": complexity,
+        "consistency_score": consistency_score,
+        "summary": summary,
+    }
+
+
+# ─── Classification Entry Point ───────────────────────────────────────────────
+
+def classify_report(extraction: ExtractionResult) -> HaikuClassification:
+    """Classify an extraction result into semantic tags.
+
+    When VNX_HAIKU_CLASSIFY=1:
+        Calls claude-haiku via CLI subprocess. On failure, falls back to
+        rule_based silently — pipeline never crashes on classifier failure.
+
+    When VNX_HAIKU_CLASSIFY != 1 (or unset):
+        Returns rule_based classification immediately (no subprocess).
+
+    Args:
+        extraction: Populated ExtractionResult from run_extraction().
+
+    Returns:
+        HaikuClassification with classified_by="haiku" or "rule_based".
+    """
+    if os.environ.get("VNX_HAIKU_CLASSIFY") != "1":
+        logger.debug("classify_report: VNX_HAIKU_CLASSIFY not set; using rule_based")
+        return HaikuClassification.rule_based(extraction)
+
+    prompt = _build_prompt(extraction)
+    raw_text = _call_haiku(prompt)
+
+    if raw_text is None:
+        logger.info("classify_report: haiku call failed; falling back to rule_based")
+        return HaikuClassification.rule_based(extraction)
+
+    parsed = _parse_haiku_response(raw_text)
+    if parsed is None:
+        logger.info("classify_report: haiku response not parseable; falling back to rule_based")
+        return HaikuClassification.rule_based(extraction)
+
+    validated = _validate_parsed(parsed)
+    if validated is None:
+        logger.info("classify_report: haiku response invalid; falling back to rule_based")
+        return HaikuClassification.rule_based(extraction)
+
+    try:
+        return HaikuClassification(
+            content_type=ContentType(validated["content_type"]),
+            quality_score=validated["quality_score"],
+            complexity=Complexity(validated["complexity"]),
+            consistency_score=validated["consistency_score"],
+            summary=validated["summary"],
+            classified_by="haiku",
+        )
+    except (ValueError, KeyError) as exc:
+        logger.info("classify_report: HaikuClassification construction failed: %s; rule_based", exc)
+        return HaikuClassification.rule_based(extraction)

--- a/scripts/lib/report_extraction.py
+++ b/scripts/lib/report_extraction.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Deterministic Extraction Module — PR-2 (F37 Auto-Report Pipeline).
+
+Extracts structured data from git history, pytest output, and subprocess
+event streams. No LLM calls — pure parsing.
+
+Public API:
+    extract_git_provenance(repo_path)   → GitProvenance
+    parse_pytest_output(text)           → Optional[TestResults]
+    extract_pytest_from_events(path)    → Optional[TestResults]
+    aggregate_event_metrics(path)       → EventMetrics
+    run_extraction(...)                 → ExtractionResult
+
+All functions return empty/default objects on missing input — never raise.
+
+BILLING SAFETY: No Anthropic SDK imports. Subprocess calls to git only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Import PR-0 contract schemas
+import sys as _sys
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in _sys.path:
+    _sys.path.insert(0, _LIB)
+
+from auto_report_contract import (
+    EventMetrics,
+    ExtractionResult,
+    GitProvenance,
+    TestResults,
+)
+
+
+# ─── Git Extraction ──────────────────────────────────────────────────────────
+
+def extract_git_provenance(repo_path: Optional[Path] = None) -> GitProvenance:
+    """Extract git state from the repository.
+
+    Runs git log and git show --stat to capture the most recent commit's
+    metadata and file-change summary. Falls back to an empty GitProvenance
+    on any failure (missing git, no commits, detached HEAD, etc.).
+
+    Args:
+        repo_path: Repository root. Defaults to current working directory.
+
+    Returns:
+        GitProvenance with commit hash, message, branch, files changed,
+        insertions, deletions, and dirty flag.
+    """
+    cwd = str(repo_path) if repo_path else None
+
+    try:
+        commit_hash, commit_message = _git_last_commit(cwd)
+        if not commit_hash:
+            return GitProvenance()
+
+        branch = _git_branch(cwd)
+        files_changed, insertions, deletions = _git_diff_stat(cwd)
+        is_dirty = _git_is_dirty(cwd)
+
+        return GitProvenance(
+            commit_hash=commit_hash,
+            commit_message=commit_message,
+            branch=branch,
+            files_changed=tuple(files_changed),
+            insertions=insertions,
+            deletions=deletions,
+            is_dirty=is_dirty,
+        )
+    except Exception as exc:
+        logger.debug("extract_git_provenance: unexpected error: %s", exc)
+        return GitProvenance()
+
+
+def _run_git(args: List[str], cwd: Optional[str]) -> Tuple[int, str, str]:
+    """Run a git command and return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=15,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.debug("_run_git %s: %s", args, exc)
+        return 1, "", str(exc)
+
+
+def _git_last_commit(cwd: Optional[str]) -> Tuple[str, str]:
+    """Return (commit_hash, commit_message) for HEAD. Empty strings on failure."""
+    rc, stdout, _ = _run_git(["log", "--oneline", "-1"], cwd)
+    if rc != 0 or not stdout.strip():
+        return "", ""
+    parts = stdout.strip().split(None, 1)
+    commit_hash = parts[0]
+    commit_message = parts[1] if len(parts) > 1 else ""
+    return commit_hash, commit_message
+
+
+def _git_branch(cwd: Optional[str]) -> str:
+    """Return current branch name. Empty string on failure."""
+    rc, stdout, _ = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    return stdout.strip() if rc == 0 else ""
+
+
+def _git_diff_stat(cwd: Optional[str]) -> Tuple[List[str], int, int]:
+    """Return (files_changed, insertions, deletions) from git show --stat HEAD.
+
+    Uses --format= to suppress the commit header, leaving only the stat block.
+    """
+    rc, stdout, _ = _run_git(["show", "--stat", "--format=", "HEAD"], cwd)
+    if rc != 0:
+        return [], 0, 0
+    return _parse_diff_stat(stdout)
+
+
+def _git_is_dirty(cwd: Optional[str]) -> bool:
+    """Return True if working tree has uncommitted changes."""
+    rc, stdout, _ = _run_git(["status", "--porcelain"], cwd)
+    return bool(stdout.strip()) if rc == 0 else False
+
+
+def _parse_diff_stat(stat_output: str) -> Tuple[List[str], int, int]:
+    """Parse git diff/show --stat output into (files, insertions, deletions).
+
+    Handles:
+    - Standard file lines:   `` path/to/file.py | 10 +++++-----``
+    - Binary file lines:     `` image.png | Bin 0 -> 1234 bytes``
+    - Summary line:          `` 2 files changed, 10 insertions(+), 5 deletions(-)``
+    - Rename lines:          `` old.py => new.py | 5 +++++``
+    """
+    files: List[str] = []
+    insertions = 0
+    deletions = 0
+
+    for raw_line in stat_output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        # Summary line (must come before file-line check to avoid false match)
+        if re.search(r"\d+ files? changed", line):
+            ins_m = re.search(r"(\d+) insertion", line)
+            del_m = re.search(r"(\d+) deletion", line)
+            if ins_m:
+                insertions = int(ins_m.group(1))
+            if del_m:
+                deletions = int(del_m.group(1))
+            continue
+
+        # File stat line: "path/to/file.py | 10 +++++-----"
+        if "|" in line:
+            parts = line.split("|", 1)
+            file_part = parts[0].strip()
+            stat_part = parts[1].strip() if len(parts) > 1 else ""
+            # Skip binary files ("Bin N -> M bytes"), empty names, and diff markers
+            is_binary = stat_part.startswith("Bin ") or "Bin " in stat_part[:10]
+            if file_part and not is_binary and not file_part.startswith(("---", "+++")):
+                # Handle rename notation: "old.py => new.py" → take new name
+                if "=>" in file_part:
+                    # "old.py => new.py" or "{old => new}/suffix.py"
+                    arrow_match = re.search(r"=>\s*(.+?)$", file_part)
+                    if arrow_match:
+                        file_part = arrow_match.group(1).strip().rstrip("}")
+                files.append(file_part)
+
+    return files, insertions, deletions
+
+
+# ─── Pytest Output Parsing ───────────────────────────────────────────────────
+
+# Matches the terminal summary line from any pytest output format:
+#   "5 passed in 1.23s"
+#   "3 failed, 2 passed in 0.50s"
+#   "1 error in 0.05s"
+#   "5 passed, 2 skipped, 1 xfailed in 2.10s"
+_PYTEST_SUMMARY_RE = re.compile(
+    r"(?:=+\s*)?((?:\d+\s+\w+(?:,\s*)?)+)\s+in\s+(\d+\.?\d*)\s*s",
+    re.IGNORECASE,
+)
+
+# Individual count patterns within the summary segment
+_COUNT_PATTERNS = {
+    "passed": re.compile(r"(\d+)\s+passed"),
+    "failed": re.compile(r"(\d+)\s+failed"),
+    "errors": re.compile(r"(\d+)\s+error"),
+    "skipped": re.compile(r"(\d+)\s+skipped"),
+}
+
+# Coverage percentage: "TOTAL ... 63%" or "coverage: 63%"
+_COVERAGE_RE = re.compile(r"(?:TOTAL\s+\d+\s+\d+\s+(\d+)%|coverage[:\s]+(\d+)%)", re.IGNORECASE)
+
+
+def parse_pytest_output(text: str) -> Optional[TestResults]:
+    """Parse pytest stdout/stderr and extract test counts and duration.
+
+    Handles standard, verbose, and short (dot) pytest output formats.
+    Returns None when no pytest summary line is detected (not a pytest run).
+    Returns a zero-count TestResults when pytest ran but found nothing.
+
+    Args:
+        text: Raw pytest output string.
+
+    Returns:
+        TestResults on success, None if text contains no pytest output.
+    """
+    if not text or not _looks_like_pytest(text):
+        return None
+
+    # Find the last summary line (most specific match wins)
+    summary_match = None
+    for m in _PYTEST_SUMMARY_RE.finditer(text):
+        summary_match = m
+
+    if summary_match is None:
+        # Pytest ran but produced no counted summary (e.g. collection error)
+        return TestResults(raw_output=text[:500])
+
+    summary_segment = summary_match.group(1)
+    duration_str = summary_match.group(2)
+
+    passed = _extract_count(summary_segment, _COUNT_PATTERNS["passed"])
+    failed = _extract_count(summary_segment, _COUNT_PATTERNS["failed"])
+    errors = _extract_count(summary_segment, _COUNT_PATTERNS["errors"])
+    skipped = _extract_count(summary_segment, _COUNT_PATTERNS["skipped"])
+
+    try:
+        duration = float(duration_str)
+    except ValueError:
+        duration = 0.0
+
+    return TestResults(
+        passed=passed,
+        failed=failed,
+        errors=errors,
+        skipped=skipped,
+        duration_seconds=duration,
+        raw_output=text[:500],
+    )
+
+
+def _looks_like_pytest(text: str) -> bool:
+    """Return True if text contains recognisable pytest markers."""
+    markers = ("passed", "failed", "error", "skipped", "pytest", "collected")
+    lower = text.lower()
+    return any(m in lower for m in markers)
+
+
+def _extract_count(segment: str, pattern: re.Pattern) -> int:
+    """Extract integer count from a regex match, 0 if not found."""
+    m = pattern.search(segment)
+    return int(m.group(1)) if m else 0
+
+
+# ─── Event Stream Aggregation ────────────────────────────────────────────────
+
+def aggregate_event_metrics(
+    events_path: Path,
+    dispatch_id: str = "",
+) -> EventMetrics:
+    """Aggregate metrics from a terminal's NDJSON event file.
+
+    Reads .vnx-data/events/T{N}.ndjson (or an archived copy). Counts
+    tool_use, text, thinking, and error events. Computes session duration
+    from first-to-last timestamp. Extracts model from the init event.
+
+    Filters to dispatch_id when provided (empty string = all events).
+
+    Args:
+        events_path: Path to the NDJSON event file.
+        dispatch_id: Optional dispatch ID filter.
+
+    Returns:
+        EventMetrics with aggregated counts and timing. Empty on any failure.
+    """
+    if not events_path or not Path(events_path).exists():
+        return EventMetrics()
+
+    tool_use_count = 0
+    text_block_count = 0
+    thinking_block_count = 0
+    error_count = 0
+    first_ts: Optional[str] = None
+    last_ts: Optional[str] = None
+    model_used = ""
+
+    try:
+        with open(events_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    logger.debug("aggregate_event_metrics: skipping corrupt line")
+                    continue
+
+                # Apply dispatch_id filter
+                if dispatch_id and event.get("dispatch_id", "") not in ("", dispatch_id):
+                    continue
+
+                event_type = event.get("type", "")
+                timestamp = event.get("timestamp", "")
+
+                if timestamp:
+                    if first_ts is None:
+                        first_ts = timestamp
+                    last_ts = timestamp
+
+                if event_type == "tool_use":
+                    tool_use_count += 1
+                elif event_type == "text":
+                    text_block_count += 1
+                elif event_type == "thinking":
+                    thinking_block_count += 1
+                elif event_type == "error":
+                    error_count += 1
+                elif event_type == "init":
+                    data = event.get("data", {})
+                    if isinstance(data, dict) and data.get("model"):
+                        model_used = data["model"]
+
+    except OSError as exc:
+        logger.debug("aggregate_event_metrics: cannot read %s: %s", events_path, exc)
+        return EventMetrics()
+
+    duration = _compute_duration_seconds(first_ts, last_ts)
+
+    return EventMetrics(
+        tool_use_count=tool_use_count,
+        text_block_count=text_block_count,
+        thinking_block_count=thinking_block_count,
+        error_count=error_count,
+        session_duration_seconds=duration,
+        model_used=model_used,
+    )
+
+
+def extract_pytest_from_events(
+    events_path: Path,
+    dispatch_id: str = "",
+) -> Optional[TestResults]:
+    """Scan tool_result events in the NDJSON file for pytest output.
+
+    Workers run pytest via Bash tool. The output appears in tool_result
+    events as the content field. This function scans all tool_result events
+    and returns the TestResults from the last recognisable pytest run.
+
+    Args:
+        events_path: Path to the NDJSON event file.
+        dispatch_id: Optional dispatch ID filter.
+
+    Returns:
+        TestResults from the last pytest invocation found, or None.
+    """
+    if not events_path or not Path(events_path).exists():
+        return None
+
+    last_result: Optional[TestResults] = None
+
+    try:
+        with open(events_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                if dispatch_id and event.get("dispatch_id", "") not in ("", dispatch_id):
+                    continue
+
+                if event.get("type") != "tool_result":
+                    continue
+
+                data = event.get("data", {})
+                if not isinstance(data, dict):
+                    continue
+
+                content = data.get("content", "")
+                if not isinstance(content, str):
+                    continue
+
+                parsed = parse_pytest_output(content)
+                if parsed is not None:
+                    last_result = parsed
+
+    except OSError as exc:
+        logger.debug("extract_pytest_from_events: cannot read %s: %s", events_path, exc)
+
+    return last_result
+
+
+def _compute_duration_seconds(first_ts: Optional[str], last_ts: Optional[str]) -> int:
+    """Compute integer seconds between two ISO 8601 timestamps.
+
+    Returns 0 on any parse failure or when timestamps are identical.
+    """
+    if not first_ts or not last_ts or first_ts == last_ts:
+        return 0
+    try:
+        fmt = "%Y-%m-%dT%H:%M:%S.%f+00:00"
+        # Try multiple ISO formats
+        for ts_fmt in (
+            "%Y-%m-%dT%H:%M:%S.%f+00:00",
+            "%Y-%m-%dT%H:%M:%S+00:00",
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%SZ",
+        ):
+            try:
+                t0 = datetime.strptime(first_ts[:26].replace("Z", "+00:00"), ts_fmt)
+                t1 = datetime.strptime(last_ts[:26].replace("Z", "+00:00"), ts_fmt)
+                return max(0, int((t1 - t0).total_seconds()))
+            except ValueError:
+                continue
+        # Fallback: fromisoformat
+        t0 = datetime.fromisoformat(first_ts)
+        t1 = datetime.fromisoformat(last_ts)
+        return max(0, int((t1 - t0).total_seconds()))
+    except Exception as exc:
+        logger.debug("_compute_duration_seconds: %s", exc)
+        return 0
+
+
+# ─── Exit Summary Extraction ─────────────────────────────────────────────────
+
+def extract_exit_summary(events_path: Optional[Path], dispatch_id: str = "") -> str:
+    """Extract the last text block from the event stream as exit summary.
+
+    Workers emit a final text block summarising their work. This function
+    returns the content of the last ``text`` event, truncated to 200 chars.
+
+    Returns empty string when no text events are found.
+    """
+    if not events_path or not Path(events_path).exists():
+        return ""
+
+    last_text = ""
+
+    try:
+        with open(events_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                if dispatch_id and event.get("dispatch_id", "") not in ("", dispatch_id):
+                    continue
+
+                if event.get("type") == "text":
+                    data = event.get("data", {})
+                    if isinstance(data, dict):
+                        text = data.get("text", "")
+                        if isinstance(text, str) and text.strip():
+                            last_text = text.strip()
+
+    except OSError as exc:
+        logger.debug("extract_exit_summary: cannot read %s: %s", events_path, exc)
+
+    return last_text[:200]
+
+
+# ─── Main Entry Point ─────────────────────────────────────────────────────────
+
+def run_extraction(
+    dispatch_id: str,
+    terminal: str,
+    track: str,
+    gate: str,
+    repo_path: Optional[Path] = None,
+    events_path: Optional[Path] = None,
+    exit_summary: str = "",
+) -> ExtractionResult:
+    """Compose all extractors into a single ExtractionResult.
+
+    This is the primary entry point for the stop hook. Each extractor is
+    called independently; failures in one do not affect others.
+
+    Args:
+        dispatch_id: Active dispatch identifier.
+        terminal:    Worker terminal (T1, T2, T3).
+        track:       Track letter (A, B, C).
+        gate:        Quality gate name.
+        repo_path:   Repository root for git extraction. Defaults to cwd.
+        events_path: Path to NDJSON event file. Auto-resolved from
+                     VNX_DATA_DIR when omitted.
+        exit_summary: Override for exit summary (skips event scan).
+
+    Returns:
+        ExtractionResult populated with all available data.
+    """
+    # Resolve events path from env when not provided
+    if events_path is None:
+        import os
+        vnx_data = os.environ.get("VNX_DATA_DIR")
+        if vnx_data:
+            events_path = Path(vnx_data) / "events" / f"{terminal}.ndjson"
+
+    git_provenance = extract_git_provenance(repo_path)
+
+    # Pytest: prefer events scan over direct git extraction
+    test_results = extract_pytest_from_events(events_path, dispatch_id)
+
+    event_metrics = aggregate_event_metrics(events_path, dispatch_id)
+
+    # Exit summary: use override, then event scan, then empty
+    if not exit_summary:
+        exit_summary = extract_exit_summary(events_path, dispatch_id)
+
+    extracted_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    return ExtractionResult(
+        dispatch_id=dispatch_id,
+        terminal=terminal,
+        track=track,
+        gate=gate,
+        git=git_provenance,
+        tests=test_results,
+        events=event_metrics,
+        exit_summary=exit_summary,
+        extracted_at=extracted_at,
+    )

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -18,6 +18,8 @@ import signal
 import subprocess
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -552,6 +554,104 @@ class SubprocessAdapter:
     def reheal(self, terminal_id: str):  # type: ignore[return]
         from adapter_types import RehealResult, UnsupportedCapability
         raise UnsupportedCapability("reheal", adapter_type="subprocess")
+
+    # ------------------------------------------------------------------
+    # Auto-Report Pipeline Trigger
+    # ------------------------------------------------------------------
+
+    def trigger_report_pipeline(
+        self,
+        terminal_id: str,
+        dispatch_id: str,
+        *,
+        cwd: Optional[str] = None,
+        project_root: Optional[str] = None,
+        gate: str = "",
+        track: str = "",
+        pr_id: str = "",
+    ) -> bool:
+        """Write an extraction trigger file for the auto-report pipeline.
+
+        Mirrors the stop_report_hook.sh output so subprocess completions feed
+        the same pipeline as interactive session Stop hook firings.
+
+        Gate: only runs when VNX_AUTO_REPORT=1 is set. Returns True when trigger
+        file is written, False when skipped or on error.
+
+        Non-blocking — does not invoke any subprocess or LLM.
+        """
+        if os.environ.get("VNX_AUTO_REPORT", "0") != "1":
+            return False
+
+        terminal_map = {"T1": "A", "T2": "B", "T3": "C"}
+        if terminal_id not in terminal_map:
+            logger.debug(
+                "trigger_report_pipeline: %s is not a worker terminal, skipping",
+                terminal_id,
+            )
+            return False
+
+        # Resolve project root
+        if project_root is None:
+            vnx_data_env = os.environ.get("VNX_DATA_DIR", "")
+            if vnx_data_env:
+                project_root = str(Path(vnx_data_env).parent)
+            else:
+                # Walk up from this file to find .vnx-data
+                search = Path(__file__).resolve()
+                for _ in range(6):
+                    search = search.parent
+                    if (search / ".vnx-data").is_dir():
+                        project_root = str(search)
+                        break
+
+        if project_root is None:
+            logger.warning(
+                "trigger_report_pipeline: could not resolve project root for %s",
+                terminal_id,
+            )
+            return False
+
+        vnx_data_dir = os.environ.get("VNX_DATA_DIR", str(Path(project_root) / ".vnx-data"))
+        pipeline_dir = Path(vnx_data_dir) / "state" / "report_pipeline"
+        pipeline_dir.mkdir(parents=True, exist_ok=True)
+
+        # Infer track from terminal if not provided
+        effective_track = track or terminal_map.get(terminal_id, "")
+
+        session_id = self._session_ids.get(terminal_id, "")
+        effective_cwd = cwd or str(Path(project_root) / ".claude" / "terminals" / terminal_id)
+
+        trigger = {
+            "trigger_time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "dispatch_id": dispatch_id,
+            "terminal": terminal_id,
+            "track": effective_track,
+            "gate": gate,
+            "pr_id": pr_id,
+            "session_id": session_id,
+            "transcript_path": "",
+            "cwd": effective_cwd,
+            "project_root": project_root,
+            "source": "subprocess",
+        }
+
+        trigger_file = pipeline_dir / f"{dispatch_id}.trigger.json"
+        try:
+            trigger_file.write_text(json.dumps(trigger, indent=2))
+            logger.info(
+                "trigger_report_pipeline: wrote trigger for %s → %s",
+                dispatch_id,
+                trigger_file,
+            )
+            return True
+        except OSError as exc:
+            logger.warning(
+                "trigger_report_pipeline: failed to write trigger for %s: %s",
+                dispatch_id,
+                exc,
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Shutdown

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -144,6 +144,7 @@ def deliver_via_subprocess(
         )
         heartbeat_thread.start()
 
+    success = False
     try:
         for _event in adapter.read_events_with_timeout(
             terminal_id,
@@ -151,6 +152,7 @@ def deliver_via_subprocess(
             total_deadline=total_deadline,
         ):
             pass
+        success = True
         return True
     except Exception:
         logger.exception("deliver_via_subprocess failed for %s", terminal_id)
@@ -160,6 +162,12 @@ def deliver_via_subprocess(
             heartbeat_stop.set()
         if heartbeat_thread is not None:
             heartbeat_thread.join(timeout=5)
+        # Trigger auto-report pipeline on completion (gated by VNX_AUTO_REPORT=1)
+        adapter.trigger_report_pipeline(
+            terminal_id,
+            dispatch_id,
+            cwd=str(agent_cwd) if agent_cwd is not None else None,
+        )
 
 
 def _write_receipt(

--- a/tests/test_auto_report_contract.py
+++ b/tests/test_auto_report_contract.py
@@ -1,0 +1,631 @@
+"""Tests for auto_report_contract.py — PR-0 schema validation.
+
+Covers: construction, serialization, validation, round-trip, edge cases,
+and receipt processor compatibility.
+"""
+
+import json
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from auto_report_contract import (
+    SCHEMA_VERSION,
+    AutoDerivedTags,
+    AutoReport,
+    AutoReportMetadata,
+    ClassifiedTags,
+    Complexity,
+    ContentType,
+    DispatchTags,
+    DispatchType,
+    EventMetrics,
+    ExtractionResult,
+    GitProvenance,
+    HaikuClassification,
+    OutcomeStatus,
+    RiskLevel,
+    Scope,
+    StopHookInput,
+    StopHookOutput,
+    SyntaxCheck,
+    TestResults,
+    UnifiedTagSet,
+    render_markdown,
+    validate_auto_report,
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def dispatch_tags():
+    return DispatchTags(
+        dispatch_type=DispatchType.IMPLEMENTATION,
+        risk=RiskLevel.MEDIUM,
+        scope=Scope.MULTI_FILE,
+        expected_ois=2,
+        depends_on=("20260408-dep1-A",),
+    )
+
+
+@pytest.fixture
+def git_provenance():
+    return GitProvenance(
+        commit_hash="abc123def456",
+        commit_message="feat(core): add new feature",
+        branch="feature/f37-auto-report",
+        files_changed=("scripts/lib/auto_report_contract.py", "tests/test_auto_report_contract.py"),
+        insertions=150,
+        deletions=20,
+        is_dirty=False,
+    )
+
+
+@pytest.fixture
+def test_results():
+    return TestResults(passed=10, failed=0, errors=0, skipped=1, duration_seconds=2.5)
+
+
+@pytest.fixture
+def event_metrics():
+    return EventMetrics(
+        tool_use_count=15,
+        text_block_count=8,
+        thinking_block_count=5,
+        error_count=0,
+        session_duration_seconds=120,
+        model_used="claude-sonnet-4-6",
+    )
+
+
+@pytest.fixture
+def extraction_result(git_provenance, test_results, event_metrics):
+    return ExtractionResult(
+        dispatch_id="20260408-110915-auto-report-C",
+        terminal="T3",
+        track="C",
+        gate="gate_pr0_auto_report_contract",
+        git=git_provenance,
+        tests=test_results,
+        syntax_checks=(
+            SyntaxCheck("scripts/lib/auto_report_contract.py", "python", True),
+        ),
+        events=event_metrics,
+        exit_summary="Contract module implemented with all schemas.",
+        extracted_at="2026-04-08T11:30:00Z",
+    )
+
+
+@pytest.fixture
+def haiku_classification():
+    return HaikuClassification(
+        content_type=ContentType.IMPLEMENTATION,
+        quality_score=4,
+        complexity=Complexity.MEDIUM,
+        consistency_score=0.95,
+        summary="Schema definition for auto-report pipeline contract.",
+        classified_by="haiku",
+    )
+
+
+@pytest.fixture
+def full_auto_report(extraction_result, haiku_classification, dispatch_tags):
+    auto_derived = AutoDerivedTags.from_extraction(extraction_result)
+    classified = ClassifiedTags.from_classification(haiku_classification)
+    tags = UnifiedTagSet(
+        dispatch_tags=dispatch_tags,
+        auto_derived=auto_derived,
+        classified=classified,
+        outcome=OutcomeStatus.SUCCESS,
+    )
+    return AutoReport(
+        metadata=AutoReportMetadata(
+            dispatch_id="20260408-110915-auto-report-C",
+            pr_id="PR-0",
+            terminal="T3",
+            track="C",
+            gate="gate_pr0_auto_report_contract",
+            status="success",
+            assembled_at="2026-04-08T11:30:00Z",
+        ),
+        extraction=extraction_result,
+        classification=haiku_classification,
+        tags=tags,
+    )
+
+
+# ─── Stop Hook Contract ──────────────────────────────────────────────────────
+
+class TestStopHookInput:
+    def test_from_stdin_minimal(self):
+        raw = json.dumps({
+            "session_id": "abc123",
+            "transcript_path": "/tmp/transcript.jsonl",
+            "cwd": "/Users/test/.claude/terminals/T1",
+        })
+        hook = StopHookInput.from_stdin(raw)
+        assert hook.session_id == "abc123"
+        assert hook.hook_event_name == "Stop"
+        assert hook.permission_mode == "default"
+
+    def test_from_stdin_full(self):
+        raw = json.dumps({
+            "session_id": "abc123",
+            "transcript_path": "/tmp/transcript.jsonl",
+            "cwd": "/Users/test/.claude/terminals/T2",
+            "hook_event_name": "Stop",
+            "permission_mode": "bypassPermissions",
+        })
+        hook = StopHookInput.from_stdin(raw)
+        assert hook.permission_mode == "bypassPermissions"
+
+    def test_detect_terminal_t1(self):
+        hook = StopHookInput("s1", "/tmp/t.jsonl", "/Users/x/.claude/terminals/T1")
+        assert hook.detect_terminal() == "T1"
+
+    def test_detect_terminal_t3(self):
+        hook = StopHookInput("s1", "/tmp/t.jsonl", "/Users/x/.claude/terminals/T3")
+        assert hook.detect_terminal() == "T3"
+
+    def test_detect_terminal_t0_returns_none(self):
+        hook = StopHookInput("s1", "/tmp/t.jsonl", "/Users/x/.claude/terminals/T0")
+        assert hook.detect_terminal() is None
+
+    def test_detect_terminal_non_vnx_returns_none(self):
+        hook = StopHookInput("s1", "/tmp/t.jsonl", "/Users/x/projects/myapp")
+        assert hook.detect_terminal() is None
+
+    def test_from_stdin_missing_field_raises(self):
+        raw = json.dumps({"session_id": "abc"})
+        with pytest.raises(KeyError):
+            StopHookInput.from_stdin(raw)
+
+
+class TestStopHookOutput:
+    def test_to_json_minimal(self):
+        out = StopHookOutput()
+        parsed = json.loads(out.to_json())
+        assert parsed["skipped"] is False
+
+    def test_to_json_with_report(self):
+        out = StopHookOutput(
+            auto_report_path="/tmp/report.json",
+            dispatch_id="20260408-test-C",
+            terminal="T3",
+        )
+        parsed = json.loads(out.to_json())
+        assert parsed["dispatch_id"] == "20260408-test-C"
+
+    def test_to_json_skipped(self):
+        out = StopHookOutput(skipped=True, skip_reason="No active dispatch")
+        parsed = json.loads(out.to_json())
+        assert parsed["skipped"] is True
+        assert parsed["skip_reason"] == "No active dispatch"
+
+
+# ─── Tag Taxonomy ─────────────────────────────────────────────────────────────
+
+class TestDispatchTags:
+    def test_construction(self, dispatch_tags):
+        assert dispatch_tags.dispatch_type == DispatchType.IMPLEMENTATION
+        assert dispatch_tags.risk == RiskLevel.MEDIUM
+        assert dispatch_tags.expected_ois == 2
+        assert len(dispatch_tags.depends_on) == 1
+
+    def test_negative_expected_ois_raises(self):
+        with pytest.raises(ValueError, match="expected_ois"):
+            DispatchTags(
+                dispatch_type=DispatchType.TEST,
+                risk=RiskLevel.LOW,
+                scope=Scope.SINGLE_FILE,
+                expected_ois=-1,
+            )
+
+    def test_round_trip(self, dispatch_tags):
+        d = dispatch_tags.to_dict()
+        restored = DispatchTags.from_dict(d)
+        assert restored == dispatch_tags
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            DispatchType("nonexistent")
+
+
+class TestAutoDerivedTags:
+    def test_from_extraction(self, extraction_result):
+        tags = AutoDerivedTags.from_extraction(extraction_result)
+        assert tags.file_count == 2
+        assert tags.test_count == 11  # 10 passed + 1 skipped
+        assert tags.line_delta_add == 150
+        assert tags.line_delta_del == 20
+        assert tags.has_commit is True
+        assert tags.syntax_valid is True
+        assert tags.tests_passed is True
+        assert tags.model_used == "claude-sonnet-4-6"
+
+    def test_from_extraction_no_tests(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T1",
+            track="A",
+            gate="test",
+            extracted_at="2026-04-08T00:00:00Z",
+        )
+        tags = AutoDerivedTags.from_extraction(ext)
+        assert tags.test_count == 0
+        assert tags.tests_passed is True  # No tests = not failed
+
+
+class TestClassifiedTags:
+    def test_from_classification(self, haiku_classification):
+        tags = ClassifiedTags.from_classification(haiku_classification)
+        assert tags.content_type == "implementation"
+        assert tags.quality_score == 4
+        assert tags.classified_by == "haiku"
+
+
+class TestUnifiedTagSet:
+    def test_round_trip(self, dispatch_tags, extraction_result, haiku_classification):
+        auto = AutoDerivedTags.from_extraction(extraction_result)
+        classified = ClassifiedTags.from_classification(haiku_classification)
+        tags = UnifiedTagSet(
+            dispatch_tags=dispatch_tags,
+            auto_derived=auto,
+            classified=classified,
+            outcome=OutcomeStatus.SUCCESS,
+        )
+        d = tags.to_dict()
+        restored = UnifiedTagSet.from_dict(d)
+        assert restored.outcome == OutcomeStatus.SUCCESS
+        assert restored.dispatch_tags.risk == RiskLevel.MEDIUM
+        assert restored.classified.quality_score == 4
+
+    def test_partial_tags(self):
+        tags = UnifiedTagSet(outcome=OutcomeStatus.CRASHED)
+        d = tags.to_dict()
+        assert d["dispatch_tags"] is None
+        assert d["auto_derived"] is None
+        assert d["classified"] is None
+        assert d["outcome"] == "crashed"
+
+
+# ─── Extraction ───────────────────────────────────────────────────────────────
+
+class TestExtractionResult:
+    def test_invalid_terminal_raises(self):
+        with pytest.raises(ValueError, match="terminal"):
+            ExtractionResult(
+                dispatch_id="test-1", terminal="T0", track="A", gate="test"
+            )
+
+    def test_invalid_track_raises(self):
+        with pytest.raises(ValueError, match="track"):
+            ExtractionResult(
+                dispatch_id="test-1", terminal="T1", track="D", gate="test"
+            )
+
+    def test_has_test_failures(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T1",
+            track="A",
+            gate="test",
+            tests=TestResults(passed=5, failed=2),
+        )
+        assert ext.has_test_failures is True
+
+    def test_no_tests_no_failures(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1", terminal="T1", track="A", gate="test"
+        )
+        assert ext.has_test_failures is False
+
+    def test_syntax_check_detection(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T1",
+            track="A",
+            gate="test",
+            syntax_checks=(
+                SyntaxCheck("a.py", "python", True),
+                SyntaxCheck("b.sh", "shell", False, "syntax error near line 10"),
+            ),
+        )
+        assert ext.has_syntax_errors is True
+        assert ext.all_syntax_valid is False
+
+    def test_round_trip(self, extraction_result):
+        d = extraction_result.to_dict()
+        restored = ExtractionResult.from_dict(d)
+        assert restored.dispatch_id == extraction_result.dispatch_id
+        assert restored.git.commit_hash == extraction_result.git.commit_hash
+        assert restored.tests.passed == extraction_result.tests.passed
+        assert len(restored.syntax_checks) == len(extraction_result.syntax_checks)
+
+
+class TestGitProvenance:
+    def test_line_delta(self, git_provenance):
+        assert git_provenance.line_delta == 130  # 150 - 20
+
+    def test_round_trip(self, git_provenance):
+        d = git_provenance.to_dict()
+        assert isinstance(d["files_changed"], list)
+        restored = GitProvenance.from_dict(d)
+        assert restored == git_provenance
+
+
+class TestTestResults:
+    def test_total(self, test_results):
+        assert test_results.total == 11
+
+    def test_all_passed(self, test_results):
+        assert test_results.all_passed is True
+
+    def test_failures_not_passed(self):
+        t = TestResults(passed=5, failed=1)
+        assert t.all_passed is False
+
+    def test_empty_not_passed(self):
+        t = TestResults()
+        assert t.all_passed is False  # total == 0
+
+
+# ─── Haiku Classification ────────────────────────────────────────────────────
+
+class TestHaikuClassification:
+    def test_valid_construction(self, haiku_classification):
+        assert haiku_classification.quality_score == 4
+        assert haiku_classification.classified_by == "haiku"
+
+    def test_invalid_quality_score_raises(self):
+        with pytest.raises(ValueError, match="quality_score"):
+            HaikuClassification(
+                content_type=ContentType.TEST,
+                quality_score=6,
+                complexity=Complexity.LOW,
+                consistency_score=0.5,
+                summary="test",
+                classified_by="haiku",
+            )
+
+    def test_invalid_consistency_score_raises(self):
+        with pytest.raises(ValueError, match="consistency_score"):
+            HaikuClassification(
+                content_type=ContentType.TEST,
+                quality_score=3,
+                complexity=Complexity.LOW,
+                consistency_score=1.5,
+                summary="test",
+                classified_by="haiku",
+            )
+
+    def test_round_trip(self, haiku_classification):
+        d = haiku_classification.to_dict()
+        restored = HaikuClassification.from_dict(d)
+        assert restored == haiku_classification
+
+    def test_rule_based_fallback_implementation(self, extraction_result):
+        c = HaikuClassification.rule_based(extraction_result)
+        assert c.classified_by == "rule_based"
+        assert c.content_type == ContentType.IMPLEMENTATION
+        assert 1 <= c.quality_score <= 5
+
+    def test_rule_based_fallback_tests_only(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T2",
+            track="B",
+            gate="test",
+            git=GitProvenance(
+                files_changed=("tests/test_foo.py", "tests/test_bar.py"),
+                insertions=50,
+                deletions=10,
+                commit_hash="abc123",
+            ),
+            tests=TestResults(passed=5),
+        )
+        c = HaikuClassification.rule_based(ext)
+        assert c.content_type == ContentType.TEST
+
+    def test_rule_based_fallback_docs_only(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T1",
+            track="A",
+            gate="test",
+            git=GitProvenance(
+                files_changed=("README.md", "docs/guide.md"),
+                insertions=30,
+                deletions=5,
+                commit_hash="abc123",
+            ),
+        )
+        c = HaikuClassification.rule_based(ext)
+        assert c.content_type == ContentType.DOCS
+
+    def test_rule_based_high_complexity(self):
+        ext = ExtractionResult(
+            dispatch_id="test-1",
+            terminal="T1",
+            track="A",
+            gate="test",
+            git=GitProvenance(
+                files_changed=tuple(f"file{i}.py" for i in range(10)),
+                insertions=500,
+                deletions=100,
+            ),
+        )
+        c = HaikuClassification.rule_based(ext)
+        assert c.complexity == Complexity.HIGH
+
+
+# ─── Auto Report ──────────────────────────────────────────────────────────────
+
+class TestAutoReport:
+    def test_round_trip_json(self, full_auto_report):
+        json_str = full_auto_report.to_json()
+        restored = AutoReport.from_json(json_str)
+        assert restored.metadata.dispatch_id == full_auto_report.metadata.dispatch_id
+        assert restored.extraction.git.commit_hash == full_auto_report.extraction.git.commit_hash
+        assert restored.classification.quality_score == full_auto_report.classification.quality_score
+        assert restored.tags.outcome == OutcomeStatus.SUCCESS
+
+    def test_without_classification(self, extraction_result):
+        report = AutoReport(
+            metadata=AutoReportMetadata(
+                dispatch_id="test-1",
+                pr_id="PR-0",
+                terminal="T1",
+                track="A",
+                gate="test",
+                status="success",
+            ),
+            extraction=extraction_result,
+        )
+        d = report.to_dict()
+        assert d["classification"] is None
+        restored = AutoReport.from_dict(d)
+        assert restored.classification is None
+
+    def test_schema_version_in_output(self, full_auto_report):
+        d = full_auto_report.to_dict()
+        assert d["schema_version"] == SCHEMA_VERSION
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+class TestValidation:
+    def test_valid_report(self, full_auto_report):
+        errors = validate_auto_report(full_auto_report)
+        assert errors == []
+
+    def test_missing_dispatch_id(self, extraction_result):
+        report = AutoReport(
+            metadata=AutoReportMetadata(
+                dispatch_id="",
+                pr_id="PR-0",
+                terminal="T1",
+                track="A",
+                gate="test",
+                status="success",
+            ),
+            extraction=extraction_result,
+        )
+        errors = validate_auto_report(report)
+        assert any("dispatch_id" in e for e in errors)
+
+    def test_mismatched_dispatch_ids(self):
+        report = AutoReport(
+            metadata=AutoReportMetadata(
+                dispatch_id="id-1",
+                pr_id="PR-0",
+                terminal="T1",
+                track="A",
+                gate="test",
+                status="success",
+            ),
+            extraction=ExtractionResult(
+                dispatch_id="id-2",
+                terminal="T1",
+                track="A",
+                gate="test",
+            ),
+        )
+        errors = validate_auto_report(report)
+        assert any("does not match" in e for e in errors)
+
+
+# ─── Markdown Rendering ──────────────────────────────────────────────────────
+
+class TestRenderMarkdown:
+    def test_contains_required_metadata(self, full_auto_report):
+        md = render_markdown(full_auto_report)
+        assert "**Dispatch ID**: 20260408-110915-auto-report-C" in md
+        assert "**PR**: PR-0" in md
+        assert "**Track**: C" in md
+        assert "**Gate**: gate_pr0_auto_report_contract" in md
+        assert "**Status**: success" in md
+        assert "**Auto-Generated**: true" in md
+
+    def test_contains_files_section(self, full_auto_report):
+        md = render_markdown(full_auto_report)
+        assert "auto_report_contract.py" in md
+        assert "+150/-20" in md
+
+    def test_contains_test_results(self, full_auto_report):
+        md = render_markdown(full_auto_report)
+        assert "Passed**: 10" in md
+        assert "Failed**: 0" in md
+
+    def test_contains_tags(self, full_auto_report):
+        md = render_markdown(full_auto_report)
+        assert "risk=medium" in md
+        assert "quality=4/5" in md
+
+    def test_open_items_always_present(self, full_auto_report):
+        md = render_markdown(full_auto_report)
+        assert "## Open Items" in md
+
+    def test_no_classification_still_renders(self, extraction_result):
+        report = AutoReport(
+            metadata=AutoReportMetadata(
+                dispatch_id="test-1",
+                pr_id="PR-0",
+                terminal="T1",
+                track="A",
+                gate="test",
+                status="success",
+            ),
+            extraction=extraction_result,
+        )
+        md = render_markdown(report)
+        assert "**Dispatch ID**: test-1" in md
+        assert "## Summary" in md
+
+    def test_empty_extraction_renders(self):
+        report = AutoReport(
+            metadata=AutoReportMetadata(
+                dispatch_id="test-empty",
+                pr_id="PR-0",
+                terminal="T1",
+                track="A",
+                gate="test",
+                status="success",
+            ),
+            extraction=ExtractionResult(
+                dispatch_id="test-empty",
+                terminal="T1",
+                track="A",
+                gate="test",
+            ),
+        )
+        md = render_markdown(report)
+        assert "No file changes detected" in md
+        assert "No test results captured" in md
+
+
+# ─── Enum Completeness ───────────────────────────────────────────────────────
+
+class TestEnumCompleteness:
+    """Verify the taxonomy is closed — all values are known."""
+
+    def test_dispatch_types(self):
+        assert len(DispatchType) == 7
+
+    def test_risk_levels(self):
+        assert len(RiskLevel) == 3
+
+    def test_scopes(self):
+        assert len(Scope) == 4
+
+    def test_content_types(self):
+        assert len(ContentType) == 8
+
+    def test_complexities(self):
+        assert len(Complexity) == 3
+
+    def test_outcome_statuses(self):
+        assert len(OutcomeStatus) == 5

--- a/tests/test_auto_report_integration.py
+++ b/tests/test_auto_report_integration.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""Integration tests for the auto-report pipeline (PR-5, F37).
+
+Covers:
+  - Auto-generated markdown reports pass receipt processor (ReportParser) validation
+  - auto_generated metadata field present in rendered output
+  - End-to-end fixture: mock extraction → assembly → receipt processing
+  - Tag flow integrity: dispatch → extraction → classification → receipt
+  - Manual report backward compatibility (no breaking changes)
+  - Subprocess trigger path: trigger.json → assemble_from_trigger → valid receipt
+  - validate_auto_report() passes on well-formed reports
+  - Partial extraction (no tests, no git commit) produces valid output
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from auto_report_contract import (
+    AutoDerivedTags,
+    AutoReport,
+    AutoReportMetadata,
+    ClassifiedTags,
+    Complexity,
+    ContentType,
+    DispatchTags,
+    DispatchType,
+    EventMetrics,
+    ExtractionResult,
+    GitProvenance,
+    HaikuClassification,
+    OutcomeStatus,
+    RiskLevel,
+    Scope,
+    TestResults,
+    UnifiedTagSet,
+    render_markdown,
+    validate_auto_report,
+)
+from report_assembler import (
+    AssemblyResult,
+    assemble,
+    assemble_from_trigger,
+    write_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DISPATCH_ID = "20260408-110915-receipt-processor-integration-B"
+PR_ID = "PR-5"
+TERMINAL = "T2"
+TRACK = "B"
+GATE = "gate_pr5_integration_tests"
+
+
+def _make_extraction(
+    dispatch_id: str = DISPATCH_ID,
+    terminal: str = TERMINAL,
+    track: str = TRACK,
+    gate: str = GATE,
+    commit_hash: str = "abc123def456",
+    files_changed: tuple = ("scripts/lib/report_assembler.py", "tests/test_auto_report_integration.py"),
+    insertions: int = 120,
+    deletions: int = 10,
+    passed: int = 12,
+    failed: int = 0,
+    exit_summary: str = "All integration tests passed. Pipeline wired end-to-end.",
+) -> ExtractionResult:
+    """Build a realistic ExtractionResult for testing."""
+    git = GitProvenance(
+        commit_hash=commit_hash,
+        commit_message="feat(integration): wire receipt processor e2e tests",
+        branch="feature/f37-pr5-integration",
+        files_changed=files_changed,
+        insertions=insertions,
+        deletions=deletions,
+        is_dirty=False,
+    )
+    tests = TestResults(
+        passed=passed,
+        failed=failed,
+        errors=0,
+        skipped=0,
+        duration_seconds=0.42,
+        raw_output=f"{passed} passed in 0.42s",
+    ) if passed > 0 or failed > 0 else None
+    events = EventMetrics(
+        tool_use_count=18,
+        text_block_count=5,
+        thinking_block_count=3,
+        error_count=0,
+        session_duration_seconds=420,
+        model_used="claude-sonnet-4-6",
+    )
+    return ExtractionResult(
+        dispatch_id=dispatch_id,
+        terminal=terminal,
+        track=track,
+        gate=gate,
+        git=git,
+        tests=tests,
+        syntax_checks=(),
+        events=events,
+        exit_summary=exit_summary,
+        extracted_at="2026-04-08T11:30:00+00:00",
+    )
+
+
+def _make_report(extraction: Optional[ExtractionResult] = None, status: str = "success") -> AutoReport:
+    """Build a complete AutoReport for testing."""
+    if extraction is None:
+        extraction = _make_extraction()
+
+    auto_derived = AutoDerivedTags.from_extraction(extraction)
+    classification = HaikuClassification.rule_based(extraction)
+    classified_tags = ClassifiedTags.from_classification(classification)
+    dispatch_tags = DispatchTags(
+        dispatch_type=DispatchType.TEST,
+        risk=RiskLevel.MEDIUM,
+        scope=Scope.MULTI_FILE,
+        expected_ois=0,
+    )
+    tags = UnifiedTagSet(
+        dispatch_tags=dispatch_tags,
+        auto_derived=auto_derived,
+        classified=classified_tags,
+        outcome=OutcomeStatus.SUCCESS,
+    )
+    metadata = AutoReportMetadata(
+        dispatch_id=extraction.dispatch_id,
+        pr_id=PR_ID,
+        terminal=extraction.terminal,
+        track=extraction.track,
+        gate=extraction.gate,
+        status=status,
+        auto_generated=True,
+        assembled_at="2026-04-08T11:30:00+00:00",
+    )
+    return AutoReport(
+        metadata=metadata,
+        extraction=extraction,
+        classification=classification,
+        tags=tags,
+        quality_checks=(),
+    )
+
+
+@pytest.fixture
+def vnx_env(tmp_path, monkeypatch):
+    """Set up a minimal VNX environment for testing."""
+    data_dir = tmp_path / ".vnx-data"
+    state_dir = data_dir / "state"
+    unified_dir = data_dir / "unified_reports"
+    pipeline_dir = data_dir / "state" / "report_pipeline"
+    dispatch_dir = data_dir / "dispatches" / "completed"
+    receipts_file = state_dir / "t0_receipts.ndjson"
+
+    for d in [state_dir, unified_dir, pipeline_dir, dispatch_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+    receipts_file.touch()
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(unified_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+
+    return {
+        "data_dir": data_dir,
+        "state_dir": state_dir,
+        "unified_dir": unified_dir,
+        "pipeline_dir": pipeline_dir,
+        "receipts_file": receipts_file,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Markdown rendering: required fields present
+# ---------------------------------------------------------------------------
+
+class TestMarkdownRendering:
+
+    def test_required_receipt_fields_present(self):
+        """render_markdown produces all five fields required by receipt_processor_v4.sh."""
+        report = _make_report()
+        md = render_markdown(report)
+
+        assert f"**Dispatch ID**: {DISPATCH_ID}" in md
+        assert f"**PR**: {PR_ID}" in md
+        assert f"**Track**: {TRACK}" in md
+        assert f"**Gate**: {GATE}" in md
+        assert "**Status**: success" in md
+
+    def test_auto_generated_field_present(self):
+        """Rendered markdown includes **Auto-Generated**: true for audit trail."""
+        report = _make_report()
+        md = render_markdown(report)
+        assert "**Auto-Generated**: true" in md
+
+    def test_files_modified_section(self):
+        """Files Modified section lists changed files from git extraction."""
+        report = _make_report()
+        md = render_markdown(report)
+        assert "report_assembler.py" in md
+        assert "test_auto_report_integration.py" in md
+
+    def test_test_results_section(self):
+        """Test Results section contains pass/fail counts."""
+        report = _make_report()
+        md = render_markdown(report)
+        assert "**Passed**: 12" in md
+        assert "**Failed**: 0" in md
+
+    def test_tags_section_dispatch_tags(self):
+        """Tags section includes dispatch-level tags."""
+        report = _make_report()
+        md = render_markdown(report)
+        assert "dispatch_type" in md or "type=test" in md
+
+    def test_open_items_section_always_present(self):
+        """Open Items section is always present, even when empty."""
+        report = _make_report()
+        md = render_markdown(report)
+        assert "## Open Items" in md
+
+    def test_empty_extraction_produces_valid_markdown(self):
+        """Partial extraction (no tests, no git commit) still produces valid markdown."""
+        extraction = ExtractionResult(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            exit_summary="Partial run: no commit staged.",
+        )
+        report = _make_report(extraction=extraction)
+        md = render_markdown(report)
+        # All required fields must be present even with empty extraction
+        assert f"**Dispatch ID**: {DISPATCH_ID}" in md
+        assert "**Auto-Generated**: true" in md
+        assert "No file changes detected." in md
+        assert "No test results captured." in md
+
+
+# ---------------------------------------------------------------------------
+# 2. validate_auto_report()
+# ---------------------------------------------------------------------------
+
+class TestValidateAutoReport:
+
+    def test_valid_report_returns_no_errors(self):
+        """validate_auto_report() returns empty list for a well-formed report."""
+        report = _make_report()
+        errors = validate_auto_report(report)
+        assert errors == [], f"Unexpected validation errors: {errors}"
+
+    def test_missing_dispatch_id_flagged(self):
+        """validate_auto_report() catches missing dispatch_id in metadata."""
+        extraction = _make_extraction(dispatch_id=DISPATCH_ID)
+        metadata = AutoReportMetadata(
+            dispatch_id="",  # intentionally empty
+            pr_id=PR_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            status="success",
+        )
+        report = AutoReport(metadata=metadata, extraction=extraction)
+        errors = validate_auto_report(report)
+        assert any("dispatch_id" in e for e in errors)
+
+    def test_dispatch_id_mismatch_flagged(self):
+        """validate_auto_report() catches extraction/metadata dispatch_id mismatch."""
+        extraction = _make_extraction(dispatch_id="dispatch-A")
+        metadata = AutoReportMetadata(
+            dispatch_id="dispatch-B",
+            pr_id=PR_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            status="success",
+        )
+        report = AutoReport(metadata=metadata, extraction=extraction)
+        errors = validate_auto_report(report)
+        assert any("dispatch_id" in e for e in errors)
+
+    def test_partial_report_validates_with_no_tests(self):
+        """Partial extraction with no test data still validates."""
+        extraction = ExtractionResult(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+        )
+        metadata = AutoReportMetadata(
+            dispatch_id=DISPATCH_ID,
+            pr_id=PR_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            status="partial",
+        )
+        report = AutoReport(metadata=metadata, extraction=extraction)
+        errors = validate_auto_report(report)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# 3. ReportParser integration (receipt processor validation)
+# ---------------------------------------------------------------------------
+
+class TestReportParserValidation:
+    """Verify auto-generated markdown is parseable by the receipt processor."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_report_parser(self, vnx_env):
+        """Import ReportParser with VNX env set up."""
+        from report_parser import ReportParser
+        self.parser = ReportParser()
+
+    def test_auto_report_dispatch_id_parsed(self, tmp_path):
+        """ReportParser extracts correct dispatch_id from auto-generated markdown.
+
+        parse_report() returns a flat receipt dict; dispatch_id is at the top level.
+        """
+        report = _make_report()
+        md = render_markdown(report)
+        md_path = tmp_path / "test_report.md"
+        md_path.write_text(md, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        # receipt dict is flat: dispatch_id at top level
+        assert result.get("dispatch_id") == DISPATCH_ID
+
+    def test_auto_report_gate_parsed(self, tmp_path):
+        """ReportParser extracts correct gate from auto-generated markdown."""
+        report = _make_report()
+        md = render_markdown(report)
+        md_path = tmp_path / "test_report.md"
+        md_path.write_text(md, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        assert result.get("gate") == GATE
+
+    def test_auto_report_status_parsed(self, tmp_path):
+        """ReportParser extracts correct status from auto-generated markdown."""
+        report = _make_report()
+        md = render_markdown(report)
+        md_path = tmp_path / "test_report.md"
+        md_path.write_text(md, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        assert result.get("status") == "success"
+
+    def test_auto_report_terminal_detected(self, tmp_path):
+        """ReportParser detects terminal T2 from Track B in auto-generated markdown."""
+        report = _make_report()
+        md = render_markdown(report)
+        md_path = tmp_path / "test_report.md"
+        md_path.write_text(md, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        # Track B → T2
+        assert result.get("terminal") in ("T2", "B")
+
+    def test_auto_generated_field_accessible(self, tmp_path):
+        """auto_generated field is present in rendered markdown content."""
+        report = _make_report()
+        md = render_markdown(report)
+        md_path = tmp_path / "test_report.md"
+        md_path.write_text(md, encoding="utf-8")
+
+        content = md_path.read_text()
+        assert "Auto-Generated" in content
+
+
+# ---------------------------------------------------------------------------
+# 4. Manual report backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestManualReportBackwardCompatibility:
+    """Manual reports must still be parseable after PR-5 changes."""
+
+    MANUAL_REPORT = """\
+# Worker Report: receipt-processor-integration
+
+**Dispatch ID**: {dispatch_id}
+**PR**: PR-5
+**Track**: B
+**Gate**: gate_pr5_integration_tests
+**Status**: success
+**Terminal**: T2
+
+## Implementation Summary
+
+Wired receipt processor integration. All manual tests pass.
+
+## Files Modified
+
+- `scripts/receipt_processor_v4.sh` — validation logic
+- `tests/test_receipt_processor.py` — regression tests
+
+## Testing Evidence
+
+12 passed in 0.31s
+
+## Commit
+
+`deadbeef1234`
+
+## Open Items
+
+None
+"""
+
+    @pytest.fixture(autouse=True)
+    def _setup_report_parser(self, vnx_env):
+        from report_parser import ReportParser
+        self.parser = ReportParser()
+
+    def test_manual_report_dispatch_id_parsed(self, tmp_path):
+        """Manual report dispatch_id is still parsed correctly.
+
+        parse_report() returns a flat receipt dict; fields are at the top level.
+        """
+        content = self.MANUAL_REPORT.format(dispatch_id=DISPATCH_ID)
+        md_path = tmp_path / "manual_report.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        assert result.get("dispatch_id") == DISPATCH_ID
+
+    def test_manual_report_gate_parsed(self, tmp_path):
+        """Manual report gate is still parsed correctly."""
+        content = self.MANUAL_REPORT.format(dispatch_id=DISPATCH_ID)
+        md_path = tmp_path / "manual_report.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        assert result.get("gate") == "gate_pr5_integration_tests"
+
+    def test_manual_report_status_parsed(self, tmp_path):
+        """Manual report status is still parsed correctly."""
+        content = self.MANUAL_REPORT.format(dispatch_id=DISPATCH_ID)
+        md_path = tmp_path / "manual_report.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        result = self.parser.parse_report(str(md_path))
+        assert result.get("status") == "success"
+
+    def test_manual_report_not_marked_auto_generated(self, tmp_path):
+        """Manual reports do NOT have Auto-Generated field."""
+        content = self.MANUAL_REPORT.format(dispatch_id=DISPATCH_ID)
+        md_path = tmp_path / "manual_report.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        assert "Auto-Generated" not in content
+
+
+# ---------------------------------------------------------------------------
+# 5. Tag flow integrity
+# ---------------------------------------------------------------------------
+
+class TestTagFlowIntegrity:
+    """Tags must survive the full dispatch → extraction → classification → receipt chain."""
+
+    def test_dispatch_tags_present_in_auto_report(self):
+        """DispatchTags set at creation are present in assembled AutoReport."""
+        report = _make_report()
+        assert report.tags.dispatch_tags is not None
+        assert report.tags.dispatch_tags.dispatch_type == DispatchType.TEST
+        assert report.tags.dispatch_tags.risk == RiskLevel.MEDIUM
+        assert report.tags.dispatch_tags.scope == Scope.MULTI_FILE
+
+    def test_auto_derived_tags_populated_from_extraction(self):
+        """AutoDerivedTags are populated from ExtractionResult."""
+        extraction = _make_extraction(
+            insertions=120,
+            deletions=10,
+            passed=12,
+        )
+        report = _make_report(extraction=extraction)
+        ad = report.tags.auto_derived
+        assert ad is not None
+        assert ad.line_delta_add == 120
+        assert ad.line_delta_del == 10
+        assert ad.test_count == 12
+        assert ad.has_commit is True
+
+    def test_classified_tags_present(self):
+        """ClassifiedTags from rule-based classification are present."""
+        report = _make_report()
+        assert report.tags.classified is not None
+        assert report.tags.classified.content_type in (ct.value for ct in ContentType)
+        assert 1 <= report.tags.classified.quality_score <= 5
+
+    def test_outcome_tag_correct(self):
+        """Outcome status is correctly set in UnifiedTagSet."""
+        report = _make_report()
+        assert report.tags.outcome == OutcomeStatus.SUCCESS
+
+    def test_tag_chain_immutable(self):
+        """UnifiedTagSet is frozen — cannot be modified after construction."""
+        report = _make_report()
+        with pytest.raises((AttributeError, TypeError)):
+            report.tags.outcome = OutcomeStatus.FAILURE  # type: ignore
+
+    def test_tags_serialization_round_trip(self):
+        """Tag set survives JSON serialization → deserialization."""
+        report = _make_report()
+        serialized = report.tags.to_dict()
+        restored = UnifiedTagSet.from_dict(serialized)
+
+        assert restored.dispatch_tags.dispatch_type == report.tags.dispatch_tags.dispatch_type
+        assert restored.auto_derived.test_count == report.tags.auto_derived.test_count
+        assert restored.classified.quality_score == report.tags.classified.quality_score
+        assert restored.outcome == report.tags.outcome
+
+    def test_tags_in_rendered_markdown(self):
+        """Classified and dispatch tags appear in rendered markdown."""
+        report = _make_report()
+        md = render_markdown(report)
+        # Dispatch tags section
+        assert "type=test" in md or "dispatch_type" in md
+        assert "risk=medium" in md or "medium" in md
+        # Classified tags section
+        assert "quality=" in md or "quality_score" in md or "/5" in md
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end fixture: mock dispatch → assembly → receipt
+# ---------------------------------------------------------------------------
+
+class TestEndToEndFixture:
+    """Full pipeline: mock data → assemble → write → parse."""
+
+    def test_assembly_with_mocked_extraction(self, vnx_env):
+        """assemble() with patched run_extraction produces valid receipt-ready report."""
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                vnx_data_dir=vnx_env["data_dir"],
+            )
+
+        assert result.is_valid, f"Assembly errors: {result.errors}"
+        assert result.report.metadata.dispatch_id == DISPATCH_ID
+        assert result.report.metadata.auto_generated is True
+
+    def test_write_report_creates_files(self, vnx_env):
+        """write_report() creates both JSON sidecar and markdown file."""
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                vnx_data_dir=vnx_env["data_dir"],
+            )
+
+        json_path, md_path = write_report(result, vnx_env["data_dir"])
+
+        assert json_path is not None and json_path.exists()
+        assert md_path is not None and md_path.exists()
+        assert md_path.suffix == ".md"
+        assert "auto-" in md_path.name
+
+    def test_written_markdown_parseable_by_report_parser(self, vnx_env):
+        """Written markdown can be parsed by ReportParser (receipt processor)."""
+        from report_parser import ReportParser
+        parser = ReportParser()
+
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                vnx_data_dir=vnx_env["data_dir"],
+            )
+
+        _, md_path = write_report(result, vnx_env["data_dir"])
+        assert md_path is not None and md_path.exists()
+
+        parsed = parser.parse_report(str(md_path))
+        # parse_report returns a flat receipt dict
+        assert parsed.get("dispatch_id") == DISPATCH_ID
+        assert parsed.get("gate") == GATE
+        assert parsed.get("status") == "success"
+
+    def test_written_json_sidecar_round_trips(self, vnx_env):
+        """JSON sidecar can be deserialized back to AutoReport."""
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                vnx_data_dir=vnx_env["data_dir"],
+            )
+
+        json_path, _ = write_report(result, vnx_env["data_dir"])
+        assert json_path is not None
+
+        restored = AutoReport.from_json(json_path.read_text(encoding="utf-8"))
+        assert restored.metadata.dispatch_id == DISPATCH_ID
+        assert restored.metadata.auto_generated is True
+        assert restored.tags.dispatch_tags is None  # no dispatch file in test env
+
+
+# ---------------------------------------------------------------------------
+# 7. Subprocess trigger path
+# ---------------------------------------------------------------------------
+
+class TestSubprocessTriggerPath:
+    """Test the full trigger file → assemble_from_trigger → valid report path."""
+
+    def test_trigger_file_produces_valid_report(self, vnx_env, tmp_path):
+        """assemble_from_trigger() with a valid trigger JSON produces a valid report."""
+        trigger = {
+            "dispatch_id": DISPATCH_ID,
+            "terminal": TERMINAL,
+            "track": TRACK,
+            "gate": GATE,
+            "pr_id": PR_ID,
+            "project_root": str(VNX_ROOT),
+            "session_id": "test-session-abc123",
+        }
+        trigger_path = tmp_path / f"{DISPATCH_ID}.trigger.json"
+        trigger_path.write_text(json.dumps(trigger), encoding="utf-8")
+
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble_from_trigger(trigger_path)
+
+        assert result.report.metadata.dispatch_id == DISPATCH_ID
+        assert result.report.metadata.auto_generated is True
+        assert result.is_valid, f"Trigger assembly errors: {result.errors}"
+
+    def test_trigger_file_missing_produces_failed_result(self, tmp_path):
+        """assemble_from_trigger() with missing file returns a failed result, not an exception."""
+        missing_path = tmp_path / "missing.trigger.json"
+        result = assemble_from_trigger(missing_path)
+        # Should return a failed result rather than raise
+        assert result is not None
+        assert len(result.errors) > 0
+
+    def test_trigger_file_write_then_parse_receipt(self, vnx_env, tmp_path):
+        """Full subprocess path: trigger → assemble → write → receipt processor parses output."""
+        from report_parser import ReportParser
+        parser = ReportParser()
+
+        trigger = {
+            "dispatch_id": DISPATCH_ID,
+            "terminal": TERMINAL,
+            "track": TRACK,
+            "gate": GATE,
+            "pr_id": PR_ID,
+            "project_root": str(VNX_ROOT),
+            "session_id": "test-session-xyz789",
+        }
+        trigger_path = tmp_path / f"{DISPATCH_ID}.trigger.json"
+        trigger_path.write_text(json.dumps(trigger), encoding="utf-8")
+
+        mock_extraction = _make_extraction()
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble_from_trigger(trigger_path)
+
+        _, md_path = write_report(result, vnx_env["data_dir"])
+        assert md_path is not None and md_path.exists()
+
+        parsed = parser.parse_report(str(md_path))
+        assert parsed.get("dispatch_id") == DISPATCH_ID
+
+    def test_trigger_with_partial_fields_does_not_crash(self, vnx_env, tmp_path):
+        """Trigger with minimal fields (no gate, no pr_id) produces partial report without crash."""
+        trigger = {
+            "dispatch_id": DISPATCH_ID,
+            "terminal": TERMINAL,
+            # gate and pr_id intentionally omitted
+        }
+        trigger_path = tmp_path / "partial.trigger.json"
+        trigger_path.write_text(json.dumps(trigger), encoding="utf-8")
+
+        mock_extraction = ExtractionResult(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track="A",  # default fallback
+            gate="",
+        )
+
+        with patch("report_assembler.run_extraction", return_value=mock_extraction):
+            result = assemble_from_trigger(trigger_path)
+
+        assert result is not None
+        assert result.report.metadata.dispatch_id == DISPATCH_ID
+
+
+# ---------------------------------------------------------------------------
+# 8. AutoReport schema: JSON round-trip and auto_generated field
+# ---------------------------------------------------------------------------
+
+class TestAutoReportSchema:
+
+    def test_auto_generated_true_by_default(self):
+        """AutoReportMetadata.auto_generated defaults to True."""
+        metadata = AutoReportMetadata(
+            dispatch_id=DISPATCH_ID,
+            pr_id=PR_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            status="success",
+        )
+        assert metadata.auto_generated is True
+
+    def test_auto_generated_in_json_output(self):
+        """auto_generated field is present in AutoReport.to_json() output."""
+        report = _make_report()
+        data = json.loads(report.to_json())
+        assert data["metadata"]["auto_generated"] is True
+
+    def test_full_report_json_round_trip(self):
+        """AutoReport serializes and deserializes correctly."""
+        report = _make_report()
+        data = json.loads(report.to_json())
+        restored = AutoReport.from_dict(data)
+
+        assert restored.metadata.dispatch_id == report.metadata.dispatch_id
+        assert restored.metadata.auto_generated == report.metadata.auto_generated
+        assert restored.extraction.terminal == report.extraction.terminal
+        assert restored.extraction.git.commit_hash == report.extraction.git.commit_hash
+        assert restored.extraction.tests.passed == report.extraction.tests.passed  # type: ignore
+
+    def test_schema_version_present(self):
+        """Schema version is present in JSON output."""
+        report = _make_report()
+        data = json.loads(report.to_json())
+        assert "schema_version" in data
+        assert data["schema_version"] == "1.0.0"

--- a/tests/test_report_assembler.py
+++ b/tests/test_report_assembler.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Tests for PR-3: Auto-Report Assembler.
+
+Gate: gate_pr3_auto_report_assembler
+
+Covers:
+- Generated markdown validates against receipt processor parsing
+- All required metadata fields present in output
+- Tag propagation preserves dispatch-level tags
+- Partial extraction input produces valid (incomplete) report
+- End-to-end: extraction → assembly → markdown file exists in unified_reports/
+- assemble_from_trigger reads trigger file correctly
+- write_report creates JSON + markdown files
+- _short_title_from_dispatch_id parsing
+- _derive_outcome logic
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Ensure scripts/lib is on path
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from report_assembler import (
+    AssemblyResult,
+    _derive_outcome,
+    _short_title_from_dispatch_id,
+    assemble,
+    assemble_from_trigger,
+    write_report,
+)
+from auto_report_contract import (
+    AutoReport,
+    DispatchTags,
+    DispatchType,
+    ExtractionResult,
+    GitProvenance,
+    OutcomeStatus,
+    RiskLevel,
+    Scope,
+    TestResults,
+    validate_auto_report,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+DISPATCH_ID = "20260408-110915-test-assembler-A"
+TERMINAL = "T1"
+TRACK = "A"
+GATE = "gate_pr3_auto_report_assembler"
+PR_ID = "PR-3"
+
+
+def _make_trigger_json(**overrides) -> dict:
+    base = {
+        "trigger_time": "2026-04-08T10:00:00Z",
+        "dispatch_id": DISPATCH_ID,
+        "terminal": TERMINAL,
+        "track": TRACK,
+        "gate": GATE,
+        "pr_id": PR_ID,
+        "session_id": "sess-abc-123",
+        "transcript_path": "/tmp/t.jsonl",
+        "cwd": "/dev/test/.claude/terminals/T1",
+        "project_root": "/dev/test",
+        "source": "stop_hook",
+    }
+    base.update(overrides)
+    return base
+
+
+# ─── Unit Tests ───────────────────────────────────────────────────────────────
+
+class TestShortTitle(unittest.TestCase):
+    def test_standard_dispatch_id(self):
+        result = _short_title_from_dispatch_id("20260408-110915-auto-report-assembler-A")
+        self.assertEqual(result, "auto-report-assembler")
+
+    def test_dispatch_id_b_track(self):
+        result = _short_title_from_dispatch_id("20260408-110915-stop-hook-infrastructure-B")
+        self.assertEqual(result, "stop-hook-infrastructure")
+
+    def test_dispatch_id_no_match_falls_back(self):
+        result = _short_title_from_dispatch_id("some-random-id")
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) <= 30)
+
+    def test_long_slug_truncated(self):
+        long_id = "20260408-110915-" + "a" * 50 + "-A"
+        result = _short_title_from_dispatch_id(long_id)
+        self.assertLessEqual(len(result), 30)
+
+
+class TestDeriveOutcome(unittest.TestCase):
+    def _make_extraction(self, tests=None, has_commit=True, has_syntax_err=False):
+        from auto_report_contract import EventMetrics, SyntaxCheck
+        syntax = (SyntaxCheck(file_path="f.py", language="python", valid=not has_syntax_err),) if has_syntax_err else ()
+        git = GitProvenance(commit_hash="abc123" if has_commit else "")
+        return ExtractionResult(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            git=git,
+            tests=tests,
+            syntax_checks=syntax,
+        )
+
+    def test_override_success(self):
+        ex = self._make_extraction()
+        result = _derive_outcome(ex, "success")
+        self.assertEqual(result, OutcomeStatus.SUCCESS)
+
+    def test_override_failure(self):
+        ex = self._make_extraction()
+        result = _derive_outcome(ex, "failure")
+        self.assertEqual(result, OutcomeStatus.FAILURE)
+
+    def test_test_failures_produce_failure(self):
+        tests = TestResults(passed=2, failed=1)
+        ex = self._make_extraction(tests=tests)
+        result = _derive_outcome(ex)
+        self.assertEqual(result, OutcomeStatus.FAILURE)
+
+    def test_syntax_errors_produce_failure(self):
+        ex = self._make_extraction(has_syntax_err=True)
+        result = _derive_outcome(ex)
+        self.assertEqual(result, OutcomeStatus.FAILURE)
+
+    def test_no_commit_produces_partial(self):
+        ex = self._make_extraction(has_commit=False)
+        result = _derive_outcome(ex)
+        self.assertEqual(result, OutcomeStatus.PARTIAL)
+
+    def test_all_passed_produces_success(self):
+        tests = TestResults(passed=5)
+        ex = self._make_extraction(tests=tests)
+        result = _derive_outcome(ex)
+        self.assertEqual(result, OutcomeStatus.SUCCESS)
+
+
+class TestAssemble(unittest.TestCase):
+    """Tests for the core assemble() function."""
+
+    def test_returns_assembly_result(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        self.assertIsInstance(result, AssemblyResult)
+        self.assertIsInstance(result.report, AutoReport)
+
+    def test_required_metadata_fields_present(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        meta = result.report.metadata
+        self.assertEqual(meta.dispatch_id, DISPATCH_ID)
+        self.assertEqual(meta.pr_id, PR_ID)
+        self.assertEqual(meta.track, TRACK)
+        self.assertEqual(meta.gate, GATE)
+        self.assertIn(meta.status, ("success", "failure", "partial", "crashed", "no_execution"))
+
+    def test_auto_generated_flag(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        self.assertTrue(result.report.metadata.auto_generated)
+
+    def test_tags_auto_derived_always_present(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        self.assertIsNotNone(result.report.tags.auto_derived)
+        self.assertIsNotNone(result.report.tags.classified)
+
+    def test_partial_extraction_no_tests_still_valid(self):
+        """Partial extraction (no tests, no events) should produce valid report."""
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+            events_path=None,  # No events file
+        )
+        errors = validate_auto_report(result.report)
+        self.assertEqual(errors, [])
+
+    def test_classification_is_rule_based(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        classification = result.report.classification
+        self.assertIsNotNone(classification)
+        self.assertEqual(classification.classified_by, "rule_based")
+
+    def test_status_override_respected(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+            status_override="failure",
+        )
+        self.assertEqual(result.report.metadata.status, "failure")
+        self.assertEqual(result.report.tags.outcome, OutcomeStatus.FAILURE)
+
+    def test_dispatch_tags_from_active_dir(self):
+        """Assembler loads DispatchTags from bundle.json when present."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            active_dir = Path(tmpdir) / "active"
+            active_dir.mkdir()
+            bundle = {
+                "dispatch_type": "implementation",
+                "risk": "medium",
+                "scope": "multi_file",
+                "expected_ois": 0,
+            }
+            bundle_path = active_dir / f"{DISPATCH_ID}.bundle.json"
+            bundle_path.write_text(json.dumps(bundle))
+
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                active_dir=active_dir,
+            )
+            dt = result.report.tags.dispatch_tags
+            self.assertIsNotNone(dt)
+            self.assertEqual(dt.dispatch_type, DispatchType.IMPLEMENTATION)
+            self.assertEqual(dt.risk, RiskLevel.MEDIUM)
+
+    def test_dispatch_tags_absent_when_no_bundle(self):
+        """No bundle.json → dispatch_tags is None, pipeline continues."""
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        # dispatch_tags may be None — that's fine for partial extraction
+        self.assertIsNone(result.report.tags.dispatch_tags)
+
+
+class TestTagPropagation(unittest.TestCase):
+    """Verify that dispatch-level tags survive to the assembled report."""
+
+    def test_dispatch_tags_preserved_in_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            active_dir = Path(tmpdir) / "active"
+            active_dir.mkdir()
+            bundle = {
+                "dispatch_type": "test",
+                "risk": "low",
+                "scope": "single_file",
+                "depends_on": ["PR-1"],
+            }
+            (active_dir / f"{DISPATCH_ID}.bundle.json").write_text(json.dumps(bundle))
+
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+                active_dir=active_dir,
+            )
+            dt = result.report.tags.dispatch_tags
+            self.assertIsNotNone(dt)
+            self.assertEqual(dt.dispatch_type.value, "test")
+            self.assertEqual(dt.risk.value, "low")
+            self.assertIn("PR-1", dt.depends_on)
+
+    def test_auto_derived_tags_populated(self):
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+        )
+        ad = result.report.tags.auto_derived
+        self.assertIsNotNone(ad)
+        # These fields should always have a value (even if 0/False)
+        self.assertIsInstance(ad.file_count, int)
+        self.assertIsInstance(ad.tests_passed, bool)
+        self.assertIsInstance(ad.tool_use_count, int)
+
+
+class TestMarkdownFormat(unittest.TestCase):
+    """Verify generated markdown contains required receipt processor fields."""
+
+    REQUIRED_FIELDS = [
+        "**Dispatch ID**",
+        "**PR**",
+        "**Track**",
+        "**Gate**",
+        "**Status**",
+        "## Open Items",
+    ]
+
+    def _get_markdown(self, **kwargs) -> str:
+        from auto_report_contract import render_markdown
+        result = assemble(
+            dispatch_id=DISPATCH_ID,
+            terminal=TERMINAL,
+            track=TRACK,
+            gate=GATE,
+            pr_id=PR_ID,
+            **kwargs,
+        )
+        return render_markdown(result.report)
+
+    def test_required_fields_present(self):
+        md = self._get_markdown()
+        for field in self.REQUIRED_FIELDS:
+            self.assertIn(field, md, f"Missing required field: {field}")
+
+    def test_dispatch_id_in_markdown(self):
+        md = self._get_markdown()
+        self.assertIn(DISPATCH_ID, md)
+
+    def test_pr_id_in_markdown(self):
+        md = self._get_markdown()
+        self.assertIn(PR_ID, md)
+
+    def test_open_items_section_always_present(self):
+        md = self._get_markdown()
+        self.assertIn("## Open Items", md)
+
+    def test_no_tests_omits_test_counts(self):
+        """Missing tests → section says 'No test results captured.' not a crash."""
+        md = self._get_markdown()
+        # Should not crash; section must exist with graceful message
+        self.assertIn("## Test Results", md)
+        # When no pytest ran, the section should say no results
+        self.assertIn("No test results", md)
+
+    def test_partial_extraction_valid_markdown(self):
+        """Even with minimal extraction data, markdown must parse correctly."""
+        md = self._get_markdown()
+        # All required bold fields must appear in first 500 chars
+        header = md[:1000]
+        self.assertIn("**Dispatch ID**", header)
+        self.assertIn("**PR**", header)
+
+
+class TestAssembleFromTrigger(unittest.TestCase):
+    """Tests for assemble_from_trigger()."""
+
+    def test_reads_trigger_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _make_trigger_json()
+            trigger_path = Path(tmpdir) / f"{DISPATCH_ID}.trigger.json"
+            trigger_path.write_text(json.dumps(trigger))
+
+            result = assemble_from_trigger(trigger_path)
+            self.assertIsInstance(result, AssemblyResult)
+            self.assertEqual(result.report.metadata.dispatch_id, DISPATCH_ID)
+
+    def test_missing_trigger_returns_failed_result(self):
+        result = assemble_from_trigger(Path("/nonexistent/path.trigger.json"))
+        self.assertIsInstance(result, AssemblyResult)
+        self.assertGreater(len(result.errors), 0)
+
+    def test_partial_trigger_no_gate_still_assembles(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _make_trigger_json(gate="", pr_id="")
+            trigger_path = Path(tmpdir) / "partial.trigger.json"
+            trigger_path.write_text(json.dumps(trigger))
+
+            result = assemble_from_trigger(trigger_path)
+            self.assertIsInstance(result, AssemblyResult)
+            # No crash on partial data
+            self.assertIsNotNone(result.report)
+
+    def test_pr_id_from_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trigger = _make_trigger_json(pr_id="PR-99")
+            trigger_path = Path(tmpdir) / "t.trigger.json"
+            trigger_path.write_text(json.dumps(trigger))
+
+            result = assemble_from_trigger(trigger_path)
+            self.assertEqual(result.report.metadata.pr_id, "PR-99")
+
+
+class TestWriteReport(unittest.TestCase):
+    """Tests for write_report()."""
+
+    def test_writes_json_and_markdown(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            json_path, md_path = write_report(result, vnx_data_dir=vnx_data)
+
+            self.assertIsNotNone(json_path)
+            self.assertIsNotNone(md_path)
+            self.assertTrue(json_path.exists())
+            self.assertTrue(md_path.exists())
+
+    def test_json_contains_required_schema_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            json_path, _ = write_report(result, vnx_data_dir=vnx_data)
+
+            data = json.loads(json_path.read_text())
+            self.assertIn("metadata", data)
+            self.assertIn("extraction", data)
+            self.assertIn("tags", data)
+            self.assertEqual(data["metadata"]["dispatch_id"], DISPATCH_ID)
+
+    def test_json_written_to_pipeline_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            json_path, _ = write_report(result, vnx_data_dir=vnx_data)
+
+            expected = vnx_data / "state" / "report_pipeline" / f"{DISPATCH_ID}.json"
+            self.assertEqual(json_path, expected)
+
+    def test_markdown_written_to_unified_reports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            _, md_path = write_report(result, vnx_data_dir=vnx_data)
+
+            self.assertTrue(str(md_path).startswith(str(vnx_data / "unified_reports")))
+            self.assertTrue(md_path.name.endswith(".md"))
+            self.assertIn("-auto-", md_path.name)
+
+    def test_markdown_contains_required_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            _, md_path = write_report(result, vnx_data_dir=vnx_data)
+            content = md_path.read_text()
+
+            for field in ("**Dispatch ID**", "**PR**", "**Track**", "**Gate**", "**Status**"):
+                self.assertIn(field, content, f"Missing field: {field}")
+
+    def test_no_vnx_data_dir_returns_none_pair(self):
+        import os
+        # Temporarily unset env var
+        saved = os.environ.pop("VNX_DATA_DIR", None)
+        try:
+            result = assemble(
+                dispatch_id=DISPATCH_ID,
+                terminal=TERMINAL,
+                track=TRACK,
+                gate=GATE,
+                pr_id=PR_ID,
+            )
+            json_path, md_path = write_report(result, vnx_data_dir=None)
+            self.assertIsNone(json_path)
+            self.assertIsNone(md_path)
+        finally:
+            if saved:
+                os.environ["VNX_DATA_DIR"] = saved
+
+
+class TestEndToEnd(unittest.TestCase):
+    """End-to-end: trigger → assemble → write → files exist in unified_reports."""
+
+    def test_e2e_trigger_to_markdown_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+
+            # Create trigger file
+            trigger = _make_trigger_json()
+            trigger["project_root"] = tmpdir
+            trigger_path = vnx_data / "state" / "report_pipeline" / f"{DISPATCH_ID}.trigger.json"
+            trigger_path.parent.mkdir(parents=True, exist_ok=True)
+            trigger_path.write_text(json.dumps(trigger))
+
+            # Run assembler
+            import os
+            saved = os.environ.get("VNX_DATA_DIR")
+            os.environ["VNX_DATA_DIR"] = str(vnx_data)
+            try:
+                result = assemble_from_trigger(trigger_path)
+                json_path, md_path = write_report(result, vnx_data_dir=vnx_data)
+            finally:
+                if saved:
+                    os.environ["VNX_DATA_DIR"] = saved
+                else:
+                    os.environ.pop("VNX_DATA_DIR", None)
+
+            # Verify files exist
+            self.assertIsNotNone(md_path, "No markdown path returned")
+            self.assertTrue(md_path.exists(), f"Markdown file not created: {md_path}")
+
+            unified_reports = vnx_data / "unified_reports"
+            files = list(unified_reports.glob("*.md"))
+            self.assertGreater(len(files), 0, "No .md files in unified_reports/")
+
+    def test_e2e_report_passes_validation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vnx_data = Path(tmpdir)
+            trigger = _make_trigger_json()
+            trigger_path = vnx_data / "t.trigger.json"
+            trigger_path.write_text(json.dumps(trigger))
+
+            result = assemble_from_trigger(trigger_path)
+            errors = validate_auto_report(result.report)
+            self.assertEqual(errors, [], f"Validation errors: {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_report_classifier.py
+++ b/tests/test_report_classifier.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Tests for PR-4: Haiku Semantic Classifier.
+
+Gate: gate_pr4_haiku_classification
+
+Covers:
+- classify_report returns rule_based when VNX_HAIKU_CLASSIFY unset
+- classify_report returns rule_based when VNX_HAIKU_CLASSIFY=0
+- classify_report invokes haiku when VNX_HAIKU_CLASSIFY=1 (mocked subprocess)
+- Haiku subprocess failure falls back to rule_based (no crash)
+- Haiku timeout falls back to rule_based (no crash)
+- Haiku non-zero exit falls back to rule_based
+- Valid haiku JSON response produces HaikuClassification with classified_by="haiku"
+- Invalid haiku JSON falls back to rule_based
+- Partial/missing JSON fields fall back to rule_based
+- quality_score out of range falls back to rule_based
+- content_type invalid falls back to rule_based
+- complexity invalid falls back to rule_based
+- consistency_score clamped to [0.0, 1.0]
+- summary truncated to 200 chars
+- Markdown code-fence-wrapped JSON is parsed correctly
+- classify_report never raises (all errors → fallback)
+- _build_prompt includes key extraction fields
+- _parse_haiku_response handles clean JSON, code-fenced JSON, invalid text
+- assembler uses classify_report (classified_by reflects VNX_HAIKU_CLASSIFY state)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from auto_report_contract import (
+    Complexity,
+    ContentType,
+    EventMetrics,
+    ExtractionResult,
+    GitProvenance,
+    HaikuClassification,
+    TestResults,
+)
+from report_classifier import (
+    _HAIKU_MODEL,
+    _build_prompt,
+    _call_haiku,
+    _parse_haiku_response,
+    _validate_parsed,
+    classify_report,
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+def _make_extraction(**overrides) -> ExtractionResult:
+    defaults = dict(
+        dispatch_id="20260408-110915-test-classifier-A",
+        terminal="T1",
+        track="A",
+        gate="gate_pr4_haiku_classification",
+        git=GitProvenance(
+            commit_hash="abc1234",
+            commit_message="feat(classifier): add haiku classification",
+            branch="feature/f37-pr4",
+            files_changed=("scripts/lib/report_classifier.py",),
+            insertions=150,
+            deletions=10,
+        ),
+        tests=TestResults(passed=8, failed=0, errors=0, skipped=0, duration_seconds=1.5),
+        events=EventMetrics(tool_use_count=20, error_count=0, session_duration_seconds=300),
+        exit_summary="Implemented haiku classifier with rule_based fallback.",
+    )
+    defaults.update(overrides)
+    return ExtractionResult(**defaults)
+
+
+def _valid_haiku_json(**overrides) -> str:
+    base = {
+        "content_type": "implementation",
+        "quality_score": 4,
+        "complexity": "medium",
+        "consistency_score": 0.9,
+        "summary": "Implemented haiku semantic classifier with graceful fallback.",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+# ─── Env-var Gate Tests ────────────────────────────────────────────────────────
+
+class TestEnvVarGate(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    def test_unset_returns_rule_based(self):
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    def test_zero_returns_rule_based(self):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "0"
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    def test_false_returns_rule_based(self):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "false"
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_one_invokes_haiku(self, mock_call):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "1"
+        mock_call.return_value = _valid_haiku_json()
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertTrue(mock_call.called)
+        self.assertEqual(result.classified_by, "haiku")
+
+    def test_rule_based_never_crashes_on_empty_extraction(self):
+        ex = _make_extraction(
+            git=GitProvenance(),
+            tests=None,
+            events=EventMetrics(),
+            exit_summary="",
+        )
+        result = classify_report(ex)
+        self.assertIn(result.classified_by, ("rule_based", "haiku"))
+
+
+# ─── Haiku Fallback Tests ─────────────────────────────────────────────────────
+
+class TestHaikuFallback(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    @patch("report_classifier._call_haiku", return_value=None)
+    def test_subprocess_failure_falls_back(self, _):
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku", return_value="not json at all")
+    def test_unparseable_response_falls_back(self, _):
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku", return_value="{}")
+    def test_empty_json_falls_back(self, _):
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_invalid_content_type_falls_back(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(content_type="garbage")
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_quality_score_out_of_range_falls_back(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(quality_score=6)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_invalid_complexity_falls_back(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(complexity="extreme")
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_missing_required_field_falls_back(self, mock_call):
+        # Missing content_type
+        mock_call.return_value = json.dumps({
+            "quality_score": 3,
+            "complexity": "low",
+            "consistency_score": 0.8,
+            "summary": "test",
+        })
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "rule_based")
+
+
+# ─── Valid Haiku Response Tests ───────────────────────────────────────────────
+
+class TestValidHaikuResponse(unittest.TestCase):
+
+    def setUp(self):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    @patch("report_classifier._call_haiku")
+    def test_valid_response_classified_by_haiku(self, mock_call):
+        mock_call.return_value = _valid_haiku_json()
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.classified_by, "haiku")
+
+    @patch("report_classifier._call_haiku")
+    def test_valid_content_type_parsed(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(content_type="test")
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.content_type, ContentType.TEST)
+
+    @patch("report_classifier._call_haiku")
+    def test_quality_score_preserved(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(quality_score=5)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.quality_score, 5)
+
+    @patch("report_classifier._call_haiku")
+    def test_complexity_parsed(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(complexity="high")
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.complexity, Complexity.HIGH)
+
+    @patch("report_classifier._call_haiku")
+    def test_consistency_score_preserved(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(consistency_score=0.75)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertAlmostEqual(result.consistency_score, 0.75)
+
+    @patch("report_classifier._call_haiku")
+    def test_summary_preserved(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(summary="Feature implemented cleanly.")
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(result.summary, "Feature implemented cleanly.")
+
+    @patch("report_classifier._call_haiku")
+    def test_summary_truncated_to_200(self, mock_call):
+        long_summary = "x" * 300
+        mock_call.return_value = _valid_haiku_json(summary=long_summary)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertEqual(len(result.summary), 200)
+
+    @patch("report_classifier._call_haiku")
+    def test_consistency_score_clamped_above_1(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(consistency_score=1.5)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertLessEqual(result.consistency_score, 1.0)
+
+    @patch("report_classifier._call_haiku")
+    def test_consistency_score_clamped_below_0(self, mock_call):
+        mock_call.return_value = _valid_haiku_json(consistency_score=-0.5)
+        ex = _make_extraction()
+        result = classify_report(ex)
+        self.assertGreaterEqual(result.consistency_score, 0.0)
+
+    @patch("report_classifier._call_haiku")
+    def test_all_content_types_accepted(self, mock_call):
+        valid_types = [
+            "implementation", "test", "refactor", "docs",
+            "review", "config", "planning", "mixed",
+        ]
+        ex = _make_extraction()
+        for ct in valid_types:
+            mock_call.return_value = _valid_haiku_json(content_type=ct)
+            result = classify_report(ex)
+            self.assertEqual(result.classified_by, "haiku", f"Failed for content_type={ct}")
+
+    @patch("report_classifier._call_haiku")
+    def test_all_complexities_accepted(self, mock_call):
+        ex = _make_extraction()
+        for c in ("low", "medium", "high"):
+            mock_call.return_value = _valid_haiku_json(complexity=c)
+            result = classify_report(ex)
+            self.assertEqual(result.classified_by, "haiku", f"Failed for complexity={c}")
+
+    @patch("report_classifier._call_haiku")
+    def test_all_quality_scores_accepted(self, mock_call):
+        ex = _make_extraction()
+        for q in (1, 2, 3, 4, 5):
+            mock_call.return_value = _valid_haiku_json(quality_score=q)
+            result = classify_report(ex)
+            self.assertEqual(result.quality_score, q)
+
+
+# ─── _parse_haiku_response Tests ──────────────────────────────────────────────
+
+class TestParseHaikuResponse(unittest.TestCase):
+
+    def test_clean_json(self):
+        text = '{"content_type": "implementation", "quality_score": 4}'
+        result = _parse_haiku_response(text)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["content_type"], "implementation")
+
+    def test_markdown_code_fence(self):
+        text = '```json\n{"content_type": "test", "quality_score": 3}\n```'
+        result = _parse_haiku_response(text)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["content_type"], "test")
+
+    def test_json_embedded_in_prose(self):
+        text = 'Here is the classification:\n{"content_type": "docs"}\nDone.'
+        result = _parse_haiku_response(text)
+        self.assertIsNotNone(result)
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(_parse_haiku_response(""))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_parse_haiku_response(None))
+
+    def test_plain_prose_returns_none(self):
+        self.assertIsNone(_parse_haiku_response("This is just text without JSON."))
+
+    def test_incomplete_json_returns_none(self):
+        self.assertIsNone(_parse_haiku_response('{"content_type": "impl"'))
+
+
+# ─── _build_prompt Tests ──────────────────────────────────────────────────────
+
+class TestBuildPrompt(unittest.TestCase):
+
+    def test_prompt_contains_dispatch_id(self):
+        ex = _make_extraction()
+        prompt = _build_prompt(ex)
+        self.assertIn(ex.dispatch_id, prompt)
+
+    def test_prompt_contains_exit_summary(self):
+        ex = _make_extraction()
+        prompt = _build_prompt(ex)
+        self.assertIn(ex.exit_summary, prompt)
+
+    def test_prompt_contains_files_changed(self):
+        ex = _make_extraction()
+        prompt = _build_prompt(ex)
+        self.assertIn("report_classifier.py", prompt)
+
+    def test_prompt_contains_commit_hash(self):
+        ex = _make_extraction()
+        prompt = _build_prompt(ex)
+        self.assertIn("abc1234", prompt)
+
+    def test_prompt_specifies_required_json_fields(self):
+        ex = _make_extraction()
+        prompt = _build_prompt(ex)
+        for field in ("content_type", "quality_score", "complexity", "consistency_score", "summary"):
+            self.assertIn(field, prompt)
+
+
+# ─── _call_haiku Tests ────────────────────────────────────────────────────────
+
+class TestCallHaiku(unittest.TestCase):
+
+    @patch("report_classifier.subprocess.run")
+    def test_success_returns_stdout(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="  {}\n  ", stderr="")
+        result = _call_haiku("test prompt")
+        self.assertEqual(result, "{}")
+
+    @patch("report_classifier.subprocess.run")
+    def test_non_zero_exit_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+        result = _call_haiku("test prompt")
+        self.assertIsNone(result)
+
+    @patch("report_classifier.subprocess.run")
+    def test_empty_stdout_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="   ", stderr="")
+        result = _call_haiku("test prompt")
+        self.assertIsNone(result)
+
+    @patch("report_classifier.subprocess.run", side_effect=FileNotFoundError())
+    def test_claude_not_found_returns_none(self, _):
+        result = _call_haiku("test prompt")
+        self.assertIsNone(result)
+
+    @patch("report_classifier.subprocess.run", side_effect=subprocess.TimeoutExpired("claude", 30))
+    def test_timeout_returns_none(self, _):
+        result = _call_haiku("test prompt")
+        self.assertIsNone(result)
+
+    @patch("report_classifier.subprocess.run")
+    def test_uses_correct_model(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        _call_haiku("test")
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        model_idx = cmd.index("--model")
+        self.assertEqual(cmd[model_idx + 1], _HAIKU_MODEL)
+
+
+# ─── _validate_parsed Tests ───────────────────────────────────────────────────
+
+class TestValidateParsed(unittest.TestCase):
+
+    def _valid_dict(self, **overrides):
+        base = {
+            "content_type": "implementation",
+            "quality_score": 3,
+            "complexity": "medium",
+            "consistency_score": 0.8,
+            "summary": "Test summary.",
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_dict_passes(self):
+        result = _validate_parsed(self._valid_dict())
+        self.assertIsNotNone(result)
+
+    def test_invalid_content_type_returns_none(self):
+        self.assertIsNone(_validate_parsed(self._valid_dict(content_type="bogus")))
+
+    def test_quality_score_zero_returns_none(self):
+        self.assertIsNone(_validate_parsed(self._valid_dict(quality_score=0)))
+
+    def test_quality_score_six_returns_none(self):
+        self.assertIsNone(_validate_parsed(self._valid_dict(quality_score=6)))
+
+    def test_invalid_complexity_returns_none(self):
+        self.assertIsNone(_validate_parsed(self._valid_dict(complexity="extreme")))
+
+    def test_consistency_above_1_clamped(self):
+        result = _validate_parsed(self._valid_dict(consistency_score=2.0))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["consistency_score"], 1.0)
+
+    def test_consistency_below_0_clamped(self):
+        result = _validate_parsed(self._valid_dict(consistency_score=-1.0))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["consistency_score"], 0.0)
+
+    def test_summary_truncated(self):
+        result = _validate_parsed(self._valid_dict(summary="a" * 300))
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["summary"]), 200)
+
+
+# ─── Integration: Assembler Uses Classifier ───────────────────────────────────
+
+class TestAssemblerIntegration(unittest.TestCase):
+    """Verify the assembler imports and routes through classify_report."""
+
+    def setUp(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_HAIKU_CLASSIFY", None)
+
+    def test_assembler_rule_based_when_disabled(self):
+        # Import here to avoid circular import issues at module level
+        from report_assembler import assemble
+
+        result = assemble(
+            dispatch_id="20260408-999999-test-integration-A",
+            terminal="T1",
+            track="A",
+            gate="gate_pr4_haiku_classification",
+            pr_id="PR-4",
+        )
+        self.assertIsNotNone(result.report.classification)
+        self.assertEqual(result.report.classification.classified_by, "rule_based")
+
+    @patch("report_classifier._call_haiku")
+    def test_assembler_haiku_when_enabled(self, mock_call):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "1"
+        mock_call.return_value = _valid_haiku_json()
+
+        from report_assembler import assemble
+
+        result = assemble(
+            dispatch_id="20260408-999999-test-integration-haiku-A",
+            terminal="T1",
+            track="A",
+            gate="gate_pr4_haiku_classification",
+            pr_id="PR-4",
+        )
+        self.assertIsNotNone(result.report.classification)
+        self.assertEqual(result.report.classification.classified_by, "haiku")
+
+    @patch("report_classifier._call_haiku", return_value=None)
+    def test_assembler_falls_back_when_haiku_fails(self, _):
+        os.environ["VNX_HAIKU_CLASSIFY"] = "1"
+
+        from report_assembler import assemble
+
+        result = assemble(
+            dispatch_id="20260408-999999-test-fallback-A",
+            terminal="T1",
+            track="A",
+            gate="gate_pr4_haiku_classification",
+            pr_id="PR-4",
+        )
+        self.assertIsNotNone(result.report.classification)
+        self.assertEqual(result.report.classification.classified_by, "rule_based")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_report_extraction.py
+++ b/tests/test_report_extraction.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Tests for PR-2: Deterministic Extraction Module.
+
+Gate: gate_pr2_deterministic_extraction
+
+Covers:
+- Git extraction with real fixture data
+- Pytest output parsing (standard, verbose, short formats)
+- Event stream aggregation (tool counts, errors, duration)
+- ExtractionResult production from all extractors
+- Edge cases: empty diff, no tests, no events, corrupt NDJSON
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Ensure scripts/lib is on path
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from report_extraction import (
+    _parse_diff_stat,
+    aggregate_event_metrics,
+    extract_exit_summary,
+    extract_git_provenance,
+    extract_pytest_from_events,
+    parse_pytest_output,
+    run_extraction,
+)
+from auto_report_contract import (
+    EventMetrics,
+    ExtractionResult,
+    GitProvenance,
+    TestResults,
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+PYTEST_STANDARD = """\
+==================== test session starts ====================
+platform darwin -- Python 3.11.0
+collected 10 items
+
+tests/test_foo.py .....
+tests/test_bar.py .....
+
+==================== 10 passed in 1.23s ====================
+"""
+
+PYTEST_WITH_FAILURES = """\
+==================== test session starts ====================
+collected 15 items
+
+tests/test_foo.py ...F..F.
+tests/test_bar.py .....
+
+FAILED tests/test_foo.py::test_third - AssertionError: expected 3, got 4
+FAILED tests/test_foo.py::test_seventh - RuntimeError
+
+==================== 2 failed, 13 passed in 2.45s ====================
+"""
+
+PYTEST_WITH_ERRORS_AND_SKIPPED = """\
+==================== test session starts ====================
+collected 8 items
+
+tests/test_foo.py ..sE..s.
+
+==================== 1 error, 4 passed, 2 skipped in 0.87s ====================
+"""
+
+PYTEST_VERBOSE = """\
+==================== test session starts ====================
+platform darwin -- Python 3.11.0, pytest-7.4.0
+rootdir: /project
+collected 5 items
+
+tests/test_module.py::test_alpha PASSED        [  20%]
+tests/test_module.py::test_beta PASSED         [  40%]
+tests/test_module.py::test_gamma FAILED        [  60%]
+tests/test_module.py::test_delta PASSED        [  80%]
+tests/test_module.py::test_epsilon PASSED      [ 100%]
+
+==================== 1 failed, 4 passed in 0.56s ====================
+"""
+
+PYTEST_SHORT = """\
+..........
+10 passed in 0.45s
+"""
+
+PYTEST_XFAIL = """\
+....x.
+5 passed, 1 xfailed in 1.10s
+"""
+
+PYTEST_NO_RESULTS = """\
+==================== test session starts ====================
+platform darwin
+collected 0 items
+
+==================== no tests ran in 0.02s ====================
+"""
+
+DIFF_STAT_STANDARD = """\
+ scripts/lib/foo.py     | 42 ++++++++++++++++++++++++++++++------------
+ scripts/lib/bar.py     |  8 ++++++++
+ tests/test_foo.py      | 15 +++++++++++++++
+ 3 files changed, 65 insertions(+), 12 deletions(-)
+"""
+
+DIFF_STAT_SINGLE = """\
+ scripts/lib/only.py | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+"""
+
+DIFF_STAT_EMPTY = ""
+
+DIFF_STAT_BINARY = """\
+ docs/image.png | Bin 0 -> 1234 bytes
+ scripts/lib/module.py |  5 +++++
+ 2 files changed, 5 insertions(+), 0 deletions(-)
+"""
+
+DIFF_STAT_RENAME = """\
+ scripts/{old_name.py => new_name.py} | 2 ++
+ 1 file changed, 2 insertions(+), 0 deletions(-)
+"""
+
+
+def _make_ndjson_file(events: list, dispatch_id: str = "test-dispatch") -> Path:
+    """Write events to a temp NDJSON file and return the path."""
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ndjson", delete=False, encoding="utf-8"
+    )
+    for i, event in enumerate(events):
+        envelope = {
+            "type": event.get("type", "unknown"),
+            "timestamp": event.get("timestamp", f"2026-01-01T10:00:{i:02d}.000+00:00"),
+            "dispatch_id": event.get("dispatch_id", dispatch_id),
+            "terminal": event.get("terminal", "T1"),
+            "sequence": i + 1,
+            "data": event.get("data", {}),
+        }
+        tmp.write(json.dumps(envelope) + "\n")
+    tmp.close()
+    return Path(tmp.name)
+
+
+# ─── _parse_diff_stat ─────────────────────────────────────────────────────────
+
+class TestParseDiffStat(unittest.TestCase):
+
+    def test_standard_three_files(self):
+        files, ins, dels = _parse_diff_stat(DIFF_STAT_STANDARD)
+        self.assertEqual(len(files), 3)
+        self.assertIn("scripts/lib/foo.py", files)
+        self.assertIn("scripts/lib/bar.py", files)
+        self.assertIn("tests/test_foo.py", files)
+        self.assertEqual(ins, 65)
+        self.assertEqual(dels, 12)
+
+    def test_single_file(self):
+        files, ins, dels = _parse_diff_stat(DIFF_STAT_SINGLE)
+        self.assertEqual(files, ["scripts/lib/only.py"])
+        self.assertEqual(ins, 7)
+        self.assertEqual(dels, 3)
+
+    def test_empty_diff(self):
+        files, ins, dels = _parse_diff_stat(DIFF_STAT_EMPTY)
+        self.assertEqual(files, [])
+        self.assertEqual(ins, 0)
+        self.assertEqual(dels, 0)
+
+    def test_binary_file_excluded(self):
+        files, ins, dels = _parse_diff_stat(DIFF_STAT_BINARY)
+        self.assertNotIn("docs/image.png", files)
+        self.assertIn("scripts/lib/module.py", files)
+        self.assertEqual(ins, 5)
+        self.assertEqual(dels, 0)
+
+    def test_rename_notation(self):
+        files, ins, dels = _parse_diff_stat(DIFF_STAT_RENAME)
+        self.assertEqual(len(files), 1)
+        # Should contain new name portion
+        self.assertTrue(any("new_name" in f for f in files))
+        self.assertEqual(ins, 2)
+
+    def test_whitespace_only_input(self):
+        files, ins, dels = _parse_diff_stat("   \n  \t  \n")
+        self.assertEqual(files, [])
+        self.assertEqual(ins, 0)
+        self.assertEqual(dels, 0)
+
+
+# ─── parse_pytest_output ──────────────────────────────────────────────────────
+
+class TestParsePytestOutput(unittest.TestCase):
+
+    def test_standard_all_passed(self):
+        result = parse_pytest_output(PYTEST_STANDARD)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.passed, 10)
+        self.assertEqual(result.failed, 0)
+        self.assertEqual(result.errors, 0)
+        self.assertEqual(result.skipped, 0)
+        self.assertAlmostEqual(result.duration_seconds, 1.23)
+
+    def test_with_failures(self):
+        result = parse_pytest_output(PYTEST_WITH_FAILURES)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.passed, 13)
+        self.assertEqual(result.failed, 2)
+        self.assertEqual(result.errors, 0)
+
+    def test_with_errors_and_skipped(self):
+        result = parse_pytest_output(PYTEST_WITH_ERRORS_AND_SKIPPED)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.errors, 1)
+        self.assertEqual(result.passed, 4)
+        self.assertEqual(result.skipped, 2)
+
+    def test_verbose_format(self):
+        result = parse_pytest_output(PYTEST_VERBOSE)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.passed, 4)
+        self.assertEqual(result.failed, 1)
+
+    def test_short_format(self):
+        result = parse_pytest_output(PYTEST_SHORT)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.passed, 10)
+        self.assertAlmostEqual(result.duration_seconds, 0.45)
+
+    def test_xfailed_not_counted_as_failed(self):
+        result = parse_pytest_output(PYTEST_XFAIL)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.passed, 5)
+        self.assertEqual(result.failed, 0)  # xfailed is not a failure
+
+    def test_no_tests_ran(self):
+        result = parse_pytest_output(PYTEST_NO_RESULTS)
+        # no tests ran but it's still pytest output
+        self.assertIsNotNone(result)
+        self.assertEqual(result.total, 0)
+
+    def test_non_pytest_text_returns_none(self):
+        result = parse_pytest_output("Hello world, nothing to see here")
+        self.assertIsNone(result)
+
+    def test_empty_string_returns_none(self):
+        result = parse_pytest_output("")
+        self.assertIsNone(result)
+
+    def test_all_passed_property(self):
+        result = parse_pytest_output(PYTEST_STANDARD)
+        self.assertTrue(result.all_passed)
+
+    def test_has_failures_property(self):
+        result = parse_pytest_output(PYTEST_WITH_FAILURES)
+        self.assertFalse(result.all_passed)
+
+    def test_raw_output_truncated_to_500(self):
+        long_text = PYTEST_STANDARD + ("x" * 1000)
+        result = parse_pytest_output(long_text)
+        self.assertIsNotNone(result)
+        self.assertLessEqual(len(result.raw_output), 500)
+
+
+# ─── aggregate_event_metrics ──────────────────────────────────────────────────
+
+class TestAggregateEventMetrics(unittest.TestCase):
+
+    def test_counts_tool_uses(self):
+        path = _make_ndjson_file([
+            {"type": "tool_use", "data": {"name": "Read"}},
+            {"type": "tool_use", "data": {"name": "Edit"}},
+            {"type": "text", "data": {"text": "done"}},
+        ])
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.tool_use_count, 2)
+            self.assertEqual(metrics.text_block_count, 1)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_counts_thinking_blocks(self):
+        path = _make_ndjson_file([
+            {"type": "thinking", "data": {"thinking": "Let me think..."}},
+            {"type": "thinking", "data": {"thinking": "...and more"}},
+            {"type": "tool_use", "data": {"name": "Bash"}},
+        ])
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.thinking_block_count, 2)
+            self.assertEqual(metrics.tool_use_count, 1)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_counts_errors(self):
+        path = _make_ndjson_file([
+            {"type": "error", "data": {"message": "something failed"}},
+            {"type": "tool_use", "data": {}},
+        ])
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.error_count, 1)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_extracts_model_from_init(self):
+        path = _make_ndjson_file([
+            {"type": "init", "data": {"session_id": "abc", "model": "claude-sonnet-4-6"}},
+            {"type": "tool_use", "data": {}},
+        ])
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.model_used, "claude-sonnet-4-6")
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_session_duration_from_timestamps(self):
+        events = [
+            {
+                "type": "tool_use",
+                "timestamp": "2026-01-01T10:00:00.000+00:00",
+                "data": {},
+            },
+            {
+                "type": "text",
+                "timestamp": "2026-01-01T10:00:30.000+00:00",
+                "data": {},
+            },
+        ]
+        path = _make_ndjson_file(events)
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.session_duration_seconds, 30)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_dispatch_id_filter(self):
+        path = _make_ndjson_file([
+            {"type": "tool_use", "dispatch_id": "dispatch-A", "data": {}},
+            {"type": "tool_use", "dispatch_id": "dispatch-B", "data": {}},
+            {"type": "tool_use", "dispatch_id": "dispatch-A", "data": {}},
+        ])
+        try:
+            metrics = aggregate_event_metrics(path, dispatch_id="dispatch-A")
+            self.assertEqual(metrics.tool_use_count, 2)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_missing_file_returns_empty(self):
+        metrics = aggregate_event_metrics(Path("/nonexistent/T1.ndjson"))
+        self.assertIsInstance(metrics, EventMetrics)
+        self.assertEqual(metrics.tool_use_count, 0)
+        self.assertEqual(metrics.error_count, 0)
+
+    def test_corrupt_ndjson_lines_skipped(self):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ndjson", delete=False, encoding="utf-8"
+        )
+        tmp.write('{"type":"tool_use","timestamp":"2026-01-01T10:00:00.000+00:00","dispatch_id":"","terminal":"T1","sequence":1,"data":{}}\n')
+        tmp.write("CORRUPT LINE\n")
+        tmp.write('{"type":"text","timestamp":"2026-01-01T10:00:01.000+00:00","dispatch_id":"","terminal":"T1","sequence":2,"data":{"text":"hi"}}\n')
+        tmp.close()
+        path = Path(tmp.name)
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertEqual(metrics.tool_use_count, 1)
+            self.assertEqual(metrics.text_block_count, 1)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_empty_file_returns_empty_metrics(self):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ndjson", delete=False, encoding="utf-8"
+        )
+        tmp.close()
+        path = Path(tmp.name)
+        try:
+            metrics = aggregate_event_metrics(path)
+            self.assertIsInstance(metrics, EventMetrics)
+            self.assertEqual(metrics.tool_use_count, 0)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+# ─── extract_pytest_from_events ───────────────────────────────────────────────
+
+class TestExtractPytestFromEvents(unittest.TestCase):
+
+    def test_finds_pytest_in_tool_result(self):
+        path = _make_ndjson_file([
+            {"type": "tool_use", "data": {"name": "Bash"}},
+            {
+                "type": "tool_result",
+                "data": {"tool_use_id": "t1", "content": PYTEST_STANDARD},
+            },
+        ])
+        try:
+            result = extract_pytest_from_events(path)
+            self.assertIsNotNone(result)
+            self.assertEqual(result.passed, 10)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_returns_last_pytest_run(self):
+        """When multiple pytest runs appear, the last one is returned."""
+        path = _make_ndjson_file([
+            {
+                "type": "tool_result",
+                "data": {"content": "5 passed in 0.50s"},
+            },
+            {
+                "type": "tool_result",
+                "data": {"content": PYTEST_WITH_FAILURES},
+            },
+        ])
+        try:
+            result = extract_pytest_from_events(path)
+            self.assertIsNotNone(result)
+            self.assertEqual(result.failed, 2)
+            self.assertEqual(result.passed, 13)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_no_pytest_in_events_returns_none(self):
+        path = _make_ndjson_file([
+            {"type": "tool_use", "data": {"name": "Read"}},
+            {"type": "text", "data": {"text": "done"}},
+        ])
+        try:
+            result = extract_pytest_from_events(path)
+            self.assertIsNone(result)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_missing_file_returns_none(self):
+        result = extract_pytest_from_events(Path("/nonexistent/T1.ndjson"))
+        self.assertIsNone(result)
+
+    def test_empty_events_returns_none(self):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ndjson", delete=False, encoding="utf-8"
+        )
+        tmp.close()
+        try:
+            result = extract_pytest_from_events(Path(tmp.name))
+            self.assertIsNone(result)
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+
+# ─── extract_git_provenance ───────────────────────────────────────────────────
+
+class TestExtractGitProvenance(unittest.TestCase):
+
+    def test_returns_git_provenance_instance(self):
+        # Run in the project repo (guaranteed to exist)
+        repo_path = Path(__file__).resolve().parent.parent
+        result = extract_git_provenance(repo_path)
+        self.assertIsInstance(result, GitProvenance)
+
+    def test_commit_hash_is_short_hex(self):
+        repo_path = Path(__file__).resolve().parent.parent
+        result = extract_git_provenance(repo_path)
+        if result.commit_hash:
+            # Short git hash is 7-40 hex chars
+            self.assertRegex(result.commit_hash, r"^[0-9a-f]{7,40}$")
+
+    def test_branch_non_empty(self):
+        repo_path = Path(__file__).resolve().parent.parent
+        result = extract_git_provenance(repo_path)
+        self.assertIsInstance(result.branch, str)
+        # branch may be empty in detached HEAD but should be a string
+
+    def test_no_git_repo_returns_empty(self):
+        """Running in a non-git dir returns empty GitProvenance, not an exception."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = extract_git_provenance(Path(tmpdir))
+        self.assertIsInstance(result, GitProvenance)
+        self.assertEqual(result.commit_hash, "")
+        self.assertEqual(result.insertions, 0)
+
+    def test_files_changed_is_tuple(self):
+        repo_path = Path(__file__).resolve().parent.parent
+        result = extract_git_provenance(repo_path)
+        self.assertIsInstance(result.files_changed, tuple)
+
+    def test_returns_valid_provenance_instance(self):
+        """to_dict() round-trip works without error."""
+        repo_path = Path(__file__).resolve().parent.parent
+        result = extract_git_provenance(repo_path)
+        d = result.to_dict()
+        self.assertIn("commit_hash", d)
+        self.assertIn("files_changed", d)
+        self.assertIsInstance(d["files_changed"], list)
+
+
+# ─── run_extraction ───────────────────────────────────────────────────────────
+
+class TestRunExtraction(unittest.TestCase):
+
+    def _make_full_event_file(self, dispatch_id: str) -> Path:
+        return _make_ndjson_file(
+            [
+                {"type": "init", "data": {"model": "claude-haiku-4-5"}, "dispatch_id": dispatch_id},
+                {"type": "thinking", "data": {"thinking": "..."}, "dispatch_id": dispatch_id},
+                {"type": "tool_use", "data": {"name": "Bash"}, "dispatch_id": dispatch_id},
+                {
+                    "type": "tool_result",
+                    "data": {"content": PYTEST_STANDARD},
+                    "dispatch_id": dispatch_id,
+                    "timestamp": "2026-01-01T10:00:05.000+00:00",
+                },
+                {
+                    "type": "text",
+                    "data": {"text": "Implementation complete."},
+                    "dispatch_id": dispatch_id,
+                    "timestamp": "2026-01-01T10:01:00.000+00:00",
+                },
+            ],
+            dispatch_id=dispatch_id,
+        )
+
+    def test_returns_extraction_result_instance(self):
+        dispatch_id = "test-dispatch-001"
+        events_path = self._make_full_event_file(dispatch_id)
+        repo_path = Path(__file__).resolve().parent.parent
+
+        try:
+            result = run_extraction(
+                dispatch_id=dispatch_id,
+                terminal="T1",
+                track="A",
+                gate="gate_test",
+                repo_path=repo_path,
+                events_path=events_path,
+            )
+            self.assertIsInstance(result, ExtractionResult)
+        finally:
+            events_path.unlink(missing_ok=True)
+
+    def test_dispatch_id_propagated(self):
+        dispatch_id = "test-dispatch-002"
+        events_path = self._make_full_event_file(dispatch_id)
+
+        try:
+            result = run_extraction(
+                dispatch_id=dispatch_id,
+                terminal="T2",
+                track="B",
+                gate="gate_test",
+                events_path=events_path,
+            )
+            self.assertEqual(result.dispatch_id, dispatch_id)
+            self.assertEqual(result.terminal, "T2")
+            self.assertEqual(result.track, "B")
+        finally:
+            events_path.unlink(missing_ok=True)
+
+    def test_test_results_extracted_from_events(self):
+        dispatch_id = "test-dispatch-003"
+        events_path = self._make_full_event_file(dispatch_id)
+
+        try:
+            result = run_extraction(
+                dispatch_id=dispatch_id,
+                terminal="T1",
+                track="A",
+                gate="gate_test",
+                events_path=events_path,
+            )
+            self.assertIsNotNone(result.tests)
+            self.assertEqual(result.tests.passed, 10)
+        finally:
+            events_path.unlink(missing_ok=True)
+
+    def test_exit_summary_from_events(self):
+        dispatch_id = "test-dispatch-004"
+        events_path = self._make_full_event_file(dispatch_id)
+
+        try:
+            result = run_extraction(
+                dispatch_id=dispatch_id,
+                terminal="T1",
+                track="A",
+                gate="gate_test",
+                events_path=events_path,
+            )
+            self.assertEqual(result.exit_summary, "Implementation complete.")
+        finally:
+            events_path.unlink(missing_ok=True)
+
+    def test_exit_summary_override(self):
+        dispatch_id = "test-dispatch-005"
+        events_path = self._make_full_event_file(dispatch_id)
+
+        try:
+            result = run_extraction(
+                dispatch_id=dispatch_id,
+                terminal="T1",
+                track="A",
+                gate="gate_test",
+                events_path=events_path,
+                exit_summary="Manual override summary",
+            )
+            self.assertEqual(result.exit_summary, "Manual override summary")
+        finally:
+            events_path.unlink(missing_ok=True)
+
+    def test_no_events_file_still_produces_valid_result(self):
+        result = run_extraction(
+            dispatch_id="dispatch-no-events",
+            terminal="T1",
+            track="A",
+            gate="gate_test",
+            events_path=Path("/nonexistent/T1.ndjson"),
+        )
+        self.assertIsInstance(result, ExtractionResult)
+        self.assertIsNone(result.tests)
+        self.assertIsInstance(result.events, EventMetrics)
+        self.assertEqual(result.events.tool_use_count, 0)
+
+    def test_invalid_terminal_raises(self):
+        with self.assertRaises(ValueError):
+            run_extraction(
+                dispatch_id="test",
+                terminal="T0",  # T0 is not a valid worker terminal
+                track="A",
+                gate="gate_test",
+            )
+
+    def test_invalid_track_raises(self):
+        with self.assertRaises(ValueError):
+            run_extraction(
+                dispatch_id="test",
+                terminal="T1",
+                track="X",  # invalid
+                gate="gate_test",
+            )
+
+    def test_to_dict_round_trip(self):
+        """ExtractionResult.to_dict() produces JSON-serialisable output."""
+        result = run_extraction(
+            dispatch_id="round-trip-test",
+            terminal="T1",
+            track="A",
+            gate="gate_test",
+            events_path=Path("/nonexistent/T1.ndjson"),
+        )
+        import json
+        d = result.to_dict()
+        serialised = json.dumps(d)
+        self.assertIn("round-trip-test", serialised)
+
+    def test_extracted_at_is_iso_timestamp(self):
+        result = run_extraction(
+            dispatch_id="ts-test",
+            terminal="T1",
+            track="A",
+            gate="gate_test",
+        )
+        self.assertRegex(result.extracted_at, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

F37: Auto-Report Pipeline — replaces manual unified reports (72% quality failure rate) with automated report assembly.

- **PR-0**: Contract & schema definition (`auto_report_contract.py` — 20 dataclasses, 6 enums, 58 tests)
- **PR-1**: Stop hook infrastructure (`.claude/settings.json`, `stop_report_hook.sh`, subprocess trigger)
- **PR-2**: Deterministic extraction module (git diff, pytest parsing, event aggregation — 48 tests)
- **PR-3**: Auto-report assembler (JSON + markdown assembly, tag propagation — 39 tests)
- **PR-4**: Haiku semantic classification (CLI-only, env-gated, rule-based fallback — 53 tests)
- **PR-5**: Receipt processor integration & e2e tests (backward compat verified — 39 tests)

**237 tests total**, all passing. Activation: `VNX_AUTO_REPORT=1`, optional `VNX_HAIKU_CLASSIFY=1`.

## Architecture

```
Stop hook → deterministic extraction → haiku classification → report assembly → receipt processor
```

Tag flow: dispatch tags → auto-derived tags → classified tags → receipt.

## Test plan

- [ ] Codex gate passes
- [ ] Gemini review passes
- [ ] CI green
- [ ] Full F37 test suite: `pytest tests/test_auto_report_*.py tests/test_report_*.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)