### PR TITLE
fix(F37): hardening — event archive, fallback policy, naming, gate sidecar

### DIFF
--- a/scripts/lib/auto_report_contract.py
+++ b/scripts/lib/auto_report_contract.py
@@ -35,6 +35,28 @@ from typing import Any, Dict, List, Optional
 SCHEMA_VERSION = "1.0.0"
 
 
+# ─── Fallback Policy ─────────────────────────────────────────────────────────
+
+FALLBACK_POLICY = """\
+Auto-report pipeline fallback policy (V1):
+
+- ENABLED: VNX_AUTO_REPORT=1 AND a Stop hook or subprocess trigger fires.
+  The pipeline assembles an AutoReport from git/event extraction + optional
+  haiku classification, and writes JSON + markdown to .vnx-data/.
+
+- PIPELINE FAILURE: If the assembler crashes or writes no output, the worker's
+  manually-written report in unified_reports/ is still processed by
+  receipt_processor_v4.sh unchanged. Auto-report is additive, never a blocker.
+
+- CODEX/GEMINI GATES: Use a separate report path via gate_artifacts.py and
+  write JSON sidecars to $VNX_STATE_DIR/report_pipeline/. Not affected by
+  VNX_AUTO_REPORT.
+
+- DISABLED (VNX_AUTO_REPORT unset or != "1"): Workers must write manual
+  reports to unified_reports/ as before. The pipeline is not invoked.
+"""
+
+
 # ─── Closed Tag Taxonomy ─────────────────────────────────────────────────────
 #
 # V1 taxonomy is CLOSED. No free-form tags. All values must be from these enums.

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 from governance_receipts import utc_now_iso
 import gate_recorder
