### PR TITLE
feat(wave5): PR-W5.5 — production plumbing for P0-P4 context-bundle classes

### DIFF
--- a/scripts/lib/subprocess_dispatch_internals/delivery.py
+++ b/scripts/lib/subprocess_dispatch_internals/delivery.py
@@ -85,6 +85,8 @@ def _assemble_instruction(
     dispatch_id: str,
     model: str,
     repo_map: str | None,
+    dispatch_paths: "list[str] | None" = None,
+    pr_id: "str | None" = None,
 ) -> str:
     """Append repo map, layered skill context, then permission preamble."""
     import subprocess_dispatch as _sd
@@ -94,7 +96,12 @@ def _assemble_instruction(
         terminal_id,
         instruction,
         role=role,
-        dispatch_metadata={"dispatch_id": dispatch_id, "model": model},
+        dispatch_metadata={
+            "dispatch_id": dispatch_id,
+            "model": model,
+            "dispatch_paths": dispatch_paths,
+            "pr_id": pr_id,
+        },
     )
     return _sd._inject_permission_profile(terminal_id, role, instruction)
 
@@ -335,6 +342,8 @@ def _prepare_dispatch(
     role: str | None,
     repo_map: str | None,
     commit_hash_before: str,
+    dispatch_paths: "list[str] | None" = None,
+    pr_id: "str | None" = None,
 ) -> tuple[str, "Path | None", "Path | None", str]:
     """Run pre-deliver phases: handover continuation, assembly, cwd, manifest write.
 
@@ -344,6 +353,7 @@ def _prepare_dispatch(
     instruction, pending_handover = _apply_handover_continuation(terminal_id, instruction)
     instruction = _assemble_instruction(
         terminal_id, instruction, role, dispatch_id, model, repo_map,
+        dispatch_paths=dispatch_paths, pr_id=pr_id,
     )
     agent_cwd = _resolve_agent_cwd_and_log_profile(role)
     manifest_path = _sd._write_manifest(
@@ -408,6 +418,8 @@ def deliver_via_subprocess(
     total_deadline: float = 900.0,
     health_monitor=None,
     commit_hash_before: str = "",
+    dispatch_paths: "list[str] | None" = None,
+    pr_id: "str | None" = None,
 ) -> _SubprocessResult:
     """Deliver a dispatch via SubprocessAdapter and consume the event stream.
 
