### PR TITLE
feat(governance): dispatch_register hooks integration (Sprint 3 split 2/3)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1060,8 +1060,21 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
         pr_id = str(receipt.get("pr_id", ""))
         feature_id = str(receipt.get("feature_id", ""))
 
+        _SUCCESS_STATUSES = {"success", "completed", "complete", "ok"}
+        _FAILURE_STATUSES = {"failed", "failure", "error", "blocked"}
+
         if event_type in ("task_complete", "task_completed"):
-            register_event = "dispatch_failed" if status in ("failed", "failure", "error", "blocked") else "dispatch_completed"
+            if status in _FAILURE_STATUSES:
+                register_event = "dispatch_failed"
+            elif status in _SUCCESS_STATUSES or status == "":
+                register_event = "dispatch_completed"
+            else:
+                import logging as _logging
+                _logging.warning(
+                    "_emit_dispatch_register: task_complete with unknown status=%r; skipping register emit",
+                    status,
+                )
+                return
         elif event_type == "task_failed":
             register_event = "dispatch_failed"
         elif event_type == "task_timeout":

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1086,6 +1086,16 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
         elif event_type == "task_timeout":
             register_event = "dispatch_failed"
         elif event_type == "review_gate_request":
+            gate = str(receipt.get("gate", "")).lower()
+            if gate != "codex_gate":
+                # Symmetric with fixup #6: only codex_gate has full register lifecycle
+                # gemini_review and claude_github_optional defer until proper parsers exist
+                import logging as _logging
+                _logging.info(
+                    "_emit_dispatch_register: review_gate_request for gate=%r deferred (symmetric defer — only codex_gate has full register lifecycle)",
+                    gate,
+                )
+                return
             register_event = "gate_requested"
         else:
             return  # not register-worthy

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1048,7 +1048,8 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
     """Emit a dispatch_register event mirroring this receipt. Best-effort."""
     try:
         from dispatch_register import append_event
