### PR TITLE
fix(guards): haiku parser + run_id regex + drain idempotency (W3C)

### DIFF
--- a/scripts/check_active_drain.py
+++ b/scripts/check_active_drain.py
@@ -232,6 +232,13 @@ def drain_one(
     dest_dir = dispatches_dir / dest_bucket
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / entry.directory.name
+    if dest.exists():
+        return DrainResult(
+            dispatch_id=entry.dispatch_id,
+            action=dest_bucket,
+            reason=f"[skip] destination already exists: {dest.name}",
+            dry_run=False,
+        )
     try:
         shutil.move(str(entry.directory), str(dest))
     except (OSError, shutil.Error) as exc:

--- a/scripts/lib/log_artifact.py
+++ b/scripts/lib/log_artifact.py
@@ -17,14 +17,14 @@ import re
 from pathlib import Path
 from typing import Optional
 
-_SAFE_RUN_ID = re.compile(r'^[A-Za-z0-9_\-.]+$')
+_SAFE_RUN_ID = re.compile(r'^[A-Za-z0-9_][A-Za-z0-9_\-.]*$')
 
 
 def _assert_safe_run_id(run_id: str) -> str:
     """Validate run_id is filesystem-safe — raises ValueError if not."""
-    if not run_id or not _SAFE_RUN_ID.match(run_id) or ".." in run_id:
+    if not run_id or not _SAFE_RUN_ID.match(run_id):
         raise ValueError(
-            f"invalid run_id: {run_id!r} (must match [A-Za-z0-9_\\-.]+ and not contain ..)"
+            f"invalid run_id: {run_id!r} (must start with [A-Za-z0-9_] and match [A-Za-z0-9_\\-.]*)"
         )
     return run_id
 

--- a/scripts/lib/t0_decision_summarizer.py
+++ b/scripts/lib/t0_decision_summarizer.py
@@ -187,6 +187,9 @@ def _parse_haiku_output(stdout: str) -> dict[str, Any]:
     except json.JSONDecodeError:
         return _build_fallback("Haiku summarization failed: invalid JSON response")
 
+    if not isinstance(outer, dict):
+        return _build_fallback("Haiku summarization failed: outer JSON is not a dict")
+
     result_str = outer.get("result", "")
     if not result_str:
         return _build_fallback("Haiku summarization failed: empty result")
@@ -195,6 +198,9 @@ def _parse_haiku_output(stdout: str) -> dict[str, Any]:
         record = json.loads(_strip_code_fences(result_str))
     except json.JSONDecodeError:
         return _build_fallback("Haiku summarization failed: invalid inner JSON")
+
+    if not isinstance(record, dict):
+        return _build_fallback("Haiku summarization failed: inner JSON is not a dict")
 
     _apply_record_defaults(record)
     return record

--- a/tests/test_active_drain.py
+++ b/tests/test_active_drain.py
@@ -295,6 +295,31 @@ class TestDrainOne:
         )
         assert result.action == "completed"
 
+    def test_drain_skips_when_destination_exists(self, tmp_path: Path) -> None:
+        """OI-1127: shutil.move raises when dest exists; drain must skip idempotently."""
+        data = _make_data_dir(tmp_path)
+        did = "20260501-dest-exists-A"
+        d = _make_active_dispatch(data, did, hours_old=5.0)
+        receipt_index = frozenset({did})
+
+        # Pre-create the destination to simulate a prior partial run
+        dest = data / "dispatches" / "completed" / did
+        dest.mkdir(parents=True)
+
+        ts = self._now() - timedelta(hours=5)
+        entry = DispatchEntry(dispatch_id=did, directory=d, timestamp=ts)
+
+        result = drain_one(
+            entry=entry,
+            receipt_index=receipt_index,
+            dispatches_dir=data / "dispatches",
+            now=self._now(),
+            older_than_seconds=3600,
+            dry_run=False,
+        )
+        assert result.action == "completed"
+        assert "[skip]" in result.reason
+
 
 # ---------------------------------------------------------------------------
 # drain_active (integration)

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -30,3 +30,27 @@ def test_run_id_empty_rejected():
 
 def test_run_id_valid_accepted():
     assert _assert_safe_run_id("abc-123_v2") == "abc-123_v2"
+
+
+# OI-1117: bare-dot and dot-prefixed run_ids must be rejected
+def test_run_id_bare_dot_rejected():
+    with pytest.raises(ValueError):
+        _assert_safe_run_id(".")
+
+
+def test_run_id_double_dot_rejected():
+    with pytest.raises(ValueError):
+        _assert_safe_run_id("..")
+
+
+def test_run_id_dot_prefix_rejected():
+    with pytest.raises(ValueError):
+        _assert_safe_run_id(".log")
+
+
+def test_run_id_interior_dot_allowed():
+    assert _assert_safe_run_id("a.b") == "a.b"
+
+
+def test_run_id_alnum_allowed():
+    assert _assert_safe_run_id("abc") == "abc"

--- a/tests/test_t0_decision_summarizer.py
+++ b/tests/test_t0_decision_summarizer.py
@@ -190,6 +190,23 @@ class TestParseHaikuOutput:
         assert record["next_expected"] == ""
         assert "timestamp" in record
 
+    def test_parse_haiku_handles_non_dict_layers(self):
+        # OI-1103: non-dict JSON at outer or inner layer must not crash
+        # list at top level — outer.get() would AttributeError without guard
+        record = _parse_haiku_output(json.dumps(["a", "b", "c"]))
+        assert record["action"] == "wait"
+        assert "Haiku summarization failed" in record["reasoning"]
+
+        # inner JSON is null — _apply_record_defaults(None) would AttributeError
+        record = _parse_haiku_output(json.dumps({"result": json.dumps(None)}))
+        assert record["action"] == "wait"
+        assert "Haiku summarization failed" in record["reasoning"]
+
+        # inner JSON is a string — _apply_record_defaults("str") would AttributeError
+        record = _parse_haiku_output(json.dumps({"result": json.dumps("just a string")}))
+        assert record["action"] == "wait"
+        assert "Haiku summarization failed" in record["reasoning"]
+
 
 # ---------------------------------------------------------------------------
 # summarize_with_haiku


### PR DESCRIPTION
## Summary
- **OI-1103**: `_parse_haiku_output` now guards against non-dict outer/inner JSON (`AttributeError` on `.get()` / `setdefault()` eliminated)
- **OI-1117**: `_assert_safe_run_id` regex tightened from `[A-Za-z0-9_\-.]+` to `[A-Za-z0-9_][A-Za-z0-9_\-.]*` — rejects bare dots (`.`, `..`) and dot-prefixed IDs (`.log`)
- **OI-1127**: `drain_one` pre-checks destination existence before `shutil.move`; skips with `[skip]` reason instead of raising — makes drain idempotent across re-runs

Each fix has a dedicated regression test. 85 tests pass total.

## Test plan
- [x] `pytest tests/test_t0_decision_summarizer.py` — includes `test_parse_haiku_handles_non_dict_layers`
- [x] `pytest tests/test_log_artifact.py` — includes bare-dot/dot-prefix rejection cases
- [x] `pytest tests/test_active_drain.py` — includes `test_drain_skips_when_destination_exists`
- [x] `test_log_artifacts.py` confirmed pre-existing collection error (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)