### PR TITLE
feat(f42): EventStore restore + headless T0 decision loop

### DIFF
--- a/dashboard/api_agent_stream.py
+++ b/dashboard/api_agent_stream.py
@@ -89,7 +89,55 @@ def handle_agent_stream_status(handler: BaseHTTPRequestHandler) -> None:
     _send_json(handler, HTTPStatus.OK, {"terminals": terminals})
 
 
-def _send_json(handler: BaseHTTPRequestHandler, status: HTTPStatus, payload: dict) -> None:
+def handle_agent_stream_archive_list(handler: "BaseHTTPRequestHandler", terminal: str) -> None:
+    """List all archived dispatch IDs for a terminal."""
+    if terminal not in VALID_TERMINALS:
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+        return
+
+    archive_dir = _store.archive_dir(terminal)
+    if not archive_dir.exists():
+        _send_json(handler, HTTPStatus.OK, [])
+        return
+
+    entries = []
+    for f in sorted(archive_dir.glob("*.ndjson")):
+        stat = f.stat()
+        entries.append({
+            "dispatch_id": f.stem,
+            "file_size": stat.st_size,
+            "modified_at": stat.st_mtime,
+        })
+    _send_json(handler, HTTPStatus.OK, entries)
+
+
+def handle_agent_stream_archive(
+    handler: "BaseHTTPRequestHandler", terminal: str, dispatch_id: str
+) -> None:
+    """Return all events for a specific archived dispatch."""
+    if terminal not in VALID_TERMINALS:
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+        return
+
+    archive_file = _store.archive_dir(terminal) / f"{dispatch_id}.ndjson"
+    if not archive_file.exists():
+        _send_json(handler, HTTPStatus.NOT_FOUND, {"error": f"Archive not found: {dispatch_id}"})
+        return
+
+    events = []
+    with open(archive_file, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    _send_json(handler, HTTPStatus.OK, events)
+
+
+def _send_json(handler: BaseHTTPRequestHandler, status: HTTPStatus, payload) -> None:
     body = json.dumps(payload).encode("utf-8")
     handler.send_response(status)
     handler.send_header("Content-Type", "application/json")

--- a/dashboard/api_agent_stream.py
+++ b/dashboard/api_agent_stream.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from http import HTTPStatus
@@ -95,6 +96,10 @@ def handle_agent_stream_archive_list(handler: "BaseHTTPRequestHandler", terminal
         _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
         return
 
+    if not re.match(r'^[a-zA-Z0-9_-]+$', terminal):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid terminal"})
+        return
+
     archive_dir = _store.archive_dir(terminal)
     if not archive_dir.exists():
         _send_json(handler, HTTPStatus.OK, [])
@@ -117,6 +122,14 @@ def handle_agent_stream_archive(
     """Return all events for a specific archived dispatch."""
     if terminal not in VALID_TERMINALS:
         _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+        return
+
+    if not re.match(r'^[a-zA-Z0-9_-]+$', terminal):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid terminal"})
+        return
+
+    if not re.match(r'^[a-zA-Z0-9_-]+$', dispatch_id):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid dispatch_id"})
         return
 
     archive_file = _store.archive_dir(terminal) / f"{dispatch_id}.ndjson"

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -142,6 +142,8 @@ from api_operator import (  # noqa: E402
 
 from api_agent_stream import (  # noqa: E402
     handle_agent_stream,
+    handle_agent_stream_archive,
+    handle_agent_stream_archive_list,
     handle_agent_stream_status,
 )
 
@@ -281,6 +283,20 @@ class DashboardHandler(SimpleHTTPRequestHandler):
         if path == "/api/agent-stream/status":
             handle_agent_stream_status(self)
             return
+
+        if path.startswith("/api/agent-stream/") and path.endswith("/archives"):
+            terminal = path[len("/api/agent-stream/"):-len("/archives")]
+            handle_agent_stream_archive_list(self, terminal)
+            return
+
+        _ARCHIVE_PREFIX = "/api/agent-stream/"
+        _ARCHIVE_INFIX = "/archive/"
+        if path.startswith(_ARCHIVE_PREFIX) and _ARCHIVE_INFIX in path:
+            rest = path[len(_ARCHIVE_PREFIX):]
+            if _ARCHIVE_INFIX in rest:
+                terminal, dispatch_id = rest.split(_ARCHIVE_INFIX, 1)
+                handle_agent_stream_archive(self, terminal, dispatch_id)
+                return
 
         if path.startswith("/api/agent-stream/"):
             terminal = path[len("/api/agent-stream/"):]

--- a/scripts/f39/replay_harness.py
+++ b/scripts/f39/replay_harness.py
@@ -30,7 +30,6 @@ import argparse
 import copy
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -44,6 +43,13 @@ _SCENARIOS_DIR = _REPO_ROOT / "tests" / "f39" / "scenarios"
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from context_assembler import assemble_t0_context, _DEFAULT_STATE, _DEFAULT_FEATURE_PLAN, _DEFAULT_SKILL, _DEFAULT_CLAUDE_MD  # noqa: E402
+
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+from decision_parser import (  # noqa: E402
+    extract_json as _extract_json,
+    extract_decision_from_stream as _extract_decision_from_stream,
+    collect_text_from_stream as _collect_text_from_stream,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -144,50 +150,8 @@ class ChainReplayResult:
 
 # ---------------------------------------------------------------------------
 # JSON extraction from LLM output
+# (imported from scripts/lib/decision_parser — see import block above)
 # ---------------------------------------------------------------------------
-
-def _extract_json(text: str) -> dict[str, Any] | None:
-    """Extract the first valid JSON object from LLM output.
-
-    The model may wrap the object in ```json ... ``` or emit it bare.
-    """
-    # Try: bare JSON object starting with {
-    for match in re.finditer(r"\{", text):
-        start = match.start()
-        # Greedily expand to find matching close brace
-        depth = 0
-        for i, ch in enumerate(text[start:], start):
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    candidate = text[start: i + 1]
-                    try:
-                        return json.loads(candidate)
-                    except json.JSONDecodeError:
-                        break  # Try next {
-
-    return None
-
-
-def _extract_decision_from_stream(stream_output: str) -> dict[str, Any] | None:
-    """Extract T0 decision JSON from claude -p stream-json output.
-
-    Parses NDJSON lines, finds the result event, extracts decision from result text.
-    """
-    for line in stream_output.split('\n'):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-            if event.get('type') == 'result':
-                result_text = str(event.get('result', ''))
-                return _extract_json(result_text)
-        except json.JSONDecodeError:
-            continue
-    return None
 
 
 def _extract_tokens_from_stream(stream_output: str) -> int:
@@ -212,32 +176,7 @@ def _extract_tokens_from_stream(stream_output: str) -> int:
     return total
 
 
-def _collect_text_from_stream(stream_output: str) -> str:
-    """Collect all text content blocks from stream-json output."""
-    parts: list[str] = []
-    for line in stream_output.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            # Plain text line — accumulate in case output-format isn't stream-json
-            parts.append(line)
-            continue
-        # stream-json content_block_delta
-        delta = obj.get("delta") or {}
-        if delta.get("type") == "text_delta":
-            parts.append(delta.get("text", ""))
-        # Plain assistant message
-        content = obj.get("content")
-        if isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    parts.append(block.get("text", ""))
-        elif isinstance(content, str):
-            parts.append(content)
-    return "".join(parts)
+# _collect_text_from_stream imported from scripts/lib/decision_parser above.
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/headless_trigger.py
+++ b/scripts/headless_trigger.py
@@ -154,6 +154,16 @@ def trigger_headless_t0(
         _LOG.error("context_assembler failed: %s", exc)
         return
 
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+    try:
+        from decision_parser import parse_decision  # noqa: PLC0415
+        from decision_executor import execute_decision, reset_cycle_counter  # noqa: PLC0415
+    except ImportError as exc:
+        _LOG.error("Cannot import decision_parser/executor: %s", exc)
+        return
+
+    reset_cycle_counter()
+
     try:
         result = subprocess.run(
             ["claude", "-p", "--output-format", "stream-json", "--verbose", prompt],
@@ -165,7 +175,20 @@ def trigger_headless_t0(
         if result.returncode != 0:
             _LOG.warning("claude exited %d: %s", result.returncode, result.stderr[:200])
         else:
-            _LOG.info("Headless T0 completed (reason=%s)", reason)
+            raw_stdout = result.stdout if isinstance(result.stdout, str) else result.stdout.decode()
+            decision_type, parsed = parse_decision(raw_stdout)
+            _LOG.info("T0 decision: %s", decision_type)
+            if parsed and not dry_run:
+                status = execute_decision(parsed, reason, state_dir=state_dir)
+                _LOG.info("Decision executed: %s", status)
+            elif parsed and dry_run:
+                _LOG.info(
+                    "[dry-run] Would execute: %s → %s",
+                    decision_type,
+                    parsed.get("dispatch_target", "N/A"),
+                )
+            else:
+                _LOG.info("Headless T0 completed (reason=%s, no parsed decision)", reason)
     except subprocess.TimeoutExpired:
         _LOG.error("Headless T0 timed out after %ds (reason=%s)", _T0_TIMEOUT, reason)
     except FileNotFoundError:

--- a/scripts/lib/decision_executor.py
+++ b/scripts/lib/decision_executor.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Decision executor — execute parsed T0 decisions from the headless loop.
+
+Routes by decision type (DISPATCH / WAIT / COMPLETE / REJECT / ESCALATE)
+and enforces loop guards:
+  - MAX_DISPATCHES_PER_CYCLE: hard cap on dispatches per invocation cycle.
+  - Duplicate detection: same dispatch_task within 30 min → refuse.
+
+BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_LOG = logging.getLogger(__name__)
+
+MAX_DISPATCHES_PER_CYCLE = 3
+
+# Duplicate window: 30 minutes in seconds
+_DUPLICATE_WINDOW_SECONDS = 1800
+
+# Terminal → track mapping
+_TERMINAL_TO_TRACK: dict[str, str] = {
+    "T1": "A",
+    "T2": "B",
+    "T3": "C",
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _task_hash(task_text: str) -> str:
+    return hashlib.sha256(task_text.encode("utf-8")).hexdigest()[:16]
+
+
+def _load_recent_hashes(state_dir: Path) -> dict[str, str]:
+    """Load recent_dispatch_hashes.json → {hash: iso_timestamp}."""
+    path = state_dir / "recent_dispatch_hashes.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_recent_hashes(state_dir: Path, hashes: dict[str, str]) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "recent_dispatch_hashes.json"
+    path.write_text(json.dumps(hashes, indent=2) + "\n", encoding="utf-8")
+
+
+def _purge_expired_hashes(hashes: dict[str, str]) -> dict[str, str]:
+    """Remove entries older than _DUPLICATE_WINDOW_SECONDS."""
+    now_ts = datetime.now(timezone.utc).timestamp()
+    result = {}
+    for h, ts in hashes.items():
+        try:
+            age = now_ts - datetime.fromisoformat(ts).timestamp()
+            if age < _DUPLICATE_WINDOW_SECONDS:
+                result[h] = ts
+        except Exception:
+            pass
+    return result
+
+
+def _log_decision_event(state_dir: Path, event: dict[str, Any]) -> None:
+    events_dir = state_dir.parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    log_path = events_dir / "t0_decisions.ndjson"
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event) + "\n")
+
+
+def _get_event_store(state_dir: Path) -> Any | None:
+    """Import EventStore from the lib directory if available."""
+    lib_dir = Path(__file__).parent
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    try:
+        from event_store import EventStore  # type: ignore[import]
+        events_dir = state_dir.parent / "events"
+        return EventStore(events_dir=events_dir)
+    except Exception:
+        return None
+
+
+def _get_dispatch_writer():
+    """Import write_dispatch and generate_dispatch_id from headless_dispatch_writer."""
+    lib_dir = Path(__file__).parent
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    from headless_dispatch_writer import write_dispatch, generate_dispatch_id  # type: ignore[import]
+    return write_dispatch, generate_dispatch_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch counter (per-process cycle guard)
+# ---------------------------------------------------------------------------
+
+_cycle_dispatch_count: int = 0
+
+
+def reset_cycle_counter() -> None:
+    """Reset the per-cycle dispatch counter. Call at the start of each trigger cycle."""
+    global _cycle_dispatch_count
+    _cycle_dispatch_count = 0
+
+
+# ---------------------------------------------------------------------------
+# Decision handlers
+# ---------------------------------------------------------------------------
+
+def _handle_dispatch(
+    decision: dict[str, Any],
+    trigger_reason: str,
+    *,
+    state_dir: Path,
+    dry_run: bool,
+) -> str:
+    global _cycle_dispatch_count
+
+    dispatch_target = str(decision.get("dispatch_target", "")).upper()
+    dispatch_task = str(decision.get("dispatch_task", "")).strip()
+    role = str(decision.get("role", "backend-developer")).strip() or "backend-developer"
+
+    # Validate target
+    if dispatch_target not in _TERMINAL_TO_TRACK:
+        msg = f"Invalid dispatch_target {dispatch_target!r}; must be T1/T2/T3"
+        _LOG.warning(msg)
+        return f"error: {msg}"
+
+    # Validate task
+    if not dispatch_task:
+        msg = "dispatch_task is empty — refusing dispatch"
+        _LOG.warning(msg)
+        return f"error: {msg}"
+
+    # Cycle guard
+    if _cycle_dispatch_count >= MAX_DISPATCHES_PER_CYCLE:
+        msg = f"MAX_DISPATCHES_PER_CYCLE ({MAX_DISPATCHES_PER_CYCLE}) reached — refusing dispatch"
+        _LOG.warning(msg)
+        return f"error: {msg}"
+
+    # Duplicate detection
+    h = _task_hash(dispatch_task)
+    hashes = _purge_expired_hashes(_load_recent_hashes(state_dir))
+    if h in hashes:
+        msg = f"Duplicate dispatch_task (hash={h}) within {_DUPLICATE_WINDOW_SECONDS}s window — refusing"
+        _LOG.warning(msg)
+        return f"duplicate: {msg}"
+
+    track = _TERMINAL_TO_TRACK[dispatch_target]
+    feature = str(decision.get("feature", "")).strip() or None
+    pr_id = str(decision.get("pr_id", "")).strip() or None
+
+    if dry_run:
+        _LOG.info("[dry-run] Would dispatch to %s (track %s): %.80s…", dispatch_target, track, dispatch_task)
+        return "dry-run dispatch"
+
+    try:
+        write_dispatch, generate_dispatch_id = _get_dispatch_writer()
+        dispatch_id = generate_dispatch_id(
+            prefix=f"t0-auto-{dispatch_target.lower()}",
+            track=track,
+        )
+        dispatch_path = write_dispatch(
+            dispatch_id=dispatch_id,
+            terminal=dispatch_target,
+            track=track,
+            role=role,
+            instruction=dispatch_task,
+            feature=feature,
+            pr_id=pr_id,
+        )
+        _LOG.info("Dispatch written: %s → %s", dispatch_id, dispatch_path)
+
+        # Record hash
+        hashes[h] = _now_utc()
+        _save_recent_hashes(state_dir, hashes)
+
+        # Increment cycle counter
+        _cycle_dispatch_count += 1
+
+        # Log event
+        event_store = _get_event_store(state_dir)
+        event = {
+            "event_type": "t0_dispatch",
+            "dispatch_id": dispatch_id,
+            "dispatch_target": dispatch_target,
+            "trigger_reason": trigger_reason,
+            "task_hash": h,
+            "timestamp": _now_utc(),
+        }
+        if event_store:
+            try:
+                event_store.append("T0", event, dispatch_id=dispatch_id)
+            except Exception:
+                pass
+        _log_decision_event(state_dir, event)
+
+        return "dispatched"
+    except Exception as exc:
+        _LOG.error("write_dispatch failed: %s", exc)
+        return f"error: {exc}"
+
+
+def _handle_wait(decision: dict[str, Any], state_dir: Path) -> str:
+    reason = str(decision.get("reason", "no reason given"))
+    _LOG.info("T0 WAIT: %s", reason)
+    _log_decision_event(state_dir, {
+        "event_type": "t0_wait",
+        "reason": reason,
+        "timestamp": _now_utc(),
+    })
+    return "waited"
+
+
+def _handle_complete(decision: dict[str, Any], state_dir: Path) -> str:
+    reason = str(decision.get("reason", ""))
+    _LOG.info("T0 COMPLETE: %s", reason)
+    _log_decision_event(state_dir, {
+        "event_type": "t0_complete",
+        "reason": reason,
+        "timestamp": _now_utc(),
+    })
+    return "completed"
+
+
+def _handle_reject(decision: dict[str, Any], state_dir: Path) -> str:
+    reason = str(decision.get("reason", ""))
+    _LOG.info("T0 REJECT: %s", reason)
+    _log_decision_event(state_dir, {
+        "event_type": "t0_reject",
+        "reason": reason,
+        "timestamp": _now_utc(),
+    })
+    return "rejected"
+
+
+def _handle_escalate(decision: dict[str, Any], state_dir: Path, dry_run: bool) -> str:
+    reason = str(decision.get("reason", ""))
+    _LOG.info("T0 ESCALATE: %s", reason)
+
+    if not dry_run:
+        escalations_dir = state_dir.parent / "state" / "escalations"
+        # Handle case where state_dir IS the state dir
+        alt = state_dir / "escalations"
+        if not (state_dir.parent / "state").exists():
+            escalations_dir = alt
+        escalations_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        esc_path = escalations_dir / f"escalation_{ts}.json"
+        esc_path.write_text(
+            json.dumps({
+                "timestamp": _now_utc(),
+                "decision": decision,
+                "reason": reason,
+            }, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        _LOG.info("Escalation written to %s", esc_path)
+
+    _log_decision_event(state_dir, {
+        "event_type": "t0_escalate",
+        "reason": reason,
+        "timestamp": _now_utc(),
+    })
+    return "escalated"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def execute_decision(
+    decision: dict[str, Any],
+    trigger_reason: str,
+    *,
+    state_dir: Path,
+    dry_run: bool = False,
+) -> str:
+    """Execute a parsed T0 decision. Returns a status string.
+
+    Args:
+        decision:       Parsed decision dict with at minimum a 'decision' key.
+        trigger_reason: Human-readable reason for the trigger (e.g. 'new_report').
+        state_dir:      VNX state directory (contains recent_dispatch_hashes.json).
+        dry_run:        If True, log but do not write files or call dispatch writer.
+
+    Returns:
+        One of: 'dispatched', 'waited', 'completed', 'rejected', 'escalated',
+        'dry-run dispatch', 'duplicate: …', 'error: …'
+    """
+    decision_type = str(decision.get("decision", "UNKNOWN")).upper()
+    _LOG.debug("execute_decision: type=%s trigger=%s dry_run=%s", decision_type, trigger_reason, dry_run)
+
+    if decision_type == "DISPATCH":
+        return _handle_dispatch(decision, trigger_reason, state_dir=state_dir, dry_run=dry_run)
+    elif decision_type == "WAIT":
+        return _handle_wait(decision, state_dir)
+    elif decision_type == "COMPLETE":
+        return _handle_complete(decision, state_dir)
+    elif decision_type == "REJECT":
+        return _handle_reject(decision, state_dir)
+    elif decision_type == "ESCALATE":
+        return _handle_escalate(decision, state_dir, dry_run)
+    else:
+        _LOG.warning("Unknown decision type %r — no action taken", decision_type)
+        _log_decision_event(state_dir, {
+            "event_type": "t0_unknown_decision",
+            "raw_decision": decision,
+            "timestamp": _now_utc(),
+        })
+        return f"unknown decision type: {decision_type}"

--- a/scripts/lib/decision_parser.py
+++ b/scripts/lib/decision_parser.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Decision parser — extract and parse T0 decisions from LLM stream output.
+
+Extracted from scripts/f39/replay_harness.py for reuse in headless_trigger.py
+and other consumers.
+
+BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+def extract_json(text: str) -> dict[str, Any] | None:
+    """Extract the first valid JSON object from text.
+
+    The model may wrap the object in ```json ... ``` or emit it bare.
+    Handles markdown code fences and partial/trailing text.
+    """
+    for match_start in range(len(text)):
+        if text[match_start] != "{":
+            continue
+        depth = 0
+        for i in range(match_start, len(text)):
+            ch = text[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[match_start : i + 1]
+                    try:
+                        return json.loads(candidate)
+                    except json.JSONDecodeError:
+                        break  # Try next {
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Stream-json NDJSON parsing
+# ---------------------------------------------------------------------------
+
+def extract_decision_from_stream(stream_output: str) -> dict[str, Any] | None:
+    """Extract T0 decision JSON from claude -p stream-json NDJSON output.
+
+    Parses NDJSON lines, finds the 'result' event, extracts decision JSON
+    from the result text.
+    """
+    for line in stream_output.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+            if event.get("type") == "result":
+                result_text = str(event.get("result", ""))
+                return extract_json(result_text)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def collect_text_from_stream(stream_output: str) -> str:
+    """Collect all text content blocks from stream-json output.
+
+    Handles content_block_delta lines, plain assistant messages, and
+    non-JSON lines (fallback for non-stream-json output).
+    """
+    parts: list[str] = []
+    for line in stream_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            # Plain text line — accumulate in case output-format isn't stream-json
+            parts.append(line)
+            continue
+        # stream-json content_block_delta
+        delta = obj.get("delta") or {}
+        if delta.get("type") == "text_delta":
+            parts.append(delta.get("text", ""))
+        # Plain assistant message
+        content = obj.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+        elif isinstance(content, str):
+            parts.append(content)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# High-level parse
+# ---------------------------------------------------------------------------
+
+def parse_decision(raw_output: str) -> tuple[str, dict[str, Any] | None]:
+    """Parse raw LLM stream-json output into a (decision_type, parsed_dict) tuple.
+
+    Strategy:
+      1. Try to extract JSON from the 'result' event in the NDJSON stream.
+      2. Fall back to collecting all text blocks and extracting JSON from those.
+
+    Returns:
+        (decision_type, parsed_dict) where decision_type is one of:
+          'DISPATCH', 'WAIT', 'COMPLETE', 'REJECT', 'ESCALATE', 'UNKNOWN'
+        and parsed_dict is the full decision object or None on parse failure.
+
+    Examples:
+        >>> parse_decision('{"type":"result","result":"{\\"decision\\":\\"WAIT\\"}"}')
+        ('WAIT', {'decision': 'WAIT'})
+        >>> parse_decision('garbage')
+        ('UNKNOWN', None)
+    """
+    # First: try result event (most reliable)
+    parsed = extract_decision_from_stream(raw_output)
+
+    # Fallback: collect text blocks and scan for JSON
+    if parsed is None:
+        collected_text = collect_text_from_stream(raw_output)
+        if collected_text:
+            parsed = extract_json(collected_text)
+
+    if parsed is None:
+        return ("UNKNOWN", None)
+
+    decision_type = str(parsed.get("decision", "UNKNOWN")).upper()
+    _VALID = {"DISPATCH", "WAIT", "COMPLETE", "REJECT", "ESCALATE"}
+    if decision_type not in _VALID:
+        decision_type = "UNKNOWN"
+
+    return (decision_type, parsed)

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""EventStore — NDJSON persistence for agent stream events.
+
+Stores one NDJSON file per terminal at .vnx-data/events/{terminal}.ndjson.
+Supports atomic append, tail-with-since, and clear (per-dispatch retention).
+
+File locking via fcntl.flock ensures concurrent write safety.
+
+BILLING SAFETY: No Anthropic SDK imports. Local filesystem only.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+# Size warning threshold (10 MB per contract)
+_SIZE_WARNING_BYTES = 10 * 1024 * 1024
+
+
+def _events_dir() -> Path:
+    """Resolve the events directory from environment or default."""
+    vnx_data = os.environ.get("VNX_DATA_DIR")
+    if vnx_data:
+        return Path(vnx_data).expanduser().resolve() / "events"
+    # Fallback: .vnx-data/events relative to repo root
+    script_dir = Path(__file__).resolve().parent
+    return script_dir.parent.parent / ".vnx-data" / "events"
+
+
+class EventStore:
+    """NDJSON event store with per-terminal files and file locking."""
+
+    def __init__(self, events_dir: Optional[Path] = None) -> None:
+        self._events_dir = events_dir or _events_dir()
+        self._sequences: Dict[str, int] = {}
+
+    def _terminal_path(self, terminal: str) -> Path:
+        return self._events_dir / f"{terminal}.ndjson"
+
+    def _next_sequence(self, terminal: str) -> int:
+        seq = self._sequences.get(terminal, 0) + 1
+        self._sequences[terminal] = seq
+        return seq
+
+    def append(self, terminal: str, event: Dict[str, Any], dispatch_id: str = "") -> None:
+        """Append a single event as an atomic NDJSON line.
+
+        Uses LOCK_EX for write safety. The line is written in a single write()
+        call including the trailing newline to prevent partial reads.
+        """
+        self._events_dir.mkdir(parents=True, exist_ok=True)
+        path = self._terminal_path(terminal)
+
+        # Build envelope per contract
+        envelope: Dict[str, Any] = {
+            "type": event.get("type", "unknown"),
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+            "dispatch_id": dispatch_id or event.get("dispatch_id", ""),
+            "terminal": terminal,
+            "sequence": self._next_sequence(terminal),
+            "data": event.get("data", event),
+        }
+
+        line = json.dumps(envelope, separators=(",", ":")) + "\n"
+
+        with open(path, "a", encoding="utf-8") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.write(line)
+                f.flush()
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+        # Size warning
+        try:
+            if path.stat().st_size > _SIZE_WARNING_BYTES:
+                logger.warning(
+                    "event_store: %s exceeds %d bytes — operator intervention recommended",
+                    path,
+                    _SIZE_WARNING_BYTES,
+                )
+        except OSError:
+            pass
+
+    def tail(self, terminal: str, since: Optional[str] = None) -> Iterator[Dict[str, Any]]:
+        """Yield events since a timestamp (ISO 8601 string).
+
+        Uses LOCK_SH for read safety. Events are yielded in file order.
+        If since is None, all events are returned.
+        """
+        path = self._terminal_path(terminal)
+        if not path.exists():
+            return
+
+        with open(path, "r", encoding="utf-8") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+            try:
+                for raw_line in f:
+                    raw_line = raw_line.rstrip("\n")
+                    if not raw_line:
+                        continue
+                    try:
+                        event = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        logger.warning("event_store: malformed line in %s (skipped)", path)
+                        continue
+
+                    if since and event.get("timestamp", "") <= since:
+                        continue
+
+                    yield event
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    def archive_dir(self, terminal: str) -> Path:
+        """Return the archive directory for a terminal."""
+        return self._events_dir / "archive" / terminal
+
+    def archive(self, terminal: str, dispatch_id: str) -> Optional[Path]:
+        """Copy current event file to archive before clearing.
+
+        Returns the archive path on success, None if nothing to archive.
+        """
+        event_file = self._terminal_path(terminal)
+        if not event_file.exists() or event_file.stat().st_size == 0:
+            return None
+
+        archive_path = self.archive_dir(terminal)
+        archive_path.mkdir(parents=True, exist_ok=True)
+        dest = archive_path / f"{dispatch_id}.ndjson"
+        shutil.copy2(str(event_file), str(dest))
+        logger.info("event_store: archived %s -> %s", event_file, dest)
+        return dest
+
+    def clear(self, terminal: str, archive_dispatch_id: Optional[str] = None) -> None:
+        """Truncate the event file for a terminal (new dispatch clears old events).
+
+        If archive_dispatch_id is provided and the file has content, the events
+        are archived to .vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson
+        before truncation.
+
+        Also resets the sequence counter.
+        """
+        if archive_dispatch_id:
+            self.archive(terminal, archive_dispatch_id)
+
+        path = self._terminal_path(terminal)
+        self._sequences.pop(terminal, None)
+
+        if not path.exists():
+            return
+
+        with open(path, "w", encoding="utf-8") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.truncate(0)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    def event_count(self, terminal: str) -> int:
+        """Count events in the NDJSON file for a terminal."""
+        path = self._terminal_path(terminal)
+        if not path.exists():
+            return 0
+        count = 0
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    count += 1
+        return count
+
+    def last_event(self, terminal: str) -> Optional[Dict[str, Any]]:
+        """Return the last event for a terminal, or None."""
+        path = self._terminal_path(terminal)
+        if not path.exists():
+            return None
+        last = None
+        with open(path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.rstrip("\n")
+                if not raw_line:
+                    continue
+                try:
+                    last = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+        return last

--- a/tests/test_agent_stream_archive.py
+++ b/tests/test_agent_stream_archive.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for archive endpoints in api_agent_stream."""
+
+import json
+import sys
+from http import HTTPStatus
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+DASHBOARD_DIR = Path(__file__).resolve().parent.parent / "dashboard"
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(DASHBOARD_DIR))
+
+
+def _make_handler(wfile=None):
+    handler = MagicMock()
+    handler.wfile = wfile or BytesIO()
+    return handler
+
+
+def _capture_json(handler):
+    handler.wfile.seek(0)
+    raw = handler.wfile.read()
+    return json.loads(raw)
+
+
+def test_archive_list_returns_dispatch_ids(tmp_path, monkeypatch):
+    import api_agent_stream as mod
+    from event_store import EventStore
+
+    store = EventStore(events_dir=tmp_path / "events")
+    store.append("T1", {"type": "init", "data": {}}, dispatch_id="d-001")
+    store.clear("T1", archive_dispatch_id="d-001")
+    store.append("T1", {"type": "init", "data": {}}, dispatch_id="d-002")
+    store.clear("T1", archive_dispatch_id="d-002")
+
+    monkeypatch.setattr(mod, "_store", store)
+
+    handler = _make_handler()
+    mod.handle_agent_stream_archive_list(handler, "T1")
+
+    body = handler.wfile.getvalue()
+    result = json.loads(body)
+    assert isinstance(result, list)
+    dispatch_ids = {entry["dispatch_id"] for entry in result}
+    assert dispatch_ids == {"d-001", "d-002"}
+    for entry in result:
+        assert "file_size" in entry
+        assert "modified_at" in entry
+
+
+def test_archive_returns_events(tmp_path, monkeypatch):
+    import api_agent_stream as mod
+    from event_store import EventStore
+
+    store = EventStore(events_dir=tmp_path / "events")
+    store.append("T2", {"type": "text", "data": {"text": "hello"}}, dispatch_id="d-010")
+    store.append("T2", {"type": "result", "data": {}}, dispatch_id="d-010")
+    store.clear("T2", archive_dispatch_id="d-010")
+
+    monkeypatch.setattr(mod, "_store", store)
+
+    handler = _make_handler()
+    mod.handle_agent_stream_archive(handler, "T2", "d-010")
+
+    body = handler.wfile.getvalue()
+    result = json.loads(body)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["type"] == "text"
+    assert result[1]["type"] == "result"
+
+
+def test_archive_404_on_missing(tmp_path, monkeypatch):
+    import api_agent_stream as mod
+    from event_store import EventStore
+
+    store = EventStore(events_dir=tmp_path / "events")
+    monkeypatch.setattr(mod, "_store", store)
+
+    handler = _make_handler()
+    mod.handle_agent_stream_archive(handler, "T1", "nonexistent-dispatch")
+
+    handler.send_response.assert_called_once_with(HTTPStatus.NOT_FOUND)

--- a/tests/test_decision_executor.py
+++ b/tests/test_decision_executor.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Tests for decision_parser and decision_executor.
+
+Covers:
+- parse_decision: DISPATCH, WAIT, malformed input
+- execute_decision: DISPATCH writes pending dir, duplicate blocking, max-cycle guard
+- Other decision types: WAIT, COMPLETE, REJECT, ESCALATE
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Add scripts/lib to path
+_LIB_DIR = Path(__file__).resolve().parents[1] / "scripts" / "lib"
+sys.path.insert(0, str(_LIB_DIR))
+
+from decision_parser import parse_decision, extract_json, collect_text_from_stream  # noqa: E402
+import decision_executor  # noqa: E402
+from decision_executor import (  # noqa: E402
+    execute_decision,
+    reset_cycle_counter,
+    MAX_DISPATCHES_PER_CYCLE,
+    _task_hash,
+    _save_recent_hashes,
+    _now_utc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stream_result(decision_json: dict) -> str:
+    """Build a minimal stream-json NDJSON string with a result event."""
+    result_line = json.dumps({"type": "result", "result": json.dumps(decision_json)})
+    return result_line
+
+
+def _dispatch_decision(target: str = "T1", task: str = "Implement feature X") -> dict:
+    return {
+        "decision": "DISPATCH",
+        "dispatch_target": target,
+        "dispatch_task": task,
+        "role": "backend-developer",
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_decision tests
+# ---------------------------------------------------------------------------
+
+class TestParseDispatchDecision:
+    def test_valid_dispatch_json_is_parsed(self):
+        raw = _make_stream_result({"decision": "DISPATCH", "dispatch_target": "T1", "dispatch_task": "do work"})
+        decision_type, parsed = parse_decision(raw)
+        assert decision_type == "DISPATCH"
+        assert parsed is not None
+        assert parsed["dispatch_target"] == "T1"
+
+    def test_dispatch_decision_key_case_insensitive(self):
+        raw = _make_stream_result({"decision": "dispatch", "dispatch_target": "T2", "dispatch_task": "test stuff"})
+        decision_type, parsed = parse_decision(raw)
+        assert decision_type == "DISPATCH"
+
+    def test_fallback_from_text_blocks(self):
+        # No result event — only text block content
+        text_block = json.dumps({
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": json.dumps({"decision": "DISPATCH", "dispatch_target": "T3", "dispatch_task": "x"})},
+        })
+        decision_type, parsed = parse_decision(text_block)
+        assert decision_type == "DISPATCH"
+
+
+class TestParseWaitDecision:
+    def test_wait_decision_returns_correct_type(self):
+        raw = _make_stream_result({"decision": "WAIT", "reason": "terminal busy"})
+        decision_type, parsed = parse_decision(raw)
+        assert decision_type == "WAIT"
+        assert parsed is not None
+        assert parsed["reason"] == "terminal busy"
+
+
+class TestParseMalformed:
+    def test_garbage_input_returns_unknown(self):
+        decision_type, parsed = parse_decision("not json at all just garbage text")
+        assert decision_type == "UNKNOWN"
+        assert parsed is None
+
+    def test_empty_string_returns_unknown(self):
+        decision_type, parsed = parse_decision("")
+        assert decision_type == "UNKNOWN"
+        assert parsed is None
+
+    def test_unknown_decision_type_normalized(self):
+        raw = _make_stream_result({"decision": "FROBULATE", "reason": "weird"})
+        decision_type, parsed = parse_decision(raw)
+        assert decision_type == "UNKNOWN"
+
+    def test_missing_decision_key_returns_unknown(self):
+        raw = _make_stream_result({"reason": "no decision key"})
+        decision_type, parsed = parse_decision(raw)
+        assert decision_type == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# execute_decision — DISPATCH tests
+# ---------------------------------------------------------------------------
+
+class TestExecuteDispatchWritesPending:
+    def test_dispatch_creates_file_in_pending_dir(self, tmp_path, monkeypatch):
+        """DISPATCH creates a dispatch.json in the pending/ directory."""
+        dispatches_dir = tmp_path / "dispatches"
+        pending_dir = dispatches_dir / "pending"
+        pending_dir.mkdir(parents=True)
+
+        # Create a skills dir with the role subdir so role validation passes
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "backend-developer").mkdir(parents=True)
+
+        # Patch headless_dispatch_writer to use tmp_path
+        import headless_dispatch_writer
+
+        monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
+        monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+
+        reset_cycle_counter()
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        decision = _dispatch_decision(target="T1", task="Build the auth module")
+        status = execute_decision(decision, "test_trigger", state_dir=state_dir)
+
+        assert status == "dispatched"
+        # Find the created pending dir
+        created = list(pending_dir.iterdir())
+        assert len(created) == 1
+        dispatch_json = created[0] / "dispatch.json"
+        assert dispatch_json.exists()
+        payload = json.loads(dispatch_json.read_text())
+        assert payload["terminal"] == "T1"
+        assert payload["track"] == "A"
+        assert "Build the auth module" in payload["instruction"]
+
+
+class TestDuplicateDispatchBlocked:
+    def test_same_dispatch_task_within_window_is_refused(self, tmp_path, monkeypatch):
+        """Same dispatch_task within 30 min is blocked."""
+        import headless_dispatch_writer
+
+        dispatches_dir = tmp_path / "dispatches"
+        (dispatches_dir / "pending").mkdir(parents=True)
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "backend-developer").mkdir(parents=True)
+
+        monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
+        monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        task_text = "Implement duplicate detection"
+        decision = _dispatch_decision(task=task_text)
+
+        # Seed the hash file with the same task hash
+        h = _task_hash(task_text)
+        _save_recent_hashes(state_dir, {h: _now_utc()})
+
+        reset_cycle_counter()
+        status = execute_decision(decision, "trigger", state_dir=state_dir)
+
+        assert status.startswith("duplicate:")
+
+
+class TestMaxDispatchesEnforced:
+    def test_exceeding_max_dispatches_returns_error(self, tmp_path, monkeypatch):
+        """More than MAX_DISPATCHES_PER_CYCLE dispatches are refused."""
+        import headless_dispatch_writer
+
+        dispatches_dir = tmp_path / "dispatches"
+        (dispatches_dir / "pending").mkdir(parents=True)
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "backend-developer").mkdir(parents=True)
+
+        monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
+        monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        reset_cycle_counter()
+
+        statuses = []
+        for i in range(MAX_DISPATCHES_PER_CYCLE + 1):
+            # Each task must be unique to avoid duplicate detection
+            decision = _dispatch_decision(task=f"Unique task number {i} at {time.monotonic()}")
+            status = execute_decision(decision, "trigger", state_dir=state_dir)
+            statuses.append(status)
+
+        # First MAX_DISPATCHES_PER_CYCLE should succeed
+        assert all(s == "dispatched" for s in statuses[:MAX_DISPATCHES_PER_CYCLE])
+        # The next one should be refused
+        assert statuses[MAX_DISPATCHES_PER_CYCLE].startswith("error:")
+
+
+# ---------------------------------------------------------------------------
+# Other decision types
+# ---------------------------------------------------------------------------
+
+class TestOtherDecisionTypes:
+    def test_wait_decision_returns_waited(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        status = execute_decision({"decision": "WAIT", "reason": "nothing to do"}, "trigger", state_dir=state_dir)
+        assert status == "waited"
+
+    def test_complete_decision_returns_completed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        status = execute_decision({"decision": "COMPLETE", "reason": "all done"}, "trigger", state_dir=state_dir)
+        assert status == "completed"
+
+    def test_reject_decision_returns_rejected(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        status = execute_decision({"decision": "REJECT", "reason": "missing tests"}, "trigger", state_dir=state_dir)
+        assert status == "rejected"
+
+    def test_escalate_decision_writes_file(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        status = execute_decision(
+            {"decision": "ESCALATE", "reason": "architectural blocker"},
+            "trigger",
+            state_dir=state_dir,
+        )
+        assert status == "escalated"
+        # Check escalation file was created
+        esc_files = list((state_dir / "escalations").glob("escalation_*.json"))
+        assert len(esc_files) == 1
+        payload = json.loads(esc_files[0].read_text())
+        assert "architectural blocker" in payload["reason"]
+
+    def test_dry_run_dispatch_skips_file_write(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        dispatches_dir = tmp_path / "dispatches"
+        (dispatches_dir / "pending").mkdir(parents=True)
+
+        reset_cycle_counter()
+        decision = _dispatch_decision(task="dry run task")
+        status = execute_decision(decision, "trigger", state_dir=state_dir, dry_run=True)
+
+        assert status == "dry-run dispatch"
+        # No files written
+        assert list((dispatches_dir / "pending").iterdir()) == []


### PR DESCRIPTION
## Summary

- **EventStore restore**: Recovered from git history (PR #205 cleanup), 196 LOC with full test suite
- **Dashboard archive endpoints**: `/api/agent-stream/{terminal}/archives` and `/archive/{dispatch_id}`
- **Decision parser**: Extracted from replay_harness into reusable `decision_parser.py`
- **Decision executor**: Routes DISPATCH/WAIT/COMPLETE/REJECT/ESCALATE with loop guards
- **Trigger wiring**: headless_trigger.py now parses T0 output and executes decisions

Winner of A/B test (Track A: 1113 LOC, 19 tests) vs Track B (1070 LOC, 16 tests).

## Test plan

- [ ] Codex gate
- [ ] Gemini review
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)