### PR TITLE
chore(release): v0.8.0 — headless intelligence & governance profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.8.0 — Headless Intelligence & Governance Profiles (2026-04-11)
+
+### Features
+- **F39**: Headless T0 benchmark — decision framework with deterministic pre-filter (Level-1: 100%, Level-2: 73-87%, Level-3: 67-78%), context assembler, replay harness, file-based gate locks (#204)
+- **F41**: Intelligence pipeline activation — governance aggregator backfill (722 metrics, 58 SPC control limits), nightly pipeline scheduling via launchd, quality digest with real SPC data (#206)
+- **F41**: 3-layer headless trigger system — file watcher on unified_reports, silence watchdog (10-min stale lease/dispatch detection), optional haiku LLM triage, 366 LOC (#206)
+- **Headless dispatch writer** — programmatic dispatch creation for autonomous T0 orchestration (#207)
+- **Governance profiles** — config-driven review profiles (default/light/minimal) replacing hardcoded business/coding split, configurable via `.vnx/governance_profiles.yaml` (#207)
+
+### Fixes
+- **Subprocess adapter**: Add `--dangerously-skip-permissions` for headless `claude -p` write/edit capability (#207)
+- **Receipt processor**: Replace 10-minute time cutoff with watermark-based processing; update watermark after sweep, not per-file (#206)
+- **CI**: Replace hardcoded absolute paths in launchd plists with install-time placeholders (#206)
+- **Receipt processor**: Handle `on_moved` events for atomic file delivery (#206)
+
+### Docs
+- README: Add headless workers, multi-provider review gates, and mission control dashboard sections (#208)
+
+### Housekeeping
+- System cleanup: blocker fixes, ~25K LOC dead code removed, doc updates (#205)
+- Unified T0 state builder replacing 8+ startup scripts (#200)
+
 ## v0.7.x — F38 Dashboard Unified (2026-04-10)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ VNX is an open-source governance-first orchestration runtime for AI CLI workflow
 
 **No framework to import. No cloud dependency. Governance, provenance, and operator control built in.**
 
-Current release: `v0.5.0`
+Current release: `v0.8.0`
 See [CHANGELOG.md](CHANGELOG.md) for the release summary.
 
 ## The Problem
@@ -310,6 +310,20 @@ See [VNX vs Claude Code](docs/comparisons/vnx_vs_claude_code.md) and [VNX vs Mul
 | **Automated multi-provider review** | Built-in (Codex + Gemini triple gate) | None built-in | Not typically included |
 
 Detailed comparisons: [VNX vs Claude Code](docs/comparisons/vnx_vs_claude_code.md) | [VNX vs Multi-Agent Frameworks](docs/comparisons/vnx_vs_frameworks.md)
+
+## Roadmap
+
+Active development. Priorities shift based on real usage patterns.
+
+- **Headless A/B testing** — run interactive and autonomous side-by-side on the same feature, compare output quality
+- **Governance profiles** — configurable review depth per folder/project: full, light, minimal (landed in v0.8.0)
+- **Context rotation package** — extract the automatic context window management as a standalone installable package
+- **Multi-channel operator input** — Slack, WhatsApp, and webhook triggers alongside tmux terminal control
+- **Dynamic worker pools** — scale headless workers based on queue depth and API budget
+- **Model-agnostic adapter layer** — unified dispatch interface across Claude, Codex, Gemini, Kimi, and future CLI providers
+- **Business agent templates** — pre-built agent configurations for content creation, research, and analysis workflows
+
+See [CHANGELOG.md](CHANGELOG.md) for what shipped recently.
 
 ## Architecture & Docs
 


### PR DESCRIPTION
## Summary

- Version bump: v0.5.0 → v0.8.0
- CHANGELOG: v0.8.0 entry with F39, F41, headless infra, governance profiles
- README: Roadmap section with 7 planned items

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)