### PR TITLE
fix(governance): OI dedup key directory-aware (OI-1176)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -938,15 +938,13 @@ def _count_quality_violations(receipt: dict) -> int:
     open_items = rec.get("open_items") or []
     if not open_items:
         return 0
-    # Mirror dedup_key from _register_quality_open_items: qa:{check_id}:{basename}:{symbol}.
-    # Collisions across directories tracked as OI-1176; out of scope for PR-4b3.
+    # Mirror dedup_key from _register_quality_open_items: qa:{check_id}:{full_path}:{symbol}.
     seen_keys: set = set()
     for item in open_items:
         check_id = str(item.get("check_id", "unknown"))
-        file_path = str(item.get("file", ""))
-        file_basename = Path(file_path).name if file_path else "unknown"
+        file_path = str(item.get("file", "")) or "unknown"
         symbol = str(item.get("symbol") or "")
-        seen_keys.add(f"qa:{check_id}:{file_basename}:{symbol}")
+        seen_keys.add(f"qa:{check_id}:{file_path}:{symbol}")
     return len(seen_keys)
 
 
@@ -989,12 +987,8 @@ def _register_quality_open_items(receipt: Dict[str, Any]) -> int:
                     raw_severity = str(item.get("severity", "info"))
                     mapped_severity = _SEVERITY_MAP.get(raw_severity, "info")
                     title = str(item.get("item", ""))
