### PR TITLE
feat(governance): auto-rebuild t0_state + state_mutation_receipt (Sprint 2)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1058,13 +1058,6 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
         except Exception:
             pass
 
-        try:
-            tmp = throttle_file.with_name(throttle_file.name + ".tmp")
-            tmp.write_text(str(time.time()), encoding="utf-8")
-            os.replace(str(tmp), str(throttle_file))
-        except Exception:
-            pass
-
         subprocess.Popen(
             ["python3", "scripts/build_t0_state.py"],
             cwd=str(_REPO_ROOT),
@@ -1072,6 +1065,14 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
+        # Write throttle marker only after Popen succeeds; a failed launch
+        # should not suppress the next rebuild attempt for 30s.
+        try:
+            tmp = throttle_file.with_name(throttle_file.name + ".tmp")
+            tmp.write_text(str(time.time()), encoding="utf-8")
+            os.replace(str(tmp), str(throttle_file))
+        except Exception:
+            pass
     except Exception:
         pass
 

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -60,6 +60,11 @@ DISPATCH_REQUIRED_EVENTS = {
     "ack",
 }
 
+STATE_MUTATION_EVENTS = {"state_mutation"}
+
+_REPO_ROOT = SCRIPT_DIR.parent
+_REBUILD_THROTTLE_SECONDS = 30
+
 _warned_review_gate_no_dispatch_id = False
 
 
@@ -922,12 +927,14 @@ def append_receipt_payload(
     *,
     receipts_file: Optional[str] = None,
     cache_window_seconds: int = 300,
+    skip_enrichment: bool = False,
 ) -> AppendResult:
     if not isinstance(receipt, dict):
         raise AppendReceiptError("invalid_receipt_type", EXIT_INVALID_INPUT, "Receipt payload must be a JSON object")
 
     # Enrich completion receipts with quality advisory and terminal snapshot (best-effort)
-    receipt = _enrich_completion_receipt(receipt)
+    if not skip_enrichment:
+        receipt = _enrich_completion_receipt(receipt)
 
     # Route ghost gate receipts (dispatch_id="unknown" + gate event) to gate_events.ndjson.
     # review_gate_request with empty/missing dispatch_id is redirected here (pre-existing
@@ -994,14 +1001,14 @@ def append_receipt_payload(
     except OSError as exc:
         raise AppendReceiptError("lock_failed", EXIT_LOCK_ERROR, f"Failed to acquire append lock: {exc}") from exc
 
-    # Best-effort: register quality advisory violations as tracked open items
-    # (outside flock to avoid holding the receipt lock during OI registration)
-    if result is not None and result.status == "appended":
+    # Best-effort post-append hooks (skipped for skip_enrichment=True lightweight events)
+    if result is not None and result.status == "appended" and not skip_enrichment:
         created_count = _register_quality_open_items(receipt)
         receipt["open_items_created"] = created_count
 
-        # Best-effort: update pattern confidence from dispatch outcome
         _update_confidence_from_receipt(receipt)
+
+        _maybe_trigger_state_rebuild(receipt)
 
     return result
 
@@ -1031,6 +1038,42 @@ def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:
         update_confidence_from_outcome(db_path, dispatch_id, terminal, outcome)
     except Exception as exc:
         _emit("WARN", "confidence_update_failed", error=str(exc))
+
+
+def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
+    """Fire non-blocking rebuild of t0_state.json after qualifying events. Best-effort."""
+    try:
+        event_type = str(receipt.get("event_type") or receipt.get("event") or "")
+        if not (_is_completion_event(receipt) or event_type in ("dispatch_promoted", "dispatch_started")):
+            return
+
+        state_dir = resolve_state_dir(__file__)
+        throttle_file = state_dir / ".last_state_rebuild_ts"
+
+        try:
+            if throttle_file.exists():
+                last_ts = float(throttle_file.read_text(encoding="utf-8").strip())
+                if time.time() - last_ts < _REBUILD_THROTTLE_SECONDS:
+                    return
+        except Exception:
+            pass
+
+        try:
+            tmp = throttle_file.with_name(throttle_file.name + ".tmp")
+            tmp.write_text(str(time.time()), encoding="utf-8")
+            os.replace(str(tmp), str(throttle_file))
+        except Exception:
+            pass
+
+        subprocess.Popen(
+            ["python3", "scripts/build_t0_state.py"],
+            cwd=str(_REPO_ROOT),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass
 
 
 def _parse_input(receipt_json: Optional[str], receipt_file: Optional[str]) -> Dict[str, Any]:
@@ -1066,6 +1109,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--receipt-file", help="Path to file containing a single receipt JSON payload", default=None)
     parser.add_argument("--receipts-file", help="Override canonical receipts file path", default=None)
     parser.add_argument("--cache-window-seconds", type=int, default=300, help="Recent idempotency window in seconds")
+    parser.add_argument("--skip-enrichment", action="store_true", default=False, help="Skip quality advisory and provenance enrichment (for state-mutation events)")
     args = parser.parse_args(argv)
 
     try:
@@ -1074,6 +1118,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             receipt,
             receipts_file=args.receipts_file,
             cache_window_seconds=args.cache_window_seconds,
+            skip_enrichment=args.skip_enrichment,
         )
     except AppendReceiptError as exc:
         _emit("ERROR", exc.code, message=exc.message)

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -76,6 +76,9 @@ IDEMPOTENCY_FIELDS = (
     "event",
     "report_path",
     "source",
+    "file",
+    "trigger",
+    "section",
 )
 
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -675,12 +675,30 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    output_path = Path(args.output)
+    elapsed = 0.0
     try:
+        t_start = time.monotonic()
         state = build_t0_state(_STATE_DIR, _DISPATCH_DIR)
         payload = _state_to_brief(state) if args.format == "brief" else state
-        _write_atomic(Path(args.output), payload)
+        _write_atomic(output_path, payload)
+        elapsed = time.monotonic() - t_start
     except Exception:
         pass  # SessionStart hook must never block session
+
+    try:
+        if str(_LIB_DIR) not in sys.path:
+            sys.path.insert(0, str(_LIB_DIR))
+        from state_mutation import emit_state_mutation
+        size_bytes = output_path.stat().st_size if output_path.exists() else 0
+        emit_state_mutation(
+            output_path.name,
+            trigger="auto_rebuild",
+            rebuild_seconds=elapsed,
+            size_bytes=size_bytes,
+        )
+    except Exception:
+        pass
 
     return 0  # Always exit 0
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -470,6 +470,7 @@ def _build_recent_receipts(state_dir: Path, n: int = 3) -> List[Dict[str, Any]]:
             except Exception:
                 continue
 
+        events = [e for e in events if e.get("event_type") != "state_mutation"]
         return events[-n:]
     except Exception:
         return []
@@ -677,28 +678,31 @@ def main() -> int:
 
     output_path = Path(args.output)
     elapsed = 0.0
+    _build_succeeded = False
     try:
         t_start = time.monotonic()
         state = build_t0_state(_STATE_DIR, _DISPATCH_DIR)
         payload = _state_to_brief(state) if args.format == "brief" else state
         _write_atomic(output_path, payload)
         elapsed = time.monotonic() - t_start
+        _build_succeeded = True
     except Exception:
         pass  # SessionStart hook must never block session
 
-    try:
-        if str(_LIB_DIR) not in sys.path:
-            sys.path.insert(0, str(_LIB_DIR))
-        from state_mutation import emit_state_mutation
-        size_bytes = output_path.stat().st_size if output_path.exists() else 0
-        emit_state_mutation(
-            output_path.name,
-            trigger="auto_rebuild",
-            rebuild_seconds=elapsed,
-            size_bytes=size_bytes,
-        )
-    except Exception:
-        pass
+    if _build_succeeded:
+        try:
+            if str(_LIB_DIR) not in sys.path:
+                sys.path.insert(0, str(_LIB_DIR))
+            from state_mutation import emit_state_mutation
+            size_bytes = output_path.stat().st_size if output_path.exists() else 0
+            emit_state_mutation(
+                output_path.name,
+                trigger="auto_rebuild",
+                rebuild_seconds=elapsed,
+                size_bytes=size_bytes,
+            )
+        except Exception:
+            pass
 
     return 0  # Always exit 0
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -438,27 +438,17 @@ def _build_recent_receipts(state_dir: Path, n: int = 3) -> List[Dict[str, Any]]:
         return []
 
     try:
-        # Tail-read without loading entire file
-        with open(receipts_path, "rb") as f:
-            f.seek(0, os.SEEK_END)
-            end = f.tell()
-            data = b""
-            block = 8192
-            while end > 0 and data.count(b"\n") < 100:
-                start = max(0, end - block)
-                f.seek(start)
-                data = f.read(end - start) + data
-                end = start
-                if start == 0:
-                    break
+        raw_lines = receipts_path.read_bytes().splitlines()
 
         events: List[Dict[str, Any]] = []
-        for line in data.splitlines()[-100:]:
-            line = line.strip()
+        for raw_line in raw_lines:
+            line = raw_line.strip()
             if not line:
                 continue
             try:
                 e = json.loads(line.decode("utf-8"))
+                if e.get("event_type") == "state_mutation":
+                    continue
                 events.append({
                     "terminal": e.get("terminal"),
                     "status": e.get("status"),
@@ -470,8 +460,7 @@ def _build_recent_receipts(state_dir: Path, n: int = 3) -> List[Dict[str, Any]]:
             except Exception:
                 continue
 
-        events = [e for e in events if e.get("event_type") != "state_mutation"]
-        return events[-n:]
+        return events[-100:][-n:]
     except Exception:
         return []
 

--- a/scripts/lib/state_mutation.py
+++ b/scripts/lib/state_mutation.py
@@ -12,7 +12,7 @@ _SCRIPTS_DIR = _LIB_DIR.parent
 
 
 def _utc_now_iso() -> str:
-    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def emit_state_mutation(

--- a/scripts/lib/state_mutation.py
+++ b/scripts/lib/state_mutation.py
@@ -1,0 +1,48 @@
+"""Helper for emitting state_mutation receipts for state-file writes."""
+
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LIB_DIR = Path(__file__).resolve().parent
+_SCRIPTS_DIR = _LIB_DIR.parent
+
+
+def _utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def emit_state_mutation(
+    file: str,
+    *,
+    trigger: str,
+    section: str = "",
+    size_bytes: int = 0,
+    rebuild_seconds: float = 0.0,
+) -> Optional[Any]:
+    """Emit a state_mutation receipt for a state-file write. Best-effort."""
+    receipt: Dict[str, Any] = {
+        "timestamp": _utc_now_iso(),
+        "event_type": "state_mutation",
+        "terminal": "T0",
+        "source": "vnx_state",
+        "file": file,
+        "trigger": trigger,
+    }
+    if section:
+        receipt["section"] = section
+    if size_bytes:
+        receipt["size_bytes"] = size_bytes
+    if rebuild_seconds:
+        receipt["rebuild_seconds"] = round(rebuild_seconds, 3)
+
+    try:
+        if str(_SCRIPTS_DIR) not in sys.path:
+            sys.path.insert(0, str(_SCRIPTS_DIR))
+        from append_receipt import append_receipt_payload
+        return append_receipt_payload(receipt, skip_enrichment=True)
+    except Exception:
+        return None

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -112,6 +112,18 @@ def test_rebuild_failure_does_not_raise(tmp_path: Path) -> None:
         ar._maybe_trigger_state_rebuild(receipt)
 
 
+def test_popen_failure_does_not_write_throttle(tmp_path: Path) -> None:
+    """Throttle file must NOT be written when Popen raises (advisory fix)."""
+    throttle_file = tmp_path / ".last_state_rebuild_ts"
+    receipt = _minimal_receipt("task_complete")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen", side_effect=OSError("popen failed")):
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    assert not throttle_file.exists(), "throttle file must not be written on Popen failure"
+
+
 def test_rebuild_failure_does_not_break_append(tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     state_dir.mkdir()

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(LIB_DIR))
 
 import append_receipt as ar
+import build_t0_state as bts
 
 
 def _minimal_receipt(event_type: str = "task_complete", dispatch_id: str = "DISP-001") -> dict:
@@ -148,3 +149,30 @@ def test_rebuild_failure_does_not_break_append(tmp_path: Path) -> None:
         result = ar.append_receipt_payload(receipt, receipts_file=receipts_file)
 
     assert result.status == "appended"
+
+
+def test_task_complete_survives_100_state_mutations(tmp_path: Path) -> None:
+    """filter-before-trim: task_complete must survive when followed by 100 state_mutations."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_path = state_dir / "t0_receipts.ndjson"
+
+    lines = []
+    lines.append(json.dumps({
+        "event_type": "task_complete",
+        "terminal": "T1",
+        "timestamp": "2026-04-28T09:00:00Z",
+        "dispatch_id": "D1",
+    }))
+    for i in range(100):
+        lines.append(json.dumps({
+            "event_type": "state_mutation",
+            "terminal": "T0",
+            "timestamp": f"2026-04-28T10:{i // 60:02d}:{i % 60:02d}Z",
+        }))
+    receipts_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = bts._build_recent_receipts(state_dir, n=3)
+    types = [r.get("event_type") for r in result]
+    assert "task_complete" in types, f"task_complete disappeared after 100 state_mutations: {result}"
+    assert "state_mutation" not in types, f"state_mutation leaked into recency summary: {result}"

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Tests for auto-rebuild trigger in append_receipt.py.
+
+Coverage:
+  1. Completion event triggers rebuild (subprocess.Popen called)
+  2. Non-completion event does NOT trigger rebuild
+  3. Throttle prevents second rebuild within 30s
+  4. Rebuild failure does not break receipt append
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(LIB_DIR))
+
+import append_receipt as ar
+
+
+def _minimal_receipt(event_type: str = "task_complete", dispatch_id: str = "DISP-001") -> dict:
+    return {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": event_type,
+        "terminal": "T1",
+        "source": "pytest",
+        "dispatch_id": dispatch_id,
+    }
+
+
+def test_completion_event_triggers_rebuild(tmp_path: Path) -> None:
+    receipt = _minimal_receipt("task_complete")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen") as mock_popen:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_popen.assert_called_once()
+    call_kwargs = mock_popen.call_args
+    assert call_kwargs[0][0] == ["python3", "scripts/build_t0_state.py"]
+    assert call_kwargs[1].get("start_new_session") is True
+
+
+def test_non_completion_event_does_not_trigger_rebuild(tmp_path: Path) -> None:
+    receipt = _minimal_receipt("task_started")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen") as mock_popen:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_popen.assert_not_called()
+
+
+def test_dispatch_promoted_event_triggers_rebuild(tmp_path: Path) -> None:
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "dispatch_promoted",
+        "terminal": "T0",
+        "source": "pytest",
+    }
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen") as mock_popen:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_popen.assert_called_once()
+
+
+def test_throttle_prevents_double_rebuild(tmp_path: Path) -> None:
+    throttle_file = tmp_path / ".last_state_rebuild_ts"
+    throttle_file.write_text(str(time.time()), encoding="utf-8")
+
+    receipt = _minimal_receipt("task_complete")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen") as mock_popen:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_popen.assert_not_called()
+
+
+def test_throttle_allows_rebuild_after_window(tmp_path: Path) -> None:
+    throttle_file = tmp_path / ".last_state_rebuild_ts"
+    old_ts = time.time() - ar._REBUILD_THROTTLE_SECONDS - 5
+    throttle_file.write_text(str(old_ts), encoding="utf-8")
+
+    receipt = _minimal_receipt("task_complete")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen") as mock_popen:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_popen.assert_called_once()
+
+
+def test_rebuild_failure_does_not_raise(tmp_path: Path) -> None:
+    receipt = _minimal_receipt("task_complete")
+
+    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+         mock.patch("append_receipt.subprocess.Popen", side_effect=OSError("popen failed")):
+        ar._maybe_trigger_state_rebuild(receipt)
+
+
+def test_rebuild_failure_does_not_break_append(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    receipt = _minimal_receipt("task_complete")
+
+    env_patch = {
+        "PROJECT_ROOT": str(tmp_path),
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(SCRIPTS_DIR.parent),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+    }
+
+    with mock.patch.dict(os.environ, env_patch), \
+         mock.patch("append_receipt.resolve_state_dir", return_value=state_dir), \
+         mock.patch("append_receipt._enrich_completion_receipt", side_effect=lambda r: r), \
+         mock.patch("append_receipt._register_quality_open_items", return_value=0), \
+         mock.patch("append_receipt._update_confidence_from_receipt"), \
+         mock.patch("append_receipt.subprocess.Popen", side_effect=OSError("boom")):
+        result = ar.append_receipt_payload(receipt, receipts_file=receipts_file)
+
+    assert result.status == "appended"

--- a/tests/test_state_mutation_receipt.py
+++ b/tests/test_state_mutation_receipt.py
@@ -197,3 +197,97 @@ def test_state_mutation_excluded_from_recency_summary(tmp_path: Path) -> None:
     assert "state_mutation" not in returned_types, f"state_mutation leaked into recency summary: {result}"
     assert "task_complete" in returned_types
     assert "review_gate_request" in returned_types
+
+
+def test_idempotency_key_differs_for_different_files() -> None:
+    """Same-second state_mutations for different files must produce different idempotency keys."""
+    ts = "2026-04-28T10:00:00Z"
+    receipt_a = {
+        "timestamp": ts,
+        "event_type": "state_mutation",
+        "terminal": "T0",
+        "source": "vnx_state",
+        "file": "t0_state.json",
+        "trigger": "auto_rebuild",
+    }
+    receipt_b = {
+        "timestamp": ts,
+        "event_type": "state_mutation",
+        "terminal": "T0",
+        "source": "vnx_state",
+        "file": "t0_brief.json",
+        "trigger": "auto_rebuild",
+    }
+
+    key_a = ar._compute_idempotency_key(receipt_a, "state_mutation")
+    key_b = ar._compute_idempotency_key(receipt_b, "state_mutation")
+
+    assert key_a != key_b, f"Expected different idempotency keys for different files, got same: {key_a}"
+
+
+def test_non_state_mutation_idempotency_key_unchanged() -> None:
+    """Adding file/trigger/section fields must not change idempotency keys for other event types."""
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "task_complete",
+        "terminal": "T1",
+        "source": "pytest",
+        "dispatch_id": "DISP-001",
+    }
+
+    key = ar._compute_idempotency_key(receipt, "task_complete")
+    assert isinstance(key, str) and len(key) == 64
+
+    receipt_with_extra = dict(receipt)
+    del receipt_with_extra["dispatch_id"]
+    receipt_with_extra["dispatch_id"] = "DISP-001"
+    key2 = ar._compute_idempotency_key(receipt_with_extra, "task_complete")
+    assert key == key2, "Idempotency key changed for non-state-mutation receipt"
+
+
+def test_emit_state_mutation_timestamp_has_microseconds() -> None:
+    """emit_state_mutation must produce microsecond-precision timestamps."""
+    captured: list[dict] = []
+
+    def _fake_append(receipt, *, skip_enrichment=False, **kwargs):
+        captured.append(receipt)
+        return ar.AppendResult(status="appended", receipts_file=Path("/dev/null"), idempotency_key="k")
+
+    with mock.patch("append_receipt.append_receipt_payload", _fake_append):
+        sm.emit_state_mutation("t0_state.json", trigger="auto_rebuild")
+
+    assert len(captured) == 1
+    ts = captured[0]["timestamp"]
+    assert "." in ts, f"Expected microsecond-precision timestamp (with '.'), got: {ts}"
+
+
+def test_same_timestamp_different_files_both_persisted(tmp_path: Path) -> None:
+    """Two state_mutations with same mocked timestamp but different files must both be persisted."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = state_dir / "t0_receipts.ndjson"
+
+    ts = "2026-04-28T10:00:00Z"
+
+    env_patch = {
+        "PROJECT_ROOT": str(tmp_path),
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(SCRIPTS_DIR.parent),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+    }
+
+    with mock.patch.dict(os.environ, env_patch), \
+         mock.patch("append_receipt.resolve_state_dir", return_value=state_dir), \
+         mock.patch("append_receipt._maybe_trigger_state_rebuild"), \
+         mock.patch("state_mutation._utc_now_iso", return_value=ts):
+        r1 = sm.emit_state_mutation("t0_state.json", trigger="auto_rebuild")
+        r2 = sm.emit_state_mutation("t0_brief.json", trigger="auto_rebuild")
+
+    assert r1 is not None and r1.status == "appended", f"First emit failed: {r1}"
+    assert r2 is not None and r2.status == "appended", f"Second emit was dropped as duplicate: {r2}"
+
+    lines = [l for l in receipts_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 2, f"Expected both receipts persisted, got {len(lines)}: {lines}"
+    files = {json.loads(l)["file"] for l in lines}
+    assert files == {"t0_state.json", "t0_brief.json"}

--- a/tests/test_state_mutation_receipt.py
+++ b/tests/test_state_mutation_receipt.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests for state_mutation_receipt event type.
+
+Coverage:
+  1. emit_state_mutation writes receipt with event_type=state_mutation
+  2. skip_enrichment=True skips _enrich_completion_receipt
+  3. state_mutation receipt does NOT recursively trigger rebuild
+  4. Integration: emit_state_mutation -> read back from ndjson file
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(LIB_DIR))
+
+import append_receipt as ar
+import state_mutation as sm
+
+
+def test_emit_state_mutation_receipt_shape(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    captured: list[dict] = []
+
+    def _fake_append(receipt, *, skip_enrichment=False, **kwargs):
+        captured.append({"receipt": receipt, "skip_enrichment": skip_enrichment})
+        return ar.AppendResult(
+            status="appended",
+            receipts_file=Path(receipts_file),
+            idempotency_key="test-key",
+        )
+
+    with mock.patch("append_receipt.append_receipt_payload", _fake_append):
+        sm.emit_state_mutation(
+            "t0_state.json",
+            trigger="auto_rebuild",
+            rebuild_seconds=1.23,
+            size_bytes=4567,
+        )
+
+    assert len(captured) == 1
+    r = captured[0]["receipt"]
+    assert r["event_type"] == "state_mutation"
+    assert r["file"] == "t0_state.json"
+    assert r["trigger"] == "auto_rebuild"
+    assert r["rebuild_seconds"] == 1.23
+    assert r["size_bytes"] == 4567
+    assert r["terminal"] == "T0"
+    assert r["source"] == "vnx_state"
+    assert captured[0]["skip_enrichment"] is True
+
+
+def test_skip_enrichment_skips_enrich_completion_receipt(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "state_mutation",
+        "terminal": "T0",
+        "source": "vnx_state",
+        "file": "t0_state.json",
+        "trigger": "auto_rebuild",
+    }
+
+    with mock.patch("append_receipt._enrich_completion_receipt") as mock_enrich, \
+         mock.patch("append_receipt._register_quality_open_items", return_value=0), \
+         mock.patch("append_receipt._update_confidence_from_receipt"), \
+         mock.patch("append_receipt._maybe_trigger_state_rebuild"):
+        ar.append_receipt_payload(receipt, receipts_file=receipts_file, skip_enrichment=True)
+
+    mock_enrich.assert_not_called()
+
+
+def test_state_mutation_does_not_trigger_rebuild(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "state_mutation",
+        "terminal": "T0",
+        "source": "vnx_state",
+        "file": "t0_state.json",
+        "trigger": "auto_rebuild",
+    }
+
+    with mock.patch("append_receipt.subprocess.Popen") as mock_popen, \
+         mock.patch("append_receipt._enrich_completion_receipt", side_effect=lambda r: r), \
+         mock.patch("append_receipt._register_quality_open_items", return_value=0), \
+         mock.patch("append_receipt._update_confidence_from_receipt"):
+        ar.append_receipt_payload(receipt, receipts_file=receipts_file, skip_enrichment=True)
+
+    mock_popen.assert_not_called()
+
+
+def test_integration_emit_and_read_back(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = state_dir / "t0_receipts.ndjson"
+
+    env_patch = {
+        "PROJECT_ROOT": str(tmp_path),
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(SCRIPTS_DIR.parent),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+    }
+
+    with mock.patch.dict(os.environ, env_patch), \
+         mock.patch("append_receipt.resolve_state_dir", return_value=state_dir), \
+         mock.patch("append_receipt._maybe_trigger_state_rebuild"):
+        result = sm.emit_state_mutation(
+            "t0_state.json",
+            trigger="auto_rebuild",
+            rebuild_seconds=0.5,
+            section="feature_state",
+        )
+
+    assert result is not None
+    assert result.status == "appended"
+
+    lines = [l for l in receipts_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["event_type"] == "state_mutation"
+    assert parsed["file"] == "t0_state.json"
+    assert parsed["trigger"] == "auto_rebuild"
+    assert parsed["section"] == "feature_state"
+    assert parsed["rebuild_seconds"] == 0.5

--- a/tests/test_state_mutation_receipt.py
+++ b/tests/test_state_mutation_receipt.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(LIB_DIR))
 
 import append_receipt as ar
 import state_mutation as sm
+import build_t0_state as bts
 
 
 def test_emit_state_mutation_receipt_shape(tmp_path: Path) -> None:
@@ -145,3 +146,54 @@ def test_integration_emit_and_read_back(tmp_path: Path) -> None:
     assert parsed["trigger"] == "auto_rebuild"
     assert parsed["section"] == "feature_state"
     assert parsed["rebuild_seconds"] == 0.5
+
+
+def test_build_failure_does_not_emit_state_mutation(tmp_path: Path) -> None:
+    """main() must NOT emit state_mutation when build_t0_state raises (blocking fix)."""
+    output_path = tmp_path / "t0_state.json"
+
+    with mock.patch("sys.argv", ["build_t0_state.py", "--output", str(output_path)]), \
+         mock.patch("build_t0_state.build_t0_state", side_effect=RuntimeError("simulated build failure")), \
+         mock.patch("state_mutation.emit_state_mutation") as mock_emit:
+        result = bts.main()
+
+    assert result == 0
+    mock_emit.assert_not_called()
+
+
+def test_write_atomic_failure_does_not_emit_state_mutation(tmp_path: Path) -> None:
+    """main() must NOT emit state_mutation when _write_atomic raises (blocking fix)."""
+    output_path = tmp_path / "t0_state.json"
+    fake_state: dict = {"schema_version": "2.0"}
+
+    with mock.patch("sys.argv", ["build_t0_state.py", "--output", str(output_path)]), \
+         mock.patch("build_t0_state.build_t0_state", return_value=fake_state), \
+         mock.patch("build_t0_state._write_atomic", side_effect=OSError("disk full")), \
+         mock.patch("state_mutation.emit_state_mutation") as mock_emit:
+        result = bts.main()
+
+    assert result == 0
+    mock_emit.assert_not_called()
+
+
+def test_state_mutation_excluded_from_recency_summary(tmp_path: Path) -> None:
+    """_build_recent_receipts must filter out state_mutation events (advisory fix)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_path = state_dir / "t0_receipts.ndjson"
+
+    events = [
+        {"event_type": "task_complete", "terminal": "T1", "timestamp": "2026-04-28T10:00:00Z", "dispatch_id": "D1"},
+        {"event_type": "state_mutation", "terminal": "T0", "timestamp": "2026-04-28T10:01:00Z"},
+        {"event_type": "state_mutation", "terminal": "T0", "timestamp": "2026-04-28T10:02:00Z"},
+        {"event_type": "review_gate_request", "terminal": "T3", "timestamp": "2026-04-28T10:03:00Z", "gate": "codex"},
+        {"event_type": "state_mutation", "terminal": "T0", "timestamp": "2026-04-28T10:04:00Z"},
+    ]
+    receipts_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+    result = bts._build_recent_receipts(state_dir, n=3)
+
+    returned_types = [r.get("event_type") for r in result]
+    assert "state_mutation" not in returned_types, f"state_mutation leaked into recency summary: {result}"
+    assert "task_complete" in returned_types
+    assert "review_gate_request" in returned_types


### PR DESCRIPTION
## Summary
- Auto-rebuild t0_state.json after every completion/dispatch-promotion receipt (non-blocking Popen, throttled 30s)
- New `state_mutation_receipt` event type (`STATE_MUTATION_EVENTS`) for tracking state-file writes
- `skip_enrichment=True` flag bypasses quality advisory + provenance pipeline (idempotency/locking unchanged)
- `--skip-enrichment` CLI flag added to `append_receipt.py`
- Helper at `scripts/lib/state_mutation.py` for callers
- `build_t0_state.py` emits `state_mutation` receipt at end of each rebuild (with `rebuild_seconds`)

## Test plan
- [x] Auto-rebuild fires on completion + dispatch_promoted events
- [x] Throttle prevents rebuild storm within 30s window
- [x] Throttle allows rebuild after window expires
- [x] state_mutation receipts don't recursively trigger rebuild (skip_enrichment guard)
- [x] skip_enrichment=True skips _enrich_completion_receipt
- [x] Rebuild failure (Popen OSError) does not break receipt append
- [x] Integration: emit_state_mutation -> read back from ndjson file
- [x] Existing append_receipt test suite green (10/11 — 1 pre-existing failure: missing receipt_notifier.sh)
- [x] Existing governance/state test suite unaffected (32 pre-existing failures, all unrelated)

Refs synthesis 2026-04-28 §D Sprint 2.