### PR TITLE
feat(f59-pr4): dashboard dispatch viewer with 3-tab detail + event replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - **F59-PR1 event-archive-analyzer**: `scripts/lib/event_analyzer.py` — deterministic behavioral analysis of dispatch NDJSON event archives; extracts tool counts (Read/Write/Edit/Bash/Grep/Glob), exploration depth (`reads_before_first_write`), rework indicators (`edit_cycles_same_file`, `test_fail_edit_cycles`), phase sequences (explore→implement→test→commit), bash error extraction, pytest result parsing, and commit/push/report detection; CLI supports `--dispatch`, `--all`, `--summary`, and `--output` modes; 22 tests in `tests/test_event_analyzer.py` covering real archive fixtures and synthetic NDJSON scenarios
 
+### Dashboard
+- **dispatch-viewer**: Add `/operator/dispatches` list view with stage tabs (staging/pending/active/review/done), track/terminal/search filters, and per-row receipt status indicator. Add `/operator/dispatches/[id]` detail page with Overview/Event Replay/Instruction/Result tabs; replay tab renders phase-colored tool-use timeline from archived NDJSON with scrubbable cursor, play/pause/step controls, and phase filter chips. Data flows through existing `/api/dispatches*` endpoints (F59-PR4).
+
 ### Docs
 - **event-streams**: Add `docs/operations/EVENT_STREAMS.md` documenting the per-dispatch ring-buffer lifecycle of `.vnx-data/events/T{n}.ndjson` and the `events/archive/{terminal}/{dispatch_id}.ndjson` layout; linked from `docs/operations/README.md` and `docs/DOCS_INDEX.md`. Clarifies a misinterpretation flagged as W-2 in the 2026-04-23 audit-trail investigation (OI-AT-6a). Updates CHANGELOG to remove a stale `(missing source)` parenthetical on the ghost-receipt-filter entry now that `scripts/lib/headless_review_receipt.py` is in tree (OI-1133).
 

