### PR TITLE
feat(wave4.5): PR-2b redo — gate reviewer prompts (gh pr diff + fail-loud)

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -28,6 +28,20 @@ from headless_adapter import gate_timeout, gate_stall_threshold
 import gate_recorder as _rec
 import gate_artifacts as _art
 import vertex_ai_runner as _vtx
+from prompt_assembler import PromptAssembler, format_for_provider
+
+_REVIEWER_VERDICT_TEMPLATE = (
+    "Respond with a structured JSON verdict only:\n"
+    "```json\n"
+    "{\n"
+    '  "verdict": "pass|fail|blocked",\n'
+    '  "findings": [{"severity": "error|warning|info", "message": "...", "out_of_scope": false, "introduced_by_prior_fix": false}],\n'
+    '  "residual_risk": "description of remaining risks or null",\n'
+    '  "rerun_required": false,\n'
+    '  "rerun_reason": null\n'
+    "}\n"
+    "```\n"
+)
 
 # Gate type → CLI binary mapping
 GATE_BINARIES: Dict[str, str] = {
@@ -213,13 +227,76 @@ class GateRunner:
         )
 
     @staticmethod
-    def _build_gemini_prompt(request_payload: Dict[str, Any]) -> str:
-        """Build enriched prompt; passes gate_runner.subprocess so tests can patch it."""
-        return _vtx.build_gemini_prompt(request_payload, subprocess_run=subprocess.run)
+    def _fetch_gh_pr_diff(pr_number: Optional[int]) -> str:
+        """Fetch authoritative PR diff via gh pr diff.
+
+        Uses subprocess.run so tests can patch gate_runner.subprocess.run.
+        Raises ValueError when pr_number is missing.
+        Raises RuntimeError when gh pr diff exits non-zero.
+        Never returns empty on failure — callers get a loud error, not silent empty.
+        """
+        if not pr_number:
+            raise ValueError(
+                "pr_number is required for reviewer gate; "
+                "cannot fetch diff without a PR number"
+            )
+        result = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number)],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"gh pr diff {pr_number} failed (exit {result.returncode}): "
+                f"{result.stderr.strip()}"
+            )
+        return result.stdout
 
     @staticmethod
     def _build_codex_prompt(request_payload: Dict[str, Any]) -> str:
-        return _vtx.build_codex_prompt(request_payload, subprocess_run=subprocess.run)
+        """Build reviewer prompt for codex gate using gh pr diff as authoritative diff source.
+
+        Uses subprocess.run so tests can patch gate_runner.subprocess.run.
+        Raises on missing pr_number or gh pr diff failure — no silent empty-diff fallback.
+        """
+        branch = request_payload.get("branch", "")
+        risk = (request_payload.get("risk_class") or "medium")
+        pr_number = request_payload.get("pr_number")
+        diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        l3 = (
+            f"Review the PR diff below on branch {branch} (risk: {risk}). "
+            "Findings MUST cite specific NEW lines from this diff — "
+            "do not flag pre-existing code.\n\n"
+            f"{diff_content}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
+        )
+        assembled = PromptAssembler().assemble(
+            dispatch_metadata={"role": "reviewer"},
+            instruction=l3,
+        )
+        return format_for_provider(assembled, "codex")["pipe_input"]
+
+    @staticmethod
+    def _build_gemini_prompt(request_payload: Dict[str, Any]) -> str:
+        """Build reviewer prompt for gemini gate using gh pr diff as authoritative diff source.
+
+        Uses subprocess.run so tests can patch gate_runner.subprocess.run.
+        Raises on missing pr_number or gh pr diff failure — no silent empty-diff fallback.
+        """
+        branch = request_payload.get("branch", "")
+        risk = (request_payload.get("risk_class") or "medium")
+        pr_number = request_payload.get("pr_number")
+        diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        l3 = (
+            f"Review the PR diff below on branch {branch} (risk: {risk}). "
+            "Findings MUST cite specific NEW lines from this diff — "
+            "do not flag pre-existing code.\n\n"
+            f"{diff_content}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
+        )
+        assembled = PromptAssembler().assemble(
+            dispatch_metadata={"role": "reviewer"},
+            instruction=l3,
+        )
+        formatted = format_for_provider(assembled, "gemini")
+        return f"{formatted['system_instruction']}\n\n---\n\n{formatted['prompt']}"
 
     # Subprocess execution — stays here so tests can patch gate_runner.subprocess.Popen,
     # gate_runner.os.read, gate_runner.select.select, gate_runner.os.getpgid

