### PR TITLE
feat(wave4.5): PR-3 — intelligence injection per-provider (adapter-side)

### DIFF
--- a/claudedocs/burn-in-monitoring-runbook-2026-05-12.md
+++ b/claudedocs/burn-in-monitoring-runbook-2026-05-12.md
@@ -96,7 +96,23 @@ Wave 5 measures dispatch quality success-rate. Baseline: 88.9% with naïve injec
 
 ### Per-dispatch injection evidence
 
-Each `subprocess_dispatch.py` invocation now logs which smart-context components fired. Check a recent dispatch:
+**Recorded injection facts** — the authoritative source is `intelligence_injections` in the
+quality DB (written by `IntelligenceSelector.record_injection`):
+
+```bash
+sqlite3 .vnx-data/state/quality_intelligence.db <<EOF
+.mode column
+.headers on
+SELECT dispatch_id, injection_type, role, created_at
+FROM intelligence_injections
+WHERE created_at > datetime('now', '-1 day')
+ORDER BY created_at DESC
+LIMIT 20;
+EOF
+```
+
+**Live event stream** — the archived events NDJSON is a secondary check for streamed
+event records (only present for subprocess-routed terminals; empty live file = look in archive):
 
 ```bash
 # Pick a recent dispatch_id
@@ -105,11 +121,11 @@ DISPATCH_ID=$(ls -t .vnx-data/dispatches/completed/ | head -1)
 # Read its manifest
 cat ".vnx-data/dispatches/completed/$DISPATCH_ID/manifest.json" | python3 -m json.tool
 
-# Find the dispatch's events archive
+# Find the dispatch's archived events
 EVENTS=".vnx-data/events/archive/T1/$DISPATCH_ID.ndjson"
 # (or T2/T3 — check whichever terminal handled it)
 
-# Filter for injection events
+# Filter for injection events in the live event stream
 grep -i "intelligence_injection\|smart_context\|adr_match\|prior_round\|code_anchor\|operator_memory\|schema_introspect" "$EVENTS" 2>/dev/null | python3 -c "
 import json, sys
 for line in sys.stdin:

--- a/claudedocs/burn-in-monitoring-runbook-2026-05-12.md
+++ b/claudedocs/burn-in-monitoring-runbook-2026-05-12.md
@@ -1,0 +1,285 @@
+# Burn-in Monitoring Runbook — Wave 1 + Wave 5
+
+**Date**: 2026-05-12
+**Scope**: Mission Control + Sales Copilot pilot deployments
+**Purpose**: Concrete commands to verify that the post-rc1 work (Wave 1 shadow read cutover + Wave 5 smart-context injection) is actually firing on dispatched work, and to measure the +30pp dispatch-quality lift in production.
+
+---
+
+## What "burn-in" means here
+
+Two parallel things need validation on real dispatches before the v1.0.0 final tag is cut:
+
+| Wave | What it does | Burn-in question |
+|---|---|---|
+| **Wave 1** (shadow read cutover) | Reads central state via the new path in parallel with the legacy path; logs divergences. | Does the new path return the same answers as the legacy path? Any divergences = central-reader regression. |
+| **Wave 5** (smart context injection) | Injects prior-round findings, ADR matches, code anchors, operator memory, schema introspection into worker context at dispatch time. | Does the +30pp dispatch-quality lift (measured on 658 historical dispatches) hold up on new dispatches? |
+
+Both depend on dispatches actually going through `subprocess_dispatch.py`. Direct `claude --print` invocations bypass both — see `T0/CLAUDE.md` §Dispatch-routing in mc + sales-copilot.
+
+---
+
+## Pre-flight: confirm the dispatch path
+
+Before measuring anything, verify each dispatch is going through the canonical path. Run in the target project:
+
+```bash
+# 1. Recent T1 events stream — should have entries from today
+ls -la .vnx-data/events/T1.ndjson
+wc -l .vnx-data/events/T1.ndjson
+
+# 2. Recent receipts in t0_receipts.ndjson — should have entries from today
+tail -5 .vnx-data/state/t0_receipts.ndjson
+
+# 3. Active dispatch manifest — confirm dispatch was routed via subprocess_dispatch.py
+ls .vnx-data/dispatches/active/
+# Each active dir should have manifest.json (from subprocess_dispatch entry)
+
+# 4. Lease state — should show terminal busy DURING active work
+sqlite3 .vnx-data/state/runtime_coordination.db \
+  "SELECT terminal_id, state, dispatch_id FROM terminal_leases;"
+```
+
+If `T1.ndjson` is empty after running real dispatches, T0 used direct `claude --print` (bypassing VNX governance). Update T0's `.claude/terminals/T0/CLAUDE.md` per `T0/CLAUDE.md` §Dispatch-routing, restart T0.
+
+---
+
+## Wave 1 — Shadow read divergence
+
+Wave 1 added a `shadow_logger` (NDJSON, lazy-written) that records both legacy-read and central-read results for the same query. Divergences = bugs in the central reader.
+
+### Read the shadow log
+
+```bash
+# Path is project-local
+SHADOW_LOG=.vnx-data/state/shadow_divergence.ndjson  # adjust if differs
+
+# Quick count
+wc -l "$SHADOW_LOG" 2>/dev/null || echo "no shadow log yet"
+
+# Recent divergences (last hour)
+tail -100 "$SHADOW_LOG" 2>/dev/null | python3 -c "
+import json, sys, time
+from datetime import datetime, timedelta
+cutoff = (datetime.now() - timedelta(hours=1)).isoformat()
+count = 0
+diverged = 0
+for line in sys.stdin:
+    try:
+        e = json.loads(line)
+        if e.get('timestamp', '') < cutoff:
+            continue
+        count += 1
+        if e.get('diverged'):
+            diverged += 1
+            print(f\"DIVERGE: {e.get('read_site')} key={e.get('key')} legacy={str(e.get('legacy_value'))[:40]} central={str(e.get('central_value'))[:40]}\")
+    except: pass
+print(f'\\nTotal reads (last 1h): {count}; diverged: {diverged}')
+"
+```
+
+### Decision rule
+
+| Diverged in last 24h | Verdict |
+|---|---|
+| 0 divergences over ≥100 reads | Wave 1 cutover **READY** for hot-path migration |
+| 1-5 divergences | Investigate each manually; could be expected (timing windows, legacy bugs we're fixing) |
+| >5 divergences or any blocking-class | Wave 1 **NOT READY** — file OI per divergence pattern |
+
+Per the strategic replan v1.2: Wave 1 success criterion is "shadow read cutover validates clean for 3 weeks before reader cutover."
+
+---
+
+## Wave 5 — Smart context injection (+30pp lift)
+
+Wave 5 measures dispatch quality success-rate. Baseline: 88.9% with naïve injection. Target: mid-90s after P0-P4.
+
+### Per-dispatch injection evidence
+
+Each `subprocess_dispatch.py` invocation now logs which smart-context components fired. Check a recent dispatch:
+
+```bash
+# Pick a recent dispatch_id
+DISPATCH_ID=$(ls -t .vnx-data/dispatches/completed/ | head -1)
+
+# Read its manifest
+cat ".vnx-data/dispatches/completed/$DISPATCH_ID/manifest.json" | python3 -m json.tool
+
+# Find the dispatch's events archive
+EVENTS=".vnx-data/events/archive/T1/$DISPATCH_ID.ndjson"
+# (or T2/T3 — check whichever terminal handled it)
+
+# Filter for injection events
+grep -i "intelligence_injection\|smart_context\|adr_match\|prior_round\|code_anchor\|operator_memory\|schema_introspect" "$EVENTS" 2>/dev/null | python3 -c "
+import json, sys
+for line in sys.stdin:
+    try:
+        e = json.loads(line)
+        t = e.get('type', '?')
+        d = e.get('data', {})
+        print(f\"  {t}: {d.get('name','')} {str(d.get('payload',''))[:80]}\")
+    except: pass
+"
+```
+
+### Quality success-rate from quality DB
+
+```bash
+# Quality DB lives in .vnx-data/state/quality_intelligence.db
+sqlite3 .vnx-data/state/quality_intelligence.db <<'EOF'
+.headers on
+.mode column
+SELECT
+  date(timestamp) as day,
+  COUNT(*) as dispatches,
+  SUM(CASE WHEN outcome='success' THEN 1 ELSE 0 END) as successes,
+  ROUND(100.0 * SUM(CASE WHEN outcome='success' THEN 1 ELSE 0 END) / COUNT(*), 1) as pct
+FROM dispatch_outcomes
+WHERE timestamp > date('now', '-14 days')
+GROUP BY day
+ORDER BY day DESC;
+EOF
+```
+
+### Per-injection-type effectiveness
+
+```bash
+sqlite3 .vnx-data/state/quality_intelligence.db <<'EOF'
+.headers on
+.mode column
+SELECT
+  injection_type,
+  COUNT(*) as fired,
+  SUM(CASE WHEN dispatch_outcome='success' THEN 1 ELSE 0 END) as successes,
+  ROUND(100.0 * SUM(CASE WHEN dispatch_outcome='success' THEN 1 ELSE 0 END) / COUNT(*), 1) as pct
+FROM intelligence_injections
+WHERE created_at > date('now', '-14 days')
+GROUP BY injection_type
+ORDER BY fired DESC;
+EOF
+```
+
+### Per-provider segmentation
+
+After Wave 4.5 PR-3 merges, codex and gemini worker dispatches also emit
+`intelligence_injection` events (prior-round findings, ADR matches, code anchors,
+operator memory, schema intro) in addition to standard antipattern/pattern items.
+
+Split the quality success-rate query by `model_provider` to compare Claude vs
+non-Claude lift:
+
+```sql
+-- Per-provider success rate (last 14 days)
+SELECT
+  model_provider,
+  date(timestamp) AS day,
+  COUNT(*) AS dispatches,
+  SUM(CASE WHEN outcome='success' THEN 1 ELSE 0 END) AS successes,
+  ROUND(
+    100.0 * SUM(CASE WHEN outcome='success' THEN 1 ELSE 0 END) / COUNT(*), 1
+  ) AS pct
+FROM dispatch_outcomes
+WHERE timestamp > date('now', '-14 days')
+GROUP BY model_provider, day
+ORDER BY model_provider, day DESC;
+```
+
+Use this query to confirm that codex/gemini-routed dispatches show the same
+intelligence injection event (look for `intelligence_injection` in the archived
+events) and that their success rate trend is comparable to the Claude baseline.
+
+**Note**: Intelligence injection for codex/gemini dispatches only fires when the
+dispatch includes `role` or `dispatch_metadata`.  Gate-runner invocations (PR-4.5.2b,
+currently deferred as #473) are a separate scope and will be tracked under a future
+runbook update.
+
+### Decision rule
+
+| 7-day success rate | Verdict |
+|---|---|
+| ≥93% | Wave 5 **on target** — push toward v1.0.0 final |
+| 88-93% | Hold; investigate which injection-type isn't lifting |
+| <88% | Regression vs 88.9% baseline — Wave 5 kill-switch criteria per replan §Wave 5 |
+| Token-bloat alerts in injection logs | Wave 5 P5 cleanup needed before final tag |
+
+---
+
+## Cost monitoring
+
+Both Wave 5 injections cost tokens (extra context = extra input tokens). Per-dispatch cost:
+
+```bash
+# Aggregate today's costs by terminal
+sqlite3 .vnx-data/state/quality_intelligence.db <<'EOF'
+.headers on
+.mode column
+SELECT
+  terminal_id,
+  COUNT(*) as dispatches,
+  ROUND(SUM(input_tokens) / 1000.0, 1) as input_k,
+  ROUND(SUM(output_tokens) / 1000.0, 1) as output_k,
+  ROUND(SUM(cost_usd), 2) as cost_usd
+FROM dispatch_costs
+WHERE timestamp > date('now', '-1 day')
+GROUP BY terminal_id;
+EOF
+```
+
+If injection-token-bloat pushes per-dispatch input above ~30k tokens, file an OI for Wave 5 P5 (token-budget enforcement).
+
+---
+
+## Health checks
+
+### Are daemons up?
+
+```bash
+# Dispatcher daemon (must run for dispatches to be picked up)
+pgrep -fl "dispatcher_v8_minimal\|dispatcher_supervisor" | head -3
+
+# Receipt processor
+pgrep -fl "receipt_processor" | head -3
+
+# Smart tap (legacy pickup, optional with subprocess_dispatch)
+pgrep -fl "smart_tap" | head -3
+```
+
+If dispatcher is missing in mc/sales-copilot:
+
+```bash
+# Start from project root:
+.claude/vnx-system/scripts/dispatcher_supervisor.sh &
+.claude/vnx-system/scripts/receipt_processor_supervisor.sh &
+```
+
+### Lease state sanity
+
+```bash
+sqlite3 .vnx-data/state/runtime_coordination.db <<'EOF'
+SELECT terminal_id, state, dispatch_id,
+       CAST((julianday('now') - julianday(lease_acquired_at)) * 86400 AS INTEGER) AS age_seconds
+FROM terminal_leases;
+EOF
+```
+
+A `state='busy'` lease older than 60 minutes without an active claude subprocess = stale; release via:
+
+```bash
+python3 .claude/vnx-system/scripts/runtime_core_cli.py release-on-failure \
+  --terminal T1 --dispatch-id <stuck-id> --generation <gen-from-db> \
+  --reason "stale_lease_manual_cleanup"
+```
+
+---
+
+## When to stop burn-in and cut v1.0.0 final
+
+Per strategic replan v1.2 §Wave 1/5 success criteria:
+
+- [ ] 3 weeks Wave 1 shadow with zero blocking divergences
+- [ ] 7 consecutive days Wave 5 success rate ≥93% (per injection-effective analysis)
+- [ ] Zero unresolved P0 OIs (currently: OI-1369 + OI-1370 — fix PRs in flight today)
+- [ ] codex_gate infra restored (currently broken — codex CLI binary missing)
+- [ ] PR #462 (CFX-W5-2) + #463 (queue-popup default) + #464 (T0 routing) merged
+
+When all green: tag `v1.0.0` from main (drops the `-rc1` suffix), cut GitHub Release, mark as Latest (replaces v0.5.0's badge).

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -100,7 +100,15 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
 
         role = context.get("role")
         dispatch_meta = context.get("dispatch_metadata", {})
-        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
+        prompt = self._build_prompt(
+            instruction,
+            changed_files,
+            role=role,
+            dispatch_id=context.get("dispatch_id"),
+            pr_id=context.get("pr_id"),
+            dispatch_paths=context.get("dispatch_paths"),
+            dispatch_metadata=dispatch_meta,
+        )
         cmd = self._build_cmd(model)
 
         self._current_terminal_id = terminal_id
@@ -225,7 +233,15 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         role = context.get("role")
         dispatch_meta = context.get("dispatch_metadata", {})
 
-        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
+        prompt = self._build_prompt(
+            instruction,
+            changed_files,
+            role=role,
+            dispatch_id=context.get("dispatch_id"),
+            pr_id=context.get("pr_id"),
+            dispatch_paths=context.get("dispatch_paths"),
+            dispatch_metadata=dispatch_meta,
+        )
         cmd = self._build_cmd(model)
 
         self._current_terminal_id = terminal_id
@@ -626,7 +642,11 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         self,
         instruction: str,
         changed_files: list[str],
+        *,
         role: Optional[str] = None,
+        dispatch_id: Optional[str] = None,
+        pr_id: Optional[str] = None,
+        dispatch_paths: Optional[list] = None,
         dispatch_metadata: Optional[dict] = None,
     ) -> str:
         """Build prompt from instruction + inline file contents.
@@ -635,21 +655,30 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         (L1 base rules + L2 role context + L3 instruction) with Wave 5 intelligence
         injected for codex. Falls back to raw instruction+files when neither is
         given (backward compat).
+
+        Wave 5 selector inputs are sourced in priority order:
+          explicit kwargs > dispatch_metadata fallback > empty defaults.
+        This handles callers (headless_dispatch_daemon) that pass dispatch_id/pr_id
+        at the top level of the context dict rather than nested under dispatch_metadata.
         """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
         full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
 
-        if role or dispatch_metadata:
+        if role or dispatch_metadata or dispatch_id or pr_id:
             from intelligence_selector import build_intelligence_context  # noqa: PLC0415
             from prompt_assembler import PromptAssembler, format_for_provider
 
             meta = dispatch_metadata or {}
+            eff_dispatch_id = dispatch_id or meta.get("dispatch_id") or ""
+            eff_pr_id = pr_id or meta.get("pr_id") or meta.get("pr")
+            eff_dispatch_paths = dispatch_paths or meta.get("dispatch_paths") or []
+
             intel_ctx = build_intelligence_context(
-                dispatch_id=(meta).get("dispatch_id", ""),
+                dispatch_id=eff_dispatch_id,
                 role=role or "",
-                pr_id=(meta).get("pr_id") or (meta).get("pr"),
-                dispatch_paths=(meta).get("dispatch_paths", []),
+                pr_id=eff_pr_id,
+                dispatch_paths=eff_dispatch_paths,
                 instruction_text=instruction,
             )
             intel_markdown = intel_ctx.serialize_for("codex") if intel_ctx else ""

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -632,18 +632,32 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         """Build prompt from instruction + inline file contents.
 
         When role or dispatch_metadata is provided, routes through PromptAssembler
-        (L1 base rules + L2 role context + L3 instruction). Falls back to raw
-        instruction+files when neither is given (backward compat).
+        (L1 base rules + L2 role context + L3 instruction) with Wave 5 intelligence
+        injected for codex. Falls back to raw instruction+files when neither is
+        given (backward compat).
         """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
         full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
 
         if role or dispatch_metadata:
+            from intelligence_selector import build_intelligence_context  # noqa: PLC0415
             from prompt_assembler import PromptAssembler, format_for_provider
+
+            meta = dispatch_metadata or {}
+            intel_ctx = build_intelligence_context(
+                dispatch_id=(meta).get("dispatch_id", ""),
+                role=role or "",
+                pr_id=(meta).get("pr_id") or (meta).get("pr"),
+                dispatch_paths=(meta).get("dispatch_paths", []),
+                instruction_text=instruction,
+            )
+            intel_markdown = intel_ctx.serialize_for("codex") if intel_ctx else ""
+            l3_payload = f"{intel_markdown}\n\n{full_instruction}" if intel_markdown else full_instruction
+
             assembled = PromptAssembler().assemble(
-                dispatch_metadata={"role": role, **(dispatch_metadata or {})},
-                instruction=full_instruction,
+                dispatch_metadata={"role": role, **meta},
+                instruction=l3_payload,
             )
             return format_for_provider(assembled, "codex")["pipe_input"]
 

--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -99,7 +99,15 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
 
         role = context.get("role")
         dispatch_meta = context.get("dispatch_metadata", {})
-        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
+        prompt = self._build_prompt(
+            instruction,
+            changed_files,
+            role=role,
+            dispatch_id=context.get("dispatch_id"),
+            pr_id=context.get("pr_id"),
+            dispatch_paths=context.get("dispatch_paths"),
+            dispatch_metadata=dispatch_meta,
+        )
 
         if _gemini_stream_enabled():
             return self._execute_streaming(
@@ -133,7 +141,15 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
 
-        prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
+        prompt = self._build_prompt(
+            instruction,
+            changed_files,
+            role=role,
+            dispatch_id=context.get("dispatch_id"),
+            pr_id=context.get("pr_id"),
+            dispatch_paths=context.get("dispatch_paths"),
+            dispatch_metadata=dispatch_meta,
+        )
 
         if not _gemini_stream_enabled():
             # Legacy path: execute and yield a single synthetic result event
@@ -604,7 +620,11 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         self,
         instruction: str,
         changed_files: list[str],
+        *,
         role: Optional[str] = None,
+        dispatch_id: Optional[str] = None,
+        pr_id: Optional[str] = None,
+        dispatch_paths: Optional[list] = None,
         dispatch_metadata: Optional[dict] = None,
     ) -> str:
         """Build prompt from instruction + inline file contents.
@@ -613,21 +633,30 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         (L1 base rules + L2 role context + L3 instruction) with Wave 5 intelligence
         injected for gemini. Falls back to raw instruction+files when neither is
         given (backward compat).
+
+        Wave 5 selector inputs are sourced in priority order:
+          explicit kwargs > dispatch_metadata fallback > empty defaults.
+        This handles callers (headless_dispatch_daemon) that pass dispatch_id/pr_id
+        at the top level of the context dict rather than nested under dispatch_metadata.
         """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
         full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
 
-        if role or dispatch_metadata:
+        if role or dispatch_metadata or dispatch_id or pr_id:
             from intelligence_selector import build_intelligence_context  # noqa: PLC0415
             from prompt_assembler import PromptAssembler, format_for_provider
 
             meta = dispatch_metadata or {}
+            eff_dispatch_id = dispatch_id or meta.get("dispatch_id") or ""
+            eff_pr_id = pr_id or meta.get("pr_id") or meta.get("pr")
+            eff_dispatch_paths = dispatch_paths or meta.get("dispatch_paths") or []
+
             intel_ctx = build_intelligence_context(
-                dispatch_id=(meta).get("dispatch_id", ""),
+                dispatch_id=eff_dispatch_id,
                 role=role or "",
-                pr_id=(meta).get("pr_id") or (meta).get("pr"),
-                dispatch_paths=(meta).get("dispatch_paths", []),
+                pr_id=eff_pr_id,
+                dispatch_paths=eff_dispatch_paths,
                 instruction_text=instruction,
             )
             intel_markdown = intel_ctx.serialize_for("gemini") if intel_ctx else ""

--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -610,18 +610,32 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         """Build prompt from instruction + inline file contents.
 
         When role or dispatch_metadata is provided, routes through PromptAssembler
-        (L1 base rules + L2 role context + L3 instruction). Falls back to raw
-        instruction+files when neither is given (backward compat).
+        (L1 base rules + L2 role context + L3 instruction) with Wave 5 intelligence
+        injected for gemini. Falls back to raw instruction+files when neither is
+        given (backward compat).
         """
         payload = {"changed_files": changed_files}
         file_contents = collect_file_contents(payload, subprocess_run=subprocess.run)
         full_instruction = f"{instruction}\n\n{file_contents}" if file_contents else instruction
 
         if role or dispatch_metadata:
+            from intelligence_selector import build_intelligence_context  # noqa: PLC0415
             from prompt_assembler import PromptAssembler, format_for_provider
+
+            meta = dispatch_metadata or {}
+            intel_ctx = build_intelligence_context(
+                dispatch_id=(meta).get("dispatch_id", ""),
+                role=role or "",
+                pr_id=(meta).get("pr_id") or (meta).get("pr"),
+                dispatch_paths=(meta).get("dispatch_paths", []),
+                instruction_text=instruction,
+            )
+            intel_markdown = intel_ctx.serialize_for("gemini") if intel_ctx else ""
+            l3_payload = f"{intel_markdown}\n\n{full_instruction}" if intel_markdown else full_instruction
+
             assembled = PromptAssembler().assemble(
-                dispatch_metadata={"role": role, **(dispatch_metadata or {})},
-                instruction=full_instruction,
+                dispatch_metadata={"role": role, **meta},
+                instruction=l3_payload,
             )
             result = format_for_provider(assembled, "gemini")
             return f"{result['system_instruction']}\n\n---\n\n{result['prompt']}"

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import sqlite3
 import uuid
@@ -29,6 +30,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_logger = logging.getLogger(__name__)
 
 try:
     import shadow_verifier as _shadow_verifier
@@ -291,6 +294,128 @@ class InjectionResult:
             "payload_chars": self.payload_chars,
             "item_ids": [item.item_id for item in self.items],
         }
+
+
+# ---------------------------------------------------------------------------
+# Per-provider structured context
+# ---------------------------------------------------------------------------
+
+@dataclass
+class IntelligenceContext:
+    """Structured intelligence payload for per-provider serialization.
+
+    Named fields hold Wave 5 direct-injection item classes.  _standard_items
+    stores failure_prevention / proven_pattern / recent_comparable items for
+    byte-identical Claude-path rendering.
+
+    Build via build_intelligence_context() — do not construct manually.
+    """
+
+    prior_round_findings: list  # IntelligenceItem objects (class "prior_round_finding")
+    adr_matches: list           # IntelligenceItem objects (class "adr_relevant")
+    code_anchors: list          # IntelligenceItem objects (class "code_anchor")
+    operator_memory: list       # IntelligenceItem objects (class "operator_memory")
+    schema_intro: dict | None   # first schema_section item dict, or None
+    _standard_items: list = field(default_factory=list)
+
+    @classmethod
+    def from_injection_result(cls, result: "InjectionResult") -> "IntelligenceContext":
+        """Build from InjectionResult, categorizing items by class."""
+        standard: list = []
+        prior: list = []
+        adrs: list = []
+        anchors: list = []
+        memory: list = []
+        schema: dict | None = None
+        for item in result.items:
+            c = item.item_class
+            if c == "prior_round_finding":
+                prior.append(item)
+            elif c == "adr_relevant":
+                adrs.append(item)
+            elif c == "code_anchor":
+                anchors.append(item)
+            elif c == "operator_memory":
+                memory.append(item)
+            elif c == "schema_section":
+                if schema is None:
+                    schema = item.to_dict()
+            else:
+                standard.append(item)
+        return cls(
+            prior_round_findings=prior,
+            adr_matches=adrs,
+            code_anchors=anchors,
+            operator_memory=memory,
+            schema_intro=schema,
+            _standard_items=standard,
+        )
+
+    def serialize_for(self, provider: str) -> str:
+        """Return intelligence as formatted text for the given provider.
+
+        claude / gemini / litellm:* / unknown — markdown with ### headers.
+        codex — same content prefixed with a CONTEXT: header line.
+
+        Byte-identity guarantee: when all Wave 5 fields are empty, output for
+        'claude' is identical to _format_intelligence_items(_standard_items).
+        """
+        content = self._render_markdown()
+        if not content:
+            return ""
+        if (provider or "").split(":")[0] == "codex":
+            return f"CONTEXT:\n\n{content}"
+        return content
+
+    def _render_markdown(self) -> str:
+        """Render all items as markdown sections."""
+        parts: list[str] = []
+        by_class: dict[str, list] = {}
+        for item in self._standard_items:
+            by_class.setdefault(item.item_class, []).append(item)
+        if "failure_prevention" in by_class:
+            parts.append("### Antipatterns to avoid")
+            for item in by_class["failure_prevention"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if "proven_pattern" in by_class:
+            parts.append("### Proven success patterns")
+            for item in by_class["proven_pattern"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if "recent_comparable" in by_class:
+            parts.append("### Tag warnings")
+            for item in by_class["recent_comparable"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if self.prior_round_findings:
+            parts.append("### Prior round findings")
+            for item in self.prior_round_findings:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if self.adr_matches:
+            parts.append("### ADR matches")
+            for item in self.adr_matches:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if self.code_anchors:
+            parts.append("### Code anchors")
+            for item in self.code_anchors:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if self.operator_memory:
+            parts.append("### Operator memory")
+            for item in self.operator_memory:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if self.schema_intro:
+            title = self.schema_intro.get("title", "Schema")
+            content = self.schema_intro.get("content", "")
+            if content:
+                parts.append("### Schema context")
+                parts.append(f"- **{title}**: {content}")
+                parts.append("")
+        return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -2395,3 +2520,79 @@ def select_intelligence(
         return result
     finally:
         selector.close()
+
+
+def _resolve_state_dir() -> Path:
+    """Resolve VNX state directory from environment (mirrors state_paths._default_state_dir)."""
+    env = os.environ.get("VNX_STATE_DIR", "")
+    if env:
+        return Path(env)
+    data_dir = os.environ.get("VNX_DATA_DIR", "")
+    if data_dir:
+        return Path(data_dir) / "state"
+    return Path(__file__).resolve().parents[2] / ".vnx-data" / "state"
+
+
+def build_intelligence_context(
+    dispatch_id: str,
+    role: str,
+    *,
+    pr_id: Optional[str] = None,
+    dispatch_paths: Optional[List[str]] = None,
+    instruction_text: str = "",
+    state_dir: Optional[Path] = None,
+) -> Optional[IntelligenceContext]:
+    """Run IntelligenceSelector and return a structured IntelligenceContext (best-effort).
+
+    Performs all side effects: emit_event, record_injection, stamp_source_dispatch_ids.
+    Returns None when no items are selected or on any failure so callers can safely
+    skip intelligence injection.
+
+    Args:
+        dispatch_id:      Dispatch identifier for event emission and source stamping.
+        role:             Skill/role name used for task-class resolution.
+        pr_id:            Optional PR identifier forwarded to selector.
+        dispatch_paths:   Optional list of changed file paths forwarded to selector.
+        instruction_text: Raw instruction text forwarded to selector.
+        state_dir:        Override for the VNX state directory.  Defaults to
+                          VNX_STATE_DIR / VNX_DATA_DIR / .vnx-data/state resolution.
+    """
+    try:
+        resolved_state_dir = state_dir or _resolve_state_dir()
+        quality_db_path = resolved_state_dir / "quality_intelligence.db"
+        selector = IntelligenceSelector(
+            quality_db_path=quality_db_path,
+            coord_db_state_dir=resolved_state_dir,
+        )
+        try:
+            result = selector.select(
+                dispatch_id=dispatch_id,
+                injection_point="dispatch_create",
+                skill_name=role or "",
+                dispatch_paths=dispatch_paths or [],
+                instruction_text=instruction_text or "",
+                pr_id=pr_id,
+            )
+            try:
+                selector.emit_event(result, coord_state_dir=resolved_state_dir)
+            except Exception as exc:
+                _logger.debug("build_intelligence_context: emit_event failed %s: %s", dispatch_id, exc)
+            try:
+                selector.record_injection(result, coord_state_dir=resolved_state_dir)
+            except Exception as exc:
+                _logger.debug("build_intelligence_context: record_injection failed %s: %s", dispatch_id, exc)
+            try:
+                selector.stamp_source_dispatch_ids(result)
+            except Exception as exc:
+                _logger.debug(
+                    "build_intelligence_context: stamp_source_dispatch_ids failed %s: %s",
+                    dispatch_id, exc,
+                )
+        finally:
+            selector.close()
+        if not result.items:
+            return None
+        return IntelligenceContext.from_injection_result(result)
+    except Exception as exc:
+        _logger.warning("build_intelligence_context failed (%s); returning None", exc)
+        return None

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -74,65 +74,29 @@ def _build_intelligence_section(
 ) -> str:
     """Return formatted intelligence items as markdown, or empty string (best-effort).
 
-    Calls IntelligenceSelector to gather antipatterns, success patterns, and
-    recent comparable dispatches from quality_intelligence.db.  After selecting,
-    emits the coordination event and records the injection (intelligence_injections
-    + pattern_usage + dispatch_pattern_offered) so the post-dispatch confidence
-    feedback loop has dispatch-scoped rows to update.  Any import or DB failure
-    is caught and logged — dispatch proceeds without intelligence.
+    Delegates to build_intelligence_context() for selection + side effects, then
+    serializes for the Claude provider.  The output is byte-identical to the prior
+    _format_intelligence_items path for standard item classes (regression-tested).
 
     dispatch_paths, instruction_text, pr_id are forwarded to selector.select() so
     W5 item classes (adr_relevant, code_anchor, operator_memory, schema_section,
     prior_round_finding) can fire in production dispatches.
     """
     try:
-        from intelligence_selector import IntelligenceSelector  # noqa: PLC0415
-        # Look up _default_state_dir via subprocess_dispatch namespace so test
-        # monkeypatches at the facade ("subprocess_dispatch._default_state_dir")
-        # are honoured when this helper is called directly by tests.
+        from intelligence_selector import build_intelligence_context  # noqa: PLC0415
         import subprocess_dispatch as _sd
         state_dir = _sd._default_state_dir()
-        quality_db_path = state_dir / "quality_intelligence.db"
-        selector = IntelligenceSelector(
-            quality_db_path=quality_db_path,
-            coord_db_state_dir=state_dir,
+        ctx = build_intelligence_context(
+            dispatch_id=dispatch_id,
+            role=role or "",
+            pr_id=pr_id,
+            dispatch_paths=dispatch_paths or [],
+            instruction_text=instruction_text or "",
+            state_dir=state_dir,
         )
-        try:
-            result = selector.select(
-                dispatch_id=dispatch_id,
-                injection_point="dispatch_create",
-                skill_name=role or "",
-                dispatch_paths=dispatch_paths or [],
-                instruction_text=instruction_text or "",
-                pr_id=pr_id,
-            )
-            try:
-                selector.emit_event(result, coord_state_dir=state_dir)
-            except Exception as exc:
-                logger.debug("emit_event failed for %s: %s", dispatch_id, exc)
-            try:
-                selector.record_injection(result, coord_state_dir=state_dir)
-            except Exception as exc:
-                logger.debug("record_injection failed for %s: %s", dispatch_id, exc)
-            # Phase 1.5 PR-2 / OI-1315 / OI-1321: stamp source_dispatch_ids
-            # at the record_injection call site even when _record_pattern_usage
-            # is partially or fully skipped.  Without this, FRESHLY injected
-            # patterns can't be matched back to their source dispatch on
-            # receipt arrival (intelligence_persist.update_confidence_from_outcome
-            # filters by ``source_dispatch_ids LIKE '%dispatch_id%'``).  The
-            # call is idempotent and resilient — each item is wrapped
-            # individually so partial failure cannot lose subsequent stamps.
-            try:
-                selector.stamp_source_dispatch_ids(result)
-            except Exception as exc:
-                logger.debug(
-                    "stamp_source_dispatch_ids failed for %s: %s", dispatch_id, exc
-                )
-        finally:
-            selector.close()
-        if not result.items:
+        if ctx is None:
             return ""
-        return _format_intelligence_items(result.items)
+        return ctx.serialize_for("claude")
     except Exception as exc:
         logger.warning("intelligence injection failed (%s); proceeding without", exc)
         return ""

--- a/tests/test_intelligence_per_provider.py
+++ b/tests/test_intelligence_per_provider.py
@@ -249,7 +249,8 @@ class TestCodexAdapterIncludesPriorRoundFindings:
     def test_no_role_skips_intelligence(self):
         from adapters.codex_adapter import CodexAdapter
 
-        with patch("intelligence_selector.build_intelligence_context") as mock_bic:
+        with patch("intelligence_selector.build_intelligence_context") as mock_bic, \
+             patch("adapters.codex_adapter.collect_file_contents", return_value=""):
             adapter = CodexAdapter("T3")
             prompt = adapter._build_prompt(
                 instruction="bare instruction",
@@ -300,7 +301,8 @@ class TestGeminiAdapterIncludesPriorRoundFindings:
     def test_no_role_skips_intelligence(self):
         from adapters.gemini_adapter import GeminiAdapter
 
-        with patch("intelligence_selector.build_intelligence_context") as mock_bic:
+        with patch("intelligence_selector.build_intelligence_context") as mock_bic, \
+             patch("adapters.gemini_adapter.collect_file_contents", return_value=""):
             adapter = GeminiAdapter("T2")
             prompt = adapter._build_prompt(
                 instruction="bare instruction",
@@ -311,3 +313,104 @@ class TestGeminiAdapterIncludesPriorRoundFindings:
 
         mock_bic.assert_not_called()
         assert prompt == "bare instruction"
+
+
+# ---------------------------------------------------------------------------
+# Top-level kwarg sourcing tests (codex round-1 fix)
+# ---------------------------------------------------------------------------
+
+class TestCodexAdapterTopLevelDispatchId:
+    """dispatch_id/pr_id passed at top level (not in dispatch_metadata) must work."""
+
+    def test_intelligence_with_top_level_dispatch_id(self):
+        from adapters.codex_adapter import CodexAdapter
+
+        ctx = _make_ctx_with_prior_finding("Gate skip is unacceptable")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = CodexAdapter("T3")
+            prompt = adapter._build_prompt(
+                instruction="Review PR",
+                changed_files=[],
+                role="reviewer",
+                dispatch_id="top-level-dispatch-001",
+                # intentionally no dispatch_metadata
+            )
+
+        assert "Gate skip is unacceptable" in prompt
+
+    def test_top_level_dispatch_id_forwarded_to_selector(self):
+        """build_intelligence_context must receive the top-level dispatch_id, not ''."""
+        import intelligence_selector as _mod
+        from adapters.codex_adapter import CodexAdapter
+
+        with patch.object(_mod, "build_intelligence_context", return_value=None) as mock_bic:
+            adapter = CodexAdapter("T3")
+            adapter._build_prompt(
+                instruction="Review PR",
+                changed_files=[],
+                role="reviewer",
+                dispatch_id="explicit-id-codex",
+                pr_id="474",
+            )
+
+        mock_bic.assert_called_once()
+        call_kwargs = mock_bic.call_args[1] if mock_bic.call_args[1] else mock_bic.call_args[0]
+        assert call_kwargs.get("dispatch_id") == "explicit-id-codex"
+        assert call_kwargs.get("pr_id") == "474"
+
+    def test_intelligence_fallback_to_metadata(self):
+        """Backward compat: dispatch_id in dispatch_metadata still works."""
+        from adapters.codex_adapter import CodexAdapter
+
+        ctx = _make_ctx_with_prior_finding("Always release lease after receipt")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = CodexAdapter("T3")
+            prompt = adapter._build_prompt(
+                instruction="Review PR",
+                changed_files=[],
+                role="reviewer",
+                dispatch_metadata={"dispatch_id": "meta-dispatch-001", "pr_id": "474"},
+            )
+
+        assert "Always release lease after receipt" in prompt
+
+
+class TestGeminiAdapterTopLevelDispatchId:
+    """Same top-level kwarg sourcing for GeminiAdapter."""
+
+    def test_intelligence_with_top_level_dispatch_id(self):
+        from adapters.gemini_adapter import GeminiAdapter
+
+        ctx = _make_ctx_with_prior_finding("Never skip gates before merge")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = GeminiAdapter("T2")
+            prompt = adapter._build_prompt(
+                instruction="Gemini review",
+                changed_files=[],
+                role="reviewer",
+                dispatch_id="top-level-gemini-001",
+            )
+
+        assert "Never skip gates before merge" in prompt
+
+    def test_top_level_dispatch_id_forwarded_to_selector(self):
+        import intelligence_selector as _mod
+        from adapters.gemini_adapter import GeminiAdapter
+
+        with patch.object(_mod, "build_intelligence_context", return_value=None) as mock_bic:
+            adapter = GeminiAdapter("T2")
+            adapter._build_prompt(
+                instruction="Gemini review",
+                changed_files=[],
+                role="reviewer",
+                dispatch_id="explicit-id-gemini",
+                pr_id="474",
+            )
+
+        mock_bic.assert_called_once()
+        call_kwargs = mock_bic.call_args[1] if mock_bic.call_args[1] else mock_bic.call_args[0]
+        assert call_kwargs.get("dispatch_id") == "explicit-id-gemini"
+        assert call_kwargs.get("pr_id") == "474"

--- a/tests/test_intelligence_per_provider.py
+++ b/tests/test_intelligence_per_provider.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tests for per-provider intelligence injection (Wave 4.5 PR-3).
+
+Coverage:
+- IntelligenceContext.serialize_for per provider
+- Claude path byte-identical regression against _format_intelligence_items
+- Codex CONTEXT: header
+- Gemini markdown format
+- Unknown provider fallback
+- Codex/Gemini adapter _build_prompt includes prior_round_findings
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_item(item_class: str, title: str, content: str):
+    from intelligence_selector import IntelligenceItem
+    return IntelligenceItem(
+        item_id=f"intel_{item_class[:8]}_{title[:6]}",
+        item_class=item_class,
+        title=title,
+        content=content,
+        confidence=0.9,
+        evidence_count=3,
+        last_seen="2026-05-13T00:00:00.000000Z",
+        scope_tags=["backend-developer"],
+    )
+
+
+def _make_injection_result(items):
+    from intelligence_selector import InjectionResult
+    return InjectionResult(
+        injection_point="dispatch_create",
+        injected_at="2026-05-13T00:00:00.000000Z",
+        items=items,
+        suppressed=[],
+        task_class="coding_interactive",
+        dispatch_id="test-dispatch-per-provider",
+    )
+
+
+# ---------------------------------------------------------------------------
+# IntelligenceContext serialization tests
+# ---------------------------------------------------------------------------
+
+class TestIntelligenceContextSerializesForClaude:
+    """Regression: serialize_for('claude') must match _format_intelligence_items."""
+
+    def _format_intelligence_items(self, items: list) -> str:
+        """Replicate the original _format_intelligence_items logic verbatim."""
+        by_class: dict[str, list] = {}
+        for item in items:
+            by_class.setdefault(item.item_class, []).append(item)
+        parts: list[str] = []
+        if "failure_prevention" in by_class:
+            parts.append("### Antipatterns to avoid")
+            for item in by_class["failure_prevention"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if "proven_pattern" in by_class:
+            parts.append("### Proven success patterns")
+            for item in by_class["proven_pattern"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        if "recent_comparable" in by_class:
+            parts.append("### Tag warnings")
+            for item in by_class["recent_comparable"]:
+                parts.append(f"- **{item.title}**: {item.content}")
+            parts.append("")
+        return "\n".join(parts)
+
+    def test_failure_prevention_only(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("failure_prevention", "Avoid mocks", "Don't mock the DB")]
+        result = _make_injection_result(items)
+        ctx = IntelligenceContext.from_injection_result(result)
+        expected = self._format_intelligence_items(items)
+        assert ctx.serialize_for("claude") == expected
+
+    def test_proven_pattern_only(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("proven_pattern", "Atomic writes", "Use os.replace()")]
+        result = _make_injection_result(items)
+        ctx = IntelligenceContext.from_injection_result(result)
+        expected = self._format_intelligence_items(items)
+        assert ctx.serialize_for("claude") == expected
+
+    def test_all_standard_classes(self):
+        from intelligence_selector import IntelligenceContext
+        items = [
+            _make_item("failure_prevention", "No mocks", "Real DB only"),
+            _make_item("proven_pattern", "Atomic writes", "Use os.replace()"),
+            _make_item("recent_comparable", "Similar dispatch", "Succeeded on test-001"),
+        ]
+        result = _make_injection_result(items)
+        ctx = IntelligenceContext.from_injection_result(result)
+        expected = self._format_intelligence_items(items)
+        assert ctx.serialize_for("claude") == expected
+
+    def test_empty_items_returns_empty_string(self):
+        from intelligence_selector import IntelligenceContext
+        result = _make_injection_result([])
+        ctx = IntelligenceContext.from_injection_result(result)
+        assert ctx.serialize_for("claude") == ""
+
+
+class TestIntelligenceContextSerializesForCodex:
+    def test_has_context_header(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("failure_prevention", "No mocks", "Use real fixtures")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("codex")
+        assert out.startswith("CONTEXT:\n\n")
+
+    def test_content_follows_header(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("proven_pattern", "Atomic writes", "Use os.replace()")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("codex")
+        assert "### Proven success patterns" in out
+        assert "Atomic writes" in out
+
+    def test_empty_items_returns_empty_string(self):
+        from intelligence_selector import IntelligenceContext
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result([]))
+        assert ctx.serialize_for("codex") == ""
+
+    def test_prior_round_finding_appears_under_context_header(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("prior_round_finding", "Stale lease", "Release lease after receipt")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("codex")
+        assert out.startswith("CONTEXT:\n\n")
+        assert "Stale lease" in out
+        assert "Prior round findings" in out
+
+
+class TestIntelligenceContextSerializesForGemini:
+    def test_no_context_header(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("failure_prevention", "No raw tmux", "Use dispatch files")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("gemini")
+        assert not out.startswith("CONTEXT:")
+
+    def test_markdown_headers_present(self):
+        from intelligence_selector import IntelligenceContext
+        items = [
+            _make_item("failure_prevention", "No raw tmux", "Use dispatch files"),
+            _make_item("proven_pattern", "Atomic writes", "Use os.replace()"),
+        ]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("gemini")
+        assert "### Antipatterns to avoid" in out
+        assert "### Proven success patterns" in out
+
+    def test_wave5_adr_matches_rendered(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("adr_relevant", "ADR-010", "Subprocess adapter is canonical")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out = ctx.serialize_for("gemini")
+        assert "ADR-010" in out
+        assert "### ADR matches" in out
+
+
+class TestIntelligenceContextUnknownProviderFallback:
+    def test_falls_back_to_markdown(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("failure_prevention", "No mocks", "Real DB only")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out_unknown = ctx.serialize_for("unknown_provider")
+        out_claude = ctx.serialize_for("claude")
+        assert out_unknown == out_claude
+
+    def test_litellm_prefix_falls_back_to_markdown(self):
+        from intelligence_selector import IntelligenceContext
+        items = [_make_item("proven_pattern", "Atomic writes", "Use os.replace()")]
+        ctx = IntelligenceContext.from_injection_result(_make_injection_result(items))
+        out_litellm = ctx.serialize_for("litellm:openai")
+        out_claude = ctx.serialize_for("claude")
+        assert out_litellm == out_claude
+
+
+# ---------------------------------------------------------------------------
+# Adapter integration tests
+# ---------------------------------------------------------------------------
+
+def _patch_build_intelligence_context(return_value):
+    """Context manager patching build_intelligence_context in adapters."""
+    import intelligence_selector as _mod
+    return patch.object(_mod, "build_intelligence_context", return_value=return_value)
+
+
+def _make_ctx_with_prior_finding(content: str):
+    """Return IntelligenceContext with one prior_round_finding item."""
+    from intelligence_selector import IntelligenceContext
+    item = _make_item("prior_round_finding", "Gate skip detected", content)
+    result = _make_injection_result([item])
+    return IntelligenceContext.from_injection_result(result)
+
+
+class TestCodexAdapterIncludesPriorRoundFindings:
+    def test_prior_round_finding_in_prompt(self, tmp_path):
+        from adapters.codex_adapter import CodexAdapter
+
+        ctx = _make_ctx_with_prior_finding("T0 skipped all gates before merge")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = CodexAdapter("T3")
+            prompt = adapter._build_prompt(
+                instruction="Review this PR",
+                changed_files=[],
+                role="reviewer",
+                dispatch_metadata={"dispatch_id": "test-codex-001"},
+            )
+
+        assert "T0 skipped all gates before merge" in prompt
+        assert "Gate skip detected" in prompt
+
+    def test_codex_context_header_present(self, tmp_path):
+        from adapters.codex_adapter import CodexAdapter
+
+        ctx = _make_ctx_with_prior_finding("Never skip codex gate")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = CodexAdapter("T3")
+            prompt = adapter._build_prompt(
+                instruction="Do review",
+                changed_files=[],
+                role="reviewer",
+                dispatch_metadata={"dispatch_id": "test-codex-002"},
+            )
+
+        assert "CONTEXT:" in prompt
+
+    def test_no_role_skips_intelligence(self):
+        from adapters.codex_adapter import CodexAdapter
+
+        with patch("intelligence_selector.build_intelligence_context") as mock_bic:
+            adapter = CodexAdapter("T3")
+            prompt = adapter._build_prompt(
+                instruction="bare instruction",
+                changed_files=[],
+                role=None,
+                dispatch_metadata=None,
+            )
+
+        mock_bic.assert_not_called()
+        assert prompt == "bare instruction"
+
+
+class TestGeminiAdapterIncludesPriorRoundFindings:
+    def test_prior_round_finding_in_prompt(self):
+        from adapters.gemini_adapter import GeminiAdapter
+
+        ctx = _make_ctx_with_prior_finding("Release lease after every receipt")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = GeminiAdapter("T2")
+            prompt = adapter._build_prompt(
+                instruction="Gemini review",
+                changed_files=[],
+                role="reviewer",
+                dispatch_metadata={"dispatch_id": "test-gemini-001"},
+            )
+
+        assert "Release lease after every receipt" in prompt
+
+    def test_gemini_no_context_header(self):
+        from adapters.gemini_adapter import GeminiAdapter
+
+        ctx = _make_ctx_with_prior_finding("Use dispatch files not tmux")
+
+        with _patch_build_intelligence_context(ctx):
+            adapter = GeminiAdapter("T2")
+            prompt = adapter._build_prompt(
+                instruction="Gemini review",
+                changed_files=[],
+                role="reviewer",
+                dispatch_metadata={"dispatch_id": "test-gemini-002"},
+            )
+
+        # Gemini uses markdown, not CONTEXT: prefix
+        assert not prompt.startswith("CONTEXT:")
+        assert "Use dispatch files not tmux" in prompt
+
+    def test_no_role_skips_intelligence(self):
+        from adapters.gemini_adapter import GeminiAdapter
+
+        with patch("intelligence_selector.build_intelligence_context") as mock_bic:
+            adapter = GeminiAdapter("T2")
+            prompt = adapter._build_prompt(
+                instruction="bare instruction",
+                changed_files=[],
+                role=None,
+                dispatch_metadata=None,
+            )
+
+        mock_bic.assert_not_called()
+        assert prompt == "bare instruction"


### PR DESCRIPTION
## Summary

Wave 4.5 PR-3 per claudedocs/wave4.5-provider-parity-design-2026-05-13.md.

- **IntelligenceContext** dataclass added to `intelligence_selector.py` with `serialize_for()` method — `codex` gets `CONTEXT:` header prefix, `claude`/`gemini`/unknown get markdown `###` headers
- **`build_intelligence_context()`** new module-level entry point: runs IntelligenceSelector + all side effects (emit_event, record_injection, stamp_source_dispatch_ids), returns structured context or `None`
- **`_build_intelligence_section`** in `skill_injection.py` refactored to delegate to `build_intelligence_context().serialize_for('claude')` — byte-identical output verified by regression tests
- **`codex_adapter._build_prompt`**: injects Wave 5 intelligence via `build_intelligence_context()` + `serialize_for('codex')` before PromptAssembler L3 assembly
- **`gemini_adapter._build_prompt`**: same pattern with `serialize_for('gemini')`
- **19 new tests** in `tests/test_intelligence_per_provider.py` — all pass
- **Burn-in runbook** updated with §Per-provider segmentation + `GROUP BY model_provider` query

Reviewer-side intelligence injection for gate_runner.py waits for PR-4.5.2b-redo (deferred #473). Claude path byte-identical via regression test.

## Test plan

- [x] `pytest tests/test_intelligence_per_provider.py -v` — 19/19 pass
- [x] `pytest tests/test_subprocess_intelligence_injection.py -v` — 12/12 pass (no regressions)
- [x] Pre-existing failures (2 tests in test_intelligence_selector.py) confirmed pre-existing before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)