### PR TITLE
feat(observability): codex+gemini token tracking in receipts (Tier 5 GAP-4)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -366,7 +366,7 @@ def _build_git_provenance(repo_root: Path) -> Dict[str, Any]:
     return provenance
 
 
-def _resolve_session_id(receipt: Dict[str, Any]) -> str:
+def _resolve_session_id(receipt: Dict[str, Any], state_dir: Optional[Path] = None) -> str:
     """Resolve session_id with deterministic priority chain (parallel-terminal safe).
 
     Priority chain (matches session_resolver.sh):
@@ -375,6 +375,11 @@ def _resolve_session_id(receipt: Dict[str, Any]) -> str:
     3. Environment variables (with auto-create of per-terminal files)
     4. Provider "current" files (global session files)
     5. Fallback: "unknown"
+
+    Args:
+        receipt: Receipt payload.
+        state_dir: Resolved state directory (caller should supply to avoid
+                   double-resolution). Falls back to resolve_state_dir(__file__).
     """
     metadata = receipt.get("metadata") if isinstance(receipt.get("metadata"), dict) else {}
     terminal = str(receipt.get("terminal") or "unknown").strip()
@@ -391,7 +396,8 @@ def _resolve_session_id(receipt: Dict[str, Any]) -> str:
             return value
 
     # Priority 2: Per-terminal current_session file (DETERMINISTIC)
-    state_dir = resolve_state_dir(__file__)
+    if state_dir is None:
+        state_dir = resolve_state_dir(__file__)
     current_session_file = state_dir / f"current_session_{terminal}"
     if current_session_file.exists():
         try:
@@ -401,22 +407,18 @@ def _resolve_session_id(receipt: Dict[str, Any]) -> str:
         except Exception:
             pass
 
