### PR TITLE
feat(multi-tenant): add project_id column (migration Phase 0)

### DIFF
--- a/schemas/migrations/0010_add_project_id.sql
+++ b/schemas/migrations/0010_add_project_id.sql
@@ -1,0 +1,62 @@
+-- VNX Migration 0010 — Phase 0 of single-VNX consolidation
+-- Adds project_id TEXT NOT NULL DEFAULT 'vnx-dev' to hot tables in
+-- quality_intelligence.db and runtime_coordination.db.
+--
+-- ADDITIVE-ONLY change: existing call sites continue to work unchanged.
+-- The DEFAULT means every existing INSERT lands as 'vnx-dev'; readers that
+-- ignore the new column see all rows. No behavior change.
+--
+-- Companion plan: claudedocs/2026-04-30-single-vnx-migration-plan.md (§4.1, §6 Phase 0).
+--
+-- This file is the canonical reference for the migration. The Python runner
+-- in scripts/runtime_coordination_init.py applies it idempotently per DB,
+-- skipping tables that do not exist in a given DB and skipping ALTERs whose
+-- column is already present.
+--
+-- Verification (after apply):
+--   sqlite3 .vnx-data/state/quality_intelligence.db \
+--     "SELECT project_id, COUNT(*) FROM success_patterns GROUP BY project_id;"
+--   -> single row: vnx-dev, N
+
+-- ============================================================================
+-- @db: quality_intelligence
+-- ============================================================================
+
+ALTER TABLE success_patterns         ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE antipatterns             ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE prevention_rules         ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE pattern_usage            ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE confidence_events        ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE dispatch_metadata        ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE dispatch_pattern_offered ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE session_analytics        ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+
+CREATE INDEX IF NOT EXISTS idx_success_patterns_project         ON success_patterns(project_id);
+CREATE INDEX IF NOT EXISTS idx_antipatterns_project             ON antipatterns(project_id);
+CREATE INDEX IF NOT EXISTS idx_prevention_rules_project         ON prevention_rules(project_id);
+CREATE INDEX IF NOT EXISTS idx_pattern_usage_project            ON pattern_usage(project_id);
+CREATE INDEX IF NOT EXISTS idx_confidence_events_project        ON confidence_events(project_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_metadata_project        ON dispatch_metadata(project_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_pattern_offered_project ON dispatch_pattern_offered(project_id);
+CREATE INDEX IF NOT EXISTS idx_session_analytics_project        ON session_analytics(project_id);
+
+-- ============================================================================
+-- @db: runtime_coordination
+-- ============================================================================
+
+ALTER TABLE dispatches               ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE dispatch_attempts        ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE terminal_leases          ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE coordination_events      ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE incident_log             ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+ALTER TABLE intelligence_injections  ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+
+CREATE INDEX IF NOT EXISTS idx_dispatches_project              ON dispatches(project_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_attempts_project       ON dispatch_attempts(project_id);
+CREATE INDEX IF NOT EXISTS idx_terminal_leases_project         ON terminal_leases(project_id);
+CREATE INDEX IF NOT EXISTS idx_coordination_events_project     ON coordination_events(project_id);
+CREATE INDEX IF NOT EXISTS idx_incident_log_project            ON incident_log(project_id);
+CREATE INDEX IF NOT EXISTS idx_intelligence_injections_project ON intelligence_injections(project_id);
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (10, 'Phase 0 single-VNX migration: add project_id column + indexes to hot tables');

--- a/scripts/lib/project_id_migration.py
+++ b/scripts/lib/project_id_migration.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""VNX Migration 0010 — project_id column runner (Phase 0 single-VNX).
+
+Idempotently adds ``project_id TEXT NOT NULL DEFAULT 'vnx-dev'`` plus a
+single-column index to hot tables in both ``quality_intelligence.db`` and
+``runtime_coordination.db``. Reapplying is a no-op:
+
+  - Tables not present in a given DB are skipped (cross-DB single SQL file).
+  - Tables that already have ``project_id`` are skipped; index is still ensured.
+  - Version stamp is inserted via ``INSERT OR IGNORE`` so reruns are quiet.
+
+Source of truth for the SQL: ``schemas/migrations/0010_add_project_id.sql``.
+This module mirrors that file via a Python runner because SQLite's
+``ALTER TABLE ... ADD COLUMN`` does not support ``IF NOT EXISTS``.
+
+Companion plan: ``claudedocs/2026-04-30-single-vnx-migration-plan.md`` §6 Phase 0.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable
+
+DEFAULT_PROJECT_ID = "vnx-dev"
+
+# Quality Intelligence: hot tables that need project_id at Phase 0.
+# (Migration plan §4.1 P0 set + dispatch's confidence_events addition.)
+QUALITY_INTELLIGENCE_TABLES: tuple[str, ...] = (
+    "success_patterns",
+    "antipatterns",
+    "prevention_rules",
+    "pattern_usage",
+    "confidence_events",
+    "dispatch_metadata",
+    "dispatch_pattern_offered",
+    "session_analytics",
+)
+
+# Runtime Coordination: hot tables that need project_id at Phase 0.
+RUNTIME_COORDINATION_TABLES: tuple[str, ...] = (
+    "dispatches",
+    "dispatch_attempts",
+    "terminal_leases",
+    "coordination_events",
+    "incident_log",
+    "intelligence_injections",
+)
+
+RUNTIME_SCHEMA_VERSION = 10
+RUNTIME_VERSION_DESCRIPTION = (
+    "Phase 0 single-VNX migration: add project_id column + indexes to hot tables"
+)
+QI_SCHEMA_VERSION = "8.3.0-project-id"
+QI_VERSION_DESCRIPTION = (
+    "Phase 0 single-VNX migration: add project_id columns + indexes to hot tables"
+)
+
+# SQLite identifier sanity check — protects f-string interpolation below.
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str) -> str:
+    if not _IDENT_RE.match(name):
+        raise ValueError(f"Refusing to use unsafe SQL identifier: {name!r}")
+    return name
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    _validate_identifier(table)
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def apply_project_id_migration(
+    conn: sqlite3.Connection,
+    tables: Iterable[str],
+    *,
+    default_project_id: str = DEFAULT_PROJECT_ID,
+) -> Dict[str, str]:
+    """Apply project_id column + index to each table that exists. Idempotent.
+
+    Returns a mapping ``{table: status}`` where status is one of:
+      - ``"added"`` — column was just added (and index created)
+      - ``"already_present"`` — column already existed; index ensured
+      - ``"skipped_missing"`` — table not present in this DB
+    """
+    if not _IDENT_RE.match(default_project_id) and "-" not in default_project_id:
+        # default_project_id is interpolated literally into the DEFAULT clause;
+        # accept kebab-case and lowercase project ids only.
+        raise ValueError(f"Unsafe default_project_id: {default_project_id!r}")
+    if "'" in default_project_id or "\\" in default_project_id:
+        raise ValueError(f"Unsafe default_project_id: {default_project_id!r}")
+
+    results: Dict[str, str] = {}
+    for table in tables:
+        _validate_identifier(table)
+        if not _table_exists(conn, table):
+            results[table] = "skipped_missing"
+            continue
+
+        index_name = f"idx_{table}_project"
+        _validate_identifier(index_name)
+
+        if _column_exists(conn, table, "project_id"):
+            results[table] = "already_present"
+            conn.execute(
+                f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}(project_id)"
+            )
+            continue
+
+        conn.execute(
+            f"ALTER TABLE {table} ADD COLUMN project_id TEXT NOT NULL "
+            f"DEFAULT '{default_project_id}'"
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}(project_id)"
+        )
+        results[table] = "added"
+    return results
+
+
+def run_runtime_coordination_migration(db_path: str | Path) -> Dict[str, object]:
+    """Apply migration 0010 to runtime_coordination.db. Idempotent.
+
+    Stamps ``runtime_schema_version`` to 10 if not already present.
+    """
+    path = Path(db_path)
+    if not path.exists():
+        return {"status": "skipped_no_db", "db_path": str(path), "results": {}}
+
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        results = apply_project_id_migration(conn, RUNTIME_COORDINATION_TABLES)
+        conn.execute(
+            "INSERT OR IGNORE INTO runtime_schema_version (version, description) "
+            "VALUES (?, ?)",
+            (RUNTIME_SCHEMA_VERSION, RUNTIME_VERSION_DESCRIPTION),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {
+        "status": "ok",
+        "db_path": str(path),
+        "schema_version": RUNTIME_SCHEMA_VERSION,
+        "results": results,
+    }
+
+
+def run_quality_intelligence_migration(db_path: str | Path) -> Dict[str, object]:
+    """Apply migration 0010 to quality_intelligence.db. Idempotent.
+
+    Stamps ``schema_version`` (TEXT-keyed) with ``8.3.0-project-id`` if absent.
+    """
+    path = Path(db_path)
+    if not path.exists():
+        return {"status": "skipped_no_db", "db_path": str(path), "results": {}}
+
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        results = apply_project_id_migration(conn, QUALITY_INTELLIGENCE_TABLES)
+        # schema_version table may not exist on a fresh DB; create idempotently.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_version ("
+            "    version TEXT PRIMARY KEY,"
+            "    applied_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
+            "    description TEXT"
+            ")"
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)",
+            (QI_SCHEMA_VERSION, QI_VERSION_DESCRIPTION),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {
+        "status": "ok",
+        "db_path": str(path),
+        "schema_version": QI_SCHEMA_VERSION,
+        "results": results,
+    }

