### PR TITLE
fix(launchd): plist reload helper + active-jobs smoke test (ARC-1)

### DIFF
--- a/scripts/launchd/reload_plist.sh
+++ b/scripts/launchd/reload_plist.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Generic launchd plist reload helper.
+#
+# Usage: bash scripts/launchd/reload_plist.sh <name>
+#   <name> — plist filename without .plist extension
+#            e.g. com.vnx.conversation-analyzer
+#
+# Requires $VNX_HOME to be set, or derives from script location (scripts/launchd/ → repo root).
+# Substitutes ${VNX_HOME} in the plist template, writes resolved plist to
+# ~/Library/LaunchAgents/<name>.plist, and reloads via launchctl.
+#
+# Returns 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <name>" >&2
+    echo "  <name> — plist name without .plist (e.g. com.vnx.conversation-analyzer)" >&2
+    exit 1
+fi
+
+PLIST_LABEL="$1"
+PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLIST_SRC="$SCRIPT_DIR/${PLIST_LABEL}.plist"
+
+if [ -z "${VNX_HOME:-}" ]; then
+    VNX_HOME="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    echo "VNX_HOME not set — using derived path: $VNX_HOME"
+fi
+
+if [ ! -f "$PLIST_SRC" ]; then
+    echo "ERROR: plist template not found: $PLIST_SRC" >&2
+    exit 1
+fi
+
+# Unload existing agent if present (ignore errors — may not be loaded yet)
+if [ -f "$PLIST_DEST" ]; then
+    echo "Unloading existing agent: $PLIST_LABEL"
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+# Substitute ${VNX_HOME} placeholder and write to LaunchAgents
+echo "Writing resolved plist to: $PLIST_DEST"
+sed "s|\${VNX_HOME}|$VNX_HOME|g" "$PLIST_SRC" > "$PLIST_DEST"
+
+# Load the agent
+launchctl load "$PLIST_DEST"
+echo "Loaded: $PLIST_LABEL"
+
+# Verify the agent appears in launchctl list
+if launchctl list | grep -q "$PLIST_LABEL"; then
+    echo "OK: agent registered in launchctl"
+else
+    echo "WARNING: agent not found in launchctl list — check $PLIST_DEST" >&2
+    exit 1
+fi

--- a/tests/smoke/smoke_launchd_active_jobs.sh
+++ b/tests/smoke/smoke_launchd_active_jobs.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Liveness smoke test: verify launchd agents are registered and last-exited cleanly.
+#
+# Only runs when VNX_LAUNCHD_LIVE_CHECK=1 — skipped by default so CI never blocks.
+# Also skipped automatically when launchctl is absent (Linux CI).
+#
+# Usage: VNX_LAUNCHD_LIVE_CHECK=1 bash tests/smoke/smoke_launchd_active_jobs.sh
+# Exit 0: all agents registered and LastExitStatus=0.
+# Exit 1: any agent missing or LastExitStatus non-zero (file-not-found 32512, cmd-not-found 127, etc.)
+
+set -uo pipefail
+
+if [ "${VNX_LAUNCHD_LIVE_CHECK:-0}" != "1" ]; then
+    echo "SKIP: set VNX_LAUNCHD_LIVE_CHECK=1 to run live launchd checks"
+    exit 0
+fi
+
+if ! command -v launchctl &>/dev/null; then
+    echo "SKIP: launchctl not available (not macOS or not in PATH)"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLIST_DIR="$REPO_ROOT/scripts/launchd"
+
+PASS=0
+FAIL=0
+
+shopt -s nullglob
+plist_files=("$PLIST_DIR"/*.plist)
+shopt -u nullglob
+
+if [ ${#plist_files[@]} -eq 0 ]; then
+    echo "ERROR: no plist files found in $PLIST_DIR" >&2
+    exit 1
+fi
+
+echo "Checking launchd agents for plists in $PLIST_DIR"
+echo ""
+
+for plist in "${plist_files[@]}"; do
+    label="$(python3 - "$plist" <<'PYEOF'
+import sys, plistlib
+with open(sys.argv[1], "rb") as f:
+    data = plistlib.load(f)
+print(data.get("Label", ""))
+PYEOF
+)"
+    if [ -z "$label" ]; then
+        echo "  SKIP  $(basename "$plist") — no Label key found"
+        continue
+    fi
+
+    list_output="$(launchctl list "$label" 2>/dev/null || true)"
+    if [ -z "$list_output" ]; then
+        echo "  FAIL  [$label] not registered in launchctl" >&2
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    last_exit="$(echo "$list_output" | grep -m1 '"LastExitStatus"' | grep -oE '[0-9]+' | head -1 || echo "")"
+    if [ "${last_exit:-}" = "0" ]; then
+        echo "  OK    [$label] LastExitStatus=0"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  [$label] LastExitStatus=${last_exit:-unknown} (expected 0)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo ""
+echo "Results: $PASS ok, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "FAIL: $FAIL agent(s) not clean" >&2
+    exit 1
+fi
+
+echo "PASS: all registered agents clean"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/launchd/reload_plist.sh <name>`: generic launchd reload helper — substitutes `${VNX_HOME}`, writes resolved plist to `~/Library/LaunchAgents/`, unloads/loads via launchctl, verifies registration. Replaces the one-off `reload_conversation_analyzer.sh` with a reusable entrypoint.
- Adds `tests/smoke/smoke_launchd_active_jobs.sh`: liveness verification that checks `launchctl list <label>` and asserts `LastExitStatus=0` for every plist in `scripts/launchd/`. Guard-gated via `VNX_LAUNCHD_LIVE_CHECK=1`; skips gracefully when launchctl is absent (CI).
- Existing `tests/smoke/smoke_launchd_plist_paths_resolve.sh` from PR #330 verified: exits 0 (4 ok, 0 failed, 2 skipped unsubstituted templates).

## Test plan

- [x] `bash -n scripts/launchd/reload_plist.sh` — syntax OK
- [x] `bash -n tests/smoke/smoke_launchd_active_jobs.sh` — syntax OK
- [x] `bash tests/smoke/smoke_launchd_plist_paths_resolve.sh` — exit 0 (4 ok, 0 failed)
- [x] `bash tests/smoke/smoke_launchd_active_jobs.sh` without env var — exits 0 with SKIP message
- [ ] `VNX_LAUNCHD_LIVE_CHECK=1 bash tests/smoke/smoke_launchd_active_jobs.sh` — manual on macOS with agents loaded

Dispatch-ID: 20260430-arc1-plist-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)