### PR TITLE
fix(dispatch_project_guard): canonicalize non-existent paths + Project-ID stamping (Phase 1.5 PR-3)

### DIFF
--- a/scripts/lib/dispatch_project_guard.sh
+++ b/scripts/lib/dispatch_project_guard.sh
@@ -19,12 +19,13 @@
 #       Compare the dispatch's stamped Project-ID (extracted via
 #       vnx_dispatch_extract_project_id from dispatch_metadata.sh) against
 #       <expected_pid>. Behavior:
-#         - empty stamp (legacy): print 'legacy' and return 0
-#         - matching:             print 'match'  and return 0
-#         - mismatching:          print 'reject' and return 1; appends a
-#                                 [REJECTED: project_id mismatch] marker to
-#                                 the dispatch, then moves it to <rejected_dir>
-#         - malformed expected:   print 'fatal'  and return 2
+#         - empty stamp:        print 'reject' and return 1 (OI-1316 — unstamped
+#                               dispatches are quarantined, not accepted as legacy)
+#         - matching:           print 'match'  and return 0
+#         - mismatching:        print 'reject' and return 1; appends a
+#                               [REJECTED: project_id mismatch] marker to
+#                               the dispatch, then moves it to <rejected_dir>
+#         - malformed expected: print 'fatal'  and return 2
 #
 #       Pure: no logging side effects beyond the dispatch file move + marker.
 #       Callers (dispatcher_v8_minimal.sh) translate the printed status into
@@ -43,11 +44,27 @@ vnx_dispatch_resolve_project_id() {
     return 0
 }
 
-# Canonicalize a directory path. If the path doesn't exist, fall back to
-# the literal string — callers should still get a deterministic answer when
-# a test creates the parent in a tmpdir but the child hasn't been mkdir'd yet.
+# Canonicalize a directory path by resolving symlinks. For non-existent paths,
+# walk up to the deepest existing ancestor, canonicalize that, then append the
+# remaining suffix. This ensures ".." components in a non-existent child path
+# cannot slip past the prefix check — bash case "*" matches "/" so a raw
+# "../other" suffix would falsely satisfy the parent-prefix pattern.
 _vnx_dpg_canon() {
-    if [ -d "$1" ]; then (cd -P "$1" && pwd -P); else printf '%s\n' "$1"; fi
+    local p="$1"
+    if [ -d "$p" ]; then
+        (cd -P "$p" && pwd -P)
+        return
+    fi
+    local base="$p" rest=""
+    while [ -n "$base" ] && [ "$base" != "/" ] && ! [ -d "$base" ]; do
+        rest="/$(basename "$base")${rest}"
+        base="$(dirname "$base")"
+    done
+    if [ -d "$base" ]; then
+        printf '%s\n' "$(cd -P "$base" && pwd -P)${rest}"
+    else
+        printf '%s\n' "$p"
+    fi
 }
 
 vnx_dispatch_assert_dir_under() {
@@ -74,8 +91,15 @@ vnx_dispatch_validate_project_id() {
     stamped="$(vnx_dispatch_extract_project_id "$dispatch" 2>/dev/null || true)"
 
     if [ -z "$stamped" ]; then
-        printf 'legacy\n'
-        return 0
+        if ! grep -q "\[REJECTED: unstamped dispatch\]" "$dispatch" 2>/dev/null; then
+            printf '\n\n[REJECTED: unstamped dispatch] no Project-ID header; dispatcher bound to %q (OI-1316).\n' \
+                "$expected" >> "$dispatch"
+        fi
+        if [ -n "$rejected_dir" ] && [ -d "$rejected_dir" ] && [ -f "$dispatch" ]; then
+            mv "$dispatch" "$rejected_dir/" 2>/dev/null || true
+        fi
+        printf 'reject\n'
+        return 1
     fi
 
     if [ "$stamped" = "$expected" ]; then

--- a/scripts/lib/headless_dispatch_writer.py
+++ b/scripts/lib/headless_dispatch_writer.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -73,6 +74,23 @@ def _skills_dir() -> Path:
 
 VALID_TERMINALS = {"T1", "T2", "T3"}
 VALID_TRACKS = {"A", "B", "C"}
+
+
+def _get_project_id() -> str:
+    """Return project ID from VNX_PROJECT_ID env, falling back to git root basename."""
+    pid = os.environ.get("VNX_PROJECT_ID", "").strip()
+    if pid:
+        return pid
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()).name
+    except Exception:
+        pass
+    return "vnx-dev"
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +212,7 @@ def write_dispatch(
         "instruction": instruction,
         "context_files": context_files or [],
         "created_at": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "project_id": _get_project_id(),
     }
 
     # --- write atomically ---

--- a/scripts/pr_queue_manager.py
+++ b/scripts/pr_queue_manager.py
@@ -7,6 +7,7 @@ Manages PR queue with dependency tracking and state persistence
 
 import os
 import re
+import subprocess as _subprocess
 import sys
 import json
 import yaml
@@ -28,6 +29,23 @@ from result_contract import (
     result_exit_code,
     result_ok,
 )
+
+
+def _get_project_id() -> str:
+    """Return project ID from VNX_PROJECT_ID env, falling back to git root basename."""
+    pid = os.environ.get("VNX_PROJECT_ID", "").strip()
+    if pid:
+        return pid
+    try:
+        result = _subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()).name
+    except Exception:
+        pass
+    return "vnx-dev"
 
 
 ROLLBACK_ENV_FLAG = "VNX_STATE_SIMPLIFICATION_ROLLBACK"