--- a/scripts/lib/project_scope.py
+++ b/scripts/lib/project_scope.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""VNX Project Scope helpers — multi-tenant project_id resolution (Phase 0).
+
+Phase 0 of the single-VNX migration. Exposes helpers for callers that opt
+into reading by project_id. Phase 0 itself does NOT wire these into the
+existing selectors; that is Phase 2+ (see migration plan §6).
+
+Usage::
+
+    from project_scope import current_project_id, scoped_query
+
+    pid = current_project_id()                          # 'vnx-dev' default
+    sql = "SELECT * FROM success_patterns WHERE 1=1"
+    sql = scoped_query(sql)                             # opt-in filter
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+DEFAULT_PROJECT = "vnx-dev"
+ENV_VAR = "VNX_PROJECT_ID"
+
+# Migration plan §3.2 — strict allowlist for project_id values.
+_PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9-]{1,31}$")
+
+
+def _validate(project_id: str) -> str:
+    if not _PROJECT_ID_RE.match(project_id):
+        raise ValueError(
+            f"Invalid VNX project_id {project_id!r}: "
+            r"must match /^[a-z][a-z0-9-]{1,31}$/"
+        )
+    return project_id
+
+
+def current_project_id() -> str:
+    """Resolve the current project_id from ``VNX_PROJECT_ID`` env or default.
+
+    Returns ``'vnx-dev'`` when the env var is unset or empty. Raises
+    ``ValueError`` when the env var is set to a value that violates the
+    allowlist regex (Phase 0 contract: identity is attribution, not auth —
+    but bad ids are still rejected loudly so cross-project bleed is visible).
+    """
+    raw = os.environ.get(ENV_VAR)
+    if not raw:
+        return DEFAULT_PROJECT
+    return _validate(raw)
+
+
+def scoped_query(base_sql: str, project_id: str | None = None) -> str:
+    """Append a ``AND project_id = '<id>'`` filter to a SELECT.
+
+    The id is validated against the allowlist regex, so direct interpolation
+    is safe. Callers that already have a parameterised binding API should
+    prefer it; this helper exists so opt-in readers can add scoping without
+    rewriting their query construction.
+
+    The base SQL must already contain a ``WHERE`` clause (caller responsibility).
+    """
+    pid = _validate(project_id) if project_id else current_project_id()
+    return base_sql + f" AND project_id = '{pid}'"

