### PR TITLE
feat(observability): component health beacon framework (PR-T1)

### DIFF
--- a/dashboard/api_health.py
+++ b/dashboard/api_health.py
@@ -1,0 +1,55 @@
+"""Component health beacon API for the dashboard.
+
+Exposes :func:`_operator_get_health` which serves
+``GET /api/operator/health`` — JSON of every component beacon under
+``$VNX_DATA_DIR/health/``, plus a roll-up summary.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+# Make scripts/lib importable so we can reuse health_beacon helpers.
+_DASHBOARD_DIR = Path(__file__).resolve().parent
+_SCRIPTS_LIB = _DASHBOARD_DIR.parent / "scripts" / "lib"
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+from health_beacon import beacon_summary  # noqa: E402
+
+
+def _resolve_data_dir() -> Path:
+    """Resolve the .vnx-data root, mirroring api_operator's logic."""
+    import os
+    project_root = _DASHBOARD_DIR.parent
+    state_dir = Path(os.environ.get("VNX_STATE_DIR", str(project_root / ".vnx-data" / "state")))
+    return state_dir.parent
+
+
+def _operator_get_health() -> Dict[str, Any]:
+    """GET /api/operator/health — beacon dump with classification."""
+    now = datetime.now(timezone.utc).isoformat()
+    data_dir = _resolve_data_dir()
+    try:
+        summary = beacon_summary(data_dir)
+        return {
+            "queried_at": now,
+            "data_dir": str(data_dir),
+            "overall": summary["overall"],
+            "counts": summary["counts"],
+            "beacons": summary["beacons"],
+        }
+    except Exception as exc:
+        return {
+            "queried_at": now,
+            "data_dir": str(data_dir),
+            "overall": "fail",
+            "counts": {"ok": 0, "stale": 0, "fail": 0, "corrupt": 0},
+            "beacons": {},
+            "error": str(exc),
+        }
+
+
+__all__ = ["_operator_get_health"]

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -116,6 +116,10 @@ from api_token_stats import (  # noqa: E402
     _query_token_sessions,
 )
 
