### PR TITLE
refactor: decompose intelligence_daemon.py from 1116 to 499 lines

### DIFF
--- a/scripts/intelligence_daemon.py
+++ b/scripts/intelligence_daemon.py
@@ -11,19 +11,17 @@ Version: 1.0.0
 """
 
 import os
-import re
-import sys
 import json
 import time
 import signal
 import logging
-import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, List
 
 # Add scripts directory to path for imports
 script_dir = Path(__file__).parent
+import sys
 sys.path.insert(0, str(script_dir))
 sys.path.insert(0, str(script_dir / "lib"))
 try:
@@ -40,6 +38,9 @@ try:
     from learning_loop import LearningLoop
     from cached_intelligence import CachedIntelligence
     from tag_intelligence import TagIntelligenceEngine
+    from pr_discovery import PRDiscovery
+    from intelligence_dashboard import DashboardBuilder
+    from intelligence_hygiene import HygieneRunner
 except ImportError as e:
     print(f"ERROR: Could not import required modules: {e}", file=sys.stderr)
     sys.exit(1)
@@ -69,14 +70,8 @@ def _rollback_mode_enabled() -> bool:
 
 
 class GovernanceDigestRunner:
-    """Periodic governance digest builder.
-
-    Reads governance signals from the runtime state directory, calls the F18
-    extractors and digest builder, and writes the result to
-    ``state_dir/governance_digest.json`` every ``interval`` seconds.
-
-    Interval defaults to 300 s (5 min) and is configurable via the
-    ``VNX_DIGEST_INTERVAL`` environment variable.
+    """Periodic governance digest builder — writes governance_digest.json every ``interval`` seconds.
+    Reads F18 extractors. Interval from VNX_DIGEST_INTERVAL env var (default 300 s).
     """
 
     OUTPUT_FILENAME = "governance_digest.json"
@@ -97,16 +92,12 @@ class GovernanceDigestRunner:
             interval = 300
         return cls(state_dir, interval)
 
-    # ── Scheduling ──────────────────────────────────────────────────────────
-
     def should_run(self) -> bool:
         """Return True if the interval has elapsed since the last run."""
         if self.last_run is None:
             return True
         elapsed = (datetime.now() - self.last_run).total_seconds()
         return elapsed >= self.interval
-
-    # ── Signal loading ───────────────────────────────────────────────────────
 
     def _load_gate_results(self) -> List[Dict]:
         """Extract gate result records from t0_receipts.ndjson."""
@@ -205,16 +196,8 @@ class GovernanceDigestRunner:
 
         return anomalies
 
-    # ── Core execution ───────────────────────────────────────────────────────
-
     def run_once(self) -> bool:
