### PR TITLE
feat(wave5): PR-W5.1 — ADR injection by file-touch (governance context to dispatches)

### DIFF
--- a/scripts/lib/adr_indexer.py
+++ b/scripts/lib/adr_indexer.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Wave 5 P1 — ADR-to-file-path indexer for context injection.
+
+Scans docs/governance/decisions/ADR-*.md for file_path references in their
+"See also" / "Context" / "Implementation note" sections; builds an inverted
+index file_path → [ADR_ids]. Supports lookup by file_path overlap with
+dispatch_paths.
+
+Cached for 60s (ADRs change rarely; refresh on file mtime change).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import sys as _sys
+_sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+ADR_DIR = Path("docs/governance/decisions")
+CACHE_TTL_SEC = 60
+
+# Extracts file references from ADR markdown (path with recognized extension, optional :line).
+# Allows hyphens in path components (e.g. claudedocs/2026-05-09-p4-lessons.md).
+_FILE_PATH_RE = re.compile(
+    r'\b([\w./][\w./-]*\.(?:py|md|sql|sh|ts|js|tsx|jsx|yaml|yml))(?::\d+(?:-\d+)?)?\b'
+)
+
+_TITLE_RE = re.compile(r'^#\s+ADR-\d+\s*[-—]\s*(.+)', re.MULTILINE)
+_ADR_STEM_RE = re.compile(r'^(ADR-\d+)', re.IGNORECASE)
+_DECISION_RE = re.compile(r'##\s+Decision\s*\n+([\s\S]+?)(?=\n##|\Z)')
+
+
+def _resolve_adr_dir(adr_dir: Optional[Path]) -> Path:
+    if adr_dir is not None:
+        return Path(adr_dir)
+    try:
+        from vnx_paths import resolve_paths
+        paths = resolve_paths()
+        return Path(paths["PROJECT_ROOT"]) / "docs" / "governance" / "decisions"
+    except Exception:
+        return ADR_DIR
+
+
+def _parse_adr_id(stem: str) -> str:
+    m = _ADR_STEM_RE.match(stem)
+    return m.group(1).upper() if m else stem
+
+
+def _parse_title(text: str) -> str:
+    m = _TITLE_RE.search(text)
+    return m.group(1).strip() if m else "Unknown"
+
+
+def _parse_decision_excerpt(text: str) -> str:
+    m = _DECISION_RE.search(text)
+    body = m.group(1).strip() if m else text.strip()
+    return body[:200]
+
+
+def _parse_referenced_files(text: str) -> frozenset:
+    files: set = set()
+    for m in _FILE_PATH_RE.finditer(text):
+        files.add(m.group(1))
+    return frozenset(files)
+
+
+@dataclass(frozen=True)
+class AdrEntry:
+    adr_id: str
+    title: str
+    file_path: Path
+    referenced_files: frozenset
+    excerpt: str
+
+
+@dataclass
+class AdrIndex:
+    """In-memory ADR index. Reload via load() if files changed."""
+    entries: dict = field(default_factory=dict)
+    file_to_adrs: dict = field(default_factory=dict)
+    loaded_at: float = 0.0
+
+    def __post_init__(self) -> None:
+        self._file_mtimes: dict = {}
+        self._loaded_dir: Optional[Path] = None
+
+    def load(self, adr_dir: Optional[Path] = None) -> None:
+        """Scan ADR_DIR, build index."""
+        resolved = _resolve_adr_dir(adr_dir)
+        self._loaded_dir = resolved
+        new_entries: dict = {}
+        new_file_to_adrs: dict = {}
+        new_mtimes: dict = {}
+
+        if resolved.is_dir():
+            for adr_file in sorted(resolved.glob("ADR-*.md")):
+                try:
+                    stat = adr_file.stat()
+                    new_mtimes[str(adr_file)] = stat.st_mtime
+                    text = adr_file.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+
+                adr_id = _parse_adr_id(adr_file.stem)
+                entry = AdrEntry(
+                    adr_id=adr_id,
+                    title=_parse_title(text),
+                    file_path=adr_file,
+                    referenced_files=_parse_referenced_files(text),
+                    excerpt=_parse_decision_excerpt(text),
+                )
+                new_entries[adr_id] = entry
+                for fp in entry.referenced_files:
+                    new_file_to_adrs.setdefault(fp, [])
+                    if adr_id not in new_file_to_adrs[fp]:
+                        new_file_to_adrs[fp].append(adr_id)
+
+        self.entries = new_entries
+        self.file_to_adrs = new_file_to_adrs
+        self._file_mtimes = new_mtimes
+        self.loaded_at = time.time()
+
+    def lookup(self, file_paths: List[str]) -> List[AdrEntry]:
+        """Return ADRs whose referenced_files overlap with given paths."""
+        seen: set = set()
+        result: List[AdrEntry] = []
+        for fp in file_paths:
+            for adr_id in self.file_to_adrs.get(fp, []):
+                if adr_id not in seen:
+                    seen.add(adr_id)
+                    entry = self.entries.get(adr_id)
+                    if entry is not None:
+                        result.append(entry)
+        return result
+
+    def needs_refresh(self) -> bool:
+        if (time.time() - self.loaded_at) > CACHE_TTL_SEC:
+            return True
+        return self._mtime_changed()
+
+    def _mtime_changed(self) -> bool:
+        d = self._loaded_dir
+        if d is None or not d.is_dir():
+            return False
+        for adr_file in d.glob("ADR-*.md"):
+            try:
+                mtime = adr_file.stat().st_mtime
+            except OSError:
+                continue
+            if mtime != self._file_mtimes.get(str(adr_file), 0.0):
+                return True
+        return False
+
+
+# Module-level singleton (cached)
+_INDEX = AdrIndex()
+
+
+def _ensure_loaded(adr_dir: Optional[Path] = None) -> None:
+    if _INDEX.loaded_at == 0.0 or _INDEX.needs_refresh():
+        _INDEX.load(adr_dir)
+
+
+def fetch_relevant_adrs(
+    dispatch_paths: List[str],
+    *,
+    max_chars: int = 1500,
+    adr_dir: Optional[Path] = None,
+) -> List[AdrEntry]:
+    """Fetch ADRs whose referenced files overlap dispatch_paths, budget-bounded."""
+    _ensure_loaded(adr_dir)
+    matched = _INDEX.lookup(dispatch_paths)
+
+    trimmed: List[AdrEntry] = []
+    for entry in matched:
+        candidate = trimmed + [entry]
+        if len(format_adrs_section(candidate)) <= max_chars:
+            trimmed.append(entry)
+        else:
+            break
+
+    return trimmed
+
+
+def format_adrs_section(adrs: List[AdrEntry]) -> str:
+    """Format as markdown section for dispatch instruction injection.
+
+    Includes anti-anchoring instruction:
+    "These ADRs are governance constraints, not task descriptions. The actual
+    task in this dispatch may extend or refine them."
+    """
+    if not adrs:
+        return ""
+
+    lines = [
+        "## RELEVANT ARCHITECTURAL DECISIONS",
+        "",
+        "> **Note:** These ADRs are governance constraints, not task descriptions. "
+        "The actual task in this dispatch may extend or refine them.",
+        "",
+    ]
+
+    for adr in adrs:
+        lines.append(f"### {adr.adr_id} — {adr.title}")
+        lines.append("")
+        if adr.excerpt:
+            lines.append(adr.excerpt)
+            lines.append("")
+
+    return "\n".join(lines)

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -40,6 +40,11 @@ except ImportError:
     _prior_round_injector = None  # type: ignore[assignment]
 
 try:
