### PR TITLE
fix(governance): closure_verifier CLI flag forwarding + E2E coverage (CFX-2)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -941,7 +941,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--require-github-pr",
         action="store_true",
-        help="In --pr-id mode, also require a real GitHub PR for --branch with OPEN/CLEAN state and green CI",
+        help="In --pr-id mode, require a real GitHub PR + green checks for the branch (auto-enabled when --mode pre_merge).",
     )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--emit-receipt", action="store_true")
@@ -973,10 +973,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         branch = args.branch or _run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=project_root
         ).stdout.strip() or None
-        # In pre_merge mode, --require-github-pr enforces a real GitHub PR with
-        # OPEN/CLEAN state and green CI; in post_merge mode the caller can still
-        # opt in but it is only meaningful pre-merge.
-        require_github_pr = bool(args.require_github_pr) and args.mode == "pre_merge"
+        # pre_merge mode auto-enables GitHub PR enforcement; --require-github-pr
+        # forces it explicitly in any mode (CFX-2).
+        require_github_pr = bool(args.require_github_pr or args.mode == "pre_merge")
         result = verify_pr_closure(
             pr_id=args.pr_id,
             project_root=project_root,

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -294,6 +294,28 @@ def _find_gate_request_payload(
     return None
 
 
+def _gate_terminal_status(result: Dict[str, Any]) -> str:
+    """Return canonical terminal status ("pass"/"fail") for a gate result, or empty when non-terminal.
+
+    Two persisted formats are recognised so completed Claude reviews cannot bypass enforcement:
+    - Standard gates persist ``{"status": ...}`` or ``{"verdict": ...}``.
+    - claude_github_optional persists ``{"state": "completed", "result_status": "pass"|"fail"}``
+      and does not write top-level ``status``/``verdict``. Without this branch, terminal-failure
+      and report-path enforcement skip a completed Claude review with ``result_status="fail"``.
+    """
+    status = (result.get("status") or "").lower()
+    if status in ("pass", "fail"):
+        return status
+    verdict = (result.get("verdict") or "").lower()
+    if verdict in ("pass", "fail"):
+        return verdict
+    if (result.get("state") or "").lower() == "completed":
+        rs = (result.get("result_status") or "").lower()
+        if rs in ("pass", "fail"):
+            return rs
+    return ""
+
+
 def _validate_review_evidence(
     contract: ReviewContract,
     results_dir: Path,
@@ -346,6 +368,36 @@ def _validate_review_evidence(
                     "FAIL",
                     f"no evidence for optional gate {gate} — state must be explicit",
                 ))
+            elif (result.get("state") or "").lower() == "completed":
+                # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
+                # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
+                terminal = _gate_terminal_status(result)
+                blocking_count = int(result.get("blocking_count") or 0)
+                if terminal == "fail":
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        f"{gate} completed with result_status=fail",
+                    ))
+                elif blocking_count > 0:
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        f"{gate} completed with {blocking_count} blocking finding(s)",
+                    ))
+                elif terminal == "pass":
+                    advisory_count = int(result.get("advisory_count") or 0)
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "PASS",
+                        f"{gate} completed: pass (0 blocking, {advisory_count} advisory)",
+                    ))
+                else:
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        f"{gate} state=completed but result_status is missing or unknown",
+                    ))
             elif result.get("was_intentionally_absent") or result.get("contributed_evidence"):
                 state = result.get("state", "unknown")
                 source = result.get("__source", "result")
