### PR TITLE
docs(skill): add Codex Defense Checklist to backend-developer skill

### DIFF
--- a/scripts/lib/prompts/roles/backend-developer.md
+++ b/scripts/lib/prompts/roles/backend-developer.md
@@ -52,3 +52,37 @@ You implement features, fix bugs, and write tests for backend systems.
 - All shell changes must pass `bash -n`
 - Backward compatibility with existing commands is mandatory unless dispatch says otherwise
 - Path handling must work in both main repo and worktree contexts
+
+## Codex Defense Checklist (mandatory before commit)
+
+These patterns recur in codex_gate findings. Apply preemptively.
+
+### File I/O
+- [ ] **Atomic writes**: any rewrite of a persistent file (YAML, NDJSON, JSON config, schema files) MUST write to `<path>.tmp` then `os.replace(tmp, path)`. Never `open(path, 'w')` directly on canonical state.
+- [ ] **fcntl.flock for shared NDJSON**: any read-then-rewrite of an NDJSON file consumed by live appenders MUST acquire `fcntl.flock(fd, fcntl.LOCK_EX)` on the same lock the appenders use. Hold through atomic rename.
+- [ ] **Subprocess stdin writes**: wrap `proc.stdin.write()` in `try: ... except BrokenPipeError: return AdapterResult(status='failed', ...)`. Provider startup-failures must surface as structured failures, not raised exceptions.
+
+### Defensive Reads
+- [ ] **Null guards on string ops**: `(value or '').lower()`, `(value or {}).get(...)`. Especially for fields from external/legacy sources or DB columns that could be NULL.
+- [ ] **Strict-load by default**: parse-and-validate functions auto-validate. If parse-only mode is needed, add `strict=True` keyword and default to `True`.
+- [ ] **Schema version checks**: when loading versioned files, explicitly check version. `if v != EXPECTED: raise UnsupportedVersionError`. No silent accept.
+
+### Cross-cutting Consistency
+- [ ] **Same fix to all handlers**: if the bug exists in Handler A (e.g. `gemini_review`), grep for the equivalent code in Handler B (e.g. `codex_gate`) and apply the same fix. Don't ship asymmetric handlers.
+- [ ] **All call sites use the helper**: when introducing a helper (e.g. `_get_project_id()`), grep for ALL inline equivalents and replace them. Partial migration = silent skip in untouched paths.
+- [ ] **Documented contracts enforced**: if docstring says "raises X on invalid", make sure code actually raises X with a test asserting it. Drift between contract and implementation is a primary codex finding.
+
+### State Stores & Mirroring
+- [ ] **No double-write on cross-store mirror**: before writing to a secondary store, check `if primary_path.resolve() != secondary_path.resolve()`. Required for any dual-write pattern.
+- [ ] **State dir override**: when reading state, derive path from explicit argument, NOT ambient env (`VNX_STATE_DIR`, `_central_state_dir()`). Tests/migrations/debugging must be able to override.
+- [ ] **Idempotency on cross-store writes**: events written to multiple stores need per-event idempotency keys (e.g. `event_id` + `target_store`). Re-runs must not double-write.
+
+### Tests Run Real Code
+- [ ] **Don't reimplement in tests**: a Bash test runs the actual Bash via subprocess; a Python test runs the actual function. Reimplementing the logic in the test = passing tests with broken code.
+- [ ] **Each fix has a regression test**: every bug fixed by this PR has a test that fails before the fix and passes after. Not just unit tests for happy path.
+- [ ] **Negative-path test**: every new function has at least one test for malformed/missing/error input. Crashing > silently-succeeding.
+
+### Worker Convention
+- [ ] **Run pytest before push**: `pytest <test files> -x` succeeds. Don't push if any test red.
+- [ ] **`bash -n` on shell changes**: every modified `.sh` file must pass syntax check.
+- [ ] **No TODO/FIXME**: full implementation only. If something's not done, escalate, don't comment.


### PR DESCRIPTION
## Summary

- Adds a mandatory **Codex Defense Checklist** section to all backend-developer skill copies, preempting the recurring patterns that codex_gate consistently flags.
- The checklist covers five categories: File I/O (atomic writes, fcntl locks, BrokenPipe wrapping), Defensive Reads (null guards, strict-load, schema version checks), Cross-cutting Consistency (symmetric handler fixes, full helper migration, contract/impl drift), State Stores & Mirroring (dual-write guard, state-dir override, idempotency keys), and Tests Run Real Code (no reimplementation, regression tests per fix, negative-path tests).

## Files updated

| File | Git-tracked | Updated |
|------|-------------|---------|
| `scripts/lib/prompts/roles/backend-developer.md` | yes | yes (committed) |
| `.claude/skills/backend-developer/SKILL.md` | no (info/exclude) | yes (on disk) |
| `.agents/skills/backend-developer/SKILL.md` | no (info/exclude) | yes (on disk) |
| `.gemini/skills/backend-developer/SKILL.md` | no (info/exclude) | yes (on disk) |

The `.claude/skills/`, `.agents/skills/`, `.gemini/skills/` directories are intentionally excluded from git tracking — they are runtime-installed skill copies. Only the canonical role prompt in `scripts/lib/prompts/roles/` is committed.

## Codex finding patterns preempted

- **Atomic writes** — `open(path, 'w')` on canonical state files without tmp+rename
- **fcntl.flock** — NDJSON shared with live appenders written without lock
- **BrokenPipeError** — subprocess stdin writes not wrapped, propagating as exceptions
- **Null guards** — string ops on potentially-NULL DB/legacy fields
- **Contract drift** — docstring says "raises X" but code doesn't; tests don't assert it
- **Asymmetric handlers** — fix applied to `gemini_review` but not `codex_gate` (or vice versa)
- **Partial helper migration** — `_get_project_id()` introduced but inline equivalents left behind

## Test plan

- [ ] Verify checklist section appears verbatim in `scripts/lib/prompts/roles/backend-developer.md`
- [ ] Verify checklist section appears in `.claude/skills/backend-developer/SKILL.md` on disk
- [ ] No existing skill behavior changed (additive only)
- [ ] Dispatch ID: `20260507-skill-update-backend-developer-codex-defense`

🤖 Generated with [Claude Code](https://claude.com/claude-code)