### PR TITLE
feat(observability): WorkerHealthMonitor → EventStore + receipt stuck_event_count (Tier 5 GAP-2)

### DIFF
--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -483,6 +483,12 @@ def deliver_via_subprocess(
     if not result.success:
         return _SubprocessResult(success=False, session_id=None, event_count=0, manifest_path=manifest_path)
 
+    # Wire event_store into health_monitor so STUCK events are persisted to NDJSON
+    if health_monitor is not None and health_monitor._event_store is None:
+        _es = adapter._get_event_store()
+        if _es is not None:
+            health_monitor._event_store = _es
+
     # Start heartbeat thread if lease generation is known
     heartbeat_stop: threading.Event | None = None
     heartbeat_thread: threading.Thread | None = None
@@ -733,6 +739,7 @@ def _write_receipt(
     commit_hash_before: str = "",
     commit_hash_after: str = "",
     manifest_path: str | None = None,
+    stuck_event_count: int = 0,
 ) -> Path:
     """Append a subprocess completion receipt to t0_receipts.ndjson.
 
@@ -764,6 +771,8 @@ def _write_receipt(
         receipt["failure_reason"] = failure_reason
     if commit_missing:
         receipt["commit_missing"] = True
+    if stuck_event_count:
+        receipt["stuck_event_count"] = stuck_event_count
 
     _scripts_dir = Path(__file__).resolve().parents[1]
     try:
@@ -1056,6 +1065,7 @@ def deliver_with_recovery(
                 commit_hash_before=commit_hash_before,
                 commit_hash_after=commit_hash_after,
                 manifest_path=sub_result.manifest_path,
+                stuck_event_count=monitor.stuck_count,
             )
 
             # Feedback loop: boost pattern confidence for successful dispatch
@@ -1099,6 +1109,7 @@ def deliver_with_recovery(
                 failure_reason=f"Exhausted {max_retries} retries",
                 commit_hash_before=commit_hash_before,
                 manifest_path=sub_result.manifest_path,
+                stuck_event_count=monitor.stuck_count,
             )
 
             # Feedback loop: decay pattern confidence for failed dispatch

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -237,6 +237,33 @@ class _SubprocessResult(NamedTuple):
     manifest_path: str | None
 
 
+def _get_dirty_files(cwd: Path) -> set[str]:
+    """Return the set of dirty (modified/untracked) file paths from git status --porcelain.
+
+    Handles rename lines ("old -> new") by capturing only the destination path.
+    Returns an empty set on any failure so callers can safely subtract.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, timeout=15,
+            cwd=cwd,
+        )
+        files: set[str] = set()
+        for line in proc.stdout.splitlines():
+            if not line.strip():
+                continue
+            # git status --porcelain: XY<space>filename (or XY<space>old -> new)
+            path_part = line[3:].strip()
+            if " -> " in path_part:
+                path_part = path_part.split(" -> ", 1)[1]
+            files.add(path_part)
+        return files
+    except Exception as exc:
+        logger.debug("_get_dirty_files failed: %s", exc)
+        return set()
+
+
 def _get_commit_hash() -> str:
     """Return current HEAD commit hash, or empty string on failure."""
     try:
@@ -631,29 +658,56 @@ def _check_commit_since(dispatch_start_ts: str) -> bool:
     return False
 
 
-def _auto_commit_changes(dispatch_id: str, terminal_id: str, gate: str = "") -> bool:
-    """Stage and commit any uncommitted changes after a successful dispatch.
+def _auto_commit_changes(
+    dispatch_id: str,
+    terminal_id: str,
+    gate: str = "",
+    pre_dispatch_dirty: "set[str] | None" = None,
+) -> bool:
+    """Stage and commit changes introduced by this dispatch.
+
+    When pre_dispatch_dirty is provided, only files that were NOT already dirty
+    before the dispatch started are staged.  This prevents sweeping concurrent or
+    pre-existing dirty files from other terminals into this worker's commit.
 
     Returns True if a commit was made, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
     try:
+        cwd = Path(__file__).resolve().parents[2]
         # Check for uncommitted changes
         status_proc = subprocess.run(
             ["git", "status", "--porcelain"],
             capture_output=True, text=True, timeout=15,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=cwd,
         )
         dirty_lines = [l for l in status_proc.stdout.splitlines() if l.strip()]
         if not dirty_lines:
             logger.debug("auto_commit: working tree clean for dispatch %s", dispatch_id)
             return False
 
-        # Stage all changes (respects .gitignore — excludes .vnx-data/, .venv/, etc.)
+        # Scope staging to files that became dirty during this dispatch
+        if pre_dispatch_dirty is not None:
+            current_dirty = _get_dirty_files(cwd)
+            files_to_stage = sorted(current_dirty - pre_dispatch_dirty)
+            if not files_to_stage:
+                logger.debug(
+                    "auto_commit: no new files to stage for dispatch %s "
+                    "(all dirty files pre-existed the dispatch)",
+                    dispatch_id,
+                )
+                return False
+            add_cmd = ["git", "add", "--"] + files_to_stage
+        else:
+            # Fallback: stage all current dirty files when pre-dispatch state is unknown.
+            # This is equivalent to the old git add -A behaviour and should only occur
+            # when _auto_commit_changes is called directly (not via deliver_with_recovery).
+            add_cmd = ["git", "add", "-A"]
+
         add_proc = subprocess.run(
-            ["git", "add", "-A"],
+            add_cmd,
             capture_output=True, text=True, timeout=15,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=cwd,
         )
         if add_proc.returncode != 0:
             logger.warning("auto_commit: git add failed for %s: %s", dispatch_id, add_proc.stderr)