--- a/dashboard/token-dashboard/__tests__/dispatch-detail-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/dispatch-detail-page.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for app/operator/dispatches/[id]/page.tsx — dispatch detail page.
+ *
+ * Quality gate: f59-pr4-dashboard-viewer (codex follow-up)
+ * - Malformed URL-encoded id does not crash the page with URIError;
+ *   an inline error state is rendered instead.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Synchronously unwrap the params promise so the component renders without
+// needing a Suspense boundary. React 19's `use(promise)` requires a tracked
+// thenable; in unit tests we just hand back the resolved value directly.
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    use: (value: unknown) => {
+      if (value && typeof (value as { __resolved?: unknown }).__resolved !== 'undefined') {
+        return (value as { __resolved: unknown }).__resolved;
+      }
+      return value;
+    },
+  };
+});
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...rest }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <a {...(rest as Record<string, string>)}>{children}</a>
+  ),
+}));
+
+jest.mock('@/lib/hooks', () => ({
+  useDispatchDetail: jest.fn(),
+  useDispatchEvents: jest.fn(),
+  useDispatchResult: jest.fn(),
+}));
+
+import {
+  useDispatchDetail,
+  useDispatchEvents,
+  useDispatchResult,
+} from '@/lib/hooks';
+import DispatchDetailPage from '@/app/operator/dispatches/[id]/page';
+
+const mockDetail = useDispatchDetail as jest.MockedFunction<typeof useDispatchDetail>;
+const mockEvents = useDispatchEvents as jest.MockedFunction<typeof useDispatchEvents>;
+const mockResult = useDispatchResult as jest.MockedFunction<typeof useDispatchResult>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function idle<T extends (...a: any[]) => any>(): ReturnType<T> {
+  return {
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: jest.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function paramsOf(id: string) {
+  // Stub shape consumed by the mocked `use()` above.
+  return { __resolved: { id } } as unknown as Promise<{ id: string }>;
+}
+
+describe('DispatchDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDetail.mockReturnValue(idle<typeof useDispatchDetail>());
+    mockEvents.mockReturnValue(idle<typeof useDispatchEvents>());
+    mockResult.mockReturnValue(idle<typeof useDispatchResult>());
+  });
+
+  test('malformed percent-encoded id renders an inline error, not a URIError crash', () => {
+    // `%E0%A4%A` is an incomplete UTF-8 escape — decodeURIComponent throws URIError.
+    expect(() => render(<DispatchDetailPage params={paramsOf('%E0%A4%A')} />)).not.toThrow();
+
+    const err = screen.getByTestId('dispatch-detail-error');
+    expect(err).toHaveTextContent(/Invalid dispatch id/i);
+    // Tabs must NOT render when decode failed.
+    expect(screen.queryByTestId('tab-overview')).not.toBeInTheDocument();
+  });
+
+  test('valid id renders the tab row and does not show the error state', () => {
+    mockDetail.mockReturnValue({
+      ...idle<typeof useDispatchDetail>(),
+      data: {
+        dispatch_id: '20260424-abc-C',
+        stage: 'done',
+        file: 'x.md',
+        metadata: {},
+        instruction: 'hello',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    render(<DispatchDetailPage params={paramsOf(encodeURIComponent('20260424-abc-C'))} />);
+
+    expect(screen.queryByTestId('dispatch-detail-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tab-overview')).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/__tests__/dispatches-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/dispatches-page.test.tsx
@@ -182,6 +182,26 @@ describe('DispatchesPage', () => {
     expect(screen.getByTestId('dispatch-row-t3-1')).toBeInTheDocument();
   });
 
+  test('receipt_status="pass" is classified as a successful receipt', () => {
+    // Governance emits receipt_status="pass" for gates that passed; the
+    // list view must render a green success dot, not an orange alert.
+    const data = envelope([
+      card('pass-1', 'done', { has_receipt: true, receipt_status: 'pass' }),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    const row = screen.getByTestId('dispatch-row-pass-1');
+    const dot = row.querySelector('[aria-label="Receipt: pass"]');
+    expect(dot).not.toBeNull();
+    // lucide renders inline SVG; the success icon (CheckCircle2) carries
+    // the distinctive green color set inline — jsdom normalizes the hex
+    // (#22c55e) into its rgb() equivalent.
+    const svg = dot!.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute('style')).toMatch(/rgb\(34,\s*197,\s*94\)|#22c55e/);
+  });
+
   test('dispatch row links to the detail page with encoded id', () => {
     const id = '20260424-020100-f59-pr4-dashboard-viewer-C';
     const data = envelope([card(id, 'active')]);

--- a/dashboard/token-dashboard/__tests__/dispatches-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/dispatches-page.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for app/operator/dispatches/page.tsx — dispatch viewer list page.
+ *
+ * Quality gate: f59-pr4-dashboard-viewer
+ * - List page renders all dispatches across stages with counts
+ * - Stage tabs filter the visible dispatches
+ * - Search box filters by id, gate, PR id, role
+ * - Track and terminal filters narrow the result set
+ * - Empty, loading, and error states render correctly
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/operator/dispatches',
+}));
+
+jest.mock('@/lib/hooks', () => ({
+  useDispatches: jest.fn(),
+}));
+
+import { useDispatches } from '@/lib/hooks';
+import DispatchesPage from '@/app/operator/dispatches/page';
+import type { DispatchesResponse, DispatchSummary, DispatchStage } from '@/lib/types';
+
+const mockUseDispatches = useDispatches as jest.MockedFunction<typeof useDispatches>;
+
+function card(id: string, stage: DispatchStage, overrides: Partial<DispatchSummary> = {}): DispatchSummary {
+  return {
+    id,
+    file: `${id}.md`,
+    pr_id: 'PR-42',
+    track: 'A',
+    terminal: 'T1',
+    role: 'backend-developer',
+    gate: 'gate_x',
+    priority: 'P1',
+    status: 'active',
+    reason: '—',
+    domain: 'coding',
+    dir: stage,
+    stage,
+    duration_secs: 120,
+    duration_label: '2m',
+    has_receipt: false,
+    receipt_status: null,
+    ...overrides,
+  };
+}
+
+function envelope(cards: DispatchSummary[]): DispatchesResponse {
+  const stages: Record<DispatchStage, DispatchSummary[]> = {
+    staging: [],
+    pending: [],
+    active: [],
+    review: [],
+    done: [],
+  };
+  for (const c of cards) stages[c.stage].push(c);
+  return { stages, total: cards.length };
+}
+
+function mockResponse(data: DispatchesResponse | undefined, opts: { isLoading?: boolean; error?: unknown } = {}) {
+  mockUseDispatches.mockReturnValue({
+    data,
+    error: opts.error,
+    isLoading: opts.isLoading ?? false,
+    isValidating: false,
+    mutate: jest.fn(),
+  } as ReturnType<typeof useDispatches>);
+}
+
+describe('DispatchesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders loading skeleton when isLoading is true', () => {
+    mockResponse(undefined, { isLoading: true });
+    render(<DispatchesPage />);
+    expect(screen.getByText(/Loading dispatches/i)).toBeInTheDocument();
+  });
+
+  test('renders error message when fetch fails', () => {
+    mockResponse(undefined, { error: new Error('network down') });
+    render(<DispatchesPage />);
+    expect(screen.getByText(/Failed to load dispatches/i)).toBeInTheDocument();
+    expect(screen.getByText(/network down/)).toBeInTheDocument();
+  });
+
+  test('renders empty state when no dispatches match filters', () => {
+    mockResponse(envelope([]));
+    render(<DispatchesPage />);
+    expect(screen.getByText(/No dispatches match/i)).toBeInTheDocument();
+  });
+
+  test('renders dispatches with per-stage counts in the tab chips', () => {
+    const data = envelope([
+      card('d-1', 'pending'),
+      card('d-2', 'active'),
+      card('d-3', 'review'),
+      card('d-4', 'done'),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    // All tab shows 4
+    const allTab = screen.getByTestId('stage-tab-all');
+    expect(allTab).toHaveTextContent(/All/);
+    expect(allTab).toHaveTextContent('4');
+
+    // Each dispatch row is present
+    expect(screen.getByTestId('dispatch-row-d-1')).toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-d-2')).toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-d-3')).toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-d-4')).toBeInTheDocument();
+  });
+
+  test('clicking a stage tab filters the list to dispatches in that stage', () => {
+    const data = envelope([
+      card('p-1', 'pending'),
+      card('a-1', 'active'),
+      card('a-2', 'active'),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    fireEvent.click(screen.getByTestId('stage-tab-active'));
+
+    expect(screen.queryByTestId('dispatch-row-p-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-a-1')).toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-a-2')).toBeInTheDocument();
+  });
+
+  test('search box filters rows by dispatch id substring', () => {
+    const data = envelope([
+      card('alpha-001', 'pending'),
+      card('beta-002', 'pending'),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    fireEvent.change(screen.getByTestId('dispatches-search'), {
+      target: { value: 'alpha' },
+    });
+
+    expect(screen.getByTestId('dispatch-row-alpha-001')).toBeInTheDocument();
+    expect(screen.queryByTestId('dispatch-row-beta-002')).not.toBeInTheDocument();
+  });
+
+  test('track filter limits the list to the selected track', () => {
+    const data = envelope([
+      card('a-1', 'pending', { track: 'A' }),
+      card('c-1', 'pending', { track: 'C' }),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    fireEvent.change(screen.getByTestId('track-filter'), {
+      target: { value: 'C' },
+    });
+
+    expect(screen.queryByTestId('dispatch-row-a-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-c-1')).toBeInTheDocument();
+  });
+
+  test('terminal filter limits the list to the selected terminal', () => {
+    const data = envelope([
+      card('t1-1', 'pending', { terminal: 'T1' }),
+      card('t3-1', 'pending', { terminal: 'T3' }),
+    ]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    fireEvent.change(screen.getByTestId('terminal-filter'), {
+      target: { value: 'T3' },
+    });
+
+    expect(screen.queryByTestId('dispatch-row-t1-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dispatch-row-t3-1')).toBeInTheDocument();
+  });
+
+  test('dispatch row links to the detail page with encoded id', () => {
+    const id = '20260424-020100-f59-pr4-dashboard-viewer-C';
+    const data = envelope([card(id, 'active')]);
+    mockResponse(data);
+    render(<DispatchesPage />);
+
+    const row = screen.getByTestId(`dispatch-row-${id}`);
+    expect(row).toHaveAttribute(
+      'href',
+      `/operator/dispatches/${encodeURIComponent(id)}`,
+    );
+  });
+});

--- a/dashboard/token-dashboard/__tests__/event-timeline.test.tsx
+++ b/dashboard/token-dashboard/__tests__/event-timeline.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for components/operator/event-timeline.tsx — execution replay viewer.
+ *
+ * Quality gate: f59-pr4-dashboard-viewer
+ * - Renders empty state when no events present
+ * - Renders tool_use events with phase label and timestamp offset
+ * - Phase filter chips narrow the visible events
+ * - Replay scrubber advances the active cursor
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import EventTimeline from '@/components/operator/event-timeline';
+import type { DispatchEvent } from '@/lib/types';
+
+function explore(summary: string, offset = 0): DispatchEvent {
+  return {
+    type: 'tool_use',
+    timestamp_offset: offset,
+    tool_name: 'Read',
+    file_path: summary,
+    summary,
+  };
+}
+
+function write(summary: string, offset = 0): DispatchEvent {
+  return {
+    type: 'tool_use',
+    timestamp_offset: offset,
+    tool_name: 'Write',
+    file_path: summary,
+    summary,
+  };
+}
+
+function commit(offset = 0): DispatchEvent {
+  return {
+    type: 'tool_use',
+    timestamp_offset: offset,
+    tool_name: 'Bash',
+    file_path: '',
+    summary: 'git commit -m "feat: x"',
+  };
+}
+
+describe('EventTimeline', () => {
+  test('renders empty state when events array is empty', () => {
+    render(<EventTimeline events={[]} />);
+    expect(screen.getByText(/No tool events recorded/i)).toBeInTheDocument();
+  });
+
+  test('renders tool_use events with tool name and summary', () => {
+    const events: DispatchEvent[] = [
+      { type: 'phase_marker', phase: 'explore' },
+      explore('src/lib/api.ts', 0),
+      { type: 'phase_marker', phase: 'implement' },
+      write('src/lib/new.ts', 12.5),
+    ];
+    render(<EventTimeline events={events} />);
+    expect(screen.getByTestId('event-timeline')).toBeInTheDocument();
+    expect(screen.getAllByText('Read').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Write').length).toBeGreaterThan(0);
+    expect(screen.getByText('src/lib/api.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/lib/new.ts')).toBeInTheDocument();
+  });
+
+  test('phase filter narrows events to the selected phase', () => {
+    const events: DispatchEvent[] = [
+      { type: 'phase_marker', phase: 'explore' },
+      explore('file-a', 0),
+      { type: 'phase_marker', phase: 'implement' },
+      write('file-b', 5),
+      { type: 'phase_marker', phase: 'commit' },
+      commit(10),
+    ];
+    render(<EventTimeline events={events} />);
+
+    fireEvent.click(screen.getByTestId('phase-filter-commit'));
+
+    expect(screen.queryByText('file-a')).not.toBeInTheDocument();
+    expect(screen.queryByText('file-b')).not.toBeInTheDocument();
+    expect(screen.getByText('git commit -m "feat: x"')).toBeInTheDocument();
+  });
+
+  test('replay step-forward button advances the cursor', () => {
+    const events: DispatchEvent[] = [
+      { type: 'phase_marker', phase: 'explore' },
+      explore('a', 0),
+      explore('b', 1),
+      explore('c', 2),
+    ];
+    render(<EventTimeline events={events} />);
+
+    // Initially cursor = null → label reads "0 / 3"
+    expect(screen.getByText(/0 \/ 3/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('replay-forward'));
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('replay-forward'));
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument();
+
+    const active = screen.getByTestId('event-1');
+    expect(active).toHaveAttribute('data-active', 'true');
+  });
+
+  test('replay reset clears the cursor back to pre-start', () => {
+    const events: DispatchEvent[] = [
+      { type: 'phase_marker', phase: 'explore' },
+      explore('a', 0),
+      explore('b', 1),
+    ];
+    render(<EventTimeline events={events} />);
+
+    fireEvent.click(screen.getByTestId('replay-forward'));
+    fireEvent.click(screen.getByTestId('replay-forward'));
+    expect(screen.getByText(/2 \/ 2/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('replay-reset'));
+    expect(screen.getByText(/0 \/ 2/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/__tests__/event-timeline.test.tsx
+++ b/dashboard/token-dashboard/__tests__/event-timeline.test.tsx
@@ -51,6 +51,20 @@ describe('EventTimeline', () => {
     expect(screen.getByText(/No tool events recorded/i)).toBeInTheDocument();
   });
 
+  test('renders empty state when archive has only phase markers (no tool_use)', () => {
+    // Archives that never emitted tool_use should not render replay controls,
+    // otherwise the "1 / 0" cursor state would appear on step-forward.
+    const phaseOnly: DispatchEvent[] = [
+      { type: 'phase_marker', phase: 'explore' },
+      { type: 'phase_marker', phase: 'implement' },
+      { type: 'phase_marker', phase: 'commit' },
+    ];
+    render(<EventTimeline events={phaseOnly} />);
+    expect(screen.getByText(/No tool events recorded/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('replay-forward')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('replay-scrub')).not.toBeInTheDocument();
+  });
+
   test('renders tool_use events with tool name and summary', () => {
     const events: DispatchEvent[] = [
       { type: 'phase_marker', phase: 'explore' },

--- a/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
+++ b/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
@@ -141,7 +141,13 @@ export default function DispatchDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = use(params);
-  const dispatchId = decodeURIComponent(id);
+  let dispatchId = id;
+  let decodeError: string | null = null;
+  try {
+    dispatchId = decodeURIComponent(id);
+  } catch {
+    decodeError = `Invalid dispatch id in URL: ${id}`;
+  }
   const [tab, setTab] = useState<Tab>('overview');
 
   const { data: detail, error: detailErr, isLoading: detailLoading, mutate: mutateDetail } =
@@ -237,7 +243,7 @@ export default function DispatchDetailPage({
       </div>
 
       {/* Error / 404 */}
-      {detailErr || detail?.error ? (
+      {decodeError || detailErr || detail?.error ? (
         <div
           data-testid="dispatch-detail-error"
           style={{
@@ -249,7 +255,7 @@ export default function DispatchDetailPage({
             fontSize: 13,
           }}
         >
-          {detail?.error ?? `Failed to load dispatch: ${String(detailErr)}`}
+          {decodeError ?? detail?.error ?? `Failed to load dispatch: ${String(detailErr)}`}
         </div>
       ) : (
         <>

--- a/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
+++ b/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
@@ -1,0 +1,463 @@
+'use client';
+
+import { use, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  FileText,
+  GitCommit,
+  Activity,
+  ClipboardList,
+  RefreshCw,
+  Copy,
+  Check,
+} from 'lucide-react';
+import {
+  useDispatchDetail,
+  useDispatchEvents,
+  useDispatchResult,
+} from '@/lib/hooks';
+import type { DispatchStage } from '@/lib/types';
+import DispatchStageBadge from '@/components/operator/dispatch-stage-badge';
+import EventTimeline from '@/components/operator/event-timeline';
+
+type Tab = 'overview' | 'events' | 'instruction' | 'result';
+
+const TABS: { id: Tab; label: string; icon: typeof FileText }[] = [
+  { id: 'overview', label: 'Overview', icon: ClipboardList },
+  { id: 'events', label: 'Event Replay', icon: Activity },
+  { id: 'instruction', label: 'Instruction', icon: FileText },
+  { id: 'result', label: 'Result', icon: GitCommit },
+];
+
+function Card({
+  title,
+  children,
+  right,
+}: {
+  title: string;
+  children: React.ReactNode;
+  right?: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        padding: 20,
+        borderRadius: 12,
+        background: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.05)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <h3
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--color-muted)',
+          }}
+        >
+          {title}
+        </h3>
+        {right}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string | undefined | null }) {
+  if (!value) return null;
+  return (
+    <div style={{ display: 'flex', gap: 10, padding: '6px 0', fontSize: 12 }}>
+      <span
+        style={{
+          color: 'var(--color-muted)',
+          minWidth: 90,
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          fontWeight: 600,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          color: 'var(--color-foreground)',
+          fontFamily: 'var(--font-mono, monospace)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        if (typeof navigator !== 'undefined' && navigator.clipboard) {
+          navigator.clipboard.writeText(text).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          });
+        }
+      }}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '4px 8px',
+        borderRadius: 6,
+        fontSize: 10,
+        background: 'rgba(255,255,255,0.05)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        color: copied ? '#22c55e' : 'var(--color-muted)',
+        cursor: 'pointer',
+      }}
+    >
+      {copied ? <Check size={11} /> : <Copy size={11} />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+export default function DispatchDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const dispatchId = decodeURIComponent(id);
+  const [tab, setTab] = useState<Tab>('overview');
+
+  const { data: detail, error: detailErr, isLoading: detailLoading, mutate: mutateDetail } =
+    useDispatchDetail(dispatchId);
+  const { data: events, error: eventsErr, isLoading: eventsLoading, mutate: mutateEvents } =
+    useDispatchEvents(dispatchId);
+  const { data: result, error: resultErr, isLoading: resultLoading, mutate: mutateResult } =
+    useDispatchResult(dispatchId);
+
+  const stage = (detail?.stage ?? 'staging') as DispatchStage;
+  const meta = detail?.metadata ?? {};
+
+  function refreshAll() {
+    mutateDetail();
+    mutateEvents();
+    mutateResult();
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div style={{ marginBottom: 20 }}>
+        <Link
+          href="/operator/dispatches"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 11,
+            color: 'var(--color-muted)',
+            textDecoration: 'none',
+            marginBottom: 10,
+          }}
+        >
+          <ArrowLeft size={12} />
+          Back to dispatches
+        </Link>
+        <div className="flex items-center justify-between" style={{ gap: 12, flexWrap: 'wrap' }}>
+          <div className="flex items-center gap-3" style={{ minWidth: 0 }}>
+            <div
+              style={{
+                height: 28,
+                width: 4,
+                borderRadius: 2,
+                background: 'var(--color-accent)',
+                flexShrink: 0,
+              }}
+            />
+            <div style={{ minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+                <h2
+                  style={{
+                    fontSize: '1.25rem',
+                    fontWeight: 700,
+                    letterSpacing: '-0.02em',
+                    color: 'var(--color-foreground)',
+                    fontFamily: 'var(--font-mono, monospace)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {dispatchId}
+                </h2>
+                {detail && <DispatchStageBadge stage={stage} />}
+              </div>
+              {meta.gate && (
+                <p style={{ fontSize: 12, color: 'var(--color-accent)', marginTop: 2 }}>
+                  {meta.gate}
+                </p>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={refreshAll}
+            data-testid="dispatch-refresh"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '7px 14px',
+              borderRadius: 8,
+              background: 'rgba(255,255,255,0.05)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              cursor: 'pointer',
+              fontSize: 12,
+              color: 'var(--color-muted)',
+            }}
+          >
+            <RefreshCw size={13} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Error / 404 */}
+      {detailErr || detail?.error ? (
+        <div
+          data-testid="dispatch-detail-error"
+          style={{
+            padding: 16,
+            borderRadius: 10,
+            background: 'rgba(239, 68, 68, 0.08)',
+            border: '1px solid rgba(239, 68, 68, 0.25)',
+            color: '#fca5a5',
+            fontSize: 13,
+          }}
+        >
+          {detail?.error ?? `Failed to load dispatch: ${String(detailErr)}`}
+        </div>
+      ) : (
+        <>
+          {/* Tabs */}
+          <div
+            role="tablist"
+            aria-label="Dispatch sections"
+            style={{
+              display: 'flex',
+              gap: 2,
+              marginBottom: 20,
+              borderBottom: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            {TABS.map(({ id: tabId, label, icon: Icon }) => {
+              const active = tab === tabId;
+              return (
+                <button
+                  key={tabId}
+                  role="tab"
+                  aria-selected={active}
+                  data-testid={`tab-${tabId}`}
+                  onClick={() => setTab(tabId)}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '10px 16px',
+                    fontSize: 12,
+                    fontWeight: active ? 600 : 400,
+                    background: 'transparent',
+                    border: 'none',
+                    borderBottom: `2px solid ${active ? 'var(--color-accent)' : 'transparent'}`,
+                    color: active ? 'var(--color-accent)' : 'var(--color-muted)',
+                    cursor: 'pointer',
+                    marginBottom: -1,
+                  }}
+                >
+                  <Icon size={13} />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Panels */}
+          {tab === 'overview' && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+                gap: 16,
+              }}
+            >
+              <Card title="Metadata">
+                {detailLoading ? (
+                  <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading…</p>
+                ) : (
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <MetaRow label="Terminal" value={meta.terminal} />
+                    <MetaRow label="Track" value={meta.track} />
+                    <MetaRow label="Role" value={meta.role} />
+                    <MetaRow label="Gate" value={meta.gate} />
+                    <MetaRow label="PR" value={meta.pr ?? meta.pr_id} />
+                    <MetaRow label="Priority" value={meta.priority} />
+                    <MetaRow label="Model" value={meta.model} />
+                    <MetaRow label="Cognition" value={meta.cognition} />
+                    <MetaRow label="Skill" value={meta.skill} />
+                    <MetaRow label="Stage" value={detail?.stage} />
+                    <MetaRow label="File" value={detail?.file} />
+                  </div>
+                )}
+              </Card>
+              <Card title="Receipt">
+                {resultLoading ? (
+                  <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading…</p>
+                ) : result?.receipt ? (
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <MetaRow label="Status" value={String(result.receipt.status ?? '')} />
+                    <MetaRow label="Terminal" value={String(result.receipt.terminal ?? '')} />
+                    <MetaRow label="Track" value={String(result.receipt.track ?? '')} />
+                    <MetaRow label="Gate" value={String(result.receipt.gate ?? '')} />
+                    <MetaRow
+                      label="PR"
+                      value={result.receipt.pr !== undefined ? String(result.receipt.pr) : undefined}
+                    />
+                    <MetaRow
+                      label="Commit"
+                      value={
+                        result.receipt.commit_after
+                          ? String(result.receipt.commit_after).slice(0, 10)
+                          : undefined
+                      }
+                    />
+                    <MetaRow
+                      label="Duration"
+                      value={
+                        result.receipt.duration_secs !== undefined
+                          ? `${result.receipt.duration_secs}s`
+                          : undefined
+                      }
+                    />
+                    <MetaRow label="Timestamp" value={String(result.receipt.timestamp ?? '')} />
+                  </div>
+                ) : (
+                  <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+                    No receipt filed yet for this dispatch.
+                  </p>
+                )}
+              </Card>
+            </div>
+          )}
+
+          {tab === 'events' && (
+            <Card
+              title={`Event Replay${events?.events ? ` · ${events.events.filter(e => e.type === 'tool_use').length} events` : ''}`}
+            >
+              {eventsErr || events?.error ? (
+                <p
+                  data-testid="events-error"
+                  style={{ fontSize: 12, color: '#fca5a5' }}
+                >
+                  {events?.error ?? `Failed to load events: ${String(eventsErr)}`}
+                </p>
+              ) : eventsLoading ? (
+                <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading event archive…</p>
+              ) : events?.events ? (
+                <EventTimeline events={events.events} />
+              ) : null}
+            </Card>
+          )}
+
+          {tab === 'instruction' && (
+            <Card
+              title="Dispatch Instruction"
+              right={detail?.instruction ? <CopyButton text={detail.instruction} /> : null}
+            >
+              {detailLoading ? (
+                <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading…</p>
+              ) : detail?.instruction ? (
+                <pre
+                  data-testid="dispatch-instruction"
+                  style={{
+                    maxHeight: 600,
+                    overflow: 'auto',
+                    padding: 14,
+                    borderRadius: 8,
+                    background: 'rgba(0,0,0,0.3)',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    fontSize: 11,
+                    lineHeight: 1.6,
+                    fontFamily: 'var(--font-mono, monospace)',
+                    color: 'var(--color-foreground)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {detail.instruction}
+                </pre>
+              ) : (
+                <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>No instruction text.</p>
+              )}
+            </Card>
+          )}
+
+          {tab === 'result' && (
+            <Card
+              title={result?.report_file ? `Report · ${result.report_file}` : 'Result Report'}
+              right={result?.report ? <CopyButton text={result.report} /> : null}
+            >
+              {resultErr || result?.error ? (
+                <p
+                  data-testid="result-error"
+                  style={{ fontSize: 12, color: 'var(--color-muted)' }}
+                >
+                  {result?.error ?? `Failed to load result: ${String(resultErr)}`}
+                </p>
+              ) : resultLoading ? (
+                <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading report…</p>
+              ) : result?.report ? (
+                <pre
+                  data-testid="dispatch-report"
+                  style={{
+                    maxHeight: 600,
+                    overflow: 'auto',
+                    padding: 14,
+                    borderRadius: 8,
+                    background: 'rgba(0,0,0,0.3)',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    fontSize: 11,
+                    lineHeight: 1.6,
+                    fontFamily: 'var(--font-mono, monospace)',
+                    color: 'var(--color-foreground)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {result.report}
+                </pre>
+              ) : (
+                <p style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+                  No result report available yet.
+                </p>
+              )}
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/app/operator/dispatches/page.tsx
+++ b/dashboard/token-dashboard/app/operator/dispatches/page.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { RefreshCw, ClipboardList, Search } from 'lucide-react';
+import { useDispatches } from '@/lib/hooks';
+import type { DispatchStage, DispatchSummary } from '@/lib/types';
+import DispatchList from '@/components/operator/dispatch-list';
+
+const ALL_STAGES: (DispatchStage | 'all')[] = ['all', 'pending', 'active', 'review', 'done', 'staging'];
+
+const STAGE_LABELS: Record<string, string> = {
+  all: 'All',
+  staging: 'Staging',
+  pending: 'Pending',
+  active: 'Active',
+  review: 'Review',
+  done: 'Done',
+};
+
+function LoadingSkeleton() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {[0, 1, 2, 3, 4, 5].map(i => (
+        <div
+          key={i}
+          aria-hidden="true"
+          style={{
+            height: 56,
+            borderRadius: 8,
+            background:
+              'linear-gradient(90deg, rgba(255,255,255,0.03), rgba(255,255,255,0.06), rgba(255,255,255,0.03))',
+            backgroundSize: '200% 100%',
+            animation: 'pulse 1.4s ease-in-out infinite',
+          }}
+        />
+      ))}
+      <style jsx>{`
+        @keyframes pulse {
+          0%, 100% { background-position: 0% 0%; }
+          50% { background-position: 100% 0%; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default function DispatchesPage() {
+  const { data, error, isLoading, mutate } = useDispatches();
+  const [stageFilter, setStageFilter] = useState<DispatchStage | 'all'>('all');
+  const [trackFilter, setTrackFilter] = useState<string>('');
+  const [terminalFilter, setTerminalFilter] = useState<string>('');
+  const [query, setQuery] = useState<string>('');
+
+  const allDispatches: DispatchSummary[] = useMemo(() => {
+    if (!data?.stages) return [];
+    const out: DispatchSummary[] = [];
+    for (const stage of ['pending', 'active', 'review', 'done', 'staging'] as DispatchStage[]) {
+      const group = data.stages[stage];
+      if (group) out.push(...group);
+    }
+    return out;
+  }, [data]);
+
+  const stageCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: allDispatches.length };
+    for (const stage of ALL_STAGES) {
+      if (stage === 'all') continue;
+      counts[stage] = data?.stages?.[stage]?.length ?? 0;
+    }
+    return counts;
+  }, [data, allDispatches]);
+
+  const { tracks, terminals } = useMemo(() => {
+    const t = new Set<string>();
+    const term = new Set<string>();
+    for (const d of allDispatches) {
+      if (d.track && d.track !== '—') t.add(d.track);
+      if (d.terminal && d.terminal !== '—') term.add(d.terminal);
+    }
+    return {
+      tracks: Array.from(t).sort(),
+      terminals: Array.from(term).sort(),
+    };
+  }, [allDispatches]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allDispatches.filter(d => {
+      if (stageFilter !== 'all' && d.stage !== stageFilter) return false;
+      if (trackFilter && d.track !== trackFilter) return false;
+      if (terminalFilter && d.terminal !== terminalFilter) return false;
+      if (q && !(
+        d.id.toLowerCase().includes(q) ||
+        (d.gate ?? '').toLowerCase().includes(q) ||
+        (d.pr_id ?? '').toLowerCase().includes(q) ||
+        (d.role ?? '').toLowerCase().includes(q)
+      )) return false;
+      return true;
+    });
+  }, [allDispatches, stageFilter, trackFilter, terminalFilter, query]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between" style={{ marginBottom: 24 }}>
+        <div className="flex items-center gap-3">
+          <div
+            style={{
+              height: 28,
+              width: 4,
+              borderRadius: 2,
+              background: 'var(--color-accent)',
+            }}
+          />
+          <div>
+            <h2
+              style={{
+                fontSize: '1.5rem',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                color: 'var(--color-foreground)',
+              }}
+            >
+              Dispatches
+            </h2>
+            <p style={{ fontSize: 12, color: 'var(--color-muted)', marginTop: 2 }}>
+              Browse dispatch queue and replay execution from archived events
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => mutate()}
+          data-testid="dispatches-refresh"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '7px 14px',
+            borderRadius: 8,
+            background: 'rgba(255,255,255,0.05)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            cursor: 'pointer',
+            fontSize: 12,
+            color: 'var(--color-muted)',
+          }}
+        >
+          <RefreshCw size={13} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stage tabs */}
+      <div
+        role="tablist"
+        aria-label="Filter by stage"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 6,
+          marginBottom: 16,
+        }}
+      >
+        {ALL_STAGES.map(s => {
+          const active = stageFilter === s;
+          return (
+            <button
+              key={s}
+              role="tab"
+              aria-selected={active}
+              data-testid={`stage-tab-${s}`}
+              onClick={() => setStageFilter(s)}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '6px 12px',
+                borderRadius: 8,
+                fontSize: 11,
+                fontWeight: active ? 600 : 400,
+                background: active ? 'rgba(249, 115, 22, 0.12)' : 'rgba(255,255,255,0.04)',
+                border: `1px solid ${active ? 'rgba(249, 115, 22, 0.35)' : 'rgba(255,255,255,0.08)'}`,
+                color: active ? 'var(--color-accent)' : 'var(--color-muted)',
+                cursor: 'pointer',
+              }}
+            >
+              <span>{STAGE_LABELS[s]}</span>
+              <span
+                style={{
+                  fontSize: 10,
+                  padding: '1px 6px',
+                  borderRadius: 10,
+                  background: 'rgba(255,255,255,0.06)',
+                  color: active ? 'var(--color-accent)' : 'var(--color-muted)',
+                }}
+              >
+                {stageCounts[s] ?? 0}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Secondary filters */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 12,
+          marginBottom: 20,
+          padding: 12,
+          borderRadius: 10,
+          background: 'rgba(255,255,255,0.02)',
+          border: '1px solid rgba(255,255,255,0.05)',
+        }}
+      >
+        <div style={{ position: 'relative', flex: '1 1 240px', minWidth: 200 }}>
+          <Search
+            size={12}
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              color: 'var(--color-muted)',
+            }}
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search id, gate, PR, role…"
+            data-testid="dispatches-search"
+            style={{
+              width: '100%',
+              padding: '7px 10px 7px 28px',
+              borderRadius: 7,
+              fontSize: 12,
+              background: 'rgba(0,0,0,0.25)',
+              border: '1px solid rgba(255,255,255,0.08)',
+              color: 'var(--color-foreground)',
+              outline: 'none',
+            }}
+          />
+        </div>
+        <select
+          value={trackFilter}
+          onChange={e => setTrackFilter(e.target.value)}
+          data-testid="track-filter"
+          style={{
+            padding: '7px 10px',
+            borderRadius: 7,
+            fontSize: 12,
+            background: 'rgba(0,0,0,0.25)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            color: 'var(--color-foreground)',
+          }}
+        >
+          <option value="">All tracks</option>
+          {tracks.map(t => (
+            <option key={t} value={t}>Track {t}</option>
+          ))}
+        </select>
+        <select
+          value={terminalFilter}
+          onChange={e => setTerminalFilter(e.target.value)}
+          data-testid="terminal-filter"
+          style={{
+            padding: '7px 10px',
+            borderRadius: 7,
+            fontSize: 12,
+            background: 'rgba(0,0,0,0.25)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            color: 'var(--color-foreground)',
+          }}
+        >
+          <option value="">All terminals</option>
+          {terminals.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Result count */}
+      <div
+        className="flex items-center gap-2"
+        style={{ marginBottom: 10 }}
+      >
+        <ClipboardList size={14} style={{ color: 'var(--color-accent)' }} />
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-foreground)' }}>
+          {isLoading ? 'Loading dispatches…' : `${filtered.length} dispatch${filtered.length === 1 ? '' : 'es'}`}
+        </span>
+      </div>
+
+      {/* Body */}
+      {error ? (
+        <div
+          style={{
+            padding: 16,
+            borderRadius: 10,
+            background: 'rgba(239, 68, 68, 0.08)',
+            border: '1px solid rgba(239, 68, 68, 0.25)',
+            color: '#fca5a5',
+            fontSize: 13,
+          }}
+        >
+          Failed to load dispatches: {String(error)}
+        </div>
+      ) : isLoading ? (
+        <LoadingSkeleton />
+      ) : (
+        <DispatchList dispatches={filtered} />
+      )}
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/operator/dispatch-list.tsx
+++ b/dashboard/token-dashboard/components/operator/dispatch-list.tsx
@@ -17,7 +17,11 @@ function ReceiptDot({ status }: { status: string | null }) {
       </span>
     );
   }
-  const ok = status === 'success' || status === 'completed' || status === 'passed';
+  const ok =
+    status === 'success' ||
+    status === 'completed' ||
+    status === 'passed' ||
+    status === 'pass';
   const Icon = ok ? CheckCircle2 : AlertCircle;
   const color = ok ? '#22c55e' : '#f97316';
   return (

--- a/dashboard/token-dashboard/components/operator/dispatch-list.tsx
+++ b/dashboard/token-dashboard/components/operator/dispatch-list.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, FileText, CheckCircle2, Clock, AlertCircle } from 'lucide-react';
+import type { DispatchSummary } from '@/lib/types';
+import DispatchStageBadge from './dispatch-stage-badge';
+
+interface Props {
+  dispatches: DispatchSummary[];
+}
+
+function ReceiptDot({ status }: { status: string | null }) {
+  if (!status) {
+    return (
+      <span title="No receipt" aria-label="No receipt">
+        <Clock size={12} style={{ color: 'var(--color-muted)', opacity: 0.5 }} />
+      </span>
+    );
+  }
+  const ok = status === 'success' || status === 'completed' || status === 'passed';
+  const Icon = ok ? CheckCircle2 : AlertCircle;
+  const color = ok ? '#22c55e' : '#f97316';
+  return (
+    <span title={`Receipt: ${status}`} aria-label={`Receipt: ${status}`}>
+      <Icon size={12} style={{ color }} />
+    </span>
+  );
+}
+
+function trackColor(track: string): string {
+  if (track === 'A') return '#22d3ee';
+  if (track === 'B') return '#a855f7';
+  if (track === 'C') return '#f97316';
+  return 'var(--color-muted)';
+}
+
+export default function DispatchList({ dispatches }: Props) {
+  if (dispatches.length === 0) {
+    return (
+      <div
+        style={{
+          padding: '40px 20px',
+          textAlign: 'center',
+          color: 'var(--color-muted)',
+          fontSize: 13,
+          background: 'rgba(255,255,255,0.02)',
+          borderRadius: 12,
+          border: '1px dashed rgba(255,255,255,0.08)',
+        }}
+      >
+        No dispatches match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="table"
+      aria-label="Dispatches"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <div
+        role="row"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '90px 1fr 60px 90px 120px 80px 24px',
+          gap: 12,
+          padding: '8px 14px',
+          fontSize: 10,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          color: 'var(--color-muted)',
+          borderBottom: '1px solid rgba(255,255,255,0.05)',
+        }}
+      >
+        <span role="columnheader">Stage</span>
+        <span role="columnheader">Dispatch</span>
+        <span role="columnheader">Track</span>
+        <span role="columnheader">Terminal</span>
+        <span role="columnheader">Role</span>
+        <span role="columnheader">Age</span>
+        <span role="columnheader" aria-label="Receipt" />
+      </div>
+      {dispatches.map(d => (
+        <Link
+          key={d.id}
+          href={`/operator/dispatches/${encodeURIComponent(d.id)}`}
+          role="row"
+          data-testid={`dispatch-row-${d.id}`}
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '90px 1fr 60px 90px 120px 80px 24px',
+            gap: 12,
+            alignItems: 'center',
+            padding: '10px 14px',
+            borderRadius: 8,
+            background: 'rgba(255,255,255,0.02)',
+            border: '1px solid rgba(255,255,255,0.04)',
+            textDecoration: 'none',
+            color: 'var(--color-foreground)',
+            transition: 'all 0.15s',
+          }}
+          className="dispatch-row"
+        >
+          <DispatchStageBadge stage={d.stage} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+            <FileText size={12} style={{ color: 'var(--color-muted)', flexShrink: 0 }} />
+            <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+              <span
+                style={{
+                  fontSize: 12,
+                  fontFamily: 'var(--font-mono, monospace)',
+                  color: 'var(--color-foreground)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {d.id}
+              </span>
+              {d.gate && d.gate !== '—' && (
+                <span style={{ fontSize: 10, color: 'var(--color-muted)', marginTop: 1 }}>
+                  {d.gate}
+                </span>
+              )}
+            </div>
+          </div>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: trackColor(d.track),
+            }}
+          >
+            {d.track}
+          </span>
+          <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>{d.terminal}</span>
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--color-muted)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {d.role}
+          </span>
+          <span style={{ fontSize: 10, color: 'var(--color-muted)' }}>{d.duration_label}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <ReceiptDot status={d.receipt_status} />
+            <ChevronRight size={13} style={{ color: 'var(--color-muted)', opacity: 0.5 }} />
+          </div>
+        </Link>
+      ))}
+      <style jsx>{`
+        :global(.dispatch-row:hover) {
+          background: rgba(255,255,255,0.05) !important;
+          border-color: rgba(249, 115, 22, 0.3) !important;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/operator/dispatch-stage-badge.tsx
+++ b/dashboard/token-dashboard/components/operator/dispatch-stage-badge.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { DispatchStage } from '@/lib/types';
+
+const STAGE_STYLES: Record<DispatchStage, { bg: string; border: string; color: string; label: string }> = {
+  staging: {
+    bg: 'rgba(148, 163, 184, 0.12)',
+    border: 'rgba(148, 163, 184, 0.30)',
+    color: '#94a3b8',
+    label: 'Staging',
+  },
+  pending: {
+    bg: 'rgba(249, 115, 22, 0.12)',
+    border: 'rgba(249, 115, 22, 0.35)',
+    color: '#f97316',
+    label: 'Pending',
+  },
+  active: {
+    bg: 'rgba(34, 211, 238, 0.12)',
+    border: 'rgba(34, 211, 238, 0.35)',
+    color: '#22d3ee',
+    label: 'Active',
+  },
+  review: {
+    bg: 'rgba(168, 85, 247, 0.12)',
+    border: 'rgba(168, 85, 247, 0.35)',
+    color: '#a855f7',
+    label: 'Review',
+  },
+  done: {
+    bg: 'rgba(34, 197, 94, 0.12)',
+    border: 'rgba(34, 197, 94, 0.35)',
+    color: '#22c55e',
+    label: 'Done',
+  },
+};
+
+export default function DispatchStageBadge({ stage }: { stage: DispatchStage }) {
+  const s = STAGE_STYLES[stage] ?? STAGE_STYLES.staging;
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 8px',
+        borderRadius: 12,
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        background: s.bg,
+        border: `1px solid ${s.border}`,
+        color: s.color,
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
+export { STAGE_STYLES };

--- a/dashboard/token-dashboard/components/operator/event-timeline.tsx
+++ b/dashboard/token-dashboard/components/operator/event-timeline.tsx
@@ -140,7 +140,7 @@ export default function EventTimeline({ events }: Props) {
     return () => clearInterval(timer);
   }, [playing, filtered.length]);
 
-  if (events.length === 0) {
+  if (toolEvents.length === 0) {
     return (
       <div
         style={{

--- a/dashboard/token-dashboard/components/operator/event-timeline.tsx
+++ b/dashboard/token-dashboard/components/operator/event-timeline.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Search,
+  FileEdit,
+  FileText,
+  Terminal,
+  GitCommit,
+  TestTube2,
+  Compass,
+  Hammer,
+  Play,
+  Pause,
+  Rewind,
+  FastForward,
+} from 'lucide-react';
+import type {
+  DispatchEvent,
+  DispatchEventPhase,
+  DispatchToolUseEvent,
+  DispatchPhaseMarker,
+} from '@/lib/types';
+
+const PHASE_META: Record<DispatchEventPhase, { label: string; color: string; icon: typeof Compass }> = {
+  explore: { label: 'Explore', color: '#22d3ee', icon: Compass },
+  implement: { label: 'Implement', color: '#f97316', icon: Hammer },
+  test: { label: 'Test', color: '#a855f7', icon: TestTube2 },
+  commit: { label: 'Commit', color: '#22c55e', icon: GitCommit },
+  other: { label: 'Other', color: '#94a3b8', icon: Terminal },
+};
+
+function toolIcon(tool: string) {
+  if (tool === 'Read' || tool === 'Grep' || tool === 'Glob') return Search;
+  if (tool === 'Write') return FileText;
+  if (tool === 'Edit' || tool === 'MultiEdit') return FileEdit;
+  if (tool === 'Bash') return Terminal;
+  return Terminal;
+}
+
+function formatOffset(secs: number | null): string {
+  if (secs === null || secs === undefined) return '—';
+  if (secs < 60) return `+${secs.toFixed(1)}s`;
+  const m = Math.floor(secs / 60);
+  const s = Math.round(secs % 60);
+  return `+${m}m${s.toString().padStart(2, '0')}s`;
+}
+
+function isPhase(ev: DispatchEvent): ev is DispatchPhaseMarker {
+  return ev.type === 'phase_marker';
+}
+
+function isTool(ev: DispatchEvent): ev is DispatchToolUseEvent {
+  return ev.type === 'tool_use';
+}
+
+interface Props {
+  events: DispatchEvent[];
+}
+
+export default function EventTimeline({ events }: Props) {
+  const [phaseFilter, setPhaseFilter] = useState<DispatchEventPhase | 'all'>('all');
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toolEvents = useMemo(() => events.filter(isTool), [events]);
+
+  const phaseCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: toolEvents.length };
+    let currentPhase: DispatchEventPhase = 'other';
+    for (const ev of events) {
+      if (isPhase(ev)) {
+        currentPhase = ev.phase;
+        continue;
+      }
+      if (isTool(ev)) {
+        counts[currentPhase] = (counts[currentPhase] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }, [events, toolEvents.length]);
+
+  const toolWithPhase = useMemo(() => {
+    const out: Array<{ event: DispatchToolUseEvent; phase: DispatchEventPhase; index: number }> = [];
+    let currentPhase: DispatchEventPhase = 'other';
+    let idx = 0;
+    for (const ev of events) {
+      if (isPhase(ev)) {
+        currentPhase = ev.phase;
+        continue;
+      }
+      if (isTool(ev)) {
+        out.push({ event: ev, phase: currentPhase, index: idx });
+        idx += 1;
+      }
+    }
+    return out;
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    if (phaseFilter === 'all') return toolWithPhase;
+    return toolWithPhase.filter(x => x.phase === phaseFilter);
+  }, [toolWithPhase, phaseFilter]);
+
+  const totalDuration = useMemo(() => {
+    const last = toolEvents[toolEvents.length - 1];
+    return last?.timestamp_offset ?? null;
+  }, [toolEvents]);
+
+  // Replay: advance cursor through filtered events
+  function stepForward() {
+    const max = filtered.length - 1;
+    setCursor(c => (c === null ? 0 : Math.min(max, c + 1)));
+  }
+  function stepBack() {
+    setCursor(c => (c === null ? null : Math.max(0, c - 1)));
+  }
+  function reset() {
+    setCursor(null);
+    setPlaying(false);
+  }
+
+  useEffect(() => {
+    if (!playing) return;
+    const max = filtered.length - 1;
+    if (max < 0) {
+      setPlaying(false);
+      return;
+    }
+    const timer = setInterval(() => {
+      setCursor(c => {
+        const next = c === null ? 0 : c + 1;
+        if (next >= max) {
+          setPlaying(false);
+          return max;
+        }
+        return next;
+      });
+    }, 400);
+    return () => clearInterval(timer);
+  }, [playing, filtered.length]);
+
+  if (events.length === 0) {
+    return (
+      <div
+        style={{
+          padding: '32px 20px',
+          textAlign: 'center',
+          fontSize: 13,
+          color: 'var(--color-muted)',
+          background: 'rgba(255,255,255,0.02)',
+          borderRadius: 12,
+          border: '1px dashed rgba(255,255,255,0.08)',
+        }}
+      >
+        No tool events recorded in the event archive for this dispatch.
+      </div>
+    );
+  }
+
+  const phases: (DispatchEventPhase | 'all')[] = ['all', 'explore', 'implement', 'test', 'commit', 'other'];
+
+  return (
+    <div>
+      {/* Replay controls */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          marginBottom: 12,
+          borderRadius: 10,
+          background: 'rgba(255,255,255,0.02)',
+          border: '1px solid rgba(255,255,255,0.05)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <button
+          onClick={reset}
+          data-testid="replay-reset"
+          title="Reset"
+          style={iconBtn}
+        >
+          <Rewind size={14} />
+        </button>
+        <button
+          onClick={stepBack}
+          data-testid="replay-back"
+          disabled={cursor === null || cursor === 0}
+          style={{ ...iconBtn, opacity: cursor === null || cursor === 0 ? 0.4 : 1 }}
+        >
+          <Rewind size={12} />
+        </button>
+        <button
+          onClick={() => setPlaying(p => !p)}
+          data-testid="replay-play"
+          style={{ ...iconBtn, color: playing ? 'var(--color-accent)' : 'var(--color-foreground)' }}
+        >
+          {playing ? <Pause size={14} /> : <Play size={14} />}
+        </button>
+        <button
+          onClick={stepForward}
+          data-testid="replay-forward"
+          disabled={cursor !== null && cursor >= filtered.length - 1}
+          style={{
+            ...iconBtn,
+            opacity: cursor !== null && cursor >= filtered.length - 1 ? 0.4 : 1,
+          }}
+        >
+          <FastForward size={12} />
+        </button>
+        <div style={{ flex: 1, minWidth: 120 }}>
+          <input
+            type="range"
+            min={-1}
+            max={filtered.length - 1}
+            value={cursor ?? -1}
+            onChange={e => {
+              const v = Number(e.target.value);
+              setCursor(v < 0 ? null : v);
+            }}
+            data-testid="replay-scrub"
+            style={{ width: '100%', accentColor: 'var(--color-accent)' }}
+          />
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--color-muted)',
+            fontFamily: 'var(--font-mono, monospace)',
+            minWidth: 80,
+            textAlign: 'right',
+          }}
+        >
+          {cursor === null ? `0 / ${filtered.length}` : `${cursor + 1} / ${filtered.length}`}
+          {totalDuration !== null && (
+            <span style={{ marginLeft: 6, opacity: 0.7 }}>
+              · {formatOffset(totalDuration)}
+            </span>
+          )}
+        </span>
+      </div>
+
+      {/* Phase filter chips */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 6,
+          marginBottom: 12,
+        }}
+      >
+        {phases.map(p => {
+          const active = phaseFilter === p;
+          const meta = p === 'all' ? null : PHASE_META[p];
+          return (
+            <button
+              key={p}
+              onClick={() => {
+                setPhaseFilter(p);
+                setCursor(null);
+              }}
+              data-testid={`phase-filter-${p}`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+                padding: '4px 10px',
+                borderRadius: 16,
+                fontSize: 10,
+                fontWeight: active ? 600 : 400,
+                background: active
+                  ? meta
+                    ? `${meta.color}22`
+                    : 'rgba(249, 115, 22, 0.12)'
+                  : 'rgba(255,255,255,0.04)',
+                border: `1px solid ${
+                  active
+                    ? meta
+                      ? `${meta.color}66`
+                      : 'rgba(249, 115, 22, 0.35)'
+                    : 'rgba(255,255,255,0.08)'
+                }`,
+                color: active ? (meta?.color ?? 'var(--color-accent)') : 'var(--color-muted)',
+                cursor: 'pointer',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+              }}
+            >
+              <span>{p === 'all' ? 'All' : meta!.label}</span>
+              <span style={{ fontSize: 9, opacity: 0.8 }}>({phaseCounts[p] ?? 0})</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Timeline */}
+      <div
+        role="list"
+        aria-label="Event timeline"
+        data-testid="event-timeline"
+        style={{
+          position: 'relative',
+          paddingLeft: 22,
+        }}
+      >
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 7,
+            top: 4,
+            bottom: 4,
+            width: 1,
+            background: 'rgba(255,255,255,0.08)',
+          }}
+        />
+        {filtered.map((item, i) => {
+          const { event, phase } = item;
+          const Icon = toolIcon(event.tool_name);
+          const meta = PHASE_META[phase];
+          const isActive = cursor !== null && i === cursor;
+          const isFaded = cursor !== null && i > cursor;
+
+          return (
+            <div
+              key={i}
+              role="listitem"
+              data-testid={`event-${i}`}
+              data-active={isActive ? 'true' : undefined}
+              style={{
+                position: 'relative',
+                display: 'flex',
+                gap: 10,
+                padding: '6px 10px',
+                marginBottom: 4,
+                borderRadius: 8,
+                background: isActive ? 'rgba(249, 115, 22, 0.08)' : 'transparent',
+                border: `1px solid ${isActive ? 'rgba(249, 115, 22, 0.35)' : 'transparent'}`,
+                opacity: isFaded ? 0.35 : 1,
+                transition: 'opacity 0.15s, background 0.15s',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  left: -19,
+                  top: 12,
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  background: meta.color,
+                  boxShadow: isActive
+                    ? `0 0 0 3px ${meta.color}33`
+                    : `0 0 0 2px rgba(0,0,0,0.4)`,
+                }}
+              />
+              <Icon
+                size={13}
+                style={{
+                  color: meta.color,
+                  flexShrink: 0,
+                  marginTop: 2,
+                }}
+              />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 600,
+                      color: 'var(--color-foreground)',
+                    }}
+                  >
+                    {event.tool_name}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 9,
+                      padding: '0 6px',
+                      borderRadius: 10,
+                      background: `${meta.color}1a`,
+                      color: meta.color,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {meta.label}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--color-muted)',
+                      fontFamily: 'var(--font-mono, monospace)',
+                      marginLeft: 'auto',
+                    }}
+                  >
+                    {formatOffset(event.timestamp_offset)}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--color-muted)',
+                    fontFamily: 'var(--font-mono, monospace)',
+                    marginTop: 2,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={event.summary}
+                >
+                  {event.summary || event.file_path || '—'}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const iconBtn: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 28,
+  height: 28,
+  borderRadius: 7,
+  background: 'rgba(255,255,255,0.05)',
+  border: '1px solid rgba(255,255,255,0.08)',
+  color: 'var(--color-foreground)',
+  cursor: 'pointer',
+};

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -434,75 +434,101 @@ export interface ProposalActionResponse {
 
 // ===== Dispatch Viewer Types =====
 
+export type DispatchStage = 'staging' | 'pending' | 'active' | 'review' | 'done';
+
 export interface DispatchSummary {
-  dispatch_id: string;
+  id: string;
+  file: string;
+  pr_id: string;
+  track: string;
   terminal: string;
   role: string;
   gate: string;
-  pr: string | null;
+  priority: string;
   status: string;
-  timestamp: string;
-  duration_secs: number | null;
-  track: string | null;
-}
-
-export interface DispatchDetail {
-  dispatch_id: string;
-  terminal: string;
-  role: string;
-  gate: string;
-  pr: string | null;
-  model: string | null;
-  track: string | null;
-  instruction: string;
-  intelligence_patterns: string[];
-  repo_map: string[];
-}
-
-export interface DispatchEvent {
-  offset_secs: number;
-  tool: string;
-  target: string;
-  input?: string;
-  output?: string;
-  has_error: boolean;
-  timestamp?: string;
-}
-
-export interface DispatchResult {
-  status: string;
-  cqs_score: number | null;
-  cqs_components: Record<string, number>;
-  commit_before: string | null;
-  commit_after: string | null;
-  files_changed: number | null;
-  lines_added: number | null;
-  lines_removed: number | null;
-  test_pass: number | null;
-  test_fail: number | null;
-  report_markdown: string | null;
-  exploration_depth: number | null;
-  rework_count: number | null;
-  duration_secs: number | null;
-  baseline_secs: number | null;
+  reason: string;
+  domain: string;
+  dir: string;
+  stage: DispatchStage;
+  duration_secs: number;
+  duration_label: string;
+  has_receipt: boolean;
+  receipt_status: string | null;
 }
 
 export interface DispatchesResponse {
-  dispatches: DispatchSummary[];
+  stages: Record<DispatchStage, DispatchSummary[]>;
   total: number;
 }
 
-export interface DispatchDetailResponse {
-  dispatch: DispatchDetail;
+export interface DispatchDetailMetadata {
+  dispatch_id?: string;
+  terminal?: string;
+  role?: string;
+  gate?: string;
+  track?: string;
+  pr?: string;
+  pr_id?: string;
+  priority?: string;
+  model?: string;
+  status?: string;
+  cognition?: string;
+  skill?: string;
+  [key: string]: string | undefined;
 }
 
+export interface DispatchDetailResponse {
+  dispatch_id: string;
+  stage: string;
+  file: string;
+  instruction: string;
+  metadata: DispatchDetailMetadata;
+  error?: string;
+}
+
+export type DispatchEventPhase = 'explore' | 'implement' | 'commit' | 'test' | 'other';
+
+export interface DispatchPhaseMarker {
+  type: 'phase_marker';
+  phase: DispatchEventPhase;
+}
+
+export interface DispatchToolUseEvent {
+  type: 'tool_use';
+  timestamp_offset: number | null;
+  tool_name: string;
+  file_path: string;
+  summary: string;
+}
+
+export type DispatchEvent = DispatchPhaseMarker | DispatchToolUseEvent;
+
 export interface DispatchEventsResponse {
+  dispatch_id: string;
   events: DispatchEvent[];
-  is_live: boolean;
+  error?: string;
+}
+
+export interface DispatchReceipt {
+  dispatch_id?: string;
+  status?: string;
+  terminal?: string;
+  track?: string;
+  gate?: string;
+  pr?: string | number;
+  commit_after?: string;
+  commit_before?: string;
+  duration_secs?: number;
+  timestamp?: string;
+  [key: string]: unknown;
 }
 
 export interface DispatchResultResponse {
-  result: DispatchResult;
+  dispatch_id: string;
+  receipt: DispatchReceipt | null;
+  report: string | null;
+  report_file?: string;
+  error?: string;
 }
 
 // ===== Transcript Types =====


### PR DESCRIPTION
## Summary
- New `/operator/dispatches` list view: stage tabs (All/Pending/Active/Review/Done/Staging) with counts, track/terminal filters, free-text search, SWR 30s refresh
- New `/operator/dispatches/[id]` detail view: 4 tabs (Overview/Event Replay/Instruction/Result)
- Event Replay: scrubbable timeline over archived NDJSON events, phase-colored markers (explore/implement/test/commit), play/pause with 400ms auto-advance, phase filter chips
- TS types in `lib/types.ts` corrected — placeholder stubs didn't match real `/api/dispatches*` responses
- 14 new component tests (8 page + 6 timeline)
- Closes F59-PR4 of sorted-herding-kay.md plan
- Parent-Dispatch: 20260424-020100-f59-pr4-dashboard-viewer-C

## Why
Operator had no way to browse dispatch queue or replay execution. F59-PR1 ships the analyzer; PR4 ships the UI that makes behavioral data visible.

## Test plan
- [ ] CI green
- [ ] codex_gate pass
- [ ] gemini_review pass
- [ ] Frontend build succeeds
- [ ] Smoke: navigate `/operator/dispatches` → pick a recent dispatch → Event Replay tab shows timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)