### PR TITLE
docs(headless): missing transition doc + 4-mode matrix in README + adapter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ The same governance applies regardless of mode. Receipts, quality gates, and pro
 
 Typical use cases: overnight feature execution, CI/CD integration, shadow testing of new agent configurations.
 
+### Adapter mode matrix (Operator mode)
+
+Within Operator mode, each terminal (T0/T1/T2/T3) can independently use tmux (interactive) or subprocess (headless) adapter:
+
+| Mode | T0 | Workers (T1/T2/T3) | When to use |
+|------|----|--------------------|-------------|
+| 2×2 grid | tmux | tmux | Live operator session |
+| Hybrid | tmux | subprocess | Operator drives, workers background |
+| Fully headless | subprocess | subprocess | CI/cron/autonomous |
+
+```bash
+# Hybrid (recommended for solo dev)
+VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess vnx start
+
+# Fully headless
+VNX_ADAPTER_T0=subprocess VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess \
+  python3 scripts/headless_orchestrator.py
+```
+
+See [HEADLESS_TRANSITION.md](docs/manifesto/HEADLESS_TRANSITION.md) for the architectural narrative and migration guide.
+
 ## Why CLI Subprocess — Not OAuth, Not API
 
 Anthropic's April 2026 policy bans third-party tools from using OAuth tokens obtained through Pro/Max subscriptions. OpenClaw (340K+ stars) and similar "harness" tools were affected. **VNX was not.**

--- a/docs/manifesto/HEADLESS_TRANSITION.md
+++ b/docs/manifesto/HEADLESS_TRANSITION.md
@@ -37,6 +37,74 @@ The system worked, but it required continuous attention. A chain of 10 PRs meant
 
 ---
 
+## Four Run Modes
+
+VNX supports four adapter configurations. Each terminal (T0/T1/T2/T3) independently selects `tmux` (interactive) or `subprocess` (headless):
+
+| Mode | T0 | Workers (T1/T2/T3) | When to use |
+|------|----|--------------------|-------------|
+| 1. All interactive | tmux | tmux | Live operator session, visible 2×2 grid |
+| 2. Interactive T0 + headless workers | tmux | subprocess | Operator drives, workers run in background |
+| 3. All headless | subprocess | subprocess | CI/cron, autonomous overnight chains |
+| 4. Headless T0 + interactive workers | subprocess | tmux | Edge case — operator wants to inspect worker panes |
+
+### Configuration
+
+```bash
+VNX_ADAPTER_T0=subprocess     # headless T0
+VNX_ADAPTER_T1=subprocess     # headless T1
+VNX_ADAPTER_T2=subprocess     # headless T2
+VNX_ADAPTER_T3=subprocess     # headless T3
+# Default (unset): tmux for all
+```
+
+**Mode 2 (recommended for solo dev):**
+```bash
+VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess vnx start
+```
+
+**Mode 3 (fully headless):**
+```bash
+VNX_ADAPTER_T0=subprocess VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess \
+  python3 scripts/headless_orchestrator.py
+```
+
+### What stays identical across modes
+
+- Receipt schema (append-only NDJSON)
+- Quality gate enforcement (codex + gemini + CI)
+- Provenance chain (instruction_sha256 → manifest → receipt → audit)
+- Open items lifecycle
+- Pattern intelligence DB
+
+### What differs
+
+| Aspect | Interactive (tmux) | Headless (subprocess) |
+|--------|--------------------|-----------------------|
+| Tmux pane | yes | no |
+| Event stream | basic | full per-dispatch in `events/T<n>.ndjson` |
+| Context rotation | Claude Code /clear | F43 explicit handover |
+| Crash recovery | tmux session restore | `dispatcher_supervisor.sh` wrapper |
+| Memory hooks | Claude Code native | Receipt-driven post-hooks (ARC-3) |
+
+### When to choose which mode
+
+- **Mode 1**: First-time setup, debugging, or when you want to watch every agent decision live.
+- **Mode 2**: Daily development. You approve dispatches; workers run silently and produce receipts. Low cognitive overhead.
+- **Mode 3**: Overnight chains, CI pipelines, or any context where no human is present between dispatch approval cycles.
+- **Mode 4**: Rare. Useful when you want T0 to operate headlessly (e.g., driven by a webhook) while keeping worker panes open for manual inspection.
+
+### Migration path from interactive-only
+
+If you've been running Mode 1 and want to try Mode 2:
+
+1. Set `VNX_ADAPTER_T1=subprocess` for one terminal first
+2. Run a dispatch and verify the receipt appears identically
+3. Gradually enable T2, then T3
+4. Consider Mode 3 once comfortable with event-archive debugging
+
+---
+
 ## The Transition: What Changed and When
 
 ### Step 1 — SubprocessAdapter (F32, March 2026)
