### PR TITLE
refactor(supervisor): single-owner cleanup_worker_exit helper (SUP-PR1)

### DIFF
--- a/scripts/lib/cleanup_worker_exit.py
+++ b/scripts/lib/cleanup_worker_exit.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""cleanup_worker_exit.py — Single-owner post-worker-exit cleanup helper.
+
+Foundation refactor for the unified supervisor pack (SUP-PR1).  Both the
+interactive (tmux/dispatch_lifecycle.sh) and headless (subprocess_dispatch.py)
+worker exit paths converge on `cleanup_worker_exit()` so the lease release,
+worker state transition, dispatch file disposition, and audit event are
+performed exactly once and in the same order.
+
+Idempotent and never raises — cleanup must not block worker exit.  All errors
+are caught and surfaced via CleanupResult.errors plus a structured stderr log.
+
+CLI surface (used from bash callers):
+
+    python3 cleanup_worker_exit.py \\
+        --terminal-id T1 \\
+        --dispatch-id 20260429-foo \\
+        --exit-status success \\
+        [--lease-generation 3] \\
+        [--dispatch-file /path/to/active/foo.md]
+
+Always exits 0 — best-effort cleanup, errors land in stderr/log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, List, Optional
+
+_THIS_DIR = Path(__file__).resolve().parent
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+try:
+    from project_root import resolve_data_dir, resolve_state_dir
+except ImportError:  # pragma: no cover - bootstrap failure
+    resolve_data_dir = None  # type: ignore[assignment]
+    resolve_state_dir = None  # type: ignore[assignment]
+
+
+VALID_EXIT_STATUSES = ("success", "failure", "timeout", "killed", "stuck")
+
+EXIT_STATUS_TO_WORKER_STATE = {
+    "success": "exited_clean",
+    "failure": "exited_bad",
+    "timeout": "exited_bad",
+    "killed": "exited_bad",
+    "stuck": "exited_bad",
+}
+
+EXIT_STATUS_TO_DISPOSITION = {
+    "success": ("completed", None),
+    "failure": ("rejected", "failure"),
+    "timeout": ("rejected", "timeout"),
+    "killed": ("rejected", "killed"),
+    "stuck": ("rejected", "stuck"),
+}
+
+
+@dataclass
+class CleanupResult:
+    """Outcome of a cleanup_worker_exit() invocation.
+
+    All fields default to "did not happen" so a partial cleanup (e.g. lease
+    already released, no dispatch_file given) reports truthfully.
+    """
+
+    lease_released: bool = False
+    worker_transitioned: bool = False
+    dispatch_moved: Optional[Path] = None
+    errors: List[str] = field(default_factory=list)
+
+
+def _emit(level: str, code: str, **fields: Any) -> None:
+    """Structured stderr log mirroring scripts/append_receipt.py:_emit."""
+    payload = {
+        "level": level,
+        "code": code,
+        "timestamp": int(time.time()),
+    }
+    payload.update(fields)
+    try:
+        print(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True, default=str),
+            file=sys.stderr,
+        )
+    except Exception:  # pragma: no cover - logging must never raise
+        pass
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _resolve_state_dir() -> Path:
+    """Resolve VNX state dir using project_root with explicit-env fallbacks."""
+    if resolve_state_dir is not None:
+        try:
+            return resolve_state_dir(__file__)
+        except Exception as exc:
+            _emit("WARN", "state_dir_resolution_failed", error=str(exc))
+
+    state_env = os.environ.get("VNX_STATE_DIR")
+    if state_env:
+        return Path(state_env)
+    data_env = os.environ.get("VNX_DATA_DIR")
+    if data_env:
+        return Path(data_env) / "state"
+    return _THIS_DIR.parent.parent / ".vnx-data" / "state"
+
+
+def _resolve_dispatch_register_path() -> Path:
+    """Resolve dispatch_register.ndjson path matching gate_register_emit.py."""
+    state_env = os.environ.get("VNX_STATE_DIR")
+    if state_env:
+        return Path(state_env) / "dispatch_register.ndjson"
+    if (
+        os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+        and os.environ.get("VNX_DATA_DIR")
+    ):
+        return Path(os.environ["VNX_DATA_DIR"]) / "state" / "dispatch_register.ndjson"
+    if resolve_state_dir is not None:
+        try:
+            return resolve_state_dir(__file__) / "dispatch_register.ndjson"
+        except Exception:
+            pass
+    return _THIS_DIR.parent.parent / ".vnx-data" / "state" / "dispatch_register.ndjson"
+
+
+def _release_lease_step(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    lease_generation: Optional[int],
+    exit_status: str,
+    state_dir: Path,
+    result: CleanupResult,
+) -> None:
+    """Step 1: release lease via LeaseManager.release.
+
+    Idempotent: if the lease is already idle/expired, treat as released-already
+    and surface a non-fatal note in errors[].  Generation mismatch is recorded
+    but does not raise.  None generation means we have nothing to release with —
+    skip with a note.
+    """
+    if lease_generation is None:
+        result.errors.append("lease_generation_missing")
+        return
+
+    try:
+        from lease_manager import LeaseManager  # noqa: PLC0415
+        from runtime_coordination import InvalidTransitionError  # noqa: PLC0415
+    except Exception as exc:
+        result.errors.append(f"lease_import_failed:{exc}")
+        _emit("WARN", "lease_import_failed", error=str(exc), dispatch_id=dispatch_id)
+        return
+
+    try:
+        mgr = LeaseManager(state_dir, auto_init=False)
+        # Pre-check: if the lease is already idle, no-op.
+        try:
+            current = mgr.get(terminal_id)
+        except Exception:
+            current = None
+
+        if current is not None and current.state != "leased":
+            result.lease_released = True
+            result.errors.append("lease_already_released")
+            return
+
+        mgr.release(
+            terminal_id,
+            generation=lease_generation,
+            actor="cleanup_worker_exit",
+            reason=f"worker exited:{exit_status}",
+        )
+        result.lease_released = True
+    except InvalidTransitionError as exc:
+        result.lease_released = True
+        result.errors.append(f"lease_already_released:{exc}")
+    except ValueError as exc:
+        result.errors.append(f"lease_generation_mismatch:{exc}")
+        _emit(
+            "WARN",
+            "lease_generation_mismatch",
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            generation=lease_generation,
+            error=str(exc),
+        )
+    except Exception as exc:
+        result.errors.append(f"lease_release_failed:{exc}")
+        _emit(
+            "WARN",
+            "lease_release_failed",
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            error=str(exc),
+        )
+
+
+def _transition_worker_step(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    exit_status: str,
+    state_dir: Path,
+    result: CleanupResult,
+) -> None:
+    """Step 2: transition worker state to exited_clean / exited_bad.
+
+    Idempotent: if the worker state row is already in a terminal state or
+    missing, no-op with a note.
+    """
+    target = EXIT_STATUS_TO_WORKER_STATE.get(exit_status, "exited_bad")
+
+    try:
+        from worker_state_manager import (  # noqa: PLC0415
+            TERMINAL_WORKER_STATES,
+            WorkerStateManager,
+        )
+    except Exception as exc:
+        result.errors.append(f"worker_state_import_failed:{exc}")
+        _emit("WARN", "worker_state_import_failed", error=str(exc))
+        return
+
+    try:
+        mgr = WorkerStateManager(state_dir, auto_init=False)
+        try:
+            current = mgr.get(terminal_id)
+        except Exception as exc:
+            result.errors.append(f"worker_state_lookup_failed:{exc}")
+            return
+
+        if current is None:
+            result.errors.append("worker_state_missing")
+            return
+
+        if current.state in TERMINAL_WORKER_STATES:
+            result.worker_transitioned = True
+            result.errors.append("worker_already_terminal")
+            return
+
+        mgr.transition(
+            terminal_id,
+            target,
+            actor="cleanup_worker_exit",
+            reason=f"worker exited:{exit_status}",
+        )
+        result.worker_transitioned = True
+    except Exception as exc:
+        result.errors.append(f"worker_transition_failed:{exc}")
+        _emit(
+            "WARN",
+            "worker_transition_failed",
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            target=target,
+            error=str(exc),
+        )
+
+
+def _move_dispatch_file_step(
+    *,
+    dispatch_file: Optional[Path],
+    exit_status: str,
+    result: CleanupResult,
+) -> None:
+    """Step 3: move dispatch file to completed/ or rejected/<reason>/.
+
+    Resolves the destination relative to the file's grandparent (the dispatches
+    dir):  active/foo.md → completed/foo.md  or  rejected/<reason>/foo.md.
+    No-op when dispatch_file is None or already moved.
+    """
+    if dispatch_file is None:
+        return
+
+    try:
+        src = Path(dispatch_file)
+        if not src.exists():
+            result.errors.append("dispatch_file_missing")
+            return
+
+        bucket, reason = EXIT_STATUS_TO_DISPOSITION.get(
+            exit_status, ("rejected", "failure")
+        )
+        dispatch_dir = src.parent.parent
+        if reason:
+            dest_dir = dispatch_dir / bucket / reason
+        else:
+            dest_dir = dispatch_dir / bucket
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / src.name
+
+        # Idempotent: if already moved (dest exists, src removed by prior call),
+        # we won't reach here because src.exists() returned False above.
+        shutil.move(str(src), str(dest))
+        result.dispatch_moved = dest
+    except Exception as exc:
+        result.errors.append(f"dispatch_move_failed:{exc}")
+        _emit(
+            "WARN",
+            "dispatch_move_failed",
+            dispatch_file=str(dispatch_file),
+            exit_status=exit_status,
+            error=str(exc),
+        )
+
+
+def _append_audit_event_step(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    exit_status: str,
+    result: CleanupResult,
+) -> None:
+    """Step 4: append worker_exited audit event to dispatch_register.ndjson."""
+    try:
+        import fcntl  # noqa: PLC0415
+
+        record = {
+            "timestamp": _now_iso(),
+            "event": "worker_exited",
+            "dispatch_id": dispatch_id,
+            "terminal_id": terminal_id,
+            "exit_status": exit_status,
+            "lease_released": result.lease_released,
+            "worker_transitioned": result.worker_transitioned,
+            "dispatch_moved": str(result.dispatch_moved) if result.dispatch_moved else None,
+        }
+
+        path = _resolve_dispatch_register_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        result.errors.append(f"audit_append_failed:{exc}")
+        _emit(
+            "WARN",
+            "audit_append_failed",
+            dispatch_id=dispatch_id,
+            error=str(exc),
+        )
+
+
+def _archive_event_store_step(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    result: CleanupResult,
+) -> None:
+    """Step 5: best-effort EventStore archive for subprocess context.
+
+    Only runs when the EventStore module is importable AND a default store
+    can be located.  Tmux callers will have nothing to archive — that's fine.
+    """
+    try:
+        from event_store import EventStore  # noqa: PLC0415
+    except Exception:
+        return
+
+    try:
+        store = EventStore()
+        store.clear(terminal_id, archive_dispatch_id=dispatch_id)
+    except Exception as exc:
+        result.errors.append(f"event_archive_failed:{exc}")
+        _emit(
+            "WARN",
+            "event_archive_failed",
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            error=str(exc),
+        )
+
+
+def cleanup_worker_exit(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    exit_status: str,
+    lease_generation: Optional[int] = None,
+    dispatch_file: Optional[Path] = None,
+    state_dir: Optional[Path] = None,
+) -> CleanupResult:
+    """Idempotent post-worker-exit cleanup.  Both adapters call this.
+
+    Steps (all best-effort, errors caught and recorded):
+      1. Release lease via LeaseManager.release.
+      2. Transition worker state via WorkerStateManager.transition →
+         exited_clean (success) or exited_bad (any other exit).
+      3. Move dispatch file: success → completed/, otherwise →
+         rejected/<reason>/ where <reason> is the exit_status.
+      4. Append worker_exited event to dispatch_register.ndjson.
+      5. Best-effort EventStore archive (no-op when not subprocess context).
+
+    Args:
+        terminal_id:      Terminal whose worker has just exited (e.g. "T1").
+        dispatch_id:      Dispatch identifier the worker was processing.
+        exit_status:      One of "success", "failure", "timeout", "killed",
+                          "stuck".  Unknown values are normalised to "failure".
+        lease_generation: Generation captured at lease acquire.  When None,
+                          lease release is skipped (recorded in errors).
+        dispatch_file:    Path to the dispatch file in dispatches/active/.
+                          When None, file move is skipped.
+        state_dir:        Optional override; defaults to project-root
+                          resolution.
+
+    Returns:
+        CleanupResult — never raises.
+    """
+    if exit_status not in VALID_EXIT_STATUSES:
+        _emit(
+            "WARN",
+            "unknown_exit_status",
+            exit_status=exit_status,
+            dispatch_id=dispatch_id,
+        )
+        exit_status = "failure"
+
+    result = CleanupResult()
+    resolved_state_dir = state_dir if state_dir is not None else _resolve_state_dir()
+
+    _release_lease_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        lease_generation=lease_generation,
+        exit_status=exit_status,
+        state_dir=resolved_state_dir,
+        result=result,
+    )
+
+    _transition_worker_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        exit_status=exit_status,
+        state_dir=resolved_state_dir,
+        result=result,
+    )
+
+    _move_dispatch_file_step(
+        dispatch_file=dispatch_file,
+        exit_status=exit_status,
+        result=result,
+    )
+
+    _append_audit_event_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        exit_status=exit_status,
+        result=result,
+    )
+
+    _archive_event_store_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        result=result,
+    )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="cleanup_worker_exit",
+        description="Single-owner post-worker-exit cleanup (lease, worker state, "
+                    "dispatch file, audit event).  Always exits 0.",
+    )
+    parser.add_argument("--terminal-id", required=True)
+    parser.add_argument("--dispatch-id", required=True)
+    parser.add_argument(
+        "--exit-status",
+        required=True,
+        choices=list(VALID_EXIT_STATUSES),
+    )
+    parser.add_argument(
+        "--lease-generation",
+        type=int,
+        default=None,
+        help="Lease generation captured at acquire-time (optional).",
+    )
+    parser.add_argument(
+        "--dispatch-file",
+        type=Path,
+        default=None,
+        help="Path to dispatch file in dispatches/active/ (optional).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    result = cleanup_worker_exit(
+        terminal_id=args.terminal_id,
+        dispatch_id=args.dispatch_id,
+        exit_status=args.exit_status,
+        lease_generation=args.lease_generation,
+        dispatch_file=args.dispatch_file,
+    )
+    payload = {
+        "lease_released": result.lease_released,
+        "worker_transitioned": result.worker_transitioned,
+        "dispatch_moved": str(result.dispatch_moved) if result.dispatch_moved else None,
+        "errors": result.errors,
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -233,19 +233,25 @@ rc_delivery_success() {
 _call_cleanup_worker_exit() {
     local terminal_id="$1" dispatch_id="$2" exit_status="$3"
     local generation="${4:-}"
+    local gen_args=()
+    [[ -n "$generation" ]] && gen_args=(--lease-generation "$generation")
     python3 "$VNX_DIR/scripts/lib/cleanup_worker_exit.py" \
         --terminal-id "$terminal_id" \
         --dispatch-id "$dispatch_id" \
         --exit-status "$exit_status" \
-        ${generation:+--lease-generation "$generation"} >/dev/null 2>&1 || true
+        "${gen_args[@]+"${gen_args[@]}"}" >/dev/null 2>&1 || true
     return 0
 }
 
 # Release canonical lease (leased -> idle).
 # Emits structured audit on success and uses log_structured_failure on error.
+# Optional 4th arg dispatch_exit_status (default "success") controls the exit
+# status forwarded to _call_cleanup_worker_exit.  Pass "failure" when calling
+# from a failed-dispatch fallback path so audit state is not corrupted.
 rc_release_lease() {
     local terminal_id="$1" generation="$2"
     local dispatch_id="${3:-unknown}"
+    local dispatch_exit_status="${4:-success}"
     _rc_enabled || return 0
     [[ -n "$generation" && "$generation" != "0" ]] || return 0
 
@@ -263,7 +269,7 @@ rc_release_lease() {
     log "V8 RUNTIME_CORE: lease released terminal=$terminal_id dispatch=$dispatch_id"
     emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
         "lease_released_on_failure" "true"
-    _call_cleanup_worker_exit "$terminal_id" "$dispatch_id" "success" "$generation"
+    _call_cleanup_worker_exit "$terminal_id" "$dispatch_id" "$dispatch_exit_status" "$generation"
 }
 
 # Release canonical lease and record delivery failure atomically.
@@ -287,8 +293,10 @@ rc_release_on_failure() {
         log_structured_failure "release_on_failure_cli_failed" \
             "release-on-failure CLI invocation failed — emitting direct lease release" \
             "dispatch=$dispatch_id terminal=$terminal_id"
-        # Fall back to direct release-lease so the lease is not stranded
-        rc_release_lease "$terminal_id" "$generation" "$dispatch_id"
+        # Fall back to direct release-lease so the lease is not stranded.
+        # Pass "failure" so _call_cleanup_worker_exit emits the correct exit
+        # status; this is a failed dispatch, not a successful one.
+        rc_release_lease "$terminal_id" "$generation" "$dispatch_id" "failure"
         return 1
     }
 

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -228,6 +228,19 @@ rc_delivery_success() {
     fi
 }
 
+# Invoke the unified cleanup_worker_exit helper (SUP-PR1).  Best-effort —
+# always returns 0 because the helper itself is best-effort and never raises.
+_call_cleanup_worker_exit() {
+    local terminal_id="$1" dispatch_id="$2" exit_status="$3"
+    local generation="${4:-}"
+    python3 "$VNX_DIR/scripts/lib/cleanup_worker_exit.py" \
+        --terminal-id "$terminal_id" \
+        --dispatch-id "$dispatch_id" \
+        --exit-status "$exit_status" \
+        ${generation:+--lease-generation "$generation"} >/dev/null 2>&1 || true
+    return 0
+}
+
 # Release canonical lease (leased -> idle).
 # Emits structured audit on success and uses log_structured_failure on error.
 rc_release_lease() {
@@ -244,11 +257,13 @@ rc_release_lease() {
             "terminal=$terminal_id dispatch=$dispatch_id generation=$generation"
         emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
             "lease_release_failed" "false" "release-lease python invocation failed"
+        _call_cleanup_worker_exit "$terminal_id" "$dispatch_id" "failure" "$generation"
         return 1
     fi
     log "V8 RUNTIME_CORE: lease released terminal=$terminal_id dispatch=$dispatch_id"
     emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
         "lease_released_on_failure" "true"
+    _call_cleanup_worker_exit "$terminal_id" "$dispatch_id" "success" "$generation"
 }
 
 # Release canonical lease and record delivery failure atomically.
@@ -299,6 +314,7 @@ rc_release_on_failure() {
         emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
             "lease_release_failed" "false" "$lease_error"
     fi
+    _call_cleanup_worker_exit "$terminal_id" "$dispatch_id" "failure" "$generation"
 }
 
 # ===== END RUNTIME CORE INTEGRATION =====

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -25,8 +25,29 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from subprocess_adapter import SubprocessAdapter
 from worker_health_monitor import WorkerHealthMonitor, HealthStatus, SLOW_THRESHOLD
+from cleanup_worker_exit import cleanup_worker_exit
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_active_dispatch_file(dispatch_id: str) -> Path | None:
+    """Locate the dispatch file in dispatches/active/ for cleanup_worker_exit.
+
+    Returns None when no matching file exists (e.g. file already moved by
+    another path).  Used by the deliver_with_recovery exit hooks.
+    """
+    data_dir = os.environ.get("VNX_DATA_DIR", "")
+    base = (
+        Path(data_dir) / "dispatches" / "active"
+        if data_dir
+        else Path(__file__).resolve().parents[2] / ".vnx-data" / "dispatches" / "active"
+    )
+    if not base.is_dir():
+        return None
+    for path in base.iterdir():
+        if path.is_file() and dispatch_id in path.name:
+            return path
+    return None
 
 
 def _inject_permission_profile(terminal_id: str, role: str | None, instruction: str) -> str:
@@ -1186,6 +1207,18 @@ def deliver_with_recovery(
                 start_ts=dispatch_start_ts,
                 committed=committed,
             )
+
+            # Single-owner post-exit cleanup (SUP-PR1).  Idempotent — the bash
+            # caller's rc_release_lease may have already released the lease,
+            # which is fine; this records the worker state transition and
+            # dispatch_register audit event regardless.
+            cleanup_worker_exit(
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                exit_status="success",
+                lease_generation=lease_generation,
+                dispatch_file=_resolve_active_dispatch_file(dispatch_id),
+            )
             return True
 
         if attempt < max_retries:
@@ -1229,6 +1262,17 @@ def deliver_with_recovery(
                 success=False,
                 start_ts=dispatch_start_ts,
                 committed=False,
+            )
+
+            # Single-owner post-exit cleanup (SUP-PR1).  Routes failure-path
+            # disposition (move to rejected/failure/, transition worker to
+            # exited_bad, audit) through the same helper as the bash caller.
+            cleanup_worker_exit(
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                exit_status="failure",
+                lease_generation=lease_generation,
+                dispatch_file=_resolve_active_dispatch_file(dispatch_id),
             )
 
     return False

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -257,6 +257,81 @@ class _SubprocessResult(NamedTuple):
     session_id: str | None
     event_count: int
     manifest_path: str | None
+    # Repo-relative paths the worker explicitly wrote/edited via structured tool
+    # calls (Write/Edit/MultiEdit/NotebookEdit) during this dispatch.  Used by
+    # _auto_commit_changes / _auto_stash_changes to scope staging to *this*
+    # worker's writes, even in shared worktrees where concurrent terminals or
+    # the operator may produce additional dirty files during the dispatch
+    # window.  Empty frozenset() when no structured file writes occurred.
+    touched_files: frozenset[str] = frozenset()
+
+
+# Tool names whose ``input`` block names a file path the worker is modifying.
+# Read/Bash/Glob/Grep are deliberately excluded — they do not modify files
+# (or, in Bash's case, may modify them but cannot be reliably parsed).  Workers
+# that rely on Bash for file modifications must commit those changes manually.
+_FILE_WRITING_TOOLS = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+
+
+def _normalize_repo_path(path_str: str, repo_root: Path) -> str | None:
+    """Convert a tool-event file_path to a repo-relative POSIX string.
+
+    Returns None when ``path_str`` resolves outside ``repo_root`` or is empty
+    or unparseable.  The result is suitable for matching against
+    ``git status --porcelain`` output, which always uses POSIX-style
+    repo-relative paths.
+
+    Symlink-resolves both sides so a path like ``./foo/../bar.py`` collapses
+    to ``bar.py`` and a worktree-relative path matches the repo root.
+    """
+    if not path_str:
+        return None
+    try:
+        p = Path(path_str)
+        if not p.is_absolute():
+            p = repo_root / p
+        try:
+            resolved = p.resolve(strict=False)
+        except (OSError, RuntimeError):
+            resolved = p
+        try:
+            root_resolved = repo_root.resolve(strict=False)
+        except (OSError, RuntimeError):
+            root_resolved = repo_root
+        rel = resolved.relative_to(root_resolved)
+        return rel.as_posix()
+    except (ValueError, OSError):
+        return None
+
+
+def _extract_touched_paths_from_event(event: "StreamEvent | object") -> list[str]:  # type: ignore[name-defined]
+    """Return raw ``file_path`` / ``notebook_path`` strings from a tool_use event.
+
+    Accepts a ``StreamEvent`` (or any object exposing ``.type`` + ``.data``).
+    Returns an empty list for non-tool_use events or tools that do not write
+    files.  Path normalization (repo-relative, in-repo filtering) is performed
+    by the caller via ``_normalize_repo_path``.
+    """
+    event_type = getattr(event, "type", None)
+    if event_type != "tool_use":
+        return []
+    data = getattr(event, "data", {}) or {}
+    name = data.get("name", "")
+    if name not in _FILE_WRITING_TOOLS:
+        return []
+    tool_input = data.get("input") or {}
+    if not isinstance(tool_input, dict):
+        return []
+    paths: list[str] = []
+    if name == "NotebookEdit":
+        candidate = tool_input.get("notebook_path") or tool_input.get("file_path")
+        if isinstance(candidate, str):
+            paths.append(candidate)
+    else:
+        candidate = tool_input.get("file_path")
+        if isinstance(candidate, str):
+            paths.append(candidate)
+    return paths
 
 
 def _get_dirty_files(cwd: Path) -> set[str]:
@@ -531,7 +606,18 @@ def deliver_via_subprocess(
         resume_session=resume_session,
     )
     if not result.success:
-        return _SubprocessResult(success=False, session_id=None, event_count=0, manifest_path=manifest_path)
+        return _SubprocessResult(
+            success=False,
+            session_id=None,
+            event_count=0,
+            manifest_path=manifest_path,
+            touched_files=frozenset(),
+        )
+
+    # Resolve repo root once for path normalization; agent_cwd may point into
+    # a sub-directory but the repo root anchors all git status output.
+    _repo_root = Path(__file__).resolve().parents[2]
+    _touched_files: set[str] = set()
 
     # Wire event_store into health_monitor so STUCK events are persisted to NDJSON
     if health_monitor is not None and health_monitor._event_store is None:
@@ -562,6 +648,13 @@ def deliver_via_subprocess(
             total_deadline=total_deadline,
         ):
             event_count += 1
+            # Track files written by this dispatch's structured tool calls so
+            # auto-commit / auto-stash can scope to *this* worker's writes,
+            # not whatever else became dirty in a shared worktree.
+            for raw_path in _extract_touched_paths_from_event(_event):
+                norm = _normalize_repo_path(raw_path, _repo_root)
+                if norm:
+                    _touched_files.add(norm)
             if health_monitor is not None:
                 health_monitor.update(_event)
                 # Log stuck warning at most once per SLOW_THRESHOLD window
@@ -589,6 +682,7 @@ def deliver_via_subprocess(
                 session_id=session_id,
                 event_count=event_count,
                 manifest_path=completed_manifest or manifest_path,
+                touched_files=frozenset(_touched_files),
             )
         # Fail-closed: timeout-terminated dispatches must not be classified as success.
         # stop() removes the process from _processes so returncode above is None,
@@ -604,6 +698,7 @@ def deliver_via_subprocess(
                 session_id=session_id,
                 event_count=event_count,
                 manifest_path=completed_manifest or manifest_path,
+                touched_files=frozenset(_touched_files),
             )
 
         # Only persist session_id once all fail-closed checks pass, so the next
@@ -621,10 +716,17 @@ def deliver_via_subprocess(
             session_id=session_id,
             event_count=event_count,
             manifest_path=completed_manifest or manifest_path,
+            touched_files=frozenset(_touched_files),
         )
     except Exception:
         logger.exception("deliver_via_subprocess failed for %s", terminal_id)
-        return _SubprocessResult(success=False, session_id=None, event_count=event_count, manifest_path=manifest_path)
+        return _SubprocessResult(
+            success=False,
+            session_id=None,
+            event_count=event_count,
+            manifest_path=manifest_path,
+            touched_files=frozenset(_touched_files),
+        )
     finally:
         if heartbeat_stop is not None:
             heartbeat_stop.set()
@@ -689,13 +791,27 @@ def _auto_commit_changes(
     terminal_id: str,
     gate: str = "",
     pre_dispatch_dirty: "set[str] | None" = None,
+    dispatch_touched_files: "frozenset[str] | set[str] | None" = None,
 ) -> bool:
     """Stage and commit changes introduced by this dispatch.
 
-    pre_dispatch_dirty is REQUIRED for safe operation: only files that became
-    dirty during the dispatch are staged.  When None is passed, the helper
-    refuses to commit anything (fail-safe) rather than sweeping unrelated
-    user/terminal changes into this worker's commit via ``git add -A``.
+    Two safety filters compose to determine the file set staged:
+
+    1. ``pre_dispatch_dirty`` — files dirty *before* the dispatch started.
+       Excluded from staging so pre-existing operator/agent edits are never
+       swept into this worker's commit.
+    2. ``dispatch_touched_files`` — files this dispatch's worker explicitly
+       wrote via structured tool calls (Write/Edit/MultiEdit/NotebookEdit).
+       In a *shared* or *concurrently-edited* worktree, files that became
+       dirty during the dispatch window may have been written by another
+       terminal or by the operator, not by this worker.  Intersecting with
+       this set prevents auto-commit from sweeping those concurrent edits.
+
+    Both kwargs are REQUIRED.  Passing ``None`` for either causes the helper
+    to refuse to commit (fail-safe) — better to leave changes uncommitted
+    than to sweep unrelated work into this worker's commit.  An empty set is
+    treated as "no eligible files" and is therefore also a no-op (correct: a
+    worker that performed no structured file writes should not auto-commit).
 
     Returns True if a commit was made, False otherwise.
     Never raises — all exceptions are logged and swallowed.
@@ -704,6 +820,13 @@ def _auto_commit_changes(
         logger.warning(
             "auto_commit: pre_dispatch_dirty=None — refusing to commit for dispatch %s "
             "(would otherwise sweep unrelated dirty files via git add -A)",
+            dispatch_id,
+        )
+        return False
+    if dispatch_touched_files is None:
+        logger.warning(
+            "auto_commit: dispatch_touched_files=None — refusing to commit for dispatch %s "
+            "(cannot distinguish this worker's writes from concurrent edits in a shared worktree)",
             dispatch_id,
         )
         return False
@@ -720,15 +843,32 @@ def _auto_commit_changes(
             logger.debug("auto_commit: working tree clean for dispatch %s", dispatch_id)
             return False
 
-        # Scope staging to files that became dirty during this dispatch.
+        # Scope staging to (files that became dirty during this dispatch) ∩
+        # (files this dispatch's worker explicitly wrote).  The intersection
+        # is the deepest scoping signal available: it filters out both
+        # pre-existing dirty files and concurrent-terminal edits that happen
+        # to land within the dispatch window.
         current_dirty = _get_dirty_files(cwd)
-        files_to_stage = sorted(current_dirty - pre_dispatch_dirty)
+        new_during_dispatch = current_dirty - pre_dispatch_dirty
+        touched = set(dispatch_touched_files)
+        files_to_stage = sorted(new_during_dispatch & touched)
         if not files_to_stage:
-            logger.debug(
-                "auto_commit: no new files to stage for dispatch %s "
-                "(all dirty files pre-existed the dispatch)",
-                dispatch_id,
-            )
+            ignored_dispatch_dirty = sorted(new_during_dispatch - touched)
+            if ignored_dispatch_dirty:
+                logger.warning(
+                    "auto_commit: %d dispatch-window dirty file(s) not in "
+                    "touched_files — refusing to commit (likely concurrent "
+                    "edits from another terminal). dispatch=%s files=%s",
+                    len(ignored_dispatch_dirty),
+                    dispatch_id,
+                    ignored_dispatch_dirty[:10],
+                )
+            else:
+                logger.debug(
+                    "auto_commit: no dispatch-touched files dirty for dispatch %s "
+                    "(all dirty files pre-existed the dispatch)",
+                    dispatch_id,
+                )
             return False
         add_cmd = ["git", "add", "--"] + files_to_stage
 
@@ -772,13 +912,25 @@ def _auto_stash_changes(
     dispatch_id: str,
     terminal_id: str,
     pre_dispatch_dirty: "set[str] | None" = None,
+    dispatch_touched_files: "frozenset[str] | set[str] | None" = None,
 ) -> bool:
     """Stash changes introduced by this dispatch after a failure (preserves but does not commit).
 
-    pre_dispatch_dirty is REQUIRED for safe operation: only files that became
-    dirty during the dispatch are stashed via ``git stash push -u -- <files>``.
-    When None is passed, the helper refuses to stash anything (fail-safe)
-    rather than hiding unrelated tracked/untracked edits from other terminals.
+    Two safety filters compose to determine the file set stashed:
+
+    1. ``pre_dispatch_dirty`` — files dirty *before* the dispatch started.
+       Excluded from the stash so pre-existing edits remain in the worktree
+       and are not hidden from the operator or other terminals.
+    2. ``dispatch_touched_files`` — files this dispatch's worker explicitly
+       wrote via structured tool calls.  In a shared worktree, files that
+       became dirty during the dispatch window may have been written by
+       another terminal — those must NOT be stashed under this dispatch's
+       name.
+
+    Both kwargs are REQUIRED.  Passing ``None`` for either causes the helper
+    to refuse to stash (fail-safe).  An empty ``dispatch_touched_files`` is
+    a legitimate "no structured writes happened" signal and also yields a
+    no-op stash.
 
     Returns True if a stash was created, False otherwise.
     Never raises — all exceptions are logged and swallowed.
@@ -787,6 +939,13 @@ def _auto_stash_changes(
         logger.warning(
             "auto_stash: pre_dispatch_dirty=None — refusing to stash for dispatch %s "
             "(would otherwise sweep unrelated dirty files into a global stash)",
+            dispatch_id,
+        )
+        return False
+    if dispatch_touched_files is None:
+        logger.warning(
+            "auto_stash: dispatch_touched_files=None — refusing to stash for dispatch %s "
+            "(cannot distinguish this worker's writes from concurrent edits in a shared worktree)",
             dispatch_id,
         )
         return False
@@ -804,13 +963,26 @@ def _auto_stash_changes(
         stash_name = f"vnx-auto-stash-{dispatch_id}"
 
         current_dirty = _get_dirty_files(cwd)
-        files_to_stash = sorted(current_dirty - pre_dispatch_dirty)
+        new_during_dispatch = current_dirty - pre_dispatch_dirty
+        touched = set(dispatch_touched_files)
+        files_to_stash = sorted(new_during_dispatch & touched)
         if not files_to_stash:
-            logger.debug(
-                "auto_stash: no new files to stash for dispatch %s "
-                "(all dirty files pre-existed the dispatch)",
-                dispatch_id,
-            )
+            ignored_dispatch_dirty = sorted(new_during_dispatch - touched)
+            if ignored_dispatch_dirty:
+                logger.warning(
+                    "auto_stash: %d dispatch-window dirty file(s) not in "
+                    "touched_files — refusing to stash (likely concurrent "
+                    "edits from another terminal). dispatch=%s files=%s",
+                    len(ignored_dispatch_dirty),
+                    dispatch_id,
+                    ignored_dispatch_dirty[:10],
+                )
+            else:
+                logger.debug(
+                    "auto_stash: no dispatch-touched files dirty for dispatch %s "
+                    "(all dirty files pre-existed the dispatch)",
+                    dispatch_id,
+                )
             return False
         # -u includes untracked files matching the specified paths so
         # newly-created files from the failed dispatch are also captured.
@@ -1170,6 +1342,7 @@ def deliver_with_recovery(
                 committed = _auto_commit_changes(
                     dispatch_id, terminal_id, gate=gate,
                     pre_dispatch_dirty=pre_dispatch_dirty,
+                    dispatch_touched_files=sub_result.touched_files,
                 )
                 if committed:
                     commit_missing = False
@@ -1232,7 +1405,12 @@ def deliver_with_recovery(
             monitor.mark_completed()
             # Stash uncommitted changes from failed dispatch
             if auto_commit:
-                _auto_stash_changes(dispatch_id, terminal_id, pre_dispatch_dirty=pre_dispatch_dirty)
+                _auto_stash_changes(
+                    dispatch_id,
+                    terminal_id,
+                    pre_dispatch_dirty=pre_dispatch_dirty,
+                    dispatch_touched_files=sub_result.touched_files,
+                )
             _write_receipt(
                 dispatch_id, terminal_id, "failed",
                 event_count=sub_result.event_count,

--- a/tests/test_auto_commit_stash_isolation.py
+++ b/tests/test_auto_commit_stash_isolation.py
@@ -103,7 +103,11 @@ class TestAutoCommitIsolation(unittest.TestCase):
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"old_file.py", "new_file.py"}):
-            result = _auto_commit_changes("d-001", "T1", pre_dispatch_dirty=pre)
+            result = _auto_commit_changes(
+                "d-001", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"new_file.py"}),
+            )
 
         self.assertTrue(result)
         add_call = mock_sp.run.call_args_list[1]
@@ -122,7 +126,11 @@ class TestAutoCommitIsolation(unittest.TestCase):
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"already_dirty.py"}):
-            result = _auto_commit_changes("d-002", "T1", pre_dispatch_dirty=pre)
+            result = _auto_commit_changes(
+                "d-002", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset(),
+            )
 
         self.assertFalse(result)
         # git add must NOT have been called
@@ -137,7 +145,11 @@ class TestAutoCommitIsolation(unittest.TestCase):
         status_lines = [" M some_file.py"]
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_commit_changes("d-003", "T1", pre_dispatch_dirty=None)
+            result = _auto_commit_changes(
+                "d-003", "T1",
+                pre_dispatch_dirty=None,
+                dispatch_touched_files=frozenset({"some_file.py"}),
+            )
 
         self.assertFalse(result)
         # No git command must have been invoked at all — fail-safe before any git work.
@@ -147,7 +159,11 @@ class TestAutoCommitIsolation(unittest.TestCase):
         """Returns False without calling add/commit when tree is clean."""
         mock_sp = self._mock_subprocess([])
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_commit_changes("d-004", "T1", pre_dispatch_dirty=set())
+            result = _auto_commit_changes(
+                "d-004", "T1",
+                pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(),
+            )
 
         self.assertFalse(result)
         self.assertEqual(mock_sp.run.call_count, 1)  # only git status
@@ -159,7 +175,11 @@ class TestAutoCommitIsolation(unittest.TestCase):
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"foo.py"}):
-            _auto_commit_changes("dispatch-xyz-123", "T2", pre_dispatch_dirty=pre)
+            _auto_commit_changes(
+                "dispatch-xyz-123", "T2",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"foo.py"}),
+            )
 
         commit_call = mock_sp.run.call_args_list[2]
         cmd = commit_call[0][0]
