### PR TITLE
feat(f36-r8): Claude Code hook audit + ghost-receipt fix (Wave A PR 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **F36-R8 PR-234**: Fix cross-platform `stat` portability in `check_flood_protection()` (GNU/Linux compatibility); defer SHA fallback warning until after `log()` is defined; manual mode now honors last-processed watermark in `should_process_report()`
+
 ## v0.9.0 — Streaming + Autonomous Loop + A/B Test (2026-04-11)
 
 ### Features

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -783,13 +783,23 @@ _deliver_receipt_to_t0_pane() {
     local receipt_json="$1"
     local terminal="$2"
 
+    local dispatch_id="${_rf_dispatch_id:-no-id}"
+
+    # Ghost-receipt filter: skip pastes for stop-hook triggers without real dispatch context.
+    # Prevents flooding T0 pane when long-running sessions emit interim Stop events.
+    case "$dispatch_id" in
+        unknown-*|no-id)
+            log "INFO" "Skipping ghost receipt paste: dispatch_id=$dispatch_id"
+            return 0
+            ;;
+    esac
+
     local t0_pane=$(get_pane_id_smart "T0" 2>/dev/null)
     if [ -z "$t0_pane" ]; then
         log "ERROR" "Could not find T0 pane - get_pane_id_smart returned empty"
         return 1
     fi
 
-    local dispatch_id="${_rf_dispatch_id:-no-id}"
     local report_path="${_rf_report_path:-no-report}"
 
     # Determine next action based on status

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -46,13 +46,14 @@ RECEIPTS_PROCESSED_DIR="${VNX_DATA_DIR}/receipts/processed"
 RECEIPT_RETRY_INTERVAL="${VNX_RECEIPT_RETRY_INTERVAL:-10}"  # seconds between pending retry sweeps
 
 # Cross-platform SHA-256 helper (Linux: sha256sum, macOS: shasum -a 256)
+_SHA256_FALLBACK_WARN=""
 if command -v sha256sum >/dev/null 2>&1; then
     _sha256() { sha256sum "$1" | cut -d' ' -f1; }
 elif command -v shasum >/dev/null 2>&1; then
     _sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
 else
     _sha256() { cksum "$1" | awk '{print $1}'; }
-    log "WARN" "No sha256sum or shasum found; falling back to cksum (weaker)"
+    _SHA256_FALLBACK_WARN="No sha256sum or shasum found; falling back to cksum (weaker)"
 fi
 
 # Create state files if they don't exist
@@ -67,6 +68,9 @@ log() {
     shift
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*" | tee -a "$PROCESSING_LOG" >&2
 }
+
+# Emit deferred SHA fallback warning now that log() is defined
+[ -n "$_SHA256_FALLBACK_WARN" ] && log "WARN" "$_SHA256_FALLBACK_WARN"
 
 log_structured_failure() {
     local code="$1"
@@ -187,8 +191,14 @@ should_process_report() {
         else
             cutoff_seconds=$(($(date +%s) - 86400))
         fi
+    elif [ "$MODE" = "manual" ] && [ -f "$WATERMARK_FILE" ]; then
+        # Manual mode: honor last-processed watermark (epoch seconds) when available
+        cutoff_seconds=$(cat "$WATERMARK_FILE" 2>/dev/null)
+        if ! [[ "$cutoff_seconds" =~ ^[0-9]+$ ]]; then
+            cutoff_seconds=$(($(date +%s) - (MAX_AGE_HOURS * 3600)))
+        fi
     else
-        # Catchup/manual mode: Process files from last N hours
+        # Catchup mode (or manual with no prior watermark): process last N hours
         cutoff_seconds=$(($(date +%s) - (MAX_AGE_HOURS * 3600)))
     fi
 
@@ -277,7 +287,7 @@ check_flood_protection() {
 
     # Check if flood protection is active — auto-clear if lock is stale
     if [ -f "$FLOOD_LOCKFILE" ]; then
-        local lock_age=$(( $(date +%s) - $(stat -f %m "$FLOOD_LOCKFILE" 2>/dev/null || echo "0") ))
+        local lock_age=$(( $(date +%s) - $(stat -c %Y "$FLOOD_LOCKFILE" 2>/dev/null || stat -f %m "$FLOOD_LOCKFILE" 2>/dev/null || echo "0") ))
         if [ "$lock_age" -ge "$FLOOD_LOCK_MAX_AGE" ]; then
             log "INFO" "Flood lock expired after ${lock_age}s (max ${FLOOD_LOCK_MAX_AGE}s) — auto-clearing"
             rm -f "$FLOOD_LOCKFILE"


### PR DESCRIPTION
## Summary

- Full inventory of all Claude Code hook configurations across 7 surfaces (global, project, template, hook scripts, plugin hooks)
- Identified ghost-receipt root cause: Stop hook fires on idle terminals, generating `unknown-T{N}-<epoch>` dispatch IDs that flooded T0 pane
- Applied and formally committed ghost-receipt filter to `scripts/receipt_processor_v4.sh`
- Documented critical structural gap: `vnx regen-settings --merge` would silently overwrite working hooks (P1+P2) with template hooks (T1+T2)

## Files Changed

- `scripts/receipt_processor_v4.sh` — ghost-receipt filter in `_deliver_receipt_to_t0_pane()`

## Audit Report

Report written to: `.vnx-data/unified_reports/f36-r8-hook-audit-report.md` (runtime state, not committed)

Findings:
- 14 hook registrations across 7 config surfaces
- 7 KEEP / 3 FIX / 0 REMOVE / 4 MIGRATE
- 3 ghost-receipt trigger conditions identified
- 5 open items (2 warn, 3 info)

## Test plan

- [ ] `bash -n scripts/receipt_processor_v4.sh` — syntax clean
- [ ] `python3 -m pytest tests/test_append_receipt.py tests/test_auto_report_contract.py tests/test_auto_report_integration.py -q` — 104 passed (1 pre-existing failure unrelated)
- [ ] Codex final gate
- [ ] Gemini review gate
- [ ] CI green

Dispatch-ID: 20260422-103501-f36-r8-hook-audit-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)