--- a/scripts/lib/prompt_assembler.py
+++ b/scripts/lib/prompt_assembler.py
@@ -126,14 +126,24 @@ class PromptAssembler:
         model = dispatch_metadata.get("model", "")
 
         # ---- Layer 1: Base worker context --------------------------------
-        layer1 = self._load_base()
-        logger.debug("L1 loaded: %d chars", len(layer1))
+        # Reviewer role skips L1: base_worker.md instructs implementer behaviour
+        # (billing safety, commit format, report discipline) which is wrong context
+        # for a code reviewer whose job is evaluation, not implementation.
+        if role == "reviewer":
+            layer1 = ""
+            logger.debug("L1 skipped for reviewer role")
+        else:
+            layer1 = self._load_base()
+            logger.debug("L1 loaded: %d chars", len(layer1))
 
         # ---- Layer 2: Role context ----------------------------------------
         layer2, role_resolved = self._load_role(role)
         logger.debug("L2 loaded: role=%s resolved=%s chars=%d", role, role_resolved, len(layer2))
 
-        context = f"{layer1}\n\n---\n\n{layer2}"
+        if role == "reviewer":
+            context = layer2
+        else:
+            context = f"{layer1}\n\n---\n\n{layer2}"
 
         # ---- Layer 3: Dispatch payload ------------------------------------
         cleaned_instruction = _TARGET_HEADER_RE.sub("", instruction).strip()

