### PR TITLE
feat(governance): build_t0_state register-canonical aggregation (Sprint 3 split 3/3)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -43,11 +43,11 @@ _DISPATCH_DIR = Path(_PATHS["VNX_DISPATCH_DIR"])
 _DATA_DIR = Path(_PATHS["VNX_DATA_DIR"])
 _PROJECT_ROOT = Path(_PATHS["PROJECT_ROOT"])
 
-# Register events reader (raw events list exposure for now; aggregation is PR-4c)
+# Register events reader — used by _build_register_events and _build_feature_state
 try:
-    from dispatch_register import read_events as _read_register_events
+    from dispatch_register import read_events as _dr_read_events
 except ImportError:
-    _read_register_events = None  # Module is optional during initial deploy
+    _dr_read_events = None
 
 
 # ---------------------------------------------------------------------------
@@ -240,12 +240,99 @@ def _build_tracks(state_dir: Path) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Feature state (via FeatureStateMachine)
+# Feature state — register-canonical aggregation with FEATURE_PLAN.md fallback
 # ---------------------------------------------------------------------------
 
-def _build_feature_state() -> Dict[str, Any]:
-    """Parse FEATURE_PLAN.md and return structured feature state for T0 context."""
+def _read_register_events(state_dir: Optional[Path] = None) -> list[dict]:
+    """Read all register events, honoring state_dir for test isolation."""
+    if _dr_read_events is None:
+        return []
+    try:
+        return _dr_read_events(state_dir=state_dir) or []
+    except Exception:
+        return []
+
+
+_EVENT_TO_STATUS: Dict[str, str] = {
+    "dispatch_completed": "completed",
+    "dispatch_failed": "failed",
+    "gate_failed": "failed",
+    "dispatch_promoted": "active",
+    "dispatch_started": "active",
+    "gate_requested": "active",
+    "gate_passed": "active",
+    "dispatch_created": "queued",
+}
+
+
+def _build_feature_state(state_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Build feature_state from dispatch_register.ndjson (register-canonical).
+
+    Aggregation contract:
+    - Group events by dispatch_id (primary key)
+    - Per-dispatch status: latest-event-wins (recency)
+    - Per-PR/feature: most-recently-active dispatch supplies status
+    - FEATURE_PLAN.md fallback when register has no data
+
+    Refs: synthesis 2026-04-28 §D Sprint 3 split 3/3, codex findings PR #276 r1+r2.
+    """
+    register_events = _read_register_events(state_dir=state_dir)
+    if not register_events:
+        return _build_feature_state_from_feature_plan()
+
+    by_dispatch: Dict[str, list] = {}
+    for ev in register_events:
+        did = ev.get("dispatch_id", "").strip()
+        if not did:
+            continue
+        by_dispatch.setdefault(did, []).append(ev)
+
+    dispatch_records: Dict[str, Any] = {}
+    for did, events in by_dispatch.items():
+        events_sorted = sorted(events, key=lambda e: e.get("timestamp", ""))
+        latest = events_sorted[-1]
+        latest_event = latest.get("event", "")
+        status = _EVENT_TO_STATUS.get(latest_event, "unknown")
+        pr_number = next(
+            (e.get("pr_number") for e in events if e.get("pr_number") is not None), None
+        )
+        feature_id = next((e.get("feature_id") for e in events if e.get("feature_id")), "")
+        dispatch_records[did] = {
+            "status": status,
+            "latest_event": latest_event,
+            "latest_event_ts": latest.get("timestamp", ""),
+            "pr_number": pr_number,
+            "feature_id": feature_id,
+            "event_count": len(events),
+        }
+
+    by_pr: Dict[str, Any] = {}
+    by_feature: Dict[str, Any] = {}
+    for did, rec in dispatch_records.items():
+        if rec["pr_number"] is not None:
+            pr_key = str(rec["pr_number"])
+            existing = by_pr.get(pr_key)
+            if existing is None or rec["latest_event_ts"] > existing["latest_event_ts"]:
+                by_pr[pr_key] = rec
+        if rec["feature_id"]:
+            f_key = rec["feature_id"]
+            existing = by_feature.get(f_key)
+            if existing is None or rec["latest_event_ts"] > existing["latest_event_ts"]:
+                by_feature[f_key] = rec
+
+    return {
+        "source": "dispatch_register",
+        "dispatches": dispatch_records,
+        "pr_status": by_pr,
+        "feature_status": by_feature,
+        "register_event_count": len(register_events),
+    }
+
+
+def _build_feature_state_from_feature_plan() -> Dict[str, Any]:
+    """FEATURE_PLAN.md parser — fallback when register is empty."""
     _empty: Dict[str, Any] = {
+        "source": "feature_plan_md",
         "feature_name": None,
         "current_pr": None,
         "next_task": None,
@@ -262,7 +349,9 @@ def _build_feature_state() -> Dict[str, Any]:
     try:
         from feature_state_machine import parse_feature_plan
         state = parse_feature_plan(feature_plan)
-        return state.as_dict()
+        result = state.as_dict()
+        result["source"] = "feature_plan_md"
+        return result
     except Exception:
         return _empty
 
@@ -534,11 +623,11 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
 # ---------------------------------------------------------------------------
 
 def _build_register_events(state_dir: Optional[Path] = None, limit: int = 50) -> list[dict]:
-    """Last N register events. Aggregation is PR-4c."""
-    if _read_register_events is None:
+    """Last N register events (raw; for debugging)."""
+    if _dr_read_events is None:
         return []
     try:
-        events = _read_register_events(state_dir=state_dir) if state_dir else _read_register_events()
+        events = _dr_read_events(state_dir=state_dir)
         return events[-limit:] if events else []
     except Exception:
         return []
@@ -562,7 +651,7 @@ def build_t0_state(
     queues = _build_queues(dispatch_dir, state_dir)
     tracks = _build_tracks(state_dir)
     pr_progress = _build_pr_progress(dispatch_dir, state_dir)
-    feature_state = _build_feature_state()
+    feature_state = _build_feature_state(state_dir=state_dir)
     open_items = _build_open_items(state_dir)
     quality_digest = _build_quality_digest(state_dir)
     dispatch_insights = _build_dispatch_insights(state_dir=state_dir)

--- a/tests/test_build_feature_state_canonical.py
+++ b/tests/test_build_feature_state_canonical.py
@@ -1,0 +1,269 @@
+"""Tests for register-canonical _build_feature_state() in build_t0_state.py (PR-4c).
+
+Covers:
+  1. Empty register → falls back to FEATURE_PLAN.md parser
+  2. Single dispatch_completed → dispatches[did].status == "completed"
+  3. dispatch_promoted then dispatch_completed (same id) → status "completed"
+  4. dispatch_completed then new dispatch_promoted on same PR → PR status "active"
+  5. dispatch_promoted + gate_failed → dispatch status "failed"
+  6. dispatch_promoted + gate_passed (no completion) → dispatch status "active"
+  7. PR-level rollup: 2 dispatches for same pr_number, most-recently-active wins
+  8. Feature-level rollup: same logic for feature_id
+  9. state_dir parameter respected (custom location)
+  10. dispatch_failed event → status "failed"
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from build_t0_state import _build_feature_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_register(state_dir: Path, events: list[dict]) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    reg = state_dir / "dispatch_register.ndjson"
+    reg.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+    return reg
+
+
+def _ev(event: str, dispatch_id: str, ts: str, **kwargs) -> dict:
+    rec: dict = {"timestamp": ts, "event": event, "dispatch_id": dispatch_id}
+    rec.update(kwargs)
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty register → falls back to FEATURE_PLAN.md
+# ---------------------------------------------------------------------------
+
+class TestEmptyRegisterFallback:
+    def test_source_is_feature_plan_md(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # No dispatch_register.ndjson — falls back to FEATURE_PLAN.md parser
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["source"] == "feature_plan_md"
+
+    def test_fallback_returns_dict_not_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        result = _build_feature_state(state_dir=state_dir)
+        assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# 2. Single dispatch_completed → status "completed"
+# ---------------------------------------------------------------------------
+
+class TestSingleCompleted:
+    def test_dispatch_status_completed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["source"] == "dispatch_register"
+        assert result["dispatches"]["d001"]["status"] == "completed"
+
+    def test_register_event_count(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["register_event_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. dispatch_promoted then dispatch_completed (same id) → "completed"
+# ---------------------------------------------------------------------------
+
+class TestRecencyPromotedThenCompleted:
+    def test_latest_event_wins(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_promoted", "d001", "2026-04-28T10:00:00.000000Z"),
+            _ev("dispatch_completed", "d001", "2026-04-28T10:05:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["dispatches"]["d001"]["status"] == "completed"
+        assert result["dispatches"]["d001"]["latest_event"] == "dispatch_completed"
+
+
+# ---------------------------------------------------------------------------
+# 4. dispatch_completed then NEW dispatch_promoted on same PR → PR "active"
+# ---------------------------------------------------------------------------
+
+class TestNewDispatchSamePR:
+    def test_pr_status_active_when_newer_dispatch_promoted(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z", pr_number=42),
+            _ev("dispatch_promoted",  "d002", "2026-04-28T10:10:00.000000Z", pr_number=42),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        # d001 completed, d002 promoted later — PR 42 should reflect d002
+        pr_rec = result["pr_status"]["42"]
+        assert pr_rec["status"] == "active"
+
+    def test_dispatches_both_present(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z", pr_number=42),
+            _ev("dispatch_promoted",  "d002", "2026-04-28T10:10:00.000000Z", pr_number=42),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert "d001" in result["dispatches"]
+        assert "d002" in result["dispatches"]
+        assert result["dispatches"]["d001"]["status"] == "completed"
+        assert result["dispatches"]["d002"]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# 5. dispatch_promoted + gate_failed → dispatch status "failed"
+# ---------------------------------------------------------------------------
+
+class TestGateFailed:
+    def test_gate_failed_maps_to_failed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_promoted", "d001", "2026-04-28T10:00:00.000000Z"),
+            _ev("gate_failed",       "d001", "2026-04-28T10:05:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["dispatches"]["d001"]["status"] == "failed"
+        assert result["dispatches"]["d001"]["latest_event"] == "gate_failed"
+
+
+# ---------------------------------------------------------------------------
+# 6. dispatch_promoted + gate_passed (no completion) → status "active"
+# ---------------------------------------------------------------------------
+
+class TestGatePassed:
+    def test_gate_passed_maps_to_active(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_promoted", "d001", "2026-04-28T10:00:00.000000Z"),
+            _ev("gate_passed",       "d001", "2026-04-28T10:05:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["dispatches"]["d001"]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# 7. PR-level rollup: most-recently-active dispatch wins
+# ---------------------------------------------------------------------------
+
+class TestPRRollup:
+    def test_most_recent_dispatch_wins_for_pr(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T09:00:00.000000Z", pr_number=55),
+            _ev("dispatch_completed", "d002", "2026-04-28T11:00:00.000000Z", pr_number=55),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        pr_rec = result["pr_status"]["55"]
+        # d002 is more recent — must win
+        assert pr_rec["latest_event_ts"] == "2026-04-28T11:00:00.000000Z"
+
+    def test_earlier_dispatch_not_pr_winner(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "earlier", "2026-04-28T08:00:00.000000Z", pr_number=55),
+            _ev("dispatch_started",   "later",   "2026-04-28T12:00:00.000000Z", pr_number=55),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        pr_rec = result["pr_status"]["55"]
+        assert pr_rec["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# 8. Feature-level rollup: same recency logic for feature_id
+# ---------------------------------------------------------------------------
+
+class TestFeatureRollup:
+    def test_most_recent_dispatch_wins_for_feature(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T09:00:00.000000Z", feature_id="F46"),
+            _ev("dispatch_started",   "d002", "2026-04-28T11:00:00.000000Z", feature_id="F46"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        f_rec = result["feature_status"]["F46"]
+        assert f_rec["status"] == "active"
+
+    def test_feature_rollup_multiple_features(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z", feature_id="F46"),
+            _ev("dispatch_failed",    "d002", "2026-04-28T10:00:00.000000Z", feature_id="F47"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["feature_status"]["F46"]["status"] == "completed"
+        assert result["feature_status"]["F47"]["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# 9. state_dir parameter respected
+# ---------------------------------------------------------------------------
+
+class TestStateDirIsolation:
+    def test_reads_from_given_state_dir(self, tmp_path):
+        canonical = tmp_path / "canonical"
+        custom = tmp_path / "custom"
+        # Canonical has completed event; custom has active event
+        _write_register(canonical, [
+            _ev("dispatch_completed", "c001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        _write_register(custom, [
+            _ev("dispatch_promoted", "x001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=custom)
+        assert "x001" in result["dispatches"]
+        assert "c001" not in result["dispatches"]
+
+    def test_empty_custom_dir_falls_back_to_feature_plan(self, tmp_path):
+        state_dir = tmp_path / "empty_state"
+        state_dir.mkdir()
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["source"] == "feature_plan_md"
+
+
+# ---------------------------------------------------------------------------
+# 10. dispatch_failed event → status "failed"
+# ---------------------------------------------------------------------------
+
+class TestDispatchFailed:
+    def test_dispatch_failed_maps_to_failed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_started", "d001", "2026-04-28T10:00:00.000000Z"),
+            _ev("dispatch_failed",  "d001", "2026-04-28T10:08:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["dispatches"]["d001"]["status"] == "failed"
+
+    def test_dispatch_failed_no_pr_no_feature(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_failed", "d001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["pr_status"] == {}
+        assert result["feature_status"] == {}


### PR DESCRIPTION
## Summary
- Replace _build_feature_state to read dispatch_register.ndjson as canonical source
- Group events by dispatch_id; recency-based status per dispatch
- Roll up to PR/feature level via most-recently-active dispatch
- FEATURE_PLAN.md fallback when register is empty

## Test plan
- [x] Empty register falls back to FEATURE_PLAN.md
- [x] Recency aggregation: completed dispatch + new promoted dispatch → status "active"
- [x] gate_failed flips dispatch status to failed
- [x] PR-level rollup picks most-recent dispatch
- [x] Existing governance test suite green (63 passed)

## Sprint 3 completion
With PR-4a (#277) + PR-4b (#278) + PR-4c (this), Sprint 3 of state-persistence
convergence is complete. Synthesis 2026-04-28 §D Sprint 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)