### PR TITLE
fix(audit): headless reports go to unified_reports/headless/ subdir (OI-AT-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - **headless-receipts-backfill**: Backfill script `scripts/backfill_headless_receipts.py` retroactively patches all 363 processed receipts and 275 ndjson entries that carried `dispatch_id="unknown"` prior to OI-AT-4 phase 1; idempotent; 34 tests in `tests/test_backfill_headless_receipts.py`
+- **headless-reports-layout**: Gate reports now written to `unified_reports/headless/` subdir; `VNX_HEADLESS_REPORTS_DIR` added to `vnx_paths.py` and `vnx_paths.sh`; receipt processor scans both dirs; 11 new tests (OI-AT-7)
 - **ci-slug-match-gate**: `scripts/check_ci_slug_match.py` — CI gate validates Dispatch-ID present in commit bodies and slug portion matches branch name; shadow mode by default (`VNX_SLUG_ENFORCEMENT=1` to block); new `slug-match-check` job added to `vnx-ci.yml`; 57 tests in `tests/test_ci_slug_match_gate.py`
 - **headless-gate-dispatch-id**: Gate request handlers now accept and persist `dispatch_id` in request payloads; `materialize_artifacts` emits real dispatch_id in result JSON and sidecar instead of synthetic `gate-<gate>-pr-<n>` strings; `review_gate_manager` CLI gains `--dispatch-id` arg; 12 new tests (OI-AT-4)
 - **audit-hook-active-drain**: Install `prepare-commit-msg` hook via `core.hooksPath=hooks/git`; add `scripts/check_active_drain.py` janitor that moves receipted dispatches from `active/` to `completed/` and orphans older than threshold to `dead_letter/`; 23 passing tests

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -129,6 +129,11 @@ def resolve_paths() -> Dict[str, str]:
         "VNX_DB_DIR": str(Path(os.environ.get("VNX_DB_DIR") or (vnx_data_dir / "database")).expanduser()),
     }
 
