### PR TITLE
fix(latency-pr3): timeout misclassification + SessionStore flock

### DIFF
--- a/scripts/lib/session_store.py
+++ b/scripts/lib/session_store.py
@@ -13,6 +13,8 @@ BILLING SAFETY: No Anthropic SDK. Pure file I/O.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import logging
 import os
@@ -59,6 +61,35 @@ class SessionStore:
     def _path(self) -> Path:
         base = self._state_dir if self._state_dir is not None else _default_state_dir()
         return base / SESSIONS_FILENAME
+
+    @contextlib.contextmanager
+    def _flock(self, exclusive: bool = True):
+        """Acquire flock on a sentinel lock file to serialize access across
+        concurrent dispatcher/worker processes. Non-fatal on failure."""
+        lock_path = self._path().parent / (SESSIONS_FILENAME + ".lock")
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            logger.debug("SessionStore._flock: mkdir failed: %s", exc)
+            yield
+            return
+        lock_fd = None
+        try:
+            lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+            fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except Exception as exc:
+            logger.debug("SessionStore._flock: %s (degraded, no lock)", exc)
+            yield
+        finally:
+            if lock_fd is not None:
+                try:
+                    os.close(lock_fd)
+                except OSError:
+                    pass
 
     def _read_raw(self) -> Dict[str, Any]:
         """Read and parse the sessions file. Returns empty dict on any error."""
@@ -121,15 +152,16 @@ class SessionStore:
         if not session_id:
             return
         try:
-            data = self._read_raw()
-            data.setdefault("schema_version", SCHEMA_VERSION)
-            terminals = data.setdefault("terminals", {})
-            terminals[terminal_id] = {
-                "session_id": session_id,
-                "dispatch_id": dispatch_id,
-                "updated_at": _now_iso(),
-            }
-            self._write_raw(data)
+            with self._flock(exclusive=True):
+                data = self._read_raw()
+                data.setdefault("schema_version", SCHEMA_VERSION)
+                terminals = data.setdefault("terminals", {})
+                terminals[terminal_id] = {
+                    "session_id": session_id,
+                    "dispatch_id": dispatch_id,
+                    "updated_at": _now_iso(),
+                }
+                self._write_raw(data)
             logger.info(
                 "SessionStore.save: %s session_id=%s dispatch=%s",
                 terminal_id, session_id, dispatch_id,
@@ -140,12 +172,13 @@ class SessionStore:
     def clear(self, terminal_id: str) -> None:
         """Remove persisted session for terminal_id.  Never raises."""
         try:
-            data = self._read_raw()
-            terminals = data.get("terminals", {})
-            if terminal_id in terminals:
-                del terminals[terminal_id]
-                self._write_raw(data)
-                logger.info("SessionStore.clear: removed %s", terminal_id)
+            with self._flock(exclusive=True):
+                data = self._read_raw()
+                terminals = data.get("terminals", {})
+                if terminal_id in terminals:
+                    del terminals[terminal_id]
+                    self._write_raw(data)
+                    logger.info("SessionStore.clear: removed %s", terminal_id)
         except Exception as exc:
             logger.debug("SessionStore.clear(%s): %s", terminal_id, exc)
 

--- a/scripts/lib/session_store.py
+++ b/scripts/lib/session_store.py
@@ -74,17 +74,21 @@ class SessionStore:
             yield
             return
         lock_fd = None
+        lock_acquired = False
         try:
-            lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-            fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
             try:
-                yield
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        except Exception as exc:
-            logger.debug("SessionStore._flock: %s (degraded, no lock)", exc)
+                lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+                fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+                lock_acquired = True
+            except Exception as exc:
+                logger.debug("SessionStore._flock: %s (degraded, no lock)", exc)
             yield
         finally:
+            if lock_acquired and lock_fd is not None:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
             if lock_fd is not None:
                 try:
                     os.close(lock_fd)

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -86,9 +86,17 @@ class SubprocessAdapter:
         self._session_ids: Dict[str, str] = {}
         # terminal_id -> dispatch_id from most recent deliver()
         self._dispatch_ids: Dict[str, str] = {}
+        # Set of terminal_ids that were killed by chunk/total timeout
+        self._timed_out: set = set()
         # Lazy-loaded EventStore (optional dependency)
         self._event_store = None
         self._event_store_loaded = False
+
+    def was_timed_out(self, terminal_id: str) -> bool:
+        """Return True if the last read_events_with_timeout() for terminal_id
+        hit chunk_timeout or total_deadline. Callers should check this after
+        iteration to classify outcome as failure rather than success."""
+        return terminal_id in self._timed_out
 
     def _get_event_store(self):
         """Lazy-load EventStore. Returns None if not available."""
@@ -400,6 +408,8 @@ class SubprocessAdapter:
             total_deadline = float(os.environ["VNX_TOTAL_DEADLINE"])
         except (KeyError, ValueError):
             pass
+        # Clear any prior timeout flag for this terminal
+        self._timed_out.discard(terminal_id)
         process = self._processes.get(terminal_id)
         if process is None or process.stdout is None:
             return
@@ -414,6 +424,7 @@ class SubprocessAdapter:
                     "read_events_with_timeout: total deadline (%.0fs) exceeded for %s",
                     total_deadline, terminal_id,
                 )
