### PR TITLE
feat(wave1): PR-W1.3 — T0 state-builder shadow wiring (4 read sites)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -73,6 +74,13 @@ try:
     from pr_queue_state import build_pr_queue_state as _build_pqs
 except ImportError:
     _build_pqs = None
+
+try:
+    import shadow_verifier as _shadow_verifier  # noqa: E402
+    import shadow_logger as _shadow_logger  # noqa: E402
+except ImportError:
+    _shadow_verifier = None  # type: ignore[assignment]
+    _shadow_logger = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +134,24 @@ def _central_state_dir_for(state_dir: Path) -> Optional[Path]:
         return central_state
     except Exception:
         return None
+
+
+def _central_qi_db_for_project(project_id: str) -> Optional[Path]:
+    """Return central quality_intelligence.db path for a project_id, or None."""
+    if not project_id or resolve_central_data_dir is None:
+        return None
+    try:
+        db_path = resolve_central_data_dir(project_id) / "state" / "quality_intelligence.db"
+        return db_path if db_path.exists() else None
+    except Exception:
+        return None
+
+
+def _shadow_log(cmp: Any, project_id: str, read_site: str) -> None:
+    """Write comparison divergences to shadow ledger if any."""
+    if _shadow_logger is None or not cmp.divergences:
+        return
+    _shadow_logger.write_comparison_result(cmp, project_id, read_site)
 
 
 def _count_md(directory: Path) -> int:
@@ -546,18 +572,57 @@ def _build_pr_progress(dispatch_dir: Path, state_dir: Path) -> Dict[str, Any]:
 # Open items (reads existing digest)
 # ---------------------------------------------------------------------------
 
-def _build_open_items(state_dir: Path) -> Dict[str, Any]:
+# Wave 1 shadow — _collect_open_items is the 3-state dispatcher; the original
+# _build_open_items logic lives in _collect_open_items_per_project.
+
+_OPEN_ITEMS_SQL_TEMPLATE = "open_items_digest.json"
+
+
+def _collect_open_items_per_project(project_id: str, state_dir: Path) -> Dict[str, Any]:
     digest_path = state_dir / "open_items_digest.json"
     data = _safe_json(digest_path) if digest_path.exists() else None
     if not data:
         return {"open_count": 0, "blocker_count": 0, "top_blockers": []}
-
     summary = data.get("summary") or {}
     return {
         "open_count": int(summary.get("open_count") or 0),
         "blocker_count": int(summary.get("blocker_count") or 0),
         "top_blockers": (data.get("top_blockers") or [])[:3],
     }
+
+
+def _collect_open_items_central(project_id: str) -> Dict[str, Any]:
+    if not project_id or resolve_central_data_dir is None:
+        return {"open_count": 0, "blocker_count": 0, "top_blockers": []}
+    try:
+        central_state = resolve_central_data_dir(project_id) / "state"
+        return _collect_open_items_per_project(project_id, central_state)
+    except Exception:
+        return {"open_count": 0, "blocker_count": 0, "top_blockers": []}
+
+
+def _collect_open_items(project_id: str, state_dir: Path) -> Dict[str, Any]:
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _collect_open_items_per_project(project_id, state_dir)
+    if flag == "1":
+        return _collect_open_items_central(project_id)
+    # flag == "shadow": read both, compare via metric 4; metric 1 skipped because
+    # open_items_digest.json rows carry no project_id field to scope-check against.
+    legacy_result = _collect_open_items_per_project(project_id, state_dir)
+    central_result = _collect_open_items_central(project_id)
+    if _shadow_verifier is not None:
+        cmp = _shadow_verifier.compare(
+            [legacy_result],
+            [central_result],
+            project_id=project_id,
+            read_site="build_t0_state._collect_open_items",
+            sql_template=_OPEN_ITEMS_SQL_TEMPLATE,
+            metric_id=4,
+            table="open_items",
+        )
+        _shadow_log(cmp, project_id, "build_t0_state._collect_open_items")
+    return legacy_result
 
 
 # ---------------------------------------------------------------------------
@@ -598,11 +663,153 @@ def _build_quality_digest(state_dir: Path) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Dispatch insights (from DispatchParameterTracker)
+# Recent dispatches (direct query of dispatch_metadata) — Wave 1 shadow read
 # ---------------------------------------------------------------------------
 
