### PR TITLE
fix(hooks): resolve stop hook path via git rev-parse for terminal subdirectories

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/stop_report_hook.sh"
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel)/scripts/hooks/stop_report_hook.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Stop hook failed with "No such file or directory" on all interactive terminals (T0-T3) because the hook command used a relative path. Terminals run from `.claude/terminals/T{N}/`, not project root.

**Fix**: Use `git rev-parse --show-toplevel` to resolve project root from any subdirectory.

## Test plan

- [ ] Codex gate
- [ ] Gemini review  
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)