### PR TITLE
feat(observability): /api/register-stream SSE endpoint (Tier 5 GAP-3)

### DIFF
--- a/dashboard/api_register_stream.py
+++ b/dashboard/api_register_stream.py
@@ -34,45 +34,110 @@ def _register_file() -> Path:
     return resolve_state_dir(__file__) / "dispatch_register.ndjson"
 
 
+def _resolve_start_index(path: Path, since_ts: str | None) -> int:
+    """Convert a since_ts API parameter into a line-index cursor.
+
+    Returns the count of records (non-blank lines) whose timestamp is
+    less than or equal to since_ts. Records past this point are the
+    "new" events the caller wants delivered.
+
+    Records with no timestamp or with malformed JSON are treated as
+    already-seen (their slot is consumed by the cursor) so that the
+    line index stays in sync with file position regardless of content.
+
+    A None since_ts means "start from the beginning" → 0.
+    """
+    if not since_ts or not path.exists():
+        return 0
+    index = 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    rec = json.loads(stripped)
+                except json.JSONDecodeError:
+                    index += 1
+                    continue
+                ts = rec.get("timestamp", "")
+                if ts and ts > since_ts:
+                    break
+                index += 1
+    except OSError:
+        return 0
+    return index
+
+
+def _read_new_events_after(
+    path: Path,
+    last_index: int,
+    event_types: set[str] | None,
+) -> tuple[list[dict], int]:
+    """Read records past line-index ``last_index``.
+
+    Returns ``(events, new_last_index)`` where ``new_last_index`` is the
+    record-slot count after the last consumed line (whether delivered,
+    filtered out, or malformed). Using a positional cursor instead of
+    timestamps means two events written with the same timestamp are
+    both delivered — the timestamp-only cursor previously dropped
+    same-ts records (codex regate finding, PR #304).
+    """
+    if not path.exists():
+        return [], last_index
+    events: list[dict] = []
+    new_index = last_index
+    current = 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                current += 1
+                if current <= last_index:
+                    continue
+                # This slot is being consumed — advance the cursor even
+                # when the record is malformed or filtered out, so we
+                # never re-scan it on the next poll.
+                new_index = current
+                try:
+                    rec = json.loads(stripped)
+                except json.JSONDecodeError:
+                    print(
+                        f"[register-stream] WARNING: malformed JSON line skipped: {stripped[:80]}",
+                        file=sys.stderr,
+                    )
+                    continue
+                if event_types and rec.get("event") not in event_types:
+                    continue
+                events.append(rec)
+    except OSError:
+        return [], last_index
+    return events, new_index
+
+
 def _read_new_events(
     path: Path,
     since_ts: str | None,
     event_types: set[str] | None,
 ) -> tuple[list[dict], str | None]:
-    """Read events from path that are strictly newer than since_ts.
+    """Backward-compatible wrapper around the line-indexed reader.
 
-    Returns (events, latest_timestamp) where latest_timestamp is the
-    maximum timestamp seen in the returned events (or since_ts if none).
-    Skips malformed JSON lines with a stderr warning.
+    Returns ``(events, latest_timestamp)`` where ``latest_timestamp`` is
+    the maximum timestamp seen in the returned events (or ``since_ts``
+    if none). Internally uses the line-index cursor to avoid the
+    same-timestamp-skip bug, but presents a timestamp-shaped result
+    for callers that have not migrated.
     """
-    if not path.exists():
-        return [], since_ts
-    events = []
+    start_index = _resolve_start_index(path, since_ts)
+    events, _new_index = _read_new_events_after(path, start_index, event_types)
     latest_ts = since_ts
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except json.JSONDecodeError:
-                    print(
-                        f"[register-stream] WARNING: malformed JSON line skipped: {line[:80]}",
-                        file=sys.stderr,
-                    )
-                    continue
-                ts = rec.get("timestamp", "")
-                if since_ts and ts <= since_ts:
-                    continue
-                if event_types and rec.get("event") not in event_types:
-                    continue
-                events.append(rec)
-                if ts and (latest_ts is None or ts > latest_ts):
-                    latest_ts = ts
-    except OSError:
-        return [], since_ts
+    for rec in events:
+        ts = rec.get("timestamp", "")
+        if ts and (latest_ts is None or ts > latest_ts):
+            latest_ts = ts
     return events, latest_ts
 
 
@@ -91,8 +156,13 @@ def handle_register_stream(
     Sends a heartbeat comment every heartbeat_interval seconds to keep the
     connection alive. Stops when the client disconnects.
 
+    The cursor is a line index (count of records already delivered) so
+    that two events sharing a timestamp are both streamed — the previous
+    timestamp-only cursor silently dropped the second one.
+
     Query params (handled by caller, passed as args here):
-      since_ts    ISO8601 timestamp — replay only events strictly newer than this
+      since_ts    ISO8601 timestamp — replay only events strictly newer than this.
+                  Resolved once at session start to a line-index cursor.
       event_type  comma-separated event type filter (e.g. dispatch_created,gate_passed)
     """
     src = register_file if register_file is not None else _register_file()
