### PR TITLE
feat(ollama): adapter streaming refactor via W7-B mixin (Phase 3 W7-F)

### DIFF
--- a/scripts/lib/adapters/ollama_adapter.py
+++ b/scripts/lib/adapters/ollama_adapter.py
@@ -4,6 +4,9 @@
 Routes requests to a local Ollama endpoint via HTTP (no subprocess, no SDK).
 Supports DECISION (structured JSON verdict) and DIGEST (narrative text).
 
+Streaming: uses an HTTP-line drain that emits CanonicalEvent objects live.
+Tier-2 baseline (text-only); Tier-1 when tool_calls are detected in the stream.
+
 Config via env vars:
   VNX_OLLAMA_HOST    — Ollama base URL  (default: http://localhost:11434)
   VNX_OLLAMA_MODEL   — Model to use     (default: gemma3:27b)
@@ -22,11 +25,13 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Dict, Iterator, List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from canonical_event import CanonicalEvent
 from provider_adapter import AdapterResult, Capability, ProviderAdapter
+from _streaming_drainer import StreamingDrainerMixin
 
 logger = logging.getLogger(__name__)
 
@@ -34,21 +39,44 @@ _DEFAULT_HOST    = "http://localhost:11434"
 _DEFAULT_MODEL   = "gemma3:27b"
 _DEFAULT_TIMEOUT = 60
 
+# Observability tier labels per spec W7-F
+_TIER_FULL     = 1  # tool_use detected (OpenAI tool-trained model)
+_TIER_BASELINE = 2  # text-only streaming (default for Ollama)
 
-class OllamaAdapter(ProviderAdapter):
+
+class OllamaAdapter(StreamingDrainerMixin, ProviderAdapter):
     """Provider adapter for local Ollama endpoint (decision and digest only).
 
     Calls the Ollama HTTP API directly via urllib — no subprocess, no SDK.
+    Emits CanonicalEvent objects live via HTTP line-by-line drain.
     Returns structured JSON for DECISION tasks and raw narrative for DIGEST.
 
-    Fallback behaviour: any HTTP error → AdapterResult(status="failed",
+    Fallback behaviour: any HTTP/network error → AdapterResult(status="failed",
     output="ollama_unavailable") so callers can gracefully degrade.
     """
+
+    # StreamingDrainerMixin contract
+    provider_name = "ollama"
 
     def __init__(self, terminal_id: str) -> None:
         self._terminal_id = terminal_id
         self._host  = os.environ.get("VNX_OLLAMA_HOST",  _DEFAULT_HOST).rstrip("/")
         self._model = os.environ.get("VNX_OLLAMA_MODEL", _DEFAULT_MODEL)
+        # Context used by _normalize() when called through the mixin's drain_stream()
+        self._current_dispatch_id: str = ""
+        self._current_terminal_id: str = terminal_id
+
+    # ------------------------------------------------------------------
+    # StreamingDrainerMixin._normalize() implementation
+    # ------------------------------------------------------------------
+
+    def _normalize(self, raw_chunk: Dict[str, Any]) -> CanonicalEvent:
+        """Satisfy StreamingDrainerMixin contract — delegates to static normalizer."""
+        return self._normalize_ollama_event(
+            raw_chunk,
+            dispatch_id=self._current_dispatch_id,
+            terminal_id=self._current_terminal_id,
+        )
 
     # ------------------------------------------------------------------
     # ProviderAdapter interface
@@ -70,68 +98,60 @@ class OllamaAdapter(ProviderAdapter):
             return False
 
     def execute(self, instruction: str, context: dict) -> AdapterResult:
-        """POST instruction to /api/generate and return structured result.
+        """POST instruction to /api/generate via HTTP streaming and collect events.
+
+        Uses HTTP line-by-line drain internally to emit CanonicalEvents live.
+        Accumulates text across text and complete events to build output.
 
         context keys used:
-          capability : str  — "decision" or "digest" (affects log verbosity only)
-          timeout    : int  — override VNX_OLLAMA_TIMEOUT for this call
-
-        For DECISION tasks the caller is expected to parse output as JSON via
-        _parse_llm_response(); OllamaAdapter returns the raw LLM text extracted
-        from Ollama's {"response": "..."} wrapper.
-
-        Returns AdapterResult(status="failed", output="ollama_unavailable") on
-        any network/timeout error so callers can fall back without crashing.
+          capability  : str        — "decision" or "digest" (log only)
+          timeout     : int        — override VNX_OLLAMA_TIMEOUT
+          terminal_id : str        — terminal for EventStore writes
+          dispatch_id : str        — dispatch for EventStore writes
+          event_store : EventStore — live event storage (optional)
         """
         timeout = int(
             context.get("timeout")
             or os.environ.get("VNX_OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT))
         )
-        capability = context.get("capability", "digest")
-
-        payload = json.dumps({
-            "model": self._model,
-            "prompt": instruction,
-            "stream": False,
-        }).encode("utf-8")
-
-        url = f"{self._host}/api/generate"
-        req = urllib.request.Request(
-            url,
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
+        terminal_id = context.get("terminal_id", self._terminal_id)
+        dispatch_id = context.get("dispatch_id", "")
+        event_store = context.get("event_store")
 
         t0 = time.monotonic()
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                body = resp.read().decode("utf-8")
-            duration = time.monotonic() - t0
-        except (urllib.error.URLError, OSError, TimeoutError) as exc:
-            duration = time.monotonic() - t0
-            logger.warning(
-                "OllamaAdapter [%s] request failed (%s)", capability, exc
-            )
-            return AdapterResult(
-                status="failed",
-                output="ollama_unavailable",
-                events=[],
-                event_count=0,
-                duration_seconds=duration,
-                committed=False,
-                commit_hash=None,
-                report_path=None,
-                provider="ollama",
-                model=self._model,
-            )
+        canonical_events: List[CanonicalEvent] = []
+        text_parts: List[str] = []
 
-        response_text = self._extract_response(body)
+        for event in self._drain_http_stream(
+            instruction=instruction,
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            event_store=event_store,
+            timeout=timeout,
+        ):
+            canonical_events.append(event)
+            if event.event_type == "text":
+                text_parts.append(event.data.get("text", ""))
+            elif event.event_type == "complete":
+                # Final chunk may carry the last token on generate API
+                if "text" in event.data:
+                    text_parts.append(event.data["text"])
+
+        duration = time.monotonic() - t0
+        output = "".join(text_parts)
+
+        error_events = [e for e in canonical_events if e.event_type == "error"]
+        if error_events and not output:
+            status = "failed"
+            output = "ollama_unavailable"
+        else:
+            status = "done"
+
         return AdapterResult(
-            status="done",
-            output=response_text,
-            events=[{"type": "result", "data": response_text}],
-            event_count=1,
+            status=status,
+            output=output,
+            events=[e.to_dict() for e in canonical_events],
+            event_count=len(canonical_events),
             duration_seconds=duration,
             committed=False,
             commit_hash=None,
@@ -141,18 +161,49 @@ class OllamaAdapter(ProviderAdapter):
         )
 
     def stream_events(self, instruction: str, context: dict) -> Iterator[dict]:
-        """POST with stream=true and yield each chunk as an event.
+        """POST with stream=True and yield each CanonicalEvent as a dict.
 
-        Ollama streaming format: each line is JSON {"response": "...", "done": bool}.
-        Yields {"type": "chunk", "data": "<text>"} for each token.
-        Yields {"type": "done"} when the stream ends.
-
-        Falls back to {"type": "error", "data": "ollama_unavailable"} on failure.
+        Uses the HTTP line-by-line drain for live per-event delivery.
+        Falls back to {"type": "error", "data": {"reason": "..."}} on failure.
         """
         timeout = int(
             context.get("timeout")
             or os.environ.get("VNX_OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT))
         )
+        terminal_id = context.get("terminal_id", self._terminal_id)
+        dispatch_id = context.get("dispatch_id", "")
+        event_store = context.get("event_store")
+
+        for event in self._drain_http_stream(
+            instruction=instruction,
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            event_store=event_store,
+            timeout=timeout,
+        ):
+            yield event.to_dict()
+
+    # ------------------------------------------------------------------
+    # HTTP streaming drain (HTTP-line variant of StreamingDrainerMixin)
+    # ------------------------------------------------------------------
+
+    def _drain_http_stream(
+        self,
+        instruction: str,
+        terminal_id: str,
+        dispatch_id: str,
+        event_store: Optional[Any] = None,
+        timeout: float = 60.0,
+    ) -> Iterator[CanonicalEvent]:
+        """POST to /api/generate with stream=True, yield CanonicalEvents line-by-line.
+
+        Reads NDJSON lines from the HTTP response, maps each via
+        _normalize_ollama_event(), and writes to EventStore live (not post-hoc).
+        Emits a synthetic error event on connection failure mid-stream.
+        """
+        # Set instance context for _normalize() (satisfies mixin contract)
+        self._current_dispatch_id = dispatch_id
+        self._current_terminal_id = terminal_id
 
         payload = json.dumps({
             "model": self._model,
@@ -170,39 +221,159 @@ class OllamaAdapter(ProviderAdapter):
 
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                for raw_line in resp:
-                    line = raw_line.decode("utf-8").strip()
-                    if not line:
-                        continue
-                    try:
-                        chunk = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    token = chunk.get("response", "")
-                    if token:
-                        yield {"type": "chunk", "data": token}
-                    if chunk.get("done"):
-                        yield {"type": "done"}
-                        return
+                yield from self._drain_response_lines(
+                    resp=resp,
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    event_store=event_store,
+                )
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
-            logger.warning("OllamaAdapter stream failed: %s", exc)
-            yield {"type": "error", "data": "ollama_unavailable"}
+            err = CanonicalEvent(
+                dispatch_id=dispatch_id,
+                terminal_id=terminal_id,
+                provider="ollama",
+                event_type="error",
+                data={"reason": f"connection failed: {exc}"},
+                observability_tier=_TIER_BASELINE,
+            )
+            _append_to_store(event_store, terminal_id, err, dispatch_id)
+            yield err
+
+    def _drain_response_lines(
+        self,
+        resp: Any,
+        terminal_id: str,
+        dispatch_id: str,
+        event_store: Optional[Any] = None,
+    ) -> Iterator[CanonicalEvent]:
+        """Read HTTP response lines, parse JSON, yield CanonicalEvents.
+
+        Writes each event to EventStore immediately (live, not post-hoc).
+        Yields a synthetic error event for malformed JSON lines.
+        Stops after emitting the complete event (done=True chunk).
+        """
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+
+            try:
+                chunk = json.loads(line)
+            except json.JSONDecodeError as exc:
+                err = CanonicalEvent(
+                    dispatch_id=dispatch_id,
+                    terminal_id=terminal_id,
+                    provider="ollama",
+                    event_type="error",
+                    data={"reason": str(exc), "raw": line[:500]},
+                    observability_tier=_TIER_BASELINE,
+                )
+                _append_to_store(event_store, terminal_id, err, dispatch_id)
+                yield err
+                continue
+
+            event = self._normalize_ollama_event(chunk, dispatch_id, terminal_id)
+            _append_to_store(event_store, terminal_id, event, dispatch_id)
+            yield event
+
+            if event.event_type == "complete":
+                break
 
     # ------------------------------------------------------------------
-    # Helpers
+    # Event normalization
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_response(body: str) -> str:
-        """Extract LLM text from Ollama's JSON wrapper.
+    def _normalize_ollama_event(
+        raw: Dict[str, Any],
+        dispatch_id: str = "",
+        terminal_id: str = "",
+    ) -> CanonicalEvent:
+        """Map one Ollama HTTP-stream JSON chunk to a CanonicalEvent.
 
-        Ollama non-streaming response: {"model":..., "response":"<text>", "done":true, ...}
-        Returns the inner response text, or raw body if parsing fails.
+        Supports both /api/generate (response field) and /api/chat (message field).
+        Tier-2 baseline for text-only streaming; Tier-1 when tool_calls detected.
+
+        Ollama chunk fields:
+          response   : str  — token text (/api/generate format)
+          message    : dict — {"role":"assistant","content":"...","tool_calls":[...]}
+          done       : bool — True on the final chunk
+          eval_count : int  — total token count (only on final done=True chunk)
         """
-        try:
-            data = json.loads(body)
-            if isinstance(data, dict) and "response" in data:
-                return str(data["response"])
-        except (json.JSONDecodeError, ValueError):
-            pass
-        return body.strip()
+        message = raw.get("message")
+        response = raw.get("response")
+        done = bool(raw.get("done", False))
+        eval_count = raw.get("eval_count")
+
+        # Detect tool-use: OpenAI tool-use shape on tool-trained models (e.g. llama3.1-tools)
+        tool_calls = None
+        if isinstance(message, dict):
+            tool_calls = message.get("tool_calls")
+
+        tier = _TIER_FULL if tool_calls else _TIER_BASELINE
+
+        if done:
+            data: Dict[str, Any] = {"done": True}
+            if eval_count is not None:
+                data["token_count"] = int(eval_count)
+            # Final chunk may carry the last token on generate API
+            last_text = ""
+            if response is not None:
+                last_text = response
+            elif isinstance(message, dict):
+                last_text = message.get("content", "")
+            if last_text:
+                data["text"] = last_text
+            return CanonicalEvent(
+                dispatch_id=dispatch_id,
+                terminal_id=terminal_id,
+                provider="ollama",
+                event_type="complete",
+                data=data,
+                observability_tier=tier,
+            )
+
+        if tool_calls:
+            return CanonicalEvent(
+                dispatch_id=dispatch_id,
+                terminal_id=terminal_id,
+                provider="ollama",
+                event_type="tool_use",
+                data={"tool_calls": tool_calls},
+                observability_tier=_TIER_FULL,
+            )
+
+        # Text token
+        text = ""
+        if response is not None:
+            text = response
+        elif isinstance(message, dict):
+            text = message.get("content", "")
+
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="ollama",
+            event_type="text",
+            data={"text": text},
+            observability_tier=tier,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper
+# ---------------------------------------------------------------------------
+
+def _append_to_store(
+    event_store: Optional[Any],
+    terminal_id: str,
+    event: CanonicalEvent,
+    dispatch_id: str,
+) -> None:
+    """Write event to EventStore; swallow all errors so the drain stays live."""
+    if event_store is None:
+        return
+    try:
+        event_store.append(terminal_id, event, dispatch_id=dispatch_id)
+    except Exception:
+        logger.exception("OllamaAdapter: EventStore.append failed for %s", terminal_id)

--- a/tests/integration/test_ollama_crash_negative.py
+++ b/tests/integration/test_ollama_crash_negative.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Crash / negative integration tests for OllamaAdapter.
+
+These tests verify error handling paths — connection refused, mid-stream
+connection drop, malformed JSON — and do NOT require a running Ollama daemon.
+They use mocks or deliberate bad configurations.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+sys.path.insert(0, str(_LIB_DIR))
+sys.path.insert(0, str(_LIB_DIR / "adapters"))
+
+from adapters.ollama_adapter import OllamaAdapter, _TIER_BASELINE
+from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_stream_response(lines: list[str]) -> "mock.MagicMock":
+    """Return a mock urllib response that yields the given NDJSON lines."""
+    encoded = b"".join((l.rstrip("\n") + "\n").encode() for l in lines)
+
+    class _FakeResp:
+        status = 200
+
+        def __iter__(self):
+            for line in encoded.split(b"\n"):
+                if line:
+                    yield line + b"\n"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    return _FakeResp()
+
+
+def _make_chunk(response: str = "", done: bool = False, eval_count: int | None = None) -> str:
+    obj: dict = {"model": "gemma3:27b", "response": response, "done": done}
+    if eval_count is not None:
+        obj["eval_count"] = eval_count
+    return json.dumps(obj)
+
+
+# ---------------------------------------------------------------------------
+# Connection refused
+# ---------------------------------------------------------------------------
+
+class TestConnectionRefused:
+    def test_drain_yields_error_event_on_url_error(self):
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = urllib.error.URLError("connection refused")
+            events = list(adapter._drain_http_stream(
+                instruction="hello",
+                terminal_id="T1",
+                dispatch_id="neg-001",
+            ))
+        assert len(events) == 1
+        assert events[0].event_type == "error"
+        assert "connection failed" in events[0].data["reason"]
+
+    def test_drain_yields_error_event_on_oserror(self):
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = OSError("network unreachable")
+            events = list(adapter._drain_http_stream(
+                instruction="hello",
+                terminal_id="T1",
+                dispatch_id="neg-002",
+            ))
+        assert events[0].event_type == "error"
+
+    def test_drain_yields_error_on_timeout(self):
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = TimeoutError("timed out")
+            events = list(adapter._drain_http_stream(
+                instruction="hello",
+                terminal_id="T1",
+                dispatch_id="neg-003",
+            ))
+        assert events[0].event_type == "error"
+
+    def test_execute_returns_failed_on_connection_refused(self):
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = urllib.error.URLError("refused")
+            result = adapter.execute("decide something", {})
+        assert result.status == "failed"
+        assert result.output == "ollama_unavailable"
+
+    def test_stream_events_yields_error_dict_on_refusal(self):
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = urllib.error.URLError("refused")
+            events = list(adapter.stream_events("prompt", {}))
+        assert len(events) == 1
+        assert events[0]["event_type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON in stream
+# ---------------------------------------------------------------------------
+
+class TestMalformedJsonStream:
+    def test_malformed_line_becomes_error_event(self):
+        adapter = OllamaAdapter("T1")
+        resp = _fake_stream_response([
+            "this is not json",
+            _make_chunk("hello", done=True, eval_count=5),
+        ])
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            events = list(adapter._drain_http_stream(
+                instruction="test",
+                terminal_id="T1",
+                dispatch_id="neg-malformed-001",
+            ))
+
+        assert len(events) == 2
+        assert events[0].event_type == "error"
+        assert "raw" in events[0].data
+        assert events[1].event_type == "complete"
+
+    def test_malformed_line_reason_in_data(self):
+        adapter = OllamaAdapter("T1")
+        resp = _fake_stream_response(["not-valid-json"])
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            events = list(adapter._drain_http_stream(
+                instruction="test",
+                terminal_id="T1",
+                dispatch_id="neg-malformed-002",
+            ))
+        assert events[0].data.get("reason")
+
+    def test_mixed_valid_and_malformed(self):
+        adapter = OllamaAdapter("T1")
+        resp = _fake_stream_response([
+            _make_chunk("token1"),
+            "bad line",
+            _make_chunk("token2"),
+            _make_chunk("", done=True, eval_count=3),
+        ])
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            events = list(adapter._drain_http_stream(
+                instruction="test",
+                terminal_id="T1",
+                dispatch_id="neg-mixed-001",
+            ))
+
+        types = [e.event_type for e in events]
+        assert "error" in types
+        assert "text" in types
+        assert "complete" in types
+
+
+# ---------------------------------------------------------------------------
+# Error events written to EventStore
+# ---------------------------------------------------------------------------
+
+class TestErrorEventsWrittenToStore:
+    def test_connection_error_event_in_store(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        adapter = OllamaAdapter("T1")
+        with mock.patch("urllib.request.urlopen") as m:
+            m.side_effect = urllib.error.URLError("refused")
+            list(adapter._drain_http_stream(
+                instruction="test",
+                terminal_id="T1",
+                dispatch_id="neg-store-001",
+                event_store=es,
+            ))
+
+        stored = list(es.tail("T1"))
+        assert len(stored) == 1
+        assert stored[0]["type"] == "error"
+        assert stored[0]["dispatch_id"] == "neg-store-001"
+
+    def test_malformed_json_error_event_in_store(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        adapter = OllamaAdapter("T1")
+        resp = _fake_stream_response(["not-json", _make_chunk("", done=True, eval_count=1)])
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            list(adapter._drain_http_stream(
+                instruction="test",
+                terminal_id="T1",
+                dispatch_id="neg-store-002",
+                event_store=es,
+            ))
+
+        stored = list(es.tail("T1"))
+        error_events = [e for e in stored if e["type"] == "error"]
+        assert len(error_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unreachable host — custom host env var
+# ---------------------------------------------------------------------------
+
+class TestUnreachableCustomHost:
+    def test_unreachable_custom_host_returns_error_event(self):
+        import os
+
+        with mock.patch.dict(os.environ, {"VNX_OLLAMA_HOST": "http://192.0.2.1:11434"}):
+            adapter = OllamaAdapter("T1")
+            with mock.patch("urllib.request.urlopen") as m:
+                m.side_effect = urllib.error.URLError("no route to host")
+                events = list(adapter._drain_http_stream(
+                    instruction="test",
+                    terminal_id="T1",
+                    dispatch_id="neg-custom-host",
+                ))
+
+        assert events[0].event_type == "error"

--- a/tests/integration/test_ollama_streaming.py
+++ b/tests/integration/test_ollama_streaming.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Integration tests for OllamaAdapter HTTP streaming (requires running Ollama daemon).
+
+Tests are skipped gracefully when no local Ollama daemon is reachable OR when
+no models are installed.  Run with:
+
+    pytest tests/integration/test_ollama_streaming.py -v
+
+Requires a small model to be pulled, e.g.:
+    ollama pull qwen2.5-coder:0.5b
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+sys.path.insert(0, str(_LIB_DIR))
+sys.path.insert(0, str(_LIB_DIR / "adapters"))
+
+from adapters.ollama_adapter import OllamaAdapter, _TIER_BASELINE, _TIER_FULL
+from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Daemon / model availability helpers
+# ---------------------------------------------------------------------------
+
+def _get_available_model() -> Optional[str]:
+    """Return first available model name, or None if daemon down or no models."""
+    try:
+        with urllib.request.urlopen("http://localhost:11434/api/tags", timeout=3) as resp:
+            if resp.status != 200:
+                return None
+            data = json.loads(resp.read())
+            models = [m["name"] for m in data.get("models", [])]
+            return models[0] if models else None
+    except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+_AVAILABLE_MODEL = _get_available_model()
+
+pytestmark = pytest.mark.skipif(
+    _AVAILABLE_MODEL is None,
+    reason=(
+        "Ollama daemon not reachable on localhost:11434 or no models installed. "
+        "Pull a model first: ollama pull qwen2.5-coder:0.5b"
+    ),
+)
+
+_SIMPLE_PROMPT = "Reply with exactly one word: pong"
+
+
+@pytest.fixture(autouse=True)
+def set_test_model(monkeypatch):
+    """Use the first available model so tests run regardless of which model is pulled."""
+    if _AVAILABLE_MODEL:
+        monkeypatch.setenv("VNX_OLLAMA_MODEL", _AVAILABLE_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Streaming produces CanonicalEvent objects
+# ---------------------------------------------------------------------------
+
+class TestStreamingProducesCanonicalEvents:
+    def test_stream_events_yields_dicts(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter.stream_events(_SIMPLE_PROMPT, {}))
+        assert len(events) > 0
+        for ev in events:
+            assert isinstance(ev, dict), f"expected dict, got {type(ev)}"
+
+    def test_stream_events_has_complete_event(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter.stream_events(_SIMPLE_PROMPT, {}))
+        types = [ev.get("event_type") for ev in events]
+        assert "complete" in types, f"no complete event in {types}"
+
+    def test_stream_events_complete_has_done_flag(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter.stream_events(_SIMPLE_PROMPT, {}))
+        complete = next((e for e in events if e.get("event_type") == "complete"), None)
+        assert complete is not None
+        assert complete["data"].get("done") is True
+
+    def test_drain_http_stream_yields_canonical_events(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-test-001",
+            event_store=None,
+        ))
+        assert all(isinstance(e, CanonicalEvent) for e in events)
+
+    def test_text_events_have_text_field(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-test-002",
+            event_store=None,
+        ))
+        text_events = [e for e in events if e.event_type == "text"]
+        for ev in text_events:
+            assert "text" in ev.data
+
+
+# ---------------------------------------------------------------------------
+# Tier labeling
+# ---------------------------------------------------------------------------
+
+class TestTierLabeling:
+    def test_text_only_model_is_tier_2(self):
+        adapter = OllamaAdapter("T1")
+        events = list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-tier-001",
+            event_store=None,
+        ))
+        text_events = [e for e in events if e.event_type == "text"]
+        assert len(text_events) > 0
+        for ev in text_events:
+            assert ev.observability_tier == _TIER_BASELINE, (
+                f"expected tier {_TIER_BASELINE}, got {ev.observability_tier}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# EventStore live writes
+# ---------------------------------------------------------------------------
+
+class TestEventStoreLiveWrites:
+    def test_events_written_to_store_during_streaming(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        adapter = OllamaAdapter("T1")
+        list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-store-001",
+            event_store=es,
+        ))
+        count = es.event_count("T1")
+        assert count > 0, "EventStore received no events"
+
+    def test_stored_events_have_correct_dispatch_id(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        adapter = OllamaAdapter("T1")
+        list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-store-dispatch",
+            event_store=es,
+        ))
+        stored = list(es.tail("T1"))
+        assert all(e["dispatch_id"] == "int-store-dispatch" for e in stored)
+
+    def test_stored_events_have_observability_tier(self, tmp_path):
+        from event_store import EventStore
+
+        es = EventStore(events_dir=tmp_path / "events")
+        adapter = OllamaAdapter("T1")
+        list(adapter._drain_http_stream(
+            instruction=_SIMPLE_PROMPT,
+            terminal_id="T1",
+            dispatch_id="int-tier-store",
+            event_store=es,
+        ))
+        stored = list(es.tail("T1"))
+        for ev in stored:
+            assert "observability_tier" in ev
+            assert ev["observability_tier"] in (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# execute() integration
+# ---------------------------------------------------------------------------
+
+class TestExecuteIntegration:
+    def test_execute_returns_done(self):
+        adapter = OllamaAdapter("T1")
+        result = adapter.execute(_SIMPLE_PROMPT, {})
+        assert result.status == "done"
+
+    def test_execute_output_is_non_empty(self):
+        adapter = OllamaAdapter("T1")
+        result = adapter.execute(_SIMPLE_PROMPT, {})
+        assert len(result.output) > 0
+
+    def test_execute_events_include_complete(self):
+        adapter = OllamaAdapter("T1")
+        result = adapter.execute(_SIMPLE_PROMPT, {})
+        types = [e.get("event_type") for e in result.events]
+        assert "complete" in types
+
+    def test_execute_complete_event_has_token_count(self):
+        adapter = OllamaAdapter("T1")
+        result = adapter.execute(_SIMPLE_PROMPT, {})
+        complete = next((e for e in result.events if e.get("event_type") == "complete"), None)
+        assert complete is not None
+        assert "token_count" in complete["data"]
+        assert complete["data"]["token_count"] > 0

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -68,7 +68,7 @@ def _ollama_json_response(response_text: str) -> bytes:
 
 
 class _FakeHTTPResponse:
-    """Minimal urllib HTTP response mock."""
+    """Minimal urllib HTTP response mock — supports both read() and line iteration."""
 
     def __init__(self, body: bytes, status: int = 200) -> None:
         self._body = body
@@ -76,6 +76,12 @@ class _FakeHTTPResponse:
 
     def read(self) -> bytes:
         return self._body
+
+    def __iter__(self):
+        """Yield body as NDJSON lines for streaming drain compatibility."""
+        for line in self._body.split(b"\n"):
+            if line:
+                yield line + b"\n"
 
     def __enter__(self):
         return self

--- a/tests/unit/test_ollama_event_normalizer.py
+++ b/tests/unit/test_ollama_event_normalizer.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Unit tests for OllamaAdapter._normalize_ollama_event().
+
+Validates that every Ollama HTTP-stream chunk type maps to the correct
+CanonicalEvent shape, observability tier, and data fields.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+sys.path.insert(0, str(_LIB_DIR))
+sys.path.insert(0, str(_LIB_DIR / "adapters"))
+
+from adapters.ollama_adapter import OllamaAdapter, _TIER_BASELINE, _TIER_FULL
+from canonical_event import CanonicalEvent
+
+_normalize = OllamaAdapter._normalize_ollama_event
+
+
+# ---------------------------------------------------------------------------
+# /api/generate format — text tokens
+# ---------------------------------------------------------------------------
+
+class TestGenerateApiTextTokens:
+    def test_generate_token_is_text_event(self):
+        ev = _normalize({"response": "hello", "done": False})
+        assert ev.event_type == "text"
+
+    def test_generate_token_data_contains_text(self):
+        ev = _normalize({"response": "world", "done": False})
+        assert ev.data["text"] == "world"
+
+    def test_generate_token_tier_is_baseline(self):
+        ev = _normalize({"response": "x", "done": False})
+        assert ev.observability_tier == _TIER_BASELINE
+
+    def test_generate_empty_token_is_text_event(self):
+        ev = _normalize({"response": "", "done": False})
+        assert ev.event_type == "text"
+        assert ev.data["text"] == ""
+
+    def test_generate_done_true_is_complete_event(self):
+        ev = _normalize({"response": "last", "done": True})
+        assert ev.event_type == "complete"
+
+    def test_generate_done_carries_text(self):
+        ev = _normalize({"response": "final token", "done": True})
+        assert ev.data.get("text") == "final token"
+
+    def test_generate_done_carries_token_count(self):
+        ev = _normalize({"response": "", "done": True, "eval_count": 42})
+        assert ev.data["token_count"] == 42
+
+    def test_generate_done_without_eval_count(self):
+        ev = _normalize({"response": "", "done": True})
+        assert "token_count" not in ev.data
+        assert ev.data["done"] is True
+
+    def test_generate_done_empty_text_not_in_data(self):
+        ev = _normalize({"response": "", "done": True, "eval_count": 5})
+        assert "text" not in ev.data
+
+
+# ---------------------------------------------------------------------------
+# /api/chat format — message field
+# ---------------------------------------------------------------------------
+
+class TestChatApiTokens:
+    def test_chat_message_is_text_event(self):
+        ev = _normalize({"message": {"role": "assistant", "content": "hi"}, "done": False})
+        assert ev.event_type == "text"
+
+    def test_chat_message_content_in_data(self):
+        ev = _normalize({"message": {"role": "assistant", "content": "stream"}, "done": False})
+        assert ev.data["text"] == "stream"
+
+    def test_chat_message_tier_is_baseline(self):
+        ev = _normalize({"message": {"role": "assistant", "content": "x"}, "done": False})
+        assert ev.observability_tier == _TIER_BASELINE
+
+    def test_chat_done_is_complete_event(self):
+        ev = _normalize({"message": {"role": "assistant", "content": ""}, "done": True, "eval_count": 10})
+        assert ev.event_type == "complete"
+
+    def test_chat_done_token_count(self):
+        ev = _normalize({"message": {"role": "assistant", "content": ""}, "done": True, "eval_count": 10})
+        assert ev.data["token_count"] == 10
+
+    def test_chat_done_content_as_text(self):
+        ev = _normalize({"message": {"role": "assistant", "content": "end"}, "done": True})
+        assert ev.data.get("text") == "end"
+
+
+# ---------------------------------------------------------------------------
+# Tool-use detection — Tier-1
+# ---------------------------------------------------------------------------
+
+class TestToolUseDetection:
+    _tool_calls = [{"function": {"name": "search", "arguments": {"q": "ollama"}}}]
+
+    def test_tool_calls_in_message_yields_tool_use_event(self):
+        raw = {
+            "message": {"role": "assistant", "content": "", "tool_calls": self._tool_calls},
+            "done": False,
+        }
+        ev = _normalize(raw)
+        assert ev.event_type == "tool_use"
+
+    def test_tool_use_tier_is_full(self):
+        raw = {
+            "message": {"role": "assistant", "content": "", "tool_calls": self._tool_calls},
+            "done": False,
+        }
+        ev = _normalize(raw)
+        assert ev.observability_tier == _TIER_FULL
+
+    def test_tool_calls_in_data(self):
+        raw = {
+            "message": {"role": "assistant", "content": "", "tool_calls": self._tool_calls},
+            "done": False,
+        }
+        ev = _normalize(raw)
+        assert ev.data["tool_calls"] == self._tool_calls
+
+    def test_done_with_tool_calls_complete_tier_1(self):
+        raw = {
+            "message": {"role": "assistant", "content": "", "tool_calls": self._tool_calls},
+            "done": True,
+            "eval_count": 7,
+        }
+        ev = _normalize(raw)
+        assert ev.event_type == "complete"
+        assert ev.observability_tier == _TIER_FULL
+        assert ev.data["token_count"] == 7
+
+    def test_no_tool_calls_is_tier_2(self):
+        raw = {"message": {"role": "assistant", "content": "plain text"}, "done": False}
+        ev = _normalize(raw)
+        assert ev.observability_tier == _TIER_BASELINE
+
+
+# ---------------------------------------------------------------------------
+# Provider / identity fields
+# ---------------------------------------------------------------------------
+
+class TestProviderFields:
+    def test_provider_is_ollama(self):
+        ev = _normalize({"response": "x", "done": False})
+        assert ev.provider == "ollama"
+
+    def test_dispatch_id_passed_through(self):
+        ev = _normalize({"response": "x", "done": False}, dispatch_id="d-999")
+        assert ev.dispatch_id == "d-999"
+
+    def test_terminal_id_passed_through(self):
+        ev = _normalize({"response": "x", "done": False}, terminal_id="T3")
+        assert ev.terminal_id == "T3"
+
+    def test_defaults_empty_strings(self):
+        ev = _normalize({"response": "x", "done": False})
+        assert ev.dispatch_id == ""
+        assert ev.terminal_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_empty_raw_dict_is_text_event(self):
+        ev = _normalize({})
+        assert ev.event_type == "text"
+        assert ev.data["text"] == ""
+
+    def test_done_false_without_response_or_message(self):
+        ev = _normalize({"done": False, "model": "gemma3:27b"})
+        assert ev.event_type == "text"
+
+    def test_eval_count_cast_to_int(self):
+        ev = _normalize({"done": True, "eval_count": "100"})
+        assert ev.data["token_count"] == 100
+
+    def test_returns_canonical_event_instance(self):
+        ev = _normalize({"response": "token", "done": False})
+        assert isinstance(ev, CanonicalEvent)
+
+    def test_message_none_does_not_crash(self):
+        ev = _normalize({"message": None, "done": False})
+        assert ev.event_type == "text"


### PR DESCRIPTION
## Summary

- Refactored `OllamaAdapter` onto the W7-B `StreamingDrainerMixin` contract (HTTP-line variant — Ollama uses HTTP not subprocess)
- Added `_normalize_ollama_event()`: maps `/api/generate` (`response` field) and `/api/chat` (`message` field) chunks → `CanonicalEvent`; Tier-2 baseline; Tier-1 when `tool_calls` detected
- `execute()` and `stream_events()` now drain HTTP line-by-line with live `EventStore.append` per event (not post-hoc)
- 34 existing `test_ollama_adapter.py` tests updated for streaming compat and pass unchanged

## Test plan

- [x] `pytest tests/unit/test_ollama_event_normalizer.py` — 29 passed
- [x] `pytest tests/integration/test_ollama_crash_negative.py` — 11 passed (no daemon required)
- [x] `pytest tests/test_ollama_adapter.py` — 34 passed (backward compat verified)
- [x] `pytest tests/integration/test_ollama_streaming.py` — 13 skipped gracefully (no model installed; skips when `ollama pull` not run)
- [x] Full suite: 91 passed, 13 skipped, 0 failed

## Notes

- HTTP drain follows the same principles as `StreamingDrainerMixin.drain_stream()` but reads from `urllib` response lines instead of subprocess stdout + `select()`
- `OllamaAdapter` inherits `StreamingDrainerMixin` for the `_normalize()` interface; `drain_stream()` (subprocess path) is also available if needed in future
- Dispatch-ID: 20260506-phase03-w7f-ollama-streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)