+    reports_dir = Path(paths["VNX_REPORTS_DIR"])
+    paths["VNX_HEADLESS_REPORTS_DIR"] = str(
+        Path(os.environ.get("VNX_HEADLESS_REPORTS_DIR") or (reports_dir / "headless")).expanduser()
+    )
+
     # Git-tracked intelligence directory (portable across worktrees)
     paths["VNX_INTELLIGENCE_DIR"] = str(
         Path(os.environ.get("VNX_INTELLIGENCE_DIR") or (canonical_root / ".vnx-intelligence")).expanduser().resolve()

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -101,7 +101,7 @@ unset _VNX_HOME_GIT_ROOT _VNX_HOME_COMMON_ROOT
 if [ -n "${VNX_HOME:-}" ] && [ "$VNX_HOME" != "$VNX_HOME_DEFAULT" ]; then
   # Preserve explicit VNX_DATA_DIR override (worktree isolation)
   _vnx_saved_data_dir="${VNX_DATA_DIR:-}"
-  unset VNX_HOME PROJECT_ROOT VNX_CANONICAL_ROOT VNX_INTELLIGENCE_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_LOGS_DIR VNX_PIDS_DIR VNX_LOCKS_DIR VNX_REPORTS_DIR VNX_DB_DIR
+  unset VNX_HOME PROJECT_ROOT VNX_CANONICAL_ROOT VNX_INTELLIGENCE_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_LOGS_DIR VNX_PIDS_DIR VNX_LOCKS_DIR VNX_REPORTS_DIR VNX_HEADLESS_REPORTS_DIR VNX_DB_DIR
   if [ -n "$_vnx_saved_data_dir" ]; then
     VNX_DATA_DIR="$_vnx_saved_data_dir"
   else
@@ -138,6 +138,7 @@ export VNX_LOGS_DIR="${VNX_LOGS_DIR:-$VNX_DATA_DIR/logs}"
 export VNX_PIDS_DIR="${VNX_PIDS_DIR:-$VNX_DATA_DIR/pids}"
 export VNX_LOCKS_DIR="${VNX_LOCKS_DIR:-$VNX_DATA_DIR/locks}"
 export VNX_REPORTS_DIR="${VNX_REPORTS_DIR:-$VNX_DATA_DIR/unified_reports}"
+export VNX_HEADLESS_REPORTS_DIR="${VNX_HEADLESS_REPORTS_DIR:-$VNX_REPORTS_DIR/headless}"
 export VNX_DB_DIR="${VNX_DB_DIR:-$VNX_DATA_DIR/database}"
 export LEGACY_REPORTS_DIR="${LEGACY_REPORTS_DIR:-$VNX_HOME/unified_reports}"
 
@@ -169,6 +170,7 @@ if [ "$_vnx_cwd" != "$PROJECT_ROOT" ]; then
       export VNX_PIDS_DIR="$VNX_DATA_DIR/pids"
       export VNX_LOCKS_DIR="$VNX_DATA_DIR/locks"
       export VNX_REPORTS_DIR="$VNX_DATA_DIR/unified_reports"
+      export VNX_HEADLESS_REPORTS_DIR="$VNX_REPORTS_DIR/headless"
       export VNX_DB_DIR="$VNX_DATA_DIR/database"
     fi
     # Re-derive skills dir

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -9,6 +9,7 @@ source "$SCRIPT_DIR/lib/receipt_terminal_detection.sh"
 # Base directories
 VNX_BASE="$VNX_HOME"
 UNIFIED_REPORTS="$VNX_REPORTS_DIR"
+HEADLESS_REPORTS="${VNX_HEADLESS_REPORTS_DIR:-$VNX_REPORTS_DIR/headless}"
 STATE_DIR="$VNX_STATE_DIR"
 SCRIPTS_DIR="$VNX_BASE/scripts"
 APPEND_RECEIPT_SCRIPT="$SCRIPTS_DIR/append_receipt.py"
@@ -1075,9 +1076,9 @@ process_pending_reports() {
 
     log "INFO" "Scanning for reports newer than: $cutoff"
 
-    # Count pending reports first
+    # Count pending reports first (unified_reports/ and unified_reports/headless/)
     local pending_reports=()
-    for report in "$UNIFIED_REPORTS"/*.md; do
+    for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
         [ -f "$report" ] || continue
         if should_process_report "$report"; then
             pending_reports+=("$report")
@@ -1143,7 +1144,7 @@ _poll_new_reports() {
     local _cycle=0
     while true; do
         local _poll_max_mtime=0
-        for report in "$UNIFIED_REPORTS"/*.md; do
+        for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
             [ -f "$report" ] || continue
             if should_process_report "$report" && process_single_report "$report"; then
                 local _mtime
@@ -1176,7 +1177,7 @@ monitor_new_reports() {
     # may have been written while the receipt processor was down (restart gap).
     local catchup_count=0
     local now=$(date +%s)
-    for report in "$UNIFIED_REPORTS"/*.md; do
+    for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
         [ -f "$report" ] || continue
         local mtime=$(stat -f%m "$report" 2>/dev/null || stat -c%Y "$report" 2>/dev/null || echo 0)
         local age_secs=$(( now - mtime ))

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -50,9 +50,11 @@ class ReviewGateManager(
         self.paths = ensure_env()
         self.state_dir = Path(self.paths["VNX_STATE_DIR"])
         self.reports_dir = Path(self.paths["VNX_REPORTS_DIR"])
+        self.headless_reports_dir = Path(self.paths["VNX_HEADLESS_REPORTS_DIR"])
         self.requests_dir = self.state_dir / "review_gates" / "requests"
         self.results_dir = self.state_dir / "review_gates" / "results"
         self.reports_dir.mkdir(parents=True, exist_ok=True)
+        self.headless_reports_dir.mkdir(parents=True, exist_ok=True)
         self.requests_dir.mkdir(parents=True, exist_ok=True)
         self.results_dir.mkdir(parents=True, exist_ok=True)
 
@@ -110,7 +112,7 @@ class ReviewGateManager(
         ts = self._report_timestamp_slug(requested_at)
         pr_slug = self._report_pr_slug(pr_number=pr_number, pr_id=pr_id)
         filename = f"{ts}-HEADLESS-{gate}-{pr_slug}.md"
-        return str((self.reports_dir / filename).resolve())
+        return str((self.headless_reports_dir / filename).resolve())
 
     def _load_request_payload(self, gate: str, pr_number: int) -> Dict[str, Any]:
         path = self._request_path(gate, pr_number)

--- a/tests/test_headless_reports_layout.py
+++ b/tests/test_headless_reports_layout.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Tests for OI-AT-7: headless gate reports written to unified_reports/headless/ subdir."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# vnx_paths.py: VNX_HEADLESS_REPORTS_DIR is defined and points to headless/
+# ---------------------------------------------------------------------------
+
+class TestVnxPathsHeadlessDir:
+    def test_headless_reports_dir_in_resolve_paths(self, tmp_path):
+        import vnx_paths
+        env = {
+            "VNX_HOME": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_DATA_DIR": str(tmp_path / ".vnx-data"),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            paths = vnx_paths.resolve_paths()
+        assert "VNX_HEADLESS_REPORTS_DIR" in paths
+
+    def test_headless_reports_dir_is_subdir_of_reports_dir(self, tmp_path):
+        import vnx_paths
+        env = {
+            "VNX_HOME": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_DATA_DIR": str(tmp_path / ".vnx-data"),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            paths = vnx_paths.resolve_paths()
+        reports = Path(paths["VNX_REPORTS_DIR"])
+        headless = Path(paths["VNX_HEADLESS_REPORTS_DIR"])
+        assert headless == reports / "headless"
+
+    def test_headless_reports_dir_env_override(self, tmp_path):
+        import vnx_paths
+        custom = str(tmp_path / "custom_headless")
+        env = {
+            "VNX_HOME": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_DATA_DIR": str(tmp_path / ".vnx-data"),
+            "VNX_HEADLESS_REPORTS_DIR": custom,
+        }
+        with patch.dict(os.environ, env, clear=False):
+            paths = vnx_paths.resolve_paths()
+        assert paths["VNX_HEADLESS_REPORTS_DIR"] == custom
+
+
+# ---------------------------------------------------------------------------
+# ReviewGateManager: _build_report_path uses headless_reports_dir
+# ---------------------------------------------------------------------------
+
+class TestReviewGateManagerHeadlessDir:
+    def _make_manager(self, tmp_path):
+        from review_gate_manager import ReviewGateManager
+        env = {
+            "VNX_HOME": str(tmp_path),
+            "PROJECT_ROOT": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_DATA_DIR": str(tmp_path / ".vnx-data"),
+            "VNX_STATE_DIR": str(tmp_path / ".vnx-data" / "state"),
+            "VNX_REPORTS_DIR": str(tmp_path / ".vnx-data" / "unified_reports"),
+            "VNX_HEADLESS_REPORTS_DIR": str(tmp_path / ".vnx-data" / "unified_reports" / "headless"),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            return ReviewGateManager(), tmp_path
+
+    def test_headless_reports_dir_attribute(self, tmp_path):
+        mgr, base = self._make_manager(tmp_path)
+        expected = base / ".vnx-data" / "unified_reports" / "headless"
+        assert mgr.headless_reports_dir == expected
+
+    def test_headless_reports_dir_created_on_init(self, tmp_path):
+        mgr, base = self._make_manager(tmp_path)
+        assert mgr.headless_reports_dir.is_dir()
+
+    def test_build_report_path_in_headless_subdir(self, tmp_path):
+        mgr, base = self._make_manager(tmp_path)
+        path = mgr._build_report_path(
+            gate="gemini_review",
+            requested_at="20260424-120000",
+            pr_number=42,
+        )
+        report = Path(path)
+        headless_dir = base / ".vnx-data" / "unified_reports" / "headless"
+        assert report.parent == headless_dir
+
+    def test_build_report_path_not_in_root_reports_dir(self, tmp_path):
+        mgr, base = self._make_manager(tmp_path)
+        path = mgr._build_report_path(
+            gate="codex_gate",
+            requested_at="20260424-120000",
+            pr_number=7,
+        )
+        report = Path(path)
+        root_reports = base / ".vnx-data" / "unified_reports"
+        assert report.parent != root_reports
+
+    def test_build_report_path_filename_pattern(self, tmp_path):
+        mgr, _ = self._make_manager(tmp_path)
+        path = mgr._build_report_path(
+            gate="codex_gate",
+            requested_at="20260424-120000",
+            pr_number=5,
+        )
+        name = Path(path).name
+        assert "HEADLESS" in name
+        assert "codex_gate" in name
+        assert "pr-5" in name
+        assert name.endswith(".md")
+
+    def test_build_report_path_with_pr_id(self, tmp_path):
+        mgr, base = self._make_manager(tmp_path)
+        path = mgr._build_report_path(
+            gate="gemini_review",
+            requested_at="20260424-150000",
+            pr_id="pr-999",
+        )
+        report = Path(path)
+        headless_dir = base / ".vnx-data" / "unified_reports" / "headless"
+        assert report.parent == headless_dir
+
+
+# ---------------------------------------------------------------------------
+# gate_artifacts: materialize_artifacts writes to headless subdir path
+# ---------------------------------------------------------------------------
+
+class TestMaterializeArtifactsHeadlessPath:
+    def test_report_written_to_provided_path(self, tmp_path):
+        """materialize_artifacts honours report_path — writing to headless/ is a layout concern."""
+        import gate_artifacts
+
+        headless_dir = tmp_path / "unified_reports" / "headless"
+        headless_dir.mkdir(parents=True)
+        requests_dir = tmp_path / "requests"
+        results_dir = tmp_path / "results"
+        requests_dir.mkdir()
+        results_dir.mkdir()
+
+        report_file = headless_dir / "20260424-120000-HEADLESS-gemini_review-pr-1.md"
+        stdout = "line1\nline2\nline3\nline4\n"
+        request_payload = {
+            "gate": "gemini_review",
+            "pr_number": 1,
+            "pr_id": "",
+            "branch": "test-branch",
+            "report_path": str(report_file),
+            "dispatch_id": "test-dispatch-id",
+        }
+
+        result = gate_artifacts.materialize_artifacts(
+            gate="gemini_review",
+            pr_number=1,
+            pr_id="",
+            stdout=stdout,
+            request_payload=request_payload,
+            duration_seconds=1.5,
+            requests_dir=requests_dir,
+            results_dir=results_dir,
+            reports_dir=headless_dir,
+        )
+
+        assert result.get("status") == "completed"
+        assert report_file.exists()
+        assert report_file.stat().st_size > 0
+
+    def test_report_path_inside_headless_subdir(self, tmp_path):
+        """result payload report_path reflects the headless/ location."""
+        import gate_artifacts
+
+        headless_dir = tmp_path / "unified_reports" / "headless"
+        headless_dir.mkdir(parents=True)
+        requests_dir = tmp_path / "requests"
+        results_dir = tmp_path / "results"
+        requests_dir.mkdir()
+        results_dir.mkdir()
+
+        report_file = headless_dir / "20260424-120000-HEADLESS-codex_gate-pr-2.md"
+        stdout = "Finding A\nFinding B\nFinding C\n"
+        request_payload = {
+            "gate": "codex_gate",
+            "pr_number": 2,
+            "pr_id": "",
+            "branch": "fix/headless-layout",
+            "report_path": str(report_file),
+            "dispatch_id": "test-dispatch-002",
+        }
+
+        result = gate_artifacts.materialize_artifacts(
+            gate="codex_gate",
+            pr_number=2,
+            pr_id="",
+            stdout=stdout,
+            request_payload=request_payload,
+            duration_seconds=2.0,
+            requests_dir=requests_dir,
+            results_dir=results_dir,
+            reports_dir=headless_dir,
+        )
+
+        assert "headless" in result.get("report_path", "")


### PR DESCRIPTION
## Summary
- Move headless gate reports from `unified_reports/` (root) to `unified_reports/headless/` subdir per CLAUDE.md contract
- Add `VNX_HEADLESS_REPORTS_DIR` to `vnx_paths.py` and `vnx_paths.sh` (worktree-aware)
- `ReviewGateManager` writes to headless dir; receipt processor scans both dirs
- 11 new tests
- Parent-Dispatch: 20260423-070000-t3-audit-trail-investigation-C

## Why
T3 audit W-3: CLAUDE.md states headless reports belong in `unified_reports/headless/` but the subdir was empty — all reports mixed with worker reports at root. This separates the two streams for cleaner governance tracking.

## Test plan
- [ ] CI green
- [ ] codex_gate pass
- [ ] gemini_review pass
- [ ] Smoke: trigger a gate, verify new report lands in `unified_reports/headless/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)