### PR TITLE
fix(oi-1370): PR N4 — final systemic locking migration; closes OI-1370

### DIFF
--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -19,6 +19,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import state_writer
+
 try:
     import shadow_verifier as _shadow_verifier
     import shadow_logger as _shadow_logger
@@ -203,15 +205,8 @@ def _merge_dedup_key(event: dict) -> tuple[str, str, str, str, str]:
 
 
 def _write_event_locked(path: Path, record: dict) -> None:
-    # Acquire directory-level sentinel BEFORE opening the file so that a
-    # concurrent re-stamper that holds the sentinel and is about to os.replace()
-    # cannot leave this writer holding an fd to the unlinked (old) inode.
-    sentinel = path.parent / ".state.lock"
-    with sentinel.open("a+", encoding="utf-8") as _sentinel_fh:
-        fcntl.flock(_sentinel_fh.fileno(), fcntl.LOCK_EX)
-        with path.open("a", encoding="utf-8") as fh:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+    """Backwards-compatible wrapper around the shared state writer."""
+    state_writer.append_locked(path, record)
 
 
 def _mirror_event_to_central(record: dict, primary_path: Path, project_id: str) -> None:

--- a/scripts/migrate_phase3_envelope.py
+++ b/scripts/migrate_phase3_envelope.py
@@ -10,12 +10,9 @@ Usage:
     python3 scripts/migrate_phase3_envelope.py --project-id vnx-dev --state-dir /path/to/.vnx-data/state
 
 Locking contract (race-free with concurrent appends during P5 cutover):
-- For dispatch_register.ndjson: acquires LOCK_EX on the NDJSON file itself
-  (same as dispatch_register._write_event_locked).
-- For t0_receipts.ndjson: acquires LOCK_EX on <dir>/append_receipt.lock
-  (same as append_receipt_internals.idempotency._write_receipt_under_lock).
-Lock is held through the atomic rename so concurrent writers block until
-the stamped file is in place.
+- All rewrite paths delegate to scripts.lib.state_writer.rewrite_locked().
+- The shared state_writer sentinel registry coordinates concurrent appenders,
+  rewriters, and migrators across dispatch_register.ndjson and t0_receipts.ndjson.
 
 Idempotent: running twice yields identical output (envelope fields already
 present are not overwritten).
@@ -24,11 +21,10 @@ present are not overwritten).
 from __future__ import annotations
 
 import argparse
-import fcntl
 import json
 import os
 import sys
-import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -36,6 +32,8 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 _LIB_DIR = _SCRIPT_DIR / "lib"
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
+
+import state_writer
 
 
 def _default_primary_state_dir(project_id: str) -> Path:
@@ -91,78 +89,74 @@ def _stamp_line(record: Dict[str, Any], envelope: Dict[str, Optional[str]]) -> D
     return result
 
 
+def _restamp_content(
+    content: bytes,
+    envelope: Dict[str, Optional[str]],
+    *,
+    hold_lock_delay: float = 0.0,
+) -> tuple[bytes, int]:
+    """Re-stamp raw NDJSON bytes and return rewritten content plus stamped count."""
+    if hold_lock_delay > 0:
+        time.sleep(hold_lock_delay)
+
+    text = content.decode("utf-8", errors="replace")
+    stamped_lines: List[str] = []
+    count = 0
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError:
+            stamped_lines.append(stripped)
+            continue
+        stamped = _stamp_line(record, envelope)
+        stamped_lines.append(json.dumps(stamped, separators=(",", ":"), sort_keys=False))
+        count += 1
+
+    new_content = "\n".join(stamped_lines) + ("\n" if stamped_lines else "")
+    return new_content.encode("utf-8"), count
+
+
 def _restamp_ndjson_inplace(
     ndjson_path: Path,
     envelope: Dict[str, Optional[str]],
     *,
-    lock_path: Optional[Path] = None,
     dry_run: bool = False,
+    hold_lock_delay: float = 0.0,
 ) -> int:
     """Re-stamp a single NDJSON file with envelope fields. Returns stamped line count.
 
-    Locking: acquires LOCK_EX on a directory-level sentinel (.state.lock) first,
-    then on lock_path (if given) or ndjson_path itself. Both locks are held through
-    the atomic rename.
-
-    The sentinel coordinates with dispatch_register._write_event_locked so that
-    writers that open the NDJSON file before the rename complete will always open
-    the new inode (they block on the sentinel, which is released only after rename).
+    Locking is delegated to scripts.lib.state_writer.rewrite_locked(), which
+    acquires the registered sentinel and the data-file lock before reading the
+    file and holds both through any atomic replace.
     """
     if not ndjson_path.exists():
         return 0
 