@@ -667,7 +721,7 @@ def _auto_commit_changes(dispatch_id: str, terminal_id: str, gate: str = "") -> 
         commit_proc = subprocess.run(
             ["git", "commit", "-m", commit_msg],
             capture_output=True, text=True, timeout=30,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=cwd,
         )
         if commit_proc.returncode == 0:
             logger.info(
@@ -686,27 +740,57 @@ def _auto_commit_changes(dispatch_id: str, terminal_id: str, gate: str = "") -> 
         return False
 
 
-def _auto_stash_changes(dispatch_id: str, terminal_id: str) -> bool:
-    """Stash uncommitted changes after a failed dispatch (preserves but does not commit).
+def _auto_stash_changes(
+    dispatch_id: str,
+    terminal_id: str,
+    pre_dispatch_dirty: "set[str] | None" = None,
+) -> bool:
+    """Stash changes introduced by this dispatch after a failure (preserves but does not commit).
+
+    When pre_dispatch_dirty is provided, only files that were NOT dirty before
+    the dispatch started are stashed via ``git stash push -u -- <files>``.
+    This prevents hiding unrelated tracked edits from other terminals and ensures
+    untracked files created by the failed dispatch are also captured.
 
     Returns True if a stash was created, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
     try:
+        cwd = Path(__file__).resolve().parents[2]
         status_proc = subprocess.run(
             ["git", "status", "--porcelain"],
             capture_output=True, text=True, timeout=15,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=cwd,
         )
         dirty_lines = [l for l in status_proc.stdout.splitlines() if l.strip()]
         if not dirty_lines:
             return False
 
         stash_name = f"vnx-auto-stash-{dispatch_id}"
+
+        if pre_dispatch_dirty is not None:
+            current_dirty = _get_dirty_files(cwd)
+            files_to_stash = sorted(current_dirty - pre_dispatch_dirty)
+            if not files_to_stash:
+                logger.debug(
+                    "auto_stash: no new files to stash for dispatch %s "
+                    "(all dirty files pre-existed the dispatch)",
+                    dispatch_id,
+                )
+                return False
+            # -u includes untracked files matching the specified paths so
+            # newly-created files from the failed dispatch are also captured.
+            stash_cmd = ["git", "stash", "push", "-u", "-m", stash_name, "--"] + files_to_stash
+        else:
+            # Fallback when pre-dispatch state is unknown: stash all tracked
+            # changes including untracked files (-u).  This replaces the old
+            # ``git stash save`` (no -u) which left untracked files behind.
+            stash_cmd = ["git", "stash", "push", "-u", "-m", stash_name]
+
         stash_proc = subprocess.run(
-            ["git", "stash", "save", stash_name],
+            stash_cmd,
             capture_output=True, text=True, timeout=30,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=cwd,
         )
         if stash_proc.returncode == 0:
             logger.info(
@@ -1014,6 +1098,10 @@ def deliver_with_recovery(
 
     dispatch_start_ts = datetime.now(timezone.utc).isoformat()
     commit_hash_before = _get_commit_hash()
+    # Snapshot dirty files before dispatch so auto-commit/stash can scope to
+    # changes introduced by this dispatch only (not pre-existing dirty state).
+    _repo_cwd = Path(__file__).resolve().parents[2]
+    pre_dispatch_dirty = _get_dirty_files(_repo_cwd)
 
     # Capture dispatch parameters before execution
     _capture_dispatch_parameters(
@@ -1050,7 +1138,10 @@ def deliver_with_recovery(
             # Post-dispatch commit enforcement
             committed = commit_hash_before != commit_hash_after
             if auto_commit and commit_missing and not committed:
-                committed = _auto_commit_changes(dispatch_id, terminal_id, gate=gate)
+                committed = _auto_commit_changes(
+                    dispatch_id, terminal_id, gate=gate,
+                    pre_dispatch_dirty=pre_dispatch_dirty,
+                )
                 if committed:
                     commit_missing = False
                     commit_hash_after = _get_commit_hash()
@@ -1100,7 +1191,7 @@ def deliver_with_recovery(
             monitor.mark_completed()
             # Stash uncommitted changes from failed dispatch
             if auto_commit:
-                _auto_stash_changes(dispatch_id, terminal_id)
+                _auto_stash_changes(dispatch_id, terminal_id, pre_dispatch_dirty=pre_dispatch_dirty)
             _write_receipt(
                 dispatch_id, terminal_id, "failed",
                 event_count=sub_result.event_count,

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -551,14 +551,6 @@ def deliver_via_subprocess(
                         _last_stuck_log_time = _now
         session_id = adapter.get_session_id(terminal_id)
 
-        # Persist session_id for next dispatch to resume (VNX_SESSION_RESUME=1)
-        if session_id and os.environ.get("VNX_SESSION_RESUME", "0") == "1":
-            try:
-                from session_store import SessionStore as _SessionStore
-                _SessionStore().save(terminal_id, session_id, dispatch_id=dispatch_id)
-            except Exception as _exc:
-                logger.debug("deliver_via_subprocess: session save failed: %s", _exc)
-
         # Fail-closed: non-zero exit code means failure even when events were parsed.
         obs = adapter.observe(terminal_id)
         returncode = obs.transport_state.get("returncode")
@@ -590,6 +582,17 @@ def deliver_via_subprocess(
                 event_count=event_count,
                 manifest_path=completed_manifest or manifest_path,
             )
+
+        # Only persist session_id once all fail-closed checks pass, so the next
+        # dispatch (with VNX_SESSION_RESUME=1) cannot resume a failed or
+        # timeout-killed conversation.
+        if session_id and os.environ.get("VNX_SESSION_RESUME", "0") == "1":
+            try:
+                from session_store import SessionStore as _SessionStore
+                _SessionStore().save(terminal_id, session_id, dispatch_id=dispatch_id)
+            except Exception as _exc:
+                logger.debug("deliver_via_subprocess: session save failed: %s", _exc)
+
         return _SubprocessResult(
             success=True,
             session_id=session_id,
@@ -666,13 +669,21 @@ def _auto_commit_changes(
 ) -> bool:
     """Stage and commit changes introduced by this dispatch.
 
-    When pre_dispatch_dirty is provided, only files that were NOT already dirty
-    before the dispatch started are staged.  This prevents sweeping concurrent or
-    pre-existing dirty files from other terminals into this worker's commit.
+    pre_dispatch_dirty is REQUIRED for safe operation: only files that became
+    dirty during the dispatch are staged.  When None is passed, the helper
+    refuses to commit anything (fail-safe) rather than sweeping unrelated
+    user/terminal changes into this worker's commit via ``git add -A``.
 
     Returns True if a commit was made, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
+    if pre_dispatch_dirty is None:
+        logger.warning(
+            "auto_commit: pre_dispatch_dirty=None — refusing to commit for dispatch %s "
+            "(would otherwise sweep unrelated dirty files via git add -A)",
+            dispatch_id,
+        )
+        return False
     try:
         cwd = Path(__file__).resolve().parents[2]
         # Check for uncommitted changes
@@ -686,23 +697,17 @@ def _auto_commit_changes(
             logger.debug("auto_commit: working tree clean for dispatch %s", dispatch_id)
             return False
 
-        # Scope staging to files that became dirty during this dispatch
-        if pre_dispatch_dirty is not None:
-            current_dirty = _get_dirty_files(cwd)
-            files_to_stage = sorted(current_dirty - pre_dispatch_dirty)
-            if not files_to_stage:
-                logger.debug(
-                    "auto_commit: no new files to stage for dispatch %s "
-                    "(all dirty files pre-existed the dispatch)",
-                    dispatch_id,
-                )
-                return False
-            add_cmd = ["git", "add", "--"] + files_to_stage
-        else:
-            # Fallback: stage all current dirty files when pre-dispatch state is unknown.
-            # This is equivalent to the old git add -A behaviour and should only occur
-            # when _auto_commit_changes is called directly (not via deliver_with_recovery).
-            add_cmd = ["git", "add", "-A"]
+        # Scope staging to files that became dirty during this dispatch.
+        current_dirty = _get_dirty_files(cwd)
+        files_to_stage = sorted(current_dirty - pre_dispatch_dirty)
+        if not files_to_stage:
+            logger.debug(
+                "auto_commit: no new files to stage for dispatch %s "
+                "(all dirty files pre-existed the dispatch)",
+                dispatch_id,
+            )
+            return False
+        add_cmd = ["git", "add", "--"] + files_to_stage
 
         add_proc = subprocess.run(
             add_cmd,
@@ -747,14 +752,21 @@ def _auto_stash_changes(
 ) -> bool:
     """Stash changes introduced by this dispatch after a failure (preserves but does not commit).
 
-    When pre_dispatch_dirty is provided, only files that were NOT dirty before
-    the dispatch started are stashed via ``git stash push -u -- <files>``.
-    This prevents hiding unrelated tracked edits from other terminals and ensures
-    untracked files created by the failed dispatch are also captured.
+    pre_dispatch_dirty is REQUIRED for safe operation: only files that became
+    dirty during the dispatch are stashed via ``git stash push -u -- <files>``.
+    When None is passed, the helper refuses to stash anything (fail-safe)
+    rather than hiding unrelated tracked/untracked edits from other terminals.
 
     Returns True if a stash was created, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
+    if pre_dispatch_dirty is None:
+        logger.warning(
+            "auto_stash: pre_dispatch_dirty=None — refusing to stash for dispatch %s "
+            "(would otherwise sweep unrelated dirty files into a global stash)",
+            dispatch_id,
+        )
+        return False
     try:
         cwd = Path(__file__).resolve().parents[2]
         status_proc = subprocess.run(
@@ -768,24 +780,18 @@ def _auto_stash_changes(
 
         stash_name = f"vnx-auto-stash-{dispatch_id}"
 
-        if pre_dispatch_dirty is not None:
-            current_dirty = _get_dirty_files(cwd)
-            files_to_stash = sorted(current_dirty - pre_dispatch_dirty)
-            if not files_to_stash:
-                logger.debug(
-                    "auto_stash: no new files to stash for dispatch %s "
-                    "(all dirty files pre-existed the dispatch)",
-                    dispatch_id,
-                )
-                return False
-            # -u includes untracked files matching the specified paths so
-            # newly-created files from the failed dispatch are also captured.
-            stash_cmd = ["git", "stash", "push", "-u", "-m", stash_name, "--"] + files_to_stash
-        else:
-            # Fallback when pre-dispatch state is unknown: stash all tracked
-            # changes including untracked files (-u).  This replaces the old
-            # ``git stash save`` (no -u) which left untracked files behind.
-            stash_cmd = ["git", "stash", "push", "-u", "-m", stash_name]
+        current_dirty = _get_dirty_files(cwd)
+        files_to_stash = sorted(current_dirty - pre_dispatch_dirty)
+        if not files_to_stash:
+            logger.debug(
+                "auto_stash: no new files to stash for dispatch %s "
+                "(all dirty files pre-existed the dispatch)",
+                dispatch_id,
+            )
+            return False
+        # -u includes untracked files matching the specified paths so
+        # newly-created files from the failed dispatch are also captured.
+        stash_cmd = ["git", "stash", "push", "-u", "-m", stash_name, "--"] + files_to_stash
 
         stash_proc = subprocess.run(
             stash_cmd,

--- a/scripts/lib/worker_health_monitor.py
+++ b/scripts/lib/worker_health_monitor.py
@@ -77,6 +77,7 @@ class WorkerHealthMonitor:
         *,
         events_dir: Optional[Path] = None,
         avg_events: int = AVG_EVENTS_PER_DISPATCH,
+        event_store: Optional[Any] = None,
     ) -> None:
         self.terminal_id = terminal_id
         self.dispatch_id = dispatch_id
@@ -86,7 +87,10 @@ class WorkerHealthMonitor:
         self._last_event_time = time.monotonic()
         self._event_count = 0
         self._last_tool = ""
+        self._last_event_type = ""
         self._completed = False
+        self._stuck_count = 0
+        self._event_store = event_store
         self._lock = threading.Lock()
 
         # Resolve events dir
@@ -129,6 +133,7 @@ class WorkerHealthMonitor:
             else:
                 return
 
+            self._last_event_type = etype
             if etype == "tool_use":
                 tool_name = edata.get("name", "")
                 if tool_name:
@@ -179,6 +184,12 @@ class WorkerHealthMonitor:
         # Write final snapshot
         self._write_health_json()
 
+    @property
+    def stuck_count(self) -> int:
+        """Number of times this dispatch transitioned into STUCK status."""
+        with self._lock:
+            return self._stuck_count
+
     def stop(self) -> None:
         """Stop background writer thread."""
         self._stop_event.set()
@@ -210,10 +221,14 @@ class WorkerHealthMonitor:
             logger.debug("worker_health_monitor: failed to write health json: %s", exc)
 
     def log_stuck_event(self, stuck_log_path: Optional[Path] = None) -> None:
-        """Append a stuck-warning entry to events/worker_stuck.ndjson."""
+        """Append a stuck-warning entry to events/worker_stuck.ndjson and EventStore."""
         h = self.health_status()
         if h.status != HealthStatus.STUCK:
             return
+
+        with self._lock:
+            self._stuck_count += 1
+            last_event_type = self._last_event_type
 
         try:
             log_path = stuck_log_path or (self._events_dir / "worker_stuck.ndjson")
@@ -237,3 +252,18 @@ class WorkerHealthMonitor:
             )
         except Exception as exc:
             logger.debug("worker_health_monitor: failed to log stuck event: %s", exc)
+
+        if self._event_store is not None:
+            try:
+                self._event_store.append(
+                    self.terminal_id,
+                    {
+                        "type": "worker_stuck",
+                        "elapsed_secs": h.elapsed_seconds,
+                        "dispatch_id": self.dispatch_id,
+                        "last_event_type": last_event_type,
+                    },
+                    dispatch_id=self.dispatch_id,
+                )
+            except Exception as exc:
+                logger.debug("worker_health_monitor: event_store.append failed: %s", exc)

--- a/tests/test_auto_commit_stash_isolation.py
+++ b/tests/test_auto_commit_stash_isolation.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Regression tests for codex findings on _auto_commit_changes and _auto_stash_changes.
+
+Finding 1: _auto_commit_changes must NOT use git add -A when pre_dispatch_dirty is
+           provided — only stage files that became dirty during the dispatch.
+
+Finding 2: _auto_stash_changes must use git stash push -u -- <files> (not git stash
+           save without -u) so that: (a) untracked dispatch files are included, and
+           (b) pre-existing dirty files from other terminals are excluded.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch
+from subprocess_dispatch import (
+    _auto_commit_changes,
+    _auto_stash_changes,
+    _get_dirty_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# _get_dirty_files
+# ---------------------------------------------------------------------------
+
+class TestGetDirtyFiles(unittest.TestCase):
+    def _run(self, stdout: str) -> set:
+        with patch("subprocess_dispatch.subprocess") as mock_sp:
+            proc = MagicMock()
+            proc.stdout = stdout
+            mock_sp.run.return_value = proc
+            from pathlib import Path as _Path
+            return _get_dirty_files(_Path("/fake/repo"))
+
+    def test_empty_output_returns_empty_set(self):
+        result = self._run("")
+        self.assertEqual(result, set())
+
+    def test_single_modified_file(self):
+        result = self._run(" M scripts/lib/foo.py\n")
+        self.assertIn("scripts/lib/foo.py", result)
+
+    def test_untracked_file(self):
+        result = self._run("?? scripts/lib/new_file.py\n")
+        self.assertIn("scripts/lib/new_file.py", result)
+
+    def test_renamed_file_captures_destination(self):
+        result = self._run("R  old_name.py -> new_name.py\n")
+        self.assertIn("new_name.py", result)
+        self.assertNotIn("old_name.py", result)
+
+    def test_multiple_files(self):
+        stdout = " M a.py\n?? b.py\n M c.py\n"
+        result = self._run(stdout)
+        self.assertEqual(result, {"a.py", "b.py", "c.py"})
+
+    def test_returns_empty_set_on_subprocess_exception(self):
+        with patch("subprocess_dispatch.subprocess") as mock_sp:
+            mock_sp.run.side_effect = OSError("git not found")
+            result = _get_dirty_files(Path("/fake/repo"))
+        self.assertEqual(result, set())
+
+
+# ---------------------------------------------------------------------------
+# _auto_commit_changes — Finding 1
+# ---------------------------------------------------------------------------
+
+class TestAutoCommitIsolation(unittest.TestCase):
+    """_auto_commit_changes must scope staging to dispatch-specific files."""
+
+    def _mock_subprocess(self, status_lines: list[str], add_rc: int = 0, commit_rc: int = 0):
+        """Return a mock subprocess module. Calls: status -> add -> commit."""
+        mock_sp = MagicMock()
+        calls = []
+
+        status_proc = MagicMock()
+        status_proc.stdout = "\n".join(status_lines)
+        status_proc.returncode = 0
+
+        add_proc = MagicMock()
+        add_proc.returncode = add_rc
+        add_proc.stderr = ""
+
+        commit_proc = MagicMock()
+        commit_proc.returncode = commit_rc
+        commit_proc.stderr = ""
+
+        mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+        return mock_sp
+
+    def test_scoped_add_excludes_pre_existing_files(self):
+        """Only the file NOT in pre_dispatch_dirty is staged."""
+        pre = {"old_file.py"}
+        status_lines = [" M old_file.py", " M new_file.py"]
+
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"old_file.py", "new_file.py"}):
+            result = _auto_commit_changes("d-001", "T1", pre_dispatch_dirty=pre)
+
+        self.assertTrue(result)
+        add_call = mock_sp.run.call_args_list[1]
+        cmd = add_call[0][0]
+        self.assertIn("--", cmd)
+        self.assertIn("new_file.py", cmd)
+        self.assertNotIn("old_file.py", cmd)
+        # Must NOT be git add -A
+        self.assertNotIn("-A", cmd)
+
+    def test_no_stage_when_all_files_pre_existing(self):
+        """If all dirty files were dirty before the dispatch, nothing is staged."""
+        pre = {"already_dirty.py"}
+        status_lines = [" M already_dirty.py"]
+
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"already_dirty.py"}):
+            result = _auto_commit_changes("d-002", "T1", pre_dispatch_dirty=pre)
+
+        self.assertFalse(result)
+        # git add must NOT have been called
+        for c in mock_sp.run.call_args_list:
+            cmd = c[0][0]
+            self.assertNotEqual(cmd[0:2], ["git", "add"])
+
+    def test_fallback_to_add_all_when_pre_dispatch_dirty_is_none(self):
+        """Without pre_dispatch_dirty, falls back to git add -A (backward compat)."""
+        status_lines = [" M some_file.py"]
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_commit_changes("d-003", "T1", pre_dispatch_dirty=None)
+
+        self.assertTrue(result)
+        add_call = mock_sp.run.call_args_list[1]
+        cmd = add_call[0][0]
+        self.assertIn("-A", cmd)
+
+    def test_returns_false_on_clean_tree(self):
+        """Returns False without calling add/commit when tree is clean."""
+        mock_sp = self._mock_subprocess([])
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_commit_changes("d-004", "T1", pre_dispatch_dirty=set())
+
+        self.assertFalse(result)
+        self.assertEqual(mock_sp.run.call_count, 1)  # only git status
+
+    def test_commit_message_contains_dispatch_id(self):
+        """Commit message includes the dispatch ID."""
+        pre = set()
+        status_lines = [" M foo.py"]
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"foo.py"}):
+            _auto_commit_changes("dispatch-xyz-123", "T2", pre_dispatch_dirty=pre)
+
+        commit_call = mock_sp.run.call_args_list[2]
+        cmd = commit_call[0][0]
+        msg_idx = cmd.index("-m") + 1
+        self.assertIn("dispatch-xyz-123", cmd[msg_idx])
+
+
+# ---------------------------------------------------------------------------
+# _auto_stash_changes — Finding 2
+# ---------------------------------------------------------------------------
+
+class TestAutoStashIsolation(unittest.TestCase):
+    """_auto_stash_changes must use git stash push -u -- <files> scoped to dispatch."""
+
+    def _mock_subprocess(self, status_lines: list[str], stash_rc: int = 0):
+        """Return a mock subprocess module. Calls: status -> stash."""
+        mock_sp = MagicMock()
+
+        status_proc = MagicMock()
+        status_proc.stdout = "\n".join(status_lines)
+        status_proc.returncode = 0
+
+        stash_proc = MagicMock()
+        stash_proc.returncode = stash_rc
+        stash_proc.stderr = ""
+
+        mock_sp.run.side_effect = [status_proc, stash_proc]
+        return mock_sp
+
+    def test_scoped_stash_excludes_pre_existing_files(self):
+        """Only dispatch-specific files are passed to git stash push."""
+        pre = {"pre_existing.py"}
+        status_lines = [" M pre_existing.py", "?? new_untracked.py"]
+
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files",
+                   return_value={"pre_existing.py", "new_untracked.py"}):
+            result = _auto_stash_changes("d-010", "T1", pre_dispatch_dirty=pre)
+
+        self.assertTrue(result)
+        stash_call = mock_sp.run.call_args_list[1]
+        cmd = stash_call[0][0]
+        # Must use git stash push
+        self.assertEqual(cmd[:3], ["git", "stash", "push"])
+        # Must include -u flag
+        self.assertIn("-u", cmd)
+        # Must include the file separator
+        self.assertIn("--", cmd)
+        # Must include the new file
+        self.assertIn("new_untracked.py", cmd)
+        # Must NOT include the pre-existing file
+        self.assertNotIn("pre_existing.py", cmd)
+
+    def test_no_stash_when_all_files_pre_existing(self):
+        """If all dirty files pre-existed the dispatch, nothing is stashed."""
+        pre = {"already_there.py"}
+        status_lines = [" M already_there.py"]
+
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"already_there.py"}):
+            result = _auto_stash_changes("d-011", "T1", pre_dispatch_dirty=pre)
+
+        self.assertFalse(result)
+        # stash must NOT have been called
+        for c in mock_sp.run.call_args_list:
+            cmd = c[0][0]
+            self.assertNotEqual(cmd[:2], ["git", "stash"])
+
+    def test_fallback_uses_stash_push_with_u_flag(self):
+        """Without pre_dispatch_dirty, fallback also uses -u to capture untracked files."""
+        status_lines = [" M some.py"]
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_stash_changes("d-012", "T1", pre_dispatch_dirty=None)
+
+        self.assertTrue(result)
+        stash_call = mock_sp.run.call_args_list[1]
+        cmd = stash_call[0][0]
+        self.assertEqual(cmd[:3], ["git", "stash", "push"])
+        self.assertIn("-u", cmd)
+        # Fallback must NOT use the old 'git stash save' form
+        self.assertNotIn("save", cmd)
+
+    def test_returns_false_on_clean_tree(self):
+        """Returns False without calling stash when tree is clean."""
+        mock_sp = self._mock_subprocess([])
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_stash_changes("d-013", "T1", pre_dispatch_dirty=set())
+
+        self.assertFalse(result)
+        self.assertEqual(mock_sp.run.call_count, 1)  # only git status
+
+    def test_stash_name_contains_dispatch_id(self):
+        """Stash message / name contains the dispatch ID."""
+        pre = set()
+        status_lines = [" M bar.py"]
+        mock_sp = self._mock_subprocess(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"bar.py"}):
+            _auto_stash_changes("dispatch-abc-789", "T3", pre_dispatch_dirty=pre)
+
+        stash_call = mock_sp.run.call_args_list[1]
+        cmd_str = " ".join(stash_call[0][0])
+        self.assertIn("dispatch-abc-789", cmd_str)
+
+
+# ---------------------------------------------------------------------------
+# deliver_with_recovery: pre_dispatch_dirty captured and forwarded
+# ---------------------------------------------------------------------------
+
+class TestDeliverWithRecoveryPreDispatchCapture(unittest.TestCase):
+    """deliver_with_recovery must capture pre_dispatch_dirty and forward to auto_commit/stash."""
+
+    def _make_mock_adapter(self, success: bool = True, returncode: int = 0):
+        adapter = MagicMock()
+        adapter.deliver.return_value = MagicMock(success=success)
+        adapter.read_events_with_timeout.return_value = iter([])
+        obs = MagicMock()
+        obs.transport_state = {"returncode": returncode}
+        adapter.observe.return_value = obs
+        adapter.was_timed_out.return_value = False
+        adapter._get_event_store.return_value = None
+        adapter.get_session_id.return_value = "sess-abc"
+        adapter.trigger_report_pipeline.return_value = None
+        return adapter
+
+    def test_pre_dispatch_dirty_forwarded_to_auto_commit_on_success(self):
+        """On success path, _auto_commit_changes receives the pre-dispatch dirty set."""
+        fake_pre_dirty = {"existing_file.py"}
+
+        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch._write_receipt") as mock_receipt, \
+             patch("subprocess_dispatch._check_commit_since", return_value=True), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=fake_pre_dirty) as mock_gdf, \
+             patch("subprocess_dispatch._auto_commit_changes", return_value=True) as mock_ac, \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor_cls:
+
+            mock_cls.return_value = self._make_mock_adapter(success=True)
+            monitor = MagicMock()
+            monitor.stuck_count = 0
+            monitor.mark_completed = MagicMock()
+            mock_monitor_cls.return_value = monitor
+            mock_receipt.return_value = Path("/tmp/r.ndjson")
+
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "do work", "sonnet", "dispatch-fwd-01",
+                max_retries=0, auto_commit=True,
+            )
+
+        mock_ac.assert_called_once()
+        _, kwargs = mock_ac.call_args
+        self.assertEqual(
+            kwargs.get("pre_dispatch_dirty"), fake_pre_dirty,
+            "deliver_with_recovery must forward pre_dispatch_dirty to _auto_commit_changes",
+        )
+
+    def test_pre_dispatch_dirty_forwarded_to_auto_stash_on_failure(self):
+        """On failure path, _auto_stash_changes receives the pre-dispatch dirty set."""
+        fake_pre_dirty = {"other_terminal_work.py"}
+
+        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch._write_receipt") as mock_receipt, \
+             patch("subprocess_dispatch._check_commit_since", return_value=False), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=fake_pre_dirty), \
+             patch("subprocess_dispatch._auto_stash_changes", return_value=False) as mock_stash, \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor_cls:
+
+            failed_adapter = MagicMock()
+            failed_adapter.deliver.return_value = MagicMock(success=False)
+            failed_adapter._get_event_store.return_value = None
+            failed_adapter.trigger_report_pipeline.return_value = None
+            mock_cls.return_value = failed_adapter
+
+            monitor = MagicMock()
+            monitor.stuck_count = 0
+            monitor.mark_completed = MagicMock()
+            mock_monitor_cls.return_value = monitor
+            mock_receipt.return_value = Path("/tmp/r.ndjson")
+
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "do work", "sonnet", "dispatch-fwd-02",
+                max_retries=0, auto_commit=True,
+            )
+
+        mock_stash.assert_called_once()
+        _, kwargs = mock_stash.call_args
+        self.assertEqual(
+            kwargs.get("pre_dispatch_dirty"), fake_pre_dirty,
+            "deliver_with_recovery must forward pre_dispatch_dirty to _auto_stash_changes",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auto_commit_stash_isolation.py
+++ b/tests/test_auto_commit_stash_isolation.py
@@ -130,17 +130,18 @@ class TestAutoCommitIsolation(unittest.TestCase):
             cmd = c[0][0]
             self.assertNotEqual(cmd[0:2], ["git", "add"])
 
-    def test_fallback_to_add_all_when_pre_dispatch_dirty_is_none(self):
-        """Without pre_dispatch_dirty, falls back to git add -A (backward compat)."""
+    def test_refuses_to_commit_when_pre_dispatch_dirty_is_none(self):
+        """Codex round-2 finding 1: when pre_dispatch_dirty is None, refuse to commit
+        rather than fall back to git add -A — that would sweep unrelated user changes
+        in a dirty or shared worktree, breaking dispatch isolation."""
         status_lines = [" M some_file.py"]
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp):
             result = _auto_commit_changes("d-003", "T1", pre_dispatch_dirty=None)
 
