### PR TITLE
feat(wave4.5): PR-2 — codex/gemini adapters use PromptAssembler

### DIFF
--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -98,7 +98,9 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         event_store = context.get("event_store")
         changed_files = context.get("changed_files", [])
 
-        prompt = self._build_prompt(instruction, changed_files)
+        role = context.get("role")
+        dispatch_meta = context.get("dispatch_metadata", {})
+        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
         cmd = self._build_cmd(model)
 
         self._current_terminal_id = terminal_id
@@ -128,8 +130,22 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
             )
 
         if proc.stdin:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
+            try:
+                proc.stdin.write(prompt.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                return AdapterResult(
+                    status="failed",
+                    output="stdin write failed (BrokenPipeError): codex process exited early",
+                    events=[],
+                    event_count=0,
+                    duration_seconds=0.0,
+                    committed=False,
+                    commit_hash=None,
+                    report_path=None,
+                    provider="codex",
+                    model=model,
+                )
 
         events: list[dict] = []
         findings_parts: list[str] = []
@@ -206,8 +222,10 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         dispatch_id = context.get("dispatch_id", "unknown")
         event_store = context.get("event_store")
         changed_files = context.get("changed_files", [])
+        role = context.get("role")
+        dispatch_meta = context.get("dispatch_metadata", {})
 
-        prompt = self._build_prompt(instruction, changed_files)
+        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
         cmd = self._build_cmd(model)
 
         self._current_terminal_id = terminal_id
@@ -226,8 +244,12 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
             return
 
         if proc.stdin:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
+            try:
+                proc.stdin.write(prompt.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                yield {"type": "error", "data": {"reason": "stdin write failed (BrokenPipeError)"}}
+                return
 
         for canonical_event in self.drain_stream(
             proc,
@@ -600,13 +622,32 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
             pass
         return None
 
-    def _build_prompt(self, instruction: str, changed_files: list[str]) -> str:
-        """Combine instruction with inline file contents (no PR references)."""
+    def _build_prompt(
+        self,
+        instruction: str,
+        changed_files: list[str],
+        role: Optional[str] = None,
+        dispatch_metadata: Optional[dict] = None,
+    ) -> str:
+        """Build prompt from instruction + inline file contents.
+
+        When role or dispatch_metadata is provided, routes through PromptAssembler
+        (L1 base rules + L2 role context + L3 instruction). Falls back to raw
+        instruction+files when neither is given (backward compat).
+        """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
-        if file_contents:
-            return f"{instruction}\n\n{file_contents}"
-        return instruction
+        full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
+
+        if role or dispatch_metadata:
+            from prompt_assembler import PromptAssembler, format_for_provider
+            assembled = PromptAssembler().assemble(
+                dispatch_metadata={"role": role, **(dispatch_metadata or {})},
+                instruction=full_instruction,
+            )
+            return format_for_provider(assembled, "codex")["pipe_input"]
+
+        return full_instruction
 
     @staticmethod
     def _kill(proc: subprocess.Popen) -> None:

--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -97,7 +97,9 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
 
-        prompt = self._build_prompt(instruction, changed_files)
+        role = context.get("role")
+        dispatch_meta = context.get("dispatch_metadata", {})
+        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
 
         if _gemini_stream_enabled():
             return self._execute_streaming(
@@ -125,11 +127,13 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             os.environ.get("VNX_GEMINI_TIMEOUT",
                            context.get("total_deadline", _DEFAULT_TIMEOUT))
         )
+        role = context.get("role")
+        dispatch_meta = context.get("dispatch_metadata", {})
 
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
 
-        prompt = self._build_prompt(instruction, changed_files)
+        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
 
         if not _gemini_stream_enabled():
             # Legacy path: execute and yield a single synthetic result event
@@ -157,8 +161,12 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             return
 
         if proc.stdin:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
+            try:
+                proc.stdin.write(prompt.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                yield {"type": "error", "data": {"reason": "stdin write failed (BrokenPipeError)"}}
+                return
 
         for canonical_event in self.drain_stream(
             proc,
@@ -310,8 +318,22 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             )
 
         if proc.stdin:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
+            try:
+                proc.stdin.write(prompt.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                return AdapterResult(
+                    status="failed",
+                    output="stdin write failed (BrokenPipeError): gemini process exited early",
+                    events=[],
+                    event_count=0,
+                    duration_seconds=0.0,
+                    committed=False,
+                    commit_hash=None,
+                    report_path=None,
+                    provider="gemini",
+                    model=model,
+                )
 
         events: list[dict] = []
         findings_parts: list[str] = []
@@ -401,8 +423,22 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             )
 
         if proc.stdin:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
+            try:
+                proc.stdin.write(prompt.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                return AdapterResult(
+                    status="failed",
+                    output="stdin write failed (BrokenPipeError): gemini process exited early",
+                    events=[],
+                    event_count=0,
+                    duration_seconds=0.0,
+                    committed=False,
+                    commit_hash=None,
+                    report_path=None,
+                    provider="gemini",
+                    model=model,
+                )
 
         stdout, stderr, status = self._drain_with_timeout(proc, timeout)
         duration = time.monotonic() - t0
@@ -564,13 +600,33 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             pass
         return None
 
-    def _build_prompt(self, instruction: str, changed_files: list[str]) -> str:
-        """Combine instruction with inline file contents."""
+    def _build_prompt(
+        self,
+        instruction: str,
+        changed_files: list[str],
+        role: Optional[str] = None,
+        dispatch_metadata: Optional[dict] = None,
+    ) -> str:
+        """Build prompt from instruction + inline file contents.
+
+        When role or dispatch_metadata is provided, routes through PromptAssembler
+        (L1 base rules + L2 role context + L3 instruction). Falls back to raw
+        instruction+files when neither is given (backward compat).
+        """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
-        if file_contents:
-            return f"{instruction}\n\n{file_contents}"
-        return instruction
+        full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
+
+        if role or dispatch_metadata:
+            from prompt_assembler import PromptAssembler, format_for_provider
+            assembled = PromptAssembler().assemble(
+                dispatch_metadata={"role": role, **(dispatch_metadata or {})},
+                instruction=full_instruction,
+            )
+            result = format_for_provider(assembled, "gemini")
+            return f"{result['system_instruction']}\n\n---\n\n{result['prompt']}"
+
+        return full_instruction
 
     def _drain_with_timeout(
         self, proc: subprocess.Popen, timeout: int

--- a/scripts/lib/prompt_assembler.py
+++ b/scripts/lib/prompt_assembler.py
@@ -63,20 +63,17 @@ class AssembledPrompt:
         return self.to_pipe_input()
 
     def for_codex_subprocess(self) -> str:
-        """Codex header-style format: context + '# DISPATCH' markdown header."""
-        return f"{self.context}\n\n# DISPATCH\n\n{self.instruction}"
+        """Deprecated thin wrapper. Use format_for_provider(assembled, 'codex')['pipe_input'] instead."""
+        return format_for_provider(self, "codex")["pipe_input"]
 
     def for_gemini_subprocess(self) -> str:
-        """Gemini simple-separator format: context + '---' with no extra header."""
-        return f"{self.context}\n\n---\n\n{self.instruction}"
+        """Deprecated thin wrapper. Use format_for_provider(assembled, 'gemini') instead."""
+        result = format_for_provider(self, "gemini")
+        return f"{result['system_instruction']}\n\n---\n\n{result['prompt']}"
 
     def for_litellm_provider(self, provider_name: str) -> dict:
-        """OpenAI-shaped payload for LiteLLM-proxied providers (DeepSeek, Kimi, etc.)."""
-        return {
-            "system": self.context,
-            "messages": [{"role": "user", "content": self.instruction}],
-            "metadata": {"provider": provider_name, **self.metadata},
-        }
+        """Deprecated thin wrapper. Use format_for_provider(assembled, f'litellm:{provider_name}') instead."""
+        return format_for_provider(self, f"litellm:{provider_name}")
 
 
 class PromptAssembler:
@@ -263,9 +260,17 @@ def format_for_provider(assembled: "AssembledPrompt", provider: str) -> dict:
         {"system": "<L1+L2>", "prompt": "<L3>"}
         Ollama HTTP API has a native "system" field separate from "prompt".
 
+    litellm / litellm:<provider_name>:
+        {"messages": [{"role": "system", "content": "<L1+L2>"},
+                       {"role": "user", "content": "<L3>"}],
+         "metadata": {"provider": "<provider_name>", ...}}
+        OpenAI-compatible messages array. System context is a system-role message
+        (not a top-level "system" key) to match litellm.completion() actual contract.
+
     Args:
         assembled: AssembledPrompt from PromptAssembler.assemble().
-        provider:  One of "claude", "gemini", "codex", "ollama".
+        provider:  One of "claude", "gemini", "codex", "ollama", "litellm",
+                   or "litellm:<provider_name>" (e.g. "litellm:deepseek").
 
     Returns:
         Dict with provider-specific payload keys.
@@ -293,7 +298,17 @@ def format_for_provider(assembled: "AssembledPrompt", provider: str) -> dict:
             "prompt": assembled.instruction,
         }
 
+    if provider == "litellm" or provider.startswith("litellm:"):
+        provider_name = provider.split(":", 1)[1] if ":" in provider else "litellm"
+        return {
+            "messages": [
+                {"role": "system", "content": assembled.context},
+                {"role": "user", "content": assembled.instruction},
+            ],
+            "metadata": {"provider": provider_name, **assembled.metadata},
+        }
+
     raise ValueError(
         f"Unknown provider '{provider}'. "
-        "Supported: claude, gemini, codex, ollama"
+        "Supported: claude, gemini, codex, ollama, litellm, litellm:<provider_name>"
     )

--- a/scripts/vnx_init.py
+++ b/scripts/vnx_init.py
@@ -429,6 +429,61 @@ def init_db(paths: Dict[str, str]) -> StepResult:
 
 
 # ---------------------------------------------------------------------------
+# Step: generate tri-files (AGENTS.md + GEMINI.md mirror of CLAUDE.md)
+# ---------------------------------------------------------------------------
+
+_BOOTSTRAP_START = "<!-- VNX:BEGIN BOOTSTRAP -->"
+_BOOTSTRAP_END = "<!-- VNX:END BOOTSTRAP -->"
+
+
+def generate_tri_files(paths: Dict[str, str]) -> StepResult:
+    """Generate AGENTS.md + GEMINI.md mirroring CLAUDE.md bootstrap block.
+
+    Extracts the VNX bootstrap block from CLAUDE.md and writes/updates
+    AGENTS.md and GEMINI.md so all three provider instruction files stay
+    in sync. Idempotent: skips files whose bootstrap block is already current.
+    """
+    project_root = Path(paths["PROJECT_ROOT"])
+    claude_md = project_root / "CLAUDE.md"
+
+    if not claude_md.exists():
+        return StepResult("tri-files", SKIP, "CLAUDE.md not found; skipping tri-file generation")
+
+    content = claude_md.read_text(encoding="utf-8")
+    start_idx = content.find(_BOOTSTRAP_START)
+    end_idx = content.find(_BOOTSTRAP_END)
+    if start_idx == -1 or end_idx == -1:
+        return StepResult("tri-files", SKIP, "No VNX bootstrap block in CLAUDE.md; skipping")
+
+    bootstrap_block = content[start_idx:end_idx + len(_BOOTSTRAP_END)]
+
+    generated = []
+    for filename in ("AGENTS.md", "GEMINI.md"):
+        target = project_root / filename
+        if target.exists():
+            existing = target.read_text(encoding="utf-8")
+            if bootstrap_block in existing:
+                continue
+            s = existing.find(_BOOTSTRAP_START)
+            e = existing.find(_BOOTSTRAP_END)
+            if s != -1 and e != -1:
+                updated = existing[:s] + bootstrap_block + existing[e + len(_BOOTSTRAP_END):]
+            else:
+                updated = bootstrap_block + "\n"
+        else:
+            updated = bootstrap_block + "\n"
+
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(updated, encoding="utf-8")
+        os.replace(tmp, target)
+        generated.append(filename)
+
+    if generated:
+        return StepResult("tri-files", PASS, f"Generated/updated: {', '.join(generated)}")
+    return StepResult("tri-files", SKIP, "AGENTS.md + GEMINI.md already in sync with CLAUDE.md")
+
+
+# ---------------------------------------------------------------------------
 # Step: patch agent files
 # ---------------------------------------------------------------------------
 
@@ -508,6 +563,7 @@ def run_init(paths: Dict[str, str], skip_hooks: bool = False,
     if not skip_hooks:
         results.append(bootstrap_hooks(paths))
 
+    results.append(generate_tri_files(paths))
     results.append(patch_agent_files(paths))
     results.append(init_db(paths))
     results.append(intelligence_import(paths))
@@ -529,7 +585,7 @@ def main() -> int:
                         help="Initialize in operator mode (full tmux grid)")
     parser.add_argument("--step", choices=[
         "layout", "profiles", "config", "skills", "terminals",
-        "hooks", "agent-files", "init-db", "intelligence-import",
+        "hooks", "tri-files", "agent-files", "init-db", "intelligence-import",
     ], help="Run only a specific step")
     args = parser.parse_args()
 
@@ -543,6 +599,7 @@ def main() -> int:
             "skills": lambda: bootstrap_skills(paths),
             "terminals": lambda: bootstrap_terminals(paths),
             "hooks": lambda: bootstrap_hooks(paths),
+            "tri-files": lambda: generate_tri_files(paths),
             "agent-files": lambda: patch_agent_files(paths),
             "init-db": lambda: init_db(paths),
             "intelligence-import": lambda: intelligence_import(paths),

--- a/tests/test_codex_adapter_prompt_assembly.py
+++ b/tests/test_codex_adapter_prompt_assembly.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""tests/test_codex_adapter_prompt_assembly.py — Unit tests for CodexAdapter._build_prompt.
+
+Verifies that _build_prompt routes through PromptAssembler when role is provided,
+and falls back to raw instruction+files when no role is given (backward compat).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib" / "adapters"))
+
+from codex_adapter import CodexAdapter
+
+
+@pytest.fixture()
+def adapter() -> CodexAdapter:
+    return CodexAdapter(terminal_id="T1")
+
+
+def _mock_collect(payload: dict, subprocess_run=None) -> str:
+    """Stub that returns empty file contents so tests stay filesystem-independent."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# test_codex_build_prompt_uses_assembler_when_role_given
+# ---------------------------------------------------------------------------
+
+def test_codex_build_prompt_uses_assembler_when_role_given(adapter: CodexAdapter) -> None:
+    """When role= is given, _build_prompt must route through PromptAssembler."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Fix the parser",
+            changed_files=[],
+            role="backend-developer",
+        )
+    assert isinstance(result, str)
+    assert len(result) > len("Fix the parser"), "Assembler should expand prompt with L1+L2 context"
+    assert "DISPATCH INSTRUCTION:" in result
+
+
+# ---------------------------------------------------------------------------
+# test_codex_build_prompt_fallback_to_raw_when_no_role
+# ---------------------------------------------------------------------------
+
+def test_codex_build_prompt_fallback_to_raw_when_no_role(adapter: CodexAdapter) -> None:
+    """When role= is None and dispatch_metadata is absent, _build_prompt returns raw instruction."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Fix the parser",
+            changed_files=[],
+        )
+    assert result == "Fix the parser"
+
+
+# ---------------------------------------------------------------------------
+# test_codex_prompt_includes_base_worker_rules
+# ---------------------------------------------------------------------------
+
+def test_codex_prompt_includes_base_worker_rules(adapter: CodexAdapter) -> None:
+    """Assembled codex prompt must include Layer 1 base worker rules (billing safety)."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Do work",
+            changed_files=[],
+            role="backend-developer",
+        )
+    content_lower = result.lower()
+    assert "billing" in content_lower or "anthropic" in content_lower, \
+        "Layer 1 billing safety must appear in assembled codex prompt"
+
+
+# ---------------------------------------------------------------------------
+# test_codex_prompt_includes_role_context
+# ---------------------------------------------------------------------------
+
+def test_codex_prompt_includes_role_context(adapter: CodexAdapter) -> None:
+    """Assembled codex prompt must include role-specific context for 'backend-developer'."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Do work",
+            changed_files=[],
+            role="backend-developer",
+        )
+    assert "backend" in result.lower() or "backend-developer" in result.lower(), \
+        "Role context for backend-developer must appear in assembled codex prompt"

--- a/tests/test_gemini_adapter_prompt_assembly.py
+++ b/tests/test_gemini_adapter_prompt_assembly.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""tests/test_gemini_adapter_prompt_assembly.py — Unit tests for GeminiAdapter._build_prompt.
+
+Mirrors the codex adapter tests. Verifies that _build_prompt routes through
+PromptAssembler when role is provided, and falls back to raw instruction+files
+when no role is given (backward compat).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib" / "adapters"))
+
+from gemini_adapter import GeminiAdapter
+
+
+@pytest.fixture()
+def adapter() -> GeminiAdapter:
+    return GeminiAdapter(terminal_id="T2")
+
+
+def _mock_collect(payload: dict, subprocess_run=None) -> str:
+    """Stub that returns empty file contents so tests stay filesystem-independent."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# test_gemini_build_prompt_uses_assembler_when_role_given
+# ---------------------------------------------------------------------------
+
+def test_gemini_build_prompt_uses_assembler_when_role_given(adapter: GeminiAdapter) -> None:
+    """When role= is given, _build_prompt must route through PromptAssembler."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Review the PR",
+            changed_files=[],
+            role="backend-developer",
+        )
+    assert isinstance(result, str)
+    assert len(result) > len("Review the PR"), "Assembler should expand prompt with L1+L2 context"
+    assert "---" in result
+
+
+# ---------------------------------------------------------------------------
+# test_gemini_build_prompt_fallback_to_raw_when_no_role
+# ---------------------------------------------------------------------------
+
+def test_gemini_build_prompt_fallback_to_raw_when_no_role(adapter: GeminiAdapter) -> None:
+    """When role= is None and dispatch_metadata is absent, _build_prompt returns raw instruction."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Review the PR",
+            changed_files=[],
+        )
+    assert result == "Review the PR"
+
+
+# ---------------------------------------------------------------------------
+# test_gemini_prompt_includes_base_worker_rules
+# ---------------------------------------------------------------------------
+
+def test_gemini_prompt_includes_base_worker_rules(adapter: GeminiAdapter) -> None:
+    """Assembled gemini prompt must include Layer 1 base worker rules (billing safety)."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Do work",
+            changed_files=[],
+            role="backend-developer",
+        )
+    content_lower = result.lower()
+    assert "billing" in content_lower or "anthropic" in content_lower, \
+        "Layer 1 billing safety must appear in assembled gemini prompt"
+
+
+# ---------------------------------------------------------------------------
+# test_gemini_prompt_includes_role_context
+# ---------------------------------------------------------------------------
+
+def test_gemini_prompt_includes_role_context(adapter: GeminiAdapter) -> None:
+    """Assembled gemini prompt must include role-specific context for 'backend-developer'."""
+    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+        result = adapter._build_prompt(
+            instruction="Do work",
+            changed_files=[],
+            role="backend-developer",
+        )
+    assert "backend" in result.lower() or "backend-developer" in result.lower(), \
+        "Role context for backend-developer must appear in assembled gemini prompt"

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -331,11 +331,12 @@ def test_for_claude_subprocess_equals_to_pipe_input(assembler: PromptAssembler) 
 
 
 def test_for_codex_subprocess_uses_dispatch_header(assembler: PromptAssembler) -> None:
-    """for_codex_subprocess() must use '# DISPATCH' markdown header."""
+    """for_codex_subprocess() delegates to format_for_provider('codex') — same as to_pipe_input()."""
     r = assembler.assemble(dispatch_metadata={"role": "backend-developer"}, instruction="x")
     pipe = r.for_codex_subprocess()
-    assert "# DISPATCH" in pipe
+    assert "DISPATCH INSTRUCTION:" in pipe
     assert pipe.endswith("x")
+    assert pipe == r.to_pipe_input()
 
 
 def test_for_gemini_subprocess_uses_simple_separator(assembler: PromptAssembler) -> None:
@@ -348,11 +349,45 @@ def test_for_gemini_subprocess_uses_simple_separator(assembler: PromptAssembler)
 
 
 def test_for_litellm_provider_openai_shape(assembler: PromptAssembler) -> None:
-    """for_litellm_provider() must return OpenAI-shaped dict with system + messages + metadata."""
+    """for_litellm_provider() must return messages-array dict with system role entry + metadata (ADV-1 fix)."""
     r = assembler.assemble(dispatch_metadata={"role": "backend-developer"}, instruction="x")
     result = r.for_litellm_provider("deepseek")
     assert isinstance(result, dict)
-    assert result["system"]
-    assert result["messages"][0]["role"] == "user"
-    assert result["messages"][0]["content"] == "x"
+    assert "system" not in result  # no top-level system key — system is in messages array
+    assert result["messages"][0]["role"] == "system"
+    assert result["messages"][0]["content"] == r.context
+    assert result["messages"][1]["role"] == "user"
+    assert result["messages"][1]["content"] == "x"
     assert result["metadata"]["provider"] == "deepseek"
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.5 PR-2 — alignment + ADV-1 fix tests
+# ---------------------------------------------------------------------------
+
+def test_for_codex_subprocess_equals_format_for_provider_codex(assembler: PromptAssembler) -> None:
+    """for_codex_subprocess() output must equal format_for_provider(assembled, 'codex')['pipe_input']."""
+    r = assembler.assemble(dispatch_metadata={"role": "backend-developer"}, instruction="align-check")
+    assert r.for_codex_subprocess() == format_for_provider(r, "codex")["pipe_input"]
+
+
+def test_for_gemini_subprocess_equals_format_for_provider_gemini(assembler: PromptAssembler) -> None:
+    """for_gemini_subprocess() must produce the same content as combining format_for_provider('gemini') fields."""
+    r = assembler.assemble(dispatch_metadata={"role": "backend-developer"}, instruction="align-check")
+    ffp = format_for_provider(r, "gemini")
+    expected = f"{ffp['system_instruction']}\n\n---\n\n{ffp['prompt']}"
+    assert r.for_gemini_subprocess() == expected
+
+
+def test_for_litellm_provider_returns_messages_with_system_role(assembler: PromptAssembler) -> None:
+    """ADV-1 fix: system context must be messages[0] with role='system', not a top-level 'system' key."""
+    r = assembler.assemble(dispatch_metadata={"role": "backend-developer"}, instruction="litellm-test")
+    result = r.for_litellm_provider("kimi")
+    assert isinstance(result.get("messages"), list)
+    assert len(result["messages"]) == 2
+    assert result["messages"][0]["role"] == "system"
+    assert result["messages"][0]["content"] == r.context
+    assert result["messages"][1]["role"] == "user"
+    assert result["messages"][1]["content"] == "litellm-test"
+    assert "system" not in result
+    assert result["metadata"]["provider"] == "kimi"


### PR DESCRIPTION
Wave 4.5 PR-2 per claudedocs/wave4.5-provider-parity-design-2026-05-13.md. Codex + Gemini adapters now route through PromptAssembler.assemble() + format_for_provider(). Tri-file AGENTS.md + GEMINI.md activated by vnx init bootstrap (auto-mirror of CLAUDE.md template). Resolves codex round-1 advisories from PR #471 (litellm shape, format_for_provider alignment).

## Summary

- **ADV-1 fix**: `for_litellm_provider()` now returns `messages` array with `role=system` entry instead of top-level `"system"` key, matching actual `litellm.completion()` contract
- **ADV-2 fix**: `format_for_provider()` is now the single canonical entry point; `for_codex_subprocess` / `for_gemini_subprocess` / `for_litellm_provider` are deprecated thin wrappers that delegate to it
- **Codex adapter**: `_build_prompt` routes through `PromptAssembler` when `role=` is given; falls back to raw instruction+files without role (backward compat)
- **Gemini adapter**: same pattern using `'gemini'` provider key; `execute()` / `stream_events()` extract `role` from context dict
- **Both adapters**: `BrokenPipeError` guard on stdin writes (codex defense checklist)
- **vnx_init.py**: `generate_tri_files()` step generates AGENTS.md + GEMINI.md mirroring CLAUDE.md bootstrap block; idempotent, atomic writes, available as `--step tri-files`

## Test plan

- [x] `pytest tests/test_prompt_assembler.py -v` — 23 passed (3 new + 2 updated for ADV-1/ADV-2)
- [x] `pytest tests/test_codex_adapter_prompt_assembly.py -v` — 4 passed (new)
- [x] `pytest tests/test_gemini_adapter_prompt_assembly.py -v` — 4 passed (new)
- [x] `pytest tests/test_prompt_assembler.py tests/test_codex_adapter_prompt_assembly.py tests/test_gemini_adapter_prompt_assembly.py` — 31 passed total
- [x] All modified Python files pass `python3 -c "ast.parse(...)"` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)