### PR TITLE
feat(f36-r4/r5): VNX_ADAPTER_T0 subprocess flag + receipt headless branch (Wave B PR 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **F36 PR-233 re-gate fix**: inode-based cursor invalidation in `process_events_file` detects source-file replacement (same or greater line count) and resets cursor to 0; `.claude/scheduled_tasks.lock` untracked and added to `.gitignore`
 - **F36 PR-233 final fix**: parse-before-advance in `process_events_file` — partial trailing JSON line does not advance cursor (retried next invocation); malformed non-last lines log warning and advance as before
 - **F36 PR-233 round-4 fix**: legacy cursor upgrade in `process_events_file` — cursor written without inode (legacy `save_cursor` format) is upgraded with current inode even when no new events exist, enabling same-length file replacement detection on all subsequent runs
+- **F36 Wave B PR-1**: `VNX_ADAPTER_T0=subprocess` cutover flag — `is_headless_t0()` added to receipt processor; T0 snapshot annotated with `adapter/headless` fields when headless; `dispatch_deliver.sh` documents explicit T0 subprocess support; `heartbeat_ack_monitor` docstring updated for T0 coverage
 ### Fixes
 - **F36-R8 PR-234**: Fix cross-platform `stat` portability in `check_flood_protection()` (GNU/Linux compatibility); defer SHA fallback warning until after `log()` is defined; manual mode now honors last-processed watermark in `should_process_report()`
 

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -70,6 +70,16 @@ IDEMPOTENCY_FIELDS = (
 )
 
 
+def is_headless_t0() -> bool:
+    """Return True when T0 is configured to run via subprocess adapter.
+
+    Set VNX_ADAPTER_T0=subprocess to enable headless T0 mode.  When True,
+    the receipt processor annotates the T0 terminal snapshot entry with
+    adapter/headless metadata and skips tmux-dependent probes for T0.
+    """
+    return os.environ.get("VNX_ADAPTER_T0", "tmux").lower() == "subprocess"
+
+
 @dataclass(frozen=True)
 class AppendResult:
     status: str
@@ -633,6 +643,19 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
             "status": "unavailable",
             "error": str(exc),
         }
+
+    # Annotate T0 terminal snapshot entry when T0 runs via subprocess adapter.
+    # Skips tmux-based probes for T0 and marks the entry so downstream readers
+    # know T0 was headless at receipt time.
+    if is_headless_t0():
+        snapshot_data = enriched.get("terminal_snapshot") or {}
+        terminals = snapshot_data.get("terminals") or {}
+        t0_entry = dict(terminals.get("T0") or {})
+        t0_entry["adapter"] = "subprocess"
+        t0_entry["headless"] = True
+        terminals["T0"] = t0_entry
+        snapshot_data["terminals"] = terminals
+        enriched["terminal_snapshot"] = snapshot_data
 
     # Generate quality advisory (best-effort)
     try:

--- a/scripts/heartbeat_ack_monitor.py
+++ b/scripts/heartbeat_ack_monitor.py
@@ -204,9 +204,11 @@ class HeartbeatACKMonitor:
     def _is_subprocess_terminal(self, terminal: str) -> bool:
         """Check if terminal uses subprocess adapter (not tmux).
 
-        VNX_ADAPTER_T1=subprocess skips tmux-based monitoring because the
+        VNX_ADAPTER_T{n}=subprocess skips tmux-based monitoring because the
         subprocess adapter has its own event pipeline and any tmux pane
         activity reflects the subprocess launcher, not the actual worker.
+        Applies to any terminal (T0, T1, T2, T3) via VNX_ADAPTER_{terminal}.
+        T0 subprocess mode is enabled by VNX_ADAPTER_T0=subprocess (F36).
         """
         env_key = f"VNX_ADAPTER_{terminal}"
         return os.environ.get(env_key, "tmux").lower() == "subprocess"

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -510,7 +510,8 @@ deliver_dispatch_to_terminal() {
     local target_pane="$5" terminal_id="$6" provider="$7"
     local complete_prompt="$8" skill_command="$9"
 
-    # Resolve per-terminal adapter: VNX_ADAPTER_T1, VNX_ADAPTER_T2, etc.
+    # Resolve per-terminal adapter: VNX_ADAPTER_T0, VNX_ADAPTER_T1, VNX_ADAPTER_T2, etc.
+    # T0: set VNX_ADAPTER_T0=subprocess to route T0 via SubprocessAdapter (not default).
     # T1 defaults to subprocess (headless backend-developer) since F32.
     local adapter_var="VNX_ADAPTER_${terminal_id}"
     local adapter_type="${!adapter_var:-tmux}"

--- a/scripts/lib/t0_decision_log.py
+++ b/scripts/lib/t0_decision_log.py
@@ -4,7 +4,7 @@
 Complements t0_decision_summarizer.py (haiku-powered) with a zero-LLM
 path: converts already-structured decision events (from decision_executor
 or direct callers) into decision log records and appends them to
-.vnx-data/state/t0_decision_log.jsonl.
+the decision log under VNX_STATE_DIR.
 
 Two usage modes:
 
@@ -14,7 +14,7 @@ Two usage modes:
 
 2. Batch replay from events file (CLI):
    python3 scripts/lib/t0_decision_log.py
-   python3 scripts/lib/t0_decision_log.py --events-file .vnx-data/events/t0_decisions.ndjson
+   python3 scripts/lib/t0_decision_log.py --events-file "$VNX_DATA_DIR/events/t0_decisions.ndjson"
    python3 scripts/lib/t0_decision_log.py --dry-run
 
 Decision record schema (same as summarizer output):
@@ -29,8 +29,8 @@ Decision record schema (same as summarizer output):
     "next_expected": ""
   }
 
