### PR TITLE
feat(strategy): typed current_state.md projector v2 (Phase 2 W-state-3)

### DIFF
--- a/docs/architecture/STRATEGIC_STATE.md
+++ b/docs/architecture/STRATEGIC_STATE.md
@@ -128,6 +128,55 @@ visible.
   `strategic_state` block surfaces directly to T0 at SessionStart.
   Feature-end gate; high-blast-radius wave.
 
+## What W-state-3 delivers
+
+W-state-3 rewrites `scripts/build_current_state.py` to consume the typed
+`strategy.roadmap` and `strategy.decisions` modules from W-state-1 and W-state-2.
+The result is a schema-stable, idempotent Markdown file at
+`.vnx-data/strategy/current_state.md`.
+
+### current_state.md schema (PROJECT_STATE_DESIGN §4.2)
+
+The file always contains exactly **seven sections** in this order:
+
+| # | Header | Source | Notes |
+|---|--------|--------|-------|
+| 1 | `# Mission` | `roadmap.title` | Placeholder when roadmap is absent |
+| 2 | `## Current focus` | `next_actionable_wave()` + wave statuses | Shows active/in_progress wave or next planned |
+| 3 | `## Roadmap snapshot` | `phases` list + derived phase status | Phase-level table: id, title, badge, blockers |
+| 4 | `## In flight` | `gh pr list` + `t0_state.json` tracks | Open PRs and active dispatcher slots |
+| 5 | `## Last 3 decisions` | `recent_decisions(n=3)` | Sorted by `(ts, decision_id)` for determinism |
+| 6 | `## Recommended next move` | `next_actionable_wave()` | Includes rationale, branch, risk, dep-chain status |
+| 7 | `## Resume hints` | derived | Static guidance for T0 after `/clear`; contains `Last updated:` mtime line |
+
+#### Idempotency guarantee
+
+Running `python3 scripts/build_current_state.py` twice on unchanged inputs
+produces **byte-identical output**. This is enforced by:
+- Never calling `datetime.now()` — all timestamps come from input-file mtimes.
+- Sorting decisions by `(ts, decision_id)` so ties are resolved deterministically.
+- Sorting active dispatches by track ID (dict ordering is not relied on).
+
+#### Section placeholders
+
+Every section emits a placeholder line when its data source is empty or
+unavailable, so the file always has all seven sections regardless of state:
+
+```
+_No mission set._              # Mission, when roadmap missing or title empty
+_No roadmap available._        # Current focus / Recommended next move, no roadmap file
+_No roadmap data._             # Roadmap snapshot, no phases
+_No open PRs or gh CLI unavailable._   # In flight, gh CLI absent or no open PRs
+_No active dispatches._        # In flight, no active dispatch slots
+_No decisions recorded._       # Last 3 decisions, file absent or empty
+```
+
+#### Hook wiring (W-UX-2 preserved)
+
+The script is invoked automatically via `.claude/settings.json` SessionEnd
+hook and post-merge hook — both from W-UX-2. W-state-3 does not re-wire
+these hooks; it only replaces the script body.
+
 ## Quick smoke test
 
 ```bash

--- a/scripts/build_current_state.py
+++ b/scripts/build_current_state.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """build_current_state.py — Auto-project current_state.md from strategy/ sources.
 
-Idempotent: "Last updated:" is derived from the latest input-file mtime,
-never from datetime.now(). Run twice on unchanged inputs → byte-identical output.
+Seven-section schema per PROJECT_STATE_DESIGN §4.2. Idempotent: timestamps are
+derived from input-file mtime, never from datetime.now(). Two consecutive runs
+on unchanged inputs produce byte-identical output.
 """
 from __future__ import annotations
 
@@ -14,12 +15,24 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 from project_root import resolve_data_dir  # noqa: E402
+from strategy.roadmap import Roadmap, Phase, Wave, load_roadmap, next_actionable_wave, RoadmapValidationError  # noqa: E402
+from strategy.decisions import recent_decisions, Decision  # noqa: E402
 
-MAX_RECEIPTS = 5
 MAX_PRS = 5
-MAX_OI = 5
-MAX_DECISIONS = 3
+SECTION_HEADERS = [
+    "# Mission",
+    "## Current focus",
+    "## Roadmap snapshot",
+    "## In flight",
+    "## Last 3 decisions",
+    "## Recommended next move",
+    "## Resume hints",
+]
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def _mtime(p: Path) -> float:
     try:
@@ -29,7 +42,6 @@ def _mtime(p: Path) -> float:
 
 
 def _latest_mtime_iso(paths: list[Path]) -> str:
-    """Return ISO-8601 string of the latest mtime among existing paths."""
     mtimes = [_mtime(p) for p in paths if p.exists()]
     if not mtimes:
         return "unknown"
@@ -37,61 +49,24 @@ def _latest_mtime_iso(paths: list[Path]) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _load_roadmap(strategy_dir: Path) -> dict:
+def _load_roadmap(strategy_dir: Path) -> Roadmap | None:
     rmap = strategy_dir / "roadmap.yaml"
     if not rmap.exists():
+        return None
+    try:
+        return load_roadmap(rmap, strict=False)
+    except Exception:
+        return None
+
+
+def _load_t0_state(state_dir: Path) -> dict:
+    f = state_dir / "t0_state.json"
+    if not f.exists():
         return {}
     try:
-        import yaml
-        return yaml.safe_load(rmap.read_text()) or {}
+        return json.loads(f.read_text(encoding="utf-8"))
     except Exception:
         return {}
-
-
-def _load_open_items(state_dir: Path) -> dict:
-    oi = state_dir / "open_items_digest.json"
-    if not oi.exists():
-        return {}
-    try:
-        return json.loads(oi.read_text())
-    except Exception:
-        return {}
-
-
-def _load_receipts(state_dir: Path, n: int = MAX_RECEIPTS) -> list[dict]:
-    receipts_file = state_dir / "t0_receipts.ndjson"
-    if not receipts_file.exists():
-        return []
-    lines: list[dict] = []
-    try:
-        for raw in receipts_file.read_text().splitlines():
-            raw = raw.strip()
-            if raw:
-                try:
-                    lines.append(json.loads(raw))
-                except Exception:
-                    pass
-    except Exception:
-        pass
-    return lines[-n:]
-
-
-def _load_decisions(strategy_dir: Path, n: int = MAX_DECISIONS) -> list[dict]:
-    dec = strategy_dir / "decisions.ndjson"
-    if not dec.exists():
-        return []
-    lines: list[dict] = []
-    try:
-        for raw in dec.read_text().splitlines():
-            raw = raw.strip()
-            if raw:
-                try:
-                    lines.append(json.loads(raw))
-                except Exception:
-                    pass
-    except Exception:
-        pass
-    return lines[-n:]
 
 
 def _fetch_prs(n: int = MAX_PRS) -> list[dict]:
@@ -108,117 +83,196 @@ def _fetch_prs(n: int = MAX_PRS) -> list[dict]:
     return []
 
 
-def _wave_badge(status: str) -> str:
-    return {"in_progress": "[~]", "planned": "[ ]", "completed": "[x]",
-            "blocked": "[!]"}.get(status, f"[{status}]")
+def _status_badge(status: str) -> str:
+    return {
+        "in_progress": "[~]",
+        "planned": "[ ]",
+        "completed": "[x]",
+        "blocked": "[!]",
+        "deferred": "[d]",
+        "cancelled": "[c]",
+    }.get(status, f"[{status}]")
 
 
-def _render_roadmap(roadmap: dict) -> list[str]:
-    lines = ["## Roadmap Waves", ""]
-    phases = roadmap.get("phases", [])
-    waves_by_id = {w["wave_id"]: w for w in roadmap.get("waves", [])}
+def _phase_status(phase: Phase, roadmap: Roadmap) -> str:
+    waves_in_phase = [w for w in roadmap.waves if w.phase_id == phase.phase_id]
+    if not waves_in_phase:
+        return "empty"
+    statuses = {w.status for w in waves_in_phase}
+    if "in_progress" in statuses:
+        return "in_progress"
+    if all(s == "completed" for s in statuses):
+        return "completed"
+    if "blocked" in statuses:
+        return "blocked"
+    return "planned"
 
-    if not phases and not waves_by_id:
+
+def _sort_decisions(decisions: list[Decision]) -> list[Decision]:
+    return sorted(decisions, key=lambda d: (d.ts, d.decision_id))
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+
+def _render_mission(roadmap: Roadmap | None) -> list[str]:
+    title = roadmap.title if (roadmap and roadmap.title) else "_No mission set._"
+    return ["# Mission", "", title, ""]
+
+
+def _render_current_focus(roadmap: Roadmap | None) -> list[str]:
+    lines = ["## Current focus", ""]
+    if not roadmap:
+        return lines + ["_No roadmap available._", ""]
+
+    active_wave = next((w for w in roadmap.waves if w.status in ("in_progress", "blocked")), None)
+    next_wave = next_actionable_wave(roadmap)
+    phase_map = {p.phase_id: p for p in roadmap.phases}
+
+    if active_wave:
+        phase = phase_map.get(active_wave.phase_id)
+        phase_title = phase.title if phase else "?"
+        lines.append(f"**Phase {active_wave.phase_id}**: {phase_title}")
+        lines.append(
+            f"**Active wave**: `{active_wave.wave_id}` — {active_wave.title} "
+            f"{_status_badge(active_wave.status)}"
+        )
+    elif next_wave:
+        phase = phase_map.get(next_wave.phase_id)
+        phase_title = phase.title if phase else "?"
+        lines.append(f"**Phase {next_wave.phase_id}**: {phase_title}")
+        lines.append(
+            f"**Next wave**: `{next_wave.wave_id}` — {next_wave.title} "
+            f"{_status_badge(next_wave.status)}"
+        )
+    else:
+        lines.append("_No active phase. All waves completed or roadmap empty._")
+
+    lines.append("")
+    return lines
+
+
+def _render_roadmap_snapshot(roadmap: Roadmap | None) -> list[str]:
+    lines = ["## Roadmap snapshot", ""]
+    if not roadmap or not roadmap.phases:
         return lines + ["_No roadmap data._", ""]
 
-    for phase in phases:
-        pid = phase.get("phase_id", "?")
-        title = phase.get("title", "")
-        lines.append(f"### Phase {pid}: {title}")
-        for wid in phase.get("waves", []):
-            w = waves_by_id.get(wid)
-            if w is None:
-                continue
-            status = w.get("status", "planned")
-            lines.append(f"- {_wave_badge(status)} `{wid}`: {w.get('title', wid)}")
-        lines.append("")
+    lines.append("| Phase | Title | Status | Blockers |")
+    lines.append("|-------|-------|--------|----------|")
+    for phase in roadmap.phases:
+        status = _phase_status(phase, roadmap)
+        badge = _status_badge(status)
+        blockers = ", ".join(phase.blocked_on) if phase.blocked_on else "—"
+        lines.append(f"| {phase.phase_id} | {phase.title} | {badge} {status} | {blockers} |")
+
+    lines.append("")
     return lines
 
 
-def _render_prs(prs: list[dict]) -> list[str]:
-    lines = ["## Open Pull Requests", ""]
-    if not prs:
-        return lines + ["_No open PRs or gh CLI unavailable._", ""]
-    for pr in prs:
-        lines.append(
-            f"- PR #{pr.get('number', '?')}: {pr.get('title', '')} "
-            f"(`{pr.get('headRefName', '')}`)"
-        )
-    return lines + [""]
+def _render_in_flight(prs: list[dict], t0_state: dict) -> list[str]:
+    lines = ["## In flight", ""]
 
+    if prs:
+        lines.append("**Open PRs:**")
+        for pr in prs:
+            lines.append(
+                f"- PR #{pr.get('number', '?')}: {pr.get('title', '')} "
+                f"(`{pr.get('headRefName', '')}`)"
+            )
+    else:
+        lines.append("_No open PRs or gh CLI unavailable._")
 
-def _render_open_items(oi: dict) -> list[str]:
-    lines = ["## Open Items", ""]
-    summary = oi.get("summary", {})
-    open_count = summary.get("open_count", 0)
-    blocker_count = summary.get("blocker_count", 0)
-
-    if not oi:
-        return lines + ["_No open items data._", ""]
-
-    lines.append(
-        f"**{open_count} open** ({blocker_count} blocking, "
-        f"{summary.get('warn_count', 0)} warnings)"
-    )
     lines.append("")
 
-    blockers = oi.get("top_blockers", [])
-    if blockers:
-        lines.append("**Blockers:**")
-        for item in blockers[:MAX_OI]:
-            lines.append(f"- [{item.get('id', '?')}] {item.get('title', '')}")
-        lines.append("")
+    tracks = t0_state.get("tracks", {})
+    active = [(tid, t) for tid, t in tracks.items() if t.get("active_dispatch_id")]
+    if active:
+        lines.append("**Active dispatches:**")
+        for tid, t in sorted(active):
+            dispatch_id = t.get("active_dispatch_id", "?")
+            status = t.get("status", "?")
+            gate = t.get("current_gate", "?")
+            lines.append(f"- {tid}: `{dispatch_id}` ({status}, gate: {gate})")
+    else:
+        lines.append("_No active dispatches._")
 
-    open_items = oi.get("open_items", [])
-    non_blockers = [i for i in open_items if i.get("severity") != "blocking"][:MAX_OI]
-    if non_blockers:
-        lines.append("**Top open items:**")
-        for item in non_blockers:
-            sev = item.get("severity", "")
-            lines.append(f"- [{item.get('id', '?')}] ({sev}) {item.get('title', '')}")
-        if open_count > MAX_OI + len(blockers):
-            lines.append(f"- … and {open_count - MAX_OI - len(blockers)} more")
-        lines.append("")
-
+    lines.append("")
     return lines
 
 
-def _render_receipts(receipts: list[dict]) -> list[str]:
-    lines = ["## Recent Receipts", ""]
-    if not receipts:
-        return lines + ["_No receipts found._", ""]
-    for r in reversed(receipts):
-        ts = str(r.get("timestamp", ""))[:10]
-        event = r.get("event_type", r.get("event", "?"))
-        status = r.get("status", "")
-        terminal = r.get("terminal", "?")
-        dispatch = str(r.get("dispatch_id", "?"))[:30]
-        badge = "[ok]" if status == "success" else "[x]" if status in ("failed", "error") else "[~]"
-        lines.append(f"- {badge} {ts} {terminal} `{dispatch}` ({event})")
-    return lines + [""]
-
-
-def _render_decisions(decisions: list[dict]) -> list[str]:
+def _render_last_3_decisions(decisions: list[Decision]) -> list[str]:
+    lines = ["## Last 3 decisions", ""]
     if not decisions:
-        return []
-    lines = ["## Recent Decisions", ""]
-    for d in reversed(decisions):
-        ts = str(d.get("timestamp", d.get("decided_at", "")))[:10]
-        title = d.get("title", d.get("decision_id", "?"))
-        decision = d.get("decision", "")
-        lines.append(f"- {ts}: **{title}** → {decision}")
-    return lines + [""]
+        return lines + ["_No decisions recorded._", ""]
+
+    for d in decisions:
+        ts = str(d.ts)[:10]
+        lines.append(f"- **{d.decision_id}** ({ts}): [{d.scope}] {d.rationale}")
+
+    lines.append("")
+    return lines
 
 
-def _find_focus(roadmap: dict) -> str:
-    waves_by_id = {w["wave_id"]: w for w in roadmap.get("waves", [])}
-    for phase in roadmap.get("phases", []):
-        for wid in phase.get("waves", []):
-            w = waves_by_id.get(wid)
-            if w and w.get("status") in ("in_progress", "blocked"):
-                return f"Phase {phase.get('phase_id')}: {phase.get('title', '')}"
-    return "No active phase"
+def _render_recommended_next_move(roadmap: Roadmap | None) -> list[str]:
+    lines = ["## Recommended next move", ""]
+    if not roadmap:
+        return lines + ["_No roadmap available._", ""]
 
+    wave = next_actionable_wave(roadmap)
+    if wave is None:
+        planned = [w for w in roadmap.waves if w.status == "planned"]
+        if planned:
+            first = planned[0]
+            wave_status = {w.wave_id: w.status for w in roadmap.waves}
+            unresolved = [d for d in first.depends_on if wave_status.get(d) != "completed"]
+            lines.append(f"No immediately actionable wave. Next planned: `{first.wave_id}`")
+            if unresolved:
+                lines.append(f"Blocked on: {', '.join(f'`{d}`' for d in unresolved)}")
+        else:
+            lines.append("_All waves completed or no roadmap. Nothing to do._")
+        lines.append("")
+        return lines
+
+    lines.append(f"**Wave**: `{wave.wave_id}` — {wave.title}")
+    lines.append(f"**Status**: {wave.status} → ready to start")
+    if wave.risk_class:
+        lines.append(f"**Risk**: {wave.risk_class}")
+    if wave.branch_name:
+        lines.append(f"**Branch**: `{wave.branch_name}`")
+    if wave.depends_on:
+        lines.append(f"**Depends on**: {', '.join(f'`{d}`' for d in wave.depends_on)} (all resolved)")
+    if wave.blocked_on:
+        lines.append(f"**Blocked on**: {', '.join(wave.blocked_on)}")
+    if wave.rationale:
+        lines.append(f"**Rationale**: {wave.rationale}")
+    if wave.notes:
+        lines.append(f"**Notes**: {wave.notes}")
+
+    lines.append("")
+    return lines
+
+
+def _render_resume_hints(roadmap: Roadmap | None, last_updated: str) -> list[str]:
+    lines = ["## Resume hints", ""]
+    lines.append(f"Last updated: {last_updated}")
+    lines.append("")
+    lines.append("After `/clear`, T0 should:")
+    lines.append("1. Check `## Recommended next move` above for the actionable wave.")
+    lines.append("2. Run `python3 scripts/build_current_state.py` to refresh this file.")
+    lines.append("3. Check `.vnx-data/state/t0_state.json` for terminal availability.")
+    lines.append("4. Review `## Last 3 decisions` to restore decision context.")
+    if roadmap:
+        lines.append(
+            f"5. Roadmap has {len(roadmap.waves)} wave(s) across {len(roadmap.phases)} phase(s)."
+        )
+    lines.append("")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
 
 def build(data_dir: Path | None = None) -> str:
     if data_dir is None:
@@ -229,29 +283,25 @@ def build(data_dir: Path | None = None) -> str:
 
     roadmap = _load_roadmap(strategy_dir)
     prs = _fetch_prs()
-    receipts = _load_receipts(state_dir)
-    oi = _load_open_items(state_dir)
-    decisions = _load_decisions(strategy_dir)
+    t0_state = _load_t0_state(state_dir)
+    raw_decisions = recent_decisions(n=3, path=strategy_dir / "decisions.ndjson")
+    decisions = _sort_decisions(raw_decisions)
 
     last_updated = _latest_mtime_iso([
         strategy_dir / "roadmap.yaml",
-        state_dir / "t0_receipts.ndjson",
+        state_dir / "t0_state.json",
         state_dir / "open_items_digest.json",
         strategy_dir / "decisions.ndjson",
     ])
 
-    body: list[str] = [
-        "# VNX Project State",
-        f"Last updated: {last_updated}",
-        "",
-        f"**Focus**: {_find_focus(roadmap)}",
-        "",
-    ]
-    body += _render_roadmap(roadmap)
-    body += _render_prs(prs)
-    body += _render_open_items(oi)
-    body += _render_receipts(receipts)
-    body += _render_decisions(decisions)
+    body: list[str] = []
+    body += _render_mission(roadmap)
+    body += _render_current_focus(roadmap)
+    body += _render_roadmap_snapshot(roadmap)
+    body += _render_in_flight(prs, t0_state)
+    body += _render_last_3_decisions(decisions)
+    body += _render_recommended_next_move(roadmap)
+    body += _render_resume_hints(roadmap, last_updated)
 
     if len(body) > 200:
         body = body[:199] + ["_[truncated to 200 lines]_"]
