### PR TITLE
feat(wave5): PR-W5.3 — operator memory injection (curated wisdom into worker context)

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -6,8 +6,8 @@ Implements the FP-C Intelligence Contract (docs/core/31_FPC_INTELLIGENCE_CONTRAC
   - Selection algorithm (Section 2.3): one item per class, highest confidence wins
   - Payload bounds (Section 2.2): max 3 items, max 2000 chars total for standard classes
     (proven_pattern, failure_prevention, recent_comparable); direct-injection classes
-    (code_anchor, prior_round_finding, adr_relevant) carry up to 1500 chars each and
-    the combined payload limit is raised to 4000 chars to allow two such items to coexist.
+    (code_anchor, prior_round_finding, adr_relevant, operator_memory) carry up to 1500 chars
+    each and the combined payload limit is raised to 4000 chars to allow multiple such items.
   - Evidence thresholds: proven_pattern >= 0.6, failure_prevention >= 0.5, recent_comparable >= 0.4
   - Task-class-aware filtering via scope_tags and task_class_filter
   - Injection and suppression events emitted to coordination_events
@@ -53,6 +53,11 @@ except ImportError:
     _code_anchor_finder = None  # type: ignore[assignment]
 
 try:
+    import operator_memory_indexer as _operator_memory_indexer
+except ImportError:
+    _operator_memory_indexer = None  # type: ignore[assignment]
+
+try:
     from vnx_paths import resolve_central_data_dir as _resolve_central_data_dir
 except ImportError:
     _resolve_central_data_dir = None  # type: ignore[assignment]
@@ -78,7 +83,7 @@ MAX_CODE_ANCHOR_CHARS = 1500
 # Item classes that carry pre-formatted sections and must not be clipped to the
 # 500-char standard limit.  These are direct-injection classes whose full content
 # (up to MAX_CODE_ANCHOR_CHARS) the worker is expected to read verbatim.
-_DIRECT_INJECTION_CLASSES = frozenset({"code_anchor", "prior_round_finding", "adr_relevant"})
+_DIRECT_INJECTION_CLASSES = frozenset({"code_anchor", "prior_round_finding", "adr_relevant", "operator_memory"})
 
 # Per-class confidence thresholds (Section 1.2 / 2.3)
 CONFIDENCE_THRESHOLDS = {
@@ -745,6 +750,35 @@ class IntelligenceSelector:
                 )
                 selected.append(anchor_item)
                 selected = self._enforce_payload_limit_with_code_anchor(selected, suppressed)
+
+        # Wave 5 P3: inject operator memories (curated wisdom) when role, dispatch_paths,
+        # or instruction_text are present. Provides accumulated operator feedback so workers
+        # inherit hard-won lessons without discovering them the hard way.
+        if (skill_name or dispatch_paths or instruction_text) and _operator_memory_indexer is not None:
+            memories = _operator_memory_indexer.fetch_relevant_memories(
+                skill_name,
+                dispatch_paths or [],
+                instruction_text or "",
+                max_chars=MAX_CODE_ANCHOR_CHARS,
+            )
+            if memories:
+                now_ts = _now_utc()
+                memory_item = IntelligenceItem(
+                    item_id=f"intel_om_{dispatch_id}",
+                    item_class="operator_memory",
+                    title=f"Relevant operator memories ({len(memories)})",
+                    content=_operator_memory_indexer.format_memories_section(memories),
+                    confidence=1.0,
+                    evidence_count=len(memories),
+                    last_seen=now_ts,
+                    scope_tags=[],
+                    source_refs=[m.name for m in memories],
+                    task_class_filter=[],
+                    pattern_category=PATTERN_CATEGORY_CODE,
+                    content_hash="",
+                )
+                selected.append(memory_item)
+                selected = self._enforce_payload_limit_with_operator_memory(selected, suppressed)
 
         now = _now_utc()
         result = InjectionResult(
@@ -2163,6 +2197,54 @@ class IntelligenceSelector:
 
         drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + [
             "prior_round_finding", "adr_relevant", "code_anchor"
+        ]
+        for drop_class in drop_order:
+            to_drop = [i for i in selected if i.item_class == drop_class]
+            if not to_drop:
+                continue
+
+            selected = [i for i in selected if i.item_class != drop_class]
+            suppressed.append(SuppressionRecord(
+                item_class=drop_class,
+                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
+            ))
+
+            payload_size = len(json.dumps({
+                "injection_point": "dispatch_create",
+                "injected_at": _now_utc(),
+                "items": [item.to_dict() for item in selected],
+                "suppressed": [s.to_dict() for s in suppressed],
+            }))
+
+            if payload_size <= MAX_PAYLOAD_CHARS:
+                break
+
+        return selected
+
+    def _enforce_payload_limit_with_operator_memory(
+        self,
+        selected: List[IntelligenceItem],
+        suppressed: List[SuppressionRecord],
+    ) -> List[IntelligenceItem]:
+        """Re-enforce payload limit after an operator_memory item has been appended.
+
+        Drops standard classes first (recent_comparable → failure_prevention →
+        proven_pattern → prior_round_finding → adr_relevant → code_anchor) and
+        only removes operator_memory as last resort since it carries operator-curated
+        lessons with confidence 1.0.
+        """
+        payload_size = len(json.dumps({
+            "injection_point": "dispatch_create",
+            "injected_at": _now_utc(),
+            "items": [item.to_dict() for item in selected],
+            "suppressed": [s.to_dict() for s in suppressed],
+        }))
+
+        if payload_size <= MAX_PAYLOAD_CHARS:
+            return selected
+
+        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + [
+            "prior_round_finding", "adr_relevant", "code_anchor", "operator_memory"
         ]
         for drop_class in drop_order:
             to_drop = [i for i in selected if i.item_class == drop_class]

--- a/scripts/lib/operator_memory_indexer.py
+++ b/scripts/lib/operator_memory_indexer.py
@@ -157,8 +157,8 @@ def _project_memory_dir(cwd: Optional[Path] = None) -> Optional[Path]:
         cwd = Path.cwd()
     cwd = cwd.resolve()
 
-    # Claude Code slug: posix path with '/' replaced by '-'
-    # e.g. /Users/x/Development/foo → -Users-x-Development-foo
+    # Claude Code slug: posix path with each '/' replaced by '-'
+    # e.g. <HOME>/Development/foo → -<HOME>-Development-foo
     slug = cwd.as_posix().replace("/", "-")
     candidate = Path.home() / ".claude" / "projects" / slug / "memory"
     if candidate.is_dir():

--- a/scripts/lib/operator_memory_indexer.py
+++ b/scripts/lib/operator_memory_indexer.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Wave 5 P3 — Operator memory indexer for context injection.
+
+Scans ~/.claude/projects/<project-slug>/memory/*.md for operator-curated
+feedback / project / user / reference memories. Builds a per-memory tag set
+from frontmatter + content, then matches against worker role + dispatch_paths
++ instruction_text to pick the most relevant ones.
+
+Memory file format expected:
+    ---
+    name: ...
+    description: ...
+    type: feedback|project|user|reference
+    ---
+    body markdown...
+
+Selection algorithm (mirrors smart-context-design §3.3 step 5):
+1. Parse frontmatter from each *.md (YAML between --- markers)
+2. Compute tag set per memory:
+   - explicit tags from frontmatter (if present)
+   - role inference from name/description (e.g. "database" → matches database-engineer)
+   - file_path references in body (matches dispatch_paths)
+3. Score each memory by:
+   - role match: +3
+   - dispatch_path overlap: +2 per match
+   - instruction_text term overlap with name/description: +1 per match
+   - feedback type weighted 1.5x (operator's hard-won corrections)
+4. Top-K selected (cap 3) within MAX_MEMORY_CHARS budget (1200 chars total)
+5. Format as markdown section for injection
+
+Cached for 60s with mtime-change invalidation (mirrors adr_indexer pattern).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+MAX_MEMORY_CHARS = 1200       # leaves budget for prior_round + adr + code_anchor
+MAX_MEMORIES_PER_DISPATCH = 3
+CACHE_TTL_SEC = 60
+
+_FRONTMATTER_RE = re.compile(r'^---\n(.*?)\n---\n?(.*)', re.DOTALL)
+_FILE_REF_RE = re.compile(r'\b([\w./][\w./-]*\.(?:py|md|sql|sh|yaml|yml|ts|js|tsx|jsx))\b')
+_KV_RE = re.compile(r'^(\w+)\s*:\s*(.+)$', re.MULTILINE)
+# Identifier tokens for instruction-term overlap (≥4 chars, snake_case or CamelCase)
+_IDENT_RE = re.compile(r'\b([A-Z][a-zA-Z0-9_]{3,}|[a-z_][a-z_0-9]{4,})\b')
+# Stopwords to filter from inferred tags
+_STOPWORDS = frozenset({
+    'about', 'always', 'never', 'should', 'would', 'could', 'where', 'which',
+    'these', 'those', 'first', 'second', 'third', 'after', 'before', 'using',
+    'via', 'through', 'memory', 'memories', 'operator', 'return', 'value',
+    'other', 'given', 'makes', 'tests', 'test', 'with', 'from', 'that',
+    'into', 'each', 'must', 'need', 'such', 'both', 'then', 'than', 'does',
+    'files', 'false', 'lines', 'match', 'right', 'found', 'error', 'class',
+    'fetch', 'list', 'dict', 'none', 'true', 'path', 'type', 'name', 'data',
+    'text', 'item', 'args', 'self', 'this', 'init', 'call', 'load', 'read',
+    'write', 'send', 'note', 'pass', 'base', 'case', 'code', 'file', 'line',
+    'step', 'only', 'same', 'more', 'less', 'over', 'like', 'make',
+})
+
+# Role-keyword mapping: keywords that appear in memory name/description → role tags
+_ROLE_KEYWORDS: Dict[str, List[str]] = {
+    "database": ["database-engineer", "database", "migration", "schema", "sqlite"],
+    "migration": ["database-engineer", "migration"],
+    "backend": ["backend-developer", "backend"],
+    "frontend": ["frontend-developer", "frontend", "dashboard"],
+    "security": ["security-engineer", "security"],
+    "testing": ["test-engineer", "tests", "pytest"],
+    "codex": ["codex", "gate", "review"],
+    "dispatch": ["dispatch", "vnx", "orchestrat"],
+    "lease": ["lease", "terminal", "runtime_coordination"],
+    "docker": ["docker", "container"],
+    "api": ["api", "endpoint"],
+    "github": ["github", "pull_request", "merge"],
+    "subprocess": ["subprocess", "adapter", "headless"],
+}
+
+
+@dataclass(frozen=True)
+class OperatorMemory:
+    name: str
+    description: str
+    type: str               # 'feedback' / 'project' / 'user' / 'reference'
+    file_path: Path
+    body: str
+    tags: frozenset         # inferred + explicit
+    referenced_files: frozenset
+
+
+@dataclass
+class _MemoryCache:
+    """In-memory cache for operator memories with mtime-invalidation."""
+    entries: List[OperatorMemory] = field(default_factory=list)
+    loaded_at: float = 0.0
+    _loaded_dir: Optional[Path] = None
+    _file_mtimes: Dict[str, float] = field(default_factory=dict)
+
+    def needs_refresh(self) -> bool:
+        if (time.time() - self.loaded_at) > CACHE_TTL_SEC:
+            return True
+        return self._mtime_changed()
+
+    def _mtime_changed(self) -> bool:
+        d = self._loaded_dir
+        if d is None or not d.is_dir():
+            return False
+        for mem_file in d.glob("*.md"):
+            try:
+                mtime = mem_file.stat().st_mtime
+            except OSError:
+                continue
+            if mtime != self._file_mtimes.get(str(mem_file), 0.0):
+                return True
+        return False
+
+    def load(self, memory_dir: Path) -> None:
+        self._loaded_dir = memory_dir
+        new_entries: List[OperatorMemory] = []
+        new_mtimes: Dict[str, float] = {}
+
+        if memory_dir.is_dir():
+            for mem_file in sorted(memory_dir.glob("*.md")):
+                if mem_file.name == "MEMORY.md":
+                    continue  # index file — not a memory itself
+                try:
+                    stat = mem_file.stat()
+                    new_mtimes[str(mem_file)] = stat.st_mtime
+                    text = mem_file.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+
+                entry = _parse_memory_file(mem_file, text)
+                if entry is not None:
+                    new_entries.append(entry)
+
+        self.entries = new_entries
+        self._file_mtimes = new_mtimes
+        self.loaded_at = time.time()
+
+
+# Module-level caches keyed by memory_dir (str)
+_CACHES: Dict[str, _MemoryCache] = {}
+
+
+def _project_memory_dir(cwd: Optional[Path] = None) -> Optional[Path]:
+    """Find current project's memory dir under ~/.claude/projects/.
+
+    Derives the project slug from cwd by replacing '/' with '-' (Claude Code
+    convention). Returns None if the directory does not exist (graceful skip —
+    not all installs have memories yet).
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+    cwd = cwd.resolve()
+
+    # Claude Code slug: posix path with '/' replaced by '-'
+    # e.g. /Users/x/Development/foo → -Users-x-Development-foo
+    slug = cwd.as_posix().replace("/", "-")
+    candidate = Path.home() / ".claude" / "projects" / slug / "memory"
+    if candidate.is_dir():
+        return candidate
+
+    return None
+
+
+def _parse_frontmatter(text: str) -> Tuple[Dict[str, str], str]:
+    """Extract YAML frontmatter key-value pairs and body from a memory file.
+
+    Returns (kv_dict, body_text). If no frontmatter present, returns ({}, text).
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+
+    fm_text = m.group(1)
+    body = m.group(2)
+
+    kv: Dict[str, str] = {}
+    for kv_match in _KV_RE.finditer(fm_text):
+        key = kv_match.group(1).strip()
+        val = kv_match.group(2).strip()
+        kv[key] = val
+
+    return kv, body
+
+
+def _infer_tags(name: str, description: str) -> frozenset:
+    """Infer tag set from memory name and description.
+
+    Extracts identifier tokens and maps them to role/domain tags via
+    _ROLE_KEYWORDS; also includes the raw lowercased tokens for term overlap.
+    """
+    combined = f"{name} {description}".lower()
+    tokens: set = set()
+
+    # Raw identifier tokens (≥4 chars, not stopwords)
+    for m in _IDENT_RE.finditer(combined):
+        tok = m.group(1).lower()
+        if tok not in _STOPWORDS and len(tok) >= 4:
+            tokens.add(tok)
+
+    # Role/domain keywords
+    role_tags: set = set()
+    for role_key, keywords in _ROLE_KEYWORDS.items():
+        if any(kw in combined for kw in keywords):
+            role_tags.add(role_key)
+
+    return frozenset(tokens | role_tags)
+
+
+def _parse_memory_file(file_path: Path, text: str) -> Optional[OperatorMemory]:
+    """Parse a single memory .md file into an OperatorMemory.
+
+    Returns None if the file cannot be parsed meaningfully.
+    """
+    kv, body = _parse_frontmatter(text)
+
+    name = kv.get("name", file_path.stem)
+    description = kv.get("description", "")
+    mem_type = kv.get("type", "reference").strip().lower()
+
+    # Explicit tags from frontmatter (if present as comma-separated list)
+    explicit_tags: set = set()
+    if "tags" in kv:
+        for t in kv["tags"].split(","):
+            t = t.strip().lower()
+            if t:
+                explicit_tags.add(t)
+
+    inferred = _infer_tags(name, description)
+    tags = frozenset(explicit_tags | inferred)
+
+    # File references extracted from body
+    referenced: set = set()
+    for ref_m in _FILE_REF_RE.finditer(body):
+        referenced.add(ref_m.group(1))
+
+    return OperatorMemory(
+        name=name,
+        description=description,
+        type=mem_type,
+        file_path=file_path,
+        body=body.strip(),
+        tags=tags,
+        referenced_files=frozenset(referenced),
+    )
+
+
+def _score_memory(
+    mem: OperatorMemory,
+    role: Optional[str],
+    dispatch_paths: List[str],
+    instruction_terms: List[str],
+) -> float:
+    """Compute relevance score for a memory against dispatch context.
+
+    Scoring:
+    - role match: +3 (if role keyword appears in memory tags or name/description)
+    - dispatch_path overlap: +2 per matching path
+    - instruction_term overlap with name+description: +1 per term
+    - feedback type: 1.5x multiplier (operator hard-won corrections carry more weight)
+    """
+    score = 0.0
+
+    # Role match
+    if role:
+        role_lower = role.lower()
+        role_parts = set(re.split(r'[-_]', role_lower))
+        # Direct role tag match
+        if role_lower in mem.tags:
+            score += 3
+        # Partial match on role fragments (e.g. "database" from "database-engineer")
+        elif role_parts & mem.tags:
+            score += 2
+        # Fallback: check if role appears in name or description
+        elif role_lower in f"{mem.name} {mem.description}".lower():
+            score += 1
+
+    # Dispatch path overlap (+2 per match)
+    if dispatch_paths:
+        dispatch_path_set = set(dispatch_paths)
+        # Check if any referenced file in memory matches a dispatch path
+        for ref_file in mem.referenced_files:
+            if ref_file in dispatch_path_set:
+                score += 2
+        # Also check if dispatch path fragments appear in memory name/description
+        mem_text = f"{mem.name} {mem.description}".lower()
+        for dp in dispatch_paths:
+            dp_parts = re.split(r'[/._-]', dp.lower())
+            for part in dp_parts:
+                if len(part) >= 4 and part in mem_text and part not in _STOPWORDS:
+                    score += 0.5
+                    break
+
+    # Instruction term overlap (+1 per term found in name or description)
+    if instruction_terms:
+        mem_text = f"{mem.name} {mem.description}".lower()
+        for term in instruction_terms:
+            if term.lower() in mem_text:
+                score += 1
+
+    # Feedback type multiplier
+    if mem.type == "feedback":
+        score *= 1.5
+
+    return score
+
+
+def _extract_instruction_terms(instruction_text: str) -> List[str]:
+    """Extract identifier-like tokens from instruction text for overlap scoring."""
+    seen: set = set()
+    result: List[str] = []
+    for m in _IDENT_RE.finditer(instruction_text or ""):
+        tok = m.group(1).lower()
+        if tok not in _STOPWORDS and len(tok) >= 4 and tok not in seen:
+            seen.add(tok)
+            result.append(tok)
+    return result
+
+
+def _get_cache(memory_dir: Path) -> _MemoryCache:
+    key = str(memory_dir.resolve())
+    if key not in _CACHES:
+        _CACHES[key] = _MemoryCache()
+    cache = _CACHES[key]
+    if cache.loaded_at == 0.0 or cache.needs_refresh():
+        cache.load(memory_dir)
+    return cache
+
+
+def fetch_relevant_memories(
+    role: Optional[str],
+    dispatch_paths: List[str],
+    instruction_text: str,
+    *,
+    max_chars: int = MAX_MEMORY_CHARS,
+    memory_dir: Optional[Path] = None,
+) -> List[OperatorMemory]:
+    """Fetch operator memories matching this dispatch's role + scope + instruction.
+
+    Selection per smart-context-design §3.3 step 5.
+
+    If memory_dir is not provided, it is derived from cwd using the Claude Code
+    slug convention. Returns empty list if memory dir is missing (graceful skip).
+    """
+    # Resolve memory directory
+    if memory_dir is None:
+        memory_dir = _project_memory_dir()
+        if memory_dir is None:
+            return []
+    else:
+        memory_dir = Path(memory_dir).resolve()
+
+    if not memory_dir.is_dir():
+        return []
+
+    # Path traversal safety: ensure memory_dir is resolved to an absolute path;
+    # individual file reads enforce is_relative_to below.
+    resolved_memory_dir = memory_dir.resolve()
+
+    # Load (possibly cached) entries
+    cache = _get_cache(resolved_memory_dir)
+    entries = cache.entries
+
+    if not entries:
+        return []
+
+    # Path-traversal guard: filter to only files within resolved_memory_dir
+    safe_entries: List[OperatorMemory] = []
+    for mem in entries:
+        try:
+            resolved_fp = mem.file_path.resolve()
+            resolved_fp.relative_to(resolved_memory_dir)
+            safe_entries.append(mem)
+        except ValueError:
+            continue  # escape attempt — silently skip
+
+    if not safe_entries:
+        return []
+
+    # Extract instruction terms for overlap scoring
+    instruction_terms = _extract_instruction_terms(instruction_text)
+
+    # Score all memories
+    scored: List[Tuple[float, OperatorMemory]] = []
+    for mem in safe_entries:
+        s = _score_memory(mem, role, dispatch_paths or [], instruction_terms)
+        if s > 0:
+            scored.append((s, mem))
+
+    # Sort by score descending, then by type (feedback first on ties)
+    scored.sort(key=lambda x: (-x[0], x[1].type != "feedback"))
+
+    # Cap at MAX_MEMORIES_PER_DISPATCH and fit within budget
+    candidates = [m for _, m in scored[:MAX_MEMORIES_PER_DISPATCH * 2]]
+    trimmed: List[OperatorMemory] = []
+    for mem in candidates:
+        if len(trimmed) >= MAX_MEMORIES_PER_DISPATCH:
+            break
+        candidate_list = trimmed + [mem]
+        if len(format_memories_section(candidate_list)) <= max_chars:
+            trimmed.append(mem)
+
+    return trimmed
+
+
+def format_memories_section(memories: List[OperatorMemory]) -> str:
+    """Format as markdown section for dispatch instruction injection.
+
+    Anti-anchoring instruction included: operator memories from past sessions
+    may no longer apply — verify against current code state before treating
+    as binding.
+    """
+    if not memories:
+        return ""
+
+    lines = [
+        "## OPERATOR MEMORIES (curated wisdom from past sessions)",
+        "",
+        "> **Anti-anchoring notice:** These are operator memories from past sessions. "
+        "Apply where relevant; the current task may have shifted context — verify "
+        "against current code state before treating as binding.",
+        "",
+    ]
+
+    for mem in memories:
+        type_label = f"[{mem.type}]" if mem.type else ""
+        lines.append(f"### {type_label} {mem.name}")
+        lines.append("")
+        if mem.description:
+            lines.append(f"*{mem.description}*")
+            lines.append("")
+        if mem.body:
+            lines.append(mem.body)
+            lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_intelligence_selector.py
+++ b/tests/test_intelligence_selector.py
@@ -1831,6 +1831,233 @@ class TestCodeAnchorInjection(unittest.TestCase):
         self.assertLessEqual(payload_size, MAX_PAYLOAD_CHARS * 2)
 
 
+# ---------------------------------------------------------------------------
+# Wave 5 P3: operator_memory integration tests
+# ---------------------------------------------------------------------------
+
+class TestOperatorMemoryInjection(unittest.TestCase):
+    """Integration tests for Wave 5 P3 operator memory injection in IntelligenceSelector."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._base = Path(self._tmpdir.name)
+        self._quality_db_path = self._base / "quality_intelligence.db"
+        self._state_dir = self._base / "state"
+        self._state_dir.mkdir()
+        init_schema(str(self._state_dir))
+        db = _setup_quality_db(self._quality_db_path)
+        db.close()
+
+        # Set up a memory directory with a relevant feedback file
+        self._memory_dir = self._base / "memory"
+        self._memory_dir.mkdir()
+        (self._memory_dir / "feedback_database_lease.md").write_text(
+            "---\n"
+            "name: Stale lease cleanup\n"
+            "description: Check runtime_coordination database leases before dispatch\n"
+            "type: feedback\n"
+            "---\n"
+            "Before first dispatch, release stale leases in runtime_coordination.db.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        import operator_memory_indexer
+        operator_memory_indexer._CACHES.clear()
+        self._tmpdir.cleanup()
+
+    def _patch_memory_dir(self, memory_dir):
+        """Patch operator_memory_indexer._project_memory_dir to return memory_dir."""
+        import operator_memory_indexer
+
+        original = operator_memory_indexer._project_memory_dir
+
+        def _patched(cwd=None):
+            return memory_dir
+
+        operator_memory_indexer._project_memory_dir = _patched
+        return original
+
+    def _restore_memory_dir(self, original):
+        import operator_memory_indexer
+        operator_memory_indexer._project_memory_dir = original
+
+    def test_select_includes_operator_memory_when_role_present(self):
+        """When skill_name is provided and matching memories exist, operator_memory is injected."""
+        import operator_memory_indexer
+        original = self._patch_memory_dir(self._memory_dir)
+
+        try:
+            operator_memory_indexer._CACHES.clear()
+            selector = IntelligenceSelector(
+                quality_db_path=self._quality_db_path,
+                coord_db_state_dir=self._state_dir,
+            )
+            result = selector.select(
+                "om-test-001",
+                "dispatch_create",
+                skill_name="database-engineer",
+                instruction_text="Check database leases and dispatch to runtime_coordination",
+            )
+            selector.close()
+        finally:
+            self._restore_memory_dir(original)
+
+        item_classes = [item.item_class for item in result.items]
+        self.assertIn("operator_memory", item_classes,
+                      f"Expected operator_memory in items, got: {item_classes}")
+
+        om_items = [i for i in result.items if i.item_class == "operator_memory"]
+        self.assertEqual(len(om_items), 1)
+        self.assertEqual(om_items[0].confidence, 1.0)
+        self.assertGreater(om_items[0].evidence_count, 0)
+        self.assertTrue(len(om_items[0].source_refs) > 0)
+
+    def test_select_does_not_include_operator_memory_when_no_inputs(self):
+        """Without skill_name, dispatch_paths, or instruction_text, no operator_memory is injected."""
+        import operator_memory_indexer
+        original = self._patch_memory_dir(self._memory_dir)
+
+        try:
+            operator_memory_indexer._CACHES.clear()
+            selector = IntelligenceSelector(
+                quality_db_path=self._quality_db_path,
+                coord_db_state_dir=self._state_dir,
+            )
+            result = selector.select(
+                "om-test-002",
+                "dispatch_create",
+                skill_name=None,
+                dispatch_paths=None,
+                instruction_text=None,
+            )
+            selector.close()
+        finally:
+            self._restore_memory_dir(original)
+
+        item_classes = [item.item_class for item in result.items]
+        self.assertNotIn("operator_memory", item_classes)
+
+    def test_select_combines_all_wave5_classes_within_budget(self):
+        """prior_round + adr + code_anchor + operator_memory all fit within 4000-char payload."""
+        import prior_round_injector
+        import operator_memory_indexer
+        import adr_indexer
+
+        # Seed prior-round finding
+        results_dir = self._base / "review_gates" / "results"
+        results_dir.mkdir(parents=True)
+        gate_file = results_dir / "pr-777-codex_gate.json"
+        gate_file.write_text(
+            json.dumps({
+                "recorded_at": "2026-05-10T12:00:00Z",
+                "contract_hash": "abc777",
+                "blocking_findings": [{"message": "Missing null guard in fetch_code_anchors"}],
+                "advisory_findings": [],
+            }),
+            encoding="utf-8",
+        )
+
+        # Set up ADR dir with a matching ADR
+        adr_dir = self._base / "docs" / "governance" / "decisions"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "ADR-009-schema-first.md").write_text(
+            "# ADR-009 — Schema first migrations\n\n"
+            "## Decision\n\n"
+            "All CREATE TABLE statements go in schemas/quality_intelligence.sql first.\n\n"
+            "## See also\n\n"
+            "See scripts/lib/code_anchor_finder.py for implementation details.\n",
+            encoding="utf-8",
+        )
+
+        # Set up real Python source file for code_anchor
+        scripts_dir = self._base / "scripts" / "lib"
+        scripts_dir.mkdir(parents=True)
+        source_file = scripts_dir / "code_anchor_finder.py"
+        source_file.write_text(
+            "def fetch_code_anchors(dispatch_paths, instruction_text):\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        dispatch_path = "scripts/lib/code_anchor_finder.py"
+
+        prior_round_injector._fetch_cached.cache_clear()
+        original_prior_resolve = prior_round_injector._resolve_state_dir
+
+        def _patched_prior_resolve(state_dir=None):
+            return self._base
+
+        prior_round_injector._resolve_state_dir = _patched_prior_resolve
+
+        original_memory = self._patch_memory_dir(self._memory_dir)
+        operator_memory_indexer._CACHES.clear()
+
+        # Snapshot full INDEX state before mutation
+        original_adr_loaded_dir = adr_indexer._INDEX._loaded_dir
+        original_adr_entries = dict(adr_indexer._INDEX.entries)
+        original_adr_fta = dict(adr_indexer._INDEX.file_to_adrs)
+        original_adr_mtimes = dict(adr_indexer._INDEX._file_mtimes)
+        original_loaded_at = adr_indexer._INDEX.loaded_at
+        adr_indexer._INDEX.loaded_at = 0.0  # force reload
+
+        try:
+            selector = IntelligenceSelector(
+                quality_db_path=self._quality_db_path,
+                coord_db_state_dir=self._state_dir,
+            )
+            result = selector.select(
+                "om-test-003",
+                "dispatch_create",
+                pr_id="777",
+                skill_name="database-engineer",
+                dispatch_paths=[dispatch_path],
+                instruction_text="Edit fetch_code_anchors and database schema dispatch",
+            )
+            selector.close()
+        finally:
+            prior_round_injector._resolve_state_dir = original_prior_resolve
+            self._restore_memory_dir(original_memory)
+            # Fully restore INDEX singleton so we don't pollute other tests
+            adr_indexer._INDEX.loaded_at = original_loaded_at
+            adr_indexer._INDEX.entries = original_adr_entries
+            adr_indexer._INDEX.file_to_adrs = original_adr_fta
+            adr_indexer._INDEX._file_mtimes = original_adr_mtimes
+            adr_indexer._INDEX._loaded_dir = original_adr_loaded_dir
+
+        payload_size = len(json.dumps(result.to_payload_dict()))
+        self.assertLessEqual(payload_size, MAX_PAYLOAD_CHARS * 2,
+                             f"Payload {payload_size} chars exceeds 2x limit")
+
+        # At least operator_memory should be present (prior_round also likely)
+        item_classes = [item.item_class for item in result.items]
+        self.assertIn("operator_memory", item_classes,
+                      f"Expected operator_memory in items, got: {item_classes}")
+
+    def test_operator_memory_class_in_direct_injection_set(self):
+        """operator_memory must be in _DIRECT_INJECTION_CLASSES (1500-char cap applies)."""
+        from intelligence_selector import _DIRECT_INJECTION_CLASSES
+        self.assertIn("operator_memory", _DIRECT_INJECTION_CLASSES)
+
+        # Also verify to_dict() does not truncate operator_memory content at 500
+        content = "o" * 1500
+        item = IntelligenceItem(
+            item_id="test-om",
+            item_class="operator_memory",
+            title="Test operator memory",
+            content=content,
+            confidence=1.0,
+            evidence_count=2,
+            last_seen="2026-05-10T00:00:00Z",
+            scope_tags=[],
+        )
+        serialized = item.to_dict()
+        self.assertEqual(
+            len(serialized["content"]),
+            1500,
+            "operator_memory content was truncated — should use MAX_CODE_ANCHOR_CHARS cap",
+        )
+
+
 class TestIntelligenceItemSerialization(unittest.TestCase):
     """Verify that to_dict() round-trips content for direct-injection item classes."""
 

--- a/tests/test_operator_memory_indexer.py
+++ b/tests/test_operator_memory_indexer.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Tests for operator_memory_indexer.py (Wave 5 P3)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+import operator_memory_indexer
+from operator_memory_indexer import (
+    MAX_MEMORIES_PER_DISPATCH,
+    MAX_MEMORY_CHARS,
+    OperatorMemory,
+    _MemoryCache,
+    _extract_instruction_terms,
+    _infer_tags,
+    _parse_frontmatter,
+    _parse_memory_file,
+    _project_memory_dir,
+    _score_memory,
+    fetch_relevant_memories,
+    format_memories_section,
+)
+
+
+def _make_memory_file(directory: Path, filename: str, content: str) -> Path:
+    p = directory / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _feedback_file(name: str, description: str, body: str) -> str:
+    return f"---\nname: {name}\ndescription: {description}\ntype: feedback\n---\n{body}"
+
+
+def _project_file(name: str, description: str, body: str) -> str:
+    return f"---\nname: {name}\ndescription: {description}\ntype: project\n---\n{body}"
+
+
+class TestParseFrontmatter(unittest.TestCase):
+    def test_parse_frontmatter_extracts_name_description_type(self):
+        text = "---\nname: My Memory\ndescription: A test memory\ntype: feedback\n---\nBody content here."
+        kv, body = _parse_frontmatter(text)
+        self.assertEqual(kv["name"], "My Memory")
+        self.assertEqual(kv["description"], "A test memory")
+        self.assertEqual(kv["type"], "feedback")
+        self.assertIn("Body content here", body)
+
+    def test_parse_handles_no_frontmatter_gracefully(self):
+        text = "No frontmatter here, just content."
+        kv, body = _parse_frontmatter(text)
+        self.assertEqual(kv, {})
+        self.assertEqual(body, text)
+
+    def test_parse_frontmatter_with_empty_body(self):
+        text = "---\nname: Empty\ndescription: empty\ntype: reference\n---\n"
+        kv, body = _parse_frontmatter(text)
+        self.assertEqual(kv["name"], "Empty")
+        # body may be empty string
+        self.assertIsInstance(body, str)
+
+    def test_parse_frontmatter_multiline_body(self):
+        text = "---\nname: Multi\ndescription: multi-line body test\ntype: user\n---\nLine1\nLine2\nLine3"
+        kv, body = _parse_frontmatter(text)
+        self.assertIn("Line1", body)
+        self.assertIn("Line3", body)
+
+
+class TestTagInference(unittest.TestCase):
+    def test_tag_inference_from_name_and_description(self):
+        tags = _infer_tags("database migration cleanup", "Check expired leases before dispatch")
+        self.assertTrue(len(tags) > 0)
+        # Should infer database-related tags
+        tag_str = " ".join(tags)
+        self.assertTrue(
+            "database" in tag_str or "migration" in tag_str or "lease" in tag_str,
+            f"Expected database/migration/lease tags, got: {tags}"
+        )
+
+    def test_tag_inference_backend_role(self):
+        tags = _infer_tags("backend subprocess adapter", "Backend developer subprocess dispatch")
+        tag_str = " ".join(tags)
+        self.assertTrue(
+            "backend" in tag_str or "subprocess" in tag_str,
+            f"Expected backend/subprocess tags, got: {tags}"
+        )
+
+    def test_tag_inference_filters_stopwords(self):
+        tags = _infer_tags("always never should would", "using via through")
+        # None of the stopwords should appear as tags
+        for t in tags:
+            self.assertNotIn(t, {"always", "never", "should", "would", "using", "via", "through"})
+
+
+class TestScoringAlgorithm(unittest.TestCase):
+    def _make_memory(self, name: str, description: str, mem_type: str, body: str = "") -> OperatorMemory:
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "test.md"
+            content = f"---\nname: {name}\ndescription: {description}\ntype: {mem_type}\n---\n{body}"
+            p.write_text(content, encoding="utf-8")
+            return _parse_memory_file(p, content)
+
+    def test_select_by_role_match_scores_highest(self):
+        mem_db = self._make_memory(
+            "Database stale lease", "Check runtime_coordination.db leases", "feedback"
+        )
+        mem_unrelated = self._make_memory(
+            "Frontend styling tip", "CSS tricks for dashboard", "feedback"
+        )
+        score_db = _score_memory(mem_db, "database-engineer", [], [])
+        score_unrelated = _score_memory(mem_unrelated, "database-engineer", [], [])
+        self.assertGreater(score_db, score_unrelated)
+
+    def test_select_by_dispatch_paths_overlap(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "lease.md"
+            body = "Check runtime_coordination.db before dispatch.\n\nSee scripts/lib/runtime_coordination.py for details."
+            content = f"---\nname: Lease cleanup\ndescription: lease cleanup\ntype: feedback\n---\n{body}"
+            p.write_text(content, encoding="utf-8")
+            mem = _parse_memory_file(p, content)
+
+        score_with_path = _score_memory(
+            mem, None, ["scripts/lib/runtime_coordination.py"], []
+        )
+        score_no_path = _score_memory(mem, None, [], [])
+        self.assertGreater(score_with_path, score_no_path)
+
+    def test_select_by_instruction_term_overlap(self):
+        mem = self._make_memory(
+            "Codex gate findings", "Parse codex findings from blocking_findings array", "feedback"
+        )
+        score_match = _score_memory(mem, None, [], ["codex", "blocking", "findings"])
+        score_no_match = _score_memory(mem, None, [], ["frontend", "styling"])
+        self.assertGreater(score_match, score_no_match)
+
+    def test_feedback_type_weighted_higher_than_project(self):
+        mem_feedback = self._make_memory(
+            "Test memory", "Some database migration tip", "feedback"
+        )
+        mem_project = self._make_memory(
+            "Test memory", "Some database migration tip", "project"
+        )
+        score_feedback = _score_memory(mem_feedback, "database-engineer", [], [])
+        score_project = _score_memory(mem_project, "database-engineer", [], [])
+        self.assertGreater(score_feedback, score_project)
+
+
+class TestFetchAndBudget(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.memory_dir = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        # Clear module-level caches
+        operator_memory_indexer._CACHES.clear()
+
+    def _write_memory(self, filename: str, content: str) -> None:
+        (self.memory_dir / filename).write_text(content, encoding="utf-8")
+
+    def test_top_k_capped_at_3(self):
+        # Write 5 highly relevant memories
+        for i in range(5):
+            content = _feedback_file(
+                f"Database migration tip {i}",
+                f"database migration runtime_coordination tip {i}",
+                f"Check leases before dispatch. Tip number {i}.",
+            )
+            self._write_memory(f"feedback_db_{i}.md", content)
+
+        results = fetch_relevant_memories(
+            "database-engineer",
+            [],
+            "database migration dispatch",
+            memory_dir=self.memory_dir,
+        )
+        self.assertLessEqual(len(results), MAX_MEMORIES_PER_DISPATCH)
+
+    def test_budget_truncates_at_max_chars(self):
+        # Write 3 very large memory files
+        for i in range(3):
+            body = "x" * 1000  # large body
+            content = _feedback_file(
+                f"Large memory {i}",
+                "database migration large memory",
+                body,
+            )
+            self._write_memory(f"feedback_large_{i}.md", content)
+
+        results = fetch_relevant_memories(
+            "database-engineer",
+            [],
+            "database migration",
+            max_chars=MAX_MEMORY_CHARS,
+            memory_dir=self.memory_dir,
+        )
+        formatted = format_memories_section(results)
+        self.assertLessEqual(len(formatted), MAX_MEMORY_CHARS)
+
+    def test_returns_empty_when_memory_dir_missing(self):
+        missing_dir = self.memory_dir / "nonexistent"
+        results = fetch_relevant_memories(
+            "backend-developer",
+            [],
+            "some instruction",
+            memory_dir=missing_dir,
+        )
+        self.assertEqual(results, [])
+
+    def test_path_traversal_guard_rejects_escape(self):
+        # Create a legitimate memory file
+        content = _feedback_file("Legit memory", "database dispatch", "body")
+        self._write_memory("feedback_legit.md", content)
+
+        # Create a symlink that escapes the memory dir
+        import os
+        escape_target = self.memory_dir / ".." / "escape.md"
+        escape_link = self.memory_dir / "escape_link.md"
+        # Write the target file
+        (self.memory_dir.parent / "escape.md").write_text(
+            _feedback_file("Escape", "escape attempt", "body"),
+            encoding="utf-8",
+        )
+        try:
+            os.symlink(str(escape_target.resolve()), str(escape_link))
+        except (OSError, NotImplementedError):
+            # Symlinks might not be supported in all test environments
+            return
+
+        # Clear cache so new scan picks up the symlink
+        operator_memory_indexer._CACHES.clear()
+
+        # fetch_relevant_memories should skip the symlink-based escape
+        results = fetch_relevant_memories(
+            "database-engineer",
+            [],
+            "database dispatch",
+            memory_dir=self.memory_dir,
+        )
+        # All returned memories should be inside memory_dir
+        for mem in results:
+            self.assertTrue(
+                str(mem.file_path.resolve()).startswith(str(self.memory_dir.resolve())),
+                f"Memory file {mem.file_path} escapes memory_dir {self.memory_dir}",
+            )
+
+    def test_cache_refreshes_after_ttl(self):
+        # Write initial memory
+        content = _feedback_file("Initial memory", "database dispatch tip", "Initial body")
+        self._write_memory("feedback_initial.md", content)
+
+        results_1 = fetch_relevant_memories(
+            "database-engineer", [], "database dispatch", memory_dir=self.memory_dir
+        )
+        self.assertEqual(len(results_1), 1)
+
+        # Manually expire the cache
+        cache_key = str(self.memory_dir.resolve())
+        if cache_key in operator_memory_indexer._CACHES:
+            operator_memory_indexer._CACHES[cache_key].loaded_at = 0.0
+
+        # Write a second memory
+        content2 = _feedback_file("Second memory", "database migration tip 2", "Second body")
+        self._write_memory("feedback_second.md", content2)
+
+        results_2 = fetch_relevant_memories(
+            "database-engineer", [], "database dispatch", memory_dir=self.memory_dir
+        )
+        # After TTL expiry, should see both memories
+        self.assertGreater(len(results_2), len(results_1))
+
+
+class TestFormatSection(unittest.TestCase):
+    def test_format_section_includes_anti_anchoring_instruction(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "feedback_test.md"
+            content = _feedback_file("Test memory", "A test memory", "Test body content.")
+            p.write_text(content, encoding="utf-8")
+            mem = _parse_memory_file(p, content)
+
+        formatted = format_memories_section([mem])
+        self.assertIn("Anti-anchoring", formatted)
+        self.assertIn("verify", formatted.lower())
+
+    def test_format_section_returns_empty_for_no_memories(self):
+        self.assertEqual(format_memories_section([]), "")
+
+    def test_format_section_includes_memory_names(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "feedback_lease.md"
+            content = _feedback_file(
+                "Stale lease cleanup", "Check leases before dispatch", "Release old leases."
+            )
+            p.write_text(content, encoding="utf-8")
+            mem = _parse_memory_file(p, content)
+
+        formatted = format_memories_section([mem])
+        self.assertIn("Stale lease cleanup", formatted)
+        self.assertIn("[feedback]", formatted)
+
+    def test_format_section_includes_description(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "feedback_x.md"
+            content = _feedback_file("Name", "Specific description here", "Body text.")
+            p.write_text(content, encoding="utf-8")
+            mem = _parse_memory_file(p, content)
+
+        formatted = format_memories_section([mem])
+        self.assertIn("Specific description here", formatted)
+
+
+class TestNoBodyInLogs(unittest.TestCase):
+    def test_no_body_content_in_logs(self):
+        """Memory body content must not appear in log output (privacy guard)."""
+        PRIVATE_BODY = "PRIVATE_OPERATOR_CONTENT_XYZ_12345_SECRET"
+
+        with tempfile.TemporaryDirectory() as td:
+            memory_dir = Path(td)
+            content = _feedback_file(
+                "Private memory",
+                "test privacy guard",
+                PRIVATE_BODY,
+            )
+            (memory_dir / "feedback_private.md").write_text(content, encoding="utf-8")
+
+            # Capture log output
+            import io
+            log_capture = io.StringIO()
+            handler = logging.StreamHandler(log_capture)
+            handler.setLevel(logging.DEBUG)
+
+            root_logger = logging.getLogger()
+            root_logger.addHandler(handler)
+            old_level = root_logger.level
+            root_logger.setLevel(logging.DEBUG)
+
+            try:
+                operator_memory_indexer._CACHES.clear()
+                fetch_relevant_memories(
+                    "backend-developer",
+                    [],
+                    "test privacy guard instruction",
+                    memory_dir=memory_dir,
+                )
+            finally:
+                root_logger.removeHandler(handler)
+                root_logger.setLevel(old_level)
+
+            log_output = log_capture.getvalue()
+            self.assertNotIn(
+                PRIVATE_BODY,
+                log_output,
+                "Memory body content appeared in log output — privacy violation",
+            )


### PR DESCRIPTION
## Summary

- Implements Wave 5 P3 from smart-context-design §3.3 step 5: auto-inject operator-curated memories into worker dispatches
- New `scripts/lib/operator_memory_indexer.py`: scans `~/.claude/projects/<slug>/memory/*.md`, scores by role match (+3), dispatch_path overlap (+2), instruction_term overlap (+1), feedback-type 1.5× multiplier
- `IntelligenceSelector.select()` wires `operator_memory` as a new direct-injection class alongside `prior_round_finding`, `adr_relevant`, `code_anchor`
- **Example:** a `database-engineer` dispatch on `runtime_coordination.db` auto-receives `feedback_stale_lease_cleanup.md` ("Check runtime_coordination.db leases before first dispatch") — worker no longer has to discover this the hard way

## Architecture

Per smart-context-design §3.3 step 5:
```
memory_index.match(role=d.role, scope=d.target_files, tags=d.tags, max=3)
```

Selection algorithm:
1. Parse frontmatter (name, description, type) from each `*.md`
2. Infer tag set: role-keyword mapping + identifier extraction
3. Score: role match +3, path overlap +2/match, term overlap +1/term, `feedback` type × 1.5
4. Top-K=3 within MAX_MEMORY_CHARS=1200 budget
5. Path-traversal guard: `is_relative_to()` on each file
6. Project slug: `Path.home()/.claude/projects/{cwd.as_posix().replace('/', '-')}/memory/` — no hardcoded paths

## Safety

- **Path traversal:** `is_relative_to(resolved_memory_dir)` guard mirrors W5.2 pattern
- **Privacy:** memory bodies never logged to NDJSON or audit output — only name + score
- **Anti-anchoring:** formatted section includes "verify against current code state before treating as binding" notice
- **Graceful skip:** returns empty list if memory dir is missing (not all installs have memories)
- **Budget-bounded:** MAX_MEMORY_CHARS=1200 leaves room for prior_round (P0) + ADR (P1) + code_anchor (P2)

## Test plan

- [x] 21 unit tests in `tests/test_operator_memory_indexer.py` — all pass
- [x] 4 integration tests in `tests/test_intelligence_selector.py::TestOperatorMemoryInjection` — all pass
- [x] Full selector test suite: 86/86 pass
- [x] Pre-existing `test_adr_indexer::TestBudgetTruncation` failure confirmed as pre-existing (W5.2 `TestCodeAnchorInjection` pollution, not introduced here)

## Codex defense checklist

- [x] No hardcoded `/Users/...` paths — `Path.home()` + `Path.cwd()`
- [x] No `.vnx-data/state/` hardcoding — uses `vnx_paths.resolve_paths()` fallback pattern
- [x] Path-traversal guard mirrors W5.2
- [x] No SDK imports (`import anthropic` absent)
- [x] No memory body content in logs
- [x] `bash -n` not applicable (no shell scripts modified)
- [x] All test cases have regression tests for negative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)