### PR TITLE
fix(intelligence): pattern dedup + injection diversity (P1 mid)

### DIFF
--- a/schemas/migrations/0011_add_pattern_category.sql
+++ b/schemas/migrations/0011_add_pattern_category.sql
@@ -1,0 +1,52 @@
+-- Migration 0011: Add pattern_category column to success_patterns and antipatterns
+--
+-- Background (from claudedocs/2026-04-30-intelligence-system-audit.md):
+--   54 of 55 successful intelligence injections returned BYTE-IDENTICAL governance
+--   gate-pass content ("gate gate_pr0_input_ready_contract passed"). Governance
+--   signals were dominating the proven_pattern slot, drowning out actual code
+--   patterns.
+--
+-- This migration introduces a `pattern_category` column to classify patterns by
+-- *kind* (code / governance / process / antipattern_evidence) so the selector
+-- can apply diversity rules without colliding with the pre-existing `category`
+-- column (which carries semantic domain values like "crawler", "storage", etc.).
+--
+-- Backfill heuristic: titles or descriptions matching the gate-pass shape
+--   (^gate ... passed$) → 'governance'. All others default to 'code'.
+--
+-- Idempotent via ALTER TABLE ... ADD COLUMN guarded by a column check at the
+-- application layer (sqlite has no IF NOT EXISTS for ADD COLUMN); the
+-- companion migrator (scripts/lib/pattern_dedup.py --apply / migrate_schema)
+-- detects existing column before re-running.
+
+-- success_patterns: classify pattern kind
+ALTER TABLE success_patterns ADD COLUMN pattern_category TEXT NOT NULL DEFAULT 'code';
+
+-- antipatterns: same classification space (used to mark advisory-only entries)
+ALTER TABLE antipatterns ADD COLUMN pattern_category TEXT NOT NULL DEFAULT 'antipattern_evidence';
+
+-- Index for fast diversity filtering
+CREATE INDEX IF NOT EXISTS idx_success_patterns_pattern_category
+    ON success_patterns (pattern_category, confidence_score DESC);
+CREATE INDEX IF NOT EXISTS idx_antipatterns_pattern_category
+    ON antipatterns (pattern_category, occurrence_count DESC);
+
+-- Backfill governance heuristic on success_patterns:
+--   match title or description starting with "gate" and ending with "passed"
+UPDATE success_patterns
+SET    pattern_category = 'governance'
+WHERE  pattern_category = 'code'
+   AND (
+            (title       IS NOT NULL AND lower(title)       GLOB 'gate *passed*')
+         OR (description IS NOT NULL AND lower(description) GLOB 'gate *passed*')
+       );
+
+-- Backfill process heuristic: phrases like "dispatch", "receipt", "gate request"
+UPDATE success_patterns
+SET    pattern_category = 'process'
+WHERE  pattern_category = 'code'
+   AND (
+            lower(coalesce(title, ''))       GLOB '*dispatch *'
+         OR lower(coalesce(title, ''))       GLOB '*receipt *'
+         OR lower(coalesce(description, '')) GLOB '*receipt processor*'
+       );

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -17,6 +17,7 @@ Governance:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import uuid
@@ -50,6 +51,25 @@ EVIDENCE_THRESHOLDS = {
 
 # Selection priority order (highest first) — used for payload overflow trimming
 ITEM_CLASS_PRIORITY = ["proven_pattern", "failure_prevention", "recent_comparable"]
+
+# Pattern categories (see schemas/migrations/0011_add_pattern_category.sql).
+# Diversity rules consume these to demote governance signals out of the
+# proven_pattern slot and avoid repeating identical content across a batch.
+PATTERN_CATEGORY_CODE = "code"
+PATTERN_CATEGORY_GOVERNANCE = "governance"
+PATTERN_CATEGORY_PROCESS = "process"
+PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE = "antipattern_evidence"
+
+# Maximum governance items per batch — they win the proven_pattern slot only
+# when no real code pattern is available, and never appear more than once
+# across a single injection.
+MAX_GOVERNANCE_PER_BATCH = 1
+
+# Confidence multiplier applied to governance proven_patterns so that, all else
+# equal, a code pattern with the same raw confidence wins. Pure penalty —
+# governance patterns are still allowed when they're the only candidates above
+# threshold.
+GOVERNANCE_CONFIDENCE_PENALTY = 0.7
 
 # Recent comparable window
 RECENT_COMPARABLE_DAYS = 14
@@ -107,6 +127,8 @@ class IntelligenceItem:
     scope_tags: List[str]
     source_refs: List[str] = field(default_factory=list)
     task_class_filter: List[str] = field(default_factory=list)
+    pattern_category: str = PATTERN_CATEGORY_CODE
+    content_hash: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -120,7 +142,35 @@ class IntelligenceItem:
             "scope_tags": self.scope_tags,
             "source_refs": self.source_refs,
             "task_class_filter": self.task_class_filter,
+            "pattern_category": self.pattern_category,
+            "content_hash": self.content_hash,
         }
