### PR TITLE
feat(governance): compact_state.py + nightly rotation (Tier 3 Sprint 5)

### DIFF
--- a/scripts/compact_state.py
+++ b/scripts/compact_state.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""compact_state.py — VNX state file rotation and compaction.
+
+Modes:
+  intelligence_archive  Rotate t0_intelligence_archive.ndjson (skip <50MB, keep 7d)
+  receipts              Cap t0_receipts.ndjson at 10000 records, archive overflow
+  open_items_digest     Evict open_items_digest.json entries with last_updated >30d
+  all                   Run all three modes
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import gzip
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from project_root import resolve_data_dir
+
+INTELLIGENCE_ARCHIVE_MIN_MB = 50
+INTELLIGENCE_ARCHIVE_KEEP_DAYS = 7
+RECEIPTS_MAX_RECORDS = 10_000
+OPEN_ITEMS_STALE_DAYS = 30
+
+
+def _emit(level: str, code: str, **fields: object) -> None:
+    payload: dict = {
+        "level": level,
+        "code": code,
+        "timestamp": int(time.time()),
+    }
+    payload.update(fields)
+    print(json.dumps(payload, separators=(",", ":"), sort_keys=True), file=sys.stderr)
+
+
+def _archive_path(state_dir: Path, stem: str) -> Path:
+    date_str = datetime.date.today().isoformat()
+    return state_dir / "archive" / f"{stem}_{date_str}.ndjson.gz"
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".tmp_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".tmp_")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def compact_intelligence_archive(state_dir: Path, *, dry_run: bool = False) -> int:
+    """Rotate t0_intelligence_archive.ndjson. Returns 0 on success, non-zero on error."""
+    live_file = state_dir / "t0_intelligence_archive.ndjson"
+
+    if not live_file.exists():
+        _emit("INFO", "intelligence_archive_skip", reason="file_not_found", path=str(live_file))
+        return 0
+
+    size_bytes = live_file.stat().st_size
+    min_bytes = INTELLIGENCE_ARCHIVE_MIN_MB * 1024 * 1024
+
+    if size_bytes < min_bytes:
+        _emit(
+            "INFO",
+            "intelligence_archive_skip",
+            reason="below_threshold_mb",
+            size_mb=round(size_bytes / 1024 / 1024, 2),
+            threshold_mb=INTELLIGENCE_ARCHIVE_MIN_MB,
+        )
+        return 0
+
+    archive_file = _archive_path(state_dir, "t0_intelligence_archive")
+    if archive_file.exists():
+        _emit(
+            "INFO",
+            "intelligence_archive_skip",
+            reason="archive_already_exists_today",
+            archive=str(archive_file),
+        )
+        return 0
+
+    cutoff_ts = time.time() - INTELLIGENCE_ARCHIVE_KEEP_DAYS * 86400
+    raw = live_file.read_text(encoding="utf-8", errors="replace")
+    lines = raw.splitlines(keepends=True)
+
+    keep: list[str] = []
+    archive: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            keep.append(line)
+            continue
+        try:
+            record = json.loads(stripped)
+            ts = record.get("timestamp")
+            if ts is not None and float(ts) < cutoff_ts:
+                archive.append(line)
+            else:
+                keep.append(line)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            keep.append(line)
+
+    if not archive:
+        _emit("INFO", "intelligence_archive_skip", reason="all_records_within_7d", total_lines=len(lines))
+        return 0
+
+    _emit(
+        "INFO",
+        "intelligence_archive_rotating",
+        live_path=str(live_file),
+        archive_path=str(archive_file),
+        archive_lines=len(archive),
+        keep_lines=len(keep),
+        dry_run=dry_run,
+    )
+
+    if dry_run:
+        return 0
+
+    try:
+        _atomic_write_bytes(archive_file, gzip.compress("".join(archive).encode("utf-8")))
+        _atomic_write_text(live_file, "".join(keep))
+    except OSError as exc:
+        _emit("ERROR", "intelligence_archive_io_error", error=str(exc))
+        return 1
+
+    _emit(
+        "INFO",
+        "intelligence_archive_done",
+        archive=str(archive_file),
+        archive_lines=len(archive),
+        live_lines=len(keep),
+    )
+    return 0
+
+
+def compact_receipts(state_dir: Path, *, dry_run: bool = False) -> int:
+    """Cap t0_receipts.ndjson at 10000 lines, archive overflow. Returns 0 on success."""
+    live_file = state_dir / "t0_receipts.ndjson"
+
+    if not live_file.exists():
+        _emit("INFO", "receipts_skip", reason="file_not_found", path=str(live_file))
+        return 0
+
+    lines = live_file.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+
+    if len(lines) <= RECEIPTS_MAX_RECORDS:
+        _emit("INFO", "receipts_skip", reason="within_cap", line_count=len(lines), cap=RECEIPTS_MAX_RECORDS)
+        return 0
+
+    archive_file = _archive_path(state_dir, "t0_receipts")
+    if archive_file.exists():
+        _emit("INFO", "receipts_skip", reason="archive_already_exists_today", archive=str(archive_file))
+        return 0
+
+    keep = lines[-RECEIPTS_MAX_RECORDS:]
+    overflow = lines[: -RECEIPTS_MAX_RECORDS]
+
+    _emit(
+        "INFO",
+        "receipts_rotating",
+        live_path=str(live_file),
+        archive_path=str(archive_file),
+        archive_lines=len(overflow),
+        keep_lines=len(keep),
+        dry_run=dry_run,
+    )
+
+    if dry_run:
+        return 0
+
+    try:
+        _atomic_write_bytes(archive_file, gzip.compress("".join(overflow).encode("utf-8")))
+        _atomic_write_text(live_file, "".join(keep))
+    except OSError as exc:
+        _emit("ERROR", "receipts_io_error", error=str(exc))
+        return 1
+
+    _emit(
+        "INFO",
+        "receipts_done",
+        archive=str(archive_file),
+        archive_lines=len(overflow),
+        live_lines=len(keep),
+    )
+    return 0
+
+
+def compact_open_items_digest(state_dir: Path, *, dry_run: bool = False) -> int:
+    """Evict open_items_digest.json entries where last_updated >30d. Returns 0 on success."""
+    digest_file = state_dir / "open_items_digest.json"
+
+    if not digest_file.exists():
+        _emit("INFO", "open_items_digest_skip", reason="file_not_found", path=str(digest_file))
+        return 0
+
+    try:
+        digest: dict = json.loads(digest_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        _emit("ERROR", "open_items_digest_parse_error", error=str(exc))
+        return 1
+
+    if not isinstance(digest, dict):
+        _emit("ERROR", "open_items_digest_unexpected_schema", type=type(digest).__name__)
+        return 1
+
+    cutoff = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=OPEN_ITEMS_STALE_DAYS)
+
+    def _is_stale(entry: object) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        raw = entry.get("last_updated")
+        if not raw:
+            return False
+        try:
+            ts = datetime.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=datetime.timezone.utc)
+            return ts < cutoff
+        except (ValueError, AttributeError):
+            return False
+
+    new_digest: dict = {}
+    total_evicted = 0
+
+    for key, value in digest.items():
+        if isinstance(value, list):
+            fresh = [e for e in value if not _is_stale(e)]
+            evicted = len(value) - len(fresh)
+            total_evicted += evicted
+            new_digest[key] = fresh
+        else:
+            new_digest[key] = value
+
+    if total_evicted == 0:
+        _emit("INFO", "open_items_digest_skip", reason="no_stale_entries")
+        return 0
+
+    _emit("INFO", "open_items_digest_evicting", evicted=total_evicted, dry_run=dry_run)
+
+    if dry_run:
+        return 0
+
+    try:
+        content = json.dumps(new_digest, indent=2, ensure_ascii=False) + "\n"
+        _atomic_write_text(digest_file, content)
+    except OSError as exc:
+        _emit("ERROR", "open_items_digest_io_error", error=str(exc))
+        return 1
+
+    _emit("INFO", "open_items_digest_done", evicted=total_evicted)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="VNX state file compaction")
+    parser.add_argument(
+        "--mode",
+        choices=["intelligence_archive", "receipts", "open_items_digest", "all"],
+        default="all",
+        help="Which compaction mode to run (default: all)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Describe what would be done without mutating any files",
+    )
+    args = parser.parse_args()
+
+    data_dir = resolve_data_dir(__file__)
+    state_dir = data_dir / "state"
+
+    _emit("INFO", "compact_state_start", mode=args.mode, dry_run=args.dry_run, state_dir=str(state_dir))
+
+    codes: list[int] = []
+
+    if args.mode in ("intelligence_archive", "all"):
+        codes.append(compact_intelligence_archive(state_dir, dry_run=args.dry_run))
+
+    if args.mode in ("receipts", "all"):
+        codes.append(compact_receipts(state_dir, dry_run=args.dry_run))
+
+    if args.mode in ("open_items_digest", "all"):
+        codes.append(compact_open_items_digest(state_dir, dry_run=args.dry_run))
+
+    overall = max(codes) if codes else 0
+    _emit("INFO", "compact_state_done", mode=args.mode, exit_code=overall)
+    return overall
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_nightly_crons.sh
+++ b/scripts/install_nightly_crons.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# install_nightly_crons.sh — idempotently installs the compact_state nightly cron.
+# Safe to run multiple times; checks for the entry before adding.
+set -euo pipefail
+
+CRON_ENTRY='30 2 * * * cd /Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt && python3 scripts/compact_state.py --mode all >> .vnx-data/logs/compact_state.log 2>&1'
+
+existing=$(crontab -l 2>/dev/null || true)
+
+if printf '%s\n' "$existing" | grep -qF "$CRON_ENTRY"; then
+    printf 'compact_state cron entry already installed — no change.\n'
+else
+    if [ -n "$existing" ]; then
+        printf '%s\n%s\n' "$existing" "$CRON_ENTRY" | crontab -
+    else
+        printf '%s\n' "$CRON_ENTRY" | crontab -
+    fi
+    printf 'compact_state cron entry installed.\n'
+fi
+
+printf '\nCurrent crontab:\n'
+crontab -l

