### PR TITLE
feat(strategy): decisions.ndjson append-only log + writer (Phase 2 W-state-2)

### DIFF
--- a/scripts/aggregator/__init__.py
+++ b/scripts/aggregator/__init__.py
@@ -1,0 +1,22 @@
+"""Read-only federation aggregator for VNX multi-project deployments.
+
+Phase 6 P1 of the single-VNX migration plan. Attaches all registered
+project DBs in `?mode=ro` and materializes a unified view DB at
+`~/.vnx-aggregator/data.db`. Reversible: operator can `rm -rf
+~/.vnx-aggregator/` at any point with zero data loss.
+
+See `claudedocs/2026-04-30-single-vnx-migration-plan.md` Sections 0.1
+and 4.3 for context.
+"""
+
+from __future__ import annotations
+
+DEFAULT_AGGREGATOR_DIR = "~/.vnx-aggregator"
+DEFAULT_REGISTRY_PATH = "~/.vnx/projects.json"
+DEFAULT_AGGREGATOR_DB = "data.db"
+
+__all__ = [
+    "DEFAULT_AGGREGATOR_DIR",
+    "DEFAULT_REGISTRY_PATH",
+    "DEFAULT_AGGREGATOR_DB",
+]

--- a/scripts/aggregator/aggregator_dashboard.py
+++ b/scripts/aggregator/aggregator_dashboard.py
@@ -1,0 +1,86 @@
+"""FastAPI dashboard for the read-only federation aggregator.
+
+Renders a single HTML page at `/` summarizing each registered project's
+DB sizes and WAL bytes. Aggregator is read-only — this dashboard never
+opens source DBs in writable mode.
+
+Run:
+    uvicorn scripts.aggregator.aggregator_dashboard:app --host 127.0.0.1 --port 8910
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from scripts.aggregator import DEFAULT_AGGREGATOR_DB, DEFAULT_AGGREGATOR_DIR
+from scripts.aggregator.build_central_view import (
+    SOURCE_DBS,
+    _default_registry_path,
+    _default_view_db_path,
+    load_registry,
+)
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+_env = Environment(
+    loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+    autoescape=select_autoescape(["html"]),
+)
+
+app = FastAPI(title="VNX Aggregator", docs_url=None, redoc_url=None)
+
+
+def _file_bytes(p: Path) -> int:
+    try:
+        return p.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def _project_rows() -> list[dict]:
+    try:
+        projects = load_registry(_default_registry_path())
+    except FileNotFoundError:
+        return []
+    rows: list[dict] = []
+    for proj in projects:
+        state = proj.state_dir
+        qi = state / SOURCE_DBS[0]
+        rc = state / SOURCE_DBS[1]
+        dt = state / SOURCE_DBS[2]
+        wal_total = sum(
+            _file_bytes(state / f"{name}-wal") for name in SOURCE_DBS
+        )
+        rows.append(
+            {
+                "project_id": proj.project_id,
+                "name": proj.name,
+                "state_dir": str(state),
+                "qi_size": _file_bytes(qi) if qi.is_file() else "missing",
+                "rc_size": _file_bytes(rc) if rc.is_file() else "missing",
+                "dt_size": _file_bytes(dt) if dt.is_file() else "missing",
+                "wal_bytes": wal_total,
+                "all_present": qi.is_file() and rc.is_file() and dt.is_file(),
+            }
+        )
+    return rows
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> HTMLResponse:
+    template = _env.get_template("index.html")
+    html = template.render(
+        view_db=str(_default_view_db_path()),
+        refreshed_at=_dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        rows=_project_rows(),
+    )
+    return HTMLResponse(html)
+
+
+@app.get("/healthz", response_class=HTMLResponse)
+def healthz() -> HTMLResponse:
+    return HTMLResponse("ok")

--- a/scripts/aggregator/build_central_view.py
+++ b/scripts/aggregator/build_central_view.py
@@ -1,0 +1,311 @@
+"""Build the unified read-only federation view DB.
+
+Attaches each registered project's `quality_intelligence.db`,
+`runtime_coordination.db`, and `dispatch_tracker.db` in `?mode=ro` and
+materializes a small set of unified views in `~/.vnx-aggregator/data.db`.
+
+Read-only at the source: writes only happen against the central view DB
+under `~/.vnx-aggregator/`. The operator can delete that directory at
+any moment without data loss.
+
+CLI:
+    python3 scripts/aggregator/build_central_view.py            # build
+    python3 scripts/aggregator/build_central_view.py --dry-run  # plan only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from scripts.aggregator import (
+    DEFAULT_AGGREGATOR_DB,
+    DEFAULT_AGGREGATOR_DIR,
+    DEFAULT_REGISTRY_PATH,
+)
+
+LOG = logging.getLogger("vnx.aggregator.build")
+
+SOURCE_DBS = ("quality_intelligence.db", "runtime_coordination.db", "dispatch_tracker.db")
+
+# Tables we materialize into the unified view. Each entry: (source_db, table, has_project_id).
+# Tables marked has_project_id=True already carry a `project_id` column post-Phase 0; for
+# legacy rows where the value is NULL we synthesize from the project's slug.
+UNIFIED_TABLES: tuple[tuple[str, str, bool], ...] = (
+    ("quality_intelligence.db", "success_patterns", True),
+    ("quality_intelligence.db", "antipatterns", True),
+    ("quality_intelligence.db", "dispatch_metadata", True),
+    ("runtime_coordination.db", "dispatches", True),
+    ("runtime_coordination.db", "terminal_leases", True),
+)
+
+
+@dataclass(frozen=True)
+class ProjectEntry:
+    name: str
+    path: Path
+    project_id: str
+
+    @property
+    def state_dir(self) -> Path:
+        return self.path / ".vnx-data" / "state"
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def synthesize_project_id(name: str) -> str:
+    """Slugify a project name into a `project_id` token.
+
+    `[^a-z0-9]+` -> `-`, trimmed of leading/trailing dashes, max 32 chars.
+    """
+    slug = _SLUG_RE.sub("-", name.lower()).strip("-")
+    if not slug:
+        raise ValueError(f"Cannot synthesize project_id from empty name: {name!r}")
+    return slug[:32]
+
+
+def load_registry(path: Path) -> list[ProjectEntry]:
+    """Load `~/.vnx/projects.json` and return resolved `ProjectEntry` rows.
+
+    Tolerates the schema_v1 format (no explicit `project_id`) — synthesizes
+    from `name`. Raises FileNotFoundError if the registry is missing.
+    """
+    raw = json.loads(path.read_text())
+    out: list[ProjectEntry] = []
+    for entry in raw.get("projects", []):
+        name = entry["name"]
+        proj_path = Path(entry["path"]).expanduser()
+        pid = entry.get("project_id") or synthesize_project_id(name)
+        out.append(ProjectEntry(name=name, path=proj_path, project_id=pid))
+    return out
+
+
+def attach_readonly(con: sqlite3.Connection, alias: str, db_path: Path) -> None:
+    """Attach `db_path` to `con` under `alias` in read-only mode (`?mode=ro`)."""
+    uri = f"file:{db_path}?mode=ro"
+    con.execute(f"ATTACH DATABASE ? AS {alias}", (uri,))
+
+
+def _table_exists(con: sqlite3.Connection, alias: str, table: str) -> bool:
+    cur = con.execute(
+        f"SELECT 1 FROM {alias}.sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    )
+    return cur.fetchone() is not None
+
+
+def _column_names(con: sqlite3.Connection, alias: str, table: str) -> list[str]:
+    cur = con.execute(f"PRAGMA {alias}.table_info({table})")
+    return [row[1] for row in cur.fetchall()]
+
+
+def _create_unified_table(con: sqlite3.Connection, table: str, columns: list[str]) -> None:
+    # Drop & recreate so the run is fully idempotent and tolerant of column drift.
+    con.execute(f"DROP TABLE IF EXISTS {table}_unified")
+    col_defs = ", ".join(f'"{c}"' for c in columns)
+    con.execute(f"CREATE TABLE {table}_unified ({col_defs})")
+
+
+def _copy_table(
+    con: sqlite3.Connection,
+    alias: str,
+    table: str,
+    columns: list[str],
+    project_id: str,
+    has_project_id: bool,
+) -> int:
+    quoted = ", ".join(f'"{c}"' for c in columns)
+    rows = con.execute(f"SELECT {quoted} FROM {alias}.{table}").fetchall()
+    if not rows:
+        return 0
+    if has_project_id:
+        idx = columns.index("project_id")
+        rows = [
+            tuple(project_id if i == idx and v in (None, "") else v for i, v in enumerate(r))
+            for r in rows
+        ]
+    placeholders = ", ".join("?" for _ in columns)
+    con.executemany(
+        f"INSERT INTO {table}_unified ({quoted}) VALUES ({placeholders})",
+        rows,
+    )
+    return len(rows)
+
+
+def materialize_views(
+    view_db_path: Path,
+    projects: list[ProjectEntry],
+    *,
+    dry_run: bool = False,
+) -> dict:
+    """Build the unified view DB. In dry-run mode, only plan and emit a report."""
+    plan: dict = {"view_db": str(view_db_path), "projects": []}
+
+    if dry_run:
+        for proj in projects:
+            attached: list[dict] = []
+            for db_name in SOURCE_DBS:
+                src = proj.state_dir / db_name
+                attached.append({"db": db_name, "path": str(src), "exists": src.is_file()})
+            plan["projects"].append(
+                {
+                    "name": proj.name,
+                    "project_id": proj.project_id,
+                    "attached": attached,
+                }
+            )
+            print(
+                f"DRY-RUN: would attach project={proj.project_id} "
+                f"path={proj.path} ({sum(1 for a in attached if a['exists'])}/"
+                f"{len(SOURCE_DBS)} dbs present)",
+                file=sys.stderr,
+            )
+        plan["dry_run"] = True
+        return plan
+
+    view_db_path.parent.mkdir(parents=True, exist_ok=True)
+    if view_db_path.exists():
+        view_db_path.unlink()
+
+    con = sqlite3.connect(view_db_path, uri=False)
+    try:
+        con.execute("PRAGMA journal_mode=WAL")
+        # Create per-table aggregates by attaching every project for one source DB,
+        # collecting the union of columns, then copying.
+        for source_db, table, has_pid in UNIFIED_TABLES:
+            per_project_cols: dict[str, list[str]] = {}
+            attached_aliases: list[tuple[str, ProjectEntry]] = []
+            for idx, proj in enumerate(projects):
+                src_path = proj.state_dir / source_db
+                if not src_path.is_file():
+                    continue
+                alias = f"src_{idx}"
+                try:
+                    attach_readonly(con, alias, src_path)
+                except sqlite3.Error as exc:
+                    LOG.warning("attach failed project=%s db=%s err=%s", proj.project_id, source_db, exc)
+                    continue
+                attached_aliases.append((alias, proj))
+                if _table_exists(con, alias, table):
+                    per_project_cols[alias] = _column_names(con, alias, table)
+
+            if not per_project_cols:
+                for alias, _ in attached_aliases:
+                    con.execute(f"DETACH DATABASE {alias}")
+                continue
+
+            union_cols: list[str] = []
+            for cols in per_project_cols.values():
+                for c in cols:
+                    if c not in union_cols:
+                        union_cols.append(c)
+            if has_pid and "project_id" not in union_cols:
+                union_cols.append("project_id")
+
+            _create_unified_table(con, table, union_cols)
+
+            row_total = 0
+            per_proj: dict = {}
+            for alias, proj in attached_aliases:
+                if alias not in per_project_cols:
+                    continue
+                source_cols = per_project_cols[alias]
+                # Build a column list that matches `union_cols`; missing cols get NULL.
+                select_parts: list[str] = []
+                for c in union_cols:
+                    if c in source_cols:
+                        select_parts.append(f'"{c}"')
+                    elif c == "project_id":
+                        select_parts.append(f"'{proj.project_id}'")
+                    else:
+                        select_parts.append("NULL")
+                select_sql = (
+                    f"SELECT {', '.join(select_parts)} FROM {alias}.{table}"
+                )
+                rows = con.execute(select_sql).fetchall()
+                if has_pid:
+                    pid_idx = union_cols.index("project_id")
+                    rows = [
+                        tuple(
+                            proj.project_id if i == pid_idx and v in (None, "") else v
+                            for i, v in enumerate(r)
+                        )
+                        for r in rows
+                    ]
+                if rows:
+                    placeholders = ", ".join("?" for _ in union_cols)
+                    quoted = ", ".join(f'"{c}"' for c in union_cols)
+                    con.executemany(
+                        f"INSERT INTO {table}_unified ({quoted}) VALUES ({placeholders})",
+                        rows,
+                    )
+                row_total += len(rows)
+                per_proj[proj.project_id] = len(rows)
+
+            # Commit & close any implicit txn before DETACH; otherwise SQLite
+            # rejects the DETACH because the attached DB is still locked.
+            con.commit()
+            for alias, _ in attached_aliases:
+                con.execute(f"DETACH DATABASE {alias}")
+
+            plan["projects"].append(
+                {"table": f"{table}_unified", "rows": row_total, "per_project": per_proj}
+            )
+            LOG.info("materialized %s_unified rows=%d", table, row_total)
+
+        con.commit()
+    finally:
+        con.close()
+
+    plan["dry_run"] = False
+    return plan
+
+
+def _default_view_db_path() -> Path:
+    return Path(os.environ.get("VNX_AGGREGATOR_DIR", DEFAULT_AGGREGATOR_DIR)).expanduser() / DEFAULT_AGGREGATOR_DB
+
+
+def _default_registry_path() -> Path:
+    return Path(os.environ.get("VNX_REGISTRY_PATH", DEFAULT_REGISTRY_PATH)).expanduser()
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Plan only; no writes to view DB")
+    parser.add_argument("--registry", type=Path, default=None, help="Override path to projects.json")
+    parser.add_argument("--view-db", type=Path, default=None, help="Override view DB path")
+    parser.add_argument("--json", action="store_true", help="Emit plan/result as JSON to stdout")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    registry_path = args.registry or _default_registry_path()
+    view_db_path = args.view_db or _default_view_db_path()
+
+    try:
+        projects = load_registry(registry_path)
+    except FileNotFoundError:
+        print(f"ERROR: registry not found at {registry_path}", file=sys.stderr)
+        return 2
+
+    plan = materialize_views(view_db_path, projects, dry_run=args.dry_run)
+    if args.json:
+        print(json.dumps(plan, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aggregator/launchd/com.vnx.aggregator.plist.template
+++ b/scripts/aggregator/launchd/com.vnx.aggregator.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  VNX Read-Only Federation Aggregator launchd template.
+
+  Operator install (NOT done by this PR):
+    1. cp this file to ~/Library/LaunchAgents/com.vnx.aggregator.plist
+    2. Replace {{REPO_ROOT}} with the full path to vnx-roadmap-autopilot.
+    3. launchctl load ~/Library/LaunchAgents/com.vnx.aggregator.plist
+    4. Verify: launchctl list | grep com.vnx.aggregator
+
+  Reverse:
+    launchctl unload ~/Library/LaunchAgents/com.vnx.aggregator.plist
+    rm ~/Library/LaunchAgents/com.vnx.aggregator.plist
+    rm -rf ~/.vnx-aggregator/    # zero-data-loss removal
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.vnx.aggregator</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{REPO_ROOT}}/scripts/aggregator/refresh_loop.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VNX_AGGREGATOR_REPO_ROOT</key>
+    <string>{{REPO_ROOT}}</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/com.vnx.aggregator.out</string>
+
+  <key>StandardErrorPath</key>
+  <string>/tmp/com.vnx.aggregator.err</string>
+</dict>
+</plist>

--- a/scripts/aggregator/projects.json.example
+++ b/scripts/aggregator/projects.json.example
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "projects": [
+    {
+      "name": "vnx-roadmap-autopilot",
+      "project_id": "vnx-dev",
+      "path": "/Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt",
+      "layout": "vnx-data-state",
+      "registered_at": "2026-04-03T12:53:57.796283+00:00"
+    },
+    {
+      "name": "mission-control",
+      "project_id": "mc",
+      "path": "/Users/vincentvandeth/Desktop/BUSINESS/development/mission-control",
+      "layout": "vnx-data-state",
+      "registered_at": "2026-05-06T00:00:00+00:00"
+    },
+    {
+      "name": "sales-copilot",
+      "project_id": "sales-copilot",
+      "path": "/Users/vincentvandeth/Desktop/BUSINESS/development/sales-copilot",
+      "layout": "vnx-data-state",
+      "registered_at": "2026-05-06T00:00:00+00:00"
+    },
+    {
+      "name": "SEOcrawler_v2",
+      "project_id": "seocrawler-v2",
+      "path": "/Users/vincentvandeth/Development/SEOcrawler_v2",
+      "layout": "vnx-data-state",
+      "registered_at": "2026-05-06T00:00:00+00:00"
+    }
+  ]
+}

--- a/scripts/aggregator/refresh_loop.sh
+++ b/scripts/aggregator/refresh_loop.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Refresh loop wrapper for the VNX read-only federation aggregator.
+# Invoked by launchd (com.vnx.aggregator.plist) on a 60s schedule.
+#
+# READ-ONLY: this script attaches every source DB in `?mode=ro` and
+# materializes a unified view at $AGG_DIR/data.db. The operator can
+# `rm -rf $AGG_DIR` at any point with zero data loss.
+
+set -euo pipefail
+
+REPO_ROOT="${VNX_AGGREGATOR_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+AGG_DIR="${VNX_AGGREGATOR_DIR:-$HOME/.vnx-aggregator}"
+LOG_DIR="$AGG_DIR/logs"
+LOG_FILE="$LOG_DIR/refresh.log"
+
+mkdir -p "$AGG_DIR" "$LOG_DIR"
+
+cd "$REPO_ROOT"
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "[$ts] refresh start" >> "$LOG_FILE"
+
+if python3 -m scripts.aggregator.build_central_view >> "$LOG_FILE" 2>&1; then
+  ts_done="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[$ts_done] refresh ok" >> "$LOG_FILE"
+  exit 0
+else
+  rc=$?
+  ts_err="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[$ts_err] refresh failed rc=$rc" >> "$LOG_FILE"
+  exit "$rc"
+fi

--- a/scripts/aggregator/schema_drift_report.py
+++ b/scripts/aggregator/schema_drift_report.py
@@ -1,0 +1,154 @@
+"""Schema-drift report across all registered project DBs.
+
+Preflight tool for w6-p4 (one-shot data import). Attaches every project
+DB in `?mode=ro`, walks `sqlite_master`, and prints (or emits JSON) the
+per-project table list plus column-level diffs against the reference
+project (first entry in the registry).
+
+Read-only: never writes to source DBs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from scripts.aggregator.build_central_view import (
+    SOURCE_DBS,
+    ProjectEntry,
+    _default_registry_path,
+    attach_readonly,
+    load_registry,
+)
+
+
+def _project_schema(project: ProjectEntry) -> dict[str, dict[str, list[str]]]:
+    """Return `{db_name: {table: [columns]}}` for one project (read-only).
+
+    Missing DBs and missing tables are silently skipped (registry-light operation);
+    the caller computes drift by diffing the dicts.
+    """
+    out: dict[str, dict[str, list[str]]] = {}
+    for db_name in SOURCE_DBS:
+        path = project.state_dir / db_name
+        if not path.is_file():
+            out[db_name] = {}
+            continue
+        con = sqlite3.connect(":memory:")
+        try:
+            try:
+                attach_readonly(con, "src", path)
+            except sqlite3.Error:
+                out[db_name] = {}
+                continue
+            tables: dict[str, list[str]] = {}
+            for (name,) in con.execute(
+                "SELECT name FROM src.sqlite_master "
+                "WHERE type='table' AND name NOT LIKE 'sqlite_%' "
+                "ORDER BY name"
+            ).fetchall():
+                cols = [row[1] for row in con.execute(f"PRAGMA src.table_info({name})")]
+                tables[name] = cols
+            out[db_name] = tables
+            con.execute("DETACH DATABASE src")
+        finally:
+            con.close()
+    return out
+
+
+def compute_drift(
+    schemas: dict[str, dict[str, dict[str, list[str]]]],
+) -> dict:
+    """Compute drift relative to the first project (the reference).
+
+    Returns:
+      {
+        "reference": "<project_id>",
+        "projects": {
+            "<project_id>": {
+                "<db>": {
+                    "missing_tables": [...],
+                    "extra_tables": [...],
+                    "column_diffs": {"<table>": {"missing": [...], "extra": [...]}},
+                }
+            }
+        }
+      }
+    """
+    project_ids = list(schemas.keys())
+    if not project_ids:
+        return {"reference": None, "projects": {}}
+    ref = project_ids[0]
+    ref_schema = schemas[ref]
+    drift: dict = {"reference": ref, "projects": {}}
+    for pid in project_ids:
+        per_db: dict = {}
+        for db_name in SOURCE_DBS:
+            ref_tables = ref_schema.get(db_name, {})
+            this_tables = schemas[pid].get(db_name, {})
+            ref_names = set(ref_tables)
+            this_names = set(this_tables)
+            missing = sorted(ref_names - this_names)
+            extra = sorted(this_names - ref_names)
+            col_diffs: dict[str, dict[str, list[str]]] = {}
+            for tbl in ref_names & this_names:
+                ref_cols = set(ref_tables[tbl])
+                this_cols = set(this_tables[tbl])
+                if ref_cols != this_cols:
+                    col_diffs[tbl] = {
+                        "missing": sorted(ref_cols - this_cols),
+                        "extra": sorted(this_cols - ref_cols),
+                    }
+            per_db[db_name] = {
+                "missing_tables": missing,
+                "extra_tables": extra,
+                "column_diffs": col_diffs,
+            }
+        drift["projects"][pid] = per_db
+    return drift
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=None)
+    parser.add_argument("--json", action="store_true", help="Emit drift report as JSON")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    registry_path = args.registry or _default_registry_path()
+    try:
+        projects = load_registry(registry_path)
+    except FileNotFoundError:
+        print(f"ERROR: registry not found at {registry_path}", file=sys.stderr)
+        return 2
+
+    schemas = {p.project_id: _project_schema(p) for p in projects}
+    drift = compute_drift(schemas)
+
+    if args.json:
+        print(json.dumps(drift, indent=2))
+        return 0
+
+    print(f"Reference project: {drift['reference']}")
+    for pid, per_db in drift["projects"].items():
+        print(f"\nProject: {pid}")
+        for db_name, diff in per_db.items():
+            tag = "OK" if not (diff["missing_tables"] or diff["extra_tables"] or diff["column_diffs"]) else "DRIFT"
+            print(f"  {db_name}: {tag}")
+            if diff["missing_tables"]:
+                print(f"    missing tables: {', '.join(diff['missing_tables'])}")
+            if diff["extra_tables"]:
+                print(f"    extra tables:   {', '.join(diff['extra_tables'])}")
+            for tbl, cdiff in diff["column_diffs"].items():
+                print(
+                    f"    column drift in {tbl}: "
+                    f"missing={cdiff['missing']} extra={cdiff['extra']}"
+                )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/strategy/decisions.py
+++ b/scripts/lib/strategy/decisions.py
@@ -1,0 +1,277 @@
+"""Append-only NDJSON log of operator and T0 decisions.
+
+Layer 1 strategic state — decisions.ndjson lives at
+``.vnx-data/strategy/decisions.ndjson``.  Every decision is one JSON
+object per line.  Concurrent writers are safe: ``record_decision`` holds
+an exclusive ``fcntl.flock`` while writing so lines cannot interleave.
+
+Decision-ID format
+------------------
+- Operator decision:  ``OD-YYYY-MM-DD-NNN``
+- T0 decision:        ``TD-YYYY-MM-DD-NNN``
+
+where YYYY-MM-DD is the calendar date (UTC) and NNN is a zero-padded
+3-digit sequence number (001, 002, …) that the caller assigns.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_DECISION_ID_RE = re.compile(
+    r"^(OD|TD)-(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-(?P<seq>\d{3})$"
+)
+_DEFAULT_RELATIVE_PATH = Path(".vnx-data/strategy/decisions.ndjson")
+
+REQUIRED_FIELDS: tuple[str, ...] = ("decision_id", "scope", "ts", "rationale")
+
+
+# ---------------------------------------------------------------------------
+# Error class
+# ---------------------------------------------------------------------------
+class DecisionValidationError(ValueError):
+    """Raised when a decision entry fails schema validation."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Decision:
+    decision_id: str
+    scope: str
+    ts: str
+    rationale: str
+    supersedes: str | None = None
+    evidence_path: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Path resolution (mirrors roadmap.py pattern)
+# ---------------------------------------------------------------------------
+def _git_root_from(start: Path) -> Path | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return Path(out).resolve() if out else None
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def _default_path() -> Path:
+    here = Path(__file__).resolve().parent
+    root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
+    if root is None:
+        env_root = os.environ.get("VNX_CANONICAL_ROOT")
+        root = Path(env_root).resolve() if env_root else Path.cwd().resolve()
+    return root / _DEFAULT_RELATIVE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+def _validate_decision_id(decision_id: str) -> None:
+    """Raise DecisionValidationError if decision_id does not match the schema."""
+    m = _DECISION_ID_RE.match(decision_id)
+    if not m:
+        raise DecisionValidationError(
+            f"invalid decision_id '{decision_id}': must match OD-YYYY-MM-DD-NNN "
+            "or TD-YYYY-MM-DD-NNN (e.g. OD-2026-05-06-001)"
+        )
+    month = int(m.group("month"))
+    day = int(m.group("day"))
+    if not (1 <= month <= 12):
+        raise DecisionValidationError(
+            f"invalid decision_id '{decision_id}': month {month:02d} is out of range 01-12"
+        )
+    if not (1 <= day <= 31):
+        raise DecisionValidationError(
+            f"invalid decision_id '{decision_id}': day {day:02d} is out of range 01-31"
+        )
+
+
+def _validate_entry(data: dict) -> None:
+    """Raise DecisionValidationError on schema violations."""
+    for field in REQUIRED_FIELDS:
+        if field not in data or data[field] is None:
+            raise DecisionValidationError(f"missing required field '{field}'")
+        if isinstance(data[field], str) and not data[field].strip():
+            raise DecisionValidationError(f"required field '{field}' must not be empty")
+    _validate_decision_id(data["decision_id"])
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+def _decision_to_dict(d: Decision) -> dict:
+    record: dict = {
+        "decision_id": d.decision_id,
+        "scope": d.scope,
+        "ts": d.ts,
+        "rationale": d.rationale,
+    }
+    if d.supersedes is not None:
+        record["supersedes"] = d.supersedes
+    if d.evidence_path is not None:
+        record["evidence_path"] = d.evidence_path
+    return record
+
+
+def _dict_to_decision(data: dict) -> Decision:
+    return Decision(
+        decision_id=data["decision_id"],
+        scope=data["scope"],
+        ts=data["ts"],
+        rationale=data["rationale"],
+        supersedes=data.get("supersedes"),
+        evidence_path=data.get("evidence_path"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def record_decision(
+    decision_id: str,
+    scope: str,
+    rationale: str,
+    supersedes: str | None = None,
+    evidence_path: str | None = None,
+    *,
+    path: Path | None = None,
+) -> Decision:
+    """Append a decision to the log and return the persisted Decision object.
+
+    Acquires an exclusive file lock (``fcntl.LOCK_EX``) before writing so
+    concurrent callers (T0 + background hooks) cannot interleave lines.
+
+    Raises ``DecisionValidationError`` on schema violations before any I/O.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    record: dict = {
+        "decision_id": decision_id,
+        "scope": scope,
+        "ts": ts,
+        "rationale": rationale,
+    }
+    if supersedes is not None:
+        record["supersedes"] = supersedes
+    if evidence_path is not None:
+        record["evidence_path"] = evidence_path
+
+    _validate_entry(record)
+
+    target = Path(path) if path is not None else _default_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+
+    with target.open("a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            fh.write(line)
+            fh.flush()
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    return Decision(
+        decision_id=decision_id,
+        scope=scope,
+        ts=ts,
+        rationale=rationale,
+        supersedes=supersedes,
+        evidence_path=evidence_path,
+    )
+
+
+def recent_decisions(n: int = 10, *, path: Path | None = None) -> list[Decision]:
+    """Return the last *n* decisions in chronological order (oldest first).
+
+    Returns an empty list when the file does not exist or contains no valid
+    entries.  Malformed lines are silently skipped.
+    """
+    target = Path(path) if path is not None else _default_path()
+    if not target.exists():
+        return []
+
+    valid_lines = [
+        line for line in target.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    tail = valid_lines[-n:] if n > 0 else []
+
+    result: list[Decision] = []
+    for line in tail:
+        try:
+            data = json.loads(line)
+            result.append(_dict_to_decision(data))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return result
+
+
+def supersedes_chain(decision_id: str, *, path: Path | None = None) -> list[Decision]:
+    """Walk the supersedes pointer chain backward from *decision_id* to the root.
+
+    Returns the chain ordered from root to the given decision (oldest first),
+    so ``chain[0]`` is the original decision and ``chain[-1]`` is the most
+    recent one that ultimately supersedes all earlier entries.
+
+    Returns an empty list when the file does not exist or *decision_id* is not
+    found.  A cycle guard prevents infinite loops on malformed data.
+    """
+    target = Path(path) if path is not None else _default_path()
+    if not target.exists():
+        return []
+
+    all_decisions: dict[str, Decision] = {}
+    for line in target.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+            d = _dict_to_decision(data)
+            all_decisions[d.decision_id] = d
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    if decision_id not in all_decisions:
+        return []
+
+    chain: list[Decision] = []
+    current_id: str | None = decision_id
+    visited: set[str] = set()
+    while current_id is not None:
+        if current_id in visited:
+            break
+        visited.add(current_id)
+        d = all_decisions.get(current_id)
+        if d is None:
+            break
+        chain.append(d)
+        current_id = d.supersedes
+
+    # chain is [decision_id → … → root]; reverse so root comes first
+    chain.reverse()
+    return chain
+
+
+__all__ = [
+    "Decision",
+    "DecisionValidationError",
+    "REQUIRED_FIELDS",
+    "record_decision",
+    "recent_decisions",
+    "supersedes_chain",
+]

--- a/tests/test_aggregator_build_central_view.py
+++ b/tests/test_aggregator_build_central_view.py
@@ -1,0 +1,378 @@
+"""Tests for the read-only federation aggregator builder.
+
+Covers:
+  - 4-project fixture attach + materialize
+  - Legacy rows (NULL project_id) get synthesized project_id from the
+    project's slug (Phase 0 backfill behavior, plan §0.1)
+  - Read-only mode is honored: writes against the attached source DB
+    raise sqlite3.OperationalError
+  - --dry-run produces no view DB
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.aggregator.build_central_view import (
+    UNIFIED_TABLES,
+    attach_readonly,
+    load_registry,
+    main,
+    materialize_views,
+    synthesize_project_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _make_quality_intelligence_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(
+            """
+            CREATE TABLE success_patterns (
+                pattern_id INTEGER PRIMARY KEY,
+                pattern_name TEXT,
+                project_id TEXT
+            );
+            CREATE TABLE antipatterns (
+                antipattern_id INTEGER PRIMARY KEY,
+                signal TEXT,
+                project_id TEXT
+            );
+            CREATE TABLE dispatch_metadata (
+                dispatch_id TEXT PRIMARY KEY,
+                project_id TEXT
+            );
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _make_runtime_coordination_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(
+            """
+            CREATE TABLE dispatches (
+                dispatch_id TEXT PRIMARY KEY,
+                state TEXT,
+                project_id TEXT
+            );
+            CREATE TABLE terminal_leases (
+                terminal_id TEXT PRIMARY KEY,
+                holder TEXT,
+                project_id TEXT
+            );
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _make_dispatch_tracker_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        con.execute("CREATE TABLE dispatch_experiments (id INTEGER PRIMARY KEY)")
+        con.commit()
+    finally:
+        con.close()
+
+
+def _seed_success_patterns(
+    db_path: Path, rows: list[tuple[int, str, str | None]]
+) -> None:
+    con = sqlite3.connect(db_path)
+    try:
+        con.executemany(
+            "INSERT INTO success_patterns (pattern_id, pattern_name, project_id) VALUES (?,?,?)",
+            rows,
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _seed_dispatches(db_path: Path, rows: list[tuple[str, str, str | None]]) -> None:
+    con = sqlite3.connect(db_path)
+    try:
+        con.executemany(
+            "INSERT INTO dispatches (dispatch_id, state, project_id) VALUES (?,?,?)",
+            rows,
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def four_project_fixture(tmp_path: Path) -> tuple[Path, list[dict]]:
+    """Build a 4-project fixture with mini DBs.
+
+    Returns `(registry_path, project_specs)` where project_specs lists
+    each project's name/path/project_id.
+    """
+    specs: list[dict] = []
+    for name, pid in [
+        ("vnx-roadmap-autopilot", "vnx-dev"),
+        ("mission-control", "mc"),
+        ("sales-copilot", "sales-copilot"),
+        ("SEOcrawler_v2", "seocrawler-v2"),
+    ]:
+        proj = tmp_path / name
+        state = proj / ".vnx-data" / "state"
+        _make_quality_intelligence_db(state / "quality_intelligence.db")
+        _make_runtime_coordination_db(state / "runtime_coordination.db")
+        _make_dispatch_tracker_db(state / "dispatch_tracker.db")
+        specs.append({"name": name, "path": str(proj), "project_id": pid})
+
+    # Seed:
+    # - vnx-dev gets two patterns with explicit project_id
+    # - mc gets one pattern with NULL project_id (legacy)
+    # - sales-copilot gets one pattern with empty-string project_id (also legacy)
+    # - seocrawler-v2 gets one pattern with explicit project_id
+    _seed_success_patterns(
+        tmp_path / "vnx-roadmap-autopilot/.vnx-data/state/quality_intelligence.db",
+        [(1, "p1", "vnx-dev"), (2, "p2", "vnx-dev")],
+    )
+    _seed_success_patterns(
+        tmp_path / "mission-control/.vnx-data/state/quality_intelligence.db",
+        [(1, "p1", None)],
+    )
+    _seed_success_patterns(
+        tmp_path / "sales-copilot/.vnx-data/state/quality_intelligence.db",
+        [(1, "p1", "")],
+    )
+    _seed_success_patterns(
+        tmp_path / "SEOcrawler_v2/.vnx-data/state/quality_intelligence.db",
+        [(1, "p1", "seocrawler-v2")],
+    )
+
+    _seed_dispatches(
+        tmp_path / "vnx-roadmap-autopilot/.vnx-data/state/runtime_coordination.db",
+        [("d1", "completed", "vnx-dev")],
+    )
+    _seed_dispatches(
+        tmp_path / "mission-control/.vnx-data/state/runtime_coordination.db",
+        [("d2", "completed", None)],
+    )
+
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({"schema_version": 1, "projects": specs}))
+    return registry, specs
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_project_id_basic():
+    assert synthesize_project_id("vnx-roadmap-autopilot") == "vnx-roadmap-autopilot"
+    assert synthesize_project_id("Mission-Control") == "mission-control"
+    assert synthesize_project_id("SEOcrawler_v2") == "seocrawler-v2"
+
+
+def test_synthesize_project_id_strips_and_truncates():
+    assert synthesize_project_id("__weird name!!__") == "weird-name"
+    long = "x" * 64
+    assert len(synthesize_project_id(long)) == 32
+
+
+def test_synthesize_project_id_rejects_empty():
+    with pytest.raises(ValueError):
+        synthesize_project_id("...")
+
+
+def test_load_registry(four_project_fixture):
+    registry, specs = four_project_fixture
+    projects = load_registry(registry)
+    assert [p.project_id for p in projects] == [s["project_id"] for s in specs]
+
+
+def test_load_registry_synthesizes_missing_project_id(tmp_path: Path):
+    registry = tmp_path / "projects.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {"name": "mission-control", "path": str(tmp_path)}
+                ]
+            }
+        )
+    )
+    projects = load_registry(registry)
+    assert projects[0].project_id == "mission-control"
+
+
+# ---------------------------------------------------------------------------
+# Read-only attachment guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_attach_readonly_blocks_writes(tmp_path: Path):
+    db = tmp_path / "src.db"
+    con0 = sqlite3.connect(db)
+    con0.execute("CREATE TABLE t (id INTEGER)")
+    con0.execute("INSERT INTO t VALUES (1)")
+    con0.commit()
+    con0.close()
+
+    view = sqlite3.connect(":memory:")
+    try:
+        attach_readonly(view, "src", db)
+        # Reads succeed.
+        assert view.execute("SELECT id FROM src.t").fetchone() == (1,)
+        # Writes raise OperationalError because of mode=ro.
+        with pytest.raises(sqlite3.OperationalError):
+            view.execute("INSERT INTO src.t VALUES (2)")
+    finally:
+        view.close()
+
+
+# ---------------------------------------------------------------------------
+# Materialize behavior
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_attaches_all_four_projects(four_project_fixture, tmp_path: Path):
+    registry, _ = four_project_fixture
+    projects = load_registry(registry)
+    view_db = tmp_path / "agg" / "data.db"
+
+    plan = materialize_views(view_db, projects, dry_run=False)
+    assert plan["dry_run"] is False
+    assert view_db.exists()
+
+    con = sqlite3.connect(view_db)
+    try:
+        seen = {
+            row[0]
+            for row in con.execute(
+                "SELECT DISTINCT project_id FROM success_patterns_unified"
+            )
+        }
+    finally:
+        con.close()
+    assert seen == {"vnx-dev", "mc", "sales-copilot", "seocrawler-v2"}
+
+
+def test_materialize_synthesizes_project_id_for_legacy_rows(four_project_fixture, tmp_path: Path):
+    registry, _ = four_project_fixture
+    projects = load_registry(registry)
+    view_db = tmp_path / "agg" / "data.db"
+    materialize_views(view_db, projects, dry_run=False)
+
+    con = sqlite3.connect(view_db)
+    try:
+        # The mc row had NULL project_id; the sales-copilot row had "".
+        # Both should be backfilled to their project's slug in the unified view.
+        rows = con.execute(
+            "SELECT project_id FROM success_patterns_unified ORDER BY project_id"
+        ).fetchall()
+    finally:
+        con.close()
+    pids = sorted(r[0] for r in rows)
+    assert "mc" in pids
+    assert "sales-copilot" in pids
+    # No NULL or empty project_ids leak into the unified table.
+    assert all(p not in (None, "") for p in pids)
+
+
+def test_materialize_idempotent(four_project_fixture, tmp_path: Path):
+    registry, _ = four_project_fixture
+    projects = load_registry(registry)
+    view_db = tmp_path / "agg" / "data.db"
+
+    materialize_views(view_db, projects, dry_run=False)
+    con = sqlite3.connect(view_db)
+    try:
+        first = con.execute(
+            "SELECT COUNT(*) FROM success_patterns_unified"
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    materialize_views(view_db, projects, dry_run=False)
+    con = sqlite3.connect(view_db)
+    try:
+        second = con.execute(
+            "SELECT COUNT(*) FROM success_patterns_unified"
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert first == second
+
+
+def test_materialize_does_not_mutate_source_dbs(four_project_fixture, tmp_path: Path):
+    registry, specs = four_project_fixture
+    projects = load_registry(registry)
+    view_db = tmp_path / "agg" / "data.db"
+
+    src_paths = []
+    for spec in specs:
+        for db in (
+            "quality_intelligence.db",
+            "runtime_coordination.db",
+            "dispatch_tracker.db",
+        ):
+            p = Path(spec["path"]) / ".vnx-data" / "state" / db
+            src_paths.append((p, p.stat().st_size, p.stat().st_mtime_ns))
+
+    materialize_views(view_db, projects, dry_run=False)
+
+    for p, size, mtime in src_paths:
+        st = p.stat()
+        assert st.st_size == size, f"{p} size changed"
+        assert st.st_mtime_ns == mtime, f"{p} mtime changed"
+
+
+def test_dry_run_writes_nothing(four_project_fixture, tmp_path: Path):
+    registry, _ = four_project_fixture
+    projects = load_registry(registry)
+    view_db = tmp_path / "agg" / "data.db"
+
+    plan = materialize_views(view_db, projects, dry_run=True)
+    assert plan["dry_run"] is True
+    # The view DB must not exist after a dry-run.
+    assert not view_db.exists()
+    # And neither should the directory have been created.
+    assert not view_db.parent.exists()
+
+
+def test_unified_tables_constants_consistent():
+    # Each entry is (db_name, table, has_project_id) and the db_name must be one
+    # of the three source DBs we attach.
+    valid_dbs = {"quality_intelligence.db", "runtime_coordination.db", "dispatch_tracker.db"}
+    for db_name, _table, _has_pid in UNIFIED_TABLES:
+        assert db_name in valid_dbs
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_exits_zero_and_prints_plan(four_project_fixture, tmp_path: Path, capsys):
+    registry, _ = four_project_fixture
+    view_db = tmp_path / "agg" / "data.db"
+    rc = main(["--dry-run", "--registry", str(registry), "--view-db", str(view_db), "--json"])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    plan = json.loads(captured)
+    assert plan["dry_run"] is True
+    assert not view_db.exists()

--- a/tests/test_aggregator_schema_drift.py
+++ b/tests/test_aggregator_schema_drift.py
@@ -1,0 +1,150 @@
+"""Tests for the schema-drift report (Phase 6 P1, plan §4.3).
+
+Synthesizes a 4-project fixture where one project is intentionally missing a
+column from `success_patterns` and one project is missing a whole table
+(`dispatch_metadata`). Asserts the drift report flags the diffs.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.aggregator.schema_drift_report import compute_drift, main, _project_schema
+from scripts.aggregator.build_central_view import ProjectEntry
+
+
+def _mk_qi(path: Path, tables: dict[str, list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        for tbl, cols in tables.items():
+            col_defs = ", ".join(f'"{c}" TEXT' for c in cols)
+            con.execute(f"CREATE TABLE {tbl} ({col_defs})")
+        con.commit()
+    finally:
+        con.close()
+
+
+def _mk_minimal_other_dbs(state: Path) -> None:
+    """Create empty rc/dt DBs so the schema walker has something to attach."""
+    for name in ("runtime_coordination.db", "dispatch_tracker.db"):
+        con = sqlite3.connect(state / name)
+        con.execute("CREATE TABLE _placeholder (id INTEGER)")
+        con.commit()
+        con.close()
+
+
+@pytest.fixture
+def drift_fixture(tmp_path: Path):
+    """Build 4 projects:
+      vnx-dev: full schema (reference)
+      mc: missing `dispatch_metadata` table entirely
+      sales-copilot: success_patterns missing the `confidence` column
+      seocrawler-v2: full schema
+    """
+    full_qi = {
+        "success_patterns": ["pattern_id", "pattern_name", "project_id", "confidence"],
+        "antipatterns": ["antipattern_id", "signal", "project_id"],
+        "dispatch_metadata": ["dispatch_id", "project_id"],
+    }
+    drifted_qi = {
+        "success_patterns": ["pattern_id", "pattern_name", "project_id"],  # missing 'confidence'
+        "antipatterns": ["antipattern_id", "signal", "project_id"],
+        "dispatch_metadata": ["dispatch_id", "project_id"],
+    }
+    missing_table_qi = {
+        "success_patterns": ["pattern_id", "pattern_name", "project_id", "confidence"],
+        "antipatterns": ["antipattern_id", "signal", "project_id"],
+        # dispatch_metadata MISSING
+    }
+
+    layout = {
+        "vnx-roadmap-autopilot": ("vnx-dev", full_qi),
+        "mission-control": ("mc", missing_table_qi),
+        "sales-copilot": ("sales-copilot", drifted_qi),
+        "SEOcrawler_v2": ("seocrawler-v2", full_qi),
+    }
+
+    specs = []
+    for name, (pid, qi_schema) in layout.items():
+        proj = tmp_path / name
+        state = proj / ".vnx-data" / "state"
+        _mk_qi(state / "quality_intelligence.db", qi_schema)
+        _mk_minimal_other_dbs(state)
+        specs.append({"name": name, "path": str(proj), "project_id": pid})
+
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({"projects": specs}))
+    return registry
+
+
+def test_project_schema_walks_tables(tmp_path: Path):
+    proj = tmp_path / "p"
+    state = proj / ".vnx-data" / "state"
+    _mk_qi(state / "quality_intelligence.db", {"success_patterns": ["a", "b"]})
+    _mk_minimal_other_dbs(state)
+    entry = ProjectEntry(name="p", path=proj, project_id="p")
+    schema = _project_schema(entry)
+    assert "success_patterns" in schema["quality_intelligence.db"]
+    assert schema["quality_intelligence.db"]["success_patterns"] == ["a", "b"]
+
+
+def test_compute_drift_flags_missing_table(drift_fixture):
+    from scripts.aggregator.build_central_view import load_registry
+
+    projects = load_registry(drift_fixture)
+    schemas = {p.project_id: _project_schema(p) for p in projects}
+    drift = compute_drift(schemas)
+
+    mc = drift["projects"]["mc"]["quality_intelligence.db"]
+    assert "dispatch_metadata" in mc["missing_tables"]
+
+
+def test_compute_drift_flags_missing_column(drift_fixture):
+    from scripts.aggregator.build_central_view import load_registry
+
+    projects = load_registry(drift_fixture)
+    schemas = {p.project_id: _project_schema(p) for p in projects}
+    drift = compute_drift(schemas)
+
+    sc = drift["projects"]["sales-copilot"]["quality_intelligence.db"]
+    assert "success_patterns" in sc["column_diffs"]
+    assert "confidence" in sc["column_diffs"]["success_patterns"]["missing"]
+
+
+def test_compute_drift_clean_for_reference(drift_fixture):
+    from scripts.aggregator.build_central_view import load_registry
+
+    projects = load_registry(drift_fixture)
+    schemas = {p.project_id: _project_schema(p) for p in projects}
+    drift = compute_drift(schemas)
+
+    # The reference project must have no drift against itself.
+    ref_pid = drift["reference"]
+    ref_per_db = drift["projects"][ref_pid]
+    qi = ref_per_db["quality_intelligence.db"]
+    assert qi["missing_tables"] == []
+    assert qi["extra_tables"] == []
+    assert qi["column_diffs"] == {}
+
+
+def test_cli_json_emits_valid_report(drift_fixture, capsys):
+    rc = main(["--registry", str(drift_fixture), "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["reference"] == "vnx-dev"
+    assert "mc" in payload["projects"]
+
+
+def test_cli_text_mode(drift_fixture, capsys):
+    rc = main(["--registry", str(drift_fixture)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "vnx-dev" in out
+    assert "mc" in out
+    assert "DRIFT" in out

--- a/tests/test_strategy_decisions.py
+++ b/tests/test_strategy_decisions.py
@@ -1,0 +1,322 @@
+"""Unit tests for scripts.lib.strategy.decisions."""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.strategy.decisions import (  # noqa: E402
+    Decision,
+    DecisionValidationError,
+    record_decision,
+    recent_decisions,
+    supersedes_chain,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _record(
+    decision_id: str,
+    scope: str = "test-scope",
+    rationale: str = "test rationale",
+    supersedes: str | None = None,
+    evidence_path: str | None = None,
+    *,
+    path: Path,
+) -> Decision:
+    return record_decision(
+        decision_id,
+        scope,
+        rationale,
+        supersedes=supersedes,
+        evidence_path=evidence_path,
+        path=path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Append + tail roundtrip
+# ---------------------------------------------------------------------------
+class TestAppendTailRoundtrip:
+    def test_single_entry(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        d = _record("OD-2026-05-06-001", path=p)
+        assert d.decision_id == "OD-2026-05-06-001"
+        assert d.scope == "test-scope"
+        assert d.rationale == "test rationale"
+        assert d.supersedes is None
+        assert d.evidence_path is None
+
+        tail = recent_decisions(n=10, path=p)
+        assert len(tail) == 1
+        assert tail[0].decision_id == "OD-2026-05-06-001"
+        assert tail[0].ts == d.ts
+
+    def test_multiple_entries_order(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", scope="s1", path=p)
+        _record("OD-2026-05-06-002", scope="s2", path=p)
+        _record("OD-2026-05-06-003", scope="s3", path=p)
+
+        tail = recent_decisions(n=10, path=p)
+        assert len(tail) == 3
+        ids = [d.decision_id for d in tail]
+        assert ids == ["OD-2026-05-06-001", "OD-2026-05-06-002", "OD-2026-05-06-003"]
+
+    def test_optional_fields_roundtrip(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        d = _record(
+            "TD-2026-05-06-001",
+            scope="scope-with-evidence",
+            rationale="multi-line\nrationale",
+            supersedes="OD-2026-05-01-001",
+            evidence_path="claudedocs/my-adr.md",
+            path=p,
+        )
+        tail = recent_decisions(n=1, path=p)
+        assert len(tail) == 1
+        assert tail[0].supersedes == "OD-2026-05-01-001"
+        assert tail[0].evidence_path == "claudedocs/my-adr.md"
+        assert tail[0].rationale == "multi-line\nrationale"
+
+    def test_file_contains_valid_ndjson(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", path=p)
+        _record("OD-2026-05-06-002", path=p)
+        lines = [l for l in p.read_text().splitlines() if l.strip()]
+        assert len(lines) == 2
+        for line in lines:
+            obj = json.loads(line)
+            assert "decision_id" in obj
+            assert "scope" in obj
+            assert "ts" in obj
+            assert "rationale" in obj
+
+    def test_no_file_returns_empty_list(self, tmp_path):
+        p = tmp_path / "nonexistent.ndjson"
+        assert recent_decisions(n=10, path=p) == []
+
+
+# ---------------------------------------------------------------------------
+# recent_decisions honors n
+# ---------------------------------------------------------------------------
+class TestRecentDecisionsN:
+    def test_n_limits_results(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        for i in range(1, 8):
+            _record(f"OD-2026-05-06-{i:03d}", scope=f"s{i}", path=p)
+
+        tail3 = recent_decisions(n=3, path=p)
+        assert len(tail3) == 3
+        assert [d.decision_id for d in tail3] == [
+            "OD-2026-05-06-005",
+            "OD-2026-05-06-006",
+            "OD-2026-05-06-007",
+        ]
+
+    def test_n_larger_than_total_returns_all(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", path=p)
+        _record("OD-2026-05-06-002", path=p)
+
+        assert len(recent_decisions(n=100, path=p)) == 2
+
+    def test_n_zero_returns_empty(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", path=p)
+        assert recent_decisions(n=0, path=p) == []
+
+    def test_default_n_is_10(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        for i in range(1, 16):
+            _record(f"OD-2026-05-06-{i:03d}", scope=f"s{i}", path=p)
+
+        tail = recent_decisions(path=p)
+        assert len(tail) == 10
+        assert tail[0].decision_id == "OD-2026-05-06-006"
+        assert tail[-1].decision_id == "OD-2026-05-06-015"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writers — no interleaving
+# ---------------------------------------------------------------------------
+class TestConcurrentWriters:
+    def test_no_corruption_under_threading(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        errors: list[Exception] = []
+        n_threads = 4
+        entries_per_thread = 10
+
+        def write_entries(thread_idx: int) -> None:
+            try:
+                for j in range(1, entries_per_thread + 1):
+                    seq = thread_idx * 100 + j
+                    _record(f"OD-2026-05-06-{seq:03d}", scope=f"t{thread_idx}-entry{j}", path=p)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=write_entries, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+
+        lines = [l for l in p.read_text().splitlines() if l.strip()]
+        assert len(lines) == n_threads * entries_per_thread
+
+        for line in lines:
+            obj = json.loads(line)
+            assert "decision_id" in obj
+            assert "scope" in obj
+            assert "ts" in obj
+            assert "rationale" in obj
+
+
+# ---------------------------------------------------------------------------
+# Schema rejection
+# ---------------------------------------------------------------------------
+class TestSchemaRejection:
+    def test_missing_decision_id(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError, match="decision_id"):
+            record_decision("", "scope", "rationale", path=p)
+
+    def test_missing_scope(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError, match="scope"):
+            record_decision("OD-2026-05-06-001", "", "rationale", path=p)
+
+    def test_missing_rationale(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError, match="rationale"):
+            record_decision("OD-2026-05-06-001", "scope", "", path=p)
+
+    def test_bad_prefix_rejected(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError):
+            _record("XX-2026-05-06-001", path=p)
+
+    def test_lowercase_prefix_rejected(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError):
+            _record("od-2026-05-06-001", path=p)
+
+    def test_no_file_written_on_rejection(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError):
+            _record("XX-2026-05-06-001", path=p)
+        assert not p.exists()
+
+
+# ---------------------------------------------------------------------------
+# Decision-ID format validation
+# ---------------------------------------------------------------------------
+class TestDecisionIdFormat:
+    @pytest.mark.parametrize("valid_id", [
+        "OD-2026-05-06-001",
+        "OD-2026-12-31-999",
+        "TD-2026-05-06-001",
+        "TD-2000-01-01-001",
+        "OD-2026-05-06-042",
+    ])
+    def test_valid_ids_accepted(self, tmp_path, valid_id):
+        p = tmp_path / "decisions.ndjson"
+        d = _record(valid_id, path=p)
+        assert d.decision_id == valid_id
+
+    @pytest.mark.parametrize("invalid_id", [
+        "XX-2026-05-06-001",        # wrong prefix
+        "od-2026-05-06-001",        # lowercase
+        "OD-2026-13-01-001",        # month 13 invalid
+        "OD-2026-00-01-001",        # month 0 invalid
+        "OD-2026-05-00-001",        # day 0 invalid
+        "OD-2026-05-32-001",        # day 32 invalid
+        "OD-26-05-06-001",          # 2-digit year
+        "OD-2026-5-6-001",          # unpadded month/day
+        "OD-2026-05-06-01",         # 2-digit sequence
+        "OD-2026-05-06-0001",       # 4-digit sequence
+        "2026-05-06-001",           # missing prefix
+        "",                          # empty
+        "OD-2026-05-06",            # missing sequence
+    ])
+    def test_invalid_ids_rejected(self, tmp_path, invalid_id):
+        p = tmp_path / "decisions.ndjson"
+        with pytest.raises(DecisionValidationError):
+            _record(invalid_id, path=p)
+
+
+# ---------------------------------------------------------------------------
+# supersedes_chain
+# ---------------------------------------------------------------------------
+class TestSupersedesChain:
+    def test_three_deep_chain(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", scope="original", path=p)
+        _record("OD-2026-05-06-002", scope="revised", supersedes="OD-2026-05-06-001", path=p)
+        _record("OD-2026-05-06-003", scope="final", supersedes="OD-2026-05-06-002", path=p)
+
+        chain = supersedes_chain("OD-2026-05-06-003", path=p)
+        assert len(chain) == 3
+        assert chain[0].decision_id == "OD-2026-05-06-001"
+        assert chain[1].decision_id == "OD-2026-05-06-002"
+        assert chain[2].decision_id == "OD-2026-05-06-003"
+
+    def test_root_node_chain_length_one(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", path=p)
+        chain = supersedes_chain("OD-2026-05-06-001", path=p)
+        assert len(chain) == 1
+        assert chain[0].decision_id == "OD-2026-05-06-001"
+
+    def test_chain_from_middle(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", scope="root", path=p)
+        _record("OD-2026-05-06-002", scope="mid", supersedes="OD-2026-05-06-001", path=p)
+        _record("OD-2026-05-06-003", scope="leaf", supersedes="OD-2026-05-06-002", path=p)
+
+        chain = supersedes_chain("OD-2026-05-06-002", path=p)
+        assert len(chain) == 2
+        assert chain[0].decision_id == "OD-2026-05-06-001"
+        assert chain[1].decision_id == "OD-2026-05-06-002"
+
+    def test_missing_decision_returns_empty(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", path=p)
+        assert supersedes_chain("OD-2026-05-06-999", path=p) == []
+
+    def test_no_file_returns_empty(self, tmp_path):
+        p = tmp_path / "nonexistent.ndjson"
+        assert supersedes_chain("OD-2026-05-06-001", path=p) == []
+
+    def test_cycle_guard(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        # Manually write a cycle
+        p.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            json.dumps({"decision_id": "OD-2026-05-06-001", "scope": "a", "ts": "2026-05-06T00:00:00+00:00", "rationale": "r", "supersedes": "OD-2026-05-06-002"}),
+            json.dumps({"decision_id": "OD-2026-05-06-002", "scope": "b", "ts": "2026-05-06T00:00:01+00:00", "rationale": "r", "supersedes": "OD-2026-05-06-001"}),
+        ]
+        p.write_text("\n".join(lines) + "\n")
+        chain = supersedes_chain("OD-2026-05-06-001", path=p)
+        # Should not infinite loop; length is bounded
+        assert len(chain) <= 2
+
+    def test_chain_scopes_preserved(self, tmp_path):
+        p = tmp_path / "decisions.ndjson"
+        _record("OD-2026-05-06-001", scope="signing-key-location", path=p)
+        _record("OD-2026-05-06-002", scope="signing-key-location-v2", supersedes="OD-2026-05-06-001", path=p)
+
+        chain = supersedes_chain("OD-2026-05-06-002", path=p)
+        assert chain[0].scope == "signing-key-location"
+        assert chain[1].scope == "signing-key-location-v2"


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/strategy/decisions.py`: append-only NDJSON log at `.vnx-data/strategy/decisions.ndjson` with `fcntl.flock`-safe concurrent writes
- Decision IDs follow `OD-YYYY-MM-DD-NNN` (operator) / `TD-YYYY-MM-DD-NNN` (T0) with strict format + month/day range validation
- Three public functions: `record_decision`, `recent_decisions(n=10)`, `supersedes_chain` (walks supersedes pointers root-first)

## W-state-2 Success Criteria

- [x] `record_decision(...)` appends a valid NDJSON line and returns the Decision object
- [x] Concurrent writes do not corrupt the file (threading lock test passes)
- [x] `recent_decisions(n)` returns last N entries in chronological order
- [x] Schema rejection on missing required fields (decision_id, scope, rationale) and bad ID format
- [x] `supersedes_chain` resolves 3-deep chains ordered root → leaf

## Test plan

- `pytest tests/test_strategy_decisions.py -x` → 41 passed
- Covers: append+tail roundtrip, 4-thread concurrent writes (40 entries, no corruption), schema rejection (6 cases), ID format parametrized (5 valid, 13 invalid), supersedes_chain (7 cases including cycle guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)