### PR TITLE
fix(scripts): path resolution sweep + smoke gate (CFX-11)

### DIFF
--- a/scripts/launchd/com.vnx.nightly-intelligence-pipeline.plist
+++ b/scripts/launchd/com.vnx.nightly-intelligence-pipeline.plist
@@ -7,7 +7,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>/Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt/scripts/nightly_intelligence_pipeline.sh</string>
+    <string>__VNX_PIPELINE_SCRIPT__</string>
   </array>
   <key>StartCalendarInterval</key>
   <dict>

--- a/tests/smoke/smoke_no_hardcoded_user_paths.sh
+++ b/tests/smoke/smoke_no_hardcoded_user_paths.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Smoke test: no unannotated hardcoded user paths in shell scripts.
+# Scans scripts/**/*.sh for /Users/<name> or /home/<name> literal paths.
+# Exempt a line with: # vnx-allow-hardcoded: <rationale>
+#
+# Usage: bash tests/smoke/smoke_no_hardcoded_user_paths.sh
+# Exit 0: clean. Exit 1: unannotated hardcoded user path found.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+
+FAIL=0
+VIOLATIONS=""
+
+while IFS= read -r match; do
+    line_content="$(printf '%s' "$match" | cut -d: -f3-)"
+    case "$line_content" in
+        *'# vnx-allow-hardcoded:'*) continue ;;
+    esac
+    VIOLATIONS="${VIOLATIONS}  ${match}
+"
+    FAIL=1
+done < <(grep -rn -E '/Users/[a-zA-Z]|/home/[a-zA-Z]' "$SCRIPTS_DIR" --include='*.sh' 2>/dev/null || true)
+
+if [ "$FAIL" -eq 1 ]; then
+    echo "[FAIL] Unannotated hardcoded user paths found in shell scripts:"
+    printf '%s' "$VIOLATIONS"
+    echo "  → Add '# vnx-allow-hardcoded: <rationale>' to the offending line to exempt it"
+    exit 1
+fi
+
+echo "[PASS] No unannotated hardcoded user paths in scripts/**/*.sh"
+exit 0


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/Users/vincentvandeth/...` in `com.vnx.nightly-intelligence-pipeline.plist` with `__VNX_PIPELINE_SCRIPT__` template placeholder, consistent with `install-nightly-pipeline.sh`'s existing `sed` substitution pattern
- Adds `tests/smoke/smoke_no_hardcoded_user_paths.sh`: scans `scripts/**/*.sh` for unannotated `/Users/<name>` or `/home/<name>` paths; exits 1 on any violation; exemptions via inline `# vnx-allow-hardcoded: <rationale>` comment

## Findings from sweep
- 94 shell scripts scanned — **zero** hardcoded user paths (all clean)
- 1 plist file with hardcoded path fixed (template was missing placeholder)
- `vnx_doctor.sh:10` uses `/Users/` as a grep pattern string (no letter follows — not matched by `/Users/[a-zA-Z]`), no annotation needed

## Test plan
- [x] `bash -n tests/smoke/smoke_no_hardcoded_user_paths.sh` → OK
- [x] `bash tests/smoke/smoke_no_hardcoded_user_paths.sh` → `[PASS]`
- [x] `smoke_launchd_plist_paths_resolve.sh` shows `SKIP` for `__VNX_PIPELINE_SCRIPT__` (pre-existing receipt_classifier_batch failure unrelated to this PR)
- [x] `git stash` confirms receipt_classifier failure pre-dates this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)