### PR TITLE
fix(project-id): unify _get_project_id fallback via project_scope.current_project_id (closes OI-1342)

### DIFF
--- a/scripts/lib/headless_dispatch_writer.py
+++ b/scripts/lib/headless_dispatch_writer.py
@@ -21,12 +21,18 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+
+# Ensure lib dir (this file's directory) is on sys.path for project_scope import
+_lib_dir = str(Path(__file__).resolve().parent)
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from project_scope import current_project_id as _current_project_id  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Path resolution
@@ -77,20 +83,8 @@ VALID_TRACKS = {"A", "B", "C"}
 
 
 def _get_project_id() -> str:
-    """Return project ID from VNX_PROJECT_ID env, falling back to git root basename."""
-    pid = os.environ.get("VNX_PROJECT_ID", "").strip()
-    if pid:
-        return pid
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5, check=False,
-        )
-        if result.returncode == 0:
-            return Path(result.stdout.strip()).name
-    except Exception:
-        pass
-    return "vnx-dev"
+    """Return project ID — delegates to project_scope.current_project_id (OI-1342)."""
+    return _current_project_id()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/pr_queue_manager.py
+++ b/scripts/pr_queue_manager.py
@@ -22,6 +22,7 @@ if _lib_dir not in sys.path:
 
 from vnx_paths import resolve_paths as _resolve_vnx_paths
 from pr_queue_state_snapshot import build_vnx_state_snapshot
+from project_scope import current_project_id as _current_project_id
 from result_contract import (
     EXIT_DEPENDENCY,
     Result,
@@ -32,20 +33,8 @@ from result_contract import (
 
 
 def _get_project_id() -> str:
-    """Return project ID from VNX_PROJECT_ID env, falling back to git root basename."""
-    pid = os.environ.get("VNX_PROJECT_ID", "").strip()
-    if pid:
-        return pid
-    try:
-        result = _subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5, check=False,
-        )
-        if result.returncode == 0:
-            return Path(result.stdout.strip()).name
-    except Exception:
-        pass
-    return "vnx-dev"
+    """Return project ID — delegates to project_scope.current_project_id (OI-1342)."""
+    return _current_project_id()
 
 
 ROLLBACK_ENV_FLAG = "VNX_STATE_SIMPLIFICATION_ROLLBACK"

--- a/tests/test_headless_dispatch_project_id.py
+++ b/tests/test_headless_dispatch_project_id.py
@@ -1,0 +1,107 @@
+"""Regression tests for OI-1342: _get_project_id() unification.
+
+Both pr_queue_manager._get_project_id() and
+headless_dispatch_writer._get_project_id() must delegate to
+project_scope.current_project_id() so dispatch stamps are always
+consistent regardless of which stamper is called.
+
+Two scenarios:
+  1. VNX_PROJECT_ID is set — all three return the explicit value.
+  2. VNX_PROJECT_ID is unset — all three return the same default ('vnx-dev').
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+for _p in (SCRIPTS_DIR, SCRIPTS_LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def _reload_modules():
+    """Reload all three modules so env-var changes take effect."""
+    import project_scope
+    import headless_dispatch_writer
+    import pr_queue_manager
+
+    importlib.reload(project_scope)
+    importlib.reload(headless_dispatch_writer)
+    importlib.reload(pr_queue_manager)
+
+    return project_scope, headless_dispatch_writer, pr_queue_manager
+
+
+ENV_KEY = "VNX_PROJECT_ID"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """Ensure VNX_PROJECT_ID is restored after each test."""
+    saved = os.environ.get(ENV_KEY)
+    yield
+    if saved is None:
+        os.environ.pop(ENV_KEY, None)
+    else:
+        os.environ[ENV_KEY] = saved
+
+
+class TestProjectIdWithEnvSet:
+    """When VNX_PROJECT_ID is set, all stampers must return that exact value."""
+
+    def test_project_scope_returns_env_value(self):
+        os.environ[ENV_KEY] = "my-project"
+        ps, _, _ = _reload_modules()
+        assert ps.current_project_id() == "my-project"
+
+    def test_headless_dispatch_writer_matches_project_scope(self):
+        os.environ[ENV_KEY] = "my-project"
+        ps, hdw, _ = _reload_modules()
+        assert hdw._get_project_id() == ps.current_project_id()
+
+    def test_pr_queue_manager_matches_project_scope(self):
+        os.environ[ENV_KEY] = "my-project"
+        ps, _, pqm = _reload_modules()
+        assert pqm._get_project_id() == ps.current_project_id()
+
+    def test_all_three_stampers_agree(self):
+        os.environ[ENV_KEY] = "vnx-seo-v2"
+        ps, hdw, pqm = _reload_modules()
+        scope_val = ps.current_project_id()
+        assert hdw._get_project_id() == scope_val
+        assert pqm._get_project_id() == scope_val
+
+
+class TestProjectIdWithEnvUnset:
+    """When VNX_PROJECT_ID is unset, all stampers must return 'vnx-dev'."""
+
+    def test_project_scope_returns_default(self):
+        os.environ.pop(ENV_KEY, None)
+        ps, _, _ = _reload_modules()
+        assert ps.current_project_id() == "vnx-dev"
+
+    def test_headless_dispatch_writer_matches_project_scope(self):
+        os.environ.pop(ENV_KEY, None)
+        ps, hdw, _ = _reload_modules()
+        assert hdw._get_project_id() == ps.current_project_id()
+
+    def test_pr_queue_manager_matches_project_scope(self):
+        os.environ.pop(ENV_KEY, None)
+        ps, _, pqm = _reload_modules()
+        assert pqm._get_project_id() == ps.current_project_id()
+
+    def test_all_three_stampers_agree_on_default(self):
+        os.environ.pop(ENV_KEY, None)
+        ps, hdw, pqm = _reload_modules()
+        scope_val = ps.current_project_id()
+        assert scope_val == "vnx-dev"
+        assert hdw._get_project_id() == scope_val
+        assert pqm._get_project_id() == scope_val


### PR DESCRIPTION
## Summary

- `pr_queue_manager._get_project_id()` and `headless_dispatch_writer._get_project_id()` previously fell back to git-root basename when `VNX_PROJECT_ID` was unset, while `project_scope.current_project_id()` defaulted to `'vnx-dev'`.
- Both functions now delegate entirely to `project_scope.current_project_id()` — single source of truth for project ID resolution.
- Added `tests/test_headless_dispatch_project_id.py` with 8 regression tests covering both stampers in env-set and env-unset scenarios.

## Test plan

- [x] `pytest tests/test_project_scope_filesystem.py tests/test_pr_queue_completion_attempt_logging.py tests/test_pr_queue_integration.py tests/test_pr_queue_state_snapshot.py tests/test_pr_queue_roadmap_metadata.py tests/test_pr_queue_state.py tests/test_headless_dispatch_project_id.py -x` → 66 passed
- [x] `TestProjectIdWithEnvSet` — all three stampers return explicit `VNX_PROJECT_ID` value
- [x] `TestProjectIdWithEnvUnset` — all three stampers return `'vnx-dev'` default

Dispatch-ID: 20260506-oifix-1342-project-id-fallback-unify

🤖 Generated with [Claude Code](https://claude.com/claude-code)