### PR TITLE
fix(governance): rc_release_on_failure cleanup_complete handling (CFX-16)

### DIFF
--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -347,6 +347,10 @@ rc_release_on_failure() {
                 "dispatch=$dispatch_id terminal=$terminal_id attempt_id=${attempt_id:-} failure_recorded=${failure_recorded:-} failure_error=${failure_error:-}"
             emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
                 "lease_released_broker_inconsistent" "false" "broker_failure_not_recorded"
+            if [[ "$failure_recorded" == "false" ]]; then
+                python3 "$VNX_DIR/scripts/lib/dispatch_register.py" append lease_released_on_failure_partial \
+                    "dispatch_id=$dispatch_id" "terminal=$terminal_id" 2>/dev/null || true
+            fi
         else
             emit_lease_cleanup_audit "$dispatch_id" "$terminal_id" \
                 "lease_released_on_failure" "true"

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -27,7 +27,8 @@ VALID_EVENTS = {
     "gate_failed",              # gate completed with blocking findings
     "pr_opened",
     "pr_merged",
-    "runtime_anomaly_detected", # RuntimeSupervisor detected a stalled/zombie worker
+    "runtime_anomaly_detected",          # RuntimeSupervisor detected a stalled/zombie worker
+    "lease_released_on_failure_partial", # lease released but failure_recorded=False — incomplete cleanup
 }
 
 

--- a/tests/test_rc_release_partial.sh
+++ b/tests/test_rc_release_partial.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# CFX-16: rc_release_on_failure emits lease_released_on_failure_partial to dispatch_register
+# when failure_recorded=false, lease_released=true, cleanup_complete=false.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIFECYCLE="$SCRIPT_DIR/../scripts/lib/dispatch_lifecycle.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF "$needle"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected '$needle' not found in output: ${haystack:-<empty>}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF "$needle"; then
+        echo "FAIL: $label — unexpected '$needle' found in output: $haystack"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Run rc_release_on_failure with mocked dependencies.
+# Captures stdout from the mock dispatch_register.py (prints appended event names).
+_run_scenario() {
+    local mock_json="$1"
+    local TMP
+    TMP="$(mktemp -d)"
+
+    mkdir -p "$TMP/scripts/lib"
+    printf '%s\n' \
+        'import sys' \
+        'if len(sys.argv) >= 3 and sys.argv[1] == "append":' \
+        '    print(sys.argv[2])' \
+        > "$TMP/scripts/lib/dispatch_register.py"
+    printf '%s' "$mock_json" > "$TMP/mock.json"
+
+    local SCRIPT="$TMP/run.sh"
+    cat > "$SCRIPT" <<HEREDOC
+#!/bin/bash
+set -uo pipefail
+log() { :; }
+log_structured_failure() { :; }
+emit_lease_cleanup_audit() { :; }
+rc_release_lease() { :; }
+_rc_enabled() { return 0; }
+_call_cleanup_worker_exit() { :; }
+_rc_python() { cat "$TMP/mock.json"; return 0; }
+VNX_DIR="$TMP"
+eval "\$(awk '
+    /^rc_release_on_failure\(\)/ { inside=1 }
+    inside {
+        print
+        n += gsub(/[{]/, "&")
+        n -= gsub(/[}]/, "&")
+        if (started && n==0) exit
+        if (n>0) started=1
+    }
+' "$LIFECYCLE")"
+rc_release_on_failure "dispatch-001" "attempt-1" "T1" "5" "test"
+HEREDOC
+
+    bash "$SCRIPT" 2>/dev/null
+    rm -rf "$TMP"
+}
+
+# --- Scenario 1: partial cleanup (failure_recorded=false, lease_released=true, cleanup_complete=false) ---
+out=$(_run_scenario '{"failure_recorded": false, "lease_released": true, "cleanup_complete": false, "lease_error": null}')
+assert_contains "partial: register emits lease_released_on_failure_partial" \
+    "lease_released_on_failure_partial" "$out"
+
+# --- Scenario 2: full success (failure_recorded=true, lease_released=true, cleanup_complete=true) ---
+out=$(_run_scenario '{"failure_recorded": true, "lease_released": true, "cleanup_complete": true, "lease_error": null}')
+assert_not_contains "full success: no partial register event" \
+    "lease_released_on_failure_partial" "$out"
+
+# --- Scenario 3: lease release failed (lease_released=false) ---
+out=$(_run_scenario '{"failure_recorded": false, "lease_released": false, "cleanup_complete": false, "lease_error": "stale gen"}')
+assert_not_contains "lease release failure: no partial register event" \
+    "lease_released_on_failure_partial" "$out"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Emits `lease_released_on_failure_partial` to `dispatch_register` when `failure_recorded=false` and `lease_released=true` (i.e. `cleanup_complete=false`)
- Adds `lease_released_on_failure_partial` to `VALID_EVENTS` in `dispatch_register.py`
- Adds bash test `tests/test_rc_release_partial.sh` covering 3 scenarios (partial/full/lease-fail)

## Test plan
- [x] `bash -n scripts/lib/dispatch_lifecycle.sh` passes
- [x] `python3 -m py_compile scripts/lib/dispatch_register.py` passes
- [x] `bash tests/test_rc_release_partial.sh` — 3/3 passed
- [x] `pytest tests/test_release_on_failure_partial_cleanup.py tests/test_dispatch_register.py` — 42/42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)