### PR TITLE
feat(intelligence): receipt classifier with provider abstraction (ARC-3)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -1242,6 +1242,8 @@ def append_receipt_payload(
 
         _maybe_trigger_state_rebuild(receipt)
 
+        _trigger_receipt_classifier(receipt)
+
     return result
 
 
@@ -1282,6 +1284,25 @@ def _update_confidence_from_receipt(receipt: Dict[str, Any]) -> None:
         update_confidence_from_outcome(db_path, dispatch_id, terminal, outcome)
     except Exception as exc:
         _emit("WARN", "confidence_update_failed", error=str(exc))
+
+
+def _trigger_receipt_classifier(receipt: Dict[str, Any]) -> None:
+    """Best-effort fire of the adaptive receipt classifier (ARC-3).
+
+    Disabled by default; opt-in via VNX_RECEIPT_CLASSIFIER_ENABLED=1. Never
+    raises — the receipt writer must remain on its happy path even if the
+    classifier import or subprocess spawn fails.
+    """
+    if os.environ.get("VNX_RECEIPT_CLASSIFIER_ENABLED", "0") != "1":
+        return
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+        from receipt_classifier import trigger_receipt_classifier_async
+        action = trigger_receipt_classifier_async(receipt)
+        if action:
+            _emit("INFO", "receipt_classifier_action", action=action)
+    except Exception as exc:
+        _emit("WARN", "receipt_classifier_trigger_failed", error=str(exc))
 
 
 def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:

--- a/scripts/launchd/com.vnx.receipt-classifier-batch.plist
+++ b/scripts/launchd/com.vnx.receipt-classifier-batch.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.vnx.receipt-classifier-batch</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3</string>
+        <string>${VNX_HOME}/scripts/lib/receipt_classifier_batch.py</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/vnx-receipt-classifier-batch.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/vnx-receipt-classifier-batch.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>VNX_HOME</key>
+        <string>${VNX_HOME}</string>
+        <key>VNX_DATA_DIR</key>
+        <string>${VNX_HOME}/.vnx-data</string>
+        <key>VNX_STATE_DIR</key>
+        <string>${VNX_HOME}/.vnx-data/state</string>
+        <key>VNX_RECEIPT_CLASSIFIER_ENABLED</key>
+        <string>0</string>
+        <key>VNX_RECEIPT_CLASSIFIER_MODE</key>
+        <string>batch</string>
+        <key>VNX_RECEIPT_CLASSIFIER_PROVIDER</key>
+        <string>haiku</string>
+        <key>VNX_RECEIPT_CLASSIFIER_DAILY_COST_USD</key>
+        <string>0.20</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/reload_receipt_classifier.sh
+++ b/scripts/launchd/reload_receipt_classifier.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Reload the com.vnx.receipt-classifier-batch launchd agent.
+#
+# Usage: bash scripts/launchd/reload_receipt_classifier.sh
+#
+# Substitutes ${VNX_HOME} in the plist template and (re)loads the agent.
+# After merge, run this once to schedule the hourly classifier batch job.
+# IMPORTANT: the plist ships with VNX_RECEIPT_CLASSIFIER_ENABLED=0 so it is
+# inert until the operator flips that flag.
+
+set -euo pipefail
+
+PLIST_LABEL="com.vnx.receipt-classifier-batch"
+PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLIST_SRC="$SCRIPT_DIR/${PLIST_LABEL}.plist"
+
+if [ -z "${VNX_HOME:-}" ]; then
+    VNX_HOME="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    echo "VNX_HOME not set — using derived path: $VNX_HOME"
+fi
+
+if [ ! -f "$PLIST_SRC" ]; then
+    echo "ERROR: plist template not found: $PLIST_SRC" >&2
+    exit 1
+fi
+
+TARGET_SCRIPT="$VNX_HOME/scripts/lib/receipt_classifier_batch.py"
+if [ ! -f "$TARGET_SCRIPT" ]; then
+    echo "ERROR: target script not found: $TARGET_SCRIPT" >&2
+    echo "  VNX_HOME=$VNX_HOME may be wrong. Set VNX_HOME to the repo root and retry." >&2
+    exit 1
+fi
+
+if [ -f "$PLIST_DEST" ]; then
+    echo "Unloading existing agent: $PLIST_LABEL"
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+echo "Writing resolved plist to: $PLIST_DEST"
+sed "s|\${VNX_HOME}|$VNX_HOME|g" "$PLIST_SRC" > "$PLIST_DEST"
+
+launchctl load "$PLIST_DEST"
+echo "Loaded: $PLIST_LABEL (runs hourly)"
+
+if launchctl list | grep -q "$PLIST_LABEL"; then
+    echo "OK: agent registered in launchctl"
+else
+    echo "WARNING: agent not found in launchctl list — check $PLIST_DEST" >&2
+    exit 1
+fi
+
+echo "Logs: /tmp/vnx-receipt-classifier-batch.log / /tmp/vnx-receipt-classifier-batch.err"
+echo
+echo "NOTE: the plist ships with VNX_RECEIPT_CLASSIFIER_ENABLED=0."
+echo "      Edit \$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist and re-run this"
+echo "      script to enable. Or export the env var in your shell when invoking ad-hoc."

--- a/scripts/lib/classifier_providers/__init__.py
+++ b/scripts/lib/classifier_providers/__init__.py
@@ -1,0 +1,9 @@
+"""Provider abstraction for the receipt classifier.
+
+Providers wrap CLI calls (claude, ollama, gemini, codex) and return a uniform
+result dict. No Anthropic SDK; subprocess only.
+"""
+
+from .base import ClassifierProvider, ClassifierResult, get_provider
+
+__all__ = ["ClassifierProvider", "ClassifierResult", "get_provider"]

--- a/scripts/lib/classifier_providers/base.py
+++ b/scripts/lib/classifier_providers/base.py
@@ -1,0 +1,141 @@
+"""Abstract receipt-classifier provider and registry.
+
+Concrete providers subclass `ClassifierProvider` and implement `classify`.
+Selection happens through `get_provider(name)`, driven by
+`VNX_RECEIPT_CLASSIFIER_PROVIDER` (defaults to "haiku").
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ClassifierResult:
+    """Uniform result returned by every classifier provider."""
+
+    raw_response: str
+    parsed_json: Optional[Dict[str, Any]]
+    cost_usd: float
+    latency_ms: int
+    provider: str
+    error: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "raw_response": self.raw_response,
+            "parsed_json": self.parsed_json,
+            "cost_usd": self.cost_usd,
+            "latency_ms": self.latency_ms,
+            "provider": self.provider,
+            "error": self.error,
+            "extra": self.extra,
+        }
+
+
+class ClassifierProvider(ABC):
+    """Abstract receipt classifier provider."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        """Run the classifier on `prompt`. Must return a ClassifierResult.
+
+        Implementations must:
+        - never raise on subprocess errors; return ClassifierResult(error=...)
+        - never import Anthropic / OpenAI SDKs
+        - cap execution with a timeout
+        """
+
+
+_JSON_BLOCK_RE = re.compile(r"\{(?:[^{}]|(?:\{[^{}]*\}))*\}", re.DOTALL)
+
+
+def parse_json_block(text: str) -> Optional[Dict[str, Any]]:
+    """Best-effort JSON extraction from arbitrary CLI text output.
+
+    Tries: full string parse → fenced ```json``` block → first balanced {...}.
+    Returns None if no parseable object is found.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict):
+            return obj
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # ```json ... ``` fenced block
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", stripped, re.DOTALL)
+    if fence_match:
+        try:
+            obj = json.loads(fence_match.group(1))
+            if isinstance(obj, dict):
+                return obj
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # First balanced JSON object — depth scan to handle nested objects.
+    start = stripped.find("{")
+    while start != -1:
+        depth = 0
+        in_str = False
+        esc = False
+        for idx in range(start, len(stripped)):
+            ch = stripped[idx]
+            if esc:
+                esc = False
+                continue
+            if ch == "\\":
+                esc = True
+                continue
+            if ch == '"' and not esc:
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = stripped[start:idx + 1]
+                    try:
+                        obj = json.loads(candidate)
+                        if isinstance(obj, dict):
+                            return obj
+                    except (json.JSONDecodeError, ValueError):
+                        break
+        start = stripped.find("{", start + 1)
+
+    return None
+
+
+def get_provider(name: Optional[str] = None) -> ClassifierProvider:
+    """Return a configured provider instance for `name`.
+
+    Lazy imports keep optional dependencies out of the import path until used.
+    Unknown names raise ValueError so misconfigurations surface loudly.
+    """
+    key = (name or "haiku").strip().lower()
+    if key == "haiku":
+        from .haiku_provider import HaikuProvider
+        return HaikuProvider()
+    if key == "ollama":
+        from .ollama_provider import OllamaProvider
+        return OllamaProvider()
+    if key == "gemini":
+        from .gemini_provider import GeminiProvider
+        return GeminiProvider()
+    if key == "codex":
+        from .codex_provider import CodexProvider
+        return CodexProvider()
+    raise ValueError(f"unknown classifier provider: {key}")

