### PR TITLE
fix(closure_verifier): require pr_id on claude_github_optional payloads (closes OI-1339)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -304,6 +304,15 @@ def _find_gate_request_payload(
             data = json.loads(_read_text(path))
         except (json.JSONDecodeError, OSError):
             continue
+        # claude_github_optional payloads must carry an explicit pr_id so that a
+        # file written for one PR cannot silently satisfy another PR's closure check.
+        if gate == "claude_github_optional" and not data.get("pr_id"):
+            print(
+                f"WARNING: claude_github_optional request payload {path.name} is missing"
+                f" pr_id — rejected to prevent cross-PR false-green (OI-1339)",
+                file=sys.stderr,
+            )
+            continue
         if data.get("pr_id") and data["pr_id"] != pr_id:
             continue
         if data.get("gate") and data["gate"] != gate:

--- a/tests/test_closure_verifier.py
+++ b/tests/test_closure_verifier.py
@@ -954,6 +954,7 @@ class TestClosureVerifierRoundOneCodexFindings:
         # writes `status`, no `state` / `was_intentionally_absent` fields.
         legacy_payload = {
             "gate": "claude_github_optional",
+            "pr_id": "PR-0",
             "status": "configured_dry_run",
             "branch": "feature/demo",
             "pr_number": 45,

--- a/tests/test_closure_verifier_evidence_contract.py
+++ b/tests/test_closure_verifier_evidence_contract.py
@@ -655,3 +655,64 @@ class TestReportPathEnforcementCodexGate:
         # Gate fails (pending is not passing), but NOT because of missing report_path
         assert check_map["gate_codex_gate"].status == "FAIL"
         assert "report_path" not in check_map["gate_codex_gate"].detail
+
+
+# ---------------------------------------------------------------------------
+# OI-1339: claude_github_optional payloads must carry pr_id
+# ---------------------------------------------------------------------------
+
+class TestRequireClaudeGithubOptionalPrId:
+    """OI-1339 — _find_gate_request_payload must reject claude_github_optional
+    payloads that lack an explicit pr_id.
+
+    Without this check, a file like pr-45-claude_github_optional.json (written
+    for PR-45 with no pr_id field) can satisfy the closure check for any other
+    PR, producing a false-green on the optional-gate contract.
+    """
+
+    def test_payload_without_pr_id_is_rejected(self, tmp_path):
+        """claude_github_optional request with no pr_id field must be rejected."""
+        results_dir = tmp_path / "results"
+
+        # Payload deliberately omits pr_id — simulates the legacy/buggy writer.
+        payload_no_pr_id = {
+            "gate": "claude_github_optional",
+            "state": "not_configured",
+            "branch": "feature/demo",
+            "was_intentionally_absent": True,
+            "contributed_evidence": False,
+        }
+        _write_request(results_dir, "claude_github_optional", "PR-0", payload_no_pr_id)
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+
+        checks = cv._validate_review_evidence(contract, results_dir, branch="feature/demo")
+        check_map = {c.name: c for c in checks}
+
+        assert "gate_claude_github_optional" in check_map
+        # Payload without pr_id must not satisfy the evidence requirement.
+        assert check_map["gate_claude_github_optional"].status == "FAIL"
+
+    def test_payload_with_mismatched_pr_id_is_rejected(self, tmp_path):
+        """claude_github_optional request with a different pr_id must be rejected."""
+        results_dir = tmp_path / "results"
+
+        # Payload written for PR-99 — must not satisfy PR-0's closure.
+        payload_wrong_pr = {
+            "gate": "claude_github_optional",
+            "pr_id": "PR-99",
+            "state": "not_configured",
+            "branch": "feature/demo",
+            "was_intentionally_absent": True,
+            "contributed_evidence": False,
+        }
+        _write_request(results_dir, "claude_github_optional", "PR-0", payload_wrong_pr)
+
+        contract = _make_contract(review_stack=["claude_github_optional"])
+
+        checks = cv._validate_review_evidence(contract, results_dir, branch="feature/demo")
+        check_map = {c.name: c for c in checks}
+
+        assert "gate_claude_github_optional" in check_map
+        # Mismatched pr_id must be filtered out — no valid evidence → FAIL.
+        assert check_map["gate_claude_github_optional"].status == "FAIL"


### PR DESCRIPTION
## Summary

- `_find_gate_request_payload` accepted `claude_github_optional` request payloads with no `pr_id` field, allowing a file written for any PR to silently satisfy closure for a different PR (false-green on the optional-gate contract)
- Fix: reject any `claude_github_optional` candidate lacking an explicit `pr_id`; emit a stderr warning for operator traceability
- Updated legacy test fixture in `test_closure_verifier.py` to include `pr_id: "PR-0"` so the normalisation path remains covered
- Added `TestRequireClaudeGithubOptionalPrId` class with two new tests: payload without `pr_id` rejected, payload with mismatched `pr_id` rejected

## Test plan

- [ ] `pytest tests/test_closure_verifier.py tests/test_closure_verifier_evidence_contract.py -x` — 56 passed, 0 failed (verified locally)
- [ ] New tests: `TestRequireClaudeGithubOptionalPrId::test_payload_without_pr_id_is_rejected` + `test_payload_with_mismatched_pr_id_is_rejected`
- [ ] Existing legacy normalisation test `test_finding_2_legacy_status_only_request_normalised` still passes with `pr_id` added to fixture

Dispatch-ID: 20260507-oifix-1339-claude-github-optional-pr-id

🤖 Generated with [Claude Code](https://claude.com/claude-code)