-        """Execute one digest cycle.
-
-        1. Load signals from state files.
-        2. Call collect_governance_signals() (F18 extractor).
-        3. Call build_digest() (F18 digest builder).
-        4. Write output to state_dir/governance_digest.json.
-
+        """Execute one digest cycle: load signals, collect, build, write JSON.
         Returns True on success, False on failure.
         """
         try:
@@ -280,9 +263,7 @@ class GovernanceDigestRunner:
         """Write payload to digest_path via a temporary file (atomic replace)."""
         import tempfile
         self.digest_path.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            mode="w", dir=self.digest_path.parent, delete=False, suffix=".tmp"
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.digest_path.parent, delete=False, suffix=".tmp") as tmp:
             json.dump(payload, tmp, indent=2)
             tmp_path = tmp.name
         os.replace(tmp_path, self.digest_path)
@@ -298,12 +279,9 @@ class IntelligenceDaemon:
         self.vnx_dir = Path(paths["VNX_HOME"])
         self.state_dir = Path(paths["VNX_STATE_DIR"]).expanduser().resolve()
         self.legacy_state_dir = (self.vnx_dir / "state").resolve()
-        self.dashboard_file = self.state_dir / "dashboard_status.json"
-        self.legacy_dashboard_file = self.legacy_state_dir / "dashboard_status.json"
-        self.intelligence_health_file = self.state_dir / "intelligence_health.json"
-        self.legacy_intelligence_health_file = self.legacy_state_dir / "intelligence_health.json"
-        self.dashboard_write_enabled = os.getenv("VNX_INTELLIGENCE_DASHBOARD_WRITE", "0") == "1"
         self.rollback_mode = _rollback_mode_enabled()
+        self.dashboard_write_enabled = os.getenv("VNX_INTELLIGENCE_DASHBOARD_WRITE", "0") == "1"
+        self.refresh_daily = os.getenv("VNX_DAILY_INTEL_REFRESH", "1") == "1"
 
         self.compat_state_dirs: List[Path] = [self.state_dir]
         if self.rollback_mode:
@@ -327,8 +305,6 @@ class IntelligenceDaemon:
         self.last_learning_cycle = None
         self.extraction_interval = 3600  # 1 hour in seconds
         self.daily_hygiene_hour = 18  # 18:00 (6 PM)
-        self.learning_cycle_hour = 18  # Run learning at same time as hygiene
-        self.refresh_daily = os.getenv("VNX_DAILY_INTEL_REFRESH", "1") == "1"
 
         # Health tracking
         self.health_status = {
@@ -339,6 +315,25 @@ class IntelligenceDaemon:
             'uptime_seconds': 0,
             'last_health_update': None
         }
+
+        # Decomposed components
+        self.pr_discovery = PRDiscovery(self.compat_state_dirs)
+        self.dashboard_builder = DashboardBuilder(
+            state_dir=self.state_dir,
+            legacy_state_dir=self.legacy_state_dir,
+            rollback_mode=self.rollback_mode,
+            dashboard_write_enabled=self.dashboard_write_enabled,
+            pr_discovery=self.pr_discovery,
+            find_state_file=self._find_state_file,
+            health_status=self.health_status,
+        )
+        self.hygiene_runner = HygieneRunner(
+            gatherer=self.gatherer,
+            project_root=self.project_root,
+            vnx_dir=self.vnx_dir,
+            refresh_daily=self.refresh_daily,
+            find_state_file=self._find_state_file,
+        )
 
         # Governance digest runner (5-min cadence by default)
         self.digest_runner = GovernanceDigestRunner.from_env(self.state_dir)
@@ -357,15 +352,6 @@ class IntelligenceDaemon:
                 return candidate
         return None
 
-    def _write_json_atomic(self, destination: Path, payload: Dict) -> None:
-        import tempfile
-
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(mode='w', dir=destination.parent, delete=False, suffix='.tmp') as tmp:
-            json.dump(payload, tmp, indent=2)
-            tmp_path = tmp.name
-        os.replace(tmp_path, destination)
-
     def _signal_handler(self, signum, frame):
         """Handle shutdown signals gracefully"""
         logger.info(f"Received signal {signum}, shutting down gracefully...")
@@ -375,20 +361,15 @@ class IntelligenceDaemon:
         """Check if hourly extraction is due"""
         if not self.last_extraction:
             return True
-
         elapsed = (datetime.now() - self.last_extraction).total_seconds()
         return elapsed >= self.extraction_interval
 
     def should_run_daily_hygiene(self) -> bool:
         """Check if daily hygiene is due (runs at 18:00)"""
         now = datetime.now()
-
-        # Skip if already ran today
         if self.last_daily_hygiene:
             if self.last_daily_hygiene.date() == now.date():
                 return False
-
-        # Check if current hour matches target hour
         return now.hour == self.daily_hygiene_hour
 
     def hourly_extraction(self):
@@ -396,13 +377,9 @@ class IntelligenceDaemon:
         logger.info("🔄 Starting hourly intelligence extraction...")
 
         try:
-            # Count patterns available
-            pattern_count = self._count_available_patterns()
+            pattern_count = self.hygiene_runner._count_available_patterns()
 
-            # Update last extraction time
             self.last_extraction = datetime.now()
-
-            # Update health status
             self.health_status['status'] = 'healthy'
             self.health_status['last_extraction'] = self.last_extraction.isoformat()
             self.health_status['patterns_available'] = pattern_count
@@ -417,626 +394,32 @@ class IntelligenceDaemon:
 
     def daily_hygiene(self):
         """Run daily hygiene operations at 18:00"""
-        logger.info("🧹 Starting daily hygiene operations...")
-
-        try:
-            # Refresh intelligence database (quality scan + snippet extraction)
-            if self.refresh_daily:
-                self._refresh_quality_intelligence()
-
-            # Database optimization
-            self._optimize_database()
-
-            # Pattern quality check
-            self._verify_pattern_quality()
-
-            # Bulk citation freshness verification
-            self._verify_pattern_freshness_bulk()
-
-            # Tag auto-refresh from completed dispatches
-            self._refresh_tags_from_completed_dispatches()
-
-            # Cleanup old data
-            self._cleanup_old_data()
-
-            # Run learning cycle
-            self.run_learning_cycle()
-
-            # Update cache rankings
-            self.cached_intelligence.update_pattern_rankings()
-
-            # Update last hygiene time
-            self.last_daily_hygiene = datetime.now()
-
-            logger.info("✅ Daily hygiene complete")
-
-        except Exception as e:
-            logger.error(f"❌ Daily hygiene failed: {e}")
-
-    def _count_available_patterns(self) -> int:
-        """Count total patterns available in database"""
-        try:
-            # Check if database is loaded, if not, try to load it
-            if not self.gatherer.quality_db:
-                # Try to load the database
-                db_path = self._find_state_file("quality_intelligence.db")
-                if db_path and db_path.exists():
-                    import sqlite3
-                    self.gatherer.quality_db = sqlite3.connect(str(db_path))
-                    logger.info(f"Loaded quality database from {db_path}")
-                else:
-                    logger.error("Database not found in active state roots")
-                    return 0
-
-            if self.gatherer.quality_db:
-                # Count high-quality snippets (PR #8 Fix)
-                cursor = self.gatherer.quality_db.execute(
-                    "SELECT COUNT(*) FROM code_snippets WHERE quality_score > 80"
-                )
-                count = cursor.fetchone()[0]
-                return count
-            return 0
-        except Exception as e:
-            logger.error(f"Error counting patterns: {e}")
-            return 0
-
-    def _optimize_database(self):
-        """Optimize SQLite database"""
-        try:
-            if self.gatherer.quality_db:
-                self.gatherer.quality_db.execute("VACUUM")
-                self.gatherer.quality_db.execute("ANALYZE")
-                logger.info("Database optimization complete")
-        except Exception as e:
-            logger.error(f"Database optimization failed: {e}")
-
-    def _refresh_quality_intelligence(self):
-        """Run quality scanner + snippet extractor to refresh patterns"""
-        try:
-            base_dir = str(self.vnx_dir)
-            scanner = os.path.join(base_dir, "scripts", "code_quality_scanner.py")
-            extractor = os.path.join(base_dir, "scripts", "code_snippet_extractor.py")
-            if os.path.exists(scanner):
-                logger.info("🔄 Refreshing quality intelligence database...")
-                subprocess.run(["python3", scanner], check=False)
-            if os.path.exists(extractor):
-                subprocess.run(["python3", extractor], check=False)
-            doc_extractor = os.path.join(base_dir, "scripts", "doc_section_extractor.py")
-            if os.path.exists(doc_extractor):
-                subprocess.run(["python3", doc_extractor], check=False)
-            logger.info("✅ Intelligence refresh complete")
-        except Exception as e:
-            logger.error(f"❌ Intelligence refresh failed: {e}")
-
-    def _verify_pattern_quality(self):
-        """Verify pattern quality metrics"""
-        try:
-            if self.gatherer.quality_db:
-                cursor = self.gatherer.quality_db.execute("""
-                    SELECT
-                        COUNT(*) as total,
-                        AVG(quality_score) as avg_quality,
-                        COUNT(CASE WHEN quality_score >= 85 THEN 1 END) as high_quality
-                    FROM code_snippets
-                """)
-                result = cursor.fetchone()
-
-                logger.info(
-                    f"Pattern quality: {result['total']} total, "
-                    f"{result['avg_quality']:.1f} avg quality, "
-                    f"{result['high_quality']} high quality (≥85)"
-                )
-        except Exception as e:
-            logger.error(f"Pattern quality check failed: {e}")
-
-    def _cleanup_old_data(self):
-        """Cleanup old data from database"""
-        try:
-            if self.gatherer.quality_db:
-                # Remove old prevention rules with low confidence (older than 30 days)
-                cutoff = (datetime.now() - timedelta(days=30)).isoformat()
-                self.gatherer.quality_db.execute("""
-                    DELETE FROM prevention_rules
-                    WHERE confidence < 0.5 AND created_at < ?
-                """, (cutoff,))
-
-                # Commit changes
-                self.gatherer.quality_db.commit()
-                logger.info("Old data cleanup complete")
-        except Exception as e:
-            logger.error(f"Data cleanup failed: {e}")
-
-    def _verify_pattern_freshness_bulk(self):
-        """Bulk verification of snippet citations against current git state.
-
-        Iterates all snippet_metadata rows with source_commit_hash,
-        compares with the current commit for each file, and updates verified_at.
-        Stale snippets get their quality_score penalized.
-        """
-        if not self.gatherer.quality_db:
-            return
-
-        try:
-            cursor = self.gatherer.quality_db.execute('''
-                SELECT id, file_path, source_commit_hash
-                FROM snippet_metadata
-                WHERE source_commit_hash IS NOT NULL
-            ''')
-            rows = cursor.fetchall()
-
-            if not rows:
-                logger.info("No snippets with commit hashes to verify")
-                return
-
-            now = datetime.now().isoformat()
-            verified = 0
-            stale = 0
-
-            for row in rows:
-                file_path = row['file_path']
-                stored_hash = row['source_commit_hash']
-
-                try:
-                    result = subprocess.run(
-                        ['git', 'log', '-1', '--format=%H', '--', file_path],
-                        capture_output=True, text=True, timeout=5,
-                        cwd=str(self.project_root)
-                    )
-                    current_hash = result.stdout.strip() if result.returncode == 0 else None
-
-                    if current_hash and current_hash != stored_hash:
-                        stale += 1
-                        # Penalize stale snippet quality
-                        self.gatherer.quality_db.execute('''
-                            UPDATE snippet_metadata
-                            SET verified_at = ?, quality_score = MAX(0, quality_score * 0.8)
-                            WHERE id = ?
-                        ''', (now, row['id']))
-                    else:
-                        self.gatherer.quality_db.execute('''
-                            UPDATE snippet_metadata
-                            SET verified_at = ?
-                            WHERE id = ?
-                        ''', (now, row['id']))
-
-                    verified += 1
-
-                except Exception:
-                    continue
-
-            self.gatherer.quality_db.commit()
-            logger.info(f"Freshness check: {verified} verified, {stale} stale out of {len(rows)} snippets")
-
-        except Exception as e:
-            logger.error(f"Bulk freshness verification failed: {e}")
-
-    def _refresh_tags_from_completed_dispatches(self):
-        """Scan completed dispatches from the last 24h and feed extracted tags into tag intelligence.
-
-        For each dispatch, extracts tags from metadata (Priority, Gate, Role, Reason)
-        and instruction text (compound tag detection), then runs them through
-        analyze_multi_tag_patterns() for pattern detection and prevention rule generation.
-        """
-        dispatches_dir = self.vnx_dir / "dispatches" / "completed"
-        if not dispatches_dir.is_dir():
-            logger.info("No completed dispatches directory found")
-            return
-
-        cutoff = (datetime.now() - timedelta(days=1)).timestamp()
-        tag_engine = TagIntelligenceEngine()
-        processed = 0
-
-        for dispatch_file in dispatches_dir.glob("*.md"):
-            try:
-                if dispatch_file.stat().st_mtime < cutoff:
-                    continue
-            except OSError:
-                continue
-
-            tags = tag_engine.extract_tags_from_dispatch(dispatch_file)
-            if not tags:
-                continue
-
-            normalized = tag_engine.normalize_tags(tags)
-            if normalized:
-                tag_engine.analyze_multi_tag_patterns(
-                    list(normalized),
-                    phase=None,
-                    terminal=None,
-                    outcome="completed",
-                )
-                processed += 1
-
-        tag_engine.close()
-        logger.info(f"Tag refresh: processed {processed} completed dispatches")
+        self.hygiene_runner.daily_hygiene()
+        self.run_learning_cycle()
+        self.cached_intelligence.update_pattern_rankings()
+        self.last_daily_hygiene = datetime.now()
 
     def run_learning_cycle(self):
         """Run the learning loop to update pattern confidence"""
         logger.info("🔄 Starting learning cycle...")
 
         try:
-            # Run the daily learning cycle
             report = self.learning_loop.daily_learning_cycle()
-
-            # Update health status with learning metrics
             self.health_status['learning_stats'] = report.get('statistics', {})
             self.health_status['pattern_metrics'] = report.get('pattern_metrics', {})
-
-            # Update last learning cycle time
             self.last_learning_cycle = datetime.now()
-
             logger.info(f"✅ Learning cycle complete: {report['statistics'].get('confidence_adjustments', 0)} confidence adjustments made")
 
         except Exception as e:
             logger.error(f"❌ Learning cycle failed: {e}")
 
-    # ── PR Auto-Discovery ──────────────────────────────────────────
-    # No config file needed. PRs are discovered from:
-    #   1. Track gate names matching pattern gate_pr{N}_{description}
-    #   2. Receipt history (task_complete events referencing PRs)
-    #   3. Dispatch IDs containing PR references
-    # ──────────────────────────────────────────────────────────────
-
-    _PR_GATE_RE = re.compile(r"gate_pr(\d+)_(.*)", re.IGNORECASE)
-    _PR_REF_RE = re.compile(r"PR[- ]?(\d+)", re.IGNORECASE)
-
-    @staticmethod
-    def _register_gate(discovered: dict, gate: str, gate_re) -> None:
-        """Register a PR from a gate name if it matches the pattern."""
-        m = gate_re.match(gate)
-        if m:
-            pr_num = int(m.group(1))
-            desc = m.group(2).replace("_", " ").strip().title()
-            if pr_num not in discovered:
-                discovered[pr_num] = {
-                    "id": f"PR{pr_num}", "num": pr_num, "description": desc,
-                    "gate_trigger": gate, "receipt_done": False,
-                }
-
-    def _discover_from_track_history(self, discovered: dict) -> None:
-        """Discover PRs from progress_state.yaml track history."""
-        progress_file = self._find_state_file("progress_state.yaml")
-        if not (progress_file and progress_file.exists()):
-            return
-        try:
-            import yaml
-            with open(progress_file, "r") as f:
-                progress = yaml.safe_load(f) or {}
-            for track_id, track_data in progress.get("tracks", {}).items():
-                self._register_gate(discovered, track_data.get("current_gate", ""), self._PR_GATE_RE)
-                for entry in track_data.get("history", []):
-                    self._register_gate(discovered, entry.get("gate", ""), self._PR_GATE_RE)
-        except Exception as e:
-            logger.error(f"Error reading progress_state.yaml: {e}")
-
-    def _discover_from_receipts(self, discovered: dict) -> None:
-        """Discover PRs from t0_receipts.ndjson receipt history."""
-        receipts_file = self._find_state_file("t0_receipts.ndjson")
-        if not (receipts_file and receipts_file.exists()):
-            return
-        try:
-            with open(receipts_file, "r") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        receipt = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    self._process_receipt_pr_refs(discovered, receipt)
-        except Exception as e:
-            logger.error(f"Error scanning receipts for PR discovery: {e}")
-
-    def _process_receipt_pr_refs(self, discovered: dict, receipt: dict) -> None:
-        """Extract and register PR references from a single receipt."""
-        searchable = " ".join(
-            str(receipt.get(k, "")) for k in ("type", "title", "gate", "task_id", "dispatch_id")
-        )
-        for m in self._PR_REF_RE.finditer(searchable):
-            pr_num = int(m.group(1))
-            is_done = (
-                receipt.get("event_type") == "task_complete"
-                and receipt.get("status") in ("success", "unknown")
-            )
-            if pr_num not in discovered:
-                title = receipt.get("title", "")
-                desc = self._PR_REF_RE.sub("", title).strip(" -\u2013\u2014:").strip() or f"PR {pr_num}"
-                discovered[pr_num] = {
-                    "id": f"PR{pr_num}", "num": pr_num, "description": desc,
-                    "gate_trigger": f"gate_pr{pr_num}_unknown", "receipt_done": is_done,
-                }
-            elif is_done:
-                discovered[pr_num]["receipt_done"] = True
-            receipt_gate = receipt.get("gate", "")
-            gm = self._PR_GATE_RE.match(receipt_gate)
-            if gm and int(gm.group(1)) == pr_num:
-                discovered[pr_num]["gate_trigger"] = receipt_gate
-                if not discovered[pr_num]["description"] or discovered[pr_num]["description"] == f"PR {pr_num}":
-                    discovered[pr_num]["description"] = gm.group(2).replace("_", " ").strip().title()
-
-    def _auto_discover_prs(self, brief: dict) -> dict:
-        """Auto-discover PRs from tracks, track history, receipts, and dispatches.
-
-        Returns dict: { pr_num: { id, num, description, gate_trigger, receipt_done } }
-        """
-        discovered = {}
-
-        # Source 1: Current track gates
-        for track_id, track_data in brief.get("tracks", {}).items():
-            self._register_gate(discovered, track_data.get("current_gate", ""), self._PR_GATE_RE)
-
-        # Source 1b: Track history
-        self._discover_from_track_history(discovered)
-
-        # Source 2: Receipt history
-        self._discover_from_receipts(discovered)
-
-        # Source 3: Dispatch IDs in brief
-        for receipt in brief.get("recent_receipts", []):
-            dispatch_id = receipt.get("dispatch_id", "")
-            for m in self._PR_REF_RE.finditer(dispatch_id):
-                pr_num = int(m.group(1))
-                if pr_num not in discovered:
-                    discovered[pr_num] = {
-                        "id": f"PR{pr_num}", "num": pr_num, "description": f"PR {pr_num}",
-                        "gate_trigger": f"gate_pr{pr_num}_unknown", "receipt_done": False,
-                    }
-
-        return discovered
-
-    def _determine_pr_statuses(self, discovered: dict, tracks: dict) -> dict:
-        """Determine status for all discovered PRs.
-
-        Priority:
-        1. Live track gate match (working → in_progress, idle → done)
-        2. Receipt history completion → done
-        3. Dependency inference (if higher PR active, lower numbered deps are done)
-        4. Default → pending
-        """
-        status_map = {}
-
-        # First pass: track data + receipt signals
-        for pr_num, pr_info in discovered.items():
-            pr_id = pr_info["id"]
-            gate = pr_info["gate_trigger"]
-            status_map[pr_id] = "pending"
-
-            # Check live track data (highest priority)
-            for track_id, track_data in tracks.items():
-                current_gate = track_data.get("current_gate", "")
-                track_status = track_data.get("status", "")
-
-                if current_gate == gate:
-                    if track_status in ("working", "active"):
-                        status_map[pr_id] = "in_progress"
-                    elif track_status == "idle":
-                        status_map[pr_id] = "done"
-                    break
-
-            # Fallback: receipt history
-            if status_map[pr_id] == "pending" and pr_info.get("receipt_done"):
-                status_map[pr_id] = "done"
-
-        # Second pass: sequential inference
-        # If PR N is in_progress or done, all PRs with lower numbers
-        # that share the same track lineage are implicitly done
-        sorted_nums = sorted(discovered.keys())
-        for pr_num in sorted_nums:
-            pr_id = discovered[pr_num]["id"]
-            if status_map[pr_id] in ("in_progress", "done"):
-                # Mark all lower-numbered PRs on the same track lineage as done
-                gate = discovered[pr_num]["gate_trigger"]
-                # Find which track this PR is on
-                pr_track = None
-                for track_id, track_data in tracks.items():
-                    if track_data.get("current_gate", "") == gate:
-                        pr_track = track_id
-                        break
-
-                for lower_num in sorted_nums:
-                    if lower_num >= pr_num:
-                        break
-                    lower_id = discovered[lower_num]["id"]
-                    lower_gate = discovered[lower_num]["gate_trigger"]
-
-                    # Same track lineage: check if the lower PR's gate was on the same track
-                    if pr_track:
-                        # If this track is currently on a higher PR, lower ones are done
-                        if status_map[lower_id] == "pending":
-                            # Check if the lower gate belongs to the same track pattern
-                            lower_gate_match = self._PR_GATE_RE.match(lower_gate)
-                            current_gate_match = self._PR_GATE_RE.match(gate)
-                            if lower_gate_match and current_gate_match:
-                                status_map[lower_id] = "done"
-
-        return status_map
-
-    @staticmethod
-    def _merge_pr_registry(discovered: dict, registry: dict) -> None:
-        """Merge persisted PR registry into discovered dict (enriches, never removes)."""
-        for num_str, pr_info in registry.items():
-            pr_num = int(num_str)
-            if pr_num not in discovered:
-                discovered[pr_num] = pr_info
-            else:
-                if discovered[pr_num]["description"] == f"PR {pr_num}":
-                    discovered[pr_num]["description"] = pr_info.get("description", discovered[pr_num]["description"])
-                if pr_info.get("receipt_done"):
-                    discovered[pr_num]["receipt_done"] = True
-
-    @staticmethod
-    def _build_pr_list(discovered: dict, status_map: dict) -> List[dict]:
-        """Build sorted PR list with dependencies and blocked status."""
-        all_prs = []
-        sorted_nums = sorted(discovered.keys())
-        for pr_num in sorted_nums:
-            pr_info = discovered[pr_num]
-            pr_id = pr_info["id"]
-            status = status_map.get(pr_id, "pending")
-            deps = []
-            if pr_num > 1:
-                prev_num = None
-                for n in sorted_nums:
-                    if n < pr_num:
-                        prev_num = n
-                    else:
-                        break
-                if prev_num is not None and prev_num in discovered:
-                    deps = [discovered[prev_num]["id"]]
-            blocked = status == "pending" and deps and any(status_map.get(d) != "done" for d in deps)
-            all_prs.append({
-                "id": pr_id, "description": pr_info["description"],
-                "status": status, "deps": deps, "blocked": blocked,
-            })
-        return all_prs
-
-    def _build_pr_queue(self, brief: dict, existing_dashboard: dict) -> dict:
-        """Build PR queue from auto-discovered data with persistence.
-
-        Merges newly discovered PRs with previously persisted registry so
-        PRs that were on a track gate in the past are not lost when the
-        track moves forward.
-        """
-        tracks = brief.get("tracks", {})
-        discovered = self._auto_discover_prs(brief)
-        self._merge_pr_registry(discovered, existing_dashboard.get("_pr_registry", {}))
-
-        if not discovered:
-            return {
-                "active_feature": "Active Development", "total_prs": 0,
-                "completed_prs": 0, "progress_percent": 0, "prs": [], "_pr_registry": {},
-            }
-
-        status_map = self._determine_pr_statuses(discovered, tracks)
-        all_prs = self._build_pr_list(discovered, status_map)
-        completed_count = sum(1 for pr in all_prs if pr["status"] == "done")
-        total_count = len(all_prs)
-
-        return {
-            "active_feature": "Active Development", "total_prs": total_count,
-            "completed_prs": completed_count,
-            "progress_percent": int((completed_count / total_count * 100)) if total_count > 0 else 0,
-            "prs": all_prs,
-            "_pr_registry": {str(k): v for k, v in discovered.items()},
-        }
-
-    def _build_terminals_from_brief(self, brief: dict) -> dict:
-        """Build terminal status dict from t0_brief data."""
-        terminals = {"T0": {
-            "status": "active", "gate": "ORCHESTRATION",
-            "type": "ORCHESTRATOR", "ready": True,
-        }}
-        for tid, tdata in brief.get("terminals", {}).items():
-            terminals[tid] = {
-                "status": "active" if tdata.get("status") in ["working", "idle"] else "offline",
-                "gate": tdata.get("track", ""),
-                "current_task": tdata.get("current_task", ""),
-                "ready": tdata.get("ready", False),
-                "type": "WORKER",
-            }
-        return terminals
-
-    def _build_open_items(self, brief: dict, pr_queue: dict) -> dict:
-        """Build open items section from terminals with PR correlation."""
-        gate_to_pr_id = {}
-        for pr in pr_queue.get("prs", []):
-            for track_id, track_data in brief.get("tracks", {}).items():
-                gate = track_data.get("current_gate", "")
-                m = self._PR_GATE_RE.match(gate)
-                if m and f"PR{m.group(1)}" == pr["id"]:
-                    gate_to_pr_id[gate] = pr["id"]
-
-        open_items = []
-        for tid, tdata in brief.get("terminals", {}).items():
-            if tdata.get("current_task"):
-                severity = "warning" if tdata.get("status") == "working" else "info"
-                pr_id = None
-                track_id = tdata.get("track", "")
-                if track_id:
-                    track_info = brief.get("tracks", {}).get(track_id, {})
-                    pr_id = gate_to_pr_id.get(track_info.get("current_gate", ""))
-                open_items.append({
-                    "id": tdata["current_task"],
-                    "title": f"{tdata.get('current_task', 'Task')} ({tid})",
-                    "severity": severity, "pr_id": pr_id,
-                })
-        return {
-            "open_count": len(open_items),
-            "summary": {
-                "open_count": len(open_items), "blocker_count": 0,
-                "warn_count": sum(1 for i in open_items if i["severity"] == "warning"),
-                "info_count": sum(1 for i in open_items if i["severity"] == "info"),
-            },
-            "top_blockers": [], "open_items": open_items,
-        }
-
-    def _build_intelligence_section(self) -> dict:
-        """Build the intelligence_daemon section for the dashboard."""
-        return {
-            'status': self.health_status['status'],
-            'last_extraction': self.health_status['last_extraction'],
-            'patterns_available': self.health_status['patterns_available'],
-            'extraction_errors': self.health_status['extraction_errors'],
-            'uptime_seconds': self.health_status['uptime_seconds'],
-            'last_update': datetime.now().isoformat(),
-        }
-
     def write_health_status(self):
-        """Legacy dashboard projection (disabled by default for single-writer ownership)."""
-        if not self.dashboard_write_enabled:
-            return
-        try:
-            dashboard = {}
-            dashboard_source = self._find_state_file("dashboard_status.json")
-            if dashboard_source and dashboard_source.exists():
-                with open(dashboard_source, 'r') as f:
-                    dashboard = json.load(f)
-
-            t0_brief_file = self._find_state_file("t0_brief.json")
-            if t0_brief_file and t0_brief_file.exists():
-                with open(t0_brief_file, 'r') as f:
-                    brief = json.load(f)
-                dashboard["terminals"] = self._build_terminals_from_brief(brief)
-                pr_result = self._build_pr_queue(brief, dashboard)
-                dashboard["_pr_registry"] = pr_result.pop("_pr_registry", {})
-                dashboard["pr_queue"] = pr_result
-                dashboard["open_items"] = self._build_open_items(brief, dashboard["pr_queue"])
-                dashboard["tracks"] = brief.get("tracks", {})
-                dashboard["recent_receipts"] = brief.get("recent_receipts", [])
-                dashboard["queues"] = brief.get("queues", {})
-
-            dashboard['intelligence_daemon'] = self._build_intelligence_section()
-            self._write_json_atomic(self.dashboard_file, dashboard)
-            if self.rollback_mode and self.legacy_dashboard_file != self.dashboard_file:
-                self._write_json_atomic(self.legacy_dashboard_file, dashboard)
-            self.health_status['last_health_update'] = datetime.now()
-
-        except Exception as e:
-            logger.error(f"Failed to write health status: {e}")
+        """Delegate to dashboard builder."""
+        self.dashboard_builder.write_health_status()
 
     def write_intelligence_health(self):
-        """Write to dedicated intelligence health file (PR #8 Fix - avoid dashboard races)"""
-        import os
-
-        health_data = {
-            'timestamp': datetime.now().isoformat(),
-            'daemon_running': True,
-            'daemon_pid': os.getpid(),
-            'patterns_available': self.health_status.get('patterns_available', 0),
-            'last_extraction': self.health_status.get('last_extraction', 'never'),
-            'extraction_errors': self.health_status.get('extraction_errors', 0),
-            'uptime_seconds': self.health_status.get('uptime_seconds', 0),
-            'status': self.health_status.get('status', 'unknown')
-        }
-
-        try:
-            self._write_json_atomic(self.intelligence_health_file, health_data)
-            if self.rollback_mode and self.legacy_intelligence_health_file != self.intelligence_health_file:
-                self._write_json_atomic(self.legacy_intelligence_health_file, health_data)
-
-        except Exception as e:
-            logger.error(f"Failed to write intelligence health file: {e}")
+        """Delegate to dashboard builder."""
+        self.dashboard_builder.write_intelligence_health()
 
     def run(self):
         """Main daemon loop"""
@@ -1050,8 +433,8 @@ class IntelligenceDaemon:
 
         # Initial extraction on startup
         self.hourly_extraction()
-        self.write_intelligence_health()  # PR #8 Fix - dedicated health file
-        self.write_health_status()
+        self.dashboard_builder.write_intelligence_health()  # PR #8 Fix - dedicated health file
+        self.dashboard_builder.write_health_status()
 
         start_time = datetime.now()
 
@@ -1073,8 +456,8 @@ class IntelligenceDaemon:
                     self.digest_runner.run_once()
 
                 # Health reporting (every minute)
-                self.write_intelligence_health()  # Write to dedicated file (PR #8 Fix)
-                self.write_health_status()  # Update dashboard every cycle for live sync
+                self.dashboard_builder.write_intelligence_health()  # Write to dedicated file (PR #8 Fix)
+                self.dashboard_builder.write_health_status()  # Update dashboard every cycle for live sync
 
                 # Sleep for 60 seconds
                 time.sleep(60)
@@ -1087,7 +470,7 @@ class IntelligenceDaemon:
         # Graceful shutdown
         logger.info("Intelligence Daemon shutting down...")
         self.health_status['status'] = 'stopped'
-        self.write_health_status()
+        self.dashboard_builder.write_health_status()
 
         # Close database connection
         if self.gatherer.quality_db:

--- a/scripts/lib/intelligence_dashboard.py
+++ b/scripts/lib/intelligence_dashboard.py
@@ -1,0 +1,169 @@
+"""
+Intelligence Dashboard
+======================
+Builds and writes dashboard_status.json and intelligence_health.json.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class DashboardBuilder:
+    """Builds and writes dashboard_status.json and intelligence_health.json."""
+
+    def __init__(
+        self,
+        state_dir: Path,
+        legacy_state_dir: Path,
+        rollback_mode: bool,
+        dashboard_write_enabled: bool,
+        pr_discovery,
+        find_state_file: Callable,
+        health_status: dict,
+    ) -> None:
+        self.state_dir = Path(state_dir)
+        self.legacy_state_dir = Path(legacy_state_dir)
+        self.rollback_mode = rollback_mode
+        self.dashboard_write_enabled = dashboard_write_enabled
+        self.pr_discovery = pr_discovery
+        self._find_state_file = find_state_file
+        self.health_status = health_status
+        self.dashboard_file = self.state_dir / "dashboard_status.json"
+        self.legacy_dashboard_file = self.legacy_state_dir / "dashboard_status.json"
+        self.intelligence_health_file = self.state_dir / "intelligence_health.json"
+        self.legacy_intelligence_health_file = self.legacy_state_dir / "intelligence_health.json"
+
+    # ── Section builders ─────────────────────────────────────────────────────
+
+    def _build_terminals_from_brief(self, brief: dict) -> dict:
+        """Build terminal status dict from t0_brief data."""
+        terminals = {"T0": {
+            "status": "active", "gate": "ORCHESTRATION",
+            "type": "ORCHESTRATOR", "ready": True,
+        }}
+        for tid, tdata in brief.get("terminals", {}).items():
+            terminals[tid] = {
+                "status": "active" if tdata.get("status") in ["working", "idle"] else "offline",
+                "gate": tdata.get("track", ""),
+                "current_task": tdata.get("current_task", ""),
+                "ready": tdata.get("ready", False),
+                "type": "WORKER",
+            }
+        return terminals
+
+    def _build_open_items(self, brief: dict, pr_queue: dict) -> dict:
+        """Build open items section from terminals with PR correlation."""
+        gate_re = self.pr_discovery._PR_GATE_RE
+        gate_to_pr_id = {}
+        for pr in pr_queue.get("prs", []):
+            for track_id, track_data in brief.get("tracks", {}).items():
+                gate = track_data.get("current_gate", "")
+                m = gate_re.match(gate)
+                if m and f"PR{m.group(1)}" == pr["id"]:
+                    gate_to_pr_id[gate] = pr["id"]
+
+        open_items = []
+        for tid, tdata in brief.get("terminals", {}).items():
+            if tdata.get("current_task"):
+                severity = "warning" if tdata.get("status") == "working" else "info"
+                pr_id = None
+                track_id = tdata.get("track", "")
+                if track_id:
+                    track_info = brief.get("tracks", {}).get(track_id, {})
+                    pr_id = gate_to_pr_id.get(track_info.get("current_gate", ""))
+                open_items.append({
+                    "id": tdata["current_task"],
+                    "title": f"{tdata.get('current_task', 'Task')} ({tid})",
+                    "severity": severity, "pr_id": pr_id,
+                })
+        return {
+            "open_count": len(open_items),
+            "summary": {
+                "open_count": len(open_items), "blocker_count": 0,
+                "warn_count": sum(1 for i in open_items if i["severity"] == "warning"),
+                "info_count": sum(1 for i in open_items if i["severity"] == "info"),
+            },
+            "top_blockers": [], "open_items": open_items,
+        }
+
+    def _build_intelligence_section(self) -> dict:
+        """Build the intelligence_daemon section for the dashboard."""
+        return {
+            'status': self.health_status['status'],
+            'last_extraction': self.health_status['last_extraction'],
+            'patterns_available': self.health_status['patterns_available'],
+            'extraction_errors': self.health_status['extraction_errors'],
+            'uptime_seconds': self.health_status['uptime_seconds'],
+            'last_update': datetime.now().isoformat(),
+        }
+
+    # ── Write methods ─────────────────────────────────────────────────────────
+
+    def _write_json_atomic(self, destination: Path, payload: Dict) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(mode='w', dir=destination.parent, delete=False, suffix='.tmp') as tmp:
+            json.dump(payload, tmp, indent=2)
+            tmp_path = tmp.name
+        os.replace(tmp_path, destination)
+
+    def write_health_status(self):
+        """Legacy dashboard projection (disabled by default for single-writer ownership)."""
+        if not self.dashboard_write_enabled:
+            return
+        try:
+            dashboard = {}
+            dashboard_source = self._find_state_file("dashboard_status.json")
+            if dashboard_source and dashboard_source.exists():
+                with open(dashboard_source, 'r') as f:
+                    dashboard = json.load(f)
+
+            t0_brief_file = self._find_state_file("t0_brief.json")
+            if t0_brief_file and t0_brief_file.exists():
+                with open(t0_brief_file, 'r') as f:
+                    brief = json.load(f)
+                dashboard["terminals"] = self._build_terminals_from_brief(brief)
+                pr_result = self.pr_discovery.build_pr_queue(brief, dashboard)
+                dashboard["_pr_registry"] = pr_result.pop("_pr_registry", {})
+                dashboard["pr_queue"] = pr_result
+                dashboard["open_items"] = self._build_open_items(brief, dashboard["pr_queue"])
+                dashboard["tracks"] = brief.get("tracks", {})
+                dashboard["recent_receipts"] = brief.get("recent_receipts", [])
+                dashboard["queues"] = brief.get("queues", {})
+
+            dashboard['intelligence_daemon'] = self._build_intelligence_section()
+            self._write_json_atomic(self.dashboard_file, dashboard)
+            if self.rollback_mode and self.legacy_dashboard_file != self.dashboard_file:
+                self._write_json_atomic(self.legacy_dashboard_file, dashboard)
+            self.health_status['last_health_update'] = datetime.now()
+
+        except Exception as e:
+            logger.error(f"Failed to write health status: {e}")
+
+    def write_intelligence_health(self):
+        """Write to dedicated intelligence health file (PR #8 Fix - avoid dashboard races)."""
+        health_data = {
+            'timestamp': datetime.now().isoformat(),
+            'daemon_running': True,
+            'daemon_pid': os.getpid(),
+            'patterns_available': self.health_status.get('patterns_available', 0),
+            'last_extraction': self.health_status.get('last_extraction', 'never'),
+            'extraction_errors': self.health_status.get('extraction_errors', 0),
+            'uptime_seconds': self.health_status.get('uptime_seconds', 0),
+            'status': self.health_status.get('status', 'unknown')
+        }
+
+        try:
+            self._write_json_atomic(self.intelligence_health_file, health_data)
+            if self.rollback_mode and self.legacy_intelligence_health_file != self.intelligence_health_file:
+                self._write_json_atomic(self.legacy_intelligence_health_file, health_data)
+
+        except Exception as e:
+            logger.error(f"Failed to write intelligence health file: {e}")

--- a/scripts/lib/intelligence_hygiene.py
+++ b/scripts/lib/intelligence_hygiene.py
@@ -1,0 +1,249 @@
+"""
+Intelligence Hygiene
+====================
+Daily hygiene operations: database optimization, pattern quality checks,
+freshness verification, tag refresh, and cleanup.
+"""
+
+import logging
+import os
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HygieneRunner:
+    """Runs daily intelligence hygiene operations."""
+
+    def __init__(
+        self,
+        gatherer,
+        project_root: Path,
+        vnx_dir: Path,
+        refresh_daily: bool,
+        find_state_file: Callable,
+    ) -> None:
+        self.gatherer = gatherer
+        self.project_root = Path(project_root)
+        self.vnx_dir = Path(vnx_dir)
+        self.refresh_daily = refresh_daily
+        self._find_state_file = find_state_file
+
+    def _count_available_patterns(self) -> int:
+        """Count total patterns available in database."""
+        try:
+            if not self.gatherer.quality_db:
+                db_path = self._find_state_file("quality_intelligence.db")
+                if db_path and db_path.exists():
+                    import sqlite3
+                    self.gatherer.quality_db = sqlite3.connect(str(db_path))
+                    logger.info(f"Loaded quality database from {db_path}")
+                else:
+                    logger.error("Database not found in active state roots")
+                    return 0
+
+            if self.gatherer.quality_db:
+                # Count high-quality snippets (PR #8 Fix)
+                cursor = self.gatherer.quality_db.execute(
+                    "SELECT COUNT(*) FROM code_snippets WHERE quality_score > 80"
+                )
+                count = cursor.fetchone()[0]
+                return count
+            return 0
+        except Exception as e:
+            logger.error(f"Error counting patterns: {e}")
+            return 0
+
+    def _optimize_database(self):
+        """Optimize SQLite database."""
+        try:
+            if self.gatherer.quality_db:
+                self.gatherer.quality_db.execute("VACUUM")
+                self.gatherer.quality_db.execute("ANALYZE")
+                logger.info("Database optimization complete")
+        except Exception as e:
+            logger.error(f"Database optimization failed: {e}")
+
+    def _refresh_quality_intelligence(self):
+        """Run quality scanner + snippet extractor to refresh patterns."""
+        try:
+            base_dir = str(self.vnx_dir)
+            scanner = os.path.join(base_dir, "scripts", "code_quality_scanner.py")
+            extractor = os.path.join(base_dir, "scripts", "code_snippet_extractor.py")
+            if os.path.exists(scanner):
+                logger.info("🔄 Refreshing quality intelligence database...")
+                subprocess.run(["python3", scanner], check=False)
+            if os.path.exists(extractor):
+                subprocess.run(["python3", extractor], check=False)
+            doc_extractor = os.path.join(base_dir, "scripts", "doc_section_extractor.py")
+            if os.path.exists(doc_extractor):
+                subprocess.run(["python3", doc_extractor], check=False)
+            logger.info("✅ Intelligence refresh complete")
+        except Exception as e:
+            logger.error(f"❌ Intelligence refresh failed: {e}")
+
+    def _verify_pattern_quality(self):
+        """Verify pattern quality metrics."""
+        try:
+            if self.gatherer.quality_db:
+                cursor = self.gatherer.quality_db.execute("""
+                    SELECT
+                        COUNT(*) as total,
+                        AVG(quality_score) as avg_quality,
+                        COUNT(CASE WHEN quality_score >= 85 THEN 1 END) as high_quality
+                    FROM code_snippets
+                """)
+                result = cursor.fetchone()
+
+                logger.info(
+                    f"Pattern quality: {result['total']} total, "
+                    f"{result['avg_quality']:.1f} avg quality, "
+                    f"{result['high_quality']} high quality (≥85)"
+                )
+        except Exception as e:
+            logger.error(f"Pattern quality check failed: {e}")
+
+    def _cleanup_old_data(self):
+        """Cleanup old data from database."""
+        try:
+            if self.gatherer.quality_db:
+                # Remove old prevention rules with low confidence (older than 30 days)
+                cutoff = (datetime.now() - timedelta(days=30)).isoformat()
+                self.gatherer.quality_db.execute("""
+                    DELETE FROM prevention_rules
+                    WHERE confidence < 0.5 AND created_at < ?
+                """, (cutoff,))
+
+                # Commit changes
+                self.gatherer.quality_db.commit()
+                logger.info("Old data cleanup complete")
+        except Exception as e:
+            logger.error(f"Data cleanup failed: {e}")
+
+    def _verify_pattern_freshness_bulk(self):
+        """Bulk verification of snippet citations against current git state.
+
+        Iterates all snippet_metadata rows with source_commit_hash,
+        compares with the current commit for each file, and updates verified_at.
+        Stale snippets get their quality_score penalized.
+        """
+        if not self.gatherer.quality_db:
+            return
+
+        try:
+            cursor = self.gatherer.quality_db.execute('''
+                SELECT id, file_path, source_commit_hash
+                FROM snippet_metadata
+                WHERE source_commit_hash IS NOT NULL
+            ''')
+            rows = cursor.fetchall()
+
+            if not rows:
+                logger.info("No snippets with commit hashes to verify")
+                return
+
+            now = datetime.now().isoformat()
+            verified = 0
+            stale = 0
+
+            for row in rows:
+                file_path = row['file_path']
+                stored_hash = row['source_commit_hash']
+
+                try:
+                    result = subprocess.run(
+                        ['git', 'log', '-1', '--format=%H', '--', file_path],
+                        capture_output=True, text=True, timeout=5,
+                        cwd=str(self.project_root)
+                    )
+                    current_hash = result.stdout.strip() if result.returncode == 0 else None
+
+                    if current_hash and current_hash != stored_hash:
+                        stale += 1
+                        # Penalize stale snippet quality
+                        self.gatherer.quality_db.execute('''
+                            UPDATE snippet_metadata
+                            SET verified_at = ?, quality_score = MAX(0, quality_score * 0.8)
+                            WHERE id = ?
+                        ''', (now, row['id']))
+                    else:
+                        self.gatherer.quality_db.execute('''
+                            UPDATE snippet_metadata
+                            SET verified_at = ?
+                            WHERE id = ?
+                        ''', (now, row['id']))
+
+                    verified += 1
+
+                except Exception:
+                    continue
+
+            self.gatherer.quality_db.commit()
+            logger.info(f"Freshness check: {verified} verified, {stale} stale out of {len(rows)} snippets")
+
+        except Exception as e:
+            logger.error(f"Bulk freshness verification failed: {e}")
+
+    def _refresh_tags_from_completed_dispatches(self):
+        """Scan completed dispatches from the last 24h and feed extracted tags into tag intelligence.
+
+        For each dispatch, extracts tags from metadata (Priority, Gate, Role, Reason)
+        and instruction text (compound tag detection), then runs them through
+        analyze_multi_tag_patterns() for pattern detection and prevention rule generation.
+        """
+        from tag_intelligence import TagIntelligenceEngine
+
+        dispatches_dir = self.vnx_dir / "dispatches" / "completed"
+        if not dispatches_dir.is_dir():
+            logger.info("No completed dispatches directory found")
+            return
+
+        cutoff = (datetime.now() - timedelta(days=1)).timestamp()
+        tag_engine = TagIntelligenceEngine()
+        processed = 0
+
+        for dispatch_file in dispatches_dir.glob("*.md"):
+            try:
+                if dispatch_file.stat().st_mtime < cutoff:
+                    continue
+            except OSError:
+                continue
+
+            tags = tag_engine.extract_tags_from_dispatch(dispatch_file)
+            if not tags:
+                continue
+
+            normalized = tag_engine.normalize_tags(tags)
+            if normalized:
+                tag_engine.analyze_multi_tag_patterns(
+                    list(normalized),
+                    phase=None,
+                    terminal=None,
+                    outcome="completed",
+                )
+                processed += 1
+
+        tag_engine.close()
+        logger.info(f"Tag refresh: processed {processed} completed dispatches")
+
+    def daily_hygiene(self):
+        """Run daily hygiene operations (all steps except learning cycle and cache rankings)."""
+        logger.info("🧹 Starting daily hygiene operations...")
+
+        try:
+            if self.refresh_daily:
+                self._refresh_quality_intelligence()
+
+            self._optimize_database()
+            self._verify_pattern_quality()
+            self._verify_pattern_freshness_bulk()
+            self._refresh_tags_from_completed_dispatches()
+            self._cleanup_old_data()
+
+            logger.info("✅ Daily hygiene complete")
+
+        except Exception as e:
+            logger.error(f"❌ Daily hygiene failed: {e}")

--- a/scripts/lib/pr_discovery.py
+++ b/scripts/lib/pr_discovery.py
@@ -1,0 +1,265 @@
+"""
+PR Auto-Discovery
+=================
+Discovers active and historical PRs from gate names, receipt history,
+and dispatch IDs. Used by IntelligenceDaemon to build the PR queue.
+"""
+
+import json
+import re
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PRDiscovery:
+    """Discovers and tracks PRs from gate names, receipts, and dispatch IDs."""
+
+    _PR_GATE_RE = re.compile(r"gate_pr(\d+)_(.*)", re.IGNORECASE)
+    _PR_REF_RE = re.compile(r"PR[- ]?(\d+)", re.IGNORECASE)
+
+    def __init__(self, compat_state_dirs: List[Path]) -> None:
+        self.compat_state_dirs = list(compat_state_dirs)
+
+    def _find_state_file(self, filename: str) -> Optional[Path]:
+        for state_dir in self.compat_state_dirs:
+            candidate = state_dir / filename
+            if candidate.exists():
+                return candidate
+        return None
+
+    @staticmethod
+    def _register_gate(discovered: dict, gate: str, gate_re) -> None:
+        """Register a PR from a gate name if it matches the pattern."""
+        m = gate_re.match(gate)
+        if m:
+            pr_num = int(m.group(1))
+            desc = m.group(2).replace("_", " ").strip().title()
+            if pr_num not in discovered:
+                discovered[pr_num] = {
+                    "id": f"PR{pr_num}", "num": pr_num, "description": desc,
+                    "gate_trigger": gate, "receipt_done": False,
+                }
+
+    def _discover_from_track_history(self, discovered: dict) -> None:
+        """Discover PRs from progress_state.yaml track history."""
+        progress_file = self._find_state_file("progress_state.yaml")
+        if not (progress_file and progress_file.exists()):
+            return
+        try:
+            import yaml
+            with open(progress_file, "r") as f:
+                progress = yaml.safe_load(f) or {}
+            for track_id, track_data in progress.get("tracks", {}).items():
+                self._register_gate(discovered, track_data.get("current_gate", ""), self._PR_GATE_RE)
+                for entry in track_data.get("history", []):
+                    self._register_gate(discovered, entry.get("gate", ""), self._PR_GATE_RE)
+        except Exception as e:
+            logger.error(f"Error reading progress_state.yaml: {e}")
+
+    def _discover_from_receipts(self, discovered: dict) -> None:
+        """Discover PRs from t0_receipts.ndjson receipt history."""
+        receipts_file = self._find_state_file("t0_receipts.ndjson")
+        if not (receipts_file and receipts_file.exists()):
+            return
+        try:
+            with open(receipts_file, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        receipt = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    self._process_receipt_pr_refs(discovered, receipt)
+        except Exception as e:
+            logger.error(f"Error scanning receipts for PR discovery: {e}")
+
+    def _process_receipt_pr_refs(self, discovered: dict, receipt: dict) -> None:
+        """Extract and register PR references from a single receipt."""
+        searchable = " ".join(
+            str(receipt.get(k, "")) for k in ("type", "title", "gate", "task_id", "dispatch_id")
+        )
+        for m in self._PR_REF_RE.finditer(searchable):
+            pr_num = int(m.group(1))
+            is_done = (
+                receipt.get("event_type") == "task_complete"
+                and receipt.get("status") in ("success", "unknown")
+            )
+            if pr_num not in discovered:
+                title = receipt.get("title", "")
+                desc = self._PR_REF_RE.sub("", title).strip(" -\u2013\u2014:").strip() or f"PR {pr_num}"
+                discovered[pr_num] = {
+                    "id": f"PR{pr_num}", "num": pr_num, "description": desc,
+                    "gate_trigger": f"gate_pr{pr_num}_unknown", "receipt_done": is_done,
+                }
+            elif is_done:
+                discovered[pr_num]["receipt_done"] = True
+            receipt_gate = receipt.get("gate", "")
+            gm = self._PR_GATE_RE.match(receipt_gate)
+            if gm and int(gm.group(1)) == pr_num:
+                discovered[pr_num]["gate_trigger"] = receipt_gate
+                if not discovered[pr_num]["description"] or discovered[pr_num]["description"] == f"PR {pr_num}":
+                    discovered[pr_num]["description"] = gm.group(2).replace("_", " ").strip().title()
+
+    def _auto_discover_prs(self, brief: dict) -> dict:
+        """Auto-discover PRs from tracks, track history, receipts, and dispatches.
+
+        Returns dict: { pr_num: { id, num, description, gate_trigger, receipt_done } }
+        """
+        discovered = {}
+
+        # Source 1: Current track gates
+        for track_id, track_data in brief.get("tracks", {}).items():
+            self._register_gate(discovered, track_data.get("current_gate", ""), self._PR_GATE_RE)
+
+        # Source 1b: Track history
+        self._discover_from_track_history(discovered)
+
+        # Source 2: Receipt history
+        self._discover_from_receipts(discovered)
+
+        # Source 3: Dispatch IDs in brief
+        for receipt in brief.get("recent_receipts", []):
+            dispatch_id = receipt.get("dispatch_id", "")
+            for m in self._PR_REF_RE.finditer(dispatch_id):
+                pr_num = int(m.group(1))
+                if pr_num not in discovered:
+                    discovered[pr_num] = {
+                        "id": f"PR{pr_num}", "num": pr_num, "description": f"PR {pr_num}",
+                        "gate_trigger": f"gate_pr{pr_num}_unknown", "receipt_done": False,
+                    }
+
+        return discovered
+
+    def _determine_pr_statuses(self, discovered: dict, tracks: dict) -> dict:
+        """Determine status for all discovered PRs.
+
+        Priority:
+        1. Live track gate match (working → in_progress, idle → done)
+        2. Receipt history completion → done
+        3. Dependency inference (if higher PR active, lower numbered deps are done)
+        4. Default → pending
+        """
+        status_map = {}
+
+        # First pass: track data + receipt signals
+        for pr_num, pr_info in discovered.items():
+            pr_id = pr_info["id"]
+            gate = pr_info["gate_trigger"]
+            status_map[pr_id] = "pending"
+
+            # Check live track data (highest priority)
+            for track_id, track_data in tracks.items():
+                current_gate = track_data.get("current_gate", "")
+                track_status = track_data.get("status", "")
+
+                if current_gate == gate:
+                    if track_status in ("working", "active"):
+                        status_map[pr_id] = "in_progress"
+                    elif track_status == "idle":
+                        status_map[pr_id] = "done"
+                    break
+
+            # Fallback: receipt history
+            if status_map[pr_id] == "pending" and pr_info.get("receipt_done"):
+                status_map[pr_id] = "done"
+
+        # Second pass: sequential inference
+        sorted_nums = sorted(discovered.keys())
+        for pr_num in sorted_nums:
+            pr_id = discovered[pr_num]["id"]
+            if status_map[pr_id] in ("in_progress", "done"):
+                gate = discovered[pr_num]["gate_trigger"]
+                pr_track = None
+                for track_id, track_data in tracks.items():
+                    if track_data.get("current_gate", "") == gate:
+                        pr_track = track_id
+                        break
+
+                for lower_num in sorted_nums:
+                    if lower_num >= pr_num:
+                        break
+                    lower_id = discovered[lower_num]["id"]
+                    lower_gate = discovered[lower_num]["gate_trigger"]
+
+                    if pr_track:
+                        if status_map[lower_id] == "pending":
+                            lower_gate_match = self._PR_GATE_RE.match(lower_gate)
+                            current_gate_match = self._PR_GATE_RE.match(gate)
+                            if lower_gate_match and current_gate_match:
+                                status_map[lower_id] = "done"
+
+        return status_map
+
+    @staticmethod
+    def _merge_pr_registry(discovered: dict, registry: dict) -> None:
+        """Merge persisted PR registry into discovered dict (enriches, never removes)."""
+        for num_str, pr_info in registry.items():
+            pr_num = int(num_str)
+            if pr_num not in discovered:
+                discovered[pr_num] = pr_info
+            else:
+                if discovered[pr_num]["description"] == f"PR {pr_num}":
+                    discovered[pr_num]["description"] = pr_info.get("description", discovered[pr_num]["description"])
+                if pr_info.get("receipt_done"):
+                    discovered[pr_num]["receipt_done"] = True
+
+    @staticmethod
+    def _build_pr_list(discovered: dict, status_map: dict) -> List[dict]:
+        """Build sorted PR list with dependencies and blocked status."""
+        all_prs = []
+        sorted_nums = sorted(discovered.keys())
+        for pr_num in sorted_nums:
+            pr_info = discovered[pr_num]
+            pr_id = pr_info["id"]
+            status = status_map.get(pr_id, "pending")
+            deps = []
+            if pr_num > 1:
+                prev_num = None
+                for n in sorted_nums:
+                    if n < pr_num:
+                        prev_num = n
+                    else:
+                        break
+                if prev_num is not None and prev_num in discovered:
+                    deps = [discovered[prev_num]["id"]]
+            blocked = status == "pending" and deps and any(status_map.get(d) != "done" for d in deps)
+            all_prs.append({
+                "id": pr_id, "description": pr_info["description"],
+                "status": status, "deps": deps, "blocked": blocked,
+            })
+        return all_prs
+
+    def build_pr_queue(self, brief: dict, existing_dashboard: dict) -> dict:
+        """Build PR queue from auto-discovered data with persistence.
+
+        Merges newly discovered PRs with previously persisted registry so
+        PRs that were on a track gate in the past are not lost when the
+        track moves forward.
+        """
+        tracks = brief.get("tracks", {})
+        discovered = self._auto_discover_prs(brief)
+        self._merge_pr_registry(discovered, existing_dashboard.get("_pr_registry", {}))
+
+        if not discovered:
+            return {
+                "active_feature": "Active Development", "total_prs": 0,
+                "completed_prs": 0, "progress_percent": 0, "prs": [], "_pr_registry": {},
+            }
+
+        status_map = self._determine_pr_statuses(discovered, tracks)
+        all_prs = self._build_pr_list(discovered, status_map)
+        completed_count = sum(1 for pr in all_prs if pr["status"] == "done")
+        total_count = len(all_prs)
+
+        return {
+            "active_feature": "Active Development", "total_prs": total_count,
+            "completed_prs": completed_count,
+            "progress_percent": int((completed_count / total_count * 100)) if total_count > 0 else 0,
+            "prs": all_prs,
+            "_pr_registry": {str(k): v for k, v in discovered.items()},
+        }


### PR DESCRIPTION
## Summary

- Extract `pr_discovery.py` (265L), `intelligence_dashboard.py` (169L), `intelligence_hygiene.py` (249L) from `intelligence_daemon.py`
- Daemon reduced from 1116 → 499 lines (under 800-line threshold)
- Pure refactor — no behavior change, same methods, same output
- Resolves OI-952 and OI-956

## Test plan

- [ ] Codex gate passes
- [ ] Gemini review passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)