### PR TITLE
refactor(governance): canonicalize gate result schema (CFX-3)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -226,6 +226,74 @@ def _find_gate_result(
     return None
 
 
+# Request-side states for the optional Claude GitHub review gate that record
+# an explicit, intentional absence (writer: gate_request_handler).  These are
+# canonicalized in claude_github_receipt.INTENTIONALLY_ABSENT_STATES /
+# EVIDENCE_STATES; duplicated here to avoid an import cycle since
+# closure_verifier already pins sys.path on its own.
+_INTENTIONALLY_ABSENT_REQUEST_STATES = frozenset({"not_configured", "configured_dry_run"})
+_EVIDENCE_REQUEST_STATES = frozenset({"requested", "completed"})
+
+
+def _find_gate_request_payload(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+) -> Optional[Dict[str, Any]]:
+    """Locate a gate **request** payload as a fallback when no result exists.
+
+    For optional gates (notably ``claude_github_optional``), the explicit-absence
+    state (``not_configured``, ``configured_dry_run``) is recorded by
+    gate_request_handler in the requests directory only — no separate result
+    file is written.  This helper finds that payload and normalises legacy
+    ``status``-only writers into the same shape the closure verifier expects
+    (with ``state``/``contributed_evidence``/``was_intentionally_absent``).
+    """
+    requests_dir = results_dir.parent / "requests"
+    if not requests_dir.exists():
+        return None
+
+    pr_slug = pr_id.lower().replace("-", "")
+    candidates: List[Path] = []
+    contract_path = requests_dir / f"{pr_slug}-{gate}-contract.json"
+    if contract_path.exists():
+        candidates.append(contract_path)
+    candidates.extend(
+        path for path in requests_dir.glob(f"*-{gate}*.json")
+        if path not in candidates
+    )
+
+    for path in candidates:
+        try:
+            data = json.loads(_read_text(path))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("pr_id") and data["pr_id"] != pr_id:
+            continue
+        if data.get("gate") and data["gate"] != gate:
+            continue
+
+        # Normalise legacy `status`-only payloads (writer: _request_claude_github)
+        # so downstream checks can read `state` / contributed_evidence /
+        # was_intentionally_absent uniformly.
+        normalised = dict(data)
+        if "state" not in normalised and "status" in normalised:
+            normalised["state"] = normalised["status"]
+        state = normalised.get("state")
+        if isinstance(state, str):
+            normalised.setdefault(
+                "was_intentionally_absent",
+                state in _INTENTIONALLY_ABSENT_REQUEST_STATES,
+            )
+            normalised.setdefault(
+                "contributed_evidence",
+                state in _EVIDENCE_REQUEST_STATES,
+            )
+        normalised["__source"] = "request"
+        return normalised
+    return None
+
+
 def _validate_review_evidence(
     contract: ReviewContract,
     results_dir: Path,
@@ -261,6 +329,12 @@ def _validate_review_evidence(
         result = _find_gate_result(gate, contract.pr_id, results_dir)
 
         if gate == "claude_github_optional":
+            # Fallback: explicit-absence state for the optional gate is recorded
+            # in the requests directory by gate_request_handler — not as a
+            # separate result file — so a missing result is not by itself
+            # ambiguous.  Look there before declaring no evidence.
+            if result is None:
+                result = _find_gate_request_payload(gate, contract.pr_id, results_dir)
             if result is None:
                 checks.append(CheckResult(
                     f"gate_{gate}",
@@ -269,10 +343,11 @@ def _validate_review_evidence(
                 ))
             elif result.get("was_intentionally_absent") or result.get("contributed_evidence"):
                 state = result.get("state", "unknown")
+                source = result.get("__source", "result")
                 checks.append(CheckResult(
                     f"gate_{gate}",
                     "PASS",
-                    f"{gate} state explicit: {state}",
+                    f"{gate} state explicit: {state} (source: {source})",
                 ))
             else:
                 checks.append(CheckResult(

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -25,6 +25,7 @@ from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt
 from review_contract import ReviewContract
 from codex_final_gate import enforce_codex_gate
+from gate_status import is_pass as gate_is_pass, is_terminal as gate_is_terminal
 
 
 @dataclass(frozen=True)
@@ -290,8 +291,8 @@ def _validate_review_evidence(
                         f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
                     ))
                 else:
-                    verdict = result.get("verdict", "missing")
-                    if verdict == "pass":
+                    passed, reason = gate_is_pass(result)
+                    if passed:
                         checks.append(CheckResult(
                             f"gate_{gate}",
                             "PASS",
@@ -301,7 +302,7 @@ def _validate_review_evidence(
                         checks.append(CheckResult(
                             f"gate_{gate}",
                             "FAIL",
-                            f"codex gate verdict: {verdict}",
+                            f"codex gate not passing — {reason}",
                         ))
             else:
                 checks.append(CheckResult(
@@ -318,10 +319,9 @@ def _validate_review_evidence(
                     f"no gate result for required reviewer {gate}",
                 ))
             else:
-                status = result.get("status", "missing")
-                blocking_count = result.get("blocking_count", 0)
-                if status == "pass" and blocking_count == 0:
-                    advisory_count = result.get("advisory_count", 0)
+                passed, reason = gate_is_pass(result)
+                advisory_count = result.get("advisory_count", 0)
+                if passed:
                     checks.append(CheckResult(
                         f"gate_{gate}",
                         "PASS",
@@ -331,7 +331,7 @@ def _validate_review_evidence(
                     checks.append(CheckResult(
                         f"gate_{gate}",
                         "FAIL",
-                        f"gemini review status: {status}, {blocking_count} blocking finding(s)",
+                        f"gemini review not passing — {reason}",
                     ))
 
         else:
@@ -366,15 +366,7 @@ def _validate_review_evidence(
     # under $VNX_DATA_DIR/unified_reports/.
     for gate in contract.review_stack:
         result = _find_gate_result(gate, contract.pr_id, results_dir)
-        # Check both status and verdict fields independently to avoid the OR-priority escape:
-        # if status="requested" (truthy) but verdict="pass", the old OR logic would yield
-        # gate_status="requested" and skip report_path enforcement for a terminal verdict.
-        _terminal = ("pass", "fail")
-        _has_terminal = result is not None and (
-            (result.get("status") or "").lower() in _terminal
-            or (result.get("verdict") or "").lower() in _terminal
-        )
-        if _has_terminal:
+        if result is not None and gate_is_terminal(result):
             report_path = result.get("report_path", "")
             if not report_path:
                 checks.append(CheckResult(
@@ -612,14 +604,16 @@ def _detect_gate_report_contradictions(
         except OSError:
             continue
 
-        gate_status = result.get("status") or result.get("verdict") or "unknown"
+        passed, _reason = gate_is_pass(result)
         gate_blocking = result.get("blocking_count", 0)
+        if not isinstance(gate_blocking, int):
+            gate_blocking = len(result.get("blocking_findings") or [])
 
         # Count blocking-severity indicators in report
         report_blocking_indicators = _count_report_blocking_indicators(report_content)
 
         # Contradiction 1: gate says pass but report has blocking indicators
-        if gate_status == "pass" and report_blocking_indicators > 0:
+        if passed and report_blocking_indicators > 0:
             checks.append(CheckResult(
                 f"contradiction_{gate}",
                 "FAIL",
@@ -627,7 +621,7 @@ def _detect_gate_report_contradictions(
                 f"{report_blocking_indicators} blocking indicator(s) — evidence mismatch",
             ))
         # Contradiction 2: gate says fail/blocking but report has none
-        elif gate_status == "fail" and gate_blocking > 0 and report_blocking_indicators == 0:
+        elif (not passed) and gate_blocking > 0 and report_blocking_indicators == 0:
             checks.append(CheckResult(
                 f"contradiction_{gate}",
                 "FAIL",

--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -1,0 +1,95 @@
+"""Canonical gate result status interpretation (CFX-3).
+
+Single source of truth for "is this gate result a pass?" across closure
+verification, postmerge audit summaries, and any other consumer of files
+under ``.vnx-data/state/review_gates/results/``.
+
+Schema drift fixed here:
+- writers populate ``status`` with values from one canonical set
+- readers call :func:`is_pass` instead of comparing fields ad hoc
+- legacy ``verdict`` field is honored as fallback when ``status`` is null
+"""
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, Tuple
+
+PASS_STATES = frozenset({"approve", "completed", "pass", "passed"})
+FAIL_STATES = frozenset({"failed", "errored", "fail", "blocked"})
+INCOMPLETE_STATES = frozenset({"pending", "running", "queued", "requested"})
+
+ALL_KNOWN_STATES = PASS_STATES | FAIL_STATES | INCOMPLETE_STATES | frozenset({"not_executable"})
+
+
+def _coerce_status(result: Dict[str, Any]) -> Tuple[str, bool]:
+    """Return (status, used_legacy_verdict_fallback).
+
+    Uses ``status`` when present and non-empty. Falls back to legacy
+    ``verdict`` for old files written before CFX-3 — this is graceful
+    migration, not a permanent contract.
+    """
+    status = result.get("status")
+    if isinstance(status, str) and status:
+        return status.lower(), False
+    verdict = result.get("verdict")
+    if isinstance(verdict, str) and verdict:
+        warnings.warn(
+            "gate_status: result file uses legacy 'verdict' field; "
+            "writers should populate 'status' (CFX-3 migration).",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return verdict.lower(), True
+    return "", False
+
+
+def is_pass(result: Dict[str, Any]) -> Tuple[bool, str]:
+    """Return ``(passed, reason)`` for a gate result dict.
+
+    ``reason`` always explains the decision so callers can surface it.
+    Pass requires: canonical pass status AND zero blocking findings AND
+    ``blocking_count`` is zero or absent.
+    """
+    status, _legacy = _coerce_status(result)
+    blocking_findings = result.get("blocking_findings") or []
+    blocking_len = len(blocking_findings) if isinstance(blocking_findings, list) else 0
+    blocking_count = result.get("blocking_count")
+    if not isinstance(blocking_count, int):
+        blocking_count = None
+
+    if status in PASS_STATES and blocking_len == 0 and blocking_count in (0, None):
+        return True, "passed"
+    if status in FAIL_STATES:
+        return False, f"status: {status}"
+    if blocking_len > 0:
+        return False, f"{blocking_len} blocking finding(s)"
+    if blocking_count is not None and blocking_count > 0:
+        return False, f"blocking_count: {blocking_count}"
+    if status in INCOMPLETE_STATES:
+        return False, f"incomplete: {status}"
+    if status == "not_executable":
+        return False, "status: not_executable"
+    if not status:
+        return False, "no status or verdict field"
+    return False, f"unknown status: {status}"
+
+
+def is_terminal(result: Dict[str, Any]) -> bool:
+    """True when the result represents a decided pass/fail (not in-flight).
+
+    Used by closure verifier to decide whether to enforce report_path on
+    a result (pass/fail must carry evidence; in-flight states must not).
+    ``not_executable`` is treated as terminal because the gate has been
+    finally classified even though no execution happened.
+    """
+    status, _ = _coerce_status(result)
+    return status in PASS_STATES or status in FAIL_STATES or status == "not_executable"
+
+
+def canonical_status(result: Dict[str, Any]) -> str:
+    """Return the canonical status string for a result, "" if unknown.
+
+    Honors legacy ``verdict`` fallback. Always lowercased.
+    """
+    status, _ = _coerce_status(result)
+    return status

--- a/tests/test_closure_verifier.py
+++ b/tests/test_closure_verifier.py
@@ -753,3 +753,253 @@ class TestClosureVerifierContractEnforcement:
         assert result["verdict"] == "fail"
         failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
         assert "gate_claude_github_optional" in failed
+
+
+# ---------------------------------------------------------------------------
+# Round-1 codex finding regressions (PR #322 / CFX-3)
+# ---------------------------------------------------------------------------
+
+
+def _make_gate_artifact_payload(
+    *,
+    gate,
+    pr_id="PR-0",
+    contract_hash="abcdef1234567890",
+    report_path="",
+    blocking=None,
+    advisory=None,
+):
+    """Build a gate result payload that mirrors gate_artifacts.materialize_artifacts.
+
+    Crucially, this payload uses ``status="completed"`` and does NOT carry a
+    top-level ``verdict`` field — i.e. the exact production schema produced by
+    scripts/lib/gate_artifacts.py for a successful headless gate execution.
+    """
+    return {
+        "gate": gate,
+        "pr_id": pr_id,
+        "pr_number": None,
+        "status": "completed",
+        "summary": f"{gate} execution completed successfully",
+        "contract_hash": contract_hash,
+        "report_path": report_path,
+        "findings": (blocking or []) + (advisory or []),
+        "blocking_findings": blocking or [],
+        "advisory_findings": advisory or [],
+        "required_reruns": [],
+        "residual_risk": "",
+        "duration_seconds": 12.5,
+        "recorded_at": "2026-04-29T10:00:00Z",
+    }
+
+
+class TestClosureVerifierRoundOneCodexFindings:
+    """PR #322 codex round-1 findings — production-schema regressions.
+
+    Finding 1: closure verifier must accept the exact result payload produced
+    by gate_artifacts (status="completed", no top-level verdict, no
+    blocking_count) for both codex_gate and gemini_review.
+
+    Finding 2: closure verifier must locate explicit-absence state for
+    claude_github_optional in the requests directory when gate_request_handler
+    has not written a result file (its standard path).
+    """
+
+    def test_finding_1_codex_completed_payload_passes(self, verifier_env, monkeypatch, tmp_path):
+        """Codex gate result with production schema (status=completed) passes."""
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        codex_report = reports_dir / "codex.md"
+        codex_report.write_text("# Codex Gate\n\nclean run\n", encoding="utf-8")
+        gemini_report = reports_dir / "gemini.md"
+        gemini_report.write_text("# Gemini Review\n\nno findings\n", encoding="utf-8")
+
+        contract = _make_contract(
+            review_stack=["gemini_review", "codex_gate"],
+            risk_class="high",
+        )
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "gemini_review", "PR-0",
+            _make_gate_artifact_payload(gate="gemini_review", report_path=str(gemini_report)),
+        )
+        _write_gate_result(
+            results_dir, "codex_gate", "PR-0",
+            _make_gate_artifact_payload(gate="codex_gate", report_path=str(codex_report)),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        passed = {c["name"] for c in result["checks"] if c["status"] == "PASS"}
+        assert "gate_codex_gate" in passed, [c for c in result["checks"] if "codex" in c["name"]]
+        assert "gate_gemini_review" in passed, [c for c in result["checks"] if "gemini" in c["name"]]
+
+    def test_finding_1_codex_completed_with_blocking_finding_fails(
+        self, verifier_env, monkeypatch, tmp_path,
+    ):
+        """status=completed but with a blocking finding still fails — pass requires zero blocking."""
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        codex_report = reports_dir / "codex.md"
+        codex_report.write_text(
+            "# Codex Gate\n\n[BLOCKING] something is wrong\n",
+            encoding="utf-8",
+        )
+
+        contract = _make_contract(
+            review_stack=["codex_gate"],
+            risk_class="high",
+        )
+        results_dir = tmp_path / "results"
+        _write_gate_result(
+            results_dir, "codex_gate", "PR-0",
+            _make_gate_artifact_payload(
+                gate="codex_gate",
+                report_path=str(codex_report),
+                blocking=[{"severity": "blocking", "category": "correctness", "message": "x"}],
+            ),
+        )
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
+        assert "gate_codex_gate" in failed
+
+    def test_finding_2_claude_github_state_in_requests_dir_passes(
+        self, verifier_env, monkeypatch, tmp_path,
+    ):
+        """Explicit `not_configured` state in requests dir is accepted as evidence."""
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        # Mirror the production layout: results/ has nothing for the optional
+        # gate; requests/ has the contract-driven request payload that
+        # gate_request_handler.request_claude_github_with_contract writes.
+        results_dir = tmp_path / "review_gates" / "results"
+        results_dir.mkdir(parents=True)
+        requests_dir = tmp_path / "review_gates" / "requests"
+        requests_dir.mkdir(parents=True)
+        request_payload = {
+            "gate": "claude_github_optional",
+            "pr_id": "PR-0",
+            "state": "not_configured",
+            "contributed_evidence": False,
+            "was_intentionally_absent": True,
+            "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
+            "review_mode": "per_pr",
+        }
+        (requests_dir / "pr0-claude_github_optional-contract.json").write_text(
+            json.dumps(request_payload), encoding="utf-8",
+        )
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        claude_check = next(
+            c for c in result["checks"] if c["name"] == "gate_claude_github_optional"
+        )
+        assert claude_check["status"] == "PASS", claude_check
+
+    def test_finding_2_legacy_status_only_request_normalised(
+        self, verifier_env, monkeypatch, tmp_path,
+    ):
+        """Legacy pr-number request payload (status only, no state) is normalised to pass."""
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        results_dir = tmp_path / "review_gates" / "results"
+        results_dir.mkdir(parents=True)
+        requests_dir = tmp_path / "review_gates" / "requests"
+        requests_dir.mkdir(parents=True)
+        # Legacy writer (gate_request_handler._request_claude_github) — only
+        # writes `status`, no `state` / `was_intentionally_absent` fields.
+        legacy_payload = {
+            "gate": "claude_github_optional",
+            "status": "configured_dry_run",
+            "branch": "feature/demo",
+            "pr_number": 45,
+        }
+        (requests_dir / "pr-45-claude_github_optional.json").write_text(
+            json.dumps(legacy_payload), encoding="utf-8",
+        )
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        claude_check = next(
+            c for c in result["checks"] if c["name"] == "gate_claude_github_optional"
+        )
+        assert claude_check["status"] == "PASS", claude_check
+
+    def test_finding_2_no_request_or_result_still_fails(
+        self, verifier_env, monkeypatch, tmp_path,
+    ):
+        """Total absence of any request or result still fails — fallback is not a free pass."""
+        monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+        monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+
+        results_dir = tmp_path / "review_gates" / "results"
+        results_dir.mkdir(parents=True)
+        # Sibling requests dir does not exist at all.
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+
+        result = cv.verify_closure(
+            project_root=verifier_env["project_root"],
+            feature_plan=verifier_env["feature_plan"],
+            pr_queue=verifier_env["pr_queue"],
+            branch="feature/demo",
+            mode="pre_merge",
+            claim_file=verifier_env["claim_file"],
+            review_contract=contract,
+            gate_results_dir=results_dir,
+        )
+
+        assert result["verdict"] == "fail"
+        failed = {c["name"] for c in result["checks"] if c["status"] == "FAIL"}
+        assert "gate_claude_github_optional" in failed

--- a/tests/test_gate_status_schema.py
+++ b/tests/test_gate_status_schema.py
@@ -1,0 +1,363 @@
+"""tests/test_gate_status_schema.py — CFX-3 gate result schema canonicalization.
+
+Verifies that scripts/lib/gate_status.is_pass() interprets the canonical
+``status`` field correctly across every shape that real writers in this
+repo produce, plus the legacy ``verdict`` fallback for graceful migration.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
+
+from gate_status import (
+    FAIL_STATES,
+    INCOMPLETE_STATES,
+    PASS_STATES,
+    canonical_status,
+    is_pass,
+    is_terminal,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cases A-G: canonical decision matrix
+# ---------------------------------------------------------------------------
+
+
+def test_case_a_status_approve_no_findings_passes() -> None:
+    result = {"status": "approve", "blocking_findings": [], "blocking_count": 0}
+    passed, reason = is_pass(result)
+    assert passed is True
+    assert reason == "passed"
+
+
+def test_case_b_status_completed_no_findings_passes() -> None:
+    result = {"status": "completed", "blocking_findings": [], "blocking_count": 0}
+    passed, reason = is_pass(result)
+    assert passed is True
+    assert reason == "passed"
+
+
+def test_case_c_status_failed_fails() -> None:
+    result = {"status": "failed"}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "failed" in reason
+
+
+def test_case_d_status_approve_with_blocking_fails() -> None:
+    result = {
+        "status": "approve",
+        "blocking_findings": [{"severity": "error"}, {"severity": "error"}],
+        "blocking_count": 2,
+    }
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "blocking" in reason
+
+
+def test_case_e_status_running_fails_as_incomplete() -> None:
+    result = {"status": "running"}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "incomplete" in reason
+
+
+def test_case_f_legacy_verdict_pass_uses_fallback() -> None:
+    """Legacy file: verdict=pass, status absent → must still be honored.
+
+    Migration must be graceful — old files on disk are not rewritten.
+    A DeprecationWarning is emitted to discourage new writers from this shape.
+    """
+    result = {"verdict": "pass", "blocking_findings": [], "blocking_count": 0}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        passed, reason = is_pass(result)
+    assert passed is True
+    assert reason == "passed"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+        "expected DeprecationWarning for legacy verdict fallback"
+    )
+
+
+def test_case_g_no_status_no_verdict_fails_unknown() -> None:
+    result: Dict[str, Any] = {"summary": "nothing here"}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "no status" in reason or "unknown" in reason
+
+
+# ---------------------------------------------------------------------------
+# Edge cases the canonical sets must cover
+# ---------------------------------------------------------------------------
+
+
+def test_status_pending_treated_as_incomplete_not_pass() -> None:
+    result = {"status": "pending"}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "incomplete" in reason
+
+
+def test_status_blocked_treated_as_fail() -> None:
+    result = {"status": "blocked"}
+    passed, _ = is_pass(result)
+    assert passed is False
+
+
+def test_status_pass_with_zero_blocking_count_passes() -> None:
+    result = {"status": "pass", "blocking_count": 0}
+    passed, _ = is_pass(result)
+    assert passed is True
+
+
+def test_status_completed_with_blocking_count_three_fails() -> None:
+    result = {"status": "completed", "blocking_count": 3}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "blocking_count" in reason or "blocking" in reason
+
+
+def test_blocking_findings_list_overrides_pass_status() -> None:
+    result = {"status": "approve", "blocking_findings": [{"sev": "error"}]}
+    passed, _ = is_pass(result)
+    assert passed is False
+
+
+def test_canonical_status_lowercases_and_trims() -> None:
+    assert canonical_status({"status": "APPROVE"}) == "approve"
+    assert canonical_status({"status": ""}) == ""
+    assert canonical_status({}) == ""
+    assert canonical_status({"verdict": "PASS"}) == "pass"
+
+
+def test_is_terminal_distinguishes_terminal_vs_inflight() -> None:
+    assert is_terminal({"status": "approve"}) is True
+    assert is_terminal({"status": "completed"}) is True
+    assert is_terminal({"status": "failed"}) is True
+    assert is_terminal({"status": "not_executable"}) is True
+    assert is_terminal({"status": "pending"}) is False
+    assert is_terminal({"status": "running"}) is False
+    assert is_terminal({}) is False
+    # Legacy verdict fallback
+    assert is_terminal({"verdict": "pass"}) is True
+
+
+def test_pass_states_disjoint_from_fail_and_incomplete() -> None:
+    """Canonical sets must not overlap — no status string can be both."""
+    assert PASS_STATES.isdisjoint(FAIL_STATES)
+    assert PASS_STATES.isdisjoint(INCOMPLETE_STATES)
+    assert FAIL_STATES.isdisjoint(INCOMPLETE_STATES)
+
+
+# ---------------------------------------------------------------------------
+# Case H: schema validator — every writer's output passes is_pass parse
+# ---------------------------------------------------------------------------
+
+
+def _writer_output_gate_artifacts() -> Dict[str, Any]:
+    """Shape produced by scripts/lib/gate_artifacts.py:materialize_artifacts."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "100",
+        "pr_number": 100,
+        "status": "completed",
+        "summary": "codex_gate execution completed successfully",
+        "contract_hash": "abc123",
+        "report_path": "/tmp/report.md",
+        "findings": [],
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "required_reruns": [],
+        "residual_risk": "",
+        "duration_seconds": 12.3,
+        "recorded_at": "2026-04-29T00:00:00Z",
+    }
+
+
+def _writer_output_gate_recorder_failure() -> Dict[str, Any]:
+    """Shape produced by scripts/lib/gate_recorder.py:record_failure."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "100",
+        "pr_number": 100,
+        "status": "failed",
+        "reason": "timeout",
+        "reason_detail": "Gate exceeded 600s",
+        "duration_seconds": 600.0,
+        "partial_output_lines": 0,
+        "runner_pid": 1234,
+        "killed_at": "2026-04-29T00:00:00Z",
+        "summary": "Gate execution timeout: Gate exceeded 600s",
+        "contract_hash": "abc123",
+        "report_path": "",
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "required_reruns": ["codex_gate"],
+        "residual_risk": "Gate timeout. Re-run required.",
+        "recorded_at": "2026-04-29T00:00:00Z",
+    }
+
+
+def _writer_output_gate_recorder_not_executable() -> Dict[str, Any]:
+    """Shape produced by scripts/lib/gate_recorder.py:record_not_executable."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "100",
+        "pr_number": 100,
+        "status": "not_executable",
+        "reason": "provider_disabled",
+        "reason_detail": "VNX_CODEX_HEADLESS_ENABLED=0",
+        "summary": "codex_gate not executable: VNX_CODEX_HEADLESS_ENABLED=0",
+        "contract_hash": "abc123",
+        "report_path": "",
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "required_reruns": [],
+        "residual_risk": "Gate evidence not available.",
+        "recorded_at": "2026-04-29T00:00:00Z",
+    }
+
+
+def _writer_output_gate_result_parser_approve() -> Dict[str, Any]:
+    """Shape produced by scripts/lib/gate_result_parser.py:record_result on approve."""
+    return {
+        "gate": "gemini_review",
+        "pr_number": 100,
+        "pr_id": "100",
+        "branch": "feat/x",
+        "status": "approve",
+        "summary": "approved",
+        "findings": [],
+        "advisory_findings": [],
+        "blocking_findings": [],
+        "advisory_count": 0,
+        "blocking_count": 0,
+        "residual_risk": "",
+        "contract_hash": "abc123",
+        "report_path": "/tmp/report.md",
+        "required_reruns": [],
+        "recorded_at": "2026-04-29T00:00:00Z",
+    }
+
+
+@pytest.mark.parametrize(
+    "writer,expected_pass",
+    [
+        (_writer_output_gate_artifacts, True),
+        (_writer_output_gate_recorder_failure, False),
+        (_writer_output_gate_recorder_not_executable, False),
+        (_writer_output_gate_result_parser_approve, True),
+    ],
+)
+def test_every_writer_output_parses_via_is_pass(writer, expected_pass) -> None:
+    """Schema H: each writer's output must be classifiable by is_pass."""
+    result = writer()
+    passed, reason = is_pass(result)
+    assert passed is expected_pass, (
+        f"writer {writer.__name__}: expected pass={expected_pass}, got {passed} ({reason})"
+    )
+    # And it must be JSON-roundtrippable (real writers persist via json.dumps)
+    roundtripped = json.loads(json.dumps(result))
+    passed2, _ = is_pass(roundtripped)
+    assert passed2 is expected_pass
+
+
+# ---------------------------------------------------------------------------
+# Real-disk regression: existing approve/completed files in this repo's
+# .vnx-data/ must classify correctly. Skipped when the dir is unavailable
+# (e.g., CI without runtime state).
+# ---------------------------------------------------------------------------
+
+
+_REAL_RESULTS_DIR = (
+    Path(__file__).resolve().parent.parent
+    / ".vnx-data"
+    / "state"
+    / "review_gates"
+    / "results"
+)
+
+
+@pytest.mark.skipif(not _REAL_RESULTS_DIR.is_dir(), reason="no runtime state present")
+def test_real_disk_results_classify_without_unknown_status() -> None:
+    """Every real result file on disk must produce a known classification.
+
+    Catches the original CFX-3 bug: closure verifier returning false-negative
+    for status="completed"/"approve" because it only matched verdict=="pass".
+    """
+    files = list(_REAL_RESULTS_DIR.glob("*.json"))
+    if not files:
+        pytest.skip("no result files present")
+    unknown: list[str] = []
+    for path in files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        _passed, reason = is_pass(data)
+        if "unknown status" in reason:
+            unknown.append(f"{path.name}: {reason}")
+    assert not unknown, "results with unknown status:\n" + "\n".join(unknown[:10])
+
+
+# ---------------------------------------------------------------------------
+# Integration: closure_verifier reader path uses is_pass()
+# ---------------------------------------------------------------------------
+
+
+def test_closure_verifier_reads_status_completed_as_pass(tmp_path: Path) -> None:
+    """The original CFX-3 bug: gate_artifacts writes status=completed but
+    closure_verifier required verdict==pass. This regression test asserts
+    the closure verifier reader path now accepts status=completed.
+    """
+    import closure_verifier  # noqa: WPS433
+    from review_contract import ReviewContract, Deliverable
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    report = tmp_path / "report.md"
+    report.write_text("dummy", encoding="utf-8")
+
+    payload = {
+        "gate": "codex_gate",
+        "pr_id": "PR-99",
+        "status": "completed",
+        "blocking_findings": [],
+        "blocking_count": 0,
+        "report_path": str(report),
+        "contract_hash": "deadbeef",
+    }
+    (results_dir / "pr99-codex_gate-contract.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    contract = ReviewContract(
+        pr_id="PR-99",
+        pr_title="x",
+        feature_title="f",
+        branch="b",
+        track="A",
+        risk_class="high",
+        merge_policy="standard",
+        closure_stage="ready",
+        deliverables=[Deliverable(category="impl", description="d")],
+        review_stack=["codex_gate"],
+        content_hash="deadbeef",
+    )
+
+    checks = closure_verifier._validate_review_evidence(contract, results_dir)
+    gate_check = next(c for c in checks if c.name == "gate_codex_gate")
+    assert gate_check.status == "PASS", (
+        f"closure_verifier must accept status=completed as pass, got {gate_check.status}: {gate_check.detail}"
+    )


### PR DESCRIPTION
## Summary

Fixes the gate-result schema drift identified in `claudedocs/2026-04-29-codex-findings-synthesis.md` §2.5 and §7.1 (item 3): writers populate `status` (e.g. `"completed"`, `"approve"`) while `closure_verifier` only accepted `verdict == "pass"`, causing every successful codex/gemini gate to register as a false-negative. Canonicalizes on `status` and migrates readers in lockstep.

- **New helper**: `scripts/lib/gate_status.py` — canonical `PASS_STATES`/`FAIL_STATES`/`INCOMPLETE_STATES` sets and `is_pass(result) -> (bool, reason)`. Honors legacy `verdict` field as graceful fallback (with `DeprecationWarning`) so old files on disk still classify correctly.
- **Reader migration**: `scripts/closure_verifier.py` codex_gate/gemini_review checks, terminal-state report-path enforcement, and gate↔report contradiction detector now all call `gate_status.is_pass`/`is_terminal` instead of ad-hoc `status`/`verdict` comparisons.
- **No writer changes needed**: existing writers (`gate_artifacts.py`, `gate_recorder.py`, `gate_result_parser.py`) already populate `status` with values from the canonical set — the bug was strictly reader-side.

## Test plan

- [x] `python3 -m py_compile scripts/lib/gate_status.py scripts/closure_verifier.py scripts/lib/gate_recorder.py scripts/lib/gate_artifacts.py`
- [x] `python3 -m pytest tests/test_gate_status_schema.py -xvs` — 20 passed, 1 skipped (skipped real-disk regression test requires `.vnx-data/` runtime state)
- [x] `python3 -m pytest tests/test_closure_verifier.py tests/test_per_pr_closure.py tests/test_gate_artifacts_atomicity.py tests/test_gate_recorder_register.py tests/test_codex_final_gate.py tests/test_gate_status_check.py` — **118 passed, 1 skipped, 0 failures**
- [x] Schema validator (test Case H): every existing writer's output classifies through `is_pass` to the expected verdict.
- [x] Integration regression: `test_closure_verifier_reads_status_completed_as_pass` proves the original CFX-3 bug is fixed (closure_verifier now accepts `status="completed"` as a pass for codex_gate).

Closes recurring pattern §2.5 and the round-1 PR #301 finding family in the synthesis report.

Dispatch-ID: 20260429-cfx-3-gate-schema-canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)