### PR TITLE
fix(w0-cleanup): auto-compute gate scope + D-8 blocker severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - **fix(w0-pr3)**: Restore comprehensive `scripts/lib/terminal_state_check.py` deleted in c90615e; add `tests/test_terminal_state_check_regression.py` to prevent re-deletion (12 tests, 12 passed)
 ## Unreleased
 
+### Fixes
+- **W0 cleanup**: `scripts/review_gate_manager.py` — auto-compute `changed_files` from git diff when `--changed-files` is empty and `--branch` is provided (eliminates context contamination); `scripts/lib/dispatch_instruction_validator.py` — D-8 rule bumped from `warn` to `blocker` for gate-bearing dispatches; 4 new tests
+
 ### Bug Fixes
 
 - **W0 PR-2 fix**: `receipt_processor_v4.sh` — fix shell quoting in `_auto_release_lease_on_receipt` (array-based args replace unquoted `${:+}` expansion) and fix conflicting state on `task_timeout+no_confirmation` (skip auto-release when shadow intentionally keeps terminal blocked); 8 new tests (22 total)

--- a/scripts/lib/dispatch_instruction_validator.py
+++ b/scripts/lib/dispatch_instruction_validator.py
@@ -218,7 +218,7 @@ def _check_gate_has_success_criteria(content: str, result: DispatchValidationRes
         has_criteria = bool(re.search(r"###\s+Success\s+Criteria", content, re.IGNORECASE))
         if not has_criteria:
             result.findings.append(DispatchFinding(
-                rule="D-8", severity="warn",
+                rule="D-8", severity="blocker",
                 message=f"Gate '{gate_value}' declared but no '### Success Criteria' section found. "
                         "Workers cannot self-assess completion without explicit acceptance criteria.",
             ))

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -131,6 +131,26 @@ def _parse_changed_files(value: str) -> List[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def _compute_changed_files(branch: str) -> List[str]:
+    """Auto-compute changed files by diffing branch against origin/main or main."""
+    for base in ("origin/main", "main"):
+        try:
+            proc = subprocess.run(
+                ["git", "diff", "--name-only", f"{base}...{branch}"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if proc.returncode == 0:
+                files = [f.strip() for f in proc.stdout.splitlines() if f.strip()]
+                print(
+                    f"review_gate_manager: auto-computed {len(files)} changed files from {base}",
+                    file=sys.stderr,
+                )
+                return files
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    return []
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser with all subcommands."""
     parser = argparse.ArgumentParser(description="VNX review gate manager")
@@ -182,12 +202,15 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _handle_request_and_execute(manager: ReviewGateManager, args: argparse.Namespace) -> int:
     """Handle request-and-execute subcommand."""
+    changed_files = _parse_changed_files(args.changed_files)
+    if not changed_files and args.branch:
+        changed_files = _compute_changed_files(args.branch)
     result = manager.request_and_execute(
         pr_number=args.pr,
         branch=args.branch,
         review_stack=[item.strip() for item in args.review_stack.split(",") if item.strip()],
         risk_class=args.risk_class,
-        changed_files=_parse_changed_files(args.changed_files),
+        changed_files=changed_files,
         mode=args.mode,
     )
     print(json.dumps(result, indent=2))
@@ -231,12 +254,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     manager = ReviewGateManager()
 
     if args.command == "request":
+        changed_files = _parse_changed_files(args.changed_files)
+        if not changed_files and args.branch:
+            changed_files = _compute_changed_files(args.branch)
         result = manager.request_reviews(
             pr_number=args.pr,
             branch=args.branch,
             review_stack=[item.strip() for item in args.review_stack.split(",") if item.strip()],
             risk_class=args.risk_class,
-            changed_files=_parse_changed_files(args.changed_files),
+            changed_files=changed_files,
             mode=args.mode,
         )
         print(json.dumps(result, indent=2))

--- a/tests/test_dispatch_instruction_validator.py
+++ b/tests/test_dispatch_instruction_validator.py
@@ -414,11 +414,11 @@ class TestGateRequiresSuccessCriteria:
         d8 = [f for f in result.findings if f.rule == "D-8"]
         assert len(d8) == 0
 
-    def test_gate_without_criteria_is_warn(self) -> None:
+    def test_gate_without_criteria_is_blocker(self) -> None:
         result = validate_dispatch_instruction(GATE_NO_CRITERIA)
         d8 = [f for f in result.findings if f.rule == "D-8"]
         assert len(d8) == 1
-        assert d8[0].severity == "warn"
+        assert d8[0].severity == "blocker"
 
     def test_no_gate_no_d8(self) -> None:
         content = """
@@ -430,6 +430,24 @@ Simple task without gate.
         result = validate_dispatch_instruction(content)
         d8 = [f for f in result.findings if f.rule == "D-8"]
         assert len(d8) == 0
+
+    def test_d8_gate_bearing_without_success_criteria_is_blocker(self) -> None:
+        result = validate_dispatch_instruction(GATE_NO_CRITERIA)
+        d8 = [f for f in result.findings if f.rule == "D-8"]
+        assert len(d8) == 1
+        assert d8[0].severity == "blocker"
+        assert result.passed is False
+
+    def test_d8_no_gate_header_still_warn(self) -> None:
+        content = """
+Dispatch-ID: 20260422-182004-nogate3-A
+
+### Description
+Simple task without a Gate header or Success Criteria.
+"""
+        result = validate_dispatch_instruction(content)
+        d8_blockers = [f for f in result.findings if f.rule == "D-8" and f.severity == "blocker"]
+        assert len(d8_blockers) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_gate_manager.py
+++ b/tests/test_review_gate_manager.py
@@ -193,3 +193,81 @@ def test_record_result_rejects_pass_without_report_path_or_request(review_env, m
             summary="No blocking findings",
             contract_hash="hash-999",
         )
+
+
+def test_changed_files_auto_computed_from_branch(review_env, monkeypatch):
+    """When --changed-files is empty and --branch is set, git diff is invoked."""
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+    monkeypatch.setenv("VNX_GEMINI_REVIEW_ENABLED", "1")
+
+    captured_changed_files: list = []
+
+    def fake_request_reviews(self, pr_number, branch, review_stack, risk_class, changed_files, mode):
+        captured_changed_files.extend(changed_files)
+        return {"requested": []}
+
+    git_calls: list = []
+
+    def fake_run(cmd, **kwargs):
+        git_calls.append(cmd)
+
+        class FakeProc:
+            returncode = 0
+            stdout = "scripts/foo.py\nscripts/bar.py\n"
+
+        return FakeProc()
+
+    monkeypatch.setattr(rgm.ReviewGateManager, "request_reviews", fake_request_reviews)
+    monkeypatch.setattr(rgm.subprocess, "run", fake_run)
+
+    argv = [
+        "request",
+        "--pr", "99",
+        "--branch", "feature/auto-scope",
+        "--changed-files", "",
+    ]
+    rgm.main(argv)
+
+    assert any("git" in str(c) for c in git_calls), "git diff should have been called"
+    assert "scripts/foo.py" in captured_changed_files
+    assert "scripts/bar.py" in captured_changed_files
+
+
+def test_changed_files_override_preserves_explicit(review_env, monkeypatch):
+    """When --changed-files is provided, no auto-compute git call is made."""
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+    monkeypatch.setenv("VNX_GEMINI_REVIEW_ENABLED", "1")
+
+    captured_changed_files: list = []
+
+    def fake_request_reviews(self, pr_number, branch, review_stack, risk_class, changed_files, mode):
+        captured_changed_files.extend(changed_files)
+        return {"requested": []}
+
+    git_calls: list = []
+
+    def fake_run(cmd, **kwargs):
+        git_calls.append(cmd)
+
+        class FakeProc:
+            returncode = 0
+            stdout = "should/not/appear.py\n"
+
+        return FakeProc()
+
+    monkeypatch.setattr(rgm.ReviewGateManager, "request_reviews", fake_request_reviews)
+    monkeypatch.setattr(rgm.subprocess, "run", fake_run)
+
+    argv = [
+        "request",
+        "--pr", "100",
+        "--branch", "feature/explicit-files",
+        "--changed-files", "a.py,b.py",
+    ]
+    rgm.main(argv)
+
+    diff_calls = [c for c in git_calls if "diff" in c and "--name-only" in c]
+    assert len(diff_calls) == 0, "git diff --name-only should NOT be called when --changed-files is explicit"
+    assert "a.py" in captured_changed_files
+    assert "b.py" in captured_changed_files
+    assert "should/not/appear.py" not in captured_changed_files


### PR DESCRIPTION
## Summary

Two follow-up fixes from W0 chain:

- **OI-1112/OI-1114**: review_gate_manager auto-computes `--changed-files` from `git diff --name-only <base>...<branch>` when not provided, giving reviewers explicit scope anchor (fixes recurring contamination where gates returned findings about files not in the PR)
- **OI-1113**: dispatch_instruction_validator D-8 (Success Criteria must-have) now emits blocker severity for gate-bearing dispatches instead of warn

## Test plan

- [x] 4 new tests for both changes pass
- [x] Full suite: 115 passed in 61.60s
- [x] Backward compatible: explicit --changed-files still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)