### PR TITLE
fix(security/validator): 4 hardening fixes (W3H)

### DIFF
--- a/scripts/check_ci_slug_match.py
+++ b/scripts/check_ci_slug_match.py
@@ -26,9 +26,13 @@ Usage
 
 Environment (GitHub Actions compatible)
 ---------------------------------------
-  GITHUB_HEAD_REF      current PR branch name
+  GITHUB_EVENT_NAME    event type (e.g. ``pull_request`` or ``push``)
+  GITHUB_HEAD_REF      PR source branch (set only on ``pull_request`` events)
+  GITHUB_REF_NAME      ref name for ``push`` events (e.g. ``main``)
   GITHUB_BASE_REF      target/base branch name
   VNX_SLUG_ENFORCEMENT "1" = block on failure (default shadow/warn)
+  VNX_DEFAULT_BRANCHES comma-separated list of default branches to skip on
+                       push events (default: ``main,master``)
 """
 from __future__ import annotations
 
@@ -375,21 +379,77 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+DEFAULT_BRANCH_NAMES = ("main", "master")
+
+
+def _default_branches() -> tuple[str, ...]:
+    import os
+    raw = os.environ.get("VNX_DEFAULT_BRANCHES", "")
+    if not raw.strip():
+        return DEFAULT_BRANCH_NAMES
+    return tuple(b.strip() for b in raw.split(",") if b.strip())
+
+
+def resolve_branch_name(args_branch_name: str | None) -> tuple[str, bool]:
+    """Resolve the branch name and detect push-to-default-branch events.
+
+    Returns (branch_name, skip_push_default).
+
+    Resolution order:
+      1. Explicit ``--branch-name`` argument (overrides everything)
+      2. ``GITHUB_HEAD_REF`` (set on ``pull_request`` events)
+      3. ``GITHUB_REF_NAME`` (set on ``push`` events; previously the gate
+         left this empty and silently passed)
+      4. ``git rev-parse --abbrev-ref HEAD``
+
+    When the resolved branch is a default branch (e.g. ``main``) and the
+    event is a ``push`` (or no PR head ref is available), the gate is
+    skipped: the dispatch-id-vs-branch invariant only meaningfully
+    applies on PR/topic branches.
+    """
     import os
 
+    if args_branch_name:
+        return args_branch_name, False
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "").strip()
+    head_ref = os.environ.get("GITHUB_HEAD_REF", "").strip()
+    ref_name = os.environ.get("GITHUB_REF_NAME", "").strip()
+
+    if head_ref:
+        return head_ref, False
+
+    if ref_name:
+        is_push = event_name == "push" or event_name == ""
+        if is_push and ref_name in _default_branches():
+            return ref_name, True
+        return ref_name, False
+
+    branch = current_branch()
+    if event_name == "push" and branch in _default_branches():
+        return branch, True
+    return branch, False
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    branch_name = args.branch_name
-    if not branch_name:
-        branch_name = os.environ.get("GITHUB_HEAD_REF", "")
-    if not branch_name:
-        try:
-            branch_name = current_branch()
-        except RuntimeError as exc:
-            print(f"[ERROR] Cannot determine branch: {exc}", file=sys.stderr)
-            return 2
+    try:
+        branch_name, skip_push_default = resolve_branch_name(args.branch_name)
+    except RuntimeError as exc:
+        print(f"[ERROR] Cannot determine branch: {exc}", file=sys.stderr)
+        return 2
+
+    if skip_push_default:
+        _bar()
+        print(" VNX CI — Dispatch-ID Slug-Match Gate")
+        print(f" Branch : {branch_name}")
+        print(" Mode   : SKIPPED (push event on default branch)")
+        _bar()
+        print()
+        print("RESULT: SKIP (gate only meaningful on PR/topic branches)")
+        return 0
 
     return run_gate(
         base_ref=args.base_ref,

--- a/tests/test_ci_slug_match_gate.py
+++ b/tests/test_ci_slug_match_gate.py
@@ -27,6 +27,7 @@ from check_ci_slug_match import (
     branch_slug,
     dispatch_id_slug,
     main,
+    resolve_branch_name,
     run_gate,
     scan_commits,
     slugs_match,
@@ -407,3 +408,128 @@ class TestMainCLI:
              patch("check_ci_slug_match.commits_since", return_value=commits):
             rc = main(["--branch-name", "fix/ci-slug-match-gate", "--base-ref", "main"])
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# OI-1130: Push-event branch resolution + default-branch skip
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBranchName:
+    """Branch resolution must prefer GITHUB_HEAD_REF on PR events and fall
+    back to GITHUB_REF_NAME on push events. Without this, push events on
+    default branches left branch_name='' and the gate passed spuriously.
+    """
+
+    def test_explicit_arg_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_HEAD_REF", "fix/from-env")
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        branch, skip = resolve_branch_name("feat/explicit-arg")
+        assert branch == "feat/explicit-arg"
+        assert skip is False
+
+    def test_pull_request_uses_head_ref(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_HEAD_REF", "fix/pr-branch")
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        branch, skip = resolve_branch_name(None)
+        assert branch == "fix/pr-branch"
+        assert skip is False
+
+    def test_push_event_with_empty_head_ref_uses_ref_name(self, monkeypatch):
+        # Reproduces OI-1130: push event leaves GITHUB_HEAD_REF empty.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "fix/topic-branch")
+        branch, skip = resolve_branch_name(None)
+        assert branch == "fix/topic-branch"
+        assert skip is False
+
+    def test_push_event_on_default_branch_is_skipped(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        branch, skip = resolve_branch_name(None)
+        assert branch == "main"
+        assert skip is True
+
+    def test_push_event_on_master_default_is_skipped(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "master")
+        branch, skip = resolve_branch_name(None)
+        assert skip is True
+
+    def test_custom_default_branches_via_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "develop")
+        monkeypatch.setenv("VNX_DEFAULT_BRANCHES", "develop,trunk")
+        branch, skip = resolve_branch_name(None)
+        assert skip is True
+
+    def test_falls_back_to_current_branch(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+        with patch("check_ci_slug_match.current_branch", return_value="fix/local"):
+            branch, skip = resolve_branch_name(None)
+        assert branch == "fix/local"
+        assert skip is False
+
+
+class TestPushEventGateSkip:
+    """End-to-end: push-event-on-default-branch must SKIP without running
+    commits_since. Previously the check ran against an empty branch name
+    and passed silently.
+    """
+
+    def test_push_to_main_skips_gate(self, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        with patch("check_ci_slug_match.commits_since") as commits_mock, \
+             patch("check_ci_slug_match.resolve_base_ref") as base_mock:
+            rc = main([])
+        assert rc == 0
+        commits_mock.assert_not_called()
+        base_mock.assert_not_called()
+        out = capsys.readouterr().out
+        assert "SKIP" in out
+
+    def test_push_to_topic_branch_runs_gate(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "fix/ci-slug-match-gate")
+        commits = [
+            ("sha55555", "feat: ok\n\nDispatch-ID: 20260423-230100-ci-slug-match-gate-B\n"),
+        ]
+        with patch("check_ci_slug_match.resolve_base_ref", return_value="main"), \
+             patch("check_ci_slug_match.commits_since", return_value=commits):
+            rc = main([])
+        assert rc == 0
+
+    def test_pr_event_runs_gate_with_head_ref(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_HEAD_REF", "fix/ci-slug-match-gate")
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        commits = [
+            ("sha66666", "feat: ok\n\nDispatch-ID: 20260423-230100-ci-slug-match-gate-B\n"),
+        ]
+        with patch("check_ci_slug_match.resolve_base_ref", return_value="main"), \
+             patch("check_ci_slug_match.commits_since", return_value=commits):
+            rc = main([])
+        assert rc == 0
+
+    def test_push_to_main_does_not_pass_spuriously_with_bad_commits(self, monkeypatch):
+        # Regression: previously commits with mismatched dispatch ids on a
+        # push to main would be evaluated against an empty branch slug and
+        # silently pass. With the fix, we skip without evaluating.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        with patch("check_ci_slug_match.commits_since") as commits_mock:
+            rc = main(["--enforce"])
+        assert rc == 0
+        commits_mock.assert_not_called()


### PR DESCRIPTION
## Summary

W3H wave: security + validator + slug-check fixes. **Of the 4 OIs in scope, only OI-1130 produced a code change in this repo.** The others were verified non-applicable or already-resolved — see the worker report at `.vnx-data/unified_reports/20260501-w3h-security-validator_report.md` for full evidence.

### OI-1130 — slug-check push events (FIXED)
- New `resolve_branch_name()` helper with explicit precedence: `--branch-name` arg > `GITHUB_HEAD_REF` (PR) > `GITHUB_REF_NAME` (push) > `current_branch()`.
- Push events on default branches (`main`/`master`, configurable via `VNX_DEFAULT_BRANCHES`) cleanly SKIP the gate instead of evaluating against an empty branch slug and passing spuriously.
- 11 new tests, including a regression test that asserts `commits_since` is never invoked on push-to-default-branch.

### OI-1095 — provision_workspace tenant_id (NOT APPLICABLE)
`provision_workspace` and `tenant_id` do not exist in this repo. `grep -rn "provision_workspace|tenant_id" scripts/ dashboard/` returns 0 hits. The dashboard surface is read-only API helpers + a static Next.js token dashboard; no tenancy model exists. Flagged for OI ledger to retire or re-target.

### OI-1113 — Validator D-8 severity (ALREADY RESOLVED)
`scripts/lib/dispatch_instruction_validator.py:224` already emits `severity="blocker"` for missing Success Criteria. `tests/test_dispatch_instruction_validator.py:487` already asserts it. Flagged for OI ledger cleanup.

### OI-1131 — slug-check docs (DEFERRED)
Per the dispatch's own conditional: this is the docs side of W5C's regex change, and W5C has not landed. Updating docs now would either be a no-op or pre-commit to a regex W5C may not adopt. Re-issue after W5C merges.

## Test plan

- [x] `pytest tests/test_ci_slug_match_gate.py -q` → 68 passed (was 57).
- [x] `pytest tests/test_dispatch_instruction_validator.py tests/test_ci_slug_match_gate.py -q` → 112 passed.
- [x] `python3 -c "import ast; ast.parse(open('scripts/check_ci_slug_match.py').read())"` → OK.
- [ ] CI green on the new push-event behaviour.

Resolves OI-1130. See report for OI-1095/1113/1131 disposition.