### PR TITLE
feat(oi-1370): PR N3 — migrate compact_receipts + backfill_headless_receipts

### DIFF
--- a/scripts/backfill_headless_receipts.py
+++ b/scripts/backfill_headless_receipts.py
@@ -40,6 +40,8 @@ from typing import Any, Dict, List, Optional, Tuple
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
+import state_writer
+
 try:
     from vnx_paths import ensure_env
     _PATHS = ensure_env()
@@ -338,9 +340,13 @@ def _update_ndjson(
     if not T0_RECEIPTS_NDJSON.exists():
         return 0, 0
     patched = skipped = 0
-    updated_lines: List[str] = []
-    with T0_RECEIPTS_NDJSON.open() as f:
-        for raw_line in f:
+    def _rewrite(current_content: bytes) -> bytes:
+        nonlocal patched, skipped
+
+        updated_lines: List[str] = []
+        patched = 0
+        skipped = 0
+        for raw_line in current_content.decode("utf-8", errors="replace").splitlines():
             raw_line = raw_line.rstrip("\n")
             if not raw_line.strip():
                 updated_lines.append(raw_line)
@@ -358,17 +364,15 @@ def _update_ndjson(
             else:
                 skipped += 1
                 updated_lines.append(raw_line)
-    if not dry_run:
-        tmp = T0_RECEIPTS_NDJSON.parent / (T0_RECEIPTS_NDJSON.name + ".backfill_tmp")
-        try:
-            with tmp.open("w") as f:
-                f.write("\n".join(updated_lines))
-                if updated_lines and updated_lines[-1]:
-                    f.write("\n")
-            tmp.replace(T0_RECEIPTS_NDJSON)
-        except Exception:
-            tmp.unlink(missing_ok=True)
-            raise
+        updated_content = "\n".join(updated_lines)
+        if updated_lines and updated_lines[-1]:
+            updated_content += "\n"
+        return updated_content.encode("utf-8")
+
+    if dry_run:
+        _rewrite(T0_RECEIPTS_NDJSON.read_bytes())
+    else:
+        state_writer.rewrite_locked(T0_RECEIPTS_NDJSON, _rewrite)
     return patched, skipped
 
 

--- a/scripts/compact_state.py
+++ b/scripts/compact_state.py
@@ -23,6 +23,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 from project_root import resolve_data_dir
+import state_writer
 
 INTELLIGENCE_ARCHIVE_MIN_MB = 50
 INTELLIGENCE_ARCHIVE_KEEP_DAYS = 7
@@ -215,48 +216,86 @@ def compact_intelligence_archive(state_dir: Path, *, dry_run: bool = False) -> i
 def compact_receipts(state_dir: Path, *, dry_run: bool = False) -> int:
     """Cap t0_receipts.ndjson at 10000 lines, archive overflow. Returns 0 on success."""
     live_file = state_dir / "t0_receipts.ndjson"
+    archive_file = _archive_path(state_dir, "t0_receipts")
 
     if not live_file.exists():
         _emit("INFO", "receipts_skip", reason="file_not_found", path=str(live_file))
         return 0
 
-    lines = live_file.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
-
-    if len(lines) <= RECEIPTS_MAX_RECORDS:
-        _emit("INFO", "receipts_skip", reason="within_cap", line_count=len(lines), cap=RECEIPTS_MAX_RECORDS)
-        return 0
-
-    archive_file = _archive_path(state_dir, "t0_receipts")
-    # Check for an already-committed archive; staging temps do not count (partial-failure remnants).
-    if archive_file.exists():
-        _emit("INFO", "receipts_skip", reason="archive_already_exists_today", archive=str(archive_file))
-        return 0
-
-    keep = lines[-RECEIPTS_MAX_RECORDS:]
-    overflow = lines[: -RECEIPTS_MAX_RECORDS]
-
-    _emit(
-        "INFO",
-        "receipts_rotating",
-        live_path=str(live_file),
-        archive_path=str(archive_file),
-        archive_lines=len(overflow),
-        keep_lines=len(keep),
-        dry_run=dry_run,
-    )
-
     if dry_run:
+        lines = live_file.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+        if len(lines) <= RECEIPTS_MAX_RECORDS:
+            _emit("INFO", "receipts_skip", reason="within_cap", line_count=len(lines), cap=RECEIPTS_MAX_RECORDS)
+            return 0
+        if archive_file.exists():
+            _emit("INFO", "receipts_skip", reason="archive_already_exists_today", archive=str(archive_file))
+            return 0
+        keep = lines[-RECEIPTS_MAX_RECORDS:]
+        overflow = lines[: -RECEIPTS_MAX_RECORDS]
+        _emit(
+            "INFO",
+            "receipts_rotating",
+            live_path=str(live_file),
+            archive_path=str(archive_file),
+            archive_lines=len(overflow),
+            keep_lines=len(keep),
+            dry_run=True,
+        )
         return 0
 
     # Two-phase write: stage archive content to a temp path so the real archive path
     # only appears after the live-file rewrite succeeds.  A partial failure leaves no
     # committed archive, allowing safe retry.
     archive_tmp: Path | None = None
+    plan: dict[str, object] = {}
     try:
-        archive_tmp = _stage_bytes(
-            archive_file.parent, gzip.compress("".join(overflow).encode("utf-8"))
+        def _rewrite(current_content: bytes) -> bytes:
+            nonlocal archive_tmp, plan
+
+            current_lines = current_content.decode("utf-8", errors="replace").splitlines(keepends=True)
+            if len(current_lines) <= RECEIPTS_MAX_RECORDS:
+                plan = {
+                    "action": "within_cap",
+                    "line_count": len(current_lines),
+                }
+                return current_content
+
+            if archive_file.exists():
+                plan = {
+                    "action": "archive_exists",
+                }
+                return current_content
+
+            current_keep = current_lines[-RECEIPTS_MAX_RECORDS:]
+            current_overflow = current_lines[: -RECEIPTS_MAX_RECORDS]
+            archive_tmp = _stage_bytes(
+                archive_file.parent,
+                gzip.compress("".join(current_overflow).encode("utf-8")),
+            )
+            plan = {
+                "action": "rotate",
+                "keep": current_keep,
+                "overflow": current_overflow,
+            }
+            return "".join(current_keep).encode("utf-8")
+
+        state_writer.rewrite_locked(live_file, _rewrite)
+        if plan.get("action") == "within_cap":
+            _emit("INFO", "receipts_skip", reason="within_cap", line_count=plan["line_count"], cap=RECEIPTS_MAX_RECORDS)
+            return 0
+        if plan.get("action") == "archive_exists":
+            _emit("INFO", "receipts_skip", reason="archive_already_exists_today", archive=str(archive_file))
+            return 0
+
+        _emit(
+            "INFO",
+            "receipts_rotating",
+            live_path=str(live_file),
+            archive_path=str(archive_file),
+            archive_lines=len(plan["overflow"]),
+            keep_lines=len(plan["keep"]),
+            dry_run=dry_run,
         )
-        _atomic_write_text(live_file, "".join(keep))
         os.replace(archive_tmp, archive_file)
         archive_tmp = None
     except OSError as exc:
@@ -273,8 +312,8 @@ def compact_receipts(state_dir: Path, *, dry_run: bool = False) -> int:
         "INFO",
         "receipts_done",
         archive=str(archive_file),
-        archive_lines=len(overflow),
-        live_lines=len(keep),
+        archive_lines=len(plan["overflow"]),
+        live_lines=len(plan["keep"]),
     )
     return 0
 

--- a/scripts/lib/state_writer.py
+++ b/scripts/lib/state_writer.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
+import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 _SENTINEL_REGISTRY = {
@@ -25,11 +28,47 @@ def append_locked(path: Path, record: dict) -> None:
     """Append one JSON record under the shared sentinel and data-file locks."""
     path.parent.mkdir(parents=True, exist_ok=True)
     sentinel = _sentinel_path(path)
+    payload = (json.dumps(record, separators=(",", ":"), sort_keys=False) + "\n").encode("utf-8")
     with sentinel.open("a+", encoding="utf-8") as sentinel_fh:
         fcntl.flock(sentinel_fh.fileno(), fcntl.LOCK_EX)
-        with path.open("a", encoding="utf-8") as fh:
+        with path.open("a+b") as fh:
             fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            fh.write(json.dumps(record, separators=(",", ":"), sort_keys=False) + "\n")
+            fh.seek(0, os.SEEK_END)
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
 
 
-__all__ = ["append_locked"]
+def rewrite_locked(path: Path, new_content: bytes | Callable[[bytes], bytes]) -> None:
+    """Rewrite a state file under the shared sentinel and data-file locks."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel = _sentinel_path(path)
+    with sentinel.open("a+", encoding="utf-8") as sentinel_fh:
+        fcntl.flock(sentinel_fh.fileno(), fcntl.LOCK_EX)
+        with path.open("a+b") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.seek(0)
+            current_content = fh.read()
+            rewritten = new_content(current_content) if callable(new_content) else new_content
+            if not isinstance(rewritten, (bytes, bytearray)):
+                raise TypeError("rewrite_locked requires bytes output")
+            rewritten_bytes = bytes(rewritten)
+            if rewritten_bytes == current_content:
+                return
+
+            fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.tmp_")
+            try:
+                with os.fdopen(fd, "wb") as tmp_fh:
+                    tmp_fh.write(rewritten_bytes)
+                    tmp_fh.flush()
+                    os.fsync(tmp_fh.fileno())
+                os.replace(tmp, path)
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+
+
+__all__ = ["append_locked", "rewrite_locked"]

--- a/tests/test_compact_state.py
+++ b/tests/test_compact_state.py
@@ -493,7 +493,11 @@ class TestTwoPhaseWrite:
         live = state / "t0_receipts.ndjson"
         live.write_text("".join(json.dumps({"seq": i}) + "\n" for i in range(15_000)))
 
-        monkeypatch.setattr(cs, "_atomic_write_text", lambda *_: (_ for _ in ()).throw(OSError("simulated live failure")))
+        def _fail_rewrite(path: Path, writer) -> None:
+            writer(path.read_bytes())
+            raise OSError("simulated live failure")
+
+        monkeypatch.setattr(cs.state_writer, "rewrite_locked", _fail_rewrite)
 
         rc = cs.compact_receipts(state)
 
@@ -538,7 +542,11 @@ class TestTwoPhaseWrite:
         live.write_text("".join(json.dumps({"seq": i}) + "\n" for i in range(15_000)))
 
         # First run: live write fails → archive not committed
-        monkeypatch.setattr(cs, "_atomic_write_text", lambda *_: (_ for _ in ()).throw(OSError("first-run failure")))
+        def _fail_rewrite(path: Path, writer) -> None:
+            writer(path.read_bytes())
+            raise OSError("first-run failure")
+
+        monkeypatch.setattr(cs.state_writer, "rewrite_locked", _fail_rewrite)
         rc1 = cs.compact_receipts(state)
         assert rc1 == 1
 

--- a/tests/test_state_writer_compact_backfill_migration.py
+++ b/tests/test_state_writer_compact_backfill_migration.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import fcntl
+import multiprocessing
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+import backfill_headless_receipts as bfr  # noqa: E402
+import compact_state as cs  # noqa: E402
+import state_writer  # noqa: E402
+
+
+def _probe_lock(lock_path: str, ready: multiprocessing.synchronize.Event, result_queue: multiprocessing.queues.Queue) -> None:
+    ready.wait(timeout=5)
+    with Path(lock_path).open("a+", encoding="utf-8") as fh:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            result_queue.put("blocked")
+            return
+        result_queue.put("acquired")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def test_compact_receipts_uses_state_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    live_file = state_dir / "t0_receipts.ndjson"
+    live_file.write_text("".join(f'{{"seq":{index}}}\n' for index in range(12000)), encoding="utf-8")
+
+    captured: list[tuple[Path, object]] = []
+
+    def _fake_rewrite_locked(path: Path, writer: object) -> None:
+        captured.append((path, writer))
+        current_content = path.read_bytes()
+        rewritten = writer(current_content) if callable(writer) else writer
+        if rewritten != current_content:
+            path.write_bytes(rewritten)
+
+    monkeypatch.setattr(cs.state_writer, "rewrite_locked", _fake_rewrite_locked)
+
+    rc = cs.compact_receipts(state_dir)
+
+    assert rc == 0
+    assert len(captured) == 1
+    assert captured[0][0] == live_file
+
+
+def test_backfill_headless_receipts_uses_state_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    live_file = tmp_path / "t0_receipts.ndjson"
+    live_file.write_text(
+        '{"dispatch_id":"unknown","task_id":"unknown","terminal":"unknown","track":"unknown","gate":"unknown","status":"unknown","report_file":"20260401-075225-HEADLESS-codex_gate-pr-0.md","report_path":"/some/path/20260401-075225-HEADLESS-codex_gate-pr-0.md","missing_fields":["task_id","dispatch_id"],"legacy_format":true}\n',
+        encoding="utf-8",
+    )
+    captured: list[tuple[Path, object]] = []
+
+    def _fake_rewrite_locked(path: Path, writer: object) -> None:
+        captured.append((path, writer))
+        current_content = path.read_bytes()
+        rewritten = writer(current_content) if callable(writer) else writer
+        if rewritten != current_content:
+            path.write_bytes(rewritten)
+
+    monkeypatch.setattr(bfr, "T0_RECEIPTS_NDJSON", live_file)
+    monkeypatch.setattr(bfr.state_writer, "rewrite_locked", _fake_rewrite_locked)
+
+    patched, skipped = bfr._update_ndjson({}, {}, dry_run=False)
+
+    assert patched == 1
+    assert skipped == 0
+    assert len(captured) == 1
+    assert captured[0][0] == live_file
+
+
+def test_rewrite_locked_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "t0_receipts.ndjson"
+    path.write_text("old\n", encoding="utf-8")
+    sentinel = state_writer._sentinel_path(path)
+    ctx = multiprocessing.get_context("spawn")
+    ready = ctx.Event()
+    result_queue = ctx.Queue()
+    process = ctx.Process(target=_probe_lock, args=(str(sentinel), ready, result_queue))
+    original_replace = state_writer.os.replace
+
+    def _replace(src: str | bytes | Path, dst: str | bytes | Path) -> None:
+        ready.set()
+        assert result_queue.get(timeout=5) == "blocked"
+        original_replace(src, dst)
+
+    monkeypatch.setattr(state_writer.os, "replace", _replace)
+
+    process.start()
+    try:
+        state_writer.rewrite_locked(path, b"new\n")
+        process.join(timeout=5)
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+
+    assert path.read_text(encoding="utf-8") == "new\n"


### PR DESCRIPTION
OI-1370 systemic locking refactor PR N3 per claudedocs/oi1370-systemic-locking-refactor-plan-2026-05-13.md. Migrates 2 more writers (compact_state + backfill_headless_receipts) to state_writer helper. Adds rewrite_locked() if bulk-rewrite semantics are needed. dispatch_register + migrate_phase3_envelope remain for PR N4.