-        self.assertTrue(result)
-        add_call = mock_sp.run.call_args_list[1]
-        cmd = add_call[0][0]
-        self.assertIn("-A", cmd)
+        self.assertFalse(result)
+        # No git command must have been invoked at all — fail-safe before any git work.
+        self.assertEqual(mock_sp.run.call_count, 0)
 
     def test_returns_false_on_clean_tree(self):
         """Returns False without calling add/commit when tree is clean."""
@@ -229,20 +230,18 @@ class TestAutoStashIsolation(unittest.TestCase):
             cmd = c[0][0]
             self.assertNotEqual(cmd[:2], ["git", "stash"])
 
-    def test_fallback_uses_stash_push_with_u_flag(self):
-        """Without pre_dispatch_dirty, fallback also uses -u to capture untracked files."""
+    def test_refuses_to_stash_when_pre_dispatch_dirty_is_none(self):
+        """Codex round-2 finding 1: when pre_dispatch_dirty is None, refuse to stash
+        rather than running ``git stash push -u`` over the whole repo — that would
+        hide unrelated edits from other terminals into this dispatch's stash."""
         status_lines = [" M some.py"]
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp):
             result = _auto_stash_changes("d-012", "T1", pre_dispatch_dirty=None)
 
-        self.assertTrue(result)
-        stash_call = mock_sp.run.call_args_list[1]
-        cmd = stash_call[0][0]
-        self.assertEqual(cmd[:3], ["git", "stash", "push"])
-        self.assertIn("-u", cmd)
-        # Fallback must NOT use the old 'git stash save' form
-        self.assertNotIn("save", cmd)
+        self.assertFalse(result)
+        # No git command must have been invoked — fail-safe before any git work.
+        self.assertEqual(mock_sp.run.call_count, 0)
 
     def test_returns_false_on_clean_tree(self):
         """Returns False without calling stash when tree is clean."""

