### PR TITLE
fix(pane-manager): prevent cross-project T0 pane discovery leak

### DIFF
--- a/scripts/pane_manager_v2.sh
+++ b/scripts/pane_manager_v2.sh
@@ -48,8 +48,10 @@ discover_pane_by_title() {
             head -1)
     fi
 
-    # Fallback: search all sessions
-    if [ -z "$pane_id" ]; then
+    # Fallback: search all sessions — ONLY when PROJECT_ROOT is unset.
+    # Cross-project fallback caused receipts to leak to other projects' T0
+    # panes when the own tmux session had no matching pane (e.g. T0-less workers).
+    if [ -z "$pane_id" ] && [ -z "${PROJECT_ROOT:-}" ]; then
         pane_id=$(tmux list-panes -a -F "#{pane_id} #{pane_title}" 2>/dev/null | \
             grep -E "(T${terminal#T}|${terminal})" | \
             awk '{print $1}' | \
@@ -185,22 +187,39 @@ get_pane_id_smart() {
             local cached_pane=$(cat "$cache_file")
             # Verify pane still exists
             if tmux list-panes -a -F "#{pane_id}" 2>/dev/null | grep -q "^${cached_pane}$"; then
-                # If an attached-session pane exists for this terminal path, prefer it.
-                # This avoids routing to stale panes in detached duplicate sessions.
-                local attached_preferred=""
+                # Invalidate cache if the cached pane's cwd does not belong to PROJECT_ROOT.
+                # Prevents stale cross-project cache entries from a prior unscoped fallback.
                 if [ -n "${PROJECT_ROOT:-}" ]; then
-                    local terminal_path="${PROJECT_ROOT}/.claude/terminals/${terminal}"
-                    attached_preferred=$(tmux list-panes -a -F "#{pane_id} #{session_attached} #{pane_current_path}" 2>/dev/null | \
-                        awk -v p="$terminal_path" '$2=="1" && $3==p {print $1; exit}')
+                    local cached_path
+                    cached_path=$(tmux list-panes -a -F "#{pane_id} #{pane_current_path}" 2>/dev/null | \
+                        awk -v p="$cached_pane" '$1==p {print $2; exit}')
+                    case "$cached_path" in
+                        "${PROJECT_ROOT}"/*) : ;;
+                        *)
+                            _pm_log "Cached pane $cached_pane path ($cached_path) outside PROJECT_ROOT; invalidating"
+                            rm -f "$cache_file"
+                            cached_pane=""
+                            ;;
+                    esac
                 fi
-                if [ -n "$attached_preferred" ] && [ "$attached_preferred" != "$cached_pane" ]; then
-                    _pm_log "Cached pane $cached_pane for $terminal is stale; using attached pane $attached_preferred"
-                    echo "$attached_preferred" > "$cache_file"
-                    echo "$attached_preferred"
+                if [ -n "$cached_pane" ]; then
+                    # If an attached-session pane exists for this terminal path, prefer it.
+                    # This avoids routing to stale panes in detached duplicate sessions.
+                    local attached_preferred=""
+                    if [ -n "${PROJECT_ROOT:-}" ]; then
+                        local terminal_path="${PROJECT_ROOT}/.claude/terminals/${terminal}"
+                        attached_preferred=$(tmux list-panes -a -F "#{pane_id} #{session_attached} #{pane_current_path}" 2>/dev/null | \
+                            awk -v p="$terminal_path" '$2=="1" && $3==p {print $1; exit}')
+                    fi
+                    if [ -n "$attached_preferred" ] && [ "$attached_preferred" != "$cached_pane" ]; then
+                        _pm_log "Cached pane $cached_pane for $terminal is stale; using attached pane $attached_preferred"
+                        echo "$attached_preferred" > "$cache_file"
+                        echo "$attached_preferred"
+                        return 0
+                    fi
+                    echo "$cached_pane"
                     return 0
                 fi
-                echo "$cached_pane"
-                return 0
             else
                 _pm_log "Cached pane $cached_pane no longer exists, rediscovering..."
                 rm -f "$cache_file"

--- a/tests/test_pane_manager_scope.sh
+++ b/tests/test_pane_manager_scope.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression test for cross-project pane discovery leak.
+# When PROJECT_ROOT is set and no pane matches in the own tmux session,
+# discover_pane_by_title must NOT fall back to a global tmux scan.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/scripts/pane_manager_v2.sh"
+
+fail=0
+pass=0
+
+_assert() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "ok   — $name"
+        pass=$((pass+1))
+    else
+        echo "FAIL — $name (expected='$expected' actual='$actual')"
+        fail=$((fail+1))
+    fi
+}
+
+# Stub tmux: returns panes from a fake foreign session only (no own session).
+tmux() {
+    case "$*" in
+        "has-session -t vnx-dummy-project"*) return 1 ;;
+        "list-panes -s -t vnx-dummy-project"*) return 0 ;;
+        "list-panes -a -F #{pane_id} #{pane_title}")
+            printf '%s\n' "%99 T0" ;;
+        "list-panes -a -F #{pane_id} #{pane_current_path}")
+            printf '%s\n' "%99 /Users/foreign/project/.claude/terminals/T0" ;;
+        "list-panes -a -F"*session_attached*)
+            printf '%s\n' "%99 1 /Users/foreign/project/.claude/terminals/T0" ;;
+        *) return 0 ;;
+    esac
+}
+export -f tmux
+
+# Case 1: PROJECT_ROOT set, no own-session pane → must return empty (no cross-project leak)
+export PROJECT_ROOT="/Users/me/my-project"
+result=$(discover_pane_by_title T0 2>/dev/null || echo "")
+_assert "title: PROJECT_ROOT set + no own pane → empty" "" "$result"
+
+# Case 2: PROJECT_ROOT unset → legacy global fallback allowed (backward compat)
+unset PROJECT_ROOT
+result=$(discover_pane_by_title T0 2>/dev/null || echo "")
+_assert "title: PROJECT_ROOT unset → global fallback OK" "%99" "$result"
+
+echo "---"
+echo "$pass passed, $fail failed"
+exit $fail


### PR DESCRIPTION
## Summary

- `discover_pane_by_title` no longer falls back to a global `tmux list-panes -a` scan when `PROJECT_ROOT` is set — previously caused receipts from project A to be delivered to project B's T0 pane whenever A's own tmux session lacked a T0
- Cache validation now invalidates entries whose `pane_current_path` is outside `PROJECT_ROOT`, preventing stale cross-project cache files (e.g. `/tmp/vnx_pane_cache_<hash>/T0.pane → %24`) from continuing to leak after the code fix
- Adds `tests/test_pane_manager_scope.sh` regression test

## Symptom

Mission-control T0 session received 8 unsolicited `/t0-orchestrator 📨 RECEIPT:…` paste invocations today, with `Report:` paths pointing to `vnx-roadmap-autopilot-wt/.vnx-data/unified_reports/`. Root cause: SEOcrawler_v2's live `receipt_processor_v4.sh` (PID 11226/12266, supervised daemon) falls back to a global pane scan because SEOcrawler's tmux session has no T0 pane, picks mission-control's %24 as "the T0", and caches it.

## Test plan

- [x] `bash tests/test_pane_manager_scope.sh` — both assertions pass
- [x] `bash -n scripts/pane_manager_v2.sh` — syntax OK
- [ ] CI green
- [ ] After merge: re-install in SEOcrawler_v2 + sales-copilot + any other installed clone, then `rm -rf /tmp/vnx_pane_cache_*` to flush stale cross-project cache entries

## Follow-up

- Rollout to installed clones via `sync-vnx-system.sh --apply` or re-run `install.sh`
- Log as item in operator runbook: after any pane_manager change, flush `/tmp/vnx_pane_cache_*`