### PR TITLE
feat(governance): dispatch_register.py module (Sprint 3 split 1/3)

### DIFF
--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -25,7 +25,13 @@ VALID_EVENTS = {
 
 
 def _register_path() -> Path:
-    """Resolve dispatch_register.ndjson location via canonical vnx_paths."""
+    """Resolve dispatch_register.ndjson via canonical vnx_paths resolver.
+
+    Fallback precedence (when canonical resolver unavailable):
+    1. VNX_STATE_DIR (if set) — use directly as state dir
+    2. VNX_DATA_DIR + state subdir (only when VNX_DATA_DIR_EXPLICIT=1)
+    3. Repo-relative .vnx-data/state
+    """
     try:
         scripts_lib = str(_REPO_ROOT / "scripts" / "lib")
         if scripts_lib not in sys.path:
@@ -34,12 +40,15 @@ def _register_path() -> Path:
         state_dir = resolve_paths()["VNX_STATE_DIR"]
         return Path(state_dir) / "dispatch_register.ndjson"
     except Exception:
-        # Fallback: only honor VNX_DATA_DIR if explicitly enabled (mirrors canonical contract)
-        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
-            data_dir = Path(os.environ["VNX_DATA_DIR"])
+        # Fallback chain mirrors canonical contract
+        state_dir_env = os.environ.get("VNX_STATE_DIR")
+        if state_dir_env:
+            state_dir = Path(state_dir_env)
+        elif os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+            state_dir = Path(os.environ["VNX_DATA_DIR"]) / "state"
         else:
-            data_dir = _REPO_ROOT / ".vnx-data"
-        return data_dir / "state" / "dispatch_register.ndjson"
+            state_dir = _REPO_ROOT / ".vnx-data" / "state"
+        return state_dir / "dispatch_register.ndjson"
 
 
 def _utc_now_iso() -> str:
@@ -63,6 +72,9 @@ def append_event(
     where caller flow must not break on register write failure.
     """
     if event not in VALID_EVENTS:
+        return False
+    # Require at least one identifying field — register is canonical source, must be queryable
+    if not dispatch_id and pr_number is None and not feature_id:
         return False
     record = {
         "timestamp": _utc_now_iso(),

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -4,7 +4,7 @@ File: $VNX_STATE_DIR/dispatch_register.ndjson
 Source of truth for feature/PR queue state (consumed by build_t0_state.py).
 """
 from __future__ import annotations
-import datetime as _dt, json, os, fcntl
+import datetime as _dt, json, os, fcntl, sys
 from pathlib import Path
 from typing import Optional
 
@@ -25,8 +25,18 @@ VALID_EVENTS = {
 
 
 def _register_path() -> Path:
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
-    return data_dir / "state" / "dispatch_register.ndjson"
+    """Resolve dispatch_register.ndjson location via canonical vnx_paths."""
+    try:
+        scripts_lib = str(_REPO_ROOT / "scripts" / "lib")
+        if scripts_lib not in sys.path:
+            sys.path.insert(0, scripts_lib)
+        from vnx_paths import resolve_paths
+        state_dir = resolve_paths()["VNX_STATE_DIR"]
+        return Path(state_dir) / "dispatch_register.ndjson"
+    except Exception:
+        # Fallback: derive from VNX_DATA_DIR with /state subdir
+        data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
+        return data_dir / "state" / "dispatch_register.ndjson"
 
 
 def _utc_now_iso() -> str:
@@ -101,24 +111,30 @@ def read_events(*, since_iso: Optional[str] = None) -> list[dict]:
 # CLI for bash callers
 def _cli(argv: list[str]) -> int:
     if len(argv) < 3 or argv[1] != "append":
-        print("Usage: dispatch_register.py append <event> [key=value ...]", flush=True)
+        print("Usage: dispatch_register.py append <event> [key=value ...] [extra.key=value ...]", flush=True)
         return 2
     event = argv[2]
-    kwargs = {}
+    kwargs: dict = {}
+    extra: dict = {}
     for arg in argv[3:]:
         if "=" not in arg:
             continue
         k, v = arg.split("=", 1)
-        if k == "pr_number":
+        if k.startswith("extra."):
+            extra_key = k[len("extra."):]
+            if extra_key:
+                extra[extra_key] = v
+        elif k == "pr_number":
             try:
                 kwargs[k] = int(v)
             except ValueError:
                 continue
         elif k in ("dispatch_id", "feature_id", "terminal", "gate"):
             kwargs[k] = v
+    if extra:
+        kwargs["extra"] = extra
     return 0 if append_event(event, **kwargs) else 1
 
 
 if __name__ == "__main__":
-    import sys
     sys.exit(_cli(sys.argv))

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -1,0 +1,124 @@
+"""Dispatch lifecycle register — append-only NDJSON log of dispatch state changes.
+
+File: $VNX_STATE_DIR/dispatch_register.ndjson
+Source of truth for feature/PR queue state (consumed by build_t0_state.py).
+"""
+from __future__ import annotations
+import datetime as _dt, json, os, fcntl
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+VALID_EVENTS = {
+    "dispatch_created",     # written to pending/
+    "dispatch_promoted",    # moved pending/ → active/
+    "dispatch_started",     # worker began
+    "dispatch_completed",   # successful task_complete
+    "dispatch_failed",      # task_failed OR task_complete with status=failed OR task_timeout
+    "gate_requested",       # review_gate_request
+    "gate_passed",          # gate completed with no blocking findings
+    "gate_failed",          # gate completed with blocking findings
+    "pr_opened",
+    "pr_merged",
+}
+
+
+def _register_path() -> Path:
+    data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
+    return data_dir / "state" / "dispatch_register.ndjson"
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp with microsecond precision (avoids same-second collisions)."""
+    return _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def append_event(
+    event: str,
+    *,
+    dispatch_id: str = "",
+    pr_number: Optional[int] = None,
+    feature_id: str = "",
+    terminal: str = "",
+    gate: str = "",
+    extra: Optional[dict] = None,
+) -> bool:
+    """Append a lifecycle event. Returns True on success, False on any failure.
+
+    Best-effort: never raises. Intended for use as a fire-and-forget hook
+    where caller flow must not break on register write failure.
+    """
+    if event not in VALID_EVENTS:
+        return False
+    record = {
+        "timestamp": _utc_now_iso(),
+        "event": event,
+    }
+    if dispatch_id:
+        record["dispatch_id"] = dispatch_id
+    if pr_number is not None:
+        record["pr_number"] = pr_number
+    if feature_id:
+        record["feature_id"] = feature_id
+    if terminal:
+        record["terminal"] = terminal
+    if gate:
+        record["gate"] = gate
+    if extra and isinstance(extra, dict):
+        record["extra"] = extra
+    try:
+        path = _register_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def read_events(*, since_iso: Optional[str] = None) -> list[dict]:
+    """Read all events as list of dicts, optionally filtered by minimum timestamp."""
+    path = _register_path()
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            if since_iso and rec.get("timestamp", "") < since_iso:
+                continue
+            events.append(rec)
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+# CLI for bash callers
+def _cli(argv: list[str]) -> int:
+    if len(argv) < 3 or argv[1] != "append":
+        print("Usage: dispatch_register.py append <event> [key=value ...]", flush=True)
+        return 2
+    event = argv[2]
+    kwargs = {}
+    for arg in argv[3:]:
+        if "=" not in arg:
+            continue
+        k, v = arg.split("=", 1)
+        if k == "pr_number":
+            try:
+                kwargs[k] = int(v)
+            except ValueError:
+                continue
+        elif k in ("dispatch_id", "feature_id", "terminal", "gate"):
+            kwargs[k] = v
+    return 0 if append_event(event, **kwargs) else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(_cli(sys.argv))

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -34,8 +34,11 @@ def _register_path() -> Path:
         state_dir = resolve_paths()["VNX_STATE_DIR"]
         return Path(state_dir) / "dispatch_register.ndjson"
     except Exception:
-        # Fallback: derive from VNX_DATA_DIR with /state subdir
-        data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
+        # Fallback: only honor VNX_DATA_DIR if explicitly enabled (mirrors canonical contract)
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+            data_dir = Path(os.environ["VNX_DATA_DIR"])
+        else:
+            data_dir = _REPO_ROOT / ".vnx-data"
         return data_dir / "state" / "dispatch_register.ndjson"
 
 
@@ -89,22 +92,31 @@ def append_event(
 
 
 def read_events(*, since_iso: Optional[str] = None) -> list[dict]:
-    """Read all events as list of dicts, optionally filtered by minimum timestamp."""
+    """Read all events; takes shared lock to avoid partial-write reads."""
     path = _register_path()
     if not path.exists():
         return []
     events = []
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            rec = json.loads(line)
-            if since_iso and rec.get("timestamp", "") < since_iso:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+            try:
+                content = fh.read()
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
                 continue
-            events.append(rec)
-        except json.JSONDecodeError:
-            continue
+            try:
+                rec = json.loads(line)
+                if since_iso and rec.get("timestamp", "") < since_iso:
+                    continue
+                events.append(rec)
+            except json.JSONDecodeError:
+                continue
+    except Exception:
+        return []
     return events
 
 

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -43,8 +43,10 @@ _MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "dis
 @pytest.fixture(autouse=True)
 def isolated_data_dir(monkeypatch, tmp_path):
     """Route all register I/O into a fresh tmp dir for every test."""
-    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
-    return tmp_path / ".vnx-data"
+    data_dir = tmp_path / ".vnx-data"
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(data_dir / "state"))
+    return data_dir
 
 
 def _reg_path(data_dir: Path) -> Path:
@@ -261,6 +263,29 @@ class TestCli:
         )
         assert result.returncode == 2
 
+    def test_cli_extra_field(self, isolated_data_dir):
+        env = self._env(isolated_data_dir)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_MODULE_PATH),
+                "append",
+                "dispatch_failed",
+                "dispatch_id=abc",
+                "extra.reason=timeout",
+                "extra.attempt=3",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        reg = _reg_path(isolated_data_dir)
+        rec = json.loads(reg.read_text().strip())
+        assert rec["event"] == "dispatch_failed"
+        assert rec["dispatch_id"] == "abc"
+        assert rec["extra"] == {"reason": "timeout", "attempt": "3"}
+
 
 # ---------------------------------------------------------------------------
 # 12. Concurrent writes via threads — no corruption
@@ -300,16 +325,61 @@ class TestBestEffortOsError:
 
 
 # ---------------------------------------------------------------------------
-# 14. VNX_DATA_DIR path resolution
+# 14. VNX_STATE_DIR path resolution
 # ---------------------------------------------------------------------------
 
 class TestPathResolution:
-    def test_register_lands_in_vnx_data_dir(self, tmp_path, monkeypatch):
-        custom_data = tmp_path / "custom-data"
-        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+    def test_register_lands_in_vnx_state_dir(self, tmp_path, monkeypatch):
+        custom_state = tmp_path / "custom-state"
+        monkeypatch.setenv("VNX_STATE_DIR", str(custom_state))
         result = append_event("dispatch_created", dispatch_id="path-test")
         assert result is True
-        expected = custom_data / "state" / "dispatch_register.ndjson"
+        expected = custom_state / "dispatch_register.ndjson"
         assert expected.exists(), f"Register not found at {expected}"
         rec = json.loads(expected.read_text().strip())
         assert rec["dispatch_id"] == "path-test"
+
+
+# ---------------------------------------------------------------------------
+# 15–17. Canonical resolver: VNX_STATE_DIR override, fallback
+# ---------------------------------------------------------------------------
+
+class TestPathResolutionCanonical:
+    def test_register_path_uses_canonical_resolver(self, tmp_path, monkeypatch):
+        """Canonical resolver is used: register lands at resolve_paths()['VNX_STATE_DIR']."""
+        custom_state = tmp_path / "canonical-state"
+        monkeypatch.setenv("VNX_STATE_DIR", str(custom_state))
+        result = append_event("dispatch_created", dispatch_id="canonical-test")
+        assert result is True
+        expected = custom_state / "dispatch_register.ndjson"
+        assert expected.exists(), f"Register not at VNX_STATE_DIR: {expected}"
+        rec = json.loads(expected.read_text().strip())
+        assert rec["dispatch_id"] == "canonical-test"
+
+    def test_register_path_respects_state_dir_override(self, tmp_path, monkeypatch):
+        """VNX_STATE_DIR=X lands register at X, not VNX_DATA_DIR/state."""
+        custom_data = tmp_path / "override-data"
+        custom_state = tmp_path / "override-state"
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.setenv("VNX_STATE_DIR", str(custom_state))
+        result = append_event("dispatch_created", dispatch_id="override-test")
+        assert result is True
+        expected = custom_state / "dispatch_register.ndjson"
+        assert expected.exists(), f"Register not at VNX_STATE_DIR override: {expected}"
+        wrong = custom_data / "state" / "dispatch_register.ndjson"
+        assert not wrong.exists(), f"Register incorrectly landed at VNX_DATA_DIR/state: {wrong}"
+
+    def test_register_path_fallback(self, tmp_path, monkeypatch):
+        """When vnx_paths import fails, falls back to VNX_DATA_DIR/state."""
+        custom_data = tmp_path / "fallback-data"
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+        with patch.dict(sys.modules, {"vnx_paths": None}):
+            result = append_event("dispatch_created", dispatch_id="fallback-test")
+        assert result is True
+        expected = custom_data / "state" / "dispatch_register.ndjson"
+        assert expected.exists(), f"Fallback register not found at {expected}"
+        rec = json.loads(expected.read_text().strip())
+        assert rec["dispatch_id"] == "fallback-test"
+
+

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -1,0 +1,315 @@
+"""Tests for dispatch_register.py — append-only NDJSON lifecycle log.
+
+Covers:
+  1.  append_event valid event → True, persists JSON line
+  2.  append_event invalid event → False, nothing written
+  3.  append_event all optional kwargs → all fields present
+  4.  append_event writes microsecond-precision timestamp
+  5.  read_events chronological order (insertion order)
+  6.  read_events since_iso filter
+  7.  read_events skips malformed JSON lines silently
+  8.  read_events returns empty list when file absent
+  9.  CLI append writes correct record
+  10. CLI invalid event → exit 1
+  11. CLI missing args → exit 2
+  12. Concurrent writes via threads → both records present, no corruption
+  13. Best-effort: OSError on open → append_event returns False (never raises)
+  14. Path resolution: VNX_DATA_DIR env var is respected
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts/lib to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import dispatch_register
+from dispatch_register import append_event, read_events
+
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "dispatch_register.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def isolated_data_dir(monkeypatch, tmp_path):
+    """Route all register I/O into a fresh tmp dir for every test."""
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+    return tmp_path / ".vnx-data"
+
+
+def _reg_path(data_dir: Path) -> Path:
+    return data_dir / "state" / "dispatch_register.ndjson"
+
+
+# ---------------------------------------------------------------------------
+# 1. append_event valid event → True, persists JSON line
+# ---------------------------------------------------------------------------
+
+class TestAppendEventValid:
+    def test_returns_true(self, isolated_data_dir):
+        assert append_event("dispatch_created", dispatch_id="d-001") is True
+
+    def test_persists_json_line(self, isolated_data_dir):
+        append_event("dispatch_created", dispatch_id="d-001")
+        reg = _reg_path(isolated_data_dir)
+        assert reg.exists()
+        lines = reg.read_text().splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["event"] == "dispatch_created"
+        assert rec["dispatch_id"] == "d-001"
+        assert "timestamp" in rec
+
+
+# ---------------------------------------------------------------------------
+# 2. append_event invalid event → False, nothing written
+# ---------------------------------------------------------------------------
+
+class TestAppendEventInvalid:
+    def test_returns_false_for_unknown_event(self, isolated_data_dir):
+        result = append_event("no_such_event", dispatch_id="d-999")
+        assert result is False
+
+    def test_no_file_written_for_invalid_event(self, isolated_data_dir):
+        append_event("no_such_event")
+        assert not _reg_path(isolated_data_dir).exists()
+
+
+# ---------------------------------------------------------------------------
+# 3. append_event all optional kwargs → all fields present
+# ---------------------------------------------------------------------------
+
+class TestAppendEventAllKwargs:
+    def test_all_fields_persisted(self, isolated_data_dir):
+        append_event(
+            "gate_passed",
+            dispatch_id="abc",
+            pr_number=42,
+            feature_id="F99",
+            terminal="T1",
+            gate="codex",
+            extra={"foo": "bar"},
+        )
+        rec = json.loads(_reg_path(isolated_data_dir).read_text().strip())
+        assert rec["event"] == "gate_passed"
+        assert rec["dispatch_id"] == "abc"
+        assert rec["pr_number"] == 42
+        assert rec["feature_id"] == "F99"
+        assert rec["terminal"] == "T1"
+        assert rec["gate"] == "codex"
+        assert rec["extra"] == {"foo": "bar"}
+
+    def test_omitted_optional_fields_absent(self, isolated_data_dir):
+        append_event("dispatch_created")
+        rec = json.loads(_reg_path(isolated_data_dir).read_text().strip())
+        assert "dispatch_id" not in rec
+        assert "pr_number" not in rec
+        assert "feature_id" not in rec
+        assert "terminal" not in rec
+        assert "gate" not in rec
+        assert "extra" not in rec
+
+
+# ---------------------------------------------------------------------------
+# 4. Microsecond-precision timestamp
+# ---------------------------------------------------------------------------
+
+class TestTimestampPrecision:
+    def test_timestamp_includes_fractional_seconds(self, isolated_data_dir):
+        append_event("dispatch_created", dispatch_id="ts-001")
+        rec = json.loads(_reg_path(isolated_data_dir).read_text().strip())
+        ts = rec["timestamp"]
+        # Format: 2026-04-28T12:34:56.123456Z — fractional part has 6 digits before Z
+        assert ts.endswith("Z"), f"Timestamp must end with Z, got: {ts}"
+        assert "." in ts, f"Timestamp must include fractional seconds, got: {ts}"
+        frac_part = ts.split(".")[1].rstrip("Z")
+        assert len(frac_part) == 6, f"Expected 6 fractional digits, got {len(frac_part)} in: {ts}"
+
+
+# ---------------------------------------------------------------------------
+# 5. read_events chronological order
+# ---------------------------------------------------------------------------
+
+class TestReadEventsOrder:
+    def test_returns_insertion_order(self, isolated_data_dir):
+        for evt in ("dispatch_created", "dispatch_promoted", "dispatch_started"):
+            append_event(evt, dispatch_id="seq-001")
+        events = read_events()
+        assert [e["event"] for e in events] == [
+            "dispatch_created",
+            "dispatch_promoted",
+            "dispatch_started",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 6. read_events since_iso filter
+# ---------------------------------------------------------------------------
+
+class TestReadEventsSinceIso:
+    def test_since_iso_excludes_older_events(self, isolated_data_dir):
+        reg = _reg_path(isolated_data_dir)
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        old_ts = "2026-01-01T00:00:00.000000Z"
+        new_ts = "2026-06-01T00:00:00.000000Z"
+        reg.write_text(
+            json.dumps({"timestamp": old_ts, "event": "dispatch_created"}) + "\n"
+            + json.dumps({"timestamp": new_ts, "event": "dispatch_promoted"}) + "\n"
+        )
+        cutoff = "2026-03-01T00:00:00.000000Z"
+        events = read_events(since_iso=cutoff)
+        assert len(events) == 1
+        assert events[0]["event"] == "dispatch_promoted"
+
+    def test_since_iso_includes_equal_timestamp(self, isolated_data_dir):
+        reg = _reg_path(isolated_data_dir)
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        ts = "2026-04-01T12:00:00.000000Z"
+        reg.write_text(json.dumps({"timestamp": ts, "event": "dispatch_created"}) + "\n")
+        events = read_events(since_iso=ts)
+        assert len(events) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. read_events skips invalid JSON silently
+# ---------------------------------------------------------------------------
+
+class TestReadEventsInvalidJson:
+    def test_skips_malformed_lines(self, isolated_data_dir):
+        reg = _reg_path(isolated_data_dir)
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(
+            '{"timestamp":"2026-01-01T00:00:00.000000Z","event":"dispatch_created"}\n'
+            "not-valid-json\n"
+            '{"timestamp":"2026-01-02T00:00:00.000000Z","event":"dispatch_promoted"}\n'
+        )
+        events = read_events()
+        assert len(events) == 2
+        assert events[0]["event"] == "dispatch_created"
+        assert events[1]["event"] == "dispatch_promoted"
+
+
+# ---------------------------------------------------------------------------
+# 8. read_events returns empty list when file absent
+# ---------------------------------------------------------------------------
+
+class TestReadEventsNoFile:
+    def test_returns_empty_list(self, isolated_data_dir):
+        assert not _reg_path(isolated_data_dir).exists()
+        assert read_events() == []
+
+
+# ---------------------------------------------------------------------------
+# 9–11. CLI tests
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def _env(self, isolated_data_dir):
+        env = os.environ.copy()
+        env["VNX_DATA_DIR"] = str(isolated_data_dir)
+        return env
+
+    def test_cli_append_writes_record(self, isolated_data_dir):
+        env = self._env(isolated_data_dir)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_MODULE_PATH),
+                "append",
+                "dispatch_promoted",
+                "dispatch_id=abc",
+                "terminal=T1",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        reg = _reg_path(isolated_data_dir)
+        rec = json.loads(reg.read_text().strip())
+        assert rec["event"] == "dispatch_promoted"
+        assert rec["dispatch_id"] == "abc"
+        assert rec["terminal"] == "T1"
+
+    def test_cli_invalid_event_exits_1(self, isolated_data_dir):
+        env = self._env(isolated_data_dir)
+        result = subprocess.run(
+            [sys.executable, str(_MODULE_PATH), "append", "bad_event"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+
+    def test_cli_missing_args_exits_2(self, isolated_data_dir):
+        env = self._env(isolated_data_dir)
+        result = subprocess.run(
+            [sys.executable, str(_MODULE_PATH)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# 12. Concurrent writes via threads — no corruption
+# ---------------------------------------------------------------------------
+
+class TestConcurrentWrites:
+    def test_both_records_present(self, isolated_data_dir):
+        results = []
+
+        def write(evt):
+            r = append_event(evt, dispatch_id="concurrent-test")
+            results.append(r)
+
+        t1 = threading.Thread(target=write, args=("dispatch_created",))
+        t2 = threading.Thread(target=write, args=("dispatch_promoted",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert all(results), f"One or both writes failed: {results}"
+        events = read_events()
+        assert len(events) == 2
+        event_names = {e["event"] for e in events}
+        assert event_names == {"dispatch_created", "dispatch_promoted"}
+
+
+# ---------------------------------------------------------------------------
+# 13. Best-effort: OSError → False, never raises
+# ---------------------------------------------------------------------------
+
+class TestBestEffortOsError:
+    def test_oserror_returns_false_not_raises(self, isolated_data_dir):
+        with patch.object(dispatch_register.Path, "open", side_effect=OSError("disk full")):
+            result = append_event("dispatch_created", dispatch_id="oserror-test")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 14. VNX_DATA_DIR path resolution
+# ---------------------------------------------------------------------------
+
+class TestPathResolution:
+    def test_register_lands_in_vnx_data_dir(self, tmp_path, monkeypatch):
+        custom_data = tmp_path / "custom-data"
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        result = append_event("dispatch_created", dispatch_id="path-test")
+        assert result is True
+        expected = custom_data / "state" / "dispatch_register.ndjson"
+        assert expected.exists(), f"Register not found at {expected}"
+        rec = json.loads(expected.read_text().strip())
+        assert rec["dispatch_id"] == "path-test"

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -18,6 +18,8 @@ Covers:
   15. Fallback ignores VNX_DATA_DIR when VNX_DATA_DIR_EXPLICIT not set
   16. Fallback honors VNX_DATA_DIR when VNX_DATA_DIR_EXPLICIT=1
   17. read_events takes shared lock (blocks on concurrent exclusive writer)
+  18. Fallback honors VNX_STATE_DIR (BLOCKING fix Codex PR #277)
+  19. append_event requires at least one identifying field (ADVISORY fix Codex PR #277)
 """
 
 import json
@@ -115,14 +117,10 @@ class TestAppendEventAllKwargs:
         assert rec["extra"] == {"foo": "bar"}
 
     def test_omitted_optional_fields_absent(self, isolated_data_dir):
-        append_event("dispatch_created")
-        rec = json.loads(_reg_path(isolated_data_dir).read_text().strip())
-        assert "dispatch_id" not in rec
-        assert "pr_number" not in rec
-        assert "feature_id" not in rec
-        assert "terminal" not in rec
-        assert "gate" not in rec
-        assert "extra" not in rec
+        """Events with no identifying fields are now rejected (require ID field)."""
+        result = append_event("dispatch_created")
+        assert result is False
+        assert not _reg_path(isolated_data_dir).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -469,4 +467,68 @@ class TestReadEventsSharedLock:
         assert not errors, f"Writer thread raised: {errors}"
         assert len(reader_results) == 1, f"Expected 1 event, got {len(reader_results)}: {reader_results}"
         assert reader_results[0]["dispatch_id"] == "lock-test"
+
+
+# ---------------------------------------------------------------------------
+# 18. Fallback honors VNX_STATE_DIR (BLOCKING fix — Codex PR #277 round 3)
+# ---------------------------------------------------------------------------
+
+class TestFallbackStateDir:
+    def test_fallback_honors_vnx_state_dir(self, tmp_path, monkeypatch):
+        """When vnx_paths import fails, VNX_STATE_DIR is used as state dir (not ignored)."""
+        custom_state = tmp_path / "state-from-env"
+        monkeypatch.setenv("VNX_STATE_DIR", str(custom_state))
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        with patch.dict(sys.modules, {"vnx_paths": None}):
+            path = dispatch_register._register_path()
+        assert path == custom_state / "dispatch_register.ndjson", (
+            f"Fallback did not honor VNX_STATE_DIR: {path}"
+        )
+
+    def test_fallback_precedence_state_dir_over_data_dir_explicit(self, tmp_path, monkeypatch):
+        """VNX_STATE_DIR beats VNX_DATA_DIR+EXPLICIT=1 in the fallback chain."""
+        custom_state = tmp_path / "state-wins"
+        custom_data = tmp_path / "data-loses"
+        monkeypatch.setenv("VNX_STATE_DIR", str(custom_state))
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        with patch.dict(sys.modules, {"vnx_paths": None}):
+            path = dispatch_register._register_path()
+        assert path == custom_state / "dispatch_register.ndjson", (
+            f"VNX_STATE_DIR did not win over VNX_DATA_DIR+EXPLICIT: {path}"
+        )
+        assert str(custom_data) not in str(path)
+
+
+# ---------------------------------------------------------------------------
+# 19. append_event requires at least one identifying field
+#     (ADVISORY fix — Codex PR #277 round 3)
+# ---------------------------------------------------------------------------
+
+class TestAppendEventIdRequirement:
+    def test_append_event_requires_id_field(self, isolated_data_dir):
+        """append_event with no dispatch_id/pr_number/feature_id returns False."""
+        result = append_event("dispatch_created")
+        assert result is False
+
+    def test_no_file_written_when_no_id(self, isolated_data_dir):
+        """When the ID requirement fails, no register file is created."""
+        append_event("dispatch_created")
+        assert not _reg_path(isolated_data_dir).exists()
+
+    def test_append_event_accepts_dispatch_id_only(self, isolated_data_dir):
+        """dispatch_id alone satisfies the ID requirement."""
+        result = append_event("dispatch_created", dispatch_id="d-id-only")
+        assert result is True
+
+    def test_append_event_accepts_pr_number_only(self, isolated_data_dir):
+        """pr_number alone satisfies the ID requirement."""
+        result = append_event("pr_opened", pr_number=99)
+        assert result is True
+
+    def test_append_event_accepts_feature_id_only(self, isolated_data_dir):
+        """feature_id alone satisfies the ID requirement."""
+        result = append_event("dispatch_created", feature_id="F-55")
+        assert result is True
 

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -15,6 +15,9 @@ Covers:
   12. Concurrent writes via threads → both records present, no corruption
   13. Best-effort: OSError on open → append_event returns False (never raises)
   14. Path resolution: VNX_DATA_DIR env var is respected
+  15. Fallback ignores VNX_DATA_DIR when VNX_DATA_DIR_EXPLICIT not set
+  16. Fallback honors VNX_DATA_DIR when VNX_DATA_DIR_EXPLICIT=1
+  17. read_events takes shared lock (blocks on concurrent exclusive writer)
 """
 
 import json
@@ -370,9 +373,10 @@ class TestPathResolutionCanonical:
         assert not wrong.exists(), f"Register incorrectly landed at VNX_DATA_DIR/state: {wrong}"
 
     def test_register_path_fallback(self, tmp_path, monkeypatch):
-        """When vnx_paths import fails, falls back to VNX_DATA_DIR/state."""
+        """When vnx_paths import fails and VNX_DATA_DIR_EXPLICIT=1, falls back to VNX_DATA_DIR/state."""
         custom_data = tmp_path / "fallback-data"
         monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
         monkeypatch.delenv("VNX_STATE_DIR", raising=False)
         with patch.dict(sys.modules, {"vnx_paths": None}):
             result = append_event("dispatch_created", dispatch_id="fallback-test")
@@ -382,4 +386,87 @@ class TestPathResolutionCanonical:
         rec = json.loads(expected.read_text().strip())
         assert rec["dispatch_id"] == "fallback-test"
 
+
+# ---------------------------------------------------------------------------
+# 15–16. Fallback VNX_DATA_DIR_EXPLICIT contract
+# ---------------------------------------------------------------------------
+
+class TestFallbackExplicitFlag:
+    def test_fallback_ignores_vnx_data_dir_when_not_explicit(self, tmp_path, monkeypatch):
+        """Fallback uses repo-relative .vnx-data when VNX_DATA_DIR_EXPLICIT is absent."""
+        custom_data = tmp_path / "no-explicit"
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+        with patch.dict(sys.modules, {"vnx_paths": None}):
+            path = dispatch_register._register_path()
+        # Must NOT route to custom_data — EXPLICIT is not set
+        assert str(custom_data) not in str(path), (
+            f"Fallback incorrectly honored VNX_DATA_DIR without EXPLICIT=1: {path}"
+        )
+        assert path.name == "dispatch_register.ndjson"
+        assert "state" in path.parts
+
+    def test_fallback_honors_vnx_data_dir_when_explicit(self, tmp_path, monkeypatch):
+        """Fallback routes to VNX_DATA_DIR/state when VNX_DATA_DIR_EXPLICIT=1."""
+        custom_data = tmp_path / "with-explicit"
+        monkeypatch.setenv("VNX_DATA_DIR", str(custom_data))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+        with patch.dict(sys.modules, {"vnx_paths": None}):
+            path = dispatch_register._register_path()
+        assert path == custom_data / "state" / "dispatch_register.ndjson", (
+            f"Fallback did not honor VNX_DATA_DIR with EXPLICIT=1: {path}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 17. read_events shared-lock: reader blocks behind active exclusive writer
+# ---------------------------------------------------------------------------
+
+class TestReadEventsSharedLock:
+    def test_read_events_takes_shared_lock(self, isolated_data_dir):
+        """Reader blocks on LOCK_EX held by writer and observes the complete record."""
+        import fcntl as _fcntl
+        import time
+
+        reg = _reg_path(isolated_data_dir)
+        reg.parent.mkdir(parents=True, exist_ok=True)
+
+        writer_has_lock = threading.Event()
+        reader_results = []
+        errors = []
+
+        record = {
+            "timestamp": "2026-01-01T00:00:00.000000Z",
+            "event": "dispatch_created",
+            "dispatch_id": "lock-test",
+        }
+
+        def locked_writer():
+            try:
+                with reg.open("a", encoding="utf-8") as wh:
+                    _fcntl.flock(wh.fileno(), _fcntl.LOCK_EX)
+                    writer_has_lock.set()
+                    time.sleep(0.05)  # hold lock long enough for reader to block
+                    wh.write(json.dumps(record) + "\n")
+                    # lock released on context exit (file close)
+            except Exception as exc:
+                errors.append(exc)
+
+        def locked_reader():
+            writer_has_lock.wait()
+            # writer holds LOCK_EX; read_events() will block here until writer releases
+            reader_results.extend(read_events())
+
+        w = threading.Thread(target=locked_writer)
+        r = threading.Thread(target=locked_reader)
+        w.start()
+        r.start()
+        w.join(timeout=2)
+        r.join(timeout=2)
+
+        assert not errors, f"Writer thread raised: {errors}"
+        assert len(reader_results) == 1, f"Expected 1 event, got {len(reader_results)}: {reader_results}"
+        assert reader_results[0]["dispatch_id"] == "lock-test"
 


### PR DESCRIPTION
## Summary
- New scripts/lib/dispatch_register.py — append-only NDJSON writer for dispatch lifecycle events
- 10 valid event types: dispatch_{created,promoted,started,completed,failed}, gate_{requested,passed,failed}, pr_{opened,merged}
- Best-effort fire-and-forget API + CLI for bash hooks
- 18 test cases (covering all 14 dispatch spec scenarios), no integration changes

## Why split
PR #276 grew to +1500 LOC / 9 files / 5 codex rounds. Splitting per synthesis recommendation (operator decision 2026-04-28). PR-4b will add hooks; PR-4c will add build_t0_state integration.

## Test plan
- [x] All 18 unit tests pass (18/18)
- [x] No existing test regressions (pre-existing failures unchanged)
- [x] No literal `state/` substring in new code (CI legacy-path gate)

Refs synthesis 2026-04-28 §D Sprint 3.