-def _build_dispatch_insights(state_dir: Optional[Path] = None) -> Dict[str, Any]:
-    """Return top 5 dispatch insights when >= 20 experiments exist."""
+_RECENT_DISPATCHES_SQL = (
+    "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+    "dispatched_at, completed_at, outcome_status "
+    "FROM dispatch_metadata "
+    "ORDER BY dispatched_at DESC "
+    "LIMIT 50"
+)
+
+_RECENT_DISPATCHES_CENTRAL_SQL = (
+    "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+    "dispatched_at, completed_at, outcome_status "
+    "FROM dispatch_metadata "
+    "WHERE project_id = ? "
+    "ORDER BY dispatched_at DESC "
+    "LIMIT 50"
+)
+
+
+def _query_qi_db(db_path: Path, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
+    """Execute a read-only query against a quality_intelligence.db and return dicts."""
+    if not db_path.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(sql, params).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return []
+
+
+def _collect_recent_dispatches_per_project(
+    project_id: str, state_dir: Path
+) -> List[Dict[str, Any]]:
+    return _query_qi_db(state_dir / "quality_intelligence.db", _RECENT_DISPATCHES_SQL)
+
+
+def _collect_recent_dispatches_central(project_id: str) -> List[Dict[str, Any]]:
+    db_path = _central_qi_db_for_project(project_id)
+    if db_path is None:
+        return []
+    return _query_qi_db(db_path, _RECENT_DISPATCHES_CENTRAL_SQL, (project_id,))
+
+
+def _collect_recent_dispatches(
+    project_id: str, state_dir: Path
+) -> List[Dict[str, Any]]:
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _collect_recent_dispatches_per_project(project_id, state_dir)
+    if flag == "1":
+        return _collect_recent_dispatches_central(project_id)
+    # flag == "shadow"
+    legacy_result = _collect_recent_dispatches_per_project(project_id, state_dir)
+    central_result = _collect_recent_dispatches_central(project_id)
+    if _shadow_verifier is not None:
+        cmp = _shadow_verifier.compare(
+            legacy_result,
+            central_result,
+            project_id=project_id,
+            read_site="build_t0_state._collect_recent_dispatches",
+            sql_template=_RECENT_DISPATCHES_SQL,
+            metric_id=4,
+            table="dispatch_metadata",
+        )
+        _shadow_log(cmp, project_id, "build_t0_state._collect_recent_dispatches")
+    return legacy_result
+
+
+# ---------------------------------------------------------------------------
+# Intelligence brief (success_patterns + antipatterns) — Wave 1 shadow read
+# ---------------------------------------------------------------------------
+
+_INTELLIGENCE_BRIEF_SQL = (
+    "SELECT id, pattern_type, category, title, description, "
+    "success_rate, confidence_score "
+    "FROM success_patterns "
+    "ORDER BY confidence_score DESC, success_rate DESC "
+    "LIMIT 10"
+)
+
+_INTELLIGENCE_BRIEF_CENTRAL_SQL = (
+    "SELECT id, pattern_type, category, title, description, "
+    "success_rate, confidence_score "
+    "FROM success_patterns "
+    "WHERE project_id = ? "
+    "ORDER BY confidence_score DESC, success_rate DESC "
+    "LIMIT 10"
+)
+
+
+def _collect_intelligence_brief_per_project(
+    project_id: str, state_dir: Path
+) -> List[Dict[str, Any]]:
+    return _query_qi_db(state_dir / "quality_intelligence.db", _INTELLIGENCE_BRIEF_SQL)
+
+
+def _collect_intelligence_brief_central(project_id: str) -> List[Dict[str, Any]]:
+    db_path = _central_qi_db_for_project(project_id)
+    if db_path is None:
+        return []
+    return _query_qi_db(db_path, _INTELLIGENCE_BRIEF_CENTRAL_SQL, (project_id,))
+
+
+def _collect_intelligence_brief(
+    project_id: str, state_dir: Path
+) -> List[Dict[str, Any]]:
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _collect_intelligence_brief_per_project(project_id, state_dir)
+    if flag == "1":
+        return _collect_intelligence_brief_central(project_id)
+    # flag == "shadow"
+    legacy_result = _collect_intelligence_brief_per_project(project_id, state_dir)
+    central_result = _collect_intelligence_brief_central(project_id)
+    if _shadow_verifier is not None:
+        cmp = _shadow_verifier.compare(
+            legacy_result,
+            central_result,
+            project_id=project_id,
+            read_site="build_t0_state._collect_intelligence_brief",
+            sql_template=_INTELLIGENCE_BRIEF_SQL,
+            metric_id=3,
+        )
+        _shadow_log(cmp, project_id, "build_t0_state._collect_intelligence_brief")
+    return legacy_result
+
+
+# ---------------------------------------------------------------------------
+# Dispatch insights (from DispatchParameterTracker) — Wave 1 shadow-wrapped
+# ---------------------------------------------------------------------------
+
+# Wave 1 shadow — _collect_dispatch_insights is the 3-state dispatcher; the
+# original _build_dispatch_insights logic is in _collect_dispatch_insights_per_project.
+
+_DISPATCH_INSIGHTS_SQL_TEMPLATE = "dispatch_experiments"
+
+
+def _collect_dispatch_insights_per_project(
+    project_id: str, state_dir: Optional[Path] = None
+) -> Dict[str, Any]:
     _empty: Dict[str, Any] = {"available": False, "insights": [], "experiment_count": 0}
     actual_state_dir = state_dir if state_dir else _STATE_DIR
     try:
@@ -621,6 +828,41 @@ def _build_dispatch_insights(state_dir: Optional[Path] = None) -> Dict[str, Any]
         }
     except Exception:
         return _empty
