### PR TITLE
fix(codex-gate): remove hardcoded gpt-5.2-codex default; use codex config.toml

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -217,13 +217,18 @@ class GateRunner:
             model = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
             cli_args = ["--model", model] + cli_args
         elif gate == "codex_gate":
+            # Model selection: only override if explicitly requested via env/payload.
+            # Default path: let codex use ~/.codex/config.toml (currently gpt-5.3-codex).
+            # 2026-04-19: gpt-5.2-codex deprecated via Codex CLI model-migration mapping;
+            # ChatGPT-account auth rejects older explicit model flags, causing gate
+            # failures with "model not supported when using Codex with a ChatGPT account".
             model = (
                 os.environ.get("VNX_CODEX_HEADLESS_MODEL")
                 or os.environ.get("VNX_CODEX_MODEL")
                 or request_payload.get("model")
-                or "gpt-5.2-codex"
             )
-            cli_args = cli_args + ["-c", f'model="{model}"']
+            if model:
+                cli_args = cli_args + ["-c", f'model="{model}"']
         return [binary] + cli_args
 
     def _drain_remaining(self, fd_map: Dict[int, str], raw_fds: List[int],

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -30,7 +30,10 @@ from vertex_ai_runner import collect_file_contents
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "gpt-5.2-codex"
+# Model: empty string = use codex CLI config.toml default (currently gpt-5.3-codex).
+# 2026-04-19: gpt-5.2-codex deprecated via Codex CLI model-migration mapping;
+# ChatGPT-account auth rejects older explicit model flags.
+_DEFAULT_MODEL = ""
 _DEFAULT_TIMEOUT = 300
 _DEFAULT_STALL_THRESHOLD = 60
 
@@ -75,7 +78,11 @@ class CodexAdapter(ProviderAdapter):
         changed_files = context.get("changed_files", [])
         prompt = self._build_prompt(instruction, changed_files)
 
-        cmd = ["codex", "exec", "--json", "-c", f'model="{model}"']
+        # Only override model if explicitly set; empty string = let codex use
+        # its own config.toml default.
+        cmd = ["codex", "exec", "--json"]
+        if model:
+            cmd += ["-c", f'model="{model}"']
         t0 = time.monotonic()
         try:
             proc = subprocess.Popen(

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -69,7 +69,13 @@ class CodexAdapter(ProviderAdapter):
         Builds prompt from instruction + inline file contents from
         context["changed_files"], invokes the codex CLI, and parses NDJSON.
         """
-        model = os.environ.get("VNX_CODEX_MODEL", _DEFAULT_MODEL)
+        # Env precedence mirrors gate_runner._build_gate_cmd and
+        # GateRequestHandlerMixin._request_codex: HEADLESS_MODEL > MODEL.
+        model = (
+            os.environ.get("VNX_CODEX_HEADLESS_MODEL")
+            or os.environ.get("VNX_CODEX_MODEL")
+            or _DEFAULT_MODEL
+        )
         timeout = int(os.environ.get("VNX_CODEX_TIMEOUT", str(_DEFAULT_TIMEOUT)))
         stall_threshold = int(
             os.environ.get("VNX_CODEX_STALL_THRESHOLD", str(_DEFAULT_STALL_THRESHOLD))

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -302,7 +302,9 @@ class GateRequestHandlerMixin:
 
         required = mode == "final" or codex_final_gate_required(changed_files)
         available = self._codex_headless_available()
-        model = os.environ.get("VNX_CODEX_HEADLESS_MODEL") or os.environ.get("VNX_CODEX_MODEL") or "gpt-5.2-codex"
+        # Model from env only; empty string means "use codex config.toml default".
+        # See gate_runner._build_gate_cmd and ~/.codex/config.toml for defaults.
+        model = os.environ.get("VNX_CODEX_HEADLESS_MODEL") or os.environ.get("VNX_CODEX_MODEL") or ""
         requested_at = _utc_now()
         payload = {
             "gate": "codex_gate",


### PR DESCRIPTION
## Root cause

Codex gate failed on every PR since at least #218 with \`Subprocess exited with code 1\` (5s). Direct reproduction of the exact codex command shows:

\`\`\`
The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.
\`\`\`

Codex CLI's \`~/.codex/config.toml\` contains a model-migration mapping (\`"gpt-5.2-codex" = "gpt-5.4"\`) and ChatGPT-account auth rejects older explicit \`-c model=\"gpt-5.x\"\` flags. The hardcoded default \`"gpt-5.2-codex"\` baked into gate code was the actual blocker — NOT the earlier-theorized "GitHub app access" issue.

## Fix

Three call sites previously forced \`-c model="gpt-5.2-codex"\`:
- \`scripts/gate_runner.py:219-229\`
- \`scripts/lib/gate_request_handler.py:305\`
- \`scripts/lib/adapters/codex_adapter.py:33,78-80\`

All now default to empty string (\`""\`) which means "omit the \`-c model=...\` flag entirely and let codex use its \`~/.codex/config.toml\` default" (currently \`gpt-5.3-codex\`). If an operator explicitly sets \`VNX_CODEX_MODEL\` or \`VNX_CODEX_HEADLESS_MODEL\`, those values still override.

## Verification

- \`codex exec --json\` without model flag → proper agent_message events, turn.completed
- \`codex exec --json -c model="gpt-5.2-codex"\` → 400 error
- No regression for operators who still want explicit model override via env vars

## Test plan

- [ ] Run codex gate on this PR; expect \`status: completed\` (not \`status: failed\` with \`exit_nonzero\`)
- [ ] Existing tests for gate_runner still pass
- [ ] \`VNX_CODEX_MODEL\` env override still honored (unit-test if present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)