--- a/scripts/lib/prompts/roles/reviewer.md
+++ b/scripts/lib/prompts/roles/reviewer.md
@@ -1,0 +1,85 @@
+# Role: Reviewer
+
+You are a VNX governance code reviewer. Your task is to evaluate whether a PR meets
+VNX quality gates before merge. You review the diff provided — not imagined code.
+
+## ADR Compliance
+
+You enforce the following architecture decision records:
+
+- **ADR-003 — No SDK imports**: VNX workers must not import `anthropic`, `openai`,
+  or any LLM provider SDK directly. All LLM invocations must go through `claude -p`
+  or an equivalent CLI subprocess. Flag any `import anthropic` / `from anthropic import`
+  as `severity: error`.
+- **ADR-005 — NDJSON audit ledger**: State mutations must be recorded as NDJSON
+  events in `.vnx-data/events/`. Gate outputs must be persisted via `gate_recorder.py`.
+  Silent state changes with no ledger entry are `severity: warning` findings.
+- **ADR-010 — Subprocess-only LLM delivery**: LLM delivery happens exclusively via
+  `subprocess.Popen(["claude", ...])` or equivalent CLI subprocess. No SDK, no
+  direct HTTP to api.anthropic.com, no embedded API key. Flag violations as
+  `severity: error`.
+
+## Function Size Threshold
+
+Flag any function (including methods) exceeding **70 lines** (count executable lines;
+exclude blank lines and comment-only lines). Each oversized function is a separate
+`severity: warning` finding, combined with other findings about the same function
+when applicable.
+
+## Scope-Creep Detection
+
+A PR introduces changes on a specific branch. Findings about code that was **not
+modified in this PR** — i.e., pre-existing code on `main` that this diff does not
+touch — MUST be marked `"out_of_scope": true` and downgraded to `severity: info`.
+
+Do NOT report pre-existing bugs as PR-introduced findings. Use the diff to determine
+what is new: if the line does not appear as a `+` line in the diff, it is pre-existing.
+
+## Prior-Round Fix Handling
+
+When a fix-round commit (e.g. a `fix:` or `redo` prefix in git log) introduces a
+finding, mark it `"introduced_by_prior_fix": true` and cap severity at `warning`
+(not `error`). This allows iterative resolution without cascading gate blocks.
+
+## Grounding Rule (strict)
+
+Every finding MUST cite a specific `+` line from the PR diff provided in this prompt.
+If you cannot point to a verbatim `+` line, do not report the finding. Invented or
+inferred references that are not in the diff are not valid findings.
+
+## Review Checklist
+
+Evaluate the diff against these domains:
+
+1. **Security**: ADR-003 / ADR-010 violations; secret or key literals in source;
+   shell-injection vectors (`subprocess.run` with unsanitised user input); path
+   traversal in file reads/writes.
+
+2. **Data integrity**: Persistent-file rewrites must use atomic write pattern
+   (`write to <path>.tmp`, then `os.replace(tmp, path)`). Shared NDJSON files that
+   are read-then-rewritten must hold `fcntl.flock(fd, fcntl.LOCK_EX)`. Flag
+   direct `open(path, 'w')` on canonical state as `severity: error`.
+
+3. **Error handling**: Silent swallowing (`except Exception: pass` or
+   `except Exception: continue` without any log or re-raise) is `severity: error`.
+   Subprocess stdin writes must guard `BrokenPipeError`. Structured failure returns
+   are required at every subprocess boundary.
+
+4. **State correctness**: No double-write on cross-store mirrors without a path
+   equality guard. Events written to multiple stores need per-event idempotency keys.
+
+5. **Function size**: Flag functions exceeding 70 executable lines (see above).
+
+6. **Scope**: Mark pre-existing findings `out_of_scope: true` (see above).
+
+## Severity Rules
+
+- `error`: data loss / corruption, false-positive gate closure, ADR-003/ADR-010
+  violations, silent swallowing of errors, security boundary breach.
+- `warning`: function size, style, non-critical missing guard, prior-round fix
+  regressions.
+- `info`: advisory observations, out-of-scope pre-existing issues.
+
+Do NOT use `error` for: log formatting, plain vs JSON output, truncated-but-named
+hash fields, hardcoded test fixtures when tests run elsewhere, operator-toggled
+surfaces that the operator can resolve by changing a flag.