@@ -158,3 +226,12 @@ A 27-PR chain (like the v0.10.0 chain) landed over two days with the operator ma
 **Gate noise is an operator tax, not a worker tax.** When codex blocks 100% of chain PRs as `error`, it's the operator who has to manually evaluate and override each one. Severity calibration (#323, #324) was necessary for sustainable headless gate operation — it's not a shortcut, it's a prerequisite.
 
 **The approval gate is intentional governance, not a scaling bottleneck.** The operator still approves each dispatch before it goes active. This is not a bug. The approval gate is the system's primary human checkpoint — the point where an operator's judgment replaces automated logic. Removing it would make the system fully autonomous, which requires a different trust model.
+
+---
+
+## See Also
+
+- [docs/comparisons/headless_vs_interactive.md](../comparisons/headless_vs_interactive.md) — detailed side-by-side comparison
+- [docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md](../operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md) — env var reference for all terminals
+- [docs/operations/EVENT_STREAMS.md](../operations/EVENT_STREAMS.md) — per-terminal NDJSON structure
+- [README.md §"Adapter mode matrix"](../../README.md) — quick-start matrix in the project overview

--- a/docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md
+++ b/docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md
@@ -11,11 +11,17 @@ instead of the default tmux send-keys delivery.
 Set a per-terminal env var before starting the dispatcher:
 
 ```bash
+# Route T0 through SubprocessAdapter (headless orchestrator)
+export VNX_ADAPTER_T0=subprocess
+
 # Route T1 through SubprocessAdapter
 export VNX_ADAPTER_T1=subprocess
 
 # Route T2 through SubprocessAdapter
 export VNX_ADAPTER_T2=subprocess
+
+# Route T3 through SubprocessAdapter
+export VNX_ADAPTER_T3=subprocess
 
 # Explicit tmux (same as default/unset)
 export VNX_ADAPTER_T1=tmux
@@ -25,6 +31,19 @@ Supported values:
 - `subprocess` — delivers via `SubprocessAdapter` (headless `claude -p` subprocess)
 - `tmux` — delivers via tmux send-keys (existing behavior)
 - unset — T0 defaults to `tmux`; T1/T2/T3 default to `subprocess` (set `VNX_ADAPTER_Tx=tmux` to opt-out)
+
+## Four-Mode Combinations
+
+| Mode | VNX_ADAPTER_T0 | VNX_ADAPTER_T1/T2/T3 | Launch command |
+|------|----------------|----------------------|----------------|
+| 1. All interactive | tmux (unset) | tmux | `vnx start` |
+| 2. Interactive T0 + headless workers | tmux (unset) | subprocess | `VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess vnx start` |
+| 3. All headless | subprocess | subprocess | `VNX_ADAPTER_T0=subprocess VNX_ADAPTER_T1=subprocess VNX_ADAPTER_T2=subprocess VNX_ADAPTER_T3=subprocess python3 scripts/headless_orchestrator.py` |
+| 4. Headless T0 + interactive workers | subprocess | tmux | `VNX_ADAPTER_T0=subprocess vnx start` |
+
+**Mode 2** is the recommended daily-driver: operator approves dispatches from a live T0 pane while workers execute silently in the background.
+
+**Mode 3** is designed for CI/cron and autonomous overnight chains. Use `scripts/headless_orchestrator.py` as the entry point — it handles T0 decision loop, file-watcher triggers, and silence watchdogs without requiring a tmux session.
 
 ## Implementation
 
@@ -55,4 +74,10 @@ The subprocess path only calls `subprocess.Popen(["claude", ...])`.
 - `scripts/lib/subprocess_dispatch.py` — thin Python helper for subprocess delivery
 - `scripts/lib/subprocess_adapter.py` — SubprocessAdapter implementation (F28 PR-2/PR-3)
 - `scripts/lib/dispatch_deliver.sh` — routing logic added in F28 PR-4
+- `scripts/headless_orchestrator.py` — all-headless entry point for Mode 3 (CI/cron)
 - `tests/test_subprocess_dispatch_integration.py` — integration tests
+
+## See Also
+
+- [docs/manifesto/HEADLESS_TRANSITION.md](../manifesto/HEADLESS_TRANSITION.md) — architectural narrative, mode decision guide, and migration path
+- [docs/operations/EVENT_STREAMS.md](EVENT_STREAMS.md) — per-terminal NDJSON structure produced by headless workers


### PR DESCRIPTION
## Summary

- Added explicit four-mode adapter matrix to `docs/manifesto/HEADLESS_TRANSITION.md` (sections: Four Run Modes, configuration env vars for all four terminals, what stays identical vs what differs, mode decision guide, migration path from interactive-only, see-also links)
- Extended `README.md` §Headless Mode with new `### Adapter mode matrix (Operator mode)` subsection — matrix table + Hybrid/Fully-headless example commands + link to manifesto
- Updated `docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md` with T0 env var example, four-mode combinations table with launch commands, `scripts/headless_orchestrator.py` reference, and see-also links

Closes the #329 follow-up gap identified in the doc audit. All referenced files verified to exist. Dispatch-ID: 20260501-headless-docs.

## Test plan

- [ ] All referenced files exist (verified via file check script)
- [ ] Bash command examples pass `bash -n` syntax check
- [ ] markdownlint (not installed in CI — best effort)
- [ ] Links in see-also sections resolve to existing paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)