### PR TITLE
docs(skill): add VNX CI workflow conclusion check before merge (t0-orchestrator)

### DIFF
--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -120,6 +120,17 @@ When a required gate remains only `queued` or `requested`:
 - do not close the PR
 - either start execution, dispatch execution, or classify the missing runner path as a blocker
 
+### CI Workflow Conclusion Verification (mandatory before any merge)
+
+BEFORE merging any PR, MUST verify the workflow-level VNX CI conclusion equals "success", not just that individual checks like Profile A appear green in `gh pr checks`.
+
+Run:
+    gh run list --branch <pr-head-ref> --workflow "VNX CI" --limit 1 --json conclusion --jq '.[0].conclusion'
+
+If output is anything other than "success", do NOT merge. Investigate the cause, dispatch a fix-forward, re-run CI, and only merge when the workflow conclusion equals "success".
+
+RATIONALE: `gh pr checks` lists individual job names but the workflow as a whole can still produce a "failure" conclusion (e.g. multi-step Profile A whose Legacy path gate sub-step fails) while the visible names appear "pass". Multiple late-night merges on 2026-05-06/07 had VNX CI = failure that was missed by checking individual names only — Legacy path gate was tripping on a literal `.vnx-data/state/` string in build_current_state.py:263 that the rg-based gate flagged repository-wide on main, but did not flag in PR-scoped diffs.
+
 ## Doubt Escalation Policy
 
 When uncertain, use this order:


### PR DESCRIPTION
## Why

`gh pr checks` lists individual job names but the workflow as a whole can still produce a `failure` conclusion while visible job names appear green. This caused multiple missed failures during the 2026-05-06/07 night session.

## 2026-05-06 Incident

PRs were merged while VNX CI had a `failure` workflow conclusion. The root cause was the Legacy path gate (in the Profile A multi-step job) tripping on a literal `.vnx-data/state/` string in `build_current_state.py:263`. The rg-based gate flagged this string repository-wide on `main` but not in PR-scoped diffs, so individual check names appeared green while the workflow-level conclusion was `failure`. This went undetected because T0 was checking individual check names only.

## Merge-gate rule (added verbatim to all skill files)

```
### CI Workflow Conclusion Verification (mandatory before any merge)

BEFORE merging any PR, MUST verify the workflow-level VNX CI conclusion equals "success", not just that individual checks like Profile A appear green in `gh pr checks`.

Run:
    gh run list --branch <pr-head-ref> --workflow "VNX CI" --limit 1 --json conclusion --jq '.[0].conclusion'

If output is anything other than "success", do NOT merge. Investigate the cause, dispatch a fix-forward, re-run CI, and only merge when the workflow conclusion equals "success".
```

## Files updated

| File | Status |
|------|--------|
| `.claude/terminals/T0/CLAUDE.md` | Committed (tracked) — rule added under Headless Review Enforcement |
| `.claude/skills/t0-orchestrator/SKILL.md` | Updated locally (gitignored) — rule added under Decision Framework §3 |
| `.agents/skills/t0-orchestrator/SKILL.md` | Updated locally (gitignored) — rule added under Critical Behaviors §3 |
| `.gemini/skills/t0-orchestrator/SKILL.md` | Updated locally (gitignored) — rule added under Critical Behaviors §3 |

Note: `.claude/skills/`, `.agents/`, and `.gemini/` are in `.gitignore`. Only `.claude/terminals/T0/CLAUDE.md` enters version history; the local skill files are correct.

---
Dispatch-ID: 20260507-add-ci-conclusion-rule-v2