### PR TITLE
feat(operator): ARC pipeline → suggest CLI + dashboard widget (ARC-5)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -144,6 +144,9 @@ Commands:
   update --latest        Update ignoring version.lock
   patch-agent-files  Insert/update VNX marked block in CLAUDE.md / AGENTS.md
   suggest <sub>      Human-in-the-loop system tuning (review/accept/reject/apply/history)
+                       review --weekly  Aggregate last 7d suggestions by target file
+  insights           Read-only F57 dispatch parameter + behavioral intelligence signals
+                       --json           Machine-readable JSON output
 
 Intelligence commands (git-tracked project knowledge):
   intelligence-export  Export SQLite + state to canonical .vnx-intelligence/ (NDJSON)
@@ -1867,6 +1870,9 @@ main() {
       ;;
     suggest)
       python3 "$VNX_HOME/scripts/apply_suggested_edits.py" "$@"
+      ;;
+    insights)
+      python3 "$VNX_HOME/scripts/vnx_insights_cli.py" "$@"
       ;;
     gate-check)
       python3 "$VNX_HOME/scripts/pre_merge_gate.py" "$@"

--- a/dashboard/api_recommendations.py
+++ b/dashboard/api_recommendations.py
@@ -1,0 +1,56 @@
+"""Dashboard API handler: /api/operator/recommendations.
+
+Returns t0_recommendations.json content with derived counts so the dashboard
+can display pending T0 recommendations without reading raw state files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+VNX_DIR = Path(__file__).resolve().parents[1]
+CANONICAL_STATE_DIR = Path(
+    os.environ.get("VNX_STATE_DIR", str(VNX_DIR / ".vnx-data" / "state"))
+)
+RECOMMENDATIONS_FILE = CANONICAL_STATE_DIR / "t0_recommendations.json"
+
+_EMPTY: dict = {
+    "recommendations": [],
+    "total": 0,
+    "total_p0": 0,
+    "total_p1": 0,
+    "total_p2": 0,
+    "active_conflicts": {},
+    "timestamp": None,
+    "engine_version": None,
+}
+
+
+def get_operator_recommendations() -> dict:
+    """Read t0_recommendations.json and return with priority counts.
+
+    Returns an empty-state dict when the file is absent or unparseable so
+    the dashboard endpoint always returns valid JSON.
+    """
+    if not RECOMMENDATIONS_FILE.exists():
+        return dict(_EMPTY)
+
+    try:
+        raw = RECOMMENDATIONS_FILE.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        return {**_EMPTY, "error": "parse_error"}
+
+    recs = data.get("recommendations") or []
+    return {
+        "recommendations": recs,
+        "total": len(recs),
+        "total_p0": sum(1 for r in recs if r.get("priority") == "P0"),
+        "total_p1": sum(1 for r in recs if r.get("priority") == "P1"),
+        "total_p2": sum(1 for r in recs if r.get("priority") == "P2"),
+        "active_conflicts": data.get("active_conflicts") or {},
+        "timestamp": data.get("timestamp"),
+        "engine_version": data.get("engine_version"),
+    }

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -156,6 +156,10 @@ from api_register_stream import (  # noqa: E402
     handle_register_stream_archive,
 )
 
+from api_recommendations import (  # noqa: E402
+    get_operator_recommendations,
+)
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -341,6 +345,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/health":
             _json_response(self, HTTPStatus.OK, _operator_get_health())
+            return
+
+        if path == "/api/operator/recommendations":
+            _json_response(self, HTTPStatus.OK, get_operator_recommendations())
             return
 
         # Register stream SSE endpoints — pass CANONICAL_STATE_DIR so the

--- a/scripts/apply_suggested_edits.py
+++ b/scripts/apply_suggested_edits.py
@@ -17,7 +17,8 @@ import argparse
 import json
 import re
 import sys
-from datetime import datetime, timezone
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 
 _UTC = timezone.utc
 from pathlib import Path
@@ -100,8 +101,88 @@ def _parse_ids(id_str: str) -> List[int]:
     return ids
 
 
-def cmd_review():
+def cmd_review_weekly():
+    """Show weekly aggregated view of suggestions grouped by target file."""
+    now = datetime.now(tz=_UTC)
+    cutoff = now - timedelta(days=7)
+
+    history = _load_history()
+    recent_history = []
+    for entry in history:
+        applied_at_str = entry.get("applied_at", "")
+        if applied_at_str:
+            try:
+                ts = datetime.fromisoformat(applied_at_str.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_UTC)
+                if ts >= cutoff:
+                    recent_history.append(entry)
+            except ValueError:
+                pass
+
+    data = _load_pending()
+    pending = data.get("edits", [])
+
+    all_entries = [{**e, "_source": "pending"} for e in pending]
+    all_entries += [{**e, "_source": "history"} for e in recent_history]
+
+    if not all_entries:
+        print("No suggestions in the last 7 days.")
+        return 0
+
+    by_target: dict = defaultdict(list)
+    for entry in all_entries:
+        by_target[entry.get("target", "unknown")].append(entry)
+
+    print(f"\n{Colors.BOLD}Weekly Suggestions Summary (last 7 days){Colors.RESET}")
+    print(f"Targets with suggestions: {len(by_target)}\n")
+
+    for target, entries in sorted(by_target.items(), key=lambda kv: -len(kv[1])):
+        count = len(entries)
+        confidences = [float(e.get("confidence", 0)) for e in entries if e.get("confidence") is not None]
+        avg_conf = sum(confidences) / len(confidences) if confidences else 0.0
+
+        print(f"  {Colors.BOLD}{target}{Colors.RESET} "
+              f"— {count} suggestion(s), avg confidence: {avg_conf:.2f}")
+
+        for entry in entries:
+            eid = entry.get("id", "?")
+            status = entry.get("status", "pending")
+            content = entry.get("content", "")
+            content_preview = content.strip().split("\n")[0][:80] if content else ""
+            source = entry.get("_source", "pending")
+
+            if source == "history":
+                status_label = f"[{Colors.GREEN}applied{Colors.RESET}]"
+            elif status == "pending":
+                status_label = f"[{Colors.YELLOW}pending{Colors.RESET}]"
+            elif status == "accepted":
+                status_label = f"[{Colors.GREEN}accepted{Colors.RESET}]"
+            else:
+                status_label = f"[{Colors.RED}{status}{Colors.RESET}]"
+
+            if count > 1:
+                print(f"    Pattern detected ({count} occurrences, last 7d): {content_preview}")
+            else:
+                print(f"    #{eid} {status_label} {content_preview}")
+
+        pending_ids = [
+            str(e["id"])
+            for e in entries
+            if e.get("_source") == "pending" and e.get("status") == "pending" and e.get("id") is not None
+        ]
+        if pending_ids:
+            print(f"    Accept batch: vnx suggest accept {','.join(pending_ids)}")
+        print()
+
+    return 0
+
+
+def cmd_review(weekly: bool = False):
     """Show all pending edits."""
+    if weekly:
+        return cmd_review_weekly()
+
     data = _load_pending()
     edits = data.get("edits", [])
 
@@ -422,7 +503,11 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    subparsers.add_parser("review", help="Show all pending edits")
+    review_parser = subparsers.add_parser("review", help="Show all pending edits")
+    review_parser.add_argument(
+        "--weekly", action="store_true",
+        help="Aggregate last 7 days of suggestions grouped by target file",
+    )
 
     accept_parser = subparsers.add_parser("accept", help="Accept edits by ID")
     accept_parser.add_argument("ids", help="Comma-separated edit IDs (e.g., 1,3,5)")
@@ -441,7 +526,7 @@ def main():
         return 1
 
     if args.command == "review":
-        return cmd_review()
+        return cmd_review(weekly=getattr(args, "weekly", False))
     elif args.command == "accept":
         return cmd_accept(args.ids)
     elif args.command == "reject":

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -51,7 +51,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "intelligence-import", "init-feature", "bootstrap-skills",
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings",
     "patch-agent-files", "register", "list-projects", "unregister",
-    "roadmap",
+    "roadmap", "insights",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",
     "init-db",
 })

--- a/scripts/vnx_insights_cli.py
+++ b/scripts/vnx_insights_cli.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+VNX Insights CLI — Read-only view of F57 dispatch parameter + behavioral intelligence signals.
+
+Surfaces Karpathy-style dispatch performance insights and per-role/terminal context
+load signals. No apply path — informational only.
+
+Usage:
+  vnx insights              Show all available insights
+  vnx insights --json       Machine-readable JSON output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+try:
+    from vnx_paths import ensure_env
+except Exception as exc:
+    raise SystemExit(f"Failed to load vnx_paths: {exc}")
+
+PATHS = ensure_env()
+STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
+DB_PATH = STATE_DIR / "quality_intelligence.db"
+
+
+class Colors:
+    BOLD = "\033[1m"
+    CYAN = "\033[96m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    RESET = "\033[0m"
+
+
+def _get_parameter_insights() -> list[str]:
+    """Return top dispatch parameter insights via DispatchParameterTracker."""
+    try:
+        from dispatch_parameter_tracker import DispatchParameterTracker
+        tracker = DispatchParameterTracker(STATE_DIR)
+        stats = tracker.stats()
+        if not stats.get("insights_available"):
+            completed = stats.get("completed", 0)
+            return [f"Insufficient data: {completed} completed experiments (need 20 for analysis)"]
+        return tracker.top_insights_for_t0(n=7)
+    except ImportError as exc:
+        return [f"dispatch_parameter_tracker unavailable: {exc}"]
+    except Exception as exc:
+        return [f"Parameter analysis error: {exc}"]
+
+
+def _get_context_load_signals() -> list[str]:
+    """Surface per-role/terminal context load signals from dispatch_experiments."""
+    if not DB_PATH.exists():
+        return []
+
+    signals: list[str] = []
+    try:
+        con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+        con.row_factory = sqlite3.Row
+        try:
+            row = con.execute(
+                "SELECT AVG(context_items) FROM dispatch_experiments WHERE context_items IS NOT NULL"
+            ).fetchone()
+            overall_avg = float(row[0]) if row and row[0] is not None else None
+
+            if overall_avg is None or overall_avg == 0:
+                return []
+
+            rows = con.execute(
+                """
+                SELECT terminal, role, AVG(context_items) AS avg_ctx, COUNT(*) AS n
+                FROM dispatch_experiments
+                WHERE context_items IS NOT NULL
+                  AND terminal IS NOT NULL
+                  AND role IS NOT NULL
+                GROUP BY terminal, role
+                HAVING n >= 3
+                ORDER BY avg_ctx DESC
+                """
+            ).fetchall()
+
+            for row in rows:
+                terminal = row["terminal"]
+                role = row["role"]
+                avg_ctx = float(row["avg_ctx"])
+                pct_diff = (avg_ctx - overall_avg) / overall_avg * 100
+                if abs(pct_diff) >= 20:
+                    direction = "extra" if pct_diff > 0 else "less"
+                    signals.append(
+                        f"{terminal} worker has {abs(pct_diff):.0f}% {direction} context "
+                        f"on {role} role (avg {avg_ctx:.1f} items, n={row['n']})"
+                    )
+        finally:
+            con.close()
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        pass
+
+    return signals
+
+
+def _get_behavioral_signals() -> dict:
+    """Return behavioral summary from intelligence_dashboard_data."""
+    try:
+        from intelligence_dashboard_data import get_behavioral_summary
+        return get_behavioral_summary()
+    except ImportError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _collect_all_insights() -> dict:
+    """Collect all signal types and return structured dict."""
+    param_insights = _get_parameter_insights()
+    context_signals = _get_context_load_signals()
+    behavioral = _get_behavioral_signals()
+
+    return {
+        "parameter_insights": param_insights,
+        "context_load_signals": context_signals,
+        "behavioral": {
+            "rework_files": behavioral.get("rework_files", [])[:5],
+            "common_errors": behavioral.get("common_errors", [])[:5],
+            "duration_baselines": behavioral.get("duration_baselines", []),
+            "exploration_insight": behavioral.get("exploration_insight", ""),
+            "total_dispatches_analyzed": behavioral.get("total_dispatches_analyzed", 0),
+        },
+    }
+
+
+def print_insights(data: dict) -> None:
+    param_insights = data["parameter_insights"]
+    context_signals = data["context_load_signals"]
+    behavioral = data["behavioral"]
+
+    print(f"\n{Colors.BOLD}VNX Insights — last 7d signals{Colors.RESET}\n")
+
+    print(f"{Colors.CYAN}── Dispatch Parameter Insights{Colors.RESET}")
+    if param_insights:
+        for insight in param_insights:
+            print(f"  • {insight}")
+    else:
+        print("  (no insights available)")
+
+    print()
+    print(f"{Colors.BLUE}── Context Load Signals{Colors.RESET}")
+    if context_signals:
+        for signal in context_signals:
+            print(f"  • {signal}")
+    else:
+        print("  (no significant context load differences detected)")
+
+    print()
+    print(f"{Colors.YELLOW}── Behavioral Patterns{Colors.RESET}")
+
+    rework = behavioral.get("rework_files", [])
+    if rework:
+        print("  High-rework files:")
+        for f in rework[:3]:
+            print(f"    {f.get('file', '?')} ({f.get('rework_count', 0)} reworks)")
+
+    errors = behavioral.get("common_errors", [])
+    if errors:
+        print("  Recurring errors:")
+        for e in errors[:3]:
+            print(f"    {e.get('error', '?')} ({e.get('count', 0)}x)")
+
+    baselines = behavioral.get("duration_baselines", [])
+    if baselines:
+        print("  Role duration baselines:")
+        for b in baselines[:4]:
+            mins = int(b.get("avg_seconds", 0) // 60)
+            print(f"    {b.get('role', '?')}: ~{mins}m avg")
+
+    exploration = behavioral.get("exploration_insight", "")
+    if exploration:
+        print(f"\n  {Colors.GREEN}Exploration:{Colors.RESET} {exploration}")
+
+    analyzed = behavioral.get("total_dispatches_analyzed", 0)
+    print(f"\n  Based on {analyzed} analyzed dispatches.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="VNX Insights — read-only dispatch parameter and behavioral intelligence"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    data = _collect_all_insights()
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+    else:
+        print_insights(data)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_arc5_operator_cli.py
+++ b/tests/test_arc5_operator_cli.py
@@ -1,0 +1,348 @@
+"""Tests for ARC-5: operator advisory CLI integration.
+
+Cases:
+  A — vnx suggest review --weekly aggregates by target file correctly
+  B — vnx insights surfaces F57 dispatch parameter data
+  C — /api/operator/recommendations dashboard endpoint returns JSON
+  D — empty t0_recommendations.json → graceful empty response
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make scripts/ and scripts/lib/ importable
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+_DASHBOARD_DIR = _REPO_ROOT / "dashboard"
+
+for _p in (_SCRIPTS_DIR, _LIB_DIR, _DASHBOARD_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+_UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_edit(eid: int, target: str, status: str = "pending", confidence: float = 0.8,
+               content: str = "add example") -> dict:
+    return {
+        "id": eid,
+        "category": "memory",
+        "status": status,
+        "target": target,
+        "action": "append",
+        "content": content,
+        "confidence": confidence,
+        "evidence": "test evidence",
+    }
+
+
+def _make_history_entry(eid: int, target: str, applied_at: str, content: str = "applied line") -> dict:
+    return {
+        "id": eid,
+        "category": "memory",
+        "status": "applied",
+        "target": target,
+        "action": "append",
+        "content": content,
+        "confidence": 0.75,
+        "evidence": "test evidence",
+        "applied_at": applied_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Case A: --weekly aggregates correctly
+# ---------------------------------------------------------------------------
+
+class TestWeeklyAggregation:
+    """vnx suggest review --weekly groups by target file and shows counts."""
+
+    def test_weekly_groups_by_target(self, tmp_path, monkeypatch, capsys):
+        import apply_suggested_edits as mod
+
+        pending_path = tmp_path / "pending_edits.json"
+        history_path = tmp_path / "edit_history.json"
+
+        # Two pending edits targeting the same file
+        pending_data = {
+            "generated_at": datetime.now(_UTC).isoformat(),
+            "edits": [
+                _make_edit(1, "memory/MEMORY.md", content="pattern A"),
+                _make_edit(2, "memory/MEMORY.md", content="pattern B"),
+            ],
+        }
+        pending_path.write_text(json.dumps(pending_data), encoding="utf-8")
+
+        # One history entry from yesterday targeting a different file
+        yesterday = (datetime.now(_UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+        history_data = [
+            _make_history_entry(10, ".claude/CLAUDE.md", applied_at=yesterday, content="rule X"),
+        ]
+        history_path.write_text(json.dumps(history_data), encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PENDING_PATH", pending_path)
+        monkeypatch.setattr(mod, "HISTORY_PATH", history_path)
+
+        rc = mod.cmd_review_weekly()
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "memory/MEMORY.md" in captured.out
+        assert ".claude/CLAUDE.md" in captured.out
+        # Multi-occurrence pattern label for the file with 2 entries
+        assert "Pattern detected (2 occurrences, last 7d)" in captured.out
+
+    def test_weekly_excludes_old_history(self, tmp_path, monkeypatch, capsys):
+        import apply_suggested_edits as mod
+
+        pending_path = tmp_path / "pending_edits.json"
+        history_path = tmp_path / "edit_history.json"
+
+        pending_path.write_text(json.dumps({"generated_at": "", "edits": []}), encoding="utf-8")
+
+        # History entry from 10 days ago — should be excluded
+        old_ts = (datetime.now(_UTC) - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        history_data = [
+            _make_history_entry(99, "scripts/foo.py", applied_at=old_ts),
+        ]
+        history_path.write_text(json.dumps(history_data), encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PENDING_PATH", pending_path)
+        monkeypatch.setattr(mod, "HISTORY_PATH", history_path)
+
+        rc = mod.cmd_review_weekly()
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "scripts/foo.py" not in captured.out
+        assert "No suggestions" in captured.out
+
+    def test_weekly_shows_batch_accept_hint(self, tmp_path, monkeypatch, capsys):
+        import apply_suggested_edits as mod
+
+        pending_path = tmp_path / "pending_edits.json"
+        history_path = tmp_path / "edit_history.json"
+
+        pending_data = {
+            "generated_at": "",
+            "edits": [
+                _make_edit(3, "skills/backend.md"),
+                _make_edit(4, "skills/backend.md"),
+            ],
+        }
+        pending_path.write_text(json.dumps(pending_data), encoding="utf-8")
+        history_path.write_text("[]", encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PENDING_PATH", pending_path)
+        monkeypatch.setattr(mod, "HISTORY_PATH", history_path)
+
+        rc = mod.cmd_review_weekly()
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "vnx suggest accept" in captured.out
+        assert "3,4" in captured.out or "4,3" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Case B: vnx insights shows F57 data
+# ---------------------------------------------------------------------------
+
+class TestVnxInsights:
+    """vnx insights surfaces F57 dispatch parameter and behavioral signals."""
+
+    def test_insights_low_data_returns_message(self, tmp_path, monkeypatch, capsys):
+        import vnx_insights_cli as mod
+
+        monkeypatch.setattr(mod, "STATE_DIR", tmp_path)
+        monkeypatch.setattr(mod, "DB_PATH", tmp_path / "quality_intelligence.db")
+
+        rc = mod.main.__wrapped__() if hasattr(mod.main, "__wrapped__") else None
+
+        # Run via _collect_all_insights instead of main() to avoid argparse
+        data = mod._collect_all_insights()
+
+        assert "parameter_insights" in data
+        assert isinstance(data["parameter_insights"], list)
+        assert len(data["parameter_insights"]) > 0
+        # Low-data message when DB absent
+        assert any("Insufficient" in s or "unavailable" in s or "error" in s
+                   for s in data["parameter_insights"])
+
+    def test_insights_context_signals_with_db(self, tmp_path, monkeypatch):
+        import sqlite3
+        import vnx_insights_cli as mod
+
+        db_path = tmp_path / "quality_intelligence.db"
+        monkeypatch.setattr(mod, "STATE_DIR", tmp_path)
+        monkeypatch.setattr(mod, "DB_PATH", db_path)
+
+        # Build a minimal dispatch_experiments table with enough signal
+        con = sqlite3.connect(str(db_path))
+        con.execute("""
+            CREATE TABLE dispatch_experiments (
+                id INTEGER PRIMARY KEY,
+                dispatch_id TEXT,
+                terminal TEXT,
+                role TEXT,
+                context_items INTEGER,
+                success BOOLEAN,
+                cqs REAL
+            )
+        """)
+        # T2 with test-engineer role has high context (avg=10 vs baseline~4)
+        for i in range(5):
+            con.execute(
+                "INSERT INTO dispatch_experiments (dispatch_id, terminal, role, context_items) VALUES (?,?,?,?)",
+                (f"t2-{i}", "T2", "test-engineer", 10),
+            )
+        for i in range(5):
+            con.execute(
+                "INSERT INTO dispatch_experiments (dispatch_id, terminal, role, context_items) VALUES (?,?,?,?)",
+                (f"t1-{i}", "T1", "backend-developer", 4),
+            )
+        con.commit()
+        con.close()
+
+        signals = mod._get_context_load_signals()
+
+        # T2/test-engineer should be flagged as having extra context vs T1/backend-developer
+        assert any("T2" in s and "extra" in s for s in signals)
+
+    def test_insights_json_output(self, tmp_path, monkeypatch, capsys):
+        import vnx_insights_cli as mod
+
+        monkeypatch.setattr(mod, "STATE_DIR", tmp_path)
+        monkeypatch.setattr(mod, "DB_PATH", tmp_path / "missing.db")
+
+        data = mod._collect_all_insights()
+        output = json.dumps(data, indent=2)
+        parsed = json.loads(output)
+
+        assert "parameter_insights" in parsed
+        assert "context_load_signals" in parsed
+        assert "behavioral" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Case C: dashboard endpoint returns JSON
+# ---------------------------------------------------------------------------
+
+class TestDashboardRecommendationsEndpoint:
+    """GET /api/operator/recommendations returns structured JSON."""
+
+    def test_returns_recommendations_with_counts(self, tmp_path, monkeypatch):
+        import api_recommendations as mod
+
+        recs_file = tmp_path / "t0_recommendations.json"
+        recs_file.write_text(
+            json.dumps({
+                "timestamp": "2026-04-30T10:00:00",
+                "engine_version": "1.1.0",
+                "recommendations": [
+                    {"trigger": "task_success", "action": "create_dispatch", "priority": "P1"},
+                    {"trigger": "task_failure", "action": "create_dispatch", "priority": "P0"},
+                    {"trigger": "pr_ready", "action": "start_next_pr", "priority": "P1"},
+                ],
+                "active_conflicts": {},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "RECOMMENDATIONS_FILE", recs_file)
+
+        result = mod.get_operator_recommendations()
+
+        assert result["total"] == 3
+        assert result["total_p0"] == 1
+        assert result["total_p1"] == 2
+        assert result["total_p2"] == 0
+        assert result["engine_version"] == "1.1.0"
+        assert isinstance(result["recommendations"], list)
+        assert len(result["recommendations"]) == 3
+
+    def test_returns_counts_by_priority(self, tmp_path, monkeypatch):
+        import api_recommendations as mod
+
+        recs_file = tmp_path / "t0_recommendations.json"
+        recs_file.write_text(
+            json.dumps({
+                "recommendations": [
+                    {"priority": "P0"},
+                    {"priority": "P0"},
+                    {"priority": "P2"},
+                ],
+                "active_conflicts": {"config.yaml": ["d1"]},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "RECOMMENDATIONS_FILE", recs_file)
+
+        result = mod.get_operator_recommendations()
+
+        assert result["total_p0"] == 2
+        assert result["total_p2"] == 1
+        assert result["active_conflicts"] == {"config.yaml": ["d1"]}
+
+
+# ---------------------------------------------------------------------------
+# Case D: empty / missing t0_recommendations → graceful empty response
+# ---------------------------------------------------------------------------
+
+class TestEmptyRecommendationsGraceful:
+    """Absent or broken recommendations file returns a safe empty response."""
+
+    def test_missing_file_returns_empty(self, tmp_path, monkeypatch):
+        import api_recommendations as mod
+
+        monkeypatch.setattr(mod, "RECOMMENDATIONS_FILE", tmp_path / "nonexistent.json")
+
+        result = mod.get_operator_recommendations()
+
+        assert result["total"] == 0
+        assert result["recommendations"] == []
+        assert result["active_conflicts"] == {}
+        assert result["timestamp"] is None
+        assert "error" not in result
+
+    def test_malformed_json_returns_error_key(self, tmp_path, monkeypatch):
+        import api_recommendations as mod
+
+        recs_file = tmp_path / "t0_recommendations.json"
+        recs_file.write_text("{broken json", encoding="utf-8")
+        monkeypatch.setattr(mod, "RECOMMENDATIONS_FILE", recs_file)
+
+        result = mod.get_operator_recommendations()
+
+        assert result["total"] == 0
+        assert result["recommendations"] == []
+        assert result.get("error") == "parse_error"
+
+    def test_empty_recommendations_list(self, tmp_path, monkeypatch):
+        import api_recommendations as mod
+
+        recs_file = tmp_path / "t0_recommendations.json"
+        recs_file.write_text(
+            json.dumps({"recommendations": [], "active_conflicts": {}, "timestamp": "2026-04-30"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "RECOMMENDATIONS_FILE", recs_file)
+
+        result = mod.get_operator_recommendations()
+
+        assert result["total"] == 0
+        assert result["total_p0"] == 0
+        assert result["recommendations"] == []
+        assert "error" not in result


### PR DESCRIPTION
## Summary
- **`vnx suggest review --weekly`**: 7-day aggregated view of suggestions grouped by target file — shows emergence count, avg confidence, and batch-accept hints per target
- **`vnx insights`**: read-only F57 dispatch parameter analysis + per-role/terminal context load signals (e.g. "T2 has 30% extra context on test-engineer role"); `--json` flag for machine-readable output
- **`GET /api/operator/recommendations`**: new dashboard endpoint exposing `t0_recommendations.json` with P0/P1/P2 priority counts; mounts in `serve_dashboard.py`

## Test plan
- [x] `python3 -m py_compile scripts/apply_suggested_edits.py dashboard/api_recommendations.py` — passes
- [x] `python3 -m pytest tests/test_arc5_operator_cli.py -xvs` — 11/11 passed
- [x] `bash -n bin/vnx` — passes
- Case A: weekly aggregation groups by target, excludes old history, shows batch-accept hint
- Case B: insights reports low-data message or context signals with minimal DB fixture
- Case C: dashboard endpoint returns structured JSON with correct priority counts
- Case D: missing/malformed recommendations file returns graceful empty response

🤖 Generated with [Claude Code](https://claude.com/claude-code)