-        event_type = str(receipt.get("event_type", "")).lower()
+        # Mirror _validate_receipt() — accept event_type (canonical) or event (legacy)
+        event_type = str(receipt.get("event_type") or receipt.get("event") or "").lower()
         status = str(receipt.get("status", "")).lower()
         dispatch_id = str(receipt.get("dispatch_id", ""))
         pr_number = receipt.get("pr_number")

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -71,6 +71,8 @@ _warned_review_gate_no_dispatch_id = False
 IDEMPOTENCY_FIELDS = (
     "dispatch_id",
     "task_id",
+    "pr_number",  # gate requests differ per PR
+    "gate",       # gate requests differ per gate type (gemini/codex/claude_github)
     "terminal",
     "event_type",
     "event",
@@ -755,35 +757,6 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
     except Exception as exc:
         _emit("WARN", "oi_delta_enrichment_failed", error=str(exc))
 
-    # Compute CQS and persist to dispatch_metadata (best-effort)
-    try:
-        db_path = state_dir / "quality_intelligence.db"
-        if db_path.exists():
-            dispatch_id = enriched.get("dispatch_id") or enriched.get("metadata", {}).get("dispatch_id")
-            if dispatch_id:
-                cqs_result = calculate_cqs(enriched, None, db_path, dispatch_id)
-                enriched["cqs"] = cqs_result
-                import sqlite3
-                conn = sqlite3.connect(str(db_path))
-                conn.execute(
-                    """UPDATE dispatch_metadata
-                       SET cqs=?, normalized_status=?, cqs_components=?,
-                           open_items_created=?, open_items_resolved=?
-                       WHERE dispatch_id=?""",
-                    (
-                        cqs_result["cqs"],
-                        cqs_result["normalized_status"],
-                        json.dumps(cqs_result["components"]),
-                        enriched.get("open_items_created", 0),
-                        enriched.get("open_items_resolved", 0),
-                        dispatch_id,
-                    ),
-                )
-                conn.commit()
-                conn.close()
-    except Exception as exc:
-        _emit("WARN", "cqs_calculation_failed", error=str(exc))
-
     return enriched
 
 
@@ -1008,6 +981,39 @@ def append_receipt_payload(
     if result is not None and result.status == "appended" and not skip_enrichment:
         created_count = _register_quality_open_items(receipt)
         receipt["open_items_created"] = created_count
+
+        # Compute CQS AFTER open items registration so open_items_created reflects actual count.
+        # Moved here from _enrich_completion_receipt to fix ordering bug: the enrich phase ran
+        # before _register_quality_open_items, so open_items_created was always 0 in CQS.
+        try:
+            _cqs_paths = ensure_env()
+            _cqs_state_dir = Path(_cqs_paths.get("VNX_STATE_DIR", ".")).resolve()
+            _cqs_db = _cqs_state_dir / "quality_intelligence.db"
+            if _cqs_db.exists():
+                _cqs_dispatch_id = receipt.get("dispatch_id") or receipt.get("metadata", {}).get("dispatch_id")
+                if _cqs_dispatch_id:
+                    import sqlite3 as _sqlite3_cqs
+                    cqs_result = calculate_cqs(receipt, None, _cqs_db, _cqs_dispatch_id)
+                    receipt["cqs"] = cqs_result
+                    _cqs_conn = _sqlite3_cqs.connect(str(_cqs_db))
+                    _cqs_conn.execute(
+                        """UPDATE dispatch_metadata
+                           SET cqs=?, normalized_status=?, cqs_components=?,
+                               open_items_created=?, open_items_resolved=?
+                           WHERE dispatch_id=?""",
+                        (
+                            cqs_result["cqs"],
+                            cqs_result["normalized_status"],
+                            json.dumps(cqs_result["components"]),
+                            receipt.get("open_items_created", 0),
+                            receipt.get("open_items_resolved", 0),
+                            _cqs_dispatch_id,
+                        ),
+                    )
+                    _cqs_conn.commit()
+                    _cqs_conn.close()
+        except Exception as _cqs_exc:
+            _emit("WARN", "cqs_calculation_failed", error=str(_cqs_exc))
 
         _update_confidence_from_receipt(receipt)
 

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -898,6 +898,25 @@ def _register_quality_open_items(receipt: Dict[str, Any]) -> int:
         return 0
 
 
+def _count_quality_violations(receipt: dict) -> int:
+    """Pre-count items in t0_recommendation.open_items without registering.
+
+    Mirrors _register_quality_open_items structure. Actual dedup-aware count
+    may differ but pre-count is correct for fresh receipts (no prior history).
+    """
+    try:
+        advisory = receipt.get("quality_advisory")
+        if not isinstance(advisory, dict):
+            return 0
+        rec = advisory.get("t0_recommendation")
+        if not isinstance(rec, dict):
+            return 0
+        open_items = rec.get("open_items") or []
+        return len(open_items) if isinstance(open_items, list) else 0
+    except Exception:
+        return 0
+
+
 def append_receipt_payload(
     receipt: Dict[str, Any],
     *,
@@ -940,6 +959,32 @@ def append_receipt_payload(
 
     min_epoch = time.time() - max(1, int(cache_window_seconds))
 
+    # Pre-compute open_items_created and CQS BEFORE ndjson write (BLOCKING 1 fix):
+    # persisted receipt carries these fields from the start, not added afterward.
+    _pre_cqs_result: Optional[Any] = None
+    if not skip_enrichment:
+        receipt["open_items_created"] = _count_quality_violations(receipt)
+        try:
+            _cqs_paths_pre = ensure_env()
+            _cqs_db_pre = Path(_cqs_paths_pre.get("VNX_STATE_DIR", ".")).resolve() / "quality_intelligence.db"
+            if _cqs_db_pre.exists():
+                _cqs_dispatch_id_pre = receipt.get("dispatch_id") or receipt.get("metadata", {}).get("dispatch_id")
+                if _cqs_dispatch_id_pre:
+                    import sqlite3 as _sqlite3_pre
+                    _pre_cqs_result = calculate_cqs(receipt, None, _cqs_db_pre, _cqs_dispatch_id_pre)
+                    receipt["cqs"] = _pre_cqs_result
+        except Exception as _cqs_pre_exc:
+            _emit("WARN", "cqs_precalc_failed", error=str(_cqs_pre_exc))
+
+        # Emit to register BEFORE ndjson commit (BLOCKING 2 fix):
+        # reduces window where ndjson committed but register missing.
+        _reg_emitted = _emit_dispatch_register(receipt)
+        if not _reg_emitted:
+            _emit("ERROR", "register_emit_failed",
+                  dispatch_id=str(receipt.get("dispatch_id", "")),
+                  event_type=str(receipt.get("event_type", "")))
+            # Continue — receipt write still proceeds (don't lose data)
+
     result: Optional[AppendResult] = None
 
     try:
@@ -979,45 +1024,41 @@ def append_receipt_payload(
 
     # Best-effort post-append hooks (skipped for skip_enrichment=True lightweight events)
     if result is not None and result.status == "appended" and not skip_enrichment:
-        created_count = _register_quality_open_items(receipt)
-        receipt["open_items_created"] = created_count
+        _register_quality_open_items(receipt)
+        # receipt["open_items_created"] already set from _count_quality_violations before ndjson
+        # write; actual dedup-aware count may differ but pre-count is canonical in persisted receipt.
 
-        # Compute CQS AFTER open items registration so open_items_created reflects actual count.
-        # Moved here from _enrich_completion_receipt to fix ordering bug: the enrich phase ran
-        # before _register_quality_open_items, so open_items_created was always 0 in CQS.
-        try:
-            _cqs_paths = ensure_env()
-            _cqs_state_dir = Path(_cqs_paths.get("VNX_STATE_DIR", ".")).resolve()
-            _cqs_db = _cqs_state_dir / "quality_intelligence.db"
-            if _cqs_db.exists():
+        # Update CQS in DB now that receipt is confirmed appended.
+        # _pre_cqs_result was computed before the ndjson write (BLOCKING 1 fix).
+        if _pre_cqs_result is not None:
+            try:
                 _cqs_dispatch_id = receipt.get("dispatch_id") or receipt.get("metadata", {}).get("dispatch_id")
                 if _cqs_dispatch_id:
                     import sqlite3 as _sqlite3_cqs
-                    cqs_result = calculate_cqs(receipt, None, _cqs_db, _cqs_dispatch_id)
-                    receipt["cqs"] = cqs_result
-                    _cqs_conn = _sqlite3_cqs.connect(str(_cqs_db))
-                    _cqs_conn.execute(
-                        """UPDATE dispatch_metadata
-                           SET cqs=?, normalized_status=?, cqs_components=?,
-                               open_items_created=?, open_items_resolved=?
-                           WHERE dispatch_id=?""",
-                        (
-                            cqs_result["cqs"],
-                            cqs_result["normalized_status"],
-                            json.dumps(cqs_result["components"]),
-                            receipt.get("open_items_created", 0),
-                            receipt.get("open_items_resolved", 0),
-                            _cqs_dispatch_id,
-                        ),
-                    )
-                    _cqs_conn.commit()
-                    _cqs_conn.close()
-        except Exception as _cqs_exc:
-            _emit("WARN", "cqs_calculation_failed", error=str(_cqs_exc))
+                    _cqs_paths = ensure_env()
+                    _cqs_db = Path(_cqs_paths.get("VNX_STATE_DIR", ".")).resolve() / "quality_intelligence.db"
+                    if _cqs_db.exists():
+                        _cqs_conn = _sqlite3_cqs.connect(str(_cqs_db))
+                        _cqs_conn.execute(
+                            """UPDATE dispatch_metadata
+                               SET cqs=?, normalized_status=?, cqs_components=?,
+                                   open_items_created=?, open_items_resolved=?
+                               WHERE dispatch_id=?""",
+                            (
+                                _pre_cqs_result["cqs"],
+                                _pre_cqs_result["normalized_status"],
+                                json.dumps(_pre_cqs_result["components"]),
+                                receipt.get("open_items_created", 0),
+                                receipt.get("open_items_resolved", 0),
+                                _cqs_dispatch_id,
+                            ),
+                        )
+                        _cqs_conn.commit()
+                        _cqs_conn.close()
+            except Exception as _cqs_exc:
+                _emit("WARN", "cqs_db_update_failed", error=str(_cqs_exc))
 
         _update_confidence_from_receipt(receipt)
-
-        _emit_dispatch_register(receipt)  # must precede rebuild so rebuild sees this event
         _maybe_trigger_state_rebuild(receipt)
 
     return result
@@ -1050,8 +1091,12 @@ def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:
         _emit("WARN", "confidence_update_failed", error=str(exc))
 
 
-def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
-    """Emit a dispatch_register event mirroring this receipt. Best-effort."""
+def _emit_dispatch_register(receipt: Dict[str, Any]) -> bool:
+    """Emit a dispatch_register event mirroring this receipt. Best-effort.
+
+    Returns True if emitted successfully or if the event was not register-worthy.
+    Returns False only on failure (exception during append_event).
+    """
     try:
         from dispatch_register import append_event
         # Mirror _validate_receipt() — accept event_type (canonical) or event (legacy)
@@ -1080,11 +1125,13 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
                     "_emit_dispatch_register: task_complete with unknown status=%r; skipping register emit",
                     status,
                 )
-                return
+                return True  # skipped (malformed), not a failure
         elif event_type == "task_failed":
             register_event = "dispatch_failed"
         elif event_type == "task_timeout":
             register_event = "dispatch_failed"
+        elif event_type in ("task_started", "task_start", "dispatch_start"):
+            register_event = "dispatch_started"
         elif event_type == "review_gate_request":
             gate = str(receipt.get("gate", "")).lower()
             if gate != "codex_gate":
@@ -1095,10 +1142,10 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
                     "_emit_dispatch_register: review_gate_request for gate=%r deferred (symmetric defer — only codex_gate has full register lifecycle)",
                     gate,
                 )
-                return
+                return True  # deferred, not a failure
             register_event = "gate_requested"
         else:
-            return  # not register-worthy
+            return True  # not register-worthy
 
         if pr_number is not None:
             try:
@@ -1114,7 +1161,7 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
                 if not feature_id:
                     feature_id = pr_id
 
-        append_event(
+        return append_event(
             register_event,
             dispatch_id=dispatch_id,
             pr_number=pr_number,
@@ -1123,7 +1170,7 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
             gate=gate,
         )
     except Exception:
-        pass  # best-effort, never break receipt append
+        return False  # best-effort, never break receipt append
 
 
 def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1059,7 +1059,7 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
         feature_id = str(receipt.get("feature_id", ""))
 
         if event_type in ("task_complete", "task_completed"):
-            register_event = "dispatch_failed" if status in ("failed", "error", "blocked") else "dispatch_completed"
+            register_event = "dispatch_failed" if status in ("failed", "failure", "error", "blocked") else "dispatch_completed"
         elif event_type == "task_failed":
             register_event = "dispatch_failed"
         elif event_type == "task_timeout":
@@ -1099,33 +1099,8 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
             )
         ):
             return
-
-        state_dir = resolve_state_dir(__file__)
-        throttle_file = state_dir / ".last_state_rebuild_ts"
-
-        try:
-            if throttle_file.exists():
-                last_ts = float(throttle_file.read_text(encoding="utf-8").strip())
-                if time.time() - last_ts < _REBUILD_THROTTLE_SECONDS:
-                    return
-        except Exception:
-            pass
-
-        subprocess.Popen(
-            ["python3", "scripts/build_t0_state.py"],
-            cwd=str(_REPO_ROOT),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-        # Write throttle marker only after Popen succeeds; a failed launch
-        # should not suppress the next rebuild attempt for 30s.
-        try:
-            tmp = throttle_file.with_name(throttle_file.name + ".tmp")
-            tmp.write_text(str(int(time.time())), encoding="utf-8")
-            os.replace(str(tmp), str(throttle_file))
-        except Exception:
-            pass
+        from state_rebuild_trigger import maybe_trigger_state_rebuild
+        maybe_trigger_state_rebuild()
     except Exception:
         pass
 

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1011,6 +1011,7 @@ def append_receipt_payload(
 
         _update_confidence_from_receipt(receipt)
 
+        _emit_dispatch_register(receipt)  # must precede rebuild so rebuild sees this event
         _maybe_trigger_state_rebuild(receipt)
 
     return result
@@ -1043,11 +1044,60 @@ def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:
         _emit("WARN", "confidence_update_failed", error=str(exc))
 
 
+def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
+    """Emit a dispatch_register event mirroring this receipt. Best-effort."""
+    try:
+        from dispatch_register import append_event
+        event_type = str(receipt.get("event_type", "")).lower()
+        status = str(receipt.get("status", "")).lower()
+        dispatch_id = str(receipt.get("dispatch_id", ""))
+        pr_number = receipt.get("pr_number")
+        if pr_number is None:
+            pr_number = (receipt.get("metadata") or {}).get("pr_number")
+        terminal = str(receipt.get("terminal", ""))
+        gate = str(receipt.get("gate", ""))
+        feature_id = str(receipt.get("feature_id", ""))
+
+        if event_type in ("task_complete", "task_completed"):
+            register_event = "dispatch_failed" if status in ("failed", "error", "blocked") else "dispatch_completed"
+        elif event_type == "task_failed":
+            register_event = "dispatch_failed"
+        elif event_type == "task_timeout":
+            register_event = "dispatch_failed"
+        elif event_type == "review_gate_request":
+            register_event = "gate_requested"
+        else:
+            return  # not register-worthy
+
+        if pr_number is not None:
+            try:
+                pr_number = int(pr_number)
+            except (ValueError, TypeError):
+                pr_number = None
+
+        append_event(
+            register_event,
+            dispatch_id=dispatch_id,
+            pr_number=pr_number,
+            feature_id=feature_id,
+            terminal=terminal,
+            gate=gate,
+        )
+    except Exception:
+        pass  # best-effort, never break receipt append
+
+
 def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
     """Fire non-blocking rebuild of t0_state.json after qualifying events. Best-effort."""
     try:
         event_type = str(receipt.get("event_type") or receipt.get("event") or "")
-        if not (_is_completion_event(receipt) or event_type in ("dispatch_promoted", "dispatch_started")):
+        if not (
+            _is_completion_event(receipt)
+            or event_type in (
+                "dispatch_promoted", "dispatch_started",
+                "review_gate_request", "gate_passed", "gate_failed",
+            )
+        ):
             return
 
         state_dir = resolve_state_dir(__file__)
@@ -1072,7 +1122,7 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
         # should not suppress the next rebuild attempt for 30s.
         try:
             tmp = throttle_file.with_name(throttle_file.name + ".tmp")
-            tmp.write_text(str(time.time()), encoding="utf-8")
+            tmp.write_text(str(int(time.time())), encoding="utf-8")
             os.replace(str(tmp), str(throttle_file))
         except Exception:
             pass

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1056,6 +1056,7 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
             pr_number = (receipt.get("metadata") or {}).get("pr_number")
         terminal = str(receipt.get("terminal", ""))
         gate = str(receipt.get("gate", ""))
+        pr_id = str(receipt.get("pr_id", ""))
         feature_id = str(receipt.get("feature_id", ""))
 
         if event_type in ("task_complete", "task_completed"):
@@ -1074,6 +1075,14 @@ def _emit_dispatch_register(receipt: Dict[str, Any]) -> None:
                 pr_number = int(pr_number)
             except (ValueError, TypeError):
                 pr_number = None
+
+        if pr_number is None and pr_id:
+            try:
+                pr_number = int(pr_id)
+            except (ValueError, TypeError):
+                # Non-numeric pr_id (contract path "PR-6" style) — use as feature_id fallback
+                if not feature_id:
+                    feature_id = pr_id
 
         append_event(
             register_event,

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -524,15 +524,32 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 # Dispatch register events (minimal reader — full aggregation deferred to PR-4c)
 # ---------------------------------------------------------------------------
 
-def _build_register_events(limit: int = 50) -> List[Dict[str, Any]]:
+def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> List[Dict[str, Any]]:
     """Read last N events from dispatch_register.ndjson — minimal exposure for PR-4b.
 
-    Full aggregation into feature_state is deferred to PR-4c.
+    If state_dir is provided, read from that location directly (test/headless override).
+    Otherwise use the canonical dispatch_register.read_events() resolution.
     """
     try:
-        from dispatch_register import read_events
-        events = read_events()
-        return events[-limit:] if events else []
+        if state_dir is not None:
+            register_path = Path(state_dir) / "dispatch_register.ndjson"
+            if not register_path.exists():
+                return []
+            events = []
+            content = register_path.read_text(encoding="utf-8", errors="replace")
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            return events[-limit:] if events else []
+        else:
+            from dispatch_register import read_events
+            events = read_events()
+            return events[-limit:] if events else []
     except Exception:
         return []
 
@@ -562,7 +579,7 @@ def build_t0_state(
     active_work = _build_active_work(dispatch_dir)
     recent_receipts = _build_recent_receipts(state_dir)
     git_context = _build_git_context()
-    dispatch_register_events = _build_register_events(limit=50)
+    dispatch_register_events = _build_register_events(state_dir=state_dir, limit=50)
     elapsed = time.monotonic() - start
     system_health = _build_system_health(state_dir, db_ok)
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -521,6 +521,23 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 
 
 # ---------------------------------------------------------------------------
+# Dispatch register events (minimal reader — full aggregation deferred to PR-4c)
+# ---------------------------------------------------------------------------
+
+def _build_register_events(limit: int = 50) -> List[Dict[str, Any]]:
+    """Read last N events from dispatch_register.ndjson — minimal exposure for PR-4b.
+
+    Full aggregation into feature_state is deferred to PR-4c.
+    """
+    try:
+        from dispatch_register import read_events
+        events = read_events()
+        return events[-limit:] if events else []
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Main builder
 # ---------------------------------------------------------------------------
 
@@ -545,6 +562,7 @@ def build_t0_state(
     active_work = _build_active_work(dispatch_dir)
     recent_receipts = _build_recent_receipts(state_dir)
     git_context = _build_git_context()
+    dispatch_register_events = _build_register_events(limit=50)
     elapsed = time.monotonic() - start
     system_health = _build_system_health(state_dir, db_ok)
 
@@ -563,6 +581,7 @@ def build_t0_state(
         "active_work": active_work,
         "recent_receipts": recent_receipts,
         "git_context": git_context,
+        "dispatch_register_events": dispatch_register_events,
         "system_health": system_health,
         "_build_seconds": round(elapsed, 2),
     }

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -525,31 +525,11 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 # ---------------------------------------------------------------------------
 
 def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> List[Dict[str, Any]]:
-    """Read last N events from dispatch_register.ndjson — minimal exposure for PR-4b.
-
-    If state_dir is provided, read from that location directly (test/headless override).
-    Otherwise use the canonical dispatch_register.read_events() resolution.
-    """
+    """Read last N events with shared-lock contract preserved."""
     try:
-        if state_dir is not None:
-            register_path = Path(state_dir) / "dispatch_register.ndjson"
-            if not register_path.exists():
-                return []
-            events = []
-            content = register_path.read_text(encoding="utf-8", errors="replace")
-            for line in content.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    events.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-            return events[-limit:] if events else []
-        else:
-            from dispatch_register import read_events
-            events = read_events()
-            return events[-limit:] if events else []
+        from dispatch_register import read_events
+        events = read_events(state_dir=state_dir)
+        return events[-limit:] if events else []
     except Exception:
         return []
 

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -461,17 +461,13 @@ finalize_dispatch_delivery() {
         terminal="${terminal_id:-}" \
         >/dev/null 2>&1 || true
 
-    # Throttled non-blocking rebuild of t0_state.json (integer epoch only)
-    local _fdd_throttle_file _fdd_now _fdd_last
-    _fdd_throttle_file="${STATE_DIR}/.last_state_rebuild_ts"
-    _fdd_now=$(date +%s)
-    _fdd_last=$(cat "$_fdd_throttle_file" 2>/dev/null || echo 0)
-    _fdd_last=${_fdd_last%.*}
-    [ -z "$_fdd_last" ] && _fdd_last=0
-    if [ "$((_fdd_now - _fdd_last))" -ge 30 ]; then
-        nohup python3 "$VNX_DIR/scripts/build_t0_state.py" >/dev/null 2>&1 &
-        echo "$_fdd_now" > "${_fdd_throttle_file}.tmp" && mv "${_fdd_throttle_file}.tmp" "$_fdd_throttle_file" || true
-    fi
+    # Throttled non-blocking rebuild via Python helper (single source of truth for throttle+Popen)
+    python3 -c "
+import sys
+sys.path.insert(0, '$VNX_DIR/scripts/lib')
+from state_rebuild_trigger import maybe_trigger_state_rebuild
+maybe_trigger_state_rebuild()
+" >/dev/null 2>&1 || true
 
     return 0
 }

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -454,5 +454,24 @@ finalize_dispatch_delivery() {
     local filename; filename=$(basename "$dispatch_file")
     mv "$dispatch_file" "$ACTIVE_DIR/$filename"
     log "V8 DISPATCH: Activated - moved to $ACTIVE_DIR/$filename"
+
+    # Register dispatch_promoted event (best-effort)
+    python3 "$VNX_DIR/scripts/lib/dispatch_register.py" append dispatch_promoted \
+        dispatch_id="$dispatch_id" \
+        terminal="${terminal_id:-}" \
+        >/dev/null 2>&1 || true
+
+    # Throttled non-blocking rebuild of t0_state.json (integer epoch only)
+    local _fdd_throttle_file _fdd_now _fdd_last
+    _fdd_throttle_file="${STATE_DIR}/.last_state_rebuild_ts"
+    _fdd_now=$(date +%s)
+    _fdd_last=$(cat "$_fdd_throttle_file" 2>/dev/null || echo 0)
+    _fdd_last=${_fdd_last%.*}
+    [ -z "$_fdd_last" ] && _fdd_last=0
+    if [ "$((_fdd_now - _fdd_last))" -ge 30 ]; then
+        nohup python3 "$VNX_DIR/scripts/build_t0_state.py" >/dev/null 2>&1 &
+        echo "$_fdd_now" > "${_fdd_throttle_file}.tmp" && mv "${_fdd_throttle_file}.tmp" "$_fdd_throttle_file" || true
+    fi
+
     return 0
 }

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -103,9 +103,12 @@ def append_event(
         return False
 
 
-def read_events(*, since_iso: Optional[str] = None) -> list[dict]:
-    """Read all events; takes shared lock to avoid partial-write reads."""
-    path = _register_path()
+def read_events(*, since_iso: Optional[str] = None, state_dir: Optional[Path] = None) -> list[dict]:
+    """Read all events; honors optional state_dir override; takes shared lock."""
+    if state_dir is not None:
+        path = Path(state_dir) / "dispatch_register.ndjson"
+    else:
+        path = _register_path()
     if not path.exists():
         return []
     events = []

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -19,16 +19,6 @@ import gate_recorder
 from codex_parser import parse_codex_findings
 
 
-def _parse_gemini_findings(stdout: str) -> List[Dict[str, Any]]:
-    """Minimal gemini findings parser — scans for BLOCKING/blocker severity markers."""
-    findings = []
-    for line in stdout.splitlines():
-        line_lower = line.lower()
-        if "blocking" in line_lower or "blocker" in line_lower:
-            findings.append({"severity": "blocking", "message": line.strip()})
-    return findings
-
-
 # ---------------------------------------------------------------------------
 # Contract hash
 # ---------------------------------------------------------------------------
@@ -210,8 +200,6 @@ def materialize_artifacts(
         parsed = parse_codex_findings(stdout)
         _parsed_findings = parsed["findings"]
         residual_risk = parsed.get("residual_risk", "") or ""
-    elif gate == "gemini_review":
-        _parsed_findings = _parse_gemini_findings(stdout)
 
     _skip_register_emit = False
     if _parsed_findings is None:

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -232,13 +232,31 @@ def materialize_artifacts(
     gate_recorder.persist_request(requests_dir, gate, request_payload, pr_number=pr_number, pr_id=pr_id)
 
     try:
+        import logging as _logging
         from dispatch_register import append_event as _append_reg
-        _append_reg(
-            "gate_passed" if not blocking else "gate_failed",
+        from state_rebuild_trigger import maybe_trigger_state_rebuild as _trigger_rebuild
+
+        _pr_num = pr_number
+        if _pr_num is None and pr_id:
+            try:
+                _pr_num = int(pr_id)
+            except (ValueError, TypeError):
+                pass
+
+        _gate_event = "gate_passed" if not blocking else "gate_failed"
+        _reg_result = _append_reg(
+            _gate_event,
             dispatch_id=real_dispatch_id or "",
-            pr_number=pr_number,
+            pr_number=_pr_num,
             gate=gate,
         )
+        if not _reg_result:
+            _logging.warning(
+                "dispatch_register: gate event %s dropped — no identifying field "
+                "(dispatch_id=%r, pr_number=%r, pr_id=%r)",
+                _gate_event, real_dispatch_id, _pr_num, pr_id,
+            )
+        _trigger_rebuild()
     except Exception:
         pass
 

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -231,6 +231,17 @@ def materialize_artifacts(
     request_payload["completed_at"] = now
     gate_recorder.persist_request(requests_dir, gate, request_payload, pr_number=pr_number, pr_id=pr_id)
 
+    try:
+        from dispatch_register import append_event as _append_reg
+        _append_reg(
+            "gate_passed" if not blocking else "gate_failed",
+            dispatch_id=real_dispatch_id or "",
+            pr_number=pr_number,
+            gate=gate,
+        )
+    except Exception:
+        pass
+
     # Write JSON sidecar to report_pipeline/ for intelligence DB ingestion (OI-1066)
     try:
         sidecar = {

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -19,6 +19,16 @@ import gate_recorder
 from codex_parser import parse_codex_findings
 
 
+def _parse_gemini_findings(stdout: str) -> List[Dict[str, Any]]:
+    """Minimal gemini findings parser — scans for BLOCKING/blocker severity markers."""
+    findings = []
+    for line in stdout.splitlines():
+        line_lower = line.lower()
+        if "blocking" in line_lower or "blocker" in line_lower:
+            findings.append({"severity": "blocking", "message": line.strip()})
+    return findings
+
+
 # ---------------------------------------------------------------------------
 # Contract hash
 # ---------------------------------------------------------------------------
@@ -194,12 +204,26 @@ def materialize_artifacts(
 
     contract_hash = _compute_contract_hash(request_payload, gate)
     now = utc_now_iso()
-    findings: List[Dict[str, Any]] = []
+    _parsed_findings: Optional[List[Dict[str, Any]]] = None
     residual_risk = ""
     if gate == "codex_gate":
         parsed = parse_codex_findings(stdout)
-        findings = parsed["findings"]
+        _parsed_findings = parsed["findings"]
         residual_risk = parsed.get("residual_risk", "") or ""
+    elif gate == "gemini_review":
+        _parsed_findings = _parse_gemini_findings(stdout)
+
+    _skip_register_emit = False
+    if _parsed_findings is None:
+        logger.warning(
+            "materialize_artifacts: findings parser not implemented for gate=%s; skipping register emit",
+            gate,
+        )
+        findings: List[Dict[str, Any]] = []
+        _skip_register_emit = True
+    else:
+        findings = _parsed_findings
+
     blocking, advisory = _classify_findings(findings)
 
     real_dispatch_id = request_payload.get("dispatch_id", "")
@@ -245,20 +269,21 @@ def materialize_artifacts(
                 # Non-numeric pr_id (contract path "PR-6" style) — use as feature_id fallback
                 _feature_id = str(pr_id)
 
-        _gate_event = "gate_passed" if not blocking else "gate_failed"
-        _reg_result = _append_reg(
-            _gate_event,
-            dispatch_id=real_dispatch_id or "",
-            pr_number=_pr_num,
-            feature_id=_feature_id,
-            gate=gate,
-        )
-        if not _reg_result:
-            _logging.warning(
-                "dispatch_register: gate event %s dropped — no identifying field "
-                "(dispatch_id=%r, pr_number=%r, pr_id=%r)",
-                _gate_event, real_dispatch_id, _pr_num, pr_id,
+        if not _skip_register_emit:
+            _gate_event = "gate_passed" if not blocking else "gate_failed"
+            _reg_result = _append_reg(
+                _gate_event,
+                dispatch_id=real_dispatch_id or "",
+                pr_number=_pr_num,
+                feature_id=_feature_id,
+                gate=gate,
             )
+            if not _reg_result:
+                _logging.warning(
+                    "dispatch_register: gate event %s dropped — no identifying field "
+                    "(dispatch_id=%r, pr_number=%r, pr_id=%r)",
+                    _gate_event, real_dispatch_id, _pr_num, pr_id,
+                )
         _trigger_rebuild()
     except Exception:
         pass

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -237,17 +237,20 @@ def materialize_artifacts(
         from state_rebuild_trigger import maybe_trigger_state_rebuild as _trigger_rebuild
 
         _pr_num = pr_number
+        _feature_id = ""
         if _pr_num is None and pr_id:
             try:
                 _pr_num = int(pr_id)
             except (ValueError, TypeError):
-                pass
+                # Non-numeric pr_id (contract path "PR-6" style) — use as feature_id fallback
+                _feature_id = str(pr_id)
 
         _gate_event = "gate_passed" if not blocking else "gate_failed"
         _reg_result = _append_reg(
             _gate_event,
             dispatch_id=real_dispatch_id or "",
             pr_number=_pr_num,
+            feature_id=_feature_id,
             gate=gate,
         )
         if not _reg_result:

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -192,13 +192,31 @@ def record_failure(
     if rf:
         rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
     try:
+        import logging as _logging
         from dispatch_register import append_event as _append_reg
-        _append_reg(
+        from state_rebuild_trigger import maybe_trigger_state_rebuild as _trigger_rebuild
+
+        _pr_num = pr_number
+        if _pr_num is None and pr_id:
+            try:
+                _pr_num = int(pr_id)
+            except (ValueError, TypeError):
+                pass
+
+        _dispatch_id = request_payload.get("dispatch_id", "") or ""
+        _reg_result = _append_reg(
             "gate_failed",
-            dispatch_id=request_payload.get("dispatch_id", "") or "",
-            pr_number=pr_number,
+            dispatch_id=_dispatch_id,
+            pr_number=_pr_num,
             gate=gate,
         )
+        if not _reg_result:
+            _logging.warning(
+                "dispatch_register: gate event gate_failed dropped — no identifying field "
+                "(dispatch_id=%r, pr_number=%r, pr_id=%r)",
+                _dispatch_id, _pr_num, pr_id,
+            )
+        _trigger_rebuild()
     except Exception:
         pass
     return failure_payload

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -191,6 +191,16 @@ def record_failure(
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     if rf:
         rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
+
+    if gate != "codex_gate":
+        import logging as _logging
+        _logging.info(
+            "gate_recorder.record_failure: register emit deferred for gate=%s "
+            "(only codex_gate has structured findings parser)",
+            gate,
+        )
+        return failure_payload
+
     try:
         import logging as _logging
         from dispatch_register import append_event as _append_reg

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -197,17 +197,20 @@ def record_failure(
         from state_rebuild_trigger import maybe_trigger_state_rebuild as _trigger_rebuild
 
         _pr_num = pr_number
+        _feature_id = ""
         if _pr_num is None and pr_id:
             try:
                 _pr_num = int(pr_id)
             except (ValueError, TypeError):
-                pass
+                # Non-numeric pr_id (contract path "PR-6" style) — use as feature_id fallback
+                _feature_id = str(pr_id)
 
         _dispatch_id = request_payload.get("dispatch_id", "") or ""
         _reg_result = _append_reg(
             "gate_failed",
             dispatch_id=_dispatch_id,
             pr_number=_pr_num,
+            feature_id=_feature_id,
             gate=gate,
         )
         if not _reg_result:

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -191,6 +191,16 @@ def record_failure(
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     if rf:
         rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
+    try:
+        from dispatch_register import append_event as _append_reg
+        _append_reg(
+            "gate_failed",
+            dispatch_id=request_payload.get("dispatch_id", "") or "",
+            pr_number=pr_number,
+            gate=gate,
+        )
+    except Exception:
+        pass
     return failure_payload
 
 

--- a/scripts/lib/state_rebuild_trigger.py
+++ b/scripts/lib/state_rebuild_trigger.py
@@ -1,0 +1,62 @@
+"""Shared throttle-based rebuild trigger for build_t0_state.py.
+
+Called by append_receipt._maybe_trigger_state_rebuild and gate hook emitters
+so the throttle contract is consistent across all producers.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _LIB_DIR.parent.parent
+_REBUILD_THROTTLE_SECONDS = 30
+
+
+def _resolve_state_dir() -> Path:
+    """Resolve state dir using canonical vnx_paths; fall back to env vars."""
+    try:
+        if str(_LIB_DIR) not in sys.path:
+            sys.path.insert(0, str(_LIB_DIR))
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_STATE_DIR"])
+    except Exception:
+        state_dir_env = os.environ.get("VNX_STATE_DIR")
+        if state_dir_env:
+            return Path(state_dir_env)
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+            return Path(os.environ["VNX_DATA_DIR"]) / "state"
+        return _REPO_ROOT / ".vnx-data" / "state"
+
+
+def maybe_trigger_state_rebuild() -> bool:
+    """Fire build_t0_state.py if throttle expired. Best-effort, non-blocking.
+
+    Returns True if Popen was called, False if throttled or on any error.
+    """
+    try:
+        state_dir = _resolve_state_dir()
+        throttle_file = state_dir / ".last_state_rebuild_ts"
+        now = int(time.time())
+        try:
+            last = int(throttle_file.read_text(encoding="utf-8").strip()) if throttle_file.exists() else 0
+        except (ValueError, OSError):
+            last = 0
+        if now - last < _REBUILD_THROTTLE_SECONDS:
+            return False
+        subprocess.Popen(
+            ["python3", str(_REPO_ROOT / "scripts" / "build_t0_state.py")],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        # Atomic throttle update — only after Popen succeeds
+        tmp = throttle_file.with_suffix(".tmp")
+        tmp.write_text(str(now), encoding="utf-8")
+        tmp.replace(throttle_file)
+        return True
+    except Exception:
+        return False

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(LIB_DIR))
 
 import append_receipt as ar
 import build_t0_state as bts
+import state_rebuild_trigger
 
 
 def _minimal_receipt(event_type: str = "task_complete", dispatch_id: str = "DISP-001") -> dict:
@@ -43,20 +44,22 @@ def _minimal_receipt(event_type: str = "task_complete", dispatch_id: str = "DISP
 def test_completion_event_triggers_rebuild(tmp_path: Path) -> None:
     receipt = _minimal_receipt("task_complete")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen") as mock_popen:
         ar._maybe_trigger_state_rebuild(receipt)
 
     mock_popen.assert_called_once()
     call_kwargs = mock_popen.call_args
-    assert call_kwargs[0][0] == ["python3", "scripts/build_t0_state.py"]
+    cmd = call_kwargs[0][0]
+    assert cmd[0] == "python3"
+    assert "build_t0_state.py" in cmd[-1]
     assert call_kwargs[1].get("start_new_session") is True
 
 
 def test_non_completion_event_does_not_trigger_rebuild(tmp_path: Path) -> None:
     receipt = _minimal_receipt("task_started")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen") as mock_popen:
         ar._maybe_trigger_state_rebuild(receipt)
 
@@ -71,7 +74,7 @@ def test_dispatch_promoted_event_triggers_rebuild(tmp_path: Path) -> None:
         "source": "pytest",
     }
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen") as mock_popen:
         ar._maybe_trigger_state_rebuild(receipt)
 
@@ -80,11 +83,11 @@ def test_dispatch_promoted_event_triggers_rebuild(tmp_path: Path) -> None:
 
 def test_throttle_prevents_double_rebuild(tmp_path: Path) -> None:
     throttle_file = tmp_path / ".last_state_rebuild_ts"
-    throttle_file.write_text(str(time.time()), encoding="utf-8")
+    throttle_file.write_text(str(int(time.time())), encoding="utf-8")
 
     receipt = _minimal_receipt("task_complete")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen") as mock_popen:
         ar._maybe_trigger_state_rebuild(receipt)
 
@@ -98,7 +101,7 @@ def test_throttle_allows_rebuild_after_window(tmp_path: Path) -> None:
 
     receipt = _minimal_receipt("task_complete")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen") as mock_popen:
         ar._maybe_trigger_state_rebuild(receipt)
 
@@ -108,7 +111,7 @@ def test_throttle_allows_rebuild_after_window(tmp_path: Path) -> None:
 def test_rebuild_failure_does_not_raise(tmp_path: Path) -> None:
     receipt = _minimal_receipt("task_complete")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen", side_effect=OSError("popen failed")):
         ar._maybe_trigger_state_rebuild(receipt)
 
@@ -118,7 +121,7 @@ def test_popen_failure_does_not_write_throttle(tmp_path: Path) -> None:
     throttle_file = tmp_path / ".last_state_rebuild_ts"
     receipt = _minimal_receipt("task_complete")
 
-    with mock.patch("append_receipt.resolve_state_dir", return_value=tmp_path), \
+    with mock.patch("state_rebuild_trigger._resolve_state_dir", return_value=tmp_path), \
          mock.patch("append_receipt.subprocess.Popen", side_effect=OSError("popen failed")):
         ar._maybe_trigger_state_rebuild(receipt)
 

--- a/tests/test_build_t0_state.py
+++ b/tests/test_build_t0_state.py
@@ -78,6 +78,32 @@ def test_build_register_events_missing_file_returns_empty(tmp_path: Path) -> Non
     assert result == []
 
 
+def test_build_register_events_honors_state_dir(tmp_path: Path) -> None:
+    """When state_dir is provided, read from state_dir/dispatch_register.ndjson directly."""
+    state_dir = tmp_path / "custom_state"
+    state_dir.mkdir()
+    register_file = state_dir / "dispatch_register.ndjson"
+    register_file.write_text(
+        json.dumps({"timestamp": "2026-04-28T10:00:00Z", "event": "gate_passed", "dispatch_id": "D-CUSTOM"}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = bts._build_register_events(state_dir=state_dir, limit=50)
+
+    assert len(result) == 1
+    assert result[0]["dispatch_id"] == "D-CUSTOM"
+
+
+def test_build_register_events_state_dir_missing_returns_empty(tmp_path: Path) -> None:
+    """When state_dir is provided but has no dispatch_register.ndjson, return []."""
+    state_dir = tmp_path / "empty_state"
+    state_dir.mkdir()
+
+    result = bts._build_register_events(state_dir=state_dir, limit=50)
+
+    assert result == []
+
+
 # ---------------------------------------------------------------------------
 # Test 2: build_t0_state return dict contains dispatch_register_events
 # ---------------------------------------------------------------------------
@@ -106,6 +132,35 @@ def test_build_t0_state_exposes_register_events(tmp_path: Path, monkeypatch: pyt
     events = state["dispatch_register_events"]
     assert isinstance(events, list)
     assert any(e.get("event") == "gate_passed" for e in events)
+
+
+def test_build_t0_state_state_dir_reads_local_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_t0_state(state_dir=X) must read register from X, not the canonical VNX_STATE_DIR location."""
+    state_dir = tmp_path / "state"
+    dispatch_dir = tmp_path / "dispatches"
+    state_dir.mkdir(parents=True)
+    dispatch_dir.mkdir(parents=True)
+
+    # Write a recognizable event to the state_dir register
+    register_file = state_dir / "dispatch_register.ndjson"
+    register_file.write_text(
+        json.dumps({"timestamp": "2026-04-28T11:00:00Z", "event": "dispatch_completed", "dispatch_id": "D-STATEDIR-WIRE"}) + "\n",
+        encoding="utf-8",
+    )
+
+    # Point VNX_STATE_DIR to a DIFFERENT dir (no register file there)
+    canonical_state = tmp_path / "canonical_state"
+    canonical_state.mkdir(parents=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(canonical_state))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    state = bts.build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+
+    events = state.get("dispatch_register_events", [])
+    assert any(e.get("dispatch_id") == "D-STATEDIR-WIRE" for e in events), (
+        "build_t0_state(state_dir=X) must read dispatch_register.ndjson from X, not from VNX_STATE_DIR"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_build_t0_state.py
+++ b/tests/test_build_t0_state.py
@@ -1,0 +1,129 @@
+"""Tests for build_t0_state.py — dispatch_register_events exposure (PR-4b).
+
+Coverage:
+  1. _build_register_events reads events from dispatch_register.ndjson
+  2. build_t0_state return dict contains dispatch_register_events key
+  3. dispatch_lifecycle.sh uses Python helper (not inline bash throttle)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import build_t0_state as bts
+import dispatch_register
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _build_register_events reads last N events
+# ---------------------------------------------------------------------------
+
+
+def test_build_register_events_reads_ndjson(tmp_path: Path) -> None:
+    register_file = tmp_path / "dispatch_register.ndjson"
+    events = [
+        {"timestamp": "2026-04-28T10:00:00Z", "event": "gate_passed", "dispatch_id": "D-001"},
+        {"timestamp": "2026-04-28T10:01:00Z", "event": "gate_failed", "dispatch_id": "D-002"},
+        {"timestamp": "2026-04-28T10:02:00Z", "event": "dispatch_completed", "dispatch_id": "D-003"},
+    ]
+    register_file.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+    with mock.patch.object(dispatch_register, "_register_path", return_value=register_file):
+        result = bts._build_register_events(limit=50)
+
+    assert len(result) == 3
+    assert result[0]["event"] == "gate_passed"
+    assert result[2]["event"] == "dispatch_completed"
+
+
+def test_build_register_events_respects_limit(tmp_path: Path) -> None:
+    register_file = tmp_path / "dispatch_register.ndjson"
+    events = [
+        {"timestamp": f"2026-04-28T10:0{i}:00Z", "event": "gate_passed", "dispatch_id": f"D-{i:03d}"}
+        for i in range(10)
+    ]
+    register_file.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+    with mock.patch.object(dispatch_register, "_register_path", return_value=register_file):
+        result = bts._build_register_events(limit=3)
+
+    assert len(result) == 3
+    assert result[0]["dispatch_id"] == "D-007"
+    assert result[2]["dispatch_id"] == "D-009"
+
+
+def test_build_register_events_missing_file_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "no_such_file.ndjson"
+    with mock.patch.object(dispatch_register, "_register_path", return_value=missing):
+        result = bts._build_register_events(limit=50)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2: build_t0_state return dict contains dispatch_register_events
+# ---------------------------------------------------------------------------
+
+
+def test_build_t0_state_exposes_register_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir = tmp_path / "state"
+    dispatch_dir = tmp_path / "dispatches"
+    state_dir.mkdir(parents=True)
+    dispatch_dir.mkdir(parents=True)
+
+    register_file = state_dir / "dispatch_register.ndjson"
+    register_file.write_text(
+        json.dumps({"timestamp": "2026-04-28T10:00:00Z", "event": "gate_passed", "dispatch_id": "D-TEST"}) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with mock.patch.object(dispatch_register, "_register_path", return_value=register_file):
+        state = bts.build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+
+    assert "dispatch_register_events" in state, "t0_state must include dispatch_register_events key"
+    events = state["dispatch_register_events"]
+    assert isinstance(events, list)
+    assert any(e.get("event") == "gate_passed" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: dispatch_lifecycle.sh uses Python helper (not inline bash throttle)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_lifecycle_sh_uses_python_helper() -> None:
+    lifecycle_sh = SCRIPTS_DIR / "lib" / "dispatch_lifecycle.sh"
+    content = lifecycle_sh.read_text(encoding="utf-8")
+
+    assert "maybe_trigger_state_rebuild" in content, \
+        "dispatch_lifecycle.sh must call maybe_trigger_state_rebuild"
+    assert "from state_rebuild_trigger import maybe_trigger_state_rebuild" in content, \
+        "dispatch_lifecycle.sh must import from state_rebuild_trigger"
+
+    # Must NOT contain the old inline throttle reimplementation
+    assert "_fdd_throttle_file" not in content, \
+        "dispatch_lifecycle.sh must not reimplement the throttle inline"
+    assert "nohup python3" not in content, \
+        "dispatch_lifecycle.sh must not call nohup directly (use Python helper instead)"

--- a/tests/test_build_t0_state.py
+++ b/tests/test_build_t0_state.py
@@ -104,6 +104,35 @@ def test_build_register_events_state_dir_missing_returns_empty(tmp_path: Path) -
     assert result == []
 
 
+def test_build_register_events_state_dir_uses_shared_lock_reader(tmp_path: Path) -> None:
+    """_build_register_events(state_dir=X) must use shared-lock reader, not raw read_text."""
+    import fcntl as _fcntl
+
+    state_dir = tmp_path / "lock_state"
+    state_dir.mkdir()
+    register_file = state_dir / "dispatch_register.ndjson"
+    register_file.write_text(
+        json.dumps({"timestamp": "2026-04-28T10:00:00Z", "event": "gate_passed", "dispatch_id": "D-LOCK"}) + "\n",
+        encoding="utf-8",
+    )
+
+    lock_calls = []
+    original_flock = _fcntl.flock
+
+    def spy_flock(fd, op):
+        lock_calls.append(op)
+        return original_flock(fd, op)
+
+    with mock.patch("dispatch_register.fcntl.flock", side_effect=spy_flock):
+        result = bts._build_register_events(state_dir=state_dir, limit=50)
+
+    assert len(result) == 1
+    assert result[0]["dispatch_id"] == "D-LOCK"
+    assert _fcntl.LOCK_SH in lock_calls, (
+        f"LOCK_SH not observed — state_dir path must use shared-lock reader, got: {lock_calls}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 2: build_t0_state return dict contains dispatch_register_events
 # ---------------------------------------------------------------------------

--- a/tests/test_cqs_open_items.py
+++ b/tests/test_cqs_open_items.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Tests that CQS open_items_created reflects the actual count from _register_quality_open_items.
+
+Before the fix: CQS was computed inside _enrich_completion_receipt, which ran BEFORE
+_register_quality_open_items. So open_items_created was always 0 in the CQS calculation
+and in the dispatch_metadata DB update for the receipt that actually created the items.
+
+After the fix: CQS is computed in append_receipt_payload AFTER _register_quality_open_items
+sets receipt["open_items_created"], so the correct count propagates into CQS.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import subprocess
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+APPEND_SCRIPT = SCRIPTS_DIR / "append_receipt.py"
+
+
+def _build_env(tmp_path: Path) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    env["PROJECT_ROOT"] = str(tmp_path)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    env["VNX_STATE_DIR"] = str(state_dir)
+    env["VNX_HOME"] = str(VNX_ROOT)
+    return env
+
+
+def _create_dispatch_metadata_db(state_dir: Path, dispatch_id: str) -> Path:
+    """Create a minimal quality_intelligence.db with dispatch_metadata row."""
+    db_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatch_metadata (
+            dispatch_id TEXT PRIMARY KEY,
+            cqs REAL,
+            normalized_status TEXT,
+            cqs_components TEXT,
+            open_items_created INTEGER DEFAULT 0,
+            open_items_resolved INTEGER DEFAULT 0,
+            gate TEXT,
+            pr_id TEXT,
+            dispatched_at TEXT,
+            role TEXT,
+            target_open_items TEXT
+        )
+    """)
+    conn.execute(
+        "INSERT OR IGNORE INTO dispatch_metadata (dispatch_id, open_items_created) VALUES (?, 0)",
+        (dispatch_id,),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_cqs_open_items_count(tmp_path: Path):
+    """CQS open_items_created == N when N quality advisory items are created (not 0).
+
+    Uses a review_gate_request event (non-completion) so _enrich_completion_receipt
+    returns early and the pre-populated quality_advisory survives to
+    _register_quality_open_items unchanged.
+    """
+    dispatch_id = "DISP-CQS-OI-TEST-001"
+    state_dir = tmp_path / "data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = _create_dispatch_metadata_db(state_dir, dispatch_id)
+
+    receipt = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "review_gate_request",
+        "event": "review_gate_request",
+        "dispatch_id": dispatch_id,
+        "terminal": "T1",
+        "source": "pytest",
+        "gate": "codex",
+        "pr_number": "278",
+        # Pre-populate quality_advisory with 3 distinct open items.
+        # Non-completion event type prevents _enrich_completion_receipt from
+        # overwriting this with a git-based advisory.
+        "quality_advisory": {
+            "version": "1.0",
+            "summary": {"warning_count": 3, "blocking_count": 0, "risk_score": 30},
+            "t0_recommendation": {
+                "decision": "approve",
+                "open_items": [
+                    {
+                        "check_id": "cqs_ordering_A",
+                        "file": "scripts/append_receipt.py",
+                        "severity": "warning",
+                        "item": "CQS ordering test item 1",
+                    },
+                    {
+                        "check_id": "cqs_ordering_B",
+                        "file": "scripts/append_receipt.py",
+                        "severity": "warning",
+                        "item": "CQS ordering test item 2",
+                    },
+                    {
+                        "check_id": "cqs_ordering_C",
+                        "file": "scripts/lib/cqs_calculator.py",
+                        "severity": "warning",
+                        "item": "CQS ordering test item 3",
+                    },
+                ],
+            },
+        },
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(APPEND_SCRIPT)],
+        input=json.dumps(receipt),
+        capture_output=True,
+        text=True,
+        env=_build_env(tmp_path),
+    )
+    assert result.returncode == 0, f"append_receipt.py failed:\n{result.stderr}"
+
+    # Verify _register_quality_open_items created 3 items in open_items.json
+    open_items_file = state_dir / "open_items.json"
+    assert open_items_file.exists(), "open_items.json not created by _register_quality_open_items"
+    data = json.loads(open_items_file.read_text(encoding="utf-8"))
+    created = [i for i in data["items"] if i.get("origin_dispatch_id") == dispatch_id]
+    assert len(created) == 3, f"Expected 3 open items for {dispatch_id}, got {len(created)}"
+
+    # Verify CQS DB update used open_items_created = 3 (not 0).
+    # Before the fix, CQS ran before _register_quality_open_items so this was always 0.
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT open_items_created FROM dispatch_metadata WHERE dispatch_id=?",
+        (dispatch_id,),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None, f"No dispatch_metadata row for {dispatch_id}"
+    assert row[0] == 3, (
+        f"CQS open_items_created should be 3 but got {row[0]}. "
+        "This means CQS was still computed before _register_quality_open_items (ordering bug not fixed)."
+    )
+
+
+def test_cqs_zero_open_items_when_advisory_clean(tmp_path: Path):
+    """CQS open_items_created == 0 when quality_advisory has no open items."""
+    dispatch_id = "DISP-CQS-OI-TEST-002"
+    state_dir = tmp_path / "data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = _create_dispatch_metadata_db(state_dir, dispatch_id)
+
+    receipt = {
+        "timestamp": "2026-04-28T10:01:00Z",
+        "event_type": "review_gate_request",
+        "event": "review_gate_request",
+        "dispatch_id": dispatch_id,
+        "terminal": "T1",
+        "source": "pytest",
+        "gate": "gemini",
+        "pr_number": "278",
+        "quality_advisory": {
+            "version": "1.0",
+            "summary": {"warning_count": 0, "blocking_count": 0, "risk_score": 0},
+            "t0_recommendation": {
+                "decision": "approve",
+                "open_items": [],
+            },
+        },
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(APPEND_SCRIPT)],
+        input=json.dumps(receipt),
+        capture_output=True,
+        text=True,
+        env=_build_env(tmp_path),
+    )
+    assert result.returncode == 0, f"append_receipt.py failed:\n{result.stderr}"
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT open_items_created FROM dispatch_metadata WHERE dispatch_id=?",
+        (dispatch_id,),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == 0, f"Expected open_items_created=0 for clean advisory, got {row[0]}"

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -532,3 +532,67 @@ class TestAppendEventIdRequirement:
         result = append_event("dispatch_created", feature_id="F-55")
         assert result is True
 
+
+# ---------------------------------------------------------------------------
+# 20. read_events state_dir param — reads from override, preserves shared lock
+# ---------------------------------------------------------------------------
+
+class TestReadEventsStateDir:
+    def test_read_events_state_dir_reads_from_override(self, tmp_path):
+        """read_events(state_dir=X) reads from X/dispatch_register.ndjson."""
+        custom_state = tmp_path / "custom-state"
+        custom_state.mkdir()
+        reg_file = custom_state / "dispatch_register.ndjson"
+        reg_file.write_text(
+            json.dumps({"timestamp": "2026-04-28T10:00:00.000000Z", "event": "gate_passed", "dispatch_id": "SD-001"}) + "\n",
+            encoding="utf-8",
+        )
+        events = read_events(state_dir=custom_state)
+        assert len(events) == 1
+        assert events[0]["dispatch_id"] == "SD-001"
+
+    def test_read_events_state_dir_missing_file_returns_empty(self, tmp_path):
+        """read_events(state_dir=X) returns [] when X/dispatch_register.ndjson doesn't exist."""
+        custom_state = tmp_path / "empty-state"
+        custom_state.mkdir()
+        events = read_events(state_dir=custom_state)
+        assert events == []
+
+    def test_read_events_state_dir_takes_shared_lock(self, tmp_path):
+        """read_events(state_dir=X) acquires fcntl.LOCK_SH on the file."""
+        import fcntl as _fcntl
+        custom_state = tmp_path / "lock-state"
+        custom_state.mkdir()
+        reg_file = custom_state / "dispatch_register.ndjson"
+        reg_file.write_text(
+            json.dumps({"timestamp": "2026-04-28T10:00:00.000000Z", "event": "gate_passed", "dispatch_id": "LOCK-001"}) + "\n",
+            encoding="utf-8",
+        )
+
+        lock_calls = []
+        original_flock = _fcntl.flock
+
+        def spy_flock(fd, op):
+            lock_calls.append(op)
+            return original_flock(fd, op)
+
+        with patch("dispatch_register.fcntl.flock", side_effect=spy_flock):
+            events = read_events(state_dir=custom_state)
+
+        assert len(events) == 1
+        assert _fcntl.LOCK_SH in lock_calls, f"LOCK_SH not observed; calls: {lock_calls}"
+
+    def test_read_events_state_dir_since_iso_filter_still_works(self, tmp_path):
+        """read_events(state_dir=X, since_iso=...) applies the time filter correctly."""
+        custom_state = tmp_path / "filter-state"
+        custom_state.mkdir()
+        reg_file = custom_state / "dispatch_register.ndjson"
+        reg_file.write_text(
+            json.dumps({"timestamp": "2026-01-01T00:00:00.000000Z", "event": "dispatch_created", "dispatch_id": "OLD"}) + "\n"
+            + json.dumps({"timestamp": "2026-06-01T00:00:00.000000Z", "event": "gate_passed", "dispatch_id": "NEW"}) + "\n",
+            encoding="utf-8",
+        )
+        events = read_events(state_dir=custom_state, since_iso="2026-03-01T00:00:00.000000Z")
+        assert len(events) == 1
+        assert events[0]["dispatch_id"] == "NEW"
+

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -605,15 +605,8 @@ def test_gate_artifacts_pr_id_non_numeric_does_not_crash(isolated_register, tmp_
 
 
 def test_gate_artifacts_triggers_state_rebuild(isolated_register, tmp_path, monkeypatch):
-    """materialize_artifacts must call maybe_trigger_state_rebuild after writing the register event."""
-    import state_rebuild_trigger
-
+    """materialize_artifacts must reach the SUCCESS path and call maybe_trigger_state_rebuild."""
     rebuild_calls: list = []
-    monkeypatch.setattr(state_rebuild_trigger, "maybe_trigger_state_rebuild", lambda: rebuild_calls.append(1) or True)
-
-    # Also patch where gate_artifacts imported it from
-    import gate_artifacts as _ga
-    monkeypatch.setattr(_ga, "_trigger_rebuild" if hasattr(_ga, "_trigger_rebuild") else "__builtins__", None, raising=False)
 
     requests_dir = tmp_path / "requests"
     results_dir = tmp_path / "results"
@@ -630,10 +623,17 @@ def test_gate_artifacts_triggers_state_rebuild(isolated_register, tmp_path, monk
         "report_path": str(report_path),
         "dispatch_id": "D-REBUILD-019",
     }
-    stdout = "# Review\nLGTM"
+    # 4 non-empty lines — satisfies gate_artifacts._validate_content (requires >= 3)
+    stdout = (
+        "# Gemini Review\n\n"
+        "The implementation follows established patterns correctly.\n"
+        "No security issues identified.\n"
+        "Approved: LGTM."
+    )
 
-    with mock.patch("state_rebuild_trigger.maybe_trigger_state_rebuild", side_effect=lambda: rebuild_calls.append(1) or True):
-        gate_artifacts.materialize_artifacts(
+    with mock.patch("state_rebuild_trigger.maybe_trigger_state_rebuild", side_effect=lambda: rebuild_calls.append(1) or True), \
+         mock.patch.object(gate_recorder, "record_failure_simple", wraps=gate_recorder.record_failure_simple) as mock_failure:
+        result = gate_artifacts.materialize_artifacts(
             gate="gemini_review",
             pr_number=30,
             pr_id="pr-30",
@@ -645,6 +645,10 @@ def test_gate_artifacts_triggers_state_rebuild(isolated_register, tmp_path, monk
             reports_dir=reports_dir,
         )
 
+    # Success path: status must be "completed" — failure path returns status="failure"
+    assert result.get("status") == "completed", f"Expected success path, got status={result.get('status')!r}"
+    # record_failure_simple must NOT have been called on the success path
+    mock_failure.assert_not_called()
     assert len(rebuild_calls) >= 1, "maybe_trigger_state_rebuild must be called after register write"
 
 

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -149,7 +149,7 @@ def test_emit_review_gate_request_classifies_gate_requested(isolated_register):
 
 def test_emit_irrelevant_event_writes_nothing(isolated_register):
     receipt = {
-        "event_type": "task_started",
+        "event_type": "system_heartbeat",  # genuinely not register-worthy
         "dispatch_id": "D-EMIT-006",
         "terminal": "T1",
     }
@@ -193,7 +193,8 @@ def test_emit_called_before_rebuild(tmp_path):
     }
 
     with (
-        mock.patch.object(append_receipt, "_emit_dispatch_register", side_effect=lambda r: call_order.append("emit")),
+        mock.patch.object(append_receipt, "_emit_dispatch_register",
+                          side_effect=lambda r: call_order.append("emit") or True),
         mock.patch.object(append_receipt, "_maybe_trigger_state_rebuild", side_effect=lambda r: call_order.append("rebuild")),
         mock.patch.object(append_receipt, "_register_quality_open_items", return_value=0),
         mock.patch.object(append_receipt, "_update_confidence_from_receipt"),
@@ -923,4 +924,149 @@ def test_emit_review_gate_request_claude_github_optional_skips_register(isolated
     events = _reg_events(isolated_register)
     assert len(events) == 0, (
         f"claude_github_optional review_gate_request must not emit register event (deferred), got: {events}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests 31-33: task_started / task_start / dispatch_start → dispatch_started
+# (ADVISORY fix: VALID_EVENTS includes dispatch_started; map caller event types)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_task_started_maps_to_dispatch_started(isolated_register):
+    """task_started event must map to dispatch_started in register (ADVISORY fix)."""
+    receipt = {
+        "event_type": "task_started",
+        "dispatch_id": "D-STARTED-031",
+        "terminal": "T1",
+    }
+    result = append_receipt._emit_dispatch_register(receipt)
+    assert result is True
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 dispatch_started event, got: {events}"
+    assert events[0]["event"] == "dispatch_started"
+    assert events[0]["dispatch_id"] == "D-STARTED-031"
+
+
+def test_emit_task_start_maps_to_dispatch_started(isolated_register):
+    """task_start event must map to dispatch_started in register (ADVISORY fix)."""
+    receipt = {
+        "event_type": "task_start",
+        "dispatch_id": "D-STARTED-032",
+        "terminal": "T2",
+    }
+    result = append_receipt._emit_dispatch_register(receipt)
+    assert result is True
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 dispatch_started event, got: {events}"
+    assert events[0]["event"] == "dispatch_started"
+
+
+def test_emit_dispatch_start_maps_to_dispatch_started(isolated_register):
+    """dispatch_start event must map to dispatch_started in register (ADVISORY fix)."""
+    receipt = {
+        "event_type": "dispatch_start",
+        "dispatch_id": "D-STARTED-033",
+        "terminal": "T1",
+    }
+    result = append_receipt._emit_dispatch_register(receipt)
+    assert result is True
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 dispatch_started event, got: {events}"
+    assert events[0]["event"] == "dispatch_started"
+
+
+# ---------------------------------------------------------------------------
+# Test 34: persisted ndjson receipt carries open_items_created (BLOCKING 1 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_persisted_with_open_items_count(isolated_register, tmp_path):
+    """Persisted ndjson line must carry open_items_created field (BLOCKING 1 fix).
+
+    Before the fix: open_items_created was set after the ndjson write, so the
+    persisted receipt had the field absent. After the fix: pre-computed before write.
+    """
+    receipts_file = tmp_path / "receipts.ndjson"
+
+    receipt = {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-PERSIST-OI-034",
+        "terminal": "T1",
+        "quality_advisory": {
+            "t0_recommendation": {
+                "open_items": [
+                    {"check_id": "chk-1", "file": "foo.py", "severity": "warning", "item": "issue 1"},
+                    {"check_id": "chk-2", "file": "bar.py", "severity": "warning", "item": "issue 2"},
+                ],
+            },
+        },
+    }
+
+    with (
+        # Prevent _enrich_completion_receipt from overwriting quality_advisory with real repo data
+        mock.patch.object(append_receipt, "_enrich_completion_receipt", side_effect=lambda r: r),
+        mock.patch.object(append_receipt, "_register_quality_open_items", return_value=2),
+        mock.patch.object(append_receipt, "_update_confidence_from_receipt"),
+        mock.patch.object(append_receipt, "_maybe_trigger_state_rebuild"),
+    ):
+        result = append_receipt.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert result.status == "appended"
+
+    lines = [ln.strip() for ln in receipts_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1
+    persisted = json.loads(lines[0])
+
+    assert "open_items_created" in persisted, (
+        "Persisted receipt must contain open_items_created (BLOCKING 1 regression guard)"
+    )
+    assert persisted["open_items_created"] == 2, (
+        f"Expected open_items_created=2, got {persisted['open_items_created']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 35: register written before ndjson commit (BLOCKING 2 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_register_written_before_ndjson_commit(isolated_register, tmp_path):
+    """_emit_dispatch_register must be called before ndjson write (BLOCKING 2 fix).
+
+    Verified by spying on _emit_dispatch_register: at the moment it is called,
+    the ndjson file must not yet exist (or be empty).
+    """
+    receipts_file = tmp_path / "receipts.ndjson"
+
+    receipt = {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-BLOCKING2-035",
+        "terminal": "T1",
+    }
+
+    call_observations: list = []
+    real_emit = append_receipt._emit_dispatch_register  # capture before patch
+
+    def emit_spy(r):
+        ndjson_written = receipts_file.exists() and bool(receipts_file.read_text(encoding="utf-8").strip())
+        call_observations.append(ndjson_written)
+        return real_emit(r)
+
+    with (
+        mock.patch.object(append_receipt, "_emit_dispatch_register", side_effect=emit_spy),
+        mock.patch.object(append_receipt, "_register_quality_open_items", return_value=0),
+        mock.patch.object(append_receipt, "_update_confidence_from_receipt"),
+        mock.patch.object(append_receipt, "_maybe_trigger_state_rebuild"),
+    ):
+        result = append_receipt.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert result.status == "appended"
+    assert len(call_observations) == 1, f"Expected 1 emit call, got {len(call_observations)}"
+    assert not call_observations[0], (
+        "ndjson must NOT contain data when _emit_dispatch_register is called (BLOCKING 2 regression guard)"
     )

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -663,7 +663,7 @@ def test_emit_dispatch_register_non_numeric_pr_id_uses_feature_id(isolated_regis
         "pr_id": "PR-6",
         "dispatch_id": "",
         "terminal": "T3",
-        "gate": "gemini_review",
+        "gate": "codex_gate",
     }
     append_receipt._emit_dispatch_register(receipt)
     events = _reg_events(isolated_register)
@@ -873,4 +873,54 @@ def test_gate_artifacts_claude_github_optional_skips_register_emit(isolated_regi
     gate_events = [e for e in events if e.get("gate") == "claude_github_optional"]
     assert len(gate_events) == 0, (
         f"claude_github_optional must not emit register event (parser unimplemented), got: {gate_events}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests 28-30: symmetric defer — review_gate_request only emits for codex_gate
+# ---------------------------------------------------------------------------
+
+
+def test_emit_review_gate_request_gemini_skips_register(isolated_register):
+    """review_gate_request for gemini_review must NOT write to register (symmetric defer with fixup #6)."""
+    receipt = {
+        "event_type": "review_gate_request",
+        "dispatch_id": "D-SYMM-028",
+        "terminal": "T3",
+        "gate": "gemini_review",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 0, (
+        f"gemini_review review_gate_request must not emit register event (deferred), got: {events}"
+    )
+
+
+def test_emit_review_gate_request_codex_gate_emits_gate_requested(isolated_register):
+    """review_gate_request for codex_gate must emit gate_requested (only gate with full lifecycle)."""
+    receipt = {
+        "event_type": "review_gate_request",
+        "dispatch_id": "D-SYMM-029",
+        "terminal": "T3",
+        "gate": "codex_gate",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 register event for codex_gate, got: {events}"
+    assert events[0]["event"] == "gate_requested"
+    assert events[0].get("gate") == "codex_gate"
+
+
+def test_emit_review_gate_request_claude_github_optional_skips_register(isolated_register):
+    """review_gate_request for claude_github_optional must NOT write to register (symmetric defer with fixup #6)."""
+    receipt = {
+        "event_type": "review_gate_request",
+        "dispatch_id": "D-SYMM-030",
+        "terminal": "T3",
+        "gate": "claude_github_optional",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 0, (
+        f"claude_github_optional review_gate_request must not emit register event (deferred), got: {events}"
     )

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -43,6 +43,7 @@ import append_receipt
 import dispatch_register
 import gate_recorder
 import gate_artifacts
+import state_rebuild_trigger
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +217,7 @@ def test_maybe_trigger_rebuild_on_review_gate_request(monkeypatch, tmp_path):
     throttle = state_dir / ".last_state_rebuild_ts"
     throttle.write_text("1", encoding="utf-8")
 
-    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: state_dir)
 
     popen_calls: list = []
 
@@ -224,7 +225,7 @@ def test_maybe_trigger_rebuild_on_review_gate_request(monkeypatch, tmp_path):
         def __init__(self, cmd, **kwargs):
             popen_calls.append(cmd)
 
-    monkeypatch.setattr(append_receipt.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _FakePopen)
 
     receipt = {"event_type": "review_gate_request", "dispatch_id": "D-GATE-001"}
     append_receipt._maybe_trigger_state_rebuild(receipt)
@@ -246,8 +247,8 @@ def test_throttle_marker_is_integer(monkeypatch, tmp_path):
     throttle = state_dir / ".last_state_rebuild_ts"
     throttle.write_text("1", encoding="utf-8")  # stale
 
-    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
-    monkeypatch.setattr(append_receipt.subprocess, "Popen", lambda cmd, **kw: None)
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: state_dir)
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", lambda cmd, **kw: None)
 
     receipt = {"event_type": "task_complete", "dispatch_id": "D-THROTTLE-001"}
     append_receipt._maybe_trigger_state_rebuild(receipt)
@@ -299,7 +300,7 @@ def test_throttle_expiry_triggers_rebuild(monkeypatch, tmp_path):
     throttle = state_dir / ".last_state_rebuild_ts"
     throttle.write_text("1000", encoding="utf-8")
 
-    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: state_dir)
 
     popen_calls: list = []
 
@@ -307,7 +308,7 @@ def test_throttle_expiry_triggers_rebuild(monkeypatch, tmp_path):
         def __init__(self, cmd, **kwargs):
             popen_calls.append(cmd)
 
-    monkeypatch.setattr(append_receipt.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _FakePopen)
 
     receipt = {"event_type": "task_complete", "dispatch_id": "D-EXPIRE-001"}
     append_receipt._maybe_trigger_state_rebuild(receipt)
@@ -453,3 +454,195 @@ def test_gate_recorder_failure_path_emits_gate_failed(isolated_register, tmp_pat
     assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
     assert gate_events[0]["event"] == "gate_failed"
     assert gate_events[0].get("dispatch_id") == "D-FAILURE-020"
+
+
+# ---------------------------------------------------------------------------
+# Test 16: status="failure" → dispatch_failed (BLOCKING fix 1)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_task_complete_failure_status_classifies_failed(isolated_register):
+    """task_complete with status='failure' must map to dispatch_failed (not dispatch_completed)."""
+    receipt = {
+        "event_type": "task_complete",
+        "status": "failure",
+        "dispatch_id": "D-EMIT-016",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_failed", (
+        f"status='failure' must produce dispatch_failed, got {events[0]['event']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests 17-18: gate hook pr_id → pr_number parsing (BLOCKING fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_artifacts_pr_id_numeric_resolves_pr_number(isolated_register, tmp_path):
+    """gate hook with pr_id='276' and pr_number=None must write pr_number=276 to register."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "gemini_review",
+        "pr_number": None,
+        "pr_id": "276",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": "",
+    }
+    stdout = "\n".join(["# Review", "Overall: LGTM", "No issues found."])
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="gemini_review",
+        pr_number=None,
+        pr_id="276",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.0,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "gemini_review"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_passed"
+    assert gate_events[0].get("pr_number") == 276, (
+        f"pr_id='276' must resolve to pr_number=276, got {gate_events[0].get('pr_number')!r}"
+    )
+
+
+def test_gate_recorder_pr_id_numeric_resolves_pr_number(isolated_register, tmp_path):
+    """record_failure with pr_id='276' and pr_number=None must write pr_number=276 to register."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    for d in (requests_dir, results_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    request_payload = {
+        "gate": "codex_gate",
+        "pr_number": None,
+        "pr_id": "276",
+        "dispatch_id": "",
+        "report_path": str(tmp_path / "report.md"),
+    }
+    failure_result = {
+        "reason": "timeout",
+        "reason_detail": "stalled",
+        "duration_seconds": 60.0,
+        "partial_output_lines": 0,
+        "runner_pid": 99,
+    }
+
+    gate_recorder.record_failure(
+        gate="codex_gate",
+        pr_number=None,
+        pr_id="276",
+        result=failure_result,
+        request_payload=request_payload,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+    )
+
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "codex_gate"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_failed"
+    assert gate_events[0].get("pr_number") == 276, (
+        f"pr_id='276' must resolve to pr_number=276, got {gate_events[0].get('pr_number')!r}"
+    )
+
+
+def test_gate_artifacts_pr_id_non_numeric_does_not_crash(isolated_register, tmp_path):
+    """gate hook with pr_id='abc' (non-numeric) and pr_number=None must not crash."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "gemini_review",
+        "pr_number": None,
+        "pr_id": "abc-branch",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": "D-NONNUM-018",
+    }
+    stdout = "\n".join(["# Review", "Overall: LGTM", "No issues."])
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="gemini_review",
+        pr_number=None,
+        pr_id="abc-branch",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.0,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    # Must complete without raising; register event may use dispatch_id fallback
+    assert result.get("status") == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Test 19: gate hook fires Popen rebuild after register write (ADVISORY fix)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_artifacts_triggers_state_rebuild(isolated_register, tmp_path, monkeypatch):
+    """materialize_artifacts must call maybe_trigger_state_rebuild after writing the register event."""
+    import state_rebuild_trigger
+
+    rebuild_calls: list = []
+    monkeypatch.setattr(state_rebuild_trigger, "maybe_trigger_state_rebuild", lambda: rebuild_calls.append(1) or True)
+
+    # Also patch where gate_artifacts imported it from
+    import gate_artifacts as _ga
+    monkeypatch.setattr(_ga, "_trigger_rebuild" if hasattr(_ga, "_trigger_rebuild") else "__builtins__", None, raising=False)
+
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "gemini_review",
+        "pr_number": 30,
+        "pr_id": "pr-30",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": "D-REBUILD-019",
+    }
+    stdout = "# Review\nLGTM"
+
+    with mock.patch("state_rebuild_trigger.maybe_trigger_state_rebuild", side_effect=lambda: rebuild_calls.append(1) or True):
+        gate_artifacts.materialize_artifacts(
+            gate="gemini_review",
+            pr_number=30,
+            pr_id="pr-30",
+            stdout=stdout,
+            request_payload=payload,
+            duration_seconds=0.5,
+            requests_dir=requests_dir,
+            results_dir=results_dir,
+            reports_dir=reports_dir,
+        )
+
+    assert len(rebuild_calls) >= 1, "maybe_trigger_state_rebuild must be called after register write"

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -1,0 +1,455 @@
+"""Tests for dispatch_register lifecycle hook integration (Sprint 3 split 2/3).
+
+Coverage:
+  1.  _emit_dispatch_register: task_complete + success → dispatch_completed
+  2.  _emit_dispatch_register: task_complete + failed → dispatch_failed
+  3.  _emit_dispatch_register: task_failed → dispatch_failed
+  4.  _emit_dispatch_register: task_timeout → dispatch_failed
+  5.  _emit_dispatch_register: review_gate_request → gate_requested
+  6.  _emit_dispatch_register: irrelevant event → register unchanged
+  7.  _emit_dispatch_register: pr_number falls back to metadata.pr_number
+  8.  _emit_dispatch_register runs BEFORE _maybe_trigger_state_rebuild
+  9.  _maybe_trigger_state_rebuild triggers on review_gate_request
+  10. Throttle marker is integer (not float) after Python write
+  11. Bash CLI dispatch_promoted event writes register entry
+  12. Throttle expiry: rebuild triggers when stale throttle marker present
+  13. gate_artifacts success with no blocking → gate_passed in register
+  14. gate_artifacts success with blocking → gate_failed in register
+  15. gate_recorder failure path emits gate_failed (not just success-materialization)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import append_receipt
+import dispatch_register
+import gate_recorder
+import gate_artifacts
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_register(monkeypatch, tmp_path):
+    """Route dispatch_register I/O to an isolated tmp dir for every test."""
+    state_dir = tmp_path / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    return state_dir
+
+
+def _reg_events(state_dir: Path) -> list[dict]:
+    reg = state_dir / "dispatch_register.ndjson"
+    if not reg.exists():
+        return []
+    events = []
+    for line in reg.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests 1-7: _emit_dispatch_register classification and field handling
+# ---------------------------------------------------------------------------
+
+
+def test_emit_task_complete_success_classifies_completed(isolated_register):
+    receipt = {
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-EMIT-001",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_completed"
+    assert events[0]["dispatch_id"] == "D-EMIT-001"
+
+
+def test_emit_task_complete_failed_classifies_failed(isolated_register):
+    receipt = {
+        "event_type": "task_complete",
+        "status": "failed",
+        "dispatch_id": "D-EMIT-002",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_failed"
+
+
+def test_emit_task_failed_classifies_failed(isolated_register):
+    receipt = {
+        "event_type": "task_failed",
+        "dispatch_id": "D-EMIT-003",
+        "terminal": "T2",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_failed"
+
+
+def test_emit_task_timeout_classifies_failed(isolated_register):
+    receipt = {
+        "event_type": "task_timeout",
+        "dispatch_id": "D-EMIT-004",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_failed"
+
+
+def test_emit_review_gate_request_classifies_gate_requested(isolated_register):
+    receipt = {
+        "event_type": "review_gate_request",
+        "dispatch_id": "D-EMIT-005",
+        "terminal": "T3",
+        "gate": "codex_gate",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "gate_requested"
+    assert events[0].get("gate") == "codex_gate"
+
+
+def test_emit_irrelevant_event_writes_nothing(isolated_register):
+    receipt = {
+        "event_type": "task_started",
+        "dispatch_id": "D-EMIT-006",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    assert _reg_events(isolated_register) == []
+
+
+def test_emit_pr_number_falls_back_to_metadata(isolated_register):
+    receipt = {
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-EMIT-007",
+        "terminal": "T1",
+        "metadata": {"pr_number": 42},
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0].get("pr_number") == 42
+
+
+# ---------------------------------------------------------------------------
+# Test 8: ordering — emit before rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_emit_called_before_rebuild(tmp_path):
+    """_emit_dispatch_register must precede _maybe_trigger_state_rebuild in the hook chain."""
+    call_order: list[str] = []
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = state_dir / "t0_receipts.ndjson"
+
+    receipt = {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "event_type": "task_complete",
+        "dispatch_id": "D-ORDER-001",
+        "terminal": "T1",
+        "status": "success",
+    }
+
+    with (
+        mock.patch.object(append_receipt, "_emit_dispatch_register", side_effect=lambda r: call_order.append("emit")),
+        mock.patch.object(append_receipt, "_maybe_trigger_state_rebuild", side_effect=lambda r: call_order.append("rebuild")),
+        mock.patch.object(append_receipt, "_register_quality_open_items", return_value=0),
+        mock.patch.object(append_receipt, "_update_confidence_from_receipt"),
+    ):
+        append_receipt.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert call_order == ["emit", "rebuild"], f"Unexpected call order: {call_order}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: rebuild triggered by review_gate_request
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_trigger_rebuild_on_review_gate_request(monkeypatch, tmp_path):
+    """review_gate_request receipt must trigger the state rebuild Popen."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Stale throttle so the rebuild is not suppressed
+    throttle = state_dir / ".last_state_rebuild_ts"
+    throttle.write_text("1", encoding="utf-8")
+
+    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
+
+    popen_calls: list = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            popen_calls.append(cmd)
+
+    monkeypatch.setattr(append_receipt.subprocess, "Popen", _FakePopen)
+
+    receipt = {"event_type": "review_gate_request", "dispatch_id": "D-GATE-001"}
+    append_receipt._maybe_trigger_state_rebuild(receipt)
+
+    assert len(popen_calls) == 1, "Popen should have been called once"
+    assert "build_t0_state.py" in popen_calls[0][-1]
+
+
+# ---------------------------------------------------------------------------
+# Test 10: throttle marker is integer
+# ---------------------------------------------------------------------------
+
+
+def test_throttle_marker_is_integer(monkeypatch, tmp_path):
+    """Python side writes integer epoch to the throttle file (no decimal point)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    throttle = state_dir / ".last_state_rebuild_ts"
+    throttle.write_text("1", encoding="utf-8")  # stale
+
+    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
+    monkeypatch.setattr(append_receipt.subprocess, "Popen", lambda cmd, **kw: None)
+
+    receipt = {"event_type": "task_complete", "dispatch_id": "D-THROTTLE-001"}
+    append_receipt._maybe_trigger_state_rebuild(receipt)
+
+    written = throttle.read_text(encoding="utf-8").strip()
+    assert "." not in written, f"Throttle marker must be integer, got: {written!r}"
+    assert written.isdigit(), f"Throttle marker must be digits only, got: {written!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 11: bash CLI writes dispatch_promoted to register
+# ---------------------------------------------------------------------------
+
+
+def test_bash_cli_dispatch_promoted_writes_register(isolated_register):
+    """Calling the dispatch_register.py CLI (as the bash hook does) writes dispatch_promoted."""
+    register_py = LIB_DIR / "dispatch_register.py"
+    env = {
+        **os.environ,
+        "VNX_STATE_DIR": str(isolated_register),
+        "VNX_DATA_DIR": str(isolated_register.parent),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, str(register_py), "append", "dispatch_promoted",
+         "dispatch_id=BASH-HOOK-001", "terminal=T1"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_promoted"
+    assert events[0]["dispatch_id"] == "BASH-HOOK-001"
+
+
+# ---------------------------------------------------------------------------
+# Test 12: throttle expiry triggers rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_throttle_expiry_triggers_rebuild(monkeypatch, tmp_path):
+    """When throttle file is older than 30 s, rebuild Popen is called and marker refreshed."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Very old throttle
+    throttle = state_dir / ".last_state_rebuild_ts"
+    throttle.write_text("1000", encoding="utf-8")
+
+    monkeypatch.setattr(append_receipt, "resolve_state_dir", lambda f: state_dir)
+
+    popen_calls: list = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            popen_calls.append(cmd)
+
+    monkeypatch.setattr(append_receipt.subprocess, "Popen", _FakePopen)
+
+    receipt = {"event_type": "task_complete", "dispatch_id": "D-EXPIRE-001"}
+    append_receipt._maybe_trigger_state_rebuild(receipt)
+
+    assert popen_calls, "Popen not called despite stale throttle"
+    new_ts = throttle.read_text(encoding="utf-8").strip()
+    assert new_ts.isdigit()
+    assert int(new_ts) > 1000
+
+
+# ---------------------------------------------------------------------------
+# Tests 13-14: gate_artifacts success path emits gate_passed / gate_failed
+# ---------------------------------------------------------------------------
+
+
+def _make_gate_request_payload(tmp_path: Path, pr_number: int = 1) -> dict:
+    report_path = tmp_path / "reports" / "gate_report.md"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    return {
+        "gate": "gemini_review",
+        "pr_number": pr_number,
+        "pr_id": f"pr-{pr_number}",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": f"D-GATE-{pr_number:03d}",
+    }
+
+
+def test_gate_artifacts_no_blocking_emits_gate_passed(isolated_register, tmp_path):
+    """materialize_artifacts with no blocking findings emits gate_passed."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    payload = _make_gate_request_payload(tmp_path, pr_number=10)
+    stdout = "\n".join(["# Review", "Overall: LGTM", "No issues found."])
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="gemini_review",
+        pr_number=10,
+        pr_id="pr-10",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.5,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    reg_events_for_gate = [e for e in events if e.get("gate") == "gemini_review"]
+    assert len(reg_events_for_gate) == 1
+    assert reg_events_for_gate[0]["event"] == "gate_passed"
+
+
+def test_gate_artifacts_blocking_emits_gate_failed(isolated_register, tmp_path):
+    """materialize_artifacts on codex_gate with blocking findings emits gate_failed."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    payload = _make_gate_request_payload(tmp_path, pr_number=11)
+    payload["gate"] = "codex_gate"
+    payload["pr_id"] = "pr-11"
+    # Codex stdout with a blocking finding
+    stdout = (
+        "## Findings\n"
+        "- severity: error\n"
+        "  message: null-deref in foo.py:42\n"
+        "  file: foo.py\n"
+        "  line: 42\n"
+    )
+
+    # Patch codex parser to return a blocking finding
+    fake_findings = {
+        "findings": [{"severity": "error", "message": "null-deref", "file": "foo.py", "line": 42}],
+        "residual_risk": "null-deref present",
+    }
+    with mock.patch("gate_artifacts.parse_codex_findings", return_value=fake_findings):
+        result = gate_artifacts.materialize_artifacts(
+            gate="codex_gate",
+            pr_number=11,
+            pr_id="pr-11",
+            stdout=stdout,
+            request_payload=payload,
+            duration_seconds=2.0,
+            requests_dir=requests_dir,
+            results_dir=results_dir,
+            reports_dir=reports_dir,
+        )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    reg_events_for_gate = [e for e in events if e.get("gate") == "codex_gate"]
+    assert len(reg_events_for_gate) == 1
+    assert reg_events_for_gate[0]["event"] == "gate_failed"
+
+
+# ---------------------------------------------------------------------------
+# Test 15: gate_recorder failure path emits gate_failed
+# ---------------------------------------------------------------------------
+
+
+def test_gate_recorder_failure_path_emits_gate_failed(isolated_register, tmp_path):
+    """record_failure (execution failure path) must emit gate_failed to the register."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    for d in (requests_dir, results_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    request_payload = {
+        "gate": "gemini_review",
+        "pr_number": 20,
+        "pr_id": "pr-20",
+        "dispatch_id": "D-FAILURE-020",
+        "report_path": str(tmp_path / "report.md"),
+    }
+    failure_result = {
+        "reason": "timeout",
+        "reason_detail": "gate stalled after 300 s",
+        "duration_seconds": 300.0,
+        "partial_output_lines": 5,
+        "runner_pid": 12345,
+    }
+
+    gate_recorder.record_failure(
+        gate="gemini_review",
+        pr_number=20,
+        pr_id="pr-20",
+        result=failure_result,
+        request_payload=request_payload,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+    )
+
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "gemini_review"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_failed"
+    assert gate_events[0].get("dispatch_id") == "D-FAILURE-020"

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -13,9 +13,9 @@ Coverage:
   10. Throttle marker is integer (not float) after Python write
   11. Bash CLI dispatch_promoted event writes register entry
   12. Throttle expiry: rebuild triggers when stale throttle marker present
-  13. gate_artifacts success with no blocking → gate_passed in register
-  14. gate_artifacts success with blocking → gate_failed in register
-  15. gate_recorder failure path emits gate_failed (not just success-materialization)
+  13. gate_artifacts gemini_review → NO register event (parser deferred)
+  14. gate_artifacts codex_gate with blocking → gate_failed in register
+  15. gate_recorder failure for gemini_review → NO register event (parser deferred)
 """
 from __future__ import annotations
 
@@ -337,8 +337,8 @@ def _make_gate_request_payload(tmp_path: Path, pr_number: int = 1) -> dict:
     }
 
 
-def test_gate_artifacts_no_blocking_emits_gate_passed(isolated_register, tmp_path):
-    """materialize_artifacts with no blocking findings emits gate_passed."""
+def test_gate_artifacts_gemini_review_skips_register_emit(isolated_register, tmp_path):
+    """materialize_artifacts for gemini_review must not emit any register event (parser deferred)."""
     requests_dir = tmp_path / "requests"
     results_dir = tmp_path / "results"
     reports_dir = tmp_path / "reports"
@@ -363,8 +363,9 @@ def test_gate_artifacts_no_blocking_emits_gate_passed(isolated_register, tmp_pat
     assert result.get("status") == "completed"
     events = _reg_events(isolated_register)
     reg_events_for_gate = [e for e in events if e.get("gate") == "gemini_review"]
-    assert len(reg_events_for_gate) == 1
-    assert reg_events_for_gate[0]["event"] == "gate_passed"
+    assert len(reg_events_for_gate) == 0, (
+        f"gemini_review must not emit register events (parser deferred), got: {reg_events_for_gate}"
+    )
 
 
 def test_gate_artifacts_blocking_emits_gate_failed(isolated_register, tmp_path):
@@ -417,8 +418,8 @@ def test_gate_artifacts_blocking_emits_gate_failed(isolated_register, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_gate_recorder_failure_path_emits_gate_failed(isolated_register, tmp_path):
-    """record_failure (execution failure path) must emit gate_failed to the register."""
+def test_gate_recorder_gemini_failure_skips_register_emit(isolated_register, tmp_path):
+    """record_failure for gemini_review must NOT emit to the register (parser deferred)."""
     requests_dir = tmp_path / "requests"
     results_dir = tmp_path / "results"
     for d in (requests_dir, results_dir):
@@ -451,9 +452,9 @@ def test_gate_recorder_failure_path_emits_gate_failed(isolated_register, tmp_pat
 
     events = _reg_events(isolated_register)
     gate_events = [e for e in events if e.get("gate") == "gemini_review"]
-    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
-    assert gate_events[0]["event"] == "gate_failed"
-    assert gate_events[0].get("dispatch_id") == "D-FAILURE-020"
+    assert len(gate_events) == 0, (
+        f"gemini_review record_failure must not emit register event (parser deferred), got: {gate_events}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -482,8 +483,8 @@ def test_emit_task_complete_failure_status_classifies_failed(isolated_register):
 # ---------------------------------------------------------------------------
 
 
-def test_gate_artifacts_pr_id_numeric_resolves_pr_number(isolated_register, tmp_path):
-    """gate hook with pr_id='276' and pr_number=None must write pr_number=276 to register."""
+def test_gate_artifacts_gemini_pr_id_numeric_skips_register_emit(isolated_register, tmp_path):
+    """gate hook with gemini_review + pr_id='276' must complete but NOT emit a register event."""
     requests_dir = tmp_path / "requests"
     results_dir = tmp_path / "results"
     reports_dir = tmp_path / "reports"
@@ -516,10 +517,8 @@ def test_gate_artifacts_pr_id_numeric_resolves_pr_number(isolated_register, tmp_
     assert result.get("status") == "completed"
     events = _reg_events(isolated_register)
     gate_events = [e for e in events if e.get("gate") == "gemini_review"]
-    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
-    assert gate_events[0]["event"] == "gate_passed"
-    assert gate_events[0].get("pr_number") == 276, (
-        f"pr_id='276' must resolve to pr_number=276, got {gate_events[0].get('pr_number')!r}"
+    assert len(gate_events) == 0, (
+        f"gemini_review must not emit register events (parser deferred), got: {gate_events}"
     )
 
 
@@ -676,8 +675,8 @@ def test_emit_dispatch_register_non_numeric_pr_id_uses_feature_id(isolated_regis
     assert events[0].get("pr_number") is None
 
 
-def test_gate_artifacts_non_numeric_pr_id_uses_feature_id(isolated_register, tmp_path):
-    """gate hook with pr_id='PR-6', dispatch_id='', pr_number=None → feature_id='PR-6' in register."""
+def test_gate_artifacts_gemini_non_numeric_pr_id_skips_register_emit(isolated_register, tmp_path):
+    """gate hook with gemini_review + pr_id='PR-6' must complete but NOT emit a register event."""
     requests_dir = tmp_path / "requests"
     results_dir = tmp_path / "results"
     reports_dir = tmp_path / "reports"
@@ -710,12 +709,9 @@ def test_gate_artifacts_non_numeric_pr_id_uses_feature_id(isolated_register, tmp
     assert result.get("status") == "completed"
     events = _reg_events(isolated_register)
     gate_events = [e for e in events if e.get("gate") == "gemini_review"]
-    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
-    assert gate_events[0]["event"] == "gate_passed"
-    assert gate_events[0].get("feature_id") == "PR-6", (
-        f"Non-numeric pr_id='PR-6' must become feature_id='PR-6', got {gate_events[0].get('feature_id')!r}"
+    assert len(gate_events) == 0, (
+        f"gemini_review must not emit register events (parser deferred), got: {gate_events}"
     )
-    assert gate_events[0].get("pr_number") is None
 
 
 def test_gate_recorder_non_numeric_pr_id_uses_feature_id(isolated_register, tmp_path):
@@ -833,53 +829,8 @@ def test_emit_task_complete_empty_status_emits_completed(isolated_register):
 
 
 # ---------------------------------------------------------------------------
-# Tests 27-28: multi-gate findings parser (BLOCKING — Codex PR #278 round 5)
+# Test 27: claude_github_optional must not emit register events (parser deferred)
 # ---------------------------------------------------------------------------
-
-
-def test_gate_artifacts_gemini_blocking_in_stdout_emits_gate_failed(isolated_register, tmp_path):
-    """materialize_artifacts gemini_review with 'BLOCKING' in stdout emits gate_failed."""
-    requests_dir = tmp_path / "requests"
-    results_dir = tmp_path / "results"
-    reports_dir = tmp_path / "reports"
-    for d in (requests_dir, results_dir, reports_dir):
-        d.mkdir(parents=True, exist_ok=True)
-
-    report_path = reports_dir / "gate_report.md"
-    payload = {
-        "gate": "gemini_review",
-        "pr_number": 50,
-        "pr_id": "pr-50",
-        "branch": "feat/test",
-        "report_path": str(report_path),
-        "dispatch_id": "D-GEMINI-BLOCKING",
-    }
-    stdout = (
-        "# Gemini Review\n\n"
-        "This PR has a BLOCKING issue with null pointer dereference.\n"
-        "Must fix before merge.\n"
-        "Overall: FAIL"
-    )
-
-    result = gate_artifacts.materialize_artifacts(
-        gate="gemini_review",
-        pr_number=50,
-        pr_id="pr-50",
-        stdout=stdout,
-        request_payload=payload,
-        duration_seconds=1.5,
-        requests_dir=requests_dir,
-        results_dir=results_dir,
-        reports_dir=reports_dir,
-    )
-
-    assert result.get("status") == "completed"
-    events = _reg_events(isolated_register)
-    gate_events = [e for e in events if e.get("gate") == "gemini_review"]
-    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
-    assert gate_events[0]["event"] == "gate_failed", (
-        f"BLOCKING in gemini stdout must produce gate_failed, got {gate_events[0]['event']!r}"
-    )
 
 
 def test_gate_artifacts_claude_github_optional_skips_register_emit(isolated_register, tmp_path):

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -795,3 +795,131 @@ def test_emit_canonical_event_type_field_still_works(isolated_register):
     assert len(events) == 1
     assert events[0]["event"] == "dispatch_completed"
     assert events[0]["dispatch_id"] == "D-CANON-001"
+
+
+# ---------------------------------------------------------------------------
+# Tests 25-26: status defaulting guards (ADVISORY 1 — Codex PR #278 round 5)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_task_complete_unknown_status_skips_emit(isolated_register):
+    """task_complete with status='unknown' must NOT emit to register (malformed receipt guard)."""
+    receipt = {
+        "event_type": "task_complete",
+        "status": "unknown",
+        "dispatch_id": "D-UNKNOWN-001",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 0, (
+        f"task_complete with status='unknown' must not emit, got: {events}"
+    )
+
+
+def test_emit_task_complete_empty_status_emits_completed(isolated_register):
+    """task_complete with status='' (empty) must map to dispatch_completed (legacy convention)."""
+    receipt = {
+        "event_type": "task_complete",
+        "status": "",
+        "dispatch_id": "D-EMPTY-001",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_completed"
+    assert events[0]["dispatch_id"] == "D-EMPTY-001"
+
+
+# ---------------------------------------------------------------------------
+# Tests 27-28: multi-gate findings parser (BLOCKING — Codex PR #278 round 5)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_artifacts_gemini_blocking_in_stdout_emits_gate_failed(isolated_register, tmp_path):
+    """materialize_artifacts gemini_review with 'BLOCKING' in stdout emits gate_failed."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "gemini_review",
+        "pr_number": 50,
+        "pr_id": "pr-50",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": "D-GEMINI-BLOCKING",
+    }
+    stdout = (
+        "# Gemini Review\n\n"
+        "This PR has a BLOCKING issue with null pointer dereference.\n"
+        "Must fix before merge.\n"
+        "Overall: FAIL"
+    )
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="gemini_review",
+        pr_number=50,
+        pr_id="pr-50",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.5,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "gemini_review"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_failed", (
+        f"BLOCKING in gemini stdout must produce gate_failed, got {gate_events[0]['event']!r}"
+    )
+
+
+def test_gate_artifacts_claude_github_optional_skips_register_emit(isolated_register, tmp_path):
+    """materialize_artifacts claude_github_optional must not emit any register event (parser unimplemented)."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "claude_github_optional",
+        "pr_number": 60,
+        "pr_id": "pr-60",
+        "branch": "feat/test",
+        "report_path": str(report_path),
+        "dispatch_id": "D-CLAUDE-GH-060",
+    }
+    stdout = (
+        "# Claude GitHub Review\n\n"
+        "Looks good overall.\n"
+        "Minor suggestions noted."
+    )
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="claude_github_optional",
+        pr_number=60,
+        pr_id="pr-60",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.0,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "claude_github_optional"]
+    assert len(gate_events) == 0, (
+        f"claude_github_optional must not emit register event (parser unimplemented), got: {gate_events}"
+    )

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -646,3 +646,111 @@ def test_gate_artifacts_triggers_state_rebuild(isolated_register, tmp_path, monk
         )
 
     assert len(rebuild_calls) >= 1, "maybe_trigger_state_rebuild must be called after register write"
+
+
+# ---------------------------------------------------------------------------
+# Tests 20-22: non-numeric pr_id fallback to feature_id (BLOCKING fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_dispatch_register_non_numeric_pr_id_uses_feature_id(isolated_register):
+    """_emit_dispatch_register with pr_id='PR-6' + no dispatch_id must write feature_id='PR-6'."""
+    receipt = {
+        "event_type": "review_gate_request",
+        "pr_id": "PR-6",
+        "dispatch_id": "",
+        "terminal": "T3",
+        "gate": "gemini_review",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 event, got: {events}"
+    assert events[0]["event"] == "gate_requested"
+    assert events[0].get("feature_id") == "PR-6", (
+        f"Non-numeric pr_id='PR-6' must become feature_id='PR-6', got {events[0].get('feature_id')!r}"
+    )
+    assert events[0].get("pr_number") is None
+
+
+def test_gate_artifacts_non_numeric_pr_id_uses_feature_id(isolated_register, tmp_path):
+    """gate hook with pr_id='PR-6', dispatch_id='', pr_number=None → feature_id='PR-6' in register."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / "gate_report.md"
+    payload = {
+        "gate": "gemini_review",
+        "pr_number": None,
+        "pr_id": "PR-6",
+        "branch": "feat/contract",
+        "report_path": str(report_path),
+        "dispatch_id": "",
+    }
+    stdout = "# Review\nOverall: LGTM\nNo issues found."
+
+    result = gate_artifacts.materialize_artifacts(
+        gate="gemini_review",
+        pr_number=None,
+        pr_id="PR-6",
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.0,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        reports_dir=reports_dir,
+    )
+
+    assert result.get("status") == "completed"
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "gemini_review"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_passed"
+    assert gate_events[0].get("feature_id") == "PR-6", (
+        f"Non-numeric pr_id='PR-6' must become feature_id='PR-6', got {gate_events[0].get('feature_id')!r}"
+    )
+    assert gate_events[0].get("pr_number") is None
+
+
+def test_gate_recorder_non_numeric_pr_id_uses_feature_id(isolated_register, tmp_path):
+    """record_failure with pr_id='PR-6', dispatch_id='', pr_number=None → feature_id='PR-6' in register."""
+    requests_dir = tmp_path / "requests"
+    results_dir = tmp_path / "results"
+    for d in (requests_dir, results_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    request_payload = {
+        "gate": "codex_gate",
+        "pr_number": None,
+        "pr_id": "PR-6",
+        "dispatch_id": "",
+        "report_path": str(tmp_path / "report.md"),
+    }
+    failure_result = {
+        "reason": "timeout",
+        "reason_detail": "stalled after 300 s",
+        "duration_seconds": 300.0,
+        "partial_output_lines": 0,
+        "runner_pid": 42,
+    }
+
+    gate_recorder.record_failure(
+        gate="codex_gate",
+        pr_number=None,
+        pr_id="PR-6",
+        result=failure_result,
+        request_payload=request_payload,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+    )
+
+    events = _reg_events(isolated_register)
+    gate_events = [e for e in events if e.get("gate") == "codex_gate"]
+    assert len(gate_events) == 1, f"Expected 1 gate event, got: {gate_events}"
+    assert gate_events[0]["event"] == "gate_failed"
+    assert gate_events[0].get("feature_id") == "PR-6", (
+        f"Non-numeric pr_id='PR-6' must become feature_id='PR-6', got {gate_events[0].get('feature_id')!r}"
+    )
+    assert gate_events[0].get("pr_number") is None

--- a/tests/test_dispatch_register_hooks.py
+++ b/tests/test_dispatch_register_hooks.py
@@ -758,3 +758,40 @@ def test_gate_recorder_non_numeric_pr_id_uses_feature_id(isolated_register, tmp_
         f"Non-numeric pr_id='PR-6' must become feature_id='PR-6', got {gate_events[0].get('feature_id')!r}"
     )
     assert gate_events[0].get("pr_number") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests 23-24: legacy 'event' field fallback in _emit_dispatch_register
+# ---------------------------------------------------------------------------
+
+
+def test_emit_legacy_event_field_triggers_register_entry(isolated_register):
+    """Receipt with legacy 'event' key (no event_type) must trigger a register entry."""
+    receipt = {
+        "event": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-LEGACY-001",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1, f"Expected 1 register entry, got: {events}"
+    assert events[0]["event"] == "dispatch_completed", (
+        f"Legacy 'event' field must produce dispatch_completed, got {events[0]['event']!r}"
+    )
+    assert events[0]["dispatch_id"] == "D-LEGACY-001"
+
+
+def test_emit_canonical_event_type_field_still_works(isolated_register):
+    """Canonical 'event_type' key must still produce a register entry (regression guard)."""
+    receipt = {
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "D-CANON-001",
+        "terminal": "T1",
+    }
+    append_receipt._emit_dispatch_register(receipt)
+    events = _reg_events(isolated_register)
+    assert len(events) == 1
+    assert events[0]["event"] == "dispatch_completed"
+    assert events[0]["dispatch_id"] == "D-CANON-001"

--- a/tests/test_idempotency_gate_field.py
+++ b/tests/test_idempotency_gate_field.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests that gate and pr_number are included in the idempotency key.
+
+Before the fix: IDEMPOTENCY_FIELDS omitted 'gate' and 'pr_number'. Gate request
+receipts for the same dispatch_id/terminal/event_type/source shared an identical
+key, so only the first (of codex + gemini + claude_github) persisted within the
+5-minute cache window.
+
+After the fix: 'gate' and 'pr_number' are in IDEMPOTENCY_FIELDS. Each gate
+request produces a distinct key and all three persist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+APPEND_SCRIPT = SCRIPTS_DIR / "append_receipt.py"
+
+
+def _build_env(tmp_path: Path) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    env["PROJECT_ROOT"] = str(tmp_path)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    env["VNX_STATE_DIR"] = str(state_dir)
+    env["VNX_HOME"] = str(VNX_ROOT)
+    return env
+
+
+def _run_append(tmp_path: Path, payload: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(APPEND_SCRIPT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=_build_env(tmp_path),
+    )
+
+
+def test_idempotency_distinct_gates(tmp_path: Path):
+    """3 review_gate_request receipts with same dispatch_id but different gate → all 3 persist."""
+    base = {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": "review_gate_request",
+        "event": "review_gate_request",
+        "dispatch_id": "DISP-GATE-IDEM-001",
+        "terminal": "T1",
+        "source": "governance",
+        "pr_number": "278",
+    }
+
+    gates = ["codex", "gemini", "claude_github"]
+    for gate in gates:
+        r = _run_append(tmp_path, json.dumps({**base, "gate": gate}))
+        assert r.returncode == 0, f"gate={gate} append failed:\n{r.stderr}"
+
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    assert receipts_file.exists(), "receipts file not created"
+    lines = [ln for ln in receipts_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 3, (
+        f"Expected 3 distinct gate receipts but got {len(lines)}. "
+        "If only 1 line, 'gate' is still not in IDEMPOTENCY_FIELDS."
+    )
+    stored_gates = {json.loads(ln).get("gate") for ln in lines}
+    assert stored_gates == {"codex", "gemini", "claude_github"}
+
+
+def test_idempotency_same_gate_deduped(tmp_path: Path):
+    """Same dispatch_id + same gate → duplicate is dropped (idempotency still works)."""
+    receipt = {
+        "timestamp": "2026-04-28T10:01:00Z",
+        "event_type": "review_gate_request",
+        "event": "review_gate_request",
+        "dispatch_id": "DISP-GATE-IDEM-002",
+        "terminal": "T1",
+        "source": "governance",
+        "pr_number": "278",
+        "gate": "codex",
+    }
+    payload = json.dumps(receipt)
+
+    first = _run_append(tmp_path, payload)
+    second = _run_append(tmp_path, payload)
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert '"code":"duplicate_receipt_skipped"' in second.stderr, (
+        "Second identical gate receipt should be deduped"
+    )
+
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    lines = [ln for ln in receipts_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1, "Duplicate gate receipt should not create a second entry"
+
+
+def test_idempotency_existing_receipts_backward_compat(tmp_path: Path):
+    """Non-gate receipts (no gate/pr_number fields) still deduplicate correctly.
+
+    Backward compat: adding gate/pr_number to IDEMPOTENCY_FIELDS uses skip-if-None
+    logic, so existing receipts without those fields produce the same hash as before.
+    """
+    receipt = {
+        "timestamp": "2026-04-28T10:02:00Z",
+        "event_type": "task_complete",
+        "event": "task_complete",
+        "dispatch_id": "DISP-BACK-COMPAT-001",
+        "task_id": "TASK-001",
+        "terminal": "T1",
+        "source": "pytest",
+        "status": "success",
+    }
+    payload = json.dumps(receipt)
+
+    first = _run_append(tmp_path, payload)
+    second = _run_append(tmp_path, payload)
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert '"code":"duplicate_receipt_skipped"' in second.stderr, (
+        "Non-gate receipt should still deduplicate correctly"
+    )

--- a/tests/test_state_rebuild_trigger.py
+++ b/tests/test_state_rebuild_trigger.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/lib/state_rebuild_trigger.py — shared throttle/rebuild helper."""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import state_rebuild_trigger
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(monkeypatch, tmp_path):
+    """Route state_rebuild_trigger state resolution to a tmp dir."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    return state_dir
+
+
+# ---------------------------------------------------------------------------
+# Test 1: fires Popen when throttle expired
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_trigger_fires_popen_when_stale(isolated_state, monkeypatch):
+    """maybe_trigger_state_rebuild calls Popen when throttle is expired."""
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: isolated_state)
+
+    throttle = isolated_state / ".last_state_rebuild_ts"
+    throttle.write_text("1000", encoding="utf-8")  # very old timestamp
+
+    popen_calls: list = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            popen_calls.append(cmd)
+
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _FakePopen)
+
+    result = state_rebuild_trigger.maybe_trigger_state_rebuild()
+
+    assert result is True
+    assert len(popen_calls) == 1
+    assert "build_t0_state.py" in popen_calls[0][-1]
+
+
+# ---------------------------------------------------------------------------
+# Test 2: respects throttle — no Popen when recent
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_trigger_respects_throttle(isolated_state, monkeypatch):
+    """maybe_trigger_state_rebuild must NOT call Popen when throttle is fresh."""
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: isolated_state)
+
+    throttle = isolated_state / ".last_state_rebuild_ts"
+    throttle.write_text(str(int(time.time())), encoding="utf-8")  # just updated
+
+    popen_calls: list = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            popen_calls.append(cmd)
+
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _FakePopen)
+
+    result = state_rebuild_trigger.maybe_trigger_state_rebuild()
+
+    assert result is False
+    assert len(popen_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3: fires Popen when no throttle file exists
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_trigger_fires_when_no_throttle_file(isolated_state, monkeypatch):
+    """maybe_trigger_state_rebuild must call Popen when no throttle file exists yet."""
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: isolated_state)
+
+    popen_calls: list = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            popen_calls.append(cmd)
+
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _FakePopen)
+
+    result = state_rebuild_trigger.maybe_trigger_state_rebuild()
+
+    assert result is True
+    assert len(popen_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4: throttle marker is integer after write
+# ---------------------------------------------------------------------------
+
+
+def test_throttle_marker_written_as_integer(isolated_state, monkeypatch):
+    """Throttle file must contain an integer epoch string (no decimal point)."""
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: isolated_state)
+
+    throttle = isolated_state / ".last_state_rebuild_ts"
+    throttle.write_text("1000", encoding="utf-8")  # stale
+
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", lambda cmd, **kw: None)
+
+    state_rebuild_trigger.maybe_trigger_state_rebuild()
+
+    written = throttle.read_text(encoding="utf-8").strip()
+    assert "." not in written, f"Throttle must be integer, got: {written!r}"
+    assert written.isdigit(), f"Throttle must be digits only, got: {written!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: returns False on any Popen exception (best-effort)
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_trigger_returns_false_on_popen_exception(isolated_state, monkeypatch):
+    """maybe_trigger_state_rebuild must not propagate exceptions — return False."""
+    monkeypatch.setattr(state_rebuild_trigger, "_resolve_state_dir", lambda: isolated_state)
+
+    throttle = isolated_state / ".last_state_rebuild_ts"
+    throttle.write_text("1000", encoding="utf-8")  # stale
+
+    def _bad_popen(*a, **kw):
+        raise OSError("binary not found")
+
+    monkeypatch.setattr(state_rebuild_trigger.subprocess, "Popen", _bad_popen)
+
+    result = state_rebuild_trigger.maybe_trigger_state_rebuild()
+
+    assert result is False


### PR DESCRIPTION
## Summary
- Wire dispatch_register.py (PR #277) into 3 lifecycle hooks
- `_emit_dispatch_register`: status-aware classification, pr_number propagation from `metadata.pr_number` fallback
- `gate_recorder.record_failure`: emit gate_failed from BOTH record_failure and record_failure_simple paths
- `gate_artifacts.materialize_artifacts`: emit gate_passed/gate_failed from success path based on blocking findings
- `dispatch_lifecycle.sh`: bash-int throttle marker (no float arithmetic crash), dispatch_promoted CLI call
- Extended `_maybe_trigger_state_rebuild` to gate events (review_gate_request, gate_passed, gate_failed)
- 15 hook test cases in tests/test_dispatch_register_hooks.py

## Why this works after PR #276 was closed
Applies all 5 codex findings from the closed PR #276 upfront:
- Status-aware failed-completion classification (`task_complete + status=failed → dispatch_failed`)
- `task_timeout` handling (`→ dispatch_failed`)
- Bash-int throttle (no Python float, bash `set -e` safe)
- `pr_number` propagation via `metadata.pr_number` fallback
- `gate_failed` on actual failure paths in gate_recorder (not just success-materialization)

## Test plan
- [x] All 15 hook tests pass (`pytest tests/test_dispatch_register_hooks.py -v`)
- [x] Existing governance test suite green (114 passing, 1 pre-existing failure for missing receipt_notifier.sh)
- [x] Bash syntax validates: `bash -n scripts/lib/dispatch_lifecycle.sh`
- [x] 0 occurrences of literal `state/` substring in newly-touched files
- [x] Throttle integer contract verified: writes `1777366970` (no decimal point)

Refs synthesis 2026-04-28 §D Sprint 3.