@@ -108,12 +178,12 @@ def handle_register_stream(
     handler.send_header("Access-Control-Allow-Origin", "*")
     handler.end_headers()
 
-    last_ts = since_ts
+    last_index = _resolve_start_index(src, since_ts)
     last_heartbeat = time.monotonic()
 
     try:
         while True:
-            events, last_ts = _read_new_events(src, last_ts, event_types)
+            events, last_index = _read_new_events_after(src, last_index, event_types)
             for event in events:
                 line = f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
                 handler.wfile.write(line.encode("utf-8"))

--- a/dashboard/api_register_stream.py
+++ b/dashboard/api_register_stream.py
@@ -1,0 +1,169 @@
+"""Register stream SSE endpoint handlers.
+
+Provides Server-Sent Events streaming from dispatch_register.ndjson
+and a one-shot archive replay endpoint.
+
+BILLING SAFETY: No Anthropic SDK imports. Local filesystem only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from http import HTTPStatus
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from http.server import BaseHTTPRequestHandler
+
+# Make scripts/lib importable for path resolution
+_SCRIPTS_LIB = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, _SCRIPTS_LIB)
+
+from project_root import resolve_state_dir
+
+_POLL_INTERVAL = 0.5  # seconds between polls
+_HEARTBEAT_INTERVAL = float(os.environ.get("VNX_REGISTER_STREAM_HEARTBEAT", "30"))
+
+
+def _register_file() -> Path:
+    return resolve_state_dir(__file__) / "dispatch_register.ndjson"
+
+
+def _read_new_events(
+    path: Path,
+    since_ts: str | None,
+    event_types: set[str] | None,
+) -> tuple[list[dict], str | None]:
+    """Read events from path that are strictly newer than since_ts.
+
+    Returns (events, latest_timestamp) where latest_timestamp is the
+    maximum timestamp seen in the returned events (or since_ts if none).
+    Skips malformed JSON lines with a stderr warning.
+    """
+    if not path.exists():
+        return [], since_ts
+    events = []
+    latest_ts = since_ts
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    print(
+                        f"[register-stream] WARNING: malformed JSON line skipped: {line[:80]}",
+                        file=sys.stderr,
+                    )
+                    continue
+                ts = rec.get("timestamp", "")
+                if since_ts and ts <= since_ts:
+                    continue
+                if event_types and rec.get("event") not in event_types:
+                    continue
+                events.append(rec)
+                if ts and (latest_ts is None or ts > latest_ts):
+                    latest_ts = ts
+    except OSError:
+        return [], since_ts
+    return events, latest_ts
+
+
+def handle_register_stream(
+    handler: "BaseHTTPRequestHandler",
+    since_ts: str | None = None,
+    event_type_filter: str | None = None,
+    *,
+    poll_interval: float = _POLL_INTERVAL,
+    heartbeat_interval: float = _HEARTBEAT_INTERVAL,
+    register_file: Path | None = None,
+) -> None:
+    """Stream dispatch_register.ndjson as SSE.
+
+    Keeps the connection open, polling every 500ms for new events.
+    Sends a heartbeat comment every heartbeat_interval seconds to keep the
+    connection alive. Stops when the client disconnects.
+
+    Query params (handled by caller, passed as args here):
+      since_ts    ISO8601 timestamp — replay only events strictly newer than this
+      event_type  comma-separated event type filter (e.g. dispatch_created,gate_passed)
+    """
+    src = register_file if register_file is not None else _register_file()
+
+    event_types: set[str] | None = None
+    if event_type_filter:
+        event_types = {e.strip() for e in event_type_filter.split(",") if e.strip()}
+
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("Connection", "keep-alive")
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.end_headers()
+
+    last_ts = since_ts
+    last_heartbeat = time.monotonic()
+
+    try:
+        while True:
+            events, last_ts = _read_new_events(src, last_ts, event_types)
+            for event in events:
+                line = f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
+                handler.wfile.write(line.encode("utf-8"))
+
+            now = time.monotonic()
+            if now - last_heartbeat >= heartbeat_interval:
+                handler.wfile.write(b": heartbeat\n\n")
+                last_heartbeat = now
+
+            handler.wfile.flush()
+            time.sleep(poll_interval)
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        # Client disconnected — clean exit
+        pass
+
+
+def handle_register_stream_archive(
+    handler: "BaseHTTPRequestHandler",
+    register_file: Path | None = None,
+) -> None:
+    """Return full dispatch_register.ndjson as a JSON array (one-shot, not SSE).
+
+    Malformed lines are skipped with a stderr warning. Missing file returns [].
+    """
+    src = register_file if register_file is not None else _register_file()
+    events: list[dict] = []
+    if src.exists():
+        try:
+            with open(src, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        events.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        print(
+                            f"[register-stream] WARNING: malformed JSON line skipped in archive: {line[:80]}",
+                            file=sys.stderr,
+                        )
+        except OSError:
+            pass
+    _send_json(handler, HTTPStatus.OK, events)
+
+
+def _send_json(handler: "BaseHTTPRequestHandler", status: HTTPStatus, payload) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.end_headers()
+    handler.wfile.write(body)

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -147,6 +147,11 @@ from api_agent_stream import (  # noqa: E402
     handle_agent_stream_status,
 )
 
+from api_register_stream import (  # noqa: E402
+    handle_register_stream,
+    handle_register_stream_archive,
+)
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -328,6 +333,17 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/agents":
             _json_response(self, HTTPStatus.OK, _operator_get_agents())
+            return
+
+        # Register stream SSE endpoints
+        if path == "/api/register-stream/archive":
+            handle_register_stream_archive(self)
+            return
+
+        if path == "/api/register-stream":
+            since_ts = params.get("since_ts", [None])[0]
+            event_type_filter = params.get("event_type", [None])[0]
+            handle_register_stream(self, since_ts, event_type_filter)
             return
 
         # Agent stream SSE endpoints

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -335,15 +335,19 @@ class DashboardHandler(SimpleHTTPRequestHandler):
             _json_response(self, HTTPStatus.OK, _operator_get_agents())
             return
 
-        # Register stream SSE endpoints
+        # Register stream SSE endpoints — pass CANONICAL_STATE_DIR so the
+        # handler uses the same state dir as all other /state/* APIs, honoring
+        # VNX_STATE_DIR in non-default worktree / runtime configurations.
+        _register_file = CANONICAL_STATE_DIR / "dispatch_register.ndjson"
+
         if path == "/api/register-stream/archive":
-            handle_register_stream_archive(self)
+            handle_register_stream_archive(self, register_file=_register_file)
             return
 
         if path == "/api/register-stream":
             since_ts = params.get("since_ts", [None])[0]
             event_type_filter = params.get("event_type", [None])[0]
-            handle_register_stream(self, since_ts, event_type_filter)
+            handle_register_stream(self, since_ts, event_type_filter, register_file=_register_file)
             return
 
         # Agent stream SSE endpoints

--- a/tests/test_api_register_stream.py
+++ b/tests/test_api_register_stream.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Tests for /api/register-stream SSE endpoint and /api/register-stream/archive.
+
+Covers:
+  A. Append event to test file → SSE client receives event in first poll
+  B. since_ts filter — only events strictly after timestamp are replayed
+  C. event_type filter — only matching events streamed
+  D. Heartbeat sent when interval elapses (using heartbeat_interval=0)
+  E. Archive endpoint returns full content as JSON array
+  F. Malformed JSON line in source file → SSE skips with stderr warning, continues
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add dashboard and scripts/lib to path
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+from api_register_stream import (
+    handle_register_stream,
+    handle_register_stream_archive,
+    _read_new_events,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_handler(wfile=None):
+    """Build a mock HTTP handler with response tracking."""
+    handler = MagicMock()
+    handler.wfile = wfile or io.BytesIO()
+    headers_sent = {}
+
+    def send_header(name, value):
+        headers_sent[name] = value
+
+    handler.send_header = MagicMock(side_effect=send_header)
+    handler._headers_sent = headers_sent
+    return handler
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev, separators=(",", ":")) + "\n")
+
+
+def _make_event(event: str, ts: str, **kwargs) -> dict:
+    rec = {"timestamp": ts, "event": event, "dispatch_id": "test-001"}
+    rec.update(kwargs)
+    return rec
+
+
+def _run_one_poll(handler, reg_file: Path, since_ts=None, event_type_filter=None):
+    """Run one iteration of handle_register_stream then disconnect."""
+    flush_count = 0
+
+    def limited_flush():
+        nonlocal flush_count
+        flush_count += 1
+        if flush_count >= 1:
+            raise BrokenPipeError("test disconnect")
+
+    handler.wfile.flush = limited_flush
+    handle_register_stream(
+        handler,
+        since_ts=since_ts,
+        event_type_filter=event_type_filter,
+        poll_interval=0,
+        heartbeat_interval=9999,  # suppress heartbeat unless explicitly testing it
+        register_file=reg_file,
+    )
+
+
+def _sse_lines(handler) -> list[dict]:
+    output = handler.wfile.getvalue().decode("utf-8")
+    result = []
+    for line in output.split("\n"):
+        if line.startswith("data: "):
+            result.append(json.loads(line[len("data: "):]))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Case A: SSE client receives event on first poll
+# ---------------------------------------------------------------------------
+
+class TestCaseA_EventReceived:
+    def test_single_event_appears_in_sse_output(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        ev = _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z")
+        _write_events(reg, [ev])
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 1
+        assert lines[0]["event"] == "dispatch_created"
+
+    def test_multiple_events_all_received(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_started", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 3
+        assert [l["event"] for l in lines] == [
+            "dispatch_created", "dispatch_promoted", "dispatch_started"
+        ]
+
+    def test_sse_headers_sent(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        _write_events(reg, [_make_event("dispatch_created", "2026-04-28T10:00:00.000000Z")])
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        handler.send_response.assert_called_with(HTTPStatus.OK)
+        handler.send_header.assert_any_call("Content-Type", "text/event-stream")
+        handler.send_header.assert_any_call("Cache-Control", "no-cache")
+        handler.send_header.assert_any_call("Access-Control-Allow-Origin", "*")
+
+    def test_empty_file_produces_no_sse_data(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        assert lines == []
+
+    def test_missing_file_produces_no_sse_data(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"  # does not exist
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        assert lines == []
+
+
+# ---------------------------------------------------------------------------
+# Case B: since_ts filter
+# ---------------------------------------------------------------------------
+
+class TestCaseB_SinceTsFilter:
+    def test_events_before_since_ts_excluded(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_started", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        # Pass timestamp of the first event — only subsequent events should appear
+        _run_one_poll(handler, reg, since_ts="2026-04-28T10:00:00.000000Z")
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 2
+        assert lines[0]["event"] == "dispatch_promoted"
+        assert lines[1]["event"] == "dispatch_started"
+
+    def test_all_events_excluded_when_since_ts_is_latest(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, since_ts="2026-04-28T10:00:01.000000Z")
+
+        lines = _sse_lines(handler)
+        assert lines == []
+
+    def test_no_since_ts_returns_all_events(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, since_ts=None)
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 2
+
+    def test_read_new_events_tracks_latest_ts(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        events, latest_ts = _read_new_events(reg, None, None)
+        assert len(events) == 2
+        assert latest_ts == "2026-04-28T10:00:02.000000Z"
+
+    def test_read_new_events_advances_since_ts_across_polls(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        # First poll: get all events
+        events, ts1 = _read_new_events(reg, None, None)
+        assert len(events) == 2
+
+        # Append a new event
+        _write_events(reg, [_make_event("dispatch_started", "2026-04-28T10:00:02.000000Z")])
+
+        # Second poll: only the new event
+        events2, ts2 = _read_new_events(reg, ts1, None)
+        assert len(events2) == 1
+        assert events2[0]["event"] == "dispatch_started"
+        assert ts2 == "2026-04-28T10:00:02.000000Z"
+
+
+# ---------------------------------------------------------------------------
+# Case C: event_type filter
+# ---------------------------------------------------------------------------
+
+class TestCaseC_EventTypeFilter:
+    def test_single_type_filter(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("gate_passed", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_completed", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, event_type_filter="gate_passed")
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 1
+        assert lines[0]["event"] == "gate_passed"
+
+    def test_multi_type_filter_comma_separated(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("gate_passed", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_completed", "2026-04-28T10:00:02.000000Z"),
+            _make_event("gate_failed", "2026-04-28T10:00:03.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, event_type_filter="gate_passed,gate_failed")
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 2
+        types = [l["event"] for l in lines]
+        assert "gate_passed" in types
+        assert "gate_failed" in types
+
+    def test_filter_no_match_returns_nothing(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, event_type_filter="pr_opened")
+
+        lines = _sse_lines(handler)
+        assert lines == []
+
+    def test_filter_with_whitespace_in_comma_list(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("gate_passed", "2026-04-28T10:00:01.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, event_type_filter=" gate_passed , dispatch_created ")
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 2
+
+    def test_no_filter_returns_all_types(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("gate_passed", "2026-04-28T10:00:01.000000Z"),
+            _make_event("pr_merged", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg, event_type_filter=None)
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 3
+
+
+# ---------------------------------------------------------------------------
+# Case D: heartbeat
+# ---------------------------------------------------------------------------
+
+class TestCaseD_Heartbeat:
+    def test_heartbeat_sent_when_interval_zero(self, tmp_path):
+        """heartbeat_interval=0 means heartbeat fires on every loop iteration."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")  # empty file
+
+        handler = _make_handler()
+        flush_count = 0
+
+        def limited_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count >= 1:
+                raise BrokenPipeError("test disconnect")
+
+        handler.wfile.flush = limited_flush
+        handle_register_stream(
+            handler,
+            since_ts=None,
+            event_type_filter=None,
+            poll_interval=0,
+            heartbeat_interval=0,
+            register_file=reg,
+        )
+
+        output = handler.wfile.getvalue().decode("utf-8")
+        assert ": heartbeat\n\n" in output
+
+    def test_no_heartbeat_when_interval_not_elapsed(self, tmp_path):
+        """With large heartbeat_interval, no heartbeat in a single poll."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)  # heartbeat_interval=9999
+
+        output = handler.wfile.getvalue().decode("utf-8")
+        assert ": heartbeat" not in output
+
+    def test_heartbeat_line_format(self, tmp_path):
+        """Heartbeat must be SSE comment format: ': heartbeat\n\n'."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")
+
+        handler = _make_handler()
+        flush_count = 0
+
+        def limited_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count >= 1:
+                raise BrokenPipeError()
+
+        handler.wfile.flush = limited_flush
+        handle_register_stream(
+            handler,
+            poll_interval=0,
+            heartbeat_interval=0,
+            register_file=reg,
+        )
+
+        output = handler.wfile.getvalue().decode("utf-8")
+        assert ": heartbeat\n\n" in output
+
+
+# ---------------------------------------------------------------------------
+# Case E: archive endpoint
+# ---------------------------------------------------------------------------
+
+class TestCaseE_Archive:
+    def test_archive_returns_all_events_as_array(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_completed", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        handler = _make_handler()
+        handle_register_stream_archive(handler, register_file=reg)
+
+        handler.send_response.assert_called_with(HTTPStatus.OK)
+        body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        assert isinstance(body, list)
+        assert len(body) == 3
+        assert body[0]["event"] == "dispatch_created"
+        assert body[2]["event"] == "dispatch_completed"
+
+    def test_archive_returns_empty_array_for_missing_file(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"  # does not exist
+
+        handler = _make_handler()
+        handle_register_stream_archive(handler, register_file=reg)
+
+        handler.send_response.assert_called_with(HTTPStatus.OK)
+        body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        assert body == []
+
+    def test_archive_returns_empty_array_for_empty_file(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")
+
+        handler = _make_handler()
+        handle_register_stream_archive(handler, register_file=reg)
+
+        body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        assert body == []
+
+    def test_archive_content_type_is_json(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text("", encoding="utf-8")
+
+        handler = _make_handler()
+        handle_register_stream_archive(handler, register_file=reg)
+
+        handler.send_header.assert_any_call("Content-Type", "application/json")
+        handler.send_header.assert_any_call("Access-Control-Allow-Origin", "*")
+
+    def test_archive_skips_malformed_lines(self, tmp_path, capsys):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        with open(reg, "w", encoding="utf-8") as fh:
+            fh.write('{"timestamp":"2026-04-28T10:00:00.000000Z","event":"dispatch_created","dispatch_id":"x"}\n')
+            fh.write("INVALID JSON LINE\n")
+            fh.write('{"timestamp":"2026-04-28T10:00:01.000000Z","event":"dispatch_promoted","dispatch_id":"x"}\n')
+
+        handler = _make_handler()
+        handle_register_stream_archive(handler, register_file=reg)
+
+        body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+        assert len(body) == 2
+        assert body[0]["event"] == "dispatch_created"
+        assert body[1]["event"] == "dispatch_promoted"
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Case F: malformed JSON in SSE stream
+# ---------------------------------------------------------------------------
+
+class TestCaseF_MalformedJsonInStream:
+    def test_sse_skips_malformed_line_and_continues(self, tmp_path, capsys):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        with open(reg, "w", encoding="utf-8") as fh:
+            fh.write('{"timestamp":"2026-04-28T10:00:00.000000Z","event":"dispatch_created","dispatch_id":"x"}\n')
+            fh.write("NOT VALID JSON\n")
+            fh.write("{also not valid\n")
+            fh.write('{"timestamp":"2026-04-28T10:00:01.000000Z","event":"dispatch_completed","dispatch_id":"x"}\n')
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        # Valid events are streamed; malformed lines skipped
+        assert len(lines) == 2
+        assert lines[0]["event"] == "dispatch_created"
+        assert lines[1]["event"] == "dispatch_completed"
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    def test_all_malformed_lines_produce_no_sse_output(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        with open(reg, "w", encoding="utf-8") as fh:
+            fh.write("BAD LINE 1\n")
+            fh.write("BAD LINE 2\n")
+
+        handler = _make_handler()
+        _run_one_poll(handler, reg)
+
+        lines = _sse_lines(handler)
+        assert lines == []
+
+    def test_client_disconnect_stops_cleanly(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        _write_events(reg, [_make_event("dispatch_created", "2026-04-28T10:00:00.000000Z")])
+
+        handler = _make_handler()
+
+        def raise_on_write(data):
+            raise BrokenPipeError("client gone")
+
+        handler.wfile.write = raise_on_write
+
+        # Should not raise — disconnect handled gracefully
+        handle_register_stream(
+            handler,
+            poll_interval=0,
+            heartbeat_interval=9999,
+            register_file=reg,
+        )
+
+    def test_connection_reset_stops_cleanly(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        _write_events(reg, [_make_event("dispatch_created", "2026-04-28T10:00:00.000000Z")])
+
+        handler = _make_handler()
+
+        def raise_on_write(data):
+            raise ConnectionResetError("reset")
+
+        handler.wfile.write = raise_on_write
+
+        handle_register_stream(
+            handler,
+            poll_interval=0,
+            heartbeat_interval=9999,
+            register_file=reg,
+        )

--- a/tests/test_api_register_stream.py
+++ b/tests/test_api_register_stream.py
@@ -30,6 +30,8 @@ from api_register_stream import (
     handle_register_stream,
     handle_register_stream_archive,
     _read_new_events,
+    _read_new_events_after,
+    _resolve_start_index,
 )
 
 
@@ -554,3 +556,152 @@ class TestCaseF_MalformedJsonInStream:
             heartbeat_interval=9999,
             register_file=reg,
         )
+
+
+# ---------------------------------------------------------------------------
+# Case G: same-timestamp regression (codex regate finding for PR #304)
+#
+# A timestamp-only cursor silently dropped a second event whose timestamp
+# equalled the last-delivered event's timestamp. The line-index cursor
+# must deliver both records.
+# ---------------------------------------------------------------------------
+
+class TestCaseG_SameTimestampRegression:
+    def test_read_new_events_after_delivers_same_ts_appends(self, tmp_path):
+        """Two records sharing a timestamp must both be returned across polls."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        same_ts = "2026-04-28T10:00:00.000000Z"
+        _write_events(reg, [_make_event("dispatch_created", same_ts)])
+
+        # First poll consumes the only record.
+        events1, idx1 = _read_new_events_after(reg, 0, None)
+        assert len(events1) == 1
+        assert events1[0]["event"] == "dispatch_created"
+        assert idx1 == 1
+
+        # Append a second record with the IDENTICAL timestamp.
+        _write_events(reg, [_make_event("dispatch_promoted", same_ts)])
+
+        # Second poll must return the new record despite ts collision.
+        events2, idx2 = _read_new_events_after(reg, idx1, None)
+        assert len(events2) == 1
+        assert events2[0]["event"] == "dispatch_promoted"
+        assert idx2 == 2
+
+    def test_read_new_events_wrapper_first_read_keeps_same_ts(self, tmp_path):
+        """The legacy wrapper's timestamp output cannot disambiguate same-ts
+        records — but the wrapper still uses the line-index reader internally,
+        so the FIRST poll returns both same-ts events together."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        same_ts = "2026-04-28T10:00:00.000000Z"
+        _write_events(reg, [
+            _make_event("dispatch_created", same_ts),
+            _make_event("dispatch_promoted", same_ts),
+        ])
+
+        events, latest_ts = _read_new_events(reg, None, None)
+        assert len(events) == 2
+        assert latest_ts == same_ts
+
+    def test_handle_register_stream_delivers_same_ts_across_polls(self, tmp_path):
+        """End-to-end: streaming handler must deliver back-to-back same-ts
+        appends across consecutive polls (the codex repro)."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        same_ts = "2026-04-28T10:00:00.000000Z"
+        _write_events(reg, [_make_event("dispatch_created", same_ts)])
+
+        handler = _make_handler()
+
+        # Run two polls: append between the first and second flush, then
+        # raise BrokenPipe to stop. The cursor inside the handler must
+        # advance by line index, not timestamp, so the second event is
+        # streamed despite sharing the first event's timestamp.
+        flush_count = 0
+
+        def staged_flush():
+            nonlocal flush_count
+            flush_count += 1
+            if flush_count == 1:
+                _write_events(reg, [_make_event("dispatch_promoted", same_ts)])
+                return
+            raise BrokenPipeError("test disconnect")
+
+        handler.wfile.flush = staged_flush
+        handle_register_stream(
+            handler,
+            since_ts=None,
+            event_type_filter=None,
+            poll_interval=0,
+            heartbeat_interval=9999,
+            register_file=reg,
+        )
+
+        lines = _sse_lines(handler)
+        assert len(lines) == 2
+        assert [l["event"] for l in lines] == ["dispatch_created", "dispatch_promoted"]
+
+    def test_resolve_start_index_basic(self, tmp_path):
+        reg = tmp_path / "dispatch_register.ndjson"
+        evs = [
+            _make_event("dispatch_created", "2026-04-28T10:00:00.000000Z"),
+            _make_event("dispatch_promoted", "2026-04-28T10:00:01.000000Z"),
+            _make_event("dispatch_started", "2026-04-28T10:00:02.000000Z"),
+        ]
+        _write_events(reg, evs)
+
+        # No since_ts → start at 0
+        assert _resolve_start_index(reg, None) == 0
+
+        # since_ts at first record → skip just the first
+        assert _resolve_start_index(reg, "2026-04-28T10:00:00.000000Z") == 1
+
+        # since_ts past everything → skip all
+        assert _resolve_start_index(reg, "2026-04-28T10:00:09.000000Z") == 3
+
+        # Missing file → 0
+        missing = tmp_path / "missing.ndjson"
+        assert _resolve_start_index(missing, "2026-04-28T10:00:00.000000Z") == 0
+
+    def test_resolve_start_index_groups_same_ts(self, tmp_path):
+        """If multiple records share a timestamp equal to since_ts, all of
+        them are treated as already seen (cursor advances past all of them).
+        Records strictly newer than since_ts are returned to the caller."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        same_ts = "2026-04-28T10:00:00.000000Z"
+        next_ts = "2026-04-28T10:00:01.000000Z"
+        evs = [
+            _make_event("e1", same_ts),
+            _make_event("e2", same_ts),
+            _make_event("e3", next_ts),
+        ]
+        _write_events(reg, evs)
+
+        idx = _resolve_start_index(reg, same_ts)
+        assert idx == 2
+
+        events, new_idx = _read_new_events_after(reg, idx, None)
+        assert len(events) == 1
+        assert events[0]["event"] == "e3"
+        assert new_idx == 3
+
+    def test_read_new_events_after_advances_cursor_past_filtered(self, tmp_path):
+        """Filtered-out and malformed records still advance the cursor so
+        they aren't re-scanned on the next poll."""
+        reg = tmp_path / "dispatch_register.ndjson"
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        with open(reg, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(_make_event("dispatch_created", "2026-04-28T10:00:00.000000Z")) + "\n")
+            fh.write("not-json\n")
+            fh.write(json.dumps(_make_event("gate_passed", "2026-04-28T10:00:01.000000Z")) + "\n")
+
+        events, idx = _read_new_events_after(reg, 0, {"gate_passed"})
+        # Only gate_passed matches the filter, but the cursor advanced
+        # past all three slots (created, malformed, gate_passed).
+        assert len(events) == 1
+        assert events[0]["event"] == "gate_passed"
+        assert idx == 3
+
+        # Second poll on unchanged file returns nothing and keeps cursor.
+        events2, idx2 = _read_new_events_after(reg, idx, {"gate_passed"})
+        assert events2 == []
+        assert idx2 == 3

--- a/tests/test_register_stream_routing_canonical_state.py
+++ b/tests/test_register_stream_routing_canonical_state.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Regression tests: register-stream routing must pass CANONICAL_STATE_DIR.
+
+Codex finding (PR #304): serve_dashboard.py was calling handle_register_stream*()
+without forwarding the dashboard's CANONICAL_STATE_DIR. The handlers fell back to
+project_root.resolve_state_dir() which ignores VNX_STATE_DIR, so in any non-default
+runtime/worktree the register-stream endpoints read a different file than the other
+/state/* APIs — producing empty or stale data.
+
+Fix: pass register_file=CANONICAL_STATE_DIR/"dispatch_register.ndjson" explicitly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+import serve_dashboard as sd
+
+
+def _make_get_handler(path: str) -> MagicMock:
+    """Create a minimal mock that satisfies DashboardHandler.do_GET."""
+    handler = MagicMock()
+    handler.path = path
+    return handler
+
+
+class TestRegisterStreamRoutingPassesCanonicalStateDir:
+    """The /api/register-stream* routes must forward CANONICAL_STATE_DIR."""
+
+    def test_archive_route_passes_canonical_register_file(self, tmp_path):
+        custom_state = tmp_path / "custom_state"
+        expected = custom_state / "dispatch_register.ndjson"
+        captured: dict = {}
+
+        def fake_archive(h, register_file=None):
+            captured["register_file"] = register_file
+
+        handler = _make_get_handler("/api/register-stream/archive")
+        with (
+            patch.object(sd, "CANONICAL_STATE_DIR", custom_state),
+            patch.object(sd, "handle_register_stream_archive", fake_archive),
+        ):
+            sd.DashboardHandler.do_GET(handler)
+
+        assert captured["register_file"] == expected
+
+    def test_sse_route_passes_canonical_register_file(self, tmp_path):
+        custom_state = tmp_path / "custom_state"
+        expected = custom_state / "dispatch_register.ndjson"
+        captured: dict = {}
+
+        def fake_stream(h, since_ts=None, event_type_filter=None, register_file=None):
+            captured["register_file"] = register_file
+
+        handler = _make_get_handler("/api/register-stream")
+        with (
+            patch.object(sd, "CANONICAL_STATE_DIR", custom_state),
+            patch.object(sd, "handle_register_stream", fake_stream),
+        ):
+            sd.DashboardHandler.do_GET(handler)
+
+        assert captured["register_file"] == expected
+
+    def test_sse_route_forwards_since_ts_and_event_type(self, tmp_path):
+        """Query params since_ts and event_type must be forwarded unchanged."""
+        custom_state = tmp_path / "state"
+        captured: dict = {}
+
+        def fake_stream(h, since_ts=None, event_type_filter=None, register_file=None):
+            captured["since_ts"] = since_ts
+            captured["event_type_filter"] = event_type_filter
+            captured["register_file"] = register_file
+
+        path = "/api/register-stream?since_ts=2026-04-28T10:00:00Z&event_type=gate_passed"
+        handler = _make_get_handler(path)
+        with (
+            patch.object(sd, "CANONICAL_STATE_DIR", custom_state),
+            patch.object(sd, "handle_register_stream", fake_stream),
+        ):
+            sd.DashboardHandler.do_GET(handler)
+
+        assert captured["since_ts"] == "2026-04-28T10:00:00Z"
+        assert captured["event_type_filter"] == "gate_passed"
+        assert captured["register_file"] == custom_state / "dispatch_register.ndjson"
+
+    def test_archive_and_sse_share_same_register_file_path(self, tmp_path):
+        """Both routes must resolve to the same file under CANONICAL_STATE_DIR."""
+        custom_state = tmp_path / "shared_state"
+        files: list[Path] = []
+
+        def fake_archive(h, register_file=None):
+            files.append(register_file)
+
+        def fake_stream(h, since_ts=None, event_type_filter=None, register_file=None):
+            files.append(register_file)
+
+        with (
+            patch.object(sd, "CANONICAL_STATE_DIR", custom_state),
+            patch.object(sd, "handle_register_stream_archive", fake_archive),
+            patch.object(sd, "handle_register_stream", fake_stream),
+        ):
+            sd.DashboardHandler.do_GET(_make_get_handler("/api/register-stream/archive"))
+            sd.DashboardHandler.do_GET(_make_get_handler("/api/register-stream"))
+
+        assert len(files) == 2
+        assert files[0] == files[1]
+        assert files[0] == custom_state / "dispatch_register.ndjson"
+
+    def test_default_register_file_matches_canonical_state_dir(self):
+        """Without any override, register_file must equal the module's CANONICAL_STATE_DIR."""
+        captured: dict = {}
+
+        def fake_archive(h, register_file=None):
+            captured["register_file"] = register_file
+
+        handler = _make_get_handler("/api/register-stream/archive")
+        with patch.object(sd, "handle_register_stream_archive", fake_archive):
+            sd.DashboardHandler.do_GET(handler)
+
+        assert captured["register_file"] == sd.CANONICAL_STATE_DIR / "dispatch_register.ndjson"


### PR DESCRIPTION
## Summary

- Implements GAP-3 from the observability mapping: live SSE stream of dispatch lifecycle transitions from `dispatch_register.ndjson`
- Mirrors the existing `/api/agent-stream` pattern exactly (500ms polling, BrokenPipe-safe disconnect handling, SSE `data:` format)
- Adds archive replay support so the dashboard can hydrate historical state on connect

## Endpoints

| Endpoint | Description |
|---|---|
| `GET /api/register-stream` | Live SSE stream; optional `since_ts` (ISO8601) and `event_type` (comma-separated) query params |
| `GET /api/register-stream/archive` | One-shot full-file JSON array — all events in `dispatch_register.ndjson` |

## Implementation notes

- **Source**: `.vnx-data/state/dispatch_register.ndjson` (append-only, via `dispatch_register.py`)
- **Path resolution**: uses `scripts/lib/project_root.py` `resolve_state_dir()` — never hardcoded
- **Heartbeat**: `: heartbeat\n\n` SSE comment every 30s (configurable via `VNX_REGISTER_STREAM_HEARTBEAT` env var)
- **Malformed lines**: skipped with stderr warning; stream continues — no hard crash
- **Wired into router**: `serve_dashboard.py` imports and routes both endpoints; archive route checked before stream route to avoid prefix conflict

## Test coverage (27 cases, all passing)

- Case A: event received in first poll, multi-event ordering, SSE headers, empty/missing file
- Case B: `since_ts` filter with strict `>` semantics, cross-poll timestamp advancement
- Case C: single type filter, comma-separated multi-type, whitespace trimming, no match
- Case D: heartbeat fires when interval elapses (`heartbeat_interval=0` in tests), format validation
- Case E: archive full array, empty file, missing file, content-type, malformed skip
- Case F: malformed JSON skipped + stderr warning, all-malformed produces no output, disconnect handling

## Quality gates

```
python3 -m py_compile dashboard/api_register_stream.py  ✓
pytest tests/test_api_register_stream.py -xvs          ✓ 27 passed
pytest tests/test_serve_dashboard_api.py ...            ✓ no regressions (5 pre-existing failures confirmed on main)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)