### PR TITLE
fix(intelligence): fcntl-lock worker_health.json RMW (CFX-4)

### DIFF
--- a/scripts/lib/file_locking.py
+++ b/scripts/lib/file_locking.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""file_locking.py — fcntl-protected JSON read-modify-write helper.
+
+Provides ``file_locked_rmw``: a contextmanager that holds an exclusive
+``fcntl.flock`` on a JSON file while the caller mutates the parsed dict,
+then atomically writes the result back. Used by components that perform
+read-modify-write on shared JSON state (e.g. ``events/worker_health.json``)
+where multiple workers may write concurrently.
+
+BILLING SAFETY: No Anthropic SDK. No api.anthropic.com calls.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def file_locked_rmw(path: Path) -> Iterator[Dict[str, Any]]:
+    """Read-modify-write a JSON dict file under fcntl.LOCK_EX.
+
+    Behaviour:
+      - Creates the parent directory if missing.
+      - Opens the file in r+ mode (creating an empty file if needed).
+      - Holds ``fcntl.LOCK_EX`` for the lifetime of the with-block.
+      - Yields the parsed dict; if the file is empty or invalid JSON,
+        yields an empty dict.
+      - After the block, truncates and writes the (possibly mutated) dict
+        back as indented JSON, then ``flush() + os.fsync()`` for durability.
+      - Releases the lock and closes the handle even if the block raises;
+        on exception, the file is left untouched.
+
+    The caller mutates the yielded dict in place. Reassignment inside the
+    block has no effect on what is persisted; mutate keys instead.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    # Ensure file exists so r+ doesn't fail; create empty if needed.
+    if not p.exists():
+        # Open with a+ to create, then close — subsequent r+ open handles RMW.
+        with p.open("a"):
+            pass
+
+    fd = p.open("r+", encoding="utf-8")
+    fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+    success = False
+    try:
+        fd.seek(0)
+        content = fd.read().strip()
+        if content:
+            try:
+                data = json.loads(content)
+                if not isinstance(data, dict):
+                    logger.debug(
+                        "file_locked_rmw: %s did not contain a JSON object; "
+                        "resetting to {}",
+                        p,
+                    )
+                    data = {}
+            except json.JSONDecodeError:
+                logger.debug(
+                    "file_locked_rmw: %s contained invalid JSON; resetting to {}",
+                    p,
+                )
+                data = {}
+        else:
+            data = {}
+
+        yield data
+
+        serialized = json.dumps(data, indent=2)
+        fd.seek(0)
+        fd.truncate()
+        fd.write(serialized)
+        fd.flush()
+        try:
+            os.fsync(fd.fileno())
+        except OSError:
+            # fsync may fail on some filesystems; correctness is preserved
+            # by flush + flock semantics. Don't propagate.
+            pass
+        success = True
+    finally:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            fd.close()
+        if not success:
+            logger.debug("file_locked_rmw: aborted RMW on %s due to exception", p)

--- a/scripts/lib/worker_health_monitor.py
+++ b/scripts/lib/worker_health_monitor.py
@@ -20,6 +20,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+try:
+    from .file_locking import file_locked_rmw
+except ImportError:  # pragma: no cover — direct-import fallback for sys.path callers
+    from file_locking import file_locked_rmw  # type: ignore[no-redef]
+
 logger = logging.getLogger(__name__)
 
 # Thresholds in seconds
@@ -200,23 +205,17 @@ class WorkerHealthMonitor:
             self._write_health_json()
 
     def _write_health_json(self) -> None:
-        """Write current status to events/worker_health.json (merge with others)."""
+        """Write current status to events/worker_health.json (merge with others).
+
+        Uses fcntl.LOCK_EX via ``file_locked_rmw`` to make the read-modify-write
+        atomic across concurrent workers; without locking, racing writers can
+        clobber each other's terminal_id keys or leave the file half-written.
+        """
         try:
             health_path = self._events_dir / "worker_health.json"
-            self._events_dir.mkdir(parents=True, exist_ok=True)
-
-            # Load existing data (other terminals may be writing)
-            existing: Dict[str, Any] = {}
-            if health_path.exists():
-                try:
-                    existing = json.loads(health_path.read_text())
-                except (json.JSONDecodeError, OSError):
-                    existing = {}
-
             h = self.health_status()
-            existing[self.terminal_id] = h.to_dict()
-
-            health_path.write_text(json.dumps(existing, indent=2))
+            with file_locked_rmw(health_path) as data:
+                data[self.terminal_id] = h.to_dict()
         except Exception as exc:
             logger.debug("worker_health_monitor: failed to write health json: %s", exc)
 

--- a/tests/test_worker_health_fcntl.py
+++ b/tests/test_worker_health_fcntl.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""CFX-4: fcntl-locked RMW for events/worker_health.json.
+
+Covers ``scripts/lib/file_locking.py:file_locked_rmw`` directly:
+  - Case A: single-writer correctness (no race)
+  - Case B: concurrent writers — 5 threads each updating different keys land all updates
+  - Case C: lock released on exception (subsequent writer can proceed)
+  - Case D: idempotent — re-running on the same file produces the same result
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from file_locking import file_locked_rmw  # noqa: E402
+
+
+class TestSingleWriter(unittest.TestCase):
+    """Case A: single-writer RMW round-trips correctly."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name) / "worker_health.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_creates_file_on_first_write(self) -> None:
+        self.assertFalse(self.path.exists())
+        with file_locked_rmw(self.path) as data:
+            data["T1"] = {"status": "active", "events": 1}
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, {"T1": {"status": "active", "events": 1}})
+
+    def test_round_trip_preserves_existing_keys(self) -> None:
+        self.path.write_text(json.dumps({"T1": {"status": "active"}}))
+        with file_locked_rmw(self.path) as data:
+            data["T2"] = {"status": "slow"}
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(
+            loaded, {"T1": {"status": "active"}, "T2": {"status": "slow"}}
+        )
+
+    def test_empty_or_corrupt_file_yields_empty_dict(self) -> None:
+        self.path.write_text("not-json{{")
+        with file_locked_rmw(self.path) as data:
+            self.assertEqual(data, {})
+            data["T1"] = {"status": "active"}
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, {"T1": {"status": "active"}})
+
+
+class TestConcurrentWriters(unittest.TestCase):
+    """Case B: 5 threads each updating different keys → all updates land."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name) / "worker_health.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_five_threads_distinct_keys_all_persisted(self) -> None:
+        barrier = threading.Barrier(5)
+        errors: list[BaseException] = []
+
+        def writer(idx: int) -> None:
+            try:
+                barrier.wait(timeout=5)
+                # Each thread does N RMW cycles to amplify race likelihood.
+                for i in range(20):
+                    with file_locked_rmw(self.path) as data:
+                        data[f"T{idx}"] = {"events": i + 1, "status": "active"}
+            except BaseException as exc:  # pragma: no cover — recorded for assertion
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=(i,), daemon=True) for i in range(5)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(errors, [])
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(set(loaded.keys()), {f"T{i}" for i in range(5)})
+        for i in range(5):
+            self.assertEqual(loaded[f"T{i}"], {"events": 20, "status": "active"})
+
+    def test_concurrent_increment_no_lost_updates(self) -> None:
+        # Many threads incrementing the same counter under lock — without
+        # locking, classic lost-update race; with LOCK_EX, count must equal
+        # total number of RMW operations.
+        thread_count = 8
+        per_thread = 25
+        barrier = threading.Barrier(thread_count)
+        errors: list[BaseException] = []
+
+        def incrementer() -> None:
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(per_thread):
+                    with file_locked_rmw(self.path) as data:
+                        data["counter"] = int(data.get("counter", 0)) + 1
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=incrementer, daemon=True)
+            for _ in range(thread_count)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        self.assertEqual(errors, [])
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded["counter"], thread_count * per_thread)
+
+
+class TestLockReleasedOnException(unittest.TestCase):
+    """Case C: lock released on exception so subsequent writers can proceed."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name) / "worker_health.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_exception_in_block_does_not_corrupt_file(self) -> None:
+        self.path.write_text(json.dumps({"T1": {"status": "active"}}))
+
+        class Boom(RuntimeError):
+            pass
+
+        with self.assertRaises(Boom):
+            with file_locked_rmw(self.path) as data:
+                data["T2"] = {"status": "slow"}
+                raise Boom()
+
+        # File untouched on exception — still equals pre-exception state.
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, {"T1": {"status": "active"}})
+
+    def test_subsequent_writer_can_acquire_lock_after_exception(self) -> None:
+        try:
+            with file_locked_rmw(self.path):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        # If the lock was leaked, this acquire would block forever; the test
+        # harness will time out. Successful acquisition proves release.
+        with file_locked_rmw(self.path) as data:
+            data["T1"] = {"status": "active"}
+
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, {"T1": {"status": "active"}})
+
+
+class TestIdempotent(unittest.TestCase):
+    """Case D: re-running the same RMW on the same file produces the same result."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name) / "worker_health.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_repeated_identical_rmw_is_stable(self) -> None:
+        payload = {"status": "active", "events": 5, "elapsed": "0m05s"}
+        for _ in range(4):
+            with file_locked_rmw(self.path) as data:
+                data["T1"] = dict(payload)
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, {"T1": payload})
+
+    def test_no_op_block_preserves_content(self) -> None:
+        seed = {"T1": {"status": "active"}, "T2": {"status": "slow"}}
+        self.path.write_text(json.dumps(seed, indent=2))
+        with file_locked_rmw(self.path):
+            pass  # no mutation
+        loaded = json.loads(self.path.read_text())
+        self.assertEqual(loaded, seed)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Wraps `events/worker_health.json` read-modify-write in `fcntl.LOCK_EX` via a new `scripts/lib/file_locking.py` helper. Without locking, concurrent `WorkerHealthMonitor` writers (one per terminal) can clobber each other's `terminal_id` keys or leave a half-written JSON file under load.

Addresses `claudedocs/2026-04-29-codex-findings-synthesis.md` **OI-CFX-4**.

## Changes

- `scripts/lib/file_locking.py` (new) — `file_locked_rmw(path)` contextmanager: `LOCK_EX`, JSON-corruption-safe parse, truncate+rewrite, `flush()` + `fsync()`, guaranteed unlock + close on exception.
- `scripts/lib/worker_health_monitor.py` — `_write_health_json` now uses `file_locked_rmw` instead of unprotected read/write_text.
- `tests/test_worker_health_fcntl.py` (new) — 9 tests across 4 cases:
  - **A** single-writer round-trip (creates, preserves, recovers from corrupt JSON)
  - **B** concurrent writers — 5 threads × 20 RMW cycles writing distinct keys, plus an 8×25 lost-update counter race
  - **C** lock released on exception — file untouched on raise; subsequent writer can acquire lock
  - **D** idempotent — repeated identical RMW is stable; no-op block preserves content

## Test plan

- [x] `python3 -m py_compile scripts/lib/worker_health_monitor.py scripts/lib/file_locking.py`
- [x] `python3 -m pytest tests/test_worker_health_fcntl.py -xvs` → 9 passed
- [x] Regression: `python3 -m pytest tests/test_worker_health.py tests/test_worker_health_eventstore.py` → 27 passed
- [ ] CI green

Dispatch-ID: 20260430-cfx-4-worker-health-fcntl