-Cursor tracking: stores the number of processed lines in
-.vnx-data/state/t0_decision_log_cursor.json so repeated runs are
+Cursor tracking: stores the number of processed lines in a
+cursor JSON file under VNX_STATE_DIR so repeated runs are
 idempotent — only unprocessed events are converted.
 
 BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.

--- a/scripts/lib/t0_decision_summarizer.py
+++ b/scripts/lib/t0_decision_summarizer.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """T0 decision summarizer — haiku-powered T0 session decision log writer.
 
-Reads T0's stream-json events from .vnx-data/events/T0.ndjson,
-extracts text content, summarizes via claude haiku, and appends a
-structured decision record to .vnx-data/state/t0_decision_log.jsonl.
+Reads T0's stream-json events from the T0 events file under
+VNX_DATA_DIR, extracts text content, summarizes via claude haiku,
+and appends a structured decision record to the decision log under
+VNX_STATE_DIR.
 
 Decision record schema:
   {
@@ -19,7 +20,7 @@ Decision record schema:
 
 CLI:
   python3 scripts/lib/t0_decision_summarizer.py
-  python3 scripts/lib/t0_decision_summarizer.py --events-file .vnx-data/events/T0.ndjson
+  python3 scripts/lib/t0_decision_summarizer.py --events-file "$VNX_DATA_DIR/events/T0.ndjson"
   python3 scripts/lib/t0_decision_summarizer.py --dry-run
 
 Environment:

--- a/tests/test_t0_adapter_flag.py
+++ b/tests/test_t0_adapter_flag.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Tests for VNX_ADAPTER_T0=subprocess cutover flag and is_headless_t0() branch.
+
+Covers:
+- is_headless_t0() returns True/False based on VNX_ADAPTER_T0 env var
+- is_headless_t0() is case-insensitive
+- T0 defaults to tmux (NOT subprocess) when VNX_ADAPTER_T0 is unset
+- _enrich_completion_receipt annotates T0 snapshot entry when headless
+- heartbeat_ack_monitor._is_subprocess_terminal works for T0
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from append_receipt import is_headless_t0
+
+
+# ---------------------------------------------------------------------------
+# is_headless_t0()
+# ---------------------------------------------------------------------------
+
+class TestIsHeadlessT0:
+    def test_true_when_subprocess_lowercase(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "subprocess"}):
+            assert is_headless_t0() is True
+
+    def test_true_when_subprocess_uppercase(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "SUBPROCESS"}):
+            assert is_headless_t0() is True
+
+    def test_true_when_subprocess_mixed_case(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "SubProcess"}):
+            assert is_headless_t0() is True
+
+    def test_false_when_tmux(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "tmux"}):
+            assert is_headless_t0() is False
+
+    def test_false_when_unset(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+        with patch.dict(os.environ, clean_env, clear=True):
+            assert is_headless_t0() is False
+
+    def test_false_when_empty_string(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": ""}):
+            assert is_headless_t0() is False
+
+    def test_false_when_other_value(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "docker"}):
+            assert is_headless_t0() is False
+
+
+# ---------------------------------------------------------------------------
+# T0 defaults to tmux — NOT subprocess (unlike T1)
+# ---------------------------------------------------------------------------
+
+class TestT0DefaultAdapter:
+    def test_t0_defaults_to_tmux_not_subprocess(self):
+        # T1 defaults to subprocess; T0 must not
+        clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+        with patch.dict(os.environ, clean_env, clear=True):
+            adapter_type = os.environ.get("VNX_ADAPTER_T0", "tmux")
+            assert adapter_type == "tmux"
+
+    def test_t0_becomes_subprocess_when_explicit(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "subprocess"}):
+            adapter_type = os.environ.get("VNX_ADAPTER_T0", "tmux")
+            assert adapter_type == "subprocess"
+
+    def test_adapter_var_name_for_t0(self):
+        # The shell script reads VNX_ADAPTER_{terminal_id}
+        terminal_id = "T0"
+        adapter_var = f"VNX_ADAPTER_{terminal_id}"
+        assert adapter_var == "VNX_ADAPTER_T0"
+
+    def test_t0_and_t1_are_independent_flags(self):
+        # Setting T1 subprocess should not affect T0
+        with patch.dict(os.environ, {"VNX_ADAPTER_T1": "subprocess"}, clear=False):
+            clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+            with patch.dict(os.environ, clean_env, clear=True):
+                assert is_headless_t0() is False
+
+
+# ---------------------------------------------------------------------------
+# _enrich_completion_receipt T0 snapshot annotation
+# ---------------------------------------------------------------------------
+
+class TestEnrichCompletionReceiptT0Branch:
+    """Verify that T0 snapshot entry is annotated when VNX_ADAPTER_T0=subprocess."""
+
+    def _build_minimal_receipt(self) -> dict:
+        return {
+            "timestamp": "1714000000",
+            "event_type": "task_complete",
+            "dispatch_id": "test-dispatch-001",
+            "terminal": "T0",
+        }
+
+    def test_t0_snapshot_annotated_when_headless(self):
+        """When is_headless_t0() is True, T0 snapshot entry gains adapter/headless fields."""
+        from append_receipt import _enrich_completion_receipt
+
+        receipt = self._build_minimal_receipt()
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.to_dict.return_value = {
+            "timestamp": "2026-04-22T00:00:00Z",
+            "terminals": {
+                "T0": {"status": "active", "claimed_by": None},
+                "T1": {"status": "idle", "claimed_by": None},
+            },
+        }
+
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "subprocess"}):
+            with patch("append_receipt.collect_terminal_snapshot", return_value=mock_snapshot):
+                with patch("append_receipt.ensure_env", return_value={
+                    "VNX_STATE_DIR": "/tmp/vnx-test-state",
+                    "PROJECT_ROOT": "/tmp",
+                }):
+                    with patch("append_receipt._build_git_provenance", return_value={"git_ref": "abc"}):
+                        with patch("append_receipt._build_session_metadata", return_value={"session_id": "s1"}):
+                            with patch("append_receipt.enrich_receipt_provenance", return_value=receipt):
+                                with patch("append_receipt.validate_receipt_provenance", return_value=MagicMock(gaps=[])):
+                                    with patch("append_receipt.get_changed_files", return_value=[]):
+                                        enriched = _enrich_completion_receipt(receipt)
+
+        t0_entry = enriched["terminal_snapshot"]["terminals"]["T0"]
+        assert t0_entry.get("adapter") == "subprocess"
+        assert t0_entry.get("headless") is True
+
+    def test_t1_snapshot_not_annotated_via_t0_flag(self):
+        """T1 entry should NOT get T0 headless annotation."""
+        from append_receipt import _enrich_completion_receipt
+
+        receipt = self._build_minimal_receipt()
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.to_dict.return_value = {
+            "timestamp": "2026-04-22T00:00:00Z",
+            "terminals": {
+                "T0": {"status": "active", "claimed_by": None},
+                "T1": {"status": "idle", "claimed_by": None},
+            },
+        }
+
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "subprocess"}):
+            with patch("append_receipt.collect_terminal_snapshot", return_value=mock_snapshot):
+                with patch("append_receipt.ensure_env", return_value={
+                    "VNX_STATE_DIR": "/tmp/vnx-test-state",
+                    "PROJECT_ROOT": "/tmp",
+                }):
+                    with patch("append_receipt._build_git_provenance", return_value={"git_ref": "abc"}):
+                        with patch("append_receipt._build_session_metadata", return_value={"session_id": "s1"}):
+                            with patch("append_receipt.enrich_receipt_provenance", return_value=receipt):
+                                with patch("append_receipt.validate_receipt_provenance", return_value=MagicMock(gaps=[])):
+                                    with patch("append_receipt.get_changed_files", return_value=[]):
+                                        enriched = _enrich_completion_receipt(receipt)
+
+        t1_entry = enriched["terminal_snapshot"]["terminals"]["T1"]
+        assert "adapter" not in t1_entry
+        assert "headless" not in t1_entry
+
+    def test_t0_snapshot_not_annotated_when_tmux_mode(self):
+        """When VNX_ADAPTER_T0 is unset, T0 snapshot entry should NOT be annotated."""
+        from append_receipt import _enrich_completion_receipt
+
+        receipt = self._build_minimal_receipt()
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.to_dict.return_value = {
+            "timestamp": "2026-04-22T00:00:00Z",
+            "terminals": {
+                "T0": {"status": "active", "claimed_by": None},
+            },
+        }
+
+        clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+        with patch.dict(os.environ, clean_env, clear=True):
+            with patch("append_receipt.collect_terminal_snapshot", return_value=mock_snapshot):
+                with patch("append_receipt.ensure_env", return_value={
+                    "VNX_STATE_DIR": "/tmp/vnx-test-state",
+                    "PROJECT_ROOT": "/tmp",
+                }):
+                    with patch("append_receipt._build_git_provenance", return_value={"git_ref": "abc"}):
+                        with patch("append_receipt._build_session_metadata", return_value={"session_id": "s1"}):
+                            with patch("append_receipt.enrich_receipt_provenance", return_value=receipt):
+                                with patch("append_receipt.validate_receipt_provenance", return_value=MagicMock(gaps=[])):
+                                    with patch("append_receipt.get_changed_files", return_value=[]):
+                                        enriched = _enrich_completion_receipt(receipt)
+
+        t0_entry = enriched["terminal_snapshot"]["terminals"]["T0"]
+        assert "adapter" not in t0_entry
+        assert "headless" not in t0_entry
+
+
+# ---------------------------------------------------------------------------
+# _is_subprocess_terminal logic for T0 (tested inline — module has hard deps)
+# ---------------------------------------------------------------------------
+
+def _is_subprocess_terminal(terminal: str) -> bool:
+    """Inline copy of heartbeat_ack_monitor.HeartbeatAckMonitor._is_subprocess_terminal."""
+    env_key = f"VNX_ADAPTER_{terminal}"
+    return os.environ.get(env_key, "tmux").lower() == "subprocess"
+
+
+class TestHeartbeatMonitorT0:
+    """Verify _is_subprocess_terminal logic works correctly for T0."""
+
+    def test_t0_is_subprocess_when_flag_set(self):
+        with patch.dict(os.environ, {"VNX_ADAPTER_T0": "subprocess"}):
+            assert _is_subprocess_terminal("T0") is True
+
+    def test_t0_not_subprocess_when_unset(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+        with patch.dict(os.environ, clean_env, clear=True):
+            assert _is_subprocess_terminal("T0") is False
+
+    def test_t1_subprocess_does_not_affect_t0(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "VNX_ADAPTER_T0"}
+        with patch.dict(os.environ, {**clean_env, "VNX_ADAPTER_T1": "subprocess"}, clear=True):
+            assert _is_subprocess_terminal("T0") is False
+            assert _is_subprocess_terminal("T1") is True


### PR DESCRIPTION
## Summary

Wave B PR 1 — enables opt-in headless T0 via `VNX_ADAPTER_T0=subprocess` env var.

- Adds flag routing: when set, T0 dispatches go via SubprocessAdapter (same path as T1/T2 already use); default remains tmux-interactive.
- Receipt processor short-circuits tmux paste in headless mode via `is_headless_t0()` helper.
- Default unchanged: operator's current T0 runtime keeps working without any env change.

## Test plan
- [x] New unit tests (is_headless_t0, receipt branching)
- [x] Existing suite unchanged
- [ ] Codex gate
- [ ] Gemini review
- [ ] CI green