+    import adr_indexer as _adr_indexer
+except ImportError:
+    _adr_indexer = None  # type: ignore[assignment]
+
+try:
     from vnx_paths import resolve_central_data_dir as _resolve_central_data_dir
 except ImportError:
     _resolve_central_data_dir = None  # type: ignore[assignment]
@@ -663,6 +668,32 @@ class IntelligenceSelector:
                 )
                 selected.insert(0, prior_item)
                 selected = self._enforce_payload_limit_with_prior(selected, suppressed)
+
+        # Wave 5 P1: inject relevant ADR sections when dispatch_paths overlap ADR references.
+        # Added after prior_round enforcement so ADR context rides above standard class budget.
+        if dispatch_paths and _adr_indexer is not None:
+            relevant_adrs = _adr_indexer.fetch_relevant_adrs(
+                dispatch_paths,
+                max_chars=1500,
+            )
+            if relevant_adrs:
+                now_ts = _now_utc()
+                adr_item = IntelligenceItem(
+                    item_id=f"intel_adr_{'_'.join(a.adr_id for a in relevant_adrs[:3])}",
+                    item_class="adr_relevant",
+                    title=f"Relevant ADRs for {len(dispatch_paths)} touched files",
+                    content=_adr_indexer.format_adrs_section(relevant_adrs),
+                    confidence=1.0,
+                    evidence_count=len(relevant_adrs),
+                    last_seen=now_ts,
+                    scope_tags=[],
+                    source_refs=[a.adr_id for a in relevant_adrs],
+                    task_class_filter=[],
+                    pattern_category=PATTERN_CATEGORY_CODE,
+                    content_hash="",
+                )
+                selected.append(adr_item)
+                selected = self._enforce_payload_limit_with_adr(selected, suppressed)
 
         now = _now_utc()
         result = InjectionResult(
@@ -1990,6 +2021,51 @@ class IntelligenceSelector:
             return selected
 
         drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + ["prior_round_finding"]
+        for drop_class in drop_order:
+            to_drop = [i for i in selected if i.item_class == drop_class]
+            if not to_drop:
+                continue
+
+            selected = [i for i in selected if i.item_class != drop_class]
+            suppressed.append(SuppressionRecord(
+                item_class=drop_class,
+                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
+            ))
+
+            payload_size = len(json.dumps({
+                "injection_point": "dispatch_create",
+                "injected_at": _now_utc(),
+                "items": [item.to_dict() for item in selected],
+                "suppressed": [s.to_dict() for s in suppressed],
+            }))
+
+            if payload_size <= MAX_PAYLOAD_CHARS:
+                break
+
+        return selected
+
+    def _enforce_payload_limit_with_adr(
+        self,
+        selected: List[IntelligenceItem],
+        suppressed: List[SuppressionRecord],
+    ) -> List[IntelligenceItem]:
+        """Re-enforce payload limit after an adr_relevant item has been appended.
+
+        Drops standard classes first (recent_comparable → failure_prevention →
+        proven_pattern → prior_round_finding) and only removes adr_relevant as
+        last resort since it is direct governance evidence with confidence 1.0.
+        """
+        payload_size = len(json.dumps({
+            "injection_point": "dispatch_create",
+            "injected_at": _now_utc(),
+            "items": [item.to_dict() for item in selected],
+            "suppressed": [s.to_dict() for s in suppressed],
+        }))
+
+        if payload_size <= MAX_PAYLOAD_CHARS:
+            return selected
+
+        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + ["prior_round_finding", "adr_relevant"]
         for drop_class in drop_order:
             to_drop = [i for i in selected if i.item_class == drop_class]
             if not to_drop:

--- a/tests/test_adr_indexer.py
+++ b/tests/test_adr_indexer.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Tests for adr_indexer.py (Wave 5 P1).
+
+Covers:
+  - Index loading from real and fixture ADR directories
+  - File-path reference extraction
+  - Lookup by dispatch_paths overlap
+  - Budget truncation
+  - Anti-anchoring instruction presence
+  - TTL-based cache refresh
+  - Mtime-based cache invalidation
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from adr_indexer import (
+    CACHE_TTL_SEC,
+    AdrEntry,
+    AdrIndex,
+    _parse_referenced_files,
+    format_adrs_section,
+    fetch_relevant_adrs,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REAL_ADR_DIR = Path(__file__).resolve().parent.parent / "docs" / "governance" / "decisions"
+
+_ADR_TEMPLATE = """\
+# ADR-{num} — {title}
+
+**Status:** Accepted
+**Date:** 2026-05-10
+
+## Context
+
+This ADR governs work on {context_files}.
+
+## Decision
+
+**{decision_text}**
+
+## See also
+
+{see_also}
+"""
+
+
+def _write_adr(adr_dir: Path, num: str, title: str, context_files: str,
+               decision_text: str, see_also: str) -> Path:
+    filename = f"ADR-{num}-test.md"
+    content = _ADR_TEMPLATE.format(
+        num=num,
+        title=title,
+        context_files=context_files,
+        decision_text=decision_text,
+        see_also=see_also,
+    )
+    p = adr_dir / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests: loading
+# ---------------------------------------------------------------------------
+
+class TestAdrIndexLoad(unittest.TestCase):
+
+    def test_load_index_from_adr_dir(self):
+        """Loads all 14 ADRs from the real docs/governance/decisions/ directory."""
+        if not _REAL_ADR_DIR.is_dir():
+            self.skipTest("real ADR dir not available")
+
+        index = AdrIndex()
+        index.load(_REAL_ADR_DIR)
+
+        self.assertEqual(len(index.entries), 14, (
+            f"Expected 14 ADRs, got {len(index.entries)}: {sorted(index.entries.keys())}"
+        ))
+
+    def test_load_index_empty_dir(self):
+        """Loading from an empty directory yields no entries."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            index = AdrIndex()
+            index.load(Path(tmpdir))
+            self.assertEqual(len(index.entries), 0)
+            self.assertEqual(len(index.file_to_adrs), 0)
+
+    def test_loaded_at_updated_after_load(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir)
+            _write_adr(adr_dir, "001", "Test", "scripts/lib/foo.py",
+                       "Do the thing.", "- `scripts/lib/foo.py`")
+            before = time.time()
+            index = AdrIndex()
+            index.load(adr_dir)
+            self.assertGreaterEqual(index.loaded_at, before)
+
+
+# ---------------------------------------------------------------------------
+# Tests: file-path reference extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractReferences(unittest.TestCase):
+
+    def test_extracts_file_path_references_from_see_also(self):
+        """Extracts .py and .md references from a fixture ADR."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir)
+            _write_adr(
+                adr_dir, "009", "Schema-First Migrations",
+                "scripts/migrate_to_central_vnx.py",
+                "Use PRAGMA introspection.",
+                "- `scripts/migrate_to_central_vnx.py` — canonical helpers\n"
+                "- `tests/test_migrate_dry_run.py` — structural test",
+            )
+            index = AdrIndex()
+            index.load(adr_dir)
+            entry = index.entries.get("ADR-009")
+            self.assertIsNotNone(entry)
+            self.assertIn("scripts/migrate_to_central_vnx.py", entry.referenced_files)
+            self.assertIn("tests/test_migrate_dry_run.py", entry.referenced_files)
+
+    def test_extracts_sql_and_md_references(self):
+        """Extracts .sql and .md file references."""
+        text = (
+            "See `schemas/migrations/0010_add_project_id.sql` and "
+            "`claudedocs/2026-05-09-p4-lessons.md` for details."
+        )
+        refs = _parse_referenced_files(text)
+        self.assertIn("schemas/migrations/0010_add_project_id.sql", refs)
+        self.assertIn("claudedocs/2026-05-09-p4-lessons.md", refs)
+
+    def test_extracts_yaml_references(self):
+        """Extracts .yaml file references."""
+        refs = _parse_referenced_files("See `worker_permissions.yaml` for config.")
+        self.assertIn("worker_permissions.yaml", refs)
+
+    def test_ignores_unknown_extensions(self):
+        """Does not extract extensions not in the allowlist."""
+        refs = _parse_referenced_files("See `.vnx-data/events/T1.ndjson` for events.")
+        self.assertNotIn(".vnx-data/events/T1.ndjson", refs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: lookup
+# ---------------------------------------------------------------------------
+
+class TestAdrIndexLookup(unittest.TestCase):
+
+    def _make_index_with_two_adrs(self) -> tuple:
+        tmpdir = tempfile.mkdtemp()
+        adr_dir = Path(tmpdir)
+        _write_adr(
+            adr_dir, "009", "Schema-First Migrations",
+            "scripts/migrate_to_central_vnx.py",
+            "Use PRAGMA introspection.",
+            "- `scripts/migrate_to_central_vnx.py`\n- `tests/test_migrate_dry_run.py`",
+        )
+        _write_adr(
+            adr_dir, "005", "NDJSON Audit Ledger",
+            "scripts/receipt_processor.py",
+            "Write NDJSON before SQLite.",
+            "- `scripts/receipt_processor.py`\n- `scripts/lib/vnx_paths.py`",
+        )
+        index = AdrIndex()
+        index.load(adr_dir)
+        return tmpdir, index
+
+    def test_lookup_by_dispatch_paths_overlap(self):
+        """A single dispatch path matches exactly one ADR."""
+        tmpdir, index = self._make_index_with_two_adrs()
+        try:
+            results = index.lookup(["scripts/migrate_to_central_vnx.py"])
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].adr_id, "ADR-009")
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_lookup_by_dispatch_paths_overlap_multi(self):
+        """Multiple dispatch paths match multiple ADRs."""
+        tmpdir, index = self._make_index_with_two_adrs()
+        try:
+            results = index.lookup([
+                "scripts/migrate_to_central_vnx.py",
+                "scripts/receipt_processor.py",
+            ])
+            ids = {r.adr_id for r in results}
+            self.assertIn("ADR-009", ids)
+            self.assertIn("ADR-005", ids)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_lookup_no_match_returns_empty(self):
+        """Paths with no ADR overlap return empty list."""
+        tmpdir, index = self._make_index_with_two_adrs()
+        try:
+            results = index.lookup(["scripts/unrelated_tool.py"])
+            self.assertEqual(results, [])
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_lookup_empty_paths_returns_empty(self):
+        """Empty dispatch_paths list returns empty result."""
+        tmpdir, index = self._make_index_with_two_adrs()
+        try:
+            self.assertEqual(index.lookup([]), [])
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: budget truncation
+# ---------------------------------------------------------------------------
+
+class TestBudgetTruncation(unittest.TestCase):
+
+    def test_budget_truncates_at_max_chars(self):
+        """fetch_relevant_adrs respects max_chars and drops entries that exceed it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir)
+            # Write 5 ADRs all referencing the same file; each entry is ~180 chars
+            for i in range(1, 6):
+                _write_adr(
+                    adr_dir, f"00{i}", f"Decision {i}",
+                    "scripts/shared_target.py",
+                    "A" * 50,  # moderate decision text
+                    "- `scripts/shared_target.py`",
+                )
+            # Use a budget that fits exactly 1 entry but not all 5.
+            # Header alone is ~171 chars; one entry adds ~110 chars → ~281 total for 1.
+            # Use 400 to ensure at least 1 fits but not all 5.
+            results = fetch_relevant_adrs(
+                ["scripts/shared_target.py"],
+                max_chars=400,
+                adr_dir=adr_dir,
+            )
+            formatted = format_adrs_section(results)
+            self.assertLessEqual(len(formatted), 400)
+            # At least one ADR should be present
+            self.assertGreaterEqual(len(results), 1)
+            # Not all 5 should be present (budget is too small)
+            self.assertLess(len(results), 5)
+
+    def test_zero_budget_returns_empty(self):
+        """max_chars=0 returns nothing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir)
+            _write_adr(adr_dir, "001", "Test", "scripts/foo.py",
+                       "Decision.", "- `scripts/foo.py`")
+            results = fetch_relevant_adrs(
+                ["scripts/foo.py"],
+                max_chars=0,
+                adr_dir=adr_dir,
+            )
+            self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: format_adrs_section
+# ---------------------------------------------------------------------------
+
+class TestFormatAdrsSection(unittest.TestCase):
+
+    def test_anti_anchoring_instruction_in_formatted_section(self):
+        """Formatted section includes the anti-anchoring governance notice."""
+        entry = AdrEntry(
+            adr_id="ADR-009",
+            title="Schema-First Migrations",
+            file_path=Path("docs/governance/decisions/ADR-009.md"),
+            referenced_files=frozenset(["scripts/migrate_to_central_vnx.py"]),
+            excerpt="Use PRAGMA introspection instead of hardcoded column lists.",
+        )
+        section = format_adrs_section([entry])
+        self.assertIn("governance constraints", section)
+        self.assertIn("not task descriptions", section)
+        self.assertIn("ADR-009", section)
+
+    def test_empty_list_returns_empty_string(self):
+        self.assertEqual(format_adrs_section([]), "")
+
+    def test_section_header_present(self):
+        entry = AdrEntry(
+            adr_id="ADR-001",
+            title="No Redis",
+            file_path=Path("docs/governance/decisions/ADR-001.md"),
+            referenced_files=frozenset(),
+            excerpt="No external Redis.",
+        )
+        section = format_adrs_section([entry])
+        self.assertIn("RELEVANT ARCHITECTURAL DECISIONS", section)
+
+    def test_excerpt_included_in_output(self):
+        entry = AdrEntry(
+            adr_id="ADR-003",
+            title="OAuth Only",
+            file_path=Path("docs/governance/decisions/ADR-003.md"),
+            referenced_files=frozenset(),
+            excerpt="All Claude routing via OAuth subprocess only.",
+        )
+        section = format_adrs_section([entry])
+        self.assertIn("All Claude routing via OAuth subprocess only.", section)
+
+
+# ---------------------------------------------------------------------------
+# Tests: cache behavior
+# ---------------------------------------------------------------------------
+
+class TestCacheBehavior(unittest.TestCase):
+
+    def test_cache_refreshes_after_ttl(self):
+        """needs_refresh() returns True when TTL has elapsed."""
+        index = AdrIndex()
+        # Manually set loaded_at to a time that's past the TTL
+        index.loaded_at = time.time() - CACHE_TTL_SEC - 1
+        self.assertTrue(index.needs_refresh())
+
+    def test_cache_fresh_within_ttl(self):
+        """needs_refresh() returns False immediately after load."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            index = AdrIndex()
+            index.load(Path(tmpdir))
+            # Just loaded — should not need refresh
+            self.assertFalse(index.needs_refresh())
+
+    def test_cache_invalidates_on_adr_file_mtime_change(self):
+        """needs_refresh() returns True when an ADR file mtime changes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir)
+            adr_file = _write_adr(
+                adr_dir, "001", "Test ADR", "scripts/foo.py",
+                "Do something.", "- `scripts/foo.py`"
+            )
+            index = AdrIndex()
+            index.load(adr_dir)
+            # Should not need refresh right after load
+            self.assertFalse(index.needs_refresh())
+
+            # Advance the file's mtime by setting it to a future time
+            future_mtime = time.time() + 5
+            os.utime(str(adr_file), (future_mtime, future_mtime))
+
+            # Now mtime differs from stored value → needs refresh
+            self.assertTrue(index.needs_refresh())
+
+    def test_needs_refresh_true_when_never_loaded(self):
+        """A fresh AdrIndex (loaded_at=0) always needs a refresh."""
+        index = AdrIndex()
+        # loaded_at == 0.0 → needs_refresh via the loaded_at == 0 branch
+        # We check this indirectly via fetch_relevant_adrs loading on first call
+        self.assertEqual(index.loaded_at, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intelligence_selector.py
+++ b/tests/test_intelligence_selector.py
@@ -1526,5 +1526,138 @@ class TestPriorRoundFindingIntegration(unittest.TestCase):
                              "Payload unexpectedly large — budget enforcement may have failed")
 
 
