### PR TITLE
feat(cli): vnx status dashboard subcommand (W-UX-3)

### DIFF
--- a/scripts/cli/vnx_status.py
+++ b/scripts/cli/vnx_status.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """vnx status CLI dashboard — W-UX-3.
 
-Reads .vnx-data/strategy/current_state.md (strategic) +
-.vnx-data/state/t0_state.json (live terminals/queues).
-
-Outputs a 1-screen human-readable dashboard or --json for scripting.
-Read-only: no writes to .vnx-data/.
+Reads the strategic-state projection (current_state.md) and the
+runtime-state snapshot (t0_state.json) from VNX_STATE_DIR / VNX_DATA_DIR
+and renders a 1-screen human-readable dashboard, or JSON via --json.
+Read-only: no writes to runtime state.
 """
 from __future__ import annotations
 

--- a/scripts/cli/vnx_status.py
+++ b/scripts/cli/vnx_status.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""vnx status CLI dashboard — W-UX-3.
+
+Reads .vnx-data/strategy/current_state.md (strategic) +
+.vnx-data/state/t0_state.json (live terminals/queues).
+
+Outputs a 1-screen human-readable dashboard or --json for scripting.
+Read-only: no writes to .vnx-data/.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from project_root import resolve_data_dir  # noqa: E402
+
+
+# ── Color helpers ──────────────────────────────────────────────────────
+
+_CODES: dict[str, str] = {
+    "bold": "\033[1m",
+    "cyan": "\033[36m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "red": "\033[31m",
+    "dim": "\033[2m",
+    "reset": "\033[0m",
+}
+
+
+def _use_color() -> bool:
+    return sys.stdout.isatty() and not os.environ.get("NO_COLOR", "")
+
+
+def _c(code: str, text: str) -> str:
+    if not _use_color():
+        return text
+    return f"{_CODES.get(code, '')}{text}{_CODES['reset']}"
+
+
+def _header(title: str) -> None:
+    print(_c("bold", _c("cyan", f"\n── {title} ")))
+
+
+# ── Parsing current_state.md ──────────────────────────────────────────
+
+def _parse_current_state(strategy_dir: Path) -> dict:
+    """Parse sections from current_state.md into structured data."""
+    cs_file = strategy_dir / "current_state.md"
+    if not cs_file.exists():
+        return {}
+
+    text = cs_file.read_text()
+    result: dict = {
+        "focus": "",
+        "waves": [],
+        "prs": [],
+        "decisions": [],
+    }
+
+    m = re.search(r"^\*\*Focus\*\*:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        result["focus"] = m.group(1).strip()
+
+    current_section: str | None = None
+    for line in text.splitlines():
+        if line.startswith("## Roadmap Waves"):
+            current_section = "waves"
+        elif line.startswith("## Open Pull Requests"):
+            current_section = "prs"
+        elif line.startswith("## Recent Decisions"):
+            current_section = "decisions"
+        elif line.startswith("## "):
+            current_section = None
+        elif current_section == "waves" and line.startswith("- ["):
+            m2 = re.match(r"^- \[(.)\] `([^`]+)`:\s*(.+)$", line)
+            if m2:
+                badge, wid, title = m2.groups()
+                result["waves"].append({
+                    "badge": badge,
+                    "id": wid,
+                    "title": title.strip(),
+                })
+        elif current_section == "prs" and line.startswith("- PR #"):
+            result["prs"].append(line[2:].strip())
+        elif current_section == "decisions" and line.startswith("- "):
+            result["decisions"].append(line[2:].strip())
+
+    return result
+
+
+# ── Loading t0_state.json ─────────────────────────────────────────────
+
+def _load_t0_state(state_dir: Path) -> dict:
+    f = state_dir / "t0_state.json"
+    if not f.exists():
+        return {}
+    try:
+        return json.loads(f.read_text())
+    except Exception:
+        return {}
+
+
+# ── Dashboard sections ────────────────────────────────────────────────
+
+def _active_waves(waves: list[dict], n: int = 3) -> list[dict]:
+    """Return up to n in-progress/blocked waves, falling back to first n."""
+    active = [w for w in waves if w["badge"] in ("~", "!")]
+    return (active or waves)[:n]
+
+
+def _print_focus(cs: dict) -> None:
+    _header("Current Focus")
+    focus = cs.get("focus", "")
+    print(f"  {_c('bold', focus) if focus else '(no focus data)'}")
+
+
+def _print_waves(cs: dict) -> None:
+    _header("Active Waves  (top 3)")
+    waves = _active_waves(cs.get("waves", []))
+    if not waves:
+        print("  (no wave data)")
+        return
+    for w in waves:
+        b = w["badge"]
+        color = "yellow" if b == "~" else "red" if b == "!" else "dim"
+        print(f"  [{_c(color, b)}] {_c('bold', w['id'])}: {w['title']}")
+
+
+def _print_prs(cs: dict) -> None:
+    _header("Open PRs  (top 3)")
+    prs = cs.get("prs", [])[:3]
+    if not prs:
+        print("  (no open PRs found in current_state.md)")
+        return
+    for pr in prs:
+        print(f"  {_c('dim', chr(8226))} {pr}")
+
+
+def _print_terminals(t0: dict) -> None:
+    _header("Terminal Status")
+    terminals = t0.get("terminals", {})
+    if not terminals:
+        print("  (no terminal data — run vnx start first)")
+        return
+    for tid in sorted(terminals):
+        t = terminals[tid]
+        status = t.get("status", "unknown")
+        lease = t.get("lease_state", "idle")
+        track = t.get("track", "?")
+        dispatch = t.get("current_dispatch") or "—"
+        color = "green" if status == "idle" else "yellow" if status == "busy" else "dim"
+        print(
+            f"  {_c('bold', tid)} [{track}] "
+            f"{_c(color, status)}/{lease}  "
+            f"{_c('dim', str(dispatch)[:45])}"
+        )
+
+
+def _print_decisions(cs: dict) -> None:
+    _header("Recent Decisions  (last 3)")
+    decisions = cs.get("decisions", [])[:3]
+    if not decisions:
+        print("  (no decisions found in current_state.md)")
+        return
+    for d in decisions:
+        print(f"  {_c('dim', chr(8226))} {d}")
+
+
+# ── JSON output ───────────────────────────────────────────────────────
+
+def _build_json_output(cs: dict, t0: dict) -> dict:
+    return {
+        "schema": "vnx_status/1.0",
+        "focus": cs.get("focus", ""),
+        "active_waves": _active_waves(cs.get("waves", [])),
+        "open_prs": cs.get("prs", [])[:3],
+        "terminals": t0.get("terminals", {}),
+        "recent_decisions": cs.get("decisions", [])[:3],
+        "queues": t0.get("queues", {}),
+        "strategy_available": bool(cs),
+        "t0_state_available": bool(t0),
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None, data_dir: Path | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="vnx status",
+        description="VNX operator status dashboard (W-UX-3)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit parseable JSON (stable schema: vnx_status/1.0)",
+    )
+    args, _extra = parser.parse_known_args(argv)
+
+    if data_dir is None:
+        data_dir = resolve_data_dir(__file__)
+
+    strategy_dir = data_dir / "strategy"
+    state_dir = data_dir / "state"
+
+    strategy_ok = strategy_dir.exists()
+    t0_ok = (state_dir / "t0_state.json").exists()
+
+    if not strategy_ok and not t0_ok:
+        if args.emit_json:
+            print(json.dumps({
+                "schema": "vnx_status/1.0",
+                "error": "not_initialised",
+                "strategy_available": False,
+                "t0_state_available": False,
+            }))
+        else:
+            print("vnx status: not initialised — run 'vnx init' to set up .vnx-data/")
+        return 0
+
+    cs = _parse_current_state(strategy_dir) if strategy_ok else {}
+    t0 = _load_t0_state(state_dir) if t0_ok else {}
+
+    if args.emit_json:
+        print(json.dumps(_build_json_output(cs, t0), indent=2))
+        return 0
+
+    if not strategy_ok:
+        print(
+            f"{_c('yellow', 'warn')} strategy/ missing — "
+            "run: python3 scripts/build_current_state.py"
+        )
+    if not t0_ok:
+        print(
+            f"{_c('yellow', 'warn')} t0_state.json missing — "
+            "run: python3 scripts/build_t0_state.py"
+        )
+
+    _print_focus(cs)
+    _print_waves(cs)
+    _print_prs(cs)
+    _print_terminals(t0)
+    _print_decisions(cs)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/commands/status.sh
+++ b/scripts/commands/status.sh
@@ -284,22 +284,25 @@ cmd_status() {
         cat <<HELP
 Usage: vnx status [OPTIONS]
 
-Show VNX system status: terminals, dispatch queue, and gate results.
+Show VNX operator status dashboard: strategic overview + live terminal health.
 
 Options:
-  --terminals   Show only terminal health
-  --dispatches  Show only dispatch queue
-  --gates       Show only gate results
+  --terminals   Show only terminal health (legacy view)
+  --dispatches  Show only dispatch queue (legacy view)
+  --gates       Show only gate results (legacy view)
   --workers     Show live worker health (subprocess dispatches)
-  --json        Output raw t0_state.json as machine-readable JSON
+  --json        Machine-readable JSON (schema: vnx_status/1.0)
+                Keys: schema, focus, active_waves, open_prs, terminals,
+                      recent_decisions, queues, strategy_available,
+                      t0_state_available
   -h, --help    Show this help
 
 Examples:
   vnx status
+  vnx status --json | python3 -m json.tool
   vnx status --terminals
   vnx status --gates
   vnx status --workers
-  vnx status --json
 HELP
         return 0 ;;
       *)
@@ -309,20 +312,22 @@ HELP
     shift
   done
 
-  if [ "$json_out" -eq 1 ]; then
-    # Refresh t0_state and emit JSON
-    if command -v python3 >/dev/null 2>&1 && [ -f "$VNX_HOME/scripts/build_t0_state.py" ]; then
-      PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \
-        python3 "$VNX_HOME/scripts/build_t0_state.py" 2>/dev/null \
-        || cat "${VNX_STATE_DIR}/t0_state.json" 2>/dev/null \
-        || printf '{}'
-    else
-      cat "${VNX_STATE_DIR}/t0_state.json" 2>/dev/null || printf '{}'
+  # W-UX-3: Route default view and --json through the Python dashboard.
+  # Specialized filter flags (--terminals, --dispatches, --gates, --workers)
+  # retain the legacy bash implementation below for backward compatibility.
+  if [ "$mode" = "all" ] || [ "$json_out" -eq 1 ]; then
+    local _status_py="${VNX_HOME}/scripts/cli/vnx_status.py"
+    if command -v python3 >/dev/null 2>&1 && [ -f "$_status_py" ]; then
+      local _py_args=()
+      [ "$json_out" -eq 1 ] && _py_args+=("--json")
+      PYTHONPATH="${VNX_HOME}/scripts/lib:${PYTHONPATH:-}" \
+        python3 "$_status_py" "${_py_args[@]+"${_py_args[@]}"}"
+      return $?
     fi
-    return 0
+    # Fallback if vnx_status.py unavailable: continue to legacy bash path below.
   fi
 
-  # Refresh t0_state (best-effort, non-blocking)
+  # Legacy bash paths for filter flags and fallback.
   if command -v python3 >/dev/null 2>&1 && [ -f "$VNX_HOME/scripts/build_t0_state.py" ]; then
     PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \
       python3 "$VNX_HOME/scripts/build_t0_state.py" >/dev/null 2>&1 || true

--- a/tests/test_vnx_status.py
+++ b/tests/test_vnx_status.py
@@ -1,0 +1,443 @@
+"""Unit tests for scripts/cli/vnx_status.py — W-UX-3.
+
+Cases:
+- Output contains: focus, top-3 active waves, top-3 open PRs, terminal status, last-3 decisions
+- --json emits parseable JSON with stable schema (vnx_status/1.0)
+- Missing strategy/ falls back gracefully (exit 0, polite message)
+- Missing t0_state.json falls back gracefully (exit 0)
+- No write side effects (mtime check pre/post)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "cli"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+import vnx_status as vs
+
+
+# ── Sample data ────────────────────────────────────────────────────────
+
+SAMPLE_CURRENT_STATE = """\
+# VNX Project State
+Last updated: 2026-05-06T00:00:00Z
+
+**Focus**: Phase 0: Operator UX quick wins
+
+## Roadmap Waves
+
+### Phase 0: Operator UX quick wins
+- [~] `w-ux-1`: Bootstrap strategy/ folder
+- [~] `w-ux-2`: current_state.md auto-projector
+- [ ] `w-ux-3`: vnx status CLI dashboard
+- [ ] `w-ux-4`: GC retention policy
+- [ ] `w-ux-5`: vnx init strategy
+
+## Open Pull Requests
+
+- PR #400: fix(t0-state): GC retention (`fix/t0-state-gc`)
+- PR #396: fix(append_receipt): remove dead code (`fix/ur-001`)
+- PR #395: chore: ADRs + maintenance (`chore/wave6-adrs`)
+- PR #232: fix(pane-manager): cross-project leak (`fix/pane-discovery`)
+
+## Open Items
+
+**5 open** (1 blocking, 2 warnings)
+
+## Recent Receipts
+
+- [~] 2026-05-06 T1 `20260506-w-ux-2` (subprocess_completion)
+
+## Recent Decisions
+
+- 2026-05-05: **arch-model** -> jwt_symmetric
+- 2026-05-04: **db-choice** -> postgres
+- 2026-05-03: **cache-layer** -> redis
+- 2026-05-02: **old-decision** -> noop
+"""
+
+SAMPLE_T0_STATE: dict = {
+    "schema_version": "2.1",
+    "generated_at": "2026-05-06T06:00:00Z",
+    "terminals": {
+        "T1": {
+            "status": "idle",
+            "track": "A",
+            "lease_state": "idle",
+            "current_dispatch": None,
+            "last_update": "2026-05-01T08:58:35Z",
+        },
+        "T2": {
+            "status": "busy",
+            "track": "B",
+            "lease_state": "leased",
+            "current_dispatch": "20260506-w-ux-3",
+            "last_update": "2026-05-06T10:00:00Z",
+        },
+        "T3": {
+            "status": "idle",
+            "track": "C",
+            "lease_state": "idle",
+            "current_dispatch": None,
+            "last_update": "2026-05-01T09:00:00Z",
+        },
+    },
+    "queues": {
+        "pending_count": 1,
+        "active_count": 1,
+        "completed_last_hour": 3,
+    },
+}
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def data_dir(tmp_path: Path) -> Path:
+    strategy = tmp_path / "strategy"
+    state = tmp_path / "state"
+    strategy.mkdir()
+    state.mkdir()
+    (strategy / "current_state.md").write_text(SAMPLE_CURRENT_STATE)
+    (state / "t0_state.json").write_text(json.dumps(SAMPLE_T0_STATE))
+    return tmp_path
+
+
+@pytest.fixture()
+def no_strategy_dir(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "t0_state.json").write_text(json.dumps(SAMPLE_T0_STATE))
+    return tmp_path
+
+
+@pytest.fixture()
+def no_t0_state_dir(tmp_path: Path) -> Path:
+    strategy = tmp_path / "strategy"
+    strategy.mkdir()
+    (strategy / "current_state.md").write_text(SAMPLE_CURRENT_STATE)
+    return tmp_path
+
+
+@pytest.fixture()
+def empty_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+# ── Helper ─────────────────────────────────────────────────────────────
+
+def _run(argv=None, data_dir_=None):
+    buf = StringIO()
+    with patch("sys.stdout", buf):
+        rc = vs.main(argv=argv, data_dir=data_dir_)
+    return rc, buf.getvalue()
+
+
+# ── Dashboard content ──────────────────────────────────────────────────
+
+class TestDashboardContent:
+    def test_exit_code_0(self, data_dir: Path) -> None:
+        rc, _ = _run(data_dir_=data_dir)
+        assert rc == 0
+
+    def test_focus_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "Phase 0: Operator UX quick wins" in out
+
+    def test_active_waves_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "w-ux-1" in out or "w-ux-2" in out
+
+    def test_top_3_waves_at_most_3(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        wave_ids_shown = sum(1 for wid in ["w-ux-1", "w-ux-2", "w-ux-3", "w-ux-4", "w-ux-5"] if wid in out)
+        assert wave_ids_shown <= 3
+
+    def test_open_prs_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "PR #400" in out
+        assert "PR #396" in out
+
+    def test_top_3_prs_fourth_excluded(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "PR #232" not in out
+
+    def test_terminal_status_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "T1" in out
+        assert "T2" in out
+        assert "T3" in out
+
+    def test_decisions_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "arch-model" in out
+        assert "jwt_symmetric" in out
+
+    def test_last_3_decisions_fourth_excluded(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "old-decision" not in out
+
+    def test_all_five_sections_present(self, data_dir: Path) -> None:
+        rc, out = _run(data_dir_=data_dir)
+        assert rc == 0
+        assert "Current Focus" in out
+        assert "Active Waves" in out
+        assert "Open PRs" in out
+        assert "Terminal Status" in out
+        assert "Recent Decisions" in out
+
+
+# ── JSON output ────────────────────────────────────────────────────────
+
+class TestJsonOutput:
+    def test_json_parseable(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        assert rc == 0
+        data = json.loads(out)
+        assert isinstance(data, dict)
+
+    def test_json_schema_key(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert data["schema"] == "vnx_status/1.0"
+
+    def test_json_has_all_required_keys(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        required = {
+            "schema", "focus", "active_waves", "open_prs",
+            "terminals", "recent_decisions", "queues",
+            "strategy_available", "t0_state_available",
+        }
+        assert required.issubset(data.keys())
+
+    def test_json_focus_populated(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert "Phase 0" in data["focus"]
+
+    def test_json_active_waves_list(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert isinstance(data["active_waves"], list)
+        assert len(data["active_waves"]) <= 3
+
+    def test_json_wave_schema(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        for w in data["active_waves"]:
+            assert "badge" in w
+            assert "id" in w
+            assert "title" in w
+
+    def test_json_open_prs_list(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert isinstance(data["open_prs"], list)
+        assert len(data["open_prs"]) <= 3
+
+    def test_json_terminals_populated(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert "T1" in data["terminals"]
+        assert "T2" in data["terminals"]
+
+    def test_json_decisions_list(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert isinstance(data["recent_decisions"], list)
+        assert len(data["recent_decisions"]) <= 3
+
+    def test_json_queues_populated(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert "pending_count" in data["queues"]
+
+    def test_json_availability_flags_true(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert data["strategy_available"] is True
+        assert data["t0_state_available"] is True
+
+    def test_json_decisions_at_most_3(self, data_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=data_dir)
+        data = json.loads(out)
+        assert len(data["recent_decisions"]) <= 3
+
+
+# ── Graceful fallback: missing strategy/ ──────────────────────────────
+
+class TestMissingStrategyFallback:
+    def test_exits_0(self, no_strategy_dir: Path) -> None:
+        rc, _ = _run(data_dir_=no_strategy_dir)
+        assert rc == 0
+
+    def test_polite_message_or_warning(self, no_strategy_dir: Path) -> None:
+        rc, out = _run(data_dir_=no_strategy_dir)
+        lower = out.lower()
+        assert "strategy" in lower or "missing" in lower or "warn" in lower
+
+    def test_still_shows_terminal_data(self, no_strategy_dir: Path) -> None:
+        rc, out = _run(data_dir_=no_strategy_dir)
+        assert rc == 0
+        assert "T1" in out
+
+    def test_json_exits_0(self, no_strategy_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=no_strategy_dir)
+        assert rc == 0
+        data = json.loads(out)
+        assert data["strategy_available"] is False
+
+    def test_json_t0_still_available(self, no_strategy_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=no_strategy_dir)
+        data = json.loads(out)
+        assert data["t0_state_available"] is True
+
+
+# ── Graceful fallback: missing t0_state.json ──────────────────────────
+
+class TestMissingT0StateFallback:
+    def test_exits_0(self, no_t0_state_dir: Path) -> None:
+        rc, _ = _run(data_dir_=no_t0_state_dir)
+        assert rc == 0
+
+    def test_still_shows_strategic_data(self, no_t0_state_dir: Path) -> None:
+        rc, out = _run(data_dir_=no_t0_state_dir)
+        assert rc == 0
+        assert "Phase 0" in out
+
+    def test_json_exits_0(self, no_t0_state_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=no_t0_state_dir)
+        assert rc == 0
+        data = json.loads(out)
+
+    def test_json_t0_not_available(self, no_t0_state_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=no_t0_state_dir)
+        data = json.loads(out)
+        assert data["t0_state_available"] is False
+
+    def test_json_strategy_still_available(self, no_t0_state_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=no_t0_state_dir)
+        data = json.loads(out)
+        assert data["strategy_available"] is True
+
+
+# ── Graceful fallback: both missing ───────────────────────────────────
+
+class TestBothMissingFallback:
+    def test_exits_0(self, empty_dir: Path) -> None:
+        rc, _ = _run(data_dir_=empty_dir)
+        assert rc == 0
+
+    def test_not_initialised_message(self, empty_dir: Path) -> None:
+        rc, out = _run(data_dir_=empty_dir)
+        lower = out.lower()
+        assert "not initialised" in lower or "init" in lower
+
+    def test_json_exits_0(self, empty_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=empty_dir)
+        assert rc == 0
+        data = json.loads(out)
+
+    def test_json_both_unavailable(self, empty_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=empty_dir)
+        data = json.loads(out)
+        assert data["strategy_available"] is False
+        assert data["t0_state_available"] is False
+
+    def test_json_error_key_present(self, empty_dir: Path) -> None:
+        rc, out = _run(argv=["--json"], data_dir_=empty_dir)
+        data = json.loads(out)
+        assert "error" in data
+
+
+# ── No write side effects ──────────────────────────────────────────────
+
+class TestNoWriteSideEffects:
+    def _mtimes(self, root: Path) -> dict:
+        return {
+            str(p.relative_to(root)): p.stat().st_mtime
+            for p in root.rglob("*")
+            if p.is_file()
+        }
+
+    def test_no_files_mutated(self, data_dir: Path) -> None:
+        before = self._mtimes(data_dir)
+        _run(data_dir_=data_dir)
+        after = self._mtimes(data_dir)
+        assert before == after
+
+    def test_no_files_mutated_json(self, data_dir: Path) -> None:
+        before = self._mtimes(data_dir)
+        _run(argv=["--json"], data_dir_=data_dir)
+        after = self._mtimes(data_dir)
+        assert before == after
+
+    def test_no_new_files_created(self, data_dir: Path) -> None:
+        before_files = {str(p) for p in data_dir.rglob("*") if p.is_file()}
+        _run(data_dir_=data_dir)
+        after_files = {str(p) for p in data_dir.rglob("*") if p.is_file()}
+        assert after_files == before_files
+
+
+# ── Edge cases ────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_malformed_t0_state_json_falls_back(self, tmp_path: Path) -> None:
+        strategy = tmp_path / "strategy"
+        state = tmp_path / "state"
+        strategy.mkdir()
+        state.mkdir()
+        (strategy / "current_state.md").write_text(SAMPLE_CURRENT_STATE)
+        (state / "t0_state.json").write_text("NOT_VALID_JSON{{")
+        rc, out = _run(data_dir_=tmp_path)
+        assert rc == 0
+
+    def test_empty_current_state_file(self, tmp_path: Path) -> None:
+        strategy = tmp_path / "strategy"
+        state = tmp_path / "state"
+        strategy.mkdir()
+        state.mkdir()
+        (strategy / "current_state.md").write_text("")
+        (state / "t0_state.json").write_text(json.dumps(SAMPLE_T0_STATE))
+        rc, _ = _run(data_dir_=tmp_path)
+        assert rc == 0
+
+    def test_no_decisions_section_graceful(self, tmp_path: Path) -> None:
+        strategy = tmp_path / "strategy"
+        state = tmp_path / "state"
+        strategy.mkdir()
+        state.mkdir()
+        content = "# VNX Project State\n\n**Focus**: Test\n\n## Roadmap Waves\n\n## Open Pull Requests\n"
+        (strategy / "current_state.md").write_text(content)
+        (state / "t0_state.json").write_text(json.dumps(SAMPLE_T0_STATE))
+        rc, out = _run(data_dir_=tmp_path)
+        assert rc == 0
+        assert "no decisions found" in out.lower()
+
+    def test_json_no_waves_empty_list(self, tmp_path: Path) -> None:
+        strategy = tmp_path / "strategy"
+        state = tmp_path / "state"
+        strategy.mkdir()
+        state.mkdir()
+        (strategy / "current_state.md").write_text("# VNX Project State\n\n**Focus**: Empty\n")
+        (state / "t0_state.json").write_text(json.dumps(SAMPLE_T0_STATE))
+        rc, out = _run(argv=["--json"], data_dir_=tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        assert data["active_waves"] == []


### PR DESCRIPTION
## Summary

- Adds `scripts/cli/vnx_status.py` — a read-only Python dashboard that reads `.vnx-data/strategy/current_state.md` (strategic focus, top-3 waves, top-3 PRs, last-3 decisions) and `.vnx-data/state/t0_state.json` (live terminal state, queue counts) and renders a 1-screen operator overview.
- Updates `scripts/commands/status.sh` to route `vnx status` and `vnx status --json` through the Python dashboard; legacy filter flags (`--terminals`, `--dispatches`, `--gates`, `--workers`) retain backward-compatible bash implementation.
- Adds `tests/test_vnx_status.py` with 44 tests (~98% coverage, target ≥70%).

## `--json` schema (`vnx_status/1.0`)

```json
{
  "schema": "vnx_status/1.0",
  "focus": "Phase 0: Operator UX quick wins",
  "active_waves": [{"badge": "~", "id": "w-ux-1", "title": "..."}],
  "open_prs": ["PR #400: ...", "PR #396: ...", "PR #395: ..."],
  "terminals": {"T1": {"status": "idle", "track": "A", ...}},
  "recent_decisions": ["2026-05-05: **arch-model** -> jwt_symmetric"],
  "queues": {"pending_count": 0, "active_count": 2},
  "strategy_available": true,
  "t0_state_available": true
}
```

## Read-only invariant

`vnx status` never writes to `.vnx-data/`. Verified by mtime checks in `TestNoWriteSideEffects` (3 assertions, pre/post mtime equality).

## Graceful fallback behaviour

| Scenario | `vnx status` | `vnx status --json` |
|---|---|---|
| Both missing | "not initialised — run vnx init" | `{"error":"not_initialised", ...}` |
| strategy/ missing | warn + terminal section shown | `strategy_available: false` |
| t0_state.json missing | warn + strategic sections shown | `t0_state_available: false` |
| Both present | Full dashboard | Full JSON |

All cases exit 0.

## Test plan

- [x] `pytest tests/test_vnx_status.py` → 44/44 passed
- [x] `bash -n scripts/commands/status.sh` → syntax OK
- [x] `pytest tests/test_build_current_state.py tests/test_vnx_process_ux.py` → 53/53 passed (no regression)
- [x] Gate: `gate_phase00_w_ux_3_status_cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)