-    # Priority 3: Environment variables (provider-specific) with auto-create
-    env_mapping = {
-        "T0": "CLAUDE_SESSION_ID",
-        "T1": "CLAUDE_SESSION_ID",
-        "T2": "CLAUDE_SESSION_ID",
-        "T3": "CLAUDE_SESSION_ID",
-        "T-MANAGER": "CLAUDE_SESSION_ID",
+    # Priority 3: Environment variables (provider-specific) with auto-create.
+    # Use panes.json-resolved provider so a standard terminal (e.g. T3) running
+    # codex_cli or gemini_cli gets the correct session env var, not CLAUDE_SESSION_ID.
+    mp = _resolve_model_provider(terminal, state_dir)
+    provider = mp.get("provider", "unknown")
+    _PROVIDER_ENV_VAR: Dict[str, str] = {
+        "claude_code": "CLAUDE_SESSION_ID",
+        "gemini_cli": "GEMINI_SESSION_ID",
+        "codex_cli": "CODEX_SESSION_ID",
+        "kimi_cli": "KIMI_SESSION_ID",
     }
-
-    # Also check for provider-specific patterns in terminal name
-    if terminal.upper().startswith(("GEMINI", "GEM-")):
-        env_var = "GEMINI_SESSION_ID"
-    elif terminal.upper().startswith(("CODEX", "CODE-")):
-        env_var = "CODEX_SESSION_ID"
-    else:
-        env_var = env_mapping.get(terminal, "CLAUDE_SESSION_ID")
+    env_var = _PROVIDER_ENV_VAR.get(provider, "CLAUDE_SESSION_ID")
 
     env_value = os.environ.get(env_var)
     if env_value:
@@ -430,12 +432,18 @@ def _resolve_session_id(receipt: Dict[str, Any]) -> str:
                 pass  # Non-fatal, just optimization for future lookups
             return value
 
-    # Priority 4: Provider "current" session files (global)
-    provider_current_files = (
-        Path.home() / ".codex" / "sessions" / "current",
-        Path.home() / ".gemini" / "sessions" / "current",
-        Path.home() / ".claude" / "sessions" / "current",
-    )
+    # Priority 4: Provider "current" session files (global, preferred provider first).
+    # Resolved provider determines which file to try first so a Claude terminal does
+    # not accidentally pick up a Codex or Gemini session that happens to exist.
+    _PROVIDER_SESSION_FILES: Dict[str, Path] = {
+        "claude_code": Path.home() / ".claude" / "sessions" / "current",
+        "gemini_cli": Path.home() / ".gemini" / "sessions" / "current",
+        "codex_cli": Path.home() / ".codex" / "sessions" / "current",
+        "kimi_cli": Path.home() / ".kimi" / "sessions" / "current",
+    }
+    preferred_file = _PROVIDER_SESSION_FILES.get(provider)
+    other_files = [f for f in _PROVIDER_SESSION_FILES.values() if f != preferred_file]
+    provider_current_files = ([preferred_file] + other_files) if preferred_file else list(_PROVIDER_SESSION_FILES.values())
     for current_file in provider_current_files:
         try:
             if current_file.exists():
@@ -558,7 +566,7 @@ def _extract_session_token_usage(session_id: str, terminal: str) -> Optional[Dic
 def _build_session_metadata(receipt: Dict[str, Any], state_dir: Path) -> Dict[str, Any]:
     terminal = str(receipt.get("terminal") or "unknown").strip() or "unknown"
     model_provider = _resolve_model_provider(terminal, state_dir)
-    session_id = _resolve_session_id(receipt)
+    session_id = _resolve_session_id(receipt, state_dir)
     metadata: Dict[str, Any] = {
         "session_id": session_id,
         "terminal": terminal,
@@ -766,11 +774,11 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
     except Exception as exc:
         _emit("WARN", "oi_delta_enrichment_failed", error=str(exc))
 
-    # Set open_items_created from the quality_advisory generated above.
-    # Must run after quality_advisory is populated so _count_quality_violations sees real items.
-    # This ensures the CQS DB UPDATE below stores the actual count, not 0.
+    # Register quality violations now and use the actual creation count (dedup-aware).
+    # _register_quality_open_items deduplicates against the open-items store, so repeated
+    # advisories for the same finding correctly return 0 rather than inflating CQS.
     if "open_items_created" not in enriched:
-        enriched["open_items_created"] = _count_quality_violations(enriched)
+        enriched["open_items_created"] = _register_quality_open_items(enriched)
 
     # Compute CQS and persist to dispatch_metadata (best-effort).
     # quality_advisory_json is stored so update_dispatch_cqs.py can round-trip it
@@ -1119,10 +1127,6 @@ def append_receipt_payload(
 
     # Best-effort post-append hooks (skipped for skip_enrichment=True lightweight events)
     if result is not None and result.status == "appended" and not skip_enrichment:
-        # DB registration runs outside lock (existing constraint preserved).
-        # Count is already embedded in the receipt above; do not overwrite.
-        _register_quality_open_items(receipt)
-
         _update_confidence_from_receipt(receipt)
 
         _emit_dispatch_register(receipt)

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -774,11 +774,12 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
     except Exception as exc:
         _emit("WARN", "oi_delta_enrichment_failed", error=str(exc))
 
-    # Register quality violations now and use the actual creation count (dedup-aware).
-    # _register_quality_open_items deduplicates against the open-items store, so repeated
-    # advisories for the same finding correctly return 0 rather than inflating CQS.
+    # Compute the would-be creation count without mutating the open-items store.
+    # The actual _register_quality_open_items() call is deferred until after the
+    # idempotency check in append_receipt_payload(), so a replayed receipt skipped
+    # as a duplicate cannot still mutate open_items.json or CQS state.
     if "open_items_created" not in enriched:
-        enriched["open_items_created"] = _register_quality_open_items(enriched)
+        enriched["open_items_created"] = _count_quality_violations_against_store(enriched)
 
     # Compute CQS and persist to dispatch_metadata (best-effort).
     # quality_advisory_json is stored so update_dispatch_cqs.py can round-trip it
@@ -972,6 +973,63 @@ def _count_quality_violations(receipt: dict) -> int:
     return len(seen_keys)
 
 
+def _count_quality_violations_against_store(receipt: Dict[str, Any]) -> int:
+    """Dry-run dedup count: how many open items _register_quality_open_items WOULD create.
+
+    Mirrors the dedup_key construction of _register_quality_open_items and
+    consults the on-disk open-items store via OpenItemsManager.load_items()
+    so the count reflects items that are NOT already tracked (any status).
+
+    This is read-only: it never writes to open_items.json. It exists so the
+    enrichment step can record an accurate ``open_items_created`` value
+    BEFORE the receipt's idempotency check, without mutating state for
+    receipts that are later skipped as duplicates.
+
+    Returns:
+        Count of unique dedup keys that would result in new open items.
+        0 when quality_advisory or t0_recommendation is absent or on any error.
+    """
+    try:
+        advisory = receipt.get("quality_advisory")
+        if not isinstance(advisory, dict):
+            return 0
+        rec = advisory.get("t0_recommendation")
+        if not isinstance(rec, dict):
+            return 0
+        open_items = rec.get("open_items") or []
+        if not open_items:
+            return 0
+
+        # Load existing dedup keys (any status) from the OI store.
+        existing_keys: set = set()
+        try:
+            oim = _get_open_items_manager()
+            data = oim.load_items()
+            for item in data.get("items", []):
+                key = item.get("dedup_key")
+                if key:
+                    existing_keys.add(key)
+        except Exception as exc:
+            _emit("WARN", "oi_dryrun_load_failed", error=str(exc))
+            # On error, fall back to intra-receipt-only dedup so the count is
+            # still useful (matches pre-fix behaviour for first-run receipts).
+            existing_keys = set()
+
+        seen_keys: set = set()
+        for item in open_items:
+            check_id = str(item.get("check_id", "unknown"))
+            file_path = str(item.get("file", "")) or "unknown"
+            symbol = str(item.get("symbol") or "")
+            dedup_key = f"qa:{check_id}:{file_path}:{symbol}"
+            if dedup_key in existing_keys:
+                continue
+            seen_keys.add(dedup_key)
+        return len(seen_keys)
+    except Exception as exc:
+        _emit("WARN", "oi_dryrun_count_failed", error=str(exc))
+        return 0
+
+
 def _register_quality_open_items(receipt: Dict[str, Any]) -> int:
     """Best-effort: register quality advisory violations as tracked open items.
 
@@ -1125,8 +1183,14 @@ def append_receipt_payload(
     except OSError as exc:
         raise AppendReceiptError("lock_failed", EXIT_LOCK_ERROR, f"Failed to acquire append lock: {exc}") from exc
 
-    # Best-effort post-append hooks (skipped for skip_enrichment=True lightweight events)
+    # Best-effort post-append hooks (skipped for skip_enrichment=True lightweight events).
+    # IMPORTANT: _register_quality_open_items must run only AFTER the idempotency check
+    # has accepted this receipt as 'appended'. A receipt that hits the duplicate cache
+    # must not mutate open_items.json or CQS state. Run it here (post-lock release is
+    # fine — add_item_programmatic uses its own lock file).
     if result is not None and result.status == "appended" and not skip_enrichment:
+        _register_quality_open_items(receipt)
+
         _update_confidence_from_receipt(receipt)
 
         _emit_dispatch_register(receipt)

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -567,9 +567,18 @@ def _build_session_metadata(receipt: Dict[str, Any], state_dir: Path) -> Dict[st
         "captured_at": _utc_now_iso(),
     }
 
-    # Inject token usage from session JSONL (best-effort)
+    # Inject token usage — provider-specific, best-effort
+    provider = model_provider["provider"]
     try:
-        token_usage = _extract_session_token_usage(session_id, terminal)
+        if provider == "codex_cli":
+            from adapters.codex_adapter import CodexAdapter  # noqa: PLC0415
+            token_usage = CodexAdapter.get_token_usage(terminal, state_dir)
+        elif provider in ("gemini_cli", "gemini"):
+            from adapters.gemini_adapter import GeminiAdapter  # noqa: PLC0415
+            token_usage = GeminiAdapter.get_token_usage(terminal, state_dir)
+        else:
+            # Claude (and other) terminals: scan session JSONL (existing path)
+            token_usage = _extract_session_token_usage(session_id, terminal)
         if token_usage:
             metadata["token_usage"] = token_usage
     except Exception:

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import select
 import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -166,6 +167,9 @@ class CodexAdapter(ProviderAdapter):
             )
 
         events, findings = self._parse_ndjson(stdout)
+        token_usage = self._parse_token_usage_from_output(stdout)
+        if token_usage:
+            self._write_token_cache(token_usage)
         return AdapterResult(
             status="done",
             output=findings,
@@ -190,6 +194,114 @@ class CodexAdapter(ProviderAdapter):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Token usage
+    # ------------------------------------------------------------------
+
+    _TOKEN_TEXT_RE = re.compile(
+        r"tokens?:\s*(\d+)\s+input\s*/\s*(\d+)\s+output",
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _parse_token_usage_from_output(raw: str) -> Optional[dict]:
+        """Parse token counts from Codex CLI output.
+
+        Handles three formats emitted by Codex CLI (NDJSON mode):
+        1. Explicit token_usage event:  {"type":"token_usage","input_tokens":N,"output_tokens":M}
+        2. OpenAI-compat usage block:   {"usage":{"prompt_tokens":N,"completion_tokens":M}}
+           (also input_tokens/output_tokens variants)
+        3. Human-readable text line:    "Tokens: 1200 input / 350 output [/ 1550 total]"
+
+        Returns None if no parseable token info is found.
+        """
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # Try JSON event
+            try:
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    continue
+                # Format 1: explicit token_usage event
+                if event.get("type") == "token_usage":
+                    input_t = event.get("input_tokens", 0)
+                    output_t = event.get("output_tokens", 0)
+                    if isinstance(input_t, int) and isinstance(output_t, int):
+                        return {
+                            "input_tokens": input_t,
+                            "output_tokens": output_t,
+                            "cache_creation_tokens": 0,
+                            "cache_read_tokens": 0,
+                        }
+                # Format 2: OpenAI-compatible usage block
+                usage = event.get("usage")
+                if isinstance(usage, dict):
+                    input_t = (
+                        usage.get("input_tokens")
+                        or usage.get("prompt_tokens")
+                        or 0
+                    )
+                    output_t = (
+                        usage.get("output_tokens")
+                        or usage.get("completion_tokens")
+                        or 0
+                    )
+                    if isinstance(input_t, int) and isinstance(output_t, int) and (input_t or output_t):
+                        return {
+                            "input_tokens": input_t,
+                            "output_tokens": output_t,
+                            "cache_creation_tokens": 0,
+                            "cache_read_tokens": 0,
+                        }
+            except json.JSONDecodeError:
+                pass
+            # Format 3: text line "Tokens: N input / M output"
+            m = CodexAdapter._TOKEN_TEXT_RE.search(line)
+            if m:
+                return {
+                    "input_tokens": int(m.group(1)),
+                    "output_tokens": int(m.group(2)),
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                }
+        return None
+
+    def _write_token_cache(self, usage: dict, state_dir: Optional[Path] = None) -> None:
+        """Persist token usage to per-terminal state file (best-effort)."""
+        try:
+            sd = state_dir or Path(os.environ.get("VNX_STATE_DIR", ""))
+            if not sd or str(sd) == ".":
+                return
+            cache_dir = sd / "token_cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / f"{self._terminal_id}_usage.json").write_text(
+                json.dumps(usage), encoding="utf-8"
+            )
+        except Exception:
+            pass
+
+    @staticmethod
+    def get_token_usage(terminal_id: str, state_dir: Optional[Path] = None) -> Optional[dict]:
+        """Read last captured token usage for a terminal from the state cache.
+
+        Returns None if no cache file exists or the file cannot be parsed.
+        """
+        try:
+            sd = state_dir or Path(os.environ.get("VNX_STATE_DIR", ""))
+            if not sd or str(sd) == ".":
+                return None
+            cache_file = Path(sd) / "token_cache" / f"{terminal_id}_usage.json"
+            if not cache_file.is_file():
+                return None
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and "input_tokens" in data and "output_tokens" in data:
+                return data
+        except Exception:
+            pass
+        return None
 
     def _build_prompt(self, instruction: str, changed_files: list[str]) -> str:
         """Combine instruction with inline file contents (no PR references)."""

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -205,17 +205,103 @@ class CodexAdapter(ProviderAdapter):
     )
 
     @staticmethod
+    def _extract_token_count_payload(event: dict) -> Optional[dict]:
+        """Locate a `token_count` payload nested inside a Codex NDJSON event.
+
+        Codex `exec --json` emits records where the actual event body lives under
+        one of several wrapper keys, e.g.:
+
+            {"event_msg": {"payload": {"type": "token_count",
+                                        "input_tokens": N,
+                                        "cached_input_tokens": M,
+                                        "output_tokens": K, ...}}}
+
+            {"msg": {"type": "token_count", "input_tokens": N, ...}}
+
+            {"item": {"type": "token_count", ...}}
+
+        Returns the inner payload dict when type == "token_count", else None.
+        """
+        if not isinstance(event, dict):
+            return None
+        # event_msg.payload (current `codex exec` shape)
+        em = event.get("event_msg")
+        if isinstance(em, dict):
+            payload = em.get("payload")
+            if isinstance(payload, dict) and payload.get("type") == "token_count":
+                return payload
+            if em.get("type") == "token_count":
+                return em
+        # msg-wrapped variant
+        msg = event.get("msg")
+        if isinstance(msg, dict) and msg.get("type") == "token_count":
+            return msg
+        # item-wrapped variant
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "token_count":
+            return item
+        # top-level token_count
+        if event.get("type") == "token_count":
+            return event
+        return None
+
+    @staticmethod
+    def _normalize_token_count(payload: dict) -> Optional[dict]:
+        """Normalize a Codex token_count payload to the canonical token_usage dict.
+
+        Codex variants we accept:
+        - input_tokens / output_tokens (preferred)
+        - prompt_tokens / completion_tokens (OpenAI-compat key names)
+        Cache breakdown (best-effort, both names supported):
+        - cached_input_tokens / cache_read_tokens
+        - cache_creation_input_tokens / cache_creation_tokens
+        """
+        if not isinstance(payload, dict):
+            return None
+        input_t = payload.get("input_tokens")
+        if input_t is None:
+            input_t = payload.get("prompt_tokens", 0)
+        output_t = payload.get("output_tokens")
+        if output_t is None:
+            output_t = payload.get("completion_tokens", 0)
+        if not isinstance(input_t, int) or not isinstance(output_t, int):
+            return None
+        if input_t == 0 and output_t == 0:
+            return None
+        cache_read = payload.get("cached_input_tokens")
+        if cache_read is None:
+            cache_read = payload.get("cache_read_tokens", 0)
+        cache_creation = payload.get("cache_creation_input_tokens")
+        if cache_creation is None:
+            cache_creation = payload.get("cache_creation_tokens", 0)
+        return {
+            "input_tokens": int(input_t),
+            "output_tokens": int(output_t),
+            "cache_creation_tokens": int(cache_creation) if isinstance(cache_creation, int) else 0,
+            "cache_read_tokens": int(cache_read) if isinstance(cache_read, int) else 0,
+        }
+
+    @staticmethod
     def _parse_token_usage_from_output(raw: str) -> Optional[dict]:
         """Parse token counts from Codex CLI output.
 
-        Handles three formats emitted by Codex CLI (NDJSON mode):
-        1. Explicit token_usage event:  {"type":"token_usage","input_tokens":N,"output_tokens":M}
-        2. OpenAI-compat usage block:   {"usage":{"prompt_tokens":N,"completion_tokens":M}}
+        Handles the formats emitted by `codex exec --json`:
+        1. Wrapped token_count event (current shape):
+           {"event_msg":{"payload":{"type":"token_count","input_tokens":N,...}}}
+           (also matched: top-level msg/item wrappers and direct type=token_count)
+        2. Explicit token_usage event:  {"type":"token_usage","input_tokens":N,"output_tokens":M}
+        3. OpenAI-compat usage block:   {"usage":{"prompt_tokens":N,"completion_tokens":M}}
            (also input_tokens/output_tokens variants)
-        3. Human-readable text line:    "Tokens: 1200 input / 350 output [/ 1550 total]"
+        4. Human-readable text line:    "Tokens: 1200 input / 350 output [/ 1550 total]"
+
+        Codex emits multiple token_count events during a run (turn-by-turn).
+        We retain the LAST parseable token_count payload because Codex reports
+        a running total that updates as the session progresses; the final event
+        therefore reflects the complete usage for the run.
 
         Returns None if no parseable token info is found.
         """
+        last_token_count: Optional[dict] = None
         for line in raw.splitlines():
             line = line.strip()
             if not line:
@@ -223,9 +309,18 @@ class CodexAdapter(ProviderAdapter):
             # Try JSON event
             try:
                 event = json.loads(line)
-                if not isinstance(event, dict):
-                    continue
-                # Format 1: explicit token_usage event
+            except json.JSONDecodeError:
+                event = None
+
+            if isinstance(event, dict):
+                # Format 1: token_count wrapped under event_msg.payload / msg / item / top-level.
+                tc_payload = CodexAdapter._extract_token_count_payload(event)
+                if tc_payload is not None:
+                    normalized = CodexAdapter._normalize_token_count(tc_payload)
+                    if normalized is not None:
+                        last_token_count = normalized
+                        continue
+                # Format 2: explicit token_usage event
                 if event.get("type") == "token_usage":
                     input_t = event.get("input_tokens", 0)
                     output_t = event.get("output_tokens", 0)
@@ -236,7 +331,7 @@ class CodexAdapter(ProviderAdapter):
                             "cache_creation_tokens": 0,
                             "cache_read_tokens": 0,
                         }
-                # Format 2: OpenAI-compatible usage block
+                # Format 3: OpenAI-compatible usage block
                 usage = event.get("usage")
                 if isinstance(usage, dict):
                     input_t = (
@@ -256,9 +351,7 @@ class CodexAdapter(ProviderAdapter):
                             "cache_creation_tokens": 0,
                             "cache_read_tokens": 0,
                         }
-            except json.JSONDecodeError:
-                pass
-            # Format 3: text line "Tokens: N input / M output"
+            # Format 4: text line "Tokens: N input / M output"
             m = CodexAdapter._TOKEN_TEXT_RE.search(line)
             if m:
                 return {
@@ -267,7 +360,7 @@ class CodexAdapter(ProviderAdapter):
                     "cache_creation_tokens": 0,
                     "cache_read_tokens": 0,
                 }
-        return None
+        return last_token_count
 
     def _write_token_cache(self, usage: dict, state_dir: Optional[Path] = None) -> None:
         """Persist token usage to per-terminal state file (best-effort)."""

--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -128,6 +128,9 @@ class GeminiAdapter(ProviderAdapter):
             )
 
         parsed = self._parse_response(stdout)
+        token_usage = self._parse_token_usage_from_response(stdout)
+        if token_usage:
+            self._write_token_cache(token_usage)
         return AdapterResult(
             status="done",
             output=parsed,
@@ -149,6 +152,102 @@ class GeminiAdapter(ProviderAdapter):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Token usage
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_usage_metadata(data: dict) -> Optional[dict]:
+        """Extract usageMetadata from a parsed Gemini response dict.
+
+        Handles both top-level and nested usageMetadata. Field names follow the
+        Gemini REST API: promptTokenCount (input) and candidatesTokenCount (output).
+        """
+        usage_meta = data.get("usageMetadata")
+        if not isinstance(usage_meta, dict):
+            return None
+        prompt_t = usage_meta.get("promptTokenCount", 0) or 0
+        candidates_t = usage_meta.get("candidatesTokenCount", 0) or 0
+        if not isinstance(prompt_t, int) or not isinstance(candidates_t, int):
+            return None
+        if prompt_t == 0 and candidates_t == 0:
+            return None
+        return {
+            "input_tokens": prompt_t,
+            "output_tokens": candidates_t,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    @staticmethod
+    def _parse_token_usage_from_response(raw: str) -> Optional[dict]:
+        """Parse token counts from Gemini CLI stdout.
+
+        Gemini CLI (--output-format json) returns a JSON object with a top-level
+        `usageMetadata` key, or an NDJSON stream where one of the lines contains it.
+        Returns None if no parseable metadata is found.
+        """
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        # Try top-level JSON object
+        try:
+            data = json.loads(stripped)
+            if isinstance(data, dict):
+                result = GeminiAdapter._extract_usage_metadata(data)
+                if result:
+                    return result
+        except json.JSONDecodeError:
+            pass
+        # Try NDJSON stream (multiple JSON lines)
+        for line in stripped.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                if isinstance(data, dict):
+                    result = GeminiAdapter._extract_usage_metadata(data)
+                    if result:
+                        return result
+            except json.JSONDecodeError:
+                continue
+        return None
+
+    def _write_token_cache(self, usage: dict, state_dir: Optional[Path] = None) -> None:
+        """Persist token usage to per-terminal state file (best-effort)."""
+        try:
+            sd = state_dir or Path(os.environ.get("VNX_STATE_DIR", ""))
+            if not sd or str(sd) == ".":
+                return
+            cache_dir = sd / "token_cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / f"{self._terminal_id}_usage.json").write_text(
+                json.dumps(usage), encoding="utf-8"
+            )
+        except Exception:
+            pass
+
+    @staticmethod
+    def get_token_usage(terminal_id: str, state_dir: Optional[Path] = None) -> Optional[dict]:
+        """Read last captured token usage for a terminal from the state cache.
+
+        Returns None if no cache file exists or the file cannot be parsed.
+        """
+        try:
+            sd = state_dir or Path(os.environ.get("VNX_STATE_DIR", ""))
+            if not sd or str(sd) == ".":
+                return None
+            cache_file = Path(sd) / "token_cache" / f"{terminal_id}_usage.json"
+            if not cache_file.is_file():
+                return None
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and "input_tokens" in data and "output_tokens" in data:
+                return data
+        except Exception:
+            pass
+        return None
 
     def _build_prompt(self, instruction: str, changed_files: list[str]) -> str:
         """Combine instruction with inline file contents."""

--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -90,14 +90,23 @@ def generate_item_id(data: dict) -> str:
     data['next_id'] += 1
     return item_id
 
-def _find_open_by_dedup_key(data: dict, key: str) -> Optional[dict]:
-    """Scan open items for matching dedup_key (only status == 'open')."""
+def _find_by_dedup_key(data: dict, key: str) -> Optional[dict]:
+    """Scan all items for matching dedup_key (any status).
+
+    Replay safety: a duplicate receipt must not recreate findings that were
+    previously closed. Matching against any status (open/done/deferred/wontfix)
+    keeps replays idempotent. Genuine regressions of a closed finding can be
+    surfaced by manually reopening the existing item.
+    """
     for item in data.get("items", []):
-        if item.get("status") != "open":
-            continue
         if item.get("dedup_key") == key:
             return item
     return None
+
+
+# Backwards-compatible alias kept for any external callers that imported the
+# previous open-only helper. New code should call _find_by_dedup_key.
+_find_open_by_dedup_key = _find_by_dedup_key
 
 
 def add_item_programmatic(
@@ -126,9 +135,11 @@ def add_item_programmatic(
         try:
             data = load_items()
 
-            # Dedup check: if key matches an existing open item, skip
+            # Dedup check: if key matches an existing item (any status), skip.
+            # Closed items are included so duplicate/replayed receipts cannot
+            # recreate findings that were already closed.
             if dedup_key:
-                existing = _find_open_by_dedup_key(data, dedup_key)
+                existing = _find_by_dedup_key(data, dedup_key)
                 if existing is not None:
                     return (existing["id"], False)
 

--- a/tests/test_append_receipt.py
+++ b/tests/test_append_receipt.py
@@ -127,6 +127,91 @@ def test_append_receipt_session_id_falls_back_to_gemini_current_file(tmp_path: P
     assert stored["session"]["session_id"] == "gemini-session-abc"
 
 
+def test_session_id_uses_panes_json_provider_for_standard_terminal(tmp_path: Path):
+    """T3 mapped to codex_cli in panes.json must resolve CODEX_SESSION_ID, not CLAUDE_SESSION_ID.
+
+    Regression guard for Codex finding: env_mapping hard-coded all standard terminals
+    (T0-T3) to CLAUDE_SESSION_ID, ignoring the provider in panes.json.
+    """
+    state_dir = tmp_path / "data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    panes_json = state_dir / "panes.json"
+    panes_json.write_text(
+        json.dumps({"T3": {"model": "gpt-5.2-codex", "provider": "codex_cli"}}),
+        encoding="utf-8",
+    )
+
+    receipt = {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-PANES-CODEX-001",
+        "terminal": "T3",
+    }
+
+    result = _run_append(
+        tmp_path,
+        json.dumps(receipt),
+        extra_env={
+            "CODEX_SESSION_ID": "codex-panes-session-xyz",
+            "CLAUDE_SESSION_ID": "claude-should-not-be-used",
+        },
+    )
+    assert result.returncode == 0, f"append failed: {result.stderr}"
+
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    stored = json.loads(receipts_file.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert stored["session"]["session_id"] == "codex-panes-session-xyz", (
+        f"Expected codex session ID from panes.json provider, got {stored['session']['session_id']!r}. "
+        "Terminal T3 with codex_cli provider must read CODEX_SESSION_ID, not CLAUDE_SESSION_ID."
+    )
+
+
+def test_session_id_priority4_prefers_provider_session_file(tmp_path: Path, monkeypatch):
+    """Priority 4 must try the resolved-provider's session file before other providers.
+
+    T3 → codex_cli via panes.json: ~/.codex/sessions/current is checked before
+    ~/.gemini/sessions/current and ~/.claude/sessions/current.
+    Regression guard: old code had codex first globally, but that was a coincidence;
+    new code must be deterministic based on resolved provider.
+    """
+    state_dir = tmp_path / "data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    panes_json = state_dir / "panes.json"
+    panes_json.write_text(
+        json.dumps({"T3": {"model": "gpt-5.2-codex", "provider": "codex_cli"}}),
+        encoding="utf-8",
+    )
+
+    home_dir = tmp_path / "home"
+    codex_current = home_dir / ".codex" / "sessions" / "current"
+    codex_current.parent.mkdir(parents=True, exist_ok=True)
+    codex_current.write_text("codex-file-session-abc\n", encoding="utf-8")
+    # Also write a Claude session file to verify it is NOT chosen
+    claude_current = home_dir / ".claude" / "sessions" / "current"
+    claude_current.parent.mkdir(parents=True, exist_ok=True)
+    claude_current.write_text("claude-file-session-wrong\n", encoding="utf-8")
+
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    receipt = {
+        "timestamp": "2026-04-28T12:00:01Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-PANES-CODEX-002",
+        "terminal": "T3",
+    }
+
+    result = _run_append(tmp_path, json.dumps(receipt))
+    assert result.returncode == 0, f"append failed: {result.stderr}"
+
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    stored = json.loads(receipts_file.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert stored["session"]["session_id"] == "codex-file-session-abc", (
+        f"Expected codex file session for T3 with codex_cli provider, got {stored['session']['session_id']!r}."
+    )
+
+
 def test_append_receipt_skips_duplicate_idempotency_key(tmp_path: Path):
     receipt = _build_receipt(index=9)
     payload = json.dumps(receipt)

--- a/tests/test_append_receipt_register_emit.py
+++ b/tests/test_append_receipt_register_emit.py
@@ -728,12 +728,57 @@ def test_enrich_sets_open_items_created_internally(ar):
          patch.object(ar, "generate_quality_advisory", return_value=fake_advisory), \
          patch.object(ar, "_get_open_items_manager", return_value=MagicMock(count_items_closed_by_dispatch=lambda _: 0)), \
          patch.object(ar, "resolve_state_dir", return_value=Path("/tmp/fake_state")), \
+         patch.object(ar, "_register_quality_open_items", return_value=3), \
          patch("pathlib.Path.exists", return_value=False):
         enriched = ar._enrich_completion_receipt(receipt)
 
     assert enriched.get("open_items_created") == 3, (
-        f"Expected 3 (from generate_quality_advisory result), got {enriched.get('open_items_created')!r}. "
-        "_enrich_completion_receipt must set open_items_created before the CQS DB write."
+        f"Expected 3 (from _register_quality_open_items return value), got {enriched.get('open_items_created')!r}. "
+        "_enrich_completion_receipt must use _register_quality_open_items return value before the CQS DB write."
+    )
+
+
+# ── Finding 2 regression: open_items_created uses registration count, not advisory count ──
+
+def test_enrich_open_items_created_uses_registration_count_not_advisory_count(ar):
+    """When _register_quality_open_items returns 0 (all already in OIM), open_items_created
+    is 0 even when quality_advisory has items. Regression guard: pre-fix code used
+    _count_quality_violations which ignores the OIM dedup state."""
+    receipt = {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-DEDUP-REG-001",
+        "terminal": "T1",
+    }
+    advisory_dict = {
+        "version": "1.0",
+        "t0_recommendation": {
+            "open_items": [
+                {"check_id": "c1", "file": "a.py", "symbol": "", "severity": "blocker"},
+                {"check_id": "c2", "file": "b.py", "symbol": "", "severity": "warn"},
+            ]
+        },
+    }
+    fake_advisory = MagicMock()
+    fake_advisory.to_dict.return_value = advisory_dict
+
+    with patch.object(ar, "_build_git_provenance", return_value={"git_ref": "HEAD"}), \
+         patch.object(ar, "_build_session_metadata", return_value={"session_id": "s1"}), \
+         patch.object(ar, "enrich_receipt_provenance"), \
+         patch.object(ar, "validate_receipt_provenance", return_value=MagicMock(gaps=[])), \
+         patch.object(ar, "collect_terminal_snapshot", return_value=MagicMock(to_dict=lambda: {})), \
+         patch.object(ar, "get_changed_files", return_value=[Path("a.py"), Path("b.py")]), \
+         patch.object(ar, "generate_quality_advisory", return_value=fake_advisory), \
+         patch.object(ar, "_get_open_items_manager", return_value=MagicMock(count_items_closed_by_dispatch=lambda _: 0)), \
+         patch.object(ar, "resolve_state_dir", return_value=Path("/tmp/fake_state")), \
+         patch.object(ar, "_register_quality_open_items", return_value=0), \
+         patch("pathlib.Path.exists", return_value=False):
+        enriched = ar._enrich_completion_receipt(receipt)
+
+    assert enriched.get("open_items_created") == 0, (
+        f"Expected 0 (all items already in OIM), got {enriched.get('open_items_created')!r}. "
+        "Regression: _count_quality_violations used instead of _register_quality_open_items."
     )
 
 

--- a/tests/test_append_receipt_register_emit.py
+++ b/tests/test_append_receipt_register_emit.py
@@ -647,6 +647,9 @@ def test_open_items_created_from_enrichment_generated_advisory(tmp_path: Path, a
                 ]
             }
         }
+        # In round-2, _enrich is responsible for setting open_items_created from
+        # the dry-run count. Mirror that here so this stub matches the contract.
+        enriched["open_items_created"] = 2
         return enriched
 
     with patch.object(ar, "_enrich_completion_receipt", side_effect=fake_enrich), \
@@ -694,8 +697,12 @@ def test_open_items_created_zero_when_enrichment_adds_no_violations(tmp_path: Pa
 
 
 def test_enrich_sets_open_items_created_internally(ar):
-    """_enrich_completion_receipt sets open_items_created from the quality_advisory it generates.
-    Ensures the CQS DB UPDATE sees the real count (not 0 from a missing field)."""
+    """_enrich_completion_receipt sets open_items_created from the dry-run dedup count.
+
+    Round-2 fix: enrichment no longer mutates the OI store; it uses
+    _count_quality_violations_against_store so a duplicate receipt that gets
+    skipped post-idempotency does not leak side effects into open_items.json.
+    """
     receipt = {
         "timestamp": "2026-04-28T12:00:00Z",
         "event_type": "task_complete",
@@ -705,7 +712,6 @@ def test_enrich_sets_open_items_created_internally(ar):
         # No quality_advisory — the function generates it via generate_quality_advisory
     }
 
-    # Advisory dict that generate_quality_advisory would produce with 3 violations.
     advisory_dict = {
         "version": "1.0",
         "t0_recommendation": {
@@ -719,6 +725,12 @@ def test_enrich_sets_open_items_created_internally(ar):
     fake_advisory = MagicMock()
     fake_advisory.to_dict.return_value = advisory_dict
 
+    register_calls = []
+
+    def _record_register(*args, **kwargs):
+        register_calls.append(args)
+        return 3
+
     with patch.object(ar, "_build_git_provenance", return_value={"git_ref": "HEAD"}), \
          patch.object(ar, "_build_session_metadata", return_value={"session_id": "s1"}), \
          patch.object(ar, "enrich_receipt_provenance"), \
@@ -726,24 +738,34 @@ def test_enrich_sets_open_items_created_internally(ar):
          patch.object(ar, "collect_terminal_snapshot", return_value=MagicMock(to_dict=lambda: {})), \
          patch.object(ar, "get_changed_files", return_value=[Path("a.py"), Path("b.py"), Path("c.py")]), \
          patch.object(ar, "generate_quality_advisory", return_value=fake_advisory), \
-         patch.object(ar, "_get_open_items_manager", return_value=MagicMock(count_items_closed_by_dispatch=lambda _: 0)), \
+         patch.object(ar, "_get_open_items_manager", return_value=MagicMock(
+             count_items_closed_by_dispatch=lambda _: 0,
+             load_items=lambda: {"items": []},
+         )), \
          patch.object(ar, "resolve_state_dir", return_value=Path("/tmp/fake_state")), \
-         patch.object(ar, "_register_quality_open_items", return_value=3), \
+         patch.object(ar, "_register_quality_open_items", side_effect=_record_register), \
          patch("pathlib.Path.exists", return_value=False):
         enriched = ar._enrich_completion_receipt(receipt)
 
     assert enriched.get("open_items_created") == 3, (
-        f"Expected 3 (from _register_quality_open_items return value), got {enriched.get('open_items_created')!r}. "
-        "_enrich_completion_receipt must use _register_quality_open_items return value before the CQS DB write."
+        f"Expected 3 (dry-run dedup count for 3 unique findings), got {enriched.get('open_items_created')!r}."
+    )
+    assert register_calls == [], (
+        "_enrich_completion_receipt must NOT mutate the OI store. "
+        "_register_quality_open_items must run post-append, not during enrichment."
     )
 
 
 # ── Finding 2 regression: open_items_created uses registration count, not advisory count ──
 
 def test_enrich_open_items_created_uses_registration_count_not_advisory_count(ar):
-    """When _register_quality_open_items returns 0 (all already in OIM), open_items_created
-    is 0 even when quality_advisory has items. Regression guard: pre-fix code used
-    _count_quality_violations which ignores the OIM dedup state."""
+    """When all dedup keys are already in the OI store, open_items_created is 0
+    even when quality_advisory has items.
+
+    Round-2 fix: dry-run dedup uses _count_quality_violations_against_store which
+    consults the OI store (any status) rather than mutating it. Replayed receipts
+    no longer recreate previously-closed findings.
+    """
     receipt = {
         "timestamp": "2026-04-28T12:00:00Z",
         "event_type": "task_complete",
@@ -763,6 +785,17 @@ def test_enrich_open_items_created_uses_registration_count_not_advisory_count(ar
     fake_advisory = MagicMock()
     fake_advisory.to_dict.return_value = advisory_dict
 
+    # Pre-seed OI store with both dedup keys (one open, one CLOSED) so the dry-run
+    # count returns 0 — exercising the closed-item dedup safety net.
+    pre_seeded_items = {
+        "items": [
+            {"id": "OI-001", "status": "open",
+             "dedup_key": "qa:c1:a.py:"},
+            {"id": "OI-002", "status": "done",
+             "dedup_key": "qa:c2:b.py:"},
+        ]
+    }
+
     with patch.object(ar, "_build_git_provenance", return_value={"git_ref": "HEAD"}), \
          patch.object(ar, "_build_session_metadata", return_value={"session_id": "s1"}), \
          patch.object(ar, "enrich_receipt_provenance"), \
@@ -770,15 +803,17 @@ def test_enrich_open_items_created_uses_registration_count_not_advisory_count(ar
          patch.object(ar, "collect_terminal_snapshot", return_value=MagicMock(to_dict=lambda: {})), \
          patch.object(ar, "get_changed_files", return_value=[Path("a.py"), Path("b.py")]), \
          patch.object(ar, "generate_quality_advisory", return_value=fake_advisory), \
-         patch.object(ar, "_get_open_items_manager", return_value=MagicMock(count_items_closed_by_dispatch=lambda _: 0)), \
+         patch.object(ar, "_get_open_items_manager", return_value=MagicMock(
+             count_items_closed_by_dispatch=lambda _: 0,
+             load_items=lambda: pre_seeded_items,
+         )), \
          patch.object(ar, "resolve_state_dir", return_value=Path("/tmp/fake_state")), \
-         patch.object(ar, "_register_quality_open_items", return_value=0), \
          patch("pathlib.Path.exists", return_value=False):
         enriched = ar._enrich_completion_receipt(receipt)
 
     assert enriched.get("open_items_created") == 0, (
-        f"Expected 0 (all items already in OIM), got {enriched.get('open_items_created')!r}. "
-        "Regression: _count_quality_violations used instead of _register_quality_open_items."
+        f"Expected 0 (all items already in OI store, including CLOSED OI-002), "
+        f"got {enriched.get('open_items_created')!r}."
     )
 
 
@@ -818,3 +853,101 @@ def test_count_quality_violations_same_file_collapsed(ar):
     receipt = _make_quality_receipt(items)
     count = ar._count_quality_violations(receipt)
     assert count == 1, f"Expected 1 OI for identical file+check_id+symbol, got {count}"
+
+
+# ── Round-2 codex regate: side-effect ordering and closed-item dedup ─────────
+
+
+def test_count_quality_violations_against_store_dedups_against_closed(ar):
+    """Round-2 fix: dry-run count excludes items already present in OI store
+    REGARDLESS of status. Replayed receipts must not recreate closed findings."""
+    receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {
+                "open_items": [
+                    {"check_id": "c1", "file": "a.py", "symbol": "fn", "severity": "blocker"},
+                    {"check_id": "c2", "file": "b.py", "symbol": "", "severity": "warn"},
+                    {"check_id": "c3", "file": "c.py", "symbol": "", "severity": "info"},
+                ]
+            }
+        }
+    }
+    pre_seeded = {
+        "items": [
+            # Closed/done item with matching dedup_key — must still suppress recreation.
+            {"id": "OI-100", "status": "done", "dedup_key": "qa:c1:a.py:fn"},
+            # Open item that should also dedup.
+            {"id": "OI-101", "status": "open", "dedup_key": "qa:c2:b.py:"},
+            # Unrelated item.
+            {"id": "OI-102", "status": "open", "dedup_key": "qa:zzz:other.py:"},
+        ]
+    }
+
+    fake_oim = MagicMock()
+    fake_oim.load_items.return_value = pre_seeded
+    with patch.object(ar, "_get_open_items_manager", return_value=fake_oim):
+        count = ar._count_quality_violations_against_store(receipt)
+
+    # Only c3 should count: c1 dedups vs closed OI-100; c2 dedups vs open OI-101.
+    assert count == 1, f"Expected 1 (c3 only); c1 and c2 must dedup against existing items, got {count}"
+
+
+def test_count_quality_violations_against_store_empty_advisory(ar):
+    """Empty/missing advisory → 0 with no OI-store reads."""
+    fake_oim = MagicMock()
+    fake_oim.load_items.return_value = {"items": []}
+    with patch.object(ar, "_get_open_items_manager", return_value=fake_oim):
+        assert ar._count_quality_violations_against_store({}) == 0
+        assert ar._count_quality_violations_against_store({"quality_advisory": None}) == 0
+        assert ar._count_quality_violations_against_store(
+            {"quality_advisory": {"t0_recommendation": {"open_items": []}}}
+        ) == 0
+
+
+def test_duplicate_receipt_does_not_mutate_open_items_store(tmp_path: Path, ar):
+    """Round-2 codex regate Finding 1: a replayed receipt that lands as 'duplicate'
+    must NOT call _register_quality_open_items. The OI store stays untouched."""
+    receipts_file = tmp_path / "receipts.ndjson"
+    receipt = {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-REPLAY-SAFE-001",
+        "terminal": "T1",
+        "quality_advisory": {
+            "t0_recommendation": {
+                "open_items": [
+                    {"check_id": "c1", "file": "a.py", "symbol": "", "severity": "blocker"},
+                ]
+            }
+        },
+    }
+
+    register_calls: list = []
+
+    def _record_register(r):
+        register_calls.append(r.get("dispatch_id"))
+        return 1
+
+    def _passthrough_enrich(r, repo_root=None):
+        # Skip heavy enrichment but mimic the dry-run count contract.
+        enriched = dict(r)
+        enriched.setdefault("open_items_created", 1)
+        return enriched
+
+    with patch.object(ar, "_enrich_completion_receipt", side_effect=_passthrough_enrich), \
+         patch.object(ar, "_register_quality_open_items", side_effect=_record_register), \
+         patch.object(ar, "_update_confidence_from_receipt"), \
+         patch.object(ar, "_emit_dispatch_register", return_value=False), \
+         patch.object(ar, "_maybe_trigger_state_rebuild"):
+        # First append: must call _register_quality_open_items.
+        first = ar.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+        # Second append (same receipt): hits idempotency cache → status='duplicate'.
+        second = ar.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert first.status == "appended"
+    assert second.status == "duplicate"
+    assert register_calls == ["DISP-REPLAY-SAFE-001"], (
+        f"_register_quality_open_items must run once (post-append) and NOT again on duplicate. "
+        f"Got register calls: {register_calls!r}"
+    )

--- a/tests/test_codex_adapter_tokens.py
+++ b/tests/test_codex_adapter_tokens.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Unit tests for CodexAdapter token usage parsing logic."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB_DIR = Path(__file__).parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(LIB_DIR / "adapters"))
+
+from adapters.codex_adapter import CodexAdapter
+
+
+class TestParseTokenUsageTextFormat:
+    """Parse 'Tokens: N input / M output' text lines."""
+
+    def test_basic_text_format(self):
+        raw = "Tokens: 1200 input / 350 output"
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result == {
+            "input_tokens": 1200,
+            "output_tokens": 350,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    def test_text_format_with_total(self):
+        raw = "Tokens: 800 input / 200 output / 1000 total"
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 800
+        assert result["output_tokens"] == 200
+
+    def test_text_format_case_insensitive(self):
+        raw = "TOKENS: 500 INPUT / 100 OUTPUT"
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 500
+        assert result["output_tokens"] == 100
+
+    def test_text_format_embedded_in_multiline(self):
+        raw = "Starting review...\nTokens: 999 input / 111 output\nDone."
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 999
+        assert result["output_tokens"] == 111
+
+    def test_zero_cache_fields(self):
+        raw = "Tokens: 100 input / 50 output"
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result["cache_creation_tokens"] == 0
+        assert result["cache_read_tokens"] == 0
+
+
+class TestParseTokenUsageJsonEventFormat:
+    """Parse {"type":"token_usage","input_tokens":N,"output_tokens":M} NDJSON events."""
+
+    def test_explicit_token_usage_event(self):
+        raw = json.dumps({"type": "token_usage", "input_tokens": 1200, "output_tokens": 350})
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result == {
+            "input_tokens": 1200,
+            "output_tokens": 350,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    def test_token_usage_event_in_ndjson_stream(self):
+        events = [
+            {"type": "message", "content": "Analyzing..."},
+            {"type": "token_usage", "input_tokens": 2000, "output_tokens": 500},
+        ]
+        raw = "\n".join(json.dumps(e) for e in events)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 2000
+        assert result["output_tokens"] == 500
+
+
+class TestParseTokenUsageOpenAIFormat:
+    """Parse OpenAI-compatible {"usage":{"prompt_tokens":N,"completion_tokens":M}} blocks."""
+
+    def test_openai_prompt_completion_tokens(self):
+        raw = json.dumps({
+            "id": "chatcmpl-abc",
+            "usage": {"prompt_tokens": 300, "completion_tokens": 150},
+        })
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 150
+
+    def test_openai_input_output_tokens(self):
+        raw = json.dumps({
+            "usage": {"input_tokens": 400, "output_tokens": 200},
+        })
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 400
+        assert result["output_tokens"] == 200
+
+    def test_usage_block_in_ndjson_stream(self):
+        events = [
+            {"type": "start"},
+            {"type": "result", "content": "ok", "usage": {"prompt_tokens": 100, "completion_tokens": 40}},
+        ]
+        raw = "\n".join(json.dumps(e) for e in events)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 40
+
+
+class TestParseTokenUsageMissingInfo:
+    """Returns None when no token info is present."""
+
+    def test_empty_string_returns_none(self):
+        assert CodexAdapter._parse_token_usage_from_output("") is None
+
+    def test_plain_text_no_tokens_returns_none(self):
+        raw = "All findings look good. No issues detected."
+        assert CodexAdapter._parse_token_usage_from_output(raw) is None
+
+    def test_json_without_usage_returns_none(self):
+        raw = json.dumps({"type": "message", "content": "hello"})
+        assert CodexAdapter._parse_token_usage_from_output(raw) is None
+
+    def test_malformed_json_lines_skipped(self):
+        raw = "not-json\n{broken\nTokens: 77 input / 33 output"
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 77
+
+
+class TestGetTokenUsageStateCache:
+    """get_token_usage reads from the per-terminal state cache file."""
+
+    def test_reads_cached_usage(self, tmp_path: Path):
+        cache_dir = tmp_path / "token_cache"
+        cache_dir.mkdir()
+        usage = {"input_tokens": 500, "output_tokens": 120, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        (cache_dir / "T3_usage.json").write_text(json.dumps(usage))
+        result = CodexAdapter.get_token_usage("T3", state_dir=tmp_path)
+        assert result == usage
+
+    def test_returns_none_when_cache_missing(self, tmp_path: Path):
+        assert CodexAdapter.get_token_usage("T3", state_dir=tmp_path) is None
+
+    def test_returns_none_on_malformed_cache(self, tmp_path: Path):
+        cache_dir = tmp_path / "token_cache"
+        cache_dir.mkdir()
+        (cache_dir / "T1_usage.json").write_text("not-json")
+        assert CodexAdapter.get_token_usage("T1", state_dir=tmp_path) is None
+
+    def test_returns_none_when_state_dir_missing(self):
+        assert CodexAdapter.get_token_usage("T1", state_dir=None) is None
+
+    def test_write_then_read_roundtrip(self, tmp_path: Path):
+        adapter = CodexAdapter("T2")
+        usage = {"input_tokens": 300, "output_tokens": 80, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        adapter._write_token_cache(usage, state_dir=tmp_path)
+        result = CodexAdapter.get_token_usage("T2", state_dir=tmp_path)
+        assert result == usage

--- a/tests/test_codex_adapter_tokens.py
+++ b/tests/test_codex_adapter_tokens.py
@@ -166,3 +166,144 @@ class TestGetTokenUsageStateCache:
         adapter._write_token_cache(usage, state_dir=tmp_path)
         result = CodexAdapter.get_token_usage("T2", state_dir=tmp_path)
         assert result == usage
+
+
+# ── Round-2 codex regate (PR #307): parse `event_msg.payload.type=='token_count'` ──
+
+
+class TestParseTokenCountWrappedEvent:
+    """Round-2 fix: real `codex exec --json` emits token_count under event_msg.payload."""
+
+    def test_event_msg_payload_token_count(self):
+        """Primary shape flagged by codex regate: event_msg.payload.type=='token_count'."""
+        event = {
+            "id": "evt-1",
+            "event_msg": {
+                "payload": {
+                    "type": "token_count",
+                    "input_tokens": 1500,
+                    "cached_input_tokens": 200,
+                    "output_tokens": 400,
+                    "reasoning_output_tokens": 50,
+                    "total_tokens": 2150,
+                }
+            },
+        }
+        raw = json.dumps(event)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None, (
+            "Round-2 regression: event_msg.payload.type=='token_count' must be parsed. "
+            "Pre-fix _parse_token_usage_from_output returned None for this format."
+        )
+        assert result["input_tokens"] == 1500
+        assert result["output_tokens"] == 400
+        assert result["cache_read_tokens"] == 200
+
+    def test_event_msg_token_count_directly_under_event_msg(self):
+        """Variant: event_msg.type=='token_count' (no payload wrapper)."""
+        event = {
+            "event_msg": {
+                "type": "token_count",
+                "input_tokens": 800,
+                "output_tokens": 300,
+            }
+        }
+        result = CodexAdapter._parse_token_usage_from_output(json.dumps(event))
+        assert result is not None
+        assert result["input_tokens"] == 800
+        assert result["output_tokens"] == 300
+
+    def test_msg_wrapped_token_count(self):
+        """Variant: msg.type=='token_count' (older Codex shape)."""
+        event = {"id": "abc", "msg": {"type": "token_count", "input_tokens": 600, "output_tokens": 200}}
+        result = CodexAdapter._parse_token_usage_from_output(json.dumps(event))
+        assert result is not None
+        assert result["input_tokens"] == 600
+        assert result["output_tokens"] == 200
+
+    def test_token_count_takes_last_event(self):
+        """Codex emits running totals — keep the LAST token_count seen."""
+        events = [
+            {"event_msg": {"payload": {"type": "token_count",
+                                        "input_tokens": 100, "output_tokens": 20}}},
+            {"event_msg": {"payload": {"type": "token_count",
+                                        "input_tokens": 250, "output_tokens": 60}}},
+            {"event_msg": {"payload": {"type": "token_count",
+                                        "input_tokens": 412, "output_tokens": 91}}},
+        ]
+        raw = "\n".join(json.dumps(e) for e in events)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 412, (
+            "Codex emits running totals; final token_count event is the authoritative usage."
+        )
+        assert result["output_tokens"] == 91
+
+    def test_token_count_inside_realistic_ndjson_stream(self):
+        """End-to-end: a realistic NDJSON stream from `codex exec` with mixed events."""
+        events = [
+            {"event_msg": {"payload": {"type": "session_start"}}},
+            {"event_msg": {"payload": {"type": "agent_message", "text": "Reviewing files..."}}},
+            {"event_msg": {"payload": {
+                "type": "token_count",
+                "input_tokens": 2048,
+                "cached_input_tokens": 512,
+                "output_tokens": 600,
+                "cache_creation_input_tokens": 0,
+            }}},
+            {"event_msg": {"payload": {"type": "agent_message", "text": "Done."}}},
+        ]
+        raw = "\n".join(json.dumps(e) for e in events)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 2048
+        assert result["output_tokens"] == 600
+        assert result["cache_read_tokens"] == 512
+
+    def test_token_count_with_only_prompt_completion_keys(self):
+        """OpenAI-style key names inside a token_count payload are accepted too."""
+        event = {"event_msg": {"payload": {
+            "type": "token_count",
+            "prompt_tokens": 700,
+            "completion_tokens": 220,
+        }}}
+        result = CodexAdapter._parse_token_usage_from_output(json.dumps(event))
+        assert result is not None
+        assert result["input_tokens"] == 700
+        assert result["output_tokens"] == 220
+
+    def test_zero_token_count_returns_none(self):
+        """A token_count with both fields zero is not useful — return None so we don't
+        clobber a real usage value already cached."""
+        event = {"event_msg": {"payload": {
+            "type": "token_count",
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }}}
+        result = CodexAdapter._parse_token_usage_from_output(json.dumps(event))
+        assert result is None
+
+
+class TestExtractTokenCountPayloadHelper:
+    """Direct unit tests for the wrapper-extraction helper."""
+
+    def test_extract_event_msg_payload(self):
+        event = {"event_msg": {"payload": {"type": "token_count", "input_tokens": 1}}}
+        payload = CodexAdapter._extract_token_count_payload(event)
+        assert payload == {"type": "token_count", "input_tokens": 1}
+
+    def test_extract_msg_wrapper(self):
+        event = {"msg": {"type": "token_count", "x": 1}}
+        assert CodexAdapter._extract_token_count_payload(event) == {"type": "token_count", "x": 1}
+
+    def test_extract_top_level(self):
+        event = {"type": "token_count", "input_tokens": 5}
+        assert CodexAdapter._extract_token_count_payload(event) == event
+
+    def test_extract_returns_none_for_other_types(self):
+        assert CodexAdapter._extract_token_count_payload(
+            {"event_msg": {"payload": {"type": "agent_message"}}}
+        ) is None
+        assert CodexAdapter._extract_token_count_payload({"msg": {"type": "session_start"}}) is None
+        assert CodexAdapter._extract_token_count_payload({"unrelated": 1}) is None
+        assert CodexAdapter._extract_token_count_payload(None) is None  # type: ignore[arg-type]

--- a/tests/test_gemini_adapter_tokens.py
+++ b/tests/test_gemini_adapter_tokens.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Unit tests for GeminiAdapter token usage parsing logic."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB_DIR = Path(__file__).parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(LIB_DIR / "adapters"))
+
+from adapters.gemini_adapter import GeminiAdapter
+
+
+class TestExtractUsageMetadata:
+    """_extract_usage_metadata parses promptTokenCount/candidatesTokenCount."""
+
+    def test_basic_usage_metadata(self):
+        data = {"usageMetadata": {"promptTokenCount": 400, "candidatesTokenCount": 150}}
+        result = GeminiAdapter._extract_usage_metadata(data)
+        assert result == {
+            "input_tokens": 400,
+            "output_tokens": 150,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    def test_missing_usage_metadata_returns_none(self):
+        assert GeminiAdapter._extract_usage_metadata({"response": "hello"}) is None
+
+    def test_non_dict_usage_metadata_returns_none(self):
+        assert GeminiAdapter._extract_usage_metadata({"usageMetadata": "bad"}) is None
+
+    def test_zero_counts_returns_none(self):
+        data = {"usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0}}
+        assert GeminiAdapter._extract_usage_metadata(data) is None
+
+    def test_partial_counts_accepted(self):
+        # prompt=100 with no output is valid data (input-only inference or cached answer)
+        data = {"usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 0}}
+        result = GeminiAdapter._extract_usage_metadata(data)
+        assert result is not None
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 0
+
+    def test_nonzero_candidates_only(self):
+        # candidates=50 with no prompt tokens is valid data — return it
+        data = {"usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 50}}
+        result = GeminiAdapter._extract_usage_metadata(data)
+        assert result is not None
+        assert result["input_tokens"] == 0
+        assert result["output_tokens"] == 50
+
+    def test_nonzero_prompt_and_candidates(self):
+        data = {"usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 75}}
+        result = GeminiAdapter._extract_usage_metadata(data)
+        assert result is not None
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 75
+
+
+class TestParseTokenUsageFromResponse:
+    """_parse_token_usage_from_response handles JSON and NDJSON Gemini output."""
+
+    def test_top_level_json_with_usage_metadata(self):
+        raw = json.dumps({
+            "response": "Here are findings...",
+            "usageMetadata": {"promptTokenCount": 500, "candidatesTokenCount": 200},
+        })
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result is not None
+        assert result["input_tokens"] == 500
+        assert result["output_tokens"] == 200
+
+    def test_ndjson_stream_with_usage_metadata(self):
+        lines = [
+            json.dumps({"type": "chunk", "text": "partial"}),
+            json.dumps({"usageMetadata": {"promptTokenCount": 600, "candidatesTokenCount": 180}}),
+        ]
+        raw = "\n".join(lines)
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result is not None
+        assert result["input_tokens"] == 600
+        assert result["output_tokens"] == 180
+
+    def test_empty_response_returns_none(self):
+        assert GeminiAdapter._parse_token_usage_from_response("") is None
+
+    def test_plain_text_no_metadata_returns_none(self):
+        assert GeminiAdapter._parse_token_usage_from_response("Here are the findings.") is None
+
+    def test_json_without_usage_metadata_returns_none(self):
+        raw = json.dumps({"response": "no metadata here"})
+        assert GeminiAdapter._parse_token_usage_from_response(raw) is None
+
+    def test_malformed_json_top_level_falls_through_to_ndjson(self):
+        bad_header = "not-json\n"
+        valid_line = json.dumps({"usageMetadata": {"promptTokenCount": 123, "candidatesTokenCount": 45}})
+        raw = bad_header + valid_line
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result is not None
+        assert result["input_tokens"] == 123
+
+    def test_cache_fields_always_zero(self):
+        raw = json.dumps({"usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 30}})
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result["cache_creation_tokens"] == 0
+        assert result["cache_read_tokens"] == 0
+
+
+class TestGetTokenUsageStateCache:
+    """get_token_usage reads from the per-terminal state cache file."""
+
+    def test_reads_cached_usage(self, tmp_path: Path):
+        cache_dir = tmp_path / "token_cache"
+        cache_dir.mkdir()
+        usage = {"input_tokens": 700, "output_tokens": 210, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        (cache_dir / "GEMINI-1_usage.json").write_text(json.dumps(usage))
+        result = GeminiAdapter.get_token_usage("GEMINI-1", state_dir=tmp_path)
+        assert result == usage
+
+    def test_returns_none_when_cache_missing(self, tmp_path: Path):
+        assert GeminiAdapter.get_token_usage("GEMINI-1", state_dir=tmp_path) is None
+
+    def test_returns_none_on_malformed_cache(self, tmp_path: Path):
+        cache_dir = tmp_path / "token_cache"
+        cache_dir.mkdir()
+        (cache_dir / "GEMINI-1_usage.json").write_text("{bad json}")
+        assert GeminiAdapter.get_token_usage("GEMINI-1", state_dir=tmp_path) is None
+
+    def test_returns_none_when_state_dir_none(self):
+        assert GeminiAdapter.get_token_usage("GEMINI-1", state_dir=None) is None
+
+    def test_write_then_read_roundtrip(self, tmp_path: Path):
+        adapter = GeminiAdapter("GEMINI-1")
+        usage = {"input_tokens": 400, "output_tokens": 100, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        adapter._write_token_cache(usage, state_dir=tmp_path)
+        result = GeminiAdapter.get_token_usage("GEMINI-1", state_dir=tmp_path)
+        assert result == usage

--- a/tests/test_open_items_dedup_status.py
+++ b/tests/test_open_items_dedup_status.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Round-2 codex regate (PR #307): _find_by_dedup_key matches any status.
+
+Replayed/duplicate receipts must not be able to recreate findings that were
+previously closed. Dedup checks therefore consider items in any status
+(open/done/deferred/wontfix), not just open ones.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+
+
+def _load_oim(tmp_path: Path):
+    """Reload open_items_manager with a clean per-test STATE_DIR."""
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(TESTS_DIR.parent),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+
+    mod_name = f"open_items_manager_test_{tmp_path.name}"
+    with patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, SCRIPTS_DIR / "open_items_manager.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+def test_find_by_dedup_key_matches_open_item(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    data = {"items": [
+        {"id": "OI-001", "status": "open", "dedup_key": "qa:c1:foo.py:fn"},
+    ]}
+    found = oim._find_by_dedup_key(data, "qa:c1:foo.py:fn")
+    assert found is not None
+    assert found["id"] == "OI-001"
+
+
+def test_find_by_dedup_key_matches_closed_item(tmp_path: Path):
+    """Round-2 fix: closed items now match dedup key to prevent replay recreation."""
+    oim = _load_oim(tmp_path)
+    data = {"items": [
+        {"id": "OI-002", "status": "done", "dedup_key": "qa:c2:bar.py:"},
+        {"id": "OI-003", "status": "deferred", "dedup_key": "qa:c3:baz.py:"},
+        {"id": "OI-004", "status": "wontfix", "dedup_key": "qa:c4:qux.py:"},
+    ]}
+    assert oim._find_by_dedup_key(data, "qa:c2:bar.py:")["id"] == "OI-002"
+    assert oim._find_by_dedup_key(data, "qa:c3:baz.py:")["id"] == "OI-003"
+    assert oim._find_by_dedup_key(data, "qa:c4:qux.py:")["id"] == "OI-004"
+
+
+def test_find_by_dedup_key_returns_none_when_absent(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    data = {"items": [{"id": "OI-001", "status": "open", "dedup_key": "qa:other:x.py:"}]}
+    assert oim._find_by_dedup_key(data, "qa:c1:missing.py:") is None
+
+
+def test_legacy_alias_still_resolves(tmp_path: Path):
+    """_find_open_by_dedup_key is kept as a backwards-compatible alias."""
+    oim = _load_oim(tmp_path)
+    assert oim._find_open_by_dedup_key is oim._find_by_dedup_key
+
+
+def test_add_item_programmatic_dedups_against_closed_item(tmp_path: Path):
+    """Replay-safety regression: adding an item whose dedup_key matches a CLOSED
+    item must return (existing_id, False) and not create a new OI."""
+    oim = _load_oim(tmp_path)
+    # First call creates the item, second call closes it manually via JSON edit,
+    # then a third call with the same dedup_key must dedup (created=False).
+    item_id_1, created_1 = oim.add_item_programmatic(
+        title="initial finding",
+        severity="blocker",
+        dispatch_id="DISP-ALPHA",
+        dedup_key="qa:c1:foo.py:bar",
+    )
+    assert created_1 is True
+    assert item_id_1.startswith("OI-")
+
+    # Mark the item closed in the on-disk store.
+    data = oim.load_items()
+    for it in data["items"]:
+        if it["id"] == item_id_1:
+            it["status"] = "done"
+            it["closed_reason"] = "fixed"
+    oim.save_items(data)
+
+    # Replayed receipt: same dedup_key, must dedup against the closed item.
+    item_id_2, created_2 = oim.add_item_programmatic(
+        title="initial finding (replay)",
+        severity="blocker",
+        dispatch_id="DISP-ALPHA-REPLAY",
+        dedup_key="qa:c1:foo.py:bar",
+    )
+    assert created_2 is False, (
+        "Round-2 fix: closed items must dedup. Otherwise replayed receipts "
+        "recreate findings that were already closed."
+    )
+    assert item_id_2 == item_id_1

--- a/tests/test_token_tracking_providers.py
+++ b/tests/test_token_tracking_providers.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Integration tests for provider token tracking in receipts.
+
+Covers Cases A–F from the dispatch specification:
+  A. Codex CLI output with text token line → adapter returns dict
+  B. Codex output without token info → adapter returns None
+  C. Gemini JSON output with usageMetadata → adapter returns dict
+  D. Gemini malformed/missing metadata → returns None
+  E. Receipt enrichment: codex/gemini token_usage merged into session field
+  F. Claude path unchanged — existing session JSONL extraction still works
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+APPEND_SCRIPT = SCRIPTS_DIR / "append_receipt.py"
+
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(LIB_DIR / "adapters"))
+
+from adapters.codex_adapter import CodexAdapter
+from adapters.gemini_adapter import GeminiAdapter
+
+
+# ---------------------------------------------------------------------------
+# Case A — Codex: text token line → adapter returns {input:1200, output:350}
+# ---------------------------------------------------------------------------
+
+class TestCaseA_CodexTextTokenLine:
+    def test_text_token_line_parsed(self):
+        raw = "Reviewing code...\nTokens: 1200 input / 350 output\nDone."
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result == {
+            "input_tokens": 1200,
+            "output_tokens": 350,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    def test_json_token_usage_event_parsed(self):
+        events = [
+            {"type": "start"},
+            {"type": "token_usage", "input_tokens": 1200, "output_tokens": 350},
+        ]
+        raw = "\n".join(json.dumps(e) for e in events)
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 1200
+        assert result["output_tokens"] == 350
+
+    def test_openai_usage_block_parsed(self):
+        raw = json.dumps({"usage": {"prompt_tokens": 1200, "completion_tokens": 350}})
+        result = CodexAdapter._parse_token_usage_from_output(raw)
+        assert result is not None
+        assert result["input_tokens"] == 1200
+        assert result["output_tokens"] == 350
+
+
+# ---------------------------------------------------------------------------
+# Case B — Codex: no token info → adapter returns None
+# ---------------------------------------------------------------------------
+
+class TestCaseB_CodexNoTokenInfo:
+    def test_empty_output_returns_none(self):
+        assert CodexAdapter._parse_token_usage_from_output("") is None
+
+    def test_plain_text_returns_none(self):
+        raw = "The code looks fine. No critical issues found."
+        assert CodexAdapter._parse_token_usage_from_output(raw) is None
+
+    def test_json_without_usage_returns_none(self):
+        raw = json.dumps({"type": "result", "content": "findings"})
+        assert CodexAdapter._parse_token_usage_from_output(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# Case C — Gemini: JSON with usageMetadata → adapter returns dict
+# ---------------------------------------------------------------------------
+
+class TestCaseC_GeminiUsageMetadata:
+    def test_top_level_usage_metadata(self):
+        raw = json.dumps({
+            "response": "Review complete.",
+            "usageMetadata": {
+                "promptTokenCount": 800,
+                "candidatesTokenCount": 250,
+            },
+        })
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result == {
+            "input_tokens": 800,
+            "output_tokens": 250,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+
+    def test_ndjson_stream_usage_metadata(self):
+        lines = [
+            json.dumps({"text": "partial output"}),
+            json.dumps({"usageMetadata": {"promptTokenCount": 600, "candidatesTokenCount": 180}}),
+        ]
+        raw = "\n".join(lines)
+        result = GeminiAdapter._parse_token_usage_from_response(raw)
+        assert result is not None
+        assert result["input_tokens"] == 600
+        assert result["output_tokens"] == 180
+
+
+# ---------------------------------------------------------------------------
+# Case D — Gemini: missing/malformed metadata → returns None
+# ---------------------------------------------------------------------------
+
+class TestCaseD_GeminiMissingMetadata:
+    def test_empty_response_returns_none(self):
+        assert GeminiAdapter._parse_token_usage_from_response("") is None
+
+    def test_plain_text_returns_none(self):
+        assert GeminiAdapter._parse_token_usage_from_response("Here are findings.") is None
+
+    def test_json_without_usage_metadata_returns_none(self):
+        raw = json.dumps({"response": "no tokens here"})
+        assert GeminiAdapter._parse_token_usage_from_response(raw) is None
+
+    def test_usage_metadata_missing_fields_returns_none(self):
+        raw = json.dumps({"usageMetadata": {"totalTokenCount": 100}})
+        assert GeminiAdapter._parse_token_usage_from_response(raw) is None
+
+    def test_all_zero_counts_returns_none(self):
+        raw = json.dumps({"usageMetadata": {"promptTokenCount": 0, "candidatesTokenCount": 0}})
+        assert GeminiAdapter._parse_token_usage_from_response(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# Case E — Receipt enrichment: adapter get_token_usage merged into session
+# ---------------------------------------------------------------------------
+
+def _build_env(tmp_path: Path) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    env["PROJECT_ROOT"] = str(tmp_path)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    env["VNX_STATE_DIR"] = str(state_dir)
+    env["VNX_HOME"] = str(VNX_ROOT)
+    return env
+
+
+def _run_append(tmp_path: Path, payload: str) -> subprocess.CompletedProcess:
+    env = _build_env(tmp_path)
+    return subprocess.run(
+        [sys.executable, str(APPEND_SCRIPT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _build_receipt(terminal: str = "T1", event_type: str = "task_complete") -> dict:
+    return {
+        "timestamp": "2026-04-28T10:00:00Z",
+        "event_type": event_type,
+        "event": event_type,
+        "dispatch_id": "20260428-t5-pr6-test",
+        "task_id": "TASK-001",
+        "terminal": terminal,
+        "status": "success",
+        "source": "pytest",
+    }
+
+
+class TestCaseE_ReceiptEnrichmentCodex:
+    def test_codex_terminal_token_usage_merged(self, tmp_path: Path):
+        env = _build_env(tmp_path)
+        state_dir = Path(env["VNX_STATE_DIR"])
+
+        # Pre-populate token cache as if CodexAdapter.execute() ran
+        usage = {"input_tokens": 1500, "output_tokens": 400, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        cache_dir = state_dir / "token_cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "CODEX-1_usage.json").write_text(json.dumps(usage))
+
+        receipt = _build_receipt(terminal="CODEX-1")
+        result = subprocess.run(
+            [sys.executable, str(APPEND_SCRIPT)],
+            input=json.dumps(receipt),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+
+        # Verify token_usage written into the receipt ndjson
+        receipts_file = Path(env["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+        assert receipts_file.exists()
+        lines = [l for l in receipts_file.read_text().splitlines() if l.strip()]
+        assert len(lines) >= 1
+        saved = json.loads(lines[-1])
+        session = saved.get("session", {})
+        assert "token_usage" in session, f"token_usage missing from session: {session}"
+        assert session["token_usage"]["input_tokens"] == 1500
+        assert session["token_usage"]["output_tokens"] == 400
+
+    def test_gemini_terminal_token_usage_merged(self, tmp_path: Path):
+        env = _build_env(tmp_path)
+        state_dir = Path(env["VNX_STATE_DIR"])
+
+        usage = {"input_tokens": 900, "output_tokens": 300, "cache_creation_tokens": 0, "cache_read_tokens": 0}
+        cache_dir = state_dir / "token_cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "GEMINI-1_usage.json").write_text(json.dumps(usage))
+
+        receipt = _build_receipt(terminal="GEMINI-1")
+        result = subprocess.run(
+            [sys.executable, str(APPEND_SCRIPT)],
+            input=json.dumps(receipt),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+
+        receipts_file = Path(env["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+        lines = [l for l in receipts_file.read_text().splitlines() if l.strip()]
+        saved = json.loads(lines[-1])
+        session = saved.get("session", {})
+        assert "token_usage" in session, f"token_usage missing from session: {session}"
+        assert session["token_usage"]["input_tokens"] == 900
+
+    def test_no_cache_means_no_token_usage_key(self, tmp_path: Path):
+        env = _build_env(tmp_path)
+        # No token cache file written — codex terminal with no token data
+        receipt = _build_receipt(terminal="CODEX-1")
+        result = subprocess.run(
+            [sys.executable, str(APPEND_SCRIPT)],
+            input=json.dumps(receipt),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        receipts_file = Path(env["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+        lines = [l for l in receipts_file.read_text().splitlines() if l.strip()]
+        saved = json.loads(lines[-1])
+        session = saved.get("session", {})
+        # token_usage may be absent or None — either is acceptable; must not crash
+        assert session.get("token_usage") is None
+
+
+# ---------------------------------------------------------------------------
+# Case F — Claude path unchanged
+# ---------------------------------------------------------------------------
+
+class TestCaseF_ClaudePathUnchanged:
+    def test_claude_terminal_no_token_usage_without_session_file(self, tmp_path: Path):
+        env = _build_env(tmp_path)
+        receipt = _build_receipt(terminal="T1")
+        result = subprocess.run(
+            [sys.executable, str(APPEND_SCRIPT)],
+            input=json.dumps(receipt),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        receipts_file = Path(env["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+        lines = [l for l in receipts_file.read_text().splitlines() if l.strip()]
+        saved = json.loads(lines[-1])
+        session = saved.get("session", {})
+        # Without a real Claude session JSONL, token_usage is absent — no crash
+        assert "token_usage" not in session or session["token_usage"] is None
+
+    def test_claude_terminal_provider_is_claude_code(self, tmp_path: Path):
+        env = _build_env(tmp_path)
+        receipt = _build_receipt(terminal="T1")
+        result = subprocess.run(
+            [sys.executable, str(APPEND_SCRIPT)],
+            input=json.dumps(receipt),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        receipts_file = Path(env["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+        lines = [l for l in receipts_file.read_text().splitlines() if l.strip()]
+        saved = json.loads(lines[-1])
+        session = saved.get("session", {})
+        assert session.get("provider") == "claude_code"


### PR DESCRIPTION
## Summary
- Closes GAP-4 from the Tier 5 observability mapping: `codex_cli` and `gemini_cli` terminals previously produced no token usage data in receipts
- Adds `get_token_usage(terminal_id, state_dir)` to `CodexAdapter` and `GeminiAdapter`; token data captured during `execute()` is cached to `{VNX_STATE_DIR}/token_cache/{terminal_id}_usage.json`
- Wires provider-aware token extraction into `append_receipt.py:_build_session_metadata`; Claude path is bit-identical to before

## Token format support
**Codex CLI** (`codex exec --json` NDJSON stream):
1. Explicit event: `{"type":"token_usage","input_tokens":N,"output_tokens":M}`
2. OpenAI-compat block: `{"usage":{"prompt_tokens":N,"completion_tokens":M}}` (also `input_tokens`/`output_tokens` variants per `cost_tracker.py`)
3. Text line: `Tokens: N input / M output [/ T total]`

**Gemini CLI** (`gemini --output-format json`):
- `usageMetadata.promptTokenCount` (input) + `candidatesTokenCount` (output)
- Handles both top-level JSON object and NDJSON stream responses

## Test plan
- [x] `python3 -m py_compile` all modified files — syntax OK
- [x] `pytest tests/test_codex_adapter_tokens.py` — 19 passed
- [x] `pytest tests/test_gemini_adapter_tokens.py` — 19 passed
- [x] `pytest tests/test_token_tracking_providers.py` — 18 passed (Cases A–F)
- [x] `pytest tests/test_append_receipt.py tests/test_append_receipt_register_emit.py` — 48/50 passed (2 pre-existing failures: missing `receipt_notifier.sh`, flaky concurrent test — both unrelated to this PR)
- [x] Claude path unchanged — `test_claude_terminal_provider_is_claude_code` confirms provider=claude_code and no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)