+from api_health import (  # noqa: E402
+    _operator_get_health,
+)
+
 from api_operator import (  # noqa: E402
     _api_health,
     _jump_terminal,
@@ -333,6 +337,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/agents":
             _json_response(self, HTTPStatus.OK, _operator_get_agents())
+            return
+
+        if path == "/api/operator/health":
+            _json_response(self, HTTPStatus.OK, _operator_get_health())
             return
 
         # Register stream SSE endpoints — pass CANONICAL_STATE_DIR so the

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -967,6 +967,23 @@ def main() -> int:
         except Exception:
             pass
 
+    try:
+        from health_beacon import HealthBeacon
+        HealthBeacon(
+            _DATA_DIR,
+            "t0_state_builder",
+            expected_interval_seconds=1800,
+        ).heartbeat(
+            status="ok" if _build_succeeded else "fail",
+            details={
+                "format": args.format,
+                "output": str(output_path),
+                "elapsed_seconds": round(elapsed, 3),
+            },
+        )
+    except Exception:
+        pass
+
     return 0  # Always exit 0
 
 

--- a/scripts/conversation_analyzer.py
+++ b/scripts/conversation_analyzer.py
@@ -1235,6 +1235,9 @@ def main():
     analyzer = ConversationAnalyzer(DB_PATH)
     analyzer.connect()
 
+    rc = 0
+    run_status = "ok"
+    run_error: Optional[str] = None
     try:
         analyzer.run(
             max_sessions=args.max_sessions,
@@ -1243,12 +1246,27 @@ def main():
             project_filter=args.project_filter,
             terminal_filter=args.terminal_filter,
         )
-        return 0
     except Exception as e:
         log("ERROR", f"Analysis failed: {e}")
-        return 1
+        run_status = "fail"
+        run_error = str(e)
+        rc = 1
     finally:
         analyzer.close()
+        try:
+            from health_beacon import HealthBeacon
+            details = {"max_sessions": args.max_sessions, "dry_run": args.dry_run}
+            if run_error:
+                details["error"] = run_error
+            HealthBeacon(
+                Path(PATHS["VNX_DATA_DIR"]),
+                "conversation_analyzer",
+                expected_interval_seconds=86400,
+            ).heartbeat(status=run_status, details=details)
+        except Exception:
+            pass
+
+    return rc
 
 
 if __name__ == "__main__":

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""CLI entry point for VNX component health beacons.
+
+Reads all beacons under ``$VNX_DATA_DIR/health/`` (or the path given via
+``--state-dir``) and prints a compact status table. Exit codes:
+
+    0  all beacons OK
+    1  one or more beacons stale / fail / corrupt / missing
+    2  framework broken (state_dir unresolvable, internal error)
+
+Use ``--json`` for machine-readable output and ``--components`` to
+restrict to specific components.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from health_beacon import all_beacons  # noqa: E402
+
+
+def _resolve_state_dir(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    try:
+        from project_root import resolve_data_dir
+        return resolve_data_dir(__file__)
+    except Exception:
+        # Fall through — the caller decides whether to error out.
+        raise
+
+
+def _filter_components(
+    beacons: dict, components: Iterable[str] | None
+) -> dict:
+    if not components:
+        return beacons
+    wanted = {c.strip() for c in components if c.strip()}
+    if not wanted:
+        return beacons
+    return {k: v for k, v in beacons.items() if k in wanted}
+
+
+def _format_age(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    if seconds < 86400:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
+
+def _format_iso(beacon: dict) -> str:
+    iso = beacon.get("last_run_iso")
+    if isinstance(iso, str) and iso:
+        return iso
+    ts = beacon.get("last_run_ts")
+    try:
+        ts_f = float(ts) if ts is not None else None
+    except (TypeError, ValueError):
+        ts_f = None
+    if ts_f is None:
+        return "-"
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts_f))
+
+
+def _print_table(beacons: dict, requested: list[str]) -> None:
+    rows: list[tuple[str, str, str, str]] = []
+
+    seen = set(beacons.keys())
+    ordered = list(beacons.keys())
+    for r in requested:
+        if r and r not in seen:
+            ordered.append(r)
+
+    for name in ordered:
+        if name in beacons:
+            b = beacons[name]
+            health = b.get("health", "ok").upper()
+            iso = _format_iso(b)
+            age = _format_age(b.get("age_seconds"))
+        else:
+            health = "MISSING"
+            iso = "-"
+            age = "-"
+        rows.append((name, health, iso, age))
+
+    if not rows:
+        print("(no beacons found)")
+        return
+
+    name_w = max(len("Component"), max(len(r[0]) for r in rows))
+    health_w = max(len("Health"), max(len(r[1]) for r in rows))
+    iso_w = max(len("Last run"), max(len(r[2]) for r in rows))
+
+    header = (
+        f"{'Component'.ljust(name_w)}  "
+        f"{'Health'.ljust(health_w)}  "
+        f"{'Last run'.ljust(iso_w)}  "
+        f"Age"
+    )
+    print(header)
+    print("-" * len(header))
+    for name, health, iso, age in rows:
+        print(
+            f"{name.ljust(name_w)}  "
+            f"{health.ljust(health_w)}  "
+            f"{iso.ljust(iso_w)}  "
+            f"{age}"
+        )
+
+
+def _exit_code(beacons: dict, requested: list[str]) -> int:
+    requested_set = {c for c in requested if c}
+    if requested_set:
+        for name in requested_set:
+            if name not in beacons:
+                return 1
+            if beacons[name].get("health") != "ok":
+                return 1
+        return 0
+
+    if not beacons:
+        # No requested filter and no beacons present -> degraded.
+        return 1
+    for b in beacons.values():
+        if b.get("health") != "ok":
+            return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Show VNX component health beacons."
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="Override beacon root (defaults to resolved $VNX_DATA_DIR).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a table.",
+    )
+    parser.add_argument(
+        "--components",
+        default=None,
+        help="Comma-separated component names to filter on.",
+    )
+    args = parser.parse_args(argv)
+
+    requested = [
+        c.strip() for c in (args.components or "").split(",") if c.strip()
+    ]
+
+    try:
+        state_dir = _resolve_state_dir(args.state_dir)
+    except Exception as exc:
+        msg = {
+            "error": "state_dir_unresolvable",
+            "message": str(exc),
+        }
+        if args.json:
+            print(json.dumps(msg))
+        else:
+            print(f"ERROR: cannot resolve state dir: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        beacons = all_beacons(state_dir)
+    except Exception as exc:
+        msg = {"error": "beacon_read_failed", "message": str(exc)}
+        if args.json:
+            print(json.dumps(msg))
+        else:
+            print(f"ERROR: failed to read beacons: {exc}", file=sys.stderr)
+        return 2
+
+    filtered = _filter_components(beacons, requested)
+
+    if args.json:
+        # Include MISSING entries so callers can detect absent components.
+        result = {
+            "state_dir": str(state_dir),
+            "beacons": filtered,
+        }
+        if requested:
+            for name in requested:
+                if name not in filtered:
+                    result["beacons"][name] = {
+                        "component": name,
+                        "health": "missing",
+                    }
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_table(filtered, requested)
+
+    return _exit_code(filtered, requested)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/intelligence_daemon.py
+++ b/scripts/intelligence_daemon.py
@@ -447,12 +447,39 @@ class IntelligenceDaemon:
                 self.dashboard_builder.write_intelligence_health()  # Write to dedicated file (PR #8 Fix)
                 self.dashboard_builder.write_health_status()  # Update dashboard every cycle for live sync
 
+                try:
+                    from health_beacon import HealthBeacon
+                    _hb_paths = ensure_env()
+                    HealthBeacon(
+                        Path(_hb_paths["VNX_DATA_DIR"]),
+                        "intelligence_daemon",
+                        expected_interval_seconds=300,
+                    ).heartbeat(
+                        status="ok",
+                        details={
+                            "uptime_seconds": self.health_status.get("uptime_seconds", 0),
+                            "daemon_status": self.health_status.get("status", "running"),
+                        },
+                    )
+                except Exception:
+                    pass
+
                 # Sleep for 60 seconds
                 time.sleep(60)
 
             except Exception as e:
                 logger.error(f"Error in daemon loop: {e}")
                 self.health_status['status'] = 'error'
+                try:
+                    from health_beacon import HealthBeacon
+                    _hb_paths = ensure_env()
+                    HealthBeacon(
+                        Path(_hb_paths["VNX_DATA_DIR"]),
+                        "intelligence_daemon",
+                        expected_interval_seconds=300,
+                    ).heartbeat(status="fail", details={"error": str(e)})
+                except Exception:
+                    pass
                 time.sleep(60)  # Continue after error
 
         # Graceful shutdown

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -866,6 +866,27 @@ class LearningLoop:
         print(f"  • Patterns archived: {self.learning_stats['patterns_archived']}")
         print("=" * 60)
 
+        try:
+            from health_beacon import HealthBeacon
+            from vnx_paths import ensure_env as _hb_ensure_env
+            _hb_paths = _hb_ensure_env()
+            HealthBeacon(
+                Path(_hb_paths["VNX_DATA_DIR"]),
+                "learning_loop",
+                expected_interval_seconds=86400,
+            ).heartbeat(
+                status="ok",
+                details={
+                    "elapsed_seconds": round(elapsed, 2),
+                    "patterns_tracked": len(self.pattern_metrics),
+                    "confidence_adjustments": self.learning_stats.get("confidence_adjustments", 0),
+                    "new_prevention_rules": len(new_rules),
+                    "patterns_archived": self.learning_stats.get("patterns_archived", 0),
+                },
+            )
+        except Exception:
+            pass
+
         return report
 
 

--- a/scripts/lib/cleanup_worker_exit.py
+++ b/scripts/lib/cleanup_worker_exit.py
@@ -466,6 +466,26 @@ def cleanup_worker_exit(
         result=result,
     )
 
+    try:
+        from health_beacon import HealthBeacon
+        HealthBeacon(
+            resolved_state_dir.parent,
+            "cleanup_worker_exit",
+            expected_interval_seconds=None,
+        ).heartbeat(
+            status="ok" if not result.errors else "fail",
+            details={
+                "terminal_id": terminal_id,
+                "dispatch_id": dispatch_id,
+                "exit_status": exit_status,
+                "lease_released": result.lease_released,
+                "worker_transitioned": result.worker_transitioned,
+                "errors": list(result.errors),
+            },
+        )
+    except Exception:
+        pass
+
     return result
 
 

--- a/scripts/lib/health_beacon.py
+++ b/scripts/lib/health_beacon.py
@@ -1,0 +1,208 @@
+"""Component health beacon — atomic JSON heartbeat per VNX component.
+
+Each component writes a heartbeat file at:
+
+    <state_dir>/health/<component>.json
+
+with payload:
+
+    {
+        "component": "learning_loop",
+        "last_run_ts": 1714400000,
+        "last_run_iso": "2026-04-30T...Z",
+        "status": "ok|stale|fail",
+        "details": {...freeform...},
+        "expected_interval_seconds": 86400
+    }
+
+CI / dashboard reads all beacons via ``all_beacons()`` and flags any whose
+age exceeds ``expected_interval_seconds * 1.5`` as ``stale``. Components
+with ``status="fail"`` are flagged as ``fail`` regardless of age.
+
+Per the dispatch, ``state_dir`` is the VNX data root (typically
+``.vnx-data/``), and the module owns the ``health/`` subdirectory below
+it. The constructor name preserves the dispatch contract.
+
+Atomic write: payload is serialized to a sibling tmp file under an
+``fcntl`` lock, then ``os.replace``'d into place. The lock prevents two
+concurrent writers from interleaving JSON bytes; the rename gives
+readers an all-or-nothing view.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class HealthBeacon:
+    """Writer for a single component's heartbeat file."""
+
+    def __init__(
+        self,
+        state_dir: Path,
+        component: str,
+        expected_interval_seconds: Optional[int] = 86400,
+    ) -> None:
+        self.path = Path(state_dir) / "health" / f"{component}.json"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.component = component
+        self.expected_interval = expected_interval_seconds
+
+    def heartbeat(
+        self,
+        status: str = "ok",
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Atomically write the current heartbeat.
+
+        Best-effort: I/O failures are swallowed so a beacon write never
+        breaks the calling component. Callers that need confirmation
+        should call :meth:`heartbeat_strict`.
+        """
+        try:
+            self.heartbeat_strict(status=status, details=details)
+        except OSError:
+            pass
+
+    def heartbeat_strict(
+        self,
+        status: str = "ok",
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Atomically write the heartbeat, raising on I/O failure."""
+        now = time.time()
+        payload: Dict[str, Any] = {
+            "component": self.component,
+            "last_run_ts": int(now),
+            "last_run_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+            "status": status,
+            "details": details or {},
+            "expected_interval_seconds": self.expected_interval,
+        }
+
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+
+        # fcntl-locked write: serialise concurrent writers on the same
+        # component, so the tmp+rename pair is never interleaved.
+        lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, self.path)
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            os.close(lock_fd)
+
+
+def all_beacons(state_dir: Path) -> Dict[str, Dict[str, Any]]:
+    """Read all beacons under ``state_dir/health`` and classify each.
+
+    Classification rules (in order):
+      * ``status == "fail"``                         -> ``health = "fail"``
+      * unreadable JSON                              -> ``health = "corrupt"``
+      * ``expected_interval_seconds`` is None        -> ``health = "ok"``
+        (event-driven components — no staleness check)
+      * ``age > expected_interval * 1.5``            -> ``health = "stale"``
+      * otherwise                                    -> ``health = "ok"``
+
+    Returns a mapping ``component_name -> beacon_dict`` (the raw payload
+    plus the derived ``health`` and ``age_seconds`` keys).
+    """
+    state_dir = Path(state_dir)
+    health_dir = state_dir / "health"
+    if not health_dir.exists():
+        return {}
+
+    out: Dict[str, Dict[str, Any]] = {}
+    now = time.time()
+
+    for path in sorted(health_dir.glob("*.json")):
+        # Skip tmp / lock siblings.
+        if path.suffix != ".json":
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                raise ValueError("beacon payload not a JSON object")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            out[path.stem] = {
+                "component": path.stem,
+                "health": "corrupt",
+                "error": str(exc),
+            }
+            continue
+
+        component = data.get("component", path.stem)
+        last_ts = data.get("last_run_ts")
+        try:
+            last_ts_f = float(last_ts) if last_ts is not None else None
+        except (TypeError, ValueError):
+            last_ts_f = None
+
+        if last_ts_f is None:
+            out[component] = {**data, "health": "corrupt", "error": "missing last_run_ts"}
+            continue
+
+        age = now - last_ts_f
+        data["age_seconds"] = round(age, 1)
+
+        status = data.get("status")
+        interval = data.get("expected_interval_seconds")
+
+        if status == "fail":
+            data["health"] = "fail"
+        elif interval is None:
+            # Event-driven component: track last-time only, never stale.
+            data["health"] = "ok"
+        else:
+            try:
+                interval_f = float(interval)
+            except (TypeError, ValueError):
+                interval_f = 86400.0
+            if interval_f <= 0:
+                data["health"] = "ok"
+            else:
+                staleness_factor = age / interval_f
+                if staleness_factor > 1.5:
+                    data["health"] = "stale"
+                else:
+                    data["health"] = "ok"
+
+        out[component] = data
+
+    return out
+
+
+def beacon_summary(state_dir: Path) -> Dict[str, Any]:
+    """Return a compact summary suitable for dashboard / CI consumption."""
+    beacons = all_beacons(state_dir)
+    counts: Dict[str, int] = {"ok": 0, "stale": 0, "fail": 0, "corrupt": 0}
+    for b in beacons.values():
+        h = b.get("health", "corrupt")
+        counts[h] = counts.get(h, 0) + 1
+    overall = "ok"
+    if counts.get("fail", 0) or counts.get("corrupt", 0):
+        overall = "fail"
+    elif counts.get("stale", 0):
+        overall = "stale"
+    return {
+        "overall": overall,
+        "counts": counts,
+        "beacons": beacons,
+    }
+
+
+__all__ = ["HealthBeacon", "all_beacons", "beacon_summary"]

--- a/tests/smoke/smoke_health_beacons_fresh.py
+++ b/tests/smoke/smoke_health_beacons_fresh.py
@@ -1,0 +1,94 @@
+"""Smoke test — assert beacons exist and are fresh after dispatcher startup.
+
+Designed to be run after the dispatcher / intelligence daemons have had a
+chance to fire at least one heartbeat. It checks that each "critical"
+component listed below has a beacon file and that its classified health
+is ``ok``.
+
+Run as a pytest module:
+
+    pytest tests/smoke/smoke_health_beacons_fresh.py -xvs
+
+or directly (exit 0 on green, 1 on any non-ok component, 2 on framework
+errors). The component list intentionally includes only the long-lived,
+always-on services. Event-driven beacons (cleanup_worker_exit) are not
+asserted here — by definition they do not run on a schedule.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from health_beacon import all_beacons  # noqa: E402
+
+CRITICAL_COMPONENTS: List[str] = [
+    "intelligence_daemon",
+    "t0_state_builder",
+]
+
+
+def _resolve_data_dir() -> Path:
+    try:
+        from project_root import resolve_data_dir
+        return resolve_data_dir(__file__)
+    except Exception:
+        return _REPO_ROOT / ".vnx-data"
+
+
+@pytest.mark.skipif(
+    os.environ.get("VNX_RUN_SMOKE_HEALTH") != "1",
+    reason="Smoke test only runs when VNX_RUN_SMOKE_HEALTH=1",
+)
+def test_critical_beacons_present_and_fresh() -> None:
+    data_dir = _resolve_data_dir()
+    beacons = all_beacons(data_dir)
+
+    missing: list[str] = []
+    not_ok: list[tuple[str, str]] = []
+
+    for name in CRITICAL_COMPONENTS:
+        if name not in beacons:
+            missing.append(name)
+            continue
+        health = beacons[name].get("health", "unknown")
+        if health != "ok":
+            not_ok.append((name, health))
+
+    assert not missing, f"missing beacons: {missing}"
+    assert not not_ok, f"non-ok beacons: {not_ok}"
+
+
+def main() -> int:
+    data_dir = _resolve_data_dir()
+    try:
+        beacons = all_beacons(data_dir)
+    except Exception as exc:
+        print(f"FRAMEWORK_ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    bad = []
+    for name in CRITICAL_COMPONENTS:
+        b = beacons.get(name)
+        if b is None:
+            bad.append(f"{name}=missing")
+        elif b.get("health") != "ok":
+            bad.append(f"{name}={b.get('health')}")
+
+    if bad:
+        print("UNHEALTHY: " + ", ".join(bad))
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_health_beacon.py
+++ b/tests/test_health_beacon.py
@@ -1,0 +1,304 @@
+"""Tests for the component health beacon framework."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from health_beacon import HealthBeacon, all_beacons, beacon_summary  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Case A — heartbeat() writes valid JSON
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_writes_valid_json(tmp_path: Path) -> None:
+    beacon = HealthBeacon(tmp_path, "comp_a", expected_interval_seconds=600)
+    beacon.heartbeat(status="ok", details={"foo": "bar"})
+
+    path = tmp_path / "health" / "comp_a.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["component"] == "comp_a"
+    assert payload["status"] == "ok"
+    assert payload["details"] == {"foo": "bar"}
+    assert payload["expected_interval_seconds"] == 600
+    assert isinstance(payload["last_run_ts"], int)
+    assert payload["last_run_iso"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# Case B — atomic write uses tmp + os.replace
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_uses_tmp_and_replace(tmp_path: Path, monkeypatch) -> None:
+    beacon = HealthBeacon(tmp_path, "comp_b")
+
+    seen_tmp_paths: list[str] = []
+    seen_replace_calls: list[tuple[str, str]] = []
+
+    real_replace = __import__("os").replace
+
+    def fake_replace(src, dst):
+        seen_replace_calls.append((str(src), str(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr("health_beacon.os.replace", fake_replace)
+
+    real_open = open
+
+    def watching_open(path, *a, **kw):
+        if isinstance(path, (str, Path)) and str(path).endswith(".tmp"):
+            seen_tmp_paths.append(str(path))
+        return real_open(path, *a, **kw)
+
+    import builtins
+    monkeypatch.setattr(builtins, "open", watching_open)
+
+    beacon.heartbeat()
+
+    assert seen_tmp_paths, "expected a *.tmp file to be opened"
+    assert seen_replace_calls, "expected os.replace to be invoked"
+    assert seen_replace_calls[-1][1].endswith("comp_b.json")
+
+
+# ---------------------------------------------------------------------------
+# Case C — concurrent writes never produce a corrupt file
+# ---------------------------------------------------------------------------
+
+def test_concurrent_writes_are_safe(tmp_path: Path) -> None:
+    beacon = HealthBeacon(tmp_path, "comp_c", expected_interval_seconds=60)
+    iterations = 25
+
+    errors: list[Exception] = []
+
+    def writer(idx: int) -> None:
+        try:
+            for i in range(iterations):
+                beacon.heartbeat_strict(
+                    status="ok",
+                    details={"writer": idx, "i": i},
+                )
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"writers raised: {errors}"
+
+    payload = json.loads((tmp_path / "health" / "comp_c.json").read_text(encoding="utf-8"))
+    assert payload["component"] == "comp_c"
+    assert "writer" in payload["details"]
+
+
+# ---------------------------------------------------------------------------
+# Case D — all_beacons classifies fresh as ok
+# ---------------------------------------------------------------------------
+
+def test_all_beacons_fresh_is_ok(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "fresh", expected_interval_seconds=3600).heartbeat()
+    result = all_beacons(tmp_path)
+    assert "fresh" in result
+    assert result["fresh"]["health"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Case E — classifies >1.5x interval as stale
+# ---------------------------------------------------------------------------
+
+def test_all_beacons_stale_classification(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    health_dir.mkdir(parents=True)
+    stale_payload = {
+        "component": "stale_one",
+        "last_run_ts": int(time.time() - 7200),  # 2h ago
+        "last_run_iso": "2020-01-01T00:00:00Z",
+        "status": "ok",
+        "details": {},
+        "expected_interval_seconds": 3600,  # 1h interval => 2h is > 1.5x
+    }
+    (health_dir / "stale_one.json").write_text(json.dumps(stale_payload), encoding="utf-8")
+
+    result = all_beacons(tmp_path)
+    assert result["stale_one"]["health"] == "stale"
+    assert result["stale_one"]["age_seconds"] > 3600 * 1.5
+
+
+# ---------------------------------------------------------------------------
+# Case F — status="fail" classifies as fail regardless of age
+# ---------------------------------------------------------------------------
+
+def test_status_fail_overrides_age(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "broken", expected_interval_seconds=3600).heartbeat(
+        status="fail", details={"err": "boom"}
+    )
+    result = all_beacons(tmp_path)
+    assert result["broken"]["health"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Case G — missing file means component absent from output
+# ---------------------------------------------------------------------------
+
+def test_missing_file_not_in_output(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "present").heartbeat()
+    result = all_beacons(tmp_path)
+    assert "present" in result
+    assert "absent" not in result
+
+
+# ---------------------------------------------------------------------------
+# Case H — corrupt JSON marked corrupt
+# ---------------------------------------------------------------------------
+
+def test_corrupt_json_marked_corrupt(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    health_dir.mkdir(parents=True)
+    (health_dir / "garbled.json").write_text("not json {{{", encoding="utf-8")
+    result = all_beacons(tmp_path)
+    assert result["garbled"]["health"] == "corrupt"
+    assert "error" in result["garbled"]
+
+
+# ---------------------------------------------------------------------------
+# Case I — CLI exit codes
+# ---------------------------------------------------------------------------
+
+def _run_cli(state_dir: Path, *extra: str) -> tuple[int, str, str]:
+    cli_path = _REPO_ROOT / "scripts" / "health_check.py"
+    proc = subprocess.run(
+        [sys.executable, str(cli_path), "--state-dir", str(state_dir), *extra],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_cli_exits_zero_when_all_ok(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "alpha").heartbeat()
+    rc, stdout, _ = _run_cli(tmp_path)
+    assert rc == 0, stdout
+
+
+def test_cli_exits_one_on_stale(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    health_dir.mkdir(parents=True)
+    payload = {
+        "component": "old",
+        "last_run_ts": int(time.time() - 100000),
+        "last_run_iso": "2020-01-01T00:00:00Z",
+        "status": "ok",
+        "details": {},
+        "expected_interval_seconds": 60,
+    }
+    (health_dir / "old.json").write_text(json.dumps(payload), encoding="utf-8")
+    rc, _stdout, _ = _run_cli(tmp_path)
+    assert rc == 1
+
+
+def test_cli_exits_one_on_missing_requested(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "present").heartbeat()
+    rc, _stdout, _ = _run_cli(tmp_path, "--components", "absent")
+    assert rc == 1
+
+
+def test_cli_exits_two_on_unresolvable_state_dir() -> None:
+    # Provide a path inside a non-git, non-existent directory tree to force
+    # state_dir resolution to fall through. The _resolve_state_dir codepath
+    # only triggers when --state-dir is omitted; explicit --state-dir always
+    # resolves, so we test the framework-broken path by passing an entirely
+    # bogus arg combination.
+    cli_path = _REPO_ROOT / "scripts" / "health_check.py"
+    proc = subprocess.run(
+        [sys.executable, str(cli_path), "--state-dir", "/dev/null/does/not/exist"],
+        capture_output=True,
+        text=True,
+    )
+    # Non-existent dir: all_beacons returns empty, and exit code 1 (degraded).
+    # That's fine — exit 2 is reserved for *unresolvable* state-dir, which we
+    # can't easily trigger when --state-dir is explicit. So we just assert it
+    # didn't crash with a stack trace.
+    assert proc.returncode in (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Case J — --json output is parseable
+# ---------------------------------------------------------------------------
+
+def test_cli_json_output_parseable(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "j_one").heartbeat()
+    HealthBeacon(tmp_path, "j_two").heartbeat()
+    rc, stdout, _ = _run_cli(tmp_path, "--json")
+    assert rc == 0
+    payload = json.loads(stdout)
+    assert "beacons" in payload
+    assert {"j_one", "j_two"} <= set(payload["beacons"].keys())
+
+
+def test_cli_json_marks_missing_component(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "exists").heartbeat()
+    rc, stdout, _ = _run_cli(
+        tmp_path, "--json", "--components", "exists,nonexistent"
+    )
+    assert rc == 1
+    payload = json.loads(stdout)
+    assert payload["beacons"]["nonexistent"]["health"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Case K — --components filter
+# ---------------------------------------------------------------------------
+
+def test_cli_components_filter(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "keep_me").heartbeat()
+    HealthBeacon(tmp_path, "ignore_me").heartbeat()
+    rc, stdout, _ = _run_cli(tmp_path, "--json", "--components", "keep_me")
+    assert rc == 0
+    payload = json.loads(stdout)
+    assert "keep_me" in payload["beacons"]
+    assert "ignore_me" not in payload["beacons"]
+
+
+# ---------------------------------------------------------------------------
+# beacon_summary roll-up
+# ---------------------------------------------------------------------------
+
+def test_beacon_summary_rolls_up_overall_state(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "good").heartbeat()
+    HealthBeacon(tmp_path, "broken").heartbeat(status="fail")
+
+    summary = beacon_summary(tmp_path)
+    assert summary["overall"] == "fail"
+    assert summary["counts"]["fail"] == 1
+    assert summary["counts"]["ok"] == 1
+
+
+def test_event_driven_beacon_never_stale(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    health_dir.mkdir(parents=True)
+    payload = {
+        "component": "evented",
+        "last_run_ts": int(time.time() - 1_000_000),
+        "last_run_iso": "2020-01-01T00:00:00Z",
+        "status": "ok",
+        "details": {},
+        "expected_interval_seconds": None,
+    }
+    (health_dir / "evented.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = all_beacons(tmp_path)
+    assert result["evented"]["health"] == "ok"


### PR DESCRIPTION
## Summary
Adds a per-component health-beacon framework so the dashboard / CI can
detect dormant subsystems before they become incidents (e.g. the broken
learning loop and 20-day-stale conversation analyzer flagged in the
2026-04-30 audit).

- New `scripts/lib/health_beacon.py`: atomic JSON heartbeat with `fcntl`
  locking and tmp + `os.replace` writeout. Reader classifies each
  beacon as `ok` / `stale` / `fail` / `corrupt`.
- New `scripts/health_check.py` CLI: table + `--json` + `--components`
  filter, exit codes 0 / 1 / 2.
- 5 critical components wired:
  - `learning_loop.py` (interval 86400)
  - `conversation_analyzer.py` (interval 86400)
  - `build_t0_state.py` (interval 1800)
  - `intelligence_daemon.py` (interval 300, also `fail` on cycle error)
  - `lib/cleanup_worker_exit.py` (event-driven, `expected_interval=None`)
- Dashboard endpoint `GET /api/operator/health` via new
  `dashboard/api_health.py`, mounted in `serve_dashboard.py`.

References:
- `claudedocs/2026-04-30-vnx-ci-test-plan.md` — audit recommends
  liveness/recency assertions.

## Test plan
- [x] `python3 -m py_compile` for all new + modified files
- [x] `python3 -m pytest tests/test_health_beacon.py tests/smoke/smoke_health_beacons_fresh.py -xvs` → 17 passed, 1 skip (smoke harness gated on `VNX_RUN_SMOKE_HEALTH=1`)
- [x] Existing `tests/test_cleanup_worker_exit.py` still passes (10/10)
- [ ] Follow-up: dashboard widget consuming `/api/operator/health` (intentionally out of scope per dispatch)
- [ ] Follow-up: launchd plist for periodic `health_check.py` invocation (intentionally out of scope per dispatch)

Dispatch-ID: 20260430-pr-t1-health-beacons

🤖 Generated with [Claude Code](https://claude.com/claude-code)