### PR TITLE
fix(dashboard): guard null in /operator/reports toLowerCase call

### DIFF
--- a/dashboard/token-dashboard/app/operator/reports/page.tsx
+++ b/dashboard/token-dashboard/app/operator/reports/page.tsx
@@ -41,7 +41,7 @@ function TrackBadge({ track }: { track: string }) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const cfg = STATUS_COLORS[status.toLowerCase()] ?? { color: 'var(--color-muted)', bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.1)' };
+  const cfg = STATUS_COLORS[(status ?? '').toLowerCase()] ?? { color: 'var(--color-muted)', bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.1)' };
   return (
     <span
       style={{


### PR DESCRIPTION
## Summary

- `StatusBadge` in `app/operator/reports/page.tsx` called `status.toLowerCase()` directly
- When `report.status` is `null` at runtime, the page threw `Cannot read properties of null (reading 'toLowerCase')`
- Fix: guard with `(status ?? '').toLowerCase()` — minimal one-line change at the call site

## Test plan

- [x] `npx playwright test e2e/console-errors.spec.ts -g "/operator/reports"` — passes
- [x] Full `npx playwright test e2e/console-errors.spec.ts` — 27/27 passed

Dispatch-ID: 20260506-dashboard-bug2-reports-null-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)