--- a/scripts/lib/classifier_providers/codex_provider.py
+++ b/scripts/lib/classifier_providers/codex_provider.py
@@ -1,0 +1,90 @@
+"""Codex CLI provider (subprocess only). Currently rate-limited until 2026-05-05."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .base import ClassifierProvider, ClassifierResult, parse_json_block
+
+_DEFAULT_TIMEOUT = 120
+_DEFAULT_FLAT_COST_USD = 0.002
+
+
+class CodexProvider(ClassifierProvider):
+    """Run classification via the local `codex` CLI (`codex exec --json`)."""
+
+    name = "codex"
+
+    def __init__(
+        self,
+        timeout_seconds: Optional[int] = None,
+        flat_cost_usd: Optional[float] = None,
+    ) -> None:
+        self.timeout_seconds = int(
+            timeout_seconds
+            if timeout_seconds is not None
+            else os.environ.get("VNX_CODEX_TIMEOUT", _DEFAULT_TIMEOUT)
+        )
+        try:
+            self.flat_cost_usd = float(
+                flat_cost_usd
+                if flat_cost_usd is not None
+                else os.environ.get("VNX_CODEX_FLAT_COST_USD", _DEFAULT_FLAT_COST_USD)
+            )
+        except (TypeError, ValueError):
+            self.flat_cost_usd = _DEFAULT_FLAT_COST_USD
+
+    def is_available(self) -> bool:
+        return shutil.which("codex") is not None
+
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        cmd = ["codex", "exec", "--json"]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"codex CLI not found: {exc}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"timeout after {self.timeout_seconds}s: {exc}",
+            )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if proc.returncode != 0:
+            return ClassifierResult(
+                raw_response=proc.stdout or "",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+                provider=self.name,
+                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
+            )
+        raw = proc.stdout or ""
+        return ClassifierResult(
+            raw_response=raw,
+            parsed_json=parse_json_block(raw),
+            cost_usd=self.flat_cost_usd,
+            latency_ms=latency_ms,
+            provider=self.name,
+        )

--- a/scripts/lib/classifier_providers/gemini_provider.py
+++ b/scripts/lib/classifier_providers/gemini_provider.py
@@ -1,0 +1,93 @@
+"""Gemini CLI provider (subprocess only). Cost is best-effort flat-rate."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .base import ClassifierProvider, ClassifierResult, parse_json_block
+
+_DEFAULT_MODEL = "gemini-2.0-flash"
+_DEFAULT_TIMEOUT = 60
+_DEFAULT_FLAT_COST_USD = 0.0005
+
+
+class GeminiProvider(ClassifierProvider):
+    """Run classification via the local `gemini` CLI."""
+
+    name = "gemini"
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        flat_cost_usd: Optional[float] = None,
+    ) -> None:
+        self.model = model or os.environ.get("VNX_GEMINI_MODEL", _DEFAULT_MODEL)
+        self.timeout_seconds = int(
+            timeout_seconds
+            if timeout_seconds is not None
+            else os.environ.get("VNX_GEMINI_TIMEOUT", _DEFAULT_TIMEOUT)
+        )
+        try:
+            self.flat_cost_usd = float(
+                flat_cost_usd
+                if flat_cost_usd is not None
+                else os.environ.get("VNX_GEMINI_FLAT_COST_USD", _DEFAULT_FLAT_COST_USD)
+            )
+        except (TypeError, ValueError):
+            self.flat_cost_usd = _DEFAULT_FLAT_COST_USD
+
+    def is_available(self) -> bool:
+        return shutil.which("gemini") is not None
+
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        cmd = ["gemini", "--model", self.model, "--prompt", prompt]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"gemini CLI not found: {exc}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"timeout after {self.timeout_seconds}s: {exc}",
+            )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if proc.returncode != 0:
+            return ClassifierResult(
+                raw_response=proc.stdout or "",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+                provider=self.name,
+                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
+            )
+        raw = proc.stdout or ""
+        return ClassifierResult(
+            raw_response=raw,
+            parsed_json=parse_json_block(raw),
+            cost_usd=self.flat_cost_usd,
+            latency_ms=latency_ms,
+            provider=self.name,
+            extra={"model": self.model},
+        )

