### PR TITLE
fix(build_current_state): remove legacy path literal from line 263 hint

### DIFF
--- a/scripts/build_current_state.py
+++ b/scripts/build_current_state.py
@@ -260,7 +260,7 @@ def _render_resume_hints(roadmap: Roadmap | None, last_updated: str) -> list[str
     lines.append("After `/clear`, T0 should:")
     lines.append("1. Check `## Recommended next move` above for the actionable wave.")
     lines.append("2. Run `python3 scripts/build_current_state.py` to refresh this file.")
-    lines.append("3. Check `.vnx-data/state/t0_state.json` for terminal availability.")
+    lines.append("3. Check the t0_state.json snapshot under your VNX_STATE_DIR for terminal availability.")
     lines.append("4. Review `## Last 3 decisions` to restore decision context.")
     if roadmap:
         lines.append(


### PR DESCRIPTION
## Summary
- Rephrases the resume hint at line 263 of `scripts/build_current_state.py` that contained a literal `.vnx-data/state/t0_state.json` path
- New wording: "Check the t0_state.json snapshot under your VNX_STATE_DIR for terminal availability." — same intent, no literal path
- Eliminates false-positive trip on the rg-based legacy path gate (Profile A gate)

## Test plan
- [x] `rg -n "\.vnx-data/state/" scripts/build_current_state.py` returns nothing
- [x] `pytest tests/test_build_current_state.py tests/test_build_current_state_integration.py tests/test_build_current_state_v2.py -x` — 62 passed

Dispatch-ID: 20260507-legacy-path-build-current-state

🤖 Generated with [Claude Code](https://claude.ai/claude-code)