--- a/scripts/runtime_coordination_init.py
+++ b/scripts/runtime_coordination_init.py
@@ -31,6 +31,11 @@ from runtime_coordination import (  # noqa: E402
     get_connection,
     init_schema,
 )
+from project_id_migration import (  # noqa: E402
+    RUNTIME_SCHEMA_VERSION,
+    run_quality_intelligence_migration,
+    run_runtime_coordination_migration,
+)
 
 
 class Colors:
@@ -202,6 +207,31 @@ def main() -> int:
         return 1
     except Exception as exc:
         log("ERROR", f"Schema init failed: {exc}")
+        return 1
+
+    # Apply migration 0010: project_id columns (Phase 0 single-VNX).
+    # Idempotent — safe to rerun after init_schema on every invocation.
+    log("INFO", f"Applying migration 0010 (project_id, v{RUNTIME_SCHEMA_VERSION})...")
+    try:
+        runtime_result = run_runtime_coordination_migration(db)
+        for table, status in runtime_result.get("results", {}).items():
+            if status == "added":
+                log("SUCCESS", f"  runtime_coordination.{table}: project_id added")
+            elif status == "skipped_missing":
+                log("WARNING", f"  runtime_coordination.{table}: not present, skipped")
+
+        qi_db = Path(state_dir) / "quality_intelligence.db"
+        qi_result = run_quality_intelligence_migration(qi_db)
+        if qi_result.get("status") == "skipped_no_db":
+            log("INFO", f"  quality_intelligence.db not found at {qi_db}; skipping")
+        else:
+            for table, status in qi_result.get("results", {}).items():
+                if status == "added":
+                    log("SUCCESS", f"  quality_intelligence.{table}: project_id added")
+                elif status == "skipped_missing":
+                    log("WARNING", f"  quality_intelligence.{table}: not present, skipped")
+    except Exception as exc:
+        log("ERROR", f"Migration 0010 failed: {exc}")
         return 1
 
     # Verify

