### PR TITLE
feat(f32-r1): T2/T3 default to subprocess (Wave D PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- **F32 Wave D PR-1**: T2/T3 default subprocess delivery — `deliver_dispatch_to_terminal` now defaults T1/T2/T3 to subprocess adapter; T0 remains tmux by default; `VNX_ADAPTER_Tx=tmux` opts any terminal back to tmux
 - **F36 PR-1**: T0 decision summarizer (`t0_decision_summarizer.py`) — haiku-powered structured decision log writer with file-locking JSONL append, log rotation, and assembler query interface
 - **F36 PR-1b**: T0 decision log passive writer (`t0_decision_log.py`) — zero-LLM path converting decision_executor events to JSONL records with cursor tracking for idempotent incremental replay
 - **F36 PR-233 fix**: `_rotate_if_needed` holds exclusive lock across full copy+truncate to prevent concurrent-writer data loss; `process_events_file` resets stale cursor when it exceeds file length after source reset

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -501,7 +501,7 @@ _ddt_subprocess_delivery() {
 
 # deliver_dispatch_to_terminal — input-mode guard, worktree path resolution, delivery.
 # Checks VNX_ADAPTER_T{n} env var: if "subprocess", routes via SubprocessAdapter.
-# Default (tmux or unset): uses existing tmux send-keys delivery.
+# T0 defaults to tmux; T1/T2/T3 default to subprocess (set VNX_ADAPTER_Tx=tmux to opt-out).
 # Params: dispatch_file track agent_role dispatch_id target_pane terminal_id
 #         provider complete_prompt skill_command
 # Reads globals: _DL_RC_GENERATION _DL_RC_ATTEMPT_ID
@@ -512,10 +512,10 @@ deliver_dispatch_to_terminal() {
 
     # Resolve per-terminal adapter: VNX_ADAPTER_T0, VNX_ADAPTER_T1, VNX_ADAPTER_T2, etc.
     # T0: set VNX_ADAPTER_T0=subprocess to route T0 via SubprocessAdapter (not default).
-    # T1 defaults to subprocess (headless backend-developer) since F32.
+    # T1/T2/T3 default to subprocess (headless workers) since F32; set VNX_ADAPTER_Tx=tmux to opt-out.
     local adapter_var="VNX_ADAPTER_${terminal_id}"
     local adapter_type="${!adapter_var:-tmux}"
-    if [[ "$terminal_id" == "T1" && "$adapter_type" == "tmux" && -z "${!adapter_var:-}" ]]; then
+    if [[ "$terminal_id" =~ ^T[123]$ && "$adapter_type" == "tmux" && -z "${!adapter_var:-}" ]]; then
         adapter_type="subprocess"
     fi
 

--- a/tests/test_t2_t3_subprocess_default.sh
+++ b/tests/test_t2_t3_subprocess_default.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tests for T2/T3 subprocess-default adapter selection logic (F32 Wave D PR-1)
+# Verifies that T1/T2/T3 default to subprocess and T0 defaults to tmux,
+# and that VNX_ADAPTER_Tx=tmux opts out correctly.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# Inline the adapter selection logic from dispatch_deliver.sh lines 516-520
+resolve_adapter() {
+    local terminal_id="$1"
+    local adapter_var="VNX_ADAPTER_${terminal_id}"
+    local adapter_type="${!adapter_var:-tmux}"
+    if [[ "$terminal_id" =~ ^T[123]$ && "$adapter_type" == "tmux" && -z "${!adapter_var:-}" ]]; then
+        adapter_type="subprocess"
+    fi
+    echo "$adapter_type"
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label — expected='$expected' got='$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== T2/T3 subprocess-default adapter selection tests ==="
+
+# --- T0: defaults to tmux ---
+unset VNX_ADAPTER_T0
+assert_eq "T0 unset -> tmux" "tmux" "$(resolve_adapter T0)"
+
+VNX_ADAPTER_T0=subprocess
+assert_eq "T0 explicit subprocess -> subprocess" "subprocess" "$(resolve_adapter T0)"
+unset VNX_ADAPTER_T0
+
+VNX_ADAPTER_T0=tmux
+assert_eq "T0 explicit tmux -> tmux" "tmux" "$(resolve_adapter T0)"
+unset VNX_ADAPTER_T0
+
+# --- T1: defaults to subprocess ---
+unset VNX_ADAPTER_T1
+assert_eq "T1 unset -> subprocess" "subprocess" "$(resolve_adapter T1)"
+
+VNX_ADAPTER_T1=tmux
+assert_eq "T1 explicit tmux opt-out -> tmux" "tmux" "$(resolve_adapter T1)"
+unset VNX_ADAPTER_T1
+
+VNX_ADAPTER_T1=subprocess
+assert_eq "T1 explicit subprocess -> subprocess" "subprocess" "$(resolve_adapter T1)"
+unset VNX_ADAPTER_T1
+
+# --- T2: defaults to subprocess (new in Wave D PR-1) ---
+unset VNX_ADAPTER_T2
+assert_eq "T2 unset -> subprocess" "subprocess" "$(resolve_adapter T2)"
+
+VNX_ADAPTER_T2=tmux
+assert_eq "T2 explicit tmux opt-out -> tmux" "tmux" "$(resolve_adapter T2)"
+unset VNX_ADAPTER_T2
+
+VNX_ADAPTER_T2=subprocess
+assert_eq "T2 explicit subprocess -> subprocess" "subprocess" "$(resolve_adapter T2)"
+unset VNX_ADAPTER_T2
+
+# --- T3: defaults to subprocess (new in Wave D PR-1) ---
+unset VNX_ADAPTER_T3
+assert_eq "T3 unset -> subprocess" "subprocess" "$(resolve_adapter T3)"
+
+VNX_ADAPTER_T3=tmux
+assert_eq "T3 explicit tmux opt-out -> tmux" "tmux" "$(resolve_adapter T3)"
+unset VNX_ADAPTER_T3
+
+VNX_ADAPTER_T3=subprocess
+assert_eq "T3 explicit subprocess -> subprocess" "subprocess" "$(resolve_adapter T3)"
+unset VNX_ADAPTER_T3
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Wave D PR 1 — flip default delivery path for T2/T3 from tmux to subprocess. Operator can force tmux via VNX_ADAPTER_Tx=tmux escape hatch. T0/T1 unchanged (T0 still opt-in via VNX_ADAPTER_T0, T1 already subprocess).