### PR TITLE
feat(wave2): Phase 0a — package skeleton + build validation

### DIFF
--- a/dist/vnx-orchestration/.gitignore
+++ b/dist/vnx-orchestration/.gitignore
@@ -1,0 +1,5 @@
+*.egg-info/
+dist/
+build/
+__pycache__/
+*.pyc

--- a/dist/vnx-orchestration/README.md
+++ b/dist/vnx-orchestration/README.md
@@ -1,0 +1,68 @@
+# vnx-orchestration
+
+VNX glass-box governance for multi-agent coordination — pip-installable package.
+
+## Status
+
+**Phase 0a** (current): package skeleton. The `vnx_core` and `vnx_cli` modules are
+placeholders. Real runtime modules migrate in Phase 1.
+
+## Installation
+
+### Editable install (development / local repo)
+
+```bash
+pip install -e dist/vnx-orchestration
+```
+
+### With OTel export support
+
+```bash
+pip install -e "dist/vnx-orchestration[otel]"
+```
+
+### From PyPI (Phase 3+)
+
+```bash
+pip install vnx-orchestration
+```
+
+## CLI
+
+After install the `vnx` entry point is available:
+
+```bash
+vnx --version
+```
+
+Phase 0a prints a placeholder. Real CLI surface (dispatch, receipt, queue, gate
+commands) lands in Phase 1+.
+
+## Documentation
+
+- Full operator docs: see [README.md](../../README.md) at repo root.
+- Build / package runbook: see [docs/operations/PACKAGE_BUILD.md](../../docs/operations/PACKAGE_BUILD.md).
+- Architecture: see [docs/](../../docs/) for all design docs.
+
+## Package layout
+
+```
+dist/vnx-orchestration/
+  pyproject.toml          — PEP 621 build metadata
+  vnx_core/               — Runtime libraries (subprocess dispatch, intelligence, etc.)
+  vnx_cli/                — CLI entry point
+  tests/                  — Package-level smoke tests
+```
+
+## Roadmap
+
+| Phase | Scope |
+|-------|-------|
+| 0a (this PR) | Package skeleton, build validation, smoke tests |
+| 1 | Migrate `scripts/lib/` core modules into `vnx_core` |
+| 2 | Wire shim layer in `scripts/lib/` to import from `vnx_core` |
+| 3 | PyPI publish, versioned releases |
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/dist/vnx-orchestration/pyproject.toml
+++ b/dist/vnx-orchestration/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vnx-orchestration"
+description = "VNX glass-box governance for multi-agent coordination"
+readme = "README.md"
+requires-python = ">=3.11"
+dynamic = ["version"]
+license = "MIT"
+authors = [{name = "Vincent van Deth", email = "vincentvd@gmail.com"}]
+dependencies = []
+
+[project.scripts]
+vnx = "vnx_cli.__main__:main"
+
+[project.optional-dependencies]
+otel = ["opentelemetry-api>=1.20", "opentelemetry-sdk>=1.20", "opentelemetry-exporter-otlp-proto-http>=1.20"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["vnx_core*", "vnx_cli*"]
+
+[tool.setuptools_scm]
+root = "../.."
+fallback_version = "1.0.0-rc1.dev0"

--- a/dist/vnx-orchestration/tests/test_smoke.py
+++ b/dist/vnx-orchestration/tests/test_smoke.py
@@ -1,0 +1,20 @@
+def test_vnx_core_import():
+    import vnx_core
+    assert vnx_core.__version__
+
+
+def test_vnx_cli_import():
+    from vnx_cli import __main__
+    assert __main__.main
+
+
+def test_vnx_cli_runs():
+    from vnx_cli.__main__ import main
+    rc = main([])
+    assert rc == 0
+
+
+def test_vnx_cli_version_flag():
+    from vnx_cli.__main__ import main
+    rc = main(["--version"])
+    assert rc == 0

--- a/dist/vnx-orchestration/vnx_cli/__init__.py
+++ b/dist/vnx-orchestration/vnx_cli/__init__.py
@@ -1,0 +1,4 @@
+"""vnx_cli — VNX command-line interface package.
+
+Phase 0a placeholder. Real CLI commands land in Phase 1.
+"""

--- a/dist/vnx-orchestration/vnx_cli/__main__.py
+++ b/dist/vnx-orchestration/vnx_cli/__main__.py
@@ -1,0 +1,17 @@
+"""vnx CLI entry point (Phase 0a placeholder)."""
+from __future__ import annotations
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    print("vnx-orchestration package — Phase 0a skeleton.")
+    print("Real CLI surface lands in Phase 1.")
+    if args and args[0] in ("--version", "-v"):
+        from vnx_core import __version__
+        print(f"version: {__version__}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dist/vnx-orchestration/vnx_core/__init__.py
+++ b/dist/vnx-orchestration/vnx_core/__init__.py
@@ -1,0 +1,5 @@
+"""vnx_core — VNX runtime libraries (subprocess dispatch, intelligence selector, etc.)
+
+Phase 0a placeholder. Modules will be migrated in Phase 1.
+"""
+__version__ = "0.0.1.dev0"  # overridden by setuptools_scm at build time

--- a/docs/operations/PACKAGE_BUILD.md
+++ b/docs/operations/PACKAGE_BUILD.md
@@ -1,0 +1,85 @@
+# PACKAGE_BUILD — vnx-orchestration operator runbook
+
+Covers local development builds, editable installs, and test execution for the
+`vnx-orchestration` pip package (Wave 2).
+
+## Prerequisites
+
+```bash
+pip install --user build     # installs the 'build' frontend
+pip install --user pytest    # test runner
+```
+
+Or inside the project venv:
+
+```bash
+pip install build pytest
+```
+
+## Build a wheel locally
+
+```bash
+cd dist/vnx-orchestration
+python -m build --wheel
+```
+
+Output appears in `dist/vnx-orchestration/dist/*.whl`.
+
+The version string is derived from `setuptools_scm` via the nearest git tag.
+In a clean checkout without a matching tag, `fallback_version = "1.0.0-rc1.dev0"`
+is used.
+
+## Editable install (development mode)
+
+```bash
+# From repo root:
+pip install -e dist/vnx-orchestration
+
+# With OTel export extras:
+pip install -e "dist/vnx-orchestration[otel]"
+```
+
+Editable installs link directly to the source tree, so code changes take effect
+immediately without reinstalling.
+
+## Verify imports and entry point
+
+```bash
+python -c 'import vnx_core; import vnx_cli; print(vnx_core.__version__)'
+vnx --version
+```
+
+## Run smoke tests
+
+```bash
+cd dist/vnx-orchestration
+python -m pytest tests/test_smoke.py -v
+```
+
+Expected output (Phase 0a):
+
+```
+PASSED tests/test_smoke.py::test_vnx_core_import
+PASSED tests/test_smoke.py::test_vnx_cli_import
+PASSED tests/test_smoke.py::test_vnx_cli_runs
+PASSED tests/test_smoke.py::test_vnx_cli_version_flag
+4 passed
+```
+
+## Phase roadmap
+
+| Phase | Scope |
+|-------|-------|
+| **0a** (this file) | Package skeleton — empty `vnx_core` / `vnx_cli`, smoke tests, build validation |
+| **1** | Migrate `scripts/lib/` core modules into `vnx_core`; wire `dependencies` in pyproject.toml |
+| **2** | Shim layer in `scripts/lib/` imports from `vnx_core` (backward-compat bridge) |
+| **3** | PyPI publish via CI; versioned releases from git tags |
+
+## Notes
+
+- `dist/vnx-orchestration/dist/` (wheel output) is gitignored via
+  `dist/vnx-orchestration/.gitignore`. Do not commit built artifacts.
+- The `[tool.setuptools_scm] root = "../.."` setting anchors version detection to
+  the repository root, not the package subdirectory.
+- Do not add real runtime dependencies to `pyproject.toml` until Phase 1 module
+  migration; premature deps bloat the install surface.


### PR DESCRIPTION
Wave 2 Phase 0a per replan v1.2 + claudedocs/wave2-extraction-design-2026-05-12.md.

Creates `dist/vnx-orchestration/` package skeleton with pyproject.toml, minimal
`vnx_core`/`vnx_cli` modules, smoke tests, build/install docs. No existing code
migration — that lands in Phase 1. Validates: `python -m build` produces wheel,
`pip install -e .` works, `vnx --version` runs, 4 smoke tests PASS.

## Changes

- `dist/vnx-orchestration/pyproject.toml` — PEP 621 build metadata (setuptools_scm, entry point, otel extras)
- `dist/vnx-orchestration/README.md` — package overview + phase roadmap
- `dist/vnx-orchestration/vnx_core/__init__.py` — Phase 0a placeholder
- `dist/vnx-orchestration/vnx_cli/__init__.py` — Phase 0a placeholder
- `dist/vnx-orchestration/vnx_cli/__main__.py` — minimal CLI entry (`--version` flag)
- `dist/vnx-orchestration/tests/test_smoke.py` — 4 import + CLI roundtrip tests
- `dist/vnx-orchestration/.gitignore` — ignores egg-info, dist/, build/, pycache
- `docs/operations/PACKAGE_BUILD.md` — operator runbook for build/install/test/publish

## Test plan

- [ ] `python -m build --wheel` from `dist/vnx-orchestration/` produces `.whl`
- [ ] `pip install -e dist/vnx-orchestration` succeeds
- [ ] `python -c 'import vnx_core; import vnx_cli; print(vnx_core.__version__)'` prints version
- [ ] `python -m pytest dist/vnx-orchestration/tests/test_smoke.py -v` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)