### PR TITLE
fix(t0-state): GC retention for t0_detail JSON snapshots (W-UX-4)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -942,6 +942,44 @@ def _write_detail_files(state: Dict[str, Any], detail_dir: Path) -> Dict[str, st
 
 
 # ---------------------------------------------------------------------------
+# GC: retention sweep for t0_detail snapshots (W-UX-4)
+# ---------------------------------------------------------------------------
+
+def _gc_t0_detail(detail_dir: Path) -> int:
+    """Prune t0_detail/*.json files older than VNX_T0_DETAIL_RETENTION_DAYS days.
+
+    Env-var VNX_T0_DETAIL_RETENTION_DAYS (default 14). Set to 0 to disable GC.
+    Only touches *.json files inside detail_dir — never t0_state.json or t0_index.json.
+    Idempotent: a second call after files are already pruned deletes nothing more.
+    Returns the count of files deleted.
+    """
+    try:
+        retention_days = int(os.environ.get("VNX_T0_DETAIL_RETENTION_DAYS", "14"))
+    except (ValueError, TypeError):
+        retention_days = 14
+
+    if retention_days == 0:
+        return 0
+
+    if not detail_dir.is_dir():
+        return 0
+
+    cutoff = time.time() - retention_days * 86400
+    deleted = 0
+    try:
+        for p in detail_dir.glob("*.json"):
+            try:
+                if p.stat().st_mtime < cutoff:
+                    p.unlink()
+                    deleted += 1
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return deleted
+
+
+# ---------------------------------------------------------------------------
 # Atomic write
 # ---------------------------------------------------------------------------
 
@@ -1006,6 +1044,11 @@ def main() -> int:
         # Write per-section detail files — loaded on-demand (Sprint 4a)
         try:
             _write_detail_files(state, _STATE_DIR / "t0_detail")
+        except Exception:
+            pass  # best-effort — must not block SessionStart
+        # GC: prune stale t0_detail snapshots (W-UX-4)
+        try:
+            _gc_t0_detail(_STATE_DIR / "t0_detail")
         except Exception:
             pass  # best-effort — must not block SessionStart
         # Write pr_queue_state.json — replaces hand-maintained PR_QUEUE.md (Phase 2.1)

--- a/tests/test_t0_state_gc.py
+++ b/tests/test_t0_state_gc.py
@@ -1,0 +1,249 @@
+"""Unit tests for _gc_t0_detail() in build_t0_state.py (W-UX-4).
+
+Covers:
+  1. Old file (mtime > retention window) is removed
+  2. Fresh file (mtime within window) is retained
+  3. VNX_T0_DETAIL_RETENTION_DAYS=0 disables GC entirely
+  4. GC is idempotent across two consecutive runs
+  5. Non-existent detail_dir returns 0 without error
+  6. Non-JSON files are not touched
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from build_t0_state import _gc_t0_detail
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_old_file(detail_dir: Path, name: str = "feature_state.json", days_old: int = 20) -> Path:
+    """Create a JSON file with mtime set `days_old` days in the past."""
+    detail_dir.mkdir(parents=True, exist_ok=True)
+    p = detail_dir / name
+    p.write_text('{"old": true}', encoding="utf-8")
+    old_mtime = time.time() - days_old * 86400
+    os.utime(p, (old_mtime, old_mtime))
+    return p
+
+
+def _make_fresh_file(detail_dir: Path, name: str = "open_items.json", days_old: int = 1) -> Path:
+    """Create a JSON file with mtime set `days_old` days in the past (within window)."""
+    detail_dir.mkdir(parents=True, exist_ok=True)
+    p = detail_dir / name
+    p.write_text('{"fresh": true}', encoding="utf-8")
+    fresh_mtime = time.time() - days_old * 86400
+    os.utime(p, (fresh_mtime, fresh_mtime))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 1. Old file is removed
+# ---------------------------------------------------------------------------
+
+class TestOldFileRemoved:
+    def test_file_older_than_retention_is_deleted(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, days_old=20)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert not old.exists(), "Old file should have been removed"
+        assert deleted == 1
+
+    def test_returns_count_of_deleted_files(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        _make_old_file(detail_dir, name="a.json", days_old=30)
+        _make_old_file(detail_dir, name="b.json", days_old=15)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert deleted == 2
+        assert not (detail_dir / "a.json").exists()
+        assert not (detail_dir / "b.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 2. Fresh file is retained
+# ---------------------------------------------------------------------------
+
+class TestFreshFileRetained:
+    def test_file_within_window_is_not_deleted(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        fresh = _make_fresh_file(detail_dir, days_old=1)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert fresh.exists(), "Fresh file should be retained"
+        assert deleted == 0
+
+    def test_mixed_old_and_fresh_files(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, name="stale.json", days_old=20)
+        fresh = _make_fresh_file(detail_dir, name="recent.json", days_old=5)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert not old.exists(), "Stale file should be removed"
+        assert fresh.exists(), "Recent file should be retained"
+        assert deleted == 1
+
+    def test_file_13_days_old_is_retained(self, tmp_path):
+        """File 13 days old (within the 14-day window) is never deleted."""
+        detail_dir = tmp_path / "t0_detail"
+        detail_dir.mkdir(parents=True, exist_ok=True)
+        p = detail_dir / "recent.json"
+        p.write_text('{}', encoding="utf-8")
+        mtime = time.time() - 13 * 86400
+        os.utime(p, (mtime, mtime))
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert p.exists(), "13-day-old file should be within the 14-day window"
+        assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. VNX_T0_DETAIL_RETENTION_DAYS=0 disables GC
+# ---------------------------------------------------------------------------
+
+class TestGcDisabledWithZero:
+    def test_zero_disables_gc_entirely(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, days_old=365)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "0"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert old.exists(), "GC disabled: old file must not be deleted"
+        assert deleted == 0
+
+    def test_zero_string_disables_gc(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, days_old=100)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "0"}):
+            result = _gc_t0_detail(detail_dir)
+
+        assert old.exists()
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. GC is idempotent
+# ---------------------------------------------------------------------------
+
+class TestGcIdempotent:
+    def test_two_consecutive_runs_make_no_further_changes(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        _make_old_file(detail_dir, name="stale.json", days_old=20)
+        _make_fresh_file(detail_dir, name="fresh.json", days_old=3)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted_first = _gc_t0_detail(detail_dir)
+            deleted_second = _gc_t0_detail(detail_dir)
+
+        assert deleted_first == 1, "First run should delete the stale file"
+        assert deleted_second == 0, "Second run should delete nothing more"
+        assert (detail_dir / "fresh.json").exists()
+
+    def test_idempotent_with_no_files(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        detail_dir.mkdir()
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            first = _gc_t0_detail(detail_dir)
+            second = _gc_t0_detail(detail_dir)
+
+        assert first == 0
+        assert second == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-existent directory returns 0 without error
+# ---------------------------------------------------------------------------
+
+class TestMissingDirectory:
+    def test_missing_dir_returns_zero(self, tmp_path):
+        missing = tmp_path / "does_not_exist" / "t0_detail"
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            result = _gc_t0_detail(missing)
+
+        assert result == 0
+
+    def test_missing_dir_with_gc_disabled_returns_zero(self, tmp_path):
+        missing = tmp_path / "nowhere"
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "0"}):
+            result = _gc_t0_detail(missing)
+
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Non-JSON files are not touched
+# ---------------------------------------------------------------------------
+
+class TestNonJsonFilesUntouched:
+    def test_non_json_files_are_not_deleted(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        detail_dir.mkdir()
+        txt_file = detail_dir / "notes.txt"
+        txt_file.write_text("keep me")
+        old_mtime = time.time() - 30 * 86400
+        os.utime(txt_file, (old_mtime, old_mtime))
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "14"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert txt_file.exists(), "Non-JSON files must not be touched"
+        assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Default retention (no env-var set)
+# ---------------------------------------------------------------------------
+
+class TestDefaultRetention:
+    def test_default_14_days_removes_older_files(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, days_old=15)
+        fresh = _make_fresh_file(detail_dir, name="fresh.json", days_old=7)
+
+        env = {k: v for k, v in os.environ.items() if k != "VNX_T0_DETAIL_RETENTION_DAYS"}
+        with patch.dict(os.environ, env, clear=True):
+            deleted = _gc_t0_detail(detail_dir)
+
+        assert not old.exists()
+        assert fresh.exists()
+        assert deleted == 1
+
+    def test_invalid_env_var_falls_back_to_14(self, tmp_path):
+        detail_dir = tmp_path / "t0_detail"
+        old = _make_old_file(detail_dir, days_old=20)
+
+        with patch.dict(os.environ, {"VNX_T0_DETAIL_RETENTION_DAYS": "notanumber"}):
+            deleted = _gc_t0_detail(detail_dir)
+
+        # Invalid value → falls back to 14 days → 20-day-old file deleted
+        assert not old.exists()
+        assert deleted == 1


### PR DESCRIPTION
## Summary

- Adds `_gc_t0_detail()` helper to `scripts/build_t0_state.py` that prunes `.vnx-data/state/t0_detail/*.json` files older than N days
- Called at the end of `main()` after all snapshot writes, as a best-effort block (never blocks SessionStart)
- Default retention: **14 days** — override via `VNX_T0_DETAIL_RETENTION_DAYS=<days>`
- **Escape hatch**: `VNX_T0_DETAIL_RETENTION_DAYS=0` disables GC entirely
- Sweep is scoped strictly to `t0_detail/*.json` — never touches `t0_state.json`, `t0_index.json`, or any file outside the detail directory
- GC is idempotent: a second consecutive run deletes nothing further

## Test plan

- [x] `tests/test_t0_state_gc.py` — 14 unit tests: old file removed, fresh file retained, env-var=0 disables GC, idempotency, missing dir, non-JSON files untouched, invalid env-var fallback
- [x] Existing suites: `test_build_t0_state_register_reader.py` (11 tests) and `test_build_t0_brief_output.py` (14 tests) — all pass, zero regressions
- [x] Smoke: `python3 scripts/build_t0_state.py && find .vnx-data/state/t0_detail/ -mtime +14 -name '*.json'` returns empty

## Quality gate

`gate_phase00_w_ux_4_gc_retention`

- [x] Files older than retention window are removed
- [x] Files inside retention window are untouched
- [x] `VNX_T0_DETAIL_RETENTION_DAYS=0` disables GC (escape hatch)
- [x] No regression on existing build_t0_state suite

Part of Phase 0 — Operator UX Quick Wins. Dispatch-ID: 20260506-w-ux-4-gc-retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)