### PR TITLE
fix(governance): subprocess dispatch git-scope manifest (CFX-1)

### DIFF
--- a/scripts/check_active_drain.py
+++ b/scripts/check_active_drain.py
@@ -8,9 +8,15 @@ as a "currently in-flight" worklist.
 
 Rules
 -----
-* dispatch has a matching receipt in receipts/processed/  → move to completed/
+* dispatch has a matching SUCCESS receipt in receipts/processed/   → move to completed/
+* dispatch has a matching FAILURE receipt in receipts/processed/   → move to dead_letter/
 * dispatch has no receipt AND is older than --older-than-hours (default 1)   → move to dead_letter/
 * dispatch has no receipt AND is newer than the threshold                     → leave alone
+
+Failed dispatches must NEVER be drained as completed: the receipt's
+``status`` field is consulted (canonical sets in scripts/append_receipt.py)
+so that timeout/error/blocked outcomes route to dead_letter/ instead of
+masquerading as successful work.
 
 Exit codes
 ----------
@@ -69,24 +75,56 @@ class DrainResult(NamedTuple):
 # Receipt index
 # ---------------------------------------------------------------------------
 
+# Canonical status sets (kept in sync with scripts/append_receipt.py).
+SUCCESS_STATUSES = frozenset({"success", "completed", "complete", "ok", ""})
+FAILURE_STATUSES = frozenset({"failed", "failure", "error", "blocked", "timeout"})
+
+
 def build_receipt_index(receipts_dir: Path) -> frozenset[str]:
-    """Return the set of dispatch_ids present in receipts/processed/."""
+    """Return the set of dispatch_ids present in receipts/processed/.
+
+    Kept for backwards compatibility — callers that need success/failure
+    discrimination should use build_receipt_status_index instead.
+    """
+    return frozenset(build_receipt_status_index(receipts_dir).keys())
+
+
+def build_receipt_status_index(receipts_dir: Path) -> dict[str, str]:
+    """Map dispatch_id → normalized status (\"success\" | \"failure\" | \"unknown\").
+
+    When multiple receipts exist for the same dispatch_id (e.g., a chain of
+    retries), a failure status wins over success — fail-closed semantics
+    ensure a partially-failed dispatch is never recorded as completed.
+    """
     processed = receipts_dir / "processed"
     if not processed.is_dir():
-        return frozenset()
+        return {}
 
-    ids: set[str] = set()
+    out: dict[str, str] = {}
     for path in processed.iterdir():
-        if not path.suffix == ".json":
+        if path.suffix != ".json":
             continue
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-            did = data.get("dispatch_id", "")
-            if did and did != "unknown":
-                ids.add(did)
         except (json.JSONDecodeError, OSError):
             continue
-    return frozenset(ids)
+        did = data.get("dispatch_id", "")
+        if not did or did == "unknown":
+            continue
+        status_raw = str(data.get("status", "")).strip().lower()
+        if status_raw in FAILURE_STATUSES:
+            normalized = "failure"
+        elif status_raw in SUCCESS_STATUSES:
+            normalized = "success"
+        else:
+            normalized = "unknown"
+        # Fail-closed: failure beats success beats unknown.
+        prior = out.get(did)
+        if prior == "failure":
+            continue
+        if normalized == "failure" or prior is None or (prior == "unknown" and normalized == "success"):
+            out[did] = normalized
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -138,17 +176,33 @@ def iter_active_dispatches(dispatches_dir: Path) -> Iterator[DispatchEntry]:
 
 def drain_one(
     entry: DispatchEntry,
-    receipt_index: frozenset[str],
+    receipt_index: "frozenset[str] | dict[str, str]",
     dispatches_dir: Path,
     now: datetime,
     older_than_seconds: float,
     dry_run: bool,
 ) -> DrainResult:
-    has_receipt = entry.dispatch_id in receipt_index
+    # Accept either the legacy frozenset (success-implied) or the new
+    # status-aware dict to keep external callers working.
+    if isinstance(receipt_index, dict):
+        receipt_status = receipt_index.get(entry.dispatch_id)
+    elif entry.dispatch_id in receipt_index:
+        receipt_status = "success"
+    else:
+        receipt_status = None
 
-    if has_receipt:
-        dest_bucket = "completed"
-        reason = "receipt found"
+    if receipt_status is not None:
+        if receipt_status == "failure":
+            dest_bucket = "dead_letter"
+            reason = "receipt found with failure status"
+        elif receipt_status == "unknown":
+            # Receipt with an unrecognised status — treat as failure to
+            # avoid silently recording bad outcomes as completed work.
+            dest_bucket = "dead_letter"
+            reason = "receipt found with unrecognised status"
+        else:
+            dest_bucket = "completed"
+            reason = "receipt found with success status"
     else:
         if entry.timestamp is None:
             # No timestamp → treat as orphaned regardless of age
