### PR TITLE
fix(observability): use full SHA-256 for instruction_sha256 (CFX-10)

### DIFF
--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -492,7 +492,7 @@ def _write_manifest(
             "model": model,
             "role": role,
             "instruction_chars": len(instruction),
-            "instruction_sha256": hashlib.sha256(instruction.encode("utf-8")).hexdigest()[:16],
+            "instruction_sha256": hashlib.sha256(instruction.encode("utf-8")).hexdigest(),
         }
         manifest_path = manifest_dir / "manifest.json"
         manifest_path.write_text(json.dumps(manifest, indent=2))

--- a/tests/test_manifest_instruction_hash.py
+++ b/tests/test_manifest_instruction_hash.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""T5-PR2: instruction_sha256 field in dispatch manifest.
+"""T5-PR2 / CFX-10: instruction_sha256 field in dispatch manifest.
 
 Covers:
-  A. Known instruction → manifest.json contains expected sha256[:16]
+  A. Known instruction → manifest.json contains full 64-char sha256
   B. Unicode instruction → hash computed correctly
-  C. Empty instruction → hash present (sha256 of empty string)
+  C. Empty instruction → hash present (sha256 of empty string, 64 chars)
   D. Existing manifest fields preserved (regression)
 """
 
@@ -43,25 +43,28 @@ def _write_manifest(tmp_path: Path, instruction: str, dispatch_id: str = "test-d
 
 def test_manifest_has_instruction_sha256_for_known_instruction(tmp_path):
     instruction = "Do something important"
-    expected = hashlib.sha256(instruction.encode("utf-8")).hexdigest()[:16]
+    expected = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
     data = _write_manifest(tmp_path, instruction)
     assert "instruction_sha256" in data
     assert data["instruction_sha256"] == expected
+    assert len(data["instruction_sha256"]) == 64
 
 
 def test_manifest_instruction_sha256_unicode(tmp_path):
     instruction = "Execute: café résumé naïve 你好 🚀"
-    expected = hashlib.sha256(instruction.encode("utf-8")).hexdigest()[:16]
+    expected = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
     data = _write_manifest(tmp_path, instruction, dispatch_id="test-dispatch-B")
     assert data["instruction_sha256"] == expected
+    assert len(data["instruction_sha256"]) == 64
 
 
 def test_manifest_instruction_sha256_empty_instruction(tmp_path):
     instruction = ""
-    expected = hashlib.sha256(b"").hexdigest()[:16]
+    expected = hashlib.sha256(b"").hexdigest()
     data = _write_manifest(tmp_path, instruction, dispatch_id="test-dispatch-C")
     assert "instruction_sha256" in data
     assert data["instruction_sha256"] == expected
+    assert len(data["instruction_sha256"]) == 64
 
 
 def test_manifest_existing_fields_preserved(tmp_path):

--- a/tests/test_receipt_instruction_hash.py
+++ b/tests/test_receipt_instruction_hash.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""T5-PR3: instruction_sha256 surfaced in receipt session metadata.
+"""T5-PR3 / CFX-10: instruction_sha256 surfaced in receipt session metadata.
 
 Covers:
-  A. Receipt with valid manifest_path → instruction_sha256 in session metadata
+  A. Receipt with valid manifest_path (legacy 16-char) → instruction_sha256 in metadata (backward-compat: reader accepts any length)
   B. Receipt without manifest_path → field absent, no crash
   C. Manifest file missing → field absent, warning logged to stderr
   D. Malformed manifest JSON → field absent, warning logged to stderr
   E. Existing receipt enrichment (token usage etc.) unaffected
+  F. subprocess_completion event → instruction_sha256 surfaces via full append path
+  G. subprocess_completion must NOT overwrite quality_advisory_json/cqs
+  H. real task_complete still triggers quality_advisory + CQS persistence
+  I. New manifests with 64-char sha256 are read correctly
 """
 
 from __future__ import annotations
@@ -99,6 +103,34 @@ def test_valid_manifest_surfaces_instruction_sha256(ar, tmp_path):
 
     assert "instruction_sha256" in metadata
     assert metadata["instruction_sha256"] == "abcdef1234567890"
+
+
+# ── Case I: new manifest with full 64-char sha256 → surfaces correctly ───────
+
+def test_full_64char_sha256_surfaces_in_session_metadata(ar, tmp_path):
+    """CFX-10: reader handles full 64-char sha256 from new manifests."""
+    import hashlib as _hashlib
+    instruction = "Full SHA-256 instruction text"
+    full_sha = _hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+    assert len(full_sha) == 64
+
+    manifest = {
+        "dispatch_id": "DISP-IH-I01",
+        "instruction_sha256": full_sha,
+        "instruction_chars": len(instruction),
+    }
+    manifest_file = tmp_path / "manifest_full.json"
+    manifest_file.write_text(json.dumps(manifest))
+
+    receipt = _make_receipt(manifest_path=str(manifest_file))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    metadata, _ = _call_build_session(ar, receipt, state_dir)
+
+    assert "instruction_sha256" in metadata
+    assert metadata["instruction_sha256"] == full_sha
+    assert len(metadata["instruction_sha256"]) == 64
 
 
 # ── Case B: no manifest_path → field absent, no crash ────────────────────────


### PR DESCRIPTION
## Summary

- Removes `[:16]` truncation from `_write_manifest` in `subprocess_dispatch.py` — `instruction_sha256` now stores the full 64-char hex digest
- Reader in `_build_session_metadata` (`append_receipt.py`) is already length-agnostic (stores value as-is); no consumer changes needed
- Existing 16-char manifests in `dispatches/completed/` remain parseable without backfill

## Files Changed

| File | Change |
|------|--------|
| `scripts/lib/subprocess_dispatch.py:495` | Remove `[:16]` from `hexdigest()` call |
| `tests/test_manifest_instruction_hash.py` | Update expected values + assert `len==64` |
| `tests/test_receipt_instruction_hash.py` | Add Case I (64-char reader test); legacy 16-char fixtures cover backward-compat path |

## Test Plan

- [x] `pytest tests/test_manifest_instruction_hash.py tests/test_receipt_instruction_hash.py -xvs` → 13 passed
- [x] Backward-compat: Case A in receipt tests uses a 16-char manifest value and asserts it surfaces correctly
- [x] Forward path: Case I asserts full 64-char digest round-trips through `_build_session_metadata`

## Context

OI-CFX-10: field name `instruction_sha256` implied a full SHA-256 but stored only 16 hex chars, misleading downstream readers and preventing collision avoidance. Option B chosen (store full digest) per dispatch plan.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)