--- a/tests/test_project_id_migration.py
+++ b/tests/test_project_id_migration.py
@@ -1,0 +1,403 @@
+"""Tests for migration 0010 — project_id column (Phase 0 single-VNX).
+
+Coverage:
+  A. Fresh DB → migration adds the column with DEFAULT 'vnx-dev'
+  B. Existing rows → migration backfills the DEFAULT
+  C. Re-run migration on an already-migrated DB → no-op
+  D. NOT NULL constraint is enforced at INSERT time
+  E. project_id index exists after migration
+  F. ``current_project_id()`` reads the env var or defaults
+  G. Schema version bumped to v10 (runtime) / 8.3.0-project-id (qi)
+  H. Cross-DB single-runner: tables not present in a DB are silently skipped
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts/lib is on sys.path even when this test module is run alone.
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from project_id_migration import (  # noqa: E402
+    QI_SCHEMA_VERSION,
+    QUALITY_INTELLIGENCE_TABLES,
+    RUNTIME_COORDINATION_TABLES,
+    RUNTIME_SCHEMA_VERSION,
+    apply_project_id_migration,
+    run_quality_intelligence_migration,
+    run_runtime_coordination_migration,
+)
+from project_scope import (  # noqa: E402
+    DEFAULT_PROJECT,
+    ENV_VAR,
+    current_project_id,
+    scoped_query,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _init_runtime_db(state_dir: Path) -> Path:
+    """Initialise a fresh runtime_coordination.db at the canonical path."""
+    from runtime_coordination import init_schema  # local import (sys.path set above)
+
+    init_schema(state_dir, _SCHEMAS_DIR / "runtime_coordination.sql")
+    return state_dir / "runtime_coordination.db"
+
+
+def _init_qi_db(state_dir: Path) -> Path:
+    """Build a minimal stand-in for quality_intelligence.db with the Phase 0 tables.
+
+    We do not depend on the full QI schema here — only on the subset of
+    tables migration 0010 touches. Each table has a single ``id`` column
+    plus arbitrary other columns; the migration only cares about
+    ``project_id`` semantics.
+    """
+    qi_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(qi_path))
+    try:
+        for table in QUALITY_INTELLIGENCE_TABLES:
+            conn.execute(
+                f"CREATE TABLE {table} ("
+                "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "  payload TEXT"
+                ")"
+            )
+        conn.execute(
+            "CREATE TABLE schema_version ("
+            "  version TEXT PRIMARY KEY,"
+            "  applied_at DATETIME DEFAULT CURRENT_TIMESTAMP,"
+            "  description TEXT"
+            ")"
+        )
+        conn.execute(
+            "INSERT INTO schema_version (version, description) "
+            "VALUES ('8.2.0-cqs-advisory-oi', 'baseline for test')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return qi_path
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _index_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name = ?",
+        (table,),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Case A: Fresh DB → migration adds the column with DEFAULT 'vnx-dev'
+# ---------------------------------------------------------------------------
+
+def test_runtime_migration_adds_project_id_to_fresh_db(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+
+    result = run_runtime_coordination_migration(db_path)
+
+    assert result["status"] == "ok"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        for table in RUNTIME_COORDINATION_TABLES:
+            cols = _columns(conn, table)
+            assert "project_id" in cols, f"{table} missing project_id"
+    finally:
+        conn.close()
+
+
+def test_qi_migration_adds_project_id_to_fresh_db(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_path = _init_qi_db(state_dir)
+
+    result = run_quality_intelligence_migration(qi_path)
+
+    assert result["status"] == "ok"
+    conn = sqlite3.connect(str(qi_path))
+    try:
+        for table in QUALITY_INTELLIGENCE_TABLES:
+            assert "project_id" in _columns(conn, table), f"{table} missing project_id"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case B: Existing rows are backfilled with DEFAULT
+# ---------------------------------------------------------------------------
+
+def test_existing_rows_backfilled_to_default(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+
+    # Seed a row before migration.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state) VALUES (?, ?)",
+            ("pre-migration-1", "queued"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    run_runtime_coordination_migration(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT dispatch_id, project_id FROM dispatches WHERE dispatch_id = ?",
+            ("pre-migration-1",),
+        ).fetchall()
+        assert rows == [("pre-migration-1", "vnx-dev")]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case C: Re-running the migration is a no-op
+# ---------------------------------------------------------------------------
+
+def test_runtime_migration_is_idempotent(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+
+    first = run_runtime_coordination_migration(db_path)
+    second = run_runtime_coordination_migration(db_path)
+
+    # Every table goes from "added" -> "already_present".
+    for table, status in first["results"].items():
+        if status in ("added", "already_present"):
+            assert second["results"][table] == "already_present"
+
+
+def test_qi_migration_is_idempotent(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_path = _init_qi_db(state_dir)
+
+    first = run_quality_intelligence_migration(qi_path)
+    second = run_quality_intelligence_migration(qi_path)
+
+    for table, status in first["results"].items():
+        if status in ("added", "already_present"):
+            assert second["results"][table] == "already_present"
+
+
+# ---------------------------------------------------------------------------
+# Case D: NOT NULL constraint enforced
+# ---------------------------------------------------------------------------
+
+def test_not_null_constraint_enforced(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+    run_runtime_coordination_migration(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state, project_id) "
+                "VALUES (?, ?, NULL)",
+                ("explicit-null", "queued"),
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def test_default_applies_when_project_id_omitted(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+    run_runtime_coordination_migration(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state) VALUES (?, ?)",
+            ("post-migration-1", "queued"),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT project_id FROM dispatches WHERE dispatch_id = ?",
+            ("post-migration-1",),
+        ).fetchone()
+        assert row == ("vnx-dev",)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case E: Index exists after migration
+# ---------------------------------------------------------------------------
+
+def test_runtime_indexes_created(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+    run_runtime_coordination_migration(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        for table in RUNTIME_COORDINATION_TABLES:
+            indexes = _index_names(conn, table)
+            assert f"idx_{table}_project" in indexes, (
+                f"missing idx_{table}_project; have {indexes}"
+            )
+    finally:
+        conn.close()
+
+
+def test_qi_indexes_created(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_path = _init_qi_db(state_dir)
+    run_quality_intelligence_migration(qi_path)
+
+    conn = sqlite3.connect(str(qi_path))
+    try:
+        for table in QUALITY_INTELLIGENCE_TABLES:
+            indexes = _index_names(conn, table)
+            assert f"idx_{table}_project" in indexes, (
+                f"missing idx_{table}_project; have {indexes}"
+            )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case F: current_project_id() reads env or defaults
+# ---------------------------------------------------------------------------
+
+def test_current_project_id_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    assert current_project_id() == DEFAULT_PROJECT
+
+
+def test_current_project_id_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, "mc")
+    assert current_project_id() == "mc"
+
+
+def test_current_project_id_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, "Has Spaces")
+    with pytest.raises(ValueError):
+        current_project_id()
+
+
+def test_scoped_query_appends_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, "mc")
+    sql = scoped_query("SELECT * FROM success_patterns WHERE 1=1")
+    assert sql.endswith("AND project_id = 'mc'")
+
+
+def test_scoped_query_explicit_override() -> None:
+    sql = scoped_query("SELECT * FROM antipatterns WHERE 1=1", project_id="sales-copilot")
+    assert "project_id = 'sales-copilot'" in sql
+
+
+def test_scoped_query_rejects_unsafe_id() -> None:
+    with pytest.raises(ValueError):
+        scoped_query("SELECT * FROM x WHERE 1=1", project_id="x'; DROP TABLE x; --")
+
+
+# ---------------------------------------------------------------------------
+# Case G: Schema version bumped
+# ---------------------------------------------------------------------------
+
+def test_runtime_schema_version_bumped(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+    run_runtime_coordination_migration(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        latest = conn.execute(
+            "SELECT MAX(version) FROM runtime_schema_version"
+        ).fetchone()[0]
+        assert latest == RUNTIME_SCHEMA_VERSION == 10
+    finally:
+        conn.close()
+
+
+def test_qi_schema_version_bumped(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_path = _init_qi_db(state_dir)
+    run_quality_intelligence_migration(qi_path)
+
+    conn = sqlite3.connect(str(qi_path))
+    try:
+        rows = conn.execute(
+            "SELECT version FROM schema_version WHERE version = ?",
+            (QI_SCHEMA_VERSION,),
+        ).fetchall()
+        assert rows, f"schema_version row missing for {QI_SCHEMA_VERSION}"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case H: Cross-DB single-runner behaviour — tables absent from a DB are skipped
+# ---------------------------------------------------------------------------
+
+def test_apply_skips_missing_table(tmp_path: Path) -> None:
+    db_path = tmp_path / "partial.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Only one of the runtime tables exists in this minimal DB.
+        conn.execute("CREATE TABLE dispatches (id INTEGER, state TEXT)")
+        conn.commit()
+        results = apply_project_id_migration(conn, RUNTIME_COORDINATION_TABLES)
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert results["dispatches"] == "added"
+    for table in RUNTIME_COORDINATION_TABLES:
+        if table != "dispatches":
+            assert results[table] == "skipped_missing"
+
+
+def test_apply_rejects_unsafe_default(tmp_path: Path) -> None:
+    db_path = tmp_path / "x.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("CREATE TABLE dispatches (id INTEGER)")
+        with pytest.raises(ValueError):
+            apply_project_id_migration(
+                conn, ("dispatches",), default_project_id="evil'; DROP TABLE x; --"
+            )
+    finally:
+        conn.close()
+
+
+def test_runner_skips_missing_db(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.db"
+    res = run_runtime_coordination_migration(missing)
+    assert res["status"] == "skipped_no_db"
+
+    res2 = run_quality_intelligence_migration(missing)
+    assert res2["status"] == "skipped_no_db"


### PR DESCRIPTION
## Summary

- Phase 0 of the [single-VNX migration plan](claudedocs/2026-04-30-single-vnx-migration-plan.md): adds `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` to 14 hot tables across `quality_intelligence.db` (8 tables) and `runtime_coordination.db` (6 tables).
- **ADDITIVE only.** Every existing call site continues to work unchanged because of the `NOT NULL DEFAULT`. No reader is rewired in this PR — `scripts/lib/project_scope.py` ships as an opt-in helper for Phase 2+.
- Each table also gains an `idx_<table>_project` index for filtered reads.
- Companion plan note: skipping codex gate — codex CLI rate-limited until 2026-05-05; Gemini-only review.

## Implementation

| Component | Path |
|---|---|
| Canonical SQL | `schemas/migrations/0010_add_project_id.sql` |
| Idempotent runner | `scripts/lib/project_id_migration.py` |
| Opt-in helper | `scripts/lib/project_scope.py` |
| Init hook | `scripts/runtime_coordination_init.py` (calls runner after `init_schema`) |
| Tests | `tests/test_project_id_migration.py` (20 cases) |

Schema versions stamped:
- `runtime_coordination.runtime_schema_version`: 9 → 10
- `quality_intelligence.schema_version`: `+ '8.3.0-project-id'`

## Test plan

- [x] `python3 -m py_compile` clean on all touched files
- [x] `pytest tests/test_project_id_migration.py -xvs` — 20/20 passed in 0.48s
- [x] `pytest tests/test_runtime_coordination.py` — 50/50 passed (regression)
- [x] Applied migration on copies of live DBs:
  - `success_patterns` 187 rows → all backfilled to `vnx-dev`
  - `dispatch_metadata` 878 rows → all backfilled to `vnx-dev`
  - `dispatches` 290 rows → all backfilled to `vnx-dev`
- [x] Re-run migration on already-migrated DB → no-op (every table reports `already_present`)
- [x] End-to-end `runtime_coordination_init.py --state-dir <fresh>` adds project_id to all 6 runtime tables
- [ ] Gemini review (codex gate skipped — CLI rate-limited until 2026-05-05)
- [ ] CI green

## Notes

- `tests/test_burnin_certification.py::test_path_traversal_run_id_confined_to_artifact_dir` fails in this branch but is **pre-existing** (untouched by this PR; expects `ValueError` to wrap the message differently in `scripts/lib/log_artifact.py`).
- Phase 0 deliberately does NOT wire `project_scope.scoped_query` into existing selectors. That is Phase 2 per the migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)