### PR TITLE
fix(closure_verifier): extend report_path enforcement to codex_gate handler (closes OI-1338)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -496,6 +496,12 @@ def _validate_review_evidence(
                         "FAIL",
                         f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
                     ))
+                elif gate_is_terminal(result) and not result.get("report_path", ""):
+                    checks.append(CheckResult(
+                        f"gate_{gate}",
+                        "FAIL",
+                        "codex_gate result is missing required report_path field",
+                    ))
                 else:
                     # CFX-17: demote allowlisted findings before counting blocking.
                     translated = _apply_codex_severity_policy(result)

--- a/tests/test_closure_verifier_evidence_contract.py
+++ b/tests/test_closure_verifier_evidence_contract.py
@@ -564,3 +564,94 @@ class TestStatusContextRollupEvaluation:
             {"__typename": "StatusContext", "state": "SUCCESS"},
             {"__typename": "StatusContext", "state": "FAILURE"},
         ]) is False
+
+
+# ---------------------------------------------------------------------------
+# OI-1338: report_path enforcement on codex_gate handler
+# ---------------------------------------------------------------------------
+
+class TestReportPathEnforcementCodexGate:
+    """OI-1338 — codex_gate must enforce report_path on terminal-status receipts.
+
+    Mirrors TestReportPathEnforcementStandardReceipt but for the codex_gate
+    handler.  Previously only the gemini_review handler checked report_path;
+    codex_gate silently skipped the check and let a terminal result without
+    evidence pass through to gate_is_pass.
+    """
+
+    def test_missing_report_path_on_terminal_status_fails(self, tmp_path):
+        """codex_gate with terminal status=pass but no report_path → gate_codex_gate=FAIL."""
+        results_dir = tmp_path / "results"
+        # review_stack=["codex_gate"] + risk_class="medium" → enforcement.required=True
+        # (reason: codex_gate_in_review_stack, risk != low)
+        contract = _make_contract(review_stack=["codex_gate"], risk_class="medium")
+
+        codex_result = {
+            "gate": "codex_gate",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "blocking_count": 0,
+            "advisory_count": 0,
+            "contract_hash": "abcdef1234567890",
+            # report_path intentionally absent
+        }
+        _write_gate_result(results_dir, "codex_gate", "PR-0", codex_result)
+
+        checks = cv._validate_review_evidence(contract, results_dir, branch=contract.branch)
+        check_map = {c.name: c for c in checks}
+
+        assert "gate_codex_gate" in check_map
+        assert check_map["gate_codex_gate"].status == "FAIL"
+        assert "report_path" in check_map["gate_codex_gate"].detail
+
+    def test_with_report_path_passes(self, tmp_path):
+        """codex_gate with terminal status=pass and valid report_path → gate_codex_gate=PASS."""
+        results_dir = tmp_path / "results"
+        report_file = tmp_path / "codex_report.md"
+        report_file.write_text("# Codex Review\nAll clear.\n", encoding="utf-8")
+
+        contract = _make_contract(review_stack=["codex_gate"], risk_class="medium")
+        codex_result = {
+            "gate": "codex_gate",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "blocking_count": 0,
+            "advisory_count": 0,
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+        }
+        _write_gate_result(results_dir, "codex_gate", "PR-0", codex_result)
+
+        checks = cv._validate_review_evidence(contract, results_dir, branch=contract.branch)
+        check_map = {c.name: c for c in checks}
+
+        assert "gate_codex_gate" in check_map
+        assert check_map["gate_codex_gate"].status == "PASS"
+
+    def test_non_terminal_status_doesnt_apply(self, tmp_path):
+        """codex_gate with non-terminal status=pending and no report_path → not a report_path FAIL.
+
+        report_path enforcement only applies when the result has a terminal
+        status (pass/fail/completed/approve/etc.).  A pending result is
+        non-terminal so the enforcement does not trigger; the gate fails for a
+        different reason (incomplete/pending status).
+        """
+        results_dir = tmp_path / "results"
+        contract = _make_contract(review_stack=["codex_gate"], risk_class="medium")
+
+        codex_result = {
+            "gate": "codex_gate",
+            "pr_id": "PR-0",
+            "status": "pending",
+            "blocking_count": 0,
+            # no report_path — must NOT be the reason for failure
+        }
+        _write_gate_result(results_dir, "codex_gate", "PR-0", codex_result)
+
+        checks = cv._validate_review_evidence(contract, results_dir, branch=contract.branch)
+        check_map = {c.name: c for c in checks}
+
+        assert "gate_codex_gate" in check_map
+        # Gate fails (pending is not passing), but NOT because of missing report_path
+        assert check_map["gate_codex_gate"].status == "FAIL"
+        assert "report_path" not in check_map["gate_codex_gate"].detail


### PR DESCRIPTION
## Summary
- Extends the `report_path` enforcement from the `gemini_review` handler to the `codex_gate` handler in `_validate_review_evidence`
- A terminal-status codex_gate result (pass/fail/completed/approve) without a `report_path` now yields `gate_codex_gate=FAIL` instead of silently proceeding to `gate_is_pass`
- Adds `TestReportPathEnforcementCodexGate` with 3 tests: missing report_path on terminal status → fail; with report_path → pass; non-terminal status doesn't trigger enforcement

## Test plan
- [ ] `pytest tests/test_closure_verifier_evidence_contract.py -x` → 16 passed
- [ ] `TestReportPathEnforcementCodexGate::test_missing_report_path_on_terminal_status_fails` PASS
- [ ] `TestReportPathEnforcementCodexGate::test_with_report_path_passes` PASS
- [ ] `TestReportPathEnforcementCodexGate::test_non_terminal_status_doesnt_apply` PASS

Dispatch-ID: 20260506-oifix-1338-codex-gate-enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)