@@ -224,6 +227,31 @@ def materialize_artifacts(
     request_payload["status"] = "completed"
     request_payload["completed_at"] = now
     gate_recorder.persist_request(requests_dir, gate, request_payload, pr_number=pr_number, pr_id=pr_id)
+
+    # Write JSON sidecar to report_pipeline/ for intelligence DB ingestion (OI-1066)
+    try:
+        sidecar = {
+            "dispatch_id": f"gate-{gate}-pr-{pr_number}",
+            "gate": gate,
+            "pr_id": pr_id,
+            "pr_number": pr_number,
+            "status": result_payload["status"],
+            "findings": findings,
+            "blocking_findings": blocking,
+            "advisory_findings": advisory,
+            "contract_hash": contract_hash,
+            "report_path": str(report_file),
+            "duration_seconds": duration_seconds,
+            "source": "gate_runner",
+            "recorded_at": now,
+        }
+        sidecar_dir = reports_dir.parent / "state" / "report_pipeline"
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        sidecar_path = sidecar_dir / f"gate-{gate}-pr-{pr_number or pr_id}.json"
+        sidecar_path.write_text(json.dumps(sidecar, indent=2), encoding="utf-8")
+    except Exception as _exc:
+        logger.warning("materialize_artifacts: sidecar write failed: %s", _exc)
+
     return result_payload
 
 

--- a/scripts/lib/report_assembler.py
+++ b/scripts/lib/report_assembler.py
@@ -423,7 +423,7 @@ def write_report(
     # Short title: first 30 chars of dispatch_id after the datestamp prefix
     # e.g. "20260408-110915-auto-report-assembler-A" → "auto-report-assembler"
     short_title = _short_title_from_dispatch_id(dispatch_id)
-    md_filename = f"{timestamp}-{meta.track}-auto-{short_title}.md"
+    md_filename = f"{timestamp}-{meta.track}-{short_title}.md"
     md_path = unified_dir / md_filename
 
     try:

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -162,6 +162,13 @@ def deliver_via_subprocess(
             heartbeat_stop.set()
         if heartbeat_thread is not None:
             heartbeat_thread.join(timeout=5)
+        # Archive events for this dispatch before the next dispatch clears them
+        event_store = adapter._get_event_store()
+        if event_store is not None:
+            try:
+                event_store.archive(terminal_id, dispatch_id)
+            except Exception as _exc:
+                logger.debug("deliver_via_subprocess: event archive failed: %s", _exc)
         # Trigger auto-report pipeline on completion (gated by VNX_AUTO_REPORT=1)
         adapter.trigger_report_pipeline(
             terminal_id,

--- a/tests/test_f37_hardening.py
+++ b/tests/test_f37_hardening.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Tests for PR-197: F37 Hardening (OI-1062, OI-1063, OI-1064, OI-1066).
+
+Gate: gate_f37_hardening
+
+Covers:
+OI-1062 — Event archive in subprocess_dispatch finally block
+OI-1063 — FALLBACK_POLICY constant in auto_report_contract
+OI-1064 — No auto- prefix in assembler filename
+OI-1066 — Gate sidecar JSON written by materialize_artifacts
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+SCRIPTS_ROOT = str(Path(__file__).resolve().parent.parent / "scripts")
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+for _p in (SCRIPTS_LIB, SCRIPTS_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# ─── OI-1062: Event archive in deliver_via_subprocess ────────────────────────
+
+class TestEventArchiveOnCompletion(unittest.TestCase):
+    """archive() must be called in the finally block after subprocess completes."""
+
+    def _run_deliver(self, mock_adapter_cls, archive_raises=False):
+        """Helper: run deliver_via_subprocess with a mocked adapter."""
+        mock_event_store = MagicMock()
+        if archive_raises:
+            mock_event_store.archive.side_effect = RuntimeError("archive error")
+
+        mock_adapter = MagicMock()
+        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events_with_timeout.return_value = iter([])
+        mock_adapter.trigger_report_pipeline.return_value = True
+        mock_adapter_cls.return_value = mock_adapter
+
+        from subprocess_dispatch import deliver_via_subprocess
+        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
+        return mock_event_store
+
+    @patch("subprocess_dispatch.SubprocessAdapter")
+    def test_archive_called_in_finally_on_success(self, mock_cls):
+        es = self._run_deliver(mock_cls)
+        es.archive.assert_called_once_with("T1", "dispatch-123")
+
+    @patch("subprocess_dispatch.SubprocessAdapter")
+    def test_archive_called_before_trigger(self, mock_cls):
+        """archive() must be called before trigger_report_pipeline()."""
+        call_order = []
+
+        mock_event_store = MagicMock()
+        mock_event_store.archive.side_effect = lambda *a: call_order.append("archive")
+
+        mock_adapter = MagicMock()
+        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events_with_timeout.return_value = iter([])
+        mock_adapter.trigger_report_pipeline.side_effect = lambda *a, **kw: call_order.append("trigger")
+        mock_cls.return_value = mock_adapter
+
+        from subprocess_dispatch import deliver_via_subprocess
+        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
+
+        self.assertEqual(call_order, ["archive", "trigger"])
+
+    @patch("subprocess_dispatch.SubprocessAdapter")
+    def test_archive_called_even_when_subprocess_raises(self, mock_cls):
+        """archive() runs in finally even when read_events raises."""
+        mock_event_store = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events_with_timeout.side_effect = RuntimeError("stream error")
+        mock_adapter.trigger_report_pipeline.return_value = True
+        mock_cls.return_value = mock_adapter
+
+        from subprocess_dispatch import deliver_via_subprocess
+        result = deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-abc")
+        self.assertFalse(result)
+        mock_event_store.archive.assert_called_once_with("T1", "dispatch-abc")
+
+    @patch("subprocess_dispatch.SubprocessAdapter")
+    def test_archive_failure_does_not_crash(self, mock_cls):
+        """archive() exception must not propagate — pipeline must remain non-crashing."""
+        es = self._run_deliver(mock_cls, archive_raises=True)
+        es.archive.assert_called_once()  # was called; exception was swallowed
+
+    @patch("subprocess_dispatch.SubprocessAdapter")
+    def test_no_archive_when_event_store_unavailable(self, mock_cls):
+        """When _get_event_store() returns None, no crash."""
+        mock_adapter = MagicMock()
+        mock_adapter._get_event_store.return_value = None
+        mock_adapter.deliver.return_value = MagicMock(success=True)
+        mock_adapter.read_events_with_timeout.return_value = iter([])
+        mock_adapter.trigger_report_pipeline.return_value = True
+        mock_cls.return_value = mock_adapter
+
+        from subprocess_dispatch import deliver_via_subprocess
+        # Should not raise
+        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-xyz")
+
+
+# ─── OI-1063: FALLBACK_POLICY in auto_report_contract ────────────────────────
+
+class TestFallbackPolicy(unittest.TestCase):
+
+    def test_fallback_policy_exists(self):
+        from auto_report_contract import FALLBACK_POLICY
+        self.assertIsInstance(FALLBACK_POLICY, str)
+
+    def test_fallback_policy_documents_env_var(self):
+        from auto_report_contract import FALLBACK_POLICY
+        self.assertIn("VNX_AUTO_REPORT", FALLBACK_POLICY)
+
+    def test_fallback_policy_documents_pipeline_failure(self):
+        from auto_report_contract import FALLBACK_POLICY
+        # Must mention what happens when the pipeline fails
+        lower = FALLBACK_POLICY.lower()
+        self.assertTrue(
+            "failure" in lower or "fail" in lower or "manual" in lower,
+            "FALLBACK_POLICY must describe pipeline failure behavior",
+        )
+
+    def test_fallback_policy_documents_gate_path(self):
+        from auto_report_contract import FALLBACK_POLICY
+        # Codex/Gemini gate separation must be mentioned
+        lower = FALLBACK_POLICY.lower()
+        self.assertTrue(
+            "gate" in lower or "codex" in lower or "gemini" in lower,
+            "FALLBACK_POLICY must mention gate report path",
+        )
+
+    def test_fallback_policy_nonempty(self):
+        from auto_report_contract import FALLBACK_POLICY
+        self.assertGreater(len(FALLBACK_POLICY.strip()), 50)
+
+
+# ─── OI-1064: No auto- prefix in filename ────────────────────────────────────
+
+class TestFilenameNoAutoPrefix(unittest.TestCase):
+
+    def test_assembled_report_filename_has_no_auto_prefix(self):
+        from report_assembler import assemble, write_report
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = assemble(
+                dispatch_id="20260408-999-hardening-test-A",
+                terminal="T1",
+                track="A",
+                gate="gate_f37_hardening",
+                pr_id="PR-197",
+            )
+            _, md_path = write_report(result, vnx_data_dir=Path(tmpdir))
+        self.assertIsNotNone(md_path)
+        self.assertNotIn("-auto-", md_path.name)
+
+    def test_assembled_report_filename_matches_convention(self):
+        """Filename: {YYYYMMDD}-{HHMMSS}-{track}-{short_title}.md"""
+        from report_assembler import assemble, write_report
+        import re
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = assemble(
+                dispatch_id="20260408-999-hardening-test-A",
+                terminal="T1",
+                track="A",
+                gate="gate_f37_hardening",
+                pr_id="PR-197",
+            )
+            _, md_path = write_report(result, vnx_data_dir=Path(tmpdir))
+        # Pattern: YYYYMMDD-HHMMSS-A-<slug>.md
+        self.assertRegex(md_path.name, r"^\d{8}-\d{6}-A-.+\.md$")
+
+    def test_auto_generated_flag_still_true(self):
+        """Removing the filename prefix must not break auto_generated metadata."""
+        from report_assembler import assemble
+        result = assemble(
+            dispatch_id="20260408-999-hardening-test-A",
+            terminal="T1",
+            track="A",
+            gate="gate_f37_hardening",
+            pr_id="PR-197",
+        )
+        self.assertTrue(result.report.metadata.auto_generated)
+
+
+# ─── OI-1066: Gate sidecar JSON in materialize_artifacts ─────────────────────
+
+class TestGateSidecar(unittest.TestCase):
+
+    def _make_dirs(self, base: Path):
+        requests = base / "state" / "review_gates" / "requests"
+        results = base / "state" / "review_gates" / "results"
+        # reports_dir must be a direct child of base (.vnx-data) so that
+        # reports_dir.parent resolves to base for the sidecar path calculation
+        reports = base / "unified_reports"
+        for d in (requests, results, reports):
+            d.mkdir(parents=True, exist_ok=True)
+        return requests, results, reports
+
+    def _base_payload(self, reports_dir: Path) -> dict:
+        return {
+            "gate": "gemini_gate",
+            "pr_id": "PR-197",
+            "pr_number": 197,
+            "branch": "fix/f37-hardening",
+            "report_path": str(reports_dir / "test-report.md"),
+        }
+
+    def test_sidecar_written_after_materialize(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+            materialize_artifacts(
+                gate="gemini_gate",
+                pr_number=197,
+                pr_id="PR-197",
+                stdout="Finding 1\nFinding 2\nFinding 3\n",
+                request_payload=payload,
+                duration_seconds=5.0,
+                requests_dir=requests,
+                results_dir=results,
+                reports_dir=reports,
+            )
+
+            sidecar_dir = base / "state" / "report_pipeline"
+            sidecars = list(sidecar_dir.glob("gate-gemini_gate-pr-*.json"))
+            self.assertEqual(len(sidecars), 1, "Expected exactly 1 sidecar file")
+
+    def test_sidecar_contains_required_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+            materialize_artifacts(
+                gate="gemini_gate",
+                pr_number=197,
+                pr_id="PR-197",
+                stdout="Line one\nLine two\nLine three\n",
+                request_payload=payload,
+                duration_seconds=3.0,
+                requests_dir=requests,
+                results_dir=results,
+                reports_dir=reports,
+            )
+
+            sidecar_path = base / "state" / "report_pipeline" / "gate-gemini_gate-pr-197.json"
+            self.assertTrue(sidecar_path.exists())
+            data = json.loads(sidecar_path.read_text())
+
+            for field in ("gate", "pr_id", "pr_number", "status", "source", "recorded_at"):
+                self.assertIn(field, data, f"Missing field: {field}")
+
+    def test_sidecar_status_is_completed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+            materialize_artifacts(
+                gate="gemini_gate",
+                pr_number=197,
+                pr_id="PR-197",
+                stdout="A\nB\nC\n",
+                request_payload=payload,
+                duration_seconds=2.0,
+                requests_dir=requests,
+                results_dir=results,
+                reports_dir=reports,
+            )
+
+            sidecar_path = base / "state" / "report_pipeline" / "gate-gemini_gate-pr-197.json"
+            data = json.loads(sidecar_path.read_text())
+            self.assertEqual(data["status"], "completed")
+            self.assertEqual(data["source"], "gate_runner")
+
+    def test_sidecar_source_is_gate_runner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+            materialize_artifacts(
+                gate="codex_gate",
+                pr_number=99,
+                pr_id="PR-99",
+                stdout="Finding\nAnother\nThird\n",
+                request_payload={**payload, "gate": "codex_gate", "pr_number": 99,
+                                  "pr_id": "PR-99",
+                                  "report_path": str(reports / "codex-report.md")},
+                duration_seconds=1.0,
+                requests_dir=requests,
+                results_dir=results,
+                reports_dir=reports,
+            )
+
+            sidecar_dir = base / "state" / "report_pipeline"
+            sidecars = list(sidecar_dir.glob("*.json"))
+            self.assertGreater(len(sidecars), 0)
+            data = json.loads(sidecars[0].read_text())
+            self.assertEqual(data["source"], "gate_runner")
+
+    def test_sidecar_failure_does_not_propagate(self):
+        """Sidecar write failure must not crash materialize_artifacts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+
+            # Patch Path.mkdir to fail only for sidecar dir
+            original_mkdir = Path.mkdir
+
+            def patched_mkdir(self, *args, **kwargs):
+                if "report_pipeline" in str(self):
+                    raise OSError("simulated disk full")
+                return original_mkdir(self, *args, **kwargs)
+
+            with patch.object(Path, "mkdir", patched_mkdir):
+                # Should not raise
+                result = materialize_artifacts(
+                    gate="gemini_gate",
+                    pr_number=197,
+                    pr_id="PR-197",
+                    stdout="X\nY\nZ\n",
+                    request_payload=payload,
+                    duration_seconds=1.0,
+                    requests_dir=requests,
+                    results_dir=results,
+                    reports_dir=reports,
+                )
+            self.assertEqual(result.get("status"), "completed")
+
+    def test_sidecar_valid_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            requests, results, reports = self._make_dirs(base)
+            payload = self._base_payload(reports)
+
+            from gate_artifacts import materialize_artifacts
+            materialize_artifacts(
+                gate="gemini_gate",
+                pr_number=197,
+                pr_id="PR-197",
+                stdout="A\nB\nC\n",
+                request_payload=payload,
+                duration_seconds=2.0,
+                requests_dir=requests,
+                results_dir=results,
+                reports_dir=reports,
+            )
+
+            sidecar_path = base / "state" / "report_pipeline" / "gate-gemini_gate-pr-197.json"
+            # Must parse as valid JSON
+            data = json.loads(sidecar_path.read_text())
+            self.assertIsInstance(data, dict)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_report_assembler.py
+++ b/tests/test_report_assembler.py
@@ -483,7 +483,7 @@ class TestWriteReport(unittest.TestCase):
 
             self.assertTrue(str(md_path).startswith(str(vnx_data / "unified_reports")))
             self.assertTrue(md_path.name.endswith(".md"))
-            self.assertIn("-auto-", md_path.name)
+            self.assertNotIn("-auto-", md_path.name)  # OI-1064: auto- prefix removed
 
     def test_markdown_contains_required_fields(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Resolves 4 post-merge open items from F37 Auto-Report Pipeline:

- **OI-1062**: Event archive at dispatch completion (not next dispatch start) — prevents event loss
- **OI-1063**: Fallback policy documented as `FALLBACK_POLICY` constant
- **OI-1064**: Remove `auto-` prefix from report filenames — consistent naming convention
- **OI-1066**: Gate completion sidecar JSON in `materialize_artifacts()` — Codex/Gemini reports now produce structured data for intelligence DB

19 new tests, 161 total passing.

## Test plan

- [ ] Codex gate passes
- [ ] Gemini review passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)