@@ -198,7 +218,11 @@ class TestAutoStashIsolation(unittest.TestCase):
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files",
                    return_value={"pre_existing.py", "new_untracked.py"}):
-            result = _auto_stash_changes("d-010", "T1", pre_dispatch_dirty=pre)
+            result = _auto_stash_changes(
+                "d-010", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"new_untracked.py"}),
+            )
 
         self.assertTrue(result)
         stash_call = mock_sp.run.call_args_list[1]
@@ -222,7 +246,11 @@ class TestAutoStashIsolation(unittest.TestCase):
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"already_there.py"}):
-            result = _auto_stash_changes("d-011", "T1", pre_dispatch_dirty=pre)
+            result = _auto_stash_changes(
+                "d-011", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset(),
+            )
 
         self.assertFalse(result)
         # stash must NOT have been called
@@ -237,7 +265,11 @@ class TestAutoStashIsolation(unittest.TestCase):
         status_lines = [" M some.py"]
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_stash_changes("d-012", "T1", pre_dispatch_dirty=None)
+            result = _auto_stash_changes(
+                "d-012", "T1",
+                pre_dispatch_dirty=None,
+                dispatch_touched_files=frozenset({"some.py"}),
+            )
 
         self.assertFalse(result)
         # No git command must have been invoked — fail-safe before any git work.