--- a/scripts/lib/classifier_providers/haiku_provider.py
+++ b/scripts/lib/classifier_providers/haiku_provider.py
@@ -1,0 +1,101 @@
+"""Claude Haiku provider via the local `claude` CLI (subprocess only).
+
+Pricing constants are pinned to claude-haiku-4-5 list pricing. We use a
+flat-rate estimate per call because the CLI does not consistently report
+per-call token usage on stdout. Operators can override via env vars.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .base import ClassifierProvider, ClassifierResult, parse_json_block
+
+_DEFAULT_MODEL = "claude-haiku-4-5"
+_DEFAULT_TIMEOUT = 60
+_DEFAULT_FLAT_COST_USD = 0.001
+
+
+class HaikuProvider(ClassifierProvider):
+    """Run classification via `claude --print --model claude-haiku-4-5`."""
+
+    name = "haiku"
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        flat_cost_usd: Optional[float] = None,
+    ) -> None:
+        self.model = model or os.environ.get("VNX_HAIKU_MODEL", _DEFAULT_MODEL)
+        self.timeout_seconds = int(
+            timeout_seconds
+            if timeout_seconds is not None
+            else os.environ.get("VNX_HAIKU_TIMEOUT", _DEFAULT_TIMEOUT)
+        )
+        try:
+            self.flat_cost_usd = float(
+                flat_cost_usd
+                if flat_cost_usd is not None
+                else os.environ.get("VNX_HAIKU_FLAT_COST_USD", _DEFAULT_FLAT_COST_USD)
+            )
+        except (TypeError, ValueError):
+            self.flat_cost_usd = _DEFAULT_FLAT_COST_USD
+
+    def is_available(self) -> bool:
+        return shutil.which("claude") is not None
+
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        cmd = ["claude", "--print", "--model", self.model]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"claude CLI not found: {exc}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"timeout after {self.timeout_seconds}s: {exc}",
+            )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if proc.returncode != 0:
+            return ClassifierResult(
+                raw_response=proc.stdout or "",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+                provider=self.name,
+                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
+            )
+
+        raw = proc.stdout or ""
+        parsed = parse_json_block(raw)
+        return ClassifierResult(
+            raw_response=raw,
+            parsed_json=parsed,
+            cost_usd=self.flat_cost_usd,
+            latency_ms=latency_ms,
+            provider=self.name,
+            extra={"model": self.model},
+        )

--- a/scripts/lib/classifier_providers/ollama_provider.py
+++ b/scripts/lib/classifier_providers/ollama_provider.py
@@ -1,0 +1,84 @@
+"""Local Ollama provider (subprocess only). Cost is $0 (local inference)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .base import ClassifierProvider, ClassifierResult, parse_json_block
+
+_DEFAULT_MODEL = "llama3.1:8b"
+_DEFAULT_TIMEOUT = 120
+
+
+class OllamaProvider(ClassifierProvider):
+    """Run classification via `ollama run <model>`."""
+
+    name = "ollama"
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+    ) -> None:
+        self.model = model or os.environ.get("VNX_OLLAMA_MODEL", _DEFAULT_MODEL)
+        self.timeout_seconds = int(
+            timeout_seconds
+            if timeout_seconds is not None
+            else os.environ.get("VNX_OLLAMA_TIMEOUT", _DEFAULT_TIMEOUT)
+        )
+
+    def is_available(self) -> bool:
+        return shutil.which("ollama") is not None
+
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        cmd = ["ollama", "run", self.model]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"ollama CLI not found: {exc}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ClassifierResult(
+                raw_response="",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name,
+                error=f"timeout after {self.timeout_seconds}s: {exc}",
+            )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if proc.returncode != 0:
+            return ClassifierResult(
+                raw_response=proc.stdout or "",
+                parsed_json=None,
+                cost_usd=0.0,
+                latency_ms=latency_ms,
+                provider=self.name,
+                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
+            )
+        raw = proc.stdout or ""
+        return ClassifierResult(
+            raw_response=raw,
+            parsed_json=parse_json_block(raw),
+            cost_usd=0.0,
+            latency_ms=latency_ms,
+            provider=self.name,
+            extra={"model": self.model},
+        )

