### PR TITLE
ci(profile-a): exclude migration scripts from legacy path gate

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -47,7 +47,10 @@ jobs:
             --glob "!**/intelligence_export.py" \
             --glob "!**/intelligence_import.py" \
             --glob "!**/vnx_install.py" \
-            --glob "!**/commands/merge_preflight.sh" || true)
+            --glob "!**/commands/merge_preflight.sh" \
+            --glob "!**/migrate_to_central_vnx.py" \
+            --glob "!**/migrate_dry_run.py" \
+            || true)
           if [ -n "$matches" ]; then
             echo "$matches"
             echo "Legacy path literals detected. Use VNX_STATE_DIR via vnx_paths."
@@ -261,7 +264,10 @@ jobs:
             --glob "!**/intelligence_export.py" \
             --glob "!**/intelligence_import.py" \
             --glob "!**/vnx_install.py" \
-            --glob "!**/commands/merge_preflight.sh" || true)
+            --glob "!**/commands/merge_preflight.sh" \
+            --glob "!**/migrate_to_central_vnx.py" \
+            --glob "!**/migrate_dry_run.py" \
+            || true)
           if [ -n "$matches" ]; then
             echo "$matches"
             echo "Legacy path literals detected. Use VNX_STATE_DIR via vnx_paths."


### PR DESCRIPTION
## Summary

- **Why**: Profile A fails on PR #432 because the P4 migration scripts (`migrate_to_central_vnx.py`, `migrate_dry_run.py`) reference `.vnx-data/state/` in their module docstrings and dry-run output — these are documentation, not codepath uses. The Legacy path gate is meant to catch unintended literal paths in production code; migration tools that explicitly handle the legacy layout are legitimate exceptions.
- **What**: Add `migrate_to_central_vnx.py` and `migrate_dry_run.py` to the `--glob "!..."` exclusion list in **both** Legacy path gate steps (Profile A ~line 39 and Profile B ~line 253).
- **Risk**: Zero — exclusion only widens; no existing production-code matches are unblocked.

## Test plan

- [x] Verified `grep -c` returns `2` for each new glob in the workflow file
- [x] Local gate simulation (`rg` with new globs) returns clean
- [ ] CI Profile A passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)