@@ -247,7 +279,11 @@ class TestAutoStashIsolation(unittest.TestCase):
         """Returns False without calling stash when tree is clean."""
         mock_sp = self._mock_subprocess([])
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_stash_changes("d-013", "T1", pre_dispatch_dirty=set())
+            result = _auto_stash_changes(
+                "d-013", "T1",
+                pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(),
+            )
 
         self.assertFalse(result)
         self.assertEqual(mock_sp.run.call_count, 1)  # only git status
@@ -259,7 +295,11 @@ class TestAutoStashIsolation(unittest.TestCase):
         mock_sp = self._mock_subprocess(status_lines)
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"bar.py"}):
-            _auto_stash_changes("dispatch-abc-789", "T3", pre_dispatch_dirty=pre)
+            _auto_stash_changes(
+                "dispatch-abc-789", "T3",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"bar.py"}),
+            )
 
         stash_call = mock_sp.run.call_args_list[1]
         cmd_str = " ".join(stash_call[0][0])
@@ -287,7 +327,8 @@ class TestDeliverWithRecoveryPreDispatchCapture(unittest.TestCase):
         return adapter
 
     def test_pre_dispatch_dirty_forwarded_to_auto_commit_on_success(self):
-        """On success path, _auto_commit_changes receives the pre-dispatch dirty set."""
+        """On success path, _auto_commit_changes receives both the pre-dispatch
+        dirty set and the dispatch_touched_files captured from tool events."""
         fake_pre_dirty = {"existing_file.py"}
 
         with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