+# ---------------------------------------------------------------------------
+# Tests: Wave 5 P1 — adr_relevant integration
+# ---------------------------------------------------------------------------
+
+_REAL_ADR_DIR = Path(__file__).resolve().parent.parent / "docs" / "governance" / "decisions"
+
+
+class TestAdrRelevantIntegration(unittest.TestCase):
+    """Integration tests for Wave 5 P1 adr_relevant injection via select()."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._tmp_path = Path(self._tmp.name)
+        self._results_dir = self._tmp_path / "review_gates" / "results"
+        self._results_dir.mkdir(parents=True)
+
+        db_path = self._tmp_path / "quality.db"
+        conn = _setup_quality_db(db_path)
+        conn.close()
+        self._db_path = db_path
+
+        # Reset _INDEX singleton so each test starts from a clean load
+        try:
+            import adr_indexer
+            adr_indexer._INDEX.loaded_at = 0.0
+        except Exception:
+            pass
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        # Reset singleton after test to not pollute other suites
+        try:
+            import adr_indexer
+            adr_indexer._INDEX.loaded_at = 0.0
+        except Exception:
+            pass
+
+    def test_select_includes_adr_relevant_when_dispatch_paths_match(self):
+        """dispatch on scripts/migrate_to_central_vnx.py auto-receives ADR-009 context."""
+        if not _REAL_ADR_DIR.is_dir():
+            self.skipTest("real ADR dir not available")
+
+        selector = IntelligenceSelector(quality_db_path=self._db_path)
+        result = selector.select(
+            "test-dispatch-adr-migrate-001",
+            "dispatch_create",
+            skill_name="backend-developer",
+            dispatch_paths=["scripts/migrate_to_central_vnx.py"],
+        )
+        selector.close()
+
+        item_classes = [item.item_class for item in result.items]
+        self.assertIn("adr_relevant", item_classes,
+                      "Expected adr_relevant item for scripts/migrate_to_central_vnx.py path")
+
+        adr_item = next(i for i in result.items if i.item_class == "adr_relevant")
+        self.assertIn("ADR-009", adr_item.source_refs,
+                      "ADR-009 should be referenced since it mentions migrate_to_central_vnx.py")
+        self.assertEqual(adr_item.confidence, 1.0)
+        self.assertGreaterEqual(adr_item.evidence_count, 1)
+
+    def test_select_does_not_include_adr_relevant_when_no_paths_overlap(self):
+        """dispatch with unrelated paths produces no adr_relevant item."""
+        if not _REAL_ADR_DIR.is_dir():
+            self.skipTest("real ADR dir not available")
+
+        selector = IntelligenceSelector(quality_db_path=self._db_path)
+        result = selector.select(
+            "test-dispatch-no-adr-overlap",
+            "dispatch_create",
+            skill_name="backend-developer",
+            dispatch_paths=["scripts/totally_nonexistent_xyz_tool.py"],
+        )
+        selector.close()
+
+        item_classes = [item.item_class for item in result.items]
+        self.assertNotIn("adr_relevant", item_classes)
+
+    def test_select_combines_prior_round_and_adr_relevant_within_budget(self):
+        """When both pr_id and dispatch_paths are set, both item classes can appear."""
+        if not _REAL_ADR_DIR.is_dir():
+            self.skipTest("real ADR dir not available")
+
+        # Write a gate result for pr_id=300
+        gate_data = {
+            "gate": "codex_gate",
+            "pr_id": "300",
+            "blocking_findings": [
+                {"message": "Missing PRAGMA introspection in scripts/migrate_to_central_vnx.py:42."}
+            ],
+            "advisory_findings": [],
+            "recorded_at": "2026-05-10T10:00:00Z",
+            "contract_hash": "test_hash_adr_combo",
+            "status": "completed",
+        }
+        gate_path = self._results_dir / "pr-300-codex_gate.json"
+        gate_path.write_text(json.dumps(gate_data), encoding="utf-8")
+
+        import prior_round_injector
+        prior_round_injector._fetch_cached.cache_clear()
+
+        original_resolve = prior_round_injector._resolve_state_dir
+
+        def _patched_resolve(state_dir=None):
+            if state_dir is not None:
+                return state_dir
+            return self._tmp_path
+
+        prior_round_injector._resolve_state_dir = _patched_resolve
+        try:
+            selector = IntelligenceSelector(quality_db_path=self._db_path)
+            result = selector.select(
+                "test-dispatch-adr-prior-combo",
+                "dispatch_create",
+                skill_name="backend-developer",
+                pr_id="300",
+                dispatch_paths=["scripts/migrate_to_central_vnx.py"],
+            )
+            selector.close()
+        finally:
+            prior_round_injector._resolve_state_dir = original_resolve
+
+        item_classes = [item.item_class for item in result.items]
+        # At least one of the two high-priority classes should be present
+        self.assertTrue(
+            "prior_round_finding" in item_classes or "adr_relevant" in item_classes,
+            f"Expected at least one of prior_round_finding or adr_relevant, got: {item_classes}",
+        )
+        # Payload must stay bounded
+        payload_size = len(json.dumps(result.to_payload_dict()))
+        self.assertLessEqual(payload_size, MAX_PAYLOAD_CHARS * 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Wave 5 P1 — ADR injection by file-touch. When a dispatch's `dispatch_paths` overlap with files referenced in any ADR, the relevant ADR sections are auto-injected into the dispatch instruction as an `adr_relevant` IntelligenceItem.

- **Concrete example from design doc:** dispatch on `scripts/migrate_to_central_vnx.py` now automatically receives ADR-009 (Schema-First Migrations, PRAGMA introspection rule) as injected context — the governance constraint that prevents the hardcoded-column-projection bug class caught in PR #432 rounds 7–9.
- **P0 + P1 together** complete the "past-state context" half of the three-state model: prior-round review findings (P0) + relevant ADR governance constraints (P1).

## Changes

- `scripts/lib/adr_indexer.py` (NEW, ~165 LOC): ADR-to-file-path indexer with 60s TTL cache + mtime invalidation, path resolution via `vnx_paths.resolve_paths()`, budget-bounded `fetch_relevant_adrs()`, and `format_adrs_section()` with anti-anchoring governance instruction.
- `scripts/lib/intelligence_selector.py` (+70 LOC): wires `adr_relevant` item class into `select()` after the P0 prior-round-finding block; adds `_enforce_payload_limit_with_adr()` for budget enforcement (drops standard classes → prior_round → adr_relevant last resort); graceful `ImportError` fallback.
- `tests/test_adr_indexer.py` (NEW, 21 tests): load, reference extraction (py/md/sql/yaml/hyphenated filenames), lookup overlap, budget truncation, format section, TTL refresh, mtime invalidation.
- `tests/test_intelligence_selector.py` (+3 integration tests): match with real ADR dir, no-overlap returns nothing, combined prior_round + adr_relevant within budget.

## Test results

```
tests/test_adr_indexer.py: 21 passed
tests/test_intelligence_selector.py: 53 passed (3 new ADR tests + 50 existing)
tests/test_prior_round_injector.py: 14 passed
Total: 88 passed, 0 failed
```

## Design authority

- Parent dispatch: `20260510-wave5-pr0-prior-round-findings` (PR-W5.0, merged as #455)
- Design doc: `claudedocs/2026-05-09-wave5-p0-design.md` §6 (P1 spec)
- Dispatch-ID: `20260510-wave5-pr1-adr-file-touch-injection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)