### PR TITLE
fix(gates): resolve PR-branch file content via git show (W3D)

### DIFF
--- a/scripts/lib/vertex_ai_runner.py
+++ b/scripts/lib/vertex_ai_runner.py
@@ -103,23 +103,68 @@ def _gather_changed_files(files: List[str], subprocess_run: Callable) -> List[st
         return []
 
 
-def _inline_file_contents(files: List[str], max_bytes: int) -> str:
-    """Read and inline file contents up to max_bytes total."""
+def _read_file_from_branch(
+    path: str,
+    branch: str,
+    subprocess_run: Callable,
+) -> str | None:
+    """Return file content as committed on `branch` via `git show branch:path`.
+
+    Returns None when the file is not present on the branch, the path is
+    absolute (and therefore not a tracked path), or git is unavailable.
+    """
+    if not branch or os.path.isabs(path):
+        return None
+    try:
+        result = subprocess_run(
+            ["git", "show", f"{branch}:{path}"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, Exception):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _inline_file_contents(
+    files: List[str],
+    max_bytes: int,
+    *,
+    branch: str = "",
+    subprocess_run: Callable | None = None,
+) -> str:
+    """Read and inline file contents up to max_bytes total.
+
+    When `branch` is provided, file content is resolved via `git show branch:path`
+    so that gates review the PR-branch version regardless of which worktree the
+    gate runs in. Falls back to filesystem read when the file is absent on the
+    branch (e.g., uncommitted local edits) or when no branch is supplied.
+    """
     content = ""
     bytes_used = 0
     for f in files:
-        if not os.path.exists(f):
-            continue
         remaining = max_bytes - bytes_used
         if remaining <= 0:
             break
-        try:
-            with open(f, encoding="utf-8", errors="replace") as fh:
-                chunk = fh.read(remaining)
-            content += f"\n--- FILE: {f} ---\n{chunk}"
-            bytes_used += len(chunk.encode("utf-8"))
-        except OSError:
-            continue
+
+        chunk: str | None = None
+        if branch and subprocess_run is not None:
+            branch_content = _read_file_from_branch(f, branch, subprocess_run)
+            if branch_content is not None:
+                chunk = branch_content[:remaining]
+
+        if chunk is None:
+            if not os.path.exists(f):
+                continue
+            try:
+                with open(f, encoding="utf-8", errors="replace") as fh:
+                    chunk = fh.read(remaining)
+            except OSError:
+                continue
+
+        content += f"\n--- FILE: {f} ---\n{chunk}"
+        bytes_used += len(chunk.encode("utf-8"))
     return content
 
 
@@ -152,7 +197,9 @@ def build_gemini_prompt(
         "}\n"
         "```\n"
     )
-    file_content = _inline_file_contents(files, max_bytes)
+    file_content = _inline_file_contents(
+        files, max_bytes, branch=branch, subprocess_run=subprocess_run,
+    )
     return f"{review_instructions}\n{file_content}"
 
 
@@ -169,8 +216,11 @@ def collect_file_contents(
     files = _gather_changed_files(
         request_payload.get("changed_files", []), subprocess_run
     )
+    branch = request_payload.get("branch", "")
     max_bytes = int(os.environ.get("VNX_GEMINI_MAX_PROMPT_BYTES", "100000"))
-    return _inline_file_contents(files, max_bytes)
+    return _inline_file_contents(
+        files, max_bytes, branch=branch, subprocess_run=subprocess_run,
+    )
 
 
 def build_codex_prompt(
@@ -190,7 +240,9 @@ def build_codex_prompt(
     files = _gather_changed_files(
         request_payload.get("changed_files", []), subprocess_run
     )
-    file_contents = _inline_file_contents(files, max_bytes)
+    file_contents = _inline_file_contents(
+        files, max_bytes, branch=branch, subprocess_run=subprocess_run,
+    )
 
     return (
         f"Review the following code changes on branch {branch} (risk: {risk}).\n\n"

--- a/tests/test_gate_branch_file_resolution.py
+++ b/tests/test_gate_branch_file_resolution.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""W3D — Gate file resolution from PR branch (resolves OI-1112 + OI-1114).
+
+Verifies that gate prompt builders pull file content from the PR branch via
+`git show branch:path` rather than reading the cwd-relative file. Without
+this fix, gates run from the main worktree miss files added on the PR branch
+and return blocked verdicts referencing missing files (e.g. PR #375 issue:
+"The specified file 'tests/test_session_store_concurrent.py' was not found").
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import vertex_ai_runner as _vtx
+
+
+def _run(cmd, cwd):
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def branched_repo(tmp_path, monkeypatch):
+    """Build a repo with main and a feature branch that adds + modifies files.
+
+    Layout:
+      main:        existing.py = 'main version'
+      feature/x:   existing.py = 'feature version'
+                   new_only.py = 'feature only'
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], repo)
+    _run(["git", "config", "user.email", "test@test"], repo)
+    _run(["git", "config", "user.name", "Test"], repo)
+
+    (repo / "existing.py").write_text("main version\n")
+    _run(["git", "add", "existing.py"], repo)
+    _run(["git", "commit", "-q", "-m", "main: add existing"], repo)
+
+    _run(["git", "checkout", "-q", "-b", "feature/x"], repo)
+    (repo / "existing.py").write_text("feature version\n")
+    (repo / "new_only.py").write_text("feature only\n")
+    _run(["git", "add", "existing.py", "new_only.py"], repo)
+    _run(["git", "commit", "-q", "-m", "feature: modify existing, add new_only"], repo)
+
+    # Switch back to main so cwd reflects the "main worktree" scenario.
+    _run(["git", "checkout", "-q", "main"], repo)
+
+    # Run gate code as if invoked from the main worktree (cwd = repo on main).
+    monkeypatch.chdir(repo)
+    return repo
+
+
+class TestPromptBuilderResolvesFromBranch:
+    """build_gemini_prompt and build_codex_prompt must read from the PR branch."""
+
+    def test_gemini_prompt_uses_branch_version_of_modified_file(self, branched_repo):
+        """File modified on PR branch is rendered with branch content, not cwd."""
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "medium",
+            "pr_number": 1,
+            "changed_files": ["existing.py"],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        assert "feature version" in prompt
+        assert "main version" not in prompt
+        assert "--- FILE: existing.py" in prompt
+
+    def test_gemini_prompt_includes_file_added_only_on_branch(self, branched_repo):
+        """File that exists only on the PR branch is included in the prompt.
+
+        This is the exact PR #375 scenario: the file was added on the feature
+        branch, gate ran from main worktree, prompt section was empty.
+        """
+        # Sanity: the file genuinely does NOT exist on disk in the main worktree.
+        assert not (branched_repo / "new_only.py").exists()
+
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "medium",
+            "pr_number": 1,
+            "changed_files": ["new_only.py"],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        assert "feature only" in prompt
+        assert "--- FILE: new_only.py" in prompt
+
+    def test_codex_prompt_uses_branch_version(self, branched_repo):
+        """Codex prompt builder also resolves from the PR branch."""
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "high",
+            "pr_number": 2,
+            "changed_files": ["existing.py", "new_only.py"],
+        }
+        prompt = _vtx.build_codex_prompt(payload, subprocess_run=subprocess.run)
+
+        assert "feature version" in prompt
+        assert "feature only" in prompt
+        assert "main version" not in prompt
+
+    def test_collect_file_contents_uses_branch(self, branched_repo):
+        """collect_file_contents (used for contract-prompt enrichment) honors branch."""
+        payload = {
+            "branch": "feature/x",
+            "changed_files": ["existing.py", "new_only.py"],
+        }
+        contents = _vtx.collect_file_contents(payload, subprocess_run=subprocess.run)
+
+        assert "feature version" in contents
+        assert "feature only" in contents
+        assert "main version" not in contents
+
+    def test_falls_back_to_filesystem_when_file_not_in_branch(self, branched_repo):
+        """Files not committed to the branch fall back to filesystem read.
+
+        This preserves local-iteration ergonomics: an uncommitted file
+        on disk still appears in the prompt.
+        """
+        local_only = branched_repo / "uncommitted.py"
+        local_only.write_text("local edit\n")
+
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "low",
+            "pr_number": 3,
+            "changed_files": ["existing.py", "uncommitted.py"],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        assert "feature version" in prompt  # via git show
+        assert "local edit" in prompt        # via filesystem fallback
+
+    def test_no_branch_falls_back_to_filesystem(self, branched_repo):
+        """When branch is empty, behavior matches pre-fix filesystem read."""
+        payload = {
+            "branch": "",
+            "risk_class": "medium",
+            "pr_number": 4,
+            "changed_files": ["existing.py"],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        # cwd is on main, so we expect main's content.
+        assert "main version" in prompt
+        assert "feature version" not in prompt
+
+    def test_absolute_paths_skip_git_show(self, branched_repo, tmp_path):
+        """Absolute paths are not tracked git paths; resolver must fall through.
+
+        Guards against accidentally invoking `git show branch:/abs/path`,
+        which would always fail and silently drop legitimate filesystem files.
+        """
+        outside = tmp_path / "outside.py"
+        outside.write_text("absolute path content\n")
+
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "medium",
+            "pr_number": 5,
+            "changed_files": [str(outside)],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        assert "absolute path content" in prompt
+
+
+class TestBranchResolutionPreservesByteCap:
+    """VNX_GEMINI_MAX_PROMPT_BYTES must still bound branch-resolved content."""
+
+    def test_byte_cap_applied_to_branch_content(self, branched_repo, monkeypatch):
+        """Cap applies whether content comes from git show or filesystem."""
+        big = "X" * 5000 + "\n"
+        (branched_repo / "big.py").write_text(big)
+        _run(["git", "checkout", "-q", "feature/x"], branched_repo)
+        _run(["git", "add", "big.py"], branched_repo)
+        _run(["git", "commit", "-q", "-m", "add big"], branched_repo)
+        _run(["git", "checkout", "-q", "main"], branched_repo)
+
+        monkeypatch.setenv("VNX_GEMINI_MAX_PROMPT_BYTES", "300")
+
+        payload = {
+            "branch": "feature/x",
+            "risk_class": "medium",
+            "pr_number": 6,
+            "changed_files": ["big.py"],
+        }
+        prompt = _vtx.build_gemini_prompt(payload, subprocess_run=subprocess.run)
+
+        file_sections = prompt.split("--- FILE:")[1:]
+        total = sum(len(s.encode("utf-8")) for s in file_sections)
+        assert total <= 500, f"branch content not bounded by max bytes: {total}"


### PR DESCRIPTION
## Summary

Resolves **OI-1112** + **OI-1114**.

Gate prompt builders (Gemini, Codex, contract enrichment) now read each changed file via `git show <branch>:<path>` so reviews see the PR-branch version regardless of which worktree the gate runs in. Falls back to filesystem read for absolute paths and uncommitted local files.

### Concrete repro

PR #375 added `tests/test_session_store_concurrent.py`. When the Gemini gate ran from the main worktree, the file content section was empty and the gate returned:
```
verdict=blocked, severity=error: "The specified file 'tests/test_session_store_concurrent.py' was not found"
```
Re-running from the PR worktree produced verdict=pass. Root cause: `_inline_file_contents` used `open(rel_path)`, which is cwd-relative and only finds files committed to the worktree the gate was invoked from.

### Fix

`scripts/lib/vertex_ai_runner.py`:
- New `_read_file_from_branch(path, branch, subprocess_run)` helper invokes `git show branch:path` for relative paths when a branch is supplied.
- `_inline_file_contents` accepts `branch` + `subprocess_run` and tries the branch resolver first, then falls back to filesystem read (preserving local-iteration ergonomics).
- `build_gemini_prompt`, `build_codex_prompt`, `collect_file_contents` pull `branch` from the request payload (already present) and forward it.

### Constraints honored

- **No regressions**: existing `test_gate_runner_vertex.py` and `test_gate_runner.py` suites pass; the 8 unrelated failures on this branch pre-exist origin/main and are not touched by this change.
- **No new deps**: stdlib `subprocess` only.
- **Schema unchanged**: `result_path`, `contract_hash`, `blocking_findings`, `findings`, `status` all preserved.
- **Identical content for shared files**: `git show branch:path` and filesystem read return the same bytes for committed, unchanged files.

## Test plan

- [x] `pytest tests/test_gate_branch_file_resolution.py` — 8/8 pass (covers modified-on-branch, added-on-branch, codex builder, contract enrichment, fallback, no-branch, absolute paths, byte cap)
- [x] `pytest tests/test_gate_runner_vertex.py` — all pass
- [x] `pytest tests/test_gate_runner.py` — all pass except 1 unrelated pre-existing timeout-config failure
- [ ] Codex gate: rate-limited until 2026-05-05; verified by code reading + unit test (covers `build_codex_prompt`)