@@ -415,12 +427,17 @@ def deliver_via_subprocess(
     write, heartbeat thread, event consumption, completion classification, and
     cleanup.  Returns ``_SubprocessResult`` (success, session_id, event_count,
     manifest_path, touched_files).
+
+    dispatch_paths and pr_id are forwarded to dispatch_metadata so W5 item
+    classes (adr_relevant, code_anchor, operator_memory, schema_section,
+    prior_round_finding) fire in IntelligenceSelector.select() during assembly.
     """
     import subprocess_dispatch as _sd
     chunk_timeout, total_deadline = _apply_runtime_overrides(chunk_timeout, total_deadline)
 
     instruction, pending_handover, agent_cwd, manifest_path = _prepare_dispatch(
         terminal_id, instruction, model, dispatch_id, role, repo_map, commit_hash_before,
+        dispatch_paths=dispatch_paths, pr_id=pr_id,
     )
 
     resume_session = _load_resume_session(terminal_id)

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -301,6 +301,8 @@ def _attempt_delivery(
     chunk_timeout: float,
     total_deadline: float,
     commit_hash_before: str,
+    dispatch_paths: "list[str] | None" = None,
+    pr_id: "str | None" = None,
 ):
     """Single delivery attempt — proxies to ``deliver_via_subprocess``."""
     import subprocess_dispatch as _sd
@@ -313,6 +315,8 @@ def _attempt_delivery(
         total_deadline=total_deadline,
         health_monitor=monitor,
         commit_hash_before=commit_hash_before,
+        dispatch_paths=dispatch_paths,
+        pr_id=pr_id,
     )
 
 
@@ -371,6 +375,7 @@ def deliver_with_recovery(
     auto_commit: bool = True,
     gate: str = "",
     dispatch_paths: "list[str] | None" = None,
+    pr_id: "str | None" = None,
 ) -> bool:
     """Deliver with automatic retry; success -> "done" receipt, final fail -> "failed".
 
@@ -379,6 +384,9 @@ def deliver_with_recovery(
     dispatch_paths (OI-1319): when provided, the CFX-1 path manifest is written
     before delivery starts so auto-commit/stash operations are correctly scoped
     even when this function is called as a library (not via the CLI __main__ block).
+
+    pr_id: when provided, forwarded to IntelligenceSelector.select() so
+    prior_round_finding items (codex/gemini gate results) fire in production.
     """
     import subprocess_dispatch as _sd
     chunk_timeout, total_deadline = _apply_runtime_overrides(chunk_timeout, total_deadline)
@@ -400,6 +408,8 @@ def deliver_with_recovery(
             heartbeat_interval=heartbeat_interval,
             chunk_timeout=chunk_timeout, total_deadline=total_deadline,
             commit_hash_before=commit_hash_before,
+            dispatch_paths=dispatch_paths,
+            pr_id=pr_id,
         )
         if sub_result.success:
             _handle_success(

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -64,7 +64,14 @@ def _resolve_effective_role(terminal_id: str, role: str | None) -> str | None:
         return None
 
 
-def _build_intelligence_section(dispatch_id: str, role: str | None) -> str:
+def _build_intelligence_section(
+    dispatch_id: str,
+    role: str | None,
+    *,
+    dispatch_paths: "list[str] | None" = None,
+    instruction_text: str | None = None,
+    pr_id: str | None = None,
+) -> str:
     """Return formatted intelligence items as markdown, or empty string (best-effort).
 
     Calls IntelligenceSelector to gather antipatterns, success patterns, and
@@ -73,6 +80,10 @@ def _build_intelligence_section(dispatch_id: str, role: str | None) -> str:
     + pattern_usage + dispatch_pattern_offered) so the post-dispatch confidence
     feedback loop has dispatch-scoped rows to update.  Any import or DB failure
     is caught and logged — dispatch proceeds without intelligence.
+
+    dispatch_paths, instruction_text, pr_id are forwarded to selector.select() so
+    W5 item classes (adr_relevant, code_anchor, operator_memory, schema_section,
+    prior_round_finding) can fire in production dispatches.
     """
     try:
         from intelligence_selector import IntelligenceSelector  # noqa: PLC0415
@@ -91,6 +102,9 @@ def _build_intelligence_section(dispatch_id: str, role: str | None) -> str:
                 dispatch_id=dispatch_id,
                 injection_point="dispatch_create",
                 skill_name=role or "",
+                dispatch_paths=dispatch_paths or [],
+                instruction_text=instruction_text or "",
+                pr_id=pr_id,
             )
             try:
                 selector.emit_event(result, coord_state_dir=state_dir)
@@ -183,7 +197,15 @@ def _inject_skill_context(
     # subprocess_dispatch namespace so test patches at the facade are honoured.
     import subprocess_dispatch as _sd
     _dispatch_id = (dispatch_metadata or {}).get("dispatch_id") or ""
-    intelligence_section = _sd._build_intelligence_section(_dispatch_id, role)
+    _dispatch_paths = (dispatch_metadata or {}).get("dispatch_paths") or []
+    _instruction_text = instruction
+    _pr_id = (dispatch_metadata or {}).get("pr_id") or (dispatch_metadata or {}).get("pr")
+    intelligence_section = _sd._build_intelligence_section(
+        _dispatch_id, role,
+        dispatch_paths=_dispatch_paths,
+        instruction_text=_instruction_text,
+        pr_id=_pr_id,
+    )
 
     assembled = _try_prompt_assembler(
         terminal_id, instruction, role, dispatch_metadata, intelligence_section,

--- a/tests/test_intelligence_selector.py
+++ b/tests/test_intelligence_selector.py
@@ -2378,5 +2378,63 @@ class TestSchemaSectionInjection(unittest.TestCase):
         )
 
 
+class TestInjectSkillContextEndToEnd(unittest.TestCase):
+    """End-to-end: _inject_skill_context with full dispatch_metadata fires W5 params.
+
+    Patches IntelligenceSelector so the test is DB-independent, then asserts
+    the metadata keys (dispatch_paths, pr_id, instruction_text) reach
+    selector.select() via the _build_intelligence_section call chain.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._tmp_path = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_inject_skill_context_threads_w5_metadata_to_select(self):
+        """_inject_skill_context with dispatch_metadata produces a call to
+        selector.select() carrying dispatch_paths, instruction_text, and pr_id."""
+        from unittest.mock import MagicMock, patch
+        import importlib
+        import subprocess_dispatch_internals.skill_injection as si
+
+        mock_result = MagicMock()
+        mock_result.items = []
+        selector_instance = MagicMock()
+        selector_instance.select.return_value = mock_result
+
+        instruction = "Plumb dispatch_paths and pr_id to IntelligenceSelector"
+        metadata = {
+            "dispatch_id": "d-e2e-inject-001",
+            "model": "sonnet",
+            "dispatch_paths": ["scripts/lib/subprocess_dispatch.py"],
+            "pr_id": "460",
+        }
+
+        with patch("subprocess_dispatch._default_state_dir", return_value=self._tmp_path):
+            with patch(
+                "intelligence_selector.IntelligenceSelector",
+                return_value=selector_instance,
+            ):
+                with patch.object(si, "_try_prompt_assembler", return_value=None):
+                    with patch.object(si, "_legacy_claude_md_resolution", return_value=instruction):
+                        si._inject_skill_context(
+                            "T1", instruction,
+                            role="backend-developer",
+                            dispatch_metadata=metadata,
+                        )
+
+        self.assertTrue(
+            selector_instance.select.called,
+            "selector.select() was not called — intelligence injection did not fire",
+        )
+        kw = selector_instance.select.call_args.kwargs
+        self.assertEqual(kw["dispatch_paths"], ["scripts/lib/subprocess_dispatch.py"])
+        self.assertEqual(kw["pr_id"], "460")
+        self.assertEqual(kw["instruction_text"], instruction)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_injection_wave5.py
+++ b/tests/test_skill_injection_wave5.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Wave 5 production plumbing tests — dispatch_paths/instruction_text/pr_id threading.
+
+Verifies that _build_intelligence_section forwards the W5 params to
+IntelligenceSelector.select(), and that _inject_skill_context extracts them
+from dispatch_metadata and threads them through the call chain.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from subprocess_dispatch_internals.skill_injection import (
+    _build_intelligence_section,
+    _inject_skill_context,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_state_dir(tmp_path):
+    """Redirect _default_state_dir so tests never touch .vnx-data."""
+    with patch("subprocess_dispatch._default_state_dir", return_value=tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture
+def mock_selector_class():
+    """Patch IntelligenceSelector; return the mock class and its instance."""
+    mock_result = MagicMock()
+    mock_result.items = []
+    instance = MagicMock()
+    instance.select.return_value = mock_result
+    with patch(
+        "intelligence_selector.IntelligenceSelector",
+        return_value=instance,
+    ) as cls:
+        yield cls, instance
+
+
+# ---------------------------------------------------------------------------
+# _build_intelligence_section tests
+# ---------------------------------------------------------------------------
+
+class TestBuildIntelligenceSectionForwardsW5Params:
+    def test_build_intelligence_section_forwards_dispatch_paths(
+        self, mock_selector_class
+    ):
+        """dispatch_paths list is forwarded to selector.select() as-is."""
+        _, selector_instance = mock_selector_class
+        paths = ["scripts/lib/code_anchor_finder.py", "schemas/quality_intelligence.sql"]
+
+        _build_intelligence_section("d-w5-001", "backend-developer", dispatch_paths=paths)
+
+        call_kwargs = selector_instance.select.call_args.kwargs
+        assert call_kwargs["dispatch_paths"] == paths, (
+            f"Expected dispatch_paths={paths!r}, got {call_kwargs['dispatch_paths']!r}"
+        )
+
+    def test_build_intelligence_section_forwards_instruction_text(
+        self, mock_selector_class
+    ):
+        """instruction_text string is forwarded to selector.select()."""
+        _, selector_instance = mock_selector_class
+        text = "Implement schema introspection injection for database workers"
+
+        _build_intelligence_section("d-w5-002", "backend-developer", instruction_text=text)
+
+        call_kwargs = selector_instance.select.call_args.kwargs
+        assert call_kwargs["instruction_text"] == text, (
+            f"Expected instruction_text={text!r}, got {call_kwargs['instruction_text']!r}"
+        )
+
+    def test_build_intelligence_section_forwards_pr_id(self, mock_selector_class):
+        """pr_id is forwarded to selector.select()."""
+        _, selector_instance = mock_selector_class
+
+        _build_intelligence_section("d-w5-003", "backend-developer", pr_id="460")
+
+        call_kwargs = selector_instance.select.call_args.kwargs
+        assert call_kwargs["pr_id"] == "460", (
+            f"Expected pr_id='460', got {call_kwargs['pr_id']!r}"
+        )
+
+    def test_build_intelligence_section_none_defaults_pass_empty(
+        self, mock_selector_class
+    ):
+        """When new params are omitted, selector gets empty list/string and None."""
+        _, selector_instance = mock_selector_class
+
+        _build_intelligence_section("d-w5-004", "backend-developer")
+
+        call_kwargs = selector_instance.select.call_args.kwargs
+        assert call_kwargs["dispatch_paths"] == []
+        assert call_kwargs["instruction_text"] == ""
+        assert call_kwargs["pr_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# _inject_skill_context metadata extraction test
+# ---------------------------------------------------------------------------
+
+class TestInjectSkillContextExtractsMetadata:
+    def test_inject_skill_context_extracts_metadata_from_dict(
+        self, mock_selector_class, tmp_path
+    ):
+        """_inject_skill_context extracts dispatch_paths and pr_id from dispatch_metadata."""
+        _, selector_instance = mock_selector_class
+
+        metadata = {
+            "dispatch_id": "d-w5-extract-001",
+            "model": "sonnet",
+            "dispatch_paths": ["scripts/lib/subprocess_dispatch.py"],
+            "pr_id": "458",
+        }
+        instruction = "Implement the layered prompt assembler with ADR grounding"
+
+        with patch("subprocess_dispatch_internals.skill_injection._try_prompt_assembler", return_value=None):
+            with patch(
+                "subprocess_dispatch_internals.skill_injection._legacy_claude_md_resolution",
+                return_value=instruction,
+            ):
+                _inject_skill_context("T1", instruction, role="backend-developer", dispatch_metadata=metadata)
+
+        call_kwargs = selector_instance.select.call_args.kwargs
+        assert call_kwargs["dispatch_paths"] == ["scripts/lib/subprocess_dispatch.py"], (
+            f"dispatch_paths not extracted from metadata: {call_kwargs}"
+        )
+        assert call_kwargs["pr_id"] == "458", (
+            f"pr_id not extracted from metadata: {call_kwargs}"
+        )
+        assert call_kwargs["instruction_text"] == instruction, (
+            f"instruction_text not the raw instruction: {call_kwargs}"
+        )

--- a/tests/test_subprocess_dispatch.py
+++ b/tests/test_subprocess_dispatch.py
@@ -3,14 +3,14 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import pytest
 
 SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
 sys.path.insert(0, str(SCRIPTS_LIB))
 
-from subprocess_dispatch import deliver_via_subprocess
+from subprocess_dispatch import deliver_via_subprocess, _build_intelligence_section
 
 
 @pytest.fixture
@@ -71,3 +71,49 @@ class TestDeliverViaSubprocess:
         mock_adapter.read_events_with_timeout.assert_called_once_with(
             "T1", chunk_timeout=300.0, total_deadline=900.0,
         )
+
+
+class TestBuildIntelligenceSectionW5Params:
+    """Assert that _build_intelligence_section forwards W5 params to selector.select()."""
+
+    @pytest.fixture(autouse=True)
+    def patch_state_dir(self, tmp_path):
+        with patch("subprocess_dispatch._default_state_dir", return_value=tmp_path):
+            yield
+
+    @pytest.fixture
+    def mock_selector(self):
+        mock_result = MagicMock()
+        mock_result.items = []
+        instance = MagicMock()
+        instance.select.return_value = mock_result
+        with patch(
+            "intelligence_selector.IntelligenceSelector",
+            return_value=instance,
+        ):
+            yield instance
+
+    def test_dispatch_paths_forwarded_to_select(self, mock_selector):
+        paths = ["scripts/lib/subprocess_dispatch.py", "schemas/quality_intelligence.sql"]
+        _build_intelligence_section("d-w5-sd-001", "backend-developer", dispatch_paths=paths)
+        kw = mock_selector.select.call_args.kwargs
+        assert kw["dispatch_paths"] == paths
+
+    def test_instruction_text_forwarded_to_select(self, mock_selector):
+        text = "Thread dispatch_paths through to IntelligenceSelector"
+        _build_intelligence_section("d-w5-sd-002", "backend-developer", instruction_text=text)
+        kw = mock_selector.select.call_args.kwargs
+        assert kw["instruction_text"] == text
+
+    def test_pr_id_forwarded_to_select(self, mock_selector):
+        _build_intelligence_section("d-w5-sd-003", "backend-developer", pr_id="459")
+        kw = mock_selector.select.call_args.kwargs
+        assert kw["pr_id"] == "459"
+
+    def test_backward_compat_no_new_params(self, mock_selector):
+        """Existing callers that don't pass W5 params get empty defaults — no TypeError."""
+        _build_intelligence_section("d-w5-sd-004", "backend-developer")
+        kw = mock_selector.select.call_args.kwargs
+        assert kw["dispatch_paths"] == []
+        assert kw["instruction_text"] == ""
+        assert kw["pr_id"] is None


### PR DESCRIPTION
## Summary

Wave 5 P0-P4 item classes (`adr_relevant`, `code_anchor`, `operator_memory`, `schema_section`, `prior_round_finding`) were dormant in production. Every dispatch was calling `IntelligenceSelector.select()` with only `dispatch_id` + `skill_name`, so none of the W5 context-bundle classes could fire.

This PR threads `dispatch_paths`, `instruction_text`, and `pr_id` through the full delivery stack so the new item classes actually fire in real dispatches:

- **`skill_injection.py`**: `_build_intelligence_section()` now accepts and forwards the 3 new params to `selector.select()`. `_inject_skill_context()` extracts `dispatch_paths` and `pr_id` from `dispatch_metadata`, uses the raw `instruction` as `instruction_text`.
- **`delivery.py`**: `_assemble_instruction()`, `_prepare_dispatch()`, and `deliver_via_subprocess()` accept `dispatch_paths` + `pr_id` and populate `dispatch_metadata` with them.
- **`recovery.py`**: `_attempt_delivery()` and `deliver_with_recovery()` thread the same params so the existing `--dispatch-paths` CLI flag reaches the intelligence selector on every delivery attempt.

**Backward-compatible**: all new params have `None`/`[]` defaults. Existing callers receive identical behaviour.

## Test plan

- [x] `pytest tests/test_subprocess_dispatch.py` — 7 passed (4 new W5 param-forwarding tests)
- [x] `pytest tests/test_skill_injection_wave5.py` — 5 passed (new file, all W5 threading tests)
- [x] `pytest tests/test_intelligence_selector.py` — 70 passed (1 new end-to-end integration test)
- [x] Full combined run: **82 passed, 0 failures**
- [x] `bash scripts/vnx_doctor.sh` — clean (no forbidden path references)
- [x] Python AST syntax check on all 3 modified source files — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)