### PR TITLE
refactor(governance): summarizers use gate_status.is_pass() (CFX-12)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -405,21 +405,9 @@ def _validate_review_evidence(
             elif (result.get("state") or "").lower() == "completed":
                 # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
                 # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
-                terminal = _gate_terminal_status(result)
-                blocking_count = int(result.get("blocking_count") or 0)
-                if terminal == "fail":
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"{gate} completed with result_status=fail",
-                    ))
-                elif blocking_count > 0:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"{gate} completed with {blocking_count} blocking finding(s)",
-                    ))
-                elif terminal == "pass":
+                # gate_is_pass() handles state/result_status via gate_status._coerce_status (CFX-12).
+                passed, reason = gate_is_pass(result)
+                if passed:
                     advisory_count = int(result.get("advisory_count") or 0)
                     checks.append(CheckResult(
                         f"gate_{gate}",
@@ -430,7 +418,7 @@ def _validate_review_evidence(
                     checks.append(CheckResult(
                         f"gate_{gate}",
                         "FAIL",
-                        f"{gate} state=completed but result_status is missing or unknown",
+                        f"{gate} completed: {reason}",
                     ))
             elif result.get("was_intentionally_absent") or result.get("contributed_evidence"):
                 state = result.get("state", "unknown")
@@ -507,25 +495,31 @@ def _validate_review_evidence(
                     "FAIL",
                     "no ci_gate result found",
                 ))
+            elif not gate_is_terminal(result):
+                status = result.get("status", "unknown")
+                checks.append(CheckResult(
+                    f"gate_{gate}",
+                    "FAIL",
+                    f"ci_gate checks still {status} — incomplete evidence",
+                ))
             else:
-                status = result.get("status", "missing")
-                blocking_count = result.get("blocking_count", 0)
                 contract_hash = result.get("contract_hash", "")
                 report_path = result.get("report_path", "")
-                if status in ("pass", "fail"):
-                    if not contract_hash:
-                        checks.append(CheckResult(
-                            f"gate_{gate}",
-                            "FAIL",
-                            "ci_gate result is missing required contract_hash field",
-                        ))
-                    elif not report_path:
-                        checks.append(CheckResult(
-                            f"gate_{gate}",
-                            "FAIL",
-                            "ci_gate result is missing required report_path field",
-                        ))
-                    elif status == "pass" and blocking_count == 0:
+                if not contract_hash:
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        "ci_gate result is missing required contract_hash field",
+                    ))
+                elif not report_path:
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        "ci_gate result is missing required report_path field",
+                    ))
+                else:
+                    passed, reason = gate_is_pass(result)
+                    if passed:
                         advisory_count = result.get("advisory_count", 0)
                         checks.append(CheckResult(
                             f"gate_{gate}",
@@ -533,23 +527,12 @@ def _validate_review_evidence(
                             f"ci_gate passed ({advisory_count} advisory, 0 blocking)",
                         ))
                     else:
+                        blocking_count = result.get("blocking_count", 0)
                         checks.append(CheckResult(
                             f"gate_{gate}",
                             "FAIL",
-                            f"ci_gate status: {status}, {blocking_count} blocking check(s)",
+                            f"ci_gate not passing — {reason}",
                         ))
-                elif status == "running":
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        "ci_gate checks still running — incomplete evidence",
-                    ))
-                else:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"ci_gate status: {status}, {blocking_count} blocking check(s)",
-                    ))
 
         else:
             if result is None:

--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -27,7 +27,10 @@ def _coerce_status(result: Dict[str, Any]) -> Tuple[str, bool]:
 
     Uses ``status`` when present and non-empty. Falls back to legacy
     ``verdict`` for old files written before CFX-3 — this is graceful