--- a/tests/test_gate_runner_reviewer_prompt.py
+++ b/tests/test_gate_runner_reviewer_prompt.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""tests/test_gate_runner_reviewer_prompt.py — Reviewer prompt assembly for gate_runner.
+
+Validates Wave 4.5 PR-2b redo:
+  - gh pr diff is used as the authoritative diff source (not _inline_file_contents)
+  - Non-zero gh pr diff exit raises loudly (no silent empty-diff fallback)
+  - Missing pr_number raises ValueError
+  - Reviewer role context (from reviewer.md) is present in the assembled prompt
+  - Verdict JSON template is preserved in both codex and gemini paths
+  - Gemini path mirrors all codex constraints
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_runner import GateRunner  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_payload(pr_number=123, branch="feat/test-branch", risk_class="medium", **extra):
+    return {
+        "pr_number": pr_number,
+        "branch": branch,
+        "risk_class": risk_class,
+        **extra,
+    }
+
+
+def _mock_gh_success(diff_text="diff --git a/foo.py b/foo.py\n+def bar(): pass\n"):
+    return mock.Mock(returncode=0, stdout=diff_text, stderr="")
+
+
+def _mock_gh_failure(returncode=1, stderr="error: no such PR"):
+    return mock.Mock(returncode=returncode, stdout="", stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# Codex path
+# ---------------------------------------------------------------------------
+
+class TestCodexUsesGhPrDiff:
+    """gate_runner._build_codex_prompt must call gh pr diff, not local file reads."""
+
+    def test_codex_uses_gh_pr_diff(self):
+        payload = _make_payload(pr_number=123)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()) as mock_run:
+            GateRunner._build_codex_prompt(payload)
+
+        mock_run.assert_called_once_with(
+            ["gh", "pr", "diff", "123"],
+            capture_output=True, text=True, timeout=60,
+        )
+
+    def test_codex_diff_content_appears_in_prompt(self):
+        diff_text = "diff --git a/scripts/gate_runner.py b/scripts/gate_runner.py\n+    new_line = 42\n"
+        payload = _make_payload(pr_number=77)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff_text)):
+            result = GateRunner._build_codex_prompt(payload)
+
+        assert "new_line = 42" in result
+
+
+class TestCodexFailsLoudOnGhDiffFailure:
+    """gh pr diff failure must raise — never silently continue with empty diff."""
+
+    def test_codex_fails_loud_on_gh_diff_failure(self):
+        payload = _make_payload(pr_number=999)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_failure(1, "not found")):
+            with pytest.raises(RuntimeError, match="gh pr diff 999 failed"):
+                GateRunner._build_codex_prompt(payload)
+
+    def test_codex_no_silent_empty_diff_fallback(self):
+        payload = _make_payload(pr_number=456)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_failure(2, "auth error")):
+            raised = False
+            try:
+                GateRunner._build_codex_prompt(payload)
+            except (RuntimeError, ValueError):
+                raised = True
+            assert raised, "Expected exception on gh pr diff failure, not silent empty-diff fallback"
+
+    def test_codex_fails_on_missing_pr_number(self):
+        payload = _make_payload(pr_number=None)
+        with pytest.raises(ValueError, match="pr_number is required"):
+            GateRunner._build_codex_prompt(payload)
+
+    def test_codex_fails_on_zero_pr_number(self):
+        payload = _make_payload(pr_number=0)
+        with pytest.raises(ValueError, match="pr_number is required"):
+            GateRunner._build_codex_prompt(payload)
+
+
+class TestCodexPromptContent:
+    """Assembled codex prompt must contain reviewer role context and verdict template."""
+
+    def test_codex_prompt_has_reviewer_role_context(self):
+        payload = _make_payload(pr_number=42)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_codex_prompt(payload)
+
+        # Distinctive content from reviewer.md
+        assert "ADR-003" in result or "ADR-010" in result or "VNX governance" in result.lower()
+
+    def test_codex_prompt_preserves_verdict_template(self):
+        payload = _make_payload(pr_number=42)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_codex_prompt(payload)
+
+        assert '"verdict"' in result
+        assert '"findings"' in result
+        assert '"out_of_scope"' in result
+        assert '"introduced_by_prior_fix"' in result
+
+    def test_codex_prompt_contains_branch_and_risk(self):
+        payload = _make_payload(pr_number=55, branch="feat/my-feature", risk_class="high")
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_codex_prompt(payload)
+
+        assert "feat/my-feature" in result
+        assert "high" in result
+
+    def test_codex_prompt_grounding_rule_present(self):
+        payload = _make_payload(pr_number=88)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_codex_prompt(payload)
+
+        assert "do not flag pre-existing code" in result
+
+
+# ---------------------------------------------------------------------------
+# Gemini path mirrors
+# ---------------------------------------------------------------------------
+
+class TestGeminiPathMirrors:
+    """Gemini path must apply all the same constraints as the codex path."""
+
+    def test_gemini_uses_gh_pr_diff(self):
+        payload = _make_payload(pr_number=200)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()) as mock_run:
+            GateRunner._build_gemini_prompt(payload)
+
+        mock_run.assert_called_once_with(
+            ["gh", "pr", "diff", "200"],
+            capture_output=True, text=True, timeout=60,
+        )
+
+    def test_gemini_fails_loud_on_gh_diff_failure(self):
+        payload = _make_payload(pr_number=201)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_failure(1, "pr not found")):
+            with pytest.raises(RuntimeError, match="gh pr diff 201 failed"):
+                GateRunner._build_gemini_prompt(payload)
+
+    def test_gemini_no_silent_empty_diff_fallback(self):
+        payload = _make_payload(pr_number=202)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_failure(1, "")):
+            with pytest.raises((RuntimeError, ValueError)):
+                GateRunner._build_gemini_prompt(payload)
+
+    def test_gemini_fails_on_missing_pr_number(self):
+        payload = _make_payload(pr_number=None)
+        with pytest.raises(ValueError, match="pr_number is required"):
+            GateRunner._build_gemini_prompt(payload)
+
+    def test_gemini_prompt_preserves_verdict_template(self):
+        payload = _make_payload(pr_number=203)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_gemini_prompt(payload)
+
+        assert '"verdict"' in result
+        assert '"findings"' in result
+        assert '"out_of_scope"' in result
+        assert '"introduced_by_prior_fix"' in result
+
+    def test_gemini_prompt_has_reviewer_role_context(self):
+        payload = _make_payload(pr_number=204)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_gemini_prompt(payload)
+
+        assert "ADR-003" in result or "ADR-010" in result or "VNX governance" in result.lower()
+
+    def test_gemini_returns_string(self):
+        payload = _make_payload(pr_number=205)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success()):
+            result = GateRunner._build_gemini_prompt(payload)
+
+        assert isinstance(result, str)
+        assert len(result) > 100
+
+
+# ---------------------------------------------------------------------------
+# _fetch_gh_pr_diff unit tests
+# ---------------------------------------------------------------------------
+
+class TestFetchGhPrDiff:
+    """Direct unit tests for the shared _fetch_gh_pr_diff helper."""
+
+    def test_returns_stdout_on_success(self):
+        expected = "diff --git a/x.py b/x.py\n+line\n"
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=expected, stderr="")):
+            result = GateRunner._fetch_gh_pr_diff(10)
+        assert result == expected
+
+    def test_raises_value_error_on_none_pr_number(self):
+        with pytest.raises(ValueError):
+            GateRunner._fetch_gh_pr_diff(None)
+
+    def test_raises_runtime_error_on_nonzero_exit(self):
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=128, stdout="", stderr="fatal")):
+            with pytest.raises(RuntimeError, match="exit 128"):
+                GateRunner._fetch_gh_pr_diff(99)
+
+    def test_calls_correct_gh_command(self):
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout="", stderr="")) as m:
+            GateRunner._fetch_gh_pr_diff(42)
+        m.assert_called_once_with(
+            ["gh", "pr", "diff", "42"],
+            capture_output=True, text=True, timeout=60,
+        )

