### PR TITLE
docs(audit-cleanup): fix stale links, inaccurate internal-docs claim, dead references (round 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **dispatch-viewer**: Add `/operator/dispatches` list view with stage tabs (staging/pending/active/review/done), track/terminal/search filters, and per-row receipt status indicator. Add `/operator/dispatches/[id]` detail page with Overview/Event Replay/Instruction/Result tabs; replay tab renders phase-colored tool-use timeline from archived NDJSON with scrubbable cursor, play/pause/step controls, and phase filter chips. Data flows through existing `/api/dispatches*` endpoints (F59-PR4).
 
 ### Docs
+- **docs-audit-cleanup**: Fix broken link to archived `MONITORING_GUIDE.md` in `docs/README.md`; correct inaccurate "Internal (not in repo)" claim in `docs/DOCS_INDEX.md` to list the 4 tracked headless-T0 research docs; remove 5 dead markdown hyperlinks in `docs/operations/AUTONOMOUS_PRODUCTION_GUIDE.md` pointing to private planning docs not in repo.
 - **event-streams**: Add `docs/operations/EVENT_STREAMS.md` documenting the per-dispatch ring-buffer lifecycle of `.vnx-data/events/T{n}.ndjson` and the `events/archive/{terminal}/{dispatch_id}.ndjson` layout; linked from `docs/operations/README.md` and `docs/DOCS_INDEX.md`. Clarifies a misinterpretation flagged as W-2 in the 2026-04-23 audit-trail investigation (OI-AT-6a). Updates CHANGELOG to remove a stale `(missing source)` parenthetical on the ghost-receipt-filter entry now that `scripts/lib/headless_review_receipt.py` is in tree (OI-1133).
 
 ### Fixes

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -31,6 +31,13 @@
 | Examples | `docs/examples/` | Example orchestration flows |
 | Archive | `docs/_archive/` | Historical docs kept for traceability |
 
-## Internal (not in repo)
+## Internal
 
-Internal strategy, business plans, wave maps, and maintainer-only status docs are maintained privately in the BUSINESS workspace outside this repository.
+Most internal strategy, business plans, wave maps, and maintainer-only docs are gitignored and maintained privately outside this repository. The following research docs are tracked for historical reference:
+
+| Document | Path | Description |
+|----------|------|-------------|
+| Headless T0 Feasibility | `docs/internal/plans/HEADLESS_T0_FEASIBILITY_REPORT.md` | Feasibility analysis for headless T0 orchestration |
+| Headless T0 Framework | `docs/internal/plans/HEADLESS_T0_FRAMEWORK_RESEARCH.md` | Framework research for headless implementation |
+| Headless T0 State Architecture | `docs/internal/plans/HEADLESS_T0_STATE_ARCHITECTURE.md` | State architecture design for headless T0 |
+| Architecture Supplement | `docs/internal/plans/VNX_ARCHITECTURE_SUPPLEMENT_EXTERNAL_PATTERNS.md` | External patterns supplement to core architecture |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Use `DOCS_INDEX.md` for the canonical "one place to look" navigation.
 - Architecture: `core/00_VNX_ARCHITECTURE.md`
 - Getting started: `core/00_GETTING_STARTED.md`
 - Dispatch workflow: `DISPATCH_GUIDE.md`
-- Monitoring: `operations/MONITORING_GUIDE.md`
+- Monitoring: `operations/README.md`
 - Product modes: `contracts/PRODUCTIZATION_CONTRACT.md`
 - Roadmap: `manifesto/ROADMAP.md`
 

--- a/docs/operations/AUTONOMOUS_PRODUCTION_GUIDE.md
+++ b/docs/operations/AUTONOMOUS_PRODUCTION_GUIDE.md
@@ -4,8 +4,8 @@
 **Date**: 2026-04-01
 **Status**: Active reference with historical sections
 **Source**: VNX_PID.md, VNX_DIGITAL_AGENT_TEAM_VISION.md, VNX_N8N_PROJECTPLAN.md
-**Prerequisite**: [AUTONOMOUS_EXECUTION_PLAN.md](../plans/AUTONOMOUS_EXECUTION_PLAN.md)
-**Wave Mapping**: [VNX_AGENT_TEAM_WAVE_MAPPING.md](VNX_AGENT_TEAM_WAVE_MAPPING.md)
+**Prerequisite**: AUTONOMOUS_EXECUTION_PLAN.md (private planning doc, not in repo)
+**Wave Mapping**: VNX_AGENT_TEAM_WAVE_MAPPING.md (private planning doc, not in repo)
 
 ---
 
@@ -694,7 +694,7 @@ Source: VNX_PID.md (Fase 0-4, 4 Tracks, 12 weken, 23 workflows)
 Terminals: T0 (Opus) + T1 (Sonnet) + T2 (Sonnet) + T3 (Opus)
 Mode: `--dangerously-skip-permissions`
 
-Gedetailleerde PR-niveau breakdown: zie [VNX_AGENT_TEAM_WAVE_MAPPING.md](VNX_AGENT_TEAM_WAVE_MAPPING.md)
+Gedetailleerde PR-niveau breakdown: zie VNX_AGENT_TEAM_WAVE_MAPPING.md (private planning doc, not in repo)
 
 ### Fase 0: Fundament (Week 1-2) — 15 PRs, 5 Waves
 
@@ -938,9 +938,9 @@ This reduces T0 review scope to semantic review for PRs covered by deterministic
 - `VNX_N8N_PROJECTPLAN.md` — 23 workflows, Docker setup, governance
 
 ### VNX System
-- [AUTONOMOUS_EXECUTION_PLAN.md](../plans/AUTONOMOUS_EXECUTION_PLAN.md) — S1-S5, R1-R5, G1-G5
+- `AUTONOMOUS_EXECUTION_PLAN.md` — S1-S5, R1-R5, G1-G5 (private planning doc, not in repo)
 - [00_VNX_ARCHITECTURE.md](../core/00_VNX_ARCHITECTURE.md) — V11.0 architectuur
-- [VNX_AGENT_TEAM_WAVE_MAPPING.md](VNX_AGENT_TEAM_WAVE_MAPPING.md) — Gedetailleerde PR mapping
+- `VNX_AGENT_TEAM_WAVE_MAPPING.md` — Gedetailleerde PR mapping (private planning doc, not in repo)
 - [RECEIPT_PIPELINE.md](RECEIPT_PIPELINE.md) — Receipt processing flow
 - `terminals/T0/CLAUDE.md` — T0 richtlijnen
 - `scripts/vnx_worktree_setup.sh` — Worktree management


### PR DESCRIPTION
## Summary
Round 1 of the docs audit cleanup, targeting the highest-confidence findings from 3-slice parallel audit (codex-5.4 + gemini):

- `docs/README.md` — fix broken link to archived `MONITORING_GUIDE.md` → point to active `operations/README.md`
- `docs/DOCS_INDEX.md` — replace inaccurate "all internal docs are private" claim with accurate table of 4 tracked internal docs (`docs/internal/plans/*`)
- `docs/operations/AUTONOMOUS_PRODUCTION_GUIDE.md` — convert 5 dead hyperlinks to plain text with "(private planning doc)" annotation
- 4 files changed, +16/-8 lines
- Parent-Dispatch: 20260427-185500-docs-audit-cleanup-A

## Why
Round 1 only — broken-link / dead-reference / inaccurate-claim subset. Round 2 follow-up will address larger findings (00_VNX_ARCHITECTURE.md v12 drift, README sync with F59 dashboard, skill SEOcrawler refs, EXIT_CODES.md numerical→named code drift).

## Test plan
- [ ] CI green (no test changes)
- [ ] codex_gate pass
- [ ] gemini_review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)