### PR TITLE
feat(strategy): roadmap.yaml schema + reader/writer Python module (Phase 2 W-state-1)

### DIFF
--- a/docs/architecture/STRATEGIC_STATE.md
+++ b/docs/architecture/STRATEGIC_STATE.md
@@ -36,12 +36,19 @@ from scripts.lib.strategy.roadmap import (
 )
 ```
 
-- `load_roadmap(path=None) -> Roadmap` — strict reader. Default path is
-  `<repo-root>/.vnx-data/strategy/roadmap.yaml`. Raises
-  `RoadmapValidationError` on schema violations. `schema_version` defaults
-  to `1` if absent (backwards-compat shim).
+- `load_roadmap(path=None, *, strict=True) -> Roadmap` — strict reader.
+  Default path is `<repo-root>/.vnx-data/strategy/roadmap.yaml`. Raises
+  `RoadmapValidationError` on parse-time violations (missing fields, bad
+  enums) **and** on cross-reference errors (duplicate `wave_id`, dangling
+  `depends_on`, etc.). `strict=False` skips the cross-reference pass and
+  returns a possibly-invalid `Roadmap` for tooling that wants to inspect
+  errors via `validate_roadmap()`. `schema_version` is enforced to equal
+  `1`; any other value (or no value, when not defaulted to `1`) raises.
 - `write_roadmap(roadmap, path=None) -> None` — structured writer that
-  serializes a `Roadmap` dataclass tree back to YAML.
+  validates the roadmap before serializing. Raises
+  `RoadmapValidationError` if cross-reference validation fails or
+  `schema_version != 1`. The target file is left untouched on failure
+  (validation runs before any I/O).
 - `validate_roadmap(roadmap) -> list[str]` — returns a list of error
   messages; an empty list means the roadmap is valid. Catches:
   - duplicate `wave_id` / `decision_id`
@@ -91,8 +98,21 @@ visible.
   mutate it through `write_roadmap()`.
 - It does not provide a CLI. `vnx status` (W-UX-3) is the operator-facing
   surface.
-- It does not migrate `schema_version`. Only `1` is supported; future
-  schema versions will need an explicit migration path.
+- It does not migrate `schema_version`. Only `1` is supported and is now
+  actively enforced by both `load_roadmap()` and `write_roadmap()`.
+  Introducing a future schema version (e.g. `2`) will require:
+  1. A migration script that reads `schema_version=1` and writes
+     `schema_version=2` with the new shape.
+  2. Updating the dataclasses + `_parse_*` helpers to accept the new
+     fields.
+  3. Bumping the `schema_version != 1` guards (or replacing them with a
+     supported-set check, e.g. `{1, 2}`) in both `load_roadmap()` and
+     `write_roadmap()`.
+  4. A round-trip test that an old `1`-shaped file migrates cleanly to
+     the new shape.
+
+  The placeholder is intentional: there is no `2` today, so the loader
+  fails loud rather than silently accepting unknown shapes.
 
 ## Forward look
 

--- a/docs/architecture/STRATEGIC_STATE.md
+++ b/docs/architecture/STRATEGIC_STATE.md
@@ -1,0 +1,124 @@
+# Strategic State (Layer 1)
+
+This document describes Layer 1 of the strategic-state design, materialized
+in this repo by Phase 2 wave **W-state-1**. Phase 2 of the master roadmap
+delivers the full Layer-1 stack across W-state-1 through W-state-5; this
+document is updated as each wave lands.
+
+For the broader three-layer state design, see
+`.vnx-data/state/PROJECT_STATE_DESIGN.md`.
+
+## The three layers in brief
+
+| Layer | Purpose                                                               | Lifetime               |
+|------:|------------------------------------------------------------------------|------------------------|
+| 1     | Strategic, durable, machine-readable plan + decisions                  | survives `/clear`      |
+| 2     | Memory + cross-domain learning artifacts                               | weeks–months           |
+| 3     | Runtime/transient state (receipts, events, dispatcher cooldown, etc.)  | minutes–hours          |
+
+Layer 1 is the layer T0 needs at SessionStart so it does not have to
+reconstruct context after a `/clear` boundary.
+
+## What W-state-1 delivers
+
+The `scripts/lib/strategy` Python package provides typed access to
+`.vnx-data/strategy/roadmap.yaml`, the committed source of truth for the
+multi-phase roadmap.
+
+### Public API
+
+```python
+from scripts.lib.strategy.roadmap import (
+    Roadmap, Phase, Wave, OperatorDecision,
+    load_roadmap, write_roadmap, validate_roadmap,
+    next_actionable_wave, dependents_of, phase_complete,
+    RoadmapValidationError,
+)
+```
+
+- `load_roadmap(path=None) -> Roadmap` — strict reader. Default path is
+  `<repo-root>/.vnx-data/strategy/roadmap.yaml`. Raises
+  `RoadmapValidationError` on schema violations. `schema_version` defaults
+  to `1` if absent (backwards-compat shim).
+- `write_roadmap(roadmap, path=None) -> None` — structured writer that
+  serializes a `Roadmap` dataclass tree back to YAML.
+- `validate_roadmap(roadmap) -> list[str]` — returns a list of error
+  messages; an empty list means the roadmap is valid. Catches:
+  - duplicate `wave_id` / `decision_id`
+  - dangling `depends_on` to undefined waves
+  - dangling `blocked_on` to undefined `od_<n>` / `td_<n>` decision IDs
+  - status enum violations on waves and decisions
+  - phases referencing undefined waves
+  - decisions whose `blocking_waves` reference undefined waves
+- `next_actionable_wave(roadmap) -> Wave | None` — returns the first wave
+  in declaration order that is `planned`, has all `depends_on` waves
+  `completed`, and all `blocked_on` decisions `closed`.
+- `dependents_of(wave_id, roadmap) -> list[Wave]` — reverse lookup of
+  `depends_on`.
+- `phase_complete(phase_id, roadmap) -> bool` — true iff every wave in the
+  phase has `status == 'completed'`.
+
+### Where the YAML lives
+
+`<repo-root>/.vnx-data/strategy/roadmap.yaml`
+
+This file is intentionally **committed** to the repo (a `.gitignore`
+exception): the roadmap is part of the project's durable knowledge.
+Runtime artifacts under `.vnx-data/` (dispatches, receipts, events) remain
+gitignored.
+
+### Mutation discipline
+
+Hand-edits to `roadmap.yaml` are still allowed for now (the file is
+human-readable and reviewable). Programmatic mutation, however, must
+always go through `write_roadmap()` so the schema is enforced and the
+output stays stable. **Never** write the YAML by hand from Python via
+raw `dict` -> `yaml.dump`; future tooling expects the dataclass round-trip.
+
+### Comment preservation
+
+The YAML round-trip helper (`scripts/lib/strategy/_yaml_io.py`) prefers
+`ruamel.yaml` when it is installed (then comments and key ordering survive
+a load → write cycle). When only PyYAML is available — the current state
+of the project — comments and free-form ordering may be lost on rewrite.
+A one-time stderr warning is emitted at first use to make the limitation
+visible.
+
+## What W-state-1 does *not* do
+
+- It does not mutate `roadmap.yaml`. The committed file is read-only for
+  this PR; only future wave helpers (mark-completed, append-history) will
+  mutate it through `write_roadmap()`.
+- It does not provide a CLI. `vnx status` (W-UX-3) is the operator-facing
+  surface.
+- It does not migrate `schema_version`. Only `1` is supported; future
+  schema versions will need an explicit migration path.
+
+## Forward look
+
+- **W-state-2**: append-only `decisions.ndjson` writer, file-locked, with
+  decision IDs `OD-YYYY-MM-DD-NNN` (operator) and `TD-YYYY-MM-DD-NNN`
+  (T0).
+- **W-state-3**: rewrite of `scripts/build_current_state.py` to consume
+  the typed roadmap module and the decisions tail. Replaces the
+  W-UX-2 quick projector with a schema-stable markdown renderer.
+- **W-state-4**: `prd_index.json` and `adr_index.json` builders for the
+  `docs/prds/` and `docs/adrs/` artifacts.
+- **W-state-5**: extension of `scripts/build_t0_state.py` so the
+  `strategic_state` block surfaces directly to T0 at SessionStart.
+  Feature-end gate; high-blast-radius wave.
+
+## Quick smoke test
+
+```bash
+python3 -c "
+from scripts.lib.strategy.roadmap import load_roadmap, validate_roadmap, next_actionable_wave
+r = load_roadmap()
+errs = validate_roadmap(r)
+assert errs == [], errs
+print('next:', next_actionable_wave(r).wave_id)
+"
+```
+
+If this prints the next-actionable wave id with no exception, Layer 1's
+read path is wired up correctly.

--- a/scripts/lib/strategy/__init__.py
+++ b/scripts/lib/strategy/__init__.py
@@ -1,0 +1,37 @@
+"""Strategy / Layer-1 state package.
+
+Public API:
+    Phase, Wave, OperatorDecision, Roadmap dataclasses
+    load_roadmap, write_roadmap, validate_roadmap
+    next_actionable_wave, dependents_of, phase_complete
+    RoadmapValidationError
+"""
+from __future__ import annotations
+
+from .roadmap import (
+    OperatorDecision,
+    Phase,
+    Roadmap,
+    RoadmapValidationError,
+    Wave,
+    dependents_of,
+    load_roadmap,
+    next_actionable_wave,
+    phase_complete,
+    validate_roadmap,
+    write_roadmap,
+)
+
+__all__ = [
+    "OperatorDecision",
+    "Phase",
+    "Roadmap",
+    "RoadmapValidationError",
+    "Wave",
+    "dependents_of",
+    "load_roadmap",
+    "next_actionable_wave",
+    "phase_complete",
+    "validate_roadmap",
+    "write_roadmap",
+]

--- a/scripts/lib/strategy/_yaml_io.py
+++ b/scripts/lib/strategy/_yaml_io.py
@@ -1,0 +1,94 @@
+"""YAML round-trip helper.
+
+Prefers ruamel.yaml (preserves comments) when available; otherwise falls
+back to PyYAML and emits a one-time stderr warning noting the comment-loss
+limitation. Callers should treat both as opaque: pass the file content as
+text/bytes, get back a Python dict.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+from typing import Any
+
+_BACKEND = "pyyaml"
+_RUAMEL = None
+_PYYAML = None
+
+try:  # pragma: no cover - exercised only when ruamel is vendored
+    import ruamel.yaml as _ruamel_module  # type: ignore[import-not-found]
+
+    _RUAMEL = _ruamel_module
+    _BACKEND = "ruamel"
+except Exception:  # noqa: BLE001 — we want any import error to fall through
+    _RUAMEL = None
+
+import yaml as _yaml  # PyYAML is a hard dep of the project
+
+_PYYAML = _yaml
+
+_WARNED = False
+
+
+def _warn_pyyaml_once() -> None:
+    global _WARNED
+    if _WARNED or _BACKEND == "ruamel":
+        return
+    _WARNED = True
+    print(
+        "[strategy._yaml_io] ruamel.yaml not installed; using PyYAML fallback "
+        "(comments and key ordering may not round-trip).",
+        file=sys.stderr,
+    )
+
+
+def backend_name() -> str:
+    """Return 'ruamel' or 'pyyaml' so callers / tests can introspect."""
+    return _BACKEND
+
+
+def load_yaml(path: Path) -> Any:
+    """Read a YAML file and return its parsed Python object."""
+    _warn_pyyaml_once()
+    text = Path(path).read_text(encoding="utf-8")
+    if _BACKEND == "ruamel":
+        yaml_obj = _RUAMEL.YAML(typ="rt")  # type: ignore[union-attr]
+        yaml_obj.preserve_quotes = True
+        return yaml_obj.load(text)
+    return _PYYAML.safe_load(text)
+
+
+def dump_yaml(data: Any, path: Path) -> None:
+    """Write `data` to `path` as YAML.
+
+    With PyYAML fallback, comments are not preserved. The writer enforces
+    `sort_keys=False` and `default_flow_style=False` for stable output.
+    """
+    _warn_pyyaml_once()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _BACKEND == "ruamel":
+        yaml_obj = _RUAMEL.YAML(typ="rt")  # type: ignore[union-attr]
+        yaml_obj.default_flow_style = False
+        with path.open("w", encoding="utf-8") as fh:
+            yaml_obj.dump(data, fh)
+        return
+    with path.open("w", encoding="utf-8") as fh:
+        _PYYAML.safe_dump(
+            data,
+            fh,
+            sort_keys=False,
+            default_flow_style=False,
+            allow_unicode=True,
+        )
+
+
+__all__ = ["backend_name", "load_yaml", "dump_yaml"]
+
+
+# Suppress benign PyYAML deprecation chatter triggered by older versions
+# during import on some platforms.
+warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module=r"yaml.*"
+)

--- a/scripts/lib/strategy/roadmap.py
+++ b/scripts/lib/strategy/roadmap.py
@@ -1,0 +1,534 @@
+"""Typed roadmap.yaml loader, validator, writer, and derived helpers.
+
+Layer 1 of the strategic-state design (PROJECT_STATE_DESIGN.md).
+This module is the single source of truth for roadmap dataclass types;
+all downstream tooling (decisions log, current_state.md projector,
+build_t0_state extension) binds to these types.
+
+Mutation discipline: never write the YAML by hand from Python — go
+through ``write_roadmap`` so the schema is enforced and the file is
+emitted with a stable layout.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from . import _yaml_io
+
+WAVE_STATUSES = ("planned", "in_progress", "completed", "deferred", "cancelled")
+RISK_CLASSES = ("low", "medium", "high", "critical")
+DECISION_STATUSES = ("open", "closed")
+
+# Strict decision-id reference (operator: od_<n>, T0: td_<n>). Anything else
+# in `blocked_on` is treated as a free-form external label (e.g. quota labels)
+# and is not subject to dangling-reference checks.
+_DECISION_ID_RE = re.compile(r"^(od|td)_\d+$")
+
+_DEFAULT_RELATIVE_PATH = Path(".vnx-data/strategy/roadmap.yaml")
+
+
+class RoadmapValidationError(ValueError):
+    """Raised when roadmap.yaml violates the schema at load time."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Phase:
+    phase_id: int
+    title: str
+    waves: list[str] = field(default_factory=list)
+    estimated_loc: int = 0
+    estimated_weeks: float = 0.0
+    blocked_on: list[str] = field(default_factory=list)
+    rationale: str | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class Wave:
+    wave_id: str
+    title: str
+    phase_id: int
+    status: str
+    estimated_loc: int | None = None
+    branch_name: str | None = None
+    review_stack: list[str] = field(default_factory=list)
+    risk_class: str = "low"
+    depends_on: list[str] = field(default_factory=list)
+    blocked_on: list[str] = field(default_factory=list)
+    pr: int | None = None
+    pr_number: int | None = None
+    completed_at: str | None = None
+    plan_path: str | None = None
+    notes: str | None = None
+    rationale: str | None = None
+
+
+@dataclass(frozen=True)
+class OperatorDecision:
+    decision_id: str
+    title: str
+    status: str
+    recommendation: str | None = None
+    decision: str | None = None
+    rationale: str | None = None
+    closed_at: str | None = None
+    blocking_waves: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Roadmap:
+    schema_version: int
+    roadmap_id: str
+    title: str
+    generated_at: str
+    phases: list[Phase] = field(default_factory=list)
+    waves: list[Wave] = field(default_factory=list)
+    operator_decisions: list[OperatorDecision] = field(default_factory=list)
+    completed_history: list[dict] = field(default_factory=list)
+    notes: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+def _git_root_from(start: Path) -> Path | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return Path(out).resolve() if out else None
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def _default_path() -> Path:
+    """Resolve the default roadmap.yaml path against the project root."""
+    here = Path(__file__).resolve().parent
+    root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
+    if root is None:
+        env_root = os.environ.get("VNX_CANONICAL_ROOT")
+        if env_root:
+            root = Path(env_root).resolve()
+        else:
+            root = Path.cwd().resolve()
+    return root / _DEFAULT_RELATIVE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+def _require(d: dict, key: str, where: str) -> Any:
+    if key not in d:
+        raise RoadmapValidationError(f"{where}: missing required key '{key}'")
+    return d[key]
+
+
+def _as_list(value: Any, where: str) -> list:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RoadmapValidationError(f"{where}: expected list, got {type(value).__name__}")
+    return list(value)
+
+
+def _parse_phase(raw: dict) -> Phase:
+    if not isinstance(raw, dict):
+        raise RoadmapValidationError(f"phase entry must be a mapping, got {type(raw).__name__}")
+    where = f"phase[{raw.get('phase_id', '?')}]"
+    return Phase(
+        phase_id=int(_require(raw, "phase_id", where)),
+        title=str(_require(raw, "title", where)),
+        waves=[str(w) for w in _as_list(raw.get("waves"), f"{where}.waves")],
+        estimated_loc=int(raw.get("estimated_loc") or 0),
+        estimated_weeks=float(raw.get("estimated_weeks") or 0.0),
+        blocked_on=[str(b) for b in _as_list(raw.get("blocked_on"), f"{where}.blocked_on")],
+        rationale=raw.get("rationale"),
+        notes=raw.get("notes"),
+    )
+
+
+def _parse_wave(raw: dict) -> Wave:
+    if not isinstance(raw, dict):
+        raise RoadmapValidationError(f"wave entry must be a mapping, got {type(raw).__name__}")
+    where = f"wave[{raw.get('wave_id', '?')}]"
+    status = str(_require(raw, "status", where))
+    if status not in WAVE_STATUSES:
+        raise RoadmapValidationError(
+            f"{where}: invalid status '{status}' (allowed: {', '.join(WAVE_STATUSES)})"
+        )
+    risk_class = str(raw.get("risk_class", "low"))
+    if risk_class not in RISK_CLASSES:
+        raise RoadmapValidationError(
+            f"{where}: invalid risk_class '{risk_class}' (allowed: {', '.join(RISK_CLASSES)})"
+        )
+    notes_value = raw.get("notes")
+    if notes_value is not None and not isinstance(notes_value, str):
+        notes_value = str(notes_value)
+    return Wave(
+        wave_id=str(_require(raw, "wave_id", where)),
+        title=str(_require(raw, "title", where)),
+        phase_id=int(_require(raw, "phase_id", where)),
+        status=status,
+        estimated_loc=(int(raw["estimated_loc"]) if raw.get("estimated_loc") is not None else None),
+        branch_name=raw.get("branch_name"),
+        review_stack=[str(r) for r in _as_list(raw.get("review_stack"), f"{where}.review_stack")],
+        risk_class=risk_class,
+        depends_on=[str(d) for d in _as_list(raw.get("depends_on"), f"{where}.depends_on")],
+        blocked_on=[str(b) for b in _as_list(raw.get("blocked_on"), f"{where}.blocked_on")],
+        pr=(int(raw["pr"]) if raw.get("pr") is not None else None),
+        pr_number=(int(raw["pr_number"]) if raw.get("pr_number") is not None else None),
+        completed_at=(str(raw["completed_at"]) if raw.get("completed_at") is not None else None),
+        plan_path=raw.get("plan_path"),
+        notes=notes_value,
+        rationale=raw.get("rationale"),
+    )
+
+
+def _parse_decision(raw: dict) -> OperatorDecision:
+    if not isinstance(raw, dict):
+        raise RoadmapValidationError(
+            f"operator_decisions entry must be a mapping, got {type(raw).__name__}"
+        )
+    where = f"operator_decisions[{raw.get('decision_id', '?')}]"
+    status = str(_require(raw, "status", where))
+    if status not in DECISION_STATUSES:
+        raise RoadmapValidationError(
+            f"{where}: invalid status '{status}' (allowed: {', '.join(DECISION_STATUSES)})"
+        )
+    return OperatorDecision(
+        decision_id=str(_require(raw, "decision_id", where)),
+        title=str(_require(raw, "title", where)),
+        status=status,
+        recommendation=raw.get("recommendation"),
+        decision=raw.get("decision"),
+        rationale=raw.get("rationale"),
+        closed_at=(str(raw["closed_at"]) if raw.get("closed_at") is not None else None),
+        blocking_waves=[
+            str(w) for w in _as_list(raw.get("blocking_waves"), f"{where}.blocking_waves")
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def load_roadmap(path: Path | None = None) -> Roadmap:
+    """Strict reader. Returns a typed Roadmap; raises on schema violations.
+
+    `schema_version` defaults to 1 if absent (backwards-compat shim).
+    """
+    target = Path(path) if path is not None else _default_path()
+    if not target.exists():
+        raise RoadmapValidationError(f"roadmap file not found: {target}")
+    data = _yaml_io.load_yaml(target)
+    if data is None:
+        raise RoadmapValidationError(f"roadmap file is empty: {target}")
+    if not isinstance(data, dict):
+        raise RoadmapValidationError(
+            f"roadmap root must be a mapping, got {type(data).__name__}"
+        )
+
+    schema_version = int(data.get("schema_version", 1))
+    roadmap_id = str(data.get("roadmap_id", ""))
+    title = str(data.get("title", ""))
+    generated_at = str(data.get("generated_at", ""))
+
+    phases_raw = _as_list(data.get("phases"), "phases")
+    waves_raw = _as_list(data.get("waves"), "waves")
+    decisions_raw = _as_list(data.get("operator_decisions"), "operator_decisions")
+    completed_history_raw = _as_list(data.get("completed_history"), "completed_history")
+    notes_raw = data.get("notes") or {}
+    if not isinstance(notes_raw, dict):
+        raise RoadmapValidationError(
+            f"notes must be a mapping, got {type(notes_raw).__name__}"
+        )
+
+    phases = [_parse_phase(p) for p in phases_raw]
+    waves = [_parse_wave(w) for w in waves_raw]
+    decisions = [_parse_decision(d) for d in decisions_raw]
+    completed_history = [
+        dict(entry) if isinstance(entry, dict) else {"value": entry}
+        for entry in completed_history_raw
+    ]
+
+    return Roadmap(
+        schema_version=schema_version,
+        roadmap_id=roadmap_id,
+        title=title,
+        generated_at=generated_at,
+        phases=phases,
+        waves=waves,
+        operator_decisions=decisions,
+        completed_history=completed_history,
+        notes=dict(notes_raw),
+    )
+
+
+def _wave_to_dict(w: Wave) -> dict:
+    """Serialize a Wave omitting None / empty-list fields for clean YAML output."""
+    raw: dict[str, Any] = {
+        "wave_id": w.wave_id,
+        "title": w.title,
+        "phase_id": w.phase_id,
+        "status": w.status,
+    }
+    optional_scalars = (
+        "estimated_loc",
+        "branch_name",
+        "pr",
+        "pr_number",
+        "completed_at",
+        "plan_path",
+        "notes",
+        "rationale",
+    )
+    for key in optional_scalars:
+        value = getattr(w, key)
+        if value is not None:
+            raw[key] = value
+    if w.review_stack:
+        raw["review_stack"] = list(w.review_stack)
+    raw["risk_class"] = w.risk_class
+    if w.depends_on:
+        raw["depends_on"] = list(w.depends_on)
+    if w.blocked_on:
+        raw["blocked_on"] = list(w.blocked_on)
+    return raw
+
+
+def _phase_to_dict(p: Phase) -> dict:
+    raw: dict[str, Any] = {
+        "phase_id": p.phase_id,
+        "title": p.title,
+        "waves": list(p.waves),
+        "estimated_loc": p.estimated_loc,
+        "estimated_weeks": p.estimated_weeks,
+        "blocked_on": list(p.blocked_on),
+    }
+    if p.rationale is not None:
+        raw["rationale"] = p.rationale
+    if p.notes is not None:
+        raw["notes"] = p.notes
+    return raw
+
+
+def _decision_to_dict(d: OperatorDecision) -> dict:
+    raw: dict[str, Any] = {
+        "decision_id": d.decision_id,
+        "title": d.title,
+        "status": d.status,
+    }
+    if d.recommendation is not None:
+        raw["recommendation"] = d.recommendation
+    if d.decision is not None:
+        raw["decision"] = d.decision
+    if d.rationale is not None:
+        raw["rationale"] = d.rationale
+    if d.closed_at is not None:
+        raw["closed_at"] = d.closed_at
+    if d.blocking_waves:
+        raw["blocking_waves"] = list(d.blocking_waves)
+    return raw
+
+
+def write_roadmap(roadmap: Roadmap, path: Path | None = None) -> None:
+    """Structured writer. Comments are not preserved with PyYAML fallback."""
+    target = Path(path) if path is not None else _default_path()
+    payload: dict[str, Any] = {
+        "schema_version": roadmap.schema_version,
+        "roadmap_id": roadmap.roadmap_id,
+        "title": roadmap.title,
+        "generated_at": roadmap.generated_at,
+        "phases": [_phase_to_dict(p) for p in roadmap.phases],
+        "waves": [_wave_to_dict(w) for w in roadmap.waves],
+        "operator_decisions": [_decision_to_dict(d) for d in roadmap.operator_decisions],
+        "completed_history": [dict(entry) for entry in roadmap.completed_history],
+        "notes": dict(roadmap.notes),
+    }
+    _yaml_io.dump_yaml(payload, target)
+
+
+def validate_roadmap(roadmap: Roadmap) -> list[str]:
+    """Return a list of validation error messages; empty list means valid.
+
+    Catches:
+      - missing schema_version (warning; default applied at load time)
+      - dangling depends_on (wave_id referenced but not defined)
+      - dangling blocked_on (decision_id referenced but not defined)
+      - status enum violations (also caught at parse time, double-checked here)
+      - duplicate wave_ids
+      - duplicate decision_ids
+      - phase.waves referencing undefined waves
+      - wave.phase_id referencing undefined phase
+    """
+    errors: list[str] = []
+
+    if roadmap.schema_version is None:  # type: ignore[redundant-expr]
+        errors.append("warning: schema_version missing (defaulted to 1)")
+
+    wave_ids = [w.wave_id for w in roadmap.waves]
+    seen: set[str] = set()
+    for wid in wave_ids:
+        if wid in seen:
+            errors.append(f"duplicate wave_id: {wid}")
+        seen.add(wid)
+    wave_id_set = set(wave_ids)
+
+    decision_ids = [d.decision_id for d in roadmap.operator_decisions]
+    seen_dec: set[str] = set()
+    for did in decision_ids:
+        if did in seen_dec:
+            errors.append(f"duplicate decision_id: {did}")
+        seen_dec.add(did)
+    decision_id_set = set(decision_ids)
+
+    phase_id_set = {p.phase_id for p in roadmap.phases}
+
+    for w in roadmap.waves:
+        if w.status not in WAVE_STATUSES:
+            errors.append(f"wave {w.wave_id}: invalid status '{w.status}'")
+        if w.risk_class not in RISK_CLASSES:
+            errors.append(f"wave {w.wave_id}: invalid risk_class '{w.risk_class}'")
+        if w.phase_id not in phase_id_set:
+            errors.append(
+                f"wave {w.wave_id}: phase_id {w.phase_id} not present in phases list"
+            )
+        for dep in w.depends_on:
+            if dep not in wave_id_set:
+                errors.append(
+                    f"wave {w.wave_id}: dangling depends_on '{dep}' (no such wave)"
+                )
+        for blk in w.blocked_on:
+            if blk in decision_id_set or blk in wave_id_set:
+                continue
+            if _DECISION_ID_RE.match(blk):
+                # Looks like a canonical decision_id but isn't defined.
+                errors.append(
+                    f"wave {w.wave_id}: dangling blocked_on '{blk}' "
+                    f"(decision_id not defined in operator_decisions)"
+                )
+            # Otherwise free-form external label (e.g. 'gemini_quota_recovery'); ignore.
+
+    for d in roadmap.operator_decisions:
+        if d.status not in DECISION_STATUSES:
+            errors.append(f"decision {d.decision_id}: invalid status '{d.status}'")
+        for w_ref in d.blocking_waves:
+            if w_ref not in wave_id_set:
+                errors.append(
+                    f"decision {d.decision_id}: blocking_waves references "
+                    f"undefined wave '{w_ref}'"
+                )
+
+    for p in roadmap.phases:
+        for w_ref in p.waves:
+            if w_ref not in wave_id_set:
+                errors.append(
+                    f"phase {p.phase_id}: waves list references undefined wave '{w_ref}'"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Derived helpers
+# ---------------------------------------------------------------------------
+def next_actionable_wave(roadmap: Roadmap) -> Wave | None:
+    """Return the first wave that is ready to start.
+
+    A wave is ready when:
+      - status == 'planned'
+      - every depends_on wave has status == 'completed'
+      - every blocked_on operator_decision has status == 'closed'
+        (entries in blocked_on that match a wave_id must be 'completed')
+
+    Order: roadmap.waves list order — deterministic by definition.
+    """
+    wave_status = {w.wave_id: w.status for w in roadmap.waves}
+    decision_status = {d.decision_id: d.status for d in roadmap.operator_decisions}
+
+    for w in roadmap.waves:
+        if w.status != "planned":
+            continue
+        deps_ok = all(wave_status.get(dep) == "completed" for dep in w.depends_on)
+        if not deps_ok:
+            continue
+        blocks_ok = True
+        for blk in w.blocked_on:
+            if blk in decision_status:
+                if decision_status[blk] != "closed":
+                    blocks_ok = False
+                    break
+            elif blk in wave_status:
+                if wave_status[blk] != "completed":
+                    blocks_ok = False
+                    break
+            else:
+                # Unknown reference — treat as still blocking; validate_roadmap
+                # will surface it as a dangling reference.
+                blocks_ok = False
+                break
+        if not blocks_ok:
+            continue
+        return w
+    return None
+
+
+def dependents_of(wave_id: str, roadmap: Roadmap) -> list[Wave]:
+    """Return waves whose depends_on includes ``wave_id``."""
+    return [w for w in roadmap.waves if wave_id in w.depends_on]
+
+
+def phase_complete(phase_id: int, roadmap: Roadmap) -> bool:
+    """True iff every wave assigned to ``phase_id`` is completed."""
+    waves_in_phase = [w for w in roadmap.waves if w.phase_id == phase_id]
+    if not waves_in_phase:
+        return False
+    return all(w.status == "completed" for w in waves_in_phase)
+
+
+# ---------------------------------------------------------------------------
+# Test/utility helpers (re-exported)
+# ---------------------------------------------------------------------------
+def roadmap_to_dict(roadmap: Roadmap) -> dict:
+    """Serialize Roadmap to plain dict — used by tests / debugging only."""
+    return {
+        "schema_version": roadmap.schema_version,
+        "roadmap_id": roadmap.roadmap_id,
+        "title": roadmap.title,
+        "generated_at": roadmap.generated_at,
+        "phases": [asdict(p) for p in roadmap.phases],
+        "waves": [asdict(w) for w in roadmap.waves],
+        "operator_decisions": [asdict(d) for d in roadmap.operator_decisions],
+        "completed_history": [dict(e) for e in roadmap.completed_history],
+        "notes": dict(roadmap.notes),
+    }
+
+
+__all__ = [
+    "DECISION_STATUSES",
+    "OperatorDecision",
+    "Phase",
+    "RISK_CLASSES",
+    "Roadmap",
+    "RoadmapValidationError",
+    "WAVE_STATUSES",
+    "Wave",
+    "dependents_of",
+    "load_roadmap",
+    "next_actionable_wave",
+    "phase_complete",
+    "replace",
+    "roadmap_to_dict",
+    "validate_roadmap",
+    "write_roadmap",
+]

--- a/scripts/lib/strategy/roadmap.py
+++ b/scripts/lib/strategy/roadmap.py
@@ -33,7 +33,22 @@ _DEFAULT_RELATIVE_PATH = Path(".vnx-data/strategy/roadmap.yaml")
 
 
 class RoadmapValidationError(ValueError):
-    """Raised when roadmap.yaml violates the schema at load time."""
+    """Raised when roadmap.yaml violates the schema at load or write time.
+
+    Accepts either a single message string (parse-time errors) or a list of
+    error messages (cross-reference validation). The ``errors`` attribute is
+    always a list for programmatic access.
+    """
+
+    def __init__(self, errors):
+        if isinstance(errors, list):
+            self.errors = list(errors)
+            joined = "\n  - ".join(self.errors) if self.errors else "(no details)"
+            message = f"roadmap validation failed:\n  - {joined}"
+        else:
+            self.errors = [str(errors)]
+            message = str(errors)
+        super().__init__(message)
 
 
 # ---------------------------------------------------------------------------
@@ -222,10 +237,20 @@ def _parse_decision(raw: dict) -> OperatorDecision:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-def load_roadmap(path: Path | None = None) -> Roadmap:
+def load_roadmap(path: Path | None = None, *, strict: bool = True) -> Roadmap:
     """Strict reader. Returns a typed Roadmap; raises on schema violations.
 
-    `schema_version` defaults to 1 if absent (backwards-compat shim).
+    Behavior:
+      - ``schema_version`` is enforced to equal ``1``. Unsupported versions
+        raise ``RoadmapValidationError`` immediately. The default value when
+        absent is ``1`` (backwards-compat shim).
+      - When ``strict=True`` (the default) the loader runs
+        ``validate_roadmap()`` after parsing and raises
+        ``RoadmapValidationError`` if any cross-reference errors are found
+        (duplicate wave_ids, dangling depends_on/blocked_on, etc.).
+      - When ``strict=False`` the loader returns the parsed Roadmap without
+        running cross-reference validation. Use this when you want to
+        inspect a possibly-invalid roadmap (tooling that reports errors).
     """
     target = Path(path) if path is not None else _default_path()
     if not target.exists():
@@ -239,6 +264,10 @@ def load_roadmap(path: Path | None = None) -> Roadmap:
         )
 
     schema_version = int(data.get("schema_version", 1))
+    if schema_version != 1:
+        raise RoadmapValidationError(
+            [f"Unsupported schema_version: {schema_version} (expected 1)"]
+        )
     roadmap_id = str(data.get("roadmap_id", ""))
     title = str(data.get("title", ""))
     generated_at = str(data.get("generated_at", ""))
@@ -261,7 +290,7 @@ def load_roadmap(path: Path | None = None) -> Roadmap:
         for entry in completed_history_raw
     ]
 
-    return Roadmap(
+    roadmap = Roadmap(
         schema_version=schema_version,
         roadmap_id=roadmap_id,
         title=title,
@@ -272,6 +301,13 @@ def load_roadmap(path: Path | None = None) -> Roadmap:
         completed_history=completed_history,
         notes=dict(notes_raw),
     )
+
+    if strict:
+        errors = validate_roadmap(roadmap)
+        if errors:
+            raise RoadmapValidationError(errors)
+
+    return roadmap
 
 
 def _wave_to_dict(w: Wave) -> dict:
@@ -342,7 +378,23 @@ def _decision_to_dict(d: OperatorDecision) -> dict:
 
 
 def write_roadmap(roadmap: Roadmap, path: Path | None = None) -> None:
-    """Structured writer. Comments are not preserved with PyYAML fallback."""
+    """Structured writer. Validates the roadmap before persisting.
+
+    Raises ``RoadmapValidationError`` if cross-reference validation fails or
+    if ``schema_version`` is not the supported value (``1``). The target file
+    is left untouched on failure: validation runs before any I/O.
+
+    Comments are not preserved with the PyYAML fallback; install
+    ``ruamel.yaml`` to round-trip comments.
+    """
+    if roadmap.schema_version != 1:
+        raise RoadmapValidationError(
+            [f"Unsupported schema_version: {roadmap.schema_version} (expected 1)"]
+        )
+    errors = validate_roadmap(roadmap)
+    if errors:
+        raise RoadmapValidationError(errors)
+
     target = Path(path) if path is not None else _default_path()
     payload: dict[str, Any] = {
         "schema_version": roadmap.schema_version,

--- a/tests/test_strategy_roadmap.py
+++ b/tests/test_strategy_roadmap.py
@@ -101,7 +101,7 @@ def test_reject_duplicate_wave_id(tmp_path: Path) -> None:
         }
     )
     path = _write_payload(tmp_path, payload)
-    roadmap = load_roadmap(path)
+    roadmap = load_roadmap(path, strict=False)
     errors = validate_roadmap(roadmap)
     assert any("duplicate wave_id: wave-a" in e for e in errors)
 
@@ -110,7 +110,7 @@ def test_reject_dangling_depends_on(tmp_path: Path) -> None:
     payload = _minimal_payload()
     payload["waves"][1]["depends_on"] = ["wave-zzz"]
     path = _write_payload(tmp_path, payload)
-    roadmap = load_roadmap(path)
+    roadmap = load_roadmap(path, strict=False)
     errors = validate_roadmap(roadmap)
     assert any("dangling depends_on 'wave-zzz'" in e for e in errors)
 
@@ -122,7 +122,7 @@ def test_reject_dangling_blocked_on(tmp_path: Path) -> None:
         {"decision_id": "od_1", "title": "real", "status": "open"},
     ]
     path = _write_payload(tmp_path, payload)
-    roadmap = load_roadmap(path)
+    roadmap = load_roadmap(path, strict=False)
     errors = validate_roadmap(roadmap)
     assert any("dangling blocked_on 'od_99'" in e for e in errors)
 
@@ -282,7 +282,7 @@ def test_validate_phase_waves_undefined(tmp_path: Path) -> None:
     payload = _minimal_payload()
     payload["phases"][0]["waves"].append("wave-ghost")
     path = _write_payload(tmp_path, payload)
-    roadmap = load_roadmap(path)
+    roadmap = load_roadmap(path, strict=False)
     errors = validate_roadmap(roadmap)
     assert any("wave-ghost" in e for e in errors)
 
@@ -298,7 +298,7 @@ def test_validate_decision_blocking_waves_undefined(tmp_path: Path) -> None:
         }
     ]
     path = _write_payload(tmp_path, payload)
-    roadmap = load_roadmap(path)
+    roadmap = load_roadmap(path, strict=False)
     errors = validate_roadmap(roadmap)
     assert any("wave-ghost" in e for e in errors)
 
@@ -358,3 +358,188 @@ def test_construct_dataclasses_directly() -> None:
         operator_decisions=[d],
     )
     assert validate_roadmap(r) == []
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward regression tests for codex_gate findings on PR #410
+# (Phase 2 W-state-1 fix-forward, dispatch 20260506-phase02-wstate1-fixforward)
+# ---------------------------------------------------------------------------
+def test_write_roadmap_rejects_duplicate_wave_ids_and_leaves_file_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Finding 1 (BLOCKING): write_roadmap() must validate before persisting.
+
+    Synthesize a Roadmap with duplicate wave_ids → write_roadmap raises
+    RoadmapValidationError; the target file is not created/modified.
+    """
+    phase = Phase(phase_id=0, title="P", waves=["wave-a", "wave-a"])
+    wave_a = Wave(
+        wave_id="wave-a",
+        title="First",
+        phase_id=0,
+        status="planned",
+    )
+    wave_a_dup = Wave(
+        wave_id="wave-a",
+        title="Duplicate",
+        phase_id=0,
+        status="planned",
+    )
+    bad = Roadmap(
+        schema_version=1,
+        roadmap_id="bad",
+        title="Bad roadmap",
+        generated_at="2026-05-06T00:00:00Z",
+        phases=[phase],
+        waves=[wave_a, wave_a_dup],
+    )
+
+    sentinel = "untouched-original-content\n"
+    out_path = tmp_path / "preexisting.yaml"
+    out_path.write_text(sentinel, encoding="utf-8")
+
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        write_roadmap(bad, out_path)
+    assert any("duplicate wave_id: wave-a" in e for e in excinfo.value.errors)
+    # File must not have been overwritten by the failed write.
+    assert out_path.read_text(encoding="utf-8") == sentinel
+
+    # And a fresh path must not be created when validation fails.
+    fresh_path = tmp_path / "should-not-exist.yaml"
+    with pytest.raises(RoadmapValidationError):
+        write_roadmap(bad, fresh_path)
+    assert not fresh_path.exists()
+
+
+def test_write_roadmap_rejects_dangling_depends_on(tmp_path: Path) -> None:
+    """write_roadmap() must catch dangling depends_on too, not just dupes."""
+    phase = Phase(phase_id=0, title="P", waves=["wave-a"])
+    wave = Wave(
+        wave_id="wave-a",
+        title="W",
+        phase_id=0,
+        status="planned",
+        depends_on=["wave-ghost"],
+    )
+    bad = Roadmap(
+        schema_version=1,
+        roadmap_id="bad",
+        title="t",
+        generated_at="2026-05-06T00:00:00Z",
+        phases=[phase],
+        waves=[wave],
+    )
+    out_path = tmp_path / "out.yaml"
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        write_roadmap(bad, out_path)
+    assert any("wave-ghost" in e for e in excinfo.value.errors)
+    assert not out_path.exists()
+
+
+def test_load_roadmap_strict_by_default_raises_on_dangling_depends_on(
+    tmp_path: Path,
+) -> None:
+    """Finding 2 (advisory): load_roadmap() runs validate_roadmap() by default.
+
+    A roadmap with dangling depends_on must raise on load (not silently return
+    an invalid Roadmap that only fails when validate_roadmap is called).
+    """
+    payload = _minimal_payload()
+    payload["waves"][1]["depends_on"] = ["wave-zzz"]
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        load_roadmap(path)
+    assert any("wave-zzz" in e for e in excinfo.value.errors)
+
+
+def test_load_roadmap_strict_by_default_raises_on_duplicate_wave_id(
+    tmp_path: Path,
+) -> None:
+    payload = _minimal_payload()
+    payload["waves"].append(
+        {
+            "wave_id": "wave-a",
+            "title": "Duplicate",
+            "phase_id": 0,
+            "status": "planned",
+        }
+    )
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        load_roadmap(path)
+    assert any("duplicate wave_id: wave-a" in e for e in excinfo.value.errors)
+
+
+def test_load_roadmap_strict_false_returns_invalid_roadmap(tmp_path: Path) -> None:
+    """strict=False is the parse-only mode: returns Roadmap, no cross-check raise."""
+    payload = _minimal_payload()
+    payload["waves"][1]["depends_on"] = ["wave-zzz"]
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path, strict=False)
+    # No raise — and the validator still surfaces the issue when called manually.
+    errors = validate_roadmap(roadmap)
+    assert any("wave-zzz" in e for e in errors)
+
+
+def test_load_roadmap_rejects_unsupported_schema_version(tmp_path: Path) -> None:
+    """Finding 3 (advisory): only schema_version=1 is supported."""
+    payload = _minimal_payload()
+    payload["schema_version"] = 2
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        load_roadmap(path)
+    msg = str(excinfo.value)
+    assert "schema_version" in msg
+    assert "2" in msg
+
+
+def test_load_roadmap_rejects_unsupported_schema_version_in_strict_false_mode(
+    tmp_path: Path,
+) -> None:
+    """schema_version enforcement runs before strict cross-checks → strict=False
+    cannot bypass it.
+    """
+    payload = _minimal_payload()
+    payload["schema_version"] = 99
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError):
+        load_roadmap(path, strict=False)
+
+
+def test_write_roadmap_rejects_unsupported_schema_version(tmp_path: Path) -> None:
+    """write_roadmap must also enforce schema_version."""
+    phase = Phase(phase_id=0, title="P", waves=["wave-a"])
+    wave = Wave(wave_id="wave-a", title="W", phase_id=0, status="planned")
+    bad = Roadmap(
+        schema_version=2,
+        roadmap_id="rid",
+        title="t",
+        generated_at="2026-05-06T00:00:00Z",
+        phases=[phase],
+        waves=[wave],
+    )
+    out_path = tmp_path / "out.yaml"
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        write_roadmap(bad, out_path)
+    assert "schema_version" in str(excinfo.value)
+    assert not out_path.exists()
+
+
+def test_load_roadmap_accepts_schema_version_1(tmp_path: Path) -> None:
+    """The supported schema_version=1 still loads cleanly."""
+    payload = _minimal_payload()
+    payload["schema_version"] = 1
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)  # strict default — must not raise
+    assert roadmap.schema_version == 1
+
+
+def test_roadmap_validation_error_exposes_errors_attribute() -> None:
+    """RoadmapValidationError.errors must be a list for programmatic access."""
+    err = RoadmapValidationError(["a", "b"])
+    assert err.errors == ["a", "b"]
+    assert "a" in str(err) and "b" in str(err)
+    # Single-string form is wrapped in a list too.
+    err_single = RoadmapValidationError("plain message")
+    assert err_single.errors == ["plain message"]
+    assert "plain message" in str(err_single)

--- a/tests/test_strategy_roadmap.py
+++ b/tests/test_strategy_roadmap.py
@@ -1,0 +1,360 @@
+"""Unit tests for scripts.lib.strategy.roadmap."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.strategy.roadmap import (  # noqa: E402
+    OperatorDecision,
+    Phase,
+    Roadmap,
+    RoadmapValidationError,
+    Wave,
+    dependents_of,
+    load_roadmap,
+    next_actionable_wave,
+    phase_complete,
+    validate_roadmap,
+    write_roadmap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+def _minimal_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "roadmap_id": "test-roadmap",
+        "title": "Test roadmap",
+        "generated_at": "2026-05-06T00:00:00Z",
+        "phases": [
+            {
+                "phase_id": 0,
+                "title": "Test phase",
+                "waves": ["wave-a", "wave-b"],
+                "estimated_loc": 100,
+                "estimated_weeks": 0.5,
+                "blocked_on": [],
+            },
+        ],
+        "waves": [
+            {
+                "wave_id": "wave-a",
+                "title": "First wave",
+                "phase_id": 0,
+                "status": "planned",
+                "risk_class": "low",
+                "depends_on": [],
+                "blocked_on": [],
+            },
+            {
+                "wave_id": "wave-b",
+                "title": "Second wave",
+                "phase_id": 0,
+                "status": "planned",
+                "risk_class": "low",
+                "depends_on": ["wave-a"],
+                "blocked_on": [],
+            },
+        ],
+        "operator_decisions": [],
+        "completed_history": [],
+        "notes": {},
+    }
+
+
+def _write_payload(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "roadmap.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_load_valid_committed_roadmap() -> None:
+    """The committed .vnx-data/strategy/roadmap.yaml must load and validate."""
+    roadmap = load_roadmap()
+    errors = validate_roadmap(roadmap)
+    assert errors == [], f"unexpected validation errors: {errors}"
+    assert roadmap.schema_version >= 1
+    assert len(roadmap.phases) > 0
+    assert len(roadmap.waves) > 0
+
+
+def test_reject_duplicate_wave_id(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"].append(
+        {
+            "wave_id": "wave-a",
+            "title": "Duplicate",
+            "phase_id": 0,
+            "status": "planned",
+        }
+    )
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    assert any("duplicate wave_id: wave-a" in e for e in errors)
+
+
+def test_reject_dangling_depends_on(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"][1]["depends_on"] = ["wave-zzz"]
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    assert any("dangling depends_on 'wave-zzz'" in e for e in errors)
+
+
+def test_reject_dangling_blocked_on(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"][0]["blocked_on"] = ["od_99"]
+    payload["operator_decisions"] = [
+        {"decision_id": "od_1", "title": "real", "status": "open"},
+    ]
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    assert any("dangling blocked_on 'od_99'" in e for e in errors)
+
+
+def test_status_enum_violation(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"][0]["status"] = "unknown"
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError, match="invalid status"):
+        load_roadmap(path)
+
+
+def test_decision_status_enum_violation(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["operator_decisions"] = [
+        {"decision_id": "od_1", "title": "x", "status": "pending"},
+    ]
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError, match="invalid status"):
+        load_roadmap(path)
+
+
+def test_missing_required_field_raises(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"][0].pop("status")
+    path = _write_payload(tmp_path, payload)
+    with pytest.raises(RoadmapValidationError, match="missing required key 'status'"):
+        load_roadmap(path)
+
+
+def test_next_actionable_wave_respects_depends_on(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    actionable = next_actionable_wave(roadmap)
+    assert actionable is not None
+    assert actionable.wave_id == "wave-a"
+
+    payload["waves"][0]["status"] = "completed"
+    payload["waves"][0]["completed_at"] = "2026-05-06"
+    path2 = _write_payload(tmp_path, payload)
+    roadmap2 = load_roadmap(path2)
+    actionable2 = next_actionable_wave(roadmap2)
+    assert actionable2 is not None
+    assert actionable2.wave_id == "wave-b"
+
+
+def test_next_actionable_wave_respects_blocked_on(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["operator_decisions"] = [
+        {"decision_id": "od_1", "title": "open one", "status": "open"},
+        {"decision_id": "od_2", "title": "closed one", "status": "closed"},
+    ]
+    payload["waves"][0]["blocked_on"] = ["od_1"]  # blocks wave-a
+    payload["waves"][1]["blocked_on"] = ["od_2"]  # closed → wave-b unblocked
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    actionable = next_actionable_wave(roadmap)
+    # wave-a is blocked by open od_1; wave-b depends on wave-a (still planned).
+    # So no wave is actionable.
+    assert actionable is None
+
+    # Detach wave-b's dependency on wave-a → wave-b becomes actionable.
+    payload["waves"][1]["depends_on"] = []
+    path2 = _write_payload(tmp_path, payload)
+    roadmap2 = load_roadmap(path2)
+    actionable2 = next_actionable_wave(roadmap2)
+    assert actionable2 is not None
+    assert actionable2.wave_id == "wave-b"
+
+
+def test_next_actionable_wave_returns_none_when_all_done(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    for w in payload["waves"]:
+        w["status"] = "completed"
+        w["completed_at"] = "2026-05-06"
+    path = _write_payload(tmp_path, payload)
+    assert next_actionable_wave(load_roadmap(path)) is None
+
+
+def test_round_trip_stable(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["waves"][0]["estimated_loc"] = 50
+    payload["waves"][0]["branch_name"] = "feat/test"
+    payload["waves"][0]["review_stack"] = ["gemini_review"]
+    payload["operator_decisions"] = [
+        {
+            "decision_id": "od_1",
+            "title": "Sample decision",
+            "status": "closed",
+            "decision": "go",
+            "closed_at": "2026-05-06",
+        },
+    ]
+    path = _write_payload(tmp_path, payload)
+    roadmap_a = load_roadmap(path)
+
+    out_path = tmp_path / "out.yaml"
+    write_roadmap(roadmap_a, out_path)
+    roadmap_b = load_roadmap(out_path)
+
+    assert roadmap_a == roadmap_b
+
+
+def test_schema_version_defaults_to_1(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload.pop("schema_version")
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    assert roadmap.schema_version == 1
+
+
+def test_dependents_of(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    dependents = dependents_of("wave-a", roadmap)
+    assert [w.wave_id for w in dependents] == ["wave-b"]
+
+
+def test_phase_complete(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    assert phase_complete(0, roadmap) is False
+
+    payload["waves"][0]["status"] = "completed"
+    payload["waves"][1]["status"] = "completed"
+    path2 = _write_payload(tmp_path, payload)
+    roadmap2 = load_roadmap(path2)
+    assert phase_complete(0, roadmap2) is True
+
+    # Unknown phase — no waves → not complete.
+    assert phase_complete(99, roadmap2) is False
+
+
+def test_load_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(RoadmapValidationError, match="not found"):
+        load_roadmap(tmp_path / "nope.yaml")
+
+
+def test_load_empty_file_raises(tmp_path: Path) -> None:
+    path = tmp_path / "empty.yaml"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(RoadmapValidationError, match="empty"):
+        load_roadmap(path)
+
+
+def test_load_non_mapping_root_raises(tmp_path: Path) -> None:
+    path = tmp_path / "list.yaml"
+    path.write_text("- a\n- b\n", encoding="utf-8")
+    with pytest.raises(RoadmapValidationError, match="must be a mapping"):
+        load_roadmap(path)
+
+
+def test_validate_phase_waves_undefined(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["phases"][0]["waves"].append("wave-ghost")
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    assert any("wave-ghost" in e for e in errors)
+
+
+def test_validate_decision_blocking_waves_undefined(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["operator_decisions"] = [
+        {
+            "decision_id": "od_1",
+            "title": "x",
+            "status": "open",
+            "blocking_waves": ["wave-ghost"],
+        }
+    ]
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    assert any("wave-ghost" in e for e in errors)
+
+
+def test_validate_freeform_blocked_on_label_passes(tmp_path: Path) -> None:
+    """Free-form labels (not matching od_/td_<n>) are accepted as external blockers."""
+    payload = _minimal_payload()
+    payload["waves"][0]["blocked_on"] = ["external_quota_recovery"]
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    errors = validate_roadmap(roadmap)
+    # freeform label should NOT be flagged as dangling
+    assert not any("external_quota_recovery" in e for e in errors)
+
+
+def test_dataclass_immutability() -> None:
+    w = Wave(wave_id="x", title="t", phase_id=0, status="planned")
+    with pytest.raises(Exception):
+        w.status = "completed"  # type: ignore[misc]
+
+
+def test_load_path_must_exist_message(tmp_path: Path) -> None:
+    fake = tmp_path / "does-not-exist.yaml"
+    with pytest.raises(RoadmapValidationError) as excinfo:
+        load_roadmap(fake)
+    assert str(fake) in str(excinfo.value)
+
+
+def test_phase_with_rationale_and_notes(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["phases"][0]["rationale"] = "because"
+    payload["phases"][0]["notes"] = "see also"
+    path = _write_payload(tmp_path, payload)
+    roadmap = load_roadmap(path)
+    assert roadmap.phases[0].rationale == "because"
+    assert roadmap.phases[0].notes == "see also"
+
+
+def test_construct_dataclasses_directly() -> None:
+    p = Phase(phase_id=0, title="P", waves=["w"])
+    w = Wave(
+        wave_id="w",
+        title="W",
+        phase_id=0,
+        status="planned",
+        depends_on=[],
+        blocked_on=[],
+    )
+    d = OperatorDecision(decision_id="od_1", title="D", status="open")
+    r = Roadmap(
+        schema_version=1,
+        roadmap_id="rid",
+        title="t",
+        generated_at="2026-05-06T00:00:00Z",
+        phases=[p],
+        waves=[w],
+        operator_decisions=[d],
+    )
+    assert validate_roadmap(r) == []

--- a/tests/test_strategy_roadmap_real_file.py
+++ b/tests/test_strategy_roadmap_real_file.py
@@ -1,0 +1,17 @@
+"""Integration test: load and validate the committed roadmap.yaml."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.strategy.roadmap import load_roadmap, validate_roadmap  # noqa: E402
+
+
+def test_committed_roadmap_loads_and_validates() -> None:
+    roadmap = load_roadmap()
+    errors = validate_roadmap(roadmap)
+    assert errors == [], f"committed roadmap.yaml has validation errors: {errors}"


### PR DESCRIPTION
## Summary

Phase 2 **W-state-1** — Layer 1 of the strategic-state design. Introduces a typed roadmap module so downstream waves (W-state-2..5) bind to a single source of truth.

- `scripts/lib/strategy/roadmap.py` — frozen dataclasses (`Phase`, `Wave`, `OperatorDecision`, `Roadmap`), strict `load_roadmap`, structured `write_roadmap`, `validate_roadmap`, plus derived helpers `next_actionable_wave`, `dependents_of`, `phase_complete`.
- `scripts/lib/strategy/_yaml_io.py` — backend abstraction; prefers `ruamel.yaml` when available, falls back to PyYAML with a one-time stderr warning about comment loss.
- `scripts/lib/strategy/__init__.py` — re-exports public API.
- `tests/test_strategy_roadmap.py` — 24 unit tests covering parse rejection, validation, derived helpers, round-trip stability, schema-version default.
- `tests/test_strategy_roadmap_real_file.py` — integration test against the committed `.vnx-data/strategy/roadmap.yaml`.
- `docs/architecture/STRATEGIC_STATE.md` — Layer 1 reference doc.

## Success criteria

- [x] `load_roadmap()` parses the committed `.vnx-data/strategy/roadmap.yaml` without errors.
- [x] `validate_roadmap()` catches dangling `depends_on`, dangling decision-id-pattern `blocked_on`, status enum violations, duplicate wave_ids, and phase/decision back-reference mismatches. Free-form external blockers (e.g., `gemini_quota_recovery`) pass through as designed.
- [x] `next_actionable_wave()` is deterministic — list order is the canonical iteration order; honours both `depends_on` and `blocked_on`.
- [x] Round-trip (`load → write → load`) yields equal dataclass trees on a fixture with optional fields, lists, and decisions.

## Test plan

- [x] `pytest tests/test_strategy_roadmap.py tests/test_strategy_roadmap_real_file.py -x --cov=scripts.lib.strategy.roadmap --cov=scripts.lib.strategy._yaml_io` → **25 passed**, coverage 87% on `roadmap.py`, 79% on `_yaml_io.py` (target ≥ 80% on the core module).
- [x] Smoke test: `python3 -c "from scripts.lib.strategy.roadmap import load_roadmap, validate_roadmap, next_actionable_wave; r = load_roadmap(); assert validate_roadmap(r) == []; print(next_actionable_wave(r).wave_id)"` → prints `w7-a`.

## Notes

- `docs/architecture/` is gitignored (internal docs); the reference doc is force-added so this PR carries the documentation contract for downstream waves. If the policy is to keep architecture docs internal, T0 may relocate to `docs/internal/architecture/STRATEGIC_STATE.md` post-merge.
- `ruamel.yaml` is not installed, so the PyYAML fallback warning is emitted on import. Comments and key ordering may be lost on `write_roadmap()`. W-state-1 does not write the committed file, so this is informational only.

Review-Stack: gemini_review,codex_gate
Dispatch-ID: 20260506-phase02-wstate1-roadmap-module

🤖 Generated with [Claude Code](https://claude.com/claude-code)