+
+
+def _collect_dispatch_insights_central(project_id: str) -> Dict[str, Any]:
+    if not project_id or resolve_central_data_dir is None:
+        return {"available": False, "insights": [], "experiment_count": 0}
+    try:
+        central_state = resolve_central_data_dir(project_id) / "state"
+        return _collect_dispatch_insights_per_project(project_id, central_state)
+    except Exception:
+        return {"available": False, "insights": [], "experiment_count": 0}
+
+
+def _collect_dispatch_insights(
+    project_id: str, state_dir: Optional[Path] = None
+) -> Dict[str, Any]:
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _collect_dispatch_insights_per_project(project_id, state_dir)
+    if flag == "1":
+        return _collect_dispatch_insights_central(project_id)
+    # flag == "shadow"
+    legacy_result = _collect_dispatch_insights_per_project(project_id, state_dir)
+    central_result = _collect_dispatch_insights_central(project_id)
+    if _shadow_verifier is not None:
+        cmp = _shadow_verifier.compare(
+            [legacy_result],
+            [central_result],
+            project_id=project_id,
+            read_site="build_t0_state._collect_dispatch_insights",
+            sql_template=_DISPATCH_INSIGHTS_SQL_TEMPLATE,
+            metric_id=4,
+            table="dispatch_experiments",
+        )
+        _shadow_log(cmp, project_id, "build_t0_state._collect_dispatch_insights")
+    return legacy_result
 
 
 # ---------------------------------------------------------------------------
