### PR TITLE
feat(litellm): adapter proof-of-concept via W7-B mixin (Phase 3 W7-E)

### DIFF
--- a/scripts/lib/adapters/__init__.py
+++ b/scripts/lib/adapters/__init__.py
@@ -75,7 +75,15 @@ def resolve_adapter(terminal_id: str) -> ProviderAdapter:
         from adapters.ollama_adapter import OllamaAdapter  # noqa: PLC0415
         return OllamaAdapter(terminal_id)
 
+    if provider.startswith("litellm"):
+        from adapters.litellm_adapter import LiteLLMAdapter  # noqa: PLC0415
+        # Parse chain format: litellm/<provider>/<model> -> model=<provider>/<model>
+        parts = provider.split("/", 1)
+        litellm_model = parts[1] if len(parts) > 1 else ""
+        return LiteLLMAdapter(terminal_id, litellm_model=litellm_model)
+
     raise ValueError(
         f"Unknown provider '{provider}' for terminal {terminal_id}. "
-        f"Set VNX_PROVIDER_{terminal_id}=claude|gemini|codex|ollama or leave unset for default."
+        f"Set VNX_PROVIDER_{terminal_id}=claude|gemini|codex|ollama|litellm[/<provider>/<model>] "
+        f"or leave unset for default."
     )