-    migration, not a permanent contract.
+    migration, not a permanent contract.  Also handles the
+    ``claude_github_optional`` format where terminal outcome is recorded
+    as ``state="completed"`` + ``result_status="pass"|"fail"`` rather than
+    top-level ``status``/``verdict``.
     """
     status = result.get("status")
     if isinstance(status, str) and status:
@@ -41,6 +44,10 @@ def _coerce_status(result: Dict[str, Any]) -> Tuple[str, bool]:
             stacklevel=3,
         )
         return verdict.lower(), True
+    if (result.get("state") or "").lower() == "completed":
+        rs = (result.get("result_status") or "").lower()
+        if rs:
+            return rs, False
     return "", False
 
 

--- a/tests/test_gate_status_summarizer_usage.py
+++ b/tests/test_gate_status_summarizer_usage.py
@@ -1,0 +1,92 @@
+"""tests/test_gate_status_summarizer_usage.py — CFX-12 summarizer refactor verification.
+
+Verifies that gate_status.is_pass() correctly drives the ci_gate and
+claude_github_optional blocks in closure_verifier.py after the CFX-12
+ad-hoc check refactor.  Each parameterized case covers a (status,
+blocking_count) combination that was previously handled by hand-rolled
+comparisons.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
+
+from gate_status import is_pass
+
+
+# ---------------------------------------------------------------------------
+# ci_gate result shapes: standard status + blocking_count
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("result,expected_pass", [
+    ({"status": "pass", "blocking_count": 0}, True),
+    ({"status": "pass", "blocking_count": 1}, False),
+    ({"status": "pass", "blocking_count": 3}, False),
+    ({"status": "fail", "blocking_count": 0}, False),
+    ({"status": "fail", "blocking_count": 2}, False),
+    ({"status": "failed", "blocking_count": 0}, False),
+    ({"status": "running", "blocking_count": 0}, False),
+    ({"status": "completed", "blocking_count": 0}, True),
+    ({"status": "completed", "blocking_count": 1}, False),
+])
+def test_is_pass_ci_gate_shapes(result: Dict[str, Any], expected_pass: bool) -> None:
+    passed, reason = is_pass(result)
+    assert passed is expected_pass, f"is_pass({result!r}) returned passed={passed!r}, reason={reason!r}"
+    if expected_pass:
+        assert reason == "passed"
+    else:
+        assert reason
+
+
+# ---------------------------------------------------------------------------
+# claude_github_optional result shapes: state=completed + result_status
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("result,expected_pass", [
+    ({"state": "completed", "result_status": "pass", "blocking_count": 0}, True),
+    ({"state": "completed", "result_status": "pass", "blocking_count": 1}, False),
+    ({"state": "completed", "result_status": "fail", "blocking_count": 0}, False),
+    ({"state": "completed", "result_status": "fail", "blocking_count": 2}, False),
+    ({"state": "completed"}, False),
+    ({"state": "completed", "result_status": ""}, False),
+    ({"state": "COMPLETED", "result_status": "pass", "blocking_count": 0}, True),
+])
+def test_is_pass_claude_github_optional_shapes(result: Dict[str, Any], expected_pass: bool) -> None:
+    passed, reason = is_pass(result)
+    assert passed is expected_pass, f"is_pass({result!r}) returned passed={passed!r}, reason={reason!r}"
+    if expected_pass:
+        assert reason == "passed"
+    else:
+        assert reason
+
+
+# ---------------------------------------------------------------------------
+# is_pass() does not regress on standard gate_status contract
+# ---------------------------------------------------------------------------
+
+def test_state_completed_result_status_does_not_override_status() -> None:
+    """Explicit status field takes precedence over state/result_status."""
+    result = {"status": "failed", "state": "completed", "result_status": "pass"}
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "failed" in reason
+
+
+def test_state_completed_result_status_pass_with_blocking_findings() -> None:
+    """state=completed result_status=pass but blocking_findings present → fail."""
+    result = {
+        "state": "completed",
+        "result_status": "pass",
+        "blocking_findings": [{"id": "F1"}],
+        "blocking_count": 1,
+    }
+    passed, reason = is_pass(result)
+    assert passed is False
+    assert "blocking" in reason


### PR DESCRIPTION
## Summary

- Extend `gate_status._coerce_status()` to handle `claude_github_optional` format (`state=completed` + `result_status`) — also fixes `is_terminal()` incorrectly returning False for completed Claude reviews
- Refactor `ci_gate` block in `closure_verifier.py`: replace ad-hoc `status == "pass" and blocking_count == 0` with `gate_is_terminal()` + `gate_is_pass()`
- Refactor `claude_github_optional` state=completed inner block: replace `_gate_terminal_status()` + manual `blocking_count` check with `gate_is_pass()`
- Add `tests/test_gate_status_summarizer_usage.py`: 18 parameterized cases covering ci_gate shapes, claude_github_optional shapes, and field precedence

## Test plan

- [x] `python3 -m pytest tests/test_gate_status_summarizer_usage.py tests/test_gate_status_schema.py tests/test_closure_verifier.py -xvs` → 76 passed, 1 skipped
- [x] All existing gate_status schema tests pass (no regression)
- [x] All existing closure_verifier tests pass (no regression)

Dispatch-ID: 20260430-cfx-12-gate-status-helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)