@@ -1001,6 +1019,7 @@ Review-Stack: {','.join(review_stack) if review_stack else 'none'}"""
         if requires_provider:
             manager_block += f"\nRequires-Provider: {requires_provider}"
         manager_block += f"\nClearContext: {'true' if clear_context else 'false'}"
+        manager_block += f"\nProject-ID: {_get_project_id()}"
 
         manager_block += f"""
 Dispatch-ID: {dispatch_id}
@@ -1577,6 +1596,7 @@ Cognition: {cognition}
 Risk-Class: {pr_data.get('risk_class', feature_metadata.get('risk_class', 'medium'))}
 Merge-Policy: {pr_data.get('merge_policy', feature_metadata.get('merge_policy', 'human'))}
 Review-Stack: {','.join(pr_data.get('review_stack', feature_metadata.get('review_stack', []))) or 'none'}
+Project-ID: {_get_project_id()}
 Dispatch-ID: {dispatch_id}
 PR-ID: {pr_id}
 Parent-Dispatch: none

--- a/tests/test_cross_project_isolation.py
+++ b/tests/test_cross_project_isolation.py
@@ -99,16 +99,19 @@ def _run_guard(dispatch: Path, expected: str, rejected_dir: Path) -> tuple[str, 
     return lines.get("STATUS", ""), int(lines.get("RC", "-1"))
 
 
-def test_legacy_dispatch_accepted(tmp_path):
+def test_legacy_dispatch_quarantined(tmp_path):
+    """Unstamped dispatches are quarantined (OI-1316 — no more legacy passthrough)."""
     d = tmp_path / "legacy.md"
     rej = tmp_path / "rejected"
     rej.mkdir()
     _write_dispatch(d, project_id=None)
     status, rc = _run_guard(d, "vnx-dev", rej)
-    assert status == "legacy"
-    assert rc == 0
-    assert d.exists(), "legacy dispatch must not be moved"
-    assert list(rej.iterdir()) == []
+    assert status == "reject"
+    assert rc == 1
+    assert not d.exists(), "unstamped dispatch must be quarantined (moved out)"
+    moved = rej / "legacy.md"
+    assert moved.exists()
+    assert "[REJECTED: unstamped dispatch]" in moved.read_text()
 
 
 def test_matching_project_id_accepted(tmp_path):

--- a/tests/test_dispatch_project_guard.sh
+++ b/tests/test_dispatch_project_guard.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# tests/test_dispatch_project_guard.sh — OI-1316 hardening tests.
+#
+# Two new cases for Phase 1.5 PR-3:
+#   TC1: symlink-traversal on non-existent path — guard must reject
+#   TC2: unstamped dispatch quarantine          — guard must reject + move file
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GUARD_SH="$REPO_ROOT/scripts/lib/dispatch_project_guard.sh"
+META_SH="$REPO_ROOT/scripts/lib/dispatch_metadata.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $msg (expected='$expected' actual='$actual')"
+        fail=$((fail + 1))
+    else
+        echo "PASS: $msg"
+        pass=$((pass + 1))
+    fi
+}
+
+assert_file_exists() {
+    local path="$1" msg="$2"
+    if [ -e "$path" ]; then
+        echo "PASS: $msg"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $msg (file not found: $path)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_file_missing() {
+    local path="$1" msg="$2"
+    if [ ! -e "$path" ]; then
+        echo "PASS: $msg"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $msg (file should not exist: $path)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_file_contains() {
+    local path="$1" needle="$2" msg="$3"
+    if grep -qF "$needle" "$path" 2>/dev/null; then
+        echo "PASS: $msg"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $msg (pattern not found in $path)"
+        fail=$((fail + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# TC1: symlink-traversal on non-existent path
+#
+# Attack: VNX_DATA_DIR is set to a legit dir, but the child path uses "../other"
+# to escape it. The guard must canonicalize the non-existent path through its
+# deepest existing ancestor and reject when the resolved path escapes VNX_DATA_DIR.
+# ---------------------------------------------------------------------------
+
+tc1_tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tc1_tmpdir"' EXIT
+
+legit_vnx_data="$tc1_tmpdir/legit/.vnx-data"
+mkdir -p "$legit_vnx_data"
+
+# Attack path: starts with legit/.vnx-data/ but escapes via "../other/"
+attack_child="$legit_vnx_data/../other/.vnx-data/dispatches"
+
+rc=0
+result="$(bash -c "
+    set -uo pipefail
+    source \"$GUARD_SH\"
+    vnx_dispatch_assert_dir_under \"$attack_child\" \"$legit_vnx_data\"; printf '%s\n' \"\$?\"
+" 2>/dev/null)" || rc=$?
+
+assert_eq "1" "$result" "TC1: path traversal via non-existent dir is rejected"
+
+# ---------------------------------------------------------------------------
+# TC2: unstamped dispatch quarantine
+#
+# Dispatches written to pending/ without a Project-ID: header must be quarantined
+# (moved to rejected_dir with a REJECTED marker) rather than accepted as legacy.
+# ---------------------------------------------------------------------------
+
+tc2_tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tc1_tmpdir" "$tc2_tmpdir"' EXIT
+
+pending_dir="$tc2_tmpdir/pending"
+quarantine_dir="$tc2_tmpdir/quarantine"
+mkdir -p "$pending_dir" "$quarantine_dir"
+
+dispatch_file="$pending_dir/unstamped-dispatch.md"
+cat > "$dispatch_file" <<'EOF'
+[[TARGET:A]]
+Manager Block
+
+Role: backend-developer
+Track: A
+Terminal: T1
+Gate: test-gate
+Dispatch-ID: test-unstamped-001
+
+Instruction:
+noop
+[[DONE]]
+EOF
+
+status_out="$(bash -c "
+    set -uo pipefail
+    source \"$META_SH\"
+    source \"$GUARD_SH\"
+    status=\$(vnx_dispatch_validate_project_id \"$dispatch_file\" \"vnx-dev\" \"$quarantine_dir\")
+    printf 'STATUS=%s\n' \"\$status\"
+" 2>/dev/null)"
+
+status_val="${status_out#STATUS=}"
+
+assert_eq "reject" "$status_val" "TC2: unstamped dispatch returns reject status"
+assert_file_missing "$dispatch_file" "TC2: unstamped dispatch removed from pending/"
+assert_file_exists "$quarantine_dir/unstamped-dispatch.md" "TC2: unstamped dispatch moved to quarantine"
+assert_file_contains "$quarantine_dir/unstamped-dispatch.md" "[REJECTED: unstamped dispatch]" "TC2: quarantine marker written"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi
+echo "ALL PASS: test_dispatch_project_guard.sh"


### PR DESCRIPTION
## Summary

Closes OI-1316 (PR #362 Codex re-audit findings). Addresses 4 finding scenarios:

- **Finding 1 — path traversal via non-existent dir**: `_vnx_dpg_canon()` now walks up to the deepest existing ancestor and canonicalizes from there, so `..` components in a non-existent path cannot escape the prefix check (bash `case "*"` matches `/`, making a raw `../other` suffix falsely satisfy the parent-prefix pattern).
- **Finding 2 — unstamped dispatch passthrough**: `vnx_dispatch_validate_project_id` now returns `reject`/1 for dispatches with no `Project-ID:` header instead of the former `legacy`/0 passthrough. The file is moved to `rejected_dir` with a `[REJECTED: unstamped dispatch]` marker.
- **Finding 3 — pr_queue_manager dispatch writer**: both template paths (`create_dispatch_from_pr` + `init_feature_batch`) now stamp `Project-ID: <value>` derived from `VNX_PROJECT_ID` env or `git rev-parse --show-toplevel` basename.
- **Finding 4 — headless_dispatch_writer dispatch writer**: `dispatch.json` payload now includes `project_id` field.

## Grep audit — dispatch writers verified to stamp Project-ID

```
scripts/pr_queue_manager.py:1022:  manager_block += f"\nProject-ID: {_get_project_id()}"
scripts/pr_queue_manager.py:1599:  Project-ID: {_get_project_id()}
scripts/lib/headless_dispatch_writer.py:215:  "project_id": _get_project_id(),
```

`scripts/promote_dispatch.py` does not exist. `subprocess_dispatch.py` is a delivery mechanism (not a dispatch file writer) — the dispatch `.md` file has already passed the guard before delivery is invoked.

## Test plan

- [x] `bash tests/test_dispatch_project_guard.sh` — 5/5 assertions pass (TC1: symlink-traversal, TC2: unstamped quarantine)
- [x] `pytest tests/test_cross_project_isolation.py -v` — 16/16 pass (includes updated `test_legacy_dispatch_quarantined`)
- [x] `bash -n scripts/lib/dispatch_project_guard.sh` — syntax clean
- [x] `bash -n tests/test_dispatch_project_guard.sh` — syntax clean

**Review-Stack**: gemini_review, codex_gate (run by T0 post-delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)