### PR TITLE
fix(intelligence): content-addressable pattern_id stability (CFX-5)

### DIFF
--- a/schemas/migrations/0012_add_pattern_content_hash.sql
+++ b/schemas/migrations/0012_add_pattern_content_hash.sql
@@ -1,0 +1,49 @@
+-- Migration 0012: Add content_hash column to success_patterns for stable pattern_id
+--
+-- Background (CFX-5 / OI-CFX-5, audit #311 round-2 finding):
+--   The intelligence selector derives a per-pattern id ("intel_sp_<row_id>") from
+--   the success_patterns primary key. When the same underlying pattern is stored
+--   under multiple rows (because pattern_extractor emitted near-identical content
+--   on different days / from different dispatches), each row gets its own
+--   pattern_id and pattern_usage explodes into N rows for one logical pattern.
+--
+-- Decision (option B from CFX-5 dispatch — backward compatible):
+--   * Compute content_hash = sha256(normalize(title || description))[:16]
+--   * Selector resolves item_id by looking up the *canonical* (smallest id) row
+--     sharing the same content_hash, so equivalent content collapses onto a
+--     single pattern_id without renaming existing intel_sp_<id> values.
+--   * pattern_dedup keeps using the column to merge duplicates by content_hash.
+--
+-- The column is backfilled application-side (SQLite has no SHA-256 builtin)
+-- via ``pattern_dedup.backfill_content_hash`` and ``ensure_content_hash_column``.
+-- The companion Python helper applies this migration idempotently from test
+-- fixtures and the production CLI so a fresh DB never needs manual ALTER.
+--
+-- Idempotent via column-presence guard at the application layer (sqlite has no
+-- IF NOT EXISTS for ADD COLUMN); the runner skips ADD when content_hash already
+-- exists.
+--
+-- Verification (after apply + backfill):
+--   sqlite3 quality_intelligence.db \
+--     "SELECT COUNT(*) FROM success_patterns WHERE content_hash IS NULL;"
+--   -> 0
+--   sqlite3 quality_intelligence.db \
+--     "SELECT content_hash, COUNT(*) FROM success_patterns
+--      GROUP BY content_hash HAVING COUNT(*) > 1;"
+--   -> rows requiring pattern_dedup --apply
+
+-- ============================================================================
+-- @db: quality_intelligence
+-- ============================================================================
+
+ALTER TABLE success_patterns ADD COLUMN content_hash TEXT;
+
+-- Composite index on (content_hash, project_id) for fast canonical lookup.
+-- NOT UNIQUE: legacy rows may share a hash before pattern_dedup --apply runs.
+-- pattern_dedup enforces application-level uniqueness post-collapse; once the
+-- DB is clean, callers can promote this to UNIQUE manually if desired.
+CREATE INDEX IF NOT EXISTS idx_success_patterns_content_hash
+    ON success_patterns (content_hash, project_id);
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (12, 'Add content_hash column to success_patterns for stable pattern_id (CFX-5)');

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -256,6 +256,22 @@ def _stable_item_id(prefix: str, source_key: str) -> str:
     return f"intel_{prefix}_{safe_key}"
 
 
+# Length of the content_hash prefix stored in success_patterns.content_hash
+# (CFX-5 / migration 0012). Matches scripts/lib/pattern_dedup.CONTENT_HASH_PREFIX_LEN.
+SUCCESS_PATTERN_CONTENT_HASH_LEN = 16
+
+
+def _short_content_hash(*parts: str) -> str:
+    """16-char prefix of the normalized SHA-256, matching the on-row column.
+
+    Used to derive a *content-addressable* canonical id for success_patterns
+    rows that lack a stored ``content_hash`` (e.g. legacy rows on databases
+    where migration 0012 has been applied but ``backfill_content_hash`` has
+    not yet run).
+    """
+    return _content_hash(*parts)[:SUCCESS_PATTERN_CONTENT_HASH_LEN]
+
+
 def _item_hash(item_id: str) -> str:
     """SHA1 of item_id, matching learning_loop.hash_pattern() convention."""
     import hashlib
@@ -872,12 +888,15 @@ class IntelligenceSelector:
 
         items: List[IntelligenceItem] = []
         has_pattern_cat = self._has_column("success_patterns", "pattern_category")
+        has_content_hash_col = self._has_column("success_patterns", "content_hash")
         select_cols = (
             "id, title, description, category, confidence_score, "
             "usage_count, source_dispatch_ids, first_seen, last_used"
         )
         if has_pattern_cat:
             select_cols += ", pattern_category"
+        if has_content_hash_col:
+            select_cols += ", content_hash"
         try:
             rows = db.execute(
                 f"""
@@ -890,6 +909,8 @@ class IntelligenceSelector:
             ).fetchall()
         except Exception:
             return items
+
+        canonical_id_cache: Dict[str, str] = {}
 
         for row in rows:
             row_d = dict(row)
@@ -913,8 +934,24 @@ class IntelligenceSelector:
             stored_cat = row_d.get("pattern_category")
             pattern_category = stored_cat or classify_pattern_category(title, content)
 
+            # Resolve the canonical row id for this pattern's content. CFX-5:
+            # when the same content lives under multiple rows (legacy
+            # duplication or pre-dedup state), every row emits the *same*
+            # item_id so pattern_usage aggregates instead of fragmenting.
+            stored_short_hash = (
+                row_d.get("content_hash") if has_content_hash_col else None
+            )
+            short_hash = stored_short_hash or _short_content_hash(title, content)
+            canonical_key = self._resolve_canonical_id(
+                db,
+                short_hash,
+                fallback_id=row_d.get("id"),
+                cache=canonical_id_cache,
+                has_content_hash_col=has_content_hash_col,
+            )
+
             items.append(IntelligenceItem(
-                item_id=_stable_item_id("sp", str(row_d.get("id", ""))),
+                item_id=_stable_item_id("sp", canonical_key),
                 item_class="proven_pattern",
                 title=title,
                 content=content,
@@ -929,6 +966,46 @@ class IntelligenceSelector:
             ))
 
         return items
+
+    def _resolve_canonical_id(
+        self,
+        db: sqlite3.Connection,
+        short_hash: str,
+        *,
+        fallback_id: Any,
+        cache: Dict[str, str],
+        has_content_hash_col: bool,
+    ) -> str:
+        """Return the canonical (smallest-id) row key for a given content hash.
+
+        Consult the on-row ``content_hash`` index when available so that
+        ``intel_sp_<id>`` collapses across duplicate rows. When the column is
+        absent (pre-migration 0012) or no row matches the hash yet, fall back
+        to the row's own primary key — preserving the legacy ``intel_sp_<id>``
+        format and the backward-compatibility guarantee in the dispatch.
+        """
+        fallback_key = str(fallback_id) if fallback_id is not None else ""
+        if not short_hash or not has_content_hash_col:
+            return fallback_key
+        if short_hash in cache:
+            return cache[short_hash]
+        try:
+            row = db.execute(
+                "SELECT MIN(id) FROM success_patterns WHERE content_hash = ?",
+                (short_hash,),
+            ).fetchone()
+        except sqlite3.Error:
+            cache[short_hash] = fallback_key
+            return fallback_key
+        canonical_id = None
+        if row is not None:
+            canonical_id = row[0] if not isinstance(row, sqlite3.Row) else row[0]
+        if canonical_id is None:
+            cache[short_hash] = fallback_key
+            return fallback_key
+        canonical_key = str(canonical_id)
+        cache[short_hash] = canonical_key
+        return canonical_key
 
     def _query_failure_prevention(
         self,

--- a/scripts/lib/pattern_dedup.py
+++ b/scripts/lib/pattern_dedup.py
@@ -90,6 +90,80 @@ def ensure_pattern_category_columns(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+# 16-char prefix of SHA-256 — enough entropy to avoid collisions across the
+# population of success_patterns rows we expect to ever see (millions before
+# collision risk reaches 1%) while keeping pattern_id readable.
+CONTENT_HASH_PREFIX_LEN = 16
+
+
+def _short_content_hash(*parts: Optional[str]) -> str:
+    """Stable 16-char prefix of the normalized SHA-256 used by the selector.
+
+    Selector ``IntelligenceItem.content_hash`` is the full SHA-256 hex string,
+    but the on-row column is the 16-char prefix so the canonical-id lookup
+    can use a short index without sacrificing collision resistance.
+    """
+    return content_hash(*parts)[:CONTENT_HASH_PREFIX_LEN]
+
+
+def ensure_content_hash_column(conn: sqlite3.Connection) -> None:
+    """Apply migration 0012 idempotently.
+
+    Adds ``content_hash`` (TEXT) to ``success_patterns`` plus the supporting
+    composite index on (content_hash, project_id). Backfill of existing rows
+    is delegated to :func:`backfill_content_hash` so a fresh DB acquires the
+    column without paying for hashing work it doesn't need yet.
+
+    SQLite has no SHA-256 builtin, hence the column is added empty here and
+    populated by the Python helper. The index is non-unique because legacy
+    duplicates may share a hash until ``dedup_success_patterns --apply``
+    collapses them; ``pattern_dedup`` enforces application-level uniqueness
+    after the collapse.
+    """
+    if not _column_exists(conn, "success_patterns", "content_hash"):
+        conn.execute(
+            "ALTER TABLE success_patterns ADD COLUMN content_hash TEXT"
+        )
+    # project_id arrived in migration 0010; older snapshots may pre-date it,
+    # so fall back to a single-column index when the project_id column is
+    # missing rather than failing the whole migration.
+    if _column_exists(conn, "success_patterns", "project_id"):
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_success_patterns_content_hash "
+            "ON success_patterns (content_hash, project_id)"
+        )
+    else:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_success_patterns_content_hash "
+            "ON success_patterns (content_hash)"
+        )
+    conn.commit()
+
+
+def backfill_content_hash(conn: sqlite3.Connection) -> int:
+    """Populate ``content_hash`` for rows where it is NULL.
+
+    Returns the count of rows updated. Idempotent — rows whose hash is
+    already populated are skipped, so re-running is a no-op.
+    """
+    ensure_content_hash_column(conn)
+    rows = conn.execute(
+        "SELECT id, title, description FROM success_patterns "
+        "WHERE content_hash IS NULL OR content_hash = ''"
+    ).fetchall()
+    updated = 0
+    for row in rows:
+        h = _short_content_hash(row[1], row[2])
+        conn.execute(
+            "UPDATE success_patterns SET content_hash = ? WHERE id = ?",
+            (h, row[0]),
+        )
+        updated += 1
+    if updated:
+        conn.commit()
+    return updated
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
@@ -203,6 +277,8 @@ def dedup_success_patterns(
     conn.row_factory = sqlite3.Row
     try:
         ensure_pattern_category_columns(conn)
+        ensure_content_hash_column(conn)
+        backfill_content_hash(conn)
         groups = _group_duplicates(conn)
         report: Dict[str, int] = {}
         for hash_key, members in groups.items():
@@ -378,6 +454,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Re-run pattern_category classification on every row.",
     )
+    parser.add_argument(
+        "--backfill-content-hash",
+        action="store_true",
+        help="Populate the content_hash column for rows missing it (idempotent).",
+    )
     return parser
 
 
@@ -397,6 +478,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             ensure_pattern_category_columns(conn)
             counts = backfill_pattern_category(conn)
         print(f"[pattern_dedup] backfill counts: {counts}")
+
+    if args.backfill_content_hash:
+        with sqlite3.connect(str(args.db)) as conn:
+            updated = backfill_content_hash(conn)
+        print(f"[pattern_dedup] content_hash backfill: {updated} rows updated")
 
     report = dedup_success_patterns(args.db, apply=args.apply)
     if not report:

--- a/tests/test_pattern_id_stability.py
+++ b/tests/test_pattern_id_stability.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Tests for content-addressable pattern_id stability (CFX-5).
+
+Background (claudedocs/2026-04-30-intelligence-system-audit.md, OI-CFX-5):
+  The intelligence selector previously emitted ``intel_sp_<row_id>`` as the
+  pattern_id offered to dispatches. When the same logical pattern lived
+  under multiple ``success_patterns`` rows, each row produced its own
+  pattern_id and pattern_usage exploded into N rows for one underlying
+  pattern. Migration 0012 introduces a ``content_hash`` column; the
+  selector now resolves the *canonical* (smallest-id) row sharing a
+  content_hash so duplicates collapse onto one pattern_id without breaking
+  legacy callers that referenced the original ``intel_sp_<id>`` shape.
+
+Cases covered:
+  A. Same content injected to two dispatches → same pattern_id reused
+  B. Different content → distinct pattern_ids
+  C. pattern_usage rows aggregate across injections (counters, not rows)
+  D. Migration 0012 is idempotent (apply column + backfill twice = no-op)
+  E. Backfill correctness — content_hash populated for legacy rows
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+from intelligence_selector import (  # noqa: E402
+    IntelligenceSelector,
+    _short_content_hash,
+)
+from pattern_dedup import (  # noqa: E402
+    CONTENT_HASH_PREFIX_LEN,
+    _column_exists,
+    backfill_content_hash,
+    ensure_content_hash_column,
+    ensure_pattern_category_columns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema fixture mirroring the production quality_intelligence schema
+# ---------------------------------------------------------------------------
+
+def _create_quality_db(path: Path, *, with_migration_0012: bool = True) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            pattern_data TEXT, code_example TEXT, prerequisites TEXT, outcomes TEXT,
+            success_rate REAL DEFAULT 0.0, usage_count INTEGER DEFAULT 0,
+            avg_completion_time INTEGER, confidence_score REAL DEFAULT 0.0,
+            source_dispatch_ids TEXT, source_receipts TEXT,
+            first_seen DATETIME, last_used DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE antipatterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            pattern_data TEXT, problem_example TEXT, why_problematic TEXT,
+            better_alternative TEXT, occurrence_count INTEGER DEFAULT 0,
+            avg_resolution_time INTEGER, severity TEXT DEFAULT 'medium',
+            source_dispatch_ids TEXT, first_seen DATETIME, last_seen DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT, rule_type TEXT, description TEXT,
+            recommendation TEXT, confidence REAL DEFAULT 0.0,
+            created_at TEXT, triggered_count INTEGER DEFAULT 0,
+            last_triggered TEXT,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT, cognition TEXT DEFAULT 'normal',
+            priority TEXT DEFAULT 'P1', pr_id TEXT, parent_dispatch TEXT,
+            pattern_count INTEGER DEFAULT 0, prevention_rule_count INTEGER DEFAULT 0,
+            intelligence_json TEXT, instruction_char_count INTEGER DEFAULT 0,
+            context_file_count INTEGER DEFAULT 0,
+            dispatched_at DATETIME, completed_at DATETIME,
+            outcome_status TEXT, outcome_report_path TEXT, session_id TEXT
+        );
+        CREATE TABLE pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TIMESTAMP,
+            last_offered TIMESTAMP,
+            confidence REAL DEFAULT 1.0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+    )
+    conn.commit()
+    if with_migration_0012:
+        ensure_pattern_category_columns(conn)
+        ensure_content_hash_column(conn)
+    conn.close()
+
+
+def _insert_pattern(
+    db_path: Path,
+    title: str,
+    description: str,
+    *,
+    category: str = "backend-developer",
+    confidence: float = 0.85,
+    usage_count: int = 3,
+    populate_hash: bool = True,
+) -> int:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute(
+        """
+        INSERT INTO success_patterns
+            (title, description, category, confidence_score, usage_count,
+             pattern_data, first_seen, last_used)
+        VALUES (?, ?, ?, ?, ?, '{}', '2026-04-01T00:00:00Z', '2026-04-29T00:00:00Z')
+        """,
+        (title, description, category, confidence, usage_count),
+    )
+    pid = cur.lastrowid
+    if populate_hash and _column_exists(conn, "success_patterns", "content_hash"):
+        h = _short_content_hash(title, description)
+        conn.execute(
+            "UPDATE success_patterns SET content_hash = ? WHERE id = ?",
+            (h, pid),
+        )
+    conn.commit()
+    conn.close()
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Case A: same content reuses pattern_id across injections
+# ---------------------------------------------------------------------------
+
+class TestSamePatternIdAcrossInjections(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_duplicate_rows_collapse_to_canonical_pattern_id(self):
+        title = "Use a structured output schema"
+        desc = "Define a JSON schema and validate model output."
+        first_id = _insert_pattern(self.db_path, title, desc, confidence=0.9)
+        second_id = _insert_pattern(self.db_path, title, desc, confidence=0.85)
+        self.assertNotEqual(first_id, second_id,
+                            "fixture must seed two distinct rows")
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result = selector.select(
+                dispatch_id="dispatch-A",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        proven = [i for i in result.items if i.item_class == "proven_pattern"]
+        self.assertEqual(len(proven), 1, "diversity filter must collapse")
+        # Canonical id is the smallest-id row sharing the content_hash.
+        self.assertEqual(proven[0].item_id, f"intel_sp_{first_id}")
+
+    def test_two_dispatches_get_same_pattern_id_for_same_content(self):
+        title = "Cache external API responses"
+        desc = "Memoize at the gateway layer to reduce vendor latency."
+        canonical = _insert_pattern(self.db_path, title, desc)
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result_a = selector.select(
+                dispatch_id="dispatch-A",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+            result_b = selector.select(
+                dispatch_id="dispatch-B",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        ids_a = [i.item_id for i in result_a.items if i.item_class == "proven_pattern"]
+        ids_b = [i.item_id for i in result_b.items if i.item_class == "proven_pattern"]
+        self.assertEqual(ids_a, [f"intel_sp_{canonical}"])
+        self.assertEqual(ids_a, ids_b, "same content must yield same pattern_id")
+
+
+# ---------------------------------------------------------------------------
+# Case B: different content → distinct pattern_ids
+# ---------------------------------------------------------------------------
+
+class TestDistinctContentDistinctIds(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_distinct_content_yields_distinct_ids(self):
+        a_id = _insert_pattern(
+            self.db_path,
+            "Use structured output",
+            "Schema-validated model output reduces parsing errors.",
+            confidence=0.9, usage_count=4,
+        )
+        b_id = _insert_pattern(
+            self.db_path,
+            "Cache external API responses",
+            "Memoize at the gateway layer to reduce vendor latency.",
+            confidence=0.88, usage_count=4,
+        )
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                "SELECT id, content_hash FROM success_patterns ORDER BY id"
+            ).fetchall()
+        hashes = {row[0]: row[1] for row in rows}
+        self.assertEqual(len(set(hashes.values())), 2,
+                         "distinct content must hash distinctly")
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result = selector.select(
+                dispatch_id="dispatch-distinct",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        ids = sorted(i.item_id for i in result.items if i.item_class == "proven_pattern")
+        # Selection retains at most one proven_pattern slot per FP-C; the
+        # winner must be one of the two seeded rows, and never an aggregate
+        # phantom id like "intel_sp_<hash>".
+        self.assertEqual(len(ids), 1)
+        self.assertIn(ids[0], (f"intel_sp_{a_id}", f"intel_sp_{b_id}"))
+
+
+# ---------------------------------------------------------------------------
+# Case C: pattern_usage aggregation across injections
+# ---------------------------------------------------------------------------
+
+class TestPatternUsageAggregation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_two_dispatches_produce_one_pattern_usage_row(self):
+        title = "Validate inputs at boundaries"
+        desc = "Trust internal callers; check user-supplied data once at entry."
+        canonical = _insert_pattern(self.db_path, title, desc)
+        # Add a near-duplicate row to verify the aggregation works even when
+        # the source DB has not yet been deduplicated.
+        _insert_pattern(self.db_path, title, desc, confidence=0.7)
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            for did in ("dispatch-1", "dispatch-2", "dispatch-3"):
+                result = selector.select(
+                    dispatch_id=did,
+                    injection_point="dispatch_create",
+                    skill_name="backend-developer",
+                )
+                # record_injection requires a coord_state_dir to write the
+                # audit row, but the per-pattern usage upsert lives entirely
+                # in quality_intelligence.db. Call the internal helper so the
+                # test exercises the path that matters.
+                selector._record_pattern_usage(result)
+        finally:
+            selector.close()
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                "SELECT pattern_id, last_offered FROM pattern_usage"
+            ).fetchall()
+        self.assertEqual(
+            len(rows), 1,
+            f"three injections of same pattern must produce one row, got {rows}",
+        )
+        self.assertEqual(rows[0][0], f"intel_sp_{canonical}")
+
+
+# ---------------------------------------------------------------------------
+# Case D: migration is idempotent
+# ---------------------------------------------------------------------------
+
+class TestMigrationIdempotency(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        # Start without migration 0012 so we exercise the ADD COLUMN path.
+        _create_quality_db(self.db_path, with_migration_0012=False)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_apply_then_apply_no_error(self):
+        with sqlite3.connect(str(self.db_path)) as conn:
+            ensure_content_hash_column(conn)
+            ensure_content_hash_column(conn)  # re-apply
+            self.assertTrue(_column_exists(conn, "success_patterns", "content_hash"))
+
+    def test_backfill_idempotent_and_short_hash(self):
+        # Seed with the column missing so backfill must run.
+        a = _insert_pattern(self.db_path, "Title A", "Desc A", populate_hash=False)
+        b = _insert_pattern(self.db_path, "Title B", "Desc B", populate_hash=False)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            first = backfill_content_hash(conn)
+            second = backfill_content_hash(conn)
+            rows = conn.execute(
+                "SELECT id, content_hash FROM success_patterns ORDER BY id"
+            ).fetchall()
+
+        self.assertEqual(first, 2, "first backfill must hash both rows")
+        self.assertEqual(second, 0, "second backfill must be a no-op")
+        self.assertEqual({r[0] for r in rows}, {a, b})
+        for _, h in rows:
+            self.assertEqual(len(h), CONTENT_HASH_PREFIX_LEN)
+            int(h, 16)  # raises if not hex
+
+    def test_idempotent_index_creation(self):
+        with sqlite3.connect(str(self.db_path)) as conn:
+            ensure_content_hash_column(conn)
+            # Calling a second time must not error on the existing index.
+            ensure_content_hash_column(conn)
+            idx = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name='idx_success_patterns_content_hash'"
+            ).fetchone()
+        self.assertIsNotNone(idx)
+
+
+# ---------------------------------------------------------------------------
+# Case E: backfill correctness for legacy rows
+# ---------------------------------------------------------------------------
+
+class TestBackfillCorrectness(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "qi.db"
+        _create_quality_db(self.db_path, with_migration_0012=False)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_backfill_matches_in_memory_hash(self):
+        title = "Stream JSON parsing"
+        desc = "Parse incrementally to bound memory on large payloads."
+        pid = _insert_pattern(self.db_path, title, desc, populate_hash=False)
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            updated = backfill_content_hash(conn)
+            (stored,) = conn.execute(
+                "SELECT content_hash FROM success_patterns WHERE id = ?",
+                (pid,),
+            ).fetchone()
+
+        self.assertEqual(updated, 1)
+        self.assertEqual(stored, _short_content_hash(title, desc))
+
+    def test_legacy_row_without_hash_falls_back_to_row_id(self):
+        # Selector must still produce a valid item_id when the column is
+        # absent (i.e. migration 0012 has not been applied yet).
+        title = "Legacy pattern"
+        desc = "Pre-migration row."
+        pid = _insert_pattern(self.db_path, title, desc, populate_hash=False)
+
+        selector = IntelligenceSelector(quality_db_path=self.db_path)
+        try:
+            result = selector.select(
+                dispatch_id="legacy-dispatch",
+                injection_point="dispatch_create",
+                skill_name="backend-developer",
+            )
+        finally:
+            selector.close()
+
+        proven = [i for i in result.items if i.item_class == "proven_pattern"]
+        self.assertEqual(len(proven), 1)
+        self.assertEqual(proven[0].item_id, f"intel_sp_{pid}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `content_hash` column to `success_patterns` via migration 0012 plus an idempotent Python backfill helper, so equivalent pattern content is content-addressable.
- Rewrites `intelligence_selector._query_proven_patterns` to derive `item_id` from the canonical (smallest-id) row sharing a `content_hash`, collapsing duplicates onto one `pattern_id` while preserving the legacy `intel_sp_<row_id>` shape for callers that depend on it.
- Adds 9 stability tests covering canonical collapse, distinct-id preservation, `pattern_usage` aggregation, migration idempotency, and backfill correctness.

Resolves OI-CFX-5 / audit #311 round-2 finding (selector recording pattern_usage under fresh row ids per offering, exploding one pattern into N rows).

## Backward compatibility
- When migration 0012 is not yet applied (column missing), the selector falls back to the legacy `intel_sp_<row_id>` shape, so existing pattern_usage rows continue to function.
- Composite index on `(content_hash, project_id)` is non-unique; uniqueness is enforced application-side by `pattern_dedup --apply` after collapse, so the migration is safe to apply on a polluted DB without a pre-dedup step.

## Test plan
- [x] `python3 -m py_compile scripts/lib/intelligence_selector.py scripts/lib/pattern_dedup.py`
- [x] `python3 -m pytest tests/test_pattern_id_stability.py tests/test_pattern_diversity.py tests/test_intelligence_selector.py -xvs` → 57 passed
- [x] `python3 -m pytest tests/test_intelligence_recency.py tests/test_intelligence_fixes.py` → 12 passed, 1 xfailed (pre-existing)
- [ ] Real-DB smoke: `python3 scripts/lib/pattern_dedup.py --db <real-db> --backfill-content-hash --dry-run` (operator-run; no real DB present in worktree)

Dispatch-ID: 20260430-cfx-5-pattern-id

🤖 Generated with [Claude Code](https://claude.com/claude-code)