### PR TITLE
fix(launchd): conversation analyzer plist path + smoke test

### DIFF
--- a/scripts/launchd/com.vnx.conversation-analyzer.plist
+++ b/scripts/launchd/com.vnx.conversation-analyzer.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.vnx.conversation-analyzer</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${VNX_HOME}/scripts/conversation_analyzer_nightly.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/vnx-conversation-analyzer.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/vnx-conversation-analyzer.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>VNX_HOME</key>
+        <string>${VNX_HOME}</string>
+        <key>VNX_DATA_DIR</key>
+        <string>${VNX_HOME}/.vnx-data</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/reload_conversation_analyzer.sh
+++ b/scripts/launchd/reload_conversation_analyzer.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Reload the com.vnx.conversation-analyzer launchd agent.
+#
+# Usage: bash scripts/launchd/reload_conversation_analyzer.sh
+#
+# Requires $VNX_HOME to be set (or export VNX_HOME=<path-to-repo> before running).
+# Substitutes ${VNX_HOME} in the plist template and loads the agent.
+#
+# After merge, run this once to re-enable the nightly analyzer on your system.
+
+set -euo pipefail
+
+PLIST_LABEL="com.vnx.conversation-analyzer"
+PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLIST_SRC="$SCRIPT_DIR/${PLIST_LABEL}.plist"
+
+if [ -z "${VNX_HOME:-}" ]; then
+    # Derive from the location of this script: scripts/launchd/ → repo root
+    VNX_HOME="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    echo "VNX_HOME not set — using derived path: $VNX_HOME"
+fi
+
+if [ ! -f "$PLIST_SRC" ]; then
+    echo "ERROR: plist template not found: $PLIST_SRC" >&2
+    exit 1
+fi
+
+TARGET_SCRIPT="$VNX_HOME/scripts/conversation_analyzer_nightly.sh"
+if [ ! -f "$TARGET_SCRIPT" ]; then
+    echo "ERROR: target script not found: $TARGET_SCRIPT" >&2
+    echo "  VNX_HOME=$VNX_HOME may be wrong. Set VNX_HOME to the repo root and retry." >&2
+    exit 1
+fi
+
+# Unload existing agent if present (ignore errors — may not be loaded)
+if [ -f "$PLIST_DEST" ]; then
+    echo "Unloading existing agent: $PLIST_LABEL"
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+# Substitute ${VNX_HOME} placeholder with actual path and write to LaunchAgents
+echo "Writing resolved plist to: $PLIST_DEST"
+sed "s|\${VNX_HOME}|$VNX_HOME|g" "$PLIST_SRC" > "$PLIST_DEST"
+
+# Load the agent
+launchctl load "$PLIST_DEST"
+echo "Loaded: $PLIST_LABEL (runs nightly at 02:00)"
+
+# Verify it appears in launchctl list
+if launchctl list | grep -q "$PLIST_LABEL"; then
+    echo "OK: agent registered in launchctl"
+else
+    echo "WARNING: agent not found in launchctl list — check $PLIST_DEST" >&2
+    exit 1
+fi
+
+echo "Logs: /tmp/vnx-conversation-analyzer.log / /tmp/vnx-conversation-analyzer.err"

