### PR TITLE
fix(t0-state): feature_state schema split + any-ID filter (W4E)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -8,8 +8,18 @@ reconcile_terminal_state.py). Called by SessionStart hook.
 Usage:
     python3 scripts/build_t0_state.py [--output PATH] [--format {state,brief}]
 
-Output schema: schema_version "2.0" (t0_state.json)
+Output schema: schema_version "2.1" (t0_state.json)
 With --format brief: schema 1.0 backward-compat (t0_brief.json format)
+
+Schema 2.1 changes (W4E / OI-1199):
+  - feature_state union-merges register-canonical aggregation with the
+    FEATURE_PLAN.md fallback fields (current_pr/next_task/assigned_track/
+    assigned_role/completion_pct/total_prs/completed_prs/feature_name) so
+    consumers see a single stable shape regardless of register population.
+  - feature_state aggregation accepts events identified by any single ID
+    (dispatch_id OR pr_number OR feature_id), matching the writer
+    contract in dispatch_register.append_event. Events with no
+    identifying fields are still dropped.
 
 Index/detail split (Sprint 4a):
   - t0_index.json: cheap always-loaded index (≤50 fields, ≤5KB)
@@ -273,30 +283,75 @@ _EVENT_TO_STATUS: Dict[str, str] = {
     "gate_requested": "active",
     "gate_passed": "active",
     "dispatch_created": "queued",
+    "pr_opened": "active",
+    "pr_merged": "completed",
 }
+
+
+# Keys contributed by the FEATURE_PLAN.md fallback. The register-canonical path
+# union-merges these into its own output so consumers see one stable shape
+# regardless of whether dispatch_register.ndjson has been populated yet
+# (W4E / OI-1199).
+_FEATURE_PLAN_KEYS: tuple[str, ...] = (
+    "feature_name",
+    "current_pr",
+    "next_task",
+    "assigned_track",
+    "assigned_role",
+    "completion_pct",
+    "total_prs",
+    "completed_prs",
+)
 
 
 def _build_feature_state(state_dir: Optional[Path] = None) -> Dict[str, Any]:
     """Build feature_state from dispatch_register.ndjson (register-canonical).
 
     Aggregation contract:
-    - Group events by dispatch_id (primary key)
-    - Per-dispatch status: latest-event-wins (recency)
-    - Per-PR/feature: most-recently-active dispatch supplies status
-    - FEATURE_PLAN.md fallback when register has no data
+    - Group events by dispatch_id when present; events lacking a dispatch_id
+      but identified by pr_number or feature_id are aggregated directly into
+      the PR/feature rollups (mirrors dispatch_register.append_event, which
+      requires only one of dispatch_id/pr_number/feature_id).
+    - Per-dispatch status: latest-event-wins (recency).
+    - Per-PR/feature: most-recently-active source (dispatch record or
+      dispatch-less event) wins.
+    - Events with no identifying field at all are dropped.
+    - FEATURE_PLAN.md fields (current_pr/next_task/assigned_track/
+      assigned_role/completion_pct/total_prs/completed_prs/feature_name)
+      are union-merged into the result so the schema is stable across the
+      empty-register and populated-register code paths.
 
-    Refs: synthesis 2026-04-28 §D Sprint 3 split 3/3, codex findings PR #276 r1+r2.
+    Schema (schema_version 2.1):
+      source: "dispatch_register" | "feature_plan_md" (primary origin)
+      feature_plan_status: status reported by FEATURE_PLAN.md parser
+        ("planned" | "in_progress" | "completed") — only present when
+        register is populated; the top-level "status" key is reserved for
+        the FEATURE_PLAN.md fallback to preserve backward compatibility
+        with consumers that read it from the empty-register path.
+      dispatches/pr_status/feature_status/register_event_count: only
+        present when register is populated.
+      current_pr/next_task/assigned_track/assigned_role/completion_pct/
+        total_prs/completed_prs/feature_name: always present.
+
+    Refs: synthesis 2026-04-28 §D Sprint 3 split 3/3, codex findings
+    PR #276 r1+r2; W4E / OI-1199 schema split + any-ID filter.
     """
     register_events = _read_register_events(state_dir=state_dir)
+    feature_plan_part = _build_feature_state_from_feature_plan()
     if not register_events:
-        return _build_feature_state_from_feature_plan()
+        return feature_plan_part
 
     by_dispatch: Dict[str, list] = {}
+    dispatchless_events: list[dict] = []
     for ev in register_events:
-        did = ev.get("dispatch_id", "").strip()
-        if not did:
-            continue
-        by_dispatch.setdefault(did, []).append(ev)
+        did = (ev.get("dispatch_id") or "").strip()
+        pr_number = ev.get("pr_number")
+        feature_id = (ev.get("feature_id") or "").strip()
+        if did:
+            by_dispatch.setdefault(did, []).append(ev)
+        elif pr_number is not None or feature_id:
+            dispatchless_events.append(ev)
+        # else: event lacks any identifying field — drop it.
 
     dispatch_records: Dict[str, Any] = {}
     for did, events in by_dispatch.items():
@@ -331,13 +386,47 @@ def _build_feature_state(state_dir: Optional[Path] = None) -> Dict[str, Any]:
             if existing is None or rec["latest_event_ts"] > existing["latest_event_ts"]:
                 by_feature[f_key] = rec
 
-    return {
-        "source": "dispatch_register",
-        "dispatches": dispatch_records,
-        "pr_status": by_pr,
-        "feature_status": by_feature,
-        "register_event_count": len(register_events),
-    }
+    # Roll up dispatch-less events (pr_number-only or feature_id-only).
+    # These come from writers that record PR-level lifecycle (pr_opened,
+    # pr_merged) without an originating dispatch_id.
+    for ev in dispatchless_events:
+        latest_event = ev.get("event", "")
+        ts = ev.get("timestamp", "")
+        synthetic = {
+            "status": _EVENT_TO_STATUS.get(latest_event, "unknown"),
+            "latest_event": latest_event,
+            "latest_event_ts": ts,
+            "pr_number": ev.get("pr_number"),
+            "feature_id": (ev.get("feature_id") or "").strip(),
+            "event_count": 1,
+            "dispatch_id": None,
+        }
+        if synthetic["pr_number"] is not None:
+            pr_key = str(synthetic["pr_number"])
+            existing = by_pr.get(pr_key)
+            if existing is None or ts > existing["latest_event_ts"]:
+                by_pr[pr_key] = synthetic
+        if synthetic["feature_id"]:
+            f_key = synthetic["feature_id"]
+            existing = by_feature.get(f_key)
+            if existing is None or ts > existing["latest_event_ts"]:
+                by_feature[f_key] = synthetic
+
+    # Union-merge: start with FEATURE_PLAN.md fields, then overlay register
+    # aggregation. The FEATURE_PLAN "status" field is preserved as
+    # "feature_plan_status" because the top-level key isn't currently used
+    # in the register-canonical path and we don't want to introduce a name
+    # collision that would change consumer behavior unexpectedly.
+    merged: Dict[str, Any] = {}
+    for key in _FEATURE_PLAN_KEYS:
+        merged[key] = feature_plan_part.get(key)
+    merged["feature_plan_status"] = feature_plan_part.get("status")
+    merged["source"] = "dispatch_register"
+    merged["dispatches"] = dispatch_records
+    merged["pr_status"] = by_pr
+    merged["feature_status"] = by_feature
+    merged["register_event_count"] = len(register_events)
+    return merged
 
 
 def _build_feature_state_from_feature_plan() -> Dict[str, Any]:
@@ -686,7 +775,7 @@ def build_t0_state(
     system_health = _build_system_health(state_dir, db_ok)
 
     return {
-        "schema_version": "2.0",
+        "schema_version": "2.1",
         "generated_at": _now_iso(),
         "staleness_seconds": 0,
         "terminals": terminals,

--- a/tests/test_build_feature_state_canonical.py
+++ b/tests/test_build_feature_state_canonical.py
@@ -267,3 +267,134 @@ class TestDispatchFailed:
         result = _build_feature_state(state_dir=state_dir)
         assert result["pr_status"] == {}
         assert result["feature_status"] == {}
+
+
+# ---------------------------------------------------------------------------
+# 11. Schema split (W4E / OI-1199): FEATURE_PLAN.md fields union-merged
+# ---------------------------------------------------------------------------
+
+class TestSchemaSplitUnionMerge:
+    """Register-canonical output must include the FEATURE_PLAN.md fallback
+    fields so consumers see one stable shape regardless of register state."""
+
+    _UNION_KEYS = (
+        "feature_name",
+        "current_pr",
+        "next_task",
+        "assigned_track",
+        "assigned_role",
+        "completion_pct",
+        "total_prs",
+        "completed_prs",
+    )
+
+    def test_populated_register_includes_feature_plan_fields(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        # Register-canonical aggregation present
+        assert result["source"] == "dispatch_register"
+        assert "dispatches" in result
+        # And FEATURE_PLAN.md fields are NOT silently dropped
+        for key in self._UNION_KEYS:
+            assert key in result, f"feature_state missing {key!r} field"
+
+    def test_empty_register_includes_feature_plan_fields(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["source"] == "feature_plan_md"
+        for key in self._UNION_KEYS:
+            assert key in result, f"feature_state missing {key!r} field"
+
+    def test_feature_plan_status_separate_from_dispatch_status(self, tmp_path):
+        """Top-level 'status' from FEATURE_PLAN.md is exposed as
+        feature_plan_status when register is populated, so the key doesn't
+        collide with potential future 'status' aggregations."""
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z"),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert "feature_plan_status" in result
+
+
+# ---------------------------------------------------------------------------
+# 12. Any-ID filter (W4E / OI-1199): pr_number-only / feature_id-only events
+# ---------------------------------------------------------------------------
+
+class TestAnyIDFilter:
+    """Writers (dispatch_register.append_event) require only one of
+    dispatch_id/pr_number/feature_id. Reader must mirror that contract."""
+
+    def test_pr_number_only_event_appears_in_pr_status(self, tmp_path):
+        state_dir = tmp_path / "state"
+        ev = {
+            "timestamp": "2026-04-28T10:00:00.000000Z",
+            "event": "pr_merged",
+            "pr_number": 99,
+        }
+        _write_register(state_dir, [ev])
+        result = _build_feature_state(state_dir=state_dir)
+        assert "99" in result["pr_status"], (
+            f"pr_number-only event was dropped; pr_status={result['pr_status']}"
+        )
+        assert result["pr_status"]["99"]["status"] == "completed"
+        assert result["pr_status"]["99"]["dispatch_id"] is None
+
+    def test_feature_id_only_event_appears_in_feature_status(self, tmp_path):
+        state_dir = tmp_path / "state"
+        ev = {
+            "timestamp": "2026-04-28T10:00:00.000000Z",
+            "event": "pr_opened",
+            "feature_id": "F50",
+        }
+        _write_register(state_dir, [ev])
+        result = _build_feature_state(state_dir=state_dir)
+        assert "F50" in result["feature_status"]
+        assert result["feature_status"]["F50"]["dispatch_id"] is None
+
+    def test_event_without_any_id_is_dropped(self, tmp_path):
+        state_dir = tmp_path / "state"
+        # Event with NO identifying field at all — should be discarded.
+        ev = {"timestamp": "2026-04-28T10:00:00.000000Z", "event": "pr_opened"}
+        _write_register(state_dir, [ev])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["dispatches"] == {}
+        assert result["pr_status"] == {}
+        assert result["feature_status"] == {}
+
+    def test_dispatch_with_id_and_orphan_pr_event_coexist(self, tmp_path):
+        """A dispatch-anchored record and a later orphan pr_merged on the
+        same PR: the more recent timestamp wins the rollup."""
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            _ev("dispatch_started", "d001", "2026-04-28T09:00:00.000000Z", pr_number=42),
+            {
+                "timestamp": "2026-04-28T11:00:00.000000Z",
+                "event": "pr_merged",
+                "pr_number": 42,
+            },
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        assert result["pr_status"]["42"]["status"] == "completed"
+        assert result["pr_status"]["42"]["latest_event"] == "pr_merged"
+        # Dispatch record still present in dispatches map
+        assert "d001" in result["dispatches"]
+
+    def test_orphan_event_does_not_overwrite_more_recent_dispatch(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_register(state_dir, [
+            {
+                "timestamp": "2026-04-28T08:00:00.000000Z",
+                "event": "pr_opened",
+                "pr_number": 42,
+            },
+            _ev("dispatch_completed", "d001", "2026-04-28T10:00:00.000000Z", pr_number=42),
+        ])
+        result = _build_feature_state(state_dir=state_dir)
+        # Dispatch record (more recent) wins
+        assert result["pr_status"]["42"]["status"] == "completed"
+        assert result["pr_status"]["42"].get("dispatch_id", "d001") in (None, "d001")

--- a/tests/test_build_t0_brief_output.py
+++ b/tests/test_build_t0_brief_output.py
@@ -163,7 +163,7 @@ class TestFormatBriefOutputPath:
         state_path = state_dir / "t0_state.json"
         assert state_path.exists(), "t0_state.json must be written when --format state"
         data = json.loads(state_path.read_text())
-        assert data.get("schema_version") == "2.0"
+        assert data.get("schema_version") == "2.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves OI-1199.

## Problem

`build_t0_state._build_feature_state` had two correctness bugs flagged in OI-1199 (originated from PR #283 register-canonical aggregation):

1. **Schema split:** the function returned **different shapes** depending on whether `dispatch_register.ndjson` was populated. The empty-register path produced FEATURE_PLAN.md fields (`current_pr`, `next_task`, `assigned_track`, `assigned_role`, `completion_pct`, `total_prs`, `completed_prs`, `feature_name`); the populated-register path silently dropped them and exposed a totally separate `dispatches`/`pr_status`/`feature_status` shape. Any consumer reading `feature_state.current_pr` (e.g. orchestrator next-task selection) silently broke once the register had any events.

2. **Mismatched filter:** the writer (`dispatch_register.append_event`) requires only **one** of `dispatch_id` / `pr_number` / `feature_id`, but the reader's aggregation discarded every event lacking `dispatch_id`. PR-level lifecycle events (`pr_opened`, `pr_merged`) — which are typically `pr_number`-only — never made it into the rollup.

## Fix

`scripts/build_t0_state.py`:

- **Union-merge.** When the register is populated, the result starts with the FEATURE_PLAN.md fallback fields and overlays the register aggregation. Single stable shape for both paths. The FEATURE_PLAN top-level `status` is exposed as `feature_plan_status` to keep the top-level `status` key free.
- **Any-ID filter.** Events with `dispatch_id` are grouped as before. Events without `dispatch_id` but with `pr_number` or `feature_id` are aggregated directly into `pr_status` / `feature_status`. Events with no identifying field at all are dropped.
- **Event mapping.** Added `pr_opened → active` and `pr_merged → completed` to `_EVENT_TO_STATUS` so the relaxed filter produces meaningful status rather than `"unknown"`.
- **schema_version bumped 2.0 → 2.1** with the contract change documented in the module docstring.

## Tests

- `TestSchemaSplitUnionMerge` (3 cases) — populated register includes FEATURE_PLAN fields; empty register still does; `feature_plan_status` exposed.
- `TestAnyIDFilter` (5 cases) — `pr_number`-only events appear in `pr_status`; `feature_id`-only events appear in `feature_status`; no-ID events dropped; orphan + dispatch coexist with recency tie-break working both directions.
- `test_build_t0_brief_output.py` schema_version assertion updated 2.0 → 2.1.

```
$ python3 -m pytest tests/test_build_feature_state_canonical.py \
                   tests/test_build_t0_state_register_reader.py \
                   tests/test_build_t0_brief_output.py \
                   tests/test_t0_index_split.py \
                   tests/test_state_feedback_loop.py \
                   tests/test_state_mutation_receipt.py \
                   tests/test_feature_state_machine.py \
                   tests/test_governance_audit_stamping.py \
                   tests/test_context_assembler.py -q
179 passed in 13.40s
```

## Smoke

`python3 scripts/build_t0_state.py` against the worktree's empty register:
- `t0_state.json.schema_version == "2.1"`
- `feature_state.source == "feature_plan_md"`
- All 8 FEATURE_PLAN fields present.

Synthetic register with `pr_merged` (pr_number=99, no dispatch_id) and `pr_opened` (feature_id=F50, no dispatch_id):
- `pr_status["99"].status == "completed"` (was previously dropped → now captured).
- `feature_status["F50"].status == "active"`.
- All FEATURE_PLAN fields union-merged into the result.