### PR TITLE
feat(strategy): prd_index + adr_index builders (Phase 2 W-state-4)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && python3 \"$ROOT/scripts/build_current_state.py\" 2>/dev/null; exit 0'"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && python3 \"$ROOT/scripts/build_current_state.py\" 2>/dev/null && python3 \"$ROOT/scripts/build_doc_indexes.py\" 2>/dev/null; exit 0'"
           }
         ]
       }

--- a/scripts/build_doc_indexes.py
+++ b/scripts/build_doc_indexes.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""build_doc_indexes.py — Catalog PRD and ADR artifacts into JSON indexes.
+
+Walks docs/prds/ and docs/adrs/ in the project root, parses YAML frontmatter
+from each .md file, and writes:
+  .vnx-data/strategy/prd_index.json
+  .vnx-data/strategy/adr_index.json
+
+Idempotent. Missing source dirs → empty index, no error.
+Malformed frontmatter → entry written with status='draft', no crash.
+Stable output: sorted by id.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from project_root import resolve_data_dir, resolve_project_root  # noqa: E402
+
+VALID_STATUSES = frozenset({"draft", "active", "superseded", "retired"})
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+def _parse_frontmatter(text: str) -> dict:
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    try:
+        import yaml
+        parsed = yaml.safe_load(m.group(1))
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _extract_entry(md_file: Path, project_root: Path) -> dict:
+    try:
+        text = md_file.read_text(encoding="utf-8")
+    except OSError:
+        text = ""
+
+    fm = _parse_frontmatter(text)
+
+    doc_id = fm.get("id") or md_file.stem
+    title = fm.get("title") or md_file.stem
+    version = str(fm.get("version") or "")
+    status = fm.get("status") or "draft"
+    if status not in VALID_STATUSES:
+        status = "draft"
+
+    supersedes = fm.get("supersedes")
+    if supersedes is not None:
+        supersedes = str(supersedes)
+
+    try:
+        rel_path = str(md_file.relative_to(project_root))
+    except ValueError:
+        rel_path = str(md_file)
+
+    return {
+        "id": str(doc_id),
+        "path": rel_path,
+        "version": version,
+        "status": status,
+        "supersedes": supersedes,
+        "title": str(title),
+    }
+
+
+def _build_index(source_dir: Path, project_root: Path) -> list[dict]:
+    if not source_dir.exists() or not source_dir.is_dir():
+        return []
+    entries = [_extract_entry(f, project_root) for f in source_dir.glob("*.md")]
+    return sorted(entries, key=lambda e: e["id"])
+
+
+def build(
+    data_dir: Optional[Path] = None,
+    project_root: Optional[Path] = None,
+) -> tuple[list[dict], list[dict]]:
+    """Return (prd_index, adr_index) without writing anything."""
+    if project_root is None:
+        project_root = resolve_project_root(__file__)
+    if data_dir is None:
+        data_dir = resolve_data_dir(__file__)
+
+    prd_index = _build_index(project_root / "docs" / "prds", project_root)
+    adr_index = _build_index(project_root / "docs" / "adrs", project_root)
+    return prd_index, adr_index
+
+
+def main() -> None:
+    project_root = resolve_project_root(__file__)
+    data_dir = resolve_data_dir(__file__)
+    strategy_dir = data_dir / "strategy"
+    strategy_dir.mkdir(parents=True, exist_ok=True)
+
+    prd_index, adr_index = build(data_dir, project_root)
+
+    prd_out = strategy_dir / "prd_index.json"
+    adr_out = strategy_dir / "adr_index.json"
+
+    prd_out.write_text(json.dumps(prd_index, indent=2))
+    adr_out.write_text(json.dumps(adr_index, indent=2))
+
+    print(f"[ok] prd_index.json written ({len(prd_index)} entries) → {prd_out}")
+    print(f"[ok] adr_index.json written ({len(adr_index)} entries) → {adr_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/strategy/__init__.py
+++ b/scripts/lib/strategy/__init__.py
@@ -5,9 +5,16 @@ Public API:
     load_roadmap, write_roadmap, validate_roadmap
     next_actionable_wave, dependents_of, phase_complete
     RoadmapValidationError
+    DocEntry, DocStatus, load_prd_index, load_adr_index
 """
 from __future__ import annotations
 
+from .doc_indexes import (
+    DocEntry,
+    DocStatus,
+    load_adr_index,
+    load_prd_index,
+)
 from .roadmap import (
     OperatorDecision,
     Phase,
@@ -23,12 +30,16 @@ from .roadmap import (
 )
 
 __all__ = [
+    "DocEntry",
+    "DocStatus",
     "OperatorDecision",
     "Phase",
     "Roadmap",
     "RoadmapValidationError",
     "Wave",
     "dependents_of",
+    "load_adr_index",
+    "load_prd_index",
     "load_roadmap",
     "next_actionable_wave",
     "phase_complete",

--- a/scripts/lib/strategy/doc_indexes.py
+++ b/scripts/lib/strategy/doc_indexes.py
@@ -1,0 +1,68 @@
+"""doc_indexes.py — Typed loaders for prd_index.json and adr_index.json.
+
+Layer 1 strategic-state: read-only accessors for the document catalogs
+produced by scripts/build_doc_indexes.py.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+from .. import project_root as _pr_mod
+
+DocStatus = Literal["draft", "active", "superseded", "retired"]
+
+
+@dataclass(frozen=True)
+class DocEntry:
+    id: str
+    path: str
+    version: str
+    status: DocStatus
+    supersedes: Optional[str]
+    title: str
+
+
+def _load_index(json_path: Path) -> list[DocEntry]:
+    if not json_path.exists():
+        return []
+    try:
+        raw = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(raw, list):
+        return []
+    entries: list[DocEntry] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        entries.append(DocEntry(
+            id=str(item.get("id", "")),
+            path=str(item.get("path", "")),
+            version=str(item.get("version", "")),
+            status=item.get("status", "draft"),
+            supersedes=item.get("supersedes"),
+            title=str(item.get("title", "")),
+        ))
+    return entries
+
+
+def _strategy_dir() -> Path:
+    return _pr_mod.resolve_data_dir() / "strategy"
+
+
+def load_prd_index(strategy_dir: Optional[Path] = None) -> list[DocEntry]:
+    """Return parsed PRD index; empty list when prd_index.json is absent."""
+    d = strategy_dir if strategy_dir is not None else _strategy_dir()
+    return _load_index(d / "prd_index.json")
+
+
+def load_adr_index(strategy_dir: Optional[Path] = None) -> list[DocEntry]:
+    """Return parsed ADR index; empty list when adr_index.json is absent."""
+    d = strategy_dir if strategy_dir is not None else _strategy_dir()
+    return _load_index(d / "adr_index.json")
+
+
+__all__ = ["DocEntry", "DocStatus", "load_adr_index", "load_prd_index"]

--- a/tests/test_doc_indexes.py
+++ b/tests/test_doc_indexes.py
@@ -1,0 +1,317 @@
+"""Tests for build_doc_indexes.py and scripts.lib.strategy.doc_indexes."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import build_doc_indexes as builder  # noqa: E402
+from scripts.lib.strategy.doc_indexes import DocEntry, load_adr_index, load_prd_index  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _prd_frontmatter(
+    doc_id: str = "PRD-001",
+    title: str = "Foo Feature",
+    version: str = "1.0",
+    status: str = "active",
+    supersedes: str | None = None,
+) -> str:
+    lines = [
+        "---",
+        f"id: {doc_id}",
+        f"title: {title}",
+        f"version: \"{version}\"",
+        f"status: {status}",
+    ]
+    if supersedes is not None:
+        lines.append(f"supersedes: {supersedes}")
+    else:
+        lines.append("supersedes: null")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {title}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _adr_frontmatter(
+    doc_id: str = "ADR-001",
+    title: str = "Bar Decision",
+    version: str = "1.0",
+    status: str = "active",
+    supersedes: str | None = None,
+) -> str:
+    return _prd_frontmatter(doc_id, title, version, status, supersedes)
+
+
+def _setup_docs(tmp_path: Path, prds: list[tuple[str, str]], adrs: list[tuple[str, str]]) -> Path:
+    """Create synthetic docs dirs and return the project_root (tmp_path)."""
+    if prds:
+        prd_dir = tmp_path / "docs" / "prds"
+        prd_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in prds:
+            (prd_dir / filename).write_text(content, encoding="utf-8")
+    if adrs:
+        adr_dir = tmp_path / "docs" / "adrs"
+        adr_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in adrs:
+            (adr_dir / filename).write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: builder
+# ---------------------------------------------------------------------------
+
+class TestBuildDocIndexes:
+    def test_happy_path_prd_and_adr(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[("PRD-001-foo.md", _prd_frontmatter())],
+            adrs=[("ADR-001-bar.md", _adr_frontmatter())],
+        )
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert len(prd_index) == 1
+        assert len(adr_index) == 1
+
+        prd = prd_index[0]
+        assert prd["id"] == "PRD-001"
+        assert prd["title"] == "Foo Feature"
+        assert prd["version"] == "1.0"
+        assert prd["status"] == "active"
+        assert prd["supersedes"] is None
+        assert "docs/prds/PRD-001-foo.md" in prd["path"]
+
+        adr = adr_index[0]
+        assert adr["id"] == "ADR-001"
+        assert adr["title"] == "Bar Decision"
+        assert adr["status"] == "active"
+
+    def test_index_files_written(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[("PRD-001-foo.md", _prd_frontmatter())],
+            adrs=[("ADR-001-bar.md", _adr_frontmatter())],
+        )
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        strategy_dir = data_dir / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+        (strategy_dir / "prd_index.json").write_text(json.dumps(prd_index, indent=2))
+        (strategy_dir / "adr_index.json").write_text(json.dumps(adr_index, indent=2))
+
+        assert (strategy_dir / "prd_index.json").exists()
+        assert (strategy_dir / "adr_index.json").exists()
+
+        written_prd = json.loads((strategy_dir / "prd_index.json").read_text())
+        assert isinstance(written_prd, list)
+        assert written_prd[0]["id"] == "PRD-001"
+
+    def test_missing_prds_dir_returns_empty(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = tmp_path
+        # docs/prds does NOT exist; docs/adrs does
+        _setup_docs(tmp_path, prds=[], adrs=[("ADR-001-bar.md", _adr_frontmatter())])
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert prd_index == []
+        assert len(adr_index) == 1
+
+    def test_missing_adrs_dir_returns_empty(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = tmp_path
+        _setup_docs(tmp_path, prds=[("PRD-001-foo.md", _prd_frontmatter())], adrs=[])
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert adr_index == []
+        assert len(prd_index) == 1
+
+    def test_both_dirs_missing_returns_empty(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = tmp_path
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert prd_index == []
+        assert adr_index == []
+
+    def test_bad_frontmatter_no_crash(self, tmp_path):
+        bad_content = "---\n: this is: not: valid: yaml:\n---\n\n# Title\n"
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[("PRD-002-bad.md", bad_content)],
+            adrs=[],
+        )
+
+        prd_index, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert len(prd_index) == 1
+        assert prd_index[0]["status"] == "draft"
+
+    def test_bad_frontmatter_unknown_status_defaults_to_draft(self, tmp_path):
+        content = _prd_frontmatter(doc_id="PRD-003", status="unknown_status")
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(tmp_path, prds=[("PRD-003-bad.md", content)], adrs=[])
+
+        prd_index, _ = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert prd_index[0]["status"] == "draft"
+
+    def test_sorted_by_id(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[
+                ("PRD-003-c.md", _prd_frontmatter(doc_id="PRD-003", title="C")),
+                ("PRD-001-a.md", _prd_frontmatter(doc_id="PRD-001", title="A")),
+                ("PRD-002-b.md", _prd_frontmatter(doc_id="PRD-002", title="B")),
+            ],
+            adrs=[],
+        )
+
+        prd_index, _ = builder.build(data_dir=data_dir, project_root=project_root)
+
+        ids = [e["id"] for e in prd_index]
+        assert ids == sorted(ids)
+
+    def test_supersedes_chain(self, tmp_path):
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[],
+            adrs=[
+                ("ADR-001-original.md", _adr_frontmatter(
+                    doc_id="ADR-001", title="Original Decision", status="superseded"
+                )),
+                ("ADR-002-replacement.md", _adr_frontmatter(
+                    doc_id="ADR-002", title="Replacement Decision",
+                    status="active", supersedes="ADR-001"
+                )),
+            ],
+        )
+
+        _, adr_index = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert len(adr_index) == 2
+        by_id = {e["id"]: e for e in adr_index}
+        assert "ADR-001" in by_id
+        assert "ADR-002" in by_id
+        assert by_id["ADR-001"]["status"] == "superseded"
+        assert by_id["ADR-001"]["supersedes"] is None
+        assert by_id["ADR-002"]["supersedes"] == "ADR-001"
+        assert by_id["ADR-002"]["status"] == "active"
+
+    def test_no_frontmatter_uses_stem_as_id_and_title(self, tmp_path):
+        content = "# Just a plain markdown file\n\nNo frontmatter here.\n"
+        data_dir = tmp_path / ".vnx-data"
+        project_root = _setup_docs(
+            tmp_path,
+            prds=[("PRD-042-plain.md", content)],
+            adrs=[],
+        )
+
+        prd_index, _ = builder.build(data_dir=data_dir, project_root=project_root)
+
+        assert len(prd_index) == 1
+        assert prd_index[0]["id"] == "PRD-042-plain"
+        assert prd_index[0]["status"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Tests: typed loader (doc_indexes.py)
+# ---------------------------------------------------------------------------
+
+class TestDocIndexesLoader:
+    def _write_strategy(self, tmp_path: Path, prd_data: list, adr_data: list) -> Path:
+        strategy_dir = tmp_path / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+        (strategy_dir / "prd_index.json").write_text(json.dumps(prd_data, indent=2))
+        (strategy_dir / "adr_index.json").write_text(json.dumps(adr_data, indent=2))
+        return strategy_dir
+
+    def test_load_prd_index_returns_docentry_list(self, tmp_path):
+        data = [{"id": "PRD-001", "path": "docs/prds/PRD-001.md",
+                  "version": "1.0", "status": "active", "supersedes": None, "title": "Foo"}]
+        strategy_dir = self._write_strategy(tmp_path, data, [])
+
+        result = load_prd_index(strategy_dir=strategy_dir)
+
+        assert len(result) == 1
+        assert isinstance(result[0], DocEntry)
+        assert result[0].id == "PRD-001"
+        assert result[0].status == "active"
+        assert result[0].supersedes is None
+
+    def test_load_adr_index_returns_docentry_list(self, tmp_path):
+        data = [{"id": "ADR-001", "path": "docs/adrs/ADR-001.md",
+                  "version": "1.0", "status": "active", "supersedes": None, "title": "Bar"}]
+        strategy_dir = self._write_strategy(tmp_path, [], data)
+
+        result = load_adr_index(strategy_dir=strategy_dir)
+
+        assert len(result) == 1
+        assert isinstance(result[0], DocEntry)
+        assert result[0].id == "ADR-001"
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        strategy_dir = tmp_path / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+
+        assert load_prd_index(strategy_dir=strategy_dir) == []
+        assert load_adr_index(strategy_dir=strategy_dir) == []
+
+    def test_supersedes_field_preserved(self, tmp_path):
+        data = [
+            {"id": "ADR-001", "path": "docs/adrs/ADR-001.md",
+             "version": "1.0", "status": "superseded", "supersedes": None, "title": "Old"},
+            {"id": "ADR-002", "path": "docs/adrs/ADR-002.md",
+             "version": "1.0", "status": "active", "supersedes": "ADR-001", "title": "New"},
+        ]
+        strategy_dir = self._write_strategy(tmp_path, [], data)
+
+        result = load_adr_index(strategy_dir=strategy_dir)
+
+        by_id = {e.id: e for e in result}
+        assert by_id["ADR-002"].supersedes == "ADR-001"
+        assert by_id["ADR-001"].supersedes is None
+
+    def test_missing_json_file_returns_empty_not_error(self, tmp_path):
+        strategy_dir = tmp_path / "nonexistent_strategy"
+
+        result = load_prd_index(strategy_dir=strategy_dir)
+
+        assert result == []
+
+    def test_all_valid_statuses_accepted(self, tmp_path):
+        statuses = ["draft", "active", "superseded", "retired"]
+        data = [
+            {"id": f"PRD-00{i}", "path": f"docs/prds/PRD-00{i}.md",
+             "version": "1.0", "status": s, "supersedes": None, "title": f"Doc {i}"}
+            for i, s in enumerate(statuses, 1)
+        ]
+        strategy_dir = self._write_strategy(tmp_path, data, [])
+
+        result = load_prd_index(strategy_dir=strategy_dir)
+
+        loaded_statuses = {e.status for e in result}
+        assert loaded_statuses == set(statuses)


### PR DESCRIPTION
## Summary

- **`scripts/build_doc_indexes.py`**: Walks `docs/prds/` and `docs/adrs/`, parses YAML frontmatter from each `.md` file, and writes sorted `.vnx-data/strategy/prd_index.json` + `adr_index.json`. Missing source dirs emit an empty index (no error). Malformed YAML frontmatter defaults `status='draft'` without crashing.
- **`scripts/lib/strategy/doc_indexes.py`**: Typed `DocEntry` dataclass + `load_prd_index()` / `load_adr_index()` loaders (accept optional `strategy_dir` for testability). Re-exported from `scripts/lib/strategy/__init__.py`.
- **`.claude/settings.json`**: `build_doc_indexes.py` added as a second step in the SessionEnd hook alongside `build_current_state.py`.
- **`tests/test_doc_indexes.py`**: 16 tests covering happy path, file-write verification, missing dirs, bad/unknown-status frontmatter, stable sort ordering, supersedes-chain, no-frontmatter fallback, and all typed-loader variants.

## W-state-4 success criteria

- [x] Builder tolerates missing `docs/prds/` and `docs/adrs/` (emits `[]`)
- [x] Builder writes `prd_index.json` and `adr_index.json` with schema `{id, path, version, status, supersedes, title}`
- [x] Entries sorted by `id`
- [x] Bad frontmatter → `status='draft'`, no crash
- [x] `supersedes` field preserved end-to-end
- [x] Typed loaders (`load_prd_index`, `load_adr_index`) return `list[DocEntry]`
- [x] SessionEnd hook wired
- [x] 16 tests passing (`pytest tests/test_doc_indexes.py -x`)

## Test plan

- [x] `pytest tests/test_doc_indexes.py -x -v` → 16 passed, 0 failed
- [x] Builder does NOT write actual `.vnx-data/strategy/prd_index.json` from this PR (runtime-only)

## Out of scope

- Moving actual PRDs from `claudedocs/` (operator task per FEATURE_PLAN)
- Cross-domain artifact memory (Phase 12)
- CLI surface for searching the index

Dispatch-ID: 20260506-phase02-wstate4-doc-indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)