### PR TITLE
fix(dashboard): SSE + timer unmount cleanup + lifecycle tests (CFX-13)

### DIFF
--- a/dashboard/token-dashboard/app/agent-stream/page.tsx
+++ b/dashboard/token-dashboard/app/agent-stream/page.tsx
@@ -143,6 +143,7 @@ export default function AgentStreamPage() {
   const eventSourceRef = useRef<EventSource | null>(null);
   const lastTimestampRef = useRef<string | null>(null);
   const pausedRef = useRef(false);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep ref in sync with state for use in EventSource callbacks
   useEffect(() => {
@@ -170,6 +171,11 @@ export default function AgentStreamPage() {
 
   // Connect to SSE
   const connect = useCallback((term: Terminal, since: string | null) => {
+    // Cancel any pending retry before opening a new connection
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
     // Close existing connection
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -206,7 +212,8 @@ export default function AgentStreamPage() {
       setError('SSE connection failed — retrying…');
       es.close();
       eventSourceRef.current = null;
-      setTimeout(() => {
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
         connect(term, lastTimestampRef.current);
       }, 2000);
     };
@@ -220,6 +227,10 @@ export default function AgentStreamPage() {
     connect(terminal, null);
 
     return () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;

--- a/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
+++ b/dashboard/token-dashboard/app/operator/dispatches/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useState } from 'react';
+import { use, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
@@ -106,13 +106,25 @@ function MetaRow({ label, value }: { label: string; value: string | undefined | 
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
   return (
     <button
       onClick={() => {
         if (typeof navigator !== 'undefined' && navigator.clipboard) {
           navigator.clipboard.writeText(text).then(() => {
             setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
+            if (timerRef.current) clearTimeout(timerRef.current);
+            timerRef.current = setTimeout(() => {
+              timerRef.current = null;
+              setCopied(false);
+            }, 1500);
           });
         }
       }}

--- a/dashboard/token-dashboard/app/operator/page.tsx
+++ b/dashboard/token-dashboard/app/operator/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { RefreshCw, LayoutGrid, Activity } from 'lucide-react';
 import { useProjects, useTerminals, useOperatorSession } from '@/lib/hooks';
 import type { ActionOutcome } from '@/lib/types';
@@ -47,6 +47,13 @@ export default function OperatorPage() {
   const { data: terminalsEnv, isLoading: termLoading, mutate: mutateTerminals } = useTerminals();
   const { data: sessionEnv } = useOperatorSession();
   const [lastOutcome, setLastOutcome] = useState<ActionOutcome | null>(null);
+  const mutateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (mutateTimerRef.current) clearTimeout(mutateTimerRef.current);
+    };
+  }, []);
 
   function handleRefresh() {
     mutateProjects();
@@ -217,7 +224,11 @@ export default function OperatorPage() {
                   project={proj}
                   onActionComplete={outcome => {
                     setLastOutcome(outcome);
-                    setTimeout(() => mutateProjects(), 1500);
+                    if (mutateTimerRef.current) clearTimeout(mutateTimerRef.current);
+                    mutateTimerRef.current = setTimeout(() => {
+                      mutateTimerRef.current = null;
+                      mutateProjects();
+                    }, 1500);
                   }}
                 />
               ))}

--- a/dashboard/token-dashboard/e2e/sse-lifecycle.spec.ts
+++ b/dashboard/token-dashboard/e2e/sse-lifecycle.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * SSE + timer unmount lifecycle tests (CFX-13)
+ *
+ * Verifies that EventSource connections are properly opened on mount and closed
+ * on unmount/navigation. Uses a window spy injected via addInitScript so the
+ * same JS context is maintained during SPA navigation.
+ *
+ * @integration — requires a running dev server (npm run dev)
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Types (runtime shape tracked by the browser-side spy)
+// ---------------------------------------------------------------------------
+
+interface EsEntry {
+  url: string;
+  closed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Spy injection — must be called before page.goto()
+// ---------------------------------------------------------------------------
+
+async function injectEventSourceSpy(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const instances: { url: string; closed: boolean }[] = [];
+    (window as unknown as { __esInstances: typeof instances }).__esInstances = instances;
+
+    const OrigES = window.EventSource;
+
+    class SpyEventSource extends OrigES {
+      constructor(url: string | URL, init?: EventSourceInit) {
+        super(url, init);
+        const entry = { url: String(url), closed: false };
+        instances.push(entry);
+        const origClose = this.close.bind(this);
+        this.close = () => {
+          entry.closed = true;
+          origClose();
+        };
+      }
+    }
+
+    window.EventSource = SpyEventSource as typeof EventSource;
+  });
+}
+
+async function getEsInstances(page: Page): Promise<EsEntry[]> {
+  return page.evaluate(
+    () =>
+      (window as Window & { __esInstances?: { url: string; closed: boolean }[] })
+        .__esInstances ?? []
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SSE stub — stable empty stream (no onerror, no data)
+// ---------------------------------------------------------------------------
+
+async function stubSseEndpoints(page: Page): Promise<void> {
+  await page.route('**/api/agent-stream/**', async (route) => {
+    if (route.request().url().includes('/status')) {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ terminals: {} }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+      body: '',
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('SSE + timer unmount lifecycle', () => {
+  test('A: EventSource opens on mount', async ({ page }) => {
+    await injectEventSourceSpy(page);
+    await stubSseEndpoints(page);
+
+    await page.goto('/agent-stream');
+    await page.waitForLoadState('domcontentloaded');
+
+    const instances = await getEsInstances(page);
+
+    expect(instances.length, 'At least one EventSource must open on mount').toBeGreaterThan(0);
+    expect(
+      instances.some((es) => !es.closed),
+      'At least one EventSource should be open after mount'
+    ).toBe(true);
+  });
+
+  test('B: timer cleared on SPA navigation away (no zombie polling)', async ({ page }) => {
+    await injectEventSourceSpy(page);
+    await stubSseEndpoints(page);
+
+    // Track fetch calls to /api/agent-stream/status to verify polling stops
+    const statusRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('/agent-stream/status')) {
+        statusRequests.push(req.url());
+      }
+    });
+
+    await page.goto('/agent-stream');
+    await page.waitForLoadState('domcontentloaded');
+
+    const countBefore = statusRequests.length;
+
+    // SPA navigation away — the setInterval cleanup runs
+    await page.click('a[href="/"]');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Wait 6 seconds (> 5s polling interval) — no new status requests should appear
+    await page.waitForTimeout(6000);
+    const countAfter = statusRequests.length;
+
+    expect(
+      countAfter,
+      `Status polling continued after unmount: ${countAfter - countBefore} new requests after navigation`
+    ).toBe(countBefore);
+  });
+
+  test('C: no zombie EventSources after terminal switch and navigation', async ({ page }) => {
+    await injectEventSourceSpy(page);
+    await stubSseEndpoints(page);
+
+    await page.goto('/agent-stream');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Switch terminal: T1 → T2 → T3
+    const t2Btn = page.locator('[data-testid="agent-selector"] button', { hasText: 'T2' }).first();
+    await t2Btn.click();
+    await page.waitForTimeout(200);
+
+    const t3Btn = page.locator('[data-testid="agent-selector"] button', { hasText: 'T3' }).first();
+    await t3Btn.click();
+    await page.waitForTimeout(200);
+
+    // After switching terminals, only one connection should be open
+    const midInstances = await getEsInstances(page);
+    const openMid = midInstances.filter((es) => !es.closed);
+    expect(
+      openMid.length,
+      `Expected exactly 1 open EventSource after terminal switch, got ${openMid.length}: ${JSON.stringify(openMid)}`
+    ).toBe(1);
+
+    // Navigate away via SPA — all connections must close
+    await page.click('a[href="/"]');
+    await page.waitForLoadState('domcontentloaded');
+
+    const afterNav = await getEsInstances(page);
+    const streamInstances = afterNav.filter((es) => es.url.includes('agent-stream'));
+    const stillOpen = streamInstances.filter((es) => !es.closed);
+
+    expect(
+      stillOpen.length,
+      `Zombie EventSources found after navigation: ${JSON.stringify(stillOpen)}`
+    ).toBe(0);
+  });
+
+  test('D: re-mount creates a fresh EventSource, not a stale reuse', async ({ page }) => {
+    await injectEventSourceSpy(page);
+    await stubSseEndpoints(page);
+
+    // First mount
+    await page.goto('/agent-stream');
+    await page.waitForLoadState('domcontentloaded');
+    const afterFirstMount = await getEsInstances(page);
+    expect(afterFirstMount.length, 'Expected at least one EventSource on first mount').toBeGreaterThan(0);
+
+    // Navigate away (SPA — spy persists)
+    await page.click('a[href="/"]');
+    await page.waitForLoadState('domcontentloaded');
+
+    const afterNavAway = await getEsInstances(page);
+    const closedAfterNav = afterNavAway.filter((es) => es.url.includes('agent-stream') && es.closed);
+    expect(closedAfterNav.length, 'Previous connection must be closed after unmount').toBeGreaterThan(0);
+
+    // Navigate back (SPA)
+    await page.click('a[href="/agent-stream"]');
+    await page.waitForLoadState('domcontentloaded');
+
+    const afterRemount = await getEsInstances(page);
+
+    // New connection must have been created (total count grew)
+    expect(
+      afterRemount.length,
+      `Expected new EventSource on re-mount. Was ${afterFirstMount.length}, now ${afterRemount.length}`
+    ).toBeGreaterThan(afterFirstMount.length);
+
+    // The latest instance must be open (not stale/closed)
+    const latest = afterRemount[afterRemount.length - 1];
+    expect(latest.closed, 'Freshly created EventSource after re-mount must be open').toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Critical fix**: `agent-stream/page.tsx` — retry `setTimeout` in SSE `onerror` handler was never tracked or cancelled, causing zombie reconnects after unmount. Added `retryTimerRef` and cancel in both the `useEffect` cleanup and at the start of each `connect()` call.
- **Minor fix**: `operator/dispatches/[id]/page.tsx` — `CopyButton` now uses `timerRef` + `useEffect` cleanup to cancel the `setCopied` reset timeout on unmount.
- **Minor fix**: `operator/page.tsx` — `mutateTimerRef` tracks the post-action `mutateProjects` delay and clears it on unmount.
- **New tests**: `e2e/sse-lifecycle.spec.ts` — 4 Playwright integration tests covering: EventSource opens on mount, polling timer stops after navigation, no zombie connections after terminal switch, and fresh EventSource created on re-mount.

## Test plan
- [ ] `npm run typecheck` passes (1 pre-existing error in `console-errors.spec.ts` unrelated to this PR)
- [ ] Playwright tests marked `@integration` — require dev server: `npm run dev` then `npx playwright test e2e/sse-lifecycle.spec.ts`
- [ ] Test A: EventSource opens on mount — verifies connection established
- [ ] Test B: polling timer stops after navigation — 6s wait confirms no new status requests
- [ ] Test C: no zombie connections after T1→T2→T3 switch then nav away
- [ ] Test D: re-mount creates fresh connection, previous connection is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)