### PR TITLE
fix(governance): rebuild trigger covers task_failed and task_timeout

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1165,6 +1165,7 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
 
     TRIGGER_EVENTS = {
         "task_complete", "task_completed", "completion", "complete",
+        "task_failed", "task_timeout",
         "dispatch_promoted", "dispatch_started",
     }
     if event_type not in TRIGGER_EVENTS:

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -183,3 +183,23 @@ def test_task_complete_survives_100_state_mutations(tmp_path: Path) -> None:
     types = [r.get("event_type") for r in result]
     assert "task_complete" in types, f"task_complete disappeared after 100 state_mutations: {result}"
     assert "state_mutation" not in types, f"state_mutation leaked into recency summary: {result}"
+
+
+def test_task_failed_triggers_rebuild() -> None:
+    """task_failed receipts must trigger a state rebuild (codex audit v2 fix)."""
+    receipt = _minimal_receipt("task_failed")
+
+    with mock.patch.object(srt, "maybe_trigger_state_rebuild", return_value=True) as mock_fn:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_fn.assert_called_once_with(event_type="task_failed")
+
+
+def test_task_timeout_triggers_rebuild() -> None:
+    """task_timeout receipts must trigger a state rebuild (codex audit v2 fix)."""
+    receipt = _minimal_receipt("task_timeout")
+
+    with mock.patch.object(srt, "maybe_trigger_state_rebuild", return_value=True) as mock_fn:
+        ar._maybe_trigger_state_rebuild(receipt)
+
+    mock_fn.assert_called_once_with(event_type="task_timeout")


### PR DESCRIPTION
## Summary
- `task_failed` and `task_timeout` receipts now trigger `build_t0_state` rebuild
- Closes a gap from PR #279 (codex audit v2): failed dispatches were recorded in dispatch_register but t0_state.json never refreshed
- `state_rebuild_trigger.py` CRITICAL_EVENTS already included both (verified) — only `append_receipt.py` TRIGGER_EVENTS needed patching

## Test plan
- [x] `test_task_failed_triggers_rebuild` — task_failed receipt → `maybe_trigger_state_rebuild` called
- [x] `test_task_timeout_triggers_rebuild` — task_timeout receipt → called
- [x] All 35 existing tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)