--- a/tests/test_subprocess_dispatch_round2_codex.py
+++ b/tests/test_subprocess_dispatch_round2_codex.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Regression tests for codex regate round-2 findings on PR #310.
+
+Finding 1 — _auto_commit_changes / _auto_stash_changes must not sweep the whole
+repository. When pre_dispatch_dirty is None they must refuse the operation
+(fail-safe) instead of falling back to ``git add -A`` / ``git stash push -u``
+without a file scope. The detailed assertions live alongside the round-1 tests
+in ``test_auto_commit_stash_isolation.py``; the tests here cover the higher-
+level invariant that no git command runs in the None-scope path.
+
+Finding 2 — deliver_via_subprocess must NOT persist the session_id for resume
+when the subprocess failed (non-zero returncode) or was timeout-killed. With
+``VNX_SESSION_RESUME=1`` the next dispatch would otherwise resume a poisoned
+conversation state.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch  # noqa: E402
+from subprocess_dispatch import _auto_commit_changes, _auto_stash_changes  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — fail-safe when pre_dispatch_dirty is None
+# ---------------------------------------------------------------------------
+
+
+class TestFailSafeWhenScopeUnknown(unittest.TestCase):
+    """Both helpers must refuse to operate when the dispatch-owned file scope
+    is unknown — never run ``git add -A`` or ``git stash push -u`` over the
+    whole repository, which would corrupt dispatch isolation in shared
+    worktrees."""
+
+    def test_auto_commit_runs_no_git_when_scope_none(self):
+        mock_sp = MagicMock()
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_commit_changes("d-r2-1", "T1", pre_dispatch_dirty=None)
+        self.assertFalse(result)
+        self.assertFalse(
+            mock_sp.run.called,
+            "no git command may run when pre_dispatch_dirty is None",
+        )
+
+    def test_auto_stash_runs_no_git_when_scope_none(self):
+        mock_sp = MagicMock()
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_stash_changes("d-r2-2", "T1", pre_dispatch_dirty=None)
+        self.assertFalse(result)
+        self.assertFalse(
+            mock_sp.run.called,
+            "no git command may run when pre_dispatch_dirty is None",
+        )
+
+    def test_auto_commit_empty_scope_still_uses_explicit_paths(self):
+        """An empty scope (set()) is allowed and means: stage every currently-
+        dirty file by explicit path — never via ``git add -A``."""
+        status_proc = MagicMock()
+        status_proc.stdout = " M only_new.py\n"
+        status_proc.returncode = 0
+        add_proc = MagicMock(returncode=0, stderr="")
+        commit_proc = MagicMock(returncode=0, stderr="")
+
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"only_new.py"}):
+            result = _auto_commit_changes("d-r2-3", "T1", pre_dispatch_dirty=set())
+
+        self.assertTrue(result)
+        add_cmd = mock_sp.run.call_args_list[1][0][0]
+        self.assertIn("--", add_cmd)
+        self.assertIn("only_new.py", add_cmd)
+        self.assertNotIn("-A", add_cmd)
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — session_id must not be saved on failure / timeout
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(returncode: int, was_timed_out: bool = False,
+                  session_id: str | None = "post-failure-session"):
+    """Build a SubprocessAdapter mock for deliver_via_subprocess unit tests."""
+    deliver_result = MagicMock()
+    deliver_result.success = True
+
+    obs_result = MagicMock()
+    obs_result.transport_state = {"returncode": returncode}
+
+    adapter = MagicMock()
+    adapter.deliver.return_value = deliver_result
+    adapter.read_events_with_timeout.return_value = iter([])
+    adapter.get_session_id.return_value = session_id
+    adapter.observe.return_value = obs_result
+    adapter.was_timed_out.return_value = was_timed_out
+    adapter._get_event_store.return_value = None
+    adapter.trigger_report_pipeline.return_value = None
+    return adapter
+
+
+def _common_patches():
+    """Patch the helpers that aren't relevant to session-save ordering."""
+    return [
+        patch("subprocess_dispatch._inject_skill_context", return_value="instr"),
+        patch("subprocess_dispatch._inject_permission_profile", return_value="instr"),
+        patch("subprocess_dispatch._resolve_agent_cwd", return_value=None),
+        patch("subprocess_dispatch._write_manifest", return_value="/tmp/m.json"),
+        patch("subprocess_dispatch._promote_manifest", return_value="/tmp/done.json"),
+        patch("subprocess_dispatch._capture_dispatch_parameters"),
+        patch("subprocess_dispatch._capture_dispatch_outcome"),
+    ]
+
+
+class TestSessionIdNotSavedOnFailureOrTimeout(unittest.TestCase):
+    """deliver_via_subprocess must save session_id only after all fail-closed
+    checks have passed.  Otherwise a subsequent VNX_SESSION_RESUME=1 dispatch
+    will resume a failed/timed-out conversation."""
+
+    def test_session_id_not_saved_when_returncode_nonzero(self):
+        store = MagicMock()
+        adapter = _make_adapter(returncode=1)
+
+        cms = _common_patches() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+            patch("session_store.SessionStore", return_value=store),
+            patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-fail",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+
+        self.assertFalse(result.success)
+        # Session_id is captured in the result for diagnostics, but must NOT be
+        # persisted to the SessionStore for resume.
+        self.assertFalse(
+            store.save.called,
+            "session must not be saved when subprocess exited non-zero",
+        )
+
+    def test_session_id_not_saved_when_timed_out(self):
+        store = MagicMock()
+        # Timeout path: returncode is None because stop() removed the process
+        # from the adapter; was_timed_out() is the authoritative signal.
+        adapter = _make_adapter(returncode=None, was_timed_out=True)
+
+        cms = _common_patches() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+            patch("session_store.SessionStore", return_value=store),
+            patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-timeout",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+
+        self.assertFalse(result.success)
+        self.assertFalse(
+            store.save.called,
+            "session must not be saved when dispatch was killed by timeout",
+        )
+
+    def test_session_id_saved_only_on_clean_success(self):
+        """Sanity: the success path still persists the session_id when
+        VNX_SESSION_RESUME=1, so we know the move did not break the feature."""
+        store = MagicMock()
+        adapter = _make_adapter(returncode=0, was_timed_out=False,
+                                session_id="fresh-success-session")
+
+        cms = _common_patches() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+            patch("session_store.SessionStore", return_value=store),
+            patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-ok",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+
+        self.assertTrue(result.success)
+        store.save.assert_called_once()
+        args, kwargs = store.save.call_args
+        # Save signature: save(terminal_id, session_id, dispatch_id=...)
+        self.assertEqual(args[0], "T1")
+        self.assertEqual(args[1], "fresh-success-session")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subprocess_dispatch_stuck_count.py
+++ b/tests/test_subprocess_dispatch_stuck_count.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Tests for T5-PR4: stuck_event_count forwarding in subprocess_dispatch.
+
+Verifies that:
+  - _write_receipt includes stuck_event_count=N when N > 0
+  - _write_receipt omits stuck_event_count when 0
+  - deliver_with_recovery forwards monitor.stuck_count to _write_receipt
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch
+from subprocess_dispatch import _write_receipt
+
+
+class TestWriteReceiptStuckEventCount(unittest.TestCase):
+    """Direct unit tests for _write_receipt stuck_event_count field."""
+
+    def _call_write_receipt_bare(self, stuck_event_count: int) -> dict:
+        """Call _write_receipt using the bare-write fallback path and return the parsed receipt."""
+        captured = {}
+
+        def fake_open(path, mode="r", **kwargs):
+            import io
+            buf = io.StringIO()
+
+            class _Ctx:
+                def __enter__(self_inner):
+                    return buf
+
+                def __exit__(self_inner, *_):
+                    captured["raw"] = buf.getvalue()
+
+            return _Ctx()
+
+        # Force the fallback path by making append_receipt_payload raise ImportError
+        with patch.dict("sys.modules", {"append_receipt": None}):
+            with patch("subprocess_dispatch._default_state_dir") as mock_state_dir:
+                tmpdir = Path(tempfile.mkdtemp())
+                mock_state_dir.return_value = tmpdir
+                _write_receipt(
+                    "dispatch-rc-test",
+                    "T1",
+                    "done",
+                    stuck_event_count=stuck_event_count,
+                )
+                receipt_file = tmpdir / "t0_receipts.ndjson"
+                if receipt_file.exists():
+                    raw = receipt_file.read_text().strip()
+                    return json.loads(raw)
+        return {}
+
+    def test_stuck_event_count_present_when_nonzero(self):
+        receipt = self._call_write_receipt_bare(stuck_event_count=3)
+        self.assertIn("stuck_event_count", receipt, "stuck_event_count must appear in receipt when N>0")
+        self.assertEqual(receipt["stuck_event_count"], 3)
+
+    def test_stuck_event_count_absent_when_zero(self):
+        receipt = self._call_write_receipt_bare(stuck_event_count=0)
+        self.assertNotIn(
+            "stuck_event_count", receipt,
+            "stuck_event_count must NOT appear in receipt when 0",
+        )
+
+    def test_stuck_event_count_one(self):
+        receipt = self._call_write_receipt_bare(stuck_event_count=1)
+        self.assertEqual(receipt.get("stuck_event_count"), 1)
+
+    def test_receipt_has_required_fields(self):
+        receipt = self._call_write_receipt_bare(stuck_event_count=2)
+        for field in ("dispatch_id", "terminal", "status", "event_count", "source"):
+            self.assertIn(field, receipt, f"receipt missing required field: {field}")
+        self.assertEqual(receipt["dispatch_id"], "dispatch-rc-test")
+        self.assertEqual(receipt["terminal"], "T1")
+        self.assertEqual(receipt["status"], "done")
+
+
+class TestDeliverWithRecoveryStuckCount(unittest.TestCase):
+    """Integration tests: deliver_with_recovery forwards stuck_count to _write_receipt."""
+
+    def _make_mock_adapter(self, events=None, returncode=0):
+        """Build a fully mocked SubprocessAdapter."""
+        adapter = MagicMock()
+        adapter.deliver.return_value = MagicMock(success=True)
+        adapter.read_events_with_timeout.return_value = iter(events or [])
+        obs = MagicMock()
+        obs.transport_state = {"returncode": returncode}
+        adapter.observe.return_value = obs
+        adapter.was_timed_out.return_value = False
+        adapter._get_event_store.return_value = None
+        adapter.get_session_id.return_value = "sess-x"
+        adapter.trigger_report_pipeline.return_value = None
+        return adapter
+
+    def test_stuck_count_forwarded_to_write_receipt_on_success(self):
+        """On success, _write_receipt receives stuck_event_count from monitor.stuck_count."""
+        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch._write_receipt") as mock_receipt, \
+             patch("subprocess_dispatch._check_commit_since", return_value=False), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor_cls:
+
+            mock_adapter = self._make_mock_adapter(events=[MagicMock(type="text")])
+            mock_cls.return_value = mock_adapter
+
+            monitor = MagicMock()
+            monitor.stuck_count = 5
+            monitor.mark_completed = MagicMock()
+            mock_monitor_cls.return_value = monitor
+
+            mock_receipt.return_value = Path("/tmp/fake_receipt.ndjson")
+
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "run task", "sonnet", "dispatch-sc-01",
+                max_retries=0,
+                auto_commit=False,
+            )
+
+            mock_receipt.assert_called_once()
+            _, kwargs = mock_receipt.call_args
+            self.assertEqual(
+                kwargs.get("stuck_event_count"), 5,
+                "deliver_with_recovery must forward monitor.stuck_count as stuck_event_count",
+            )
+
+    def test_stuck_count_zero_forwarded_on_success(self):
+        """Zero stuck_count is correctly forwarded (no STUCK events occurred)."""
+        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch._write_receipt") as mock_receipt, \
+             patch("subprocess_dispatch._check_commit_since", return_value=False), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor_cls:
+
+            mock_adapter = self._make_mock_adapter()
+            mock_cls.return_value = mock_adapter
+
+            monitor = MagicMock()
+            monitor.stuck_count = 0
+            monitor.mark_completed = MagicMock()
+            mock_monitor_cls.return_value = monitor
+
+            mock_receipt.return_value = Path("/tmp/fake_receipt.ndjson")
+
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "run task", "sonnet", "dispatch-sc-02",
+                max_retries=0,
+                auto_commit=False,
+            )
+
+            _, kwargs = mock_receipt.call_args
+            self.assertEqual(kwargs.get("stuck_event_count"), 0)
+
+    def test_stuck_count_forwarded_on_failure(self):
+        """On final failure, stuck_count is still forwarded to the failure receipt."""
+        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch._write_receipt") as mock_receipt, \
+             patch("subprocess_dispatch._check_commit_since", return_value=False), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor_cls, \
+             patch("subprocess_dispatch._auto_stash_changes", return_value=False):
+
+            failed_adapter = MagicMock()
+            failed_adapter.deliver.return_value = MagicMock(success=False)
+            failed_adapter._get_event_store.return_value = None
+            failed_adapter.trigger_report_pipeline.return_value = None
+            mock_cls.return_value = failed_adapter
+
+            monitor = MagicMock()
+            monitor.stuck_count = 2
+            monitor.mark_completed = MagicMock()
+            mock_monitor_cls.return_value = monitor
+
+            mock_receipt.return_value = Path("/tmp/fake_receipt.ndjson")
+
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "run task", "sonnet", "dispatch-sc-03",
+                max_retries=0,
+                auto_commit=True,
+            )
+
+            mock_receipt.assert_called_once()
+            _, kwargs = mock_receipt.call_args
+            self.assertEqual(
+                kwargs.get("stuck_event_count"), 2,
+                "Failed-dispatch receipt must also carry stuck_event_count",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worker_health_eventstore.py
+++ b/tests/test_worker_health_eventstore.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Tests for T5-PR4: WorkerHealthMonitor → EventStore integration.
+
+Gate: t5-pr4-worker-health-eventstore
+Covers:
+  - Case A: stuck transition → event_store.append called with type=worker_stuck, correct fields
+  - Case B: NOT stuck → no event_store call
+  - Case C: multiple stuck transitions → counter increments, multiple events appended
+  - Case D: event_store None → only logger.warning, no crash
+  - Case E: receipt includes stuck_event_count (0 when no stuck, N when N stuck events)
+"""
+
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from worker_health_monitor import (
+    WorkerHealthMonitor,
+    HealthStatus,
+    SLOW_THRESHOLD,
+)
+
+
+def _force_stuck(monitor: WorkerHealthMonitor) -> None:
+    """Force the monitor into STUCK status by backdating last_event_time."""
+    with monitor._lock:
+        monitor._last_event_time = time.monotonic() - (SLOW_THRESHOLD + 10)
+
+
+class TestCaseA_StuckTransitionPersistsToEventStore(unittest.TestCase):
+    """Case A: stuck transition → event_store.append called with correct fields."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._events_dir = Path(self._tmpdir) / "events"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_event_store_append_called_on_stuck(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-A1",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+
+        stuck_log = self._events_dir / "worker_stuck.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        mock_store.append.assert_called_once()
+        args, kwargs = mock_store.append.call_args
+        terminal_arg = args[0]
+        event_arg = args[1]
+        self.assertEqual(terminal_arg, "T1")
+        self.assertEqual(event_arg["type"], "worker_stuck")
+        self.assertEqual(event_arg["dispatch_id"], "dispatch-A1")
+        self.assertIn("elapsed_secs", event_arg)
+        self.assertIn("last_event_type", event_arg)
+        self.assertEqual(kwargs.get("dispatch_id"), "dispatch-A1")
+
+    def test_event_store_receives_last_event_type(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-A2",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        monitor.update({"type": "tool_use", "data": {"name": "Edit"}})
+        _force_stuck(monitor)
+
+        stuck_log = self._events_dir / "worker_stuck_a2.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        _, call_args = mock_store.append.call_args
+        event_arg = mock_store.append.call_args[0][1]
+        self.assertEqual(event_arg["last_event_type"], "tool_use")
+
+    def test_elapsed_secs_is_positive(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-A3",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+
+        stuck_log = self._events_dir / "worker_stuck_a3.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        event_arg = mock_store.append.call_args[0][1]
+        self.assertGreater(event_arg["elapsed_secs"], 0)
+
+
+class TestCaseB_NotStuckNoEventStoreCall(unittest.TestCase):
+    """Case B: NOT stuck → no event_store call."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._events_dir = Path(self._tmpdir) / "events"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_no_append_when_active(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-B1",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        monitor.update({"type": "text", "data": {}})  # recent event → ACTIVE
+
+        stuck_log = self._events_dir / "worker_stuck_b1.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        mock_store.append.assert_not_called()
+        self.assertFalse(stuck_log.exists())
+
+    def test_no_append_when_slow_not_stuck(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-B2",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        with monitor._lock:
+            # 90s silence → SLOW (not STUCK)
+            from worker_health_monitor import ACTIVE_THRESHOLD
+            monitor._last_event_time = time.monotonic() - (ACTIVE_THRESHOLD + 30)
+
+        stuck_log = self._events_dir / "worker_stuck_b2.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        mock_store.append.assert_not_called()
+
+
+class TestCaseC_MultipleStuckTransitions(unittest.TestCase):
+    """Case C: multiple stuck transitions → counter increments, multiple events appended."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._events_dir = Path(self._tmpdir) / "events"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_stuck_count_increments_each_call(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-C1",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_c1.ndjson"
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        self.assertEqual(monitor.stuck_count, 1)
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        self.assertEqual(monitor.stuck_count, 2)
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        self.assertEqual(monitor.stuck_count, 3)
+
+    def test_event_store_append_called_for_each_stuck_transition(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-C2",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_c2.ndjson"
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        self.assertEqual(mock_store.append.call_count, 3)
+
+    def test_ndjson_log_has_multiple_entries(self):
+        import json
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-C3",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_c3.ndjson"
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        lines = [l for l in stuck_log.read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            entry = json.loads(line)
+            self.assertEqual(entry["dispatch_id"], "dispatch-C3")
+
+
+class TestCaseD_EventStoreNone(unittest.TestCase):
+    """Case D: event_store None → only logger.warning, no crash."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._events_dir = Path(self._tmpdir) / "events"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_no_crash_when_event_store_is_none(self):
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-D1",
+            events_dir=self._events_dir,
+            event_store=None,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+
+        stuck_log = self._events_dir / "worker_stuck_d1.ndjson"
+        # Must not raise
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        self.assertTrue(stuck_log.exists())
+        self.assertEqual(monitor.stuck_count, 1)
+
+    def test_warning_logged_when_event_store_none(self):
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-D2",
+            events_dir=self._events_dir,
+            event_store=None,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_d2.ndjson"
+
+        with patch("worker_health_monitor.logger") as mock_logger:
+            monitor.log_stuck_event(stuck_log_path=stuck_log)
+            mock_logger.warning.assert_called_once()
+
+    def test_stuck_count_increments_even_without_event_store(self):
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-D3",
+            events_dir=self._events_dir,
+            event_store=None,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_d3.ndjson"
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        self.assertEqual(monitor.stuck_count, 2)
+
+
+class TestCaseE_StuckCountOnReceipt(unittest.TestCase):
+    """Case E: stuck_count accessor returns correct values."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._events_dir = Path(self._tmpdir) / "events"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_stuck_count_zero_when_no_stuck_events(self):
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-E1",
+            events_dir=self._events_dir,
+        )
+        monitor.stop()
+        monitor.update({"type": "text", "data": {}})
+
+        self.assertEqual(monitor.stuck_count, 0)
+
+    def test_stuck_count_reflects_n_stuck_transitions(self):
+        mock_store = MagicMock()
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-E2",
+            events_dir=self._events_dir,
+            event_store=mock_store,
+        )
+        monitor.stop()
+        _force_stuck(monitor)
+        stuck_log = self._events_dir / "worker_stuck_e2.ndjson"
+
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+        monitor.log_stuck_event(stuck_log_path=stuck_log)
+
+        self.assertEqual(monitor.stuck_count, 2)
+
+    def test_stuck_count_not_incremented_by_non_stuck_log_call(self):
+        monitor = WorkerHealthMonitor(
+            "T1", "dispatch-E3",
+            events_dir=self._events_dir,
+        )
+        monitor.stop()
+        monitor.update({"type": "text", "data": {}})  # ACTIVE
+
+        stuck_log = self._events_dir / "worker_stuck_e3.ndjson"
+        monitor.log_stuck_event(stuck_log_path=stuck_log)  # ACTIVE → early return
+
+        self.assertEqual(monitor.stuck_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes observability **GAP-2**: STUCK detection events from `WorkerHealthMonitor` were previously only emitted as `logger.warning` — no durable NDJSON record, meaning operators could not distinguish a slow-but-progressing worker from a fully deadlocked one in the audit trail.

**Before:** `log_stuck_event()` wrote to `worker_stuck.ndjson` and logged a warning. Nothing reached EventStore or receipts.

**After:**
- `log_stuck_event()` also calls `event_store.append(terminal_id, {type: worker_stuck, elapsed_secs, dispatch_id, last_event_type})` — fully backward-compatible (no-op when `event_store=None`)
- `WorkerHealthMonitor` gains a `stuck_count` property (thread-safe) tracking total STUCK transitions per dispatch
- `_write_receipt` accepts `stuck_event_count` and writes it to the receipt payload when non-zero
- `deliver_with_recovery` forwards `monitor.stuck_count` into both success and failure receipts
- `deliver_via_subprocess` wires the adapter's event_store into the health monitor after `adapter.deliver()` completes

## Files changed

| File | Change |
|---|---|
| `scripts/lib/worker_health_monitor.py` | `event_store` constructor param, `stuck_count` property, `_stuck_count` increment, EventStore append in `log_stuck_event` |
| `scripts/lib/subprocess_dispatch.py` | event_store wiring, `stuck_event_count` param in `_write_receipt`, forwarding in `deliver_with_recovery` |
| `tests/test_worker_health_eventstore.py` | 14 tests: Cases A–E (stuck→append, not-stuck→no-call, multi-stuck counter, None store no-crash, count accessor) |
| `tests/test_subprocess_dispatch_stuck_count.py` | 7 tests: receipt field presence/absence, `deliver_with_recovery` forwarding on success and failure |

## Test plan

- [x] `python3 -m py_compile scripts/lib/worker_health_monitor.py scripts/lib/subprocess_dispatch.py scripts/lib/event_store.py` → OK
- [x] `pytest tests/test_worker_health_eventstore.py tests/test_subprocess_dispatch_stuck_count.py -xvs` → 21 passed
- [x] `pytest tests/test_worker_health_eventstore.py tests/test_subprocess_dispatch_stuck_count.py tests/test_worker_health.py tests/test_subprocess_dispatch.py tests/test_event_store.py -v` → 62 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)