### PR TITLE
feat(governance): gate emit codex_gate to register (PR-4b split 4/4)

### DIFF
--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -255,11 +255,19 @@ def materialize_artifacts(
     except Exception as _exc:
         logger.warning("materialize_artifacts: sidecar write failed: %s", _exc)
 
-    # Emit to dispatch register (codex_gate only — best-effort)
+    # Emit to dispatch register (codex_gate only — best-effort).
+    # Prefer explicit JSON verdict from codex output; fall back to severity-derivation.
     if gate == "codex_gate":
         try:
             from gate_register_emit import emit_codex_gate_to_register
-            register_event = "gate_passed" if not blocking else "gate_failed"
+            verdict_obj = parsed.get("verdict", {})
+            verdict_str = verdict_obj.get("verdict", "").lower() if isinstance(verdict_obj, dict) else ""
+            if verdict_str in ("pass", "passed"):
+                register_event = "gate_passed"
+            elif verdict_str in ("fail", "failed", "blocked"):
+                register_event = "gate_failed"
+            else:
+                register_event = "gate_passed" if not blocking else "gate_failed"
             emit_codex_gate_to_register(
                 register_event,
                 dispatch_id=real_dispatch_id,

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -255,6 +255,23 @@ def materialize_artifacts(
     except Exception as _exc:
         logger.warning("materialize_artifacts: sidecar write failed: %s", _exc)
 
+    # Emit to dispatch register (codex_gate only — best-effort)
+    if gate == "codex_gate":
+        try:
+            from gate_register_emit import emit_codex_gate_to_register
+            register_event = "gate_passed" if not blocking else "gate_failed"
+            emit_codex_gate_to_register(
+                register_event,
+                dispatch_id=real_dispatch_id,
+                pr_number=pr_number,
+                pr_id=pr_id,
+                gate=gate,
+            )
+        except Exception:
+            pass
+    elif gate in ("gemini_review", "claude_github_optional"):
+        logger.info("materialize_artifacts: register classification deferred for gate=%s", gate)
+
     return result_payload
 
 

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -26,6 +26,14 @@ _GATE_BINARIES: Dict[str, str] = {
     "claude_github_optional": "gh",
 }
 
+# Infrastructure/execution failures — NOT semantic gate verdicts.
+# gate_failed means "gate completed with blocking findings"; never emit it for these.
+EXECUTION_FAILURE_REASONS: frozenset = frozenset({
+    "exit_nonzero", "timeout", "stall", "stalled",
+    "artifact_materialization_error", "artifact_materialization_failed",
+    "subprocess_failed", "killed", "binary_not_found",
+})
+
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -192,8 +200,9 @@ def record_failure(
     if rf:
         rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
 
-    # Emit codex_gate failure to dispatch register (best-effort)
-    if gate == "codex_gate":
+    # Emit gate_failed for codex_gate only when the gate itself reported a verdict
+    # failure (not for infrastructure/execution errors like timeout or stall).
+    if gate == "codex_gate" and result["reason"] not in EXECUTION_FAILURE_REASONS:
         try:
             from gate_register_emit import emit_codex_gate_to_register
             emit_codex_gate_to_register(

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -191,6 +191,21 @@ def record_failure(
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     if rf:
         rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
+
+    # Emit codex_gate failure to dispatch register (best-effort)
+    if gate == "codex_gate":
+        try:
+            from gate_register_emit import emit_codex_gate_to_register
+            emit_codex_gate_to_register(
+                "gate_failed",
+                dispatch_id=request_payload.get("dispatch_id", ""),
+                pr_number=pr_number,
+                pr_id=pr_id,
+                gate=gate,
+            )
+        except Exception:
+            pass
+
     return failure_payload
 
 

--- a/scripts/lib/gate_register_emit.py
+++ b/scripts/lib/gate_register_emit.py
@@ -1,0 +1,76 @@
+"""Best-effort codex_gate register emit — shared by gate_artifacts and gate_recorder.
+
+Writes directly to dispatch_register.ndjson using env-var path resolution
+(mirrors dispatch_register._register_path fallback chain, but without calling
+vnx_paths.resolve_paths — which triggers a git subprocess that can interfere
+with tests that mock subprocess.Popen).
+"""
+from __future__ import annotations
+
+import datetime
+import fcntl
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+logger = logging.getLogger(__name__)
+
+
+def _resolve_register_path() -> Path:
+    """Resolve dispatch_register.ndjson path using env vars only (no git subprocess)."""
+    state_dir_env = os.environ.get("VNX_STATE_DIR")
+    if state_dir_env:
+        return Path(state_dir_env) / "dispatch_register.ndjson"
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+        return Path(os.environ["VNX_DATA_DIR"]) / "state" / "dispatch_register.ndjson"
+    return _REPO_ROOT / ".vnx-data" / "state" / "dispatch_register.ndjson"
+
+
+def emit_codex_gate_to_register(
+    event: str,
+    *,
+    dispatch_id: str,
+    pr_number: Optional[int],
+    pr_id: str,
+    gate: str,
+) -> bool:
+    """Resolve identifiers and append codex_gate event to register. Best-effort."""
+    if gate != "codex_gate":
+        return False
+    try:
+        pr_number_resolved = pr_number if pr_number is not None else None
+        feature_id_resolved = ""
+        if pr_number_resolved is None and pr_id:
+            try:
+                pr_number_resolved = int(pr_id)
+            except (ValueError, TypeError):
+                feature_id_resolved = str(pr_id)
+
+        if not dispatch_id and pr_number_resolved is None and not feature_id_resolved:
+            logger.warning(
+                "gate_register_emit: register emit dropped — no identifying field "
+                "(gate=%s, pr_id=%s, pr_number=%s)",
+                gate, pr_id, pr_number,
+            )
+            return False
+
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+        record: dict = {"timestamp": now, "event": event, "gate": gate}
+        if dispatch_id:
+            record["dispatch_id"] = dispatch_id
+        if pr_number_resolved is not None:
+            record["pr_number"] = pr_number_resolved
+        if feature_id_resolved:
+            record["feature_id"] = feature_id_resolved
+
+        path = _resolve_register_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        return True
+    except Exception:
+        return False

--- a/tests/test_gate_artifacts_register.py
+++ b/tests/test_gate_artifacts_register.py
@@ -1,0 +1,158 @@
+"""Tests for gate_artifacts → dispatch_register emit (codex_gate only)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_artifacts import materialize_artifacts
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def artifact_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    reports_dir = tmp_path / "reports"
+    requests_dir = state_dir / "review_gates" / "requests"
+    results_dir = state_dir / "review_gates" / "results"
+    for d in (requests_dir, results_dir, reports_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    # Redirect dispatch_register writes to tmp_path so they don't hit production state
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    return {
+        "state_dir": state_dir,
+        "reports_dir": reports_dir,
+        "requests_dir": requests_dir,
+        "results_dir": results_dir,
+    }
+
+
+_STDOUT = "Review line one.\nReview line two.\nReview line three.\n"
+
+
+def _make_payload(gate="codex_gate", pr_number=42, pr_id="", dispatch_id="test-dispatch-pr4b4", **kw):
+    base = {
+        "gate": gate,
+        "status": "requested",
+        "provider": "codex",
+        "branch": "feat/test",
+        "pr_number": pr_number,
+        "review_mode": "per_pr",
+        "risk_class": "medium",
+        "changed_files": ["scripts/foo.py"],
+        "requested_at": "20260428T100000Z",
+        "prompt": "Review this code",
+        "dispatch_id": dispatch_id,
+    }
+    if pr_id:
+        base["pr_id"] = pr_id
+    base.update(kw)
+    return base
+
+
+def _run(env, payload, stdout=_STDOUT):
+    report_file = env["reports_dir"] / "test-report.md"
+    payload.setdefault("report_path", str(report_file))
+    return materialize_artifacts(
+        gate=payload["gate"],
+        pr_number=payload.get("pr_number"),
+        pr_id=payload.get("pr_id", ""),
+        stdout=stdout,
+        request_payload=payload,
+        duration_seconds=1.5,
+        requests_dir=env["requests_dir"],
+        results_dir=env["results_dir"],
+        reports_dir=env["reports_dir"],
+    )
+
+
+def _read_register_events(env) -> list[dict]:
+    reg = env["state_dir"] / "dispatch_register.ndjson"
+    if not reg.exists():
+        return []
+    return [json.loads(ln) for ln in reg.read_text().splitlines() if ln.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGateArtifactsRegisterEmit:
+
+    def test_codex_gate_no_blocking_emits_gate_passed(self, artifact_env):
+        """codex_gate with no blocking findings emits gate_passed to register."""
+        payload = _make_payload(gate="codex_gate", pr_number=42)
+        with patch("gate_artifacts.parse_codex_findings", return_value={"findings": [], "residual_risk": ""}):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1
+        assert events[0]["event"] == "gate_passed"
+        assert events[0]["gate"] == "codex_gate"
+
+    def test_codex_gate_blocking_emits_gate_failed(self, artifact_env):
+        """codex_gate with blocking findings emits gate_failed to register."""
+        payload = _make_payload(gate="codex_gate", pr_number=42)
+        blocking = [{"severity": "error", "message": "Critical security issue"}]
+        with patch("gate_artifacts.parse_codex_findings", return_value={"findings": blocking, "residual_risk": "High"}):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1
+        assert events[0]["event"] == "gate_failed"
+        assert events[0]["gate"] == "codex_gate"
+
+    def test_gemini_review_no_register_entry(self, artifact_env):
+        """gemini_review gate must NOT emit any register event."""
+        payload = _make_payload(gate="gemini_review", pr_number=42)
+        result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert events == []
+
+    def test_claude_github_optional_no_register_entry(self, artifact_env):
+        """claude_github_optional gate must NOT emit any register event."""
+        payload = _make_payload(gate="claude_github_optional", pr_number=42)
+        result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert events == []
+
+    def test_codex_gate_numeric_pr_id_resolves_to_pr_number(self, artifact_env):
+        """pr_id='276' (numeric string) should resolve to pr_number=276 in register."""
+        payload = _make_payload(gate="codex_gate", pr_number=None, pr_id="276")
+        with patch("gate_artifacts.parse_codex_findings", return_value={"findings": [], "residual_risk": ""}):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1
+        assert events[0].get("pr_number") == 276
+        assert "feature_id" not in events[0]
+
+    def test_codex_gate_non_numeric_pr_id_resolves_to_feature_id(self, artifact_env):
+        """pr_id='PR-6' (non-numeric) should resolve to feature_id='PR-6' in register."""
+        payload = _make_payload(gate="codex_gate", pr_number=None, pr_id="PR-6")
+        with patch("gate_artifacts.parse_codex_findings", return_value={"findings": [], "residual_risk": ""}):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1
+        assert events[0].get("feature_id") == "PR-6"
+        assert "pr_number" not in events[0]

--- a/tests/test_gate_artifacts_register.py
+++ b/tests/test_gate_artifacts_register.py
@@ -156,3 +156,59 @@ class TestGateArtifactsRegisterEmit:
         assert len(events) == 1
         assert events[0].get("feature_id") == "PR-6"
         assert "pr_number" not in events[0]
+
+    def test_codex_gate_verdict_pass_overrides_blocking_findings(self, artifact_env):
+        """codex verdict='pass' must emit gate_passed even when severity-derived result would be gate_failed."""
+        payload = _make_payload(gate="codex_gate", pr_number=42)
+        blocking = [{"severity": "error", "message": "Flagged but verdict overrides"}]
+        with patch("gate_artifacts.parse_codex_findings", return_value={
+            "findings": blocking,
+            "residual_risk": "Low",
+            "verdict": {"verdict": "pass"},
+            "raw_text": "",
+        }):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1, f"Expected 1 event; got: {events}"
+        assert events[0]["event"] == "gate_passed", (
+            "Explicit verdict='pass' must override severity-derived gate_failed"
+        )
+
+    def test_codex_gate_verdict_fail_with_no_findings_emits_gate_failed(self, artifact_env):
+        """codex verdict='fail' must emit gate_failed even when there are no findings."""
+        payload = _make_payload(gate="codex_gate", pr_number=42)
+        with patch("gate_artifacts.parse_codex_findings", return_value={
+            "findings": [],
+            "residual_risk": "",
+            "verdict": {"verdict": "fail"},
+            "raw_text": "",
+        }):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1, f"Expected 1 event; got: {events}"
+        assert events[0]["event"] == "gate_failed", (
+            "Explicit verdict='fail' must emit gate_failed even with no findings"
+        )
+
+    def test_codex_gate_missing_verdict_falls_back_to_severity(self, artifact_env):
+        """When codex output has no explicit verdict, classification falls back to severity."""
+        payload = _make_payload(gate="codex_gate", pr_number=42)
+        blocking = [{"severity": "error", "message": "Critical issue"}]
+        with patch("gate_artifacts.parse_codex_findings", return_value={
+            "findings": blocking,
+            "residual_risk": "",
+            "verdict": {},
+            "raw_text": "",
+        }):
+            result = _run(artifact_env, payload)
+
+        assert result["status"] == "completed"
+        events = _read_register_events(artifact_env)
+        assert len(events) == 1
+        assert events[0]["event"] == "gate_failed", (
+            "Missing verdict with blocking severity must fall back to gate_failed"
+        )

--- a/tests/test_gate_recorder_register.py
+++ b/tests/test_gate_recorder_register.py
@@ -72,14 +72,45 @@ def _read_register_events(env) -> list[dict]:
 
 class TestGateRecorderRegisterEmit:
 
-    def test_record_failure_codex_gate_emits_gate_failed(self, recorder_env):
-        """record_failure for codex_gate must emit gate_failed to the register."""
+    def test_record_failure_codex_timeout_no_register_emit(self, recorder_env):
+        """record_failure for codex_gate with reason=timeout must NOT emit to register.
+
+        Timeouts are infrastructure failures, not gate verdicts. Emitting gate_failed
+        would abuse the 'gate completed with blocking findings' semantic.
+        """
         payload = _make_payload(gate="codex_gate", pr_number=99)
         result = record_failure(
             gate="codex_gate",
             pr_number=99,
             pr_id="",
-            result=_make_result(),
+            result=_make_result(),  # reason="timeout"
+            request_payload=payload,
+            requests_dir=recorder_env["requests_dir"],
+            results_dir=recorder_env["results_dir"],
+        )
+
+        assert result["status"] == "failed"
+        events = _read_register_events(recorder_env)
+        assert events == [], f"Expected no register events for timeout; got: {events}"
+
+    def test_record_failure_codex_non_execution_reason_emits_gate_failed(self, recorder_env):
+        """record_failure for codex_gate with a non-execution reason emits gate_failed.
+
+        When the reason is not an infrastructure failure (e.g. an explicit review
+        verdict that triggered record_failure), gate_failed must be emitted.
+        """
+        payload = _make_payload(gate="codex_gate", pr_number=99)
+        result = record_failure(
+            gate="codex_gate",
+            pr_number=99,
+            pr_id="",
+            result={
+                "reason": "review_verdict_blocked",
+                "reason_detail": "Codex explicitly blocked the gate",
+                "duration_seconds": 12.0,
+                "partial_output_lines": 8,
+                "runner_pid": os.getpid(),
+            },
             request_payload=payload,
             requests_dir=recorder_env["requests_dir"],
             results_dir=recorder_env["results_dir"],

--- a/tests/test_gate_recorder_register.py
+++ b/tests/test_gate_recorder_register.py
@@ -1,0 +1,109 @@
+"""Tests for gate_recorder.record_failure → dispatch_register emit (codex_gate only)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_recorder import record_failure
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def recorder_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    requests_dir = state_dir / "review_gates" / "requests"
+    results_dir = state_dir / "review_gates" / "results"
+    for d in (requests_dir, results_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    # Redirect register writes to tmp_path
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    return {
+        "state_dir": state_dir,
+        "requests_dir": requests_dir,
+        "results_dir": results_dir,
+    }
+
+
+def _make_result():
+    return {
+        "reason": "timeout",
+        "reason_detail": "Gate timed out after 300s",
+        "duration_seconds": 300.0,
+        "partial_output_lines": 5,
+        "runner_pid": os.getpid(),
+    }
+
+
+def _make_payload(gate="codex_gate", pr_number=42, pr_id="", dispatch_id="test-dispatch-pr4b4"):
+    base = {
+        "gate": gate,
+        "status": "requested",
+        "branch": "feat/test",
+        "pr_number": pr_number,
+        "dispatch_id": dispatch_id,
+    }
+    if pr_id:
+        base["pr_id"] = pr_id
+    return base
+
+
+def _read_register_events(env) -> list[dict]:
+    reg = env["state_dir"] / "dispatch_register.ndjson"
+    if not reg.exists():
+        return []
+    return [json.loads(ln) for ln in reg.read_text().splitlines() if ln.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGateRecorderRegisterEmit:
+
+    def test_record_failure_codex_gate_emits_gate_failed(self, recorder_env):
+        """record_failure for codex_gate must emit gate_failed to the register."""
+        payload = _make_payload(gate="codex_gate", pr_number=99)
+        result = record_failure(
+            gate="codex_gate",
+            pr_number=99,
+            pr_id="",
+            result=_make_result(),
+            request_payload=payload,
+            requests_dir=recorder_env["requests_dir"],
+            results_dir=recorder_env["results_dir"],
+        )
+
+        assert result["status"] == "failed"
+        events = _read_register_events(recorder_env)
+        assert len(events) == 1
+        assert events[0]["event"] == "gate_failed"
+        assert events[0]["gate"] == "codex_gate"
+
+    def test_record_failure_gemini_no_register_entry(self, recorder_env):
+        """record_failure for gemini_review must NOT emit any register event."""
+        payload = _make_payload(gate="gemini_review", pr_number=99)
+        result = record_failure(
+            gate="gemini_review",
+            pr_number=99,
+            pr_id="",
+            result=_make_result(),
+            request_payload=payload,
+            requests_dir=recorder_env["requests_dir"],
+            results_dir=recorder_env["results_dir"],
+        )
+
+        assert result["status"] == "failed"
+        events = _read_register_events(recorder_env)
+        assert events == []


### PR DESCRIPTION
## Summary
- `materialize_artifacts` emits `gate_passed`/`gate_failed` to register (codex_gate only)
- `record_failure` emits `gate_failed` (codex_gate only)
- `pr_id` parsing chain: `pr_number` > `int(pr_id)` > `feature_id` fallback
- gemini/claude_github gates log info and skip register
- 8 unit tests covering all 6 dispatch-specified scenarios

## Why conservative
Symmetric with PR-4b3 — only codex_gate has structured findings parser. Other gates skip register entirely until proper parsers land in a future PR.

## Design note
`gate_register_emit.py` writes directly using env-var path resolution (not `vnx_paths.resolve_paths`) to avoid triggering git subprocesses inside tests that mock `subprocess.Popen`. This is architecturally cleaner and avoids test interference.

## Test plan
- [x] codex_gate no blocking → gate_passed in register
- [x] codex_gate with blocking → gate_failed in register
- [x] gemini_review → no register entry
- [x] claude_github_optional → no register entry
- [x] pr_id='276' (numeric) → pr_number=276 in register
- [x] pr_id='PR-6' (non-numeric) → feature_id='PR-6' in register
- [x] record_failure codex_gate → gate_failed in register
- [x] record_failure gemini → no entry