--- a/scripts/lib/adapters/_litellm_runner.py
+++ b/scripts/lib/adapters/_litellm_runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""_litellm_runner.py — One-shot LiteLLM completion subprocess helper.
+
+Called by LiteLLMAdapter as: python -u _litellm_runner.py
+Reads JSON from stdin: {"model": "bedrock/claude-sonnet-4-6", "messages": [...]}
+Emits OpenAI-shaped NDJSON chunks (one JSON object per line) to stdout.
+
+Exit codes:
+  0 — success
+  1 — credentials / authentication error
+  2 — other error (import failure, service unavailable, etc.)
+
+BILLING SAFETY: No Anthropic SDK imports. Uses litellm library only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+_EXIT_OK = 0
+_EXIT_CREDS = 1
+_EXIT_ERR = 2
+
+
+def _emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except Exception as exc:
+        _emit({"error_type": "runner_error", "message": f"stdin parse error: {exc}"})
+        return _EXIT_ERR
+
+    model = payload.get("model", "")
+    messages = payload.get("messages", [])
+
+    if not model:
+        _emit({"error_type": "runner_error", "message": "model field required"})
+        return _EXIT_ERR
+
+    try:
+        import litellm  # noqa: PLC0415
+    except ImportError as exc:
+        _emit({"error_type": "runner_error", "message": f"litellm not installed: {exc}"})
+        return _EXIT_ERR
+
+    # Silence litellm's own logging to avoid polluting stdout
+    import logging
+    logging.getLogger("litellm").setLevel(logging.CRITICAL)
+    litellm.suppress_debug_info = True
+
+    try:
+        response = litellm.completion(model=model, messages=messages, stream=True)
+        for chunk in response:
+            try:
+                if hasattr(chunk, "model_dump"):
+                    obj = chunk.model_dump()
+                elif hasattr(chunk, "dict"):
+                    obj = chunk.dict()
+                else:
+                    obj = dict(chunk)
+                _emit(obj)
+            except Exception as exc:
+                _emit({"error_type": "serialize_error", "message": str(exc)})
+        return _EXIT_OK
+
+    except Exception as exc:
+        msg = str(exc)
+        msg_lower = msg.lower()
+        if any(kw in msg_lower for kw in ("authentication", "auth", "credentials", "apikey", "api key", "unauthorized", "forbidden")):
+            _emit({"error_type": "credentials_missing", "message": msg})
+            return _EXIT_CREDS
+        if any(kw in msg_lower for kw in ("unavailable", "connection", "timeout", "unreachable", "refused")):
+            _emit({"error_type": "service_unavailable", "message": msg})
+            return _EXIT_ERR
+        _emit({"error_type": "completion_error", "message": msg})
+        return _EXIT_ERR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/adapters/litellm_adapter.py
+++ b/scripts/lib/adapters/litellm_adapter.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""adapters/litellm_adapter.py — LiteLLMAdapter PoC via OpenAI-shaped streaming.
+
+Routes dispatches through a litellm subprocess shim to reach Bedrock, Mistral,
+Vertex, Azure, Groq via one OpenAI-compatible surface. Proof-of-concept scope —
+does not replace any existing adapter.
+
+Provider chain format: litellm/<provider>/<model>
+  e.g. litellm/bedrock/claude-sonnet-4-6
+       litellm/anthropic/claude-sonnet-4-6
+       litellm/groq/llama-3.1-70b
+
+Capabilities: CODE, REVIEW (no ORCHESTRATE for v0).
+Observability: Tier-1 when streaming SSE works; Tier-2 when only [DONE] reachable.
+
+BILLING SAFETY: No Anthropic SDK imports. Delegates to _litellm_runner.py subprocess.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from provider_adapter import AdapterResult, Capability, ProviderAdapter
+from canonical_event import CanonicalEvent
+from _streaming_drainer import StreamingDrainerMixin
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
+_DEFAULT_CHUNK_TIMEOUT = 60.0
+_DEFAULT_TOTAL_DEADLINE = 300.0
+_TIER_STREAMING = 1
+_TIER_FINAL_ONLY = 2
+
+# Path to the one-shot runner helper (sibling to this file)
+_RUNNER_PATH = Path(__file__).resolve().parent / "_litellm_runner.py"
+
+
+def _normalize_litellm_event(
+    chunk: Dict[str, Any],
+    dispatch_id: str,
+    terminal_id: str,
+) -> CanonicalEvent:
+    """Map an OpenAI-shaped NDJSON chunk to a CanonicalEvent.
+
+    Priority order:
+      1. error_type key (runner error) -> error
+      2. delta.tool_calls non-empty    -> tool_use
+      3. finish_reason non-null        -> complete
+      4. delta.role == "assistant"
+         with empty content            -> init
+      5. all other                     -> text
+    """
+    error_type = chunk.get("error_type")
+    if error_type:
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="litellm",
+            event_type="error",
+            data={"error_type": error_type, "message": chunk.get("message", "")},
+            observability_tier=_TIER_STREAMING,
+        )
+
+    choices = chunk.get("choices") or []
+    choice = choices[0] if choices else {}
+    delta = choice.get("delta") or {}
+    finish_reason = choice.get("finish_reason")
+
+    if delta.get("tool_calls"):
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="litellm",
+            event_type="tool_use",
+            data={"tool_calls": delta["tool_calls"]},
+            observability_tier=_TIER_STREAMING,
+        )
+
+    if finish_reason in ("stop", "tool_calls", "end_turn", "length"):
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="litellm",
+            event_type="complete",
+            data={"finish_reason": finish_reason, "model": chunk.get("model", "")},
+            observability_tier=_TIER_STREAMING,
+        )
+
+    if delta.get("role") == "assistant" and not delta.get("content"):
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="litellm",
+            event_type="init",
+            data={"model": chunk.get("model", "")},
+            observability_tier=_TIER_STREAMING,
+        )
+
+    return CanonicalEvent(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        provider="litellm",
+        event_type="text",
+        data={"content": delta.get("content") or ""},
+        observability_tier=_TIER_STREAMING,
+    )
+
+
+class LiteLLMAdapter(StreamingDrainerMixin, ProviderAdapter):
+    """Provider adapter for litellm shim subprocess (CODE + REVIEW, v0 PoC).
+
+    Spawns _litellm_runner.py with model + instruction, drains OpenAI-shaped
+    NDJSON via StreamingDrainerMixin, and maps chunks to CanonicalEvents.
+
+    Thread-safety note: _dispatch_id is instance-level state mutated before
+    each drain_stream() call. Do not share a single instance across threads.
+    """
+
+    provider_name = "litellm"
+
+    def __init__(self, terminal_id: str, litellm_model: str = "") -> None:
+        self._terminal_id = terminal_id
+        self._litellm_model = (
+            litellm_model
+            or os.environ.get("VNX_LITELLM_MODEL", _DEFAULT_MODEL)
+        )
+        self._dispatch_id = ""
+
+    # ------------------------------------------------------------------
+    # ProviderAdapter interface
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "litellm"
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.CODE, Capability.REVIEW}
+
+    def is_available(self) -> bool:
+        """Return True when the litellm package is importable."""
+        try:
+            import litellm as _  # noqa: F401, PLC0415
+            return True
+        except ImportError:
+            return bool(shutil.which("litellm"))
+
+    def health_check(self) -> bool:
+        """Run litellm --health-check stub; returns True if CLI exits 0."""
+        if not shutil.which("litellm"):
+            return False
+        try:
+            result = subprocess.run(
+                ["litellm", "--health-check"],
+                capture_output=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+
+    def execute(self, instruction: str, context: dict) -> AdapterResult:
+        """Spawn _litellm_runner.py, drain NDJSON stream, return AdapterResult."""
+        terminal_id = context.get("terminal_id", self._terminal_id)
+        dispatch_id = context.get("dispatch_id", "")
+        model = context.get("model") or self._litellm_model
+        chunk_timeout = float(context.get("chunk_timeout", _DEFAULT_CHUNK_TIMEOUT))
+        total_deadline = float(context.get("total_deadline", _DEFAULT_TOTAL_DEADLINE))
+        event_store = context.get("event_store")
+
+        self._dispatch_id = dispatch_id
+
+        payload = json.dumps({
+            "model": model,
+            "messages": [{"role": "user", "content": instruction}],
+        })
+
+        runner = context.get("_runner_path", str(_RUNNER_PATH))
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-u", runner],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            return AdapterResult(
+                status="failed",
+                output=str(exc),
+                events=[],
+                event_count=0,
+                duration_seconds=0.0,
+                committed=False,
+                commit_hash=None,
+                report_path=None,
+                provider="litellm",
+                model=model,
+            )
+
+        if proc.stdin:
+            proc.stdin.write(payload.encode("utf-8"))
+            proc.stdin.close()
+
+        t0 = time.monotonic()
+        events: List[CanonicalEvent] = []
+        status = "done"
+        output_parts: List[str] = []
+
+        for event in self.drain_stream(
+            process=proc,
+            terminal_id=terminal_id,
+            dispatch_id=dispatch_id,
+            event_store=event_store,
+            chunk_timeout=chunk_timeout,
+            total_deadline=total_deadline,
+        ):
+            events.append(event)
+            if event.event_type == "text":
+                output_parts.append(event.data.get("content", ""))
+            elif event.event_type == "error":
+                status = "failed"
+
+        duration = time.monotonic() - t0
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        if proc.returncode not in (None, 0) and status != "failed":
+            status = "failed"
+
+        return AdapterResult(
+            status=status,
+            output="".join(output_parts),
+            events=[e.to_dict() for e in events],
+            event_count=len(events),
+            duration_seconds=duration,
+            committed=False,
+            commit_hash=None,
+            report_path=None,
+            provider="litellm",
+            model=model,
+        )
+
+    def stream_events(self, instruction: str, context: dict) -> Iterator[dict]:
+        """Stream CanonicalEvent dicts as subprocess emits them."""
+        result = self.execute(instruction, context)
+        yield from result.events
+
+    def _normalize(self, raw_chunk: Dict[str, Any]) -> CanonicalEvent:
+        """Map raw litellm NDJSON chunk to CanonicalEvent (StreamingDrainerMixin hook)."""
+        return _normalize_litellm_event(
+            chunk=raw_chunk,
+            dispatch_id=self._dispatch_id,
+            terminal_id=self._terminal_id,
+        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,16 @@
+"""conftest.py — path setup and markers for integration test subdirectory."""
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_aws: integration tests requiring AWS credentials (skipped when absent)",
+    )

