### PR TITLE
docs: refresh README + CHANGELOG for post-rc1 work (Wave 1 + Wave 5 P0/P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased — post-v1.0.0-rc1 (2026-05-09 → present)
+
+Wave 1 (shadow-mode read cutover) + Wave 5 P0/P1 (smart-context smart injection) shipped on top of the v1.0.0-rc1 architectural baseline.
+
+### Added — Wave 1 shadow-mode read cutover (#450–#454)
+- **PR-W1.1 (#450)** `scripts/lib/shadow_verifier.py` — independent comparator (no shared code with the migration) computing 6 zero-tolerance divergence metrics: wrong-project rows, scoping/blocking-finding mismatch, IntelligenceSelector top-3 divergence, count drift (0%) + checksum drift (<0.01%), lease-key collision count, p95-latency ratio (central ≤ 1.5× per-project).
+- **PR-W1.2 (#451)** `scripts/lib/shadow_logger.py` NDJSON writer + `scripts/shadow_report.py` CLI + `scripts/rotate_shadow_ledger.sh` timestamp-suffix rotation under flock; routes via `vnx_paths.resolve_paths()` (no `.vnx-data/state/` literals).
+- **PR-W1.3 (#452)** T0 state-builder shadow wiring — 4 read sites in `scripts/build_t0_state.py` instrumented with `VNX_USE_CENTRAL_DB=unset|shadow|1` flag.
+- **PR-W1.4 (#453)** `IntelligenceSelector` (5 read methods) + `DispatchRegister` shadow wiring (~600 LOC additions).
+- **PR-W1.5 (#454)** Dashboard read paths shadow-wired (`api_intelligence.py`, `api_operator.py`); canary divergence test pack with 14+ deliberate-divergence fixtures (`tests/canary/test_shadow_canary_divergence.py`); operator-readable `docs/operations/wave1-rollback.md`.
+
+### Added — Wave 5 smart-context injection (#455–#456)
+- **PR-W5.0 (#455)** `scripts/lib/prior_round_injector.py` — when a dispatch has `pr_id` mapping to existing review-gate results, fetch blocking + advisory findings from prior rounds and inject as a bounded markdown section (≤2000 chars). Scope-filtered by `dispatch_paths` overlap; recency-sorted; LRU-cached 60s TTL; anti-anchoring instruction included per Codex Q4 epistemic-failure-mode mitigation. Validated against PR #432's 9-round cascade as canonical proof-of-concept.
+- **PR-W5.1 (#456)** `scripts/lib/adr_indexer.py` — scans `docs/governance/decisions/ADR-*.md` for file-path references, builds an inverted index `file_path → [ADR_ids]`. When dispatch `dispatch_paths` overlap with ADR-referenced files, the relevant ADR sections are auto-injected as governance context. Bounded by 1500-char budget; mtime-based 60s TTL cache.
+
+### Added — Governance amendment
+- **ADR-011 v2 (#449)** — split subagent pilot into 2 sequential gates: Gate 1 provenance/redaction (10 dispatches), Gate 2 performance baseline (15 dispatches, median ≥30% wall-clock saved + p25 ≥0%).
+
+### Documentation produced (claudedocs/, gitignored)
+- `claudedocs/2026-05-09-wave1-design.md` — Wave 1 spec with 6 hard metrics
+- `claudedocs/2026-05-09-wave5-p0-design.md` — prior-round-findings injection design
+- `claudedocs/2026-05-09-vnx-smart-context-design.md` — three-state context bundle pipeline
+- `claudedocs/2026-05-10-deepseek-v4-pro-harness-feasibility.md` — three integration paths analysis
+- `claudedocs/2026-05-09-vnx-codex-strategic-review.md` + `2026-05-09-vnx-gemini-strategic-review.md` + `2026-05-09-vnx-reviews-synthesis.md` — dual-LLM external review insights driving v1.2 strategic plan
+
+### Burn-in pending (not yet merged into v1.0.0 final)
+- Wave 1 cutover requires 7 consecutive days clean on all 6 hard metrics (per project, per table) before flipping `VNX_USE_CENTRAL_DB=shadow → 1`.
+- Wave 5 P2/P3/P4 (file:line code anchors / operator memory / schema introspection) extend the +30pp smart-context lift; in flight.
+- v1.0.0 final tag is operator-decision after Wave 1 cutover validates on pilot projects.
+
 ## v1.0.0-rc1 — 2026-05-09 (Architectural stabilization milestone)
 
 Chain summary: Wave 0 + Wave 0.5 of the strategic replan — architectural decisions LOCKED via 14 ADRs, central VNX state proven on real production data (855k snippets across 4 projects, 0 verifier discrepancies), CI gate enforcing OAuth-only Claude routing, smart context injection validated at +30 percentage-point dispatch quality lift on 658 outcome-tagged dispatches.

--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-10T07:10:00.770992+00:00
+**Last updated**: 2026-05-06T06:43:55.184630+00:00
 
 ## Active features
 
@@ -10,7 +10,13 @@ _No active features._
 ## Completed
 
 ### F43
-All PRs merged. (#402)
+All PRs merged. (#303)
+
+### F57
+All PRs merged. (#347)
+
+### F60
+All PRs merged. (#305 + #308 + #312)
 
 ## Planned (from ROADMAP.yaml)
 

--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-06T06:43:55.184630+00:00
+**Last updated**: 2026-05-10T07:10:00.770992+00:00
 
 ## Active features
 
@@ -10,13 +10,7 @@ _No active features._
 ## Completed
 
 ### F43
-All PRs merged. (#303)
-
-### F57
-All PRs merged. (#347)
-
-### F60
-All PRs merged. (#305 + #308 + #312)
+All PRs merged. (#402)
 
 ## Planned (from ROADMAP.yaml)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ Agent hits 65% context → blocked from further tool calls
 
 Zero human intervention. Zero lost work. The receipt ledger maintains a complete chain across rotations.
 
+## What's new in v1.0.0-rc1 (May 2026)
+
+### Architectural stabilization — 14 ADRs locked
+Decisions previously implicit are now captured as numbered ADRs (`docs/governance/decisions/ADR-001` through `ADR-014`). Highlights: ADR-003 OAuth-only Claude routing (no SDK), ADR-005 NDJSON ledger as primary substrate, ADR-008 dual-LLM adversarial review with `contract_hash` evidence binding, ADR-011 manager+worker hierarchy with Conditional/Pilot subagents, ADR-014 autonomous chain dispatch with SHA-256 consent token. From this release forward, dispatch envelope, receipt schema, and ledger format are backwards-compatibility-honoring.
+
+### CI gate — no Anthropic SDK imports
+`scripts/check_adr_003_no_sdk_imports.py` blocks any `import anthropic` / `from anthropic` / `import claude_agent_sdk` in `scripts/`, `dashboard/`, or `tests/`. Magic-comment opt-in for explicit exceptions only. Enforces ADR-003: VNX drives Claude exclusively via `claude -p` subprocess on the operator's OAuth credential — never SDK + API key.
+
+### Smart context injection — measured +30pp dispatch quality lift
+Replaced naïve "intelligence_items" with three-state-aware context bundles. PR #455 (W5.0) adds prior-round-findings injection — when a dispatch is round N+1 of a multi-round PR, the worker auto-receives blocking + advisory findings from prior rounds. PR #456 (W5.1) adds ADR injection by file-touch — dispatches whose `dispatch_paths` overlap with files referenced in ADRs auto-receive the relevant governance text. Validated on 658 outcome-tagged dispatches: 88.9% success WITH intelligence vs 58.3% WITHOUT.
+
+### Phase 6 P4 — central VNX state proven on production data
+`scripts/migrate_to_central_vnx.py` (PR #432) imported 855k code_snippets + 505 dispatches across 4 production source DBs with **0 verifier discrepancies**. Migration 0016 schema-first rewrite per ADR-009 (PR #446) replaces hardcoded column projections with PRAGMA introspection. Composite UNIQUE rebuilds for 5 multi-tenant tables; structural test parsing `0015_complete_project_id.sql` enforces ALTER↔IMPORT_TABLES symmetry.
+
+### Wave 1 — shadow-mode read cutover with 6 hard divergence metrics
+`shadow_verifier.py` (PR #450) is an independent comparator (no shared code with the migration) that computes 6 zero-tolerance metrics: wrong-project rows, scoping/blocking-finding mismatch, top-3 divergence, count drift, lease-key collisions, p95-latency ratio. `shadow_logger.py` (PR #451) writes NDJSON divergence records under flock with timestamp-suffix rotation. PRs #452–#454 wire 4 T0 read sites + 5 IntelligenceSelector/DispatchRegister read sites + dashboard read paths through `VNX_USE_CENTRAL_DB=unset|shadow|1` flag. Canary test pack with 14+ deliberate-divergence fixtures + operator-readable rollback procedure.
+
+### Repo hygiene — 49 strategic/business docs moved to private `claudedocs/`
+Five-tier OI-1373 cleanup: 8 business agent drafts, 7 strategy files, internal design docs, 18 phase FEATURE_PLANs, and 9 stale research docs moved from public `roadmap/`+`docs/internal/` to gitignored `claudedocs/`. Pattern: filesystem `mv` + `git add -u` (NOT `git mv`) — preserves files locally on disk while removing from git tracking.
+
 ## What's new in v0.10.0 (April 2026)
 
 ### Self-healing daemons
@@ -305,11 +325,13 @@ Receipts track `in_worktree: true/false` and commit provenance (`CLEAN`, `DIRTY_
 
 ## Session Intelligence
 
-VNX mines session logs to find patterns and generate tuning suggestions. Nothing is auto-applied:
+VNX continuously mines its own NDJSON ledger + dispatch metadata to learn what works and inject it into future dispatches. Three layers:
 
-1. **Analyze** — Parse logs, detect patterns, extract model performance
-2. **Brief** — Aggregate into T0-readable state file
-3. **Suggest** — Generate tuning proposals (MEMORY, rules, skills)
+1. **Pattern extraction** — `intelligence_extractor.py` writes success patterns + anti-patterns to SQLite (`quality_intelligence.db`) with `valid_from` / `valid_until` lifecycle, `source_dispatch_ids` provenance, and per-pattern confidence scores updated from outcome feedback.
+2. **Three-state-aware context bundle** — `IntelligenceSelector.select()` now combines intelligence_items, prior-round review findings (Wave 5 P0), ADR governance text by file-touch (Wave 5 P1), and on-roadmap code anchors / schemas / operator memory (Wave 5 P2-P4 in flight) into a bounded per-dispatch context pack.
+3. **Tuning suggestions** — `vnx suggest review` surfaces auto-generated proposals (MEMORY edits, rule/skill changes); nothing auto-applies. `vnx suggest accept <ids>` then `vnx suggest apply`.
+
+Measured impact: **88.9% dispatch success WITH intelligence vs 58.3% WITHOUT** over 658 outcome-tagged dispatches (+30 percentage-point lift). PR-cascade prevention validated against PR #432's 9-round chain as canonical proof-of-concept.
 
 ```bash
 vnx suggest review         # See what's proposed
@@ -319,15 +341,25 @@ vnx suggest apply          # Apply to target files
 
 ## Mission Control Dashboard
 
-A real-time operator dashboard runs locally at `localhost:3100` (Next.js frontend) with an API server at `localhost:4173`. No cloud dependency — the dashboard reads directly from `.vnx-data/` filesystem state.
+Real-time operator dashboard at `localhost:3100` (Next.js frontend) backed by a Python API server at `localhost:4173`. No cloud dependency — the dashboard reads directly from `.vnx-data/` filesystem state and the runtime SQLite DBs.
 
-What it shows:
+### Live streams (SSE)
+- **`/api/register-stream`** — dispatch lifecycle events stream (`created → promoted → started → gate_passed → completed`). Kanban no longer polls.
+- **`/api/agent-stream`** — per-terminal NDJSON event tail (`init`, `thinking`, `text`, `tool_use`, `tool_result`) — watch a headless worker reason in real time.
 
-- **Terminal status cards** — which agent is doing what, context pressure level, last heartbeat timestamp
-- **Reports browser** — auto-assembled worker reports organized by domain (coding, business), browsable without digging through files
-- **Dispatch queue** — pending, active, and completed dispatches with full provenance chain visible
-- **Quality metrics** — first-pass yield, rework rate, SPC control charts, and governance health indicators
-- **Agent selector** — pick agents by name rather than terminal ID when routing work
+### Operator pages
+- **Terminals** — per-terminal status cards: which agent is doing what, lease state, context pressure, last heartbeat.
+- **Kanban** — pending / active / completed dispatch board with full provenance chain.
+- **Dispatches** (+ detail view) — every dispatch's manifest, instruction_sha256, receipt, and gate evidence in one place.
+- **Reports** — auto-assembled worker reports browsable by domain (coding / business) and headless gate output (codex_gate, gemini_review markdown).
+- **Open Items** — blocker / warn / info ledger filterable by PR, severity, and dispatch source.
+- **Intelligence** — pattern catalog with confidence trends, injection ledger, dispatch-effectiveness bucket chart (with vs without intelligence).
+- **Improvements** — proposals view: see what `vnx suggest` would change, accept/reject inline.
+- **Governance** — ADR catalog, CI gate status, contract-hash binding for the active review stack.
+- **Conversations** — session transcript viewer for any historical dispatch.
+
+### Token + cost
+- **Tokens** + **Models** + **Usage** pages — cross-provider token counts (Claude / Codex / Gemini), per-feature spend aggregation, model-mix breakdown.
 
 ```bash
 vnx dashboard          # Launch at localhost:3100
@@ -387,41 +419,37 @@ Detailed comparisons: [VNX vs Claude Code](docs/comparisons/vnx_vs_claude_code.m
 
 Active development. Priorities shift based on real usage patterns.
 
-### Recently landed (F46–F75, April 2026)
+### Recently landed (Wave 0 + 0.5 + Wave 1 + Wave 5 P0/P1, May 2026)
 
-- **F46** Intelligence extraction pipeline — learning loop writes success/anti-patterns to SQLite; intelligence selector returns real items per dispatch
-- **F47** T0 state feedback loop — receipt watcher, feature state machine, structured feature context in `t0_brief.json`
-- **F48** Autonomous loop + headless dispatch daemon — model-agnostic LLM decision router (Ollama / Claude CLI / dry-run backends)
-- **F49** Dashboard intelligence — pattern/injection/classification API endpoints, intelligence page, session transcript viewer
-- **F50** Self-improvement loop — proposals API, confidence trends, weekly digest, pattern-usage feedback wiring
-- **F51** Configurable governance enforcement — 4-level YAML config (off / advisory / soft / hard mandatory) with per-check override support
-- **F52** Operator CLI + per-terminal permission profiles + post-dispatch commit enforcement
-- **F53** Multi-provider adapter layer — `ProviderAdapter` ABC with Claude / Gemini / Codex / Ollama adapters
-- **F54** Temporal pattern lifecycle (`valid_from` / `valid_until` on intelligence tables)
-- **F55** PageRank repo map — tree-sitter symbol extraction wired into pre-dispatch enrichment
-- **F56** Nightly NDJSON memory consolidation
-- **F57** Karpathy-style dispatch parameter tracker + correlation analysis
-- **F58** Observability fixes — dispatch manifest, session/commit traceability in receipts, event archival, layered user-message architecture
-- **F60** Intelligence activation — SQL fixes, universal-scope patterns, retroactive backfill of 829 dispatch experiments
-- **F61–F75 (chain 2026-04-28→04-30)** State self-maintenance (compact_state nightly cron), headless audit parity (instruction_sha256, stuck-event tracking, token tracking, canonical gate schema), supervisor pack (cleanup_worker_exit + receipt_processor_supervisor), codex severity prompt tightening, dashboard frontend regression suites (Playwright visual + network + console).
+Strategic replan v1.2 reframed development around 6 waves. Shipped between v1.0.0-rc1 cut and now:
 
-T0 orchestration hardening (2026-04-19 postmortem response) landed in `fix/t0-hardening-2026-04-19`: dispatch_guard cross-validates brief vs terminal_state, auto-recover expired leases, `canonical_state_views.py` restored.
+- **Wave 0** — 14 ADRs locked (003-014), CI gate `ADR-003: No Anthropic SDK Imports`, 49 strategic docs moved to private `claudedocs/` (5-tier OI-1373 cleanup), v1.0.0-rc1 release notes (#439–#449)
+- **Wave 0.5** — Phase 6 P4 data migration to central VNX state proven on real production data (855k code_snippets, 505 dispatches, 0 verifier discrepancies); migration 0016 schema-first per ADR-009 (#432, #446)
+- **Wave 1 — shadow-mode read cutover (#450–#454)** —
+  - W1.1 `shadow_verifier.py` independent comparator with 6 hard divergence-detection metrics (zero-tolerance for scoping/blocking findings)
+  - W1.2 `shadow_logger.py` NDJSON writer + report CLI + flock-rotation
+  - W1.3 T0 state-builder shadow wiring (4 read sites)
+  - W1.4 `IntelligenceSelector` + `DispatchRegister` shadow wiring (5 read sites)
+  - W1.5 Dashboard shadow wiring + canary divergence test pack (14+ fixtures) + operator-readable rollback docs
+- **Wave 5 P0 — prior-round-findings injection (#455)** — when a dispatch is round N+1 of a multi-round PR, the worker auto-receives blocking + advisory findings from prior rounds. Validated against PR #432's 9-round cascade as the canonical proof-of-concept.
+- **Wave 5 P1 — ADR injection by file-touch (#456)** — dispatches whose `dispatch_paths` overlap with files referenced in ADRs auto-receive the relevant ADR sections as governance context.
 
 ### Next
 
-- **Roadmap Autopilot (P0)** — multi-feature orchestration with auto-feature handoff after merged + verified closure (see `roadmap/features/roadmap-autopilot/FEATURE_PLAN.md`)
-- **Task Control Surface** — live dispatch board, SSE streaming, one-click re-dispatch from dashboard
-- **Battle testing** — overnight soak + failure injection on the full autonomous loop
-- **Model-agnostic execution** — route headless dispatches to Gemini / Codex / Ollama using the F53 adapter layer (currently Claude-only in practice)
-- **Multi-channel operator input** — Slack / WhatsApp / webhook triggers alongside tmux
-- **Dynamic worker pools** — scale headless workers based on queue depth and API budget
-- **Business agent templates** — pre-built configurations for content, research, analysis
+Strategic replan v1.2 sequence:
+
+- **Wave 1 cutover validation (in progress)** — pilot burn-in on mc + sales projects with `VNX_USE_CENTRAL_DB=shadow`. Required: 7 consecutive days clean on all 6 hard metrics before flipping `shadow → 1` per project per table.
+- **Wave 5 P2/P3/P4 (in progress)** — file:line code-anchor injection, operator-memory injection, schema-introspection injection (extends the +30pp smart-context lift across the remaining context bundle classes).
+- **Wave 2 — Phase 6 cleanup** — retire shadow-mode flag once all consumers cut over, remove dual-write code paths, rotate-and-archive per-project DBs.
+- **Wave 5.5 (conditional)** — cryptographic audit-integrity layer (signed checkpoints, hash-chained NDJSON) — gating decision pending operator review.
+- **Wave 6** — workers=N tactical: subagent-pilot 2-gate split per ADR-011 v2 (Gate 1 provenance/redaction, Gate 2 performance baseline median ≥30% wall-clock saved).
+- **Wave 7+** — option space: multi-operator/federation, performance/scale, integration breadth (LiteLLM bridge to non-Claude providers), domain expansion. Non-binding; refresh post-Wave 6.
 
 ### Known gaps / deferred
 
-- **Headless context rotation** (F43 follow-up, tracked in OI-1073) — subprocess workers currently use single-shot dispatch; active token-stream tracking, auto-rotation, handover writing, and continuation prompt injection are deferred. Interactive terminals retain native Claude Code rotation.
+- **Headless context rotation** (OI-1073) — subprocess workers currently use single-shot dispatch; active token-stream tracking, auto-rotation, handover writing, and continuation prompt injection are deferred. Interactive terminals retain native Claude Code rotation.
 - **MCP server** — expose VNX state to external Claude sessions; not yet built.
-- **9 chain PRs deferred** (#300–#303 fix-loop convergence; #305, #311, #316, #317, #320, #321 merge conflicts after sequential merge wave) — branches alive on origin, see OI-1211 through OI-1236 for context.
+- **v1.0.0 final tag** — operator decision after Wave 1 cutover validates on pilot projects. Currently `v1.0.0-rc1` is the public release candidate.
 
 See [CHANGELOG.md](CHANGELOG.md) for what shipped recently.
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,11 @@ Agent hits 65% context → blocked from further tool calls
 
 Zero human intervention. Zero lost work. The receipt ledger maintains a complete chain across rotations.
 
-## What's new in v1.0.0-rc1 (May 2026)
+## What's new since v1.0.0-rc1 (May 2026)
 
-### Architectural stabilization — 14 ADRs locked
+> Strategic replan v1.2 organizes work into 6 waves. v1.0.0-rc1 itself shipped Wave 0 + 0.5 (architectural stabilization + Phase 6 P4 migration). Wave 1 (shadow read cutover) and Wave 5 P0/P1 (smart-context injection) shipped on top of the rc1 baseline and are still pending burn-in before the v1.0.0 final tag — see [CHANGELOG.md](CHANGELOG.md) "Unreleased" for the post-rc1 PR list.
+
+### Architectural stabilization — 14 ADRs locked (v1.0.0-rc1)
 Decisions previously implicit are now captured as numbered ADRs (`docs/governance/decisions/ADR-001` through `ADR-014`). Highlights: ADR-003 OAuth-only Claude routing (no SDK), ADR-005 NDJSON ledger as primary substrate, ADR-008 dual-LLM adversarial review with `contract_hash` evidence binding, ADR-011 manager+worker hierarchy with Conditional/Pilot subagents, ADR-014 autonomous chain dispatch with SHA-256 consent token. From this release forward, dispatch envelope, receipt schema, and ledger format are backwards-compatibility-honoring.
 
 ### CI gate — no Anthropic SDK imports


### PR DESCRIPTION
## Summary
- README "What's new" gets a v1.0.0-rc1 (May 2026) section above v0.10.0 covering 14 ADRs, ADR-003 CI gate, +30pp smart-context lift, Phase 6 P4 central VNX state validation, Wave 1 shadow cutover, OI-1373 cleanup
- README "Recently landed" replaces F46–F75 list with Wave 0 + 0.5 + Wave 1 (#450–#454) + Wave 5 P0/P1 (#455, #456) and current "Next" sequence
- README "Session Intelligence" rewritten to reflect three-layer pipeline (pattern extraction + three-state context bundle + tuning); cites measured 88.9% vs 58.3% lift
- README "Mission Control Dashboard" enumerates SSE live-stream endpoints + operator pages (kanban / dispatches / reports / open-items / intelligence / improvements / governance / conversations) + token+cost pages
- CHANGELOG gets new Unreleased section above v1.0.0-rc1 covering Wave 1 + Wave 5 P0/P1 + ADR-011 v2 amendment + burn-in pending notes
- FEATURE_PLAN auto-generated drift refresh

Pure docs PR — no code changes. CI should be green except for any docs-touch-specific checks.

## Test plan
- [ ] CI green (no functional changes)
- [ ] Render README on GitHub — check section ordering + version banner
- [ ] CHANGELOG renders cleanly with Unreleased section above v1.0.0-rc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)