+
+
+def _normalize_for_hash(text: str) -> str:
+    return " ".join((text or "").lower().split())
+
+
+def _content_hash(*parts: str) -> str:
+    joined = "\n".join(_normalize_for_hash(p) for p in parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def classify_pattern_category(title: str, description: str) -> str:
+    """Mirror of pattern_dedup.classify_pattern, kept local to avoid import cycle.
+
+    Order matters: governance gate-pass shape wins over generic process tokens.
+    """
+    haystack = f"{_normalize_for_hash(title)} :: {_normalize_for_hash(description)}"
+    if "gate " in haystack and "passed" in haystack:
+        return PATTERN_CATEGORY_GOVERNANCE
+    if any(token in haystack for token in (
+        "receipt processor",
+        "dispatch lifecycle",
+        "lease release",
+    )):
+        return PATTERN_CATEGORY_PROCESS
+    return PATTERN_CATEGORY_CODE
 
 
 @dataclass
@@ -285,6 +335,21 @@ class IntelligenceSelector:
             self._quality_db.close()
             self._quality_db = None
 
+    def _has_column(self, table: str, column: str) -> bool:
+        """Cheap PRAGMA-based feature detection for migrations not yet applied."""
+        db = self._get_quality_db()
+        if db is None:
+            return False
+        try:
+            rows = db.execute(f"PRAGMA table_info({table})").fetchall()
+        except sqlite3.Error:
+            return False
+        for row in rows:
+            name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
+            if name == column:
+                return True
+        return False
+
     def _maybe_reconcile_confidence(self) -> None:
         """Run reconcile if the cached timestamp is older than the TTL.
 
@@ -358,9 +423,16 @@ class IntelligenceSelector:
         # Query candidates per class
         candidates = self._query_candidates(resolved_class, effective_scope)
 
+        # Apply pre-selection diversity: collapse byte-identical content_hash
+        # candidates and demote governance signals so they don't drown out
+        # real code patterns (audit 2026-04-30: 54/55 byte-identical injections).
+        candidates = self._apply_candidate_diversity(candidates, resolved_class)
+
         # Select best item per class
         selected: List[IntelligenceItem] = []
         suppressed: List[SuppressionRecord] = []
+        seen_hashes: set = set()
+        governance_used = 0
 
         for item_class in ITEM_CLASS_PRIORITY:
             class_candidates = candidates.get(item_class, [])
@@ -388,9 +460,50 @@ class IntelligenceSelector:
                 ))
                 continue
 
-            # Select highest confidence
-            best = max(eligible, key=lambda c: c.confidence)
+            # Diversity filters: drop already-seen content hashes and respect
+            # the per-batch governance cap.
+            diverse = []
+            dropped_dup = 0
+            dropped_gov = 0
+            for cand in eligible:
+                if cand.content_hash and cand.content_hash in seen_hashes:
+                    dropped_dup += 1
+                    continue
+                if (
+                    cand.pattern_category == PATTERN_CATEGORY_GOVERNANCE
+                    and governance_used >= MAX_GOVERNANCE_PER_BATCH
+                ):
+                    dropped_gov += 1
+                    continue
+                diverse.append(cand)
+
+            if not diverse:
+                reason_parts = []
+                if dropped_dup:
+                    reason_parts.append(
+                        f"{dropped_dup} duplicates removed by content hash"
+                    )
+                if dropped_gov:
+                    reason_parts.append(
+                        f"{dropped_gov} governance items past per-batch cap"
+                    )
+                reason = (
+                    "; ".join(reason_parts)
+                    if reason_parts
+                    else "no diverse candidates remain"
+                )
+                suppressed.append(SuppressionRecord(
+                    item_class=item_class,
+                    reason=f"diversity filter dropped all eligible items ({reason})",
+                ))
+                continue
+
+            best = max(diverse, key=lambda c: c.confidence)
             selected.append(best)
+            if best.content_hash:
+                seen_hashes.add(best.content_hash)
+            if best.pattern_category == PATTERN_CATEGORY_GOVERNANCE:
+                governance_used += 1
 
         # Enforce payload size limit (Section 2.3 step 6)
         selected = self._enforce_payload_limit(selected, suppressed)
@@ -652,6 +765,75 @@ class IntelligenceSelector:
             return
 
     # ------------------------------------------------------------------
+    # Diversity helpers
+    # ------------------------------------------------------------------
+
+    def _apply_candidate_diversity(
+        self,
+        candidates: Dict[str, List[IntelligenceItem]],
+        task_class: str,
+    ) -> Dict[str, List[IntelligenceItem]]:
+        """Collapse same-hash duplicates and re-rank governance vs. code.
+
+        Within each class:
+          * Patterns sharing a content_hash collapse to the single highest-
+            confidence representative. This protects the selector from
+            offering the same governance gate-pass payload N times under
+            different ids (the failure mode the audit caught).
+          * Governance-category proven_patterns get a confidence penalty so
+            that, all else equal, a real code pattern wins. The penalty is
+            applied to a copy so that downstream consumers reading
+            ``IntelligenceItem.confidence`` see the effective ranking score.
+        """
+        adjusted: Dict[str, List[IntelligenceItem]] = {}
+        for cls, items in candidates.items():
+            collapsed: Dict[str, IntelligenceItem] = {}
+            unhashed: List[IntelligenceItem] = []
+            for item in items:
+                if not item.content_hash:
+                    unhashed.append(item)
+                    continue
+                existing = collapsed.get(item.content_hash)
+                if existing is None or item.confidence > existing.confidence:
+                    collapsed[item.content_hash] = item
+            merged = list(collapsed.values()) + unhashed
+
+            if cls == "proven_pattern":
+                merged = [
+                    self._apply_governance_penalty(item, task_class)
+                    for item in merged
+                ]
+
+            merged.sort(key=lambda i: i.confidence, reverse=True)
+            adjusted[cls] = merged
+        return adjusted
+
+    def _apply_governance_penalty(
+        self,
+        item: IntelligenceItem,
+        task_class: str,
+    ) -> IntelligenceItem:
+        """Down-weight governance proven_patterns for code-context dispatches."""
+        if item.pattern_category != PATTERN_CATEGORY_GOVERNANCE:
+            return item
+        if task_class != "coding_interactive":
+            return item
+        return IntelligenceItem(
+            item_id=item.item_id,
+            item_class=item.item_class,
+            title=item.title,
+            content=item.content,
+            confidence=item.confidence * GOVERNANCE_CONFIDENCE_PENALTY,
+            evidence_count=item.evidence_count,
+            last_seen=item.last_seen,
+            scope_tags=item.scope_tags,
+            source_refs=item.source_refs,
+            task_class_filter=item.task_class_filter,
+            pattern_category=item.pattern_category,
+            content_hash=item.content_hash,
+        )
+
+    # ------------------------------------------------------------------
     # Candidate query methods
     # ------------------------------------------------------------------
 
@@ -689,11 +871,17 @@ class IntelligenceSelector:
         self._maybe_reconcile_confidence()
 
         items: List[IntelligenceItem] = []
+        has_pattern_cat = self._has_column("success_patterns", "pattern_category")
+        select_cols = (
+            "id, title, description, category, confidence_score, "
+            "usage_count, source_dispatch_ids, first_seen, last_used"
+        )
+        if has_pattern_cat:
+            select_cols += ", pattern_category"
         try:
             rows = db.execute(
-                """
-                SELECT id, title, description, category, confidence_score,
-                       usage_count, source_dispatch_ids, first_seen, last_used
+                f"""
+                SELECT {select_cols}
                 FROM success_patterns
                 WHERE (valid_until IS NULL OR valid_until > datetime('now'))
                 ORDER BY confidence_score DESC
@@ -718,13 +906,17 @@ class IntelligenceSelector:
                 except (json.JSONDecodeError, TypeError):
                     pass
 
+            title = (row_d.get("title") or "Proven pattern")[:120]
             content = (row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
             last_seen = row_d.get("last_used") or row_d.get("first_seen") or _now_utc()
+
+            stored_cat = row_d.get("pattern_category")
+            pattern_category = stored_cat or classify_pattern_category(title, content)
 
             items.append(IntelligenceItem(
                 item_id=_stable_item_id("sp", str(row_d.get("id", ""))),
                 item_class="proven_pattern",
-                title=(row_d.get("title") or "Proven pattern")[:120],
+                title=title,
                 content=content,
                 confidence=float(row_d.get("confidence_score", 0.0)),
                 evidence_count=int(row_d.get("usage_count", 0)),
@@ -732,6 +924,8 @@ class IntelligenceSelector:
                 scope_tags=pattern_scope,
                 source_refs=source_refs[:5],
                 task_class_filter=[],
+                pattern_category=pattern_category,
+                content_hash=_content_hash(title, content),
             ))
 
         return items
@@ -790,10 +984,11 @@ class IntelligenceSelector:
             severity = row_d.get("severity", "medium")
             confidence = severity_confidence.get(severity, 0.5)
 
+            ap_title = (row_d.get("title") or "Failure prevention")[:120]
             items.append(IntelligenceItem(
                 item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
                 item_class="failure_prevention",
-                title=(row_d.get("title") or "Failure prevention")[:120],
+                title=ap_title,
                 content=content,
                 confidence=confidence,
                 evidence_count=int(row_d.get("occurrence_count", 1)),
@@ -801,6 +996,8 @@ class IntelligenceSelector:
                 scope_tags=pattern_scope,
                 source_refs=[f"antipattern_{row_d['id']}"],
                 task_class_filter=[],
+                pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+                content_hash=_content_hash(ap_title, content),
             ))
 
         # Query prevention_rules
@@ -828,10 +1025,11 @@ class IntelligenceSelector:
 
             content = (row_d.get("recommendation") or row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
 
+            pr_title = (row_d.get("description") or "Prevention rule")[:120]
             items.append(IntelligenceItem(
                 item_id=_stable_item_id("pr", str(row_d.get("id", ""))),
                 item_class="failure_prevention",
-                title=(row_d.get("description") or "Prevention rule")[:120],
+                title=pr_title,
                 content=content,
                 confidence=float(row_d.get("confidence", 0.5)),
                 evidence_count=max(1, int(row_d.get("triggered_count", 1))),
@@ -839,6 +1037,8 @@ class IntelligenceSelector:
                 scope_tags=rule_scope,
                 source_refs=[f"prevention_rule_{row_d['id']}"],
                 task_class_filter=[],
+                pattern_category=PATTERN_CATEGORY_PROCESS,
+                content_hash=_content_hash(pr_title, content),
             ))
 
         return items
@@ -896,10 +1096,11 @@ class IntelligenceSelector:
 
             confidence = 0.7 if outcome == "success" else 0.45
 
+            dm_title = f"Recent: {skill} dispatch ({outcome})"[:120]
             items.append(IntelligenceItem(
                 item_id=_stable_item_id("dm", str(row_d.get("dispatch_id", ""))),
                 item_class="recent_comparable",
-                title=f"Recent: {skill} dispatch ({outcome})"[:120],
+                title=dm_title,
                 content=content,
                 confidence=confidence,
                 evidence_count=1,
@@ -907,6 +1108,8 @@ class IntelligenceSelector:
                 scope_tags=dispatch_scope,
                 source_refs=[row_d["dispatch_id"]],
                 task_class_filter=[],
+                pattern_category=PATTERN_CATEGORY_PROCESS,
+                content_hash=_content_hash(dm_title, content),
             ))
 
         return items

--- a/scripts/lib/pattern_dedup.py
+++ b/scripts/lib/pattern_dedup.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Pattern dedup utility — collapses byte-identical success_patterns.
+
+Background (claudedocs/2026-04-30-intelligence-system-audit.md):
+  54 of 55 successful injections returned byte-identical content
+  ("gate gate_pr0_input_ready_contract passed"). Many duplicate
+  ``success_patterns`` rows were created over time, each fragmenting the
+  pattern_usage learning signal. This utility collapses duplicates by SHA-256
+  of normalized content (lowercased, whitespace-stripped) and merges the
+  related learning state onto the surviving canonical row (the oldest by id).
+
+The companion migration (schemas/migrations/0011_add_pattern_category.sql)
+adds the ``pattern_category`` column used by the selector to enforce
+diversity. ``ensure_pattern_category_columns`` applies that migration
+idempotently from Python so test fixtures and the production CLI converge.
+
+CLI:
+  python3 scripts/lib/pattern_dedup.py --db <path> --dry-run
+  python3 scripts/lib/pattern_dedup.py --db <path> --apply
+
+Both flags are mutually exclusive; one is required. The ``--apply`` form
+mutates the database and must therefore be run intentionally by an operator.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Hashing helpers
+# ---------------------------------------------------------------------------
+
+def normalize_content(text: Optional[str]) -> str:
+    """Lowercase + collapse whitespace so trivial reformatting doesn't hide dups."""
+    if not text:
+        return ""
+    return " ".join(text.lower().split())
+
+
+def content_hash(*parts: Optional[str]) -> str:
+    """SHA-256 over normalized concatenation of the supplied content parts."""
+    joined = "\n".join(normalize_content(p) for p in parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def ensure_pattern_category_columns(conn: sqlite3.Connection) -> None:
+    """Apply migration 0011 idempotently.
+
+    Adds ``pattern_category`` to ``success_patterns`` and ``antipatterns``
+    when missing, plus the supporting indexes. Backfill is left to the
+    operator-run migration SQL; this Python helper exists so test fixtures
+    and the dedup CLI can run against a fresh DB without manual ALTER.
+    """
+    if not _column_exists(conn, "success_patterns", "pattern_category"):
+        conn.execute(
+            "ALTER TABLE success_patterns "
+            "ADD COLUMN pattern_category TEXT NOT NULL DEFAULT 'code'"
+        )
+    if _table_exists(conn, "antipatterns") and not _column_exists(
+        conn, "antipatterns", "pattern_category"
+    ):
+        conn.execute(
+            "ALTER TABLE antipatterns "
+            "ADD COLUMN pattern_category TEXT NOT NULL DEFAULT 'antipattern_evidence'"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_success_patterns_pattern_category "
+        "ON success_patterns (pattern_category, confidence_score DESC)"
+    )
+    if _table_exists(conn, "antipatterns"):
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_antipatterns_pattern_category "
+            "ON antipatterns (pattern_category, occurrence_count DESC)"
+        )
+    conn.commit()
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def classify_pattern(title: Optional[str], description: Optional[str]) -> str:
+    """Assign a pattern_category based on title/description heuristics.
+
+    Order matters: governance gate-pass shape wins over generic process keywords.
+    """
+    haystack = f"{normalize_content(title)} :: {normalize_content(description)}"
+    if "gate " in haystack and "passed" in haystack:
+        return "governance"
+    if any(token in haystack for token in (
+        "receipt processor",
+        "dispatch lifecycle",
+        "lease release",
+    )):
+        return "process"
+    return "code"
+
+
+def backfill_pattern_category(conn: sqlite3.Connection) -> Dict[str, int]:
+    """Re-classify rows where pattern_category is still the default."""
+    counts: Dict[str, int] = {"governance": 0, "process": 0, "code": 0}
+    rows = conn.execute(
+        "SELECT id, title, description, pattern_category FROM success_patterns"
+    ).fetchall()
+    for row in rows:
+        new_cat = classify_pattern(row[1], row[2])
+        if new_cat != row[3]:
+            conn.execute(
+                "UPDATE success_patterns SET pattern_category = ? WHERE id = ?",
+                (new_cat, row[0]),
+            )
+        counts[new_cat] = counts.get(new_cat, 0) + 1
+    conn.commit()
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Dedup core
+# ---------------------------------------------------------------------------
+
+def _merge_source_dispatch_ids(values: List[Optional[str]]) -> str:
+    """Union JSON-encoded source_dispatch_ids lists, preserving recency cap."""
+    merged: List[str] = []
+    seen = set()
+    for raw in values:
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed, list):
+            continue
+        for entry in parsed:
+            key = str(entry)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(key)
+    return json.dumps(merged[-50:])
+
+
+def _group_duplicates(
+    conn: sqlite3.Connection,
+) -> Dict[str, List[sqlite3.Row]]:
+    rows = conn.execute(
+        """
+        SELECT id, title, description, usage_count, source_dispatch_ids,
+               first_seen, last_used, confidence_score
+        FROM   success_patterns
+        ORDER  BY id ASC
+        """
+    ).fetchall()
+    groups: Dict[str, List[sqlite3.Row]] = {}
+    for row in rows:
+        h = content_hash(row["title"], row["description"])
+        groups.setdefault(h, []).append(row)
+    return groups
+
+
+def dedup_success_patterns(
+    db_path: Path,
+    *,
+    apply: bool = False,
+) -> Dict[str, int]:
+    """Collapse duplicates by SHA-256 of normalized content.
+
+    For each group with >1 member:
+      * keep the oldest (smallest ``id``) as the canonical row
+      * sum ``usage_count`` and merge ``source_dispatch_ids``
+      * rewrite ``pattern_usage.pattern_id`` rows pointing at duplicate
+        ``intel_sp_<id>`` keys onto the canonical id, summing counters
+      * rewrite ``dispatch_pattern_offered`` to the canonical id when the
+        junction table exists
+      * delete the duplicate rows from ``success_patterns``
+
+    Returns:
+      Mapping of dedup_key (content hash, 12-char prefix) -> count_collapsed.
+      A count of 0 means the group was already singleton; counts are only
+      reported for groups that had duplicates so callers can iterate over
+      meaningful work.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        ensure_pattern_category_columns(conn)
+        groups = _group_duplicates(conn)
+        report: Dict[str, int] = {}
+        for hash_key, members in groups.items():
+            if len(members) <= 1:
+                continue
+            canonical = members[0]
+            duplicates = members[1:]
+            short_key = hash_key[:12]
+            report[short_key] = len(duplicates)
+
+            if not apply:
+                continue
+
+            merged_usage = sum(int(m["usage_count"] or 0) for m in members)
+            merged_sources = _merge_source_dispatch_ids(
+                [m["source_dispatch_ids"] for m in members]
+            )
+            best_confidence = max(
+                float(m["confidence_score"] or 0.0) for m in members
+            )
+            latest_last_used = max(
+                (m["last_used"] for m in members if m["last_used"]),
+                default=canonical["last_used"],
+            )
+            conn.execute(
+                """
+                UPDATE success_patterns
+                SET    usage_count          = ?,
+                       source_dispatch_ids  = ?,
+                       confidence_score     = ?,
+                       last_used            = ?
+                WHERE  id = ?
+                """,
+                (
+                    merged_usage,
+                    merged_sources,
+                    best_confidence,
+                    latest_last_used,
+                    canonical["id"],
+                ),
+            )
+
+            canonical_pid = f"intel_sp_{canonical['id']}"
+            for dup in duplicates:
+                dup_pid = f"intel_sp_{dup['id']}"
+                _merge_pattern_usage(conn, dup_pid, canonical_pid)
+                _redirect_dispatch_pattern_offered(conn, dup_pid, canonical_pid)
+
+            placeholders = ",".join("?" * len(duplicates))
+            conn.execute(
+                f"DELETE FROM success_patterns WHERE id IN ({placeholders})",
+                tuple(d["id"] for d in duplicates),
+            )
+
+        if apply:
+            conn.commit()
+        return report
+    finally:
+        conn.close()
+
+
+def _merge_pattern_usage(
+    conn: sqlite3.Connection,
+    duplicate_pattern_id: str,
+    canonical_pattern_id: str,
+) -> None:
+    """Fold counters from duplicate row into canonical, then drop duplicate."""
+    if not _table_exists(conn, "pattern_usage"):
+        return
+    dup = conn.execute(
+        "SELECT used_count, ignored_count, success_count, failure_count, "
+        "       confidence, last_used, last_offered "
+        "FROM   pattern_usage WHERE pattern_id = ?",
+        (duplicate_pattern_id,),
+    ).fetchone()
+    if dup is None:
+        return
+    canonical = conn.execute(
+        "SELECT used_count, ignored_count, success_count, failure_count, "
+        "       confidence, last_used, last_offered "
+        "FROM   pattern_usage WHERE pattern_id = ?",
+        (canonical_pattern_id,),
+    ).fetchone()
+    if canonical is None:
+        conn.execute(
+            "UPDATE pattern_usage SET pattern_id = ? WHERE pattern_id = ?",
+            (canonical_pattern_id, duplicate_pattern_id),
+        )
+        return
+    conn.execute(
+        """
+        UPDATE pattern_usage
+        SET    used_count    = used_count    + ?,
+               ignored_count = ignored_count + ?,
+               success_count = success_count + ?,
+               failure_count = failure_count + ?,
+               confidence    = MAX(confidence, ?),
+               last_used     = COALESCE(MAX(last_used, ?), last_used, ?),
+               last_offered  = COALESCE(MAX(last_offered, ?), last_offered, ?),
+               updated_at    = CURRENT_TIMESTAMP
+        WHERE  pattern_id = ?
+        """,
+        (
+            int(dup["used_count"] or 0),
+            int(dup["ignored_count"] or 0),
+            int(dup["success_count"] or 0),
+            int(dup["failure_count"] or 0),
+            float(dup["confidence"] or 0.0),
+            dup["last_used"],
+            dup["last_used"],
+            dup["last_offered"],
+            dup["last_offered"],
+            canonical_pattern_id,
+        ),
+    )
+    conn.execute(
+        "DELETE FROM pattern_usage WHERE pattern_id = ?",
+        (duplicate_pattern_id,),
+    )
+
+
+def _redirect_dispatch_pattern_offered(
+    conn: sqlite3.Connection,
+    duplicate_pattern_id: str,
+    canonical_pattern_id: str,
+) -> None:
+    if not _table_exists(conn, "dispatch_pattern_offered"):
+        return
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO dispatch_pattern_offered
+            (dispatch_id, pattern_id, pattern_title, offered_at)
+        SELECT dispatch_id, ?, pattern_title, offered_at
+        FROM   dispatch_pattern_offered
+        WHERE  pattern_id = ?
+        """,
+        (canonical_pattern_id, duplicate_pattern_id),
+    )
+    conn.execute(
+        "DELETE FROM dispatch_pattern_offered WHERE pattern_id = ?",
+        (duplicate_pattern_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pattern_dedup",
+        description="Dedup success_patterns by content hash.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path(".vnx-data/state/quality_intelligence.db"),
+        help="Path to quality_intelligence.db (default: %(default)s)",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report duplicates without mutating the database.",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply dedup (mutates the database).",
+    )
+    parser.add_argument(
+        "--backfill-category",
+        action="store_true",
+        help="Re-run pattern_category classification on every row.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    if not args.db.exists():
+        print(f"[pattern_dedup] DB not found: {args.db}", file=sys.stderr)
+        return 2
+
+    if args.backfill_category:
+        with sqlite3.connect(str(args.db)) as conn:
+            ensure_pattern_category_columns(conn)
+            counts = backfill_pattern_category(conn)
+        print(f"[pattern_dedup] backfill counts: {counts}")
+
+    report = dedup_success_patterns(args.db, apply=args.apply)
+    if not report:
+        print("[pattern_dedup] no duplicate groups found")
+        return 0
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    total = sum(report.values())
+    print(f"[pattern_dedup] {mode}: {len(report)} duplicate groups, "
+          f"{total} rows would-be-collapsed")
+    for key, count in sorted(report.items(), key=lambda kv: -kv[1]):
+        print(f"  {key}  collapses {count} duplicates")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/pattern_dedup.py
+++ b/scripts/lib/pattern_dedup.py
@@ -359,8 +359,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--db",
         type=Path,
-        default=Path(".vnx-data/state/quality_intelligence.db"),
-        help="Path to quality_intelligence.db (default: %(default)s)",
+        default=None,
+        help="Path to quality_intelligence.db (default: ${VNX_STATE_DIR}/quality_intelligence.db via vnx_paths)",
     )
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument(
@@ -383,6 +383,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = _build_arg_parser().parse_args(argv)
+
+    if args.db is None:
+        from project_root import resolve_state_dir
+        args.db = resolve_state_dir() / "quality_intelligence.db"
 
     if not args.db.exists():
         print(f"[pattern_dedup] DB not found: {args.db}", file=sys.stderr)

--- a/tests/test_pattern_diversity.py
+++ b/tests/test_pattern_diversity.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Tests for pattern injection diversity + content dedup (B2 dispatch).
+
+Covers:
+  A. Dedup collapses byte-identical success_patterns to a single canonical row
+  B. Selector prefers code patterns over governance for coding_interactive
+  C. Backfill heuristic classifies "gate ... passed" rows as governance
+  D. Selector never returns two byte-identical patterns in one batch
+  E. Dedup preserves usage_count via aggregation onto the canonical row
+  F. Dedup is idempotent — re-running produces no further changes
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+from intelligence_selector import (  # noqa: E402
+    PATTERN_CATEGORY_CODE,
+    PATTERN_CATEGORY_GOVERNANCE,
+    IntelligenceSelector,
+    classify_pattern_category,
+)
+from pattern_dedup import (  # noqa: E402
+    backfill_pattern_category,
+    classify_pattern,
+    content_hash,
+    dedup_success_patterns,
+    ensure_pattern_category_columns,
+    main as pattern_dedup_main,
+    normalize_content,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema fixture mirroring the production quality_intelligence schema
+# ---------------------------------------------------------------------------
+
+def _create_quality_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            pattern_data TEXT, code_example TEXT, prerequisites TEXT, outcomes TEXT,
+            success_rate REAL DEFAULT 0.0, usage_count INTEGER DEFAULT 0,
+            avg_completion_time INTEGER, confidence_score REAL DEFAULT 0.0,
+            source_dispatch_ids TEXT, source_receipts TEXT,
+            first_seen DATETIME, last_used DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE antipatterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            pattern_data TEXT, problem_example TEXT, why_problematic TEXT,
+            better_alternative TEXT, occurrence_count INTEGER DEFAULT 0,
+            avg_resolution_time INTEGER, severity TEXT DEFAULT 'medium',
+            source_dispatch_ids TEXT, first_seen DATETIME, last_seen DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT, rule_type TEXT, description TEXT,
+            recommendation TEXT, confidence REAL DEFAULT 0.0,
+            created_at TEXT, triggered_count INTEGER DEFAULT 0,
+            last_triggered TEXT,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT, cognition TEXT DEFAULT 'normal',
+            priority TEXT DEFAULT 'P1', pr_id TEXT, parent_dispatch TEXT,
+            pattern_count INTEGER DEFAULT 0, prevention_rule_count INTEGER DEFAULT 0,
+            intelligence_json TEXT, instruction_char_count INTEGER DEFAULT 0,
+            context_file_count INTEGER DEFAULT 0,
+            dispatched_at DATETIME, completed_at DATETIME,
+            outcome_status TEXT, outcome_report_path TEXT, session_id TEXT
+        );
+        CREATE TABLE pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TIMESTAMP,
+            last_offered TIMESTAMP,
+            confidence REAL DEFAULT 1.0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pattern(
+    db_path: Path,
+    title: str,
+    description: str,
+    *,
+    category: str = "backend-developer",
+    confidence: float = 0.85,
+    usage_count: int = 3,
+) -> int:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute(
+        """
+        INSERT INTO success_patterns
+            (title, description, category, confidence_score, usage_count,
+             pattern_data, first_seen, last_used)
+        VALUES (?, ?, ?, ?, ?, '{}', '2026-04-01T00:00:00Z', '2026-04-29T00:00:00Z')
+        """,
+        (title, description, category, confidence, usage_count),
+    )
+    conn.commit()
+    pid = cur.lastrowid
+    conn.execute(
+        """
+        INSERT INTO pattern_usage
+            (pattern_id, pattern_title, pattern_hash, used_count, confidence)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (f"intel_sp_{pid}", title[:255], "hash_placeholder", usage_count, confidence),
+    )
+    conn.commit()
+    conn.close()
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests (no DB)
+# ---------------------------------------------------------------------------
+
+class TestNormalization(unittest.TestCase):
+    def test_normalize_lowercases_and_collapses_whitespace(self):
+        self.assertEqual(normalize_content("  Gate   X  Passed  "), "gate x passed")
+
+    def test_normalize_handles_none(self):
+        self.assertEqual(normalize_content(None), "")
+
+    def test_content_hash_stable(self):
+        self.assertEqual(
+            content_hash("Hello", "World"),
+            content_hash("hello", "world"),
+        )
+
+    def test_content_hash_differs_for_different_text(self):
+        self.assertNotEqual(content_hash("foo"), content_hash("bar"))
+
+
+class TestClassification(unittest.TestCase):
+    def test_governance_gate_pass_pattern(self):
+        self.assertEqual(
+            classify_pattern("gate gate_pr0_input_ready_contract passed", ""),
+            "governance",
+        )
+
+    def test_code_pattern_default(self):
+        self.assertEqual(
+            classify_pattern("Use structured output", "Improves first-pass success"),
+            "code",
+        )
+
+    def test_process_pattern_receipt_processor(self):
+        self.assertEqual(
+            classify_pattern("Receipt processor handler", "receipt processor flow"),
+            "process",
+        )
+
+    def test_selector_classify_matches_dedup_classify(self):
+        title = "gate gate_x passed"
+        self.assertEqual(
+            classify_pattern_category(title, ""),
+            classify_pattern(title, ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case A: dedup collapses byte-identical patterns
+# ---------------------------------------------------------------------------
+
+class TestDedupCollapses(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_five_identical_patterns_collapse_to_one(self):
+        title = "gate gate_pr0_input_ready_contract passed"
+        desc = "gate gate_pr0_input_ready_contract passed"
+        for _ in range(5):
+            _seed_pattern(self.db_path, title, desc, usage_count=1)
+
+        report = dedup_success_patterns(self.db_path, apply=True)
+        self.assertEqual(len(report), 1, f"expected 1 dedup group, got {report}")
+        # 5 members -> 4 collapsed (canonical kept)
+        self.assertEqual(sum(report.values()), 4)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            (count,) = conn.execute(
+                "SELECT COUNT(*) FROM success_patterns"
+            ).fetchone()
+        self.assertEqual(count, 1)
+
+    def test_dry_run_does_not_mutate(self):
+        title = "duplicate title"
+        desc = "duplicate description"
+        for _ in range(3):
+            _seed_pattern(self.db_path, title, desc)
+
+        report = dedup_success_patterns(self.db_path, apply=False)
+        self.assertEqual(sum(report.values()), 2)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            (count,) = conn.execute(
+                "SELECT COUNT(*) FROM success_patterns"
+            ).fetchone()
+        self.assertEqual(count, 3, "dry-run should preserve all rows")
+
+
+# ---------------------------------------------------------------------------
+# Case B: selector prefers code over governance
+# ---------------------------------------------------------------------------
+
+class TestSelectorPrefersCode(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+        with sqlite3.connect(str(self.db_path)) as conn:
+            ensure_pattern_category_columns(conn)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_code_pattern_wins_over_governance_for_coding(self):
+        # Same raw confidence, but governance gets penalty in coding context.
+        gov_id = _seed_pattern(
+            self.db_path,
+            "gate gate_pr0_input_ready_contract passed",
+            "gate gate_pr0_input_ready_contract passed",
+            confidence=0.9,
+            usage_count=10,
+        )
+        code_id = _seed_pattern(
+            self.db_path,
+            "Use structured output",
+            "Structured output improves first-pass success by 25%.",
+            confidence=0.85,
+            usage_count=5,
+        )
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            backfill_pattern_category(conn)
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result = selector.select(
+                dispatch_id="test-coding",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        proven = [i for i in result.items if i.item_class == "proven_pattern"]
+        self.assertEqual(len(proven), 1)
+        self.assertEqual(
+            proven[0].item_id,
+            f"intel_sp_{code_id}",
+            "code pattern should win over governance for coding_interactive",
+        )
+        # Sanity: the governance pattern still exists, just was demoted
+        self.assertIn(gov_id, [int(row[0]) for row in
+                                sqlite3.connect(str(self.db_path)).execute(
+                                    "SELECT id FROM success_patterns").fetchall()])
+
+
+# ---------------------------------------------------------------------------
+# Case C: backfill correctness
+# ---------------------------------------------------------------------------
+
+class TestBackfillCategory(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_gate_passed_classified_as_governance(self):
+        _seed_pattern(
+            self.db_path,
+            "gate gate_pr0_input_ready_contract passed",
+            "gate gate_pr0_input_ready_contract passed",
+        )
+        _seed_pattern(
+            self.db_path,
+            "Use structured output",
+            "Improves first-pass success by 25%.",
+        )
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            ensure_pattern_category_columns(conn)
+            backfill_pattern_category(conn)
+            rows = conn.execute(
+                "SELECT title, pattern_category FROM success_patterns ORDER BY id"
+            ).fetchall()
+
+        self.assertEqual(rows[0][1], "governance")
+        self.assertEqual(rows[1][1], "code")
+
+
+# ---------------------------------------------------------------------------
+# Case D: selector enforces no byte-identical content in batch
+# ---------------------------------------------------------------------------
+
+class TestSelectorBatchDiversity(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+        with sqlite3.connect(str(self.db_path)) as conn:
+            ensure_pattern_category_columns(conn)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_duplicate_content_collapses_in_selector(self):
+        # Three identical proven_patterns + a recent_comparable that happens to
+        # share the same content_hash. Even without dedup applied, the selector
+        # must never emit two items with the same content_hash.
+        identical_title = "Use a structured output schema"
+        identical_desc = "Define a JSON schema and validate model output."
+        for _ in range(3):
+            _seed_pattern(
+                self.db_path,
+                identical_title,
+                identical_desc,
+                confidence=0.9,
+                usage_count=4,
+            )
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result = selector.select(
+                dispatch_id="test-diverse",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        hashes = [i.content_hash for i in result.items if i.content_hash]
+        self.assertEqual(len(hashes), len(set(hashes)),
+                         "no two emitted items may share a content_hash")
+
+        proven = [i for i in result.items if i.item_class == "proven_pattern"]
+        self.assertEqual(len(proven), 1, "duplicates must collapse to one slot")
+
+
+# ---------------------------------------------------------------------------
+# Case E: dedup preserves usage_count aggregation
+# ---------------------------------------------------------------------------
+
+class TestDedupPreservesUsage(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_usage_counts_aggregate_onto_canonical(self):
+        title = "Repeated pattern"
+        desc = "Same description"
+        ids = [
+            _seed_pattern(self.db_path, title, desc, usage_count=2),
+            _seed_pattern(self.db_path, title, desc, usage_count=3),
+            _seed_pattern(self.db_path, title, desc, usage_count=4),
+        ]
+        canonical = min(ids)
+
+        dedup_success_patterns(self.db_path, apply=True)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            (rowcount,) = conn.execute(
+                "SELECT COUNT(*) FROM success_patterns"
+            ).fetchone()
+            (usage_count,) = conn.execute(
+                "SELECT usage_count FROM success_patterns WHERE id = ?",
+                (canonical,),
+            ).fetchone()
+            (pu_used,) = conn.execute(
+                "SELECT used_count FROM pattern_usage WHERE pattern_id = ?",
+                (f"intel_sp_{canonical}",),
+            ).fetchone()
+            (pu_count,) = conn.execute(
+                "SELECT COUNT(*) FROM pattern_usage"
+            ).fetchone()
+
+        self.assertEqual(rowcount, 1)
+        self.assertEqual(usage_count, 9, "aggregated usage_count must match sum")
+        self.assertEqual(pu_used, 9, "pattern_usage rows must merge counters")
+        self.assertEqual(pu_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Case F: idempotency
+# ---------------------------------------------------------------------------
+
+class TestDedupIdempotent(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_rerun_is_noop(self):
+        title = "Idempotent pattern"
+        desc = "Description"
+        for _ in range(3):
+            _seed_pattern(self.db_path, title, desc)
+
+        first = dedup_success_patterns(self.db_path, apply=True)
+        second = dedup_success_patterns(self.db_path, apply=True)
+
+        self.assertEqual(sum(first.values()), 2)
+        self.assertEqual(second, {}, "second run must report no duplicates")
+
+    def test_cli_dry_run_then_apply(self):
+        title = "CLI pattern"
+        desc = "CLI description"
+        for _ in range(2):
+            _seed_pattern(self.db_path, title, desc)
+
+        rc = pattern_dedup_main(["--db", str(self.db_path), "--dry-run"])
+        self.assertEqual(rc, 0)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            (count_before,) = conn.execute(
+                "SELECT COUNT(*) FROM success_patterns"
+            ).fetchone()
+        self.assertEqual(count_before, 2, "dry-run preserves rows")
+
+        rc = pattern_dedup_main(["--db", str(self.db_path), "--apply"])
+        self.assertEqual(rc, 0)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            (count_after,) = conn.execute(
+                "SELECT COUNT(*) FROM success_patterns"
+            ).fetchone()
+        self.assertEqual(count_after, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Address audit finding (claudedocs/2026-04-30-intelligence-system-audit.md): 54-of-55 successful intelligence injections returned BYTE-IDENTICAL governance gate-pass content, drowning out real code patterns.
- Adds `pattern_category` classification to success_patterns / antipatterns and a SHA-256 content-hash dedup utility.
- Selector now collapses same-hash candidates pre-selection, applies a 0.7x penalty to governance patterns for `coding_interactive` task class, and caps governance items at 1 per batch.

## Changes
- `schemas/migrations/0011_add_pattern_category.sql` — adds `pattern_category` column with governance/process backfill heuristic.
- `scripts/lib/pattern_dedup.py` — content-hash dedup with `--dry-run` / `--apply` CLI; merges `usage_count`, `source_dispatch_ids`, `pattern_usage` counters, and redirects `dispatch_pattern_offered` rows onto the canonical pattern.
- `scripts/lib/intelligence_selector.py` — `IntelligenceItem` gains `pattern_category` + `content_hash`; pre-selection diversity filter; governance penalty + per-batch cap.
- `tests/test_pattern_diversity.py` — 16 new test cases.

## Test plan
- [x] `python3 -m py_compile scripts/lib/pattern_dedup.py scripts/lib/intelligence_selector.py`
- [x] `python3 -m pytest tests/test_intelligence_selector.py tests/test_pattern_diversity.py` — 48 passed
- [x] Adjacent regression: `tests/test_temporal_patterns.py tests/test_audit_linkage.py tests/test_confidence_reconcile.py tests/test_learning_loop_tz.py tests/test_pr311_round2_codex_fixes.py tests/test_report_findings_schema.py` — 60 passed (108 total)
- [x] Dry-run on copy of real `quality_intelligence.db`: 187 rows → 40 duplicate groups detected
- [x] Apply on copy: 187 → 147 rows; re-run reports zero duplicates (idempotent)
- [ ] Codex gate (CLI rate-limited until 2026-05-05; gemini-only review for now)
- [ ] CI green
- [ ] Operator-driven `--apply` against production DB after gate review

## Notes
- Existing `success_patterns.category` column carries domain values ("backend-developer", "crawler", etc.); new column is named `pattern_category` to avoid collision.
- Production DB is NOT mutated by this PR — operator must invoke `python3 scripts/lib/pattern_dedup.py --db .vnx-data/state/quality_intelligence.db --apply` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)