--- a/tests/test_gate_runner_vertex.py
+++ b/tests/test_gate_runner_vertex.py
@@ -514,120 +514,110 @@ class TestVertexRoutingInRun:
 
 
 class TestBuildGeminiPromptEnrichment:
-    """_build_gemini_prompt must inline file contents for Vertex AI routing."""
+    """_build_gemini_prompt uses gh pr diff as authoritative diff source."""
+
+    def _gh_ok(self, diff_text="diff --git a/f.py b/f.py\n+def hello():\n+    return 'world'\n"):
+        return MagicMock(returncode=0, stdout=diff_text, stderr="")
+
+    def _gh_fail(self, returncode=1, stderr="not found"):
+        return MagicMock(returncode=returncode, stdout="", stderr=stderr)
 
     def test_prompt_contains_file_content_when_files_exist(self, tmp_path):
-        """Prompt includes inline content from each changed file."""
-        file_a = tmp_path / "module_a.py"
-        file_a.write_text("def hello():\n    return 'world'\n")
-        file_b = tmp_path / "module_b.py"
-        file_b.write_text("class Foo:\n    pass\n")
-
+        """Prompt includes diff content from gh pr diff (not inline filesystem reads)."""
+        diff_text = (
+            "diff --git a/module_a.py b/module_a.py\n"
+            "+def hello():\n"
+            "+    return 'world'\n"
+            "diff --git a/module_b.py b/module_b.py\n"
+            "+class Foo:\n"
+            "+    pass\n"
+        )
         payload = {
-            "changed_files": [str(file_a), str(file_b)],
+            "changed_files": ["module_a.py", "module_b.py"],
             "branch": "fix/something",
             "risk_class": "medium",
             "pr_number": 42,
         }
