### PR TITLE
feat(streaming): _streaming_drainer mixin + event_store dispatch_id fix (Phase 3 W7-B)

### DIFF
--- a/scripts/lib/_streaming_drainer.py
+++ b/scripts/lib/_streaming_drainer.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""_streaming_drainer.py — Shared NDJSON streaming drainer mixin for all provider adapters.
+
+All provider adapters (Codex, Gemini, LiteLLM, Ollama) compose this mixin to
+drain their subprocess stdout streams into CanonicalEvent objects with Tier-1
+observability. Subclasses define `_normalize(raw_chunk)` to map provider-specific
+event shapes; the mixin handles buffering, timeouts, error recovery, and EventStore writes.
+
+BILLING SAFETY: No Anthropic SDK imports. No external network calls.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import select
+import subprocess
+import threading
+import time
+from typing import Any, Callable, Dict, Iterator, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from event_store import EventStore
+
+from canonical_event import CanonicalEvent, VALID_EVENT_TYPES
+
+logger = logging.getLogger(__name__)
+
+# Sentinel object used to signal the producer thread has finished
+_SENTINEL = object()
+
+# Tier-1 means live per-event streaming (full observability)
+_STREAMING_TIER = 1
+
+# Canonical event types that represent successful completion
+_COMPLETE_TYPES = frozenset({"complete", "result"})
+
+# Default bounded queue size — large enough to buffer burst, small enough to apply backpressure
+_DEFAULT_QUEUE_MAXSIZE = 256
+
+
+class StreamingDrainerMixin:
+    """Mixin that drains provider subprocess stdout into CanonicalEvent objects.
+
+    Compose this mixin into any provider adapter class. The subclass must set
+    `provider_name` and implement `_normalize(raw_chunk)`.
+
+    Usage::
+
+        class MyAdapter(StreamingDrainerMixin, ProviderAdapter):
+            provider_name = "myprovider"
+
+            def _normalize(self, raw_chunk: dict) -> CanonicalEvent:
+                ...  # map raw provider event -> CanonicalEvent
+
+            def run(self, process, terminal_id, dispatch_id, event_store):
+                for event in self.drain_stream(process, terminal_id, dispatch_id, event_store):
+                    # handle event
+    """
+
+    # Subclasses override these
+    provider_name: str = "unknown"
+
+    def _normalize(self, raw_chunk: Dict[str, Any]) -> CanonicalEvent:
+        """Map a raw provider JSON chunk to a CanonicalEvent.
+
+        Subclasses must override this. The returned event's observability_tier
+        will be overwritten to _STREAMING_TIER (1) by the mixin.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _normalize(raw_chunk)"
+        )
+
+    def drain_stream(
+        self,
+        process: subprocess.Popen,
+        terminal_id: str,
+        dispatch_id: str,
+        event_store: Optional[Any] = None,
+        chunk_timeout: float = 300.0,
+        total_deadline: float = 900.0,
+        _queue_maxsize: int = _DEFAULT_QUEUE_MAXSIZE,
+    ) -> Iterator[CanonicalEvent]:
+        """Drain process stdout line-by-line, yielding CanonicalEvents.
+
+        A producer thread reads from subprocess stdout and pushes parsed events
+        onto a bounded queue. The caller iterates this generator to consume them.
+        The bounded queue caps memory growth and creates backpressure: when the
+        queue is full, the producer thread blocks, preventing unbounded buffering.
+
+        On chunk_timeout (no output for N seconds), or total_deadline exceeded,
+        the process is killed and a synthetic error CanonicalEvent is emitted.
+
+        If the process exits non-zero without emitting a complete/result event,
+        a synthetic error CanonicalEvent is appended to the stream.
+
+        Args:
+            process: Running subprocess with stdout=PIPE.
+            terminal_id: Terminal identifier (e.g. "T1").
+            dispatch_id: Current dispatch identifier.
+            event_store: EventStore instance for live persistence. None = skip writes.
+            chunk_timeout: Max seconds between consecutive output lines.
+            total_deadline: Max total seconds for the entire drain.
+            _queue_maxsize: Bounded queue capacity (default 256 events).
+        """
+        try:
+            chunk_timeout = float(os.environ.get("VNX_CHUNK_TIMEOUT", chunk_timeout))
+        except (TypeError, ValueError):
+            pass
+        try:
+            total_deadline = float(os.environ.get("VNX_TOTAL_DEADLINE", total_deadline))
+        except (TypeError, ValueError):
+            pass
+
+        result_queue: queue.Queue = queue.Queue(maxsize=_queue_maxsize)
+        seen_complete = threading.Event()
+        timed_out = threading.Event()
+
+        def _producer() -> None:
+            """Read stdout in background thread; push CanonicalEvents onto result_queue."""
+            try:
+                _run_producer(
+                    process=process,
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    event_store=event_store,
+                    chunk_timeout=chunk_timeout,
+                    total_deadline=total_deadline,
+                    result_queue=result_queue,
+                    seen_complete=seen_complete,
+                    timed_out=timed_out,
+                    normalize_fn=self._normalize,
+                    provider_name=self.provider_name,
+                )
+            except Exception:
+                logger.exception(
+                    "_streaming_drainer: producer thread crashed for %s/%s",
+                    terminal_id, dispatch_id,
+                )
+            finally:
+                result_queue.put(_SENTINEL)
+
+        producer = threading.Thread(target=_producer, daemon=True, name=f"drainer-{terminal_id}")
+        producer.start()
+
+        while True:
+            try:
+                item = result_queue.get(timeout=chunk_timeout + 10.0)
+            except queue.Empty:
+                # Producer appears stuck — emit a synthetic error and stop
+                logger.warning(
+                    "_streaming_drainer: consumer queue timed out for %s/%s",
+                    terminal_id, dispatch_id,
+                )
+                err = _make_error_event(
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    provider=self.provider_name,
+                    raw=None,
+                    reason="consumer queue wait exceeded chunk_timeout+10s",
+                )
+                _append_to_store(event_store, terminal_id, err, dispatch_id)
+                yield err
+                break
+
+            if item is _SENTINEL:
+                break
+
+            yield item
+
+        producer.join(timeout=5.0)
+
+        # If process exited non-zero without a complete event, emit synthetic error
+        rc = process.poll()
+        if not seen_complete.is_set() and rc is not None and rc != 0:
+            err = _make_error_event(
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                provider=self.provider_name,
+                raw=None,
+                reason=f"subprocess exited with code {rc} before complete event",
+            )
+            _append_to_store(event_store, terminal_id, err, dispatch_id)
+            yield err
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (module-level to avoid closure capture issues in threads)
+# ---------------------------------------------------------------------------
+
+def _run_producer(
+    *,
+    process: subprocess.Popen,
+    terminal_id: str,
+    dispatch_id: str,
+    event_store: Optional[Any],
+    chunk_timeout: float,
+    total_deadline: float,
+    result_queue: "queue.Queue[Any]",
+    seen_complete: threading.Event,
+    timed_out: threading.Event,
+    normalize_fn: Callable[[Dict[str, Any]], CanonicalEvent],
+    provider_name: str,
+) -> None:
+    """Read subprocess stdout, parse NDJSON, push events to queue."""
+    if process.stdout is None:
+        return
+
+    fd = process.stdout.fileno()
+    line_buffer = b""
+    start = time.monotonic()
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= total_deadline:
+            logger.warning(
+                "_streaming_drainer: total deadline (%.0fs) exceeded for %s",
+                total_deadline, terminal_id,
+            )
+            timed_out.set()
+            _kill_process(process)
+            err = _make_error_event(
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                provider=provider_name,
+                raw=None,
+                reason=f"total deadline {total_deadline:.0f}s exceeded",
+            )
+            _append_to_store(event_store, terminal_id, err, dispatch_id)
+            result_queue.put(err)
+            return
+
+        remaining = min(chunk_timeout, total_deadline - elapsed)
+        try:
+            ready, _, _ = select.select([fd], [], [], remaining)
+        except (ValueError, OSError):
+            break  # fd closed
+
+        if not ready:
+            logger.warning(
+                "_streaming_drainer: chunk timeout (%.0fs) for %s",
+                chunk_timeout, terminal_id,
+            )
+            timed_out.set()
+            _kill_process(process)
+            err = _make_error_event(
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                provider=provider_name,
+                raw=None,
+                reason=f"chunk timeout {chunk_timeout:.0f}s exceeded",
+            )
+            _append_to_store(event_store, terminal_id, err, dispatch_id)
+            result_queue.put(err)
+            return
+
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break  # fd closed (process killed)
+
+        if not chunk:
+            # EOF — process finished cleanly
+            rc = process.poll()
+            if rc is not None:
+                pass  # returncode available for post-drain check
+            break
+
+        line_buffer += chunk
+        while b"\n" in line_buffer:
+            raw_line, line_buffer = line_buffer.split(b"\n", 1)
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+
+            event = _parse_line(
+                line=line,
+                terminal_id=terminal_id,
+                dispatch_id=dispatch_id,
+                provider_name=provider_name,
+                normalize_fn=normalize_fn,
+            )
+
+            # Stamp Tier-1 on all streaming events
+            object.__setattr__(event, "observability_tier", _STREAMING_TIER) if hasattr(type(event), "__dataclass_fields__") else None
+            # Dataclasses are not frozen, so direct assignment works
+            try:
+                event.observability_tier = _STREAMING_TIER
+            except AttributeError:
+                pass
+
+            if event.event_type in _COMPLETE_TYPES:
+                seen_complete.set()
+
+            _append_to_store(event_store, terminal_id, event, dispatch_id)
+            result_queue.put(event)  # blocks if queue full (backpressure)
+
+
+def _parse_line(
+    *,
+    line: str,
+    terminal_id: str,
+    dispatch_id: str,
+    provider_name: str,
+    normalize_fn: Callable[[Dict[str, Any]], CanonicalEvent],
+) -> CanonicalEvent:
+    """Parse one NDJSON line and return a CanonicalEvent (or error event on failure)."""
+    try:
+        raw = json.loads(line)
+        if not isinstance(raw, dict):
+            raise ValueError(f"expected JSON object, got {type(raw).__name__}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        return _make_error_event(
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            provider=provider_name,
+            raw=line,
+            reason=str(exc),
+        )
+
+    try:
+        return normalize_fn(raw)
+    except Exception as exc:
+        logger.warning(
+            "_streaming_drainer: _normalize() raised for %s (line: %r): %s",
+            terminal_id, line[:200], exc,
+        )
+        return _make_error_event(
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            provider=provider_name,
+            raw=line,
+            reason=f"normalize error: {exc}",
+        )
+
+
+def _make_error_event(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    provider: str,
+    raw: Optional[str],
+    reason: str,
+) -> CanonicalEvent:
+    """Build a canonical error event for malformed chunks or fatal conditions."""
+    data: Dict[str, Any] = {"reason": reason}
+    if raw is not None:
+        data["raw"] = raw[:500]  # truncate to avoid enormous NDJSON lines
+    return CanonicalEvent(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        provider=provider,
+        event_type="error",
+        data=data,
+        observability_tier=_STREAMING_TIER,
+    )
+
+
+def _append_to_store(
+    event_store: Optional[Any],
+    terminal_id: str,
+    event: CanonicalEvent,
+    dispatch_id: str,
+) -> None:
+    """Write event to EventStore; swallow all errors so the drainer stays live."""
+    if event_store is None:
+        return
+    try:
+        # Explicit dispatch_id kwarg wins (OI-1349 fix)
+        event_store.append(terminal_id, event, dispatch_id=dispatch_id)
+    except Exception:
+        logger.exception(
+            "_streaming_drainer: EventStore.append failed for %s", terminal_id
+        )
+
+
+def _kill_process(process: subprocess.Popen) -> None:
+    """Send SIGTERM then SIGKILL to process group."""
+    import signal as _signal
+    try:
+        pgid = os.getpgid(process.pid)
+        os.killpg(pgid, _signal.SIGTERM)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(pgid, _signal.SIGKILL)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+    except (OSError, ProcessLookupError):
+        try:
+            process.kill()
+        except OSError:
+            pass

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -58,13 +58,17 @@ class EventStore:
         self,
         terminal: str,
         event: "Union[Dict[str, Any], CanonicalEvent]",
-        dispatch_id: str = "",
+        dispatch_id: Optional[str] = None,
     ) -> None:
         """Append a single event as an atomic NDJSON line.
 
         Accepts both legacy dict events and CanonicalEvent instances.
         Uses LOCK_EX for write safety. The line is written in a single write()
         call including the trailing newline to prevent partial reads.