-    sentinel = ndjson_path.parent / ".state.lock"
-    effective_lock = lock_path if lock_path is not None else ndjson_path
+    if dry_run:
+        try:
+            content = ndjson_path.read_bytes()
+        except OSError:
+            return 0
+        _, count = _restamp_content(content, envelope)
+        return count
 
-    with sentinel.open("a+", encoding="utf-8") as _sentinel_fh:
-        fcntl.flock(_sentinel_fh.fileno(), fcntl.LOCK_EX)
+    stamped_count = 0
 
-        with effective_lock.open("a+", encoding="utf-8") as lock_fh:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+    def _rewrite(current_content: bytes) -> bytes:
+        nonlocal stamped_count
+        rewritten, stamped_count = _restamp_content(
+            current_content,
+            envelope,
+            hold_lock_delay=hold_lock_delay,
+        )
+        return rewritten
 
-            # Read under lock.
-            try:
-                content = ndjson_path.read_text(encoding="utf-8", errors="replace")
-            except OSError:
-                return 0
-
-            stamped_lines: List[str] = []
-            count = 0
-            for raw_line in content.splitlines():
-                stripped = raw_line.strip()
-                if not stripped:
-                    continue
-                try:
-                    record = json.loads(stripped)
-                except json.JSONDecodeError:
-                    stamped_lines.append(stripped)
-                    continue
-                stamped = _stamp_line(record, envelope)
-                stamped_lines.append(json.dumps(stamped, separators=(",", ":"), sort_keys=False))
-                count += 1
-
-            if dry_run:
-                return count
-
-            new_content = "\n".join(stamped_lines) + ("\n" if stamped_lines else "")
-
-            # Atomic rename under lock — concurrent appenders block until complete.
-            fd, tmp_str = tempfile.mkstemp(
-                prefix=ndjson_path.name + ".restamp.tmp.",
-                dir=str(ndjson_path.parent),
-            )
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as tmp_fh:
-                    tmp_fh.write(new_content)
-                os.replace(tmp_str, str(ndjson_path))
-            except Exception:
-                try:
-                    os.unlink(tmp_str)
-                except Exception:
-                    pass
-                raise
-
-    return count
+    state_writer.rewrite_locked(ndjson_path, _rewrite)
+    return stamped_count
 
 
 def resolve_central_data_dir(project_id: str) -> Path:
@@ -182,16 +176,14 @@ def restamp_project(
     envelope = _resolve_identity(project_id)
     results: Dict[str, int] = {}
 
-    # --- dispatch_register.ndjson (self-locked) ---
+    # --- dispatch_register.ndjson ---
     dr_path = state_dir / "dispatch_register.ndjson"
-    # Lock on the file itself (same as dispatch_register._write_event_locked).
-    n = _restamp_ndjson_inplace(dr_path, envelope, lock_path=None, dry_run=dry_run)
+    n = _restamp_ndjson_inplace(dr_path, envelope, dry_run=dry_run)
     results["dispatch_register.ndjson"] = n
 
-    # --- t0_receipts.ndjson (locked via append_receipt.lock) ---
+    # --- t0_receipts.ndjson (state_writer registry maps to append_receipt.lock) ---
     receipts_path = state_dir / "t0_receipts.ndjson"
-    lock_path = state_dir / "append_receipt.lock"
-    n = _restamp_ndjson_inplace(receipts_path, envelope, lock_path=lock_path, dry_run=dry_run)
+    n = _restamp_ndjson_inplace(receipts_path, envelope, dry_run=dry_run)
     results["t0_receipts.ndjson"] = n
 
     # --- central paths (if they differ from primary) ---
@@ -200,14 +192,11 @@ def restamp_project(
             central_state = resolve_central_data_dir(project_id) / "state"
             if central_state.exists() and central_state.resolve() != state_dir.resolve():
                 c_dr = central_state / "dispatch_register.ndjson"
-                n = _restamp_ndjson_inplace(c_dr, envelope, lock_path=None, dry_run=dry_run)
+                n = _restamp_ndjson_inplace(c_dr, envelope, dry_run=dry_run)
                 results["central/dispatch_register.ndjson"] = n
 
                 c_receipts = central_state / "t0_receipts.ndjson"
-                c_lock = central_state / "append_receipt.lock"
-                n = _restamp_ndjson_inplace(
-                    c_receipts, envelope, lock_path=c_lock, dry_run=dry_run
-                )
+                n = _restamp_ndjson_inplace(c_receipts, envelope, dry_run=dry_run)
                 results["central/t0_receipts.ndjson"] = n
         except Exception:
             pass

--- a/tests/test_dispatch_register_state_writer_integration.py
+++ b/tests/test_dispatch_register_state_writer_integration.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+import dispatch_register  # noqa: E402
+
+
+def test_append_event_delegates_to_state_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "dispatch_register.ndjson"
+    captured: list[tuple[Path, dict]] = []
+
+    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda: path)
+    monkeypatch.setattr(dispatch_register, "_resolve_identity_for_register", lambda: {})
+    monkeypatch.setattr(dispatch_register, "_mirror_to_decision_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        dispatch_register.state_writer,
+        "append_locked",
+        lambda file_path, record: captured.append((file_path, record)),
+    )
+
+    result = dispatch_register.append_event("dispatch_created", dispatch_id="dispatch-123")
+
+    assert result is True
+    assert len(captured) == 1
+    file_path, record = captured[0]
+    assert file_path == path
+    assert record["event"] == "dispatch_created"
+    assert record["dispatch_id"] == "dispatch-123"
+    assert record["timestamp"].endswith("Z")
+
+
+def test_dispatch_register_public_api_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "dispatch_register.ndjson"
+
+    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda: path)
+    monkeypatch.setattr(dispatch_register, "_resolve_identity_for_register", lambda: {})
+    monkeypatch.setattr(dispatch_register, "_mirror_to_decision_log", lambda *args, **kwargs: None)
+
+    result = dispatch_register.append_event(
+        "gate_passed",
+        dispatch_id="dispatch-legacy",
+        pr_number=42,
+        feature_id="OI-1370",
+        terminal="T1",
+        gate="codex_gate",
+        extra={"source": "legacy-caller"},
+    )
+
+    assert result is True
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record == {
+        "timestamp": record["timestamp"],
+        "event": "gate_passed",
+        "dispatch_id": "dispatch-legacy",
+        "pr_number": 42,
+        "feature_id": "OI-1370",
+        "terminal": "T1",
+        "gate": "codex_gate",
+        "extra": {"source": "legacy-caller"},
+    }
+    assert record["timestamp"].endswith("Z")
+

