### PR TITLE
fix(security): OI-1369 — reject path traversal in project_id

### DIFF
--- a/tests/test_vnx_paths_traversal.py
+++ b/tests/test_vnx_paths_traversal.py
@@ -1,0 +1,74 @@
+"""OI-1369 — strict project_id validation prevents path traversal outside sandbox.
+
+Regression test pack: 18 invalid IDs that must raise ValueError,
+9 valid IDs that must succeed, plus a sandbox-escape integration check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from vnx_paths import resolve_central_data_dir
+
+
+class TestProjectIdValidation:
+    """OI-1369 — strict project_id validation prevents path traversal outside sandbox."""
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "..",           # parent dir
+            "../../etc",    # multi-level traversal
+            ".",            # current dir
+            ".hidden",      # leading dot
+            "a/b",          # forward slash
+            "a\\b",         # backslash (Windows-style)
+            "a b",          # space
+            "A",            # uppercase single char
+            "Abc",          # mixed case
+            "-abc",         # leading hyphen
+            "1abc",         # leading digit
+            "a",            # too short (1 char)
+            "a" * 33,       # too long (33 chars)
+            "",             # empty
+            "a.b",          # internal dot
+            "a_b",          # underscore (not in allowed set)
+            "a:b",          # colon
+            "$abc",         # special char
+        ],
+    )
+    def test_reject_invalid_project_ids(self, bad_id):
+        with pytest.raises(ValueError):
+            resolve_central_data_dir(bad_id)
+
+    @pytest.mark.parametrize(
+        "good_id",
+        [
+            "ab",                   # min length (2 chars)
+            "abc",                  # simple
+            "mission-control",      # operator example
+            "sales-copilot",        # operator example
+            "seocrawler-v2",        # operator example
+            "a" + "b" * 31,        # max length (32 chars)
+            "a-b-c-d-e",           # multiple hyphens
+            "p1",                   # letter + digit
+            "project1",             # letters + digit
+        ],
+    )
+    def test_accept_valid_project_ids(self, good_id):
+        result = resolve_central_data_dir(good_id)
+        assert isinstance(result, Path)
+
+    def test_traversal_attempt_does_not_escape_sandbox(self):
+        """Resolved path must stay inside ~/.vnx-data."""
+        home_vnx = Path.home() / ".vnx-data"
+        result = resolve_central_data_dir("test-project")
+        try:
+            result.relative_to(home_vnx)
+        except ValueError:
+            pytest.fail(f"resolved path {result} is NOT inside {home_vnx}")


### PR DESCRIPTION
## Summary

Closes OI-1369. Security blocker for v1.0.0 final.

- The strict regex validation (`^[a-z][a-z0-9-]{1,31}$`) in `resolve_central_data_dir` was already present on `main` (merged in #431). This PR adds the standalone regression test pack to formally close OI-1369.
- Codex flagged OI-1369 as BLOCKING on PR #431 because no dedicated traversal test suite existed.
- Adds `tests/test_vnx_paths_traversal.py`: 18 invalid IDs that must raise `ValueError`, 9 valid IDs that must succeed, plus a sandbox-escape integration check.

## Test plan

- [x] `python3 -m pytest tests/test_vnx_paths_traversal.py -v` — 28/28 passed
- [x] `python3 -m pytest tests/test_vnx_paths_central.py tests/test_vnx_paths_shell_worktree.py -v` — 19/19 passed (no regressions)
- [x] `grep -n 'PROJECT_ID_RE\|resolve_central_data_dir' scripts/lib/vnx_paths.py` — confirms regex at line 16, validation at line 217

🤖 Generated with [Claude Code](https://claude.ai/claude-code)