@@ -446,7 +498,10 @@ def _validate_review_evidence(
     # under $VNX_DATA_DIR/unified_reports/.
     for gate in contract.review_stack:
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=branch)
-        if result is not None and gate_is_terminal(result):
+        # Treat status/verdict AND state="completed" + result_status as terminal so completed
+        # Claude reviews cannot bypass report_path enforcement (they never set status/verdict).
+        _has_terminal = result is not None and bool(_gate_terminal_status(result))
+        if _has_terminal:
             report_path = result.get("report_path", "")
             if not report_path:
                 checks.append(CheckResult(
@@ -716,7 +771,10 @@ def _detect_gate_report_contradictions(
         except OSError:
             continue
 
-        passed, _reason = gate_is_pass(result)
+        # Recognise both standard (status/verdict) and Claude (state=completed/result_status)
+        # terminal formats so a completed Claude review with mismatched evidence is detected.
+        gate_status = _gate_terminal_status(result) or "unknown"
+        passed = gate_status == "pass"
         gate_blocking = result.get("blocking_count", 0)
         if not isinstance(gate_blocking, int):
             gate_blocking = len(result.get("blocking_findings") or [])

--- a/tests/test_cli_flag_forwarding.py
+++ b/tests/test_cli_flag_forwarding.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""End-to-end CLI flag forwarding tests for closure_verifier.py and review_gate_manager.py.
+
+Background (from claudedocs/2026-04-29-codex-findings-synthesis.md §4.2):
+PRs #300 and #301 shipped two distinct flag-forwarding gaps in two consecutive
+PRs (--branch, --mode, --require-github-pr parsed by argparse but never propagated
+into the verifier function body). This test exercises every supported CLI flag
+of both scripts and asserts the inner function receives it. It is the regression
+backstop for the recurring "argparse parses, body ignores" anti-pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv  # noqa: E402
+import review_gate_manager as rgm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_env(tmp_path, monkeypatch):
+    """Minimal VNX env so ensure_env() resolves cleanly inside main()."""
+    project_root = tmp_path / "repo"
+    project_root.mkdir(parents=True, exist_ok=True)
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    dispatch_dir = data_dir / "dispatches"
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir = data_dir / "unified_reports"
+    (reports_dir / "headless").mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_HEADLESS_REPORTS_DIR", str(reports_dir / "headless"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return project_root
+
+
+def _stub_verify_pr_closure_return() -> dict:
+    return {"verdict": "pass", "checks": []}
+
+
+def _stub_verify_closure_return() -> dict:
+    return {"verdict": "pass", "checks": [], "feature_title": "demo"}
+
+
+# ---------------------------------------------------------------------------
+# closure_verifier.py — per-PR mode (--pr-id)
+# ---------------------------------------------------------------------------
+
+
+def test_per_pr_forwards_pr_id_and_branch(project_env):
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        rc = cv.main(["--pr-id", "PR-7", "--branch", "feat/x"])
+    assert rc == 0
+    kwargs = mock.call_args.kwargs
+    assert kwargs["pr_id"] == "PR-7"
+    assert kwargs["branch"] == "feat/x"
+
+
+def test_per_pr_pre_merge_auto_requires_github_pr(project_env):
+    """--mode pre_merge in --pr-id mode auto-enables require_github_pr (CFX-2 fix)."""
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        cv.main(["--pr-id", "PR-7", "--branch", "feat/x", "--mode", "pre_merge"])
+    assert mock.call_args.kwargs["require_github_pr"] is True
+
+
+def test_per_pr_post_merge_does_not_auto_require_github_pr(project_env):
+    """post_merge mode must not auto-enable require_github_pr — caller may opt in explicitly."""
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        cv.main(["--pr-id", "PR-7", "--branch", "feat/x", "--mode", "post_merge"])
+    assert mock.call_args.kwargs["require_github_pr"] is False
+
+
+def test_per_pr_explicit_require_github_pr_flag(project_env):
+    """--require-github-pr forwards even when --mode is post_merge."""
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        cv.main([
+            "--pr-id", "PR-7",
+            "--branch", "feat/x",
+            "--mode", "post_merge",
+            "--require-github-pr",
+        ])
+    assert mock.call_args.kwargs["require_github_pr"] is True
+
+
+def test_per_pr_review_contract_loaded_and_forwarded(project_env, tmp_path):
+    """--review-contract path is parsed into a ReviewContract and forwarded."""
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps({
+        "pr_id": "PR-7",
+        "review_stack": ["codex_gate"],
+        "risk_class": "medium",
+        "deterministic_findings": [],
+        "deliverables": [],
+        "quality_gates": [],
+        "test_evidence": [],
+        "content_hash": "abc",
+    }))
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        cv.main([
+            "--pr-id", "PR-7",
+            "--branch", "feat/x",
+            "--review-contract", str(contract_path),
+        ])
+    forwarded = mock.call_args.kwargs["review_contract"]
+    assert forwarded is not None
+    assert forwarded.pr_id == "PR-7"
+
+
+def test_per_pr_gate_results_dir_forwarded_as_path(project_env, tmp_path):
+    gate_dir = tmp_path / "gates"
+    gate_dir.mkdir()
+    with patch.object(cv, "verify_pr_closure", return_value=_stub_verify_pr_closure_return()) as mock:
+        cv.main([
+            "--pr-id", "PR-7",
+            "--branch", "feat/x",
+            "--gate-results-dir", str(gate_dir),
+        ])
+    assert mock.call_args.kwargs["gate_results_dir"] == gate_dir
+
+
+# ---------------------------------------------------------------------------
+# closure_verifier.py — whole-feature mode (no --pr-id)
+# ---------------------------------------------------------------------------
+
+
+def test_full_mode_forwards_branch_and_mode(project_env):
+    """Whole-feature path: --branch and --mode reach verify_closure()."""
+    with patch.object(cv, "verify_closure", return_value=_stub_verify_closure_return()) as mock:
+        cv.main(["--branch", "feat/x", "--mode", "post_merge"])
+    kwargs = mock.call_args.kwargs
+    assert kwargs["branch"] == "feat/x"
+    assert kwargs["mode"] == "post_merge"
+
+
+def test_full_mode_forwards_review_contract(project_env, tmp_path):
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps({
+        "pr_id": "PR-9",
+        "review_stack": ["gemini_review"],
+        "risk_class": "low",
+        "deterministic_findings": [],
+        "deliverables": [],
+        "quality_gates": [],
+        "test_evidence": [],
+        "content_hash": "h",
+    }))
+    with patch.object(cv, "verify_closure", return_value=_stub_verify_closure_return()) as mock:
+        cv.main([
+            "--branch", "feat/x",
+            "--mode", "pre_merge",
+            "--review-contract", str(contract_path),
+        ])
+    forwarded = mock.call_args.kwargs["review_contract"]
+    assert forwarded is not None
+    assert forwarded.pr_id == "PR-9"
+
+
+def test_full_mode_forwards_gate_results_dir(project_env, tmp_path):
+    gate_dir = tmp_path / "gates"
+    gate_dir.mkdir()
+    with patch.object(cv, "verify_closure", return_value=_stub_verify_closure_return()) as mock:
+        cv.main(["--branch", "feat/x", "--gate-results-dir", str(gate_dir)])
+    assert mock.call_args.kwargs["gate_results_dir"] == gate_dir
+
+
+def test_full_mode_forwards_claim_file_when_exists(project_env, tmp_path):
+    claim_file = tmp_path / "claim.json"
+    claim_file.write_text("{}")
+    with patch.object(cv, "verify_closure", return_value=_stub_verify_closure_return()) as mock:
+        cv.main(["--branch", "feat/x", "--claim-file", str(claim_file)])
+    assert mock.call_args.kwargs["claim_file"] == claim_file
+
+
+def test_full_mode_skips_claim_file_when_missing(project_env, tmp_path):
+    """Non-existent claim file should be passed as None (preserves prior behavior)."""
+    missing = tmp_path / "no_such.json"
+    with patch.object(cv, "verify_closure", return_value=_stub_verify_closure_return()) as mock:
+        cv.main(["--branch", "feat/x", "--claim-file", str(missing)])
+    assert mock.call_args.kwargs["claim_file"] is None
+
+
+def test_verify_closure_invokes_contradiction_detector(project_env, tmp_path):
+    """verify_closure() must call _detect_gate_report_contradictions when a contract is present (CFX-2 fix)."""
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps({
+        "pr_id": "PR-9",
+        "review_stack": ["codex_gate"],
+        "risk_class": "medium",
+        "deterministic_findings": [],
+        "deliverables": [],
+        "quality_gates": [],
+        "test_evidence": [],
+        "content_hash": "h",
+    }))
+    # Patch the helpers verify_closure depends on so we can run it without git.
+    with patch.object(cv, "_detect_gate_report_contradictions", return_value=[]) as detector, \
+         patch.object(cv, "_validate_review_evidence", return_value=[]), \
+         patch.object(cv, "_check_stale_staging", return_value=cv.CheckResult("stale_staging", "PASS", "ok")), \
+         patch.object(cv, "_validate_test_claims", return_value=[]), \
+         patch.object(cv, "_remote_branch_exists", return_value=True), \
+         patch.object(cv, "_find_branch_pr", return_value=None), \
+         patch.object(cv, "_parse_feature_plan", return_value={
+             "title": "f", "status": "complete", "dependency_flow": "x", "pr_ids": ["PR-9"]
+         }), \
+         patch.object(cv, "_parse_pr_queue", return_value={
+             "title": "f", "overview": (1, 1, 0, 0, 0), "dependency_flow": "x"
+         }):
+        from review_contract import ReviewContract
+        contract = ReviewContract.from_json(contract_path.read_text())
+        cv.verify_closure(
+            project_root=project_env,
+            feature_plan=project_env / "FEATURE_PLAN.md",
+            pr_queue=project_env / "PR_QUEUE.md",
+            branch="feat/x",
+            mode="pre_merge",
+            review_contract=contract,
+        )
+    assert detector.called, "verify_closure() must wire _detect_gate_report_contradictions into its checks"
+
+
+# ---------------------------------------------------------------------------
+# review_gate_manager.py — every subcommand × every flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    """Replace ReviewGateManager() and the git-diff fallback so main() runs offline."""
+    fake = MagicMock()
+    fake.request_reviews.return_value = {"requested": []}
+    fake.request_and_execute.return_value = {"has_required_failure": False, "gates": []}
+    fake.execute_gate.return_value = {"gate": "x"}
+    fake.record_result.return_value = {"recorded": True}
+    fake.status.return_value = {}
+    monkeypatch.setattr(rgm, "ReviewGateManager", lambda: fake)
+    monkeypatch.setattr(rgm, "_compute_changed_files", lambda branch: ["a.py", "b.py"])
+    return fake
+
+
+def test_rgm_request_forwards_all_flags(fake_manager):
+    rc = rgm.main([
+        "request",
+        "--pr", "42",
+        "--branch", "feat/x",
+        "--review-stack", "codex_gate,gemini_review",
+        "--risk-class", "high",
+        "--changed-files", "a.py,b.py",
+        "--mode", "final",
+        "--dispatch-id", "D-1",
+    ])
+    assert rc == 0
+    kwargs = fake_manager.request_reviews.call_args.kwargs
+    assert kwargs["pr_number"] == 42
+    assert kwargs["branch"] == "feat/x"
+    assert kwargs["review_stack"] == ["codex_gate", "gemini_review"]
+    assert kwargs["risk_class"] == "high"
+    assert kwargs["changed_files"] == ["a.py", "b.py"]
+    assert kwargs["mode"] == "final"
+    assert kwargs["dispatch_id"] == "D-1"
+
+
+def test_rgm_request_auto_computes_changed_files_when_blank(fake_manager):
+    """Empty --changed-files triggers _compute_changed_files fallback."""
+    rgm.main([
+        "request",
+        "--pr", "5",
+        "--branch", "feat/x",
+        "--changed-files", "",
+    ])
+    assert fake_manager.request_reviews.call_args.kwargs["changed_files"] == ["a.py", "b.py"]
+
+
+def test_rgm_request_and_execute_forwards_all_flags(fake_manager):
+    rc = rgm.main([
+        "request-and-execute",
+        "--pr", "42",
+        "--branch", "feat/x",
+        "--review-stack", "codex_gate",
+        "--risk-class", "low",
+        "--changed-files", "a.py",
+        "--mode", "per_pr",
+        "--dispatch-id", "D-2",
+    ])
+    assert rc == 0
+    kwargs = fake_manager.request_and_execute.call_args.kwargs
+    assert kwargs["pr_number"] == 42
+    assert kwargs["branch"] == "feat/x"
+    assert kwargs["review_stack"] == ["codex_gate"]
+    assert kwargs["risk_class"] == "low"
+    assert kwargs["changed_files"] == ["a.py"]
+    assert kwargs["mode"] == "per_pr"
+    assert kwargs["dispatch_id"] == "D-2"
+
+
+def test_rgm_execute_forwards_gate_pr_pr_id(fake_manager):
+    rc = rgm.main([
+        "execute",
+        "--gate", "codex_gate",
+        "--pr", "42",
+        "--pr-id", "PR-7",
+    ])
+    assert rc == 0
+    kwargs = fake_manager.execute_gate.call_args.kwargs
+    assert kwargs["gate"] == "codex_gate"
+    assert kwargs["pr_number"] == 42
+    assert kwargs["pr_id"] == "PR-7"
+
+
+def test_rgm_record_result_forwards_all_flags(fake_manager, tmp_path):
+    findings_file = tmp_path / "findings.json"
+    findings_file.write_text(json.dumps([{"severity": "error", "message": "x"}]))
+    rc = rgm.main([
+        "record-result",
+        "--gate", "codex_gate",
+        "--pr", "42",
+        "--branch", "feat/x",
+        "--status", "pass",
+        "--summary", "ok",
+        "--findings-file", str(findings_file),
+        "--residual-risk", "low",
+        "--contract-hash", "abc123",
+        "--pr-id", "PR-7",
+        "--report-path", "/tmp/r.md",
+    ])
+    assert rc == 0
+    kwargs = fake_manager.record_result.call_args.kwargs
+    assert kwargs["gate"] == "codex_gate"
+    assert kwargs["pr_number"] == 42
+    assert kwargs["branch"] == "feat/x"
+    assert kwargs["status"] == "pass"
+    assert kwargs["summary"] == "ok"
+    assert kwargs["findings"] == [{"severity": "error", "message": "x"}]
+    assert kwargs["residual_risk"] == "low"
+    assert kwargs["contract_hash"] == "abc123"
+    assert kwargs["pr_id"] == "PR-7"
+    assert kwargs["report_path"] == "/tmp/r.md"
+
+
+def test_rgm_status_forwards_pr(fake_manager):
+    rc = rgm.main(["status", "--pr", "42"])
+    assert rc == 0
+    fake_manager.status.assert_called_once_with(42)