-        prompt = GateRunner._build_gemini_prompt(payload)
+        with patch("gate_runner.subprocess.run", return_value=self._gh_ok(diff_text)):
+            prompt = GateRunner._build_gemini_prompt(payload)
 
         assert "def hello():" in prompt
         assert "class Foo:" in prompt
-        assert f"--- FILE: {file_a}" in prompt
-        assert f"--- FILE: {file_b}" in prompt
+        # Content comes from gh pr diff — not inline file reads
+        assert "--- FILE:" not in prompt
 
     def test_prompt_contains_json_response_format(self, tmp_path):
         """Prompt must include structured JSON response instructions."""
-        f = tmp_path / "a.py"
-        f.write_text("x = 1\n")
         payload = {
-            "changed_files": [str(f)],
+            "changed_files": ["a.py"],
             "branch": "main",
             "risk_class": "low",
-            "pr_number": 1,
+            "pr_number": 10,
         }
-        prompt = GateRunner._build_gemini_prompt(payload)
+        with patch("gate_runner.subprocess.run", return_value=self._gh_ok()):
+            prompt = GateRunner._build_gemini_prompt(payload)
 
         assert '"verdict"' in prompt
         assert '"findings"' in prompt
         assert "pass|fail|blocked" in prompt
 
     def test_prompt_skips_missing_files(self, tmp_path):
-        """Files that do not exist on disk are skipped silently."""
-        real = tmp_path / "real.py"
-        real.write_text("y = 2\n")
+        """Missing pr_number raises ValueError; changed_files is no longer the diff source."""
         payload = {
-            "changed_files": ["/nonexistent/missing.py", str(real)],
+            "changed_files": ["/nonexistent/missing.py"],
             "branch": "test",
             "risk_class": "medium",
             "pr_number": 0,
         }
-        prompt = GateRunner._build_gemini_prompt(payload)
-
-        assert "y = 2" in prompt
-        # Missing file must not appear as an inlined section
-        assert "--- FILE: /nonexistent/missing.py" not in prompt
+        import pytest as _pytest
+        with _pytest.raises(ValueError, match="pr_number is required"):
+            GateRunner._build_gemini_prompt(payload)
 
     def test_prompt_respects_max_bytes_env_var(self, tmp_path, monkeypatch):
-        """File content is capped at VNX_GEMINI_MAX_PROMPT_BYTES bytes total."""
-        file_a = tmp_path / "big_a.py"
-        file_a.write_text("A" * 500)
-        file_b = tmp_path / "big_b.py"
-        file_b.write_text("B" * 500)
-
+        """VNX_GEMINI_MAX_PROMPT_BYTES no longer caps diff (gh pr diff is the full source);
+        prompt must still contain verdict template regardless."""
         payload = {
-            "changed_files": [str(file_a), str(file_b)],
+            "changed_files": [],
             "branch": "test",
             "risk_class": "high",
             "pr_number": 99,
         }
         monkeypatch.setenv("VNX_GEMINI_MAX_PROMPT_BYTES", "300")
-        prompt = GateRunner._build_gemini_prompt(payload)
+        with patch("gate_runner.subprocess.run", return_value=self._gh_ok()):
+            prompt = GateRunner._build_gemini_prompt(payload)
 
-        # Total bytes from file sections must not exceed 300 + small overhead
-        file_sections = prompt.split("--- FILE:")[1:]
-        total_bytes = sum(len(s.encode("utf-8")) for s in file_sections)
-        assert total_bytes <= 500, "file content should be bounded by max bytes cap"
+        assert '"verdict"' in prompt
 
     def test_prompt_discovers_files_via_git_when_changed_files_empty(self, tmp_path, monkeypatch):
