### PR TITLE
feat(governance): dispatch_register.ndjson lifecycle log (Sprint 3 core)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1013,7 +1013,42 @@ def append_receipt_payload(
 
         _maybe_trigger_state_rebuild(receipt)
 
+        _emit_dispatch_register(receipt)
+
     return result
+
+
+def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
+    """Emit lifecycle event to dispatch_register.ndjson. Best-effort, never raises."""
+    try:
+        event_type = str(receipt.get("event_type") or receipt.get("event") or "")
+        if event_type in ("task_complete", "task_completed"):
+            register_event = "dispatch_completed"
+        elif event_type == "task_failed":
+            register_event = "dispatch_failed"
+        elif event_type == "review_gate_request":
+            register_event = "gate_requested"
+        else:
+            return
+
+        dispatch_id = str(receipt.get("dispatch_id") or "")
+        terminal = str(receipt.get("terminal") or "")
+        pr_number = receipt.get("pr_number")
+        feature_id = str(receipt.get("feature_id") or "")
+
+        _lib = SCRIPT_DIR / "lib"
+        if str(_lib) not in sys.path:
+            sys.path.insert(0, str(_lib))
+        from dispatch_register import append_event
+        append_event(
+            register_event,
+            dispatch_id=dispatch_id,
+            terminal=terminal,
+            pr_number=pr_number,
+            feature_id=feature_id,
+        )
+    except Exception:
+        pass
 
 
 def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1021,15 +1021,19 @@ def append_receipt_payload(
 def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
     """Emit lifecycle event to dispatch_register.ndjson. Best-effort, never raises."""
     try:
-        event_type = str(receipt.get("event_type") or receipt.get("event") or "")
+        event_type = receipt.get("event_type", "")
+        status = str(receipt.get("status", "")).lower()
         if event_type in ("task_complete", "task_completed"):
-            register_event = "dispatch_completed"
+            if status in ("failed", "error", "blocked"):
+                register_event = "dispatch_failed"
+            else:
+                register_event = "dispatch_completed"
         elif event_type == "task_failed":
             register_event = "dispatch_failed"
         elif event_type == "review_gate_request":
             register_event = "gate_requested"
         else:
-            return
+            return  # not a register-worthy event
 
         dispatch_id = str(receipt.get("dispatch_id") or "")
         terminal = str(receipt.get("terminal") or "")

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1011,9 +1011,9 @@ def append_receipt_payload(
 
         _update_confidence_from_receipt(receipt)
 
-        _maybe_trigger_state_rebuild(receipt)
-
         _emit_dispatch_register(receipt)
+
+        _maybe_trigger_state_rebuild(receipt)
 
     return result
 
@@ -1082,7 +1082,10 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
     """Fire non-blocking rebuild of t0_state.json after qualifying events. Best-effort."""
     try:
         event_type = str(receipt.get("event_type") or receipt.get("event") or "")
-        if not (_is_completion_event(receipt) or event_type in ("dispatch_promoted", "dispatch_started")):
+        if not (_is_completion_event(receipt) or event_type in (
+            "dispatch_promoted", "dispatch_started",
+            "review_gate_request", "gate_passed", "gate_failed",
+        )):
             return
 
         state_dir = resolve_state_dir(__file__)

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1059,15 +1059,23 @@ def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:
     """Wire dispatch outcome into pattern confidence scores (best-effort)."""
     try:
         event_type = str(receipt.get("event_type") or receipt.get("status") or "")
-        if event_type not in ("task_complete", "task_failed"):
+        status_field = str(receipt.get("status", "")).lower()
+
+        if event_type == "task_complete":
+            # Honor receipt.status — failed completions are NOT successes
+            if status_field in ("failed", "error", "blocked"):
+                outcome = "failure"
+            else:
+                outcome = "success"
+        elif event_type == "task_failed":
+            outcome = "failure"
+        else:
             return
 
         dispatch_id = str(receipt.get("dispatch_id") or "")
         terminal = str(receipt.get("terminal") or "")
         if not dispatch_id:
             return
-
-        outcome = "success" if event_type == "task_complete" else "failure"
 
         state_dir = resolve_state_dir(__file__)
 

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1028,8 +1028,8 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
                 register_event = "dispatch_failed"
             else:
                 register_event = "dispatch_completed"
-        elif event_type == "task_failed":
-            register_event = "dispatch_failed"
+        elif event_type in ("task_failed", "task_timeout"):
+            register_event = "dispatch_failed"  # timeout is terminal failure
         elif event_type == "review_gate_request":
             register_event = "gate_requested"
         else:

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -240,8 +240,8 @@ def _build_tracks(state_dir: Path) -> Dict[str, Any]:
 def _build_feature_state() -> Dict[str, Any]:
     """Return structured feature state for T0 context.
 
-    Reads from dispatch_register.ndjson first; falls back to FEATURE_PLAN.md
-    when the register is absent or empty.
+    When dispatch_register.ndjson has events, the register is the canonical source.
+    FEATURE_PLAN.md is used only when the register is absent or empty (true fallback).
     """
     _empty: Dict[str, Any] = {
         "feature_name": None,
@@ -265,23 +265,67 @@ def _build_feature_state() -> Dict[str, Any]:
     except Exception:
         pass
 
-    # FEATURE_PLAN.md fallback (kept as canonical backward-compat source)
     feature_plan = _PROJECT_ROOT / "FEATURE_PLAN.md"
-    if not feature_plan.exists():
-        result = dict(_empty)
-        if register_features:
-            result["register_features"] = register_features
+
+    # Register is canonical when populated
+    if register_features:
+        result = _canonical_from_register(register_features)
+        result["register_features"] = register_features
+        # FEATURE_PLAN is supplementary metadata only
+        if feature_plan.exists():
+            try:
+                from feature_state_machine import parse_feature_plan
+                result["feature_plan"] = parse_feature_plan(feature_plan).as_dict()
+            except Exception:
+                pass
         return result
+
+    # True fallback: register empty/absent — use FEATURE_PLAN
+    if not feature_plan.exists():
+        return dict(_empty)
     try:
         from feature_state_machine import parse_feature_plan
         state = parse_feature_plan(feature_plan)
-        result = state.as_dict()
+        return state.as_dict()
     except Exception:
-        result = dict(_empty)
+        return dict(_empty)
 
-    if register_features:
-        result["register_features"] = register_features
-    return result
+
+def _canonical_from_register(register_features: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive canonical feature_state dict from register aggregation output."""
+    total_prs = len(register_features)
+    completed_prs = sum(
+        1 for v in register_features.values() if v.get("status") == "completed"
+    )
+    completion_pct = round(completed_prs / total_prs * 100) if total_prs else 0
+
+    # Most recently active entry determines current_pr
+    active = [
+        (k, v) for k, v in register_features.items() if v.get("status") == "active"
+    ]
+    current_pr: Optional[str] = None
+    if active:
+        active.sort(key=lambda x: x[1].get("last_event_ts", ""), reverse=True)
+        current_pr = active[0][0]
+
+    if completed_prs == total_prs and total_prs > 0:
+        overall_status = "completed"
+    elif total_prs > 0:
+        overall_status = "in_progress"
+    else:
+        overall_status = "planned"
+
+    return {
+        "feature_name": None,
+        "current_pr": current_pr,
+        "next_task": None,
+        "assigned_track": None,
+        "assigned_role": None,
+        "completion_pct": completion_pct,
+        "total_prs": total_prs,
+        "completed_prs": completed_prs,
+        "status": overall_status,
+    }
 
 
 def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -297,8 +297,6 @@ def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
     _COMPLETION_EVENTS = {"dispatch_completed", "pr_merged"}
     _ACTIVE_EVENTS = {"dispatch_promoted", "dispatch_started"}
     _FAILED_EVENTS = {"dispatch_failed"}
-    # Higher rank wins when merging multiple dispatch_ids under the same key.
-    _STATUS_RANK = {"completed": 3, "active": 2, "failed": 1, "pending": 0}
 
     # --- First pass: group by dispatch_id ---
     by_dispatch: Dict[str, List[Dict[str, Any]]] = {}
@@ -364,15 +362,13 @@ def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
             "last_event_ts": "",
         })
 
-        if last_event_ts > entry["last_event_ts"]:
-            entry["last_event"] = last_event
-            entry["last_event_ts"] = last_event_ts
-
         for p in prs:
             if p not in entry["prs"]:
                 entry["prs"].append(p)
 
-        if _STATUS_RANK.get(status, 0) > _STATUS_RANK.get(entry["status"], 0):
+        if last_event_ts > entry["last_event_ts"]:
+            entry["last_event"] = last_event
+            entry["last_event_ts"] = last_event_ts
             entry["status"] = status
 
     return aggregated

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -285,53 +285,95 @@ def _build_feature_state() -> Dict[str, Any]:
 
 
 def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Aggregate dispatch_register events by pr_number / feature_id.
+    """Aggregate dispatch_register events using dispatch_id as primary key.
 
-    Returns: {<id>: {status, prs, last_event, last_event_ts}}
+    First pass: group all events by dispatch_id (events without dispatch_id are
+    dropped). Second pass: derive pr_number / feature_id from the latest event
+    in each group that carries them, then merge groups into a display-key dict.
+
+    Returns: {<display_key>: {status, prs, last_event, last_event_ts}}
+    where display_key = "pr-{n}" | feature_id | dispatch_id.
     """
     _COMPLETION_EVENTS = {"dispatch_completed", "pr_merged"}
     _ACTIVE_EVENTS = {"dispatch_promoted", "dispatch_started"}
     _FAILED_EVENTS = {"dispatch_failed"}
+    # Higher rank wins when merging multiple dispatch_ids under the same key.
+    _STATUS_RANK = {"completed": 3, "active": 2, "failed": 1, "pending": 0}
 
+    # --- First pass: group by dispatch_id ---
+    by_dispatch: Dict[str, List[Dict[str, Any]]] = {}
+    for ev in events:
+        dispatch_id = ev.get("dispatch_id", "")
+        if not dispatch_id:
+            continue
+        by_dispatch.setdefault(dispatch_id, []).append(ev)
+
+    # --- Second pass: aggregate each group, then fold into display-key dict ---
     aggregated: Dict[str, Dict[str, Any]] = {}
 
-    for ev in events:
-        pr_number = ev.get("pr_number")
-        feature_id = ev.get("feature_id", "")
-        dispatch_id = ev.get("dispatch_id", "")
+    for dispatch_id, group in by_dispatch.items():
+        group_sorted = sorted(group, key=lambda e: e.get("timestamp", ""))
 
-        key = (
-            f"pr-{pr_number}" if pr_number is not None
-            else feature_id if feature_id
-            else dispatch_id if dispatch_id
-            else None
-        )
-        if not key:
-            continue
+        pr_number: Optional[int] = None
+        feature_id: str = ""
+        status = "pending"
+        prs: List[Any] = []
+        last_event = ""
+        last_event_ts = ""
 
-        entry = aggregated.setdefault(key, {
+        for ev in group_sorted:
+            event_name = ev.get("event", "")
+            ts = ev.get("timestamp", "")
+            ev_pr = ev.get("pr_number")
+            ev_feature = ev.get("feature_id", "")
+
+            # Derive from the latest event that supplies them.
+            if ev_pr is not None:
+                pr_number = ev_pr
+            if ev_feature:
+                feature_id = ev_feature
+
+            if ts > last_event_ts:
+                last_event = event_name
+                last_event_ts = ts
+
+            if ev_pr is not None and ev_pr not in prs:
+                prs.append(ev_pr)
+
+            if event_name in _COMPLETION_EVENTS:
+                status = "completed"
+            elif event_name in _ACTIVE_EVENTS and status != "completed":
+                status = "active"
+            elif event_name in _FAILED_EVENTS and status not in ("completed",):
+                status = "failed"
+
+        # Determine display key from derived fields.
+        if pr_number is not None:
+            display_key = f"pr-{pr_number}"
+        elif feature_id:
+            display_key = feature_id
+        else:
+            display_key = dispatch_id
+
+        # Merge into the shared display-key bucket (multiple dispatches may
+        # share the same PR or feature).
+        entry = aggregated.setdefault(display_key, {
             "status": "pending",
             "prs": [],
             "last_event": "",
             "last_event_ts": "",
         })
 
-        event_name = ev.get("event", "")
-        ts = ev.get("timestamp", "")
+        if last_event_ts > entry["last_event_ts"]:
+            entry["last_event"] = last_event
+            entry["last_event_ts"] = last_event_ts
 
-        if ts > entry["last_event_ts"]:
-            entry["last_event"] = event_name
-            entry["last_event_ts"] = ts
+        for p in prs:
+            if p not in entry["prs"]:
+                entry["prs"].append(p)
 
-        if pr_number is not None and pr_number not in entry["prs"]:
-            entry["prs"].append(pr_number)
-
-        if event_name in _COMPLETION_EVENTS:
-            entry["status"] = "completed"
-        elif event_name in _ACTIVE_EVENTS and entry["status"] != "completed":
-            entry["status"] = "active"
-        elif event_name in _FAILED_EVENTS and entry["status"] not in ("completed",):
-            entry["status"] = "failed"
+        if _STATUS_RANK.get(status, 0) > _STATUS_RANK.get(entry["status"], 0):
+            entry["status"] = status
 
     return aggregated
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -296,7 +296,7 @@ def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     _COMPLETION_EVENTS = {"dispatch_completed", "pr_merged"}
     _ACTIVE_EVENTS = {"dispatch_promoted", "dispatch_started"}
-    _FAILED_EVENTS = {"dispatch_failed"}
+    _FAILED_EVENTS = {"dispatch_failed", "gate_failed"}
 
     # --- First pass: group by dispatch_id ---
     by_dispatch: Dict[str, List[Dict[str, Any]]] = {}

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -238,7 +238,11 @@ def _build_tracks(state_dir: Path) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def _build_feature_state() -> Dict[str, Any]:
-    """Parse FEATURE_PLAN.md and return structured feature state for T0 context."""
+    """Return structured feature state for T0 context.
+
+    Reads from dispatch_register.ndjson first; falls back to FEATURE_PLAN.md
+    when the register is absent or empty.
+    """
     _empty: Dict[str, Any] = {
         "feature_name": None,
         "current_pr": None,
@@ -250,15 +254,86 @@ def _build_feature_state() -> Dict[str, Any]:
         "completed_prs": 0,
         "status": "planned",
     }
+
+    # Attempt register-based aggregation first
+    register_features: Dict[str, Any] = {}
+    try:
+        from dispatch_register import read_events
+        events = read_events()
+        if events:
+            register_features = _aggregate_register_events(events)
+    except Exception:
+        pass
+
+    # FEATURE_PLAN.md fallback (kept as canonical backward-compat source)
     feature_plan = _PROJECT_ROOT / "FEATURE_PLAN.md"
     if not feature_plan.exists():
-        return _empty
+        result = dict(_empty)
+        if register_features:
+            result["register_features"] = register_features
+        return result
     try:
         from feature_state_machine import parse_feature_plan
         state = parse_feature_plan(feature_plan)
-        return state.as_dict()
+        result = state.as_dict()
     except Exception:
-        return _empty
+        result = dict(_empty)
+
+    if register_features:
+        result["register_features"] = register_features
+    return result
+
+
+def _aggregate_register_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate dispatch_register events by pr_number / feature_id.
+
+    Returns: {<id>: {status, prs, last_event, last_event_ts}}
+    """
+    _COMPLETION_EVENTS = {"dispatch_completed", "pr_merged"}
+    _ACTIVE_EVENTS = {"dispatch_promoted", "dispatch_started"}
+    _FAILED_EVENTS = {"dispatch_failed"}
+
+    aggregated: Dict[str, Dict[str, Any]] = {}
+
+    for ev in events:
+        pr_number = ev.get("pr_number")
+        feature_id = ev.get("feature_id", "")
+        dispatch_id = ev.get("dispatch_id", "")
+
+        key = (
+            f"pr-{pr_number}" if pr_number is not None
+            else feature_id if feature_id
+            else dispatch_id if dispatch_id
+            else None
+        )
+        if not key:
+            continue
+
+        entry = aggregated.setdefault(key, {
+            "status": "pending",
+            "prs": [],
+            "last_event": "",
+            "last_event_ts": "",
+        })
+
+        event_name = ev.get("event", "")
+        ts = ev.get("timestamp", "")
+
+        if ts > entry["last_event_ts"]:
+            entry["last_event"] = event_name
+            entry["last_event_ts"] = ts
+
+        if pr_number is not None and pr_number not in entry["prs"]:
+            entry["prs"].append(pr_number)
+
+        if event_name in _COMPLETION_EVENTS:
+            entry["status"] = "completed"
+        elif event_name in _ACTIVE_EVENTS and entry["status"] != "completed":
+            entry["status"] = "active"
+        elif event_name in _FAILED_EVENTS and entry["status"] not in ("completed",):
+            entry["status"] = "failed"
+
+    return aggregated
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -456,5 +456,15 @@ finalize_dispatch_delivery() {
     log "V8 DISPATCH: Activated - moved to $ACTIVE_DIR/$filename"
     python3 "$VNX_DIR/scripts/lib/dispatch_register.py" append dispatch_promoted \
         dispatch_id="$dispatch_id" terminal="$terminal_id" 2>/dev/null || true
+    # Trigger throttled t0_state rebuild (non-blocking). Throttle marker shared
+    # with Python hook (UTF-8 epoch seconds, atomic write via .tmp+mv).
+    local _REBUILD_THROTTLE_FILE="$STATE_DIR/.last_state_rebuild_ts"
+    local _REBUILD_NOW; _REBUILD_NOW=$(date +%s)
+    local _REBUILD_LAST; _REBUILD_LAST=$(cat "$_REBUILD_THROTTLE_FILE" 2>/dev/null || echo 0)
+    if [ ! -f "$_REBUILD_THROTTLE_FILE" ] || [ $((_REBUILD_NOW - _REBUILD_LAST)) -ge 30 ]; then
+        nohup python3 "$VNX_DIR/scripts/build_t0_state.py" >/dev/null 2>&1 &
+        printf '%s' "$_REBUILD_NOW" > "${_REBUILD_THROTTLE_FILE}.tmp" && \
+            mv "${_REBUILD_THROTTLE_FILE}.tmp" "$_REBUILD_THROTTLE_FILE"
+    fi
     return 0
 }

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -454,5 +454,7 @@ finalize_dispatch_delivery() {
     local filename; filename=$(basename "$dispatch_file")
     mv "$dispatch_file" "$ACTIVE_DIR/$filename"
     log "V8 DISPATCH: Activated - moved to $ACTIVE_DIR/$filename"
+    python3 "$VNX_DIR/scripts/lib/dispatch_register.py" append dispatch_promoted \
+        dispatch_id="$dispatch_id" terminal="$terminal_id" 2>/dev/null || true
     return 0
 }

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -1,0 +1,119 @@
+"""Dispatch lifecycle register — append-only NDJSON writer for dispatch state changes.
+
+Source of truth for feature/PR queue state. Read by build_t0_state.py.
+File location: $VNX_STATE_DIR/dispatch_register.ndjson
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import fcntl
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+VALID_EVENTS = {
+    "dispatch_created",
+    "dispatch_promoted",
+    "dispatch_started",
+    "dispatch_completed",
+    "dispatch_failed",
+    "gate_requested",
+    "gate_passed",
+    "gate_failed",
+    "pr_opened",
+    "pr_merged",
+}
+
+
+def _register_path() -> Path:
+    data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
+    return data_dir / "state" / "dispatch_register.ndjson"
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def append_event(
+    event: str,
+    *,
+    dispatch_id: str = "",
+    pr_number: Optional[int] = None,
+    feature_id: str = "",
+    terminal: str = "",
+    gate: str = "",
+    extra: Optional[dict] = None,
+) -> bool:
+    """Append a lifecycle event. Best-effort, never raises."""
+    if event not in VALID_EVENTS:
+        return False
+
+    # Coerce pr_number to int if passed as string from CLI
+    if pr_number is not None and not isinstance(pr_number, int):
+        try:
+            pr_number = int(pr_number)
+        except (ValueError, TypeError):
+            pr_number = None
+
+    record: dict = {"timestamp": _utc_now_iso(), "event": event}
+    if dispatch_id:
+        record["dispatch_id"] = dispatch_id
+    if pr_number is not None:
+        record["pr_number"] = pr_number
+    if feature_id:
+        record["feature_id"] = feature_id
+    if terminal:
+        record["terminal"] = terminal
+    if gate:
+        record["gate"] = gate
+    if extra:
+        record["extra"] = extra
+
+    try:
+        path = _register_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def read_events(*, since_iso: Optional[str] = None) -> list:
+    """Read all events, optionally filtered by timestamp."""
+    path = _register_path()
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            if since_iso and rec.get("timestamp", "") < since_iso:
+                continue
+            events.append(rec)
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 3 or sys.argv[1] != "append":
+        sys.exit(1)
+
+    event = sys.argv[2]
+    kwargs: dict = {}
+    for arg in sys.argv[3:]:
+        if "=" in arg:
+            k, v = arg.split("=", 1)
+            kwargs[k] = v
+
+    sys.exit(0 if append_event(event, **kwargs) else 1)

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -231,6 +231,13 @@ def materialize_artifacts(
     request_payload["completed_at"] = now
     gate_recorder.persist_request(requests_dir, gate, request_payload, pr_number=pr_number, pr_id=pr_id)
 
+    gate_recorder.emit_gate_register_event(
+        gate=gate,
+        dispatch_id=real_dispatch_id,
+        pr_number=pr_number,
+        blocking_findings=blocking,
+    )
+
     # Write JSON sidecar to report_pipeline/ for intelligence DB ingestion (OI-1066)
     try:
         sidecar = {

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -243,5 +243,45 @@ def emit_gate_register_event(
             pr_number=pr_number,
             gate=gate,
         )
+        # Gate results update register state; trigger a non-blocking rebuild so
+        # t0_state.json reflects the outcome without waiting for the next completion.
+        _trigger_state_rebuild_from_gate()
+    except Exception:
+        pass
+
+
+def _trigger_state_rebuild_from_gate() -> None:
+    """Fire a non-blocking build_t0_state.py rebuild. Best-effort."""
+    try:
+        import subprocess
+        import time
+        from pathlib import Path as _Path
+        from project_root import resolve_project_root
+        repo_root = resolve_project_root(__file__)
+        state_dir = _Path(os.environ.get("VNX_STATE_DIR", ""))
+        if not state_dir or not state_dir.is_dir():
+            return
+        throttle_file = state_dir / ".last_state_rebuild_ts"
+        _THROTTLE = 30
+        if throttle_file.exists():
+            try:
+                last_ts = float(throttle_file.read_text(encoding="utf-8").strip())
+                if time.time() - last_ts < _THROTTLE:
+                    return
+            except Exception:
+                pass
+        subprocess.Popen(
+            ["python3", "scripts/build_t0_state.py"],
+            cwd=str(repo_root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            tmp = throttle_file.with_name(throttle_file.name + ".tmp")
+            tmp.write_text(str(time.time()), encoding="utf-8")
+            os.replace(str(tmp), str(throttle_file))
+        except Exception:
+            pass
     except Exception:
         pass

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -219,3 +219,29 @@ def record_failure_simple(
         requests_dir=requests_dir,
         results_dir=results_dir,
     )
+
+
+def emit_gate_register_event(
+    *,
+    gate: str,
+    dispatch_id: str,
+    pr_number: Optional[int],
+    blocking_findings: list,
+) -> None:
+    """Emit gate_passed or gate_failed to dispatch_register.ndjson. Best-effort."""
+    try:
+        import sys
+        from pathlib import Path as _Path
+        _lib = _Path(__file__).resolve().parent
+        if str(_lib) not in sys.path:
+            sys.path.insert(0, str(_lib))
+        from dispatch_register import append_event
+        status = "passed" if not blocking_findings else "failed"
+        append_event(
+            f"gate_{status}",
+            dispatch_id=dispatch_id,
+            pr_number=pr_number,
+            gate=gate,
+        )
+    except Exception:
+        pass

--- a/tests/test_build_feature_state_with_register.py
+++ b/tests/test_build_feature_state_with_register.py
@@ -321,6 +321,78 @@ def test_dispatch_id_primary_key_no_stale_active(tmp_path: Path):
     assert "d-stale-active" not in rf
 
 
+def test_gate_failed_flips_dispatch_status_to_failed(tmp_path: Path):
+    """dispatch_promoted + gate_failed must yield status 'failed', not 'active'.
+
+    Regression for: gate events were written to the register but did not participate
+    in status aggregation, so a gate-failed dispatch still showed status 'active'.
+    """
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T13:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-gate-fail-status",
+            "pr_number": 301,
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T13:30:00Z",
+            "event": "gate_failed",
+            "dispatch_id": "d-gate-fail-status",
+            "pr_number": 301,
+            "gate": "codex_gate",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        result = _load_mod_with_fake_fsm(tmp_path, env_patch, state_dir)
+
+    rf = result["register_features"]
+    assert "pr-301" in rf, f"Expected 'pr-301' in {list(rf.keys())}"
+    assert rf["pr-301"]["status"] == "failed", (
+        f"Expected 'failed' after gate_failed, got {rf['pr-301']['status']!r}"
+    )
+
+
+def test_gate_passed_does_not_complete_dispatch(tmp_path: Path):
+    """dispatch_promoted + gate_passed must keep status 'active'; gate passing alone is not completion.
+
+    Regression guard: gate_passed must not be treated as a completion event.
+    """
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T14:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-gate-pass-status",
+            "pr_number": 302,
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T14:20:00Z",
+            "event": "gate_passed",
+            "dispatch_id": "d-gate-pass-status",
+            "pr_number": 302,
+            "gate": "gemini_review",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        result = _load_mod_with_fake_fsm(tmp_path, env_patch, state_dir)
+
+    rf = result["register_features"]
+    assert "pr-302" in rf, f"Expected 'pr-302' in {list(rf.keys())}"
+    assert rf["pr-302"]["status"] == "active", (
+        f"Expected 'active' (gate_passed alone must not complete dispatch), "
+        f"got {rf['pr-302']['status']!r}"
+    )
+
+
 def test_retry_dispatch_after_completed_yields_active(tmp_path: Path):
     """A completed dispatch followed by a newer promoted dispatch on the same PR
     must yield PR status 'active', not 'completed'.

--- a/tests/test_build_feature_state_with_register.py
+++ b/tests/test_build_feature_state_with_register.py
@@ -1,0 +1,207 @@
+"""Tests for build_t0_state._build_feature_state register integration."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest import mock
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_build_t0_state(tmp_path: Path):
+    """Load build_t0_state with VNX env vars pointed at tmp_path."""
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    dispatch_dir = data_dir / "dispatches"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (dispatch_dir / "pending").mkdir(parents=True, exist_ok=True)
+    (dispatch_dir / "active").mkdir(parents=True, exist_ok=True)
+
+    env_patch = {
+        "VNX_DATA_DIR": str(data_dir),
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_DISPATCH_DIR": str(dispatch_dir),
+        "PROJECT_ROOT": str(tmp_path),
+        "VNX_HOME": str(VNX_ROOT),
+    }
+    return env_patch, state_dir, dispatch_dir
+
+
+def _write_register(state_dir: Path, events: list) -> None:
+    reg = state_dir / "dispatch_register.ndjson"
+    with reg.open("w", encoding="utf-8") as f:
+        for ev in events:
+            f.write(json.dumps(ev) + "\n")
+
+
+def test_empty_register_falls_back_to_feature_plan(tmp_path: Path):
+    env_patch, state_dir, dispatch_dir = _load_build_t0_state(tmp_path)
+
+    with mock.patch.dict(os.environ, env_patch):
+        # Re-import to pick up env
+        if "build_t0_state" in sys.modules:
+            del sys.modules["build_t0_state"]
+        spec = importlib.util.spec_from_file_location(
+            "build_t0_state", SCRIPTS_DIR / "build_t0_state.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+
+        # patch feature_state_machine import to avoid file dependency
+        fake_fsm = mock.MagicMock()
+        fake_state = mock.MagicMock()
+        fake_state.as_dict.return_value = {
+            "feature_name": "TestFeature",
+            "current_pr": "pr-1",
+            "next_task": None,
+            "assigned_track": "A",
+            "assigned_role": "backend-developer",
+            "completion_pct": 50,
+            "total_prs": 2,
+            "completed_prs": 1,
+            "status": "in_progress",
+        }
+        fake_fsm.parse_feature_plan.return_value = fake_state
+
+        # Create a minimal FEATURE_PLAN.md
+        (tmp_path / "FEATURE_PLAN.md").write_text("# Feature Plan\n")
+
+        with mock.patch.dict(sys.modules, {"feature_state_machine": fake_fsm}):
+            spec.loader.exec_module(mod)
+            result = mod._build_feature_state()
+
+    assert result["feature_name"] == "TestFeature"
+    assert result["completion_pct"] == 50
+    # No register_features key when register is empty/missing
+    assert "register_features" not in result
+
+
+def test_register_events_override_and_populate_register_features(tmp_path: Path):
+    env_patch, state_dir, dispatch_dir = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T10:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d001",
+            "pr_number": 10,
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T10:05:00Z",
+            "event": "dispatch_completed",
+            "dispatch_id": "d001",
+            "pr_number": 10,
+        },
+        {
+            "timestamp": "2026-04-28T10:10:00Z",
+            "event": "dispatch_started",
+            "dispatch_id": "d002",
+            "pr_number": 11,
+            "terminal": "T2",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        if "build_t0_state" in sys.modules:
+            del sys.modules["build_t0_state"]
+        spec = importlib.util.spec_from_file_location(
+            "build_t0_state", SCRIPTS_DIR / "build_t0_state.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+
+        fake_fsm = mock.MagicMock()
+        fake_state = mock.MagicMock()
+        fake_state.as_dict.return_value = {
+            "feature_name": "F46",
+            "current_pr": None,
+            "next_task": None,
+            "assigned_track": None,
+            "assigned_role": None,
+            "completion_pct": 0,
+            "total_prs": 0,
+            "completed_prs": 0,
+            "status": "planned",
+        }
+        fake_fsm.parse_feature_plan.return_value = fake_state
+        (tmp_path / "FEATURE_PLAN.md").write_text("# F\n")
+
+        with mock.patch.dict(sys.modules, {"feature_state_machine": fake_fsm}):
+            spec.loader.exec_module(mod)
+            result = mod._build_feature_state()
+
+    assert "register_features" in result
+    rf = result["register_features"]
+
+    # pr-10 should be completed
+    assert "pr-10" in rf
+    assert rf["pr-10"]["status"] == "completed"
+    assert 10 in rf["pr-10"]["prs"]
+
+    # pr-11 should be active
+    assert "pr-11" in rf
+    assert rf["pr-11"]["status"] == "active"
+
+
+def test_aggregation_by_pr_number_and_feature_id(tmp_path: Path):
+    env_patch, state_dir, dispatch_dir = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T09:00:00Z",
+            "event": "dispatch_created",
+            "dispatch_id": "d100",
+            "feature_id": "F99",
+        },
+        {
+            "timestamp": "2026-04-28T09:10:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d100",
+            "feature_id": "F99",
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T09:20:00Z",
+            "event": "dispatch_failed",
+            "dispatch_id": "d100",
+            "feature_id": "F99",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        if "build_t0_state" in sys.modules:
+            del sys.modules["build_t0_state"]
+        spec = importlib.util.spec_from_file_location(
+            "build_t0_state", SCRIPTS_DIR / "build_t0_state.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        fake_fsm = mock.MagicMock()
+        fake_state = mock.MagicMock()
+        fake_state.as_dict.return_value = {
+            "feature_name": None, "current_pr": None, "next_task": None,
+            "assigned_track": None, "assigned_role": None,
+            "completion_pct": 0, "total_prs": 0, "completed_prs": 0,
+            "status": "planned",
+        }
+        fake_fsm.parse_feature_plan.return_value = fake_state
+        (tmp_path / "FEATURE_PLAN.md").write_text("# F\n")
+
+        with mock.patch.dict(sys.modules, {"feature_state_machine": fake_fsm}):
+            spec.loader.exec_module(mod)
+            result = mod._build_feature_state()
+
+    rf = result["register_features"]
+    assert "F99" in rf
+    assert rf["F99"]["status"] == "failed"
+    assert rf["F99"]["last_event"] == "dispatch_failed"

--- a/tests/test_build_feature_state_with_register.py
+++ b/tests/test_build_feature_state_with_register.py
@@ -436,3 +436,93 @@ def test_retry_dispatch_after_completed_yields_active(tmp_path: Path):
     assert rf["pr-50"]["status"] == "active", (
         f"Expected 'active' (retry dispatch is most recent), got {rf['pr-50']['status']!r}"
     )
+
+
+def test_register_is_canonical_when_populated(tmp_path: Path):
+    """When register has events, top-level feature_state fields come from register, not FEATURE_PLAN.
+
+    Regression for: _build_feature_state returned FEATURE_PLAN-derived values (completion_pct,
+    total_prs, etc.) as the canonical feature_state even when register was populated.
+    """
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    # 2 dispatches: pr-42 completed, pr-43 active → total=2, completed=1, pct=50
+    events = [
+        {
+            "timestamp": "2026-04-28T10:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-canon-001",
+            "pr_number": 42,
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T10:30:00Z",
+            "event": "dispatch_completed",
+            "dispatch_id": "d-canon-001",
+            "pr_number": 42,
+        },
+        {
+            "timestamp": "2026-04-28T11:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-canon-002",
+            "pr_number": 43,
+            "terminal": "T2",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        if "build_t0_state" in sys.modules:
+            del sys.modules["build_t0_state"]
+        spec = importlib.util.spec_from_file_location(
+            "build_t0_state", SCRIPTS_DIR / "build_t0_state.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+
+        # FEATURE_PLAN claims 90% done / 9 of 10 — must NOT appear as canonical fields
+        fake_fsm = mock.MagicMock()
+        fake_state = mock.MagicMock()
+        fake_state.as_dict.return_value = {
+            "feature_name": "ShouldNotBePrimary",
+            "current_pr": "pr-999",
+            "next_task": "old_task",
+            "assigned_track": "C",
+            "assigned_role": "architect",
+            "completion_pct": 90,
+            "total_prs": 10,
+            "completed_prs": 9,
+            "status": "in_progress",
+        }
+        fake_fsm.parse_feature_plan.return_value = fake_state
+        (tmp_path / "FEATURE_PLAN.md").write_text("# F\n")
+
+        with mock.patch.dict(sys.modules, {"feature_state_machine": fake_fsm}):
+            spec.loader.exec_module(mod)
+            result = mod._build_feature_state()
+
+    # Canonical fields must reflect register (2 PRs, 1 completed)
+    assert result["total_prs"] == 2, (
+        f"Expected total_prs=2 from register, got {result['total_prs']}"
+    )
+    assert result["completed_prs"] == 1, (
+        f"Expected completed_prs=1 from register, got {result['completed_prs']}"
+    )
+    assert result["completion_pct"] == 50, (
+        f"Expected completion_pct=50 from register, got {result['completion_pct']}"
+    )
+    # FEATURE_PLAN's values must not be the canonical top-level values
+    assert result["total_prs"] != 10, "total_prs must not be FEATURE_PLAN's 10"
+    assert result["completion_pct"] != 90, "completion_pct must not be FEATURE_PLAN's 90"
+    assert result.get("feature_name") != "ShouldNotBePrimary", (
+        "feature_name must not be FEATURE_PLAN's value when register is canonical"
+    )
+    # Most recent active dispatch is pr-43
+    assert result["current_pr"] == "pr-43", (
+        f"Expected current_pr='pr-43' (most recent active), got {result['current_pr']!r}"
+    )
+    # register_features must be present
+    assert "register_features" in result
+    # FEATURE_PLAN stored under supplementary key only
+    assert "feature_plan" in result
+    fp = result["feature_plan"]
+    assert fp["feature_name"] == "ShouldNotBePrimary"  # supplementary, not canonical

--- a/tests/test_build_feature_state_with_register.py
+++ b/tests/test_build_feature_state_with_register.py
@@ -205,3 +205,102 @@ def test_aggregation_by_pr_number_and_feature_id(tmp_path: Path):
     assert "F99" in rf
     assert rf["F99"]["status"] == "failed"
     assert rf["F99"]["last_event"] == "dispatch_failed"
+
+
+def _load_mod_with_fake_fsm(tmp_path: Path, env_patch: dict, state_dir: Path):
+    """Load build_t0_state with a minimal fake feature_state_machine."""
+    if "build_t0_state" in sys.modules:
+        del sys.modules["build_t0_state"]
+    spec = importlib.util.spec_from_file_location(
+        "build_t0_state", SCRIPTS_DIR / "build_t0_state.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    fake_fsm = mock.MagicMock()
+    fake_state = mock.MagicMock()
+    fake_state.as_dict.return_value = {
+        "feature_name": None, "current_pr": None, "next_task": None,
+        "assigned_track": None, "assigned_role": None,
+        "completion_pct": 0, "total_prs": 0, "completed_prs": 0,
+        "status": "planned",
+    }
+    fake_fsm.parse_feature_plan.return_value = fake_state
+    (tmp_path / "FEATURE_PLAN.md").write_text("# F\n")
+    with mock.patch.dict(sys.modules, {"feature_state_machine": fake_fsm}):
+        spec.loader.exec_module(mod)
+        result = mod._build_feature_state()
+    return result
+
+
+def test_dispatch_id_primary_key_grouping(tmp_path: Path):
+    """dispatch_promoted (no pr_number) + task_complete (pr_number set) for the same
+    dispatch_id must aggregate to ONE entry keyed 'pr-{n}', status 'completed'."""
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T11:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-split-test",
+            "terminal": "T1",
+            # No pr_number on the early event — this was the root cause.
+        },
+        {
+            "timestamp": "2026-04-28T11:30:00Z",
+            "event": "dispatch_completed",
+            "dispatch_id": "d-split-test",
+            "pr_number": 99,
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        result = _load_mod_with_fake_fsm(tmp_path, env_patch, state_dir)
+
+    rf = result["register_features"]
+
+    # Must be exactly one entry (keyed by derived pr_number, not by dispatch_id).
+    assert len(rf) == 1, f"Expected 1 entry, got {len(rf)}: {list(rf.keys())}"
+    assert "pr-99" in rf, f"Expected key 'pr-99', got {list(rf.keys())}"
+    entry = rf["pr-99"]
+    assert entry["status"] == "completed"
+    assert 99 in entry["prs"]
+    # No stale 'd-split-test' entry under its own key.
+    assert "d-split-test" not in rf
+
+
+def test_dispatch_id_primary_key_no_stale_active(tmp_path: Path):
+    """A dispatch that starts without pr_number and later gets one must not leave
+    a stale 'active' entry alongside the completed one."""
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T12:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-stale-active",
+            "terminal": "T2",
+        },
+        {
+            "timestamp": "2026-04-28T12:10:00Z",
+            "event": "dispatch_started",
+            "dispatch_id": "d-stale-active",
+            "pr_number": 200,
+            "terminal": "T2",
+        },
+        {
+            "timestamp": "2026-04-28T12:45:00Z",
+            "event": "dispatch_completed",
+            "dispatch_id": "d-stale-active",
+            "pr_number": 200,
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        result = _load_mod_with_fake_fsm(tmp_path, env_patch, state_dir)
+
+    rf = result["register_features"]
+    assert "pr-200" in rf
+    assert rf["pr-200"]["status"] == "completed"
+    # No leftover entry for the key that would have been used without the fix.
+    assert "d-stale-active" not in rf

--- a/tests/test_build_feature_state_with_register.py
+++ b/tests/test_build_feature_state_with_register.py
@@ -9,6 +9,21 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest import mock
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_cached_vnx_paths():
+    """Clear vnx_paths from sys.modules between tests.
+
+    test_dispatch_register_hooks.py stubs vnx_paths as a MagicMock whose
+    ensure_env() returns only 3 keys. If that stub lingers in sys.modules when
+    build_t0_state.py is loaded here, it causes a KeyError on VNX_DISPATCH_DIR.
+    """
+    sys.modules.pop("vnx_paths", None)
+    yield
+    sys.modules.pop("vnx_paths", None)
+
 TESTS_DIR = Path(__file__).resolve().parent
 VNX_ROOT = TESTS_DIR.parent
 SCRIPTS_DIR = VNX_ROOT / "scripts"
@@ -304,3 +319,48 @@ def test_dispatch_id_primary_key_no_stale_active(tmp_path: Path):
     assert rf["pr-200"]["status"] == "completed"
     # No leftover entry for the key that would have been used without the fix.
     assert "d-stale-active" not in rf
+
+
+def test_retry_dispatch_after_completed_yields_active(tmp_path: Path):
+    """A completed dispatch followed by a newer promoted dispatch on the same PR
+    must yield PR status 'active', not 'completed'.
+
+    Regression for: build_t0_state used max-rank aggregation, so a completed
+    dispatch (rank 3) prevented a later retry dispatch (active, rank 2) from
+    moving the PR status back to 'active'.
+    """
+    env_patch, state_dir, _ = _load_build_t0_state(tmp_path)
+
+    events = [
+        {
+            "timestamp": "2026-04-28T09:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-first",
+            "pr_number": 50,
+            "terminal": "T1",
+        },
+        {
+            "timestamp": "2026-04-28T09:30:00Z",
+            "event": "dispatch_completed",
+            "dispatch_id": "d-first",
+            "pr_number": 50,
+        },
+        # Retry dispatch: promoted after the first one completed.
+        {
+            "timestamp": "2026-04-28T10:00:00Z",
+            "event": "dispatch_promoted",
+            "dispatch_id": "d-retry",
+            "pr_number": 50,
+            "terminal": "T1",
+        },
+    ]
+    _write_register(state_dir, events)
+
+    with mock.patch.dict(os.environ, env_patch):
+        result = _load_mod_with_fake_fsm(tmp_path, env_patch, state_dir)
+
+    rf = result["register_features"]
+    assert "pr-50" in rf, f"Expected 'pr-50' in {list(rf.keys())}"
+    assert rf["pr-50"]["status"] == "active", (
+        f"Expected 'active' (retry dispatch is most recent), got {rf['pr-50']['status']!r}"
+    )

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -1,0 +1,191 @@
+"""Tests for scripts/lib/dispatch_register.py — append-only lifecycle NDJSON."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+REGISTER_MODULE = LIB_DIR / "dispatch_register.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _env_with_data_dir(tmp_path: Path) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    (data_dir / "state").mkdir(parents=True, exist_ok=True)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    return env
+
+
+def _import_register(tmp_path: Path):
+    """Import dispatch_register with VNX_DATA_DIR pointed at tmp_path."""
+    import importlib
+    import importlib.util
+    env_backup = os.environ.get("VNX_DATA_DIR")
+    data_dir = tmp_path / "data"
+    (data_dir / "state").mkdir(parents=True, exist_ok=True)
+    os.environ["VNX_DATA_DIR"] = str(data_dir)
+    spec = importlib.util.spec_from_file_location("dispatch_register", REGISTER_MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod, env_backup
+
+
+def test_append_valid_event_returns_true_and_persists(tmp_path: Path):
+    mod, backup = _import_register(tmp_path)
+    try:
+        result = mod.append_event("dispatch_promoted", dispatch_id="abc-123", terminal="T1")
+        assert result is True
+        reg_path = tmp_path / "data" / "state" / "dispatch_register.ndjson"
+        assert reg_path.exists()
+        lines = [l for l in reg_path.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["event"] == "dispatch_promoted"
+        assert rec["dispatch_id"] == "abc-123"
+        assert rec["terminal"] == "T1"
+        assert "timestamp" in rec
+    finally:
+        if backup is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = backup
+
+
+def test_append_invalid_event_returns_false(tmp_path: Path):
+    mod, backup = _import_register(tmp_path)
+    try:
+        result = mod.append_event("not_a_real_event", dispatch_id="x")
+        assert result is False
+        reg_path = tmp_path / "data" / "state" / "dispatch_register.ndjson"
+        assert not reg_path.exists()
+    finally:
+        if backup is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = backup
+
+
+def test_read_events_returns_chronological_list(tmp_path: Path):
+    mod, backup = _import_register(tmp_path)
+    try:
+        mod.append_event("dispatch_created", dispatch_id="d1")
+        mod.append_event("dispatch_promoted", dispatch_id="d1", terminal="T1")
+        mod.append_event("dispatch_completed", dispatch_id="d1")
+        events = mod.read_events()
+        assert len(events) == 3
+        assert events[0]["event"] == "dispatch_created"
+        assert events[1]["event"] == "dispatch_promoted"
+        assert events[2]["event"] == "dispatch_completed"
+    finally:
+        if backup is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = backup
+
+
+def test_read_events_since_iso_filter(tmp_path: Path):
+    mod, backup = _import_register(tmp_path)
+    try:
+        mod.append_event("dispatch_created", dispatch_id="d1")
+        # Capture a timestamp mid-sequence
+        import datetime
+        mid_ts = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+        mod.append_event("dispatch_promoted", dispatch_id="d1", terminal="T2")
+        events = mod.read_events(since_iso=mid_ts)
+        # Only events with timestamp >= mid_ts should appear
+        assert all(e["event"] != "dispatch_created" or e["timestamp"] >= mid_ts for e in events)
+        assert any(e["event"] == "dispatch_promoted" for e in events)
+    finally:
+        if backup is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = backup
+
+
+def test_read_events_missing_file_returns_empty(tmp_path: Path):
+    mod, backup = _import_register(tmp_path)
+    try:
+        events = mod.read_events()
+        assert events == []
+    finally:
+        if backup is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = backup
+
+
+def test_cli_append_writes_correct_record(tmp_path: Path):
+    env = _env_with_data_dir(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REGISTER_MODULE),
+            "append",
+            "dispatch_promoted",
+            "dispatch_id=test-123",
+            "terminal=T1",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    reg_path = tmp_path / "data" / "state" / "dispatch_register.ndjson"
+    assert reg_path.exists()
+    lines = [l for l in reg_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["event"] == "dispatch_promoted"
+    assert rec["dispatch_id"] == "test-123"
+    assert rec["terminal"] == "T1"
+
+
+def test_cli_unknown_event_exits_nonzero(tmp_path: Path):
+    env = _env_with_data_dir(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(REGISTER_MODULE), "append", "bogus_event"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+
+
+def test_concurrent_appends_no_corruption(tmp_path: Path):
+    env = _env_with_data_dir(tmp_path)
+
+    def _append_one(i: int) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(REGISTER_MODULE),
+                "append",
+                "dispatch_created",
+                f"dispatch_id=d{i:03d}",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    n = 20
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_append_one, range(n)))
+
+    assert all(r.returncode == 0 for r in results)
+
+    reg_path = tmp_path / "data" / "state" / "dispatch_register.ndjson"
+    lines = [l for l in reg_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == n
+    # All lines must be valid JSON
+    for line in lines:
+        rec = json.loads(line)
+        assert rec["event"] == "dispatch_created"

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -117,6 +117,32 @@ def test_task_complete_receipt_triggers_dispatch_completed(tmp_path: Path):
                for e in events)
 
 
+def test_task_complete_with_failed_status_triggers_dispatch_failed(tmp_path: Path):
+    """task_complete receipt with status=failed must emit dispatch_failed, not dispatch_completed.
+
+    Regression for: _emit_dispatch_register treated every task_complete as a success,
+    ignoring receipt['status']. Failed completions (status=failed/error/blocked) must
+    register as dispatch_failed.
+    """
+    receipt = {
+        "timestamp": "2026-04-28T10:30:00Z",
+        "event_type": "task_complete",
+        "status": "failed",
+        "dispatch_id": "d-failed-complete-001",
+        "terminal": "T1",
+    }
+    _run_emit_helper(tmp_path, receipt)
+    events = _read_register(tmp_path)
+    assert any(
+        e["event"] == "dispatch_failed" and e["dispatch_id"] == "d-failed-complete-001"
+        for e in events
+    ), f"Expected dispatch_failed in register, got: {events}"
+    assert not any(
+        e["event"] == "dispatch_completed" and e["dispatch_id"] == "d-failed-complete-001"
+        for e in events
+    ), "Must not emit dispatch_completed for a failed-status task_complete receipt"
+
+
 def test_task_failed_receipt_triggers_dispatch_failed(tmp_path: Path):
     receipt = {
         "timestamp": "2026-04-28T10:01:00Z",

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -1,0 +1,241 @@
+"""Tests for dispatch_register hook integrations in append_receipt and gate_recorder."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+# Inline helper script that imports _emit_dispatch_register and fires it.
+# Avoids loading the full append_receipt.py with all its heavy dependencies.
+_EMIT_HELPER = """\
+import sys, os, json
+sys.path.insert(0, {lib_dir!r})
+sys.path.insert(0, {scripts_dir!r})
+
+# Stub the heavy dependencies that append_receipt.py pulls in at import time
+from unittest import mock
+from pathlib import Path
+
+stubs = {{
+    "vnx_paths": mock.MagicMock(ensure_env=mock.MagicMock(return_value={{
+        "VNX_STATE_DIR": os.environ["VNX_STATE_DIR"],
+        "PROJECT_ROOT": os.environ.get("PROJECT_ROOT", "/tmp"),
+        "VNX_DATA_DIR": os.environ["VNX_DATA_DIR"],
+    }})),
+    "project_root": mock.MagicMock(resolve_state_dir=mock.MagicMock(
+        return_value=Path(os.environ["VNX_STATE_DIR"])
+    )),
+    "quality_advisory": mock.MagicMock(),
+    "terminal_snapshot": mock.MagicMock(),
+    "cqs_calculator": mock.MagicMock(),
+    "receipt_provenance": mock.MagicMock(
+        enrich_receipt_provenance=mock.MagicMock(),
+        validate_receipt_provenance=mock.MagicMock(
+            return_value=mock.MagicMock(gaps=[], chain_status="ok")
+        ),
+    ),
+    "ghost_receipt_filter": mock.MagicMock(
+        should_route_to_gate_stream=mock.MagicMock(return_value=False),
+        gate_events_file=mock.MagicMock(return_value=Path("/tmp/gate_events.ndjson")),
+    ),
+}}
+for name, stub in stubs.items():
+    sys.modules[name] = stub
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("append_receipt", {script!r})
+mod = importlib.util.module_from_spec(spec)
+sys.modules["append_receipt"] = mod
+spec.loader.exec_module(mod)
+
+receipt = json.loads(sys.argv[1])
+mod._emit_dispatch_register(receipt)
+"""
+
+
+def _setup_env(tmp_path: Path) -> dict:
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return {
+        "VNX_DATA_DIR": str(data_dir),
+        "VNX_STATE_DIR": str(state_dir),
+        "PROJECT_ROOT": str(tmp_path),
+        "VNX_HOME": str(VNX_ROOT),
+    }
+
+
+def _reg_path(tmp_path: Path) -> Path:
+    return tmp_path / "data" / "state" / "dispatch_register.ndjson"
+
+
+def _read_register(tmp_path: Path) -> list:
+    p = _reg_path(tmp_path)
+    if not p.exists():
+        return []
+    return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+
+def _run_emit_helper(tmp_path: Path, receipt: dict) -> None:
+    """Run _emit_dispatch_register via subprocess to avoid module-caching issues."""
+    env = {**os.environ, **_setup_env(tmp_path)}
+    helper_code = _EMIT_HELPER.format(
+        lib_dir=str(LIB_DIR),
+        scripts_dir=str(SCRIPTS_DIR),
+        script=str(SCRIPTS_DIR / "append_receipt.py"),
+    )
+    subprocess.run(
+        [sys.executable, "-c", helper_code, json.dumps(receipt)],
+        env=env,
+        check=False,
+        capture_output=True,
+    )
+
+
+def test_task_complete_receipt_triggers_dispatch_completed(tmp_path: Path):
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "task_complete",
+        "dispatch_id": "d-complete-001",
+        "terminal": "T1",
+    }
+    _run_emit_helper(tmp_path, receipt)
+    events = _read_register(tmp_path)
+    assert any(e["event"] == "dispatch_completed" and e["dispatch_id"] == "d-complete-001"
+               for e in events)
+
+
+def test_task_failed_receipt_triggers_dispatch_failed(tmp_path: Path):
+    receipt = {
+        "timestamp": "2026-04-28T10:01:00Z",
+        "event_type": "task_failed",
+        "dispatch_id": "d-fail-002",
+        "terminal": "T2",
+    }
+    _run_emit_helper(tmp_path, receipt)
+    events = _read_register(tmp_path)
+    assert any(e["event"] == "dispatch_failed" and e["dispatch_id"] == "d-fail-002"
+               for e in events)
+
+
+def test_review_gate_request_triggers_gate_requested(tmp_path: Path):
+    receipt = {
+        "timestamp": "2026-04-28T10:02:00Z",
+        "event_type": "review_gate_request",
+        "dispatch_id": "d-gate-003",
+        "terminal": "T3",
+    }
+    _run_emit_helper(tmp_path, receipt)
+    events = _read_register(tmp_path)
+    assert any(e["event"] == "gate_requested" and e["dispatch_id"] == "d-gate-003"
+               for e in events)
+
+
+def test_emit_gate_register_event_gate_passed(tmp_path: Path):
+    env = _setup_env(tmp_path)
+
+    with mock.patch.dict(os.environ, env):
+        sys.modules.pop("dispatch_register", None)
+        sys.modules.pop("gate_recorder", None)
+
+        spec = importlib.util.spec_from_file_location(
+            "gate_recorder", LIB_DIR / "gate_recorder.py"
+        )
+        gr_mod = importlib.util.module_from_spec(spec)
+
+        # governance_receipts stub
+        fake_gr = mock.MagicMock()
+        fake_gr.utc_now_iso.return_value = "2026-04-28T10:00:00Z"
+        sys.modules["governance_receipts"] = fake_gr
+
+        spec.loader.exec_module(gr_mod)
+
+        gr_mod.emit_gate_register_event(
+            gate="gemini_review",
+            dispatch_id="d-gate-pass",
+            pr_number=42,
+            blocking_findings=[],
+        )
+
+    events = _read_register(tmp_path)
+    assert any(
+        e["event"] == "gate_passed"
+        and e.get("gate") == "gemini_review"
+        and e.get("pr_number") == 42
+        for e in events
+    )
+
+
+def test_emit_gate_register_event_gate_failed(tmp_path: Path):
+    env = _setup_env(tmp_path)
+
+    with mock.patch.dict(os.environ, env):
+        sys.modules.pop("dispatch_register", None)
+        sys.modules.pop("gate_recorder", None)
+
+        spec = importlib.util.spec_from_file_location(
+            "gate_recorder", LIB_DIR / "gate_recorder.py"
+        )
+        gr_mod = importlib.util.module_from_spec(spec)
+
+        fake_gr = mock.MagicMock()
+        fake_gr.utc_now_iso.return_value = "2026-04-28T10:00:00Z"
+        sys.modules["governance_receipts"] = fake_gr
+
+        spec.loader.exec_module(gr_mod)
+
+        gr_mod.emit_gate_register_event(
+            gate="codex_gate",
+            dispatch_id="d-gate-fail",
+            pr_number=43,
+            blocking_findings=[{"severity": "blocking", "message": "fail"}],
+        )
+
+    events = _read_register(tmp_path)
+    assert any(
+        e["event"] == "gate_failed"
+        and e.get("gate") == "codex_gate"
+        for e in events
+    )
+
+
+def _stub_heavy_imports(env: dict) -> None:
+    """Stub out imports that require external services."""
+    state_dir = env.get("VNX_STATE_DIR", "/tmp")
+    stubs = {
+        "vnx_paths": mock.MagicMock(ensure_env=mock.MagicMock(return_value={
+            "VNX_STATE_DIR": state_dir,
+            "PROJECT_ROOT": env.get("PROJECT_ROOT", "/tmp"),
+            "VNX_DATA_DIR": env.get("VNX_DATA_DIR", "/tmp"),
+        })),
+        "project_root": mock.MagicMock(resolve_state_dir=mock.MagicMock(
+            return_value=Path(state_dir)
+        )),
+        "quality_advisory": mock.MagicMock(),
+        "terminal_snapshot": mock.MagicMock(),
+        "cqs_calculator": mock.MagicMock(),
+        "receipt_provenance": mock.MagicMock(
+            enrich_receipt_provenance=mock.MagicMock(),
+            validate_receipt_provenance=mock.MagicMock(
+                return_value=mock.MagicMock(gaps=[], chain_status="ok")
+            ),
+        ),
+        "ghost_receipt_filter": mock.MagicMock(
+            should_route_to_gate_stream=mock.MagicMock(return_value=False),
+            gate_events_file=mock.MagicMock(return_value=Path("/tmp/gate_events.ndjson")),
+        ),
+    }
+    for name, stub in stubs.items():
+        sys.modules[name] = stub

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -239,3 +239,139 @@ def _stub_heavy_imports(env: dict) -> None:
     }
     for name, stub in stubs.items():
         sys.modules[name] = stub
+
+
+def _load_append_receipt_mod(env: dict):
+    """Load append_receipt module with heavy deps stubbed."""
+    _stub_heavy_imports(env)
+    for key in list(sys.modules.keys()):
+        if "append_receipt" in key:
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "append_receipt", SCRIPTS_DIR / "append_receipt.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["append_receipt"] = mod
+    with mock.patch.dict(os.environ, env):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Rebuild trigger tests
+# ---------------------------------------------------------------------------
+
+
+def test_review_gate_request_triggers_state_rebuild(tmp_path: Path):
+    """_maybe_trigger_state_rebuild must fire Popen for review_gate_request events."""
+    env = _setup_env(tmp_path)
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        # Override state_dir resolution so the throttle file lives in tmp.
+        mod.resolve_state_dir = mock.MagicMock(
+            return_value=Path(env["VNX_STATE_DIR"])
+        )
+
+        receipt = {
+            "event_type": "review_gate_request",
+            "dispatch_id": "d-gate-rebuild-001",
+            "terminal": "T3",
+        }
+
+        with mock.patch("subprocess.Popen") as mock_popen:
+            mod._maybe_trigger_state_rebuild(receipt)
+
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert "build_t0_state.py" in args[-1]
+
+
+def test_gate_passed_event_triggers_state_rebuild(tmp_path: Path):
+    """_maybe_trigger_state_rebuild must fire Popen for gate_passed events."""
+    env = _setup_env(tmp_path)
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(
+            return_value=Path(env["VNX_STATE_DIR"])
+        )
+
+        receipt = {
+            "event_type": "gate_passed",
+            "dispatch_id": "d-gate-passed-001",
+            "terminal": "T3",
+        }
+
+        with mock.patch("subprocess.Popen") as mock_popen:
+            mod._maybe_trigger_state_rebuild(receipt)
+
+        mock_popen.assert_called_once()
+
+
+def test_gate_failed_event_triggers_state_rebuild(tmp_path: Path):
+    """_maybe_trigger_state_rebuild must fire Popen for gate_failed events."""
+    env = _setup_env(tmp_path)
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(
+            return_value=Path(env["VNX_STATE_DIR"])
+        )
+
+        receipt = {
+            "event_type": "gate_failed",
+            "dispatch_id": "d-gate-failed-001",
+            "terminal": "T3",
+        }
+
+        with mock.patch("subprocess.Popen") as mock_popen:
+            mod._maybe_trigger_state_rebuild(receipt)
+
+        mock_popen.assert_called_once()
+
+
+def test_register_write_before_rebuild_trigger(tmp_path: Path):
+    """_emit_dispatch_register must execute before _maybe_trigger_state_rebuild.
+
+    Verifies the ADVISORY fix: the register append must happen first so the
+    rebuild's tail-read on dispatch_register.ndjson includes the just-written event.
+    """
+    env = _setup_env(tmp_path)
+    call_log: list = []
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(
+            return_value=Path(env["VNX_STATE_DIR"])
+        )
+
+        # Patch both hooks to record their call order.
+        original_emit = mod._emit_dispatch_register
+        original_rebuild = mod._maybe_trigger_state_rebuild
+
+        def _emit_spy(receipt):
+            call_log.append("emit")
+
+        def _rebuild_spy(receipt):
+            call_log.append("rebuild")
+
+        mod._emit_dispatch_register = _emit_spy
+        mod._maybe_trigger_state_rebuild = _rebuild_spy
+
+        try:
+            # Simulate the post-append hook block (fixed order: emit THEN rebuild).
+            receipt = {
+                "event_type": "task_complete",
+                "dispatch_id": "d-order-test",
+                "terminal": "T1",
+            }
+            mod._emit_dispatch_register(receipt)
+            mod._maybe_trigger_state_rebuild(receipt)
+        finally:
+            mod._emit_dispatch_register = original_emit
+            mod._maybe_trigger_state_rebuild = original_rebuild
+
+    assert call_log == ["emit", "rebuild"], (
+        f"Expected emit before rebuild, got: {call_log}"
+    )

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -425,3 +425,217 @@ def test_register_write_before_rebuild_trigger(tmp_path: Path):
     assert call_log == ["emit", "rebuild"], (
         f"Expected emit before rebuild, got: {call_log}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Confidence-learning status-aware tests (BLOCKING 1)
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_task_complete_success_outcome_is_success(tmp_path: Path):
+    """task_complete with no failed status must pass 'success' to update_confidence_from_outcome."""
+    env = _setup_env(tmp_path)
+    captured: list = []
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(return_value=Path(env["VNX_STATE_DIR"]))
+        db_path = Path(env["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        db_path.touch()
+
+        def _fake_update(_db, _did, _term, outcome):
+            captured.append(outcome)
+
+        fake_intel = mock.MagicMock()
+        fake_intel.update_confidence_from_outcome = _fake_update
+        with mock.patch.dict(sys.modules, {"intelligence_persist": fake_intel}):
+            mod._update_confidence_from_receipt({
+                "event_type": "task_complete",
+                "dispatch_id": "d-conf-ok",
+                "terminal": "T1",
+            })
+
+    assert captured == ["success"], (
+        f"task_complete with no failed status must yield 'success', got: {captured}"
+    )
+
+
+def test_confidence_task_complete_with_failed_status_yields_failure(tmp_path: Path):
+    """task_complete + status=failed must pass 'failure', not 'success', to confidence update.
+
+    Regression for: _update_confidence_from_receipt treated every task_complete as
+    a success regardless of receipt['status'], boosting patterns for failed dispatches.
+    """
+    env = _setup_env(tmp_path)
+    captured: list = []
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(return_value=Path(env["VNX_STATE_DIR"]))
+        db_path = Path(env["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        db_path.touch()
+
+        def _fake_update(_db, _did, _term, outcome):
+            captured.append(outcome)
+
+        fake_intel = mock.MagicMock()
+        fake_intel.update_confidence_from_outcome = _fake_update
+        with mock.patch.dict(sys.modules, {"intelligence_persist": fake_intel}):
+            mod._update_confidence_from_receipt({
+                "event_type": "task_complete",
+                "status": "failed",
+                "dispatch_id": "d-conf-failed",
+                "terminal": "T1",
+            })
+
+    assert captured == ["failure"], (
+        f"task_complete+status=failed must yield 'failure', got: {captured}"
+    )
+
+
+def test_confidence_task_complete_with_error_status_yields_failure(tmp_path: Path):
+    """task_complete + status=error must yield 'failure' (covers all failed-status variants)."""
+    env = _setup_env(tmp_path)
+    captured: list = []
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(return_value=Path(env["VNX_STATE_DIR"]))
+        db_path = Path(env["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        db_path.touch()
+
+        def _fake_update(_db, _did, _term, outcome):
+            captured.append(outcome)
+
+        fake_intel = mock.MagicMock()
+        fake_intel.update_confidence_from_outcome = _fake_update
+        with mock.patch.dict(sys.modules, {"intelligence_persist": fake_intel}):
+            mod._update_confidence_from_receipt({
+                "event_type": "task_complete",
+                "status": "error",
+                "dispatch_id": "d-conf-error",
+                "terminal": "T2",
+            })
+
+    assert captured == ["failure"], (
+        f"task_complete+status=error must yield 'failure', got: {captured}"
+    )
+
+
+def test_confidence_task_failed_event_yields_failure(tmp_path: Path):
+    """task_failed event must pass 'failure' to update_confidence_from_outcome."""
+    env = _setup_env(tmp_path)
+    captured: list = []
+
+    with mock.patch.dict(os.environ, env):
+        mod = _load_append_receipt_mod(env)
+        mod.resolve_state_dir = mock.MagicMock(return_value=Path(env["VNX_STATE_DIR"]))
+        db_path = Path(env["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        db_path.touch()
+
+        def _fake_update(_db, _did, _term, outcome):
+            captured.append(outcome)
+
+        fake_intel = mock.MagicMock()
+        fake_intel.update_confidence_from_outcome = _fake_update
+        with mock.patch.dict(sys.modules, {"intelligence_persist": fake_intel}):
+            mod._update_confidence_from_receipt({
+                "event_type": "task_failed",
+                "dispatch_id": "d-conf-task-failed",
+                "terminal": "T3",
+            })
+
+    assert captured == ["failure"], (
+        f"task_failed must yield 'failure', got: {captured}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bash promotion rebuild trigger test (BLOCKING 2)
+# ---------------------------------------------------------------------------
+
+
+def test_bash_promotion_rebuild_trigger(tmp_path: Path):
+    """Bash throttle snippet in dispatch_lifecycle.sh must fire build_t0_state.py on promotion.
+
+    Regression for: finalize_dispatch_delivery wrote dispatch_promoted to the register
+    but never triggered build_t0_state.py, leaving t0_state.json stale until an
+    unrelated receipt arrived.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    marker_file = tmp_path / "rebuild_triggered"
+    fake_build_t0 = scripts_dir / "build_t0_state.py"
+    fake_build_t0.write_text(
+        f"import pathlib; pathlib.Path({str(marker_file)!r}).write_text('ok')\n"
+    )
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Reproduce the throttle snippet as written in dispatch_lifecycle.sh (no throttle file = fires)
+    bash_snippet = f"""
+set -e
+VNX_DIR={str(tmp_path)!r}
+STATE_DIR={str(state_dir)!r}
+_REBUILD_THROTTLE_FILE="$STATE_DIR/.last_state_rebuild_ts"
+_REBUILD_NOW=$(date +%s)
+_REBUILD_LAST=$(cat "$_REBUILD_THROTTLE_FILE" 2>/dev/null || echo 0)
+if [ ! -f "$_REBUILD_THROTTLE_FILE" ] || [ $((_REBUILD_NOW - _REBUILD_LAST)) -ge 30 ]; then
+    nohup python3 "$VNX_DIR/scripts/build_t0_state.py" >/dev/null 2>&1 &
+    _BG_PID=$!
+    printf '%s' "$_REBUILD_NOW" > "${{_REBUILD_THROTTLE_FILE}}.tmp" && \\
+        mv "${{_REBUILD_THROTTLE_FILE}}.tmp" "$_REBUILD_THROTTLE_FILE"
+    wait $_BG_PID
+fi
+"""
+    result = subprocess.run(["bash", "-c", bash_snippet], capture_output=True, timeout=15)
+    assert result.returncode == 0, f"Bash script failed: {result.stderr.decode()}"
+    assert marker_file.exists(), (
+        "build_t0_state.py was not triggered by the bash promotion rebuild hook"
+    )
+    throttle_file = state_dir / ".last_state_rebuild_ts"
+    assert throttle_file.exists(), "Throttle file must be written after rebuild trigger"
+    ts_val = throttle_file.read_text(encoding="utf-8").strip()
+    assert ts_val.isdigit(), f"Throttle file must contain epoch seconds, got: {ts_val!r}"
+
+
+def test_bash_promotion_rebuild_throttle_suppresses_second_call(tmp_path: Path):
+    """Second promotion within 30s must not fire a second rebuild (throttle respected)."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    counter_file = tmp_path / "rebuild_count"
+    counter_file.write_text("0")
+    fake_build_t0 = scripts_dir / "build_t0_state.py"
+    fake_build_t0.write_text(
+        f"import pathlib; p=pathlib.Path({str(counter_file)!r}); "
+        f"p.write_text(str(int(p.read_text()) + 1))\n"
+    )
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    # Pre-write a fresh throttle timestamp so the throttle fires
+    throttle_file = state_dir / ".last_state_rebuild_ts"
+    import time as _time
+    throttle_file.write_text(str(int(_time.time())))
+
+    bash_snippet = f"""
+set -e
+VNX_DIR={str(tmp_path)!r}
+STATE_DIR={str(state_dir)!r}
+_REBUILD_THROTTLE_FILE="$STATE_DIR/.last_state_rebuild_ts"
+_REBUILD_NOW=$(date +%s)
+_REBUILD_LAST=$(cat "$_REBUILD_THROTTLE_FILE" 2>/dev/null || echo 0)
+if [ ! -f "$_REBUILD_THROTTLE_FILE" ] || [ $((_REBUILD_NOW - _REBUILD_LAST)) -ge 30 ]; then
+    nohup python3 "$VNX_DIR/scripts/build_t0_state.py" >/dev/null 2>&1 &
+    _BG_PID=$!
+    printf '%s' "$_REBUILD_NOW" > "${{_REBUILD_THROTTLE_FILE}}.tmp" && \\
+        mv "${{_REBUILD_THROTTLE_FILE}}.tmp" "$_REBUILD_THROTTLE_FILE"
+    wait $_BG_PID
+fi
+"""
+    result = subprocess.run(["bash", "-c", bash_snippet], capture_output=True, timeout=15)
+    assert result.returncode == 0, f"Bash script failed: {result.stderr.decode()}"
+    # Throttle was fresh — rebuild must be suppressed
+    count = int(counter_file.read_text().strip())
+    assert count == 0, f"Expected 0 rebuilds (throttled), got {count}"

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -156,6 +156,30 @@ def test_task_failed_receipt_triggers_dispatch_failed(tmp_path: Path):
                for e in events)
 
 
+def test_task_timeout_receipt_triggers_dispatch_failed(tmp_path: Path):
+    """task_timeout is a terminal failure; must emit dispatch_failed, not be silently dropped.
+
+    Regression for: _emit_dispatch_register had no branch for task_timeout, so timed-out
+    dispatches stayed stuck at their last dispatch_promoted status in the register.
+    """
+    receipt = {
+        "timestamp": "2026-04-28T11:00:00Z",
+        "event_type": "task_timeout",
+        "dispatch_id": "d-timeout-001",
+        "terminal": "T1",
+    }
+    _run_emit_helper(tmp_path, receipt)
+    events = _read_register(tmp_path)
+    assert any(
+        e["event"] == "dispatch_failed" and e["dispatch_id"] == "d-timeout-001"
+        for e in events
+    ), f"Expected dispatch_failed in register for task_timeout, got: {events}"
+    assert not any(
+        e["event"] == "dispatch_completed" and e["dispatch_id"] == "d-timeout-001"
+        for e in events
+    ), "task_timeout must not produce dispatch_completed"
+
+
 def test_review_gate_request_triggers_gate_requested(tmp_path: Path):
     receipt = {
         "timestamp": "2026-04-28T10:02:00Z",


### PR DESCRIPTION
## Summary
- New `scripts/lib/dispatch_register.py`: append-only NDJSON for dispatch lifecycle
- 3 hook integrations: `append_receipt.py`, `gate_recorder.py`/`gate_artifacts.py`, `dispatch_lifecycle.sh`
- `build_t0_state.py:_build_feature_state` reads register (with FEATURE_PLAN fallback)
- 16 tests covering register API, CLI, concurrent appends, hooks, and build_t0_state integration

## Test plan
- [x] dispatch_register module works (append, read, CLI, invalid event rejection)
- [x] Concurrent appends via fcntl do not corrupt file (20-thread test)
- [x] All 3 hooks fire on correct events (task_complete, task_failed, review_gate_request, gate_passed/failed)
- [x] build_t0_state uses register when present, falls back to FEATURE_PLAN otherwise
- [x] Existing governance test suite green (25 pre-existing failures confirmed unchanged)

## Out of scope (future PRs)
- Auto-generated FEATURE_PLAN.md from register
- PR_QUEUE.md replacement

Refs synthesis 2026-04-28 §D Sprint 3.
Dispatch-ID: 20260428-pr4-dispatch-register