### PR TITLE
feat(oi-1370): PR N2 — migrate gate_register_emit + cleanup_worker_exit

### DIFF
--- a/scripts/lib/cleanup_worker_exit.py
+++ b/scripts/lib/cleanup_worker_exit.py
@@ -39,6 +39,8 @@ _THIS_DIR = Path(__file__).resolve().parent
 if str(_THIS_DIR) not in sys.path:
     sys.path.insert(0, str(_THIS_DIR))
 
+import state_writer
+
 try:
     from project_root import resolve_data_dir, resolve_state_dir
 except ImportError:  # pragma: no cover - bootstrap failure
@@ -325,8 +327,6 @@ def _append_audit_event_step(
 ) -> None:
     """Step 4: append worker_exited audit event to dispatch_register.ndjson."""
     try:
-        import fcntl  # noqa: PLC0415
-
         record = {
             "timestamp": _now_iso(),
             "event": "worker_exited",
@@ -339,10 +339,7 @@ def _append_audit_event_step(
         }
 
         path = _resolve_dispatch_register_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        state_writer.append_locked(path, record)
     except Exception as exc:
         result.errors.append(f"audit_append_failed:{exc}")
         _emit(

--- a/scripts/lib/gate_register_emit.py
+++ b/scripts/lib/gate_register_emit.py
@@ -8,12 +8,12 @@ with tests that mock subprocess.Popen).
 from __future__ import annotations
 
 import datetime
-import fcntl
-import json
 import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+import state_writer
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 logger = logging.getLogger(__name__)
@@ -67,10 +67,7 @@ def emit_codex_gate_to_register(
             record["feature_id"] = feature_id_resolved
 
         path = _resolve_register_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        state_writer.append_locked(path, record)
         return True
     except Exception:
         return False

--- a/tests/test_state_writer_caller_migration.py
+++ b/tests/test_state_writer_caller_migration.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+import cleanup_worker_exit as cwe  # noqa: E402
+import gate_register_emit as gre  # noqa: E402
+import state_writer  # noqa: E402
+
+
+def test_gate_register_emit_uses_append_locked(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "dispatch_register.ndjson"
+    captured: list[tuple[Path, dict]] = []
+
+    monkeypatch.setattr(gre, "_resolve_register_path", lambda: path)
+    monkeypatch.setattr(
+        state_writer,
+        "append_locked",
+        lambda file_path, record: captured.append((file_path, record)),
+    )
+
+    result = gre.emit_codex_gate_to_register(
+        "gate_passed",
+        dispatch_id="dispatch-123",
+        pr_number=42,
+        pr_id="42",
+        gate="codex_gate",
+    )
+
+    assert result is True
+    assert len(captured) == 1
+    file_path, record = captured[0]
+    assert file_path == path
+    assert record["event"] == "gate_passed"
+    assert record["gate"] == "codex_gate"
+    assert record["dispatch_id"] == "dispatch-123"
+    assert record["pr_number"] == 42
+    assert record["timestamp"].endswith("Z")
+
+
+def test_cleanup_worker_exit_uses_append_locked(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "dispatch_register.ndjson"
+    captured: list[tuple[Path, dict]] = []
+    result = cwe.CleanupResult(
+        lease_released=True,
+        worker_transitioned=False,
+        dispatch_moved=tmp_path / "completed" / "dispatch-123.md",
+    )
+
+    monkeypatch.setattr(cwe, "_resolve_dispatch_register_path", lambda: path)
+    monkeypatch.setattr(
+        state_writer,
+        "append_locked",
+        lambda file_path, record: captured.append((file_path, record)),
+    )
+
+    cwe._append_audit_event_step(
+        terminal_id="T2",
+        dispatch_id="dispatch-123",
+        exit_status="success",
+        result=result,
+    )
+
+    assert result.errors == []
+    assert len(captured) == 1
+    file_path, record = captured[0]
+    assert file_path == path
+    assert record["event"] == "worker_exited"
+    assert record["dispatch_id"] == "dispatch-123"
+    assert record["terminal_id"] == "T2"
+    assert record["exit_status"] == "success"
+    assert record["lease_released"] is True
+    assert record["worker_transitioned"] is False
+    assert record["dispatch_moved"] == str(tmp_path / "completed" / "dispatch-123.md")
+    assert record["timestamp"].endswith("Z")
+
+
+def test_callers_no_longer_use_direct_open_append() -> None:
+    migrated_files = [
+        ROOT / "scripts" / "lib" / "gate_register_emit.py",
+        ROOT / "scripts" / "lib" / "cleanup_worker_exit.py",
+    ]
+
+    for path in migrated_files:
+        text = path.read_text(encoding="utf-8")
+        assert 'with path.open("a", encoding="utf-8") as fh:' not in text
+        assert 'fh.write(json.dumps(record, separators=(",", ":")) + "\\n")' not in text
+        assert "state_writer.append_locked(path, record)" in text


### PR DESCRIPTION
OI-1370 systemic locking refactor PR N2 per claudedocs/oi1370-systemic-locking-refactor-plan-2026-05-13.md. Migrates two writers to scripts.lib.state_writer.append_locked() helper from PR N1. No changes to dispatch_register / migrate_phase3_envelope / compact_state (those are PR N3 / N4).