### PR TITLE
fix(governance): dedup confidence updates after VNX-R4 (Tier 4)

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -468,24 +468,39 @@ class IntelligenceSelector:
         Uses item_id as pattern_id, item title as pattern_title, and dispatch_id
         from result.  Only writes for proven_pattern items (sourced from
         success_patterns); other item classes are noted with a class prefix title.
+
+        dispatch_id is recorded in the separate dispatch_pattern_offered junction table
+        (one row per dispatch+pattern pair) rather than in pattern_usage.dispatch_id, so
+        that concurrent dispatches offering the same pattern do not overwrite each other's
+        dispatch association.
         """
         db = self._get_quality_db()
         if db is None:
             return
         now = _now_utc()
         try:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+                    dispatch_id   TEXT NOT NULL,
+                    pattern_id    TEXT NOT NULL,
+                    pattern_title TEXT NOT NULL,
+                    offered_at    TEXT NOT NULL,
+                    PRIMARY KEY (dispatch_id, pattern_id)
+                )
+                """
+            )
             for item in result.items:
                 db.execute(
                     """
                     INSERT INTO pattern_usage
                         (pattern_id, pattern_title, pattern_hash, used_count,
                          ignored_count, success_count, failure_count,
-                         last_offered, confidence, created_at, updated_at, dispatch_id)
-                    VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?, ?)
+                         last_offered, confidence, created_at, updated_at)
+                    VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?)
                     ON CONFLICT(pattern_id) DO UPDATE SET
                         last_offered = excluded.last_offered,
-                        updated_at   = excluded.updated_at,
-                        dispatch_id  = excluded.dispatch_id
+                        updated_at   = excluded.updated_at
                     """,
                     (
                         item.item_id,
@@ -495,8 +510,17 @@ class IntelligenceSelector:
                         item.confidence,
                         now,
                         now,
-                        result.dispatch_id,
                     ),
+                )
+                db.execute(
+                    """
+                    INSERT INTO dispatch_pattern_offered
+                        (dispatch_id, pattern_id, pattern_title, offered_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET
+                        offered_at = excluded.offered_at
+                    """,
+                    (result.dispatch_id, item.item_id, item.title[:255], now),
                 )
             db.commit()
         except Exception:

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -189,8 +189,27 @@ def _new_id() -> str:
     return str(uuid.uuid4())
 
 
-def _item_id() -> str:
-    return f"intel_{uuid.uuid4().hex[:12]}"
+def _stable_item_id(prefix: str, source_key: str) -> str:
+    """Build a deterministic, content-derived item_id.
+
+    Patterns offered to multiple dispatches must share the SAME item_id so that
+    pattern_usage rows aggregate (one row per underlying pattern) instead of
+    fragmenting into a fresh row per offering.  Random UUIDs broke that
+    invariant — see codex regate finding for PR #311.
+
+    The id encodes the originating table via *prefix* (e.g. ``sp`` for
+    success_patterns, ``ap`` for antipatterns, ``pr`` for prevention_rules,
+    ``dm`` for dispatch_metadata) and a stable per-row key (the row PK or
+    dispatch_id).
+    """
+    safe_key = str(source_key).strip().lower().replace(" ", "_")
+    return f"intel_{prefix}_{safe_key}"
+
+
+def _item_hash(item_id: str) -> str:
+    """SHA1 of item_id, matching learning_loop.hash_pattern() convention."""
+    import hashlib
+    return hashlib.sha1(item_id.encode("utf-8")).hexdigest()
 
 
 def resolve_task_class(
@@ -465,14 +484,20 @@ class IntelligenceSelector:
     def _record_pattern_usage(self, result: InjectionResult) -> None:
         """Write one pattern_usage row per injected item so feedback can find them later.
 
-        Uses item_id as pattern_id, item title as pattern_title, and dispatch_id
-        from result.  Only writes for proven_pattern items (sourced from
-        success_patterns); other item classes are noted with a class prefix title.
+        Identity model:
+          - ``pattern_id`` is the *stable* per-pattern id derived from the
+            originating row (see :func:`_stable_item_id`).  The same pattern
+            offered to multiple dispatches collapses onto the same row via
+            ON CONFLICT(pattern_id) DO UPDATE.  This restores deduplication —
+            random ids fragmented one underlying pattern across many rows.
+          - ``pattern_hash`` is SHA1(item_id), following the convention used by
+            ``learning_loop.hash_pattern``.  Hash and pattern_id must NOT be
+            the same string; consumers may rely on the hash to detect
+            content-level identity independently of the id.
 
-        dispatch_id is recorded in the separate dispatch_pattern_offered junction table
-        (one row per dispatch+pattern pair) rather than in pattern_usage.dispatch_id, so
-        that concurrent dispatches offering the same pattern do not overwrite each other's
-        dispatch association.
+        Per-dispatch attribution is recorded in the ``dispatch_pattern_offered``
+        junction table (one row per dispatch+pattern pair) so that concurrent
+        dispatches offering the same pattern do not overwrite each other.
         """
         db = self._get_quality_db()
         if db is None:
@@ -491,6 +516,7 @@ class IntelligenceSelector:
                 """
             )
             for item in result.items:
+                pattern_hash = _item_hash(item.item_id)
                 db.execute(
                     """
                     INSERT INTO pattern_usage
@@ -499,13 +525,15 @@ class IntelligenceSelector:
                          last_offered, confidence, created_at, updated_at)
                     VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?)
                     ON CONFLICT(pattern_id) DO UPDATE SET
-                        last_offered = excluded.last_offered,
-                        updated_at   = excluded.updated_at
+                        pattern_title = excluded.pattern_title,
+                        pattern_hash  = excluded.pattern_hash,
+                        last_offered  = excluded.last_offered,
+                        updated_at    = excluded.updated_at
                     """,
                     (
                         item.item_id,
                         item.title[:255],
-                        item.item_id,   # hash = item_id for injected items
+                        pattern_hash,
                         now,
                         item.confidence,
                         now,
@@ -592,7 +620,7 @@ class IntelligenceSelector:
             last_seen = row_d.get("last_used") or row_d.get("first_seen") or _now_utc()
 
             items.append(IntelligenceItem(
-                item_id=_item_id(),
+                item_id=_stable_item_id("sp", str(row_d.get("id", ""))),
                 item_class="proven_pattern",
                 title=(row_d.get("title") or "Proven pattern")[:120],
                 content=content,
@@ -661,7 +689,7 @@ class IntelligenceSelector:
             confidence = severity_confidence.get(severity, 0.5)
 
             items.append(IntelligenceItem(
-                item_id=_item_id(),
+                item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
                 item_class="failure_prevention",
                 title=(row_d.get("title") or "Failure prevention")[:120],
                 content=content,
@@ -699,7 +727,7 @@ class IntelligenceSelector:
             content = (row_d.get("recommendation") or row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
 
             items.append(IntelligenceItem(
-                item_id=_item_id(),
+                item_id=_stable_item_id("pr", str(row_d.get("id", ""))),
                 item_class="failure_prevention",
                 title=(row_d.get("description") or "Prevention rule")[:120],
                 content=content,
@@ -767,7 +795,7 @@ class IntelligenceSelector:
             confidence = 0.7 if outcome == "success" else 0.45
 
             items.append(IntelligenceItem(
-                item_id=_item_id(),
+                item_id=_stable_item_id("dm", str(row_d.get("dispatch_id", ""))),
                 item_class="recent_comparable",
                 title=f"Recent: {skill} dispatch ({outcome})"[:120],
                 content=content,

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -351,6 +351,19 @@ def _extract_touched_paths_from_event(event: "StreamEvent | object") -> list[str
     return paths
 
 
+def _parse_dirty_files(porcelain_output: str) -> frozenset:
+    """Parse 'git status --porcelain' output into a frozenset of relative file paths."""
+    files: set[str] = set()
+    for line in porcelain_output.splitlines():
+        if not line.strip():
+            continue
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ", 1)[1]
+        files.add(path_part.strip())
+    return frozenset(files)
+
+
 def _get_dirty_files(cwd: Path) -> set[str]:
     """Return the set of dirty (modified/untracked) file paths from git status --porcelain.
 

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -1362,16 +1362,12 @@ def deliver_with_recovery(
             )
 
             # Feedback loop: boost pattern confidence for successful dispatch
