### PR TITLE
feat(intelligence): activate T0 decision log + outcome reconciliation (P0)

### DIFF
--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -125,9 +125,65 @@ def append_event(
         with path.open("a", encoding="utf-8") as fh:
             fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
             fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        _mirror_to_decision_log(event, record, extra=extra)
         return True
     except Exception:
         return False
+
+
+def _mirror_to_decision_log(event: str, record: dict, *, extra: Optional[dict] = None) -> None:
+    """Best-effort fan-out to the T0 decision log for governance-relevant events.
+
+    Captures dispatch_created, gate_passed, gate_failed, pr_merged so T0
+    has structured introspection on its own decisions. Never raises — a
+    decision-log write failure must not break dispatch_register.
+    """
+    try:
+        from t0_decision_log import log_decision
+    except Exception:
+        return
+
+    dispatch_id = record.get("dispatch_id")
+    pr_number = record.get("pr_number")
+    terminal = record.get("terminal")
+    gate = record.get("gate") or None
+    extra_dict = extra if isinstance(extra, dict) else {}
+
+    if event == "dispatch_created":
+        log_decision(
+            decision_type="dispatch_created",
+            dispatch_id=dispatch_id,
+            terminal=terminal,
+            role=extra_dict.get("role"),
+            risk_score=extra_dict.get("risk_score"),
+            reasoning=extra_dict.get("reasoning", ""),
+            expected_outcome=extra_dict.get("expected_outcome"),
+            timestamp=record.get("timestamp"),
+        )
+    elif event in ("gate_passed", "gate_failed"):
+        verdict = "passed" if event == "gate_passed" else "failed"
+        log_decision(
+            decision_type="gate_verdict",
+            dispatch_id=dispatch_id,
+            pr_number=pr_number,
+            gate=gate,
+            verdict=verdict,
+            blocking_count=extra_dict.get("blocking_count"),
+            reasoning=extra_dict.get("reasoning", ""),
+            timestamp=record.get("timestamp"),
+        )
+    elif event == "pr_merged":
+        log_decision(
+            decision_type="pr_merge",
+            pr_number=pr_number,
+            dispatches_in_pr=extra_dict.get("dispatches_in_pr"),
+            reasoning=extra_dict.get("reasoning", ""),
+            timestamp=record.get("timestamp"),
+        )
+    # Other lifecycle events (dispatch_promoted, dispatch_started,
+    # dispatch_completed, etc.) are recorded in the register but are
+    # outcome signals rather than T0 decisions; reconciliation reads
+    # them to resolve pending decisions.
 
 
 def read_events(*, since_iso: Optional[str] = None, state_dir: Optional[Path] = None) -> list[dict]:

--- a/scripts/lib/t0_decision_log.py
+++ b/scripts/lib/t0_decision_log.py
@@ -206,6 +206,98 @@ def write_decision(record: dict[str, Any], log_file: Path | None = None) -> None
 
 
 # ---------------------------------------------------------------------------
+# Activation helper: kwargs-based logger for governance call sites
+# ---------------------------------------------------------------------------
+
+# decision_type → action mapping for the canonical schema's `action` field.
+# Activation call sites use richer decision_type names; we keep the existing
+# action vocabulary stable and store the original type in `decision_type`.
+_DECISION_TYPE_TO_ACTION: dict[str, str] = {
+    "dispatch_created": "dispatch",
+    "gate_verdict": "advance_gate",
+    "pr_merge": "approve",
+    "oi_closed": "close_oi",
+}
+
+# Activation call sites whose outcomes are settled at write time (no
+# downstream signal to reconcile). Anything else is left pending.
+_TERMINAL_DECISION_TYPES: frozenset = frozenset({"oi_closed", "pr_merge"})
+
+
+def log_decision(
+    *,
+    decision_type: str,
+    dispatch_id: str | None = None,
+    terminal: str | None = None,
+    role: str | None = None,
+    risk_score: float | None = None,
+    reasoning: str = "",
+    expected_outcome: str | None = None,
+    gate: str | None = None,
+    verdict: str | None = None,
+    blocking_count: int | None = None,
+    pr_number: int | None = None,
+    dispatches_in_pr: list | None = None,
+    oi_id: str | None = None,
+    status: str | None = None,
+    log_file: Path | None = None,
+    timestamp: str | None = None,
+) -> bool:
+    """Best-effort kwargs-based decision logger for governance call sites.
+
+    Builds a record conforming to the canonical schema (timestamp,
+    session_summary_at, action, dispatch_id, track, reasoning,
+    open_items_actions, next_expected) and adds activation-specific
+    metadata (decision_type, terminal, role, risk_score, gate, verdict,
+    blocking_count, pr_number, dispatches_in_pr, oi_id, status,
+    expected_outcome, outcome_pending) so reconciliation can resolve
+    outcomes later.
+
+    Returns True on success, False on any failure. Never raises — call
+    sites are passive sinks that must not break governance flow.
+    """
+    try:
+        action = _DECISION_TYPE_TO_ACTION.get(decision_type, decision_type)
+        track = _TERMINAL_TO_TRACK.get((terminal or "").upper())
+        record = build_record(
+            action=action,
+            reasoning=reasoning,
+            dispatch_id=dispatch_id,
+            track=track,
+            timestamp=timestamp,
+        )
+        record["decision_type"] = decision_type
+        if terminal is not None:
+            record["terminal"] = terminal
+        if role is not None:
+            record["role"] = role
+        if risk_score is not None:
+            record["risk_score"] = risk_score
+        if expected_outcome is not None:
+            record["expected_outcome"] = expected_outcome
+        if gate is not None:
+            record["gate"] = gate
+        if verdict is not None:
+            record["verdict"] = verdict
+        if blocking_count is not None:
+            record["blocking_count"] = blocking_count
+        if pr_number is not None:
+            record["pr_number"] = pr_number
+        if dispatches_in_pr is not None:
+            record["dispatches_in_pr"] = list(dispatches_in_pr)
+        if oi_id is not None:
+            record["oi_id"] = oi_id
+        if status is not None:
+            record["status"] = status
+        record["outcome_pending"] = decision_type not in _TERMINAL_DECISION_TYPES
+
+        write_decision(record, log_file)
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Cursor tracking
 # ---------------------------------------------------------------------------
 

--- a/scripts/lib/t0_decision_reconcile.py
+++ b/scripts/lib/t0_decision_reconcile.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""T0 decision outcome reconciliation — resolve pending decisions post-hoc.
+
+Reads `t0_decision_log.jsonl`, for each record with `outcome_pending=true`
+checks the dispatch_register for a matching outcome event, and writes a
+resolution to `t0_decision_outcomes.ndjson` if found.
+
+Idempotent: a cursor file (`t0_decision_outcomes_cursor.json`) tracks
+already-resolved decisions so repeated runs only process new ones.
+
+Resolution rules:
+  decision_type="dispatch_created" → outcome from dispatch_completed /
+      dispatch_failed for the same dispatch_id.
+  decision_type="gate_verdict"     → outcome is the verdict itself
+      (already settled at write time, but kept pending so reconciliation
+      can attach merge / re-run signals later — for now we resolve as
+      `verdict_recorded`).
+
+Terminal types (oi_closed, pr_merge) are not pending and are skipped.
+
+BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _data_dir() -> Path:
+    vnx_data = os.environ.get("VNX_DATA_DIR")
+    if vnx_data:
+        return Path(vnx_data).expanduser().resolve()
+    return Path(__file__).resolve().parent.parent.parent / ".vnx-data"
+
+
+def _state_dir() -> Path:
+    state = os.environ.get("VNX_STATE_DIR")
+    if state:
+        return Path(state).expanduser().resolve()
+    return _data_dir() / "state"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+        try:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    return out
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+            fh.flush()
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _load_cursor(cursor_file: Path) -> set[str]:
+    if not cursor_file.exists():
+        return set()
+    try:
+        data = json.loads(cursor_file.read_text(encoding="utf-8"))
+        return set(data.get("resolved_keys", []))
+    except Exception:
+        return set()
+
+
+def _save_cursor(cursor_file: Path, resolved_keys: set[str]) -> None:
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+    cursor_file.write_text(
+        json.dumps({"resolved_keys": sorted(resolved_keys)}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _decision_key(decision: dict[str, Any]) -> str:
+    """Stable identity for a decision record.
+
+    Uses timestamp + decision_type + main subject (dispatch_id / pr_number /
+    oi_id / gate). Two writes of the same logical decision still produce
+    distinct keys when timestamps differ (intentional — every decision is
+    its own audit point), but a single record is reconciled exactly once.
+    """
+    parts = [
+        str(decision.get("timestamp", "")),
+        str(decision.get("decision_type", "")),
+        str(decision.get("dispatch_id", "")),
+        str(decision.get("pr_number", "")),
+        str(decision.get("oi_id", "")),
+        str(decision.get("gate", "")),
+    ]
+    return "|".join(parts)
+
+
+def _index_register_outcomes(register_events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build a dispatch_id → terminal-outcome index from register events."""
+    index: dict[str, dict[str, Any]] = {}
+    for ev in register_events:
+        et = ev.get("event")
+        if et not in ("dispatch_completed", "dispatch_failed"):
+            continue
+        did = ev.get("dispatch_id")
+        if not did:
+            continue
+        # Last write wins — register is append-only chronological.
+        index[str(did)] = {
+            "outcome": "success" if et == "dispatch_completed" else "failure",
+            "resolved_at": ev.get("timestamp", ""),
+            "register_event": et,
+        }
+    return index
+
+
+def reconcile(
+    *,
+    decision_log: Path | None = None,
+    register_path: Path | None = None,
+    outcomes_log: Path | None = None,
+    cursor_file: Path | None = None,
+) -> int:
+    """Resolve pending decisions by reading the dispatch register.
+
+    Returns the number of new resolutions written.
+    """
+    decision_log = decision_log or (_state_dir() / "t0_decision_log.jsonl")
+    register_path = register_path or (_state_dir() / "dispatch_register.ndjson")
+    outcomes_log = outcomes_log or (_state_dir() / "t0_decision_outcomes.ndjson")
+    cursor_file = cursor_file or (_state_dir() / "t0_decision_outcomes_cursor.json")
+
+    decisions = _read_jsonl(decision_log)
+    if not decisions:
+        return 0
+
+    resolved_keys = _load_cursor(cursor_file)
+    register_events = _read_jsonl(register_path)
+    outcome_index = _index_register_outcomes(register_events)
+
+    written = 0
+    for decision in decisions:
+        if not decision.get("outcome_pending"):
+            continue
+        key = _decision_key(decision)
+        if key in resolved_keys:
+            continue
+
+        dtype = decision.get("decision_type")
+        resolution: dict[str, Any] | None = None
+
+        if dtype == "dispatch_created":
+            did = str(decision.get("dispatch_id") or "")
+            if did and did in outcome_index:
+                hit = outcome_index[did]
+                resolution = {
+                    "decision_key": key,
+                    "decision_type": dtype,
+                    "dispatch_id": did,
+                    "expected_outcome": decision.get("expected_outcome"),
+                    "actual_outcome": hit["outcome"],
+                    "register_event": hit["register_event"],
+                    "resolved_at": _now_iso(),
+                    "decision_resolved_at": hit["resolved_at"],
+                }
+        elif dtype == "gate_verdict":
+            # Gate verdict is its own outcome — record the resolution so
+            # downstream analytics can correlate verdicts with merges.
+            resolution = {
+                "decision_key": key,
+                "decision_type": dtype,
+                "dispatch_id": decision.get("dispatch_id"),
+                "pr_number": decision.get("pr_number"),
+                "gate": decision.get("gate"),
+                "actual_outcome": decision.get("verdict"),
+                "register_event": "verdict_recorded",
+                "resolved_at": _now_iso(),
+            }
+
+        if resolution is None:
+            continue
+
+        _append_jsonl(outcomes_log, resolution)
+        resolved_keys.add(key)
+        written += 1
+
+    if written:
+        _save_cursor(cursor_file, resolved_keys)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve pending T0 decisions by reading the dispatch register."
+    )
+    parser.add_argument("--decision-log", type=Path, default=None)
+    parser.add_argument("--register-path", type=Path, default=None)
+    parser.add_argument("--outcomes-log", type=Path, default=None)
+    parser.add_argument("--cursor-file", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    written = reconcile(
+        decision_log=args.decision_log,
+        register_path=args.register_path,
+        outcomes_log=args.outcomes_log,
+        cursor_file=args.cursor_file,
+    )
+    if written == 0:
+        logger.info("t0_decision_reconcile: no new resolutions")
+    else:
+        logger.info("t0_decision_reconcile: wrote %d resolutions", written)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -256,10 +256,37 @@ def close_item(args):
         pr_id=item.get("pr_id")
     )
 
+    _log_oi_close_decision(
+        oi_id=args.item_id,
+        status=args.status,
+        reason=args.reason,
+        dispatch_id=item.get("origin_dispatch_id"),
+    )
+
     print(f"✅ Closed {args.item_id} as {args.status}")
     print(f"   Reason: {args.reason}")
 
     generate_digest()
+
+
+def _log_oi_close_decision(*, oi_id: str, status: str, reason: str,
+                           dispatch_id: Optional[str]) -> None:
+    """Best-effort decision-log fan-out for OI closures.
+
+    Failure here must never block close_item — the audit log is the
+    primary source of truth, the decision log is a governance overlay.
+    """
+    try:
+        from t0_decision_log import log_decision
+    except Exception:
+        return
+    log_decision(
+        decision_type="oi_closed",
+        oi_id=oi_id,
+        status=status,
+        reasoning=reason or "",
+        dispatch_id=dispatch_id,
+    )
 
 def list_items(args):
     """List open items with optional filtering"""

--- a/tests/test_t0_decision_log_activation.py
+++ b/tests/test_t0_decision_log_activation.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Tests for T0 decision-log activation (P0).
+
+Covers the four wired call sites and the reconciliation pass:
+
+  A. dispatch_created  (via dispatch_register.append_event)
+  B. gate_verdict      (via gate_passed / gate_failed)
+  C. pr_merge          (via pr_merged)
+  D. oi_closed         (via open_items_manager.close_item)
+  E. idempotency / dedup semantics — every call appends a record;
+     reconciliation resolves each decision exactly once.
+  F. outcome reconciliation — pending dispatch_created becomes resolved
+     once a dispatch_completed event arrives.
+  G. concurrent writes are fcntl-locked.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import multiprocessing as mp
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+
+@pytest.fixture()
+def decision_log_path(tmp_path: Path) -> Path:
+    return tmp_path / "t0_decision_log.jsonl"
+
+
+@pytest.fixture()
+def register_path(tmp_path: Path) -> Path:
+    return tmp_path / "dispatch_register.ndjson"
+
+
+@pytest.fixture()
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point VNX_STATE_DIR / VNX_DATA_DIR_EXPLICIT at tmp_path/state."""
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setenv("VNX_STATE_DIR", str(state))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    # Reload modules so they pick up the patched env.
+    for mod in ("t0_decision_log", "dispatch_register", "t0_decision_reconcile"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return state
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+
+# ---------------------------------------------------------------------------
+# A. dispatch_created
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_created_logs_decision(isolated_state: Path) -> None:
+    import dispatch_register
+
+    ok = dispatch_register.append_event(
+        "dispatch_created",
+        dispatch_id="20260430-x-A",
+        terminal="T1",
+        extra={
+            "role": "backend-developer",
+            "risk_score": 0.4,
+            "reasoning": "auto-promoted from staging",
+            "expected_outcome": "success",
+        },
+    )
+    assert ok is True
+
+    decisions = _read_jsonl(isolated_state / "t0_decision_log.jsonl")
+    assert len(decisions) == 1
+    rec = decisions[0]
+    assert rec["decision_type"] == "dispatch_created"
+    assert rec["action"] == "dispatch"
+    assert rec["dispatch_id"] == "20260430-x-A"
+    assert rec["terminal"] == "T1"
+    assert rec["track"] == "A"
+    assert rec["role"] == "backend-developer"
+    assert rec["risk_score"] == 0.4
+    assert rec["expected_outcome"] == "success"
+    assert rec["outcome_pending"] is True
+
+
+# ---------------------------------------------------------------------------
+# B. gate_verdict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("event,expected_verdict", [
+    ("gate_passed", "passed"),
+    ("gate_failed", "failed"),
+])
+def test_gate_verdict_logs_decision(isolated_state: Path, event: str,
+                                    expected_verdict: str) -> None:
+    import dispatch_register
+
+    ok = dispatch_register.append_event(
+        event,
+        dispatch_id="20260430-x-A",
+        pr_number=42,
+        gate="codex_gate",
+        extra={"blocking_count": 0 if expected_verdict == "passed" else 3,
+               "reasoning": ""},
+    )
+    assert ok is True
+
+    decisions = _read_jsonl(isolated_state / "t0_decision_log.jsonl")
+    assert len(decisions) == 1
+    rec = decisions[0]
+    assert rec["decision_type"] == "gate_verdict"
+    assert rec["action"] == "advance_gate"
+    assert rec["gate"] == "codex_gate"
+    assert rec["verdict"] == expected_verdict
+    assert rec["pr_number"] == 42
+    assert rec["outcome_pending"] is True
+
+
+# ---------------------------------------------------------------------------
+# C. pr_merge
+# ---------------------------------------------------------------------------
+
+
+def test_pr_merge_logs_decision(isolated_state: Path) -> None:
+    import dispatch_register
+
+    ok = dispatch_register.append_event(
+        "pr_merged",
+        pr_number=297,
+        extra={
+            "dispatches_in_pr": ["20260430-x-A", "20260430-x-B"],
+            "reasoning": "all gates passed",
+        },
+    )
+    assert ok is True
+
+    decisions = _read_jsonl(isolated_state / "t0_decision_log.jsonl")
+    assert len(decisions) == 1
+    rec = decisions[0]
+    assert rec["decision_type"] == "pr_merge"
+    assert rec["action"] == "approve"
+    assert rec["pr_number"] == 297
+    assert rec["dispatches_in_pr"] == ["20260430-x-A", "20260430-x-B"]
+    # Terminal type — outcome is settled at write time
+    assert rec["outcome_pending"] is False
+
+
+# ---------------------------------------------------------------------------
+# D. oi_closed
+# ---------------------------------------------------------------------------
+
+
+def test_oi_closed_logs_decision_directly(isolated_state: Path) -> None:
+    """Test the oi_closed call path by invoking log_decision the same way
+    open_items_manager._log_oi_close_decision does. We avoid running the
+    full open_items_manager CLI flow because it depends on vnx_paths
+    state-dir wiring that's already exercised by its own tests."""
+    from t0_decision_log import log_decision
+
+    ok = log_decision(
+        decision_type="oi_closed",
+        oi_id="OI-1234",
+        status="done",
+        reasoning="Fixed in PR #500",
+        dispatch_id="20260430-x-A",
+    )
+    assert ok is True
+
+    decisions = _read_jsonl(isolated_state / "t0_decision_log.jsonl")
+    assert len(decisions) == 1
+    rec = decisions[0]
+    assert rec["decision_type"] == "oi_closed"
+    assert rec["action"] == "close_oi"
+    assert rec["oi_id"] == "OI-1234"
+    assert rec["status"] == "done"
+    assert rec["reasoning"] == "Fixed in PR #500"
+    assert rec["outcome_pending"] is False
+
+
+# ---------------------------------------------------------------------------
+# E. Idempotency / dedup semantics
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_calls_append_separately(isolated_state: Path) -> None:
+    """Each call to log_decision appends a fresh record by design.
+
+    The decision log is event-sourced and append-only; deduplication is the
+    reconciler's responsibility (it dedups on the full timestamp+subject
+    key so two records at the same instant resolve as one). Documenting
+    this here so future readers don't expect implicit merge behavior.
+    """
+    from t0_decision_log import log_decision
+
+    log_decision(decision_type="oi_closed", oi_id="OI-1", status="done",
+                 reasoning="x")
+    log_decision(decision_type="oi_closed", oi_id="OI-1", status="done",
+                 reasoning="x")
+
+    decisions = _read_jsonl(isolated_state / "t0_decision_log.jsonl")
+    assert len(decisions) == 2
+
+
+# ---------------------------------------------------------------------------
+# F. Outcome reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_resolves_pending_dispatch_created(isolated_state: Path) -> None:
+    import dispatch_register
+    import t0_decision_reconcile
+
+    # 1. Write dispatch_created (decision is pending)
+    dispatch_register.append_event(
+        "dispatch_created",
+        dispatch_id="20260430-recon-A",
+        terminal="T1",
+        extra={"role": "backend-developer", "expected_outcome": "success"},
+    )
+    # No outcome event yet → first reconcile is a no-op
+    assert t0_decision_reconcile.reconcile() == 0
+
+    # 2. Worker completes — register receives dispatch_completed
+    dispatch_register.append_event(
+        "dispatch_completed",
+        dispatch_id="20260430-recon-A",
+    )
+
+    # 3. Reconcile picks up the resolution
+    written = t0_decision_reconcile.reconcile()
+    assert written == 1
+
+    outcomes = _read_jsonl(isolated_state / "t0_decision_outcomes.ndjson")
+    assert len(outcomes) == 1
+    res = outcomes[0]
+    assert res["decision_type"] == "dispatch_created"
+    assert res["dispatch_id"] == "20260430-recon-A"
+    assert res["actual_outcome"] == "success"
+    assert res["expected_outcome"] == "success"
+    assert res["register_event"] == "dispatch_completed"
+
+    # 4. Idempotency — second reconcile must not re-write
+    assert t0_decision_reconcile.reconcile() == 0
+    outcomes_after = _read_jsonl(isolated_state / "t0_decision_outcomes.ndjson")
+    assert len(outcomes_after) == 1
+
+
+def test_reconcile_failure_outcome(isolated_state: Path) -> None:
+    import dispatch_register
+    import t0_decision_reconcile
+
+    dispatch_register.append_event(
+        "dispatch_created",
+        dispatch_id="20260430-fail-A",
+        terminal="T1",
+        extra={"expected_outcome": "success"},
+    )
+    dispatch_register.append_event(
+        "dispatch_failed",
+        dispatch_id="20260430-fail-A",
+    )
+
+    assert t0_decision_reconcile.reconcile() == 1
+    outcomes = _read_jsonl(isolated_state / "t0_decision_outcomes.ndjson")
+    assert outcomes[0]["actual_outcome"] == "failure"
+    assert outcomes[0]["register_event"] == "dispatch_failed"
+
+
+# ---------------------------------------------------------------------------
+# G. Concurrent writes are fcntl-locked
+# ---------------------------------------------------------------------------
+
+
+def _write_n(log_path_str: str, n: int, oi_prefix: str) -> None:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+    from t0_decision_log import log_decision
+    log_path = Path(log_path_str)
+    for i in range(n):
+        log_decision(
+            decision_type="oi_closed",
+            oi_id=f"{oi_prefix}-{i}",
+            status="done",
+            reasoning="concurrent",
+            log_file=log_path,
+        )
+
+
+def test_concurrent_writes_no_corruption(tmp_path: Path) -> None:
+    log_path = tmp_path / "concurrent.jsonl"
+    threads = [
+        threading.Thread(target=_write_n, args=(str(log_path), 50, f"T{n}"))
+        for n in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 200
+    # Every line must be valid JSON — no torn writes.
+    for line in lines:
+        rec = json.loads(line)
+        assert rec["decision_type"] == "oi_closed"
+        assert rec["status"] == "done"


### PR DESCRIPTION
## Summary

Wires `t0_decision_log` into 4 governance choke points so every T0 decision is captured for introspection, plus a reconciler that resolves pending decisions post-hoc from dispatch-register events.

Per the audit (`claudedocs/2026-04-30-self-learning-loop-audit.md`), `t0_decision_log.py` and `t0_decision_summarizer.py` existed but had **zero callers** — `t0_decisions.ndjson` had never been written. T0 had 0% introspection on its own dispatch decisions.

## Call sites wired

| # | Decision type     | Wired in                                        |
|---|-------------------|-------------------------------------------------|
| A | `dispatch_created`| `dispatch_register.append_event` mirror         |
| B | `gate_verdict`    | `dispatch_register.append_event` mirror (`gate_passed` / `gate_failed`) |
| C | `pr_merge`        | `dispatch_register.append_event` mirror (`pr_merged`) |
| D | `oi_closed`       | `open_items_manager.close_item`                 |

A single mirror in `dispatch_register.append_event` covers Sites A/B/C, so any future writer to the register gets decision-log fan-out for free.

## API non-breaking change

`t0_decision_log.write_decision(record)` is unchanged. A new
`log_decision(**kwargs)` helper accepts the activation-call-site kwargs
schema (`decision_type`, `dispatch_id`, `terminal`, `role`,
`risk_score`, `gate`, `verdict`, `blocking_count`, `pr_number`,
`dispatches_in_pr`, `oi_id`, `status`, `reasoning`, `expected_outcome`)
and is best-effort (returns bool, never raises).

## Reconciliation

`scripts/lib/t0_decision_reconcile.py` (~200 LOC, zero-LLM):
- Reads `t0_decision_log.jsonl`
- For each `outcome_pending=true` record, looks up the matching
  `dispatch_completed` / `dispatch_failed` register event
- Writes resolution to `t0_decision_outcomes.ndjson`
- Cursor file (`t0_decision_outcomes_cursor.json`) keeps it idempotent

## Test plan

- [x] py_compile: t0_decision_log, t0_decision_reconcile, dispatch_register, open_items_manager, build_t0_state — pass
- [x] tests/test_t0_decision_log_activation.py + tests/test_t0_decision_log.py — 69 passed
- [x] dispatch_register + open_items_dedup + t0_decision regression sweep — 180 passed, no regressions
- [x] Concurrent-write test (4 threads × 50 records) — 200 valid JSON lines, no torn writes
- [ ] Operator: confirm `.vnx-data/state/t0_decision_log.jsonl` populates after first dispatch is promoted post-merge

## Test cases

`tests/test_t0_decision_log_activation.py`:
A. dispatch_created logs decision via register
B. gate_passed / gate_failed log gate_verdict
C. pr_merged logs pr_merge with `dispatches_in_pr`
D. oi_closed direct call (open_items_manager wires identically)
E. Idempotency — every call appends a fresh record (event-sourced semantics; reconciler dedups)
F. Reconcile resolves pending success / failure decisions (idempotent)
G. Concurrent writes are fcntl-locked

Refs: `claudedocs/2026-04-30-self-learning-loop-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)