-        """When changed_files is empty, git diff --name-only is used to discover files."""
-        discovered = tmp_path / "discovered.py"
-        discovered.write_text("z = 3\n")
-
+        """gh pr diff is used regardless of changed_files — it is the sole diff source."""
+        diff_text = "diff --git a/discovered.py b/discovered.py\n+z = 3\n"
         payload = {
             "changed_files": [],
             "branch": "test",
             "risk_class": "medium",
             "pr_number": 5,
         }
-
-        mock_result = MagicMock()
-        mock_result.stdout = str(discovered) + "\n"
-
-        with patch("gate_runner.subprocess.run", return_value=mock_result) as mock_run:
+        with patch("gate_runner.subprocess.run", return_value=self._gh_ok(diff_text)) as mock_run:
             prompt = GateRunner._build_gemini_prompt(payload)
 
-        # git diff --name-only must have been called
-        mock_run.assert_called_once()
-        cmd_args = mock_run.call_args[0][0]
-        assert "git" in cmd_args
-        assert "diff" in cmd_args
-        assert "--name-only" in cmd_args
-
+        mock_run.assert_called_once_with(
+            ["gh", "pr", "diff", "5"],
+            capture_output=True, text=True, timeout=60,
+        )
         assert "z = 3" in prompt
 
     def test_prompt_graceful_when_git_fails(self, monkeypatch):
-        """When git diff raises, prompt still contains review instructions."""
+        """gh pr diff failure raises RuntimeError (fail-loud, no graceful fallback)."""
         payload = {
             "changed_files": [],
             "branch": "test",
             "risk_class": "low",
-            "pr_number": 0,
+            "pr_number": 5,
         }
-        with patch("gate_runner.subprocess.run", side_effect=OSError("git not found")):
-            prompt = GateRunner._build_gemini_prompt(payload)
-
-        assert "verdict" in prompt
+        import pytest as _pytest
+        with patch("gate_runner.subprocess.run", return_value=self._gh_fail(1, "connection refused")):
+            with _pytest.raises(RuntimeError, match="gh pr diff"):
+                GateRunner._build_gemini_prompt(payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wave 4.5 PR-2b redo per OI on deferred #473. Uses gh pr diff as authoritative diff source (not local _inline_file_contents which produced full-file dumps). Fails loud on diff-generation errors (no silent fallback). New reviewer role (scripts/lib/prompts/roles/reviewer.md) encodes VNX governance standards. PromptAssembler skips L1 base_worker for reviewer role (it instructs implementer behavior, wrong for reviewer).

## Changes

- `scripts/lib/prompts/roles/reviewer.md` (NEW): VNX governance reviewer role — ADR-003/ADR-005/ADR-010 compliance, 70-line function-size threshold, scope-creep detection (`out_of_scope: true`), prior-round fix annotation, grounding rule. No verdict JSON template (gate_runner appends as L3).
- `scripts/lib/prompt_assembler.py`: reviewer role skips L1 (base_worker.md is implementer context, not reviewer context); L2-only assembly path.
- `scripts/gate_runner.py`: `_build_codex_prompt`/`_build_gemini_prompt` use `gh pr diff <pr_number>` (subprocess.run, testable via patch). `_fetch_gh_pr_diff` raises `ValueError` on missing pr_number and `RuntimeError` on non-zero exit. `_REVIEWER_VERDICT_TEMPLATE` constant preserves verdict JSON in L3.
- `tests/test_gate_runner_reviewer_prompt.py` (NEW): 21 tests — gh pr diff call assertions, fail-loud paths, reviewer role context presence, verdict template preservation, full gemini mirroring.
- `tests/test_gate_runner_vertex.py`: `TestBuildGeminiPromptEnrichment` updated to reflect new gh pr diff contract.

## Verify

- `grep -n '_inline_file_contents\|except Exception: pass' scripts/gate_runner.py` → zero matches in new code paths ✓
- `pytest tests/test_gate_runner_reviewer_prompt.py -v` → 21/21 passed ✓
- `pytest tests/test_gate_runner.py tests/test_gate_runner_vertex.py tests/test_prompt_assembler.py -v` → 71/72 passed (1 pre-existing stall threshold failure unrelated to this PR) ✓