### PR TITLE
chore(t0): canonical subprocess_dispatch.py routing in T0 template + skill

### DIFF
--- a/skills/t0-orchestrator/SKILL.md
+++ b/skills/t0-orchestrator/SKILL.md
@@ -443,12 +443,14 @@ Direct claude --print is acceptable ONLY for pure utility invocations (parsing, 
 | Task | Path |
 |---|---|
 | Code edit + PR + tests | subprocess_dispatch.py |
-| PR review (codex_gate, gemini_review) | subprocess_dispatch.py with --gate |
+| PR review gate (codex_gate, gemini_review) | scripts/review_gate_manager.py request-and-execute (or scripts/t0_gate_enforcement.sh wrapper) |
 | Burn-in measurement work | subprocess_dispatch.py REQUIRED |
 | Utility script (transcribe, parse) | direct Bash (no claude needed) |
 | Ad-hoc claude-as-utility | direct Bash claude --print acceptable |
 
-Rule of thumb: Does the work produce a PR, a gate result, or a measurement? Then subprocess_dispatch.py. Otherwise Bash is fine.
+Gate execution (codex_gate, gemini_review) uses `scripts/review_gate_manager.py request-and-execute` OR `scripts/t0_gate_enforcement.sh` — these create the canonical `review_gates/requests` and `review_gates/results` artifacts that closure verification depends on. `subprocess_dispatch.py` dispatches feature work to T1/T2/T3 workers; its `--gate` flag is metadata for auto-commit tagging, not gate execution.
+
+Rule of thumb: Does the work produce a PR or a measurement? Then subprocess_dispatch.py. Does the work produce a gate result? Then review_gate_manager.py or t0_gate_enforcement.sh. Otherwise Bash is fine.
 
 ## 10. Manager Block Quality Standard
 

--- a/skills/t0-orchestrator/SKILL.md
+++ b/skills/t0-orchestrator/SKILL.md
@@ -405,6 +405,51 @@ If any terminal pane is missing, escalate before dispatching — do not send a d
 
 If panes.json contains stale IDs, update it manually or delete it and let path-based discovery take over on next delivery.
 
+### 9.2 Dispatch-routing — required via subprocess_dispatch.py
+
+Per ADR-010 (subprocess adapter as canonical Claude routing) and ADR-005 (NDJSON ledger as primary observability):
+
+For any feature work (code edit + PR + tests), dispatches to T1/T2/T3 MUST go via subprocess_dispatch.py. This path delivers Wave 5 smart-context injection (+30pp dispatch quality lift), Wave 1 shadow logging, receipt processor audit trail, lease management, and triple-gate contract_hash binding.
+
+#### Canonical dispatch command
+
+```bash
+export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+
+python3 .claude/vnx-system/scripts/lib/subprocess_dispatch.py \
+  --terminal-id T1 \
+  --dispatch-id "$(date +%Y%m%d-%H%M%S)-<slug>" \
+  --model sonnet \
+  --role backend-developer \
+  --pr-id "<PR-ID>" \
+  --dispatch-paths "<comma-separated-allowed-paths>" \
+  --instruction "<inline instruction text>"
+```
+
+Required flags: --terminal-id, --dispatch-id, --instruction. Strongly recommended: --role (skill injection), --pr-id (Wave 5 prior-round findings keyed by pr_id), --dispatch-paths (scope guard).
+
+#### FORBIDDEN for feature work
+
+```bash
+# DO NOT USE for code/PR work — bypasses Wave 5, audit, lease, governance:
+Bash(claude --print --model sonnet "...")
+Bash(claude -p "...")
+```
+
+Direct claude --print is acceptable ONLY for pure utility invocations (parsing, ad-hoc analysis, debug checks) that have no PR outcome and do not contribute to Wave 1/5 burn-in metrics.
+
+#### Decision rule
+
+| Task | Path |
+|---|---|
+| Code edit + PR + tests | subprocess_dispatch.py |
+| PR review (codex_gate, gemini_review) | subprocess_dispatch.py with --gate |
+| Burn-in measurement work | subprocess_dispatch.py REQUIRED |
+| Utility script (transcribe, parse) | direct Bash (no claude needed) |
+| Ad-hoc claude-as-utility | direct Bash claude --print acceptable |
+
+Rule of thumb: Does the work produce a PR, a gate result, or a measurement? Then subprocess_dispatch.py. Otherwise Bash is fine.
+
 ## 10. Manager Block Quality Standard
 
 Every dispatch must include:

--- a/templates/terminals/T0.md
+++ b/templates/terminals/T0.md
@@ -59,12 +59,14 @@ Direct claude --print is acceptable ONLY for pure utility invocations (parsing, 
 | Task | Path |
 |---|---|
 | Code edit + PR + tests | subprocess_dispatch.py |
-| PR review (codex_gate, gemini_review) | subprocess_dispatch.py with --gate |
+| PR review gate (codex_gate, gemini_review) | scripts/review_gate_manager.py request-and-execute (or scripts/t0_gate_enforcement.sh wrapper) |
 | Burn-in measurement work | subprocess_dispatch.py REQUIRED |
 | Utility script (transcribe, parse) | direct Bash (no claude needed) |
 | Ad-hoc claude-as-utility | direct Bash claude --print acceptable |
 
-Rule of thumb: Does the work produce a PR, a gate result, or a measurement? Then subprocess_dispatch.py. Otherwise Bash is fine.
+Gate execution (codex_gate, gemini_review) uses `scripts/review_gate_manager.py request-and-execute` OR `scripts/t0_gate_enforcement.sh` — these create the canonical `review_gates/requests` and `review_gates/results` artifacts that closure verification depends on. `subprocess_dispatch.py` dispatches feature work to T1/T2/T3 workers; its `--gate` flag is metadata for auto-commit tagging, not gate execution.
+
+Rule of thumb: Does the work produce a PR or a measurement? Then subprocess_dispatch.py. Does the work produce a gate result? Then review_gate_manager.py or t0_gate_enforcement.sh. Otherwise Bash is fine.
 
 ## Core Responsibilities
 

--- a/templates/terminals/T0.md
+++ b/templates/terminals/T0.md
@@ -21,6 +21,51 @@ Do not run orchestration from memory; follow the skill workflow.
 - DENIED: `Write`, `Edit`, `Task`, and implementation execution
 - OUTPUT: one Manager Block to terminal output (never write dispatch files directly)
 
+## Dispatch-routing — required via subprocess_dispatch.py
+
+Per ADR-010 (subprocess adapter as canonical Claude routing) and ADR-005 (NDJSON ledger as primary observability):
+
+For any feature work (code edit + PR + tests), dispatches to T1/T2/T3 MUST go via subprocess_dispatch.py. This path delivers Wave 5 smart-context injection (+30pp dispatch quality lift), Wave 1 shadow logging, receipt processor audit trail, lease management, and triple-gate contract_hash binding.
+
+### Canonical dispatch command
+
+```bash
+export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+
+python3 .claude/vnx-system/scripts/lib/subprocess_dispatch.py \
+  --terminal-id T1 \
+  --dispatch-id "$(date +%Y%m%d-%H%M%S)-<slug>" \
+  --model sonnet \
+  --role backend-developer \
+  --pr-id "<PR-ID>" \
+  --dispatch-paths "<comma-separated-allowed-paths>" \
+  --instruction "<inline instruction text>"
+```
+
+Required flags: --terminal-id, --dispatch-id, --instruction. Strongly recommended: --role (skill injection), --pr-id (Wave 5 prior-round findings keyed by pr_id), --dispatch-paths (scope guard).
+
+### FORBIDDEN for feature work
+
+```bash
+# DO NOT USE for code/PR work — bypasses Wave 5, audit, lease, governance:
+Bash(claude --print --model sonnet "...")
+Bash(claude -p "...")
+```
+
+Direct claude --print is acceptable ONLY for pure utility invocations (parsing, ad-hoc analysis, debug checks) that have no PR outcome and do not contribute to Wave 1/5 burn-in metrics.
+
+### Decision rule
+
+| Task | Path |
+|---|---|
+| Code edit + PR + tests | subprocess_dispatch.py |
+| PR review (codex_gate, gemini_review) | subprocess_dispatch.py with --gate |
+| Burn-in measurement work | subprocess_dispatch.py REQUIRED |
+| Utility script (transcribe, parse) | direct Bash (no claude needed) |
+| Ad-hoc claude-as-utility | direct Bash claude --print acceptable |
+
+Rule of thumb: Does the work produce a PR, a gate result, or a measurement? Then subprocess_dispatch.py. Otherwise Bash is fine.
+
 ## Core Responsibilities
 
 1. Review receipts critically, not blindly.


### PR DESCRIPTION
## Problem

Operator observed in sales-copilot that T0 bypassed VNX governance by invoking `Bash(claude --print --model sonnet --dangerously-skip-permissions ...)` directly instead of using `subprocess_dispatch.py`.

**Consequences of the bypass:**
- No Wave 5 smart-context injection (+30pp dispatch quality lift unmeasurable)
- No Wave 1 shadow logging
- No receipt processor audit trail
- No lease management (terminals can double-book)
- No `project_id` stamping in events

**Root cause:** Neither `templates/terminals/T0.md` (the canonical T0 CLAUDE.md template that `vnx init` copies) nor `skills/t0-orchestrator/SKILL.md` mentions `subprocess_dispatch.py` as the required dispatch path. Fresh installs get an outdated April-style T0 with no awareness of the post-rc1 routing rule.

## Fix

Added an explicit **"Dispatch-routing — required via subprocess_dispatch.py"** section to:
- `templates/terminals/T0.md` — inserted between "Permissions and Hard Guardrails" and "Core Responsibilities"
- `skills/t0-orchestrator/SKILL.md` — inserted as section 9.2 after "Pre-Dispatch Pane Verification"
- `.claude/skills/t0-orchestrator/SKILL.md` — same (gitignored, updated locally)
- `.agents/skills/t0-orchestrator/SKILL.md` — same (gitignored, updated locally)
- `.gemini/skills/t0-orchestrator/SKILL.md` — same (gitignored, updated locally)

Each insertion contains:
1. **Canonical dispatch command** with all required flags documented
2. **FORBIDDEN block** — explicit `Bash(claude --print ...)` prohibition for feature work
3. **Decision table** — subprocess_dispatch.py vs. direct Bash by task type

References **ADR-010** (subprocess adapter as canonical Claude routing) and **ADR-005** (NDJSON ledger as primary observability).

## Test plan

- [ ] Verify `grep -c 'subprocess_dispatch.py' templates/terminals/T0.md` ≥ 1
- [ ] Verify `grep -c 'subprocess_dispatch.py' skills/t0-orchestrator/SKILL.md` ≥ 1
- [ ] Confirm new section appears between "Permissions and Hard Guardrails" and "Core Responsibilities" in T0.md
- [ ] Confirm new section 9.2 appears before "Manager Block Quality Standard" in SKILL.md
- [ ] No existing content removed or structurally broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)