+
+        dispatch_id precedence: explicit kwarg (when not None) wins over the
+        event's own dispatch_id field. Omitting the kwarg (None) falls back to
+        the event's field. Fixes OI-1349.
         """
         from canonical_event import CanonicalEvent as _CE  # local import avoids circular dep at module load
 
@@ -72,10 +76,11 @@ class EventStore:
         path = self._terminal_path(terminal)
 
         if isinstance(event, _CE):
+            effective_dispatch_id = dispatch_id if dispatch_id is not None else event.dispatch_id
             envelope: Dict[str, Any] = {
                 "type": event.event_type,
                 "timestamp": event.timestamp,
-                "dispatch_id": event.dispatch_id or dispatch_id,
+                "dispatch_id": effective_dispatch_id,
                 "terminal": terminal,
                 "sequence": self._next_sequence(terminal),
                 "data": event.data,
@@ -86,11 +91,12 @@ class EventStore:
                 "provider_meta": event.provider_meta,
             }
         else:
+            effective_dispatch_id = dispatch_id if dispatch_id is not None else event.get("dispatch_id", "")
             # Legacy dict path — default tier 2 (buffered) for backwards compat
             envelope = {
                 "type": event.get("type", "unknown"),
                 "timestamp": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
-                "dispatch_id": dispatch_id or event.get("dispatch_id", ""),
+                "dispatch_id": effective_dispatch_id,
                 "terminal": terminal,
                 "sequence": self._next_sequence(terminal),
                 "data": event.get("data", event),

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -75,6 +75,36 @@ class TestAppend:
         event = json.loads(path.read_text().strip())
         assert event["dispatch_id"] == "d-001"
 
+    def test_append_kwarg_wins_over_event_dispatch_id(self, store, tmp_events_dir):
+        """OI-1349: explicit dispatch_id kwarg takes precedence over event field."""
+        from canonical_event import CanonicalEvent
+        ce = CanonicalEvent(
+            dispatch_id="event-dispatch",
+            terminal_id="T1",
+            provider="claude",
+            event_type="text",
+            data={"text": "hi"},
+        )
+        store.append("T1", ce, dispatch_id="kwarg-dispatch")
+        path = tmp_events_dir / "T1.ndjson"
+        envelope = json.loads(path.read_text().strip())
+        assert envelope["dispatch_id"] == "kwarg-dispatch"
+
+    def test_append_canonical_event_no_kwarg_uses_event_dispatch_id(self, store, tmp_events_dir):
+        """When dispatch_id kwarg is omitted, CanonicalEvent.dispatch_id is used."""
+        from canonical_event import CanonicalEvent
+        ce = CanonicalEvent(
+            dispatch_id="event-owns-this",
+            terminal_id="T1",
+            provider="claude",
+            event_type="text",
+            data={},
+        )
+        store.append("T1", ce)
+        path = tmp_events_dir / "T1.ndjson"
+        envelope = json.loads(path.read_text().strip())
+        assert envelope["dispatch_id"] == "event-owns-this"
+
 
 class TestTail:
     def test_tail_returns_all_events(self, store):

--- a/tests/test_streaming_drainer.py
+++ b/tests/test_streaming_drainer.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Tests for _streaming_drainer.py — StreamingDrainerMixin."""
+
+from __future__ import annotations
+
+import io
+import json
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from canonical_event import CanonicalEvent
+from _streaming_drainer import (
+    StreamingDrainerMixin,
+    _make_error_event,
+    _parse_line,
+    _STREAMING_TIER,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_process(lines: list[str], returncode: int = 0, delay: float = 0.0) -> MagicMock:
+    """Return a mock Popen-like object whose stdout yields the given NDJSON lines."""
+    encoded = b"".join((l.rstrip("\n") + "\n").encode() for l in lines)
+    buf = io.BytesIO(encoded)
+
+    class _FakeStdout:
+        def __init__(self):
+            self._buf = buf
+            self.fileno = lambda: _make_process._pipe_fd  # real fd set below
+
+        def read(self, n: int = -1):
+            if delay:
+                time.sleep(delay)
+            return self._buf.read(n)
+
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.returncode = returncode
+    proc.poll.return_value = returncode
+    proc.stdout = MagicMock()
+    # We'll patch os.read and select.select in tests that need them
+    return proc
+
+
+def _make_pipe_process(lines: list[str], returncode: int = 0) -> subprocess.Popen:
+    """Spawn a real subprocess that writes NDJSON lines then exits with returncode."""
+    ndjson = "".join(l.rstrip("\n") + "\n" for l in lines)
+    script = (
+        f"import sys\n"
+        f"sys.stdout.write({ndjson!r})\n"
+        f"sys.stdout.flush()\n"
+        f"sys.exit({returncode})\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return proc
+
+
+class _EchoNormalizer(StreamingDrainerMixin):
+    """Minimal adapter that echoes raw chunks as CanonicalEvent(text)."""
+
+    provider_name = "claude"
+
+    def _normalize(self, raw: Dict[str, Any]) -> CanonicalEvent:
+        return CanonicalEvent(
+            dispatch_id=raw.get("dispatch_id", "test-dispatch"),
+            terminal_id=raw.get("terminal_id", "T1"),
+            provider="claude",
+            event_type=raw.get("type", "text"),
+            data=raw.get("data", {}),
+            observability_tier=2,
+        )
+
+
+class _ErrorNormalizer(StreamingDrainerMixin):
+    """Normalizer that always raises to simulate _normalize failures."""
+
+    provider_name = "claude"
+
+    def _normalize(self, raw: Dict[str, Any]) -> CanonicalEvent:
+        raise RuntimeError("normalize exploded")
+
+
+# ---------------------------------------------------------------------------
+# Tests: normal stream
+# ---------------------------------------------------------------------------
+
+class TestNormalStream:
+    def test_events_yielded_in_order(self):
+        lines = [
+            json.dumps({"type": "init", "data": {"session_id": "s1"}}),
+            json.dumps({"type": "text", "data": {"text": "hello"}}),
+            json.dumps({"type": "complete", "data": {"exit_code": 0}}),
+        ]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        types = [e.event_type for e in events]
+        assert types == ["init", "text", "complete"]
+
+    def test_tier_label_overridden_to_1(self):
+        lines = [json.dumps({"type": "text", "data": {}})]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert len(events) == 1
+        assert events[0].observability_tier == _STREAMING_TIER  # must be 1
+
+    def test_empty_stream_yields_no_events(self):
+        proc = _make_pipe_process([], returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+        assert events == []
+
+    def test_event_store_receives_all_events(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        lines = [
+            json.dumps({"type": "text", "data": {"n": i}}) for i in range(5)
+        ]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        list(adapter.drain_stream(proc, "T1", "d-001", event_store=es))
+
+        assert es.event_count("T1") == 5
+
+    def test_event_store_uses_explicit_dispatch_id(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        lines = [json.dumps({"type": "text", "data": {}})]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        list(adapter.drain_stream(proc, "T1", "override-dispatch", event_store=es))
+
+        stored = list(es.tail("T1"))
+        assert stored[0]["dispatch_id"] == "override-dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Tests: malformed chunks
+# ---------------------------------------------------------------------------
+
+class TestMalformedChunks:
+    def test_malformed_json_becomes_error_event(self):
+        lines = ["this is not json\n"]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert len(events) == 1
+        assert events[0].event_type == "error"
+        assert "raw" in events[0].data
+        assert "this is not json" in events[0].data["raw"]
+
+    def test_json_array_is_error(self):
+        lines = [json.dumps([1, 2, 3]) + "\n"]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert len(events) == 1
+        assert events[0].event_type == "error"
+        assert "expected JSON object" in events[0].data["reason"]
+
+    def test_mixed_valid_and_malformed(self):
+        lines = [
+            json.dumps({"type": "text", "data": {}}),
+            "bad line\n",
+            json.dumps({"type": "complete", "data": {}}),
+        ]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert len(events) == 3
+        assert events[0].event_type == "text"
+        assert events[1].event_type == "error"
+        assert events[2].event_type == "complete"
+
+    def test_normalize_exception_becomes_error_event(self):
+        lines = [json.dumps({"type": "text", "data": {}})]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _ErrorNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert len(events) == 1
+        assert events[0].event_type == "error"
+        assert "normalize error" in events[0].data["reason"]
+
+    def test_empty_lines_do_not_produce_events(self):
+        """Empty lines in stdout are silently skipped (no events, no errors)."""
+        # Build a process that outputs blank lines interspersed with valid events
+        import subprocess
+        script = (
+            "import sys\n"
+            'sys.stdout.write(\'{"type": "text", "data": {}}\' + "\\n")\n'
+            'sys.stdout.write("\\n")\n'  # blank line
+            'sys.stdout.write("\\n")\n'  # another blank
+            'sys.stdout.write(\'{"type": "complete", "data": {}}\' + "\\n")\n'
+            "sys.stdout.flush()\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+        # Only the two valid JSON events; blank lines produce nothing
+        types = [e.event_type for e in events]
+        assert types == ["text", "complete"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: crash safety (non-zero exit without complete event)
+# ---------------------------------------------------------------------------
+
+class TestCrashSafety:
+    def test_nonzero_exit_without_complete_emits_synthetic_error(self):
+        lines = [json.dumps({"type": "text", "data": {"msg": "partial"}})]
+        proc = _make_pipe_process(lines, returncode=1)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        # Last event should be a synthetic error
+        assert events[-1].event_type == "error"
+        assert "exit" in events[-1].data["reason"].lower() or "code" in events[-1].data["reason"].lower()
+
+    def test_zero_exit_without_complete_no_synthetic_error(self):
+        lines = [json.dumps({"type": "text", "data": {}})]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        error_events = [e for e in events if e.event_type == "error"]
+        assert error_events == []
+
+    def test_complete_event_suppresses_synthetic_error(self):
+        lines = [
+            json.dumps({"type": "text", "data": {}}),
+            json.dumps({"type": "complete", "data": {}}),
+        ]
+        proc = _make_pipe_process(lines, returncode=1)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        # complete event seen — no synthetic error should be appended
+        error_events = [e for e in events if e.event_type == "error"]
+        assert error_events == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: backpressure (bounded queue)
+# ---------------------------------------------------------------------------
+
+class TestBackpressure:
+    def test_small_queue_does_not_deadlock(self):
+        """draining 50 events through a queue of size 4 must not deadlock."""
+        lines = [json.dumps({"type": "text", "data": {"n": i}}) for i in range(50)]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+
+        events = list(adapter.drain_stream(
+            proc, "T1", "d-001", event_store=None, _queue_maxsize=4
+        ))
+        assert len(events) == 50
+
+    def test_consumer_receives_all_events_with_backpressure(self):
+        """Slow consumer (sleep between reads) still gets all events."""
+        lines = [json.dumps({"type": "text", "data": {"n": i}}) for i in range(20)]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+
+        received = []
+        for ev in adapter.drain_stream(proc, "T1", "d-001", event_store=None, _queue_maxsize=2):
+            time.sleep(0.001)  # simulate slow consumer
+            received.append(ev)
+
+        assert len(received) == 20
+
+
+# ---------------------------------------------------------------------------
+# Tests: tier labeling
+# ---------------------------------------------------------------------------
+
+class TestTierLabeling:
+    def test_all_events_tier_1(self):
+        lines = [
+            json.dumps({"type": t, "data": {}})
+            for t in ("init", "text", "complete")
+        ]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert all(e.observability_tier == 1 for e in events), (
+            f"Expected all tier=1, got: {[e.observability_tier for e in events]}"
+        )
+
+    def test_error_events_also_tier_1(self):
+        lines = ["not-json\n"]
+        proc = _make_pipe_process(lines, returncode=0)
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
+
+        assert events[0].observability_tier == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_error_event helper
+# ---------------------------------------------------------------------------
+
+class TestMakeErrorEvent:
+    def test_with_raw(self):
+        ev = _make_error_event(
+            terminal_id="T1",
+            dispatch_id="d-test",
+            provider="claude",
+            raw="bad chunk",
+            reason="parse failed",
+        )
+        assert ev.event_type == "error"
+        assert ev.data["raw"] == "bad chunk"
+        assert ev.data["reason"] == "parse failed"
+
+    def test_without_raw(self):
+        ev = _make_error_event(
+            terminal_id="T1",
+            dispatch_id="d-test",
+            provider="claude",
+            raw=None,
+            reason="timeout",
+        )
+        assert "raw" not in ev.data
+        assert ev.data["reason"] == "timeout"
+
+    def test_raw_truncated_at_500(self):
+        long_raw = "x" * 1000
+        ev = _make_error_event(
+            terminal_id="T1",
+            dispatch_id="d-test",
+            provider="claude",
+            raw=long_raw,
+            reason="too long",
+        )
+        assert len(ev.data["raw"]) == 500


### PR DESCRIPTION
## Summary

- **New**: `scripts/lib/_streaming_drainer.py` — `StreamingDrainerMixin` for all provider adapters. Producer-thread + bounded queue for backpressure; `select()`-based chunk/total timeouts; malformed-chunk recovery as canonical error events; synthetic error event when subprocess exits non-zero without a complete event. Subclasses implement `_normalize(raw_chunk) -> CanonicalEvent`.
- **Fix OI-1349**: `event_store.append()` `dispatch_id` kwarg changed from `str = ""` to `Optional[str] = None` — explicit kwarg now always wins over the event's own `dispatch_id` field for both CanonicalEvent and dict paths.
- **Tests**: 20 new tests in `tests/test_streaming_drainer.py` + 2 new tests in `tests/test_event_store.py`.

## Test plan

- [ ] `pytest tests/test_streaming_drainer.py tests/test_event_store.py -v` → 47 passed
- [ ] Normal stream: events yielded in order, tier-1 label stamped on all events
- [ ] Malformed chunks: JSON parse error, JSON array, normalize exception → error events
- [ ] Crash safety: non-zero exit without complete → synthetic error; complete event seen → no synthetic error
- [ ] Backpressure: 50 events through queue of size 4, no deadlock; slow consumer gets all events
- [ ] OI-1349: explicit dispatch_id kwarg wins over CanonicalEvent.dispatch_id field

## Dispatch Metadata

- Dispatch-ID: 20260506-phase03-w7b-streaming-drainer
- Terminal: T1

🤖 Generated with [Claude Code](https://claude.com/claude-code)