@@ -980,6 +1222,12 @@ def build_t0_state(
     """Build the full T0 state document. Never raises — errors produce safe fallbacks."""
     start = time.monotonic()
 
+    # Wave 1: resolve project_id for shadow-read dispatchers
+    project_id = (
+        project_id_from_state_dir(state_dir)
+        or os.environ.get("VNX_PROJECT_ID", "").strip()
+    )
+
     # Step 1: Ensure DB schema (absorbed from runtime_coordination_init.py)
     db_ok = _init_and_check_db(state_dir)
 
@@ -988,9 +1236,11 @@ def build_t0_state(
     tracks = _build_tracks(state_dir)
     pr_progress = _build_pr_progress(dispatch_dir, state_dir)
     feature_state = _build_feature_state(state_dir=state_dir)
-    open_items = _build_open_items(state_dir)
+    open_items = _collect_open_items(project_id, state_dir)
     quality_digest = _build_quality_digest(state_dir)
-    dispatch_insights = _build_dispatch_insights(state_dir=state_dir)
+    dispatch_insights = _collect_dispatch_insights(project_id, state_dir=state_dir)
+    recent_dispatches = _collect_recent_dispatches(project_id, state_dir)
+    intelligence_brief = _collect_intelligence_brief(project_id, state_dir)
     active_work = _build_active_work(dispatch_dir)
     recent_receipts = _build_recent_receipts(state_dir)
     register_events = _build_register_events(state_dir=state_dir)
@@ -1024,6 +1274,8 @@ def build_t0_state(
         "open_items": open_items,
         "quality_digest": quality_digest,
         "dispatch_insights": dispatch_insights,
+        "recent_dispatches": recent_dispatches,
+        "intelligence_brief": intelligence_brief,
         "active_work": active_work,
         "recent_receipts": recent_receipts,
         "dispatch_register_events": register_events,

--- a/tests/test_build_t0_state.py
+++ b/tests/test_build_t0_state.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Tests for Wave 1 shadow-read wiring in build_t0_state.py.
+
+Covers all 4 instrumented read sites:
+  - _collect_open_items          (open_items_digest.json)
+  - _collect_recent_dispatches   (dispatch_metadata table, quality_intelligence.db)
+  - _collect_intelligence_brief  (success_patterns table, quality_intelligence.db)
+  - _collect_dispatch_insights   (dispatch_experiments via DispatchParameterTracker)
+
+For each site: 3-state flag tests (unset / shadow+diverge / 1=central).
+Plus end-to-end shadow build + p95 latency regression guard.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Import module under test — side-effects (ensure_env) run at import time but
+# are harmless in the test environment.
+import build_t0_state as bts  # noqa: E402
+import shadow_verifier as sv   # noqa: E402
+import shadow_logger as sl     # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — minimal SQLite DB creation
+# ---------------------------------------------------------------------------
+
+SAMPLE_PROJECT_ID = "test-project"
+SAMPLE_DISPATCH = {
+    "dispatch_id": "d-001",
+    "terminal": "T1",
+    "track": "A",
+    "role": "backend-developer",
+    "gate": "",
+    "priority": "P1",
+    "pr_id": "PR-001",
+    "dispatched_at": "2026-05-01T10:00:00Z",
+    "completed_at": "2026-05-01T11:00:00Z",
+    "outcome_status": "success",
+}
+SAMPLE_PATTERN = {
+    "pattern_type": "approach",
+    "category": "testing",
+    "title": "Shadow Write Pattern",
+    "description": "Use atomic writes for state files",
+    "success_rate": 0.95,
+    "confidence_score": 0.92,
+}
+
+
+def _create_qi_db(
+    path: Path,
+    dispatches: Optional[List[Dict[str, Any]]] = None,
+    patterns: Optional[List[Dict[str, Any]]] = None,
+    *,
+    has_project_id: bool = False,
+    project_id: str = SAMPLE_PROJECT_ID,
+) -> Path:
+    """Create a minimal quality_intelligence.db with dispatch_metadata + success_patterns."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        pid_col = ", project_id TEXT" if has_project_id else ""
+        conn.executescript(f"""
+            CREATE TABLE IF NOT EXISTS dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL UNIQUE,
+                terminal TEXT, track TEXT, role TEXT, gate TEXT,
+                priority TEXT, pr_id TEXT,
+                dispatched_at TEXT, completed_at TEXT, outcome_status TEXT
+                {pid_col}
+            );
+            CREATE TABLE IF NOT EXISTS success_patterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pattern_type TEXT, category TEXT, title TEXT,
+                description TEXT, success_rate REAL, confidence_score REAL
+                {pid_col}
+            );
+        """)
+        for d in (dispatches or []):
+            if has_project_id:
+                conn.execute(
+                    "INSERT INTO dispatch_metadata "
+                    "(dispatch_id,terminal,track,role,gate,priority,pr_id,"
+                    "dispatched_at,completed_at,outcome_status,project_id) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        d["dispatch_id"], d.get("terminal", "T1"),
+                        d.get("track", "A"), d.get("role", "worker"),
+                        d.get("gate", ""), d.get("priority", "P1"),
+                        d.get("pr_id", ""), d.get("dispatched_at", ""),
+                        d.get("completed_at", ""), d.get("outcome_status", "success"),
+                        project_id,
+                    ),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO dispatch_metadata "
+                    "(dispatch_id,terminal,track,role,gate,priority,pr_id,"
+                    "dispatched_at,completed_at,outcome_status) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        d["dispatch_id"], d.get("terminal", "T1"),
+                        d.get("track", "A"), d.get("role", "worker"),
+                        d.get("gate", ""), d.get("priority", "P1"),
+                        d.get("pr_id", ""), d.get("dispatched_at", ""),
+                        d.get("completed_at", ""), d.get("outcome_status", "success"),
+                    ),
+                )
+        for p in (patterns or []):
+            if has_project_id:
+                conn.execute(
+                    "INSERT INTO success_patterns "
+                    "(pattern_type,category,title,description,success_rate,confidence_score,project_id) "
+                    "VALUES (?,?,?,?,?,?,?)",
+                    (
+                        p.get("pattern_type", "approach"), p.get("category", "test"),
+                        p.get("title", "T"), p.get("description", "D"),
+                        p.get("success_rate", 0.9), p.get("confidence_score", 0.9),
+                        project_id,
+                    ),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO success_patterns "
+                    "(pattern_type,category,title,description,success_rate,confidence_score) "
+                    "VALUES (?,?,?,?,?,?)",
+                    (
+                        p.get("pattern_type", "approach"), p.get("category", "test"),
+                        p.get("title", "T"), p.get("description", "D"),
+                        p.get("success_rate", 0.9), p.get("confidence_score", 0.9),
+                    ),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _write_open_items_digest(state_dir: Path, open_count: int = 3, blocker_count: int = 1) -> None:
+    digest = {
+        "summary": {"open_count": open_count, "blocker_count": blocker_count},
+        "top_blockers": [{"id": f"OI-{i}", "title": f"Blocker {i}"} for i in range(blocker_count)],
+    }
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "open_items_digest.json").write_text(json.dumps(digest), encoding="utf-8")
+
+
+class _CaptureShadowLogger:
+    """Minimal shadow_logger stand-in that records comparison results."""
+
+    def __init__(self) -> None:
+        self.calls: List[sv.ComparisonResult] = []
+
+    def write_comparison_result(
+        self,
+        cmp: sv.ComparisonResult,
+        project_id: str,
+        read_site: str,
+        *,
+        ledger_path: Optional[Path] = None,
+    ) -> int:
+        self.calls.append(cmp)
+        return len(cmp.divergences)
+
+
+# ---------------------------------------------------------------------------
+# _collect_open_items
+# ---------------------------------------------------------------------------
+
+
+class TestCollectOpenItems:
+    def test_collect_open_items_unset_uses_per_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("VNX_USE_CENTRAL_DB", raising=False)
+        _write_open_items_digest(tmp_path, open_count=5, blocker_count=2)
+
+        result = bts._collect_open_items(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result["open_count"] == 5
+        assert result["blocker_count"] == 2
+
+    def test_collect_open_items_shadow_logs_divergence_when_central_diverges(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+        _write_open_items_digest(tmp_path, open_count=5, blocker_count=2)
+
+        # Central state dir with different counts
+        central_state = tmp_path / "central_state"
+        _write_open_items_digest(central_state, open_count=999, blocker_count=10)
+
+        capture = _CaptureShadowLogger()
+        monkeypatch.setattr(bts, "_shadow_logger", capture)
+
+        def _fake_central(pid: str) -> Dict[str, Any]:
+            return bts._collect_open_items_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_open_items_central", _fake_central)
+
+        result = bts._collect_open_items(SAMPLE_PROJECT_ID, tmp_path)
+
+        # Legacy result is authoritative
+        assert result["open_count"] == 5
+        # Divergence must be logged
+        assert len(capture.calls) == 1
+        assert len(capture.calls[0].divergences) >= 1
+
+    def test_collect_open_items_authoritative_uses_central(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "1")
+        _write_open_items_digest(tmp_path, open_count=5, blocker_count=2)
+
+        central_state = tmp_path / "central_state"
+        _write_open_items_digest(central_state, open_count=42, blocker_count=7)
+
+        def _fake_central(pid: str) -> Dict[str, Any]:
+            return bts._collect_open_items_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_open_items_central", _fake_central)
+
+        result = bts._collect_open_items(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result["open_count"] == 42
+        assert result["blocker_count"] == 7
+
+
+# ---------------------------------------------------------------------------
+# _collect_recent_dispatches
+# ---------------------------------------------------------------------------
+
+
+class TestCollectRecentDispatches:
+    def test_collect_recent_dispatches_unset_uses_per_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("VNX_USE_CENTRAL_DB", raising=False)
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            dispatches=[SAMPLE_DISPATCH],
+        )
+
+        result = bts._collect_recent_dispatches(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert len(result) == 1
+        assert result[0]["dispatch_id"] == "d-001"
+
+    def test_collect_recent_dispatches_shadow_logs_divergence_when_central_diverges(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            dispatches=[SAMPLE_DISPATCH],
+        )
+
+        # Central DB with extra dispatch → count diverges
+        central_state = tmp_path / "central"
+        _create_qi_db(
+            central_state / "quality_intelligence.db",
+            dispatches=[
+                SAMPLE_DISPATCH,
+                {**SAMPLE_DISPATCH, "dispatch_id": "d-002"},
+            ],
+            has_project_id=True,
+        )
+
+        capture = _CaptureShadowLogger()
+        monkeypatch.setattr(bts, "_shadow_logger", capture)
+
+        def _fake_central(pid: str) -> List[Dict[str, Any]]:
+            return bts._collect_recent_dispatches_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_recent_dispatches_central", _fake_central)
+
+        result = bts._collect_recent_dispatches(SAMPLE_PROJECT_ID, tmp_path)
+
+        # Legacy is authoritative
+        assert len(result) == 1
+        # Divergence logged (count mismatch: 1 vs 2)
+        assert len(capture.calls) == 1
+        assert len(capture.calls[0].divergences) >= 1
+        assert any(d.metric_id == 4 for d in capture.calls[0].divergences)
+
+    def test_collect_recent_dispatches_authoritative_uses_central(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "1")
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            dispatches=[SAMPLE_DISPATCH],
+        )
+
+        central_state = tmp_path / "central"
+        _create_qi_db(
+            central_state / "quality_intelligence.db",
+            dispatches=[
+                {**SAMPLE_DISPATCH, "dispatch_id": "d-central-1"},
+                {**SAMPLE_DISPATCH, "dispatch_id": "d-central-2"},
+            ],
+            has_project_id=True,
+        )
+
+        def _fake_central(pid: str) -> List[Dict[str, Any]]:
+            return bts._collect_recent_dispatches_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_recent_dispatches_central", _fake_central)
+
+        result = bts._collect_recent_dispatches(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert len(result) == 2
+        ids = {r["dispatch_id"] for r in result}
+        assert "d-central-1" in ids
+
+
+# ---------------------------------------------------------------------------
+# _collect_intelligence_brief
+# ---------------------------------------------------------------------------
+
+
+class TestCollectIntelligenceBrief:
+    def test_collect_intelligence_brief_unset_uses_per_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("VNX_USE_CENTRAL_DB", raising=False)
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            patterns=[SAMPLE_PATTERN],
+        )
+
+        result = bts._collect_intelligence_brief(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert len(result) == 1
+        assert result[0]["title"] == "Shadow Write Pattern"
+
+    def test_collect_intelligence_brief_shadow_logs_divergence_when_central_diverges(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+        # Per-project: one pattern with id=1
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            patterns=[SAMPLE_PATTERN],
+        )
+
+        # Central DB: seed a dummy first so the real pattern gets id=2 → top-N IDs differ
+        # (metric 3 compares item IDs, not content; per-project top-1 id=1 vs central id=2)
+        central_state = tmp_path / "central"
+        _create_qi_db(
+            central_state / "quality_intelligence.db",
+            patterns=[
+                {**SAMPLE_PATTERN, "title": "Dummy Low", "confidence_score": 0.1},
+                {**SAMPLE_PATTERN, "title": "Divergent High", "confidence_score": 0.99},
+            ],
+            has_project_id=True,
+        )
+
+        capture = _CaptureShadowLogger()
+        monkeypatch.setattr(bts, "_shadow_logger", capture)
+
+        def _fake_central(pid: str) -> List[Dict[str, Any]]:
+            return bts._collect_intelligence_brief_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_intelligence_brief_central", _fake_central)
+
+        result = bts._collect_intelligence_brief(SAMPLE_PROJECT_ID, tmp_path)
+
+        # Legacy is authoritative
+        assert result[0]["title"] == "Shadow Write Pattern"
+        # Metric 3 divergence logged (top-1 id=1 per-project vs id=2 central)
+        assert len(capture.calls) == 1
+        assert any(d.metric_id == 3 for d in capture.calls[0].divergences)
+
+    def test_collect_intelligence_brief_authoritative_uses_central(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "1")
+        _create_qi_db(
+            tmp_path / "quality_intelligence.db",
+            patterns=[SAMPLE_PATTERN],
+        )
+
+        central_state = tmp_path / "central"
+        _create_qi_db(
+            central_state / "quality_intelligence.db",
+            patterns=[{**SAMPLE_PATTERN, "title": "Central Pattern"}],
+            has_project_id=True,
+        )
+
+        def _fake_central(pid: str) -> List[Dict[str, Any]]:
+            return bts._collect_intelligence_brief_per_project(pid, central_state)
+
+        monkeypatch.setattr(bts, "_collect_intelligence_brief_central", _fake_central)
+
+        result = bts._collect_intelligence_brief(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result[0]["title"] == "Central Pattern"
+
+
+# ---------------------------------------------------------------------------
+# _collect_dispatch_insights
+# ---------------------------------------------------------------------------
+
+
+class TestCollectDispatchInsights:
+    def test_collect_dispatch_insights_unset_uses_per_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("VNX_USE_CENTRAL_DB", raising=False)
+        # No experiments in DB → returns empty fallback
+        result = bts._collect_dispatch_insights(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result["available"] is False
+        assert result["insights"] == []
+
+    def test_collect_dispatch_insights_shadow_logs_divergence_when_central_diverges(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+        capture = _CaptureShadowLogger()
+        monkeypatch.setattr(bts, "_shadow_logger", capture)
+
+        # Per-project: empty
+        # Central: different non-empty result → diverges
+        def _fake_central(pid: str) -> Dict[str, Any]:
+            return {
+                "available": True,
+                "insights": [{"dimension": "role", "group_a": "A", "group_b": "B",
+                               "metric": "avg_cqs", "value_a": 0.9, "value_b": 0.7,
+                               "sample_a": 10, "sample_b": 10}],
+                "experiment_count": 25,
+            }
+
+        monkeypatch.setattr(bts, "_collect_dispatch_insights_central", _fake_central)
+
+        result = bts._collect_dispatch_insights(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result["available"] is False  # legacy is authoritative
+        # Divergence logged — dicts differ
+        assert len(capture.calls) == 1
+        assert len(capture.calls[0].divergences) >= 1
+
+    def test_collect_dispatch_insights_authoritative_uses_central(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_USE_CENTRAL_DB", "1")
+
+        def _fake_central(pid: str) -> Dict[str, Any]:
+            return {"available": True, "insights": ["sentinel"], "experiment_count": 99}
+
+        monkeypatch.setattr(bts, "_collect_dispatch_insights_central", _fake_central)
+
+        result = bts._collect_dispatch_insights(SAMPLE_PROJECT_ID, tmp_path)
+
+        assert result["available"] is True
+        assert result["experiment_count"] == 99
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full shadow build
+# ---------------------------------------------------------------------------
+
+
+def test_full_state_build_in_shadow_mode_runs_without_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """build_t0_state() must not raise under VNX_USE_CENTRAL_DB=shadow."""
+    monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+    monkeypatch.setenv("VNX_PROJECT_ID", SAMPLE_PROJECT_ID)
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    (dispatch_dir / "pending").mkdir(parents=True)
+    (dispatch_dir / "active").mkdir()
+    (dispatch_dir / "conflicts").mkdir()
+
+    # Plant minimal per-project data
+    _write_open_items_digest(state_dir, open_count=2, blocker_count=0)
+    _create_qi_db(state_dir / "quality_intelligence.db", dispatches=[SAMPLE_DISPATCH])
+
+    # Stub central functions to return empty so shadow compares without error
+    monkeypatch.setattr(bts, "_collect_open_items_central",
+                        lambda pid: {"open_count": 0, "blocker_count": 0, "top_blockers": []})
+    monkeypatch.setattr(bts, "_collect_recent_dispatches_central", lambda pid: [])
+    monkeypatch.setattr(bts, "_collect_intelligence_brief_central", lambda pid: [])
+    monkeypatch.setattr(bts, "_collect_dispatch_insights_central",
+                        lambda pid: {"available": False, "insights": [], "experiment_count": 0})
+
+    capture = _CaptureShadowLogger()
+    monkeypatch.setattr(bts, "_shadow_logger", capture)
+
+    # Must not raise
+    result = bts.build_t0_state(state_dir, dispatch_dir)
+
+    assert "open_items" in result
+    assert "recent_dispatches" in result
+    assert "intelligence_brief" in result
+    assert "dispatch_insights" in result
+    # Divergence was logged for recent_dispatches (1 vs 0)
+    assert any(c.divergences for c in capture.calls)
+
+
+def test_shadow_mode_p95_latency_within_2x_per_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shadow-mode latency for the 4 collect functions must stay within 2x per-project."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _write_open_items_digest(state_dir)
+    _create_qi_db(
+        state_dir / "quality_intelligence.db",
+        dispatches=[{**SAMPLE_DISPATCH, "dispatch_id": f"d-{i}"} for i in range(20)],
+        patterns=[SAMPLE_PATTERN] * 5,
+    )
+
+    # Stub central to return empty (no actual central DB on disk)
+    monkeypatch.setattr(bts, "_collect_open_items_central",
+                        lambda pid: {"open_count": 0, "blocker_count": 0, "top_blockers": []})
+    monkeypatch.setattr(bts, "_collect_recent_dispatches_central", lambda pid: [])
+    monkeypatch.setattr(bts, "_collect_intelligence_brief_central", lambda pid: [])
+    monkeypatch.setattr(bts, "_collect_dispatch_insights_central",
+                        lambda pid: {"available": False, "insights": [], "experiment_count": 0})
+    monkeypatch.setattr(bts, "_shadow_logger", _CaptureShadowLogger())
+
+    n = 10
+    per_project_times: List[float] = []
+    shadow_times: List[float] = []
+
+    monkeypatch.delenv("VNX_USE_CENTRAL_DB", raising=False)
+    for _ in range(n):
+        t0 = time.perf_counter()
+        bts._collect_open_items(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_recent_dispatches(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_intelligence_brief(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_dispatch_insights(SAMPLE_PROJECT_ID, state_dir)
+        per_project_times.append(time.perf_counter() - t0)
+
+    monkeypatch.setenv("VNX_USE_CENTRAL_DB", "shadow")
+    for _ in range(n):
+        t0 = time.perf_counter()
+        bts._collect_open_items(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_recent_dispatches(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_intelligence_brief(SAMPLE_PROJECT_ID, state_dir)
+        bts._collect_dispatch_insights(SAMPLE_PROJECT_ID, state_dir)
+        shadow_times.append(time.perf_counter() - t0)
+
+    per_project_times.sort()
+    shadow_times.sort()
+    p95_idx = int(0.95 * n) - 1
+    p95_per_project = per_project_times[p95_idx]
+    p95_shadow = shadow_times[p95_idx]
+
+    assert p95_shadow <= 2.0 * p95_per_project, (
+        f"Shadow p95 {p95_shadow*1000:.1f}ms exceeds 2× per-project p95 {p95_per_project*1000:.1f}ms"
+    )


### PR DESCRIPTION
## Summary

Wires shadow-mode reads at the T0 state-builder (`scripts/build_t0_state.py`) — the highest-traffic read path, called on every T0 SessionStart hook.

Per Wave 1 design §5.1 (read interception points) and §5.2 (shadow read pattern), adds 3-state flag dispatch (`VNX_USE_CENTRAL_DB` unset / `shadow` / `1`) to **4 read functions**:

| Function | Tables / Source | Metric |
|---|---|---|
| `_collect_open_items` | `open_items_digest.json` | metric 4 |
| `_collect_recent_dispatches` | `dispatch_metadata` (quality_intelligence.db) | metric 4 |
| `_collect_intelligence_brief` | `success_patterns` (quality_intelligence.db) | metric 3 |
| `_collect_dispatch_insights` | `dispatch_experiments` via DispatchParameterTracker | metric 4 |

Each function has `_per_project` and `_central` sister variants. Shadow mode reads both, compares via `shadow_verifier` (PR #450), logs divergences via `shadow_logger` (PR #451). Legacy result remains authoritative.

**Default behavior (`VNX_USE_CENTRAL_DB` unset) is byte-identical to pre-PR reads.**

New keys added to `t0_state.json`: `recent_dispatches`, `intelligence_brief`.

Central paths use `resolve_central_data_dir()` — no hardcoded `.vnx-data/state/` literals (legacy-path gate clean).

## Test plan

- [x] `pytest tests/test_build_t0_state.py -v` — 14 tests, all pass
  - 3 tests × 4 read sites = 12 per-site tests (unset/shadow-diverge/central-authoritative)
  - `test_full_state_build_in_shadow_mode_runs_without_error`
  - `test_shadow_mode_p95_latency_within_2x_per_project`
- [x] `pytest tests/test_shadow_verifier.py tests/test_shadow_logger.py tests/test_shadow_report_cli.py` — 61 existing tests, all pass
- [x] No `.vnx-data/state/` hardcoded literals (`grep` clean)
- [x] Python syntax OK (`ast.parse` clean)

## Dispatch-ID

`20260509-wave1-pr3-t0-state-builder-shadow`

Parent: PR #451 (PR-W1.2 shadow_logger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)