--- a/tests/test_compact_state.py
+++ b/tests/test_compact_state.py
@@ -1,0 +1,386 @@
+"""Tests for scripts/compact_state.py — state file rotation and compaction."""
+from __future__ import annotations
+
+import datetime
+import gzip
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+if str(_SCRIPTS_DIR / "lib") not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
+
+import compact_state as cs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ndjson_line(timestamp: float, extra: str = "") -> str:
+    return json.dumps({"timestamp": timestamp, "data": extra}) + "\n"
+
+
+def _iso(days_ago: float) -> str:
+    ts = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=days_ago)
+    return ts.isoformat()
+
+
+def _read_archive(archive_path: Path) -> list[str]:
+    with gzip.open(archive_path, "rt", encoding="utf-8") as f:
+        return [l for l in f.read().splitlines() if l.strip()]
+
+
+def _setup_state(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# intelligence_archive tests
+# ---------------------------------------------------------------------------
+
+class TestIntelligenceArchive:
+    def test_rotation_archives_old_keeps_recent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Synthetic 100MB+ file: lines >7d old are archived; <7d lines stay live."""
+        monkeypatch.setattr(cs, "INTELLIGENCE_ARCHIVE_MIN_MB", 0)
+
+        state = _setup_state(tmp_path)
+        live = state / "t0_intelligence_archive.ndjson"
+
+        now = time.time()
+        old_ts = now - 8 * 86400   # 8 days ago
+        new_ts = now - 1 * 86400   # 1 day ago
+
+        # Each line ~10KB; 5000 old + 5000 new ≈ 100MB synthetic file
+        padding = "x" * 9900
+        old_lines = [_make_ndjson_line(old_ts + i * 0.001, padding) for i in range(5000)]
+        new_lines = [_make_ndjson_line(new_ts + i * 0.001, padding) for i in range(5000)]
+        live.write_text("".join(old_lines + new_lines), encoding="utf-8")
+
+        rc = cs.compact_intelligence_archive(state)
+
+        assert rc == 0
+
+        archives = list((state / "archive").glob("t0_intelligence_archive_*.ndjson.gz"))
+        assert len(archives) == 1, "exactly one archive created"
+
+        archived = _read_archive(archives[0])
+        assert len(archived) == 5000, f"expected 5000 archived lines, got {len(archived)}"
+
+        live_lines = [l for l in live.read_text().splitlines() if l.strip()]
+        assert len(live_lines) == 5000, f"expected 5000 live lines, got {len(live_lines)}"
+
+        # Confirm live lines are all recent
+        for raw in live_lines:
+            record = json.loads(raw)
+            assert record["timestamp"] >= now - 7 * 86400
+
+    def test_skip_below_threshold(self, tmp_path: Path) -> None:
+        """Files below 50MB threshold are not rotated."""
+        state = _setup_state(tmp_path)
+        live = state / "t0_intelligence_archive.ndjson"
+        live.write_text(_make_ndjson_line(time.time() - 10 * 86400), encoding="utf-8")
+
+        rc = cs.compact_intelligence_archive(state)
+
+        assert rc == 0
+        assert not (state / "archive").exists() or not list((state / "archive").glob("*.gz"))
+
+    def test_skip_when_file_absent(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        rc = cs.compact_intelligence_archive(state)
+        assert rc == 0
+
+    def test_skip_when_all_records_fresh(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(cs, "INTELLIGENCE_ARCHIVE_MIN_MB", 0)
+
+        state = _setup_state(tmp_path)
+        live = state / "t0_intelligence_archive.ndjson"
+        now = time.time()
+        live.write_text("".join(_make_ndjson_line(now - i) for i in range(100)), encoding="utf-8")
+
+        rc = cs.compact_intelligence_archive(state)
+
+        assert rc == 0
+        archive_dir = state / "archive"
+        assert not archive_dir.exists() or not list(archive_dir.glob("*.gz"))
+
+
+# ---------------------------------------------------------------------------
+# receipts tests
+# ---------------------------------------------------------------------------
+
+class TestReceipts:
+    def test_15000_lines_leaves_10000_archives_5000(self, tmp_path: Path) -> None:
+        """15000-line receipts file: 10000 newest retained; 5000 oldest archived."""
+        state = _setup_state(tmp_path)
+        live = state / "t0_receipts.ndjson"
+
+        lines = [json.dumps({"seq": i, "timestamp": i}) + "\n" for i in range(15_000)]
+        live.write_text("".join(lines), encoding="utf-8")
+
+        rc = cs.compact_receipts(state)
+
+        assert rc == 0
+
+        archives = list((state / "archive").glob("t0_receipts_*.ndjson.gz"))
+        assert len(archives) == 1
+
+        archived = _read_archive(archives[0])
+        assert len(archived) == 5_000, f"expected 5000 archived, got {len(archived)}"
+
+        # Oldest 5000 are archived (seq 0..4999)
+        assert json.loads(archived[0])["seq"] == 0
+        assert json.loads(archived[-1])["seq"] == 4_999
+
+        live_lines = [l for l in live.read_text().splitlines() if l.strip()]
+        assert len(live_lines) == 10_000
+
+        # Newest 10000 retained (seq 5000..14999)
+        assert json.loads(live_lines[0])["seq"] == 5_000
+        assert json.loads(live_lines[-1])["seq"] == 14_999
+
+    def test_within_cap_no_rotation(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        live = state / "t0_receipts.ndjson"
+        lines = [json.dumps({"seq": i}) + "\n" for i in range(500)]
+        live.write_text("".join(lines))
+
+        rc = cs.compact_receipts(state)
+
+        assert rc == 0
+        assert not list((state / "archive").glob("*.gz")) if not (state / "archive").exists() else not list((state / "archive").glob("*.gz"))
+
+    def test_skip_when_file_absent(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        assert cs.compact_receipts(state) == 0
+
+    def test_atomic_write_preserves_existing_on_verify(self, tmp_path: Path) -> None:
+        """After rotation the live file is a complete, valid file (not corrupted)."""
+        state = _setup_state(tmp_path)
+        live = state / "t0_receipts.ndjson"
+        lines = [json.dumps({"seq": i}) + "\n" for i in range(12_000)]
+        live.write_text("".join(lines))
+
+        rc = cs.compact_receipts(state)
+        assert rc == 0
+
+        retained = [json.loads(l) for l in live.read_text().splitlines() if l.strip()]
+        assert len(retained) == 10_000
+        assert retained[0]["seq"] == 2_000
+
+
+# ---------------------------------------------------------------------------
+# open_items_digest tests
+# ---------------------------------------------------------------------------
+
+class TestOpenItemsDigest:
+    def _make_digest(self, state: Path, entries: list[dict]) -> Path:
+        digest_file = state / "open_items_digest.json"
+        digest = {
+            "summary": {"open_count": len(entries)},
+            "recent_closures": entries,
+            "open_items": [],
+            "last_updated": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+            "digest_generated": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+        }
+        digest_file.write_text(json.dumps(digest, indent=2))
+        return digest_file
+
+    def test_mixed_dates_only_fresh_retained(self, tmp_path: Path) -> None:
+        """Entries with last_updated >30d are evicted; fresh entries remain."""
+        state = _setup_state(tmp_path)
+
+        entries = [
+            {"id": "OI-001", "title": "Very old", "last_updated": _iso(45)},
+            {"id": "OI-002", "title": "Exactly old", "last_updated": _iso(31)},
+            {"id": "OI-003", "title": "Fresh", "last_updated": _iso(5)},
+            {"id": "OI-004", "title": "No date"},  # no last_updated → keep
+            {"id": "OI-005", "title": "Very fresh", "last_updated": _iso(0)},
+        ]
+        digest_file = self._make_digest(state, entries)
+
+        rc = cs.compact_open_items_digest(state)
+
+        assert rc == 0
+        result = json.loads(digest_file.read_text())
+        remaining_ids = [e["id"] for e in result["recent_closures"]]
+
+        assert "OI-001" not in remaining_ids, "45d-old entry should be evicted"
+        assert "OI-002" not in remaining_ids, "31d-old entry should be evicted"
+        assert "OI-003" in remaining_ids, "5d-old entry should be retained"
+        assert "OI-004" in remaining_ids, "no-date entry should be retained"
+        assert "OI-005" in remaining_ids, "fresh entry should be retained"
+
+    def test_all_fresh_no_mutation(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        entries = [
+            {"id": "OI-001", "title": "Fresh", "last_updated": _iso(1)},
+        ]
+        digest_file = self._make_digest(state, entries)
+        original = digest_file.read_text()
+
+        rc = cs.compact_open_items_digest(state)
+
+        assert rc == 0
+        # File should not have been mutated (no-op)
+        assert digest_file.read_text() == original
+
+    def test_skip_when_file_absent(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        assert cs.compact_open_items_digest(state) == 0
+
+    def test_schema_preserved(self, tmp_path: Path) -> None:
+        """Top-level scalar fields and other list keys are preserved after eviction."""
+        state = _setup_state(tmp_path)
+        entries = [
+            {"id": "OI-001", "title": "Stale", "last_updated": _iso(60)},
+            {"id": "OI-002", "title": "Fresh", "last_updated": _iso(2)},
+        ]
+        digest_file = self._make_digest(state, entries)
+
+        rc = cs.compact_open_items_digest(state)
+        assert rc == 0
+
+        result = json.loads(digest_file.read_text())
+        assert "summary" in result
+        assert "open_items" in result
+        assert "last_updated" in result
+        assert "digest_generated" in result
+
+
+# ---------------------------------------------------------------------------
+# Dry-run tests
+# ---------------------------------------------------------------------------
+
+class TestDryRun:
+    def test_intelligence_archive_dry_run_no_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cs, "INTELLIGENCE_ARCHIVE_MIN_MB", 0)
+
+        state = _setup_state(tmp_path)
+        live = state / "t0_intelligence_archive.ndjson"
+        now = time.time()
+        content = "".join(_make_ndjson_line(now - 10 * 86400) for _ in range(10))
+        live.write_text(content)
+        original = live.read_text()
+
+        rc = cs.compact_intelligence_archive(state, dry_run=True)
+
+        assert rc == 0
+        assert live.read_text() == original, "dry-run must not mutate live file"
+        assert not (state / "archive").exists() or not list((state / "archive").glob("*.gz"))
+
+    def test_receipts_dry_run_no_mutation(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        live = state / "t0_receipts.ndjson"
+        lines = [json.dumps({"seq": i}) + "\n" for i in range(12_000)]
+        content = "".join(lines)
+        live.write_text(content)
+
+        rc = cs.compact_receipts(state, dry_run=True)
+
+        assert rc == 0
+        assert live.read_text() == content, "dry-run must not mutate live file"
+        assert not (state / "archive").exists() or not list((state / "archive").glob("*.gz"))
+
+    def test_open_items_digest_dry_run_no_mutation(self, tmp_path: Path) -> None:
+        state = _setup_state(tmp_path)
+        entries = [{"id": "OI-001", "title": "Stale", "last_updated": _iso(60)}]
+        digest = {"recent_closures": entries, "summary": {}}
+        digest_file = state / "open_items_digest.json"
+        digest_file.write_text(json.dumps(digest))
+        original = digest_file.read_text()
+
+        rc = cs.compact_open_items_digest(state, dry_run=True)
+
+        assert rc == 0
+        assert digest_file.read_text() == original, "dry-run must not mutate digest"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests
+# ---------------------------------------------------------------------------
+
+class TestIdempotency:
+    def test_intelligence_archive_second_run_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Second run is a no-op: today's archive already exists."""
+        monkeypatch.setattr(cs, "INTELLIGENCE_ARCHIVE_MIN_MB", 0)
+
+        state = _setup_state(tmp_path)
+        live = state / "t0_intelligence_archive.ndjson"
+        now = time.time()
+        old_ts = now - 10 * 86400
+        content = "".join(_make_ndjson_line(old_ts + i) for i in range(20))
+        live.write_text(content)
+
+        # First run
+        rc1 = cs.compact_intelligence_archive(state)
+        assert rc1 == 0
+
+        live_after_1 = live.read_text()
+        archives_after_1 = list((state / "archive").glob("*.gz"))
+        assert len(archives_after_1) == 1
+
+        # Second run
+        rc2 = cs.compact_intelligence_archive(state)
+        assert rc2 == 0
+
+        assert live.read_text() == live_after_1, "live file unchanged on 2nd run"
+        archives_after_2 = list((state / "archive").glob("*.gz"))
+        assert len(archives_after_2) == 1, "no new archive created on 2nd run"
+
+    def test_receipts_second_run_noop(self, tmp_path: Path) -> None:
+        """Second run is a no-op: today's archive exists OR file is within cap."""
+        state = _setup_state(tmp_path)
+        live = state / "t0_receipts.ndjson"
+        lines = [json.dumps({"seq": i}) + "\n" for i in range(15_000)]
+        live.write_text("".join(lines))
+
+        rc1 = cs.compact_receipts(state)
+        assert rc1 == 0
+
+        live_after_1 = live.read_text()
+        archives_1 = list((state / "archive").glob("*.gz"))
+        assert len(archives_1) == 1
+
+        rc2 = cs.compact_receipts(state)
+        assert rc2 == 0
+
+        assert live.read_text() == live_after_1, "live file unchanged on 2nd run"
+        archives_2 = list((state / "archive").glob("*.gz"))
+        assert len(archives_2) == 1, "no new archive on 2nd run"
+
+    def test_open_items_digest_second_run_noop(self, tmp_path: Path) -> None:
+        """After eviction, second run finds no stale entries and is a no-op."""
+        state = _setup_state(tmp_path)
+        entries = [
+            {"id": "OI-001", "title": "Old", "last_updated": _iso(40)},
+            {"id": "OI-002", "title": "Fresh", "last_updated": _iso(3)},
+        ]
+        digest_file = state / "open_items_digest.json"
+        digest_file.write_text(json.dumps({"recent_closures": entries}))
+
+        rc1 = cs.compact_open_items_digest(state)
+        assert rc1 == 0
+
+        content_after_1 = digest_file.read_text()
+        remaining = json.loads(content_after_1)["recent_closures"]
+        assert len(remaining) == 1  # only fresh entry
+
+        rc2 = cs.compact_open_items_digest(state)
+        assert rc2 == 0
+
+        assert digest_file.read_text() == content_after_1, "file unchanged on 2nd run"


### PR DESCRIPTION
## Summary

- **scripts/compact_state.py**: Three-mode state compaction utility
  - `intelligence_archive`: rotates `t0_intelligence_archive.ndjson` (skip <50MB, gzip-archive lines >7d, atomic rename)
  - `receipts`: caps `t0_receipts.ndjson` at 10,000 records, archives overflow as dated `.ndjson.gz`
  - `open_items_digest`: evicts `open_items_digest.json` list entries where `last_updated` >30d ago
  - `--dry-run` flag, `--mode {intelligence_archive,receipts,open_items_digest,all}`, structured JSON stderr logging, idempotent (today's archive exists → skip)
- **scripts/install_nightly_crons.sh**: Idempotent bash installer for `30 2 * * *` cron entry; grep-guards against duplicate installs
- **tests/test_compact_state.py**: 18 pytest tests covering all modes, dry-run, and idempotency

## Test plan

- [x] `python3 -m py_compile scripts/compact_state.py scripts/lib/project_root.py` — passed
- [x] `python3 -m pytest tests/test_compact_state.py -xvs` — 18 passed in 0.91s
- [x] `bash -n scripts/install_nightly_crons.sh` — passed
- [ ] Codex gate (T0 to run after operator approval)
- [ ] Gemini review gate (T0 to run after operator approval)

## Do not merge

T0 will run codex+gemini gates before merge.

Dispatch-ID: 20260428-t3-pr1-compact-state

🤖 Generated with [Claude Code](https://claude.com/claude-code)