### PR TITLE
feat(strategy): current_state.md auto-projector + retire vestigial state (W-UX-2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && python3 \"$ROOT/scripts/build_current_state.py\" 2>/dev/null; exit 0'"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "terminals/T0",

--- a/scripts/build_current_state.py
+++ b/scripts/build_current_state.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""build_current_state.py — Auto-project current_state.md from strategy/ sources.
+
+Idempotent: "Last updated:" is derived from the latest input-file mtime,
+never from datetime.now(). Run twice on unchanged inputs → byte-identical output.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from project_root import resolve_data_dir  # noqa: E402
+
+MAX_RECEIPTS = 5
+MAX_PRS = 5
+MAX_OI = 5
+MAX_DECISIONS = 3
+
+
+def _mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _latest_mtime_iso(paths: list[Path]) -> str:
+    """Return ISO-8601 string of the latest mtime among existing paths."""
+    mtimes = [_mtime(p) for p in paths if p.exists()]
+    if not mtimes:
+        return "unknown"
+    dt = datetime.datetime.fromtimestamp(max(mtimes), tz=datetime.timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_roadmap(strategy_dir: Path) -> dict:
+    rmap = strategy_dir / "roadmap.yaml"
+    if not rmap.exists():
+        return {}
+    try:
+        import yaml
+        return yaml.safe_load(rmap.read_text()) or {}
+    except Exception:
+        return {}
+
+
+def _load_open_items(state_dir: Path) -> dict:
+    oi = state_dir / "open_items_digest.json"
+    if not oi.exists():
+        return {}
+    try:
+        return json.loads(oi.read_text())
+    except Exception:
+        return {}
+
+
+def _load_receipts(state_dir: Path, n: int = MAX_RECEIPTS) -> list[dict]:
+    receipts_file = state_dir / "t0_receipts.ndjson"
+    if not receipts_file.exists():
+        return []
+    lines: list[dict] = []
+    try:
+        for raw in receipts_file.read_text().splitlines():
+            raw = raw.strip()
+            if raw:
+                try:
+                    lines.append(json.loads(raw))
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return lines[-n:]
+
+
+def _load_decisions(strategy_dir: Path, n: int = MAX_DECISIONS) -> list[dict]:
+    dec = strategy_dir / "decisions.ndjson"
+    if not dec.exists():
+        return []
+    lines: list[dict] = []
+    try:
+        for raw in dec.read_text().splitlines():
+            raw = raw.strip()
+            if raw:
+                try:
+                    lines.append(json.loads(raw))
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return lines[-n:]
+
+
+def _fetch_prs(n: int = MAX_PRS) -> list[dict]:
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--limit", str(n),
+             "--json", "number,title,state,headRefName"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            return json.loads(result.stdout) or []
+    except Exception:
+        pass
+    return []
+
+
+def _wave_badge(status: str) -> str:
+    return {"in_progress": "[~]", "planned": "[ ]", "completed": "[x]",
+            "blocked": "[!]"}.get(status, f"[{status}]")
+
+
+def _render_roadmap(roadmap: dict) -> list[str]:
+    lines = ["## Roadmap Waves", ""]
+    phases = roadmap.get("phases", [])
+    waves_by_id = {w["wave_id"]: w for w in roadmap.get("waves", [])}
+
+    if not phases and not waves_by_id:
+        return lines + ["_No roadmap data._", ""]
+
+    for phase in phases:
+        pid = phase.get("phase_id", "?")
+        title = phase.get("title", "")
+        lines.append(f"### Phase {pid}: {title}")
+        for wid in phase.get("waves", []):
+            w = waves_by_id.get(wid)
+            if w is None:
+                continue
+            status = w.get("status", "planned")
+            lines.append(f"- {_wave_badge(status)} `{wid}`: {w.get('title', wid)}")
+        lines.append("")
+    return lines
+
+
+def _render_prs(prs: list[dict]) -> list[str]:
+    lines = ["## Open Pull Requests", ""]
+    if not prs:
+        return lines + ["_No open PRs or gh CLI unavailable._", ""]
+    for pr in prs:
+        lines.append(
+            f"- PR #{pr.get('number', '?')}: {pr.get('title', '')} "
+            f"(`{pr.get('headRefName', '')}`)"
+        )
+    return lines + [""]
+
+
+def _render_open_items(oi: dict) -> list[str]:
+    lines = ["## Open Items", ""]
+    summary = oi.get("summary", {})
+    open_count = summary.get("open_count", 0)
+    blocker_count = summary.get("blocker_count", 0)
+
+    if not oi:
+        return lines + ["_No open items data._", ""]
+
+    lines.append(
+        f"**{open_count} open** ({blocker_count} blocking, "
+        f"{summary.get('warn_count', 0)} warnings)"
+    )
+    lines.append("")
+
+    blockers = oi.get("top_blockers", [])
+    if blockers:
+        lines.append("**Blockers:**")
+        for item in blockers[:MAX_OI]:
+            lines.append(f"- [{item.get('id', '?')}] {item.get('title', '')}")
+        lines.append("")
+
+    open_items = oi.get("open_items", [])
+    non_blockers = [i for i in open_items if i.get("severity") != "blocking"][:MAX_OI]
+    if non_blockers:
+        lines.append("**Top open items:**")
+        for item in non_blockers:
+            sev = item.get("severity", "")
+            lines.append(f"- [{item.get('id', '?')}] ({sev}) {item.get('title', '')}")
+        if open_count > MAX_OI + len(blockers):
+            lines.append(f"- … and {open_count - MAX_OI - len(blockers)} more")
+        lines.append("")
+
+    return lines
+
+
+def _render_receipts(receipts: list[dict]) -> list[str]:
+    lines = ["## Recent Receipts", ""]
+    if not receipts:
+        return lines + ["_No receipts found._", ""]
+    for r in reversed(receipts):
+        ts = str(r.get("timestamp", ""))[:10]
+        event = r.get("event_type", r.get("event", "?"))
+        status = r.get("status", "")
+        terminal = r.get("terminal", "?")
+        dispatch = str(r.get("dispatch_id", "?"))[:30]
+        badge = "[ok]" if status == "success" else "[x]" if status in ("failed", "error") else "[~]"
+        lines.append(f"- {badge} {ts} {terminal} `{dispatch}` ({event})")
+    return lines + [""]
+
+
+def _render_decisions(decisions: list[dict]) -> list[str]:
+    if not decisions:
+        return []
+    lines = ["## Recent Decisions", ""]
+    for d in reversed(decisions):
+        ts = str(d.get("timestamp", d.get("decided_at", "")))[:10]
+        title = d.get("title", d.get("decision_id", "?"))
+        decision = d.get("decision", "")
+        lines.append(f"- {ts}: **{title}** → {decision}")
+    return lines + [""]
+
+
+def _find_focus(roadmap: dict) -> str:
+    waves_by_id = {w["wave_id"]: w for w in roadmap.get("waves", [])}
+    for phase in roadmap.get("phases", []):
+        for wid in phase.get("waves", []):
+            w = waves_by_id.get(wid)
+            if w and w.get("status") in ("in_progress", "blocked"):
+                return f"Phase {phase.get('phase_id')}: {phase.get('title', '')}"
+    return "No active phase"
+
+
+def build(data_dir: Path | None = None) -> str:
+    if data_dir is None:
+        data_dir = resolve_data_dir(__file__)
+
+    strategy_dir = data_dir / "strategy"
+    state_dir = data_dir / "state"
+
+    roadmap = _load_roadmap(strategy_dir)
+    prs = _fetch_prs()
+    receipts = _load_receipts(state_dir)
+    oi = _load_open_items(state_dir)
+    decisions = _load_decisions(strategy_dir)
+
+    last_updated = _latest_mtime_iso([
+        strategy_dir / "roadmap.yaml",
+        state_dir / "t0_receipts.ndjson",
+        state_dir / "open_items_digest.json",
+        strategy_dir / "decisions.ndjson",
+    ])
+
+    body: list[str] = [
+        "# VNX Project State",
+        f"Last updated: {last_updated}",
+        "",
+        f"**Focus**: {_find_focus(roadmap)}",
+        "",
+    ]
+    body += _render_roadmap(roadmap)
+    body += _render_prs(prs)
+    body += _render_open_items(oi)
+    body += _render_receipts(receipts)
+    body += _render_decisions(decisions)
+
+    if len(body) > 200:
+        body = body[:199] + ["_[truncated to 200 lines]_"]
+
+    return "\n".join(body) + "\n"
+
+
+def main() -> None:
+    data_dir = resolve_data_dir(__file__)
+    strategy_dir = data_dir / "strategy"
+    strategy_dir.mkdir(parents=True, exist_ok=True)
+
+    content = build(data_dir)
+    out = strategy_dir / "current_state.md"
+    out.write_text(content)
+    line_count = len(content.splitlines())
+    print(f"[ok] current_state.md written ({line_count} lines) → {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/receipt_processor/rp_dispatch.sh
+++ b/scripts/lib/receipt_processor/rp_dispatch.sh
@@ -44,6 +44,21 @@ _auto_release_lease_on_receipt() {
     fi
 }
 
+# Section C2c: Refresh current_state.md after lease release (non-fatal, W-UX-2).
+run_state_projector() {
+    local scripts_dir="${SCRIPTS_DIR:-}"
+    if [ -z "$scripts_dir" ]; then
+        local root
+        root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+        scripts_dir="$root/scripts"
+    fi
+    local projector="$scripts_dir/build_current_state.py"
+    [ -f "$projector" ] || return 0
+    python3 "$projector" 2>/dev/null \
+        && log "DEBUG" "State projector refreshed current_state.md" \
+        || log "WARN" "State projector failed (non-fatal)"
+}
+
 # Section D: Extract PR ID (3-tier) and attach evidence to open items.
 # Reads _rf_* variables. Non-fatal.
 attach_pr_evidence() {

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -218,6 +218,7 @@ process_single_report() {
     update_receipt_shadow_state "$terminal"
     _move_dispatch_to_completed
     _psr_release_lease_on_event "$_rf_event_type" "$_rf_status" "$terminal" "$_rf_dispatch_id"
+    run_state_projector
     _psr_update_dispatch_outcome "$_rf_dispatch_id" "$_rf_event_type" "$_rf_status" "$report_path" "$_rf_timestamp"
     attach_pr_evidence "$receipt_json" "$report_path"
     _psr_verify_contract "$_rf_dispatch_id" "$_rf_event_type"

--- a/tests/test_build_current_state.py
+++ b/tests/test_build_current_state.py
@@ -1,0 +1,312 @@
+"""Unit tests for scripts/build_current_state.py.
+
+Cases:
+- empty roadmap
+- all-completed roadmap
+- in-progress + blocked OI
+- idempotence (run twice → byte-identical output)
+- graceful degrade if gh CLI fails
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+import build_current_state as bcs
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_data_dir(tmp_path: Path) -> Path:
+    strategy = tmp_path / "strategy"
+    state = tmp_path / "state"
+    strategy.mkdir(parents=True)
+    state.mkdir(parents=True)
+    return tmp_path
+
+
+def _write_roadmap(strategy_dir: Path, content: dict) -> None:
+    import yaml
+    (strategy_dir / "roadmap.yaml").write_text(yaml.dump(content))
+
+
+def _write_oi_digest(state_dir: Path, content: dict) -> None:
+    (state_dir / "open_items_digest.json").write_text(json.dumps(content))
+
+
+def _write_receipts(state_dir: Path, records: list[dict]) -> None:
+    (state_dir / "t0_receipts.ndjson").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers to suppress gh CLI calls during tests
+# ---------------------------------------------------------------------------
+
+def _no_prs(*_args, **_kwargs):
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestEmptyRoadmap:
+    def test_builds_without_error(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "# VNX Project State" in content
+
+    def test_empty_roadmap_section(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "No roadmap data" in content
+
+    def test_no_active_phase(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "No active phase" in content
+
+    def test_within_200_lines(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert len(content.splitlines()) <= 200
+
+
+class TestAllCompletedRoadmap:
+    def _make_roadmap(self) -> dict:
+        return {
+            "schema_version": 1,
+            "phases": [
+                {
+                    "phase_id": 0,
+                    "title": "Phase Zero",
+                    "waves": ["w-a", "w-b"],
+                    "blocked_on": [],
+                }
+            ],
+            "waves": [
+                {"wave_id": "w-a", "title": "Wave A", "phase_id": 0,
+                 "status": "completed", "depends_on": []},
+                {"wave_id": "w-b", "title": "Wave B", "phase_id": 0,
+                 "status": "completed", "depends_on": []},
+            ],
+        }
+
+    def test_completed_badges(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "[x]" in content
+
+    def test_no_active_phase_when_all_done(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "No active phase" in content
+
+
+class TestInProgressWithBlockedOI:
+    def _make_roadmap(self) -> dict:
+        return {
+            "schema_version": 1,
+            "phases": [
+                {
+                    "phase_id": 0,
+                    "title": "Operator UX",
+                    "waves": ["w-ux-1", "w-ux-2"],
+                    "blocked_on": [],
+                }
+            ],
+            "waves": [
+                {"wave_id": "w-ux-1", "title": "Bootstrap strategy/", "phase_id": 0,
+                 "status": "in_progress", "depends_on": []},
+                {"wave_id": "w-ux-2", "title": "State projector", "phase_id": 0,
+                 "status": "planned", "depends_on": ["w-ux-1"]},
+            ],
+        }
+
+    def _make_oi_digest(self) -> dict:
+        return {
+            "summary": {
+                "open_count": 5,
+                "blocker_count": 1,
+                "warn_count": 3,
+                "info_count": 1,
+            },
+            "top_blockers": [
+                {"id": "OI-001", "title": "Critical blocker", "pr_id": "PR-1"},
+            ],
+            "open_items": [
+                {"id": "OI-002", "severity": "warn", "title": "Minor warning",
+                 "pr_id": None},
+            ],
+            "recent_closures": [],
+        }
+
+    def test_in_progress_badge(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "[~]" in content
+
+    def test_focus_shows_active_phase(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "Phase 0" in content
+        assert "Operator UX" in content
+
+    def test_blocker_shown_in_oi(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
+        _write_oi_digest(tmp_data_dir / "state", self._make_oi_digest())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "OI-001" in content
+        assert "Critical blocker" in content
+
+
+class TestIdempotence:
+    """Two consecutive runs on unchanged inputs must produce byte-identical output."""
+
+    def test_idempotent_empty(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2, "Output differed between run 1 and run 2"
+
+    def test_idempotent_with_data(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "phases": [{"phase_id": 0, "title": "T", "waves": ["w1"],
+                        "blocked_on": []}],
+            "waves": [{"wave_id": "w1", "title": "Wave", "phase_id": 0,
+                       "status": "in_progress", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        _write_receipts(tmp_data_dir / "state", [
+            {"event_type": "task_complete", "timestamp": "2026-05-01T10:00:00",
+             "terminal": "T1", "dispatch_id": "disp-001", "status": "success"},
+        ])
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2, "Output differed between run 1 and run 2"
+
+    def test_no_live_timestamp_in_body(self, tmp_data_dir: Path) -> None:
+        """The body must not contain the current date (only mtime-derived timestamp)."""
+        import datetime
+        today = datetime.date.today().isoformat()
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        # "Last updated: unknown" is fine; "Last updated: <today>" would only appear
+        # if the roadmap.yaml file was touched today, which it wasn't (tmpdir is fresh).
+        # The key assertion: datetime.now() is never called.
+        lines_with_today = [
+            line for line in content.splitlines()
+            if today in line and not line.startswith("Last updated:")
+        ]
+        assert not lines_with_today, (
+            f"Body contains today's date outside 'Last updated:' line: {lines_with_today}"
+        )
+
+
+class TestGhCliFail:
+    """Projector must degrade gracefully when gh CLI is unavailable."""
+
+    def _failing_gh(self, *_args, **_kwargs):
+        raise FileNotFoundError("gh not found")
+
+    def test_no_prs_on_gh_failure(self, tmp_data_dir: Path) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+            content = bcs.build(tmp_data_dir)
+        assert "gh CLI unavailable" in content or "No open PRs" in content
+
+    def test_output_still_valid_markdown(self, tmp_data_dir: Path) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+            content = bcs.build(tmp_data_dir)
+        assert content.startswith("# VNX Project State")
+        assert len(content.splitlines()) <= 200
+
+    def test_gh_nonzero_exit(self, tmp_data_dir: Path) -> None:
+        from unittest.mock import MagicMock
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result):
+            content = bcs.build(tmp_data_dir)
+        assert "# VNX Project State" in content
+
+
+class TestLastUpdatedLine:
+    def test_last_updated_from_mtime(self, tmp_data_dir: Path) -> None:
+        roadmap_path = tmp_data_dir / "strategy" / "roadmap.yaml"
+        import yaml
+        roadmap_path.write_text(yaml.dump({"schema_version": 1}))
+        # Set mtime to a known epoch
+        known_mtime = 1777939200.0  # 2026-05-05T00:00:00Z
+        os.utime(roadmap_path, (known_mtime, known_mtime))
+
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+
+        assert "Last updated: 2026-05-05T00:00:00Z" in content
+
+    def test_last_updated_unknown_when_no_files(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "Last updated: unknown" in content
+
+
+class TestDecisionsSection:
+    def test_decisions_rendered(self, tmp_data_dir: Path) -> None:
+        decisions = [
+            {"timestamp": "2026-05-01T12:00:00Z", "title": "auth-model",
+             "decision": "jwt_symmetric"},
+        ]
+        (tmp_data_dir / "strategy" / "decisions.ndjson").write_text(
+            "\n".join(json.dumps(d) for d in decisions) + "\n"
+        )
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "auth-model" in content
+        assert "jwt_symmetric" in content
+
+    def test_missing_decisions_file_graceful(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "# VNX Project State" in content
+
+
+class TestOutputLength:
+    def test_large_roadmap_truncated_to_200_lines(self, tmp_data_dir: Path) -> None:
+        import yaml
+        many_waves = [
+            {"wave_id": f"w-{i}", "title": f"Wave {i}", "phase_id": 0,
+             "status": "planned", "depends_on": []}
+            for i in range(100)
+        ]
+        roadmap = {
+            "schema_version": 1,
+            "phases": [{"phase_id": 0, "title": "Big Phase",
+                        "waves": [f"w-{i}" for i in range(100)],
+                        "blocked_on": []}],
+            "waves": many_waves,
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert len(content.splitlines()) <= 200

--- a/tests/test_build_current_state_integration.py
+++ b/tests/test_build_current_state_integration.py
@@ -1,0 +1,157 @@
+"""Integration tests for build_current_state.py.
+
+Verifies:
+- SessionEnd hook in .claude/settings.json invokes projector successfully.
+- Projector creates/updates current_state.md in the correct location.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+import build_current_state as bcs
+
+
+SETTINGS_PATH = Path(__file__).parent.parent / ".claude" / "settings.json"
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+class TestSessionEndHookWiring:
+    def test_settings_json_has_session_end_key(self) -> None:
+        """settings.json must contain a SessionEnd hook entry."""
+        assert SETTINGS_PATH.exists(), ".claude/settings.json not found"
+        settings = json.loads(SETTINGS_PATH.read_text())
+        assert "SessionEnd" in settings.get("hooks", {}), (
+            "SessionEnd key missing from hooks in .claude/settings.json"
+        )
+
+    def test_session_end_hook_references_projector(self) -> None:
+        """The SessionEnd hook command must reference build_current_state.py."""
+        settings = json.loads(SETTINGS_PATH.read_text())
+        hooks = settings["hooks"]["SessionEnd"]
+        commands = []
+        for entry in hooks:
+            for h in entry.get("hooks", []):
+                if h.get("type") == "command":
+                    commands.append(h["command"])
+        assert any("build_current_state.py" in cmd for cmd in commands), (
+            f"No hook references build_current_state.py. Commands: {commands}"
+        )
+
+    def test_session_end_hook_exits_zero_on_fail(self) -> None:
+        """Hook command must end with exit 0 so it never blocks Claude sessions."""
+        settings = json.loads(SETTINGS_PATH.read_text())
+        hooks = settings["hooks"]["SessionEnd"]
+        for entry in hooks:
+            for h in entry.get("hooks", []):
+                if h.get("type") == "command" and "build_current_state" in h.get("command", ""):
+                    assert "exit 0" in h["command"], (
+                        "SessionEnd hook missing 'exit 0' safety guard. "
+                        f"Command: {h['command']!r}"
+                    )
+
+
+class TestProjectorInvocationViaSubprocess:
+    def test_projector_exits_zero(self, tmp_path: Path) -> None:
+        """Running the projector via subprocess must exit 0 (no crashes)."""
+        strategy_dir = tmp_path / "strategy"
+        state_dir = tmp_path / "state"
+        strategy_dir.mkdir(parents=True)
+        state_dir.mkdir(parents=True)
+
+        projector = PROJECT_ROOT / "scripts" / "build_current_state.py"
+        env = {
+            "VNX_DATA_DIR": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(Path.home()),
+        }
+        result = subprocess.run(
+            [sys.executable, str(projector)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        assert result.returncode == 0, (
+            f"Projector exited with {result.returncode}.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_projector_creates_output_file(self, tmp_path: Path) -> None:
+        """Projector must write current_state.md to strategy/."""
+        strategy_dir = tmp_path / "strategy"
+        state_dir = tmp_path / "state"
+        strategy_dir.mkdir(parents=True)
+        state_dir.mkdir(parents=True)
+
+        projector = PROJECT_ROOT / "scripts" / "build_current_state.py"
+        env = {
+            "VNX_DATA_DIR": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(Path.home()),
+        }
+        subprocess.run(
+            [sys.executable, str(projector)],
+            capture_output=True, text=True, env=env, timeout=15,
+        )
+        out = strategy_dir / "current_state.md"
+        assert out.exists(), f"current_state.md not created at {out}"
+        content = out.read_text()
+        assert "# VNX Project State" in content
+
+    def test_projector_idempotent_via_subprocess(self, tmp_path: Path) -> None:
+        """Two subprocess calls produce byte-identical current_state.md."""
+        strategy_dir = tmp_path / "strategy"
+        state_dir = tmp_path / "state"
+        strategy_dir.mkdir(parents=True)
+        state_dir.mkdir(parents=True)
+
+        projector = PROJECT_ROOT / "scripts" / "build_current_state.py"
+        env = {
+            "VNX_DATA_DIR": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(Path.home()),
+        }
+        out = strategy_dir / "current_state.md"
+        subprocess.run([sys.executable, str(projector)],
+                       capture_output=True, text=True, env=env, timeout=15)
+        content_run1 = out.read_text()
+
+        subprocess.run([sys.executable, str(projector)],
+                       capture_output=True, text=True, env=env, timeout=15)
+        content_run2 = out.read_text()
+
+        assert content_run1 == content_run2, (
+            "current_state.md content changed between two consecutive runs "
+            "(idempotency violated)"
+        )
+
+    def test_projector_under_200_lines_via_subprocess(self, tmp_path: Path) -> None:
+        """Output must be ≤200 lines when run as subprocess."""
+        strategy_dir = tmp_path / "strategy"
+        state_dir = tmp_path / "state"
+        strategy_dir.mkdir(parents=True)
+        state_dir.mkdir(parents=True)
+
+        projector = PROJECT_ROOT / "scripts" / "build_current_state.py"
+        env = {
+            "VNX_DATA_DIR": str(tmp_path),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(Path.home()),
+        }
+        subprocess.run([sys.executable, str(projector)],
+                       capture_output=True, text=True, env=env, timeout=15)
+        line_count = len((strategy_dir / "current_state.md").read_text().splitlines())
+        assert line_count <= 200, f"Output has {line_count} lines (max 200)"


### PR DESCRIPTION
## Summary

- **Adds `scripts/build_current_state.py`** (~130 LOC): idempotent projector that reads `roadmap.yaml` + `gh pr list` + last-5 receipts + `open_items_digest.json` + (optional) `decisions.ndjson` and emits a ≤200-line `.vnx-data/strategy/current_state.md`. "Last updated:" derived from input file mtimes only — never `datetime.now()`.
- **Wires SessionEnd hook** in `.claude/settings.json` to run the projector on every session end (with `exit 0` guard so it never blocks Claude).
- **Wires `rp_dispatch.sh`**: adds `run_state_projector()` called from `receipt_processor_v4.sh` after lease release (non-fatal).
- **Archives 4 vestigial state files** to `.vnx-data/state/_archive/`:
  - `STATE.md`
  - `PROJECT_STATUS.md`
  - `HANDOVER_2026-04-28.md`
  - `HANDOVER_2026-04-28-evening.md`
- Adds `.vnx-data/state/_archive/README.md` with deprecation notice pointing at `current_state.md`.

## Tests

- `tests/test_build_current_state.py` — 20 unit tests covering: empty roadmap, all-completed roadmap, in-progress + blocked OI, idempotence (byte-identical across two runs), mtime-derived "Last updated:", graceful degrade when `gh` CLI fails.
- `tests/test_build_current_state_integration.py` — 7 integration tests covering: SessionEnd hook wiring, projector subprocess invocation, output file creation, subprocess-level idempotence, ≤200-line constraint.
- **27/27 tests pass. Runtime: ~0.4s (<2s requirement).**

## Quality gate

`gate_phase00_w_ux_2_projector`

## Note on tracked references

`scripts/build_project_status.py` and `scripts/generate_t0_brief.sh` contain the strings `PROJECT_STATUS.md` / `STATE.md` because they are *generators* of those files (not consumers of the archived snapshots). These are separate, live code paths untouched by this PR. HANDOVER file references are clean.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)