-                    file_basename = Path(file_path).name if file_path else "unknown"
-
-                    # Build dedup key: qa:{check_id}:{file_basename}:{symbol}
-                    # Dedup key uses basename+symbol; collisions across directories tracked as OI-1176.
-                    # Out of scope for PR-4b3.
-                    dedup_key = f"qa:{check_id}:{file_basename}:{symbol}"
+                    # Build dedup key: qa:{check_id}:{full_path}:{symbol} (OI-1176 fix)
+                    dedup_key = f"qa:{check_id}:{file_path or 'unknown'}:{symbol}"
 
                     item_id, created = oim.add_item_programmatic(
                         title=title,

--- a/tests/test_append_receipt_register_emit.py
+++ b/tests/test_append_receipt_register_emit.py
@@ -416,21 +416,25 @@ def test_count_quality_violations_dedup_same_key(ar):
 
 
 def test_count_quality_violations_five_with_two_deduped(ar):
-    """5 violations: 2 share basename+symbol with c1, 2 are duplicate c3 → returns 3."""
+    """5 violations: c1 in different dirs → 2 distinct keys; c3 same file twice → deduped.
+
+    OI-1176 fix: full path used, so a/foo.py and b/foo.py are NOT collapsed.
+    Result: 4 distinct keys (c1:a/foo.py:fn, c1:b/foo.py:fn, c2:a/foo.py:fn, c3:c/bar.py:).
+    """
     receipt = {
         "quality_advisory": {
             "t0_recommendation": {
                 "open_items": [
                     {"check_id": "c1", "file": "a/foo.py", "symbol": "fn", "severity": "blocker"},
-                    {"check_id": "c1", "file": "b/foo.py", "symbol": "fn", "severity": "blocker"},  # same basename+symbol → dedup
+                    {"check_id": "c1", "file": "b/foo.py", "symbol": "fn", "severity": "blocker"},  # different path → NOT deduped
                     {"check_id": "c2", "file": "a/foo.py", "symbol": "fn", "severity": "warn"},
                     {"check_id": "c3", "file": "c/bar.py", "symbol": "", "severity": "info"},
-                    {"check_id": "c3", "file": "c/bar.py", "symbol": "", "severity": "info"},  # identical → dedup
+                    {"check_id": "c3", "file": "c/bar.py", "symbol": "", "severity": "info"},  # identical path → deduped
                 ]
             }
         }
     }
-    assert ar._count_quality_violations(receipt) == 3
+    assert ar._count_quality_violations(receipt) == 4
 
 
 def test_count_quality_violations_different_checks_not_deduped(ar):
@@ -452,7 +456,7 @@ def test_count_quality_violations_different_checks_not_deduped(ar):
 # ── Test: NDJSON persists dedup-aware open_items_created ────────────────────
 
 def test_open_items_created_dedup_count_in_ndjson(tmp_path: Path):
-    """5 violations with 2 dedup pairs → open_items_created=3 in NDJSON."""
+    """5 violations: c1 different dirs (not deduped) + c3 same file twice (deduped) → open_items_created=4 in NDJSON."""
     receipt = {
         "timestamp": "2026-04-28T12:00:00Z",
         "event_type": "task_complete",
@@ -484,8 +488,8 @@ def test_open_items_created_dedup_count_in_ndjson(tmp_path: Path):
     lines = [l for l in receipts_file.read_text(encoding="utf-8").splitlines() if l.strip()]
     assert len(lines) == 1
     persisted = json.loads(lines[0])
-    assert persisted.get("open_items_created") == 3, (
-        f"Expected 3 (5 violations deduped to 3), got {persisted.get('open_items_created')!r}"
+    assert persisted.get("open_items_created") == 4, (
+        f"Expected 4 (5 violations: 4 distinct paths, 1 true duplicate collapsed), got {persisted.get('open_items_created')!r}"
     )
 
 
@@ -611,3 +615,41 @@ def test_confidence_task_complete_empty_status_yields_success(ar):
     _run_confidence_update(ar, receipt, captured)
     assert len(captured) == 1
     assert captured[0]["outcome"] == "success"
+
+
+# ── OI-1176: dedup key directory-aware ───────────────────────────────────────
+
+def _make_quality_receipt(open_items: list) -> dict:
+    return {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "dispatch_id": "DISP-DEDUP-001",
+        "terminal": "T2",
+        "quality_advisory": {
+            "t0_recommendation": {
+                "open_items": open_items,
+            }
+        },
+    }
+
+
+def test_count_quality_violations_different_dirs_not_collapsed(ar):
+    """Same check_id+symbol but different directories → 2 distinct keys (OI-1176 fix)."""
+    items = [
+        {"check_id": "SEC-01", "file": "scripts/foo.py", "symbol": "unsafe_call", "severity": "blocker", "item": "A"},
+        {"check_id": "SEC-01", "file": "tests/foo.py",   "symbol": "unsafe_call", "severity": "blocker", "item": "B"},
+    ]
+    receipt = _make_quality_receipt(items)
+    count = ar._count_quality_violations(receipt)
+    assert count == 2, f"Expected 2 distinct OIs for different directories, got {count}"
+
+
+def test_count_quality_violations_same_file_collapsed(ar):
+    """Same check_id+symbol+file → 1 key (dedup still works for true duplicates)."""
+    items = [
+        {"check_id": "SEC-01", "file": "scripts/foo.py", "symbol": "unsafe_call", "severity": "blocker", "item": "A"},
+        {"check_id": "SEC-01", "file": "scripts/foo.py", "symbol": "unsafe_call", "severity": "blocker", "item": "A"},
+    ]
+    receipt = _make_quality_receipt(items)
+    count = ar._count_quality_violations(receipt)
+    assert count == 1, f"Expected 1 OI for identical file+check_id+symbol, got {count}"


### PR DESCRIPTION
## Summary
- `_register_quality_open_items` and `_count_quality_violations` used `Path(file).name` (basename) in the dedup key, causing findings in different directories with the same filename + symbol to collapse onto one OI
- Fixed both functions to use the full file path: `qa:{check_id}:{file_path}:{symbol}`
- Updated two pre-existing tests that encoded the broken baseline, and added two new tests verifying directory-aware dedup

## Test plan
- [ ] `test_count_quality_violations_different_dirs_not_collapsed`: same check+symbol, different dirs → 2 OIs
- [ ] `test_count_quality_violations_same_file_collapsed`: same check+symbol+file → 1 OI (true dedup still works)
- [ ] `test_count_quality_violations_five_with_two_deduped`: updated to expect 4 (not 3)
- [ ] `test_open_items_created_dedup_count_in_ndjson`: updated to expect 4 (not 3)
- All 50 passing tests in test_append_receipt_register_emit.py remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)