### PR TITLE
refactor(path-resolution): migrate bash scripts (#225 PR 3/4)

### DIFF
--- a/scripts/lib/vnx_resolve_root.sh
+++ b/scripts/lib/vnx_resolve_root.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# vnx_resolve_root.sh — Project-aware path resolution for VNX bash scripts.
+# Bash equivalent of scripts/lib/project_root.py (issue #225 PR 2/4 Python port).
+#
+# Functions:
+#   vnx_resolve_project_root <caller_file>  → exports VNX_PROJECT_ROOT
+#   vnx_resolve_data_dir                    → exports VNX_DATA_DIR
+#   vnx_resolve_state_dir                   → exports VNX_STATE_DIR
+#   vnx_resolve_dispatch_dir                → exports VNX_DISPATCH_DIR
+#
+# Usage in scripts/:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/vnx_resolve_root.sh"
+#   vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+#   vnx_resolve_data_dir
+#   vnx_resolve_state_dir
+#   vnx_resolve_dispatch_dir
+#
+# Usage in scripts/lib/:
+#   source "$(dirname "${BASH_SOURCE[0]}")/vnx_resolve_root.sh"
+
+# Resolve caller's physical directory, following symlinks.
+# Uses cd -P to avoid requiring readlink -f (not available on macOS by default).
+_vnx_rr_caller_dir() {
+    local file="$1"
+    local dir
+    dir="$(cd "$(dirname "$file")" 2>/dev/null && pwd -P)" || dir=""
+    printf '%s' "$dir"
+}
+
+# vnx_resolve_project_root <caller_file>
+# Exports VNX_PROJECT_ROOT. Returns 1 on failure (no git repo and no fallback).
+#
+# Resolution order:
+#   1. git rev-parse from caller_file's physical directory (symlink-resolved)
+#   2. git rev-parse from CWD
+#   3. $VNX_CANONICAL_ROOT env var (emits DeprecationWarning, will be removed v0.10.0)
+#   4. return 1
+vnx_resolve_project_root() {
+    local caller="${1:-}"
+    local git_root=""
+
+    # 1. Caller file → physical directory → git toplevel
+    if [ -n "$caller" ]; then
+        local caller_dir
+        caller_dir="$(_vnx_rr_caller_dir "$caller")"
+        if [ -n "$caller_dir" ]; then
+            git_root="$(git -C "$caller_dir" rev-parse --show-toplevel 2>/dev/null)" || git_root=""
+            if [ -n "$git_root" ]; then
+                VNX_PROJECT_ROOT="$(cd "$git_root" && pwd -P)"
+                export VNX_PROJECT_ROOT
+                return 0
+            fi
+        fi
+    fi
+
+    # 2. CWD → git toplevel
+    git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || git_root=""
+    if [ -n "$git_root" ]; then
+        VNX_PROJECT_ROOT="$(cd "$git_root" && pwd -P)"
+        export VNX_PROJECT_ROOT
+        return 0
+    fi
+
+    # 3. VNX_CANONICAL_ROOT fallback (deprecated)
+    if [ -n "${VNX_CANONICAL_ROOT:-}" ]; then
+        printf '[vnx] DeprecationWarning: VNX_CANONICAL_ROOT env-var used for project root resolution. Prefer git-based resolution. This fallback will be removed in vnx-orchestration v0.10.0.\n' >&2
+        VNX_PROJECT_ROOT="$(cd "$VNX_CANONICAL_ROOT" 2>/dev/null && pwd -P)" || VNX_PROJECT_ROOT="$VNX_CANONICAL_ROOT"
+        export VNX_PROJECT_ROOT
+        return 0
+    fi
+
+    # 4. Failure
+    printf '[vnx] ERROR: Cannot resolve project root. Not in a git repo and VNX_CANONICAL_ROOT is not set. See https://github.com/Vinix24/vnx-orchestration/issues/225\n' >&2
+    return 1
+}
+
+# vnx_resolve_data_dir
+# Exports VNX_DATA_DIR. Requires VNX_PROJECT_ROOT to be set first.
+#
+# Honors VNX_DATA_DIR only when VNX_DATA_DIR_EXPLICIT=1 to prevent cross-project
+# state pollution from inherited shell environments. Otherwise uses
+# $VNX_PROJECT_ROOT/.vnx-data regardless of VNX_DATA_DIR value.
+vnx_resolve_data_dir() {
+    local explicit_val="${VNX_DATA_DIR:-}"
+    local explicit_flag="${VNX_DATA_DIR_EXPLICIT:-}"
+
+    if [ "$explicit_flag" = "1" ] && [ -n "$explicit_val" ]; then
+        export VNX_DATA_DIR="$explicit_val"
+        return 0
+    fi
+
+    if [ -n "$explicit_val" ] && [ "$explicit_flag" != "1" ]; then
+        printf '[vnx] DeprecationWarning: VNX_DATA_DIR is set but VNX_DATA_DIR_EXPLICIT=1 is not. Ignoring VNX_DATA_DIR; using git-resolved project root. See issue #225.\n' >&2
+    fi
+
+    export VNX_DATA_DIR="${VNX_PROJECT_ROOT}/.vnx-data"
+}
+
+# vnx_resolve_state_dir
+# Exports VNX_STATE_DIR=$VNX_DATA_DIR/state. Requires vnx_resolve_data_dir first.
+vnx_resolve_state_dir() {
+    export VNX_STATE_DIR="${VNX_DATA_DIR}/state"
+}
+
+# vnx_resolve_dispatch_dir
+# Exports VNX_DISPATCH_DIR=$VNX_DATA_DIR/dispatches. Requires vnx_resolve_data_dir first.
+vnx_resolve_dispatch_dir() {
+    export VNX_DISPATCH_DIR="${VNX_DATA_DIR}/dispatches"
+}

--- a/scripts/t0_gate_enforcement.sh
+++ b/scripts/t0_gate_enforcement.sh
@@ -3,8 +3,11 @@
 # Usage: bash scripts/t0_gate_enforcement.sh --pr <num> --branch <branch> --review-stack <stack> --risk-class <risk> --changed-files <files>
 set -euo pipefail
 
-export VNX_STATE_DIR="${VNX_STATE_DIR:-.vnx-data/state}"
-export VNX_DATA_DIR="${VNX_DATA_DIR:-.vnx-data}"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/vnx_resolve_root.sh"
+vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+vnx_resolve_data_dir
+vnx_resolve_state_dir
+vnx_resolve_dispatch_dir
 export VNX_CODEX_HEADLESS_ENABLED=1
 export VNX_GEMINI_REVIEW_ENABLED=1
 

--- a/tests/test_bash_project_root.sh
+++ b/tests/test_bash_project_root.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/vnx_resolve_root.sh
+# Verifies that the bash project-root helper resolves paths correctly via git,
+# honors VNX_DATA_DIR_EXPLICIT=1 for overrides, falls back to VNX_CANONICAL_ROOT,
+# and returns 1 when neither git nor the env fallback is available.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../scripts/lib/vnx_resolve_root.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected='$expected' actual='$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" label="$3"
+    if printf '%s' "$haystack" | grep -qF "$needle"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected substring='$needle' in='$haystack')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_nonempty() {
+    local val="$1" label="$2"
+    if [ -n "$val" ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected non-empty, got empty)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: resolution from existing git repo ────────────────────────────────
+# Source the helper inside a subshell so exported vars don't leak between tests.
+RESULT=$(
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    # shellcheck source=../scripts/lib/vnx_resolve_root.sh
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    printf '%s' "$VNX_PROJECT_ROOT"
+)
+assert_nonempty "$RESULT" "vnx_resolve_project_root resolves from caller file in git repo"
+
+# ── Test 2: VNX_PROJECT_ROOT is the actual git toplevel ─────────────────────
+RESULT=$(
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    expected_root="$(git rev-parse --show-toplevel)"
+    if [ "$VNX_PROJECT_ROOT" = "$expected_root" ]; then
+        printf 'ok'
+    else
+        printf 'fail:%s!=%s' "$VNX_PROJECT_ROOT" "$expected_root"
+    fi
+)
+assert_eq "ok" "$RESULT" "VNX_PROJECT_ROOT matches git rev-parse --show-toplevel"
+
+# ── Test 3: derived dirs are rooted under VNX_PROJECT_ROOT ──────────────────
+RESULT=$(
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    vnx_resolve_data_dir
+    vnx_resolve_state_dir
+    vnx_resolve_dispatch_dir
+    if [[ "$VNX_DATA_DIR" == "${VNX_PROJECT_ROOT}/.vnx-data" ]] &&
+       [[ "$VNX_STATE_DIR" == "${VNX_DATA_DIR}/state" ]] &&
+       [[ "$VNX_DISPATCH_DIR" == "${VNX_DATA_DIR}/dispatches" ]]; then
+        printf 'ok'
+    else
+        printf 'fail: data=%s state=%s dispatch=%s root=%s' "$VNX_DATA_DIR" "$VNX_STATE_DIR" "$VNX_DISPATCH_DIR" "$VNX_PROJECT_ROOT"
+    fi
+)
+assert_eq "ok" "$RESULT" "VNX_DATA_DIR/STATE_DIR/DISPATCH_DIR derived from VNX_PROJECT_ROOT"
+
+# ── Test 4: VNX_DATA_DIR_EXPLICIT=1 honors override ─────────────────────────
+RESULT=$(
+    unset VNX_PROJECT_ROOT VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT 2>/dev/null || true
+    export VNX_DATA_DIR="/custom/data/dir"
+    export VNX_DATA_DIR_EXPLICIT=1
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    vnx_resolve_data_dir
+    printf '%s' "$VNX_DATA_DIR"
+)
+assert_eq "/custom/data/dir" "$RESULT" "VNX_DATA_DIR_EXPLICIT=1 honors VNX_DATA_DIR override"
+
+# ── Test 5: VNX_DATA_DIR without EXPLICIT flag is ignored ───────────────────
+RESULT=$(
+    unset VNX_PROJECT_ROOT VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    export VNX_DATA_DIR="/stale/inherited/dir"
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    vnx_resolve_data_dir 2>/dev/null
+    if [[ "$VNX_DATA_DIR" == "${VNX_PROJECT_ROOT}/.vnx-data" ]]; then
+        printf 'ok'
+    else
+        printf 'fail: %s' "$VNX_DATA_DIR"
+    fi
+)
+assert_eq "ok" "$RESULT" "VNX_DATA_DIR without EXPLICIT flag is ignored (uses git root)"
+
+# ── Test 6: VNX_DATA_DIR without EXPLICIT emits DeprecationWarning ───────────
+WARN=$(
+    unset VNX_PROJECT_ROOT VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    export VNX_DATA_DIR="/stale/dir"
+    source "$HELPER"
+    vnx_resolve_project_root "${BASH_SOURCE[0]:-$0}"
+    vnx_resolve_data_dir 2>&1 1>/dev/null
+)
+assert_contains "DeprecationWarning" "$WARN" "VNX_DATA_DIR without EXPLICIT emits DeprecationWarning"
+
+# ── Test 7: VNX_CANONICAL_ROOT fallback in non-git tempdir ──────────────────
+RESULT=$(
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    export VNX_CANONICAL_ROOT="$tmpdir"
+    cd "$tmpdir"
+    source "$HELPER"
+    # Call without caller arg so step 1 is skipped cleanly, CWD is non-git tmpdir
+    vnx_resolve_project_root "" 2>/dev/null
+    expected="$(cd "$tmpdir" && pwd -P)"
+    if [ "$VNX_PROJECT_ROOT" = "$expected" ]; then
+        printf 'ok'
+    else
+        printf 'fail: %s' "$VNX_PROJECT_ROOT"
+    fi
+)
+assert_eq "ok" "$RESULT" "VNX_CANONICAL_ROOT used as fallback when outside git repo"
+
+# ── Test 8: VNX_CANONICAL_ROOT fallback emits DeprecationWarning ────────────
+WARN=$(
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    export VNX_CANONICAL_ROOT="$tmpdir"
+    cd "$tmpdir"
+    source "$HELPER"
+    vnx_resolve_project_root "" 2>&1 1>/dev/null
+)
+assert_contains "DeprecationWarning" "$WARN" "VNX_CANONICAL_ROOT fallback emits DeprecationWarning"
+
+# ── Test 9: returns 1 with no git and no VNX_CANONICAL_ROOT ─────────────────
+RC=0
+(
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    cd "$tmpdir"
+    source "$HELPER"
+    set +e
+    vnx_resolve_project_root "" 2>/dev/null
+    exit $?
+) || RC=$?
+assert_eq "1" "$RC" "returns exit code 1 when no git repo and VNX_CANONICAL_ROOT unset"
+
+# ── Test 10: resolution from temp git repo ───────────────────────────────────
+RESULT=$(
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    git init -q "$tmpdir"
+    unset VNX_PROJECT_ROOT VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_CANONICAL_ROOT VNX_DATA_DIR_EXPLICIT 2>/dev/null || true
+    cd "$tmpdir"
+    source "$HELPER"
+    vnx_resolve_project_root "" 2>/dev/null
+    # Canonicalize both paths for comparison
+    expected="$(cd "$tmpdir" && pwd -P)"
+    actual="$(cd "$VNX_PROJECT_ROOT" && pwd -P)"
+    if [ "$expected" = "$actual" ]; then
+        printf 'ok'
+    else
+        printf 'fail: expected=%s actual=%s' "$expected" "$actual"
+    fi
+)
+assert_eq "ok" "$RESULT" "resolves correctly from a fresh git init temp repo"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Add `scripts/lib/vnx_resolve_root.sh`: bash equivalent of `project_root.py` (PR 2/4). Exports `VNX_PROJECT_ROOT` via `git rev-parse` with resolution order: caller dir → CWD → `VNX_CANONICAL_ROOT` (deprecated) → return 1. `vnx_resolve_data_dir` only honors `VNX_DATA_DIR` when `VNX_DATA_DIR_EXPLICIT=1`.
- Migrate `scripts/t0_gate_enforcement.sh`: replace bare relative defaults (`${VNX_DATA_DIR:-.vnx-data}`) with `vnx_resolve_root.sh` helper calls.
- Add `tests/test_bash_project_root.sh`: 10 tests covering git resolution, derived dirs, `VNX_DATA_DIR_EXPLICIT=1` override, `DeprecationWarning` emission, `VNX_CANONICAL_ROOT` fallback, and failure exit code.

## Test plan
- [x] `bash -n scripts/*.sh scripts/lib/*.sh tests/*.sh` — all pass
- [x] `bash tests/test_bash_project_root.sh` — 10/10 pass
- [x] Backward compat: `VNX_DATA_DIR_EXPLICIT=1` still honored for worktree isolation

Dispatch-ID: 20260419-160200-project-root-pr3-bash-migration-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)