@@ -266,7 +316,7 @@ def main() -> None:
 
     content = build(data_dir)
     out = strategy_dir / "current_state.md"
-    out.write_text(content)
+    out.write_text(content, encoding="utf-8")
     line_count = len(content.splitlines())
     print(f"[ok] current_state.md written ({line_count} lines) → {out}")
 

--- a/scripts/lib/strategy/doc_indexes.py
+++ b/scripts/lib/strategy/doc_indexes.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional
 
-from .. import project_root as _pr_mod
+try:
+    from .. import project_root as _pr_mod
+except ImportError:
+    import project_root as _pr_mod  # type: ignore[no-redef]
 
 DocStatus = Literal["draft", "active", "superseded", "retired"]
 

--- a/tests/test_build_current_state.py
+++ b/tests/test_build_current_state.py
@@ -1,9 +1,9 @@
-"""Unit tests for scripts/build_current_state.py.
+"""Unit tests for scripts/build_current_state.py (updated for W-state-3 schema).
 
 Cases:
 - empty roadmap
 - all-completed roadmap
-- in-progress + blocked OI
+- in-progress roadmap
 - idempotence (run twice → byte-identical output)
 - graceful degrade if gh CLI fails
 """
@@ -52,6 +52,12 @@ def _write_receipts(state_dir: Path, records: list[dict]) -> None:
     )
 
 
+def _write_decisions(strategy_dir: Path, records: list[dict]) -> None:
+    (strategy_dir / "decisions.ndjson").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers to suppress gh CLI calls during tests
 # ---------------------------------------------------------------------------
@@ -68,7 +74,7 @@ class TestEmptyRoadmap:
     def test_builds_without_error(self, tmp_data_dir: Path) -> None:
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "# VNX Project State" in content
+        assert "# Mission" in content
 
     def test_empty_roadmap_section(self, tmp_data_dir: Path) -> None:
         with patch.object(bcs, "_fetch_prs", _no_prs):
@@ -78,7 +84,7 @@ class TestEmptyRoadmap:
     def test_no_active_phase(self, tmp_data_dir: Path) -> None:
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "No active phase" in content
+        assert "No roadmap available" in content or "No active phase" in content
 
     def test_within_200_lines(self, tmp_data_dir: Path) -> None:
         with patch.object(bcs, "_fetch_prs", _no_prs):
@@ -90,11 +96,16 @@ class TestAllCompletedRoadmap:
     def _make_roadmap(self) -> dict:
         return {
             "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Test",
+            "generated_at": "2026-05-06T00:00:00Z",
             "phases": [
                 {
                     "phase_id": 0,
                     "title": "Phase Zero",
                     "waves": ["w-a", "w-b"],
+                    "estimated_loc": 0,
+                    "estimated_weeks": 0.0,
                     "blocked_on": [],
                 }
             ],
@@ -116,18 +127,23 @@ class TestAllCompletedRoadmap:
         _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "No active phase" in content
+        assert "All waves completed or roadmap empty" in content or "Nothing to do" in content
 
 
-class TestInProgressWithBlockedOI:
+class TestInProgressRoadmap:
     def _make_roadmap(self) -> dict:
         return {
             "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Operator UX",
+            "generated_at": "2026-05-06T00:00:00Z",
             "phases": [
                 {
                     "phase_id": 0,
                     "title": "Operator UX",
                     "waves": ["w-ux-1", "w-ux-2"],
+                    "estimated_loc": 0,
+                    "estimated_weeks": 0.0,
                     "blocked_on": [],
                 }
             ],
@@ -137,24 +153,6 @@ class TestInProgressWithBlockedOI:
                 {"wave_id": "w-ux-2", "title": "State projector", "phase_id": 0,
                  "status": "planned", "depends_on": ["w-ux-1"]},
             ],
-        }
-
-    def _make_oi_digest(self) -> dict:
-        return {
-            "summary": {
-                "open_count": 5,
-                "blocker_count": 1,
-                "warn_count": 3,
-                "info_count": 1,
-            },
-            "top_blockers": [
-                {"id": "OI-001", "title": "Critical blocker", "pr_id": "PR-1"},
-            ],
-            "open_items": [
-                {"id": "OI-002", "severity": "warn", "title": "Minor warning",
-                 "pr_id": None},
-            ],
-            "recent_closures": [],
         }
 
     def test_in_progress_badge(self, tmp_data_dir: Path) -> None:
@@ -170,13 +168,11 @@ class TestInProgressWithBlockedOI:
         assert "Phase 0" in content
         assert "Operator UX" in content
 
-    def test_blocker_shown_in_oi(self, tmp_data_dir: Path) -> None:
+    def test_in_flight_section_present(self, tmp_data_dir: Path) -> None:
         _write_roadmap(tmp_data_dir / "strategy", self._make_roadmap())
-        _write_oi_digest(tmp_data_dir / "state", self._make_oi_digest())
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "OI-001" in content
-        assert "Critical blocker" in content
+        assert "## In flight" in content
 
 
 class TestIdempotence:
@@ -191,15 +187,18 @@ class TestIdempotence:
     def test_idempotent_with_data(self, tmp_data_dir: Path) -> None:
         roadmap = {
             "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "T",
+            "generated_at": "2026-05-06T00:00:00Z",
             "phases": [{"phase_id": 0, "title": "T", "waves": ["w1"],
-                        "blocked_on": []}],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
             "waves": [{"wave_id": "w1", "title": "Wave", "phase_id": 0,
                        "status": "in_progress", "depends_on": []}],
         }
         _write_roadmap(tmp_data_dir / "strategy", roadmap)
-        _write_receipts(tmp_data_dir / "state", [
-            {"event_type": "task_complete", "timestamp": "2026-05-01T10:00:00",
-             "terminal": "T1", "dispatch_id": "disp-001", "status": "success"},
+        _write_decisions(tmp_data_dir / "strategy", [
+            {"decision_id": "OD-2026-05-01-001", "scope": "arch",
+             "ts": "2026-05-01T10:00:00Z", "rationale": "test reason"},
         ])
         with patch.object(bcs, "_fetch_prs", _no_prs):
             run1 = bcs.build(tmp_data_dir)
@@ -212,9 +211,6 @@ class TestIdempotence:
         today = datetime.date.today().isoformat()
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        # "Last updated: unknown" is fine; "Last updated: <today>" would only appear
-        # if the roadmap.yaml file was touched today, which it wasn't (tmpdir is fresh).
-        # The key assertion: datetime.now() is never called.
         lines_with_today = [
             line for line in content.splitlines()
             if today in line and not line.startswith("Last updated:")
@@ -227,9 +223,6 @@ class TestIdempotence:
 class TestGhCliFail:
     """Projector must degrade gracefully when gh CLI is unavailable."""
 
-    def _failing_gh(self, *_args, **_kwargs):
-        raise FileNotFoundError("gh not found")
-
     def test_no_prs_on_gh_failure(self, tmp_data_dir: Path) -> None:
         with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
             content = bcs.build(tmp_data_dir)
@@ -238,7 +231,7 @@ class TestGhCliFail:
     def test_output_still_valid_markdown(self, tmp_data_dir: Path) -> None:
         with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
             content = bcs.build(tmp_data_dir)
-        assert content.startswith("# VNX Project State")
+        assert content.startswith("# Mission")
         assert len(content.splitlines()) <= 200
 
     def test_gh_nonzero_exit(self, tmp_data_dir: Path) -> None:
@@ -248,7 +241,7 @@ class TestGhCliFail:
         mock_result.stdout = ""
         with patch("subprocess.run", return_value=mock_result):
             content = bcs.build(tmp_data_dir)
-        assert "# VNX Project State" in content
+        assert "# Mission" in content
 
 
 class TestLastUpdatedLine:
@@ -274,21 +267,23 @@ class TestLastUpdatedLine:
 class TestDecisionsSection:
     def test_decisions_rendered(self, tmp_data_dir: Path) -> None:
         decisions = [
-            {"timestamp": "2026-05-01T12:00:00Z", "title": "auth-model",
-             "decision": "jwt_symmetric"},
+            {
+                "decision_id": "OD-2026-05-01-001",
+                "scope": "auth",
+                "ts": "2026-05-01T12:00:00Z",
+                "rationale": "chose jwt_symmetric for simplicity",
+            },
         ]
-        (tmp_data_dir / "strategy" / "decisions.ndjson").write_text(
-            "\n".join(json.dumps(d) for d in decisions) + "\n"
-        )
+        _write_decisions(tmp_data_dir / "strategy", decisions)
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "auth-model" in content
+        assert "OD-2026-05-01-001" in content
         assert "jwt_symmetric" in content
 
     def test_missing_decisions_file_graceful(self, tmp_data_dir: Path) -> None:
         with patch.object(bcs, "_fetch_prs", _no_prs):
             content = bcs.build(tmp_data_dir)
-        assert "# VNX Project State" in content
+        assert "# Mission" in content
 
 
 class TestOutputLength:
@@ -301,9 +296,12 @@ class TestOutputLength:
         ]
         roadmap = {
             "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Big",
+            "generated_at": "2026-05-06T00:00:00Z",
             "phases": [{"phase_id": 0, "title": "Big Phase",
                         "waves": [f"w-{i}" for i in range(100)],
-                        "blocked_on": []}],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
             "waves": many_waves,
         }
         _write_roadmap(tmp_data_dir / "strategy", roadmap)

--- a/tests/test_build_current_state_integration.py
+++ b/tests/test_build_current_state_integration.py
@@ -107,7 +107,7 @@ class TestProjectorInvocationViaSubprocess:
         out = strategy_dir / "current_state.md"
         assert out.exists(), f"current_state.md not created at {out}"
         content = out.read_text()
-        assert "# VNX Project State" in content
+        assert "# Mission" in content
 
     def test_projector_idempotent_via_subprocess(self, tmp_path: Path) -> None:
         """Two subprocess calls produce byte-identical current_state.md."""

--- a/tests/test_build_current_state_v2.py
+++ b/tests/test_build_current_state_v2.py
@@ -1,0 +1,556 @@
+"""Tests for the typed current_state.md projector (W-state-3 rewrite).
+
+Test plan:
+- Section presence: all 7 sections present in output
+- Section order: in exact expected sequence
+- Idempotency: two consecutive runs produce byte-identical output
+- Deterministic ordering: 2 decisions with same timestamp sorted by decision_id
+- Empty state: no roadmap, no decisions → output still has all sections
+- Recommended next move: resolved deps → returns wave; unresolved → blocked or None
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+import build_current_state as bcs
+
+SECTION_HEADERS = [
+    "# Mission",
+    "## Current focus",
+    "## Roadmap snapshot",
+    "## In flight",
+    "## Last 3 decisions",
+    "## Recommended next move",
+    "## Resume hints",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_data_dir(tmp_path: Path) -> Path:
+    (tmp_path / "strategy").mkdir(parents=True)
+    (tmp_path / "state").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_roadmap(strategy_dir: Path, data: dict) -> None:
+    import yaml
+    (strategy_dir / "roadmap.yaml").write_text(yaml.dump(data))
+
+
+def _write_decisions(strategy_dir: Path, records: list[dict]) -> None:
+    (strategy_dir / "decisions.ndjson").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n"
+    )
+
+
+def _write_t0_state(state_dir: Path, data: dict) -> None:
+    (state_dir / "t0_state.json").write_text(json.dumps(data))
+
+
+def _no_prs(*_args, **_kwargs):
+    return []
+
+
+def _minimal_roadmap(phase_id: int = 1) -> dict:
+    return {
+        "schema_version": 1,
+        "roadmap_id": "test-roadmap",
+        "title": "Test Roadmap",
+        "generated_at": "2026-05-06T00:00:00Z",
+        "phases": [
+            {
+                "phase_id": phase_id,
+                "title": "Test Phase",
+                "waves": ["w-1"],
+                "estimated_loc": 0,
+                "estimated_weeks": 0.0,
+                "blocked_on": [],
+            }
+        ],
+        "waves": [
+            {
+                "wave_id": "w-1",
+                "title": "Test Wave",
+                "phase_id": phase_id,
+                "status": "planned",
+                "depends_on": [],
+            }
+        ],
+    }
+
+
+def _decision_record(decision_id: str, ts: str, scope: str = "arch", rationale: str = "test") -> dict:
+    return {"decision_id": decision_id, "scope": scope, "ts": ts, "rationale": rationale}
+
+
+# ---------------------------------------------------------------------------
+# Section presence
+# ---------------------------------------------------------------------------
+
+class TestSectionPresence:
+    def test_all_7_sections_present_empty_state(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        for header in SECTION_HEADERS:
+            assert header in content, f"Missing section: {header!r}"
+
+    def test_all_7_sections_present_with_roadmap(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", _minimal_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        for header in SECTION_HEADERS:
+            assert header in content, f"Missing section: {header!r}"
+
+    def test_all_7_sections_present_with_decisions(self, tmp_data_dir: Path) -> None:
+        _write_decisions(
+            tmp_data_dir / "strategy",
+            [_decision_record("OD-2026-05-01-001", "2026-05-01T10:00:00Z")],
+        )
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        for header in SECTION_HEADERS:
+            assert header in content, f"Missing section: {header!r}"
+
+
+# ---------------------------------------------------------------------------
+# Section order
+# ---------------------------------------------------------------------------
+
+class TestSectionOrder:
+    def test_sections_in_expected_sequence(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        lines = content.splitlines()
+
+        positions: list[int] = []
+        for header in SECTION_HEADERS:
+            for i, line in enumerate(lines):
+                if line == header:
+                    positions.append(i)
+                    break
+            else:
+                pytest.fail(f"Section header not found: {header!r}")
+
+        assert positions == sorted(positions), (
+            f"Sections out of order. Positions: {list(zip(SECTION_HEADERS, positions))}"
+        )
+
+    def test_mission_is_first_section(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert content.startswith("# Mission")
+
+    def test_resume_hints_is_last_section(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        lines = content.splitlines()
+        section_lines = [i for i, l in enumerate(lines) if l in SECTION_HEADERS]
+        assert lines[section_lines[-1]] == "## Resume hints"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+class TestIdempotency:
+    def test_empty_state_idempotent(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2, "Output differed between run 1 and run 2"
+
+    def test_with_roadmap_and_decisions_idempotent(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", _minimal_roadmap())
+        _write_decisions(
+            tmp_data_dir / "strategy",
+            [_decision_record("OD-2026-05-01-001", "2026-05-01T10:00:00Z")],
+        )
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2, "Output differed between run 1 and run 2"
+
+    def test_no_datetime_now_in_body(self, tmp_data_dir: Path) -> None:
+        import datetime
+        today = datetime.date.today().isoformat()
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        offending = [
+            line for line in content.splitlines()
+            if today in line and not line.startswith("Last updated:")
+        ]
+        assert not offending, f"Body contains today's date outside 'Last updated:': {offending}"
+
+    def test_with_t0_state_idempotent(self, tmp_data_dir: Path) -> None:
+        _write_t0_state(tmp_data_dir / "state", {
+            "tracks": {"A": {"active_dispatch_id": "d-001", "status": "working", "current_gate": "g1"}},
+        })
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2
+
+
+# ---------------------------------------------------------------------------
+# Deterministic decision ordering
+# ---------------------------------------------------------------------------
+
+class TestDeterministicOrdering:
+    def test_same_timestamp_sorted_by_decision_id(self, tmp_data_dir: Path) -> None:
+        shared_ts = "2026-05-01T10:00:00Z"
+        records = [
+            _decision_record("OD-2026-05-01-002", shared_ts, rationale="second-rationale"),
+            _decision_record("OD-2026-05-01-001", shared_ts, rationale="first-rationale"),
+        ]
+        _write_decisions(tmp_data_dir / "strategy", records)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+
+        idx1 = content.index("OD-2026-05-01-001")
+        idx2 = content.index("OD-2026-05-01-002")
+        assert idx1 < idx2, "OD-001 should appear before OD-002 (sorted by decision_id)"
+
+    def test_same_timestamp_idempotent(self, tmp_data_dir: Path) -> None:
+        shared_ts = "2026-05-01T10:00:00Z"
+        records = [
+            _decision_record("OD-2026-05-01-003", shared_ts, rationale="r3"),
+            _decision_record("OD-2026-05-01-001", shared_ts, rationale="r1"),
+            _decision_record("OD-2026-05-01-002", shared_ts, rationale="r2"),
+        ]
+        _write_decisions(tmp_data_dir / "strategy", records)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            run1 = bcs.build(tmp_data_dir)
+            run2 = bcs.build(tmp_data_dir)
+        assert run1 == run2
+
+    def test_different_timestamps_ordered_chronologically(self, tmp_data_dir: Path) -> None:
+        records = [
+            _decision_record("OD-2026-05-01-001", "2026-05-01T08:00:00Z", rationale="early"),
+            _decision_record("OD-2026-05-01-002", "2026-05-01T12:00:00Z", rationale="late"),
+        ]
+        _write_decisions(tmp_data_dir / "strategy", records)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        idx_early = content.index("early")
+        idx_late = content.index("late")
+        assert idx_early < idx_late
+
+
+# ---------------------------------------------------------------------------
+# Empty state — all sections still present with placeholder text
+# ---------------------------------------------------------------------------
+
+class TestEmptyState:
+    def test_mission_placeholder_when_no_roadmap(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "# Mission" in content
+        assert "_No mission set._" in content
+
+    def test_current_focus_placeholder_when_no_roadmap(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Current focus" in content
+        assert "_No roadmap available._" in content
+
+    def test_roadmap_snapshot_placeholder_when_no_roadmap(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Roadmap snapshot" in content
+        assert "_No roadmap data._" in content
+
+    def test_in_flight_placeholder_when_no_prs(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## In flight" in content
+        assert "_No open PRs or gh CLI unavailable._" in content
+
+    def test_decisions_placeholder_when_no_file(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Last 3 decisions" in content
+        assert "_No decisions recorded._" in content
+
+    def test_recommended_next_move_placeholder_when_no_roadmap(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Recommended next move" in content
+        assert "_No roadmap available._" in content
+
+    def test_resume_hints_always_present(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Resume hints" in content
+        assert "Last updated:" in content
+
+    def test_last_updated_unknown_when_no_files(self, tmp_data_dir: Path) -> None:
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "Last updated: unknown" in content
+
+
+# ---------------------------------------------------------------------------
+# Recommended next move — depends_on resolution
+# ---------------------------------------------------------------------------
+
+class TestRecommendedNextMove:
+    def _roadmap_with_deps(self, w1_status: str, w2_status: str = "planned") -> dict:
+        return {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Dep Test",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [
+                {
+                    "phase_id": 1,
+                    "title": "Phase One",
+                    "waves": ["w-1", "w-2"],
+                    "estimated_loc": 0,
+                    "estimated_weeks": 0.0,
+                    "blocked_on": [],
+                }
+            ],
+            "waves": [
+                {
+                    "wave_id": "w-1",
+                    "title": "First Wave",
+                    "phase_id": 1,
+                    "status": w1_status,
+                    "depends_on": [],
+                },
+                {
+                    "wave_id": "w-2",
+                    "title": "Second Wave",
+                    "phase_id": 1,
+                    "status": w2_status,
+                    "depends_on": ["w-1"],
+                },
+            ],
+        }
+
+    def test_resolved_deps_returns_expected_wave(self, tmp_data_dir: Path) -> None:
+        """When depends_on wave is completed, next actionable wave is w-2."""
+        _write_roadmap(
+            tmp_data_dir / "strategy",
+            self._roadmap_with_deps(w1_status="completed"),
+        )
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "`w-2`" in content
+        assert "ready to start" in content
+
+    def test_unresolved_deps_returns_blocked_message(self, tmp_data_dir: Path) -> None:
+        """When w-1 is in_progress, w-2's deps are unresolved → no actionable wave."""
+        _write_roadmap(
+            tmp_data_dir / "strategy",
+            self._roadmap_with_deps(w1_status="in_progress"),
+        )
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Recommended next move" in content
+        assert "`w-2`" in content
+        assert "Blocked on" in content
+
+    def test_first_wave_no_deps_is_immediately_actionable(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", _minimal_roadmap())
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "`w-1`" in content
+        assert "ready to start" in content
+
+    def test_all_waves_completed_shows_nothing_to_do(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Done",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 1, "title": "P1", "waves": ["w-1"],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": [{"wave_id": "w-1", "title": "W1", "phase_id": 1,
+                       "status": "completed", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "## Recommended next move" in content
+        # No planned waves → "nothing to do" message
+        assert "Nothing to do" in content or "completed" in content
+
+
+# ---------------------------------------------------------------------------
+# Current focus section
+# ---------------------------------------------------------------------------
+
+class TestCurrentFocus:
+    def test_active_wave_shown(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Focus Test",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 2, "title": "Build Phase",
+                        "waves": ["w-active"], "estimated_loc": 0,
+                        "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": [{"wave_id": "w-active", "title": "Active Work",
+                       "phase_id": 2, "status": "in_progress", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "Phase 2" in content
+        assert "Build Phase" in content
+        assert "`w-active`" in content
+        assert "[~]" in content
+
+    def test_no_active_phase_when_all_completed(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Done",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 1, "title": "P1", "waves": ["w-1"],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": [{"wave_id": "w-1", "title": "W1", "phase_id": 1,
+                       "status": "completed", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "_No active phase. All waves completed or roadmap empty._" in content
+
+
+# ---------------------------------------------------------------------------
+# Roadmap snapshot badges
+# ---------------------------------------------------------------------------
+
+class TestRoadmapSnapshot:
+    def test_completed_badge_in_snapshot(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "T",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 1, "title": "P", "waves": ["w-1"],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": [{"wave_id": "w-1", "title": "W", "phase_id": 1,
+                       "status": "completed", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "[x]" in content
+
+    def test_in_progress_badge_in_snapshot(self, tmp_data_dir: Path) -> None:
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "T",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 1, "title": "P", "waves": ["w-1"],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": [{"wave_id": "w-1", "title": "W", "phase_id": 1,
+                       "status": "in_progress", "depends_on": []}],
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "[~]" in content
+
+
+# ---------------------------------------------------------------------------
+# In flight — t0_state dispatches
+# ---------------------------------------------------------------------------
+
+class TestInFlight:
+    def test_active_dispatches_shown(self, tmp_data_dir: Path) -> None:
+        _write_t0_state(tmp_data_dir / "state", {
+            "tracks": {
+                "A": {
+                    "active_dispatch_id": "disp-abc-123",
+                    "status": "working",
+                    "current_gate": "gate_review",
+                }
+            }
+        })
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "disp-abc-123" in content
+        assert "gate_review" in content
+
+    def test_no_active_dispatches_placeholder(self, tmp_data_dir: Path) -> None:
+        _write_t0_state(tmp_data_dir / "state", {
+            "tracks": {"A": {"active_dispatch_id": None, "status": "idle"}}
+        })
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "_No active dispatches._" in content
+
+    def test_open_prs_shown(self, tmp_data_dir: Path) -> None:
+        prs = [{"number": 42, "title": "feat: my-pr", "headRefName": "my-branch"}]
+        with patch.object(bcs, "_fetch_prs", return_value=prs):
+            content = bcs.build(tmp_data_dir)
+        assert "PR #42" in content
+        assert "feat: my-pr" in content
+        assert "`my-branch`" in content
+
+
+# ---------------------------------------------------------------------------
+# Output limits
+# ---------------------------------------------------------------------------
+
+class TestOutputLimits:
+    def test_large_roadmap_within_200_lines(self, tmp_data_dir: Path) -> None:
+        many_waves = [
+            {"wave_id": f"w-{i}", "title": f"Wave {i}", "phase_id": 1,
+             "status": "planned", "depends_on": []}
+            for i in range(100)
+        ]
+        roadmap = {
+            "schema_version": 1,
+            "roadmap_id": "r1",
+            "title": "Big",
+            "generated_at": "2026-05-06T00:00:00Z",
+            "phases": [{"phase_id": 1, "title": "Big Phase",
+                        "waves": [f"w-{i}" for i in range(100)],
+                        "estimated_loc": 0, "estimated_weeks": 0.0, "blocked_on": []}],
+            "waves": many_waves,
+        }
+        _write_roadmap(tmp_data_dir / "strategy", roadmap)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert len(content.splitlines()) <= 200
+
+
+# ---------------------------------------------------------------------------
+# Mission from roadmap title
+# ---------------------------------------------------------------------------
+
+class TestMissionSection:
+    def test_mission_shows_roadmap_title(self, tmp_data_dir: Path) -> None:
+        _write_roadmap(tmp_data_dir / "strategy", {
+            **_minimal_roadmap(),
+            "title": "VNX Orchestration Platform",
+        })
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "VNX Orchestration Platform" in content
+
+    def test_mission_placeholder_without_title(self, tmp_data_dir: Path) -> None:
+        roadmap_data = _minimal_roadmap()
+        roadmap_data["title"] = ""
+        _write_roadmap(tmp_data_dir / "strategy", roadmap_data)
+        with patch.object(bcs, "_fetch_prs", _no_prs):
+            content = bcs.build(tmp_data_dir)
+        assert "_No mission set._" in content


### PR DESCRIPTION
## Summary
- Rewrites `scripts/build_current_state.py` to consume typed `strategy.roadmap` and `strategy.decisions` modules (W-state-1, W-state-2)
- Produces schema-stable, idempotent 7-section `current_state.md` per PROJECT_STATE_DESIGN §4.2
- Fixes `doc_indexes.py` relative import to work with both the standard package path and the test harness that adds `scripts/lib` directly to sys.path
- Appended `current_state.md schema` section to `docs/architecture/STRATEGIC_STATE.md`

## Test plan
- [ ] `pytest tests/test_build_current_state_v2.py tests/test_build_current_state.py -x` → 55 passed
- [ ] `pytest tests/test_doc_indexes.py -x` → 16 passed (no regression from import fix)
- [ ] Section presence: all 7 sections in output
- [ ] Section order: in expected sequence
- [ ] Idempotency: two runs → byte-identical output
- [ ] Deterministic ordering: same-timestamp decisions sorted by decision_id
- [ ] Empty state: all sections present with placeholders
- [ ] Recommended next move: resolved deps → wave; unresolved → blocked message

🤖 Generated with [Claude Code](https://claude.com/claude-code)