--- a/tests/smoke/smoke_launchd_plist_paths_resolve.sh
+++ b/tests/smoke/smoke_launchd_plist_paths_resolve.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Smoke test: verify that every ProgramArguments path in scripts/launchd/*.plist resolves.
+#
+# Catches broken plist references before launchd silently fails with exit 32512.
+# Per audit (claudedocs/2026-04-30-vnx-ci-test-plan.md §"First-flag test"):
+# this test would have caught the conversation_analyzer SEOcrawler_v2 bug 19 days earlier.
+#
+# Usage: bash tests/smoke/smoke_launchd_plist_paths_resolve.sh
+# Exit 0: all paths resolve. Exit 1: one or more paths are missing.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VNX_HOME="${VNX_HOME:-$REPO_ROOT}"
+PLIST_DIR="$REPO_ROOT/scripts/launchd"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+check_plist_paths() {
+    local plist="$1"
+    local label
+    label="$(basename "$plist")"
+
+    # Use python3 plistlib to extract ProgramArguments strings reliably
+    local args
+    args="$(python3 - "$plist" <<'PYEOF'
+import sys, plistlib, pathlib
+
+plist_path = sys.argv[1]
+with open(plist_path, "rb") as f:
+    data = plistlib.load(f)
+
+args = data.get("ProgramArguments", [])
+for arg in args:
+    print(arg)
+PYEOF
+)"
+
+    while IFS= read -r arg; do
+        [ -z "$arg" ] && continue
+
+        # Skip template placeholders that have not been substituted yet
+        if [[ "$arg" == *"__"* ]]; then
+            echo "  SKIP  [$label] template placeholder: $arg"
+            SKIP=$((SKIP + 1))
+            continue
+        fi
+
+        # Substitute ${VNX_HOME} with actual value
+        local resolved="${arg//\$\{VNX_HOME\}/$VNX_HOME}"
+
+        # Only check absolute paths (ignore flags, option values, etc.)
+        if [[ "$resolved" != /* ]]; then
+            continue
+        fi
+
+        if [ -e "$resolved" ]; then
+            echo "  OK    [$label] $resolved"
+            PASS=$((PASS + 1))
+        else
+            echo "  FAIL  [$label] path not found: $resolved" >&2
+            FAIL=$((FAIL + 1))
+        fi
+    done <<< "$args"
+}
+
+echo "Scanning $PLIST_DIR/*.plist (VNX_HOME=$VNX_HOME)"
+echo ""
+
+shopt -s nullglob
+plist_files=("$PLIST_DIR"/*.plist)
+shopt -u nullglob
+
+if [ ${#plist_files[@]} -eq 0 ]; then
+    echo "ERROR: no plist files found in $PLIST_DIR" >&2
+    exit 1
+fi
+
+for plist in "${plist_files[@]}"; do
+    check_plist_paths "$plist"
+done
+
+echo ""
+echo "Results: $PASS ok, $FAIL failed, $SKIP skipped (unsubstituted templates)"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "FAIL: $FAIL missing path(s) — fix broken plist references before loading agents" >&2
+    exit 1
+fi
+
+echo "PASS: all resolved paths exist"
+exit 0


### PR DESCRIPTION
## Summary

- **Root cause**: `com.vnx.conversation-analyzer` launchd plist pointed to `/Users/vincentvandeth/Development/SEOcrawler_v2/.vnx/scripts/conversation_analyzer_nightly.sh` — a path that no longer exists after the project moved. LastExitStatus=32512 (file not found), 20 days of silent failures since 2026-04-10.
- **Fix**: New portable plist template using `${VNX_HOME}` placeholder, with an operator reload script to substitute and install it.
- **Prevention**: Smoke test `tests/smoke/smoke_launchd_plist_paths_resolve.sh` walks every `scripts/launchd/*.plist` and asserts all non-template paths resolve. Per audit report `claudedocs/2026-04-30-vnx-ci-test-plan.md`, this test would have caught the bug on 2026-04-11, 19 days before discovery.

## Files Changed

- `scripts/launchd/com.vnx.conversation-analyzer.plist` — portable plist template with `${VNX_HOME}` placeholder
- `scripts/launchd/reload_conversation_analyzer.sh` — unloads old agent, substitutes path, loads and verifies
- `tests/smoke/smoke_launchd_plist_paths_resolve.sh` — asserts all plist ProgramArguments paths exist

## Test Plan

- [x] `bash -n scripts/launchd/reload_conversation_analyzer.sh` → OK
- [x] `bash -n tests/smoke/smoke_launchd_plist_paths_resolve.sh` → OK
- [x] `bash tests/smoke/smoke_launchd_plist_paths_resolve.sh` → exit 0, 4 ok, 0 failed, 2 skipped (unsubstituted templates)

## Operator Action Required

After merge, run once to re-enable the nightly analyzer:
```bash
bash scripts/launchd/reload_conversation_analyzer.sh
```

This PR only fixes the repo plist and adds the smoke test. The live `~/Library/LaunchAgents/` entry is not updated until the operator runs the reload script.

Note: Codex CLI rate-limited until 2026-05-05; Gemini-only review applies for this PR.

Dispatch-ID: 20260430-p1-haiku-plist-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)