+            # update_confidence_from_outcome is handled by append_receipt_payload (VNX-R4)
             _quality_db = _default_state_dir() / "quality_intelligence.db"
             _patt_updated = _update_pattern_confidence(dispatch_id, "success", _quality_db)
             logger.debug(
                 "Feedback boost: dispatch=%s patterns_updated=%d", dispatch_id, _patt_updated
             )
-            try:
-                from intelligence_persist import update_confidence_from_outcome as _upcf
-                _upcf(_quality_db, dispatch_id, terminal_id, "success")
-            except Exception as _exc:
-                logger.debug("update_confidence_from_outcome(success) failed: %s", _exc)
 
             # Capture outcome after receipt is written
             _capture_dispatch_outcome(
@@ -1423,16 +1419,12 @@ def deliver_with_recovery(
             )
 
             # Feedback loop: decay pattern confidence for failed dispatch
+            # update_confidence_from_outcome is handled by append_receipt_payload (VNX-R4)
             _quality_db = _default_state_dir() / "quality_intelligence.db"
             _patt_updated = _update_pattern_confidence(dispatch_id, "failure", _quality_db)
             logger.debug(
                 "Feedback decay: dispatch=%s patterns_updated=%d", dispatch_id, _patt_updated
             )
-            try:
-                from intelligence_persist import update_confidence_from_outcome as _upcf
-                _upcf(_quality_db, dispatch_id, terminal_id, "failure")
-            except Exception as _exc:
-                logger.debug("update_confidence_from_outcome(failure) failed: %s", _exc)
 
             # Capture failed outcome
             _capture_dispatch_outcome(

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -995,8 +995,9 @@ def _auto_stash_changes(
         )
         if stash_proc.returncode == 0:
             logger.info(
-                "Stashed uncommitted changes from failed dispatch %s (terminal=%s, stash=%s)",
-                dispatch_id, terminal_id, stash_name,
+                "Stashed %d dispatch-produced file(s) from failed dispatch %s "
+                "(terminal=%s, stash=%s)",
+                len(files_to_stash), dispatch_id, terminal_id, stash_name,
             )
             return True
         else:
@@ -1197,10 +1198,26 @@ def _update_pattern_confidence(
         conn = _sqlite3.connect(str(db_path))
         conn.row_factory = _sqlite3.Row
 
-        injected = conn.execute(
-            "SELECT pattern_id, pattern_title FROM pattern_usage WHERE dispatch_id = ?",
-            (dispatch_id,),
-        ).fetchall()
+        # Query dispatch_pattern_offered (isolated per-dispatch junction table) so that
+        # patterns offered to multiple concurrent dispatches are not misattributed.
+        # Falls back to pattern_usage.dispatch_id for DBs that predate the junction table.
+        offered_table_exists = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='dispatch_pattern_offered'"
+        ).fetchone()
+
+        if offered_table_exists:
+            injected = conn.execute(
+                "SELECT pattern_id, pattern_title FROM dispatch_pattern_offered "
+                "WHERE dispatch_id = ?",
+                (dispatch_id,),
+            ).fetchall()
+        else:
+            injected = conn.execute(
+                "SELECT pattern_id, pattern_title FROM pattern_usage "
+                "WHERE dispatch_id = ?",
+                (dispatch_id,),
+            ).fetchall()
 
         for row in injected:
             pattern_id = row["pattern_id"]
@@ -1224,9 +1241,9 @@ def _update_pattern_confidence(
                         success_count = success_count + 1,
                         last_used     = ?,
                         updated_at    = ?
-                    WHERE dispatch_id = ? AND pattern_id = ?
+                    WHERE pattern_id = ?
                     """,
-                    (now, now, dispatch_id, pattern_id),
+                    (now, now, pattern_id),
                 )
             else:
                 conn.execute(
@@ -1244,9 +1261,9 @@ def _update_pattern_confidence(
                         failure_count  = failure_count + 1,
                         last_used      = ?,
                         updated_at     = ?
-                    WHERE dispatch_id = ? AND pattern_id = ?
+                    WHERE pattern_id = ?
                     """,
-                    (now, now, dispatch_id, pattern_id),
+                    (now, now, pattern_id),
                 )
             updated += 1
 

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -107,19 +107,36 @@ def _build_intelligence_section(dispatch_id: str, role: str | None) -> str:
     """Return formatted intelligence items as markdown, or empty string (best-effort).
 
     Calls IntelligenceSelector to gather antipatterns, success patterns, and
-    recent comparable dispatches from quality_intelligence.db.  Any import or
-    DB failure is caught and logged — dispatch proceeds without intelligence.
+    recent comparable dispatches from quality_intelligence.db.  After selecting,
+    emits the coordination event and records the injection (intelligence_injections
+    + pattern_usage + dispatch_pattern_offered) so the post-dispatch confidence
+    feedback loop has dispatch-scoped rows to update.  Any import or DB failure
+    is caught and logged — dispatch proceeds without intelligence.
     """
     try:
         from intelligence_selector import IntelligenceSelector  # noqa: PLC0415
-        quality_db_path = _default_state_dir() / "quality_intelligence.db"
-        selector = IntelligenceSelector(quality_db_path=quality_db_path)
+        state_dir = _default_state_dir()
+        quality_db_path = state_dir / "quality_intelligence.db"
+        selector = IntelligenceSelector(
+            quality_db_path=quality_db_path,
+            coord_db_state_dir=state_dir,
+        )
         try:
             result = selector.select(
                 dispatch_id=dispatch_id,
                 injection_point="dispatch_create",
                 skill_name=role or "",
             )
+            # Persist the selection so the feedback loop can find which patterns
+            # were offered for this dispatch.  Best-effort — never raises.
+            try:
+                selector.emit_event(result, coord_state_dir=state_dir)
+            except Exception as exc:
+                logger.debug("emit_event failed for %s: %s", dispatch_id, exc)
+            try:
+                selector.record_injection(result, coord_state_dir=state_dir)
+            except Exception as exc:
+                logger.debug("record_injection failed for %s: %s", dispatch_id, exc)
         finally:
             selector.close()
         if not result.items:
@@ -1173,13 +1190,22 @@ def _update_pattern_confidence(
     status: str,
     db_path: "Path",
 ) -> int:
-    """Update confidence for patterns that were injected in this dispatch.
+    """Update confidence for patterns that were OFFERED in this dispatch.
 
-    Looks up pattern_usage rows where dispatch_id matches, then:
+    Looks up dispatch_pattern_offered (or legacy pattern_usage.dispatch_id) rows
+    matching this dispatch, then:
     - success: boosts success_patterns.confidence_score + 0.05 (cap 1.0) and
-               increments pattern_usage.success_count + used_count
+               touches pattern_usage.last_used + updated_at
     - failure: decays success_patterns.confidence_score - 0.10 (floor 0.0) and
-               increments pattern_usage.failure_count + used_count
+               touches pattern_usage.last_used + updated_at
+
+    NOTE: pattern_usage.used_count must NOT be incremented here.  Existing
+    consumers treat used_count > 0 as evidence that a worker actually consumed
+    a pattern, not merely that it was offered.  Likewise success_count and
+    failure_count are reserved for confirmed worker usage outcomes.  The
+    legacy fallback only increments success_count when usage is unknown; the
+    offered-only feedback loop touches timestamps and the confidence_score in
+    success_patterns instead.
 
     Linkage is by title: pattern_usage.pattern_title → success_patterns.title.
     Returns count of pattern_usage rows updated.  Never raises.
@@ -1228,19 +1254,19 @@ def _update_pattern_confidence(
                     """
                     UPDATE success_patterns
                     SET confidence_score = MIN(confidence_score + 0.05, 1.0),
-                        usage_count      = usage_count + 1,
                         last_used        = ?
                     WHERE title = ?
                     """,
                     (now, title),
                 )
+                # Offered-only path: do NOT touch used_count, success_count, or
+                # failure_count here.  Those are reserved for confirmed worker
+                # usage signals (see learning_loop.update_confidence_scores).
                 conn.execute(
                     """
                     UPDATE pattern_usage
-                    SET used_count    = used_count + 1,
-                        success_count = success_count + 1,
-                        last_used     = ?,
-                        updated_at    = ?
+                    SET last_used  = ?,
+                        updated_at = ?
                     WHERE pattern_id = ?
                     """,
                     (now, now, pattern_id),
@@ -1257,10 +1283,8 @@ def _update_pattern_confidence(
                 conn.execute(
                     """
                     UPDATE pattern_usage
-                    SET used_count     = used_count + 1,
-                        failure_count  = failure_count + 1,
-                        last_used      = ?,
-                        updated_at     = ?
+                    SET last_used  = ?,
+                        updated_at = ?
                     WHERE pattern_id = ?
                     """,
                     (now, now, pattern_id),

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -405,6 +405,32 @@ def initialize_database() -> bool:
                 conn.commit()
                 log('INFO', f'Migrated {_tbl}: added valid_until column')
 
+        # Migration: create dispatch_pattern_offered junction table for isolated per-dispatch
+        # pattern tracking.  Replaces pattern_usage.dispatch_id as the lookup key for
+        # _update_pattern_confidence so concurrent dispatches cannot overwrite each other.
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='dispatch_pattern_offered'"
+        )
+        if not cursor.fetchone():
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+                    dispatch_id   TEXT NOT NULL,
+                    pattern_id    TEXT NOT NULL,
+                    pattern_title TEXT NOT NULL,
+                    offered_at    TEXT NOT NULL,
+                    PRIMARY KEY (dispatch_id, pattern_id)
+                )
+                """
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_dpo_dispatch_id "
+                "ON dispatch_pattern_offered (dispatch_id)"
+            )
+            conn.commit()
+            log('INFO', 'Migrated: created dispatch_pattern_offered table + index')
+
         log('SUCCESS', 'Database schema initialized successfully')
 
         # Close connection

--- a/tests/test_codex_pr311_findings.py
+++ b/tests/test_codex_pr311_findings.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Regression tests for PR #311 Codex blocking findings.
+
+Finding 1: _auto_commit_changes must not stage pre-existing dirty files.
+Finding 2: _auto_stash_changes must not stash pre-existing dirty files and must
+           include untracked files via --include-untracked.
+Finding 3: dispatch_pattern_offered table isolates per-dispatch pattern lookup so
+           concurrent dispatches cannot overwrite each other's dispatch_id association.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _porcelain(*paths, prefix="M "):
+    """Build a git status --porcelain-style string from a list of paths."""
+    return "\n".join(f"{prefix}{p}" for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: _auto_commit_changes isolation
+# ---------------------------------------------------------------------------
+
+class TestAutoCommitIsolation:
+    """_auto_commit_changes must only stage files introduced by the dispatch."""
+
+    def test_parse_dirty_files_basic(self):
+        from subprocess_dispatch import _parse_dirty_files
+
+        output = " M scripts/lib/foo.py\n?? new_file.txt\nR  old.py -> new.py"
+        result = _parse_dirty_files(output)
+        assert "scripts/lib/foo.py" in result
+        assert "new_file.txt" in result
+        assert "new.py" in result
+        assert "old.py" not in result
+
+    def test_parse_dirty_files_rename_strips_old(self):
+        from subprocess_dispatch import _parse_dirty_files
+
+        output = "R  src/old.py -> src/new.py"
+        result = _parse_dirty_files(output)
+        assert "src/new.py" in result
+        assert "src/old.py" not in result
+
+    def test_auto_commit_skips_pre_existing_dirty_files(self, tmp_path):
+        """If all dirty files were pre-existing, no commit should be attempted."""
+        from subprocess_dispatch import _auto_commit_changes
+
+        pre_existing = frozenset(["scripts/already_dirty.py"])
+        porcelain_out = " M scripts/already_dirty.py\n"
+
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(cmd)
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            committed = _auto_commit_changes(
+                "dispatch-001", "T1", gate="test",
+                pre_dispatch_dirty=pre_existing,
+            )
+
+        assert committed is False
+        # git add must NOT have been called
+        add_calls = [c for c in git_calls if len(c) > 1 and c[1] == "add"]
+        assert not add_calls, f"git add should not be called when only pre-existing files dirty: {add_calls}"
+
+    def test_auto_commit_only_stages_new_files(self, tmp_path):
+        """Only dispatch-new files are staged — pre-existing dirty file excluded."""
+        from subprocess_dispatch import _auto_commit_changes
+
+        pre_existing = frozenset(["scripts/pre_existing.py"])
+        # Both pre_existing + new dispatch file are dirty now
+        porcelain_out = " M scripts/pre_existing.py\n M scripts/new_dispatch.py\n"
+
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            committed = _auto_commit_changes(
+                "dispatch-002", "T1", gate="test",
+                pre_dispatch_dirty=pre_existing,
+            )
+
+        assert committed is True
+        add_calls = [c for c in git_calls if len(c) > 1 and c[1] == "add"]
+        assert len(add_calls) == 1
+        staged = add_calls[0]
+        assert "scripts/new_dispatch.py" in staged
+        assert "scripts/pre_existing.py" not in staged
+
+    def test_auto_commit_with_empty_pre_dispatch_stages_all(self):
+        """When pre_dispatch_dirty is empty, all dirty files are staged."""
+        from subprocess_dispatch import _auto_commit_changes
+
+        porcelain_out = " M scripts/a.py\n M scripts/b.py\n"
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            committed = _auto_commit_changes("dispatch-003", "T1", pre_dispatch_dirty=frozenset())
+
+        assert committed is True
+        add_calls = [c for c in git_calls if len(c) > 1 and c[1] == "add"]
+        assert len(add_calls) == 1
+        staged = add_calls[0]
+        assert "scripts/a.py" in staged
+        assert "scripts/b.py" in staged
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: _auto_stash_changes isolation + untracked coverage
+# ---------------------------------------------------------------------------
+
+class TestAutoStashIsolation:
+    """_auto_stash_changes must isolate to dispatch-new files and use --include-untracked."""
+
+    def test_stash_skips_pre_existing_dirty_files(self):
+        """No stash when all dirty files were pre-existing."""
+        from subprocess_dispatch import _auto_stash_changes
+
+        pre_existing = frozenset(["scripts/pre.py"])
+        porcelain_out = " M scripts/pre.py\n"
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            stashed = _auto_stash_changes(
+                "dispatch-010", "T1", pre_dispatch_dirty=pre_existing
+            )
+
+        assert stashed is False
+        stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
+        assert not stash_calls
+
+    def test_stash_uses_include_untracked_flag(self):
+        """git stash command must include --include-untracked."""
+        from subprocess_dispatch import _auto_stash_changes
+
+        porcelain_out = "?? scripts/new_untracked.py\n"
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            stashed = _auto_stash_changes("dispatch-011", "T1", pre_dispatch_dirty=frozenset())
+
+        assert stashed is True
+        stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
+        assert len(stash_calls) == 1
+        assert "--include-untracked" in stash_calls[0]
+
+    def test_stash_only_paths_from_dispatch(self):
+        """Only dispatch-new files appear in the stash -- path argument."""
+        from subprocess_dispatch import _auto_stash_changes
+
+        pre_existing = frozenset(["scripts/old.py"])
+        porcelain_out = " M scripts/old.py\n?? scripts/dispatch_new.py\n"
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            stashed = _auto_stash_changes(
+                "dispatch-012", "T1", pre_dispatch_dirty=pre_existing
+            )
+
+        assert stashed is True
+        stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
+        assert len(stash_calls) == 1
+        cmd = stash_calls[0]
+        assert "scripts/dispatch_new.py" in cmd
+        assert "scripts/old.py" not in cmd
+
+    def test_stash_uses_push_subcommand_not_save(self):
+        """git stash push is used (not the deprecated git stash save)."""
+        from subprocess_dispatch import _auto_stash_changes
+
+        porcelain_out = " M scripts/file.py\n"
+        git_calls = []
+
+        def fake_run(cmd, **kwargs):
+            git_calls.append(list(cmd))
+            result = MagicMock()
+            if cmd[1] == "status":
+                result.stdout = porcelain_out
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
+            _auto_stash_changes("dispatch-013", "T1", pre_dispatch_dirty=frozenset())
+
+        stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
+        assert stash_calls, "stash call expected"
+        assert stash_calls[0][2] == "push", (
+            f"expected 'git stash push', got '{stash_calls[0][2]}' — 'save' is deprecated and not isolated"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: dispatch_pattern_offered isolation
+# ---------------------------------------------------------------------------
+
+class TestDispatchPatternOfferedIsolation:
+    """Pattern offered to multiple dispatches must not overwrite earlier dispatch's association."""
+
+    def _make_db(self, tmp_path: Path) -> Path:
+        """Create a minimal quality_intelligence.db with needed tables."""
+        db_path = tmp_path / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE success_patterns (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                confidence_score REAL DEFAULT 0.7,
+                usage_count INTEGER DEFAULT 0,
+                last_used TEXT,
+                source_dispatch_ids TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE pattern_usage (
+                pattern_id TEXT PRIMARY KEY,
+                pattern_title TEXT NOT NULL,
+                pattern_hash TEXT NOT NULL,
+                used_count INTEGER DEFAULT 0,
+                ignored_count INTEGER DEFAULT 0,
+                success_count INTEGER DEFAULT 0,
+                failure_count INTEGER DEFAULT 0,
+                last_used TEXT,
+                last_offered TEXT,
+                confidence REAL DEFAULT 1.0,
+                created_at TEXT,
+                updated_at TEXT,
+                dispatch_id TEXT DEFAULT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE dispatch_pattern_offered (
+                dispatch_id   TEXT NOT NULL,
+                pattern_id    TEXT NOT NULL,
+                pattern_title TEXT NOT NULL,
+                offered_at    TEXT NOT NULL,
+                PRIMARY KEY (dispatch_id, pattern_id)
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_concurrent_dispatches_do_not_steal_pattern_row(self, tmp_path):
+        """If dispatch-A and dispatch-B both offer pattern-X, dispatch-A's row must
+        survive in dispatch_pattern_offered even after dispatch-B records its offer."""
+        db_path = self._make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        now = "2026-04-29T00:00:00+00:00"
+
+        # Simulate dispatch-A offering pattern-X
+        conn.execute(
+            "INSERT INTO dispatch_pattern_offered (dispatch_id, pattern_id, pattern_title, offered_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("dispatch-A", "pattern-X", "Pattern X", now),
+        )
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, last_offered, "
+            "confidence, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("pattern-X", "Pattern X", "pattern-X", now, 0.8, now, now),
+        )
+        conn.commit()
+
+        # Simulate dispatch-B offering the same pattern-X (new dispatch offer)
+        conn.execute(
+            "INSERT INTO dispatch_pattern_offered (dispatch_id, pattern_id, pattern_title, offered_at) "
+            "VALUES (?, ?, ?, ?) ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET offered_at = excluded.offered_at",
+            ("dispatch-B", "pattern-X", "Pattern X", now),
+        )
+        conn.execute(
+            "UPDATE pattern_usage SET last_offered = ?, updated_at = ? WHERE pattern_id = ?",
+            (now, now, "pattern-X"),
+        )
+        conn.commit()
+
+        # Both dispatch-A and dispatch-B should have their own rows
+        rows = conn.execute(
+            "SELECT dispatch_id FROM dispatch_pattern_offered WHERE pattern_id = ? ORDER BY dispatch_id",
+            ("pattern-X",),
+        ).fetchall()
+        dispatch_ids = [r["dispatch_id"] for r in rows]
+        assert "dispatch-A" in dispatch_ids, "dispatch-A row must survive after dispatch-B offer"
+        assert "dispatch-B" in dispatch_ids
+        conn.close()
+
+    def test_update_pattern_confidence_uses_junction_table(self, tmp_path):
+        """_update_pattern_confidence queries dispatch_pattern_offered when it exists."""
+        db_path = self._make_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        now = "2026-04-29T00:00:00+00:00"
+
+        # Insert a success pattern
+        conn.execute(
+            "INSERT INTO success_patterns (title, confidence_score, usage_count) VALUES (?, ?, ?)",
+            ("Pattern Alpha", 0.7, 1),
+        )
+        # Insert pattern_usage row for pattern-alpha (dispatch_id intentionally wrong/stale)
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, used_count, "
+            "success_count, failure_count, last_offered, confidence, created_at, updated_at, dispatch_id) "
+            "VALUES (?, ?, ?, 0, 0, 0, ?, 0.7, ?, ?, ?)",
+            ("pattern-alpha", "Pattern Alpha", "pattern-alpha", now, now, now, "dispatch-OTHER"),
+        )
+        # Junction table points to dispatch-A
+        conn.execute(
+            "INSERT INTO dispatch_pattern_offered (dispatch_id, pattern_id, pattern_title, offered_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("dispatch-A", "pattern-alpha", "Pattern Alpha", now),
+        )
+        conn.commit()
+        conn.close()
+
+        from subprocess_dispatch import _update_pattern_confidence
+
+        count = _update_pattern_confidence("dispatch-A", "success", db_path)
+        assert count == 1, (
+            f"_update_pattern_confidence should find pattern via dispatch_pattern_offered, got count={count}"
+        )
+
+        # Verify confidence was boosted
+        conn2 = sqlite3.connect(str(db_path))
+        row = conn2.execute(
+            "SELECT confidence_score FROM success_patterns WHERE title = ?", ("Pattern Alpha",)
+        ).fetchone()
+        conn2.close()
+        assert row is not None
+        assert row[0] > 0.7, f"confidence should have been boosted: {row[0]}"
+
+    def test_pattern_usage_dispatch_id_not_overwritten_on_conflict(self, tmp_path):
+        """ON CONFLICT for pattern_usage must NOT update dispatch_id."""
+        import sys
+        sys.path.insert(0, str(SCRIPTS_LIB))
+        from intelligence_selector import IntelligenceSelector, InjectionResult, IntelligenceItem
+
+        db_path = self._make_db(tmp_path)
+
+        selector = IntelligenceSelector(quality_db_path=db_path)
+
+        from intelligence_selector import SuppressionRecord
+        item = IntelligenceItem(
+            item_id="pat-1",
+            title="My Pattern",
+            content="do the thing",
+            item_class="proven_pattern",
+            confidence=0.8,
+            evidence_count=3,
+            last_seen="2026-04-01",
+            scope_tags=[],
+        )
+        result_a = InjectionResult(
+            injection_point="dispatch_create",
+            injected_at="2026-04-29T00:00:00+00:00",
+            items=[item],
+            suppressed=[],
+            task_class="backend",
+            dispatch_id="dispatch-AAA",
+        )
+        result_b = InjectionResult(
+            injection_point="dispatch_create",
+            injected_at="2026-04-29T00:00:00+00:00",
+            items=[item],
+            suppressed=[],
+            task_class="backend",
+            dispatch_id="dispatch-BBB",
+        )
+
+        selector._record_pattern_usage(result_a)
+        selector._record_pattern_usage(result_b)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+
+        # dispatch_pattern_offered must have rows for BOTH dispatches
+        rows = conn.execute(
+            "SELECT dispatch_id FROM dispatch_pattern_offered WHERE pattern_id = ? ORDER BY dispatch_id",
+            ("pat-1",),
+        ).fetchall()
+        dids = {r["dispatch_id"] for r in rows}
+        assert "dispatch-AAA" in dids
+        assert "dispatch-BBB" in dids
+
+        # pattern_usage.dispatch_id must NOT be overwritten to dispatch-BBB
+        pu = conn.execute(
+            "SELECT dispatch_id FROM pattern_usage WHERE pattern_id = ?", ("pat-1",)
+        ).fetchone()
+        # dispatch_id column should remain NULL (not set by the new code path)
+        # OR remain the original value — in either case it must NOT be 'dispatch-BBB'
+        # because the ON CONFLICT clause no longer writes dispatch_id
+        assert pu["dispatch_id"] != "dispatch-BBB", (
+            "pattern_usage.dispatch_id must not be overwritten by a later dispatch's offer"
+        )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard: 'git add -A' must not appear in _auto_commit_changes
+# ---------------------------------------------------------------------------
+
+class TestSourceGuards:
+    """Static checks ensuring banned patterns are absent from source."""
+
+    def test_no_git_add_dash_A_in_auto_commit(self):
+        src = (SCRIPTS_LIB / "subprocess_dispatch.py").read_text(encoding="utf-8")
+        # Locate _auto_commit_changes function body and check for "git", "add", "-A"
+        start = src.find("def _auto_commit_changes(")
+        end = src.find("\ndef ", start + 1)
+        func_body = src[start:end] if end != -1 else src[start:]
+        assert '"-A"' not in func_body and "'-A'" not in func_body, (
+            "_auto_commit_changes must not use 'git add -A' — it stages unrelated pre-existing files"
+        )
+
+    def test_no_git_stash_save_in_auto_stash(self):
+        src = (SCRIPTS_LIB / "subprocess_dispatch.py").read_text(encoding="utf-8")
+        start = src.find("def _auto_stash_changes(")
+        end = src.find("\ndef ", start + 1)
+        func_body = src[start:end] if end != -1 else src[start:]
+        assert '"save"' not in func_body and "'save'" not in func_body, (
+            "_auto_stash_changes must not use 'git stash save' — use 'git stash push'"
+        )
+        assert '"push"' in func_body or "'push'" in func_body, (
+            "_auto_stash_changes must use 'git stash push'"
+        )
+
+    def test_dispatch_pattern_offered_not_dispatch_id_in_conflict(self):
+        src = (SCRIPTS_LIB / "intelligence_selector.py").read_text(encoding="utf-8")
+        # Confirm 'dispatch_id = excluded.dispatch_id' is gone from ON CONFLICT block
+        assert "dispatch_id  = excluded.dispatch_id" not in src, (
+            "intelligence_selector: ON CONFLICT must not overwrite dispatch_id in pattern_usage"
+        )
+        assert "dispatch_pattern_offered" in src, (
+            "intelligence_selector: must write to dispatch_pattern_offered junction table"
+        )

--- a/tests/test_codex_pr311_findings.py
+++ b/tests/test_codex_pr311_findings.py
@@ -109,6 +109,7 @@ class TestAutoCommitIsolation:
             committed = _auto_commit_changes(
                 "dispatch-002", "T1", gate="test",
                 pre_dispatch_dirty=pre_existing,
+                dispatch_touched_files=frozenset(["scripts/new_dispatch.py"]),
             )
 
         assert committed is True
@@ -135,7 +136,10 @@ class TestAutoCommitIsolation:
             return result
 
         with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
-            committed = _auto_commit_changes("dispatch-003", "T1", pre_dispatch_dirty=frozenset())
+            committed = _auto_commit_changes(
+                "dispatch-003", "T1", pre_dispatch_dirty=frozenset(),
+                dispatch_touched_files=frozenset(["scripts/a.py", "scripts/b.py"]),
+            )
 
         assert committed is True
         add_calls = [c for c in git_calls if len(c) > 1 and c[1] == "add"]
@@ -194,12 +198,15 @@ class TestAutoStashIsolation:
             return result
 
         with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
-            stashed = _auto_stash_changes("dispatch-011", "T1", pre_dispatch_dirty=frozenset())
+            stashed = _auto_stash_changes(
+                "dispatch-011", "T1", pre_dispatch_dirty=frozenset(),
+                dispatch_touched_files=frozenset(["scripts/new_untracked.py"]),
+            )
 
         assert stashed is True
         stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
         assert len(stash_calls) == 1
-        assert "--include-untracked" in stash_calls[0]
+        assert "--include-untracked" in stash_calls[0] or "-u" in stash_calls[0]
 
     def test_stash_only_paths_from_dispatch(self):
         """Only dispatch-new files appear in the stash -- path argument."""
@@ -220,7 +227,8 @@ class TestAutoStashIsolation:
 
         with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
             stashed = _auto_stash_changes(
-                "dispatch-012", "T1", pre_dispatch_dirty=pre_existing
+                "dispatch-012", "T1", pre_dispatch_dirty=pre_existing,
+                dispatch_touched_files=frozenset(["scripts/dispatch_new.py"]),
             )
 
         assert stashed is True
@@ -247,7 +255,10 @@ class TestAutoStashIsolation:
             return result
 
         with patch("subprocess_dispatch.subprocess.run", side_effect=fake_run):
-            _auto_stash_changes("dispatch-013", "T1", pre_dispatch_dirty=frozenset())
+            _auto_stash_changes(
+                "dispatch-013", "T1", pre_dispatch_dirty=frozenset(),
+                dispatch_touched_files=frozenset(["scripts/file.py"]),
+            )
 
         stash_calls = [c for c in git_calls if len(c) > 1 and c[1] == "stash"]
         assert stash_calls, "stash call expected"

--- a/tests/test_pr311_round2_codex_fixes.py
+++ b/tests/test_pr311_round2_codex_fixes.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Regression tests for PR #311 round-2 codex findings.
+
+Three findings covered:
+
+* **Finding 1** — subprocess path silently bypassed the confidence loop.
+  ``_build_intelligence_section`` selected items but never called
+  ``IntelligenceSelector.emit_event()`` or ``record_injection()`` so
+  ``intelligence_injections`` and ``pattern_usage`` had no dispatch-scoped rows
+  for the later feedback step to update.
+
+* **Finding 2** — random ``item_id`` values fragmented the same underlying
+  pattern into many ``pattern_usage`` rows, breaking dedup and scrambling
+  ``ignored/used/confidence`` aggregates.  ``pattern_hash`` was also reused
+  from the same random value, defeating its purpose.
+
+* **Finding 3** — ``_update_pattern_confidence`` incremented
+  ``pattern_usage.used_count`` (and ``success_count`` / ``failure_count``) for
+  every *offered* item on both success and failure runs.  Existing consumers
+  treat ``used_count > 0`` as evidence that a worker actually used a pattern;
+  the offered-only feedback loop must touch only timestamps + the confidence
+  score in ``success_patterns``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Quality DB scaffolding (mirrors the production schema used by these paths)
+# ---------------------------------------------------------------------------
+
+def _bootstrap_quality_db(db_path: Path) -> None:
+    """Create the minimum schema needed by intelligence_selector + feedback."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT, description TEXT, category TEXT,
+            confidence_score REAL DEFAULT 0.0,
+            usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT,
+            first_seen TEXT, last_used TEXT,
+            valid_from DATETIME, valid_until DATETIME
+        );
+        CREATE TABLE IF NOT EXISTS antipatterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT, description TEXT, category TEXT, severity TEXT,
+            why_problematic TEXT, better_alternative TEXT,
+            occurrence_count INTEGER DEFAULT 0,
+            first_seen TEXT, last_seen TEXT,
+            valid_from DATETIME, valid_until DATETIME
+        );
+        CREATE TABLE IF NOT EXISTS prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT, rule_type TEXT, description TEXT,
+            recommendation TEXT, confidence REAL DEFAULT 0.0,
+            triggered_count INTEGER DEFAULT 0, last_triggered TEXT,
+            valid_from DATETIME, valid_until DATETIME
+        );
+        CREATE TABLE IF NOT EXISTS dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT,
+            pattern_count INTEGER DEFAULT 0,
+            prevention_rule_count INTEGER DEFAULT 0,
+            outcome_status TEXT, dispatched_at TEXT
+        );
+        CREATE TABLE IF NOT EXISTS pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TEXT,
+            last_offered TEXT,
+            confidence REAL DEFAULT 1.0,
+            created_at TEXT,
+            updated_at TEXT,
+            dispatch_id TEXT
+        );
+        CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+            dispatch_id   TEXT NOT NULL,
+            pattern_id    TEXT NOT NULL,
+            pattern_title TEXT NOT NULL,
+            offered_at    TEXT NOT NULL,
+            PRIMARY KEY (dispatch_id, pattern_id)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_proven_pattern(db_path: Path, *, title: str, confidence: float = 0.8,
+                         usage_count: int = 5, category: str = "backend-developer") -> int:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute(
+        """INSERT INTO success_patterns
+           (title, description, category, confidence_score, usage_count,
+            first_seen, last_used)
+           VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+        (title, f"desc:{title}", category, confidence, usage_count),
+    )
+    conn.commit()
+    pid = cur.lastrowid
+    conn.close()
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — subprocess path must persist the injection
+# ---------------------------------------------------------------------------
+
+class TestSubprocessInjectionPersists:
+    """``_build_intelligence_section`` must emit and record the selection."""
+
+    def test_emit_event_and_record_injection_called(self, tmp_path):
+        """selector.emit_event AND selector.record_injection must run.
+
+        Without these calls the post-dispatch feedback step has no rows to
+        update — the confidence loop becomes a no-op for the subprocess route.
+        """
+        from subprocess_dispatch import _build_intelligence_section
+        import intelligence_selector as _mod
+
+        instance = MagicMock()
+        # Real result with one item so the section is non-empty
+        from intelligence_selector import IntelligenceItem, InjectionResult
+        item = IntelligenceItem(
+            item_id="intel_sp_1",
+            item_class="proven_pattern",
+            title="Test pattern",
+            content="Use proper checks.",
+            confidence=0.9,
+            evidence_count=5,
+            last_seen="2026-04-29T00:00:00.000000Z",
+            scope_tags=["backend-developer"],
+        )
+        result = InjectionResult(
+            injection_point="dispatch_create",
+            injected_at="2026-04-29T00:00:00.000000Z",
+            items=[item],
+            suppressed=[],
+            task_class="coding_interactive",
+            dispatch_id="d-r2-001",
+        )
+        instance.select.return_value = result
+        mock_cls = MagicMock(return_value=instance)
+
+        with patch.object(_mod, "IntelligenceSelector", mock_cls):
+            section = _build_intelligence_section("d-r2-001", "backend-developer")
+
+        assert "Test pattern" in section
+        # Both event emission and injection record must fire.
+        assert instance.emit_event.called, (
+            "Finding 1: emit_event() must be called so the coordination event "
+            "for this dispatch is recorded"
+        )
+        assert instance.record_injection.called, (
+            "Finding 1: record_injection() must be called so pattern_usage / "
+            "dispatch_pattern_offered rows exist for the feedback step"
+        )
+
+    def test_pattern_usage_row_written_after_selection(self, tmp_path):
+        """End-to-end: section build must leave a pattern_usage row behind.
+
+        Uses a real (temp) quality_intelligence.db so the feedback loop has
+        something to query later.
+        """
+        from subprocess_dispatch import _build_intelligence_section
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        _seed_proven_pattern(db_path, title="Stable pattern A",
+                             confidence=0.9, usage_count=4)
+
+        with patch("subprocess_dispatch._default_state_dir", return_value=state_dir):
+            section = _build_intelligence_section("d-r2-002", "backend-developer")
+
+        # Section may be empty depending on coord-DB availability; what we
+        # require is that the pattern_usage row exists for the feedback loop.
+        del section
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT pattern_id, dispatch_id FROM dispatch_pattern_offered "
+            "WHERE dispatch_id = ?",
+            ("d-r2-002",),
+        ).fetchall()
+        conn.close()
+
+        assert rows, (
+            "Finding 1: dispatch_pattern_offered must have a row for this "
+            "dispatch so _update_pattern_confidence can find offered items"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — stable item_id, distinct pattern_hash
+# ---------------------------------------------------------------------------
+
+class TestStableItemId:
+    """The same underlying pattern must produce the same item_id every call."""
+
+    def test_same_pattern_gets_same_item_id_across_selections(self, tmp_path):
+        """Two consecutive ``select()`` calls return identical item_ids.
+
+        Random uuids broke this — every call generated a fresh pattern_id and
+        pattern_usage rows multiplied instead of aggregating.
+        """
+        from intelligence_selector import IntelligenceSelector
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        _seed_proven_pattern(db_path, title="Repeatable pattern",
+                             confidence=0.85, usage_count=4)
+
+        selector = IntelligenceSelector(quality_db_path=db_path)
+        try:
+            r1 = selector.select("d-001", "dispatch_create",
+                                 skill_name="backend-developer")
+            r2 = selector.select("d-002", "dispatch_create",
+                                 skill_name="backend-developer")
+        finally:
+            selector.close()
+
+        ids_1 = {i.item_id for i in r1.items}
+        ids_2 = {i.item_id for i in r2.items}
+        assert ids_1, "expected at least one item to be selected"
+        assert ids_1 == ids_2, (
+            f"Finding 2: stable item_id required across calls. "
+            f"call1={ids_1!r} call2={ids_2!r}"
+        )
+
+    def test_pattern_usage_dedups_across_dispatches(self, tmp_path):
+        """Two dispatches offering the same pattern => ONE pattern_usage row."""
+        from intelligence_selector import IntelligenceSelector
+        from runtime_coordination import init_schema
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        _seed_proven_pattern(db_path, title="Dedup target",
+                             confidence=0.85, usage_count=6)
+        coord_dir = tmp_path / "state"
+        coord_dir.mkdir()
+        init_schema(str(coord_dir))
+
+        selector = IntelligenceSelector(
+            quality_db_path=db_path,
+            coord_db_state_dir=coord_dir,
+        )
+        try:
+            r1 = selector.select("dispatch-A", "dispatch_create",
+                                 skill_name="backend-developer")
+            selector.record_injection(r1)
+            r2 = selector.select("dispatch-B", "dispatch_create",
+                                 skill_name="backend-developer")
+            selector.record_injection(r2)
+        finally:
+            selector.close()
+
+        conn = sqlite3.connect(str(db_path))
+        n_pattern_rows = conn.execute(
+            "SELECT COUNT(*) FROM pattern_usage"
+        ).fetchone()[0]
+        n_offered_rows = conn.execute(
+            "SELECT COUNT(*) FROM dispatch_pattern_offered"
+        ).fetchone()[0]
+        conn.close()
+
+        # ONE pattern_usage row per underlying pattern
+        assert n_pattern_rows == 1, (
+            f"Finding 2: pattern_usage must dedup; got {n_pattern_rows} rows "
+            "for one underlying pattern offered to two dispatches"
+        )
+        # TWO offered rows (one per dispatch) — that table is the per-dispatch
+        # junction, not pattern identity
+        assert n_offered_rows == 2, (
+            f"Finding 2: dispatch_pattern_offered should keep per-dispatch "
+            f"audit rows; expected 2, got {n_offered_rows}"
+        )
+
+    def test_pattern_hash_differs_from_pattern_id(self, tmp_path):
+        """``pattern_hash`` must NOT be identical to ``pattern_id``.
+
+        The original code used the same random value for both fields, defeating
+        the purpose of having a separate content hash.
+        """
+        from intelligence_selector import IntelligenceSelector
+        from runtime_coordination import init_schema
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        _seed_proven_pattern(db_path, title="Hash-id distinct",
+                             confidence=0.85, usage_count=4)
+        coord_dir = tmp_path / "state"
+        coord_dir.mkdir()
+        init_schema(str(coord_dir))
+
+        selector = IntelligenceSelector(
+            quality_db_path=db_path,
+            coord_db_state_dir=coord_dir,
+        )
+        try:
+            result = selector.select("d-hash", "dispatch_create",
+                                     skill_name="backend-developer")
+            selector.record_injection(result)
+        finally:
+            selector.close()
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT pattern_id, pattern_hash FROM pattern_usage"
+        ).fetchall()
+        conn.close()
+
+        assert rows, "expected at least one pattern_usage row"
+        for pattern_id, pattern_hash in rows:
+            assert pattern_hash != pattern_id, (
+                "Finding 2: pattern_hash must be a real hash, not the same "
+                "string as pattern_id"
+            )
+            # learning_loop convention is sha1 hex (40 chars).
+            assert len(pattern_hash) == 40, (
+                f"Finding 2: pattern_hash should be sha1 hex; got "
+                f"{pattern_hash!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — offered != used: don't bump used/success/failure counts
+# ---------------------------------------------------------------------------
+
+class TestOfferedDoesNotIncrementUsedCount:
+    """Confidence feedback must not corrupt the used/success/failure signal."""
+
+    def _seed_offered(self, db_path: Path, dispatch_id: str,
+                     pattern_id: str, pattern_title: str) -> None:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """INSERT INTO success_patterns
+                  (title, description, confidence_score, usage_count,
+                   first_seen, last_used)
+               VALUES (?, '', 0.7, 0, datetime('now'), datetime('now'))""",
+            (pattern_title,),
+        )
+        conn.execute(
+            """INSERT INTO pattern_usage
+                  (pattern_id, pattern_title, pattern_hash, used_count,
+                   ignored_count, success_count, failure_count,
+                   last_offered, confidence, created_at, updated_at)
+               VALUES (?, ?, ?, 0, 0, 0, 0, datetime('now'), 1.0,
+                       datetime('now'), datetime('now'))""",
+            (pattern_id, pattern_title, "deadbeef" * 5),
+        )
+        conn.execute(
+            """INSERT INTO dispatch_pattern_offered
+                  (dispatch_id, pattern_id, pattern_title, offered_at)
+               VALUES (?, ?, ?, datetime('now'))""",
+            (dispatch_id, pattern_id, pattern_title),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_success_does_not_bump_used_or_success_count(self, tmp_path):
+        from subprocess_dispatch import _update_pattern_confidence
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        self._seed_offered(db_path, "d-S1", "intel_sp_1", "Pattern One")
+
+        updated = _update_pattern_confidence("d-S1", "success", db_path)
+        assert updated == 1
+
+        conn = sqlite3.connect(str(db_path))
+        used, succ, fail = conn.execute(
+            "SELECT used_count, success_count, failure_count FROM pattern_usage"
+        ).fetchone()
+        conf = conn.execute(
+            "SELECT confidence_score FROM success_patterns"
+        ).fetchone()[0]
+        conn.close()
+
+        assert used == 0, (
+            f"Finding 3: used_count must stay 0 for offered-only success; got {used}"
+        )
+        assert succ == 0, (
+            f"Finding 3: success_count must stay 0 for offered-only success; got {succ}"
+        )
+        assert fail == 0, (
+            f"Finding 3: failure_count must stay 0 for offered-only success; got {fail}"
+        )
+        # The confidence side-effect on success_patterns is the whole point —
+        # +0.05 still applied.
+        assert conf == pytest.approx(0.75, abs=1e-6), (
+            f"success_patterns.confidence_score should boost +0.05; got {conf}"
+        )
+
+    def test_failure_does_not_bump_used_or_failure_count(self, tmp_path):
+        from subprocess_dispatch import _update_pattern_confidence
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        self._seed_offered(db_path, "d-F1", "intel_sp_2", "Pattern Two")
+
+        updated = _update_pattern_confidence("d-F1", "failure", db_path)
+        assert updated == 1
+
+        conn = sqlite3.connect(str(db_path))
+        used, succ, fail = conn.execute(
+            "SELECT used_count, success_count, failure_count FROM pattern_usage"
+        ).fetchone()
+        conf = conn.execute(
+            "SELECT confidence_score FROM success_patterns"
+        ).fetchone()[0]
+        conn.close()
+
+        assert used == 0, (
+            f"Finding 3: used_count must stay 0 on offered-only failure; got {used}"
+        )
+        assert fail == 0, (
+            f"Finding 3: failure_count must stay 0 on offered-only failure; got {fail}"
+        )
+        assert succ == 0, (
+            f"Finding 3: success_count must stay 0 on offered-only failure; got {succ}"
+        )
+        assert conf == pytest.approx(0.6, abs=1e-6), (
+            f"success_patterns.confidence_score should decay -0.10; got {conf}"
+        )
+
+    def test_last_used_still_updated(self, tmp_path):
+        """We DO want last_used / updated_at to advance — only the counters
+        must stay put."""
+        from subprocess_dispatch import _update_pattern_confidence
+
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap_quality_db(db_path)
+        self._seed_offered(db_path, "d-T1", "intel_sp_3", "Pattern Three")
+
+        # zero out last_used so the change is detectable
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE pattern_usage SET last_used = NULL, updated_at = NULL")
+        conn.commit()
+        conn.close()
+
+        _update_pattern_confidence("d-T1", "success", db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        last_used, updated_at = conn.execute(
+            "SELECT last_used, updated_at FROM pattern_usage"
+        ).fetchone()
+        conn.close()
+
+        assert last_used is not None
+        assert updated_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Static guard: regate findings stay fixed in the source
+# ---------------------------------------------------------------------------
+
+class TestSourceLevelGuards:
+    """Cheap source-level checks that protect against regressions."""
+
+    def test_subprocess_dispatch_calls_record_injection(self):
+        src = (SCRIPTS_LIB / "subprocess_dispatch.py").read_text(encoding="utf-8")
+        assert "record_injection(" in src, (
+            "Finding 1: subprocess_dispatch.py must call record_injection()"
+        )
+        assert "emit_event(" in src, (
+            "Finding 1: subprocess_dispatch.py must call emit_event()"
+        )
+
+    def test_intelligence_selector_uses_stable_item_id(self):
+        src = (SCRIPTS_LIB / "intelligence_selector.py").read_text(encoding="utf-8")
+        assert "_stable_item_id(" in src, (
+            "Finding 2: intelligence_selector.py must use _stable_item_id() "
+            "for content-derived ids"
+        )
+        # The old random helper must no longer be used as the item_id source.
+        assert "item_id=_item_id()" not in src, (
+            "Finding 2: random uuid item_id assignments still present"
+        )
+
+    def test_offered_only_does_not_increment_used_count(self):
+        src = (SCRIPTS_LIB / "subprocess_dispatch.py").read_text(encoding="utf-8")
+        # Targeted: the SQL fragment that bumped used_count must be gone.
+        assert "used_count    = used_count + 1" not in src, (
+            "Finding 3: used_count increment in offered-only path is back"
+        )
+        assert "used_count     = used_count + 1" not in src, (
+            "Finding 3: used_count increment in offered-only path is back"
+        )
+        assert "success_count = success_count + 1" not in src, (
+            "Finding 3: success_count increment in offered-only path is back"
+        )
+        assert "failure_count  = failure_count + 1" not in src, (
+            "Finding 3: failure_count increment in offered-only path is back"
+        )

--- a/tests/test_subprocess_dispatch_dedup.py
+++ b/tests/test_subprocess_dispatch_dedup.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Regression tests: update_confidence_from_outcome called exactly once per dispatch.
+
+After VNX-R4, the canonical confidence-update path is:
+  worker appends task_complete/task_failed receipt
+  → append_receipt_payload → _update_confidence_from_receipt → update_confidence_from_outcome
+
+The duplicate call that previously lived in deliver_with_recovery() has been removed.
+These tests confirm:
+  A) task_complete dispatch → exactly one confidence update call (via append_receipt path)
+  B) task_failed dispatch → exactly one confidence update call (via append_receipt path)
+  C) dispatch_metadata outcome capture is unaffected
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_receipt(event_type: str, dispatch_id: str, terminal: str, status: str) -> dict:
+    return {
+        "event_type": event_type,
+        "dispatch_id": dispatch_id,
+        "terminal": terminal,
+        "status": status,
+        "timestamp": "2026-04-28T00:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Case A: task_complete receipt triggers exactly ONE confidence update
+# ---------------------------------------------------------------------------
+
+class TestTaskCompleteDedup:
+    """update_confidence_from_outcome called once on task_complete receipt."""
+
+    def test_single_call_on_task_complete(self, tmp_path):
+        """Simulate append_receipt_payload receiving a task_complete receipt.
+
+        Asserts update_confidence_from_outcome is called exactly once — not twice.
+        """
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Create minimal DB so the call doesn't short-circuit on exists() check
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS success_patterns "
+            "(id INTEGER PRIMARY KEY, confidence_score REAL, usage_count INTEGER, "
+            " source_dispatch_ids TEXT, last_used TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS confidence_events "
+            "(dispatch_id TEXT, terminal TEXT, outcome TEXT, patterns_boosted INTEGER, "
+            " patterns_decayed INTEGER, confidence_change REAL, occurred_at TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+        receipt = _make_receipt("task_complete", "dispatch-A1", "T1", "success")
+        call_count = []
+
+        real_update = None
+        try:
+            from intelligence_persist import update_confidence_from_outcome as _real
+            real_update = _real
+        except ImportError:
+            pass
+
+        def counting_upcf(db, dispatch_id, terminal, outcome):
+            call_count.append((dispatch_id, terminal, outcome))
+            if real_update:
+                real_update(db, dispatch_id, terminal, outcome)
+
+        with patch("append_receipt.resolve_state_dir", return_value=db_path.parent), \
+             patch("append_receipt._register_quality_open_items"), \
+             patch("append_receipt._emit_dispatch_register"), \
+             patch("append_receipt._maybe_trigger_state_rebuild"), \
+             patch("append_receipt._enrich_completion_receipt", side_effect=lambda r: r), \
+             patch("append_receipt._count_quality_violations", return_value=0):
+            import append_receipt
+            # Patch update_confidence_from_outcome inside the module that imports it
+            with patch.object(
+                sys.modules.get("intelligence_persist", MagicMock()),
+                "update_confidence_from_outcome",
+                side_effect=counting_upcf,
+            ):
+                # Manually call _update_confidence_from_receipt directly
+                append_receipt._update_confidence_from_receipt(receipt)
+
+        assert len(call_count) == 1, (
+            f"Expected exactly 1 call to update_confidence_from_outcome, got {len(call_count)}: {call_count}"
+        )
+        assert call_count[0][2] == "success"
+
+    def test_no_call_for_subprocess_completion_receipt(self, tmp_path):
+        """subprocess_completion event_type must NOT trigger a confidence update.
+
+        This was the type written by _write_receipt in subprocess_dispatch.py.
+        Confidence updates only happen when workers write task_complete/task_failed.
+        """
+        receipt = _make_receipt("subprocess_completion", "dispatch-A2", "T1", "done")
+        call_count = []
+
+        def counting_upcf(*args, **kwargs):
+            call_count.append(args)
+
+        import append_receipt
+        with patch.object(
+            sys.modules.get("intelligence_persist", MagicMock()),
+            "update_confidence_from_outcome",
+            side_effect=counting_upcf,
+        ):
+            append_receipt._update_confidence_from_receipt(receipt)
+
+        assert len(call_count) == 0, (
+            "subprocess_completion receipt must not trigger confidence update"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case B: task_failed receipt triggers exactly ONE confidence update
+# ---------------------------------------------------------------------------
+
+class TestTaskFailedDedup:
+    """update_confidence_from_outcome called once on task_failed receipt."""
+
+    def test_single_call_on_task_failed(self, tmp_path):
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS success_patterns "
+            "(id INTEGER PRIMARY KEY, confidence_score REAL, usage_count INTEGER, "
+            " source_dispatch_ids TEXT, last_used TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS confidence_events "
+            "(dispatch_id TEXT, terminal TEXT, outcome TEXT, patterns_boosted INTEGER, "
+            " patterns_decayed INTEGER, confidence_change REAL, occurred_at TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+        receipt = _make_receipt("task_failed", "dispatch-B1", "T2", "failure")
+        call_count = []
+
+        def counting_upcf(db, dispatch_id, terminal, outcome):
+            call_count.append((dispatch_id, terminal, outcome))
+
+        import append_receipt
+        with patch("append_receipt.resolve_state_dir", return_value=db_path.parent):
+            with patch.object(
+                sys.modules.get("intelligence_persist", MagicMock()),
+                "update_confidence_from_outcome",
+                side_effect=counting_upcf,
+            ):
+                append_receipt._update_confidence_from_receipt(receipt)
+
+        assert len(call_count) == 1, (
+            f"Expected exactly 1 confidence update for task_failed, got {len(call_count)}"
+        )
+        assert call_count[0][2] == "failure"
+
+
+# ---------------------------------------------------------------------------
+# Case C: subprocess_dispatch.py no longer imports intelligence_persist
+# ---------------------------------------------------------------------------
+
+class TestNoDirectImport:
+    """deliver_with_recovery path no longer calls update_confidence_from_outcome."""
+
+    def test_intelligence_persist_not_called_in_subprocess_dispatch(self):
+        """Parse subprocess_dispatch source and confirm no import of intelligence_persist.
+
+        This is a static check — it ensures the source-level dedup fix is present
+        regardless of test environment mocking.
+        """
+        source_path = SCRIPTS_LIB / "subprocess_dispatch.py"
+        assert source_path.exists(), f"subprocess_dispatch.py not found at {source_path}"
+
+        source = source_path.read_text(encoding="utf-8")
+
+        # The inline import that caused the duplicate should be gone
+        assert "from intelligence_persist import update_confidence_from_outcome" not in source, (
+            "Found removed duplicate import 'from intelligence_persist import "
+            "update_confidence_from_outcome' — dedup fix was reverted"
+        )
+
+    def test_pattern_confidence_calls_still_present(self):
+        """_update_pattern_confidence calls must remain — they update pattern_usage table,
+        a different linkage than update_confidence_from_outcome (source_dispatch_ids)."""
+        source_path = SCRIPTS_LIB / "subprocess_dispatch.py"
+        source = source_path.read_text(encoding="utf-8")
+
+        assert "_update_pattern_confidence" in source, (
+            "_update_pattern_confidence call missing — this is NOT the duplicate; it should stay"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case C extended: dispatch_metadata outcome capture unaffected
+# ---------------------------------------------------------------------------
+
+class TestOutcomeCaptureUnchanged:
+    """_capture_dispatch_outcome still fires — only the duplicate confidence call was removed."""
+
+    def test_capture_dispatch_outcome_still_in_source(self):
+        source_path = SCRIPTS_LIB / "subprocess_dispatch.py"
+        source = source_path.read_text(encoding="utf-8")
+        assert "_capture_dispatch_outcome" in source, (
+            "_capture_dispatch_outcome missing — outcome recording regressed"
+        )
+
+    def test_capture_dispatch_outcome_called_after_receipt(self):
+        """In the success path, _capture_dispatch_outcome comes after _write_receipt.
+
+        Verifies ordering hasn't changed during dedup edit.
+        """
+        source_path = SCRIPTS_LIB / "subprocess_dispatch.py"
+        source = source_path.read_text(encoding="utf-8")
+
+        write_pos = source.find("_write_receipt(")
+        capture_pos = source.find("_capture_dispatch_outcome(")
+
+        assert write_pos != -1, "_write_receipt not found"
+        assert capture_pos != -1, "_capture_dispatch_outcome not found"
+        assert capture_pos > write_pos, (
+            "_capture_dispatch_outcome must appear after _write_receipt in source"
+        )


### PR DESCRIPTION
## Summary

- **Bug**: Since VNX-R4 (#295), `update_confidence_from_outcome()` was being called **twice** per subprocess dispatch — once directly inside `deliver_with_recovery()` in `subprocess_dispatch.py` (lines ~1068 and ~1111), and a second time via the canonical path: `append_receipt_payload → _update_confidence_from_receipt → update_confidence_from_outcome` (triggered when the worker writes a `task_complete`/`task_failed` receipt).
- **Result**: Each dispatch produced two rows in `confidence_events` and applied the confidence delta twice to `success_patterns`.
- **Fix**: Removed the two direct inline `update_confidence_from_outcome()` call blocks from `deliver_with_recovery()`. The canonical path via `append_receipt_payload` is the sole owner of this update.
- **Not removed**: `_update_pattern_confidence()` calls are retained — they update the `pattern_usage` table via `dispatch_id` linkage, which is a different mechanism not covered by `append_receipt_payload`.

## Evidence

`scripts/lib/subprocess_dispatch.py` before fix (two duplicate call sites):
- Line ~1068: `from intelligence_persist import update_confidence_from_outcome as _upcf; _upcf(..., "success")`
- Line ~1111: `from intelligence_persist import update_confidence_from_outcome as _upcf; _upcf(..., "failure")`

`scripts/append_receipt.py` canonical path (unchanged):
- Line 1117: `_update_confidence_from_receipt(receipt)` → line 1159: `update_confidence_from_outcome(...)`

## Tests

New file: `tests/test_subprocess_dispatch_dedup.py` (7 tests, all pass)

- **Case A**: `task_complete` receipt → `_update_confidence_from_receipt` called exactly once
- **Case B**: `task_failed` receipt → confidence update fires with "failure" outcome exactly once
- **Case C (static)**: Source-level assertion that `from intelligence_persist import update_confidence_from_outcome` no longer appears in `subprocess_dispatch.py`
- **C extended**: `_capture_dispatch_outcome` and `_update_pattern_confidence` still present and ordered correctly

```
pytest tests/test_subprocess_dispatch_dedup.py -v
7 passed in 0.07s
```

## Test plan
- [ ] Run `python3 -m py_compile scripts/lib/subprocess_dispatch.py scripts/append_receipt.py`
- [ ] Run `python3 -m pytest tests/test_subprocess_dispatch_dedup.py -xvs`
- [ ] Verify `confidence_events` table has single row per dispatch in integration environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)