--- a/scripts/lib/receipt_classifier.py
+++ b/scripts/lib/receipt_classifier.py
@@ -1,0 +1,563 @@
+"""Adaptive receipt classifier (ARC-3).
+
+Triggered (best-effort, non-blocking) from the append_receipt post-write hook.
+Three modes:
+  - batch (default): receipts are appended to a queue file, processed hourly
+    by `receipt_classifier_batch.py`.
+  - per_receipt: every receipt write spawns an async classifier subprocess.
+  - failures_direct: failures fire immediately, successes batch.
+
+Operator opt-in only: `VNX_RECEIPT_CLASSIFIER_ENABLED=1`. When unset/0 every
+public function is a no-op.
+
+Significance gate (per operator decision): only edits with confidence >= 0.8
+AND impact_class in {policy_change, removed_rule, new_skill, threshold_change}
+are queued to `pending_edits.json`. Trivial findings are dropped.
+
+Daily cost budget (default $0.20) is tracked in
+`<state_dir>/receipt_classifier_cost.json`. When exhausted the classifier
+skips work and emits a single warning per call.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import fcntl
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+# Local imports — keep classifier_providers package on sys.path.
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from classifier_providers import ClassifierProvider, ClassifierResult, get_provider  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------
+
+ENV_ENABLED = "VNX_RECEIPT_CLASSIFIER_ENABLED"
+ENV_MODE = "VNX_RECEIPT_CLASSIFIER_MODE"
+ENV_PROVIDER = "VNX_RECEIPT_CLASSIFIER_PROVIDER"
+ENV_DAILY_BUDGET = "VNX_RECEIPT_CLASSIFIER_DAILY_COST_USD"
+ENV_STATE_DIR = "VNX_STATE_DIR"
+
+DEFAULT_MODE = "batch"
+DEFAULT_PROVIDER = "haiku"
+DEFAULT_DAILY_BUDGET_USD = 0.20
+
+VALID_MODES = {"batch", "per_receipt", "failures_direct"}
+
+SIGNIFICANT_IMPACT_CLASSES = {
+    "policy_change",
+    "removed_rule",
+    "new_skill",
+    "threshold_change",
+}
+
+CONFIDENCE_THRESHOLD = 0.8
+
+# State file names (under VNX_STATE_DIR).
+COST_FILE_NAME = "receipt_classifier_cost.json"
+QUEUE_FILE_NAME = "receipt_classifier_queue.ndjson"
+PENDING_EDITS_FILE_NAME = "pending_edits.json"
+
+# Failure statuses we consider when sampling/branching.
+_FAILURE_STATUSES = {"failed", "failure", "error", "blocked", "timeout"}
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    return os.environ.get(ENV_ENABLED, "0") == "1"
+
+
+def get_mode() -> str:
+    mode = (os.environ.get(ENV_MODE) or DEFAULT_MODE).strip().lower()
+    return mode if mode in VALID_MODES else DEFAULT_MODE
+
+
+def get_provider_name() -> str:
+    return (os.environ.get(ENV_PROVIDER) or DEFAULT_PROVIDER).strip().lower()
+
+
+def get_daily_budget_usd() -> float:
+    raw = os.environ.get(ENV_DAILY_BUDGET)
+    if raw is None or raw == "":
+        return DEFAULT_DAILY_BUDGET_USD
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_DAILY_BUDGET_USD
+
+
+def state_dir() -> Path:
+    """Resolve the VNX state directory; falls back to repo .vnx-data/state."""
+    raw = os.environ.get(ENV_STATE_DIR)
+    if raw:
+        return Path(raw)
+    return Path(__file__).resolve().parents[2] / ".vnx-data" / "state"
+
+
+def should_classify(receipt: Dict[str, Any], mode: Optional[str] = None) -> bool:
+    """Whether the receipt is a candidate for classification at all.
+
+    Sampling rules per mode:
+      - batch / per_receipt: any task_complete / task_failed / task_timeout receipt.
+      - failures_direct: only failures fire directly; successes are queued for batch.
+
+    State-mutation, ack, dispatch_sent and other lightweight events are skipped
+    because they carry no outcome signal.
+    """
+    if not isinstance(receipt, dict):
+        return False
+    event_type = str(receipt.get("event_type") or receipt.get("event") or "").lower()
+    OUTCOME_EVENTS = {"task_complete", "task_completed", "task_failed", "task_timeout"}
+    if event_type not in OUTCOME_EVENTS:
+        return False
+    return True
+
+
+def trigger_receipt_classifier_async(receipt: Dict[str, Any]) -> Optional[str]:
+    """Best-effort async fire from the receipt write hook.
+
+    Returns:
+        Short string describing the action taken (for logging), or None when
+        the classifier is disabled. Never raises.
+    """
+    try:
+        if not is_enabled():
+            return None
+        if not should_classify(receipt):
+            return "skipped_not_outcome"
+
+        mode = get_mode()
+        if mode == "batch":
+            _append_to_queue(receipt)
+            return "queued_batch"
+
+        if mode == "per_receipt":
+            _spawn_async_classify(receipt)
+            return "fired_per_receipt"
+
+        if mode == "failures_direct":
+            status = str(receipt.get("status") or "").lower()
+            event_type = str(receipt.get("event_type") or receipt.get("event") or "").lower()
+            is_failure = status in _FAILURE_STATUSES or event_type in {"task_failed", "task_timeout"}
+            if is_failure:
+                _spawn_async_classify(receipt)
+                return "fired_failure_direct"
+            _append_to_queue(receipt)
+            return "queued_success_for_batch"
+
+        return "skipped_unknown_mode"
+    except Exception as exc:  # never propagate to the receipt writer
+        logger.warning("receipt_classifier_async_failed: %s", exc)
+        return "error"
+
+
+def classify_receipt(
+    receipt: Dict[str, Any], provider: Optional[ClassifierProvider] = None
+) -> Dict[str, Any]:
+    """Classify a single receipt synchronously. Used by per_receipt mode.
+
+    Returns the parsed classification (or an error dict). Significant
+    suggested edits are queued automatically when present.
+    """
+    return _run_classification([receipt], provider=provider, batch=False)
+
+
+def classify_batch(
+    receipts: List[Dict[str, Any]], provider: Optional[ClassifierProvider] = None
+) -> Dict[str, Any]:
+    """Classify a batch of receipts in a single provider call."""
+    return _run_classification(receipts, provider=provider, batch=True)
+
+
+# ----------------------------------------------------------------------
+# Cost tracking
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class CostEntry:
+    date: str
+    spent_usd: float
+    calls: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _today_str() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+
+
+def _cost_path() -> Path:
+    return state_dir() / COST_FILE_NAME
+
+
+def _read_cost(path: Optional[Path] = None) -> CostEntry:
+    p = path or _cost_path()
+    today = _today_str()
+    if not p.is_file():
+        return CostEntry(date=today, spent_usd=0.0, calls=0)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return CostEntry(date=today, spent_usd=0.0, calls=0)
+        if str(data.get("date")) != today:
+            return CostEntry(date=today, spent_usd=0.0, calls=0)
+        return CostEntry(
+            date=today,
+            spent_usd=float(data.get("spent_usd", 0.0)),
+            calls=int(data.get("calls", 0)),
+        )
+    except (OSError, ValueError, json.JSONDecodeError):
+        return CostEntry(date=today, spent_usd=0.0, calls=0)
+
+
+def _write_cost(entry: CostEntry, path: Optional[Path] = None) -> None:
+    p = path or _cost_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(entry.to_dict(), separators=(",", ":")), encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def track_cost(provider_name: str, cost_usd: float, path: Optional[Path] = None) -> CostEntry:
+    """Increment today's spend; ensures atomic write under concurrent fires."""
+    p = path or _cost_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        entry = _read_cost(p)
+        entry.spent_usd = round(entry.spent_usd + max(0.0, float(cost_usd)), 6)
+        entry.calls += 1
+        _write_cost(entry, p)
+    logger.debug(
+        "receipt_classifier cost: provider=%s today=%s spent=%.6f calls=%d",
+        provider_name, entry.date, entry.spent_usd, entry.calls,
+    )
+    return entry
+
+
+def is_budget_exhausted(path: Optional[Path] = None) -> bool:
+    budget = get_daily_budget_usd()
+    if budget <= 0:
+        return True
+    entry = _read_cost(path)
+    return entry.spent_usd >= budget
+
+
+# ----------------------------------------------------------------------
+# Queue (batch mode)
+# ----------------------------------------------------------------------
+
+
+def _queue_path() -> Path:
+    return state_dir() / QUEUE_FILE_NAME
+
+
+def _append_to_queue(receipt: Dict[str, Any], path: Optional[Path] = None) -> None:
+    p = path or _queue_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"queued_at": time.time(), "receipt": receipt}, separators=(",", ":")))
+            fh.write("\n")
+
+
+def drain_queue(path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Read & truncate the queue under lock. Returns raw receipts list."""
+    p = path or _queue_path()
+    if not p.is_file():
+        return []
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    receipts: List[Dict[str, Any]] = []
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            content = p.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            receipt = obj.get("receipt") if isinstance(obj, dict) else None
+            if isinstance(receipt, dict):
+                receipts.append(receipt)
+        try:
+            p.write_text("", encoding="utf-8")
+        except OSError:
+            pass
+    return receipts
+
+
+# ----------------------------------------------------------------------
+# Classification core
+# ----------------------------------------------------------------------
+
+
+_PROMPT_HEADER = """You are an adaptive receipt classifier for the VNX governance system.
+
+Task: read the dispatch receipt(s) below, classify the outcome, and (only if a
+truly significant rule/policy/skill change is warranted) suggest a single
+concrete edit. Trivial observations must be returned without any suggested_edit.
+
+Output ONLY a JSON object — no prose, no markdown fences. The schema is:
+
+{
+  "domain": "governance|coding|business|test|other",
+  "outcome_class": "success|failure|stuck|partial",
+  "recurring_pattern_observed": "<text or null>",
+  "impact_class": "trivial|moderate|significant|policy_change",
+  "suggested_edit": null OR {
+      "target_file": "<path>",
+      "edit_type": "add_line|remove_line|replace",
+      "content": "<text>",
+      "rationale": "<text>",
+      "confidence": <number between 0 and 1>
+  }
+}
+
+Significance rule: emit `suggested_edit` ONLY when confidence >= 0.8 AND the
+edit clearly changes a policy, removes a rule, adds a new skill, or shifts a
+threshold. Otherwise set `suggested_edit` to null and choose impact_class
+accordingly.
+
+Receipts:
+"""
+
+
+def _build_prompt(receipts: Iterable[Dict[str, Any]]) -> str:
+    body_parts: List[str] = []
+    for idx, rcpt in enumerate(receipts, start=1):
+        compact = {
+            "dispatch_id": rcpt.get("dispatch_id"),
+            "terminal": rcpt.get("terminal"),
+            "event_type": rcpt.get("event_type") or rcpt.get("event"),
+            "status": rcpt.get("status"),
+            "timestamp": rcpt.get("timestamp"),
+            "duration_seconds": rcpt.get("duration_seconds"),
+            "model": rcpt.get("model"),
+            "report_path": rcpt.get("report_path"),
+            "pr_id": rcpt.get("pr_id") or rcpt.get("pr_number"),
+            "summary": rcpt.get("summary") or rcpt.get("notes") or "",
+        }
+        body_parts.append(f"--- receipt {idx} ---\n{json.dumps(compact, ensure_ascii=False)}")
+    return _PROMPT_HEADER + "\n".join(body_parts) + "\n"
+
+
+def _is_significant(parsed: Dict[str, Any]) -> bool:
+    edit = parsed.get("suggested_edit")
+    if not isinstance(edit, dict):
+        return False
+    impact = str(parsed.get("impact_class") or "").strip().lower()
+    if impact not in SIGNIFICANT_IMPACT_CLASSES:
+        return False
+    try:
+        confidence = float(edit.get("confidence", 0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    if confidence < CONFIDENCE_THRESHOLD:
+        return False
+    if not edit.get("target_file") or not edit.get("edit_type"):
+        return False
+    return True
+
+
+def _pending_edits_path() -> Path:
+    return state_dir() / PENDING_EDITS_FILE_NAME
+
+
+def _queue_pending_edit(parsed: Dict[str, Any], source_dispatch_id: str) -> Optional[str]:
+    """Append a significant suggested edit to pending_edits.json. Returns id."""
+    edit = parsed.get("suggested_edit")
+    if not isinstance(edit, dict):
+        return None
+    p = _pending_edits_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        existing: List[Dict[str, Any]] = []
+        if p.is_file():
+            try:
+                raw = p.read_text(encoding="utf-8")
+                if raw.strip():
+                    data = json.loads(raw)
+                    if isinstance(data, list):
+                        existing = data
+            except (OSError, json.JSONDecodeError):
+                existing = []
+        edit_id = f"arc3-{int(time.time() * 1000)}-{len(existing)}"
+        record = {
+            "id": edit_id,
+            "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "source": "receipt_classifier",
+            "source_dispatch_id": source_dispatch_id,
+            "domain": parsed.get("domain"),
+            "outcome_class": parsed.get("outcome_class"),
+            "impact_class": parsed.get("impact_class"),
+            "recurring_pattern_observed": parsed.get("recurring_pattern_observed"),
+            "edit": edit,
+            "status": "pending",
+        }
+        existing.append(record)
+        tmp = p.with_suffix(p.suffix + ".tmp")
+        tmp.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        os.replace(tmp, p)
+    return edit_id
+
+
+def _run_classification(
+    receipts: List[Dict[str, Any]],
+    *,
+    provider: Optional[ClassifierProvider] = None,
+    batch: bool,
+) -> Dict[str, Any]:
+    """Shared classify path for single + batch."""
+    if not receipts:
+        return {"status": "skipped", "reason": "no_receipts"}
+
+    if is_budget_exhausted():
+        logger.warning(
+            "receipt_classifier budget_exhausted: daily_budget_usd=%.4f",
+            get_daily_budget_usd(),
+        )
+        return {"status": "skipped", "reason": "budget_exhausted"}
+
+    prov = provider or get_provider(get_provider_name())
+    prompt = _build_prompt(receipts)
+
+    result: ClassifierResult = prov.classify(prompt)
+    if result.cost_usd > 0:
+        track_cost(prov.name, result.cost_usd)
+
+    if result.error:
+        return {
+            "status": "provider_error",
+            "error": result.error,
+            "provider": prov.name,
+            "latency_ms": result.latency_ms,
+        }
+
+    parsed = result.parsed_json
+    if not isinstance(parsed, dict):
+        return {
+            "status": "parse_error",
+            "raw_response": result.raw_response[:1000],
+            "provider": prov.name,
+        }
+
+    queued: List[str] = []
+    if _is_significant(parsed):
+        first_dispatch_id = str(receipts[0].get("dispatch_id") or "unknown")
+        edit_id = _queue_pending_edit(parsed, first_dispatch_id)
+        if edit_id:
+            queued.append(edit_id)
+
+    return {
+        "status": "ok",
+        "batch": batch,
+        "provider": prov.name,
+        "parsed": parsed,
+        "queued_edit_ids": queued,
+        "cost_usd": result.cost_usd,
+        "latency_ms": result.latency_ms,
+    }
+
+
+# ----------------------------------------------------------------------
+# Async fire helper (per_receipt / failures_direct)
+# ----------------------------------------------------------------------
+
+
+def _spawn_async_classify(receipt: Dict[str, Any]) -> None:
+    """Spawn a detached subprocess that runs the classifier on one receipt.
+
+    The child re-enters this module via __main__ so we keep the import surface
+    minimal and reuse the same code path. Fully detached (start_new_session)
+    so it does not block the receipt writer.
+    """
+    try:
+        payload = json.dumps({"receipts": [receipt]}, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return
+    cmd = [sys.executable, str(Path(__file__).resolve()), "--from-stdin", "--mode", "per_receipt"]
+    try:
+        subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        ).stdin.write(payload.encode("utf-8"))  # type: ignore[union-attr]
+    except OSError as exc:
+        logger.warning("receipt_classifier spawn failed: %s", exc)
+
+
+# ----------------------------------------------------------------------
+# CLI entry (used by the async spawn and ad-hoc operator runs)
+# ----------------------------------------------------------------------
+
+
+def _cli(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Receipt classifier (ARC-3)")
+    parser.add_argument("--from-stdin", action="store_true", help="Read JSON {receipts:[...]} from stdin")
+    parser.add_argument("--mode", default="per_receipt", choices=sorted(VALID_MODES))
+    parser.add_argument("--dry-run", action="store_true", help="Do not call provider; print prompt only")
+    args = parser.parse_args(argv)
+
+    receipts: List[Dict[str, Any]] = []
+    if args.from_stdin:
+        try:
+            payload = json.loads(sys.stdin.read() or "{}")
+            receipts = list(payload.get("receipts") or [])
+        except json.JSONDecodeError as exc:
+            print(json.dumps({"status": "error", "reason": f"bad_stdin_json: {exc}"}))
+            return 2
+
+    if args.dry_run:
+        print(_build_prompt(receipts))
+        return 0
+
+    if not receipts:
+        print(json.dumps({"status": "skipped", "reason": "no_receipts"}))
+        return 0
+
+    if args.mode == "per_receipt":
+        result = classify_receipt(receipts[0])
+    else:
+        result = classify_batch(receipts)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/scripts/lib/receipt_classifier_batch.py
+++ b/scripts/lib/receipt_classifier_batch.py
@@ -1,0 +1,76 @@
+"""Hourly batch processor for queued receipts (ARC-3).
+
+Run by the launchd job `com.vnx.receipt-classifier-batch`. Drains the queue
+written by `_append_to_queue`, builds a single batch prompt, runs the
+configured provider, queues any significant suggested edits.
+
+CLI:
+    python3 scripts/lib/receipt_classifier_batch.py [--dry-run] [--max-receipts N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from receipt_classifier import (  # noqa: E402
+    classify_batch,
+    drain_queue,
+    is_budget_exhausted,
+    is_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Receipt classifier hourly batch (ARC-3)")
+    parser.add_argument("--dry-run", action="store_true", help="Drain queue but do not call provider")
+    parser.add_argument(
+        "--max-receipts",
+        type=int,
+        default=200,
+        help="Cap receipts per batch call (defaults to 200 to keep prompt small)",
+    )
+    parser.add_argument("--force", action="store_true", help="Run even when disabled (debugging only)")
+    args = parser.parse_args(argv)
+
+    if not is_enabled() and not args.force:
+        print(json.dumps({"status": "skipped", "reason": "disabled"}))
+        return 0
+
+    receipts = drain_queue()
+    if not receipts:
+        print(json.dumps({"status": "ok", "drained": 0}))
+        return 0
+
+    if args.dry_run:
+        print(json.dumps({"status": "dry_run", "drained": len(receipts)}))
+        return 0
+
+    if is_budget_exhausted():
+        print(
+            json.dumps(
+                {"status": "skipped", "reason": "budget_exhausted", "drained": len(receipts)}
+            )
+        )
+        return 0
+
+    cap = max(1, int(args.max_receipts))
+    batch_slice = receipts[:cap]
+    result = classify_batch(batch_slice)
+    result["drained"] = len(receipts)
+    result["processed"] = len(batch_slice)
+    print(json.dumps(result, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_classifier_providers.py
+++ b/tests/test_classifier_providers.py
@@ -1,0 +1,239 @@
+"""Tests for classifier provider abstraction (ARC-3)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+from classifier_providers import get_provider  # noqa: E402
+from classifier_providers.base import (  # noqa: E402
+    ClassifierProvider,
+    ClassifierResult,
+    parse_json_block,
+)
+from classifier_providers.haiku_provider import HaikuProvider  # noqa: E402
+from classifier_providers.ollama_provider import OllamaProvider  # noqa: E402
+
+
+def _make_completed(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["dummy"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# ----------------------------------------------------------------------
+# parse_json_block
+# ----------------------------------------------------------------------
+
+
+def test_parse_json_block_pure_json():
+    obj = parse_json_block('{"a": 1}')
+    assert obj == {"a": 1}
+
+
+def test_parse_json_block_fenced_code_block():
+    text = 'noise\n```json\n{"x": "y"}\n```\nmore noise'
+    assert parse_json_block(text) == {"x": "y"}
+
+
+def test_parse_json_block_embedded_json():
+    text = "Here is the result: {\"impact_class\": \"trivial\"} -- end"
+    assert parse_json_block(text) == {"impact_class": "trivial"}
+
+
+def test_parse_json_block_returns_none_when_no_json():
+    assert parse_json_block("no json here at all") is None
+
+
+def test_parse_json_block_handles_empty():
+    assert parse_json_block("") is None
+
+
+# ----------------------------------------------------------------------
+# get_provider
+# ----------------------------------------------------------------------
+
+
+def test_get_provider_returns_haiku_by_default():
+    prov = get_provider(None)
+    assert isinstance(prov, HaikuProvider)
+    assert prov.name == "haiku"
+
+
+def test_get_provider_returns_ollama():
+    prov = get_provider("ollama")
+    assert isinstance(prov, OllamaProvider)
+    assert prov.name == "ollama"
+
+
+def test_get_provider_unknown_raises():
+    with pytest.raises(ValueError):
+        get_provider("definitely-not-a-provider")
+
+
+def test_get_provider_is_case_insensitive():
+    prov = get_provider("HAIKU")
+    assert isinstance(prov, HaikuProvider)
+
+
+# ----------------------------------------------------------------------
+# Haiku provider
+# ----------------------------------------------------------------------
+
+
+def test_haiku_provider_parses_output():
+    prov = HaikuProvider(flat_cost_usd=0.005)
+    payload = '{"domain":"governance","outcome_class":"success","impact_class":"trivial","suggested_edit":null}'
+    with patch("classifier_providers.haiku_provider.subprocess.run", return_value=_make_completed(payload)):
+        result = prov.classify("test prompt")
+    assert isinstance(result, ClassifierResult)
+    assert result.error is None
+    assert result.parsed_json is not None
+    assert result.parsed_json["domain"] == "governance"
+    assert result.cost_usd == 0.005
+    assert result.provider == "haiku"
+
+
+def test_haiku_provider_handles_nonzero_exit():
+    prov = HaikuProvider()
+    with patch(
+        "classifier_providers.haiku_provider.subprocess.run",
+        return_value=_make_completed("", returncode=2, stderr="boom"),
+    ):
+        result = prov.classify("test")
+    assert result.error is not None
+    assert "exit 2" in result.error
+    assert result.parsed_json is None
+    assert result.cost_usd == 0.0
+
+
+def test_haiku_provider_handles_missing_cli():
+    prov = HaikuProvider()
+    with patch(
+        "classifier_providers.haiku_provider.subprocess.run",
+        side_effect=FileNotFoundError("claude"),
+    ):
+        result = prov.classify("test")
+    assert result.error is not None
+    assert "not found" in result.error
+    assert result.cost_usd == 0.0
+
+
+def test_haiku_provider_handles_timeout():
+    prov = HaikuProvider(timeout_seconds=1)
+    err = subprocess.TimeoutExpired(cmd="claude", timeout=1)
+    with patch("classifier_providers.haiku_provider.subprocess.run", side_effect=err):
+        result = prov.classify("test")
+    assert result.error is not None
+    assert "timeout" in result.error
+    assert result.cost_usd == 0.0
+
+
+def test_haiku_provider_uses_correct_command():
+    prov = HaikuProvider(model="claude-haiku-4-5")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _make_completed('{"ok": true}')
+
+    with patch("classifier_providers.haiku_provider.subprocess.run", side_effect=fake_run):
+        prov.classify("test prompt")
+    assert captured["cmd"] == ["claude", "--print", "--model", "claude-haiku-4-5"]
+    assert captured["kwargs"]["input"] == "test prompt"
+
+
+# ----------------------------------------------------------------------
+# Ollama provider
+# ----------------------------------------------------------------------
+
+
+def test_ollama_provider_parses_output():
+    prov = OllamaProvider(model="llama3.1:8b")
+    with patch(
+        "classifier_providers.ollama_provider.subprocess.run",
+        return_value=_make_completed('{"x": 1}'),
+    ):
+        result = prov.classify("test")
+    assert result.error is None
+    assert result.parsed_json == {"x": 1}
+    assert result.cost_usd == 0.0  # local — always free
+    assert result.provider == "ollama"
+
+
+def test_ollama_provider_uses_correct_command():
+    prov = OllamaProvider(model="llama3.1:8b")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _make_completed('{}')
+
+    with patch("classifier_providers.ollama_provider.subprocess.run", side_effect=fake_run):
+        prov.classify("hi")
+    assert captured["cmd"] == ["ollama", "run", "llama3.1:8b"]
+    assert captured["kwargs"]["input"] == "hi"
+
+
+def test_ollama_provider_handles_missing_cli():
+    prov = OllamaProvider()
+    with patch(
+        "classifier_providers.ollama_provider.subprocess.run",
+        side_effect=FileNotFoundError("ollama"),
+    ):
+        result = prov.classify("test")
+    assert result.error is not None
+    assert "not found" in result.error
+
+
+def test_ollama_provider_handles_nonzero_exit():
+    prov = OllamaProvider()
+    with patch(
+        "classifier_providers.ollama_provider.subprocess.run",
+        return_value=_make_completed("", returncode=1, stderr="model missing"),
+    ):
+        result = prov.classify("test")
+    assert result.error is not None
+    assert "exit 1" in result.error
+
+
+# ----------------------------------------------------------------------
+# Custom provider plug-in path
+# ----------------------------------------------------------------------
+
+
+class _FixtureProvider(ClassifierProvider):
+    name = "fixture"
+
+    def __init__(self, response: str):
+        self._response = response
+
+    def classify(self, prompt: str, max_tokens: int = 1500) -> ClassifierResult:
+        return ClassifierResult(
+            raw_response=self._response,
+            parsed_json=parse_json_block(self._response),
+            cost_usd=0.0,
+            latency_ms=1,
+            provider=self.name,
+        )
+
+
+def test_fixture_provider_round_trip():
+    prov = _FixtureProvider('{"hello": "world"}')
+    result = prov.classify("ignore")
+    assert result.parsed_json == {"hello": "world"}
+    assert result.error is None

--- a/tests/test_receipt_classifier.py
+++ b/tests/test_receipt_classifier.py
@@ -1,0 +1,380 @@
+"""Tests for the adaptive receipt classifier core (ARC-3)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+import receipt_classifier as rc  # noqa: E402
+from classifier_providers.base import ClassifierProvider, ClassifierResult  # noqa: E402
+
+
+# ----------------------------------------------------------------------
+# Fixtures / helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_state(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(state))
+    monkeypatch.delenv("VNX_RECEIPT_CLASSIFIER_ENABLED", raising=False)
+    monkeypatch.delenv("VNX_RECEIPT_CLASSIFIER_MODE", raising=False)
+    monkeypatch.delenv("VNX_RECEIPT_CLASSIFIER_PROVIDER", raising=False)
+    monkeypatch.delenv("VNX_RECEIPT_CLASSIFIER_DAILY_COST_USD", raising=False)
+    return state
+
+
+def _make_receipt(status="success", event_type="task_complete", dispatch_id="DISP-1"):
+    return {
+        "timestamp": "2026-04-30T12:00:00Z",
+        "event_type": event_type,
+        "event": event_type,
+        "dispatch_id": dispatch_id,
+        "task_id": dispatch_id + "-task",
+        "terminal": "T1",
+        "status": status,
+        "report_path": "/tmp/report.md",
+    }
+
+
+class _StubProvider(ClassifierProvider):
+    name = "stub"
+
+    def __init__(self, payload, *, error=None, cost_usd=0.0):
+        self.payload = payload
+        self.error = error
+        self.cost_usd = cost_usd
+        self.calls = []
+
+    def classify(self, prompt, max_tokens=1500):
+        self.calls.append(prompt)
+        return ClassifierResult(
+            raw_response=self.payload if isinstance(self.payload, str) else json.dumps(self.payload),
+            parsed_json=self.payload if isinstance(self.payload, dict) else None,
+            cost_usd=self.cost_usd,
+            latency_ms=10,
+            provider=self.name,
+            error=self.error,
+        )
+
+
+# ----------------------------------------------------------------------
+# Case A: env var off → no classification
+# ----------------------------------------------------------------------
+
+
+def test_disabled_env_no_op(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "0")
+    assert rc.is_enabled() is False
+    assert rc.trigger_receipt_classifier_async(_make_receipt()) is None
+    # queue must not be created
+    assert not (env_state / rc.QUEUE_FILE_NAME).exists()
+
+
+# ----------------------------------------------------------------------
+# Case B: per_receipt mode → fires async
+# ----------------------------------------------------------------------
+
+
+def test_per_receipt_mode_spawns_async(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_MODE", "per_receipt")
+
+    spawned = {}
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs):
+            spawned["args"] = args
+            spawned["kwargs"] = kwargs
+
+            class _Stdin:
+                def write(self_inner, data):
+                    spawned["stdin"] = data
+
+            self.stdin = _Stdin()
+
+    with patch("receipt_classifier.subprocess.Popen", _FakePopen):
+        action = rc.trigger_receipt_classifier_async(_make_receipt())
+
+    assert action == "fired_per_receipt"
+    assert "stdin" in spawned
+    assert b"DISP-1" in spawned["stdin"]
+
+
+# ----------------------------------------------------------------------
+# Case C: batch mode → appends to queue, doesn't spawn
+# ----------------------------------------------------------------------
+
+
+def test_batch_mode_appends_to_queue(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_MODE", "batch")
+
+    with patch("receipt_classifier.subprocess.Popen") as popen:
+        action = rc.trigger_receipt_classifier_async(_make_receipt())
+    assert action == "queued_batch"
+    popen.assert_not_called()
+
+    queue_file = env_state / rc.QUEUE_FILE_NAME
+    assert queue_file.exists()
+    line = queue_file.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["receipt"]["dispatch_id"] == "DISP-1"
+
+
+# ----------------------------------------------------------------------
+# Case D: failures_direct → fires for failures, queues successes
+# ----------------------------------------------------------------------
+
+
+def test_failures_direct_fires_for_failures(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_MODE", "failures_direct")
+
+    with patch("receipt_classifier.subprocess.Popen") as popen:
+        action = rc.trigger_receipt_classifier_async(
+            _make_receipt(status="failed", event_type="task_failed")
+        )
+        assert action == "fired_failure_direct"
+        assert popen.called
+
+        # success should NOT spawn — should queue instead
+        popen.reset_mock()
+        action = rc.trigger_receipt_classifier_async(_make_receipt(status="success"))
+        assert action == "queued_success_for_batch"
+        popen.assert_not_called()
+
+    assert (env_state / rc.QUEUE_FILE_NAME).exists()
+
+
+# ----------------------------------------------------------------------
+# Case E: cost budget exhausted → skip with warning
+# ----------------------------------------------------------------------
+
+
+def test_classify_skipped_when_budget_exhausted(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_DAILY_COST_USD", "0.10")
+
+    rc.track_cost("haiku", 0.20)  # blow the budget
+
+    assert rc.is_budget_exhausted() is True
+    result = rc.classify_receipt(_make_receipt(), provider=_StubProvider({"impact_class": "trivial"}))
+    assert result["status"] == "skipped"
+    assert result["reason"] == "budget_exhausted"
+
+
+def test_track_cost_resets_each_day(env_state):
+    rc.track_cost("haiku", 0.05)
+    entry1 = rc._read_cost()
+    assert entry1.spent_usd == pytest.approx(0.05)
+    assert entry1.calls == 1
+
+    rc.track_cost("haiku", 0.07)
+    entry2 = rc._read_cost()
+    assert entry2.spent_usd == pytest.approx(0.12)
+    assert entry2.calls == 2
+
+
+# ----------------------------------------------------------------------
+# Case F + G: provider routing
+# ----------------------------------------------------------------------
+
+
+def test_provider_haiku_invokes_correct_cli(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_PROVIDER", "haiku")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout='{"impact_class":"trivial","suggested_edit":null}', stderr=""
+        )
+
+    with patch("classifier_providers.haiku_provider.subprocess.run", side_effect=fake_run):
+        result = rc.classify_receipt(_make_receipt())
+    assert result["status"] == "ok"
+    assert captured["cmd"][0] == "claude"
+    assert "--print" in captured["cmd"]
+
+
+def test_provider_ollama_invokes_correct_cli(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_PROVIDER", "ollama")
+    monkeypatch.setenv("VNX_OLLAMA_MODEL", "llama3.1:8b")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout='{"impact_class":"trivial","suggested_edit":null}', stderr=""
+        )
+
+    with patch("classifier_providers.ollama_provider.subprocess.run", side_effect=fake_run):
+        result = rc.classify_receipt(_make_receipt())
+    assert result["status"] == "ok"
+    assert captured["cmd"] == ["ollama", "run", "llama3.1:8b"]
+
+
+# ----------------------------------------------------------------------
+# Case H: trivial-class edit NOT queued
+# ----------------------------------------------------------------------
+
+
+def test_trivial_edit_not_queued(env_state):
+    payload = {
+        "domain": "governance",
+        "outcome_class": "success",
+        "impact_class": "trivial",
+        "suggested_edit": {
+            "target_file": "CLAUDE.md",
+            "edit_type": "add_line",
+            "content": "minor tweak",
+            "rationale": "cosmetic",
+            "confidence": 0.95,
+        },
+    }
+    result = rc.classify_receipt(_make_receipt(), provider=_StubProvider(payload))
+    assert result["status"] == "ok"
+    assert result["queued_edit_ids"] == []
+    assert not (env_state / rc.PENDING_EDITS_FILE_NAME).exists()
+
+
+def test_low_confidence_significant_not_queued(env_state):
+    payload = {
+        "impact_class": "policy_change",
+        "suggested_edit": {
+            "target_file": "CLAUDE.md",
+            "edit_type": "replace",
+            "content": "new policy",
+            "rationale": "weak signal",
+            "confidence": 0.5,
+        },
+    }
+    result = rc.classify_receipt(_make_receipt(), provider=_StubProvider(payload))
+    assert result["queued_edit_ids"] == []
+
+
+# ----------------------------------------------------------------------
+# Case I: significant-class edit IS queued
+# ----------------------------------------------------------------------
+
+
+def test_significant_edit_queued_to_pending_edits(env_state):
+    payload = {
+        "domain": "governance",
+        "outcome_class": "failure",
+        "impact_class": "policy_change",
+        "recurring_pattern_observed": "T0 skipped gate",
+        "suggested_edit": {
+            "target_file": ".claude/terminals/T0/CLAUDE.md",
+            "edit_type": "add_line",
+            "content": "Always run gate before merge.",
+            "rationale": "Repeated gate skip detected.",
+            "confidence": 0.92,
+        },
+    }
+    result = rc.classify_receipt(_make_receipt(), provider=_StubProvider(payload))
+    assert result["status"] == "ok"
+    assert len(result["queued_edit_ids"]) == 1
+
+    pending_file = env_state / rc.PENDING_EDITS_FILE_NAME
+    assert pending_file.exists()
+    data = json.loads(pending_file.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    record = data[0]
+    assert record["impact_class"] == "policy_change"
+    assert record["edit"]["confidence"] == 0.92
+    assert record["status"] == "pending"
+    assert record["source_dispatch_id"] == "DISP-1"
+
+
+# ----------------------------------------------------------------------
+# should_classify sampling
+# ----------------------------------------------------------------------
+
+
+def test_should_classify_skips_non_outcome_events():
+    assert rc.should_classify({"event_type": "ack"}) is False
+    assert rc.should_classify({"event_type": "dispatch_sent"}) is False
+    assert rc.should_classify({"event_type": "task_complete"}) is True
+    assert rc.should_classify({"event_type": "task_failed"}) is True
+
+
+def test_should_classify_rejects_non_dict():
+    assert rc.should_classify(None) is False
+    assert rc.should_classify("string") is False
+
+
+# ----------------------------------------------------------------------
+# Queue drain
+# ----------------------------------------------------------------------
+
+
+def test_drain_queue_returns_and_truncates(env_state, monkeypatch):
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_ENABLED", "1")
+    monkeypatch.setenv("VNX_RECEIPT_CLASSIFIER_MODE", "batch")
+
+    for i in range(3):
+        rc.trigger_receipt_classifier_async(_make_receipt(dispatch_id=f"DISP-{i}"))
+
+    drained = rc.drain_queue()
+    assert len(drained) == 3
+    assert drained[0]["dispatch_id"] == "DISP-0"
+
+    queue_file = env_state / rc.QUEUE_FILE_NAME
+    assert queue_file.exists()
+    assert queue_file.read_text(encoding="utf-8") == ""
+
+    # second drain returns nothing
+    assert rc.drain_queue() == []
+
+
+# ----------------------------------------------------------------------
+# Batch helper end-to-end (no provider needed for skipped path)
+# ----------------------------------------------------------------------
+
+
+def test_classify_batch_skips_when_empty(env_state):
+    result = rc.classify_batch([])
+    assert result["status"] == "skipped"
+    assert result["reason"] == "no_receipts"
+
+
+def test_classify_batch_queues_significant(env_state):
+    payload = {
+        "impact_class": "new_skill",
+        "suggested_edit": {
+            "target_file": ".claude/skills/new.md",
+            "edit_type": "add_line",
+            "content": "new skill body",
+            "rationale": "Pattern observed across many receipts",
+            "confidence": 0.85,
+        },
+    }
+    receipts = [_make_receipt(dispatch_id=f"DISP-{i}") for i in range(3)]
+    result = rc.classify_batch(receipts, provider=_StubProvider(payload, cost_usd=0.001))
+    assert result["status"] == "ok"
+    assert result["batch"] is True
+    assert len(result["queued_edit_ids"]) == 1
+    cost_file = env_state / rc.COST_FILE_NAME
+    assert cost_file.exists()
+    cost_data = json.loads(cost_file.read_text(encoding="utf-8"))
+    assert cost_data["spent_usd"] == pytest.approx(0.001)
+    assert cost_data["calls"] == 1


### PR DESCRIPTION
## Summary

Adaptive post-write receipt classifier per Option B (Hybrid) from
`claudedocs/2026-04-30-adaptive-receipt-classifier-research.md`. Cross-LLM
via provider abstraction; default-OFF, opt-in via env flag; hard daily
cost cap; significance-only edit queueing.

## Operator-specified requirements

- **Toggle**: `VNX_RECEIPT_CLASSIFIER_ENABLED=0` default → `=1` to enable.
  Receipt-write hook returns immediately when unset.
- **Mode**: `VNX_RECEIPT_CLASSIFIER_MODE` ∈ {`batch` (default), `per_receipt`,
  `failures_direct`}.
- **Provider**: `VNX_RECEIPT_CLASSIFIER_PROVIDER` ∈ {`haiku` (default),
  `ollama`, `gemini`, `codex`}. Each is a subprocess wrapper around the
  matching CLI — no Anthropic SDK.
- **Cost cap**: `VNX_RECEIPT_CLASSIFIER_DAILY_COST_USD=0.20` (operator-set).
  Daily spend persisted atomically to
  `.vnx-data/state/receipt_classifier_cost.json`. When exhausted the
  classifier skips with a logged warning.
- **Significance gate (Q3)**: only edits with `confidence ≥ 0.8` AND
  `impact_class ∈ {policy_change, removed_rule, new_skill, threshold_change}`
  are queued to `pending_edits.json`. Trivial findings are dropped.

## Files

- `scripts/lib/classifier_providers/` — ABC, registry, four providers.
- `scripts/lib/receipt_classifier.py` — modes, queue, cost tracker, edit
  significance gate, async-fire helper, CLI.
- `scripts/lib/receipt_classifier_batch.py` — hourly batch CLI.
- `scripts/append_receipt.py` — single non-blocking trigger after the
  existing post-append hooks. Zero behavior change unless flag set.
- `scripts/launchd/com.vnx.receipt-classifier-batch.plist` + reload script.
  Plist ships with enable flag set to `0` so install is reversible.
- `tests/test_classifier_providers.py` + `tests/test_receipt_classifier.py`
  — 35 new tests, all passing.

## Test plan

- [x] `python3 -m py_compile` on all changed Python files
- [x] `bash -n` on the new reload script
- [x] `python3 -m pytest tests/test_receipt_classifier.py
      tests/test_classifier_providers.py -xvs` → 35 passed
- [x] append_receipt regression: 64 passed / 2 pre-existing failures
      (both reproduce on `main`, unrelated to ARC-3 — see report)
- [ ] Operator: install plist via
      `bash scripts/launchd/reload_receipt_classifier.sh` after merge
- [ ] Operator: flip `VNX_RECEIPT_CLASSIFIER_ENABLED=1` in the plist when
      ready to start collecting suggestions

## Audit reference

- `claudedocs/2026-04-30-adaptive-receipt-classifier-research.md`
  (linked in dispatch; not present in this worktree — defer cross-check
  to T0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)