--- a/tests/integration/test_litellm_bedrock_smoke.py
+++ b/tests/integration/test_litellm_bedrock_smoke.py
@@ -1,0 +1,86 @@
+"""Integration smoke test: LiteLLMAdapter -> Bedrock -> real completion.
+
+Marked @pytest.mark.requires_aws — skipped automatically when AWS credentials
+are absent (no AWS_ACCESS_KEY_ID or AWS_PROFILE in environment).
+
+To run manually:
+  AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_DEFAULT_REGION=us-east-1 \
+    pytest tests/integration/test_litellm_bedrock_smoke.py -v
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from adapters.litellm_adapter import LiteLLMAdapter
+from canonical_event import CanonicalEvent
+
+
+def _has_aws_creds() -> bool:
+    return bool(
+        os.environ.get("AWS_ACCESS_KEY_ID")
+        or os.environ.get("AWS_PROFILE")
+        or os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    )
+
+
+pytestmark = pytest.mark.requires_aws
+
+
+@pytest.fixture(autouse=True)
+def skip_without_aws():
+    if not _has_aws_creds():
+        pytest.skip("AWS credentials not present — set AWS_ACCESS_KEY_ID or AWS_PROFILE")
+
+
+class TestLiteLLMBedrockSmoke:
+    """Live tests that spawn a real litellm subprocess and call Bedrock."""
+
+    def test_bedrock_claude_emits_events(self):
+        adapter = LiteLLMAdapter("T2", litellm_model="bedrock/claude-sonnet-4-6")
+        result = adapter.execute(
+            "Reply with exactly: SMOKE_OK",
+            {"dispatch_id": "bedrock-smoke-001", "terminal_id": "T2"},
+        )
+        assert result.status == "done", f"Unexpected status: {result.status!r} output={result.output!r}"
+        assert result.event_count > 0, "No events emitted"
+        assert "SMOKE_OK" in result.output
+
+    def test_bedrock_events_are_canonical(self):
+        adapter = LiteLLMAdapter("T2", litellm_model="bedrock/claude-sonnet-4-6")
+        result = adapter.execute(
+            "Reply with exactly: CANONICAL_OK",
+            {"dispatch_id": "bedrock-canonical-001", "terminal_id": "T2"},
+        )
+        for event_dict in result.events:
+            # Each stored event must round-trip through CanonicalEvent.from_dict
+            event = CanonicalEvent.from_dict(event_dict)
+            assert event.provider == "litellm"
+            assert event.observability_tier == 1
+
+    def test_bedrock_event_types_include_text_and_complete(self):
+        adapter = LiteLLMAdapter("T2", litellm_model="bedrock/claude-sonnet-4-6")
+        result = adapter.execute(
+            "Reply with exactly: TYPES_OK",
+            {"dispatch_id": "bedrock-types-001", "terminal_id": "T2"},
+        )
+        types = {e["event_type"] for e in result.events}
+        assert "text" in types, f"Expected text event, got: {types}"
+        assert "complete" in types, f"Expected complete event, got: {types}"
+
+    def test_bedrock_missing_creds_returns_error(self, monkeypatch):
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "FAKEKEYID")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "FAKESECRET")
+
+        adapter = LiteLLMAdapter("T2", litellm_model="bedrock/claude-sonnet-4-6")
+        result = adapter.execute(
+            "Hello",
+            {"dispatch_id": "bedrock-creds-fail-001", "terminal_id": "T2"},
+        )
+        assert result.status == "failed"
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert error_events, "Expected at least one error event for bad creds"

--- a/tests/integration/test_litellm_crash_negative.py
+++ b/tests/integration/test_litellm_crash_negative.py
@@ -1,0 +1,215 @@
+"""Negative integration tests for LiteLLMAdapter — crash, unreachable endpoint.
+
+These tests use a mock runner script to simulate failure conditions without
+requiring real provider credentials. They verify:
+  - Unreachable/bad-endpoint -> structured error event + status=failed
+  - Subprocess exits non-zero before complete -> synthetic error event
+  - Credentials missing error format propagated correctly
+"""
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from adapters.litellm_adapter import LiteLLMAdapter
+from canonical_event import CanonicalEvent
+
+# ---------------------------------------------------------------------------
+# Helpers — write tiny fake runner scripts into tmp_path
+# ---------------------------------------------------------------------------
+
+def _write_runner(tmp_path: Path, script: str) -> str:
+    """Write a fake runner py file and return its path as str."""
+    runner = tmp_path / "fake_runner.py"
+    runner.write_text(textwrap.dedent(script), encoding="utf-8")
+    return str(runner)
+
+
+def _make_adapter(tmp_path: Path, script: str, model: str = "litellm/fake/model") -> LiteLLMAdapter:
+    runner_path = _write_runner(tmp_path, script)
+    a = LiteLLMAdapter("T2", litellm_model=model)
+    a._test_runner_path = runner_path
+    return a, runner_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestLiteLLMCrashNegative:
+    def test_credentials_missing_produces_error_event(self, tmp_path):
+        script = """\
+            import json, sys
+            sys.stdout.write(json.dumps({
+                "error_type": "credentials_missing",
+                "message": "NoCredentialsError: Unable to locate credentials"
+            }) + "\\n")
+            sys.stdout.flush()
+            sys.exit(1)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-creds-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        assert result.status == "failed"
+        assert result.event_count > 0
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert error_events, "Expected at least one error event"
+        assert error_events[0]["data"]["error_type"] == "credentials_missing"
+
+    def test_service_unavailable_produces_error_event(self, tmp_path):
+        script = """\
+            import json, sys
+            sys.stdout.write(json.dumps({
+                "error_type": "service_unavailable",
+                "message": "Connection refused to endpoint"
+            }) + "\\n")
+            sys.stdout.flush()
+            sys.exit(2)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-svc-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        assert result.status == "failed"
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert error_events
+
+    def test_subprocess_crash_without_output_produces_synthetic_error(self, tmp_path):
+        # Runner exits non-zero immediately with no output at all
+        script = """\
+            import sys
+            sys.exit(1)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-noout-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        assert result.status == "failed"
+        # StreamingDrainerMixin emits synthetic error for non-zero exit without complete
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert error_events, "Expected synthetic error event from drainer"
+
+    def test_malformed_json_line_becomes_error_event(self, tmp_path):
+        script = """\
+            import sys
+            sys.stdout.write("this is not json at all\\n")
+            sys.stdout.flush()
+            sys.exit(0)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-malform-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        # Malformed line -> error event from _parse_line in drainer
+        # Status depends on whether error event was emitted
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert error_events, "Expected error event for malformed JSON"
+
+    def test_successful_stream_no_error_events(self, tmp_path):
+        # Runner emits a valid mini stream: init + text + complete
+        init_chunk = {
+            "choices": [{"delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+            "model": "fake",
+        }
+        text_chunk = {
+            "choices": [{"delta": {"content": "hello"}, "finish_reason": None}],
+            "model": "fake",
+        }
+        done_chunk = {
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "model": "fake",
+        }
+        lines = "\n".join(json.dumps(c) for c in [init_chunk, text_chunk, done_chunk])
+        script = f"""\
+            import sys
+            sys.stdout.write({lines!r} + "\\n")
+            sys.stdout.flush()
+            sys.exit(0)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-success-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        assert result.status == "done"
+        assert result.output == "hello"
+        types = [e["event_type"] for e in result.events]
+        assert "text" in types
+        assert "complete" in types
+        error_events = [e for e in result.events if e["event_type"] == "error"]
+        assert not error_events, f"Unexpected error events: {error_events}"
+
+    def test_runner_not_installed_produces_failed_result(self, tmp_path):
+        # Runner immediately fails with import error
+        script = """\
+            import json, sys
+            sys.stdout.write(json.dumps({
+                "error_type": "runner_error",
+                "message": "litellm not installed: No module named 'litellm'"
+            }) + "\\n")
+            sys.stdout.flush()
+            sys.exit(2)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-nopkg-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        assert result.status == "failed"
+
+    def test_all_error_events_are_canonical(self, tmp_path):
+        script = """\
+            import json, sys
+            sys.stdout.write(json.dumps({
+                "error_type": "credentials_missing",
+                "message": "test"
+            }) + "\\n")
+            sys.stdout.flush()
+            sys.exit(1)
+        """
+        a, runner = _make_adapter(tmp_path, script)
+        result = a.execute(
+            "Hello",
+            {
+                "dispatch_id": "crash-canon-001",
+                "terminal_id": "T2",
+                "_runner_path": runner,
+            },
+        )
+        for event_dict in result.events:
+            event = CanonicalEvent.from_dict(event_dict)
+            assert event.provider == "litellm"
+            assert event.terminal_id == "T2"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,7 @@
+"""conftest.py — path setup for unit test subdirectory."""
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))

--- a/tests/unit/test_litellm_event_normalizer.py
+++ b/tests/unit/test_litellm_event_normalizer.py
@@ -1,0 +1,231 @@
+"""Unit tests for LiteLLMAdapter._normalize() / _normalize_litellm_event().
+
+No subprocess spawn required — all tests exercise the pure normalizer function
+and the adapter's _normalize() instance method directly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from adapters.litellm_adapter import LiteLLMAdapter, _normalize_litellm_event
+from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _adapter() -> LiteLLMAdapter:
+    a = LiteLLMAdapter("T2", litellm_model="anthropic/claude-sonnet-4-6")
+    a._dispatch_id = "test-dispatch-001"
+    return a
+
+
+def _chunk(
+    content: str = "",
+    role: str = "",
+    finish_reason: str | None = None,
+    tool_calls: list | None = None,
+    model: str = "gpt-4o",
+) -> dict:
+    """Build a minimal OpenAI SSE chunk dict."""
+    delta: dict = {}
+    if role:
+        delta["role"] = role
+    if content:
+        delta["content"] = content
+    if tool_calls is not None:
+        delta["tool_calls"] = tool_calls
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests — _normalize_litellm_event (module-level function)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeLiteLLMEvent:
+    def test_text_event_from_content_chunk(self):
+        chunk = _chunk(content="Hello world")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "text"
+        assert event.data["content"] == "Hello world"
+        assert event.provider == "litellm"
+
+    def test_init_event_from_first_assistant_chunk(self):
+        chunk = _chunk(role="assistant", content="")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "init"
+        assert event.data["model"] == "gpt-4o"
+
+    def test_tool_use_event_from_tool_calls(self):
+        tc = [{"index": 0, "id": "call_abc", "type": "function",
+               "function": {"name": "read_file", "arguments": '{"path":'}}]
+        chunk = _chunk(tool_calls=tc)
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "tool_use"
+        assert event.data["tool_calls"] == tc
+
+    def test_complete_event_from_stop_finish_reason(self):
+        chunk = _chunk(finish_reason="stop")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "complete"
+        assert event.data["finish_reason"] == "stop"
+
+    def test_complete_event_from_tool_calls_finish_reason(self):
+        chunk = _chunk(finish_reason="tool_calls")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "complete"
+
+    def test_complete_event_from_length_finish_reason(self):
+        chunk = _chunk(finish_reason="length")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "complete"
+
+    def test_complete_event_from_end_turn_finish_reason(self):
+        chunk = _chunk(finish_reason="end_turn")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "complete"
+
+    def test_error_event_from_credentials_missing(self):
+        chunk = {"error_type": "credentials_missing", "message": "No AWS creds"}
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "error"
+        assert event.data["error_type"] == "credentials_missing"
+        assert "No AWS creds" in event.data["message"]
+
+    def test_error_event_from_runner_error(self):
+        chunk = {"error_type": "runner_error", "message": "litellm not installed"}
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "error"
+
+    def test_error_event_from_service_unavailable(self):
+        chunk = {"error_type": "service_unavailable", "message": "connection refused"}
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "error"
+
+    def test_text_event_from_empty_choices(self):
+        chunk = {"id": "chatcmpl-x", "choices": []}
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "text"
+        assert event.data["content"] == ""
+
+    def test_text_event_when_choices_missing(self):
+        chunk = {"id": "chatcmpl-x", "model": "gpt-4o"}
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "text"
+
+    def test_dispatch_id_and_terminal_id_propagated(self):
+        chunk = _chunk(content="hi")
+        event = _normalize_litellm_event(chunk, "dispatch-xyz", "T3")
+        assert event.dispatch_id == "dispatch-xyz"
+        assert event.terminal_id == "T3"
+
+    def test_observability_tier_is_1(self):
+        chunk = _chunk(content="hi")
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.observability_tier == 1
+
+    def test_tool_calls_takes_priority_over_finish_reason(self):
+        tc = [{"index": 0, "id": "call_x", "type": "function",
+               "function": {"name": "fn", "arguments": ""}}]
+        chunk = _chunk(tool_calls=tc, finish_reason="tool_calls")
+        # tool_calls in delta -> tool_use (takes priority)
+        event = _normalize_litellm_event(chunk, "d1", "T1")
+        assert event.event_type == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Tests — LiteLLMAdapter._normalize() (instance method, uses instance state)
+# ---------------------------------------------------------------------------
+
+class TestAdapterNormalize:
+    def test_normalize_binds_instance_dispatch_and_terminal(self):
+        a = _adapter()
+        chunk = _chunk(content="test")
+        event = a._normalize(chunk)
+        assert event.dispatch_id == "test-dispatch-001"
+        assert event.terminal_id == "T2"
+
+    def test_normalize_returns_canonical_event(self):
+        a = _adapter()
+        chunk = _chunk(content="x")
+        event = a._normalize(chunk)
+        assert isinstance(event, CanonicalEvent)
+
+    def test_normalize_dispatch_id_can_be_updated(self):
+        a = _adapter()
+        a._dispatch_id = "new-dispatch-999"
+        chunk = _chunk(content="y")
+        event = a._normalize(chunk)
+        assert event.dispatch_id == "new-dispatch-999"
+
+    def test_normalize_error_chunk_produces_error_event(self):
+        a = _adapter()
+        chunk = {"error_type": "credentials_missing", "message": "test"}
+        event = a._normalize(chunk)
+        assert event.event_type == "error"
+
+
+# ---------------------------------------------------------------------------
+# Tests — LiteLLMAdapter metadata
+# ---------------------------------------------------------------------------
+
+class TestLiteLLMAdapterMeta:
+    def test_name(self):
+        assert LiteLLMAdapter("T1").name() == "litellm"
+
+    def test_provider_name_class_attr(self):
+        assert LiteLLMAdapter.provider_name == "litellm"
+
+    def test_capabilities_include_code_and_review(self):
+        from provider_adapter import Capability
+        caps = LiteLLMAdapter("T1").capabilities()
+        assert Capability.CODE in caps
+        assert Capability.REVIEW in caps
+
+    def test_capabilities_exclude_orchestrate(self):
+        from provider_adapter import Capability
+        caps = LiteLLMAdapter("T1").capabilities()
+        assert not any(c.value == "orchestrate" for c in caps)
+
+    def test_default_model_from_env(self, monkeypatch):
+        monkeypatch.setenv("VNX_LITELLM_MODEL", "groq/llama-3.1-70b")
+        a = LiteLLMAdapter("T1")
+        assert a._litellm_model == "groq/llama-3.1-70b"
+
+    def test_explicit_model_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("VNX_LITELLM_MODEL", "groq/llama-3.1-70b")
+        a = LiteLLMAdapter("T1", litellm_model="bedrock/claude-sonnet-4-6")
+        assert a._litellm_model == "bedrock/claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Tests — adapter registry integration
+# ---------------------------------------------------------------------------
+
+class TestAdapterRegistryLiteLLM:
+    def test_resolve_adapter_litellm_basic(self, monkeypatch):
+        monkeypatch.setenv("VNX_PROVIDER_T1", "litellm")
+        from adapters import resolve_adapter
+        a = resolve_adapter("T1")
+        assert isinstance(a, LiteLLMAdapter)
+        assert a._litellm_model  # has some default
+
+    def test_resolve_adapter_litellm_chain(self, monkeypatch):
+        monkeypatch.setenv("VNX_PROVIDER_T1", "litellm/bedrock/claude-sonnet-4-6")
+        from adapters import resolve_adapter
+        a = resolve_adapter("T1")
+        assert isinstance(a, LiteLLMAdapter)
+        assert a._litellm_model == "bedrock/claude-sonnet-4-6"
+
+    def test_resolve_adapter_litellm_groq_chain(self, monkeypatch):
+        monkeypatch.setenv("VNX_PROVIDER_T1", "litellm/groq/llama-3.1-70b-versatile")
+        from adapters import resolve_adapter
+        a = resolve_adapter("T1")
+        assert isinstance(a, LiteLLMAdapter)
+        assert a._litellm_model == "groq/llama-3.1-70b-versatile"