--- a/tests/test_closure_verifier.py
+++ b/tests/test_closure_verifier.py
@@ -1003,3 +1003,271 @@ class TestClosureVerifierRoundOneCodexFindings:
         assert result["verdict"] == "fail"
         failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
         assert "gate_claude_github_optional" in failed
+
+
+
+
+def _make_claude_completed_result(
+    pr_id="PR-0",
+    result_status="pass",
+    blocking_count=0,
+    advisory_count=0,
+    contract_hash="abcdef1234567890",
+    report_path="",
+):
+    """Persisted shape of a completed Claude review (state="completed", result_status, blocking_count).
+
+    Mirrors ClaudeGitHubReviewReceipt.to_dict() for state=STATE_COMPLETED — no top-level
+    status/verdict, terminal outcome lives in result_status. Used to lock down the regression
+    in `closure_verifier._gate_terminal_status` (codex round-1 finding 2 on PR #321).
+    """
+    return {
+        "gate": "claude_github_optional",
+        "pr_id": pr_id,
+        "state": "completed",
+        "contributed_evidence": True,
+        "was_intentionally_absent": False,
+        "result_status": result_status,
+        "blocking_count": blocking_count,
+        "advisory_count": advisory_count,
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "contract_hash": contract_hash,
+        "report_path": report_path,
+    }
+
+
+class TestClaudeGithubCompletedTerminalStatus:
+    """Codex round-1 finding 2 (PR #321): completed Claude reviews must not bypass enforcement.
+
+    A Claude review persists its terminal outcome as ``state="completed"`` plus
+    ``result_status="pass"|"fail"`` (no top-level status/verdict). Without recognising
+    this format, the closure verifier accepted result_status="fail", blocking findings,
+    and missing/deleted reports because contributed_evidence=true short-circuited every check.
+    """
+
+    def test_completed_with_result_status_fail_blocks_closure(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        report = tmp_path / "claude_report.md"
+        report.write_text("# Claude Review\n", encoding="utf-8")
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(result_status="fail", report_path=str(report)),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        assert result["verdict"] == "fail"
+        gate_check = next(c for c in result["checks"] if c["name"] == "gate_claude_github_optional")
+        assert gate_check["status"] == "FAIL"
+        assert "result_status=fail" in gate_check["detail"]
+
+    def test_completed_with_blocking_findings_blocks_closure(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        report = tmp_path / "claude_report.md"
+        report.write_text("# Claude Review\n", encoding="utf-8")
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(
+                result_status="pass", blocking_count=3, report_path=str(report),
+            ),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        assert result["verdict"] == "fail"
+        gate_check = next(c for c in result["checks"] if c["name"] == "gate_claude_github_optional")
+        assert gate_check["status"] == "FAIL"
+        assert "3 blocking" in gate_check["detail"]
+
+    def test_completed_with_missing_report_path_blocks_closure(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(result_status="pass", report_path=""),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        assert result["verdict"] == "fail"
+        failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
+        assert "report_claude_github_optional" in failed
+
+    def test_completed_with_deleted_report_path_blocks_closure(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        ghost_path = tmp_path / "deleted_report.md"
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(result_status="pass", report_path=str(ghost_path)),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        assert result["verdict"] == "fail"
+        failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
+        assert "report_claude_github_optional" in failed
+
+    def test_completed_with_unknown_result_status_blocks_closure(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        report = tmp_path / "claude_report.md"
+        report.write_text("# Claude Review\n", encoding="utf-8")
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        result_payload = _make_claude_completed_result(report_path=str(report))
+        result_payload["result_status"] = ""
+        _write_gate_result(results_dir, "claude_github_optional", "PR-0", result_payload)
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        gate_check = next(c for c in result["checks"] if c["name"] == "gate_claude_github_optional")
+        assert gate_check["status"] == "FAIL"
+
+    def test_completed_pass_with_real_report_clears_gate(self, verifier_env, monkeypatch, tmp_path):
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        report = tmp_path / "claude_report.md"
+        report.write_text("# Claude Review\nNo issues.\n", encoding="utf-8")
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(
+                result_status="pass", blocking_count=0, advisory_count=2,
+                report_path=str(report),
+            ),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        passed = {c["name"] for c in result["checks"] if c["status"] == "PASS"}
+        assert "gate_claude_github_optional" in passed
+        assert "report_claude_github_optional" in passed
+
+    def test_completed_contradiction_detector_recognises_result_status(self, verifier_env, monkeypatch, tmp_path):
+        """A "pass" Claude result whose report contains [BLOCKING] markers must trigger contradiction.
+
+        Pre-fix: _detect_gate_report_contradictions inspected only status/verdict, so
+        gate_status fell through to "unknown" and the contradiction was missed.
+        """
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        report = tmp_path / "claude_report.md"
+        report.write_text(
+            "# Claude Review\n[BLOCKING] auth bypass\n[BLOCKING] sql injection\n",
+            encoding="utf-8",
+        )
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "claude_github_optional", "PR-0",
+            _make_claude_completed_result(result_status="pass", blocking_count=0, report_path=str(report)),
+        )
+
+        contradictions = cv._detect_gate_report_contradictions(contract, results_dir)
+        names_failed = {c.name for c in contradictions if c.status == "FAIL"}
+        assert "contradiction_claude_github_optional" in names_failed
+
+
+class TestGateTerminalStatusHelper:
+    """Direct unit tests for the _gate_terminal_status helper added in CFX-2 round-2."""
+
+    def test_recognises_status_field(self):
+        assert cv._gate_terminal_status({"status": "pass"}) == "pass"
+        assert cv._gate_terminal_status({"status": "FAIL"}) == "fail"
+
+    def test_recognises_verdict_field(self):
+        assert cv._gate_terminal_status({"verdict": "pass"}) == "pass"
+        assert cv._gate_terminal_status({"verdict": "fail"}) == "fail"
+
+    def test_recognises_completed_state_with_result_status(self):
+        assert cv._gate_terminal_status({"state": "completed", "result_status": "pass"}) == "pass"
+        assert cv._gate_terminal_status({"state": "completed", "result_status": "FAIL"}) == "fail"
+
+    def test_returns_empty_for_non_terminal(self):
+        assert cv._gate_terminal_status({"status": "requested"}) == ""
+        assert cv._gate_terminal_status({"state": "completed"}) == ""
+        assert cv._gate_terminal_status({"state": "not_configured"}) == ""
+        assert cv._gate_terminal_status({}) == ""
+
+    def test_status_takes_precedence_over_state(self):
+        assert cv._gate_terminal_status({"status": "pass", "state": "completed", "result_status": "fail"}) == "pass"


### PR DESCRIPTION
## Summary

- Adds `--require-github-pr` CLI flag to `scripts/closure_verifier.py` and forwards `--branch` + `require_github_pr` into `verify_pr_closure()` in per-PR mode (auto-enabled by `--mode pre_merge`).
- Wires `_detect_gate_report_contradictions()` into `verify_closure()` so whole-feature mode has parity with per-PR mode (closes #300 round-1 finding).
- New `tests/test_cli_flag_forwarding.py` (18 tests) drives every supported flag of `closure_verifier.py` and every subcommand × flag of `review_gate_manager.py` through their argparse surfaces and asserts the inner function received each one.

Addresses recurring pattern §4.2 of `claudedocs/2026-04-29-codex-findings-synthesis.md` and closes the round-2 codex findings on PRs #300 / #301 about CLI-unreachable safeguards.

## Why

Codex flagged on PRs #300 and #301 (both rounds) that `closure_verifier.py` parsed flags but never forwarded them into the verifier body — making the new GitHub-PR readiness logic CLI-unreachable. The same shape of bug shipped in two consecutive PRs because there was no E2E backstop. This PR adds that backstop and fixes the latent forwarding gaps the codex findings called out.

## Test plan

- [x] `python3 -m py_compile scripts/closure_verifier.py scripts/review_gate_manager.py`
- [x] `python3 -m pytest tests/test_cli_flag_forwarding.py -xvs` — 18/18 pass.
- [x] Regression: `python3 -m pytest tests/test_cli_flag_forwarding.py tests/test_closure_verifier.py tests/test_per_pr_closure.py tests/test_review_gate_dispatch_id.py` — 56/56 pass.
- [ ] CI codex-gate / gemini-review on this PR.

### Out of scope

- Gate result schema canonicalization (CFX-3).
- Pre-existing failures in `tests/test_review_gate_manager.py` (3 tests, env-fixture leakage; reproduces on `main`) — separate fixture-hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)