### PR TITLE
fix(governance): gate_recorder execution failures don't emit gate_failed (PR #282 v2 audit)

### DIFF
--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -27,11 +27,19 @@ _GATE_BINARIES: Dict[str, str] = {
 }
 
 # Infrastructure/execution failures — NOT semantic gate verdicts.
-# gate_failed means "gate completed with blocking findings"; never emit it for these.
+# gate_failed means "gate completed with blocking findings"; only emit it for reasons
+# that represent a completed gate run with actual blocking findings. Anything else
+# (timeouts, crashes, infra errors, validation failures) is execution-level → skip.
 EXECUTION_FAILURE_REASONS: frozenset = frozenset({
-    "exit_nonzero", "timeout", "stall", "stalled",
+    # Process lifecycle
+    "exit_nonzero", "timeout", "stall", "stalled", "killed",
+    # Subprocess / binary
+    "subprocess_error", "subprocess_failed", "binary_not_found",
+    # Artifact and content issues
     "artifact_materialization_error", "artifact_materialization_failed",
-    "subprocess_failed", "killed", "binary_not_found",
+    "empty_review_content", "validation_failed",
+    # Network / auth
+    "network_error", "auth_error",
 })
 
 

--- a/tests/test_gate_recorder_register.py
+++ b/tests/test_gate_recorder_register.py
@@ -138,3 +138,39 @@ class TestGateRecorderRegisterEmit:
         assert result["status"] == "failed"
         events = _read_register_events(recorder_env)
         assert events == []
+
+    @pytest.mark.parametrize("reason", [
+        "subprocess_error",
+        "auth_error",
+        "binary_not_found",
+        "network_error",
+        "validation_failed",
+        "empty_review_content",
+        "artifact_materialization_failed",
+    ])
+    def test_record_failure_execution_reasons_no_register_emit(self, recorder_env, reason):
+        """record_failure with any execution-level reason must NOT emit gate_failed.
+
+        These are infrastructure failures, not semantic gate verdicts. Emitting
+        gate_failed would abuse the 'gate completed with blocking findings' contract.
+        """
+        payload = _make_payload(gate="codex_gate", pr_number=77)
+        result_dict = _make_result()
+        result_dict["reason"] = reason
+        result_dict["reason_detail"] = f"Execution failure: {reason}"
+
+        out = record_failure(
+            gate="codex_gate",
+            pr_number=77,
+            pr_id="",
+            result=result_dict,
+            request_payload=payload,
+            requests_dir=recorder_env["requests_dir"],
+            results_dir=recorder_env["results_dir"],
+        )
+
+        assert out["status"] == "failed"
+        events = _read_register_events(recorder_env)
+        assert events == [], (
+            f"reason={reason!r} must not emit gate_failed; got: {events}"
+        )


### PR DESCRIPTION
Comprehensive EXECUTION_FAILURE_REASONS.

## Summary
- `EXECUTION_FAILURE_REASONS` frozenset was missing `subprocess_error`, `auth_error`, `network_error`, `validation_failed`, `empty_review_content` — all of which still emitted `gate_failed` to the dispatch register despite being infrastructure failures
- Added all known non-semantic failure reasons, organized by category (process lifecycle, subprocess/binary, artifact/content, network/auth)
- Added inline contract comment: `gate_failed` ONLY for completed-with-blocking-findings paths
- 7 new parametrized tests covering each previously-missing reason

## Test plan
- [ ] `pytest tests/test_gate_recorder_register.py -v` → 10/10 passed
- [ ] `pytest tests/test_gate_artifacts_register.py -v` → 9/9 passed
- [ ] Pre-existing failures in `test_gate_execution_certification.py` (MagicMock TypeError in gate_runner.py) are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)