--- a/tests/test_migrate_phase3_envelope_e2e.py
+++ b/tests/test_migrate_phase3_envelope_e2e.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import concurrent.futures
+import hashlib
+import json
+import multiprocessing
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import migrate_phase3_envelope as migrator  # noqa: E402
+
+
+ENVELOPE = {
+    "operator_id": "op-test",
+    "project_id": "proj-test",
+    "orchestrator_id": "orch-test",
+    "agent_id": "agent-test",
+}
+
+
+def _write_seed_records(path: Path, count: int) -> list[str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dispatch_ids = [f"seed-{index:04d}" for index in range(count)]
+    with path.open("w", encoding="utf-8") as fh:
+        for dispatch_id in dispatch_ids:
+            fh.write(
+                json.dumps(
+                    {
+                        "event": "dispatch_created",
+                        "dispatch_id": dispatch_id,
+                    },
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+    return dispatch_ids
+
+
+def _append_records_worker(
+    state_dir: str,
+    start_at: float,
+    worker_index: int,
+    records_per_worker: int,
+) -> list[str]:
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+    from dispatch_register import append_event
+
+    os.environ["VNX_STATE_DIR"] = state_dir
+    os.environ.pop("VNX_PROJECT_ID", None)
+    os.environ.pop("VNX_OPERATOR_ID", None)
+    os.environ.pop("VNX_ORCHESTRATOR_ID", None)
+    os.environ.pop("VNX_AGENT_ID", None)
+
+    while time.time() < start_at:
+        time.sleep(0.001)
+
+    written_ids: list[str] = []
+    for seq in range(records_per_worker):
+        dispatch_id = f"worker-{worker_index:02d}-{seq:03d}"
+        ok = append_event("dispatch_created", dispatch_id=dispatch_id)
+        if not ok:
+            raise AssertionError(f"append_event returned False for {dispatch_id}")
+        written_ids.append(dispatch_id)
+    return written_ids
+
+
+def _migrate_worker(ndjson_path: str, start_at: float, hold_lock_delay: float) -> int:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+    import migrate_phase3_envelope as _migrator
+
+    while time.time() < start_at:
+        time.sleep(0.001)
+
+    return _migrator._restamp_ndjson_inplace(
+        Path(ndjson_path),
+        ENVELOPE,
+        hold_lock_delay=hold_lock_delay,
+    )
+
+
+def _read_records(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_migrate_envelope_uses_state_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ndjson = tmp_path / "dispatch_register.ndjson"
+    ndjson.write_text('{"event":"dispatch_created","dispatch_id":"d-001"}\n', encoding="utf-8")
+    captured: list[tuple[Path, object]] = []
+
+    def _fake_rewrite_locked(path: Path, writer: object) -> None:
+        captured.append((path, writer))
+        current_content = path.read_bytes()
+        rewritten = writer(current_content) if callable(writer) else writer
+        if rewritten != current_content:
+            path.write_bytes(rewritten)
+
+    monkeypatch.setattr(migrator.state_writer, "rewrite_locked", _fake_rewrite_locked)
+
+    stamped = migrator._restamp_ndjson_inplace(ndjson, ENVELOPE)
+
+    assert stamped == 1
+    assert len(captured) == 1
+    assert captured[0][0] == ndjson
+    record = _read_records(ndjson)[0]
+    assert record["dispatch_id"] == "d-001"
+    assert record["project_id"] == ENVELOPE["project_id"]
+
+
+def test_concurrent_writes_during_migration(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    ndjson = state_dir / "dispatch_register.ndjson"
+    seed_ids = _write_seed_records(ndjson, count=200)
+
+    appenders = 50
+    records_per_appender = 20
+    start_at = time.time() + 1.0
+    ctx = multiprocessing.get_context("fork")
+
+    appended_ids: list[str] = []
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=appenders + 1,
+        mp_context=ctx,
+    ) as pool:
+        append_futures = [
+            pool.submit(
+                _append_records_worker,
+                str(state_dir),
+                start_at,
+                worker_index,
+                records_per_appender,
+            )
+            for worker_index in range(appenders)
+        ]
+        migrate_future = pool.submit(
+            _migrate_worker,
+            str(ndjson),
+            start_at,
+            0.25,
+        )
+
+        for future in append_futures:
+            appended_ids.extend(future.result(timeout=30))
+        migrated_count = migrate_future.result(timeout=30)
+
+    final_records = _read_records(ndjson)
+    final_ids = [record["dispatch_id"] for record in final_records]
+    expected_ids = seed_ids + appended_ids
+
+    assert migrated_count >= len(seed_ids)
+    assert len(appended_ids) == appenders * records_per_appender
+    assert len(final_records) == len(expected_ids)
+    assert len(final_ids) == len(set(final_ids))
+    assert set(final_ids) == set(expected_ids)
+
+    final_digest = hashlib.sha256("\n".join(sorted(final_ids)).encode("utf-8")).hexdigest()
+    expected_digest = hashlib.sha256("\n".join(sorted(expected_ids)).encode("utf-8")).hexdigest()
+    assert final_digest == expected_digest
+
+    for record in final_records:
+        assert isinstance(record, dict)
+


### PR DESCRIPTION
OI-1370 systemic locking refactor PR N4 — FINAL. Migrates migrate_phase3_envelope (the original race site) + dispatch_register (the central writer) to scripts.lib.state_writer.append_locked(). After this PR all writer paths in the envelope/state file ecosystem share the same sentinel lock — the race is eliminated by construction. Closes OI-1370. Closes the deferred PR #466 and #475 attempts via the systemic refactor approach from OPUS plan PR #482.