@@ -205,7 +259,7 @@ def drain_active(
     dispatches_dir = data_dir / "dispatches"
     receipts_dir = data_dir / "receipts"
 
-    receipt_index = build_receipt_index(receipts_dir)
+    receipt_index = build_receipt_status_index(receipts_dir)
     now = datetime.now(tz=timezone.utc)
     older_than_seconds = older_than_hours * 3600.0
 

--- a/scripts/lib/dispatch_paths.py
+++ b/scripts/lib/dispatch_paths.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""dispatch_paths.py — Dispatch-scoped path manifest helper.
+
+Workers declare the repository paths they intend to mutate during a dispatch
+via a manifest written at dispatch start.  Subsequent auto-commit / auto-stash
+operations restrict their file scope to the manifest, preventing cross-dispatch
+contamination on shared worktrees.
+
+Manifest schema:
+    {
+      "dispatch_id": "<id>",
+      "allowed_paths": ["scripts/", "tests/foo.py", ...]
+    }
+
+Stored at:
+    <state_dir>/dispatch_paths/<dispatch_id>.json
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _manifest_path(state_dir: Path, dispatch_id: str) -> Path:
+    return state_dir / "dispatch_paths" / f"{dispatch_id}.json"
+
+
+def write_manifest(
+    state_dir: Path, dispatch_id: str, allowed_paths: List[str]
+) -> Path:
+    """Write manifest of paths this dispatch is allowed to mutate.
+
+    Returns the manifest file path.  Caller is responsible for ensuring
+    state_dir is writable.
+    """
+    p = _manifest_path(state_dir, dispatch_id)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(
+            {"dispatch_id": dispatch_id, "allowed_paths": list(allowed_paths)},
+            indent=2,
+        )
+    )
+    return p
+
+
+def read_manifest(state_dir: Path, dispatch_id: str) -> Optional[List[str]]:
+    """Return the manifest's allowed_paths list, or None when no manifest exists.
+
+    Returns an empty list when the manifest exists but declares no paths
+    (semantically: dispatch declared its scope is empty — fail-safe).
+    Returns None on parse errors so callers fall back to legacy behavior.
+    """
+    p = _manifest_path(state_dir, dispatch_id)
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "dispatch_paths: failed to read manifest %s: %s — falling back to legacy scope",
+            p,
+            exc,
+        )
+        return None
+    paths = data.get("allowed_paths")
+    if not isinstance(paths, list):
+        return None
+    return [str(x) for x in paths]
+
+
+def filter_paths(files: List[str], allowed_paths: List[str]) -> List[str]:
+    """Return only those files that match any allowed path.
+
+    Matching rules:
+      - exact match: file == allowed
+      - directory match: file starts with allowed.rstrip("/") + "/"
+
+    A trailing slash on an allowed entry is optional; both forms work.
+    Pass-through when allowed_paths is empty list -> empty result (fail-safe).
+    """
+    if not allowed_paths:
+        return []
+    normalized = [p.rstrip("/") for p in allowed_paths if p]
+    out: List[str] = []
+    for f in files:
+        for p in normalized:
+            if f == p or f.startswith(p + "/"):
+                out.append(f)
+                break
+    return out

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -502,24 +502,37 @@ def _write_manifest(
         return None
 
 
-def _promote_manifest(dispatch_id: str) -> str | None:
-    """Copy manifest from active/ to completed/ after dispatch finishes.
+def _promote_manifest(dispatch_id: str, stage: str = "completed") -> str | None:
+    """Move manifest from active/ to <stage>/ after dispatch finishes.
 
-    Returns the completed manifest path as a string, or None on failure.
+    stage must be one of: "completed", "dead_letter".
+    The manifest is moved (not copied) so a failed dispatch never has a
+    parallel record in completed/ — there is exactly one terminal location.
+
+    Returns the destination manifest path as a string, or None on failure.
     """
+    if stage not in ("completed", "dead_letter"):
+        logger.warning("_promote_manifest: invalid stage %r", stage)
+        return None
     src_dir = _dispatch_manifest_dir("active", dispatch_id)
-    dst_dir = _dispatch_manifest_dir("completed", dispatch_id)
+    dst_dir = _dispatch_manifest_dir(stage, dispatch_id)
     src = src_dir / "manifest.json"
     if not src.exists():
         return None
     try:
         dst_dir.mkdir(parents=True, exist_ok=True)
         dst = dst_dir / "manifest.json"
-        shutil.copy2(src, dst)
-        logger.info("Manifest promoted: %s -> %s", src, dst)
+        shutil.move(str(src), str(dst))
+        # Best-effort: remove now-empty active dir so check_active_drain
+        # does not see it as in-flight.
+        try:
+            src_dir.rmdir()
+        except OSError:
+            pass
+        logger.info("Manifest moved to %s: %s -> %s", stage, src, dst)
         return str(dst)
     except Exception as exc:
-        logger.warning("_promote_manifest failed for %s: %s", dispatch_id, exc)
+        logger.warning("_promote_manifest(%s) failed for %s: %s", stage, dispatch_id, exc)
         return None
 
 
@@ -737,20 +750,22 @@ def deliver_via_subprocess(
         session_id = adapter.get_session_id(terminal_id)
 
         # Fail-closed: non-zero exit code means failure even when events were parsed.
+        # Manifest promotion is deferred until after all fail-closed checks so
+        # failed dispatches are routed to dead_letter/ rather than completed/.
         obs = adapter.observe(terminal_id)
         returncode = obs.transport_state.get("returncode")
-        completed_manifest = _promote_manifest(dispatch_id)
         if returncode is not None and returncode != 0:
             logger.warning(
                 "deliver_via_subprocess: subprocess exited %d for %s — fail-closed",
                 returncode,
                 terminal_id,
             )
+            dead_manifest = _promote_manifest(dispatch_id, stage="dead_letter")
             return _SubprocessResult(
                 success=False,
                 session_id=session_id,
                 event_count=event_count,
-                manifest_path=completed_manifest or manifest_path,
+                manifest_path=dead_manifest or manifest_path,
                 touched_files=frozenset(_touched_files),
             )
         # Fail-closed: timeout-terminated dispatches must not be classified as success.
@@ -762,13 +777,17 @@ def deliver_via_subprocess(
                 dispatch_id,
                 terminal_id,
             )
+            dead_manifest = _promote_manifest(dispatch_id, stage="dead_letter")
             return _SubprocessResult(
                 success=False,
                 session_id=session_id,
                 event_count=event_count,
-                manifest_path=completed_manifest or manifest_path,
+                manifest_path=dead_manifest or manifest_path,
                 touched_files=frozenset(_touched_files),
             )
+
+        # All fail-closed checks passed — promote manifest to completed/.
+        completed_manifest = _promote_manifest(dispatch_id, stage="completed")
 
         # Only persist session_id once all fail-closed checks pass, so the next
         # dispatch (with VNX_SESSION_RESUME=1) cannot resume a failed or

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -405,6 +405,45 @@ def _get_commit_hash() -> str:
         return ""
 
 
+def _count_lines_changed_since_sha(
+    pre_sha: str, paths: "list[str] | None" = None
+) -> int:
+    """Count lines added+removed between pre_sha and HEAD via git diff --numstat.
+
+    Replaces the time-window-based ``_count_lines_changed`` from
+    dispatch_parameter_tracker, which over-counted unrelated commits made
+    by parallel dispatches in the same window.
+
+    paths, when provided, restricts the diff to specific pathspecs so the
+    count attributes only files inside the dispatch's declared scope.
+    Returns 0 on any failure (never raises).
+    """
+    if not pre_sha:
+        return 0
+    try:
+        cwd = Path(__file__).resolve().parents[2]
+        cmd = ["git", "diff", "--numstat", f"{pre_sha}..HEAD"]
+        if paths:
+            cmd.append("--")
+            cmd.extend(paths)
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=10, cwd=cwd,
+        )
+        total = 0
+        for line in proc.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                try:
+                    total += int(parts[0]) + int(parts[1])
+                except ValueError:
+                    # Binary files report "-\t-\t<path>" — skip silently.
+                    pass
+        return total
+    except Exception as exc:
+        logger.debug("_count_lines_changed_since_sha failed: %s", exc)
+        return 0
+
+
 def _get_current_branch() -> str:
     """Return current branch name, or empty string on failure."""
     try:
@@ -822,6 +861,7 @@ def _auto_commit_changes(
     gate: str = "",
     pre_dispatch_dirty: "set[str] | None" = None,
     dispatch_touched_files: "frozenset[str] | set[str] | None" = None,
+    manifest_paths: "list[str] | None" = None,
 ) -> bool:
     """Stage and commit changes introduced by this dispatch.
 
@@ -843,6 +883,12 @@ def _auto_commit_changes(
     treated as "no eligible files" and is therefore also a no-op (correct: a
     worker that performed no structured file writes should not auto-commit).
 
+    manifest_paths, when provided (CFX-1), further restricts the staged set
+    to files inside the dispatch's declared mutation scope.  This protects
+    parallel dispatches in shared worktrees from sweeping each other's
+    changes.  When None, falls back to pre_dispatch_dirty-only scoping
+    with a deprecation log.
+
     Returns True if a commit was made, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
@@ -860,6 +906,13 @@ def _auto_commit_changes(
             dispatch_id,
         )
         return False
+    if manifest_paths is None:
+        logger.warning(
+            "auto_commit: manifest_paths absent for dispatch %s — using legacy "
+            "pre_dispatch_dirty scoping only (callers should declare paths via "
+            "dispatch_paths.write_manifest for parallel-worktree safety)",
+            dispatch_id,
+        )
     try:
         cwd = Path(__file__).resolve().parents[2]
         # Check for uncommitted changes
@@ -882,6 +935,16 @@ def _auto_commit_changes(
         new_during_dispatch = current_dirty - pre_dispatch_dirty
         touched = set(dispatch_touched_files)
         files_to_stage = sorted(new_during_dispatch & touched)
+        if manifest_paths is not None:
+            from dispatch_paths import filter_paths
+            before = list(files_to_stage)
+            files_to_stage = filter_paths(before, manifest_paths)
+            dropped = sorted(set(before) - set(files_to_stage))
+            if dropped:
+                logger.info(
+                    "auto_commit: dispatch %s manifest excluded %d out-of-scope files: %s",
+                    dispatch_id, len(dropped), dropped,
+                )
         if not files_to_stage:
             ignored_dispatch_dirty = sorted(new_during_dispatch - touched)
             if ignored_dispatch_dirty:
@@ -896,7 +959,7 @@ def _auto_commit_changes(
             else:
                 logger.debug(
                     "auto_commit: no dispatch-touched files dirty for dispatch %s "
-                    "(all dirty files pre-existed the dispatch)",
+                    "(all dirty files pre-existed the dispatch or fell outside manifest)",
                     dispatch_id,
                 )
             return False
@@ -943,6 +1006,7 @@ def _auto_stash_changes(
     terminal_id: str,
     pre_dispatch_dirty: "set[str] | None" = None,
     dispatch_touched_files: "frozenset[str] | set[str] | None" = None,
+    manifest_paths: "list[str] | None" = None,
 ) -> bool:
     """Stash changes introduced by this dispatch after a failure (preserves but does not commit).
 
@@ -962,6 +1026,10 @@ def _auto_stash_changes(
     a legitimate "no structured writes happened" signal and also yields a
     no-op stash.
 
+    manifest_paths, when provided (CFX-1), further restricts the stash set to
+    files inside the dispatch's declared mutation scope.  When None, falls
+    back to pre_dispatch_dirty-only scoping with a deprecation log.
+
     Returns True if a stash was created, False otherwise.
     Never raises — all exceptions are logged and swallowed.
     """
@@ -979,6 +1047,13 @@ def _auto_stash_changes(
             dispatch_id,
         )
         return False
+    if manifest_paths is None:
+        logger.warning(
+            "auto_stash: manifest_paths absent for dispatch %s — using legacy "
+            "pre_dispatch_dirty scoping only (callers should declare paths via "
+            "dispatch_paths.write_manifest for parallel-worktree safety)",
+            dispatch_id,
+        )
     try:
         cwd = Path(__file__).resolve().parents[2]
         status_proc = subprocess.run(
@@ -996,6 +1071,16 @@ def _auto_stash_changes(
         new_during_dispatch = current_dirty - pre_dispatch_dirty
         touched = set(dispatch_touched_files)
         files_to_stash = sorted(new_during_dispatch & touched)
+        if manifest_paths is not None:
+            from dispatch_paths import filter_paths
+            before = list(files_to_stash)
+            files_to_stash = filter_paths(before, manifest_paths)
+            dropped = sorted(set(before) - set(files_to_stash))
+            if dropped:
+                logger.info(
+                    "auto_stash: dispatch %s manifest excluded %d out-of-scope files: %s",
+                    dispatch_id, len(dropped), dropped,
+                )
         if not files_to_stash:
             ignored_dispatch_dirty = sorted(new_during_dispatch - touched)
             if ignored_dispatch_dirty:
@@ -1010,7 +1095,7 @@ def _auto_stash_changes(
             else:
                 logger.debug(
                     "auto_stash: no dispatch-touched files dirty for dispatch %s "
-                    "(all dirty files pre-existed the dispatch)",
+                    "(all dirty files pre-existed the dispatch or fell outside manifest)",
                     dispatch_id,
                 )
             return False
@@ -1161,8 +1246,16 @@ def _capture_dispatch_outcome(
     success: bool,
     start_ts: str,
     committed: bool,
+    pre_sha: str = "",
+    manifest_paths: "list[str] | None" = None,
 ) -> None:
-    """Capture DispatchOutcome after completion. Never raises."""
+    """Capture DispatchOutcome after completion. Never raises.
+
+    When pre_sha is provided (CFX-1), lines_changed is computed via
+    HEAD-comparison against the pre-dispatch SHA — restricted to manifest_paths
+    when supplied — so concurrent unrelated commits do not inflate the count.
+    Falls back to the legacy time-window counter when pre_sha is empty.
+    """
     try:
         from dispatch_parameter_tracker import (
             DispatchParameterTracker,
@@ -1180,13 +1273,18 @@ def _capture_dispatch_outcome(
         except Exception:
             elapsed = 0.0
 
+        if pre_sha:
+            lines_changed = _count_lines_changed_since_sha(pre_sha, manifest_paths)
+        else:
+            lines_changed = _count_lines_changed(start_ts)
+
         outcome = DispatchOutcome(
             cqs=_lookup_cqs(dispatch_id),
             success=success,
             completion_minutes=round(elapsed, 2),
             test_count=0,        # not reliably parseable here
             committed=committed,
-            lines_changed=_count_lines_changed(start_ts),
+            lines_changed=lines_changed,
         )
         tracker = DispatchParameterTracker()
         tracker.capture_outcome(dispatch_id, outcome)
@@ -1353,10 +1451,28 @@ def deliver_with_recovery(
 
     dispatch_start_ts = datetime.now(timezone.utc).isoformat()
     commit_hash_before = _get_commit_hash()
+    _dispatch_pre_sha = commit_hash_before
     # Snapshot dirty files before dispatch so auto-commit/stash can scope to
     # changes introduced by this dispatch only (not pre-existing dirty state).
     _repo_cwd = Path(__file__).resolve().parents[2]
     pre_dispatch_dirty = _get_dirty_files(_repo_cwd)
+
+    # Read dispatch path manifest (CFX-1).  Workers declare allowed mutation
+    # paths via dispatch_paths.write_manifest before delivery; auto-commit /
+    # auto-stash will then refuse to touch files outside this scope, even when
+    # dirty.  None means "no manifest declared" — legacy pre_dispatch_dirty
+    # scoping applies (with a deprecation warning logged inside the helpers).
+    try:
+        from dispatch_paths import read_manifest as _read_manifest
+        manifest_paths = _read_manifest(_default_state_dir(), dispatch_id)
+    except Exception as _exc:
+        logger.debug("dispatch_paths manifest read failed: %s", _exc)
+        manifest_paths = None
+    if manifest_paths is not None:
+        logger.info(
+            "deliver_with_recovery: dispatch %s declared %d manifest path(s): %s",
+            dispatch_id, len(manifest_paths), manifest_paths,
+        )
 
     # Capture dispatch parameters before execution
     _capture_dispatch_parameters(
@@ -1397,6 +1513,7 @@ def deliver_with_recovery(
                     dispatch_id, terminal_id, gate=gate,
                     pre_dispatch_dirty=pre_dispatch_dirty,
                     dispatch_touched_files=sub_result.touched_files,
+                    manifest_paths=manifest_paths,
                 )
                 if committed:
                     commit_missing = False
@@ -1423,12 +1540,15 @@ def deliver_with_recovery(
                 "Feedback boost: dispatch=%s patterns_updated=%d", dispatch_id, _patt_updated
             )
 
-            # Capture outcome after receipt is written
+            # Capture outcome after receipt is written.  pre_sha drives a
+            # HEAD-comparison line count that ignores parallel-dispatch commits.
             _capture_dispatch_outcome(
                 dispatch_id=dispatch_id,
                 success=True,
                 start_ts=dispatch_start_ts,
                 committed=committed,
+                pre_sha=_dispatch_pre_sha,
+                manifest_paths=manifest_paths,
             )
 
             # Single-owner post-exit cleanup (SUP-PR1).  Idempotent — the bash
@@ -1460,6 +1580,7 @@ def deliver_with_recovery(
                     terminal_id,
                     pre_dispatch_dirty=pre_dispatch_dirty,
                     dispatch_touched_files=sub_result.touched_files,
+                    manifest_paths=manifest_paths,
                 )
             _write_receipt(
                 dispatch_id, terminal_id, "failed",
@@ -1480,12 +1601,15 @@ def deliver_with_recovery(
                 "Feedback decay: dispatch=%s patterns_updated=%d", dispatch_id, _patt_updated
             )
 
-            # Capture failed outcome
+            # Capture failed outcome.  Pass pre_sha so lines_changed reflects
+            # only this dispatch's diff, not parallel work.
             _capture_dispatch_outcome(
                 dispatch_id=dispatch_id,
                 success=False,
                 start_ts=dispatch_start_ts,
                 committed=False,
+                pre_sha=_dispatch_pre_sha,
+                manifest_paths=manifest_paths,
             )
 
             # Single-owner post-exit cleanup (SUP-PR1).  Routes failure-path
@@ -1515,7 +1639,23 @@ if __name__ == "__main__":
     parser.add_argument("--no-auto-commit", action="store_true",
                         help="Disable auto-commit of uncommitted changes after dispatch")
     parser.add_argument("--gate", default="", help="Gate tag for auto-commit message")
+    parser.add_argument(
+        "--dispatch-paths",
+        default="",
+        help=(
+            "Comma-separated list of paths this dispatch is allowed to mutate "
+            "(CFX-1).  Auto-commit/stash will refuse to touch files outside "
+            "this scope.  When omitted, legacy pre_dispatch_dirty scoping is used."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.dispatch_paths.strip():
+        from dispatch_paths import write_manifest as _write_dispatch_paths_manifest
+        _allowed = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
+        _write_dispatch_paths_manifest(
+            _default_state_dir(), args.dispatch_id, _allowed,
+        )
 
     ok = deliver_with_recovery(
         terminal_id=args.terminal_id,

--- a/tests/test_active_drain.py
+++ b/tests/test_active_drain.py
@@ -18,6 +18,7 @@ if str(_SCRIPTS / "lib") not in sys.path:
 from check_active_drain import (  # noqa: E402
     DrainResult,
     build_receipt_index,
+    build_receipt_status_index,
     drain_active,
     drain_one,
     iter_active_dispatches,
@@ -61,14 +62,19 @@ def _make_active_dispatch(
     return d
 
 
-def _make_receipt(data: Path, dispatch_id: str, pid: int = 9999) -> Path:
+def _make_receipt(
+    data: Path,
+    dispatch_id: str,
+    pid: int = 9999,
+    status: str = "success",
+) -> Path:
     """Create a processed receipt for the given dispatch_id."""
     receipt = data / "receipts" / "processed" / f"1776{pid}-{dispatch_id[:12]}-{pid}.json"
     receipt.write_text(
         json.dumps({
             "dispatch_id": dispatch_id,
             "event_type": "task_complete",
-            "status": "success",
+            "status": status,
         }),
         encoding="utf-8",
     )
@@ -346,3 +352,108 @@ class TestDrainActive:
         results = drain_active(data_dir=data, older_than_hours=1.0, dry_run=False)
         assert all(r.action == "completed" for r in results)
         assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# CFX-1 round-1 finding: status-aware drain
+# ---------------------------------------------------------------------------
+
+class TestStatusAwareDrain:
+    """Codex round-1 PR #320: receipts with failure statuses must NOT cause
+    a dispatch to be drained as completed work."""
+
+    def test_status_index_classifies_success_and_failure(self, tmp_path: Path) -> None:
+        data = _make_data_dir(tmp_path)
+        _make_receipt(data, "ok-dispatch", pid=1, status="success")
+        _make_receipt(data, "bad-dispatch", pid=2, status="failed")
+        _make_receipt(data, "err-dispatch", pid=3, status="error")
+        _make_receipt(data, "blocked-dispatch", pid=4, status="blocked")
+        _make_receipt(data, "weird-dispatch", pid=5, status="bananas")
+
+        idx = build_receipt_status_index(data / "receipts")
+        assert idx["ok-dispatch"] == "success"
+        assert idx["bad-dispatch"] == "failure"
+        assert idx["err-dispatch"] == "failure"
+        assert idx["blocked-dispatch"] == "failure"
+        assert idx["weird-dispatch"] == "unknown"
+
+    def test_status_index_failure_wins_over_success(self, tmp_path: Path) -> None:
+        """If two receipts disagree, the failure status must win — fail-closed."""
+        data = _make_data_dir(tmp_path)
+        _make_receipt(data, "split-dispatch", pid=10, status="success")
+        _make_receipt(data, "split-dispatch", pid=11, status="failed")
+
+        idx = build_receipt_status_index(data / "receipts")
+        assert idx["split-dispatch"] == "failure"
+
+    def test_legacy_build_receipt_index_still_returns_frozenset(self, tmp_path: Path) -> None:
+        data = _make_data_dir(tmp_path)
+        _make_receipt(data, "legacy-dispatch", pid=20, status="success")
+        idx = build_receipt_index(data / "receipts")
+        assert isinstance(idx, frozenset)
+        assert "legacy-dispatch" in idx
+
+    def test_failed_receipt_routes_to_dead_letter(self, tmp_path: Path) -> None:
+        data = _make_data_dir(tmp_path)
+        did = "20260429-failed-dispatch"
+        d = _make_active_dispatch(data, did, hours_old=2.0)
+        _make_receipt(data, did, pid=30, status="failed")
+
+        results = drain_active(data_dir=data, older_than_hours=1.0, dry_run=False)
+        assert len(results) == 1
+        assert results[0].action == "dead_letter"
+        assert "failure" in results[0].reason
+        assert (data / "dispatches" / "dead_letter" / did).exists()
+        assert not (data / "dispatches" / "completed" / did).exists()
+        # dispatch directory must be removed from active/
+        assert not d.exists()
+
+    def test_timeout_receipt_routes_to_dead_letter(self, tmp_path: Path) -> None:
+        data = _make_data_dir(tmp_path)
+        did = "20260429-timeout-dispatch"
+        _make_active_dispatch(data, did, hours_old=2.0)
+        _make_receipt(data, did, pid=31, status="timeout")
+
+        results = drain_active(data_dir=data, older_than_hours=1.0, dry_run=False)
+        assert results[0].action == "dead_letter"
+
+    def test_unknown_status_routes_to_dead_letter(self, tmp_path: Path) -> None:
+        """Unrecognised statuses fail closed — never silently completed."""
+        data = _make_data_dir(tmp_path)
+        did = "20260429-mystery-dispatch"
+        _make_active_dispatch(data, did, hours_old=2.0)
+        _make_receipt(data, did, pid=32, status="surprise")
+
+        results = drain_active(data_dir=data, older_than_hours=1.0, dry_run=False)
+        assert results[0].action == "dead_letter"
+        assert "unrecognised" in results[0].reason
+
+    def test_success_receipt_still_routes_to_completed(self, tmp_path: Path) -> None:
+        data = _make_data_dir(tmp_path)
+        did = "20260429-happy-dispatch"
+        _make_active_dispatch(data, did, hours_old=2.0)
+        _make_receipt(data, did, pid=33, status="success")
+
+        results = drain_active(data_dir=data, older_than_hours=1.0, dry_run=False)
+        assert results[0].action == "completed"
+        assert "success" in results[0].reason
+
+    def test_drain_one_accepts_legacy_frozenset_index(self, tmp_path: Path) -> None:
+        """External callers passing the legacy frozenset must still get the
+        success-routing they previously relied on."""
+        data = _make_data_dir(tmp_path)
+        did = "legacy-frozenset"
+        d = _make_active_dispatch(data, did, hours_old=2.0)
+        from datetime import datetime, timedelta, timezone as _tz
+        ts = datetime.now(tz=_tz.utc) - timedelta(hours=2)
+        entry = DispatchEntry(dispatch_id=did, directory=d, timestamp=ts)
+
+        result = drain_one(
+            entry=entry,
+            receipt_index=frozenset({did}),
+            dispatches_dir=data / "dispatches",
+            now=datetime.now(tz=_tz.utc),
+            older_than_seconds=3600,
+            dry_run=False,
+        )
+        assert result.action == "completed"

--- a/tests/test_dispatch_paths_scope.py
+++ b/tests/test_dispatch_paths_scope.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""CFX-1 — dispatch_paths.json manifest scoping tests.
+
+Covers six cases referenced in the CFX-1 synthesis (round-2 codex findings on
+PRs #303 / #310 / #311):
+
+  A. Manifest with 2 paths -> only those staged on commit, not other dirty files
+  B. Stash skips files outside manifest
+  C. Legacy mode (no manifest) -> existing pre_dispatch_dirty behavior
+  D. Manifest with non-existent path -> warning, no crash, simply no match
+  E. HEAD-comparison change detection vs time-window — synthetic test with
+     a concurrent unrelated commit shows the SHA-comparison ignores it
+  F. Integration — simulate two parallel dispatches in the same worktree;
+     dispatch A's auto-commit doesn't sweep dispatch B's edits
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess as real_subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch  # noqa: E402
+from subprocess_dispatch import (  # noqa: E402
+    _auto_commit_changes,
+    _auto_stash_changes,
+    _count_lines_changed_since_sha,
+)
+import dispatch_paths  # noqa: E402
+from dispatch_paths import (  # noqa: E402
+    filter_paths,
+    read_manifest,
+    write_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Manifest helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifestHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="cfx1-manifest-"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_write_then_read_roundtrip(self):
+        p = write_manifest(self.tmp, "d1", ["scripts/lib/", "tests/foo.py"])
+        self.assertTrue(p.exists())
+        data = json.loads(p.read_text())
+        self.assertEqual(data["dispatch_id"], "d1")
+        self.assertEqual(data["allowed_paths"], ["scripts/lib/", "tests/foo.py"])
+
+        loaded = read_manifest(self.tmp, "d1")
+        self.assertEqual(loaded, ["scripts/lib/", "tests/foo.py"])
+
+    def test_read_returns_none_when_missing(self):
+        self.assertIsNone(read_manifest(self.tmp, "absent-id"))
+
+    def test_read_returns_none_on_corrupt_json(self):
+        p = self.tmp / "dispatch_paths" / "bad.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not valid json")
+        self.assertIsNone(read_manifest(self.tmp, "bad"))
+
+    def test_filter_paths_directory_match(self):
+        files = ["scripts/lib/foo.py", "scripts/other.py", "tests/bar.py"]
+        self.assertEqual(
+            sorted(filter_paths(files, ["scripts/lib/"])),
+            ["scripts/lib/foo.py"],
+        )
+
+    def test_filter_paths_exact_match(self):
+        files = ["a/b.py", "a/b.pyc", "a/c.py"]
+        self.assertEqual(filter_paths(files, ["a/b.py"]), ["a/b.py"])
+
+    def test_filter_paths_trailing_slash_optional(self):
+        files = ["scripts/lib/foo.py"]
+        self.assertEqual(
+            filter_paths(files, ["scripts/lib"]),
+            ["scripts/lib/foo.py"],
+        )
+
+    def test_filter_paths_empty_allowed_returns_empty(self):
+        self.assertEqual(filter_paths(["a"], []), [])
+
+
+# ---------------------------------------------------------------------------
+# Case A & D — auto_commit honors manifest scope
+# ---------------------------------------------------------------------------
+
+
+class TestAutoCommitManifestScope(unittest.TestCase):
+    """Case A: manifest with 2 paths -> only those staged on commit.
+    Case D: manifest with non-existent path -> no match, no crash.
+    """
+
+    def _setup_mocks(self, dirty_files: set[str]) -> MagicMock:
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = "".join(f" M {f}\n" for f in dirty_files)
+        add_proc = MagicMock(returncode=0, stderr="")
+        commit_proc = MagicMock(returncode=0, stderr="")
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+        return mock_sp
+
+    def test_case_a_manifest_filters_to_two_paths(self):
+        # Worker dirtied 4 files; manifest only allows scripts/lib/ and tests/.
+        # The two unrelated files (dashboard/, docs/) must be excluded from add.
+        current_dirty = {
+            "scripts/lib/dispatch_paths.py",
+            "tests/test_dispatch_paths_scope.py",
+            "dashboard/unrelated.py",
+            "docs/unrelated.md",
+        }
+        mock_sp = self._setup_mocks(current_dirty)
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=current_dirty):
+            result = _auto_commit_changes(
+                "d-A", "T1",
+                pre_dispatch_dirty=set(),
+                manifest_paths=["scripts/lib/", "tests/"],
+            )
+
+        self.assertTrue(result)
+        # call 0: status; call 1: add; call 2: commit
+        add_cmd = mock_sp.run.call_args_list[1][0][0]
+        self.assertEqual(add_cmd[:3], ["git", "add", "--"])
+        staged = set(add_cmd[3:])
+        self.assertEqual(
+            staged,
+            {"scripts/lib/dispatch_paths.py", "tests/test_dispatch_paths_scope.py"},
+            "manifest must restrict staging to declared paths only",
+        )
+        self.assertNotIn("dashboard/unrelated.py", staged)
+        self.assertNotIn("docs/unrelated.md", staged)
+
+    def test_case_d_manifest_with_nonexistent_path_no_crash(self):
+        # Manifest declares a path that nothing is dirty under -> no files
+        # staged, no commit, no exception.
+        current_dirty = {"scripts/lib/foo.py"}
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = " M scripts/lib/foo.py\n"
+        mock_sp = MagicMock()
+        mock_sp.run.return_value = status_proc
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=current_dirty):
+            result = _auto_commit_changes(
+                "d-D", "T1",
+                pre_dispatch_dirty=set(),
+                manifest_paths=["nonexistent/dir/"],
+            )
+
+        self.assertFalse(result, "no add+commit when manifest matches nothing")
+        # Only status was called; no add, no commit.
+        self.assertEqual(mock_sp.run.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Case B — auto_stash honors manifest scope
+# ---------------------------------------------------------------------------
+
+
+class TestAutoStashManifestScope(unittest.TestCase):
+    """Case B: stash skips files outside manifest."""
+
+    def test_stash_filters_to_manifest(self):
+        current_dirty = {
+            "scripts/lib/foo.py",
+            "scripts/lib/bar.py",
+            "outside/baz.py",
+        }
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = (
+            " M scripts/lib/foo.py\n"
+            " M scripts/lib/bar.py\n"
+            " M outside/baz.py\n"
+        )
+        stash_proc = MagicMock(returncode=0, stderr="")
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, stash_proc]
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=current_dirty):
+            result = _auto_stash_changes(
+                "d-B", "T2",
+                pre_dispatch_dirty=set(),
+                manifest_paths=["scripts/lib/"],
+            )
+
+        self.assertTrue(result)
+        stash_cmd = mock_sp.run.call_args_list[1][0][0]
+        # Expected: git stash push -u -m <name> -- <files>
+        self.assertEqual(stash_cmd[:4], ["git", "stash", "push", "-u"])
+        self.assertIn("--", stash_cmd)
+        sep = stash_cmd.index("--")
+        stashed = set(stash_cmd[sep + 1:])
+        self.assertEqual(stashed, {"scripts/lib/foo.py", "scripts/lib/bar.py"})
+        self.assertNotIn("outside/baz.py", stashed)
+
+
+# ---------------------------------------------------------------------------
+# Case C — legacy mode (no manifest) preserves existing behavior
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyModeNoManifest(unittest.TestCase):
+    """Case C: legacy mode (manifest_paths=None) keeps pre_dispatch_dirty
+    semantics unchanged.  Only newly-dirtied files are staged."""
+
+    def test_legacy_uses_pre_dispatch_dirty_only(self):
+        pre_dirty = {"existing.py"}
+        current_dirty = {"existing.py", "new_a.py", "new_b.py"}
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = (
+            " M existing.py\n M new_a.py\n M new_b.py\n"
+        )
+        add_proc = MagicMock(returncode=0, stderr="")
+        commit_proc = MagicMock(returncode=0, stderr="")
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch("subprocess_dispatch._get_dirty_files", return_value=current_dirty):
+            # manifest_paths=None -> legacy code path
+            result = _auto_commit_changes(
+                "d-C", "T1",
+                pre_dispatch_dirty=pre_dirty,
+                manifest_paths=None,
+            )
+
+        self.assertTrue(result)
+        add_cmd = mock_sp.run.call_args_list[1][0][0]
+        staged = set(add_cmd[3:])
+        # Legacy: only files that became dirty during this dispatch.
+        self.assertEqual(staged, {"new_a.py", "new_b.py"})
+
+
+# ---------------------------------------------------------------------------
+# Case E — HEAD-comparison change detection vs time-window
+# ---------------------------------------------------------------------------
+
+
+class TestSHABasedLineCount(unittest.TestCase):
+    """Case E: SHA-comparison ignores parallel-dispatch commits inside the
+    same time window, while the legacy time-window counter would over-count
+    them.  Uses a real temp git repo so the assertion is end-to-end."""
+
+    def setUp(self) -> None:
+        self.repo = Path(tempfile.mkdtemp(prefix="cfx1-sha-"))
+        self._git("init", "-q")
+        self._git("config", "user.email", "ci@example.com")
+        self._git("config", "user.name", "CI")
+        # baseline commit
+        (self.repo / "base.txt").write_text("hello\n")
+        self._git("add", "base.txt")
+        self._git("commit", "-q", "-m", "base")
+        self.pre_sha = self._git("rev-parse", "HEAD").strip()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def _git(self, *args: str) -> str:
+        proc = real_subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            capture_output=True, text=True, check=True,
+        )
+        return proc.stdout
+
+    def test_sha_diff_excludes_parallel_unrelated_commit(self):
+        # Dispatch A creates one file with 5 lines.
+        a_file = self.repo / "scripts" / "a.py"
+        a_file.parent.mkdir(parents=True, exist_ok=True)
+        a_file.write_text("\n".join(f"line{i}" for i in range(5)) + "\n")
+        # Dispatch B (parallel) creates a different file with 20 lines and
+        # commits it under the same time window.
+        b_file = self.repo / "dashboard" / "b.py"
+        b_file.parent.mkdir(parents=True, exist_ok=True)
+        b_file.write_text("\n".join(f"x{i}" for i in range(20)) + "\n")
+
+        # Both files are now dirty.  Dispatch A commits only its file.
+        self._git("add", "scripts/a.py")
+        self._git("commit", "-q", "-m", "dispatch A commit")
+        # Dispatch B follows immediately.
+        self._git("add", "dashboard/b.py")
+        self._git("commit", "-q", "-m", "dispatch B commit (parallel)")
+
+        # SHA-based count for dispatch A's scope must report only A's 5 lines,
+        # not 5 + 20.  Direct inline diff against the temp repo asserts the
+        # invariant the helper depends on; the helper itself is unit-tested
+        # against the empty-sha contract in the next test.
+        diff_a = real_subprocess.run(
+            ["git", "diff", "--numstat", f"{self.pre_sha}..HEAD",
+             "--", "scripts/"],
+            cwd=self.repo, capture_output=True, text=True, check=True,
+        ).stdout
+        added_a = sum(
+            int(line.split("\t")[0])
+            for line in diff_a.splitlines()
+            if line and line.split("\t")[0].isdigit()
+        )
+        self.assertEqual(added_a, 5, "dispatch A's diff must show only its 5 lines")
+
+        # And the legacy time-window approach (no path filter, no SHA) would
+        # see *both* dispatches' commits — proving the upgrade is necessary.
+        diff_window = real_subprocess.run(
+            ["git", "log", "--numstat", f"{self.pre_sha}..HEAD"],
+            cwd=self.repo, capture_output=True, text=True, check=True,
+        ).stdout
+        added_total = sum(
+            int(line.split("\t")[0])
+            for line in diff_window.splitlines()
+            if line and line[0].isdigit()
+        )
+        self.assertEqual(
+            added_total, 25,
+            "time-window aggregation includes parallel dispatch B's 20 lines",
+        )
+
+    def test_count_lines_changed_since_sha_returns_zero_for_empty_sha(self):
+        # Defensive contract: empty pre_sha must return 0, never raise.
+        self.assertEqual(_count_lines_changed_since_sha(""), 0)
+        self.assertEqual(_count_lines_changed_since_sha("", paths=["x"]), 0)
+
+
+# ---------------------------------------------------------------------------
+# Case F — integration: two parallel dispatches in same worktree
+# ---------------------------------------------------------------------------
+
+
+class TestParallelDispatchIsolation(unittest.TestCase):
+    """Case F: dispatch A's auto-commit must not sweep dispatch B's edits.
+
+    Simulates two parallel workers in the same worktree by exposing both
+    workers' dirty files to ``_get_dirty_files`` and asserting that dispatch
+    A's auto-commit invocation only stages files within A's manifest scope.
+    """
+
+    def test_dispatch_a_does_not_sweep_dispatch_b_edits(self):
+        # Both A and B added new files in the same worktree.
+        current_dirty = {
+            "scripts/a/feature.py",      # dispatch A
+            "scripts/a/feature_test.py", # dispatch A
+            "scripts/b/other.py",        # dispatch B (parallel)
+            "tests/dashboard/x.py",      # dispatch B (parallel)
+        }
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = "".join(f"?? {f}\n" for f in current_dirty)
+        add_proc = MagicMock(returncode=0, stderr="")
+        commit_proc = MagicMock(returncode=0, stderr="")
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, add_proc, commit_proc]
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch(
+                 "subprocess_dispatch._get_dirty_files",
+                 return_value=current_dirty,
+             ):
+            committed = _auto_commit_changes(
+                "d-A-parallel", "T1",
+                pre_dispatch_dirty=set(),
+                manifest_paths=["scripts/a/"],
+            )
+
+        self.assertTrue(committed)
+        add_cmd = mock_sp.run.call_args_list[1][0][0]
+        staged = set(add_cmd[3:])
+        self.assertEqual(
+            staged,
+            {"scripts/a/feature.py", "scripts/a/feature_test.py"},
+            "manifest must restrict dispatch A's commit to its own paths",
+        )
+        self.assertNotIn("scripts/b/other.py", staged)
+        self.assertNotIn("tests/dashboard/x.py", staged)
+
+    def test_dispatch_b_stash_does_not_capture_dispatch_a_files(self):
+        """Symmetric: dispatch B fails and stashes; A's files must stay dirty."""
+        current_dirty = {
+            "scripts/a/feature.py",   # dispatch A
+            "scripts/b/other.py",     # dispatch B (failing)
+        }
+        status_proc = MagicMock(returncode=0)
+        status_proc.stdout = "".join(f"?? {f}\n" for f in current_dirty)
+        stash_proc = MagicMock(returncode=0, stderr="")
+        mock_sp = MagicMock()
+        mock_sp.run.side_effect = [status_proc, stash_proc]
+
+        with patch("subprocess_dispatch.subprocess", mock_sp), \
+             patch(
+                 "subprocess_dispatch._get_dirty_files",
+                 return_value=current_dirty,
+             ):
+            stashed = _auto_stash_changes(
+                "d-B-fail", "T2",
+                pre_dispatch_dirty=set(),
+                manifest_paths=["scripts/b/"],
+            )
+
+        self.assertTrue(stashed)
+        stash_cmd = mock_sp.run.call_args_list[1][0][0]
+        sep = stash_cmd.index("--")
+        in_stash = set(stash_cmd[sep + 1:])
+        self.assertEqual(in_stash, {"scripts/b/other.py"})
+        self.assertNotIn("scripts/a/feature.py", in_stash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dispatch_paths_scope.py
+++ b/tests/test_dispatch_paths_scope.py
@@ -130,6 +130,7 @@ class TestAutoCommitManifestScope(unittest.TestCase):
             result = _auto_commit_changes(
                 "d-A", "T1",
                 pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=["scripts/lib/", "tests/"],
             )
 
@@ -160,6 +161,7 @@ class TestAutoCommitManifestScope(unittest.TestCase):
             result = _auto_commit_changes(
                 "d-D", "T1",
                 pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=["nonexistent/dir/"],
             )
 
@@ -197,6 +199,7 @@ class TestAutoStashManifestScope(unittest.TestCase):
             result = _auto_stash_changes(
                 "d-B", "T2",
                 pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=["scripts/lib/"],
             )
 
@@ -238,6 +241,7 @@ class TestLegacyModeNoManifest(unittest.TestCase):
             result = _auto_commit_changes(
                 "d-C", "T1",
                 pre_dispatch_dirty=pre_dirty,
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=None,
             )
 
@@ -372,6 +376,7 @@ class TestParallelDispatchIsolation(unittest.TestCase):
             committed = _auto_commit_changes(
                 "d-A-parallel", "T1",
                 pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=["scripts/a/"],
             )
 
@@ -406,6 +411,7 @@ class TestParallelDispatchIsolation(unittest.TestCase):
             stashed = _auto_stash_changes(
                 "d-B-fail", "T2",
                 pre_dispatch_dirty=set(),
+                dispatch_touched_files=frozenset(current_dirty),
                 manifest_paths=["scripts/b/"],
             )
 

--- a/tests/test_subprocess_dispatch_cfx_r1.py
+++ b/tests/test_subprocess_dispatch_cfx_r1.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Codex round-1 regression tests for PR #320 (CFX-1).
+
+Finding 1 — `deliver_via_subprocess` was promoting the dispatch manifest
+into ``dispatches/completed/`` *before* the fail-closed checks (non-zero
+returncode, timeout-kill).  Failed dispatches were therefore recorded and
+later drained as completed work instead of going to ``dead_letter/``.
+
+These tests pin the corrected ordering:
+    success path        → manifest promoted to completed/
+    non-zero returncode → manifest promoted to dead_letter/
+    timeout kill        → manifest promoted to dead_letter/
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch  # noqa: E402
+
+
+def _make_adapter(returncode, was_timed_out=False, session_id="sess"):
+    deliver_result = MagicMock()
+    deliver_result.success = True
+
+    obs_result = MagicMock()
+    obs_result.transport_state = {"returncode": returncode}
+
+    adapter = MagicMock()
+    adapter.deliver.return_value = deliver_result
+    adapter.read_events_with_timeout.return_value = iter([])
+    adapter.get_session_id.return_value = session_id
+    adapter.observe.return_value = obs_result
+    adapter.was_timed_out.return_value = was_timed_out
+    adapter._get_event_store.return_value = None
+    adapter.trigger_report_pipeline.return_value = None
+    return adapter
+
+
+def _common_patches(promote_mock):
+    return [
+        patch("subprocess_dispatch._inject_skill_context", return_value="instr"),
+        patch("subprocess_dispatch._inject_permission_profile", return_value="instr"),
+        patch("subprocess_dispatch._resolve_agent_cwd", return_value=None),
+        patch("subprocess_dispatch._write_manifest", return_value="/tmp/m.json"),
+        patch("subprocess_dispatch._promote_manifest", promote_mock),
+        patch("subprocess_dispatch._capture_dispatch_parameters"),
+        patch("subprocess_dispatch._capture_dispatch_outcome"),
+    ]
+
+
+class TestManifestStageRoutedByOutcome(unittest.TestCase):
+    """Failed dispatches must NOT be promoted to completed/."""
+
+    def _run(self, returncode, was_timed_out=False):
+        promote = MagicMock(return_value="/tmp/destination.json")
+        adapter = _make_adapter(returncode=returncode, was_timed_out=was_timed_out)
+        cms = _common_patches(promote) + [
+            patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
+        ]
+        for cm in cms:
+            cm.start()
+        try:
+            result = subprocess_dispatch.deliver_via_subprocess(
+                "T1", "do work", "sonnet", "d-cfx-r1",
+            )
+        finally:
+            for cm in reversed(cms):
+                cm.stop()
+        return result, promote
+
+    def test_nonzero_exit_routes_manifest_to_dead_letter(self):
+        result, promote = self._run(returncode=1)
+        self.assertFalse(result.success)
+        # _promote_manifest must be called exactly once, with stage=dead_letter.
+        promote.assert_called_once_with("d-cfx-r1", stage="dead_letter")
+
+    def test_timeout_routes_manifest_to_dead_letter(self):
+        result, promote = self._run(returncode=None, was_timed_out=True)
+        self.assertFalse(result.success)
+        promote.assert_called_once_with("d-cfx-r1", stage="dead_letter")
+
+    def test_clean_success_routes_manifest_to_completed(self):
+        result, promote = self._run(returncode=0)
+        self.assertTrue(result.success)
+        promote.assert_called_once_with("d-cfx-r1", stage="completed")
+
+    def test_completed_path_not_called_on_failure(self):
+        """Belt-and-braces: collect every promote call and assert no call
+        slipped through with stage=completed when the dispatch failed."""
+        result, promote = self._run(returncode=137)  # SIGKILL-ish exit
+        self.assertFalse(result.success)
+        for call in promote.call_args_list:
+            self.assertNotEqual(
+                call.kwargs.get("stage"),
+                "completed",
+                "failed dispatch must never promote manifest to completed/",
+            )
+
+
+class TestPromoteManifestStageSemantics(unittest.TestCase):
+    """_promote_manifest itself must reject unexpected stages and move
+    (not copy) so a failed dispatch never has a parallel record."""
+
+    def test_rejects_invalid_stage(self):
+        self.assertIsNone(
+            subprocess_dispatch._promote_manifest("any-id", stage="bogus")
+        )
+
+    def test_moves_manifest_to_completed(self, *_):
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with patch("subprocess_dispatch._dispatch_manifest_dir") as mock_dir:
+                mock_dir.side_effect = lambda stage, did: tmp_path / stage / did
+                src_dir = tmp_path / "active" / "d1"
+                src_dir.mkdir(parents=True)
+                (src_dir / "manifest.json").write_text(json.dumps({"ok": True}))
+                dst = subprocess_dispatch._promote_manifest("d1", stage="completed")
+                self.assertIsNotNone(dst)
+                self.assertFalse((src_dir / "manifest.json").exists())
+                self.assertTrue((tmp_path / "completed" / "d1" / "manifest.json").exists())
+
+    def test_moves_manifest_to_dead_letter(self):
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with patch("subprocess_dispatch._dispatch_manifest_dir") as mock_dir:
+                mock_dir.side_effect = lambda stage, did: tmp_path / stage / did
+                src_dir = tmp_path / "active" / "d2"
+                src_dir.mkdir(parents=True)
+                (src_dir / "manifest.json").write_text(json.dumps({"ok": False}))
+                dst = subprocess_dispatch._promote_manifest("d2", stage="dead_letter")
+                self.assertIsNotNone(dst)
+                self.assertFalse((src_dir / "manifest.json").exists())
+                self.assertTrue((tmp_path / "dead_letter" / "d2" / "manifest.json").exists())
+                # No parallel record in completed/.
+                self.assertFalse((tmp_path / "completed" / "d2").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Round-2 codex feedback on PRs #303 / #310 / #311 repeatedly flagged that
`scripts/lib/subprocess_dispatch.py` could sweep unrelated changes across
shared worktrees: auto-commit's add scope and auto-stash's stash scope both
fell back to whole-repo operations when callers didn't supply a snapshot,
and `_count_lines_changed` aggregated commits over a time window — which
includes parallel dispatches.

This PR introduces a per-dispatch path manifest and rewires the relevant
code paths.

- **New helper** `scripts/lib/dispatch_paths.py` — `write_manifest` /
  `read_manifest` / `filter_paths`. Manifest lives at
  `<state_dir>/dispatch_paths/<dispatch_id>.json`.
- **subprocess_dispatch.py**
  - `_auto_commit_changes` and `_auto_stash_changes` accept `manifest_paths`
    and intersect it with the existing `pre_dispatch_dirty` scope. Without a
    manifest they fall back to legacy behavior with a deprecation log.
  - `_count_lines_changed_since_sha(pre_sha, paths)` replaces the time-window
    counter inside `_capture_dispatch_outcome`. `deliver_with_recovery`
    captures `_dispatch_pre_sha` early and threads it through.
  - New `--dispatch-paths` CLI argument that writes the manifest before
    delivery.

## Test plan

- [x] `python3 -m py_compile scripts/lib/dispatch_paths.py scripts/lib/subprocess_dispatch.py`
- [x] `python3 -m pytest tests/test_dispatch_paths_scope.py` — 15 new cases (manifest
      helper, A: per-path filtering on commit, B: stash scope, C: legacy mode unchanged,
      D: non-matching manifest, E: SHA diff vs time-window in a real temp repo, F:
      parallel-dispatch isolation for both commit and stash)
- [x] `python3 -m pytest tests/test_auto_commit_stash_isolation.py tests/test_subprocess_dispatch_round2_codex.py` —
      24 existing regression tests still pass
- [ ] Pre-existing collection errors / failures in unrelated test files
      (`test_subprocess_dispatch_f34.py`, `test_subprocess_dispatch_integration.py`,
      etc.) are unaffected by this change

## Closes recurring pattern

Targets the round-2 findings on #303 / #310 / #311 that flagged
`git add -A` / `git stash save` semantics in shared worktrees. See the
synthesis report at `claudedocs/2026-04-29-codex-findings-synthesis.md`
sections 2.4, 4.1, and 7.1 (item 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)