### PR TITLE
fix(ci): remove legacy path literals from decision log docstrings

### DIFF
--- a/scripts/lib/t0_decision_log.py
+++ b/scripts/lib/t0_decision_log.py
@@ -4,7 +4,7 @@
 Complements t0_decision_summarizer.py (haiku-powered) with a zero-LLM
 path: converts already-structured decision events (from decision_executor
 or direct callers) into decision log records and appends them to
-.vnx-data/state/t0_decision_log.jsonl.
+the decision log under VNX_STATE_DIR.
 
 Two usage modes:
 
@@ -14,7 +14,7 @@ Two usage modes:
 
 2. Batch replay from events file (CLI):
    python3 scripts/lib/t0_decision_log.py
-   python3 scripts/lib/t0_decision_log.py --events-file .vnx-data/events/t0_decisions.ndjson
+   python3 scripts/lib/t0_decision_log.py --events-file "$VNX_DATA_DIR/events/t0_decisions.ndjson"
    python3 scripts/lib/t0_decision_log.py --dry-run
 
 Decision record schema (same as summarizer output):
@@ -29,8 +29,8 @@ Decision record schema (same as summarizer output):
     "next_expected": ""
   }
 
-Cursor tracking: stores the number of processed lines in
-.vnx-data/state/t0_decision_log_cursor.json so repeated runs are
+Cursor tracking: stores the number of processed lines in a
+cursor JSON file under VNX_STATE_DIR so repeated runs are
 idempotent — only unprocessed events are converted.
 
 BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.

--- a/scripts/lib/t0_decision_summarizer.py
+++ b/scripts/lib/t0_decision_summarizer.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """T0 decision summarizer — haiku-powered T0 session decision log writer.
 
-Reads T0's stream-json events from .vnx-data/events/T0.ndjson,
-extracts text content, summarizes via claude haiku, and appends a
-structured decision record to .vnx-data/state/t0_decision_log.jsonl.
+Reads T0's stream-json events from the T0 events file under
+VNX_DATA_DIR, extracts text content, summarizes via claude haiku,
+and appends a structured decision record to the decision log under
+VNX_STATE_DIR.
 
 Decision record schema:
   {
@@ -19,7 +20,7 @@ Decision record schema:
 
 CLI:
   python3 scripts/lib/t0_decision_summarizer.py
-  python3 scripts/lib/t0_decision_summarizer.py --events-file .vnx-data/events/T0.ndjson
+  python3 scripts/lib/t0_decision_summarizer.py --events-file "$VNX_DATA_DIR/events/T0.ndjson"
   python3 scripts/lib/t0_decision_summarizer.py --dry-run
 
 Environment:


### PR DESCRIPTION
Hot-fix for failing CI Profile A on main after PR #233 merge. Docstring references to .vnx-data/state and .vnx-data/events triggered the legacy-path-gate linter; replaced with VNX_STATE_DIR / VNX_DATA_DIR variable references.