### PR TITLE
fix(w0-cleanup2): strict run_id + fail-closed compute_changed_files

### DIFF
--- a/scripts/lib/log_artifact.py
+++ b/scripts/lib/log_artifact.py
@@ -17,12 +17,16 @@ import re
 from pathlib import Path
 from typing import Optional
 
+_SAFE_RUN_ID = re.compile(r'^[A-Za-z0-9_\-.]+$')
 
-def _safe_filename(run_id: str) -> str:
-    """Return a filesystem-safe name component — no path separators or dot-dot sequences."""
-    safe = re.sub(r"[^a-zA-Z0-9\-_.]", "_", run_id)
-    safe = re.sub(r"\.{2,}", "_", safe)
-    return safe
+
+def _assert_safe_run_id(run_id: str) -> str:
+    """Validate run_id is filesystem-safe — raises ValueError if not."""
+    if not run_id or not _SAFE_RUN_ID.match(run_id) or ".." in run_id:
+        raise ValueError(
+            f"invalid run_id: {run_id!r} (must match [A-Za-z0-9_\\-.]+ and not contain ..)"
+        )
+    return run_id
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +99,7 @@ def write_log_artifact(
         status=status,
     )
 
-    log_path = artifact_dir / f"{_safe_filename(run_id)}.log"
+    log_path = artifact_dir / f"{_assert_safe_run_id(run_id)}.log"
     log_path.write_text(content, encoding="utf-8")
     return log_path
 
@@ -120,6 +124,6 @@ def write_output_artifact(
     artifact_dir = Path(artifact_dir)
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
-    out_path = artifact_dir / f"{_safe_filename(run_id)}.out"
+    out_path = artifact_dir / f"{_assert_safe_run_id(run_id)}.out"
     out_path.write_text(stdout, encoding="utf-8")
     return out_path

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -132,23 +132,27 @@ def _parse_changed_files(value: str) -> List[str]:
 
 
 def _compute_changed_files(branch: str) -> List[str]:
-    """Auto-compute changed files by diffing branch against origin/main or main."""
+    """Auto-compute changed files by diffing branch against origin/main or main.
+
+    Raises ValueError when both bases fail — callers must handle or pass --changed-files explicitly.
+    """
+    last_err = None
     for base in ("origin/main", "main"):
         try:
             proc = subprocess.run(
                 ["git", "diff", "--name-only", f"{base}...{branch}"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, text=True, timeout=10, check=True,
             )
-            if proc.returncode == 0:
-                files = [f.strip() for f in proc.stdout.splitlines() if f.strip()]
-                print(
-                    f"review_gate_manager: auto-computed {len(files)} changed files from {base}",
-                    file=sys.stderr,
-                )
-                return files
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
-    return []
+            return [f.strip() for f in proc.stdout.splitlines() if f.strip()]
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            last_err = e
+    print(
+        f"review_gate_manager: WARNING git diff failed for {branch!r} "
+        f"against origin/main/main — reviewers will lack scope context. "
+        f"Pass --changed-files explicitly to proceed. ({last_err})",
+        file=sys.stderr,
+    )
+    raise ValueError(f"cannot auto-compute changed_files for branch {branch!r}")
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -204,7 +208,11 @@ def _handle_request_and_execute(manager: ReviewGateManager, args: argparse.Names
     """Handle request-and-execute subcommand."""
     changed_files = _parse_changed_files(args.changed_files)
     if not changed_files and args.branch:
-        changed_files = _compute_changed_files(args.branch)
+        try:
+            changed_files = _compute_changed_files(args.branch)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
     result = manager.request_and_execute(
         pr_number=args.pr,
         branch=args.branch,
@@ -256,7 +264,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "request":
         changed_files = _parse_changed_files(args.changed_files)
         if not changed_files and args.branch:
-            changed_files = _compute_changed_files(args.branch)
+            try:
+                changed_files = _compute_changed_files(args.branch)
+            except ValueError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 2
         result = manager.request_reviews(
             pr_number=args.pr,
             branch=args.branch,

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Tests for OI-1115 — strict run_id validation in log_artifact."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from log_artifact import _assert_safe_run_id
+
+
+def test_run_id_path_traversal_rejected():
+    with pytest.raises(ValueError, match="invalid run_id"):
+        _assert_safe_run_id("../x")
+
+
+def test_run_id_with_slashes_rejected():
+    with pytest.raises(ValueError, match="invalid run_id"):
+        _assert_safe_run_id("a/b")
+
+
+def test_run_id_empty_rejected():
+    with pytest.raises(ValueError, match="invalid run_id"):
+        _assert_safe_run_id("")
+
+
+def test_run_id_valid_accepted():
+    assert _assert_safe_run_id("abc-123_v2") == "abc-123_v2"

--- a/tests/test_review_gate_manager.py
+++ b/tests/test_review_gate_manager.py
@@ -271,3 +271,32 @@ def test_changed_files_override_preserves_explicit(review_env, monkeypatch):
     assert "a.py" in captured_changed_files
     assert "b.py" in captured_changed_files
     assert "should/not/appear.py" not in captured_changed_files
+
+
+def test_compute_changed_files_raises_on_both_bases_fail(review_env, monkeypatch):
+    """_compute_changed_files raises ValueError when both origin/main and main bases fail."""
+    import subprocess as sp
+
+    def fake_run_fail(cmd, **kwargs):
+        raise sp.CalledProcessError(128, cmd)
+
+    monkeypatch.setattr(rgm.subprocess, "run", fake_run_fail)
+
+    with pytest.raises(ValueError, match="cannot auto-compute"):
+        rgm._compute_changed_files("feature/broken-branch")
+
+
+def test_main_handles_compute_failure_gracefully(review_env, monkeypatch):
+    """main exits with code 2 and helpful message when auto-compute fails."""
+    import subprocess as sp
+
+    def fake_run_fail(cmd, **kwargs):
+        raise sp.CalledProcessError(128, cmd)
+
+    monkeypatch.setattr(rgm.subprocess, "run", fake_run_fail)
+    monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
+
+    exit_code = rgm.main([
+        "request", "--pr", "55", "--branch", "feature/broken-refs", "--changed-files", "",
+    ])
+    assert exit_code == 2


### PR DESCRIPTION
## Summary

Close OI-1115 + OI-1116 from W0 chain tail:

- **log_artifact**: replace sanitize-on-unsafe with `_assert_safe_run_id` that raises ValueError (no silent filename collision)
- **review_gate_manager**: `_compute_changed_files` now raises instead of silent `[]` return when both git diff bases fail; callers exit with helpful error

## Test plan

- [x] 15 tests pass (4 new log_artifact + 2 new review_gate_manager)
- [x] Full suite: no regressions
- [x] Happy path unchanged for valid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)