### PR TITLE
ci(governance): enforce ADR-003 — block Anthropic SDK imports

### DIFF
--- a/.github/workflows/anthropic-sdk-block.yml
+++ b/.github/workflows/anthropic-sdk-block.yml
@@ -1,0 +1,24 @@
+name: ADR-003 Enforcement
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  adr-003-no-anthropic-sdk:
+    name: "ADR-003: No Anthropic SDK Imports"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: ADR-003 gate — scan for forbidden SDK imports
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/scripts/check_adr_003_no_sdk_imports.py" "$GITHUB_WORKSPACE"

--- a/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
+++ b/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
@@ -72,7 +72,7 @@ VNX's value proposition depends on a Claude credential model the operator alread
 
 - ADR-004 — VNX positioning as self-hosted alternative to Anthropic Managed Agents
 - ADR-005 — Append-only NDJSON audit ledger as primary observability surface
-- ADR-010 — (forthcoming) Single-VNX migration design choice
+- ADR-010 — Subprocess adapter as canonical Claude routing (concrete implementation of this ADR)
 - `CLAUDE.md` (project root) — "Subprocess Adapter Feature Flag" section
 - `scripts/lib/subprocess_adapter.py` — canonical Claude transport
 - `scripts/lib/subprocess_dispatch.py` — canonical dispatch entry point

--- a/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
+++ b/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
@@ -1,0 +1,81 @@
+# ADR-003 — OAuth-Only Claude Routing via `claude -p` Subprocess (No SDK, No API Key)
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Codification of M6 (CLI-OAuth Claude routing) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+
+## Context
+
+VNX drives Claude through `claude -p --output-format stream-json` invoked as a subprocess from `scripts/lib/subprocess_adapter.py` and `scripts/lib/subprocess_dispatch.py`. The operator's Claude licensing context is **Claude Code (OAuth login)** — not a separately-billed Anthropic API account.
+
+Three industry signals in Q2 2026 push toward adopting the Anthropic Python SDK or the new Claude Agent SDK at the transport layer:
+
+1. The **Claude Agent SDK** (`claude-agent-sdk` Python package) now ships typed `HookEventMessage` events, `atexit`-based orphan cleanup, and a control-protocol message bus that re-implements much of `subprocess_adapter.py` natively (~600 LOC of VNX duplication per `claudedocs/2026-05-09-vnx-industry-research.md` Topic 2).
+2. **Anthropic Managed Agents** (launched 2026-04-08) is the hosted execution path that the SDK is the natural client for.
+3. Strategic-replan synthesis (Topic 2) initially proposed migrating the transport layer to the SDK as a "REPLACE" verdict.
+
+The operator has rejected this transport-layer migration. The reason is structural and licensing-based, not preference-based: routing Claude through the SDK while authenticated via the Claude Code OAuth credential is treated by Anthropic as third-party-API usage and has resulted in account suspensions for wrapper projects in 2025-2026 (opencode / openclaude / opencrest-style forks). The supported "headless" pattern under a Claude Code OAuth credential is the CLI subprocess — same OAuth credential, same telemetry surface, no policy violation.
+
+## Decision
+
+**VNX MUST drive Claude exclusively via `claude -p --output-format stream-json` subprocess. The Anthropic Python SDK and the Claude Agent SDK are forbidden in VNX code.**
+
+Concrete rules:
+
+- The canonical Claude entry point is `scripts/lib/subprocess_dispatch.py` (which delegates to `scripts/lib/subprocess_adapter.py`). All Claude invocations route through this path.
+- `import anthropic`, `from anthropic import ...`, `import claude_agent_sdk`, and equivalent imports are banned in VNX scripts. A CI gate enforces this (see §Implementation note).
+- LiteLLM-style provider abstraction is **permitted only for non-Claude providers** — Codex CLI, Gemini, Ollama, Kimi, and any future model behind an API key the operator owns. The Claude path stays subprocess.
+- For features the SDK provides natively (typed hook events, structured tool-use loops, prompt-cache control, orphan-process cleanup), VNX re-implements the pattern over the CLI subprocess output stream rather than calling the SDK. `active_dispatch_janitor` already covers orphan cleanup; further parity items are tracked as VNX-internal work.
+- This rule applies until Anthropic explicitly states the SDK is permitted with a Claude Code OAuth credential. As of 2026-05-09 no such statement exists.
+
+## Reasoning
+
+VNX's value proposition depends on a Claude credential model the operator already owns and pays for, plus full visibility into what the model is doing. Five reinforcing reasons:
+
+1. **OAuth ban-risk is real and observed.** Multiple wrapper projects (opencode, openclaw, opencrest-style forks) have been impacted by Anthropic's enforcement pattern when they routed OAuth-licensed Claude credentials through API-shaped clients in 2025-2026. The CLI subprocess is the documented "headless" pattern Anthropic publishes for the OAuth credential — same telemetry surface, same TOS posture. SDK adoption with the same credential is policy-violating regardless of code-quality benefits.
+
+2. **VNX is a self-hosted alternative to Managed Agents, not a wrapper for it.** Per ADR-004, VNX competes with Managed Agents on local-control, no-per-session-billing, and glass-box observability. The SDK is the client library for Managed Agents and similar hosted runtimes; adopting it on the VNX path leaks that dependency in a way that defeats the alternative-positioning. This decision and ADR-004 reinforce each other.
+
+3. **The CLI subprocess is the licensing-required path.** The operator's monthly Claude Code subscription covers `claude` CLI usage, including headless mode. There is no per-call charge on top of the subscription. Migrating to the SDK would require an Anthropic API key with token-metered billing, which (a) costs money the operator has already paid for in the subscription, and (b) introduces a separate credential to provision, rotate, and audit.
+
+4. **Glass-box visibility into actual subprocess events.** The CLI's NDJSON stdout (`stream-json`) is what VNX captures into per-terminal ring buffers and archives in `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson`. This is the canonical observable surface — operator-readable, `tail -f`-able, recoverable from disk alone. The SDK's typed hook events are higher-level but are produced by the same underlying CLI; using the SDK abstracts them behind a Python object model that hides the raw protocol. Per ADR-005, the NDJSON ledger is the canonical record; the CLI subprocess is the cheapest path to producing it.
+
+5. **Structural moat preservation.** Per the strategic replan §4, M6 (CLI-OAuth Claude routing) is a non-negotiable VNX moat. Industry research recommendations to "REPLACE with claude-agent-sdk at the transport layer" (Topic 2) misread VNX's licensing constraint. Codifying this in an ADR makes the constraint visible to future research synthesis and prevents recurring "should we adopt the SDK" debate.
+
+## Consequences
+
+### Accepted
+
+- `scripts/lib/subprocess_dispatch.py` and `scripts/lib/subprocess_adapter.py` are the canonical Claude transport. Both remain VNX-owned code; no upstream library replaces them.
+- LiteLLM is approved for non-Claude providers (Codex API-direct, Gemini API-direct, Ollama, Kimi). CLI-subprocess adapters (Codex CLI, Claude CLI) stay custom.
+- A CI gate scans VNX scripts for forbidden imports (`anthropic`, `claude_agent_sdk`) and fails the build if any are introduced. The gate is implemented as a small `grep`-style check in the test suite or pre-commit hook.
+- New industry-research synthesis that recommends Claude Agent SDK adoption is auto-flagged as **INVALID under VNX licensing constraint** with a link to this ADR. The recommendation is reframed to "continue routing Claude via `claude -p` subprocess; only adopt SDK *patterns* (e.g. orphan cleanup, hook-event taxonomy) that don't replace the CLI invocation."
+- Parity work for SDK-native features (typed hook events, tool-use loops, prompt-cache control) is tracked as VNX-internal feature requests against the subprocess adapter — never as SDK-adoption tickets.
+- Future framework evaluations (LangGraph, AutoGen, smolagents, CrewAI, MAF, Claude Agent SDK) apply the same test: *does it require an Anthropic API key, or can it route to the Claude Code CLI subprocess?* If only the former, classify as **incompatible-with-our-licensing** and do not recommend adoption.
+
+### Rejected
+
+- Adopting `claude-agent-sdk` as the transport-layer replacement for `subprocess_adapter.py`.
+- Adopting the Anthropic Python SDK (`anthropic` package) anywhere in VNX code.
+- "Thin wrapper around SDK" patterns where VNX's governance layer sits on top of an SDK-driven Claude session.
+- Consuming Anthropic Managed Agents as the Claude execution substrate (separately rejected in ADR-004).
+- Any provider-abstraction layer that requires an Anthropic API key for the Claude path, even if the same layer is acceptable for non-Claude providers.
+
+## Implementation note
+
+- `CLAUDE.md` (project root) already states "**No Anthropic SDK is used.** Only `subprocess.Popen(['claude', ...])`." This ADR codifies that statement at the architectural-decision layer.
+- A CI gate against `import anthropic` / `import claude_agent_sdk` is required before this ADR can be considered fully enforced. Tracked as a Wave 0 task in the strategic replan.
+- Future SDK feature parity (e.g. Anthropic ships a new prompt-cache control surface) is implemented over the CLI subprocess output stream, not via SDK adoption.
+
+## See also
+
+- ADR-004 — VNX positioning as self-hosted alternative to Anthropic Managed Agents
+- ADR-005 — Append-only NDJSON audit ledger as primary observability surface
+- ADR-010 — (forthcoming) Single-VNX migration design choice
+- `CLAUDE.md` (project root) — "Subprocess Adapter Feature Flag" section
+- `scripts/lib/subprocess_adapter.py` — canonical Claude transport
+- `scripts/lib/subprocess_dispatch.py` — canonical dispatch entry point
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M6) — strategic-moat justification
+- `claudedocs/2026-05-09-vnx-industry-research.md` Topic 2 — the rejected SDK-adoption recommendation
+- Memory: `feedback_avoid_claude_sdk_use_cli_oauth.md` — operator licensing-constraint feedback

