### PR TITLE
feat(wave4): OTel export foundation

### DIFF
--- a/docs/operations/OTEL_EXPORT.md
+++ b/docs/operations/OTEL_EXPORT.md
@@ -1,0 +1,93 @@
+# OTel Export — Operator Runbook
+
+VNX emits OpenTelemetry metrics and traces to any OTLP-compatible backend (Grafana Tempo,
+Honeycomb, Datadog, Jaeger, etc.).  Emission is **opt-in**: nothing is sent unless
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+## Quick Start
+
+```bash
+# Point at a local Grafana Tempo instance (default OTLP HTTP port)
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+# Or Honeycomb
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY"
+
+# Install the OTel packages (once per virtualenv)
+pip install "opentelemetry-api>=1.20" "opentelemetry-sdk>=1.20" \
+            "opentelemetry-exporter-otlp-proto-http>=1.20"
+
+# Start your VNX dispatcher — metrics flow automatically
+python3 scripts/headless_dispatch_daemon.py
+```
+
+## What Gets Emitted
+
+### Metric: `dispatch_completion_count`
+
+A monotonically-increasing counter incremented once per completed dispatch.
+
+| Attribute     | Example value            | Notes                         |
+|---------------|--------------------------|-------------------------------|
+| `dispatch_id` | `20260513-wave4-otel-…`  | Full dispatch identifier      |
+| `terminal`    | `T1`                     | Worker terminal label         |
+| `status`      | `done` or `failed`       | Outcome of the dispatch       |
+
+### Span: `dispatch_completion`
+
+One span per completed dispatch (done or failed).
+
+| Attribute          | Type    | Notes                        |
+|--------------------|---------|------------------------------|
+| `dispatch_id`      | string  | Dispatch identifier          |
+| `terminal`         | string  | Worker terminal label        |
+| `status`           | string  | `done` or `failed`           |
+| `duration_seconds` | float   | Wall-clock dispatch duration |
+
+## Grafana / Prometheus Sample Queries
+
+```promql
+# Dispatch success rate over 5-minute windows
+sum(rate(dispatch_completion_count{status="done"}[5m]))
+  / sum(rate(dispatch_completion_count[5m]))
+
+# Failure count by terminal
+sum by (terminal) (
+  increase(dispatch_completion_count{status="failed"}[1h])
+)
+```
+
+## Honeycomb Sample Query
+
+```
+CALCULATE COUNT
+FILTER status = failed
+GROUP BY terminal
+ORDER BY COUNT DESC
+```
+
+## Configuration Reference
+
+| Env Var                            | Default  | Purpose                                       |
+|------------------------------------|----------|-----------------------------------------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT`      | (unset)  | OTLP HTTP endpoint; enables emission when set |
+| `OTEL_EXPORTER_OTLP_HEADERS`       | (unset)  | Comma-separated `key=value` auth headers      |
+| `OTEL_SERVICE_NAME`                | (unset)  | Sets `service.name` resource attribute        |
+
+## Backward Compatibility
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is **not** set:
+
+- `otel_emitter` performs **zero imports** of the `opentelemetry` package.
+- All calls are pure no-ops — no exceptions, no latency.
+- The `opentelemetry-*` packages do not need to be installed.
+
+## Future Metrics (Planned)
+
+Subsequent PRs will add:
+
+- `gate_duration_seconds` — codex / gemini / CI gate wall times
+- `lease_lifecycle_count` — acquire / renew / release events
+- `smart_context_injection_count` — intelligence items injected per dispatch
+- `shadow_read_divergence_rate` — Wave 1 shadow mode divergence fraction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ description = "Governance-first multi-agent orchestration for AI CLI workers"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
-dependencies = ["watchdog>=6.0.0"]
+dependencies = [
+    "watchdog>=6.0.0",
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+    "opentelemetry-exporter-otlp-proto-http>=1.20",
+]
 
 [project.scripts]
 vnx = "vnx_cli.main:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 watchdog>=6.0.0
+opentelemetry-api>=1.20
+opentelemetry-sdk>=1.20
+opentelemetry-exporter-otlp-proto-http>=1.20

--- a/scripts/lib/otel_emitter.py
+++ b/scripts/lib/otel_emitter.py
@@ -1,0 +1,63 @@
+"""VNX OTel emission facade — guards opentelemetry imports behind env-var gate."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Optional
+
+_ENABLED = bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+_meter = None
+_tracer = None
+
+
+def _init() -> None:
+    global _meter, _tracer
+    if not _ENABLED or _meter is not None:
+        return
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        metrics.set_meter_provider(
+            MeterProvider(
+                metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())]
+            )
+        )
+        trace.set_tracer_provider(TracerProvider())
+        trace.get_tracer_provider().add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter())
+        )
+        _meter = metrics.get_meter("vnx")
+        _tracer = trace.get_tracer("vnx")
+    except ImportError:
+        pass
+
+
+def emit_metric(name: str, value: float = 1.0, attrs: Optional[dict] = None) -> None:
+    """Emit a counter metric. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset."""
+    if not _ENABLED:
+        return
+    _init()
+    if _meter is None:
+        return
+    counter = _meter.create_counter(name)
+    counter.add(value, attributes=attrs or {})
+
+
+@contextmanager
+def emit_span(name: str, attrs: Optional[dict] = None):
+    """Context manager that emits a span. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset."""
+    if not _ENABLED:
+        yield
+        return
+    _init()
+    if _tracer is None:
+        yield
+        return
+    with _tracer.start_as_current_span(name, attributes=attrs or {}) as span:
+        yield span

--- a/scripts/lib/otel_exporter.py
+++ b/scripts/lib/otel_exporter.py
@@ -1,0 +1,24 @@
+"""VNX OTel exporter — dispatch-completion convenience wrapper."""
+from __future__ import annotations
+
+from otel_emitter import emit_metric, emit_span
+
+
+def emit_dispatch_completion(
+    dispatch_id: str,
+    terminal: str,
+    status: str,
+    duration_seconds: float,
+) -> None:
+    """Emit dispatch_completion_count metric and a dispatch span.
+
+    status should be 'done' or 'failed'. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+    """
+    attrs = {
+        "dispatch_id": dispatch_id,
+        "terminal": terminal,
+        "status": status,
+    }
+    emit_metric("dispatch_completion_count", value=1.0, attrs=attrs)
+    with emit_span("dispatch_completion", attrs={**attrs, "duration_seconds": duration_seconds}):
+        pass

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from otel_exporter import emit_dispatch_completion
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +179,11 @@ def _handle_success(
         lease_generation=lease_generation,
         dispatch_file=_resolve_active_dispatch_file(dispatch_id),
     )
+    _duration = (
+        datetime.now(timezone.utc)
+        - datetime.fromisoformat(dispatch_start_ts)
+    ).total_seconds()
+    emit_dispatch_completion(dispatch_id, terminal_id, "done", _duration)
 
 
 def _handle_final_failure(
@@ -237,6 +246,11 @@ def _handle_final_failure(
         lease_generation=lease_generation,
         dispatch_file=_resolve_active_dispatch_file(dispatch_id),
     )
+    _duration = (
+        datetime.now(timezone.utc)
+        - datetime.fromisoformat(dispatch_start_ts)
+    ).total_seconds()
+    emit_dispatch_completion(dispatch_id, terminal_id, "failed", _duration)
 
 
 def _init_recovery_state(

--- a/tests/test_otel_exporter.py
+++ b/tests/test_otel_exporter.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for otel_emitter and otel_exporter — env-gate behaviour and no-op paths."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+
+class TestOtelEmitterDisabled:
+    """When OTEL_EXPORTER_OTLP_ENDPOINT is unset, everything is a no-op."""
+
+    def setup_method(self):
+        import importlib
+        import otel_emitter
+        # Force module reload with _ENABLED=False to ensure isolation
+        self._orig_enabled = otel_emitter._ENABLED
+        otel_emitter._ENABLED = False
+        otel_emitter._meter = None
+        otel_emitter._tracer = None
+
+    def teardown_method(self):
+        import otel_emitter
+        otel_emitter._ENABLED = self._orig_enabled
+
+    def test_emit_metric_is_noop_when_disabled(self):
+        import otel_emitter
+        # Must not raise and must not attempt opentelemetry import
+        with patch.dict("sys.modules", {"opentelemetry": None}):
+            otel_emitter.emit_metric("smoke_test", value=1.0)
+
+    def test_emit_span_is_noop_when_disabled(self):
+        import otel_emitter
+        with patch.dict("sys.modules", {"opentelemetry": None}):
+            with otel_emitter.emit_span("smoke_span") as span:
+                assert span is None
+
+    def test_emit_metric_no_import_error_when_pkg_absent(self):
+        """Absence of opentelemetry package must never raise."""
+        import otel_emitter
+        otel_emitter._ENABLED = False
+        otel_emitter.emit_metric("no_pkg_test")
+
+    def test_emit_dispatch_completion_noop_when_disabled(self):
+        from otel_exporter import emit_dispatch_completion
+        import otel_emitter
+        otel_emitter._ENABLED = False
+        # Must not raise
+        emit_dispatch_completion("d-001", "T1", "done", 42.0)
+
+
+class TestOtelEmitterEnabled:
+    """When enabled, emit_metric and emit_span use in-memory exporters."""
+
+    def setup_method(self):
+        import otel_emitter
+        self._orig_enabled = otel_emitter._ENABLED
+        self._orig_meter = otel_emitter._meter
+        self._orig_tracer = otel_emitter._tracer
+        otel_emitter._meter = None
+        otel_emitter._tracer = None
+        otel_emitter._ENABLED = True
+
+    def teardown_method(self):
+        import otel_emitter
+        otel_emitter._ENABLED = self._orig_enabled
+        otel_emitter._meter = self._orig_meter
+        otel_emitter._tracer = self._orig_tracer
+
+    def test_emit_metric_calls_create_counter_and_add(self):
+        import otel_emitter
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        otel_emitter._meter = mock_meter
+
+        otel_emitter.emit_metric("dispatch_completion_count", value=1.0, attrs={"status": "done"})
+
+        mock_meter.create_counter.assert_called_once_with("dispatch_completion_count")
+        mock_counter.add.assert_called_once_with(1.0, attributes={"status": "done"})
+
+    def test_emit_metric_default_attrs_empty_dict(self):
+        import otel_emitter
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        otel_emitter._meter = mock_meter
+
+        otel_emitter.emit_metric("test_metric")
+
+        mock_counter.add.assert_called_once_with(1.0, attributes={})
+
+    def test_emit_span_enters_span_context(self):
+        import otel_emitter
+        mock_tracer = MagicMock()
+        mock_span = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = lambda s: mock_span
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+        otel_emitter._tracer = mock_tracer
+
+        with otel_emitter.emit_span("my_span", attrs={"k": "v"}) as span:
+            assert span is mock_span
+
+        mock_tracer.start_as_current_span.assert_called_once_with("my_span", attributes={"k": "v"})
+
+    def test_emit_span_default_attrs(self):
+        import otel_emitter
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = lambda s: MagicMock()
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+        otel_emitter._tracer = mock_tracer
+
+        with otel_emitter.emit_span("span_no_attrs"):
+            pass
+
+        mock_tracer.start_as_current_span.assert_called_once_with("span_no_attrs", attributes={})
+
+    def test_init_graceful_when_opentelemetry_missing(self):
+        """_init() must not raise even if the package is absent."""
+        import otel_emitter
+        otel_emitter._meter = None
+        otel_emitter._tracer = None
+        with patch.dict("sys.modules", {
+            "opentelemetry": None,
+            "opentelemetry.metrics": None,
+            "opentelemetry.trace": None,
+        }):
+            otel_emitter._init()
+        # meter/tracer remain None — that's the graceful no-op path
+        assert otel_emitter._meter is None
+
+
+class TestEmitDispatchCompletion:
+    """emit_dispatch_completion passes correct attrs to both metric and span."""
+
+    def test_calls_emit_metric_and_span(self):
+        import otel_emitter
+        from otel_exporter import emit_dispatch_completion
+
+        orig_enabled = otel_emitter._ENABLED
+        otel_emitter._ENABLED = True
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        otel_emitter._meter = mock_meter
+
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = lambda s: MagicMock()
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+        otel_emitter._tracer = mock_tracer
+
+        try:
+            emit_dispatch_completion("d-999", "T2", "failed", 30.5)
+        finally:
+            otel_emitter._ENABLED = orig_enabled
+
+        mock_meter.create_counter.assert_called_once_with("dispatch_completion_count")
+        add_attrs = mock_counter.add.call_args[1]["attributes"]
+        assert add_attrs["dispatch_id"] == "d-999"
+        assert add_attrs["terminal"] == "T2"
+        assert add_attrs["status"] == "failed"
+
+        span_attrs = mock_tracer.start_as_current_span.call_args[1]["attributes"]
+        assert span_attrs["duration_seconds"] == 30.5


### PR DESCRIPTION
Wave 4 foundation per replan v1.2. Opt-in via OTEL_EXPORTER_OTLP_ENDPOINT env var; no-op when unset (backward compatible). Initial emission: dispatch completion metrics + traces. Operator wires Honeycomb/Grafana/Datadog endpoint, gets burn-in metrics in their pipeline. Future PRs add metrics for: gate durations, lease lifecycle, smart-context injection effectiveness, shadow-read divergence rate.