### PR TITLE
fix(heartbeat-monitor): skip subprocess-adapter terminals + activate haiku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - **fix-2**: Stop hook uses `git rev-parse --show-toplevel` for PROJECT_ROOT — eliminates symlink confusion causing assembler not to be invoked; activate F37 with `VNX_AUTO_REPORT=1` default in `vnx_paths.sh`
+- **fix-3**: Heartbeat monitor skips subprocess-adapter terminals (`VNX_ADAPTER_T*=subprocess`) to prevent ghost `task_started` events and phantom leases; activate haiku classifier with `VNX_HAIKU_CLASSIFY=1` in `vnx_paths.sh`
 
 ### Features
 - **F37 PR-5**: Receipt processor integration and end-to-end tests — 39 tests covering auto-generated report validation, tag flow integrity, manual report backward compatibility, subprocess trigger path, and end-to-end fixture through `ReportParser`

--- a/scripts/heartbeat_ack_monitor.py
+++ b/scripts/heartbeat_ack_monitor.py
@@ -201,6 +201,16 @@ class HeartbeatACKMonitor:
         thread.start()
         self.polling_threads[dispatch_id] = thread
 
+    def _is_subprocess_terminal(self, terminal: str) -> bool:
+        """Check if terminal uses subprocess adapter (not tmux).
+
+        VNX_ADAPTER_T1=subprocess skips tmux-based monitoring because the
+        subprocess adapter has its own event pipeline and any tmux pane
+        activity reflects the subprocess launcher, not the actual worker.
+        """
+        env_key = f"VNX_ADAPTER_{terminal}"
+        return os.environ.get(env_key, "tmux").lower() == "subprocess"
+
     def _monitor_dispatch(self, dispatch_id: str):
         """Dedicated monitoring thread for a specific dispatch"""
 
@@ -209,6 +219,10 @@ class HeartbeatACKMonitor:
             return
 
         terminal = dispatch_info['terminal']
+
+        if self._is_subprocess_terminal(terminal):
+            logger.debug(f"[MONITOR] Skipping subprocess-adapter terminal {terminal} for {dispatch_id}")
+            return
         sent_time = dispatch_info['sent_time']
         timeout_time = dispatch_info['timeout_time']
 
@@ -454,6 +468,10 @@ class HeartbeatACKMonitor:
 
     def _check_terminal_activity(self, terminal: str, after_time: datetime) -> Optional[Dict]:
         """Check for terminal process activity via tmux"""
+
+        if self._is_subprocess_terminal(terminal):
+            logger.debug(f"Skipping subprocess-adapter terminal {terminal}")
+            return None
 
         try:
             # Get pane info from tmux

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -147,6 +147,9 @@ export VNX_INTELLIGENCE_DIR="${VNX_INTELLIGENCE_DIR:-$VNX_CANONICAL_ROOT/.vnx-in
 # F37: Auto-Report Pipeline — generates extraction + classification on session stop
 export VNX_AUTO_REPORT="${VNX_AUTO_REPORT:-1}"
 
+# F37: Haiku semantic classifier — enriches auto-reports with LLM classification
+export VNX_HAIKU_CLASSIFY="${VNX_HAIKU_CLASSIFY:-1}"
+
 # ── Worktree PROJECT_ROOT override ──────────────────────────────
 # When CWD is a git worktree of the same project, override PROJECT_ROOT
 # and re-derive all data paths so each worktree gets its own session.


### PR DESCRIPTION
## Summary
- Add `_is_subprocess_terminal()` method to `HeartbeatACKMonitor` — detects terminals configured with `VNX_ADAPTER_T*=subprocess`
- Guard `_monitor_dispatch()` with early return for subprocess terminals — prevents ghost `task_started` events and phantom leases in `runtime_coordination.db`
- Guard `_check_terminal_activity()` with same check (belt-and-suspenders) — tmux pane activity for subprocess launchers is not meaningful
- Add `VNX_HAIKU_CLASSIFY=1` default to `vnx_paths.sh` — activates F37 haiku semantic classifier

## Test plan
- [x] Python AST validation: `heartbeat_ack_monitor.py` parses cleanly
- [x] `bash -n` syntax: `vnx_paths.sh` OK
- [x] Subprocess detection: `VNX_ADAPTER_T1=subprocess` → T1 skipped, T2 not skipped
- [x] `source vnx_paths.sh && echo $VNX_HAIKU_CLASSIFY` → `1`

## Dispatch
Dispatch-ID: 20260408-203000-daemon-compat-haiku-B | PR: fix-3 | Gate: gate_fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)