### PR TITLE
feat(governance): build_t0_state register events reader (PR-4b split 2/4)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -294,6 +294,7 @@ def _build_pr_progress(dispatch_dir: Path, state_dir: Path) -> Dict[str, Any]:
         in_progress = [p.pr_id for p in result.prs if p.state == "active"]
         pct = int(completed * 100 / total) if total > 0 else 0
 
+        blocked = [p.pr_id for p in result.prs if p.state == "blocked"]
         return {
             "feature_name": result.feature_name,
             "total": total,
@@ -301,6 +302,7 @@ def _build_pr_progress(dispatch_dir: Path, state_dir: Path) -> Dict[str, Any]:
             "in_progress": in_progress,
             "completion_pct": pct,
             "has_blocking_drift": result.has_blocking_drift,
+            "blocked": blocked,
         }
     except Exception:
         return _empty
@@ -641,6 +643,7 @@ def _state_to_brief(state: Dict[str, Any]) -> Dict[str, Any]:
             "completed": pr_raw.get("completed", 0),
             "in_progress": pr_raw.get("in_progress", []),
             "completion_percentage": pr_raw.get("completion_pct", 0),
+            "blocked": pr_raw.get("blocked", []),
         },
         "system_health": {
             "status": sh.get("status", "unknown"),
@@ -699,6 +702,14 @@ def main() -> int:
         state = build_t0_state(_STATE_DIR, _DISPATCH_DIR)
         payload = _state_to_brief(state) if args.format == "brief" else state
         _write_atomic(output_path, payload)
+        # Regenerate t0_brief.json alongside t0_state.json — orchestration helpers
+        # (receipt_processor_v4, intelligence_ack, t0_intelligence_aggregator) read
+        # t0_brief.json directly and must stay in sync with the new state.
+        try:
+            brief_path = _STATE_DIR / "t0_brief.json"
+            _write_atomic(brief_path, _state_to_brief(state))
+        except Exception:
+            pass  # best-effort — must not block SessionStart
         elapsed = time.monotonic() - t_start
         _build_succeeded = True
     except Exception:

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -43,6 +43,12 @@ _DISPATCH_DIR = Path(_PATHS["VNX_DISPATCH_DIR"])
 _DATA_DIR = Path(_PATHS["VNX_DATA_DIR"])
 _PROJECT_ROOT = Path(_PATHS["PROJECT_ROOT"])
 
+# Register events reader (raw events list exposure for now; aggregation is PR-4c)
+try:
+    from dispatch_register import read_events as _read_register_events
+except ImportError:
+    _read_register_events = None  # Module is optional during initial deploy
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -367,12 +373,13 @@ def _build_quality_digest(state_dir: Path) -> Dict[str, Any]:
 # Dispatch insights (from DispatchParameterTracker)
 # ---------------------------------------------------------------------------
 
-def _build_dispatch_insights() -> Dict[str, Any]:
+def _build_dispatch_insights(state_dir: Optional[Path] = None) -> Dict[str, Any]:
     """Return top 5 dispatch insights when >= 20 experiments exist."""
     _empty: Dict[str, Any] = {"available": False, "insights": [], "experiment_count": 0}
+    actual_state_dir = state_dir if state_dir else _STATE_DIR
     try:
         from dispatch_parameter_tracker import DispatchParameterTracker
-        tracker = DispatchParameterTracker(state_dir=_STATE_DIR)
+        tracker = DispatchParameterTracker(state_dir=actual_state_dir)
         stats = tracker.stats()
         if not stats.get("insights_available"):
             return {**_empty, "experiment_count": stats.get("completed", 0)}
@@ -527,20 +534,11 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 # ---------------------------------------------------------------------------
 
 def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> list[dict]:
-    """Return last N dispatch_register events as raw list — minimal exposure.
-
-    NOT a feature_state aggregation. Full register-canonical pr_progress
-    aggregation (group-by-dispatch, recency status, PR/feature rollup) is
-    deferred to PR-4c.
-
-    Honors state_dir override (test/headless contexts) via
-    dispatch_register.read_events shared-lock contract.
-    """
+    """Last N register events. Aggregation is PR-4c."""
+    if _read_register_events is None:
+        return []
     try:
-        if str(_LIB_DIR) not in sys.path:
-            sys.path.insert(0, str(_LIB_DIR))
-        from dispatch_register import read_events
-        events = read_events(state_dir=state_dir) if state_dir else read_events()
+        events = _read_register_events(state_dir=state_dir) if state_dir else _read_register_events()
         return events[-limit:] if events else []
     except Exception:
         return []
@@ -567,7 +565,7 @@ def build_t0_state(
     feature_state = _build_feature_state()
     open_items = _build_open_items(state_dir)
     quality_digest = _build_quality_digest(state_dir)
-    dispatch_insights = _build_dispatch_insights()
+    dispatch_insights = _build_dispatch_insights(state_dir=state_dir)
     active_work = _build_active_work(dispatch_dir)
     recent_receipts = _build_recent_receipts(state_dir)
     register_events = _build_register_events(state_dir=state_dir)

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -521,6 +521,28 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 
 
 # ---------------------------------------------------------------------------
+# Register events (dispatch_register.ndjson reader)
+# ---------------------------------------------------------------------------
+
+def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> list[dict]:
+    """Read last N events from dispatch_register.ndjson — minimal exposure for PR-4b2.
+
+    Honors state_dir override (test/headless contexts). Goes through canonical
+    dispatch_register.read_events() to preserve fcntl.LOCK_SH contract.
+
+    Full register-canonical aggregation deferred to PR-4c.
+    """
+    try:
+        if str(_LIB_DIR) not in sys.path:
+            sys.path.insert(0, str(_LIB_DIR))
+        from dispatch_register import read_events
+        events = read_events(state_dir=state_dir) if state_dir else read_events()
+        return events[-limit:] if events else []
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Main builder
 # ---------------------------------------------------------------------------
 
@@ -544,6 +566,7 @@ def build_t0_state(
     dispatch_insights = _build_dispatch_insights()
     active_work = _build_active_work(dispatch_dir)
     recent_receipts = _build_recent_receipts(state_dir)
+    register_events = _build_register_events(state_dir=state_dir)
     git_context = _build_git_context()
     elapsed = time.monotonic() - start
     system_health = _build_system_health(state_dir, db_ok)
@@ -562,6 +585,7 @@ def build_t0_state(
         "dispatch_insights": dispatch_insights,
         "active_work": active_work,
         "recent_receipts": recent_receipts,
+        "dispatch_register_events": register_events,
         "git_context": git_context,
         "system_health": system_health,
         "_build_seconds": round(elapsed, 2),

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -525,12 +525,14 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 # ---------------------------------------------------------------------------
 
 def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> list[dict]:
-    """Read last N events from dispatch_register.ndjson — minimal exposure for PR-4b2.
+    """Return last N dispatch_register events as raw list — minimal exposure.
 
-    Honors state_dir override (test/headless contexts). Goes through canonical
-    dispatch_register.read_events() to preserve fcntl.LOCK_SH contract.
+    NOT a feature_state aggregation. Full register-canonical pr_progress
+    aggregation (group-by-dispatch, recency status, PR/feature rollup) is
+    deferred to PR-4c.
 
-    Full register-canonical aggregation deferred to PR-4c.
+    Honors state_dir override (test/headless contexts) via
+    dispatch_register.read_events shared-lock contract.
     """
     try:
         if str(_LIB_DIR) not in sys.path:

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -618,6 +618,14 @@ def _state_to_brief(state: Dict[str, Any]) -> Dict[str, Any]:
     pr_raw = state.get("pr_progress") or {}
     oi = state.get("open_items") or {}
     sh = state.get("system_health") or {}
+    active_work = state.get("active_work") or []
+
+    blockers = (oi.get("top_blockers") or [])[:3]
+    next_gates = [
+        item["gate"]
+        for item in active_work
+        if item.get("gate")
+    ]
 
     return {
         "timestamp": state.get("generated_at", _now_iso()),
@@ -630,9 +638,10 @@ def _state_to_brief(state: Dict[str, Any]) -> Dict[str, Any]:
             "conflicts": queues.get("conflict_count", 0),
         },
         "tracks": state.get("tracks", {}),
-        "active_work": state.get("active_work", []),
+        "active_work": active_work,
         "recent_receipts": state.get("recent_receipts", []),
-        "blockers": [],
+        "blockers": blockers,
+        "next_gates": next_gates,
         "open_items_summary": {
             "open_count": oi.get("open_count", 0),
             "blocker_count": oi.get("blocker_count", 0),
@@ -682,17 +691,26 @@ def main() -> int:
         description="Build unified T0 state JSON from all runtime sources."
     )
     parser.add_argument(
-        "--output",
-        default=str(_STATE_DIR / "t0_state.json"),
-        help="Output path (default: $VNX_STATE_DIR/t0_state.json)",
-    )
-    parser.add_argument(
         "--format",
         choices=["state", "brief"],
         default="state",
         help="Output format: 'state' (schema 2.0) or 'brief' (backward-compat 1.0)",
     )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Output path (default: t0_state.json for --format state, "
+            "t0_brief.json for --format brief)"
+        ),
+    )
     args = parser.parse_args()
+
+    if args.output is None:
+        if args.format == "brief":
+            args.output = str(_STATE_DIR / "t0_brief.json")
+        else:
+            args.output = str(_STATE_DIR / "t0_state.json")
 
     output_path = Path(args.output)
     elapsed = 0.0

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -1,9 +1,13 @@
 """Dispatch lifecycle register — append-only NDJSON log of dispatch state changes.
 
 File: $VNX_STATE_DIR/dispatch_register.ndjson
-Currently consumed by build_t0_state.py (raw events list exposure).
-Hook callers (append_receipt, gate_recorder, dispatch_lifecycle) added in
-parallel PRs (PR-4b3, PR-4b4). Full register-canonical aggregation in PR-4c.
+
+Current consumers:
+- build_t0_state.py: exposes raw events list as dispatch_register_events (PR-4b2)
+
+Future consumers (separate PRs):
+- append_receipt.py + gate_recorder.py + dispatch_lifecycle.sh: hook callers (PR-4b3, PR-4b4)
+- build_t0_state.py: full register-canonical pr_progress aggregation (PR-4c)
 """
 from __future__ import annotations
 import datetime as _dt, json, os, fcntl, sys

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -1,7 +1,9 @@
 """Dispatch lifecycle register — append-only NDJSON log of dispatch state changes.
 
 File: $VNX_STATE_DIR/dispatch_register.ndjson
-Source of truth for feature/PR queue state (consumed by build_t0_state.py).
+Currently exposed via build_t0_state as 'dispatch_register_events' (raw last 50).
+Full register-canonical pr_progress / feature_state aggregation is deferred
+to a future PR (Sprint 3 split 3/3).
 """
 from __future__ import annotations
 import datetime as _dt, json, os, fcntl, sys

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -1,9 +1,9 @@
 """Dispatch lifecycle register — append-only NDJSON log of dispatch state changes.
 
 File: $VNX_STATE_DIR/dispatch_register.ndjson
-Currently exposed via build_t0_state as 'dispatch_register_events' (raw last 50).
-Full register-canonical pr_progress / feature_state aggregation is deferred
-to a future PR (Sprint 3 split 3/3).
+Currently consumed by build_t0_state.py (raw events list exposure).
+Hook callers (append_receipt, gate_recorder, dispatch_lifecycle) added in
+parallel PRs (PR-4b3, PR-4b4). Full register-canonical aggregation in PR-4c.
 """
 from __future__ import annotations
 import datetime as _dt, json, os, fcntl, sys

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -103,9 +103,12 @@ def append_event(
         return False
 
 
-def read_events(*, since_iso: Optional[str] = None) -> list[dict]:
-    """Read all events; takes shared lock to avoid partial-write reads."""
-    path = _register_path()
+def read_events(*, since_iso: Optional[str] = None, state_dir: Optional[Path] = None) -> list[dict]:
+    """Read all events; takes shared lock to avoid partial-write reads. Honors optional state_dir override."""
+    if state_dir is not None:
+        path = Path(state_dir) / "dispatch_register.ndjson"
+    else:
+        path = _register_path()
     if not path.exists():
         return []
     events = []

--- a/tests/test_build_t0_brief_output.py
+++ b/tests/test_build_t0_brief_output.py
@@ -1,0 +1,223 @@
+"""Tests for _state_to_brief() and --format brief output path (PR-4b2 fixup 3).
+
+Covers:
+  BLOCKING 1 — pr_progress.blocked is present in brief when source has blocked PRs
+  BLOCKING 2 — --format brief routes output to t0_brief.json, not t0_state.json
+  ADVISORY   — blockers derived from open_items top_blockers; next_gates from active_work
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from build_t0_state import _state_to_brief, main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_state(**overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "schema_version": "2.0",
+        "generated_at": "2026-04-28T00:00:00+00:00",
+        "terminals": {},
+        "queues": {
+            "pending_count": 0,
+            "active_count": 0,
+            "completed_last_hour": 0,
+            "conflict_count": 0,
+        },
+        "tracks": {},
+        "pr_progress": {
+            "feature_name": "test-feature",
+            "total": 3,
+            "completed": 1,
+            "in_progress": ["PR-2"],
+            "completion_pct": 33,
+            "has_blocking_drift": False,
+            "blocked": [],
+        },
+        "open_items": {"open_count": 0, "blocker_count": 0, "top_blockers": []},
+        "active_work": [],
+        "recent_receipts": [],
+        "system_health": {"status": "healthy", "db_initialized": True, "uptime_seconds": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# BLOCKING 1: pr_progress.blocked propagation into brief
+# ---------------------------------------------------------------------------
+
+class TestBriefPrProgressBlocked:
+    def test_blocked_field_present_in_brief(self):
+        state = _minimal_state()
+        state["pr_progress"]["blocked"] = ["PR-3", "PR-4"]
+        brief = _state_to_brief(state)
+        assert "blocked" in brief["pr_progress"]
+
+    def test_blocked_values_propagated(self):
+        state = _minimal_state()
+        state["pr_progress"]["blocked"] = ["PR-3", "PR-4"]
+        brief = _state_to_brief(state)
+        assert brief["pr_progress"]["blocked"] == ["PR-3", "PR-4"]
+
+    def test_blocked_empty_when_source_empty(self):
+        state = _minimal_state()
+        state["pr_progress"]["blocked"] = []
+        brief = _state_to_brief(state)
+        assert brief["pr_progress"]["blocked"] == []
+
+    def test_blocked_defaults_to_empty_when_key_absent(self):
+        state = _minimal_state()
+        state["pr_progress"].pop("blocked", None)
+        brief = _state_to_brief(state)
+        assert brief["pr_progress"]["blocked"] == []
+
+
+# ---------------------------------------------------------------------------
+# BLOCKING 2: --format brief writes to t0_brief.json, not t0_state.json
+# ---------------------------------------------------------------------------
+
+class TestFormatBriefOutputPath:
+    def test_brief_format_writes_to_t0_brief_json(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+
+        import build_t0_state as _bts
+        monkeypatch.setattr(_bts, "_STATE_DIR", state_dir)
+        monkeypatch.setattr(_bts, "_DISPATCH_DIR", dispatch_dir)
+        monkeypatch.setattr(_bts, "_DATA_DIR", tmp_path / "data")
+
+        with patch("sys.argv", ["build_t0_state.py", "--format", "brief"]):
+            rc = main()
+
+        assert rc == 0
+        brief_path = state_dir / "t0_brief.json"
+        state_path = state_dir / "t0_state.json"
+        assert brief_path.exists(), "t0_brief.json must be written when --format brief"
+        if state_path.exists():
+            data = json.loads(state_path.read_text())
+            assert data.get("schema_version") != "1.0", (
+                "t0_state.json must not contain brief schema when --format brief"
+            )
+
+    def test_brief_output_has_version_1_0(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        import build_t0_state as _bts
+        monkeypatch.setattr(_bts, "_STATE_DIR", state_dir)
+        monkeypatch.setattr(_bts, "_DISPATCH_DIR", dispatch_dir)
+        monkeypatch.setattr(_bts, "_DATA_DIR", tmp_path / "data")
+
+        with patch("sys.argv", ["build_t0_state.py", "--format", "brief"]):
+            rc = main()
+
+        assert rc == 0
+        data = json.loads((state_dir / "t0_brief.json").read_text())
+        assert data.get("version") == "1.0"
+
+    def test_state_format_writes_to_t0_state_json(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        import build_t0_state as _bts
+        monkeypatch.setattr(_bts, "_STATE_DIR", state_dir)
+        monkeypatch.setattr(_bts, "_DISPATCH_DIR", dispatch_dir)
+        monkeypatch.setattr(_bts, "_DATA_DIR", tmp_path / "data")
+
+        with patch("sys.argv", ["build_t0_state.py", "--format", "state"]):
+            rc = main()
+
+        assert rc == 0
+        state_path = state_dir / "t0_state.json"
+        assert state_path.exists(), "t0_state.json must be written when --format state"
+        data = json.loads(state_path.read_text())
+        assert data.get("schema_version") == "2.0"
+
+
+# ---------------------------------------------------------------------------
+# ADVISORY: blockers derived from open_items; next_gates from active_work
+# ---------------------------------------------------------------------------
+
+class TestBriefBlockers:
+    def test_blockers_empty_when_no_open_items(self):
+        state = _minimal_state()
+        brief = _state_to_brief(state)
+        assert brief["blockers"] == []
+
+    def test_blockers_derived_from_top_blockers(self):
+        blocker_item = {"id": "OI-1", "title": "Auth broken", "severity": "blocker"}
+        state = _minimal_state()
+        state["open_items"]["top_blockers"] = [blocker_item]
+        brief = _state_to_brief(state)
+        assert len(brief["blockers"]) == 1
+        assert brief["blockers"][0]["id"] == "OI-1"
+
+    def test_blockers_capped_at_3(self):
+        state = _minimal_state()
+        state["open_items"]["top_blockers"] = [
+            {"id": f"OI-{i}", "title": f"Blocker {i}"} for i in range(5)
+        ]
+        brief = _state_to_brief(state)
+        assert len(brief["blockers"]) == 3
+
+
+class TestBriefNextGates:
+    def test_next_gates_empty_when_no_active_work(self):
+        state = _minimal_state()
+        brief = _state_to_brief(state)
+        assert brief["next_gates"] == []
+
+    def test_next_gates_derived_from_active_work(self):
+        state = _minimal_state()
+        state["active_work"] = [
+            {"dispatch_id": "d-001", "track": "T1", "gate": "codex", "started_at": "2026-04-28T00:00:00Z"},
+            {"dispatch_id": "d-002", "track": "T2", "gate": "ci", "started_at": "2026-04-28T00:01:00Z"},
+        ]
+        brief = _state_to_brief(state)
+        assert set(brief["next_gates"]) == {"codex", "ci"}
+
+    def test_next_gates_skips_none_gate_entries(self):
+        state = _minimal_state()
+        state["active_work"] = [
+            {"dispatch_id": "d-001", "track": "T1", "gate": None, "started_at": "2026-04-28T00:00:00Z"},
+            {"dispatch_id": "d-002", "track": "T2", "gate": "review", "started_at": "2026-04-28T00:01:00Z"},
+        ]
+        brief = _state_to_brief(state)
+        assert brief["next_gates"] == ["review"]
+
+    def test_brief_has_next_gates_key(self):
+        state = _minimal_state()
+        brief = _state_to_brief(state)
+        assert "next_gates" in brief

--- a/tests/test_build_t0_state_register_reader.py
+++ b/tests/test_build_t0_state_register_reader.py
@@ -1,0 +1,198 @@
+"""Tests for _build_register_events() in build_t0_state.py (PR-4b split 2/4).
+
+Covers:
+  1. Empty register → returns empty list
+  2. Register with 5 events → returns those 5
+  3. Register with 100 events → returns last 50 (limit enforced)
+  4. state_dir override → reads from custom location
+  5. read_events raises → returns empty list (best-effort)
+  6. Integration: build_t0_state output dict contains dispatch_register_events key
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from build_t0_state import _build_register_events, build_t0_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_events(state_dir: Path, count: int) -> list[dict]:
+    """Write `count` synthetic dispatch_register events; return them as list."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    reg = state_dir / "dispatch_register.ndjson"
+    events = []
+    for i in range(count):
+        rec = {
+            "timestamp": f"2026-04-28T00:00:{i:02d}.000000Z",
+            "event": "dispatch_created",
+            "dispatch_id": f"d-{i:04d}",
+        }
+        events.append(rec)
+    reg.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    return events
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty register → returns empty list
+# ---------------------------------------------------------------------------
+
+class TestEmptyRegister:
+    def test_returns_empty_list_when_no_file(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        result = _build_register_events(state_dir=state_dir)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Register with 5 events → returns those 5
+# ---------------------------------------------------------------------------
+
+class TestFiveEvents:
+    def test_returns_all_five(self, tmp_path):
+        state_dir = tmp_path / "state"
+        written = _write_events(state_dir, 5)
+        result = _build_register_events(state_dir=state_dir)
+        assert len(result) == 5
+        assert [e["dispatch_id"] for e in result] == [e["dispatch_id"] for e in written]
+
+
+# ---------------------------------------------------------------------------
+# 3. Register with 100 events → returns last 50 (limit enforced)
+# ---------------------------------------------------------------------------
+
+class TestLimitEnforced:
+    def test_returns_last_50_of_100(self, tmp_path):
+        state_dir = tmp_path / "state"
+        written = _write_events(state_dir, 100)
+        result = _build_register_events(state_dir=state_dir, limit=50)
+        assert len(result) == 50
+        assert result[0]["dispatch_id"] == written[50]["dispatch_id"]
+        assert result[-1]["dispatch_id"] == written[99]["dispatch_id"]
+
+    def test_custom_limit_respected(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_events(state_dir, 30)
+        result = _build_register_events(state_dir=state_dir, limit=10)
+        assert len(result) == 10
+
+
+# ---------------------------------------------------------------------------
+# 4. state_dir override → reads from custom location
+# ---------------------------------------------------------------------------
+
+class TestStateDirOverride:
+    def test_reads_from_custom_state_dir(self, tmp_path, monkeypatch):
+        canonical = tmp_path / "canonical-state"
+        canonical.mkdir()
+        custom = tmp_path / "custom-state"
+        written = _write_events(custom, 3)
+
+        # Point env at canonical (should be ignored when state_dir given explicitly)
+        monkeypatch.setenv("VNX_STATE_DIR", str(canonical))
+
+        result = _build_register_events(state_dir=custom)
+        assert len(result) == 3
+        assert result[0]["dispatch_id"] == written[0]["dispatch_id"]
+
+    def test_canonical_not_read_when_override_given(self, tmp_path, monkeypatch):
+        canonical = tmp_path / "canonical-state"
+        _write_events(canonical, 10)   # canonical has 10 events
+        custom = tmp_path / "custom-state"
+        _write_events(custom, 2)       # override has 2 events
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(canonical))
+
+        result = _build_register_events(state_dir=custom)
+        assert len(result) == 2        # override wins
+
+
+# ---------------------------------------------------------------------------
+# 5. read_events raises → returns empty list (best-effort, never raises)
+# ---------------------------------------------------------------------------
+
+class TestReadEventsFailure:
+    def test_returns_empty_on_exception(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        import dispatch_register as _dr
+        with patch.object(_dr, "read_events", side_effect=RuntimeError("boom")):
+            result = _build_register_events(state_dir=state_dir)
+
+        assert result == []
+
+    def test_never_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        import dispatch_register as _dr
+        with patch.object(_dr, "read_events", side_effect=OSError("disk error")):
+            try:
+                _build_register_events(state_dir=state_dir)
+            except Exception as exc:
+                pytest.fail(f"_build_register_events raised unexpectedly: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: build_t0_state output dict contains dispatch_register_events
+# ---------------------------------------------------------------------------
+
+class TestIntegrationKeyPresent:
+    def test_state_contains_dispatch_register_events(self, tmp_path):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        # Pre-populate register with 3 events
+        written = _write_events(state_dir, 3)
+
+        state = build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+
+        assert "dispatch_register_events" in state, (
+            "dispatch_register_events key missing from build_t0_state output"
+        )
+
+    def test_register_events_value_is_list(self, tmp_path):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        state = build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+
+        assert isinstance(state["dispatch_register_events"], list)
+
+    def test_register_events_contains_written_events(self, tmp_path):
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir(parents=True)
+        (dispatch_dir / "conflicts").mkdir(parents=True)
+
+        written = _write_events(state_dir, 5)
+
+        state = build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+
+        events = state["dispatch_register_events"]
+        assert len(events) == 5
+        assert events[0]["dispatch_id"] == written[0]["dispatch_id"]


### PR DESCRIPTION
## Summary
- `_build_register_events` helper exposes last 50 register events in `t0_state.json`
- Reads via `dispatch_register.read_events` (preserves shared-lock contract)
- Adds `state_dir` param to `read_events` for test/headless overrides (backward-compat: defaults to canonical path)

## Test plan
- [x] Unit tests for empty register, 5-event register, 100-event limit enforcement
- [x] Unit tests for `state_dir` override (canonical not read when override given)
- [x] Best-effort: exception in `read_events` → returns empty list, never raises
- [x] Integration: `build_t0_state` output dict contains `dispatch_register_events` key
- [x] No regression on existing `test_dispatch_register.py` (32 tests, all pass)
- [x] Total: 43 passed

## Constraints respected
- No `feature_state` aggregation (deferred to PR-4c)
- No changes to `append_receipt`, `gate_artifacts`, `gate_recorder`, `dispatch_lifecycle`