### PR TITLE
fix(intelligence): reconcile pattern confidence stores (P0 quick win)

### DIFF
--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -843,6 +843,17 @@ class LearningLoop:
         if superseded:
             print(f"  ✓ Superseded {superseded} stale patterns")
 
+        # 5.7 Close the feedback loop: sync pattern_usage stats back to
+        # success_patterns.confidence_score so intelligence_selector reads
+        # the current learning state rather than the static initial value.
+        print("\n🔁 Step 5.7: Reconciling confidence scores...")
+        try:
+            from confidence_reconcile import reconcile_pattern_confidence
+            reconciled = reconcile_pattern_confidence(self.db_path)
+            print(f"  ✓ Reconciled {reconciled} success_patterns rows")
+        except Exception as e:
+            print(f"❌ Error reconciling confidence: {e}")
+
         # 6. Generate report
         print("\n📈 Step 6: Generating learning report...")
         report = self.generate_learning_report()

--- a/scripts/lib/confidence_reconcile.py
+++ b/scripts/lib/confidence_reconcile.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Reconcile pattern_usage learning state into success_patterns.confidence_score.
+
+Closes the open-circuit feedback loop documented in
+``claudedocs/2026-04-30-self-learning-loop-audit.md``:
+
+  - ``intelligence_selector`` reads ``success_patterns.confidence_score``.
+  - ``learning_loop`` and ``update_confidence_from_outcome`` write to
+    ``pattern_usage`` (and previously to ``success_patterns`` with fixed
+    +0.05 / -0.1 deltas that ignored prior usage volume).
+
+Linkage between the two tables is the stable item-id convention used by
+``intelligence_selector._stable_item_id``: a ``success_patterns`` row with
+``id = N`` corresponds to a ``pattern_usage`` row with
+``pattern_id = "intel_sp_<N>"``.
+
+The Beta(alpha, beta) score with Laplace smoothing
+``score = (success_count + 1) / (success_count + failure_count + 2)`` is the
+canonical confidence used by both the per-dispatch updater and the periodic
+reconciler.  It naturally weights by usage volume: a pattern with
+8 successes / 2 failures resolves to ``9 / 12 = 0.75`` while a single bad
+outcome moves only from the 0.5 prior to ``1 / 3 = 0.333``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+# Reconcile cache TTL (seconds) for the selector-side fallback safety net.
+RECONCILE_CACHE_TTL_SECONDS = 300
+
+# pattern_usage.pattern_id prefix that maps onto success_patterns rows.
+SUCCESS_PATTERN_PREFIX = "intel_sp_"
+
+
+def beta_score(success_count: int, failure_count: int) -> float:
+    """Beta posterior with Laplace smoothing: (s+1) / (s+f+2).
+
+    Returns 0.5 when both counts are zero (uniform prior).
+    """
+    s = max(0, int(success_count or 0))
+    f = max(0, int(failure_count or 0))
+    return (s + 1) / (s + f + 2)
+
+
+def _aggregate_for_pattern(
+    conn: sqlite3.Connection,
+    success_pattern_id: int,
+) -> Optional[Tuple[float, int, int, int]]:
+    """Return (new_score, used_count, success_count, failure_count) or None.
+
+    None means "no usage data — caller must keep the current score".
+    """
+    pattern_id = f"{SUCCESS_PATTERN_PREFIX}{success_pattern_id}"
+    row = conn.execute(
+        """
+        SELECT used_count, success_count, failure_count, confidence
+        FROM pattern_usage
+        WHERE pattern_id = ?
+        """,
+        (pattern_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    used = int(row[0] or 0)
+    succ = int(row[1] or 0)
+    fail = int(row[2] or 0)
+    conf = float(row[3] if row[3] is not None else 0.0)
+
+    if succ + fail > 0:
+        return beta_score(succ, fail), used, succ, fail
+
+    if used > 0:
+        # Older rows that pre-date success_count/failure_count tracking
+        # still carry a confidence value updated by the legacy decay/boost
+        # path.  Treat that as a single weighted sample.
+        return max(0.0, min(1.0, conf)), used, succ, fail
+
+    return None
+
+
+def reconcile_pattern_confidence(db_path: Path) -> int:
+    """Sync pattern_usage learning state into success_patterns.confidence_score.
+
+    For each ``success_patterns`` row, look up the matching ``pattern_usage``
+    row (``pattern_id = "intel_sp_<id>"``).  If usage data exists, recompute
+    the confidence score via Beta-Laplace smoothing and write it back.  If
+    no usage data exists the existing ``confidence_score`` is preserved.
+
+    Idempotent: a second invocation with no new usage data is a no-op.
+
+    Returns the number of ``success_patterns`` rows whose
+    ``confidence_score`` was updated.
+    """
+    if not db_path.exists():
+        return 0
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT id, confidence_score FROM success_patterns"
+        ).fetchall()
+
+        updated = 0
+        for sp_id, current_score in rows:
+            agg = _aggregate_for_pattern(conn, int(sp_id))
+            if agg is None:
+                continue
+            new_score = round(float(agg[0]), 6)
+            current = float(current_score or 0.0)
+            if abs(new_score - current) < 1e-6:
+                continue
+            conn.execute(
+                "UPDATE success_patterns SET confidence_score = ? WHERE id = ?",
+                (new_score, sp_id),
+            )
+            updated += 1
+
+        conn.commit()
+        return updated
+    finally:
+        conn.close()
+
+
+def maybe_reconcile(
+    db_path: Path,
+    state_dir: Optional[Path] = None,
+    ttl_seconds: int = RECONCILE_CACHE_TTL_SECONDS,
+) -> bool:
+    """Run reconcile if the last reconcile happened more than ``ttl_seconds`` ago.
+
+    Used as a safety net at injection time so the selector never reads stale
+    confidence scores even if the daily ``learning_loop`` cron has not run.
+    The timestamp is cached in
+    ``<state_dir>/.last_confidence_reconcile_ts``.
+
+    Returns ``True`` if reconcile was executed.
+    """
+    if not db_path.exists():
+        return False
+    if state_dir is None:
+        state_dir = db_path.parent
+
+    ts_file = state_dir / ".last_confidence_reconcile_ts"
+    now = time.time()
+
+    if ts_file.exists():
+        try:
+            last = float(ts_file.read_text().strip())
+            if now - last < ttl_seconds:
+                return False
+        except (OSError, ValueError):
+            pass
+
+    reconcile_pattern_confidence(db_path)
+
+    try:
+        ts_file.write_text(str(now))
+    except OSError:
+        pass
+
+    return True

--- a/scripts/lib/intelligence_persist.py
+++ b/scripts/lib/intelligence_persist.py
@@ -198,12 +198,17 @@ def update_confidence_from_outcome(
 ) -> Dict[str, int]:
     """Update pattern confidence scores based on dispatch outcome.
 
-    On success: boost confidence by 0.05 (cap 1.0) for patterns linked to this
-    dispatch, and increment their used_count.
-    On failure: decay confidence by 0.1 (floor 0.0) for patterns linked to this
-    dispatch.
+    Uses Beta(success+1, failure+1) Laplace smoothing instead of fixed
+    +0.05 / -0.1 deltas so the score reflects total usage volume rather
+    than the number of consecutive boosts.  Each outcome increments
+    success_count or failure_count on the matching pattern_usage row, then
+    the new Beta posterior is written back to success_patterns.confidence_score.
 
     Linkage is via success_patterns.source_dispatch_ids (JSON array).
+    pattern_usage rows are matched / created using the stable
+    "intel_sp_<id>" id convention so the daily reconcile and the
+    per-dispatch update read and write the same row.
+
     A confidence_events row is written for audit/learning-summary queries.
 
     Args:
@@ -218,49 +223,90 @@ def update_confidence_from_outcome(
     if not db_path.exists():
         return {"boosted": 0, "decayed": 0}
 
+    # Local import to keep the module standalone-importable.
+    from confidence_reconcile import beta_score, SUCCESS_PATTERN_PREFIX
+
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     now = datetime.now(timezone.utc).isoformat()
     boosted = 0
     decayed = 0
+    net_change = 0.0
 
     try:
         rows = conn.execute(
-            "SELECT id, confidence_score, usage_count FROM success_patterns "
+            "SELECT id, confidence_score, usage_count, title FROM success_patterns "
             "WHERE source_dispatch_ids LIKE ?",
             (f"%{dispatch_id}%",),
         ).fetchall()
 
         is_success = status == "success"
-        delta = 0.05 if is_success else -0.1
 
         for row in rows:
+            sp_id = row["id"]
+            pattern_id = f"{SUCCESS_PATTERN_PREFIX}{sp_id}"
+            title = (row["title"] or f"success_pattern_{sp_id}")[:255]
+            pattern_hash = _sha1(pattern_id)
+
+            usage = conn.execute(
+                "SELECT success_count, failure_count, used_count "
+                "FROM pattern_usage WHERE pattern_id = ?",
+                (pattern_id,),
+            ).fetchone()
+
+            if usage is None:
+                succ = 1 if is_success else 0
+                fail = 0 if is_success else 1
+                used = 1 if is_success else 0
+                conn.execute(
+                    "INSERT INTO pattern_usage "
+                    "(pattern_id, pattern_title, pattern_hash, used_count, "
+                    " ignored_count, success_count, failure_count, "
+                    " last_used, confidence, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)",
+                    (pattern_id, title, pattern_hash, used,
+                     succ, fail, now, beta_score(succ, fail), now, now),
+                )
+            else:
+                succ = int(usage["success_count"] or 0) + (1 if is_success else 0)
+                fail = int(usage["failure_count"] or 0) + (0 if is_success else 1)
+                used = int(usage["used_count"] or 0) + (1 if is_success else 0)
+                conn.execute(
+                    "UPDATE pattern_usage SET success_count = ?, "
+                    "failure_count = ?, used_count = ?, "
+                    "confidence = ?, last_used = ?, updated_at = ? "
+                    "WHERE pattern_id = ?",
+                    (succ, fail, used, beta_score(succ, fail), now, now, pattern_id),
+                )
+
             old_conf = float(row["confidence_score"] or 0.0)
-            new_conf = max(0.0, min(1.0, old_conf + delta))
+            new_conf = round(beta_score(succ, fail), 6)
+            net_change += new_conf - old_conf
+
             if is_success:
-                new_usage = (row["usage_count"] or 0) + 1
+                new_usage_count = (row["usage_count"] or 0) + 1
                 conn.execute(
                     "UPDATE success_patterns SET confidence_score = ?, "
                     "usage_count = ?, last_used = ? WHERE id = ?",
-                    (new_conf, new_usage, now, row["id"]),
+                    (new_conf, new_usage_count, now, sp_id),
                 )
                 boosted += 1
             else:
                 conn.execute(
                     "UPDATE success_patterns SET confidence_score = ? WHERE id = ?",
-                    (new_conf, row["id"]),
+                    (new_conf, sp_id),
                 )
                 decayed += 1
 
         # Record a confidence_events audit row (best-effort — table may not exist yet)
-        net_change = round((boosted * 0.05) + (decayed * -0.1), 4)
         try:
             conn.execute(
                 "INSERT INTO confidence_events "
                 "(dispatch_id, terminal, outcome, patterns_boosted, patterns_decayed, "
                 " confidence_change, occurred_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (dispatch_id, terminal, status, boosted, decayed, net_change, now),
+                (dispatch_id, terminal, status, boosted, decayed,
+                 round(net_change, 4), now),
             )
         except sqlite3.OperationalError:
             pass  # Table not yet migrated in older DBs
@@ -273,6 +319,11 @@ def update_confidence_from_outcome(
         conn.close()
 
     return {"boosted": boosted, "decayed": decayed}
+
+
+def _sha1(text: str) -> str:
+    import hashlib
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
 
 
 def _append_to_json_list(existing_json: Optional[str], new_item: str) -> str:

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -285,6 +285,26 @@ class IntelligenceSelector:
             self._quality_db.close()
             self._quality_db = None
 
+    def _maybe_reconcile_confidence(self) -> None:
+        """Run reconcile if the cached timestamp is older than the TTL.
+
+        Best-effort safety net: failures are swallowed so a broken reconcile
+        never blocks dispatch creation.  The reconcile opens its own SQLite
+        connection and commits before returning, so subsequent SELECT
+        statements on ``self._quality_db`` observe the new values without
+        needing to re-open the cached reader connection.
+        """
+        if self._quality_db_path is None:
+            return
+        try:
+            from confidence_reconcile import maybe_reconcile
+        except ImportError:
+            return
+        try:
+            maybe_reconcile(self._quality_db_path)
+        except Exception:
+            pass
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -586,6 +606,11 @@ class IntelligenceSelector:
         scope_tags: List[str],
     ) -> List[IntelligenceItem]:
         """Query success_patterns for proven_pattern candidates."""
+        # Safety net: if the daily learning_loop reconcile has not run
+        # recently, sync pattern_usage learning state into
+        # success_patterns.confidence_score before reading it.
+        self._maybe_reconcile_confidence()
+
         items: List[IntelligenceItem] = []
         try:
             rows = db.execute(

--- a/tests/test_confidence_reconcile.py
+++ b/tests/test_confidence_reconcile.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/confidence_reconcile.py.
+
+Verifies that pattern_usage learning state is correctly synced into
+success_patterns.confidence_score so intelligence_selector reads the
+current Beta-Laplace posterior rather than a static initial value.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from confidence_reconcile import (  # noqa: E402
+    RECONCILE_CACHE_TTL_SECONDS,
+    SUCCESS_PATTERN_PREFIX,
+    beta_score,
+    maybe_reconcile,
+    reconcile_pattern_confidence,
+)
+
+
+def _make_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            pattern_data TEXT,
+            confidence_score REAL DEFAULT 0.5,
+            usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT,
+            first_seen DATETIME, last_used DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TIMESTAMP, last_offered TIMESTAMP,
+            confidence REAL DEFAULT 1.0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _seed_success_pattern(
+    conn: sqlite3.Connection,
+    title: str,
+    confidence: float = 0.5,
+    category: str = "test",
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO success_patterns "
+        "(pattern_type, category, title, description, pattern_data, "
+        " confidence_score) VALUES (?, ?, ?, ?, ?, ?)",
+        ("approach", category, title, title, "{}", confidence),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _seed_pattern_usage(
+    conn: sqlite3.Connection,
+    success_pattern_id: int,
+    *,
+    used_count: int = 0,
+    success_count: int = 0,
+    failure_count: int = 0,
+    confidence: float = 1.0,
+) -> str:
+    pattern_id = f"{SUCCESS_PATTERN_PREFIX}{success_pattern_id}"
+    conn.execute(
+        "INSERT INTO pattern_usage "
+        "(pattern_id, pattern_title, pattern_hash, used_count, "
+        " success_count, failure_count, confidence) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (pattern_id, f"title-{success_pattern_id}", f"hash-{success_pattern_id}",
+         used_count, success_count, failure_count, confidence),
+    )
+    conn.commit()
+    return pattern_id
+
+
+def _read_score(conn: sqlite3.Connection, sp_id: int) -> float:
+    row = conn.execute(
+        "SELECT confidence_score FROM success_patterns WHERE id = ?",
+        (sp_id,),
+    ).fetchone()
+    return float(row[0])
+
+
+class TestBetaScore(unittest.TestCase):
+    def test_neutral_prior(self):
+        self.assertAlmostEqual(beta_score(0, 0), 0.5, places=6)
+
+    def test_high_success(self):
+        # 8 successes / 2 failures → (8+1) / (10+2) = 0.75
+        self.assertAlmostEqual(beta_score(8, 2), 0.75, places=6)
+
+    def test_high_failure(self):
+        # 0 successes / 5 failures → 1/7 ≈ 0.143
+        self.assertAlmostEqual(beta_score(0, 5), 1 / 7, places=6)
+
+
+class TestReconcilePatternConfidence(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = Path(self.tmp.name)
+        self.conn = _make_db(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.tmp.name)
+
+    def test_case_a_all_success_boosts_score(self):
+        sp_id = _seed_success_pattern(self.conn, "A", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=5, success_count=5, failure_count=0,
+        )
+        updated = reconcile_pattern_confidence(self.db_path)
+        self.assertEqual(updated, 1)
+        score = _read_score(self.conn, sp_id)
+        # (5+1) / (5+0+2) = 6/7 ≈ 0.857
+        self.assertAlmostEqual(score, 6 / 7, places=4)
+
+    def test_case_b_all_failure_decays_score(self):
+        sp_id = _seed_success_pattern(self.conn, "B", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=5, success_count=0, failure_count=5,
+        )
+        reconcile_pattern_confidence(self.db_path)
+        score = _read_score(self.conn, sp_id)
+        # (0+1) / (0+5+2) = 1/7 ≈ 0.143
+        self.assertAlmostEqual(score, 1 / 7, places=4)
+
+    def test_case_c_no_usage_keeps_score(self):
+        sp_id = _seed_success_pattern(self.conn, "C", confidence=0.42)
+        # No pattern_usage row at all.
+        updated = reconcile_pattern_confidence(self.db_path)
+        self.assertEqual(updated, 0)
+        self.assertAlmostEqual(_read_score(self.conn, sp_id), 0.42, places=6)
+
+    def test_case_c2_zero_usage_keeps_score(self):
+        # pattern_usage row exists but no success/failure events recorded
+        # AND used_count = 0 — treat as "no data, don't reset".
+        sp_id = _seed_success_pattern(self.conn, "C2", confidence=0.42)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=0, success_count=0, failure_count=0, confidence=1.0,
+        )
+        updated = reconcile_pattern_confidence(self.db_path)
+        self.assertEqual(updated, 0)
+        self.assertAlmostEqual(_read_score(self.conn, sp_id), 0.42, places=6)
+
+    def test_case_d_idempotent(self):
+        sp_id = _seed_success_pattern(self.conn, "D", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=4, success_count=3, failure_count=1,
+        )
+        first = reconcile_pattern_confidence(self.db_path)
+        score_after_first = _read_score(self.conn, sp_id)
+
+        second = reconcile_pattern_confidence(self.db_path)
+        score_after_second = _read_score(self.conn, sp_id)
+
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)  # nothing changed → no update
+        self.assertAlmostEqual(score_after_first, score_after_second, places=6)
+
+    def test_case_e_volume_weighting_via_beta(self):
+        # High-volume strong-success pattern.
+        sp_high = _seed_success_pattern(self.conn, "high-volume", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_high,
+            used_count=100, success_count=90, failure_count=10,
+        )
+        # Low-volume single-failure pattern.
+        sp_low = _seed_success_pattern(self.conn, "low-volume", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_low,
+            used_count=1, success_count=0, failure_count=1,
+        )
+        reconcile_pattern_confidence(self.db_path)
+
+        score_high = _read_score(self.conn, sp_high)
+        score_low = _read_score(self.conn, sp_low)
+
+        # High-volume good: (90+1)/(100+2) ≈ 0.892
+        self.assertAlmostEqual(score_high, 91 / 102, places=4)
+        # Low-volume bad: (0+1)/(1+2) ≈ 0.333 — Beta keeps it near the prior
+        # because the evidence is thin, demonstrating volume weighting.
+        self.assertAlmostEqual(score_low, 1 / 3, places=4)
+        self.assertGreater(score_high, score_low + 0.5)
+
+    def test_case_f_integration_with_learning_loop(self):
+        sp_id = _seed_success_pattern(self.conn, "integration", confidence=0.5)
+        # Fake usage rows that the daily learning_loop would have produced.
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=7, success_count=6, failure_count=1, confidence=0.8,
+        )
+
+        # Simulate the new step in daily_learning_cycle by importing the
+        # same hook the production code uses.
+        from confidence_reconcile import (  # noqa: WPS433
+            reconcile_pattern_confidence as production_hook,
+        )
+        production_hook(self.db_path)
+
+        score = _read_score(self.conn, sp_id)
+        # (6+1)/(7+2) = 7/9 ≈ 0.778
+        self.assertAlmostEqual(score, 7 / 9, places=4)
+
+    def test_legacy_confidence_when_no_success_failure_counts(self):
+        # Older rows that pre-date success/failure tracking still need to
+        # propagate their pattern_usage.confidence value when used_count > 0.
+        sp_id = _seed_success_pattern(self.conn, "legacy", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=3, success_count=0, failure_count=0, confidence=0.72,
+        )
+        reconcile_pattern_confidence(self.db_path)
+        self.assertAlmostEqual(_read_score(self.conn, sp_id), 0.72, places=4)
+
+
+class TestMaybeReconcile(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.tmp_dir) / "qi.db"
+        self.conn = _make_db(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        for f in Path(self.tmp_dir).iterdir():
+            f.unlink()
+        os.rmdir(self.tmp_dir)
+
+    def test_first_call_runs_reconcile(self):
+        sp_id = _seed_success_pattern(self.conn, "first", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=2, success_count=2, failure_count=0,
+        )
+        ran = maybe_reconcile(self.db_path)
+        self.assertTrue(ran)
+        # Score should have been updated by the reconcile.
+        score = _read_score(self.conn, sp_id)
+        self.assertAlmostEqual(score, 3 / 4, places=4)
+
+    def test_within_ttl_skips_reconcile(self):
+        sp_id = _seed_success_pattern(self.conn, "skip", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=2, success_count=2, failure_count=0,
+        )
+        first = maybe_reconcile(self.db_path)
+        self.assertTrue(first)
+
+        # Add MORE usage — but within TTL, the second call should skip,
+        # leaving the first reconcile's score in place.
+        self.conn.execute(
+            "UPDATE pattern_usage SET success_count = 100 WHERE pattern_id = ?",
+            (f"{SUCCESS_PATTERN_PREFIX}{sp_id}",),
+        )
+        self.conn.commit()
+
+        second = maybe_reconcile(self.db_path)
+        self.assertFalse(second)
+        score = _read_score(self.conn, sp_id)
+        self.assertAlmostEqual(score, 3 / 4, places=4)  # unchanged
+
+    def test_expired_ttl_runs_reconcile(self):
+        sp_id = _seed_success_pattern(self.conn, "expired", confidence=0.5)
+        _seed_pattern_usage(
+            self.conn, sp_id,
+            used_count=2, success_count=2, failure_count=0,
+        )
+        maybe_reconcile(self.db_path)
+
+        # Backdate the timestamp file past the TTL.
+        ts_file = self.db_path.parent / ".last_confidence_reconcile_ts"
+        ts_file.write_text(str(time.time() - RECONCILE_CACHE_TTL_SECONDS - 1))
+
+        # New usage data.
+        self.conn.execute(
+            "UPDATE pattern_usage SET success_count = 8, failure_count = 2, "
+            "used_count = 10 WHERE pattern_id = ?",
+            (f"{SUCCESS_PATTERN_PREFIX}{sp_id}",),
+        )
+        self.conn.commit()
+
+        ran = maybe_reconcile(self.db_path)
+        self.assertTrue(ran)
+        score = _read_score(self.conn, sp_id)
+        self.assertAlmostEqual(score, 9 / 12, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feedback_loop.py
+++ b/tests/test_feedback_loop.py
@@ -63,6 +63,21 @@ CREATE TABLE IF NOT EXISTS antipatterns (
     last_seen DATETIME
 );
 
+CREATE TABLE IF NOT EXISTS pattern_usage (
+    pattern_id TEXT PRIMARY KEY,
+    pattern_title TEXT NOT NULL,
+    pattern_hash TEXT NOT NULL,
+    used_count INTEGER DEFAULT 0,
+    ignored_count INTEGER DEFAULT 0,
+    success_count INTEGER DEFAULT 0,
+    failure_count INTEGER DEFAULT 0,
+    last_used TIMESTAMP,
+    last_offered TIMESTAMP,
+    confidence REAL DEFAULT 1.0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS confidence_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     dispatch_id TEXT NOT NULL,
@@ -150,22 +165,29 @@ def test_success_boosts_confidence(tmp_path):
 
     assert result["boosted"] == 1
     assert result["decayed"] == 0
+    # Beta(success+1, failure+1)/(total+2): first success → (1+1)/(1+0+2) = 2/3
     new_conf = _get_confidence(db, pattern_id)
-    assert abs(new_conf - 0.65) < 1e-6, f"Expected 0.65, got {new_conf}"
-    # usage_count should increment
+    assert abs(new_conf - 2 / 3) < 1e-4, f"Expected 0.667, got {new_conf}"
+    # usage_count should increment on success
     assert _get_usage_count(db, pattern_id) == 2
 
 
 def test_success_boost_caps_at_1(tmp_path):
+    """Beta posterior never reaches 1.0 — Laplace smoothing keeps the score
+    strictly below 1 even after a long success streak.
+    """
     db = _make_db(tmp_path)
     dispatch_id = "dispatch-cap-test"
     pattern_id = _insert_pattern(db, dispatch_id, confidence=0.98)
 
-    update_confidence_from_outcome(db, dispatch_id, "T1", "success")
+    # Run many successes in a row.
+    for _ in range(50):
+        update_confidence_from_outcome(db, dispatch_id, "T1", "success")
 
     new_conf = _get_confidence(db, pattern_id)
-    assert new_conf <= 1.0
-    assert abs(new_conf - 1.0) < 1e-6
+    assert new_conf < 1.0
+    # 50 successes / 0 failures → 51/52 ≈ 0.981
+    assert abs(new_conf - 51 / 52) < 1e-4
 
 
 def test_success_no_matching_patterns_returns_zero(tmp_path):
@@ -188,20 +210,26 @@ def test_failure_decays_confidence(tmp_path):
 
     assert result["decayed"] == 1
     assert result["boosted"] == 0
+    # Beta first failure → (0+1)/(0+1+2) = 1/3
     new_conf = _get_confidence(db, pattern_id)
-    assert abs(new_conf - 0.6) < 1e-6, f"Expected 0.6, got {new_conf}"
+    assert abs(new_conf - 1 / 3) < 1e-4, f"Expected 0.333, got {new_conf}"
 
 
 def test_failure_decay_floors_at_0(tmp_path):
+    """Beta posterior never reaches 0.0 — Laplace smoothing keeps the score
+    strictly above 0 even after a long failure streak.
+    """
     db = _make_db(tmp_path)
     dispatch_id = "dispatch-floor-test"
     pattern_id = _insert_pattern(db, dispatch_id, confidence=0.05)
 
-    update_confidence_from_outcome(db, dispatch_id, "T1", "failure")
+    for _ in range(50):
+        update_confidence_from_outcome(db, dispatch_id, "T1", "failure")
 
     new_conf = _get_confidence(db, pattern_id)
-    assert new_conf >= 0.0
-    assert abs(new_conf - 0.0) < 1e-6
+    assert new_conf > 0.0
+    # 0 successes / 50 failures → 1/52 ≈ 0.019
+    assert abs(new_conf - 1 / 52) < 1e-4
 
 
 def test_confidence_event_written(tmp_path):


### PR DESCRIPTION
## Summary

Closes the self-learning loop open-circuit documented in `claudedocs/2026-04-30-self-learning-loop-audit.md`:

- `IntelligenceSelector` reads `success_patterns.confidence_score` (was static — only updated by `+0.05/-0.10` deltas).
- `learning_loop` writes only to `pattern_usage.confidence` — never reconciled back.
- 2068/2075 confidence events were decay; only 7 boost; only 1 of 606 patterns ever boosted.

This PR ties the two stores together so the selector always reads current learning state.

## Changes

- **New `scripts/lib/confidence_reconcile.py`** — `reconcile_pattern_confidence(db_path)` syncs `pattern_usage` stats into `success_patterns.confidence_score` using Beta(s+1, f+1) Laplace smoothing. Patterns with no usage data keep their existing score; idempotent.
- **`scripts/lib/intelligence_persist.py`** — `update_confidence_from_outcome` now increments `pattern_usage.success_count` / `failure_count` and writes the Beta posterior to `success_patterns`. Replaces fixed +0.05 / -0.10 deltas that ignored prior usage volume.
- **`scripts/learning_loop.py`** — `daily_learning_cycle` calls `reconcile_pattern_confidence` as its final step.
- **`scripts/lib/intelligence_selector.py`** — Runs `maybe_reconcile` (5-min TTL safety net via `.last_confidence_reconcile_ts`) before reading `success_patterns`, so injection sees current state even if the cron-driven reconcile has not run.

## Test plan

- [x] `python3 -m py_compile scripts/lib/{intelligence_persist,intelligence_selector,confidence_reconcile}.py scripts/learning_loop.py`
- [x] `pytest tests/test_confidence_reconcile.py` — 14 tests pass (cases A–F + legacy + TTL gate)
- [x] `pytest tests/test_intelligence_selector.py tests/test_learning_loop_certification.py tests/test_learning_loop_tz.py tests/test_feedback_loop.py tests/test_intelligence_fixes.py` — 164 tests pass
- [x] Pre-existing failures in `test_intelligence_pipeline_e2e.py` (5 failures, missing `valid_from` column in test schema) verified to exist on `main` — not caused by this PR.

## Notes

- Codex CLI rate-limited until 2026-05-05; Gemini-only review on this PR. Codex re-audit OI will be filed automatically.
- API stability preserved: selector query schema unchanged; `update_confidence_from_outcome` signature unchanged.

Dispatch-ID: 20260430-p0-confidence-reconcile