+                self._timed_out.add(terminal_id)
                 self.stop(terminal_id)
                 break
 
@@ -425,6 +436,7 @@ class SubprocessAdapter:
                     "read_events_with_timeout: chunk timeout (%.0fs) for %s",
                     chunk_timeout, terminal_id,
                 )
+                self._timed_out.add(terminal_id)
                 self.stop(terminal_id)
                 break
 

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -477,6 +477,21 @@ def deliver_via_subprocess(
                 event_count=event_count,
                 manifest_path=completed_manifest or manifest_path,
             )
+        # Fail-closed: timeout-terminated dispatches must not be classified as success.
+        # stop() removes the process from _processes so returncode above is None,
+        # but was_timed_out() tracks the authoritative kill-by-timeout signal.
+        if adapter.was_timed_out(terminal_id):
+            logger.warning(
+                "deliver_via_subprocess: timeout-terminated dispatch %s for %s — fail-closed",
+                dispatch_id,
+                terminal_id,
+            )
+            return _SubprocessResult(
+                success=False,
+                session_id=session_id,
+                event_count=event_count,
+                manifest_path=completed_manifest or manifest_path,
+            )
         return _SubprocessResult(
             success=True,
             session_id=session_id,

--- a/tests/test_latency_pr2_session_resume.py
+++ b/tests/test_latency_pr2_session_resume.py
@@ -160,6 +160,7 @@ def _make_deliver_mocks(session_id_returned: str | None = "sess-from-init"):
     mock_adapter.read_events_with_timeout.return_value = iter([])
     mock_adapter.get_session_id.return_value = session_id_returned
     mock_adapter.observe.return_value = obs_result
+    mock_adapter.was_timed_out.return_value = False
     mock_adapter._get_event_store.return_value = None
 
     return mock_adapter

--- a/tests/test_latency_pr3_timeout_flock.py
+++ b/tests/test_latency_pr3_timeout_flock.py
@@ -1,0 +1,94 @@
+"""Tests for latency PR-3: timeout misclassification + SessionStore flock.
+
+- was_timed_out() signal propagation from adapter into deliver_via_subprocess
+- SessionStore concurrent save() preserves all terminal entries via fcntl.flock
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+
+import subprocess_dispatch
+from session_store import SessionStore
+from subprocess_dispatch import deliver_via_subprocess
+
+
+@pytest.fixture
+def mock_adapter():
+    with patch("subprocess_dispatch.SubprocessAdapter") as cls:
+        instance = MagicMock()
+        instance.was_timed_out.return_value = False
+        deliver_result = MagicMock()
+        deliver_result.success = True
+        deliver_result.session_id = "sess-abc"
+        deliver_result.terminal_id = "T1"
+        deliver_result.dispatch_id = "d-1"
+        deliver_result.pane_id = None
+        deliver_result.path_used = "subprocess"
+        instance.deliver.return_value = deliver_result
+        instance.read_events_with_timeout.return_value = iter([])
+        obs = MagicMock()
+        obs.transport_state = {"returncode": 0}
+        instance.observe.return_value = obs
+        instance._get_event_store.return_value = None
+        instance.get_session_id.return_value = "sess-abc"
+        cls.return_value = instance
+        yield instance
+
+
+class TestTimeoutClassification:
+    def test_was_timed_out_marks_failure(self, mock_adapter):
+        mock_adapter.was_timed_out.return_value = True
+        result = deliver_via_subprocess("T1", "do stuff", "sonnet", "d-1")
+        assert result.success is False
+
+    def test_happy_path_not_timed_out(self, mock_adapter):
+        mock_adapter.was_timed_out.return_value = False
+        result = deliver_via_subprocess("T1", "do stuff", "sonnet", "d-1")
+        assert result.success is True
+
+
+class TestSessionStoreFlock:
+    def test_concurrent_save_preserves_all_entries(self, tmp_path):
+        store_dir = tmp_path / "state"
+        store = SessionStore(state_dir=store_dir)
+
+        def save_terminal(terminal_id: str, session_id: str):
+            for i in range(5):
+                store.save(terminal_id, f"{session_id}-{i}", dispatch_id=f"d-{i}")
+
+        threads = [
+            threading.Thread(target=save_terminal, args=("T1", "s1")),
+            threading.Thread(target=save_terminal, args=("T2", "s2")),
+            threading.Thread(target=save_terminal, args=("T3", "s3")),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        sessions_path = store_dir / "subprocess_sessions.json"
+        data = json.loads(sessions_path.read_text())
+        terminals = data.get("terminals", {})
+        assert "T1" in terminals
+        assert "T2" in terminals
+        assert "T3" in terminals
+
+    def test_flock_degrades_gracefully_when_fcntl_fails(self, tmp_path, monkeypatch):
+        store = SessionStore(state_dir=tmp_path / "state")
+        import fcntl
+        def broken_flock(*args, **kwargs):
+            raise OSError("mocked flock failure")
+        monkeypatch.setattr(fcntl, "flock", broken_flock)
+        store.save("T1", "sess-abc")
+        assert store.load("T1") == "sess-abc"

--- a/tests/test_subprocess_dispatch.py
+++ b/tests/test_subprocess_dispatch.py
@@ -18,6 +18,7 @@ def mock_adapter():
     """Patch SubprocessAdapter and return the mock instance."""
     with patch("subprocess_dispatch.SubprocessAdapter") as cls:
         instance = MagicMock()
+        instance.was_timed_out.return_value = False
         cls.return_value = instance
         yield instance
 


### PR DESCRIPTION
## Summary

Close OI-1117 + OI-1118 (warns filed during PR #251 gate review).

- **subprocess_adapter**: `_timed_out` set + `was_timed_out()` accessor; chunk/total-deadline timeout paths flag the terminal before calling stop()
- **subprocess_dispatch**: after event loop, check `was_timed_out()` → classify as failure (prevents timeout-killed dispatches being receipted as success when returncode is unreachable)
- **session_store**: wrap `save()` and `clear()` read-modify-write in `fcntl.flock LOCK_EX` on sentinel lock file; graceful degrade if fcntl unavailable

## Test plan

- [x] 4 new tests in test_latency_pr3_timeout_flock.py
- [x] 32/32 existing tests pass after mock adapter update
- [x] Concurrent save test with 3 threads × 5 iterations preserves all terminals
- [x] Graceful degradation tested with mocked flock failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)