### PR DESCRIPTION
## Summary

- New `scripts/lib/adapters/litellm_adapter.py` (~175 LOC): `LiteLLMAdapter` composing `StreamingDrainerMixin` with `_normalize_litellm_event()` that maps OpenAI SSE chunks to `CanonicalEvent`. Provider chain format `litellm/<provider>/<model>` (e.g. `litellm/bedrock/claude-sonnet-4-6`). Capabilities: CODE + REVIEW. Tier-1 streaming.
- New `scripts/lib/adapters/_litellm_runner.py` (~65 LOC): one-shot subprocess helper; reads model+messages from stdin, calls litellm.completion(stream=True), emits NDJSON to stdout.
- Modify `scripts/lib/adapters/__init__.py`: register litellm provider with chain format parsing.
- 28 unit tests + 7 integration crash tests + 4 Bedrock smoke tests (skip if no creds).

## Test plan

- [x] 35 passed, 4 skipped (AWS smoke tests skipped, no creds)
- [x] `pytest tests/unit/test_litellm_event_normalizer.py tests/integration/test_litellm_bedrock_smoke.py tests/integration/test_litellm_crash_negative.py -x`

## Quality Gate (gate_pr_w7_e_litellm)

- [x] Adapter parses OpenAI SSE into CanonicalEvent
- [x] Crash/unreachable endpoint produces structured error event
- [x] Bedrock smoke skips cleanly when creds absent
- [x] Tier-1 via StreamingDrainerMixin
- [x] litellm/<provider>/<model> chain accepted by registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)