### PR TITLE
feat(dashboard): F38 unified dashboard — reports browser, agent selector, domain tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ receipts/
 queue/
 reports/
 !demo/dry-run/evidence/reports/
+!dashboard/token-dashboard/app/operator/reports/
 orchestration/
 
 # Database runtime files (generated locally by init scripts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.7.x — F38 Dashboard Unified (2026-04-10)
+
+### Features
+- **F38 PR-2**: Dashboard frontend — session history browser (`/operator/reports`), agent selector component, domain filter tabs (Coding/Analytics), Reports sidebar nav link, SWR hooks and types for reports and agents
+
 ## v0.6.x — F37 Auto-Report Pipeline (2026-04-08)
 
 ### Fixes

--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -950,3 +950,203 @@ def _operator_get_governance_digest(digest_path: Path | None = None) -> dict:
         "degraded_reasons": degraded_reasons,
         "data": data or {},
     }
+
+
+# ---------- Session History / Reports API ----------
+
+# Filename pattern: YYYYMMDD-HHMMSS-{TRACK}-{slug}.md
+# Track-to-terminal mapping (inverse of TERMINAL_TRACK_MAP)
+_TRACK_TO_TERMINAL = {v: k for k, v in TERMINAL_TRACK_MAP.items()}
+# HEADLESS track maps to T0
+_TRACK_TO_TERMINAL["HEADLESS"] = "T0"
+
+
+def _parse_report_filename(filename: str) -> dict:
+    """Parse metadata from a unified report filename."""
+    stem = filename
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    parts = stem.split("-", 3)
+    result: dict = {
+        "filename": filename,
+        "timestamp": None,
+        "track": None,
+        "terminal": None,
+        "slug": None,
+    }
+    if len(parts) >= 3:
+        date_part = parts[0]   # YYYYMMDD
+        time_part = parts[1]   # HHMMSS
+        track_part = parts[2]  # track or "HEADLESS"
+        slug_part = parts[3] if len(parts) > 3 else ""
+
+        result["track"] = track_part
+        result["terminal"] = _TRACK_TO_TERMINAL.get(track_part)
+        result["slug"] = slug_part
+
+        try:
+            dt = datetime.strptime(f"{date_part}{time_part}", "%Y%m%d%H%M%S")
+            result["timestamp"] = dt.replace(tzinfo=timezone.utc).isoformat()
+        except ValueError:
+            pass
+
+    return result
+
+
+def _parse_report_metadata(path: Path) -> dict:
+    """Read first 20 lines of a report file to extract embedded metadata."""
+    meta: dict = {
+        "dispatch_id": None,
+        "pr_id": None,
+        "status": None,
+        "gate": None,
+        "title": None,
+        "auto_generated": False,
+    }
+    try:
+        lines = []
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= 20:
+                    break
+                lines.append(line.rstrip())
+
+        for line in lines:
+            if line.startswith("# "):
+                meta["title"] = line[2:].strip()
+            elif line.startswith("**Dispatch ID**:"):
+                meta["dispatch_id"] = line.split(":", 1)[1].strip()
+            elif line.startswith("**PR**:"):
+                meta["pr_id"] = line.split(":", 1)[1].strip()
+            elif line.startswith("**Status**:"):
+                meta["status"] = line.split(":", 1)[1].strip()
+            elif line.startswith("**Gate**:"):
+                meta["gate"] = line.split(":", 1)[1].strip()
+
+        # Auto-generated reports typically have dispatch_id embedded
+        meta["auto_generated"] = meta["dispatch_id"] is not None
+
+    except OSError:
+        pass
+
+    return meta
+
+
+def _operator_get_reports(params: dict[str, list[str]]) -> dict:
+    """GET /api/operator/reports?limit=50&offset=0&terminal=T1&track=A"""
+    reports_dir = _VNX_DATA_DIR / "unified_reports"
+
+    limit = int((params.get("limit") or ["50"])[0])
+    offset = int((params.get("offset") or ["0"])[0])
+    terminal_filter = (params.get("terminal") or [None])[0]
+    track_filter = (params.get("track") or [None])[0]
+
+    if not reports_dir.exists():
+        return {"reports": [], "total": 0, "limit": limit, "offset": offset}
+
+    # Collect all .md files sorted by mtime descending
+    all_files = sorted(
+        reports_dir.glob("*.md"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    # Build report objects with parsed metadata
+    reports = []
+    for path in all_files:
+        parsed = _parse_report_filename(path.name)
+        meta = _parse_report_metadata(path)
+
+        # Apply filters before slicing
+        if terminal_filter and parsed.get("terminal") != terminal_filter:
+            continue
+        if track_filter and parsed.get("track") != track_filter:
+            continue
+
+        report = {**parsed, **meta}
+        reports.append(report)
+
+    total = len(reports)
+    page = reports[offset: offset + limit]
+
+    return {"reports": page, "total": total, "limit": limit, "offset": offset}
+
+
+def _operator_get_report_content(filename: str) -> dict | None:
+    """Return full markdown content for a specific report file, or None if not found."""
+    # Sanitise: only allow plain filenames (no path traversal)
+    safe_name = Path(filename).name
+    if safe_name != filename:
+        return None
+
+    reports_dir = _VNX_DATA_DIR / "unified_reports"
+    path = reports_dir / safe_name
+
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+        return {
+            "filename": safe_name,
+            "content": content,
+            "size_bytes": path.stat().st_size,
+        }
+    except OSError:
+        return None
+
+
+# ---------- Agent Name Mapping API ----------
+
+_TERMINAL_AGENT_DEFAULTS = {
+    "T0": {"name": "Orchestrator", "role": "t0-orchestrator", "track": None},
+    "T1": {"name": "Backend Developer", "role": "backend-developer", "track": "A"},
+    "T2": {"name": "Test Engineer", "role": "test-engineer", "track": "B"},
+    "T3": {"name": "Architect", "role": "architect", "track": "C"},
+}
+
+
+def _operator_get_agents() -> dict:
+    """GET /api/operator/agents — terminal ID to agent name/role mapping."""
+    agents = []
+
+    for terminal_id in ("T0", "T1", "T2", "T3"):
+        defaults = _TERMINAL_AGENT_DEFAULTS[terminal_id]
+
+        # Resolve adapter from environment (VNX_ADAPTER_T1, etc.)
+        adapter_env_key = f"VNX_ADAPTER_{terminal_id}"
+        adapter = os.environ.get(adapter_env_key, "tmux")
+
+        # Attempt to infer actual role from the most recent active dispatch for this terminal
+        role = defaults["role"]
+        name = defaults["name"]
+
+        active_dispatch_dir = DISPATCHES_DIR / "active"
+        if active_dispatch_dir.exists():
+            for dispatch_file in sorted(
+                active_dispatch_dir.glob("*.md"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            ):
+                try:
+                    text = dispatch_file.read_text(encoding="utf-8", errors="replace")
+                    header = _parse_dispatch_header(text)
+                    if header.get("terminal") == terminal_id:
+                        if header.get("role"):
+                            role = header["role"]
+                            # Convert role slug to display name
+                            name = role.replace("-", " ").title()
+                        break
+                except Exception:
+                    pass
+
+        entry: dict = {
+            "terminal": terminal_id,
+            "name": name,
+            "role": role,
+            "track": defaults["track"],
+            "adapter": adapter,
+        }
+        agents.append(entry)
+
+    return {"agents": agents}

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -119,12 +119,15 @@ from api_token_stats import (  # noqa: E402
 from api_operator import (  # noqa: E402
     _api_health,
     _jump_terminal,
+    _operator_get_agents,
     _operator_get_gate_config,
     _operator_get_governance_digest,
     _operator_get_kanban,
     _operator_get_open_items,
     _operator_get_open_items_aggregate,
     _operator_get_projects,
+    _operator_get_report_content,
+    _operator_get_reports,
     _operator_get_session,
     _operator_get_system_health,
     _operator_get_terminal,
@@ -255,6 +258,23 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/system-health":
             _json_response(self, HTTPStatus.OK, _operator_get_system_health())
+            return
+
+        if path == "/api/operator/reports":
+            _json_response(self, HTTPStatus.OK, _operator_get_reports(params))
+            return
+
+        if path.startswith("/api/operator/reports/"):
+            filename = path[len("/api/operator/reports/"):]
+            result = _operator_get_report_content(filename)
+            if result is None:
+                _json_response(self, HTTPStatus.NOT_FOUND, {"error": "not_found", "filename": filename})
+            else:
+                _json_response(self, HTTPStatus.OK, result)
+            return
+
+        if path == "/api/operator/agents":
+            _json_response(self, HTTPStatus.OK, _operator_get_agents())
             return
 
         # Agent stream SSE endpoints

--- a/dashboard/token-dashboard/app/operator/reports/page.tsx
+++ b/dashboard/token-dashboard/app/operator/reports/page.tsx
@@ -1,0 +1,458 @@
+'use client';
+
+import { useState } from 'react';
+import { RefreshCw, ChevronDown, ChevronRight, FileText } from 'lucide-react';
+import { useReports, useReportContent, useProjects } from '@/lib/hooks';
+import AgentSelector from '@/components/operator/agent-selector';
+import FreshnessBadge from '@/components/operator/freshness-badge';
+import type { Report } from '@/lib/types';
+
+const TRACK_COLORS: Record<string, { color: string; bg: string; border: string }> = {
+  A: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
+  B: { color: '#facc15', bg: 'rgba(250, 204, 21, 0.1)', border: 'rgba(250, 204, 21, 0.3)' },
+  C: { color: '#9B6BE6', bg: 'rgba(155, 107, 230, 0.1)', border: 'rgba(155, 107, 230, 0.3)' },
+};
+
+const STATUS_COLORS: Record<string, { color: string; bg: string; border: string }> = {
+  success: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.08)', border: 'rgba(80, 250, 123, 0.25)' },
+  failure: { color: '#ff6b6b', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
+  failed:  { color: '#ff6b6b', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
+};
+
+function TrackBadge({ track }: { track: string }) {
+  const cfg = TRACK_COLORS[track.toUpperCase()] ?? { color: '#6B6B6B', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        padding: '2px 7px',
+        borderRadius: 6,
+        background: cfg.bg,
+        border: `1px solid ${cfg.border}`,
+        color: cfg.color,
+        letterSpacing: '0.04em',
+      }}
+    >
+      {track.toUpperCase()}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cfg = STATUS_COLORS[status.toLowerCase()] ?? { color: 'var(--color-muted)', bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.1)' };
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        fontWeight: 600,
+        padding: '2px 8px',
+        borderRadius: 6,
+        background: cfg.bg,
+        border: `1px solid ${cfg.border}`,
+        color: cfg.color,
+        textTransform: 'capitalize',
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function formatTimestamp(ts: string): string {
+  if (!ts) return '—';
+  try {
+    const d = new Date(ts.replace(/^(\d{8})-(\d{6})$/, '$1T$2'));
+    if (isNaN(d.getTime())) {
+      // Try yyyyMMdd-HHmmss format (e.g. 20260410-082231)
+      const m = ts.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+      if (m) {
+        const d2 = new Date(`${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}`);
+        return d2.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+      }
+      return ts;
+    }
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return ts;
+  }
+}
+
+function LoadingSkeleton() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {[0, 1, 2, 3].map(i => (
+        <div
+          key={i}
+          aria-hidden="true"
+          style={{
+            height: 56,
+            borderRadius: 10,
+            background: 'linear-gradient(90deg, rgba(255,255,255,0.04) 25%, rgba(255,255,255,0.07) 50%, rgba(255,255,255,0.04) 75%)',
+            backgroundSize: '200% 100%',
+            animation: 'shimmer 1.6s infinite',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ReportContentPanel({ filename }: { filename: string }) {
+  const { data: content, isLoading, error } = useReportContent(filename);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: '16px 20px', color: 'var(--color-muted)', fontSize: 12 }}>
+        Loading…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div style={{ padding: '16px 20px', color: 'var(--color-error)', fontSize: 12 }}>
+        Failed to load report content.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        borderTop: '1px solid rgba(255,255,255,0.06)',
+        padding: '16px 20px',
+        overflowX: 'auto',
+      }}
+    >
+      <pre
+        style={{
+          margin: 0,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 12,
+          lineHeight: 1.6,
+          color: 'var(--color-foreground)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {content}
+      </pre>
+    </div>
+  );
+}
+
+function ReportRow({ report }: { report: Report }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div
+      style={{
+        borderRadius: 10,
+        background: expanded ? 'rgba(249, 115, 22, 0.04)' : 'rgba(255,255,255,0.02)',
+        border: `1px solid ${expanded ? 'rgba(249, 115, 22, 0.2)' : 'rgba(255,255,255,0.07)'}`,
+        overflow: 'hidden',
+        transition: 'border-color 0.15s',
+      }}
+    >
+      {/* Row header */}
+      <button
+        onClick={() => setExpanded(v => !v)}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 16px',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+      >
+        {/* Expand chevron */}
+        <div style={{ color: 'var(--color-muted)', flexShrink: 0 }}>
+          {expanded
+            ? <ChevronDown size={14} />
+            : <ChevronRight size={14} />
+          }
+        </div>
+
+        {/* Timestamp */}
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--color-muted)',
+            whiteSpace: 'nowrap',
+            width: 120,
+            flexShrink: 0,
+          }}
+        >
+          {formatTimestamp(report.timestamp)}
+        </span>
+
+        {/* Track badge */}
+        <TrackBadge track={report.track} />
+
+        {/* Terminal */}
+        <span
+          style={{
+            fontSize: 11,
+            color: 'rgba(244,244,249,0.6)',
+            width: 40,
+            flexShrink: 0,
+          }}
+        >
+          {report.terminal}
+        </span>
+
+        {/* Dispatch ID */}
+        <span
+          style={{
+            fontSize: 10,
+            color: 'var(--color-muted)',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: 200,
+            flexShrink: 1,
+          }}
+          title={report.dispatch_id}
+        >
+          {report.dispatch_id || '—'}
+        </span>
+
+        {/* Status badge */}
+        <StatusBadge status={report.status} />
+
+        {/* Title */}
+        <span
+          style={{
+            fontSize: 12,
+            color: 'var(--color-foreground)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            flex: 1,
+            minWidth: 0,
+          }}
+          title={report.title}
+        >
+          {report.title || report.filename}
+        </span>
+      </button>
+
+      {/* Expanded markdown content */}
+      {expanded && <ReportContentPanel filename={report.filename} />}
+    </div>
+  );
+}
+
+const PAGE_SIZE = 50;
+
+export default function ReportsPage() {
+  const [terminalFilter, setTerminalFilter] = useState<string | undefined>(undefined);
+  const [trackFilter, setTrackFilter] = useState<string>('');
+  const [offset, setOffset] = useState(0);
+
+  const { data: reportsEnv, isLoading, mutate } = useReports({
+    limit: PAGE_SIZE,
+    offset,
+    terminal: terminalFilter,
+    track: trackFilter || undefined,
+  });
+
+  // Get projects for the freshness display
+  const reports: Report[] = reportsEnv?.reports ?? [];
+  const total = reportsEnv?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  function handleTerminalSelect(terminal: string | undefined) {
+    setTerminalFilter(terminal);
+    setOffset(0);
+  }
+
+  function handleTrackFilter(track: string) {
+    setTrackFilter(track);
+    setOffset(0);
+  }
+
+  return (
+    <div>
+      {/* Page header */}
+      <div className="flex items-center justify-between" style={{ marginBottom: 24 }}>
+        <div className="flex items-center gap-3">
+          <div
+            style={{
+              width: 4,
+              height: 28,
+              borderRadius: 2,
+              background: 'var(--color-accent)',
+            }}
+          />
+          <div>
+            <h2
+              style={{
+                fontSize: '1.5rem',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                color: 'var(--color-foreground)',
+              }}
+            >
+              Session History
+            </h2>
+            <p style={{ fontSize: 12, color: 'var(--color-muted)', marginTop: 2 }}>
+              Worker reports and dispatch receipts
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {total > 0 && (
+            <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+              {total} report{total !== 1 ? 's' : ''}
+            </span>
+          )}
+          <button
+            onClick={() => mutate()}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '7px 14px',
+              borderRadius: 8,
+              background: 'rgba(255,255,255,0.05)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              cursor: 'pointer',
+              fontSize: 12,
+              color: 'var(--color-muted)',
+            }}
+          >
+            <RefreshCw size={13} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Filter row */}
+      <div
+        className="glass-card"
+        style={{ padding: '16px 20px', marginBottom: 20 }}
+      >
+        {/* Agent selector */}
+        <div style={{ marginBottom: 16 }}>
+          <AgentSelector
+            selectedTerminal={terminalFilter}
+            onSelect={handleTerminalSelect}
+          />
+        </div>
+
+        {/* Track filter */}
+        <div className="flex items-center gap-3">
+          <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>Track:</span>
+          {['', 'A', 'B', 'C'].map(t => (
+            <button
+              key={t || 'all'}
+              onClick={() => handleTrackFilter(t)}
+              style={{
+                padding: '4px 12px',
+                borderRadius: 8,
+                fontSize: 11,
+                fontWeight: trackFilter === t ? 700 : 400,
+                background: trackFilter === t
+                  ? (t ? (TRACK_COLORS[t]?.bg ?? 'rgba(249,115,22,0.1)') : 'rgba(249,115,22,0.1)')
+                  : 'rgba(255,255,255,0.03)',
+                border: `1px solid ${trackFilter === t
+                  ? (t ? (TRACK_COLORS[t]?.border ?? 'rgba(249,115,22,0.4)') : 'rgba(249,115,22,0.4)')
+                  : 'rgba(255,255,255,0.08)'}`,
+                color: trackFilter === t
+                  ? (t ? (TRACK_COLORS[t]?.color ?? 'var(--color-accent)') : 'var(--color-accent)')
+                  : 'var(--color-muted)',
+                cursor: 'pointer',
+              }}
+            >
+              {t || 'All'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Reports list */}
+      <div className="glass-card" style={{ padding: '16px 20px' }}>
+        {isLoading ? (
+          <LoadingSkeleton />
+        ) : reports.length === 0 ? (
+          <div
+            className="flex items-center gap-3"
+            style={{
+              padding: '32px 16px',
+              justifyContent: 'center',
+              color: 'var(--color-muted)',
+            }}
+          >
+            <FileText size={20} strokeWidth={1.5} />
+            <span style={{ fontSize: 14 }}>
+              No reports found
+              {(terminalFilter || trackFilter) && ' for the selected filters'}
+            </span>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {reports.map(r => (
+              <ReportRow key={r.filename} report={r} />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div
+            className="flex items-center gap-3"
+            style={{
+              marginTop: 16,
+              paddingTop: 16,
+              borderTop: '1px solid rgba(255,255,255,0.06)',
+              justifyContent: 'center',
+            }}
+          >
+            <button
+              disabled={offset === 0}
+              onClick={() => setOffset(o => Math.max(0, o - PAGE_SIZE))}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 8,
+                fontSize: 12,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                color: offset === 0 ? 'rgba(244,244,249,0.3)' : 'var(--color-muted)',
+                cursor: offset === 0 ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Previous
+            </button>
+            <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={() => setOffset(o => o + PAGE_SIZE)}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 8,
+                fontSize: 12,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                color: offset + PAGE_SIZE >= total ? 'rgba(244,244,249,0.3)' : 'var(--color-muted)',
+                cursor: offset + PAGE_SIZE >= total ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/operator/agent-selector.tsx
+++ b/dashboard/token-dashboard/components/operator/agent-selector.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useAgents } from '@/lib/hooks';
+import type { Agent } from '@/lib/types';
+
+const ADAPTER_COLORS: Record<string, { color: string; bg: string; border: string }> = {
+  subprocess: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
+  tmux:       { color: '#6B8AE6', bg: 'rgba(107, 138, 230, 0.1)', border: 'rgba(107, 138, 230, 0.3)' },
+};
+
+const TERMINAL_COLORS: Record<string, string> = {
+  T0: '#6B8AE6',
+  T1: '#50fa7b',
+  T2: '#facc15',
+  T3: '#9B6BE6',
+};
+
+interface AgentSelectorProps {
+  selectedTerminal?: string;
+  onSelect: (terminal: string | undefined) => void;
+  /** Compact inline variant, default: false */
+  compact?: boolean;
+}
+
+function AgentPill({ agent, isSelected, onClick }: {
+  agent: Agent;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const termColor = TERMINAL_COLORS[agent.terminal] ?? '#6B6B6B';
+  const adapterCfg = ADAPTER_COLORS[agent.adapter] ?? ADAPTER_COLORS.tmux;
+
+  return (
+    <button
+      onClick={onClick}
+      title={`${agent.terminal} — ${agent.role} (${agent.adapter})`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '7px 12px',
+        borderRadius: 10,
+        background: isSelected ? 'rgba(249, 115, 22, 0.1)' : 'rgba(255,255,255,0.03)',
+        border: `1px solid ${isSelected ? 'rgba(249, 115, 22, 0.4)' : 'rgba(255,255,255,0.08)'}`,
+        cursor: 'pointer',
+        transition: 'all 0.15s',
+        textAlign: 'left',
+      }}
+    >
+      {/* Terminal color dot */}
+      <div
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: termColor,
+          flexShrink: 0,
+          boxShadow: isSelected ? `0 0 6px ${termColor}80` : 'none',
+        }}
+      />
+
+      {/* Name + terminal ID */}
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: isSelected ? 600 : 400,
+            color: isSelected ? 'var(--color-accent)' : 'var(--color-foreground)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            maxWidth: 120,
+          }}
+        >
+          {agent.name || agent.terminal}
+        </div>
+        <div style={{ fontSize: 10, color: 'var(--color-muted)', marginTop: 1 }}>
+          {agent.terminal}
+        </div>
+      </div>
+
+      {/* Adapter badge */}
+      <div
+        style={{
+          fontSize: 9,
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+          padding: '2px 6px',
+          borderRadius: 6,
+          background: adapterCfg.bg,
+          border: `1px solid ${adapterCfg.border}`,
+          color: adapterCfg.color,
+          marginLeft: 'auto',
+          flexShrink: 0,
+        }}
+      >
+        {agent.adapter}
+      </div>
+    </button>
+  );
+}
+
+export default function AgentSelector({ selectedTerminal, onSelect, compact = false }: AgentSelectorProps) {
+  const { data, isLoading } = useAgents();
+  const agents: Agent[] = data?.agents ?? [];
+
+  if (isLoading) {
+    return (
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {[0, 1, 2].map(i => (
+          <div
+            key={i}
+            style={{
+              width: 120,
+              height: 48,
+              borderRadius: 10,
+              background: 'rgba(255,255,255,0.04)',
+              border: '1px solid rgba(255,255,255,0.06)',
+              animation: 'shimmer 1.6s infinite',
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (agents.length === 0) return null;
+
+  return (
+    <div>
+      {!compact && (
+        <div style={{ fontSize: 11, color: 'var(--color-muted)', marginBottom: 8 }}>Agent</div>
+      )}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+        {/* All agents option */}
+        <button
+          onClick={() => onSelect(undefined)}
+          style={{
+            padding: '7px 12px',
+            borderRadius: 10,
+            fontSize: 12,
+            fontWeight: !selectedTerminal ? 600 : 400,
+            background: !selectedTerminal ? 'rgba(249, 115, 22, 0.1)' : 'rgba(255,255,255,0.03)',
+            border: `1px solid ${!selectedTerminal ? 'rgba(249, 115, 22, 0.4)' : 'rgba(255,255,255,0.08)'}`,
+            color: !selectedTerminal ? 'var(--color-accent)' : 'var(--color-muted)',
+            cursor: 'pointer',
+          }}
+        >
+          All
+        </button>
+
+        {agents.map(agent => (
+          <AgentPill
+            key={agent.terminal}
+            agent={agent}
+            isSelected={selectedTerminal === agent.terminal}
+            onClick={() => onSelect(selectedTerminal === agent.terminal ? undefined : agent.terminal)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -3,15 +3,17 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText } from 'lucide-react';
 
-const DOMAINS = ['All', 'Coding', 'Content', 'Marketing', 'Research'] as const;
+const DOMAINS = ['All', 'Coding', 'Analytics'] as const;
+type Domain = typeof DOMAINS[number];
 
 const OPERATOR_NAV = [
   { href: '/operator', label: 'Control Surface', icon: Radio },
   { href: '/operator/open-items', label: 'Open Items', icon: AlertTriangle },
   { href: '/operator/kanban', label: 'Kanban Board', icon: Kanban },
   { href: '/operator/governance', label: 'Governance', icon: ShieldAlert },
+  { href: '/operator/reports', label: 'Reports', icon: FileText },
   { href: '/agent-stream', label: 'Agent Stream', icon: Activity },
 ];
 
@@ -24,11 +26,19 @@ const NAV_ITEMS = [
   { href: '/usage', label: 'Usage & Costs', icon: DollarSign },
 ];
 
+function showOperator(domain: Domain | undefined): boolean {
+  return !domain || domain === 'All' || domain === 'Coding';
+}
+
+function showAnalytics(domain: Domain | undefined): boolean {
+  return !domain || domain === 'All' || domain === 'Analytics';
+}
+
 export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const activeDomain = searchParams.get('domain') ?? undefined;
+  const activeDomain = (searchParams.get('domain') ?? undefined) as Domain | undefined;
 
   function setDomain(domain: string | undefined) {
     const params = new URLSearchParams(searchParams.toString());
@@ -95,7 +105,7 @@ export default function Sidebar() {
           }}
         >
           {DOMAINS.map((d) => {
-            const value = d === 'All' ? undefined : d.toLowerCase();
+            const value = d === 'All' ? undefined : d;
             const isActive = activeDomain === value;
             return (
               <button
@@ -123,111 +133,119 @@ export default function Sidebar() {
         <div style={{ height: 1, background: 'rgba(255,255,255,0.05)', margin: '0 14px 8px' }} />
 
         {/* Operator section */}
-        <div style={{ marginBottom: 4, marginTop: 2 }}>
-          <p
-            style={{
-              fontSize: 10,
-              fontWeight: 700,
-              letterSpacing: '0.08em',
-              color: 'rgba(249, 115, 22, 0.7)',
-              textTransform: 'uppercase',
-              padding: '4px 14px 6px',
-            }}
-          >
-            Operator
-          </p>
-          {OPERATOR_NAV.map(({ href, label, icon: Icon }) => {
-            const isActive = pathname === href;
-            return (
-              <Link
-                key={href}
-                href={href}
-                className="flex items-center gap-3 text-sm transition-all"
-                style={{
-                  padding: '10px 14px',
-                  borderRadius: 10,
-                  backgroundColor: isActive ? 'rgba(249, 115, 22, 0.1)' : 'transparent',
-                  color: isActive ? 'var(--color-accent)' : 'var(--color-muted)',
-                  fontWeight: isActive ? 600 : 400,
-                  position: 'relative',
-                  textDecoration: 'none',
-                }}
-              >
-                {isActive && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      left: 0,
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      width: 3,
-                      height: 20,
-                      borderRadius: '0 3px 3px 0',
-                      background: 'linear-gradient(180deg, #f97316, #fb923c)',
-                      boxShadow: '0 0 8px rgba(249, 115, 22, 0.4)',
-                    }}
-                  />
-                )}
-                <Icon size={18} strokeWidth={isActive ? 2.2 : 1.8} />
-                <span>{label}</span>
-              </Link>
-            );
-          })}
-        </div>
-
-        {/* Divider */}
-        <div style={{ height: 1, background: 'rgba(255,255,255,0.05)', margin: '4px 14px 8px' }} />
-
-        {/* Analytics section */}
-        <p
-          style={{
-            fontSize: 10,
-            fontWeight: 700,
-            letterSpacing: '0.08em',
-            color: 'rgba(244, 244, 249, 0.35)',
-            textTransform: 'uppercase',
-            padding: '4px 14px 6px',
-          }}
-        >
-          Analytics
-        </p>
-        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-          const isActive = pathname === href;
-          return (
-            <Link
-              key={href}
-              href={href}
-              className="flex items-center gap-3 text-sm transition-all"
+        {showOperator(activeDomain) && (
+          <div style={{ marginBottom: 4, marginTop: 2 }}>
+            <p
               style={{
-                padding: '10px 14px',
-                borderRadius: 10,
-                backgroundColor: isActive ? 'rgba(249, 115, 22, 0.1)' : 'transparent',
-                color: isActive ? 'var(--color-accent)' : 'var(--color-muted)',
-                fontWeight: isActive ? 600 : 400,
-                position: 'relative',
-                textDecoration: 'none',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: 'rgba(249, 115, 22, 0.7)',
+                textTransform: 'uppercase',
+                padding: '4px 14px 6px',
               }}
             >
-              {isActive && (
-                <div
+              Operator
+            </p>
+            {OPERATOR_NAV.map(({ href, label, icon: Icon }) => {
+              const isActive = pathname === href;
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className="flex items-center gap-3 text-sm transition-all"
                   style={{
-                    position: 'absolute',
-                    left: 0,
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    width: 3,
-                    height: 20,
-                    borderRadius: '0 3px 3px 0',
-                    background: 'linear-gradient(180deg, #f97316, #fb923c)',
-                    boxShadow: '0 0 8px rgba(249, 115, 22, 0.4)',
+                    padding: '10px 14px',
+                    borderRadius: 10,
+                    backgroundColor: isActive ? 'rgba(249, 115, 22, 0.1)' : 'transparent',
+                    color: isActive ? 'var(--color-accent)' : 'var(--color-muted)',
+                    fontWeight: isActive ? 600 : 400,
+                    position: 'relative',
+                    textDecoration: 'none',
                   }}
-                />
-              )}
-              <Icon size={18} strokeWidth={isActive ? 2.2 : 1.8} />
-              <span>{label}</span>
-            </Link>
-          );
-        })}
+                >
+                  {isActive && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        left: 0,
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        width: 3,
+                        height: 20,
+                        borderRadius: '0 3px 3px 0',
+                        background: 'linear-gradient(180deg, #f97316, #fb923c)',
+                        boxShadow: '0 0 8px rgba(249, 115, 22, 0.4)',
+                      }}
+                    />
+                  )}
+                  <Icon size={18} strokeWidth={isActive ? 2.2 : 1.8} />
+                  <span>{label}</span>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Divider — only when both sections visible */}
+        {showOperator(activeDomain) && showAnalytics(activeDomain) && (
+          <div style={{ height: 1, background: 'rgba(255,255,255,0.05)', margin: '4px 14px 8px' }} />
+        )}
+
+        {/* Analytics section */}
+        {showAnalytics(activeDomain) && (
+          <>
+            <p
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: 'rgba(244, 244, 249, 0.35)',
+                textTransform: 'uppercase',
+                padding: '4px 14px 6px',
+              }}
+            >
+              Analytics
+            </p>
+            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+              const isActive = pathname === href;
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className="flex items-center gap-3 text-sm transition-all"
+                  style={{
+                    padding: '10px 14px',
+                    borderRadius: 10,
+                    backgroundColor: isActive ? 'rgba(249, 115, 22, 0.1)' : 'transparent',
+                    color: isActive ? 'var(--color-accent)' : 'var(--color-muted)',
+                    fontWeight: isActive ? 600 : 400,
+                    position: 'relative',
+                    textDecoration: 'none',
+                  }}
+                >
+                  {isActive && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        left: 0,
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        width: 3,
+                        height: 20,
+                        borderRadius: '0 3px 3px 0',
+                        background: 'linear-gradient(180deg, #f97316, #fb923c)',
+                        boxShadow: '0 0 8px rgba(249, 115, 22, 0.4)',
+                      }}
+                    />
+                  )}
+                  <Icon size={18} strokeWidth={isActive ? 2.2 : 1.8} />
+                  <span>{label}</span>
+                </Link>
+              );
+            })}
+          </>
+        )}
       </nav>
 
       {/* Footer */}

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -9,12 +9,16 @@ import {
   fetchKanban,
   fetchGateConfig,
   fetchGovernanceDigest,
+  fetchReports,
+  fetchReportContent,
+  fetchAgents,
 } from './operator-api';
 import type {
   TokenStats, SessionDetail, GroupBy, SortOrder, ConversationsResponse,
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
   GateConfigResponse, GovernanceDigestEnvelope,
+  ReportsEnvelope, AgentsEnvelope,
 } from './types';
 
 export function useTokenStats(
@@ -139,5 +143,36 @@ export function useGovernanceDigest() {
     'operator-governance-digest',
     fetchGovernanceDigest,
     { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 15000 }
+  );
+}
+
+export function useReports(params?: { limit?: number; offset?: number; terminal?: string; track?: string }) {
+  const key = [
+    'operator-reports',
+    String(params?.limit ?? 50),
+    String(params?.offset ?? 0),
+    params?.terminal ?? '',
+    params?.track ?? '',
+  ];
+  return useSWR<ReportsEnvelope>(
+    key,
+    () => fetchReports(params),
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function useReportContent(filename: string | null) {
+  return useSWR<string>(
+    filename ? ['operator-report-content', filename] : null,
+    () => fetchReportContent(filename!),
+    { revalidateOnFocus: false, dedupingInterval: 60000 }
+  );
+}
+
+export function useAgents() {
+  return useSWR<AgentsEnvelope>(
+    'operator-agents',
+    fetchAgents,
+    { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 20000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -11,6 +11,8 @@ import type {
   GateToggleRequest,
   GateToggleResponse,
   GovernanceDigestEnvelope,
+  ReportsEnvelope,
+  AgentsEnvelope,
 } from './types';
 
 const BASE = '/api/operator';
@@ -109,4 +111,29 @@ export function postGateToggle(req: GateToggleRequest): Promise<GateToggleRespon
 
 export function fetchGovernanceDigest(): Promise<GovernanceDigestEnvelope> {
   return get(`${BASE}/governance-digest`);
+}
+
+export function fetchReports(params?: {
+  limit?: number;
+  offset?: number;
+  terminal?: string;
+  track?: string;
+}): Promise<ReportsEnvelope> {
+  const p: Record<string, string> = {};
+  if (params?.limit !== undefined) p.limit = String(params.limit);
+  if (params?.offset !== undefined) p.offset = String(params.offset);
+  if (params?.terminal) p.terminal = params.terminal;
+  if (params?.track) p.track = params.track;
+  return get(`${BASE}/reports`, Object.keys(p).length ? p : undefined);
+}
+
+export function fetchReportContent(filename: string): Promise<string> {
+  return fetch(`${BASE}/reports/${encodeURIComponent(filename)}`).then(res => {
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.text();
+  });
+}
+
+export function fetchAgents(): Promise<AgentsEnvelope> {
+  return get(`${BASE}/agents`);
 }

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -314,3 +314,38 @@ export interface GovernanceDigestEnvelope {
   degraded_reasons: string[];
   data: GovernanceDigestData;
 }
+
+// ===== Reports & Agents Types =====
+
+export interface Report {
+  filename: string;
+  timestamp: string;
+  track: string;
+  terminal: string;
+  dispatch_id: string;
+  pr_id: string;
+  status: string;
+  title: string;
+  auto_generated: boolean;
+  slug: string;
+}
+
+export interface ReportsEnvelope {
+  reports: Report[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface Agent {
+  terminal: string;
+  name: string;
+  role: string;
+  track: string | null;
+  adapter: string;
+}
+
+export interface AgentsEnvelope {
+  agents: Agent[];
+  total: number;
+}


### PR DESCRIPTION
## Summary
- **3 new API endpoints**: `/api/operator/reports` (paginated list), `/api/operator/reports/<file>` (content), `/api/operator/agents` (name mapping)
- **Reports browser page** (`/operator/reports`): paginated report list with inline markdown expand, track/terminal filters, agent selector
- **Agent selector component**: reusable pill list showing agent names instead of terminal IDs, with role/adapter badges
- **Domain filter tabs** in sidebar: Coding / Analytics / All — filters navigation sections
- **SWR hooks + types** for reports and agents data fetching

## Changes
- `dashboard/api_operator.py` — 3 new handler functions (+200 lines)
- `dashboard/serve_dashboard.py` — route wiring (+20 lines)
- `dashboard/token-dashboard/app/operator/reports/page.tsx` — new page
- `dashboard/token-dashboard/components/operator/agent-selector.tsx` — new component
- `dashboard/token-dashboard/components/sidebar.tsx` — domain filter + reports link
- `dashboard/token-dashboard/lib/hooks.ts` — 3 new SWR hooks
- `dashboard/token-dashboard/lib/types.ts` — Report/Agent interfaces
- `dashboard/token-dashboard/lib/operator-api.ts` — 3 new fetchers

## Test plan
- [x] API endpoints tested with curl (reports: 379 items, agents: 4 terminals)
- [x] No test regressions (38 pre-existing failures, 0 new)
- [x] TypeScript compiles clean (excluding pre-existing test fixture issues)
- [ ] CI green
- [ ] Visual verification on http://localhost:3100/operator/reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)