--- a/docs/governance/decisions/ADR-004-vnx-as-managed-agents-alternative.md
+++ b/docs/governance/decisions/ADR-004-vnx-as-managed-agents-alternative.md
@@ -1,0 +1,79 @@
+# ADR-004 — VNX Positioning: Self-Hosted Alternative to Anthropic Managed Agents
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Codification of strategic-replan §1, §4, §7 — VNX-as-product vs VNX-as-thin-wrapper
+
+## Context
+
+On 2026-04-08 Anthropic launched **Claude Managed Agents** — a serverless agent runtime where each agent runs in a gVisor-isolated container on Anthropic infrastructure, with default-deny network egress, scoped filesystem (`/workspace` writable, `/source` read-only), built-in OAuth for user-delegated actions, and pricing at $0.08/session-hour plus standard token costs. Notion, Rakuten, and Sentry are in production on it ([Anthropic Managed Agents InfoQ](https://www.infoq.com/news/2026/04/anthropic-managed-agents/)). Three feature updates shipped by 2026-05-07.
+
+Industry-research synthesis in `claudedocs/2026-05-09-vnx-industry-research.md` (Topic 12) initially recommended "ADOPT alongside — Managed Agents is the right substrate for *production* agent execution; VNX's local-first 4-terminal model remains correct for *development* and *governance experimentation*." The closing 250-word summary went further: "VNX should pivot to a **thin governance layer over Claude Agent SDK + MCP + Managed Agents** — keep the audit/gate/review IP, drop the subprocess plumbing."
+
+The operator has rejected this pivot framing explicitly. VNX's strategic purpose is to be a **self-hosted alternative** to Managed Agents — same coordination + governance + audit goals, but on operator hardware, with Claude Code OAuth login (no per-session billing), no vendor lock-in, and full visibility into the runtime. "Just use Managed Agents" defeats the purpose of building VNX. Per the operator's memory (`project_vnx_is_alternative_not_layer.md`), Managed Agents is "the commoditization VNX is competing with, not a target to converge onto."
+
+This ADR codifies that positioning so future strategic syntheses, framework evaluations, and roadmap proposals do not re-introduce the "pivot to thin wrapper" framing.
+
+## Decision
+
+**VNX is built and maintained as a self-hosted, OAuth-only, glass-box alternative to Anthropic Managed Agents. NOT a layer on top of Managed Agents. NOT a wrapper for it. The product is the alternative itself.**
+
+Concrete positioning:
+
+- VNX targets the **same problem space** as Managed Agents (spawn-supervise-cleanup of agent processes, OAuth-delegated execution, scoped filesystem, structured event protocol).
+- VNX competes on **operator-control, OAuth-only credentials, glass-box observability, multi-vendor adversarial review, and human-approval gating**.
+- VNX may **learn architecturally** from Managed Agents (gVisor-style isolation, declarative session lifecycle, structured event protocol) without consuming the service.
+- The Wave 5 differentiation roadmap (per strategic-replan §7.3) explicitly closes parity gaps where Managed Agents is currently ahead (gVisor isolation, HTTP/webhook triggers) and exploits structural advantages where Managed Agents cannot follow (dual-LLM gating, append-only audit ledger, OAuth-only credential, per-tenant project_id isolation across operator's own DBs).
+
+## Reasoning
+
+Six reinforcing reasons for the alternative-not-layer positioning:
+
+1. **Local control is the moat, not a tactical convenience.** Managed Agents is hosted by definition; the operator cannot inspect the runtime, modify the supervision logic, or patch a bug on their own timeline. VNX runs on operator hardware where every behavior is inspectable and patchable. This is a structural property no hosted service can match — Anthropic would have to ship VNX-as-a-product to compete, and they have no incentive to do so.
+
+2. **No per-session billing.** Managed Agents charges $0.08/session-hour on top of token costs. VNX runs on the operator's existing Claude Code subscription — "free at the margin." For the operator's actual workload (3-4 worker terminals, dozens of dispatches per day), the per-session-hour line is non-trivial. More importantly, it removes the cost-anxiety from running long-lived agent loops (overnight feature work, supervisor daemons, HTTP trigger receivers).
+
+3. **No vendor lock-in on the runtime.** Managed Agents binds the operator to Anthropic's session-lifecycle protocol, their event schema, their billing portal, their support SLA. VNX's runtime is portable — `claude -p` subprocess works on any host with a Claude Code login. If Anthropic raises prices or changes terms, VNX continues to run unchanged.
+
+4. **OAuth-only credential model.** Per ADR-003, VNX drives Claude via `claude -p` subprocess under the operator's existing Claude Code OAuth login — no Anthropic API key required. Managed Agents requires API-account billing. The operator's licensing context makes the API-key path policy-violating (third-party-API ban risk for OAuth credentials). VNX is structurally compatible with the operator's existing Claude subscription; Managed Agents is structurally incompatible. This is not a preference — it is the binary fact that determines which path is even available.
+
+5. **Multi-vendor adversarial review.** Per the strategic-replan §4 (M3), VNX's dual-LLM gate uses Codex to gate Claude's work, with Gemini as a second reviewer, bound by `contract_hash` evidence to PR records. **Anthropic will never ship "use Codex to gate Claude"** — structural conflict of interest. Managed Agents' code-review story is single-vendor by definition. The dual-LLM gate is genuinely novel in 2026 (per industry-research Topic 15: "the 'two LLMs as adversarial reviewers with mandatory evidence binding before merge' pattern remains VNX-specific") and only a self-hosted system can ship it.
+
+6. **Glass-box governance, every layer inspectable.** Per ADR-005, VNX's append-only NDJSON audit ledger gives the operator a `tail -f`-able, `git diff`-friendly view into every dispatch lifecycle event, lease transition, gate outcome, and receipt. Managed Agents is a black box by service-design — Anthropic exposes whatever observability surface they choose, on their schedule. Per ADR-006, VNX's mandatory staging→promote human-approval gate is the audit trail's anchor: every active dispatch has explicit operator consent recorded. Managed Agents has `TaskCreated` hooks but no architectural approval gate. Both are structural advantages a hosted service cannot replicate without becoming a self-hosted product.
+
+The combined effect: VNX's strategic moat is not "we built it ourselves" — it is "we built a system whose key properties (operator-control, OAuth-only, glass-box, dual-vendor adversarial review, human gate) cannot be replicated by a hosted service for structural reasons." That moat is durable as long as VNX remains self-hosted.
+
+## Consequences
+
+### Accepted
+
+- The Wave 5 differentiation features in `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §7.3 are the active development priority once Waves 0-4 close: (1) 3-Layer Trigger System + HTTP/webhook receiver, (2) optional Docker/Podman sandbox isolation, (3) `vnx init` PyPI quickstart. Each closes a parity gap with Managed Agents while preserving VNX's structural advantages.
+- A differentiation table is maintained in the public-facing PRD-UH-002 v1.0 (per strategic-replan §10 D3 / D4) showing "what Managed Agents does well that VNX matches" vs "what Managed Agents structurally can't do that VNX uniquely offers."
+- The VNX public narrative shifts from "universal headless harness" (PRD-UH-001 v1.3) to "self-hosted alternative to Managed Agents with full glass-box governance" (PRD-UH-002 v1.0 framing, per strategic-replan §10 D4 default = clean break).
+- Industry research that surfaces Managed Agents (or any vendor-managed agent runtime — Cloudflare Workers AI agents, Vercel AI runtime, Replit Agent, etc.) as a "platform shift to adopt" is reframed as **competitive/commoditization signal** that informs *what VNX must beat or differentiate from*, not a migration target.
+- ADR-003 is treated as a hard prerequisite of this positioning: without OAuth-only Claude routing, the alternative-not-wrapper claim is unsupported.
+
+### Rejected
+
+- "Pivot to thin governance layer over Managed Agents" — the closing recommendation of `claudedocs/2026-05-09-vnx-industry-research.md` §250-word summary.
+- "Wrap Managed Agents with our gating" patterns — VNX governance does not sit downstream of a hosted Claude execution; it sits over the operator's own subprocess execution.
+- "Consume Managed Agents service" as a deployment target. VNX's deployment target is the operator's own hardware (or a future PyPI-installable footprint per Wave 5 candidate 3), not Anthropic's runtime.
+- Cloudflare Dynamic Workers, Daytona, E2B, Fly Machines, Vercel Sandbox, or other hosted Agent SDK substrates as the VNX runtime layer. These are valid for projects whose requirements differ; they are not valid for VNX given M6 + this ADR.
+- Any roadmap framing where VNX's value reduces to "the audit/gate IP" while the execution layer commoditizes to a hosted vendor.
+
+## Implementation note
+
+- `CLAUDE.md` (project root) is updated in Wave 0 to add a Q2 2026 platform-shift note pointing at this ADR and ADR-003.
+- The differentiation table in §7.1 / §7.2 of `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` is the canonical reference until PRD-UH-002 v1.0 supersedes it.
+- Wave 5 candidate selection (operator decision D5 in the strategic replan) is the next concrete output of this positioning.
+
+## See also
+
+- ADR-003 — OAuth-only Claude routing via `claude -p` subprocess
+- ADR-005 — Append-only NDJSON audit ledger as primary observability surface
+- ADR-006 — Staging→promote with mandatory human approval gate
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §1, §4, §7 — strategic positioning
+- `claudedocs/2026-05-09-vnx-industry-research.md` Topic 12, Topic 15, §250-word summary — the rejected pivot framing
+- Memory: `project_vnx_is_alternative_not_layer.md` — operator strategic-intent feedback
+- Memory: `project_vnx_strategic_direction.md` — VNX evolution from governance-first to multi-manager system

--- a/docs/governance/decisions/ADR-005-ndjson-audit-ledger-primary.md
+++ b/docs/governance/decisions/ADR-005-ndjson-audit-ledger-primary.md
@@ -1,0 +1,86 @@
+# ADR-005 — Append-Only NDJSON Audit Ledger as Primary Observability Surface
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Codification of M1 (NDJSON audit ledger) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+
+## Context
+
+VNX records every dispatch lifecycle event, receipt, gate outcome, and lease/heartbeat transition. Two storage shapes exist in the codebase:
+
+1. **Append-only NDJSON ledger files** — `.vnx-data/state/t0_receipts.ndjson`, `.vnx-data/dispatch_register.ndjson`, `.vnx-data/events/T{n}.ndjson` (per-terminal ring buffer with archive in `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson`), `.vnx-data/state/review_gates/results/*.json` (one file per gate result).
+2. **SQLite tables** — `.vnx-data/state/runtime_coordination.db` (leases, heartbeats, incident log), `.vnx-data/quality_intelligence.db` (cross-project intelligence, dispatch tracker projections), `.vnx-data/dispatch_tracker.db` (per-dispatch state).
+
+Both surfaces have grown organically. Several recent PRs have proposed shifting writes to SQLite-first for query performance (e.g. "we have the DB now, why log NDJSON?") or dropping the ledger entirely. Industry-research synthesis (`claudedocs/2026-05-09-vnx-industry-research.md` Topic 14) noted that OpenTelemetry GenAI semantic conventions + CloudEvents are the emerging structured-event standard, which raised a separate question of replacing NDJSON with an OTel-shaped wire format.
+
+The operator has consistently reaffirmed the NDJSON ledger as canonical. The strategic-replan §4 lists M1 (NDJSON audit ledger) as a non-negotiable VNX moat: "Managed Agents has no audit ledger; SDK has no provenance stamping; nobody else stamps git ref + dirty flag + cost per dispatch." This ADR codifies that the ledger is the primary surface and SQLite is downstream.
+
+## Decision
+
+**All dispatch lifecycle events, receipts, gate outcomes, and lease/heartbeat transitions MUST write to append-only NDJSON files before any SQLite mirror or projection. The NDJSON ledger is the canonical record; SQLite tables are projections for query performance.**
+
+Concrete rules:
+
+- Every new lifecycle event added to VNX (dispatch creation, promote, lease acquire, heartbeat, receipt arrival, gate request, gate result, dispatch close) writes a JSON line to one of the canonical ledger files, **first**, before any SQLite write.
+- The canonical ledger files are:
+  - `.vnx-data/state/t0_receipts.ndjson` — receipt arrivals (T0's view of worker output)
+  - `.vnx-data/dispatch_register.ndjson` — dispatch lifecycle (created → promoted → active → closed)
+  - `.vnx-data/events/T{n}.ndjson` — per-terminal subprocess events (ring buffer; durable archive at `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson`)
+  - `.vnx-data/state/review_gates/results/*.json` — one file per review-gate result
+  - `.vnx-data/state/incident_log.ndjson` — incident transitions (where applicable)
+- SQLite tables that mirror ledger content (e.g. `dispatch_tracker`, `runtime_coordination` projections of leases/heartbeats) are **derived state**. They may be rebuilt from the ledger on disk; the ledger may not be rebuilt from them.
+- If a system crash leaves the SQLite mirror inconsistent with the ledger, the ledger wins. Recovery procedures replay the ledger forward; they do not back-port from SQLite.
+- New observability adapters (OTel CloudEvents export per industry-research Topic 14, Datadog/Honeycomb/Grafana ingest) are **parallel exporters** off the ledger writer — they do not replace the canonical NDJSON files. Per the strategic-replan §5 A6.
+
+## Reasoning
+
+Five reinforcing reasons for the ledger-first model:
+
+1. **Operator-readable without a DB client.** The operator (and any human reviewer) can `tail -f .vnx-data/state/t0_receipts.ndjson`, `grep dispatch_id .vnx-data/dispatch_register.ndjson`, or open the file in any editor. SQLite requires a client (`sqlite3` CLI, DB GUI). For a glass-box system per ADR-004, the cheapest path to inspectability is plain text. Every minute of "let me query the DB to find out what happened" friction is a minute the human gate erodes.
+
+2. **Tamper-evident by construction.** Append-only NDJSON files have a one-way write semantic: new lines only, no in-place mutation. Any retroactive edit shows up in `git diff` (the `.vnx-data/` directory is gitignored runtime state, but the operator's backup workflow and forensic-recovery procedures rely on file-mtime + size monotonicity). SQLite UPDATE/DELETE are silent in comparison; reconstructing a tamper trail from a relational DB requires a separate audit log on top — which is what the NDJSON ledger already is.
+
+3. **Recoverable from disk alone.** If SQLite databases corrupt (page checksum failure, partial write during power loss, fsync ordering issue), the ledger remains intact because each line is independently parseable. Recovery procedure: replay the ledger, rebuild the SQLite projection. The reverse is not possible — a corrupted ledger leaves no source of truth. ADR-001 (no external Redis) already established VNX as a system whose state must be recoverable from local disk; the NDJSON ledger is what makes that promise real. Killing the dispatcher and restarting it does not lose state because the ledger is already on disk.
+
+4. **Compatible with `git diff` / `tail -f` / `jq` workflows.** Operator forensic workflows (debugging "why did the dispatcher fail closed on this lease," reconstructing the timeline of a specific PR, re-checking gate evidence for a post-merge audit) all use line-oriented Unix tools. The strategic-replan §4 calls this out explicitly: "operator-readable, not vendor-mediated." Migrating to SQLite-first would force every forensic step through a query language — slower, less scriptable, and less transparent.
+
+5. **Decouples observability from query layer.** SQLite is good at queries; NDJSON is good at audit. Coupling them inverts the dependency: if SQLite is the source of truth, every observability use case competes with every query use case for schema design. With NDJSON canonical and SQLite as a projection, query schema can evolve independently (rebuild the projection from the ledger), and the ledger format stays stable across query-layer refactors. Per memory `project_ndjson_ring_buffer.md`, the per-terminal NDJSON is intentionally a ring buffer (truncated post-dispatch) **because the durable record lives in `.vnx-data/events/archive/{terminal}/`** — this only works because the ledger is the canonical record, not the SQLite mirror.
+
+A note on the ring-buffer pattern: `.vnx-data/events/T{n}.ndjson` is per-dispatch and truncated to zero bytes after each subprocess-adapter dispatch, with the live content archived to `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson` (per `CLAUDE.md` "Event Streams" section). An empty live file ≠ broken writer. This is correct behavior under this ADR: the archive is the durable ledger; the live file is the cursor.
+
+## Consequences
+
+### Accepted
+
+- Any new lifecycle event MUST write to the ledger first; SQLite is downstream. Code review enforces this at PR time.
+- SQLite mirrors (`dispatch_tracker`, `runtime_coordination` projections, `quality_intelligence` indexes over receipts) are documented as **rebuildable from the ledger**. A `rebuild_projections.py` (or equivalent) tool exists and is exercised in recovery drills.
+- OTel CloudEvents export (per strategic-replan A6) is implemented as a parallel exporter off the ledger writer, ~100 LOC, in Wave 4 or as an opportunistic small PR. The canonical NDJSON files are unchanged; an OTel-shaped stream emits in parallel for Datadog/Honeycomb/Grafana consumers.
+- Recovery and forensic procedures are documented to start from the ledger. New runbooks reference NDJSON file paths first, SQLite queries second.
+- ADR-001's "self-contained runtime state, recoverable from disk" promise is grounded in this ADR: the ledger is what makes self-contained recovery possible without an external daemon.
+- Per-terminal ring-buffer behavior is preserved as documented in `CLAUDE.md` "Event Streams"; the archive directory is the durable surface for those events.
+
+### Rejected
+
+- "Just log to SQLite for speed" — rejected. The query-performance gain does not offset the inspectability and recovery losses. SQLite stays as a projection.
+- "Drop the ledger now that we have the DB" — rejected. The DB is downstream of the ledger by design; dropping the ledger inverts the source-of-truth and breaks the moat (M1 in the strategic replan).
+- Replacing NDJSON with an OTel-only wire format. Per industry-research Topic 14, OTel GenAI is an export target, not a primary store. The ledger format stays NDJSON; OTel emits in parallel.
+- In-place mutation of ledger lines (UPDATE-style edits to past entries). Append-only is structural — corrections are written as new lines that reference the corrected event by ID.
+- Using SQLite WAL / journal files as a substitute for the ledger. WAL is internal SQLite plumbing, not an audit surface — it lacks operator-readability and tamper-evidence.
+
+## Implementation note
+
+- The "ledger first, SQLite second" rule is enforced at code-review time. A static-analysis check (e.g. flagging SQLite writes that have no preceding ledger append in the same code path) is a candidate Wave 0 task.
+- Recovery drills (replay ledger → rebuild SQLite projection → diff vs original) are documented in operations runbooks. Frequency: at minimum once per significant schema change.
+- The ledger-archive convention for per-terminal events (`.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson`) is the canonical durable surface for subprocess events; the live `.vnx-data/events/T{n}.ndjson` is a ring buffer per memory `project_ndjson_ring_buffer.md`.
+
+## See also
+
+- ADR-001 — No external Redis (recoverable-from-disk promise relies on this ledger)
+- ADR-003 — OAuth-only Claude routing (subprocess output is what feeds `T{n}.ndjson`)
+- ADR-004 — VNX as alternative to Managed Agents (glass-box observability is the moat)
+- ADR-006 — Staging→promote human gate (the gate's evidence trail is the ledger)
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M1) — strategic-moat justification
+- `CLAUDE.md` "Event Streams" section — ring-buffer + archive convention
+- Memory: `project_ndjson_ring_buffer.md` — per-terminal NDJSON is ring buffer, durable archive in `.vnx-data/events/archive/{terminal}/`
+- `.vnx-data/state/t0_receipts.ndjson`, `.vnx-data/dispatch_register.ndjson`, `.vnx-data/events/archive/` — canonical ledger surfaces

--- a/docs/governance/decisions/ADR-006-staging-promote-human-gate.md
+++ b/docs/governance/decisions/ADR-006-staging-promote-human-gate.md
@@ -1,0 +1,91 @@
+# ADR-006 — Staging→Promote with Mandatory Human Approval Gate
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Codification of M2 (staging→promote gate) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+
+## Context
+
+Every VNX dispatch passes through a two-step lifecycle on disk:
+
+1. **Staging** — the dispatch JSON file is created in `.vnx-data/dispatches/pending/` with full instruction footer (worker rules, codex-availability note, footer metadata appended by the dispatch register).
+2. **Promote** — a human-operator action moves the file from `pending/` to `.vnx-data/dispatches/active/`, which is the cue for the dispatcher daemon to deliver it to the worker terminal.
+
+There is no architectural path from "worker requests a follow-up task" or "T0 plans the next dispatch" to "dispatch executes" that bypasses the human promote action. The promote step is the explicit consent boundary.
+
+This pattern has been challenged from several directions in 2026:
+
+- Industry-research synthesis (`claudedocs/2026-05-09-vnx-industry-research.md` Topic 1, Topic 9) noted that Anthropic's experimental Agent Teams ships `TaskCreated` / `TaskCompleted` / `TeammateIdle` hooks — but **no architectural human-approval gate** between team-lead decision and teammate execution. Microsoft Agent Framework v1.0 has the primitive but is Azure-coupled.
+- Operator memories `feedback_dispatch_via_pending.md` and `feedback_no_manager_block_output.md` document recurring proposals to "auto-drain pending → active" or "skip the promote for low-risk dispatches." Each such proposal has been rejected and the memory updated.
+- Recent T0 orchestrator behavior in autonomous mode (per `feature kickoff checklist` and the F60 / overnight-feature workflow) has tightened toward longer autonomous chains, which raises a recurring question: should we relax the human gate when the operator is asleep?
+
+The operator's position has been consistent and is now codified here: the human gate is non-negotiable. It is the distinguishing structural feature that makes VNX's audit trail meaningful.
+
+## Decision
+
+**Every VNX dispatch passes through a mandatory two-step gate: (1) staging in `.vnx-data/dispatches/pending/` with full instruction footer, (2) human-operator promote action that moves the file to `.vnx-data/dispatches/active/`. There is NO auto-execute path from worker request to dispatch execution. There is NO autonomous-mode bypass. There is NO low-risk-dispatch shortcut.**
+
+Concrete rules:
+
+- The `pending/` → `active/` transition is performed by an explicit human action (operator-issued promote command, `vnx promote` CLI, or equivalent UI affordance). The dispatcher daemon does not auto-promote.
+- T0 (the orchestrator) writes to `pending/`, not to `active/`. Per the operator memory `feedback_dispatch_via_pending.md`, dispatching directly to `staging/` or to a worker terminal via tmux send-keys bypasses the footer-metadata enrichment and is forbidden. T0 always writes to `pending/`.
+- Worker terminals (T1/T2/T3) cannot move dispatches across the gate. Even if a worker proposes a follow-up dispatch, the file lands in `pending/` and waits for the human promote.
+- Autonomous-mode orchestration (F60 overnight chains, operator-pre-approved feature loops) does **not** disable the gate. "Autonomous" means the operator pre-approved a chain; promotes still happen, but the operator's pre-approval covers the chain's expected dispatches. Any out-of-scope dispatch falls back to interactive promote.
+- Supervisor daemons (`dispatcher_supervisor.sh`, lease-sweep tickers, runtime-supervise tickers per `CLAUDE.md` "Supervisor Mode") do not promote dispatches. Their job is to keep the runtime healthy; the human gate is orthogonal.
+- A dispatch in `pending/` has no SLA. It can sit there indefinitely. The dispatcher does not time out a pending file or auto-execute it on a timer.
+
+## Reasoning
+
+Five reinforcing reasons for the mandatory human gate:
+
+1. **The human gate is the moat.** Per `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2): "Agent Teams has `TaskCreated` hooks but no architectural approval gate; MAF v1.0 has the primitive but is Azure-coupled." No competing system — Managed Agents, Agent Teams, CrewAI, smolagents, OpenCode/CAO — ships a mandatory human gate on every dispatch. VNX's distinguishing structural feature is exactly this gate. Removing it would erase the principal differentiator versus Managed Agents (per ADR-004).
+
+2. **The audit trail only means something with consent.** Per ADR-005, the NDJSON ledger records every dispatch's lifecycle. The semantic content of "this dispatch was approved" is encoded by the `pending/` → `active/` transition — without the human action, the ledger only records "the system wanted to do this." With the human action, it records "the operator authorized this." For a glass-box governance system per ADR-004, that distinction is the entire point of having an audit trail.
+
+3. **Prevents runaway autonomous loops.** AI agents that plan their own next-step dispatches without a gate exhibit known failure modes: scope creep, infinite refinement loops, recursive self-dispatch on perceived bugs, expensive token consumption on tangents. The human gate caps these at one cycle per loop iteration — the operator either promotes the next step or doesn't. The strategic-replan §4 (M2) recommends "alarm if `pending/` → `active/` transitions without a human signal" via `dispatcher_supervisor.sh`; this ADR makes the alarm conceptually mandatory, not optional.
+
+4. **Glass-box governance requires explicit consent points.** Per ADR-004, VNX competes on operator-control and inspectability. "The operator can see what happened" is necessary but not sufficient — "the operator can stop something from happening" is the dual property that makes governance meaningful. The promote step is where the operator can stop. Removing it converts VNX from a governance system into a logging system.
+
+5. **The pattern is small, robust, and proven.** The promote action is one filesystem mv (or one CLI call that does mv plus footer enrichment). The pending/ directory is a flat directory listable with `ls`. There is no clever scheduling logic to maintain. Operator memory `feedback_dispatch_via_pending.md` documents that the only correct dispatch path is "write to pending/, not staging/, not tmux." That memory has held since early 2026; recurring proposals to "simplify" the gate (auto-drain, low-risk-skip, AI-to-AI handoff) have been rejected each time. This ADR codifies the rejection as a closed decision.
+
+A note on the F28 gate-enforcement failure (memory `feedback_gate_enforcement_failure_f28.md`): T0 once skipped all 5 F28 gates before merge, which the operator flagged as unacceptable. That incident covered a different gate (the codex/gemini/CI gates before PR merge), but the underlying principle is identical to this ADR — every gate is mandatory, no skipping, no exceptions, no "low-risk" shortcuts. The dispatch staging→promote gate has the same posture.
+
+## Consequences
+
+### Accepted
+
+- The promote tool exists (currently as a manual filesystem move + register-update pair, codified in dispatch-workflow scripts). Future ergonomics improvements are welcome (CLI affordance, dashboard button) **as long as they preserve the human-action requirement** — the affordance must be operated by a human, not automated.
+- Dispatch workflows are codified in worker terminal CLAUDE.md files and the t0-orchestrator skill. These all reference `pending/` as the worker write target.
+- Supervisor daemons can detect drift (e.g. a file appearing in `active/` without a corresponding `pending/`-to-`active/` transition record) and alarm the operator. Tracked as a Wave 0 / Wave 1 task.
+- Autonomous chain pre-approval is the only operator-level relaxation. The operator may declare "I pre-approve all dispatches in this chain that match this scope" at chain kickoff; promotes still happen, just under an explicit pre-authorization umbrella. Out-of-scope dispatches drop back to interactive.
+- The audit ledger (per ADR-005) records every promote action with operator identity and timestamp. The "consent point" is therefore evidenced and queryable.
+
+### Rejected
+
+- "Autonomous queue auto-drain" — proposals to have the dispatcher periodically scan `pending/` and auto-move low-priority entries to `active/` are rejected.
+- "AI-to-AI handoff without gate" — a worker producing a follow-up dispatch that auto-executes without operator review is rejected. The follow-up lands in `pending/` like any other dispatch.
+- "Skip promote for low-risk" — risk-scored auto-promote (e.g. risk ≤ 0.1 → auto-execute) is rejected. The gate is binary: every dispatch goes through it.
+- T0 dispatching directly to `staging/` or via raw `tmux send-keys` to a worker pane (per memory `feedback_never_raw_tmux.md` and `feedback_dispatch_via_pending.md`). All instructions go through `pending/` to pick up footer metadata.
+- "Pre-approve all future dispatches indefinitely" — autonomous-mode pre-approval is scoped to a specific chain or feature, not unbounded.
+- Hot-path bypasses for "urgent fixes" — if it's urgent enough to bypass the gate, it's urgent enough for the operator to type `vnx promote`.
+
+## Implementation note
+
+- The promote action's correctness is enforced at multiple layers: (a) T0 orchestrator skill writes to `pending/` only, (b) the dispatcher daemon only reads from `active/`, (c) supervisor drift detection alarms on direct-to-`active/` writes.
+- Dispatch footer metadata (worker rules per `Worker Dispatch Standards` in T0's CLAUDE.md, codex-unavailable notes, etc.) is appended at the `pending/` write step, not at promote. This ensures every dispatch — including operator-promoted ones — carries the standard footer.
+- The pre-approved-chain pattern is the only soft mode and is documented in T0's CLAUDE.md operator policies (C2 — F60 / overnight feature work). Pre-approval is operator-explicit per chain.
+
+## See also
+
+- ADR-003 — OAuth-only Claude routing (the gate sits between operator-consent and Claude execution)
+- ADR-004 — VNX as alternative to Managed Agents (the gate is the moat)
+- ADR-005 — Append-only NDJSON audit ledger (the ledger records consent points)
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2) — strategic-moat justification
+- `CLAUDE.md` (project root) "Workflow" + "Rules" sections — codified gate references
+- `.claude/terminals/T0/CLAUDE.md` "Worker Dispatch Standards", "Permissions and Hard Guardrails" — gate enforcement at the orchestrator layer
+- Memory: `feedback_dispatch_via_pending.md` — pending/ vs staging/ vs tmux
+- Memory: `feedback_no_manager_block_output.md` — promote-only delivery model
+- Memory: `feedback_never_raw_tmux.md` — no raw tmux send-keys
+- Memory: `feedback_gate_enforcement_failure_f28.md` — gate skipping is unacceptable
+- `.vnx-data/dispatches/pending/`, `.vnx-data/dispatches/active/` — gate's filesystem surfaces

--- a/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+++ b/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
@@ -1,0 +1,74 @@
+# ADR-007 — Multi-tenant `project_id` Stamping Pattern
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Phase 0 + P4 multi-tenant migration design (PRs #410, #412, #416, #431, #432)
+
+## Context
+
+VNX began as a single-tenant orchestration system: one operator, one project (`vnx-roadmap-autopilot`), one local SQLite stack under `.vnx-data/state/`. By Q1 2026 the operator was running **four** distinct VNX deployments (`vnx-dev`, `mc`, `sales-copilot`, `seocrawler-v2`) totaling ~17.6 GB of `.vnx-data/`, each with its own per-project `quality_intelligence.db` and `runtime_coordination.db`. Patterns learned in `mission-control` could not inform a dispatch in `sales-copilot`. Cross-project learning was structurally impossible.
+
+`claudedocs/2026-04-30-single-vnx-migration-plan.md` proposed Model B: separate repos, central VNX install, **central data dir namespaced by `project_id`**. Phase 0 (PR #410) added `project_id` columns to seven hot tables; Phase 4 (PR #432) imported all four projects' data into the central DBs and stamped every row with its source `project_id`.
+
+The migration ran for **nine codex review rounds**. Each round surfaced new instances of the same root pattern: tables, indexes, or constraints that assumed single-tenancy. The lessons doc at `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` Section 1.3 documents how `INSERT OR IGNORE` against a single-column UNIQUE constraint silently dropped re-stamped rows because the existing `DEFAULT 'vnx-dev'` rows already occupied the PK slot. Section 4.2 codifies the fix: composite uniqueness as the default.
+
+This ADR captures the resulting pattern as a binding architectural rule for all future central-DB tables.
+
+## Decision
+
+**All multi-tenant tables in central VNX state DBs (`quality_intelligence.db`, `runtime_coordination.db`, `dispatch_tracker.db`) carry a `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` column, and every UNIQUE constraint or PK on a natural key is composite over `project_id`.**
+
+The pattern has three concrete rules:
+
+1. **Column rule.** Every table that holds tenant-scoped state declares `project_id TEXT NOT NULL DEFAULT 'vnx-dev'`. The default exists only as a forward-compatible bridge for legacy single-tenant rows; the importer overwrites it with the source's actual project id at migration time. New code SHOULD explicitly stamp `project_id` and SHOULD NOT rely on the default.
+
+2. **Constraint rule.** Where a table previously had `UNIQUE(natural_key)`, the central form is `UNIQUE(natural_key, project_id)` (or the inverse — order does not matter for SQLite UNIQUE semantics, but the convention places `project_id` last). Single-column UNIQUE constraints on tenant-scoped natural keys are a smell that requires per-table justification recorded in the migration file.
+
+3. **Identifier-rewrite rule.** Where two source projects can mint the same identifier (e.g., `dispatches.id=1`, `terminal_leases.id=1`), the importer prefix-rewrites with `<project_id>:<source_id>` for shared identifier columns. This is the same rule applied successfully to `pattern_usage.pattern_id` (which fixed the pre-existing single-project synthetic-id explosion as a bonus side effect, per `claudedocs/2026-04-30-single-vnx-migration-plan.md` §5.2).
+
+The structural test in `tests/test_migrate_dry_run.py` parses migration `0015_complete_project_id.sql` at CI time and asserts every multi-tenant table conforms. New migrations that introduce tenant-scoped tables MUST extend this test.
+
+## Reasoning
+
+1. **The whole value proposition rests on this.** The single-VNX move (`claudedocs/2026-04-30-single-vnx-migration-plan.md` §1.2 "Why B over A") chose Model B specifically because column-namespacing gives strong-via-column isolation while keeping reversible per-project rollback paths. Without `project_id` stamping there is no Model B — there is only Model A (monorepo) or Model C (read-only federation). The operator rejected both. `project_id` is therefore not a tactical column, it is the identity layer of the entire central system.
+
+2. **It also fixes a latent single-project bug.** The `pattern_usage.pattern_id` synthetic-id explosion (codex finding §2.12, referenced in migration plan §5.2) was a single-project bug masked by single-project assumptions. Composite-key namespacing fixes it as a free side effect — every centralized table inherits stable per-project identity.
+
+3. **Multi-tenant retrofits are the highest-risk class of change in this codebase.** Lessons doc Section 2 taxonomy: bug patterns T1, T3, T6 (and partially T9) are migration-specific; bug patterns T2, T4, T7, T8 are general data-engineering. The migration-specific cluster — DEFAULT-as-sentinel, single-column PK in multi-tenant world, dedup wider than tenancy — exists precisely because retrofit code carries forward single-tenant assumptions invisibly. Codifying composite UNIQUE as the default is the structural antidote.
+
+4. **Codex round-9 surfaced that not all tables conform yet.** Open items OI-1375 and OI-1376 enumerate the residual gaps: tables added between rounds 5 and 8 that did not pick up the new pattern. This ADR makes the pattern binding so future additions are caught at design time, not by round-N audit.
+
+5. **Verifier independence depends on it.** Lessons doc Section 4.5: the verifier (`scripts/verify_central_vnx.py` after refactor) reads central DBs through an independent connection and computes per-`(project_id, table, key)` checksums. The verifier's contract presumes `project_id` is canonical; if it is missing, the verifier silently degrades into the importer's blind spot (bug pattern T4). Mandating stamping at design time keeps verifier and importer structurally separable.
+
+6. **The composite UNIQUE pattern is itself a contract with the importer.** `INSERT OR IGNORE` is safe only when the UNIQUE constraint already encodes the intended dedup semantics (lessons doc T2). Without `project_id` in the UNIQUE, IGNORE collapses cross-tenant rows. With it, IGNORE preserves per-tenant uniqueness while still allowing replay-safe imports. The constraint and the conflict policy are not independent design decisions — they are paired.
+
+7. **MCP / cross-project learning depends on it.** The strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4) calls out: "MCP has no canonical multi-tenant pattern for SQLite. RLS is Postgres-only. We are state of the art." Wave 4 of that plan exposes central DBs as MCP servers; the MCP server must filter on `project_id` from the session header. If the column does not exist or is not authoritative, MCP cannot safely federate across the operator's projects.
+
+## Consequences
+
+### Accepted
+
+- Every new central-DB table MUST be `project_id`-stamped at design time. Migrations that add tenant-scoped tables without `project_id` are rejected at codex_gate.
+- Every UNIQUE constraint on a natural key in a multi-tenant table MUST include `project_id` as a composite component. Single-column UNIQUE in central is a smell that requires per-table justification documented in the migration file.
+- The importer (`scripts/migrate_to_central_vnx.py`) and the verifier (`scripts/verify_central_vnx.py`) treat `project_id` as canonical evidence. Verifier per-project COUNT(*) discrepancies are blocking findings.
+- FTS5 rebuilds (e.g., migration `0016_rebuild_fts5.sql`) must include `project_id` in the indexed document so cross-tenant FTS queries can be project-scoped at query time.
+- The structural test `tests/test_migrate_dry_run.py` parses `schemas/migrations/0015_complete_project_id.sql` and enforces conformance.
+- Open items OI-1375 and OI-1376 track residual non-conforming tables; they remain blocking until closed.
+
+### Rejected
+
+- **Single-tenant table additions in the central DBs.** Any new feature that adds a table without `project_id` is rejected at codex_gate.
+- **Post-hoc `project_id` retrofitting at query time.** Filtering by joining to a `project_assignments` side-table or reconstructing tenancy from `dispatch_id` prefixes is rejected — these were the patterns that produced the round-3 to round-9 fix-forward chain.
+- **`DEFAULT 'vnx-dev'` as a sentinel for legitimate rows.** The default exists only as a column-add bridge during migration. New writers MUST stamp `project_id` explicitly. Lessons doc Section 4 action item #8 reinforces: future column-add migrations should prefer `DEFAULT NULL` + explicit post-migration UPDATE + `CHECK` constraint over `DEFAULT 'vnx-dev'`.
+- **Cross-tenant deduplication.** Rolling up `tag_combinations`, `success_patterns`, etc. across projects without `project_id` partition is the bug pattern T6. Aggregates that intentionally cross tenants must do so explicitly via a derived view, not by omitting `project_id` from the underlying table.
+
+## Cross-references
+
+- ADR-009 — Schema-first migrations via PRAGMA introspection (the implementation discipline that keeps this ADR enforceable across future migrations)
+- `claudedocs/2026-04-30-single-vnx-migration-plan.md` §3 (identity layer), §4 (schema migration), §5.2 (ID collisions)
+- `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` §1.3, §2 (bug taxonomy T1/T3/T6), §4.2 (composite uniqueness as default)
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4 (multi-tenant project_id stamping)
+- PR #410 (Phase 0 column add), PR #412/#416 (verifier), PR #431/#432 (P4 data import), open items OI-1375 + OI-1376
+- `schemas/migrations/0010_add_project_id.sql`, `schemas/migrations/0015_complete_project_id.sql`, `schemas/migrations/0016_rebuild_fts5.sql`
+- `scripts/migrate_to_central_vnx.py`, `scripts/verify_central_vnx.py`, `tests/test_migrate_dry_run.py`

--- a/docs/governance/decisions/ADR-008-dual-llm-adversarial-review.md
+++ b/docs/governance/decisions/ADR-008-dual-llm-adversarial-review.md
@@ -1,0 +1,93 @@
+# ADR-008 — Dual-LLM Adversarial Review (`codex_gate` + `gemini_review`) with `contract_hash` Binding
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Mandatory triple-gate policy (codex + gemini + CI green); review-gate evidence model
+
+## Context
+
+VNX dispatches code through one or more worker terminals (T1/T2/T3) and accumulates each PR through a series of gates before merge. Anthropic shipped native Code Review on 2026-03-09, and the strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §1) names the question explicitly: "do we still need a custom review pipeline now that the platform vendor ships one?"
+
+The answer is yes — but the reasoning is structural, not feature-driven. Anthropic Code Review reviews **Claude work using Claude.** The reviewer and the author share the same model family, the same training cutoff, and the same blind spots. Empirically through the spring 2026 PR chains:
+
+- `codex_gate` (OpenAI Codex CLI) caught migration-list omissions in PR #432 that `gemini_review` missed (specifically, migration 0016 missing from the apply list — round-3 finding).
+- `gemini_review` caught dashboard SSE regressions in PR #411 series that `codex_gate` did not flag (specifically, the streaming-drainer reuse-after-close pattern).
+- A single-vendor reviewer would have missed at least one blocking finding per PR in the W7 chain.
+
+The cross-vendor review is the moat, and the strategic replan §4 codifies it as moat M3: "Custom dual-LLM gate (codex + gemini reviewing Claude work) — Anthropic will never ship 'use Codex to gate Claude'; structural conflict."
+
+VNX has shipped this pattern operationally for months, but it has not been written down as a binding architectural rule. This ADR codifies it.
+
+## Decision
+
+**Every PR with non-trivial scope passes through TWO independent LLM reviewers — `codex_gate` (OpenAI Codex CLI) and `gemini_review` (Google Gemini CLI) — orchestrated through `scripts/review_gate_manager.py`. Each review produces a structured result bound to the active review contract via a non-empty `contract_hash`. T0 cannot complete a PR without three evidence surfaces per gate (request, result, normalized markdown report). Disagreement between gates triggers operator review.**
+
+Concretely:
+
+1. **Two reviewers, not one.** The default required gates are `codex_gate` and `gemini_review`. Either gate alone is insufficient evidence. Anthropic's native Code Review MAY supplement but does NOT replace either gate.
+
+2. **Three evidence surfaces per gate.**
+   - **Request:** `.vnx-data/state/review_gates/requests/<gate>_<dispatch>.json` — proves the gate was triggered.
+   - **Result:** `.vnx-data/state/review_gates/results/<gate>_<dispatch>.json` — proves the gate ran and produced a verdict.
+   - **Normalized report:** `$VNX_DATA_DIR/unified_reports/headless/<gate>_<dispatch>.md` — operator-readable record of findings.
+
+3. **`contract_hash` binding.** Every result records the SHA-256 hash of the active review contract (the YAML/JSON describing what the gate checks for). A result with empty `contract_hash` is incomplete evidence. A result whose `contract_hash` does not match the active contract version is a stale result and does not satisfy the gate.
+
+4. **Closure verifier.** `scripts/closure_verifier.py` blocks PR completion when any of the three surfaces is missing, when `contract_hash` is empty, or when `report_path` is empty. T0's CLAUDE.md ("Headless Review Enforcement" §3-9) restates the same rule operationally.
+
+5. **Disagreement handling.** When both gates run successfully but reach contradicting verdicts (e.g., codex blocking, gemini pass), T0 routes to operator review. T0 does not silently prefer one verdict over the other.
+
+6. **`queued` is not evidence.** A request record alone — without a matching result and report — is not closure evidence. T0's CLAUDE.md §"Doubt Escalation Policy" enforces: "either start execution, dispatch execution, or classify the missing runner path as a blocker."
+
+## Reasoning
+
+1. **Same-vendor reviewers share blind spots.** A reviewer trained on a similar corpus to the author will rationalize the same patterns. Empirically, the ~200-PR spring 2026 chain shows that codex and gemini surface non-overlapping sets of findings: codex is stronger at SQL semantics, schema drift, and migration list completeness; gemini is stronger at frontend behavioral regressions, SSE lifecycle, and TypeScript type narrowing. Either alone would have missed multiple production-blocking issues.
+
+2. **Anthropic cannot ship the moat.** Strategic replan §4 moat M3 states the structural argument: Anthropic's Code Review uses Claude to review Claude. They will not ship "use Codex to gate Claude" because it requires depending on a competitor's CLI. Therefore the dual-vendor adversarial property is a feature only an operator-controlled system can offer — it is the moat that survives any platform-vendor's vertical integration.
+
+3. **`contract_hash` makes evidence falsifiable.** Without contract binding, a result file is a verdict with no provenance. With `contract_hash`, a verdict is bound to a specific set of checks; if the contract changes (new finding category added, severity threshold tightened), old results are automatically invalidated. This is the same pattern as git's commit hashes — content-addressed evidence rather than mutable label-addressed.
+
+4. **Three surfaces, not one, because each surface answers a different question.** Request answers "was the gate triggered?" Result answers "what did the gate decide?" Report answers "what did the gate find?" Operator review needs all three: an empty report with a pass result is suspicious; a result with no request is unprovenanced; a request without a result is incomplete. T0's CLAUDE.md "Headless Review Enforcement" enumerates this explicitly because every surface combination has been observed as a failure mode in the field.
+
+5. **Operator memory `feedback_mandatory_triple_gate` is the operational form of this ADR.** The memory entry says: "Every PR: codex gate → gemini review → CI green → merge. No exceptions, no skipping." This ADR is the architectural justification for that rule. Without the ADR, the rule is policy that drifts; with the ADR, the rule has structural reasoning behind it.
+
+6. **F28 gate-skip incident is the prior failure.** Operator memory `feedback_gate_enforcement_failure_f28`: "T0 skipped all 5 F28 gates before merge; operator flagged as unacceptable; NEVER skip gates." That incident demonstrated that without enforced evidence surfaces, T0 can rationalize bypassing gates under time pressure. The closure_verifier + three-surface rule is the structural defense against the rationalization.
+
+7. **Disagreement is a feature.** Two reviewers reaching different verdicts is not a bug — it is the signal the operator wants. A pass-pass result is consensus; a pass-fail result is exactly the case where human review adds the most value. The system explicitly does not auto-resolve disagreement because auto-resolution would discard the moat.
+
+8. **Codex CLI rate limits are a known risk, not a reason to skip.** Operator policy A1 (T0 CLAUDE.md): "Codex CLI rate-limited → wait for reset (default 5h+, max 5d acceptable). NEVER fall back unless explicitly authorized as Option B." When Option B is invoked (gemini-only merge), an open item is filed for codex re-audit. The dual-gate rule is preserved over time even when one gate is temporarily unavailable.
+
+## Consequences
+
+### Accepted
+
+- Every PR-promotion path enforces two-gate evidence. `closure_verifier.py` blocks closure if any of (request, result, normalized report) is missing for either gate.
+- `contract_hash` is recorded on every result and verified at closure time. Empty or stale `contract_hash` blocks closure.
+- Operator policy A1 / B1 / B2 / B3 in T0 CLAUDE.md govern temporary unavailability and finding-handling without weakening the dual-gate baseline.
+- Anthropic Code Review MAY be added as a supplementary signal but does NOT replace either required gate. If adopted, it appears as a third optional surface, not a substitute.
+- New review-gate categories (e.g., security_review, performance_gate) extend the rule rather than dilute it: each new category has its own request/result/report contract.
+- The structural test in `scripts/review_gate_manager.py` and `tests/test_review_gates.py` enforces evidence-surface presence at CI time.
+
+### Rejected
+
+- **Single-LLM review.** Either gate alone (codex-only or gemini-only) is insufficient.
+- **"Anthropic Code Review is enough now."** Single-vendor; same blind spots as the author. Does not satisfy moat M3.
+- **Silent gate skipping.** F28 incident is the cited precedent. Skipping requires operator override and an open item per the codex-unavailable template.
+- **Auto-resolution of gate disagreement.** Preferring one gate's verdict over another by configured priority discards the moat.
+- **`queued` or `requested` as terminal evidence.** A pending request without a result is not closure evidence — T0 CLAUDE.md §"Headless Review Enforcement" rule 9.
+- **Result without `contract_hash`.** Untraceable verdicts are blocking findings, not soft warnings.
+- **Result without normalized report.** Structured JSON alone is operator-unreadable; the markdown report is required.
+
+## Cross-references
+
+- ADR-005 (NDJSON ledger — the audit substrate that records gate execution events)
+- ADR-006 (human gate — adversarial review feeds into staging→promote, not around it)
+- Operator memory `feedback_mandatory_triple_gate` (operational policy)
+- Operator memory `feedback_gate_enforcement_failure_f28` (prior incident)
+- Operator memory `feedback_codex_findings_must_be_parsed`, `feedback_codex_5_2_structured_findings` (codex_gate parsing details)
+- Operator memory `feedback_review_gate_full_lifecycle` (request→execute→report→record→verify)
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M3, §5 (no replacement by Anthropic Code Review)
+- T0 `.claude/terminals/T0/CLAUDE.md` §"Headless Review Enforcement", §"Operator Policies" A1/B1-B4
+- `scripts/review_gate_manager.py`, `scripts/closure_verifier.py`, `scripts/lib/codex_parser.py`
+- `.vnx-data/state/review_gates/{requests,results}/`, `$VNX_DATA_DIR/unified_reports/headless/`

--- a/docs/governance/decisions/ADR-009-schema-first-migrations.md
+++ b/docs/governance/decisions/ADR-009-schema-first-migrations.md
@@ -1,0 +1,91 @@
+# ADR-009 — Schema-First Migrations via PRAGMA Introspection (No Hardcoded Column Projections)
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** P4 nine-round fix-forward chain root cause; future migration discipline
+
+## Context
+
+The P4 data migration (PR #432, `scripts/migrate_to_central_vnx.py` ~1757 LOC) consolidated four per-project SQLite stores into the central VNX state DBs. It took **nine codex review rounds** and three `--apply` attempts to converge. The full reflection lives in `claudedocs/2026-05-09-p4-migration-architecture-lessons.md`.
+
+A pattern emerged across rounds 7, 8, and 9: each round surfaced a different instance of the **same bug class** — a hardcoded column list, table tuple, or index projection that should have been derived from schema introspection.
+
+- **Round 7:** `dispatch_experiments` had a hardcoded column list that drifted from the deployed schema in two of four source DBs.
+- **Round 8:** `quality_system_metrics` and `scan_history` had hardcoded INSERT projections that omitted columns added in a later migration.
+- **Round 9:** `code_snippets` had a hardcoded 12-column projection that fell out of sync with the FTS5 rebuild.
+
+In each case the bug was: code that was *flexible enough* to handle the canonical schema but failed silently when a deployed DB had **extra** columns from local schema drift. The fix-forward pattern was: detect the omission, hardcode the new columns, ship — until the next round found a different table with the same shape of bug.
+
+The P4 lessons doc Sections 4.1 and 4.2 codify the structural fix:
+
+> "Schema-first beats imperative-first for multi-tenant migrations. Define a target central schema explicitly, not derived from per-source ALTERs. The importer becomes a generic engine driven by descriptors. Adding a new source = adding a descriptor, not editing the engine."
+
+Round-6 introduced `_rebuild_one_table_dynamic` — a helper that derives the column list from `PRAGMA table_info` at apply time and reconstructs the rebuilt table from that introspection rather than from a hardcoded SQL string. Where this helper was used, no rounds-7-through-9 bugs were found. Where it was *not* used, each round found another instance.
+
+This ADR makes schema-first the binding rule for all future VNX migrations.
+
+## Decision
+
+**All future VNX migrations MUST derive column lists, table shapes, and index definitions from `PRAGMA table_info` and `sqlite_master.sql` introspection at apply time. Hardcoded SQL column tuples and hardcoded table projections are prohibited in migration code.**
+
+Concretely:
+
+1. **Column projection rule.** Code that copies rows from a source table to a rebuilt target table MUST list columns by querying `PRAGMA table_info(<table>)` against the actual deployed schema, not by typing `(col1, col2, ..., colN)` literals. The canonical helper is `_rebuild_one_table_dynamic` (in `scripts/migrate_to_central_vnx.py` after PR #432 round-6, at approximately lines 720-820).
+
+2. **Index reconstruction rule.** When a UNIQUE rebuild requires recreating indexes, the migration code MUST read existing index DDL from `sqlite_master.sql WHERE type='index' AND tbl_name=?` and replay it after the rebuild. Indexes are not enumerated in code.
+
+3. **ALTER ↔ IMPORT_TABLES symmetry rule.** Every `ALTER TABLE … ADD COLUMN` in `schemas/migrations/*.sql` must have a matching entry in the importer's table-import descriptor (or be picked up automatically by introspection). The structural test in `tests/test_migrate_dry_run.py` parses migrations and the importer's `IMPORT_TABLES` constant and fails CI if they disagree.
+
+4. **Composite UNIQUE rebuilds use dynamic schema reconstruction.** When a migration converts a single-column UNIQUE to a composite UNIQUE (per ADR-007), it MUST use `_rebuild_one_table_dynamic` rather than a hand-written `CREATE TABLE … new_col_list … INSERT INTO new SELECT col_list FROM old` SQL block. The hand-written form is the bug pattern caught in rounds 7-9.
+
+5. **Schema-drift detector as preflight.** Before `--apply`, the migration tool runs a preflight that scans all source DBs and emits a column-by-column comparison table. Drift cases (autopilot has `project_id`, others don't) are surfaced explicitly to the operator rather than discovered mid-import (lessons doc Section 7 action item #14).
+
+6. **Helpers, not policies.** The schema-first discipline is enforced through library helpers (`_rebuild_one_table_dynamic`, `_collect_columns`, `_collect_indexes`) that make the right thing easy. Migration authors who write hardcoded SQL are caught at codex_gate review.
+
+## Reasoning
+
+1. **The bug class is real, recurring, and structurally fixable.** Nine rounds of P4 surfaced multiple instances of the same root cause. Each fix was correct in isolation but did not raise the floor — the next round found the next instance. Schema-first eliminates the *bug class*, not individual bugs. Lessons doc Section 1.2: "The tests grew with the bugs, not ahead of them. Each round added a regression test for the specific bug being fixed but did not raise the floor of coverage."
+
+2. **Hardcoded projections embed environment assumptions.** A hardcoded column list assumes the deployed schema matches the canonical schema. In production, deployed DBs drift: a column added by an out-of-band migration, a column added by a partial-rollback, a column added by a feature flag. Introspection reads what is actually there. Lessons doc Section 4.1: the imperative-first design "makes runtime decisions that is flexible but also the source of T4 (verifier co-blindness) and partly of T1."
+
+3. **Round-6's `_rebuild_one_table_dynamic` is empirical evidence the pattern works.** Tables that used the dynamic helper after round 6 saw zero round-7/8/9 findings. Tables that retained hardcoded projections saw one finding each per round. The correlation is causal: introspection eliminates the missing-column class.
+
+4. **Schema is data, not code.** Treating the deployed schema as source-of-truth (via introspection) and the migration as a generic transformation engine separates "what to do" from "what the data looks like." This is the standard data-engineering pattern (Singer taps, dbt, Liquibase) and it is well-understood. VNX deviated for historical reasons (the original migrations were one-off scripts) and paid the cost in rounds 7-9.
+
+5. **It composes with ADR-007.** Composite UNIQUE rebuilds (per ADR-007) require recreating the table with a new constraint. Without introspection, the rebuild script must know every column. With introspection, the rebuild adapts to whatever the deployed table actually has. ADR-007 and ADR-009 are paired: the multi-tenant constraint pattern only stays maintainable because the migration discipline is schema-first.
+
+6. **Tests catch ALTER ↔ IMPORT_TABLES drift, not engineers.** Lessons doc Section 3.2: the missing test was "size-realistic FTS rebuild." The missing test for round-7-9 bugs is "ALTER ↔ IMPORT_TABLES symmetry." That test is mechanical to write (parse the SQL on both sides, set-difference, fail if non-empty) and catches the bug class at CI time rather than at round-N codex review.
+
+7. **Open items OI-1375 and OI-1376 are the carry-forward work.** Some round-9 changes still need a schema-first rewrite for migration 0016. ADR-009 makes the rewrite mandatory rather than optional, and the structural test ensures future migrations don't reintroduce the pattern.
+
+8. **The discipline is library-enforceable, not policy-enforceable.** Asking engineers to "remember to introspect" is the same shape as asking engineers to "remember to filter by `project_id`." It does not scale. Library helpers (`_rebuild_one_table_dynamic`) plus codex_gate's review of hardcoded SQL projections enforce the rule structurally. Migration authors who try to hand-roll a column list are caught at gate time.
+
+## Consequences
+
+### Accepted
+
+- New migrations get the schema-introspection-by-default helper. `_rebuild_one_table_dynamic` and its sibling helpers are the canonical entry points for any rebuild.
+- The structural test `tests/test_migrate_dry_run.py` parses `schemas/migrations/*.sql` and the importer's `IMPORT_TABLES` constant and enforces ALTER↔IMPORT symmetry at CI time.
+- Codex_gate review contracts include a finding category "hardcoded column projection in migration code" with severity blocking. New PRs that hand-roll column lists are caught at review.
+- The schema-drift preflight (lessons doc Section 7 #14) becomes part of `--dry-run` output. Operators see drift before `--apply` rather than mid-import.
+- ADR-007 (project_id stamping) composability: composite UNIQUE rebuilds use `_rebuild_one_table_dynamic` with the new constraint specified declaratively, not by hand-writing the rebuild SQL.
+- Migration 0016 follow-up rewrites (per OI-1375 + OI-1376) are mandatory and tracked under this ADR.
+
+### Rejected
+
+- **Imperative-first migration scripts.** Hand-rolled `CREATE TABLE new (...) AS SELECT col_a, col_b FROM old` is rejected. Use `_rebuild_one_table_dynamic`.
+- **Hardcoded column tuples in migration code.** Variables like `IMPORT_COLS = ('id', 'created_at', ..., 'project_id')` are rejected. Derive from `PRAGMA table_info`.
+- **"Just list the columns explicitly for clarity."** Explicit is not always clearer when it embeds environment assumptions. Introspection is more explicit because it adapts to reality. The audit trail (logs of introspected columns) is the explicit evidence, not the source code.
+- **One-off migration scripts that bypass the helper library.** Migrations that "just need to do this one thing" are exactly the migrations that drift from the central pattern. All migrations route through the canonical helpers.
+- **Skipping the structural test "for this PR only."** ALTER↔IMPORT symmetry is the smallest possible test of this ADR. It runs in milliseconds; there is no excuse.
+
+## Cross-references
+
+- ADR-007 — Multi-tenant `project_id` stamping pattern (the constraint pattern that depends on schema-first migrations to stay maintainable)
+- `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` §1.2, §1.3, §2 (T1+T3+T6 bug patterns), §4.1 (schema-first beats imperative-first), §4.2 (composite uniqueness as default), §7 (action items)
+- PR #432 (round-6 `_rebuild_one_table_dynamic` introduction; rounds 7/8/9 fix-forward)
+- Open items OI-1375 + OI-1376 (post-432 rewrite required for migration 0016)
+- `scripts/migrate_to_central_vnx.py` (canonical helpers `_rebuild_one_table_dynamic`, `_collect_columns`, `_collect_indexes`)
+- `schemas/migrations/0010_add_project_id.sql`, `0015_complete_project_id.sql`, `0016_rebuild_fts5.sql`
+- `tests/test_migrate_dry_run.py` (structural test enforcing ALTER↔IMPORT symmetry)

--- a/docs/governance/decisions/ADR-010-subprocess-adapter-claude-routing.md
+++ b/docs/governance/decisions/ADR-010-subprocess-adapter-claude-routing.md
@@ -1,0 +1,99 @@
+# ADR-010 — Subprocess Adapter (`claude -p`) as Canonical Claude Routing
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** Canonical Claude invocation path; SDK-ban implementation; ADR-003 codification
+
+## Context
+
+VNX dispatches work to Claude worker terminals (T1, T2, T3 by default; T0 progressively). Two routing options exist:
+
+1. **Tmux send-keys.** The legacy interactive path: a worker tmux pane is open, the dispatcher injects keystrokes via `tmux send-keys`, and the operator/observer watches the pane stream. Output is scraped from the pane buffer.
+2. **Subprocess.** A headless path: the dispatcher spawns `claude -p --output-format stream-json` as a child process and consumes the event stream directly. Output is structured NDJSON; no scraping required.
+
+The subprocess path was introduced in F32 (`VNX_ADAPTER_T1=subprocess`) as opt-in per-terminal. By Q1 2026 it had become the dominant production path for T1; T2 and T3 followed. T0 progressively migrated through F36 + W7 (PRs #411-#424 streaming-drainer / canonical-event work).
+
+The canonical implementation is `scripts/lib/subprocess_dispatch.py`. The first 100 lines establish the contract:
+
+- Lines 11-12: "BILLING SAFETY: only `subprocess.Popen(['claude', ...])` is invoked downstream — no Anthropic SDK is imported anywhere in this package."
+- Lines 13-19: Success-path call order (receipt → pattern confidence → dispatch outcome) with per-dispatch event archival in a finally block.
+- Lines 41-99: Imports from `subprocess_adapter`, `headless_context_tracker`, `worker_health_monitor`, plus internals for delivery, recovery, manifest, pattern confidence, receipt writing, skill injection, state paths, and git helpers.
+
+The strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6) calls this out as **the** licensing-critical decision: "Claude Agent SDK with OAuth Code credential = third-party-API risk (opencode/openclaw precedent). Non-negotiable. Lock this in `subprocess_adapter.py`; pin via `CLAUDE.md` rule 'No Anthropic SDK is used'; CI gate to block accidental SDK imports."
+
+This ADR codifies the implementation as binding architecture and the SDK-ban as a CI-enforced rule.
+
+## Decision
+
+**`scripts/lib/subprocess_dispatch.py` is the canonical Claude invocation path in VNX. It spawns `claude -p --output-format stream-json` as a subprocess and consumes the event stream into NDJSON ledger entries. All Claude worker terminals route through this adapter by default. Tmux fallback (interactive panes) remains supported for operator-driven sessions but is NOT the dispatch primary. The Anthropic Python SDK is never imported.**
+
+Concretely:
+
+1. **Subprocess as default.** Per-terminal feature flags (`VNX_ADAPTER_T1=subprocess`, `VNX_ADAPTER_T2=subprocess`, `VNX_ADAPTER_T3=subprocess`) default to subprocess. Tmux is opt-in via `VNX_ADAPTER_T<N>=tmux` for operator-driven debugging.
+
+2. **`claude -p --output-format stream-json` as the invocation form.** The `-p` flag selects print mode; `--output-format stream-json` produces line-delimited JSON events that map directly to the canonical event schema (W7-A PR #411). No other Claude CLI invocation form is permitted in dispatch code.
+
+3. **No Anthropic SDK.** No file in `scripts/lib/subprocess_dispatch_internals/` or its callers may import `anthropic`, `@anthropic-ai/sdk`, or any client library that talks to the Anthropic HTTP API. The OAuth credential used by `claude` CLI is the Code subscription credential and is not authorized for SDK use (opencode/openclaw precedent). Strategic replan §4 moat M6: "This is the licensing-required path."
+
+4. **Tmux retained as fallback.** Per the operator memory `project_hybrid_interactive_headless`: "Keep tmux code paths permanently; headless is opt-in default, not replacement. No Wave E retire-interactive." Interactive panes remain useful for operator-driven sessions, manual recovery, and debugging. They are not removed.
+
+5. **Per-terminal NDJSON event archival.** Per the operator memory `project_ndjson_ring_buffer`: "T{n}.ndjson truncated post-dispatch; durable record in events/archive/{terminal}/." Subprocess delivery's finally block calls `event_store.clear(terminal_id, archive_dispatch_id=dispatch_id)` to archive then truncate. Empty live file is not a bug — it is the post-dispatch state.
+
+6. **Canonical event schema.** The stream-json events map directly to `canonical_event` schema entries written into `t0_receipts.ndjson` and per-dispatch archives. This is the same schema W7 (PRs #411-#424) standardized.
+
+7. **CI-enforced SDK ban.** A grep-based test in CI scans `scripts/`, `dashboard/`, and `tests/` for forbidden imports (`import anthropic`, `from anthropic`, `require('@anthropic-ai/sdk')`) and fails the build on any match. The ban is structural, not policy.
+
+## Reasoning
+
+1. **Concrete implementation of ADR-003.** ADR-003 established subprocess as the architectural direction; ADR-010 codifies the specific implementation (`subprocess_dispatch.py`), the specific invocation form (`claude -p --output-format stream-json`), and the specific ban (no Anthropic SDK). Without ADR-010, ADR-003 is a direction; with it, the direction is enforceable at code-review time.
+
+2. **Stream-json gives full per-event observability.** The tmux send-keys path scrapes a pane buffer — fundamentally a screen-scrape. The subprocess path consumes structured events: tool calls, message deltas, tool results, completion signals, errors. Every event maps to a `canonical_event` row. This observability is the foundation of the W7 streaming drainer, the smart tap, the worker health monitor, and the dashboard SSE feed. Tmux scraping cannot give VNX this surface.
+
+3. **No SDK is the licensing bedrock.** The OAuth credential used by `claude` CLI is bound to the operator's Claude Code subscription. The Code subscription terms permit CLI use; SDK access requires API billing and a separate credential. Mixing them (using the OAuth credential to drive the SDK) is the failure mode of opencode/openclaw. VNX explicitly stays on the CLI-subprocess side of that line. Strategic replan §4 moat M6: "Claude Agent SDK with OAuth Code credential = third-party-API risk. Non-negotiable."
+
+4. **Subprocess is a cleaner contract than tmux.** Tmux send-keys requires the pane to be ready, the input mode to be correct, the output buffer to be clean, the operator to not be typing. Operator memory `feedback_t3_input_mode_probe` records the recurring "T3 needs /clear before accepting new dispatches" failure — a tmux-specific failure. Subprocess has no such state: each dispatch is a fresh process with a clean stdin/stdout pipe.
+
+5. **Hybrid is intentional, not transitional.** Per `project_hybrid_interactive_headless` memory: tmux is not on a deprecation path. Interactive panes serve a different purpose (operator-driven exploration) than headless dispatch (automated work). Both stay. The subprocess primary is for governed dispatch; tmux is for hands-on operator work.
+
+6. **It composes with the canonical event schema.** W7-A (PR #411) standardized `canonical_event` as the audit ledger entry shape. Stream-json events map 1:1 to canonical events. Tmux scraping requires reverse-engineering events from text. Subprocess gives them as structured data. ADR-010 is therefore the upstream of ADR-005 (NDJSON ledger) — the ledger entries originate in the subprocess event stream.
+
+7. **The CI ban is the only durable enforcement.** Asking engineers to "not import the SDK" is policy; greppping the codebase at CI time for `import anthropic` is structural. Strategic replan §4 moat M6: "CI gate to block accidental SDK imports." The ban is checked on every PR, not just at architecture review.
+
+8. **Subprocess is also where multi-tenant identity flows.** Per the single-VNX migration plan §3.5: "Subprocess dispatch (`scripts/lib/subprocess_dispatch.py:128`): identity flows from T0's resolver through the env (`VNX_PROJECT_ID`, `VNX_ORCHESTRATOR_ID`, `VNX_AGENT_ID=<T1|T2|...>`) into the spawned `claude -p` process. The spawned worker's own `resolve_identity` then reads those env vars." ADR-007's project_id stamping requires a routing path that propagates env reliably; subprocess does, tmux does not.
+
+9. **It is a reversible decision.** If a future Anthropic offering provides equivalent observability over an OAuth-permitted programmatic interface (not the API SDK), this ADR can be revised. The reversibility is preserved because the contract surface (stream-json events → canonical events) is independent of the transport.
+
+## Consequences
+
+### Accepted
+
+- Any new Claude integration MUST extend `subprocess_dispatch.py`, not bypass it. New worker types (e.g., a fifth terminal, a sub-orchestrator pool) plug into the same adapter.
+- The CI grep-ban on `anthropic` SDK imports runs on every PR and blocks merge on hits.
+- T0 progressive migration to subprocess (per F36 + W7) continues; tmux remains as fallback per operator memory.
+- The `canonical_event` schema (W7-A PR #411) is the contract between the subprocess event stream and the audit ledger; stream-json events that don't map to canonical events are a schema drift bug.
+- Per-terminal NDJSON ring buffer truncation post-dispatch is part of the contract; archive lives at `events/archive/{terminal}/{dispatch_id}.ndjson` per operator memory `project_ndjson_ring_buffer`.
+- LiteLLM adoption (strategic replan §5 A5) is permitted ONLY for non-Claude providers (Codex, Gemini, Ollama, Kimi). The Claude path stays subprocess.
+
+### Rejected
+
+- **Direct `claude` CLI invocation that doesn't capture stream-json.** Calling `claude` without `-p --output-format stream-json` (e.g., shelling out to `claude` interactively from a script) loses the event surface and is rejected.
+- **Anthropic Python SDK.** `import anthropic` is banned at CI. The SDK is not importable from VNX dispatch code under any scenario, including testing.
+- **`@anthropic-ai/sdk` (TypeScript).** Same ban applies to the dashboard's TypeScript code.
+- **REST shim wrappers.** Wrapping the Anthropic HTTP API in a thin shim that "just makes the calls" is the SDK ban under a different name. Rejected.
+- **LiteLLM for Claude.** LiteLLM-Claude routes through the API and the SDK shape; not authorized. Per strategic replan §5 A5 explicitly: "Claude path stays subprocess — non-negotiable per M6."
+- **Tmux send-keys as default for new terminals.** New terminals default to subprocess. Tmux is opt-in fallback only.
+- **Removing the tmux path.** Per `project_hybrid_interactive_headless`: tmux is permanent. No Wave E retire-interactive.
+
+## Cross-references
+
+- ADR-003 (architectural direction this ADR implements)
+- ADR-005 (NDJSON ledger — downstream consumer of subprocess events)
+- Strategic replan `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6 (OAuth-only Claude routing, never SDK), §5 A5 (LiteLLM scope)
+- Operator memory `project_hybrid_interactive_headless` (tmux retained permanently)
+- Operator memory `project_ndjson_ring_buffer` (per-terminal NDJSON archival contract)
+- Operator memory `feedback_t3_input_mode_probe` (tmux-specific failure mode subprocess avoids)
+- `claudedocs/2026-04-30-single-vnx-migration-plan.md` §3.5 (identity propagation via subprocess env)
+- `scripts/lib/subprocess_dispatch.py` (canonical implementation), `scripts/lib/subprocess_adapter.py` (delivery primitive)
+- Project root `CLAUDE.md` "Subprocess Adapter Feature Flag" section
+- F32 (subprocess opt-in introduction), F36 (T0 migration), W7-A PR #411 (canonical event schema)

--- a/docs/governance/decisions/ADR-011-manager-worker-hierarchy.md
+++ b/docs/governance/decisions/ADR-011-manager-worker-hierarchy.md
@@ -1,0 +1,94 @@
+# ADR-011 — Manager+Worker Hierarchy with Explicit Depth>1 (vs Subagents Depth-1)
+
+**Status:** Accepted (primary architecture decision) — with a **Tentative** section labeled "When to tactically use subagents (FUTURE / RESEARCH)" that documents an OPEN QUESTION rather than a recommendation.
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Cross-references:** ADR-003 (OAuth-only Claude routing, no SDK), ADR-010 (subprocess adapter), ADR-012 (hybrid interactive + headless)
+
+## Context
+
+VNX runs as a multi-terminal orchestration system with one master orchestrator (T0) and N workers (T1, T2, T3, …). Workers are **separate Claude Code processes** with their own `CLAUDE.md`, their own tool budget, their own dispatch envelope, and their own receipt — they are not subagents in the Anthropic Task-tool sense. Workers can themselves dispatch follow-up work (e.g., T1 emitting a follow-up dispatch for T3 review, or a hypothetical sub-orchestrator pool spawning short-lived sub-workers). Hierarchy depth in VNX is therefore explicitly **greater than 1**.
+
+Claude Code natively offers a Task-tool subagent pattern. Per Perplexity verification on 2026-05-09 (`claudedocs/2026-05-09-vnx-platform-features-verification.md`, Claim 1):
+
+- v1.0.64 release note (2025-07-30: "Fixed unintended access to the recursive agent tool") establishes **depth-1 as the explicit, intentional architecture**.
+- Subagents return only a condensed summary (1,000–2,000 tokens) to the parent — no recursion path.
+- v2.1.117 (April 2026) added `CLAUDE_CODE_FORK_SUBAGENT=1` for forked subagents that inherit full parent conversation context, but forking is still **flat from the parent**, not from a subagent.
+- Anthropic's Multiagent Sessions (Managed Agents API beta `managed-agents-2026-04-01`, released 2026-04-01) extends this with a **flat coordinator + 20-agent roster**; depth > 1 is **explicitly ignored** (Claim 3 verification).
+
+A separate platform shift on **2026-05-08** added subagent-level observability events and hook-intervention points (PreToolUse / PostToolUse / Subagent lifecycle hooks) — see WebSearch verification cited below. This shift changes what subagents *expose* to the parent, but does not change their depth-1 nature.
+
+The strategic question for VNX: should T0..Tn be flattened to native subagents (giving up depth>1 but gaining first-class platform tooling), or should the manager+worker-with-depth>1 primitive remain canonical?
+
+## Decision
+
+### Primary decision (Accepted)
+
+VNX's architecture primitive is **separate-agent-per-task** orchestrated through a manager (T0) and worker terminals (T1, T2, T3, …Tn). Workers are first-class processes — each has its own dispatch lifecycle, its own receipt, its own NDJSON event stream (when subprocess-routed), its own lease, and its own audit trail in `t0_receipts.ndjson`. Workers may themselves dispatch sub-tasks (depth>1). This is the canonical primitive. New orchestration patterns extend hierarchy depth — they do not flatten it.
+
+### Tentative section — When to tactically use subagents (FUTURE / RESEARCH)
+
+As of **2026-05-08**, Claude Code subagents now expose:
+
+- Real-time hook events for subagent lifecycle (Subagent start/stop, PreToolUse, PostToolUse) — verified via `code.claude.com/docs/en/hooks` and the May 2026 changelog (Releasebot, Developers Digest "Agent Teams, Subagents, and MCP: The 2026 Playbook").
+- `PostToolUse.hookSpecificOutput.updatedToolOutput` — hooks can rewrite tool output for **all tools** (not only MCP).
+- `duration_ms` on `PostToolUse` / `PostToolUseFailure` for tool-performance observability.
+- Parallel subagent + SDK MCP-server reconnection.
+- 27 hook events across 5 categories, with 4 execution types (shell, LLM-evaluated, webhook, subagent-verifier).
+
+This means subagents are no longer the opaque depth-1 black boxes that originally justified their wholesale replacement by VNX workers. Subagents *may* be tactically useful in narrow cases — for example, a quick parallel grep/search inside a single VNX worker dispatch where spawning another full T-terminal dispatch would be wasteful. Such tactical use does **not** compromise VNX's separate-agent-per-task primitive because the subagent runs **inside** a single VNX worker dispatch and reports back to that worker (the VNX dispatch boundary is preserved).
+
+**However, when exactly to use a tactical subagent vs. spawn another VNX worker dispatch needs further research before any guidance can be Accepted.** Open questions:
+
+- What triggers (LOC, parallelism, latency budget, evidence-needed) tip the choice toward a tactical subagent vs. a new VNX dispatch?
+- Do subagent observability events (PreToolUse, PostToolUse) get captured in VNX's NDJSON ledger or do they vanish when the parent worker exits?
+- Does using subagents inside a worker break the "one dispatch = one receipt" provenance contract, or can the worker fold subagent evidence into its own receipt cleanly?
+- Does the depth-1 limit matter when the subagent is one level *under* a VNX worker (effective system depth = 2+), or is the depth-1 floor itself a problem?
+
+This section therefore documents an **OPEN QUESTION** and the answer is deliberately deferred. A research dispatch (Wave 0 doc-hygiene track or Wave 4 of the strategic replan, see `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §8) will produce concrete guidance. Until that research lands, the default is: **do not use Claude Code subagents inside VNX workers**; spawn another VNX dispatch instead.
+
+## Reasoning
+
+1. **Depth>1 is the moat that survives the platform shift.** Per the strategic replan §4, M5: "T0..Tn manager+worker hierarchy" is one of seven moats. Subagents are depth-1 only; Multiagent Sessions are flat coordinator+20-roster (also depth-1). VNX is the only one shipping a >1 hierarchy primitive. Flattening to subagents would eliminate the moat for an undocumented gain.
+
+2. **Separate processes give isolation that subagents structurally cannot.** Each VNX worker has its own subprocess, its own filesystem cwd, its own tool budget, its own lease in `runtime_coordination.db`, and its own receipt in `t0_receipts.ndjson`. A subagent shares the parent's context window (modulo summary compression) and cannot be killed independently. For long-running gate-fix-gate loops or for adversarial dual-LLM review (codex_gate + gemini_review), separate processes are the only correct primitive.
+
+3. **The OAuth-only Claude routing constraint (ADR-003) reinforces depth>1.** VNX is forbidden from using the Anthropic SDK and routes Claude through `claude -p --output-format stream-json` subprocesses. A subagent invoked inside such a subprocess is fine; a VNX worker invoked as a subagent of another VNX worker would require either an SDK call or a nested CLI invocation — the latter is exactly what `subprocess_dispatch.py` already does, by design (ADR-010). The CLI-subprocess path *is* the depth>1 mechanism.
+
+4. **Receipts and dispatch envelopes are the audit primitive.** Per `CLAUDE.md` (project root): "Every change goes through a dispatch. No cowboy commits." Subagents inside a parent dispatch are part of one dispatch, one receipt — they are not auditable as independent units of work. VNX's audit ledger (M1 in the replan) requires each work unit to have its own receipt; depth>1 dispatch chains preserve that, subagent-trees do not.
+
+5. **The May 2026 platform shift is additive, not replacement.** The new hook surface (verified via WebSearch on 2026-05-09; sources: code.claude.com/docs/en/hooks, releasebot.io/updates/anthropic/claude-code, Developers Digest "Claude Code Agent Teams, Subagents, and MCP: The 2026 Playbook", ofox.ai "Claude Code: Hooks, Subagents, and Skills — Complete Guide", boringbot.substack.com "Claude Code: Skills, Subagents, Hooks, Plugins, and Harnesses") gives subagents new *tactical* surface — observable lifecycle, parallel MCP reconnect, output-rewriting hooks — but does not give them depth>1 forking. The moat is unchanged; only the tactical surface inside a VNX worker dispatch has expanded.
+
+6. **Tactical-subagent guidance is not yet ready to be Accepted.** Until a research dispatch answers the four open questions above, premature guidance ("use subagents for parallel search inside T1") would risk: receipt-provenance leakage, cost untracked by `t0_receipts.ndjson`, evidence trails that vanish when the parent exits, and operator confusion about whether a finding came from VNX governance or from a black-box subagent. The Tentative status is the honest reflection of the current state.
+
+## Consequences
+
+### Accepted
+
+- T0..Tn architecture with depth>1 stays canonical. New features extend hierarchy (e.g., sub-orchestrator pools, per-track managers) — they do not flatten to a subagent roster.
+- The dispatch envelope, receipt, and lease primitives in `subprocess_dispatch.py` (ADR-010) remain the spawn mechanism for any depth>1 worker.
+- Future "manager-of-managers" patterns (e.g., a track-A manager that itself dispatches T1a / T1b / T1c) are explicitly in scope and do not require a new primitive — they reuse the existing dispatch path.
+- Cross-vendor adversarial gating (codex + gemini reviewing Claude work, M3 in the replan) remains a depth>1 use case: gate dispatches are siblings of the work dispatch, both children of T0.
+
+### Rejected
+
+- "Flatten T0..T3 to native subagents." Rejected because it eliminates moat M5, breaks receipt-per-dispatch provenance, and gives up cross-vendor gating that subagents cannot host (Anthropic will not ship a Codex-based subagent).
+- "VNX is just a glorified subagent dispatcher." Rejected as a framing — VNX is a separate-agent-per-task orchestration platform; subagents are an internal tool within one such agent, not a substitute for the agent itself.
+- "Adopt Multiagent Sessions coordinator pattern as the canonical T0 replacement." Rejected — coordinator is depth-1 and Anthropic-hosted; both violate VNX's local-first OAuth-only constraints (ADR-003).
+
+### Open (Tentative — research required)
+
+- **When (if ever) to tactically use Claude Code subagents inside a single VNX worker dispatch.** A research dispatch in Wave 0 or Wave 4 (per the 2026-05-09 strategic replan) will answer the four open questions and either:
+  - publish a "tactical subagent playbook" ADR amendment (status → Accepted for that section), or
+  - confirm "do not use subagents inside VNX workers" as the permanent default (status → Rejected for that section).
+- Until that research lands, the default is **do not use subagents inside VNX workers**. Operators may experiment in throwaway branches but must not ship subagent-using code through the dispatch flow without a follow-up ADR amendment.
+
+## See also
+
+- `claudedocs/2026-05-09-vnx-platform-features-verification.md` — Claims 1 (subagent depth-1) and 3 (Multiagent Sessions flat coordinator)
+- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (moat M5) and §5 (no flatten-to-subagents adoption)
+- ADR-003 — OAuth-only Claude routing (no SDK)
+- ADR-010 — Subprocess adapter as the depth>1 spawn mechanism
+- ADR-012 — Hybrid interactive + headless execution (every depth>1 worker can run in either mode)
+- WebSearch verification 2026-05-09: code.claude.com/docs/en/hooks; releasebot.io/updates/anthropic/claude-code; Developers Digest "Claude Code Agent Teams, Subagents, and MCP: The 2026 Playbook"; ofox.ai "Claude Code: Hooks, Subagents, and Skills — Complete Guide (2026)"; boringbot.substack.com "Claude Code: Skills, Subagents, Hooks, Plugins, and Harnesses for Production Multi-Agent Workflows"
+- `CLAUDE.md` (project root) — VNX governance system overview, dispatch-and-receipt rules

--- a/docs/governance/decisions/ADR-012-hybrid-interactive-headless.md
+++ b/docs/governance/decisions/ADR-012-hybrid-interactive-headless.md
@@ -1,0 +1,85 @@
+# ADR-012 — Hybrid Interactive + Headless Execution (No Retire-Interactive)
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decided by:** Operator (Vincent van Deth)
+**Cross-references:** ADR-003 (OAuth-only Claude routing), ADR-010 (subprocess adapter), ADR-011 (manager+worker hierarchy)
+
+## Context
+
+VNX worker terminals (T1, T2, T3) can run in one of two modes:
+
+- **Interactive (tmux)** — the worker is a persistent tmux pane. The operator can attach, watch the live transcript, type into the pane, and steer the worker mid-flight. Dispatches arrive via `popup_editor.sh` / queue popup watcher; output is observed by reading the pane buffer. This is the original VNX delivery path.
+- **Headless (subprocess)** — the worker is a `claude -p --output-format stream-json` subprocess spawned by `subprocess_dispatch.py` (`scripts/lib/subprocess_dispatch.py`). The dispatcher streams stdout to `.vnx-data/events/T{n}.ndjson` for the duration of one dispatch, then archives to `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson` and truncates the live file. There is no interactive surface — the operator observes via the SSE event stream and the receipt.
+
+F32 flipped the **default** to headless for T1/T2/T3 (`VNX_ADAPTER_T1=subprocess` etc., per the project root `CLAUDE.md` "Subprocess Adapter Feature Flag" section). T0 remains interactive by design.
+
+A reasonable-looking next step would be a **"retire-interactive"** wave: delete `tmux_adapter.py`, `queue_popup_watcher.sh`, `popup_editor.sh`, and all `tmux send-keys` paths — then the codebase has one execution mode and one less surface to maintain. Operator instruction (`project_hybrid_interactive_headless` memory, 2026-04-23): **do not propose this**. The hybrid model is the design, not a transitional state.
+
+This ADR codifies that decision and records the reasoning so that future "let's simplify by removing tmux" proposals are auto-rejected with a link here.
+
+## Decision
+
+VNX permanently supports **both** interactive (tmux) and headless (subprocess) execution paths for worker terminals. There is **no** "retire interactive" wave, sunset plan, or deprecation timeline. Specifically:
+
+- `TmuxAdapter` and all tmux-driven delivery paths (queue popup watcher, `popup_editor.sh`, `send-keys` wrappers, pane-id state in `panes.json`) are first-class code and must be maintained alongside `SubprocessAdapter`.
+- Headless is the **default** for T1/T2/T3 (set via `VNX_ADAPTER_T{n}=subprocess` env vars). Operators or specific dispatches can opt back into tmux delivery by unsetting that variable or by explicit per-dispatch override.
+- T0 stays tmux-routed by default (T0 is operator-facing; no SubprocessAdapter for T0 unless specifically requested).
+- New features must be designed to work in **both** modes. A feature that only works in headless mode (e.g., depends on the per-terminal NDJSON ring buffer) is acceptable only if it degrades gracefully in tmux mode (no-ops, fallback path, or explicit "headless-only" flag).
+- Documentation describes the hybrid model as the **design**, not as a transitional state.
+
+## Reasoning
+
+1. **Operator-driven sessions need attention/visibility that headless does not provide.** Headless dispatches are fast and audit-clean — the receipt + the archived NDJSON are the entire record. But for high-stakes work (architecture decisions, irreversible migrations, manual debugging of a stuck loop), the operator wants to *watch the worker think* in real time and intervene mid-stream. tmux is the only surface in VNX that supports that. Removing it removes the operator's primary trust-but-verify mechanism.
+
+2. **Modal cases require an interactive surface.** Some terminal states are modal — for example, T3's input-mode probe issue (`feedback_t3_input_mode_probe` memory) requires `/clear` before the pane will accept new dispatches. That interaction is fundamentally interactive: a headless subprocess can't `/clear` itself out of an input-mode trap. Other modal cases include: prompting the operator for an oauth code refresh, accepting a `/login` flow, recovering from a crashed Claude Code process where the pane is alive but the inner CLI exited. Each is rare; each is unsolvable headless-only.
+
+3. **Headless trust-but-verify still depends on tmux as the escalation path.** When a headless dispatch goes wrong (stuck for 2 hours, emitting suspicious events, looping), the operator's escalation path is to *attach* — either to the headless subprocess via re-launch as interactive, or to a parallel tmux pane to inspect state. If tmux paths were deleted, that escalation path would also be deleted, leaving only "kill the subprocess and restart from scratch." That is operationally unacceptable for long-running migrations.
+
+4. **The hybrid model is codified in operator memory.** The 2026-04-23 memory `project_hybrid_interactive_headless` is explicit: "Operator decided to keep interactive tmux terminals permanently — headless is opt-in default, not replacement. Never remove interactive code paths." Subsequent dispatches that proposed Wave-E retire-interactive work were operator-rejected. This ADR makes that policy a public, durable artifact rather than a memory file.
+
+5. **Per-terminal NDJSON is headless-only by design — and that is fine.** Per `CLAUDE.md` (project root): "Only subprocess-routed terminals produce this stream. TmuxAdapter-routed terminals (T0 default; T2/T3 unless `VNX_ADAPTER_T{n}=subprocess`) produce no per-terminal NDJSON." This asymmetry is intentional, not a bug. Tmux-routed terminals produce evidence via the pane buffer + receipt; headless-routed terminals produce evidence via NDJSON + archived ring buffer + receipt. Both are valid audit surfaces. The `project_ndjson_ring_buffer` memory codifies this: "Empty live file ≠ broken writer."
+
+6. **Hybrid is a competitive moat, not legacy debt.** Anthropic Managed Agents (2026-04-08 launch) is headless-only by service design — there is no "attach to a Managed Agent and watch it work" affordance. VNX's hybrid model is *uniquely able* to give the operator both: cheap fast headless for routine work, and full interactive observability for the cases that need it. Deleting tmux would erase that differentiator.
+
+7. **Subprocess routing already covers the common case.** Per F32, T1/T2/T3 default to subprocess. The 95% case of "dispatch a worker, get a receipt" is already headless. The remaining 5% (operator-driven debugging, modal recovery, T0-from-T0 escalation) needs tmux. Maintaining both is cheap because the subprocess path is the default — tmux paths see only the long-tail use cases and rarely need updates.
+
+8. **No SDK is used in either path.** Per ADR-003 / project root `CLAUDE.md`: "No Anthropic SDK is used. Only `subprocess.Popen(["claude", ...])`." Both interactive (tmux pane runs `claude` interactively) and headless (`subprocess.Popen` with `-p --output-format stream-json`) routes invoke the Claude Code CLI binary — not the Anthropic SDK. The hybrid model does not introduce new licensing or dependency risk; both modes share the same OAuth-only credential surface.
+
+## Consequences
+
+### Accepted
+
+- `tmux_adapter.py`, `queue_popup_watcher.sh`, `popup_editor.sh`, all `tmux send-keys` paths, and all pane-id tracking (`.vnx-data/state/panes.json`) are **maintained code**, not legacy. Bug fixes and feature parity work targets both modes when applicable.
+- Headless remains the default for T1/T2/T3 (per F32); flipping to tmux is a per-terminal env-var override (`unset VNX_ADAPTER_T{n}` or set to `tmux`).
+- T0 stays tmux-routed by default. There is no SubprocessAdapter for T0 unless an operator explicitly requests one for a specific dispatch.
+- New features must be hybrid-aware: design must specify behavior in both modes, even if one mode is a no-op or graceful degrade.
+- Documentation (READMEs, runbooks, ADR cross-references) describes hybrid as **the design**, not as a transitional state. Phrases like "until headless is mature" or "transitional tmux fallback" are forbidden in new docs.
+- Per-terminal NDJSON asymmetry (only headless terminals emit) is documented as intentional and not a bug — operators do not file issues for "T0 has no NDJSON."
+- Archive durability: when a headless dispatch ends, the live file is truncated and the durable record lives in `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson` (per `project_ndjson_ring_buffer` memory).
+
+### Rejected
+
+- "Wave E retire interactive." Rejected — explicitly removed from any next-step proposals per the operator memory.
+- "Headless-only refactor to remove tmux deps." Rejected — would eliminate the operator's primary trust-but-verify mechanism, break modal recovery, and erase a competitive moat vs. Managed Agents.
+- "Sunset tmux paths after N months of stable headless." Rejected — there is no time-based deprecation. The hybrid model is permanent.
+- "Move T0 to headless." Rejected for the default — T0 is the operator's interactive cockpit. A specific T0 dispatch can run headless if explicitly requested, but the default stays tmux.
+- "Auto-promote tmux to headless after first successful dispatch." Rejected — operator chooses per-dispatch or per-terminal which mode to use; VNX does not silently flip modes.
+
+## Implementation note
+
+- `scripts/lib/subprocess_adapter.py` and `scripts/lib/subprocess_dispatch.py` are the headless path.
+- `scripts/lib/tmux_adapter.py` and the popup-watcher / popup-editor scripts are the interactive path.
+- The dispatcher reads `VNX_ADAPTER_T{n}` per terminal and routes accordingly. Both paths share the same dispatch envelope, the same lease arbitration in `runtime_coordination.db`, and the same receipt format in `t0_receipts.ndjson` (with `source` field distinguishing them: `subprocess` vs implicit-tmux).
+- New OIs that propose deleting tmux paths, retiring interactive mode, or sunsetting `tmux_adapter.py` are auto-rejected with a link to this ADR.
+
+## See also
+
+- `project_hybrid_interactive_headless` memory (2026-04-23) — origin policy
+- `project_ndjson_ring_buffer` memory — per-terminal NDJSON is headless-only by design
+- `feedback_t3_input_mode_probe` memory — modal cases that require interactive surface
+- ADR-003 — OAuth-only Claude routing (no SDK in either mode)
+- ADR-010 — Subprocess adapter (the headless path)
+- ADR-011 — Manager+worker hierarchy with depth>1 (every worker, in either mode, is a separate-agent-per-task primitive)
+- `CLAUDE.md` (project root) — "Subprocess Adapter Feature Flag" and "Event Streams" sections
+- F32 PR — defaulted T1/T2/T3 to subprocess routing

--- a/scripts/check_adr_003_no_sdk_imports.py
+++ b/scripts/check_adr_003_no_sdk_imports.py
@@ -22,9 +22,20 @@ from pathlib import Path
 
 SCAN_DIRS = ("scripts", "dashboard", "tests")
 
+# Forbidden imports per ADR-003 (no Anthropic SDK / Claude Agent SDK in VNX runtime).
+# Pattern catches:
+#   import anthropic                 -> match
+#   import anthropic, os             -> match (anthropic first in multi-import)
+#   import anthropic.types           -> match (\b boundary before .)
+#   from anthropic import X          -> match
+#   from anthropic.types import Y    -> match
+#   import anthropic_utils           -> NOT match (\b boundary requires word break)
+# Limitation: `import os, anthropic` (anthropic second in multi-import) is NOT caught.
+# That style is uncommon (PEP 8 discourages multi-imports). If it lands, raise OI to
+# upgrade this scanner to ast.parse() for full coverage.
 FORBIDDEN_PATTERN = re.compile(
-    r"^(?:import anthropic(?:\s|$)|from anthropic[\s.]"
-    r"|import claude_agent_sdk(?:\s|$)|from claude_agent_sdk[\s.])"
+    r"^(?:import\s+(?:anthropic|claude_agent_sdk)\b"
+    r"|from\s+(?:anthropic|claude_agent_sdk)[\s.])"
 )
 
 ALLOWLIST_COMMENT = "# vnx:allow-anthropic-sdk-import-with-justification"

--- a/scripts/check_adr_003_no_sdk_imports.py
+++ b/scripts/check_adr_003_no_sdk_imports.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""ADR-003 enforcement: scan for forbidden Anthropic SDK imports.
+
+Scans scripts/, dashboard/, and tests/ for Python files that import the
+Anthropic Python SDK or Claude Agent SDK. Exits 1 if any violations found.
+
+Magic-comment opt-in: place the following comment on the line IMMEDIATELY
+preceding the import to permit it (rare structural exceptions only):
+    # vnx:allow-anthropic-sdk-import-with-justification
+
+See: docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SCAN_DIRS = ("scripts", "dashboard", "tests")
+
+FORBIDDEN_PATTERN = re.compile(
+    r"^(?:import anthropic(?:\s|$)|from anthropic[\s.]"
+    r"|import claude_agent_sdk(?:\s|$)|from claude_agent_sdk[\s.])"
+)
+
+ALLOWLIST_COMMENT = "# vnx:allow-anthropic-sdk-import-with-justification"
+
+ADR_URL = "docs/governance/decisions/ADR-003-oauth-only-claude-routing.md"
+
+# ---------------------------------------------------------------------------
+# Core gate logic
+# ---------------------------------------------------------------------------
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return list of (lineno, line) violations for a single file."""
+    violations: list[tuple[int, str]] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return violations
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not FORBIDDEN_PATTERN.match(stripped):
+            continue
+        preceding = lines[i - 1].strip() if i > 0 else ""
+        if preceding == ALLOWLIST_COMMENT:
+            continue
+        violations.append((i + 1, stripped))
+
+    return violations
+
+
+def scan_repo(root: Path) -> list[tuple[Path, int, str]]:
+    """Return all violations as (path, lineno, line) for the repo."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for dir_name in SCAN_DIRS:
+        scan_dir = root / dir_name
+        if not scan_dir.is_dir():
+            continue
+        for py_file in sorted(scan_dir.rglob("*.py")):
+            for lineno, line in check_file(py_file):
+                all_violations.append((py_file, lineno, line))
+    return all_violations
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _annotation(path: Path, lineno: int, line: str, root: Path) -> str:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return (
+        f"::error file={rel},line={lineno}::ADR-003 violation: forbidden import '{line}'.\n"
+        f"VNX is locked to OAuth-only Claude routing via subprocess.\n"
+        f"See: {ADR_URL}\n"
+        f"To opt in (rare): add '{ALLOWLIST_COMMENT}' on the preceding line."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    root = Path(args[0]).resolve() if args else Path.cwd()
+
+    violations = scan_repo(root)
+
+    if not violations:
+        print("[ADR-003] PASS — no forbidden SDK imports found.")
+        return 0
+
+    print(f"[ADR-003] FAIL — {len(violations)} violation(s) found:\n")
+    for path, lineno, line in violations:
+        print(_annotation(path, lineno, line, root))
+        print()
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_adr_003_no_sdk_imports.py
+++ b/tests/test_adr_003_no_sdk_imports.py
@@ -57,6 +57,10 @@ def test_clean_file_passes(tmp_path: Path) -> None:
         "from anthropic.types import Message",
         "import claude_agent_sdk",
         "from claude_agent_sdk import Agent",
+        # Codex PR #439 round-1 advisory: multi-import was missed by old regex.
+        # Now caught: package name first in the import list.
+        "import anthropic, os",
+        "import claude_agent_sdk, json",
     ],
 )
 def test_forbidden_imports_detected(tmp_path: Path, line: str) -> None:

--- a/tests/test_adr_003_no_sdk_imports.py
+++ b/tests/test_adr_003_no_sdk_imports.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""ADR-003 enforcement gate unit tests.
+
+Covers:
+- Forbidden import patterns are detected
+- Magic-comment opt-in (exact match) permits an import
+- Misspelled magic comment does NOT permit an import
+- Magic comment not on the immediately preceding line does NOT permit
+- Real repo scan returns no violations
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from check_adr_003_no_sdk_imports import (  # noqa: E402
+    ALLOWLIST_COMMENT,
+    check_file,
+    scan_repo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    f = tmp_path / name
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection tests
+# ---------------------------------------------------------------------------
+
+
+def test_clean_file_passes(tmp_path: Path) -> None:
+    f = _write(tmp_path, "clean.py", "import os\nprint('hello')\n")
+    assert check_file(f) == []
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "import anthropic",
+        "import anthropic  # some comment",
+        "from anthropic import Anthropic",
+        "from anthropic.types import Message",
+        "import claude_agent_sdk",
+        "from claude_agent_sdk import Agent",
+    ],
+)
+def test_forbidden_imports_detected(tmp_path: Path, line: str) -> None:
+    f = _write(tmp_path, "bad.py", f"import os\n{line}\n")
+    violations = check_file(f)
+    assert len(violations) == 1
+    assert violations[0][1] == line.strip()
+
+
+def test_non_matching_similar_names_pass(tmp_path: Path) -> None:
+    content = (
+        "import anthropic_utils\n"
+        "from anthropic_client import foo\n"
+        "import claude_sdk\n"
+    )
+    f = _write(tmp_path, "ok.py", content)
+    assert check_file(f) == []
+
+
+# ---------------------------------------------------------------------------
+# Magic-comment opt-in tests
+# ---------------------------------------------------------------------------
+
+
+def test_magic_comment_exact_opts_in(tmp_path: Path) -> None:
+    content = (
+        f"{ALLOWLIST_COMMENT}\n"
+        "import anthropic\n"
+    )
+    f = _write(tmp_path, "allowed.py", content)
+    assert check_file(f) == []
+
+
+def test_magic_comment_exact_opts_in_from_form(tmp_path: Path) -> None:
+    content = (
+        f"{ALLOWLIST_COMMENT}\n"
+        "from anthropic import Anthropic\n"
+    )
+    f = _write(tmp_path, "allowed2.py", content)
+    assert check_file(f) == []
+
+
+def test_misspelled_magic_comment_does_not_opt_in(tmp_path: Path) -> None:
+    misspelled = "# vnx:allow-anthropic-sdk-import"
+    content = f"{misspelled}\nimport anthropic\n"
+    f = _write(tmp_path, "bad_comment.py", content)
+    violations = check_file(f)
+    assert len(violations) == 1
+
+
+def test_magic_comment_extra_whitespace_does_not_opt_in(tmp_path: Path) -> None:
+    content = f"  {ALLOWLIST_COMMENT}  \nimport anthropic\n"
+    f = _write(tmp_path, "ws_comment.py", content)
+    # The preceding line stripped matches, so this should be allowed
+    # (we strip the line before comparison)
+    assert check_file(f) == []
+
+
+def test_magic_comment_not_adjacent_does_not_opt_in(tmp_path: Path) -> None:
+    content = (
+        f"{ALLOWLIST_COMMENT}\n"
+        "x = 1\n"
+        "import anthropic\n"
+    )
+    f = _write(tmp_path, "non_adjacent.py", content)
+    violations = check_file(f)
+    assert len(violations) == 1
+
+
+def test_magic_comment_empty_comment_does_not_opt_in(tmp_path: Path) -> None:
+    content = "# some other comment\nimport anthropic\n"
+    f = _write(tmp_path, "other_comment.py", content)
+    violations = check_file(f)
+    assert len(violations) == 1
+
+
+def test_import_on_first_line_no_preceding(tmp_path: Path) -> None:
+    f = _write(tmp_path, "first_line.py", "import anthropic\n")
+    violations = check_file(f)
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Repo-level scan
+# ---------------------------------------------------------------------------
+
+
+def test_repo_scan_returns_no_violations() -> None:
+    violations = scan_repo(VNX_ROOT)
+    if violations:
+        lines = [f"  {path}:{lineno}: {line}" for path, lineno, line in violations]
+        pytest.fail(
+            "ADR-003 violation(s) found in repo:\n" + "\n".join(lines)
+        )
+
+
+def test_scan_repo_only_scans_configured_dirs(tmp_path: Path) -> None:
+    # File in docs/ should NOT be scanned
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    _write(docs_dir, "example.py", "import anthropic\n")
+    assert scan_repo(tmp_path) == []
+
+
+def test_scan_repo_detects_in_scripts(tmp_path: Path) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    _write(scripts_dir, "bad_script.py", "import anthropic\n")
+    violations = scan_repo(tmp_path)
+    assert len(violations) == 1
+
+
+def test_scan_repo_detects_in_tests(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    _write(tests_dir, "bad_test.py", "from claude_agent_sdk import X\n")
+    violations = scan_repo(tmp_path)
+    assert len(violations) == 1
+
+
+def test_scan_repo_detects_in_dashboard(tmp_path: Path) -> None:
+    dash_dir = tmp_path / "dashboard"
+    dash_dir.mkdir()
+    _write(dash_dir, "bad.py", "from anthropic import Anthropic\n")
+    violations = scan_repo(tmp_path)
+    assert len(violations) == 1
+
+
+def test_scan_repo_respects_magic_comment(tmp_path: Path) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    content = f"{ALLOWLIST_COMMENT}\nimport anthropic\n"
+    _write(scripts_dir, "allowed.py", content)
+    assert scan_repo(tmp_path) == []


### PR DESCRIPTION
## Summary

- Adds a new CI workflow (`anthropic-sdk-block.yml`) with job **"ADR-003: No Anthropic SDK Imports"** that runs on every push and pull_request
- Scans `scripts/`, `dashboard/`, and `tests/` for `import anthropic`, `from anthropic`, `import claude_agent_sdk`, `from claude_agent_sdk` — fails the build if any are found without the magic-comment opt-in
- Gate script (`scripts/check_adr_003_no_sdk_imports.py`) outputs GitHub Actions error annotations (`::error file=…`) pointing directly at the violation and ADR-003
- Magic-comment escape hatch: a line `# vnx:allow-anthropic-sdk-import-with-justification` immediately preceding a forbidden import permits it (structural exception for gate self-tests etc.)
- Also commits ADR-003 through ADR-012 (Wave 0 governance docs, pre-authored and previously untracked); ADR-003 is referenced in gate error output

## Rationale

Anthropic's enforcement of the Claude Code OAuth credential boundary (2026-04 OpenClaw precedent) makes any accidental `import anthropic` in VNX code a ban-risk. This gate is the structural enforcement of ADR-003 (OAuth-only Claude routing, no SDK). Without it, the policy is documentation-only and vulnerable to accidental SDK adoption during future development.

## Test plan

- [ ] `pytest tests/test_adr_003_no_sdk_imports.py -v` — 21 tests, all pass
- [ ] `python3 scripts/check_adr_003_no_sdk_imports.py .` — outputs `[ADR-003] PASS` on current repo
- [ ] CI job "ADR-003: No Anthropic SDK Imports" appears in GitHub PR checks
- [ ] Verify CI green on this PR (no violations in current codebase)
- [ ] To verify CI red path: add `import anthropic` to any scanned file, observe build failure with `::error` annotation

## Open Items

- Codex gate re-audit OI to be filed by T0 (rate-limited at time of dispatch per operator policy A2/Option B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)