@@ -318,6 +359,10 @@ class TestDeliverWithRecoveryPreDispatchCapture(unittest.TestCase):
         self.assertEqual(
             kwargs.get("pre_dispatch_dirty"), fake_pre_dirty,
             "deliver_with_recovery must forward pre_dispatch_dirty to _auto_commit_changes",
+        )
+        self.assertIn(
+            "dispatch_touched_files", kwargs,
+            "deliver_with_recovery must forward dispatch_touched_files to _auto_commit_changes",
         )
 
     def test_pre_dispatch_dirty_forwarded_to_auto_stash_on_failure(self):
@@ -357,6 +402,10 @@ class TestDeliverWithRecoveryPreDispatchCapture(unittest.TestCase):
         self.assertEqual(
             kwargs.get("pre_dispatch_dirty"), fake_pre_dirty,
             "deliver_with_recovery must forward pre_dispatch_dirty to _auto_stash_changes",
+        )
+        self.assertIn(
+            "dispatch_touched_files", kwargs,
+            "deliver_with_recovery must forward dispatch_touched_files to _auto_stash_changes",
         )
 
 

--- a/tests/test_cleanup_worker_exit.py
+++ b/tests/test_cleanup_worker_exit.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/cleanup_worker_exit.py (SUP-PR1).
+
+Covers ten scenarios:
+  A. success exit              → lease released, exited_clean, completed/
+  B. failure exit              → lease released, exited_bad,  rejected/failure/
+  C. killed exit               → lease released, exited_bad,  rejected/killed/
+  D. timeout exit              → lease released, exited_bad,  rejected/timeout/
+  E. stuck exit                → lease released, exited_bad,  rejected/stuck/
+  F. idempotency               → second call is a no-op, no errors raised
+  G. lease already released    → cleanup still succeeds, errors note it
+  H. dispatch_file None        → file move skipped, other steps succeed
+  I. LeaseManager raises       → caught, logged, surfaced via errors[]
+  J. CLI invocation            → python3 cleanup_worker_exit.py exits 0
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from runtime_coordination import (  # noqa: E402
+    get_connection,
+    init_schema,
+    register_dispatch,
+)
+from lease_manager import LeaseManager  # noqa: E402
+from worker_state_manager import WorkerStateManager  # noqa: E402
+
+import cleanup_worker_exit as cwe  # noqa: E402
+
+
+class _CWETestCase(unittest.TestCase):
+    """Base — sets up a temp state_dir, dispatch_dir, and acquires a lease."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+
+        self.state_dir = self.tmp_path / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        init_schema(self.state_dir)
+
+        self.dispatch_dir = self.tmp_path / "dispatches"
+        (self.dispatch_dir / "active").mkdir(parents=True)
+
+        self.lease_mgr = LeaseManager(self.state_dir, auto_init=False)
+        self.worker_mgr = WorkerStateManager(self.state_dir, auto_init=False)
+
+        # Register dispatch row + acquire lease + initialize worker state.
+        self.dispatch_id = "d-cwe-001"
+        self.terminal_id = "T1"
+        with get_connection(self.state_dir) as conn:
+            register_dispatch(
+                conn,
+                dispatch_id=self.dispatch_id,
+                terminal_id=self.terminal_id,
+            )
+            conn.commit()
+        lease = self.lease_mgr.acquire(
+            self.terminal_id,
+            dispatch_id=self.dispatch_id,
+        )
+        self.lease_generation = lease.generation
+        self.worker_mgr.initialize(self.terminal_id, dispatch_id=self.dispatch_id)
+        # Move worker into "working" so terminal transitions are valid.
+        self.worker_mgr.transition(self.terminal_id, "working")
+
+        # Drop a fake dispatch file in active/.
+        self.dispatch_file = self.dispatch_dir / "active" / f"{self.dispatch_id}.md"
+        self.dispatch_file.write_text("dummy dispatch payload\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    _UNSET = object()
+
+    def _call(
+        self,
+        exit_status: str,
+        *,
+        lease_generation=_UNSET,
+        dispatch_file=_UNSET,
+    ):
+        """Invoke cleanup_worker_exit with fixture defaults (None to opt out)."""
+        if lease_generation is self._UNSET:
+            lease_generation = self.lease_generation
+        if dispatch_file is self._UNSET:
+            dispatch_file = self.dispatch_file
+        return cwe.cleanup_worker_exit(
+            terminal_id=self.terminal_id,
+            dispatch_id=self.dispatch_id,
+            exit_status=exit_status,
+            lease_generation=lease_generation,
+            dispatch_file=dispatch_file,
+            state_dir=self.state_dir,
+        )
+
+
+class TestSuccessPath(_CWETestCase):
+    """Case A — success exit goes to completed/, exited_clean, lease released."""
+
+    def test_success_full_cleanup(self):
+        result = self._call("success")
+
+        self.assertTrue(result.lease_released)
+        self.assertTrue(result.worker_transitioned)
+        self.assertIsNotNone(result.dispatch_moved)
+        self.assertTrue(result.dispatch_moved.exists())
+        self.assertEqual(result.dispatch_moved.parent.name, "completed")
+        self.assertFalse(self.dispatch_file.exists())
+
+        lease = self.lease_mgr.get(self.terminal_id)
+        self.assertEqual(lease.state, "idle")
+
+        worker = self.worker_mgr.get(self.terminal_id)
+        self.assertEqual(worker.state, "exited_clean")
+
+
+class TestFailureExitPaths(_CWETestCase):
+    """Cases B–E — every non-success exit_status routes to rejected/<reason>/."""
+
+    def _assert_rejected_with_reason(self, exit_status: str, expected_reason: str):
+        result = self._call(exit_status)
+        self.assertTrue(result.lease_released)
+        self.assertTrue(result.worker_transitioned)
+        self.assertIsNotNone(result.dispatch_moved)
+        self.assertEqual(result.dispatch_moved.parent.name, expected_reason)
+        self.assertEqual(result.dispatch_moved.parent.parent.name, "rejected")
+
+        worker = self.worker_mgr.get(self.terminal_id)
+        self.assertEqual(worker.state, "exited_bad")
+
+    def test_failure_routes_to_rejected_failure(self):
+        self._assert_rejected_with_reason("failure", "failure")
+
+    def test_killed_routes_to_rejected_killed(self):
+        self._assert_rejected_with_reason("killed", "killed")
+
+    def test_timeout_routes_to_rejected_timeout(self):
+        self._assert_rejected_with_reason("timeout", "timeout")
+
+    def test_stuck_routes_to_rejected_stuck(self):
+        self._assert_rejected_with_reason("stuck", "stuck")
+
+
+class TestIdempotency(_CWETestCase):
+    """Case F — calling cleanup twice is safe; second call is a no-op."""
+
+    def test_double_cleanup_is_safe(self):
+        first = self._call("success")
+        self.assertTrue(first.lease_released)
+        self.assertTrue(first.worker_transitioned)
+        moved_path = first.dispatch_moved
+
+        # Second call: dispatch_file is now gone, lease is idle, worker terminal.
+        second = self._call("success", dispatch_file=moved_path)
+
+        # Lease already released → still True via the pre-check.
+        self.assertTrue(second.lease_released)
+        # Worker already terminal → still True (records a note).
+        self.assertTrue(second.worker_transitioned)
+        # Notes recorded in errors[] but no exceptions surfaced.
+        self.assertTrue(
+            any("already" in err for err in second.errors),
+            f"expected 'already' note in errors={second.errors}",
+        )
+
+
+class TestLeaseAlreadyReleased(_CWETestCase):
+    """Case G — lease was released before cleanup runs."""
+
+    def test_lease_already_released_is_tolerated(self):
+        # Release lease out-of-band.
+        self.lease_mgr.release(self.terminal_id, generation=self.lease_generation)
+
+        result = self._call("success")
+        self.assertTrue(result.lease_released)
+        self.assertTrue(
+            any("lease_already_released" in err for err in result.errors),
+            f"expected lease_already_released note, got errors={result.errors}",
+        )
+
+
+class TestNoDispatchFile(_CWETestCase):
+    """Case H — dispatch_file=None skips the move step."""
+
+    def test_no_dispatch_file_skips_move(self):
+        result = self._call("success", dispatch_file=None)
+        self.assertTrue(result.lease_released)
+        self.assertTrue(result.worker_transitioned)
+        self.assertIsNone(result.dispatch_moved)
+        # Dispatch file remained where it was.
+        self.assertTrue(self.dispatch_file.exists())
+
+
+class TestLeaseRaises(_CWETestCase):
+    """Case I — LeaseManager.release raises; cleanup continues for other steps."""
+
+    def test_lease_failure_does_not_block_other_steps(self):
+        original_release = LeaseManager.release
+
+        def boom(self, *args, **kwargs):  # noqa: ANN001
+            raise RuntimeError("simulated DB failure")
+
+        try:
+            LeaseManager.release = boom
+            result = self._call("success")
+        finally:
+            LeaseManager.release = original_release
+
+        self.assertFalse(result.lease_released)
+        self.assertTrue(
+            any("lease_release_failed" in err for err in result.errors),
+            f"expected lease_release_failed note, got errors={result.errors}",
+        )
+        # Other steps still ran.
+        self.assertTrue(result.worker_transitioned)
+        self.assertIsNotNone(result.dispatch_moved)
+
+
+class TestCLI(_CWETestCase):
+    """Case J — `python3 cleanup_worker_exit.py ...` exits 0 with side effects."""
+
+    def test_cli_invocation(self):
+        cli_path = SCRIPT_DIR / "lib" / "cleanup_worker_exit.py"
+        env = {
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "VNX_STATE_DIR": str(self.state_dir),
+            "VNX_DATA_DIR": str(self.tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+        }
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(cli_path),
+                "--terminal-id",
+                self.terminal_id,
+                "--dispatch-id",
+                self.dispatch_id,
+                "--exit-status",
+                "success",
+                "--lease-generation",
+                str(self.lease_generation),
+                "--dispatch-file",
+                str(self.dispatch_file),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+        self.assertEqual(proc.returncode, 0, msg=f"stderr={proc.stderr}")
+        payload = json.loads(proc.stdout.strip())
+        self.assertTrue(payload["lease_released"])
+        self.assertTrue(payload["worker_transitioned"])
+        self.assertIsNotNone(payload["dispatch_moved"])
+
+        # Side effects: dispatch file moved.
+        self.assertFalse(self.dispatch_file.exists())
+        moved = Path(payload["dispatch_moved"])
+        self.assertTrue(moved.exists())
+        self.assertEqual(moved.parent.name, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_commit_enforcement.py
+++ b/tests/test_commit_enforcement.py
@@ -32,18 +32,24 @@ def _make_run_result(returncode=0, stdout="", stderr=""):
 class TestAutoCommitOnSuccess(unittest.TestCase):
     """_auto_commit_changes commits dirty changes and returns True."""
 
+    @patch("subprocess_dispatch._get_dirty_files")
     @patch("subprocess_dispatch.subprocess.run")
-    def test_auto_commit_on_success(self, mock_run):
+    def test_auto_commit_on_success(self, mock_run, mock_dirty):
         from subprocess_dispatch import _auto_commit_changes
 
         # git status --porcelain returns two dirty files
         mock_run.side_effect = [
             _make_run_result(stdout="M  scripts/lib/foo.py\nA  tests/test_foo.py\n"),  # status
-            _make_run_result(returncode=0),   # git add -A
+            _make_run_result(returncode=0),   # git add
             _make_run_result(returncode=0),   # git commit
         ]
+        mock_dirty.return_value = {"scripts/lib/foo.py", "tests/test_foo.py"}
 
-        result = _auto_commit_changes("dispatch-abc", "T1", gate="f52-pr3")
+        result = _auto_commit_changes(
+            "dispatch-abc", "T1", gate="f52-pr3",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset({"scripts/lib/foo.py", "tests/test_foo.py"}),
+        )
         self.assertTrue(result)
 
         # Verify commit message includes gate tag and terminal
@@ -55,8 +61,9 @@ class TestAutoCommitOnSuccess(unittest.TestCase):
         self.assertIn("f52-pr3", msg)
         self.assertIn("T1", msg)
 
+    @patch("subprocess_dispatch._get_dirty_files")
     @patch("subprocess_dispatch.subprocess.run")
-    def test_auto_commit_uses_dispatch_id_when_no_gate(self, mock_run):
+    def test_auto_commit_uses_dispatch_id_when_no_gate(self, mock_run, mock_dirty):
         from subprocess_dispatch import _auto_commit_changes
 
         mock_run.side_effect = [
@@ -64,8 +71,13 @@ class TestAutoCommitOnSuccess(unittest.TestCase):
             _make_run_result(returncode=0),
             _make_run_result(returncode=0),
         ]
+        mock_dirty.return_value = {"foo.py"}
 
-        result = _auto_commit_changes("dispatch-xyz1234567890", "T2")
+        result = _auto_commit_changes(
+            "dispatch-xyz1234567890", "T2",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset({"foo.py"}),
+        )
         self.assertTrue(result)
         commit_cmd = mock_run.call_args_list[2][0][0]
         msg = commit_cmd[commit_cmd.index("-m") + 1]
@@ -77,35 +89,48 @@ class TestAutoCommitOnSuccess(unittest.TestCase):
 class TestAutoStashOnFailure(unittest.TestCase):
     """_auto_stash_changes stashes dirty changes and returns True."""
 
+    @patch("subprocess_dispatch._get_dirty_files")
     @patch("subprocess_dispatch.subprocess.run")
-    def test_auto_stash_on_failure(self, mock_run):
+    def test_auto_stash_on_failure(self, mock_run, mock_dirty):
         from subprocess_dispatch import _auto_stash_changes
 
         mock_run.side_effect = [
             _make_run_result(stdout="M  scripts/lib/worker_health_monitor.py\n"),  # status
-            _make_run_result(returncode=0),   # git stash save
+            _make_run_result(returncode=0),   # git stash push
         ]
+        mock_dirty.return_value = {"scripts/lib/worker_health_monitor.py"}
 
-        result = _auto_stash_changes("dispatch-fail-001", "T1")
+        result = _auto_stash_changes(
+            "dispatch-fail-001", "T1",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset({"scripts/lib/worker_health_monitor.py"}),
+        )
         self.assertTrue(result)
 
         stash_call = mock_run.call_args_list[1]
         stash_cmd = stash_call[0][0]
-        self.assertIn("stash", stash_cmd)
-        self.assertIn("save", stash_cmd)
-        stash_name = stash_cmd[-1]
+        self.assertEqual(stash_cmd[:3], ["git", "stash", "push"])
+        # Stash name is supplied via -m <name>
+        m_idx = stash_cmd.index("-m")
+        stash_name = stash_cmd[m_idx + 1]
         self.assertIn("dispatch-fail-001", stash_name)
 
+    @patch("subprocess_dispatch._get_dirty_files")
     @patch("subprocess_dispatch.subprocess.run")
-    def test_auto_stash_git_failure_returns_false(self, mock_run):
+    def test_auto_stash_git_failure_returns_false(self, mock_run, mock_dirty):
         from subprocess_dispatch import _auto_stash_changes
 
         mock_run.side_effect = [
             _make_run_result(stdout="M  foo.py\n"),
             _make_run_result(returncode=1, stderr="stash failed"),
         ]
+        mock_dirty.return_value = {"foo.py"}
 
-        result = _auto_stash_changes("dispatch-fail-002", "T1")
+        result = _auto_stash_changes(
+            "dispatch-fail-002", "T1",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset({"foo.py"}),
+        )
         self.assertFalse(result)
 
 
@@ -118,7 +143,11 @@ class TestNoCommitWhenClean(unittest.TestCase):
 
         mock_run.return_value = _make_run_result(stdout="")  # clean working tree
 
-        result = _auto_commit_changes("dispatch-clean-001", "T1")
+        result = _auto_commit_changes(
+            "dispatch-clean-001", "T1",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset(),
+        )
         self.assertFalse(result)
 
         # Only git status should be called — no add or commit
@@ -133,9 +162,40 @@ class TestNoCommitWhenClean(unittest.TestCase):
 
         mock_run.return_value = _make_run_result(stdout="")
 
-        result = _auto_stash_changes("dispatch-clean-002", "T1")
+        result = _auto_stash_changes(
+            "dispatch-clean-002", "T1",
+            pre_dispatch_dirty=set(),
+            dispatch_touched_files=frozenset(),
+        )
         self.assertFalse(result)
         self.assertEqual(mock_run.call_count, 1)
+
+
+def _success_subprocess_result(touched: frozenset = frozenset()):
+    """Build a _SubprocessResult that matches a successful subprocess delivery.
+
+    Used by tests that patch ``deliver_via_subprocess`` directly — the helper
+    must mimic the namedtuple shape because callers access attributes like
+    ``.success`` and ``.touched_files``."""
+    from subprocess_dispatch import _SubprocessResult
+    return _SubprocessResult(
+        success=True,
+        session_id="sess-test",
+        event_count=0,
+        manifest_path="/tmp/m.json",
+        touched_files=touched,
+    )
+
+
+def _failed_subprocess_result(touched: frozenset = frozenset()):
+    from subprocess_dispatch import _SubprocessResult
+    return _SubprocessResult(
+        success=False,
+        session_id=None,
+        event_count=0,
+        manifest_path="/tmp/m.json",
+        touched_files=touched,
+    )
 
 
 class TestNoAutoCommitFlag(unittest.TestCase):
@@ -159,7 +219,7 @@ class TestNoAutoCommitFlag(unittest.TestCase):
         from subprocess_dispatch import deliver_with_recovery
 
         mock_monitor_cls.return_value = MagicMock()
-        mock_deliver.return_value = True
+        mock_deliver.return_value = _success_subprocess_result()
         mock_check.return_value = True  # commit_missing=True, but auto_commit is off
 
         deliver_with_recovery(
@@ -186,7 +246,7 @@ class TestNoAutoCommitFlag(unittest.TestCase):
         from subprocess_dispatch import deliver_with_recovery
 
         mock_monitor_cls.return_value = MagicMock()
-        mock_deliver.return_value = False  # dispatch fails
+        mock_deliver.return_value = _failed_subprocess_result()
 
         deliver_with_recovery(
             "T1", "do work", "sonnet", "dispatch-nac-002",
@@ -213,7 +273,9 @@ class TestNoAutoCommitFlag(unittest.TestCase):
         from subprocess_dispatch import deliver_with_recovery
 
         mock_monitor_cls.return_value = MagicMock()
-        mock_deliver.return_value = True
+        mock_deliver.return_value = _success_subprocess_result(
+            touched=frozenset({"foo.py"})
+        )
         mock_check.return_value = True   # commit_missing
         mock_commit.return_value = True  # auto-commit succeeded
 

--- a/tests/test_dispatch_lifecycle_codex_r1.sh
+++ b/tests/test_dispatch_lifecycle_codex_r1.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Regression tests for codex round-1 findings on dispatch_lifecycle.sh (PR #315).
+#
+# Finding 1 (lines 233-240): _call_cleanup_worker_exit must pass --lease-generation
+#   and its value as TWO separate argv entries, not a single concatenated token.
+#
+# Finding 2 (lines 246-267, 286-292): rc_release_on_failure fallback path must pass
+#   exit_status="failure" to _call_cleanup_worker_exit, not "success".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE="$SCRIPT_DIR/../scripts/lib/dispatch_lifecycle.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected='$expected' actual='$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF "$needle"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (expected substring='$needle' not found in='$haystack')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Helpers to extract only the functions under test ─────────────────────────
+
+# Capture just _call_cleanup_worker_exit from lifecycle, with VNX_DIR substitution.
+_load_call_cleanup() {
+    local vnx_dir="$1"
+    # Provide stubs for log/log_structured_failure used elsewhere; not needed here.
+    log() { :; }
+    export -f log
+    VNX_DIR="$vnx_dir"
+    # Extract and eval the function body from the source file.
+    eval "$(sed -n '/^_call_cleanup_worker_exit/,/^}/p' "$LIFECYCLE")"
+}
+
+# ── Test 1: Finding 1 — --lease-generation arrives as two argv entries ────────
+(
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+
+    # Mock cleanup_worker_exit.py: write all argv to a JSON array file.
+    MOCK_SCRIPT="$TMP/scripts/lib/cleanup_worker_exit.py"
+    mkdir -p "$TMP/scripts/lib"
+    cat > "$MOCK_SCRIPT" <<'PYEOF'
+import sys, json
+with open(sys.argv[1], "w") as f:
+    json.dump(sys.argv[2:], f)
+PYEOF
+
+    # We need the first positional arg to be the output file.
+    # Wrap: our mock writes to a fixed path, uses $1 as the target.
+    ARGV_FILE="$TMP/argv.json"
+    cat > "$MOCK_SCRIPT" <<PYEOF
+import sys, json
+with open("$ARGV_FILE", "w") as f:
+    json.dump(sys.argv[1:], f)
+PYEOF
+
+    # Load just _call_cleanup_worker_exit with VNX_DIR=$TMP
+    VNX_DIR="$TMP"
+    eval "$(sed -n '/^_call_cleanup_worker_exit/,/^}/p' "$LIFECYCLE")"
+
+    # Call with generation=3
+    _call_cleanup_worker_exit "T1" "d-test-001" "success" "3"
+
+    if [[ ! -f "$ARGV_FILE" ]]; then
+        echo "FAIL: Finding1 - mock was not invoked (argv file missing)"
+        exit 1
+    fi
+
+    # --lease-generation must be a separate entry from "3"
+    ARGS="$(cat "$ARGV_FILE")"
+    # The array must contain "--lease-generation" as its own element
+    if python3 -c "
+import json, sys
+args = json.load(open('$ARGV_FILE'))
+assert '--lease-generation' in args, f'--lease-generation not in args: {args}'
+idx = args.index('--lease-generation')
+assert args[idx+1] == '3', f'generation value not at idx+1: {args}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        echo "PASS: Finding1 - --lease-generation passed as two separate argv tokens"
+        exit 0
+    else
+        echo "FAIL: Finding1 - --lease-generation NOT passed as separate argv tokens"
+        cat "$ARGV_FILE"
+        exit 1
+    fi
+)
+RET=$?
+if [[ $RET -eq 0 ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); fi
+
+# ── Test 2: Finding 1 — no --lease-generation when generation is empty ────────
+(
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+
+    ARGV_FILE="$TMP/argv.json"
+    mkdir -p "$TMP/scripts/lib"
+    cat > "$TMP/scripts/lib/cleanup_worker_exit.py" <<PYEOF
+import sys, json
+with open("$ARGV_FILE", "w") as f:
+    json.dump(sys.argv[1:], f)
+PYEOF
+
+    VNX_DIR="$TMP"
+    eval "$(sed -n '/^_call_cleanup_worker_exit/,/^}/p' "$LIFECYCLE")"
+
+    _call_cleanup_worker_exit "T1" "d-test-002" "success" ""
+
+    if python3 -c "
+import json
+args = json.load(open('$ARGV_FILE'))
+assert '--lease-generation' not in args, f'--lease-generation should be absent: {args}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        echo "PASS: Finding1 - no --lease-generation emitted when generation is empty"
+        exit 0
+    else
+        echo "FAIL: Finding1 - unexpected --lease-generation when generation is empty"
+        cat "$ARGV_FILE"
+        exit 1
+    fi
+)
+RET=$?
+if [[ $RET -eq 0 ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); fi
+
+# ── Test 3: Finding 2 — rc_release_lease forwards dispatch_exit_status ────────
+(
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+
+    CALLS_FILE="$TMP/calls.txt"
+
+    # Stub all bash functions called by rc_release_lease.
+    log()                    { :; }
+    log_structured_failure() { :; }
+    emit_lease_cleanup_audit() { :; }
+    _rc_enabled()            { return 0; }
+    # _rc_python release-lease: succeed.
+    _rc_python()             { return 0; }
+    # _call_cleanup_worker_exit: record exit_status arg.
+    _call_cleanup_worker_exit() {
+        # $3 is exit_status
+        echo "$3" >> "$CALLS_FILE"
+    }
+    export -f log log_structured_failure emit_lease_cleanup_audit \
+               _rc_enabled _rc_python _call_cleanup_worker_exit
+
+    VNX_DIR="$TMP"
+    eval "$(sed -n '/^rc_release_lease/,/^}/p' "$LIFECYCLE")"
+
+    # Call with explicit dispatch_exit_status="failure"
+    rc_release_lease "T1" "5" "d-test-003" "failure" || true
+
+    RECORDED="$(cat "$CALLS_FILE" 2>/dev/null || echo '')"
+    if [[ "$RECORDED" == "failure" ]]; then
+        echo "PASS: Finding2 - rc_release_lease forwards dispatch_exit_status=failure"
+        exit 0
+    else
+        echo "FAIL: Finding2 - rc_release_lease exit_status was '$RECORDED', expected 'failure'"
+        exit 1
+    fi
+)
+RET=$?
+if [[ $RET -eq 0 ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); fi
+
+# ── Test 4: Finding 2 — rc_release_lease defaults to "success" ────────────────
+(
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+
+    CALLS_FILE="$TMP/calls.txt"
+
+    log()                    { :; }
+    log_structured_failure() { :; }
+    emit_lease_cleanup_audit() { :; }
+    _rc_enabled()            { return 0; }
+    _rc_python()             { return 0; }
+    _call_cleanup_worker_exit() { echo "$3" >> "$CALLS_FILE"; }
+    export -f log log_structured_failure emit_lease_cleanup_audit \
+               _rc_enabled _rc_python _call_cleanup_worker_exit
+
+    VNX_DIR="$TMP"
+    eval "$(sed -n '/^rc_release_lease/,/^}/p' "$LIFECYCLE")"
+
+    # Call WITHOUT dispatch_exit_status — must default to "success"
+    rc_release_lease "T1" "5" "d-test-004" || true
+
+    RECORDED="$(cat "$CALLS_FILE" 2>/dev/null || echo '')"
+    if [[ "$RECORDED" == "success" ]]; then
+        echo "PASS: Finding2 - rc_release_lease defaults dispatch_exit_status to success"
+        exit 0
+    else
+        echo "FAIL: Finding2 - rc_release_lease default exit_status was '$RECORDED', expected 'success'"
+        exit 1
+    fi
+)
+RET=$?
+if [[ $RET -eq 0 ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/test_subprocess_dispatch_codex_r2.py
+++ b/tests/test_subprocess_dispatch_codex_r2.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Regression tests for codex round-2 finding on PR #315.
+
+Round-2 finding: ``_auto_commit_changes`` and ``_auto_stash_changes`` operate on
+the entire repository (effectively ``git add -A`` / ``git stash save``) instead
+of the files touched by the *current dispatch*.  In a shared or already-dirty
+worktree, a successful worker exit can commit unrelated user/agent edits, and a
+failed exit can hide unrelated tracked changes.
+
+Round-1 fixed half the problem by scoping to ``current_dirty - pre_dispatch_dirty``.
+Round-2 closes the rest of the gap by adding a second filter — files this
+dispatch's worker explicitly wrote via structured tool calls (Write / Edit /
+MultiEdit / NotebookEdit).  The intersection of the two sets is the only file
+set safely attributable to this worker.
+
+This module verifies:
+1. ``_extract_touched_paths_from_event`` picks up Write/Edit/MultiEdit/NotebookEdit
+   events and ignores everything else.
+2. ``_normalize_repo_path`` resolves to repo-relative POSIX paths and discards
+   paths outside the repo root.
+3. ``_auto_commit_changes`` and ``_auto_stash_changes`` refuse when
+   ``dispatch_touched_files`` is None (fail-safe, mirrors pre_dispatch_dirty
+   behaviour).
+4. The intersection logic excludes "concurrent edit" files — files that became
+   dirty during the dispatch but were NOT written by this worker — even when
+   the dispatch did write at least one other file.
+5. ``deliver_via_subprocess`` accumulates a ``touched_files`` set from its
+   stream events and exposes it via ``_SubprocessResult.touched_files``.
+6. ``deliver_with_recovery`` forwards ``sub_result.touched_files`` to
+   ``_auto_commit_changes`` and ``_auto_stash_changes``.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch  # noqa: E402
+from subprocess_dispatch import (  # noqa: E402
+    _SubprocessResult,
+    _auto_commit_changes,
+    _auto_stash_changes,
+    _extract_touched_paths_from_event,
+    _normalize_repo_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool-event extraction
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    """Minimal stand-in for ``subprocess_adapter.StreamEvent``.
+
+    Only ``type`` and ``data`` are read by ``_extract_touched_paths_from_event``,
+    so we avoid importing the real dataclass to keep the test independent of
+    the adapter's optional dependencies."""
+
+    def __init__(self, type_: str, data: dict):
+        self.type = type_
+        self.data = data
+
+
+class TestExtractTouchedPaths(unittest.TestCase):
+    """``_extract_touched_paths_from_event`` returns raw file_path strings only
+    for tool_use events whose tool actually writes files."""
+
+    def test_write_event_yields_file_path(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "Write",
+            "input": {"file_path": "/tmp/repo/scripts/foo.py", "content": "x"},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev),
+                         ["/tmp/repo/scripts/foo.py"])
+
+    def test_edit_event_yields_file_path(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "Edit",
+            "input": {"file_path": "/tmp/repo/a.py", "old_string": "x", "new_string": "y"},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), ["/tmp/repo/a.py"])
+
+    def test_multiedit_event_yields_single_file_path(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "MultiEdit",
+            "input": {"file_path": "/tmp/repo/b.py", "edits": []},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), ["/tmp/repo/b.py"])
+
+    def test_notebook_edit_yields_notebook_path(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "NotebookEdit",
+            "input": {"notebook_path": "/tmp/repo/nb.ipynb"},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), ["/tmp/repo/nb.ipynb"])
+
+    def test_read_tool_yields_nothing(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "Read",
+            "input": {"file_path": "/tmp/repo/foo.py"},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+    def test_bash_tool_yields_nothing_even_with_filename_argument(self):
+        """Bash file modifications are intentionally not tracked — the
+        codex-fix design accepts the trade-off that workers using Bash to
+        modify files must commit those changes manually."""
+        ev = _FakeEvent("tool_use", {
+            "name": "Bash",
+            "input": {"command": "echo hi > /tmp/repo/foo.py"},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+    def test_text_event_yields_nothing(self):
+        ev = _FakeEvent("text", {"text": "hello"})
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+    def test_thinking_event_yields_nothing(self):
+        ev = _FakeEvent("thinking", {"thinking": "..."})
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+    def test_malformed_event_does_not_raise(self):
+        ev = _FakeEvent("tool_use", {"name": "Edit", "input": None})
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+    def test_non_string_file_path_ignored(self):
+        ev = _FakeEvent("tool_use", {
+            "name": "Edit",
+            "input": {"file_path": 12345},
+        })
+        self.assertEqual(_extract_touched_paths_from_event(ev), [])
+
+
+# ---------------------------------------------------------------------------
+# Path normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRepoPath(unittest.TestCase):
+    """``_normalize_repo_path`` returns repo-relative POSIX strings or None."""
+
+    def setUp(self):
+        # Use a real tmpdir so resolve() on symlinks behaves correctly.
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        (self.repo / "scripts").mkdir()
+        (self.repo / "scripts" / "foo.py").write_text("")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_absolute_path_inside_repo(self):
+        norm = _normalize_repo_path(str(self.repo / "scripts" / "foo.py"), self.repo)
+        self.assertEqual(norm, "scripts/foo.py")
+
+    def test_relative_path(self):
+        norm = _normalize_repo_path("scripts/foo.py", self.repo)
+        self.assertEqual(norm, "scripts/foo.py")
+
+    def test_path_outside_repo_returns_none(self):
+        # /tmp is not inside the temp repo (well, on macOS /tmp may symlink to
+        # /private/tmp; either way, parent dirs of self.repo are outside it).
+        outside = self.repo.parent / "definitely_outside.py"
+        self.assertIsNone(_normalize_repo_path(str(outside), self.repo))
+
+    def test_empty_path_returns_none(self):
+        self.assertIsNone(_normalize_repo_path("", self.repo))
+
+    def test_dotdot_within_repo_collapses(self):
+        norm = _normalize_repo_path("scripts/../scripts/foo.py", self.repo)
+        self.assertEqual(norm, "scripts/foo.py")
+
+
+# ---------------------------------------------------------------------------
+# Auto-commit / auto-stash with dispatch_touched_files filter
+# ---------------------------------------------------------------------------
+
+
+def _mock_subprocess_for_commit(status_lines: list[str]):
+    """Build a mock of ``subprocess`` whose run() returns: status, add, commit."""
+    mock_sp = MagicMock()
+    status_proc = MagicMock(stdout="\n".join(status_lines), returncode=0)
+    add_proc = MagicMock(returncode=0, stderr="")
+    commit_proc = MagicMock(returncode=0, stderr="")
+    mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+    return mock_sp
+
+
+def _mock_subprocess_for_stash(status_lines: list[str]):
+    """Build a mock of ``subprocess`` whose run() returns: status, stash."""
+    mock_sp = MagicMock()
+    status_proc = MagicMock(stdout="\n".join(status_lines), returncode=0)
+    stash_proc = MagicMock(returncode=0, stderr="")
+    mock_sp.run.side_effect = [status_proc, stash_proc]
+    return mock_sp
+
+
+class TestAutoCommitTouchedFilesFilter(unittest.TestCase):
+    """``_auto_commit_changes`` must intersect with ``dispatch_touched_files``."""
+
+    def test_refuses_to_commit_when_touched_files_is_none(self):
+        """``dispatch_touched_files=None`` is fail-safe — no git work runs."""
+        mock_sp = MagicMock()
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_commit_changes(
+                "d-r2-a", "T1",
+                pre_dispatch_dirty=set(),
+                dispatch_touched_files=None,
+            )
+        self.assertFalse(result)
+        self.assertFalse(mock_sp.run.called)
+
+    def test_concurrent_edit_file_excluded_when_only_other_files_touched(self):
+        """Shared-worktree scenario: this worker wrote ``mine.py`` while a
+        concurrent terminal touched ``their_concurrent.py`` during the same
+        window.  Only the file in dispatch_touched_files is staged."""
+        pre = set()
+        # Both files appear in the dispatch window (not in pre).
+        status_lines = [" M mine.py", " M their_concurrent.py"]
+        mock_sp = _mock_subprocess_for_commit(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files",
+                   return_value={"mine.py", "their_concurrent.py"}):
+            result = _auto_commit_changes(
+                "d-r2-b", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"mine.py"}),
+            )
+
+        self.assertTrue(result)
+        add_cmd = mock_sp.run.call_args_list[1][0][0]
+        self.assertIn("mine.py", add_cmd)
+        self.assertNotIn("their_concurrent.py", add_cmd)
+
+    def test_no_commit_when_only_concurrent_edits_present(self):
+        """If every dispatch-window dirty file came from another terminal
+        (none in dispatch_touched_files), refuse to commit."""
+        pre = set()
+        status_lines = [" M their_concurrent.py", "?? other_terminal_new.py"]
+        mock_sp = _mock_subprocess_for_commit(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files",
+                   return_value={"their_concurrent.py", "other_terminal_new.py"}):
+            result = _auto_commit_changes(
+                "d-r2-c", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"unrelated_touched.py"}),
+            )
+
+        self.assertFalse(result)
+        # status was checked, but add and commit must not have run.
+        called_cmds = [c[0][0] for c in mock_sp.run.call_args_list]
+        for cmd in called_cmds:
+            self.assertNotEqual(cmd[:2], ["git", "add"])
+            self.assertNotEqual(cmd[:2], ["git", "commit"])
+
+    def test_touched_file_already_dirty_pre_dispatch_excluded(self):
+        """A file the worker explicitly touched but which was *already* dirty
+        before the dispatch is excluded — operator must commit pre-existing
+        dirty files manually."""
+        pre = {"shared.py"}
+        status_lines = [" M shared.py"]
+        mock_sp = _mock_subprocess_for_commit(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value={"shared.py"}):
+            result = _auto_commit_changes(
+                "d-r2-d", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"shared.py"}),
+            )
+
+        self.assertFalse(result)
+        called_cmds = [c[0][0] for c in mock_sp.run.call_args_list]
+        for cmd in called_cmds:
+            self.assertNotEqual(cmd[:2], ["git", "add"])
+
+    def test_touched_file_not_currently_dirty_excluded(self):
+        """A file the worker touched but later reverted (no longer dirty) is
+        not staged — there is nothing to commit."""
+        pre = set()
+        status_lines = []  # clean tree
+        mock_sp = MagicMock()
+        mock_sp.run.return_value = MagicMock(stdout="", returncode=0)
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_commit_changes(
+                "d-r2-e", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"reverted.py"}),
+            )
+        self.assertFalse(result)
+
+
+class TestAutoStashTouchedFilesFilter(unittest.TestCase):
+    """``_auto_stash_changes`` must intersect with ``dispatch_touched_files``."""
+
+    def test_refuses_to_stash_when_touched_files_is_none(self):
+        mock_sp = MagicMock()
+        with patch("subprocess_dispatch.subprocess", mock_sp):
+            result = _auto_stash_changes(
+                "d-r2-s1", "T1",
+                pre_dispatch_dirty=set(),
+                dispatch_touched_files=None,
+            )
+        self.assertFalse(result)
+        self.assertFalse(mock_sp.run.called)
+
+    def test_concurrent_edit_excluded_from_stash(self):
+        pre = set()
+        status_lines = [" M mine.py", "?? their_new.py"]
+        mock_sp = _mock_subprocess_for_stash(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files",
+                   return_value={"mine.py", "their_new.py"}):
+            result = _auto_stash_changes(
+                "d-r2-s2", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"mine.py"}),
+            )
+
+        self.assertTrue(result)
+        stash_cmd = mock_sp.run.call_args_list[1][0][0]
+        self.assertEqual(stash_cmd[:3], ["git", "stash", "push"])
+        self.assertIn("mine.py", stash_cmd)
+        self.assertNotIn("their_new.py", stash_cmd)
+
+    def test_no_stash_when_only_concurrent_files_dirty(self):
+        pre = set()
+        status_lines = [" M their_concurrent.py"]
+        mock_sp = _mock_subprocess_for_stash(status_lines)
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files",
+                   return_value={"their_concurrent.py"}):
+            result = _auto_stash_changes(
+                "d-r2-s3", "T1",
+                pre_dispatch_dirty=pre,
+                dispatch_touched_files=frozenset({"unrelated.py"}),
+            )
+        self.assertFalse(result)
+        called_cmds = [c[0][0] for c in mock_sp.run.call_args_list]
+        for cmd in called_cmds:
+            self.assertNotEqual(cmd[:2], ["git", "stash"])
+
+
+# ---------------------------------------------------------------------------
+# deliver_via_subprocess: touched_files plumbed into _SubprocessResult
+# ---------------------------------------------------------------------------
+
+
+class TestDeliverViaSubprocessTouchedFiles(unittest.TestCase):
+    """``deliver_via_subprocess`` must accumulate touched_files from streamed
+    tool_use events and surface it via the returned ``_SubprocessResult``."""
+
+    def _patch_chain(self):
+        return [
+            patch("subprocess_dispatch._inject_skill_context", return_value="instr"),
+            patch("subprocess_dispatch._inject_permission_profile", return_value="instr"),
+            patch("subprocess_dispatch._resolve_agent_cwd", return_value=None),
+            patch("subprocess_dispatch._write_manifest", return_value="/tmp/m.json"),
+            patch("subprocess_dispatch._promote_manifest", return_value="/tmp/done.json"),
+        ]
+
+    def test_touched_files_accumulated_from_tool_use_events(self):
+        repo_root = subprocess_dispatch.Path(
+            subprocess_dispatch.__file__
+        ).resolve().parents[2]
+
+        # Two writes inside the repo, one Read (ignored), one path outside repo
+        # (must be filtered out by _normalize_repo_path).
+        events = iter([
+            _FakeEvent("tool_use", {
+                "name": "Edit",
+                "input": {"file_path": str(repo_root / "scripts" / "lib" / "subprocess_dispatch.py")},
+            }),
+            _FakeEvent("tool_use", {
+                "name": "Write",
+                "input": {"file_path": str(repo_root / "tests" / "test_new.py")},
+            }),
+            _FakeEvent("tool_use", {
+                "name": "Read",
+                "input": {"file_path": str(repo_root / "scripts" / "lib" / "subprocess_dispatch.py")},
+            }),
+            _FakeEvent("tool_use", {
+                "name": "Write",
+                "input": {"file_path": "/etc/passwd"},  # outside repo — drop
+            }),
+        ])
+
+        adapter = MagicMock()
+        adapter.deliver.return_value = MagicMock(success=True)
+        adapter.read_events_with_timeout.return_value = events
+        obs = MagicMock()
+        obs.transport_state = {"returncode": 0}
+        adapter.observe.return_value = obs
+        adapter.was_timed_out.return_value = False
+        adapter.get_session_id.return_value = "sess-touched"
+        adapter._get_event_store.return_value = None
+        adapter.trigger_report_pipeline.return_value = None
+
+        cms = self._patch_chain() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-touched",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+
+        self.assertTrue(result.success)
+        self.assertIsInstance(result, _SubprocessResult)
+        # Repo-internal Edit + Write captured; Read and out-of-repo Write dropped.
+        self.assertEqual(
+            result.touched_files,
+            frozenset({
+                "scripts/lib/subprocess_dispatch.py",
+                "tests/test_new.py",
+            }),
+        )
+
+    def test_touched_files_empty_set_when_no_writes(self):
+        adapter = MagicMock()
+        adapter.deliver.return_value = MagicMock(success=True)
+        adapter.read_events_with_timeout.return_value = iter([])
+        obs = MagicMock()
+        obs.transport_state = {"returncode": 0}
+        adapter.observe.return_value = obs
+        adapter.was_timed_out.return_value = False
+        adapter.get_session_id.return_value = "sess-empty"
+        adapter._get_event_store.return_value = None
+        adapter.trigger_report_pipeline.return_value = None
+
+        cms = self._patch_chain() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-empty",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+        self.assertTrue(result.success)
+        self.assertEqual(result.touched_files, frozenset())
+
+    def test_touched_files_returned_on_failure_paths_too(self):
+        """Even on non-zero exit, accumulated touched_files must be returned so
+        the failure-path stash can scope correctly."""
+        repo_root = subprocess_dispatch.Path(
+            subprocess_dispatch.__file__
+        ).resolve().parents[2]
+        events = iter([
+            _FakeEvent("tool_use", {
+                "name": "Write",
+                "input": {"file_path": str(repo_root / "scripts" / "lib" / "halfwritten.py")},
+            }),
+        ])
+
+        adapter = MagicMock()
+        adapter.deliver.return_value = MagicMock(success=True)
+        adapter.read_events_with_timeout.return_value = events
+        obs = MagicMock()
+        obs.transport_state = {"returncode": 2}  # non-zero → fail-closed
+        adapter.observe.return_value = obs
+        adapter.was_timed_out.return_value = False
+        adapter.get_session_id.return_value = "sess-failed"
+        adapter._get_event_store.return_value = None
+        adapter.trigger_report_pipeline.return_value = None
+
+        cms = self._patch_chain() + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-r2-failed",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.touched_files,
+            frozenset({"scripts/lib/halfwritten.py"}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# deliver_with_recovery: touched_files forwarded to commit/stash helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDeliverWithRecoveryForwardsTouchedFiles(unittest.TestCase):
+    """deliver_with_recovery must forward _SubprocessResult.touched_files to
+    both auto_commit and auto_stash helpers."""
+
+    def test_touched_files_forwarded_to_auto_commit(self):
+        touched = frozenset({"scripts/lib/foo.py"})
+        sub_result = _SubprocessResult(
+            success=True,
+            session_id="s1",
+            event_count=2,
+            manifest_path="/tmp/m.json",
+            touched_files=touched,
+        )
+
+        with patch("subprocess_dispatch.deliver_via_subprocess", return_value=sub_result), \
+             patch("subprocess_dispatch._auto_commit_changes", return_value=True) as mock_ac, \
+             patch("subprocess_dispatch._auto_stash_changes") as mock_as, \
+             patch("subprocess_dispatch._write_receipt"), \
+             patch("subprocess_dispatch._check_commit_since", return_value=True), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc"), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=set()), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor:
+            mock_monitor.return_value = MagicMock(stuck_count=0)
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "do work", "sonnet", "d-r2-fwd-1",
+                max_retries=0, auto_commit=True,
+            )
+            mock_as.assert_not_called()
+
+        mock_ac.assert_called_once()
+        kwargs = mock_ac.call_args.kwargs
+        self.assertEqual(kwargs.get("dispatch_touched_files"), touched)
+
+    def test_touched_files_forwarded_to_auto_stash_on_failure(self):
+        touched = frozenset({"scripts/lib/halfwritten.py"})
+        sub_result = _SubprocessResult(
+            success=False,
+            session_id=None,
+            event_count=1,
+            manifest_path="/tmp/m.json",
+            touched_files=touched,
+        )
+
+        with patch("subprocess_dispatch.deliver_via_subprocess", return_value=sub_result), \
+             patch("subprocess_dispatch._auto_commit_changes") as mock_ac, \
+             patch("subprocess_dispatch._auto_stash_changes", return_value=False) as mock_as, \
+             patch("subprocess_dispatch._write_receipt"), \
+             patch("subprocess_dispatch._get_commit_hash", return_value="abc"), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=set()), \
+             patch("subprocess_dispatch._capture_dispatch_parameters"), \
+             patch("subprocess_dispatch._capture_dispatch_outcome"), \
+             patch("subprocess_dispatch._update_pattern_confidence", return_value=0), \
+             patch("subprocess_dispatch.WorkerHealthMonitor") as mock_monitor:
+            mock_monitor.return_value = MagicMock(stuck_count=0)
+            subprocess_dispatch.deliver_with_recovery(
+                "T1", "do work", "sonnet", "d-r2-fwd-2",
+                max_retries=0, auto_commit=True,
+            )
+            mock_ac.assert_not_called()
+
+        mock_as.assert_called_once()
+        kwargs = mock_as.call_args.kwargs
+        self.assertEqual(kwargs.get("dispatch_touched_files"), touched)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subprocess_dispatch_round2_codex.py
+++ b/tests/test_subprocess_dispatch_round2_codex.py
@@ -42,7 +42,11 @@ class TestFailSafeWhenScopeUnknown(unittest.TestCase):
     def test_auto_commit_runs_no_git_when_scope_none(self):
         mock_sp = MagicMock()
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_commit_changes("d-r2-1", "T1", pre_dispatch_dirty=None)
+            result = _auto_commit_changes(
+                "d-r2-1", "T1",
+                pre_dispatch_dirty=None,
+                dispatch_touched_files=frozenset({"x.py"}),
+            )
         self.assertFalse(result)
         self.assertFalse(
             mock_sp.run.called,
@@ -52,7 +56,11 @@ class TestFailSafeWhenScopeUnknown(unittest.TestCase):
     def test_auto_stash_runs_no_git_when_scope_none(self):
         mock_sp = MagicMock()
         with patch("subprocess_dispatch.subprocess", mock_sp):
-            result = _auto_stash_changes("d-r2-2", "T1", pre_dispatch_dirty=None)
+            result = _auto_stash_changes(
+                "d-r2-2", "T1",
+                pre_dispatch_dirty=None,
+                dispatch_touched_files=frozenset({"x.py"}),
+            )
         self.assertFalse(result)
         self.assertFalse(
             mock_sp.run.called,
@@ -60,8 +68,10 @@ class TestFailSafeWhenScopeUnknown(unittest.TestCase):
         )
 
     def test_auto_commit_empty_scope_still_uses_explicit_paths(self):
-        """An empty scope (set()) is allowed and means: stage every currently-
-        dirty file by explicit path — never via ``git add -A``."""
+        """An empty pre_dispatch_dirty (set()) is allowed and means: every
+        currently-dirty file is dispatch-window-new — but the file must also
+        be in dispatch_touched_files for it to be staged.  Staging always uses
+        ``git add -- <files>``, never ``git add -A``."""
         status_proc = MagicMock()
         status_proc.stdout = " M only_new.py\n"
         status_proc.returncode = 0
@@ -73,7 +83,11 @@ class TestFailSafeWhenScopeUnknown(unittest.TestCase):
 
         with patch("subprocess_dispatch.subprocess", mock_sp), \
              patch("subprocess_dispatch._get_dirty_files", return_value={"only_new.py"}):
-            result = _auto_commit_changes("d-r2-3", "T1", pre_dispatch_dirty=set())
+            result = _auto_commit_changes(
+                "d-r2-3", "T1",
+                pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset({"only_new.py"}),
+            )
 
         self.assertTrue(result)
         add_cmd = mock_sp.run.call_args_list[1][0][0]


### PR DESCRIPTION
## Summary

Foundation refactor for the unified supervisor pack. Both worker exit paths — interactive (`scripts/lib/dispatch_lifecycle.sh` via tmux) and headless (`scripts/lib/subprocess_dispatch.py`) — now converge on a single helper `scripts/lib/cleanup_worker_exit.py` so post-worker-exit cleanup runs exactly once and in the same order.

This PR is **pure refactor**: no behavior change for end users, no `VNX_SUPERVISOR_MODE` flag (that lands in **SUP-PR2**), no removal of receipt-write logic (separate concern).

Reference: `claudedocs/2026-04-29-unified-supervisor-research.md` §§ 2.4 + 4.

## Why now

Per the supervisor research report, the MC outage on 2026-04-28 was caused by lease release + state transition + dispatch file disposition logic being scattered across two adapters. PR-1 of the supervisor pack establishes the single owner so PR-2 can wire the supervisor flag and PR-3+ can layer in the periodic ticks.

## What changed

| File | Δ | Purpose |
|---|---|---|
| `scripts/lib/cleanup_worker_exit.py` | new | Idempotent helper + CLI surface for both adapters |
| `scripts/lib/subprocess_dispatch.py` | +30 | Active-file resolver + cleanup call in success/failure paths of `deliver_with_recovery` |
| `scripts/lib/dispatch_lifecycle.sh` | +14 | `_call_cleanup_worker_exit` wrapper; `rc_release_lease` + `rc_release_on_failure` delegate to it |
| `tests/test_cleanup_worker_exit.py` | new | 10 unit tests (success / 4 failure exits / idempotency / lease-already-released / no-file / lease-raises / CLI) |

The helper performs five steps, all best-effort (errors caught, surfaced via `CleanupResult.errors`, never raised):

1. Release lease via `LeaseManager.release` — idempotent against already-idle.
2. Transition worker state via `WorkerStateManager.transition` → `exited_clean` (success) or `exited_bad` (any other) — idempotent against terminal states.
3. Move dispatch file: `success → dispatches/completed/`, otherwise `dispatches/rejected/<reason>/`.
4. Append `worker_exited` event to `dispatch_register.ndjson`.
5. Best-effort EventStore archive (no-op for tmux-only callers).

## Test plan

- [x] `python3 -m py_compile scripts/lib/cleanup_worker_exit.py scripts/lib/subprocess_dispatch.py` — clean
- [x] `bash -n scripts/lib/dispatch_lifecycle.sh` — clean
- [x] `python3 -m pytest tests/test_cleanup_worker_exit.py -xvs` — **10 passed**
- [x] Regression on `subprocess_dispatch / dispatch_lifecycle / worker_state` — **101 passed**, 6 pre-existing failures on `main` (verified independently — unrelated)

## Out of scope (deliberately deferred)

- `VNX_SUPERVISOR_MODE` flag — **SUP-PR2**
- Periodic `LeaseManager.expire_stale()` tick — **SUP-PR2**
- `RuntimeSupervisor.supervise_all()` 60s tick — **SUP-PR3**
- `receipt_processor_supervisor.sh` — **SUP-PR4**
- launchd plists — **SUP-PR6 (optional)**

## DO NOT (per dispatch)

- ❌ No `VNX_SUPERVISOR_MODE` flag — that's SUP-PR2
- ❌ No `.vnx-data/` runtime mutations
- ❌ No changes to `LeaseManager` / `WorkerStateManager` internals
- ❌ No removal of receipt-write logic from `subprocess_dispatch.py`
- ❌ No TODO/FIXME left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)