### PR TITLE
feat(wave4.6): PR-4.6.1 — provider_dispatch.py entry-point (additive shim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Wave 1 (shadow-mode read cutover) + Wave 5 P0/P1 (smart-context smart injection) shipped on top of the v1.0.0-rc1 architectural baseline.
 
+### Added — Wave 4.6 provider dispatch generalization
+
+- **PR-4.6.1** `scripts/lib/provider_dispatch.py` — provider-agnostic dispatch entry-point (`--provider {claude,codex,gemini,litellm:<model>}`). Claude path delegates byte-identically to `subprocess_dispatch.deliver_with_recovery`; codex/gemini/litellm stubs exit 64 (EX_USAGE) with PR reference until spawn handlers land in PR-4.6.3/4.6.4/4.6.5. All existing `subprocess_dispatch.py` flags forwarded verbatim. No Anthropic SDK imported. See `claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.1`.
+
 ### Added — Wave 1 shadow-mode read cutover (#450–#454)
 - **PR-W1.1 (#450)** `scripts/lib/shadow_verifier.py` — independent comparator (no shared code with the migration) computing 6 zero-tolerance divergence metrics: wrong-project rows, scoping/blocking-finding mismatch, IntelligenceSelector top-3 divergence, count drift (0%) + checksum drift (<0.01%), lease-key collision count, p95-latency ratio (central ≤ 1.5× per-project).
 - **PR-W1.2 (#451)** `scripts/lib/shadow_logger.py` NDJSON writer + `scripts/shadow_report.py` CLI + `scripts/rotate_shadow_ledger.sh` timestamp-suffix rotation under flock; routes via `vnx_paths.resolve_paths()` (no `.vnx-data/state/` literals).

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6 PR-4.6.1).
+
+Routes dispatch execution to the appropriate provider spawn handler based on
+``--provider``.  In PR-4.6.1 only the ``claude`` provider is wired; all other
+providers raise NotImplementedError with exit code 64 (EX_USAGE) until their
+respective spawn handlers land in subsequent PRs.
+
+See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.1
+
+BILLING SAFETY: this module does NOT import the Anthropic SDK.  Claude dispatch
+delegates entirely to ``subprocess_dispatch.py`` which invokes ``claude -p`` via
+subprocess only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+_EX_USAGE = 64  # sysexits.h EX_USAGE
+
+# Providers whose spawn handlers exist in this PR.
+_IMPLEMENTED_PROVIDERS = {"claude"}
+
+# Mapping: provider literal -> which future PR delivers its handler.
+_FUTURE_PR_MAP = {
+    "codex": "PR-4.6.3",
+    "gemini": "PR-4.6.4",
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="VNX provider-agnostic dispatch entry (Wave 4.6)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--provider",
+        required=True,
+        help=(
+            "Provider to use for dispatch. "
+            "Accepted values: claude, codex, gemini, litellm:<model>. "
+            "Example: --provider claude, --provider litellm:deepseek-v4-pro"
+        ),
+    )
+    # Forward all existing subprocess_dispatch.py flags verbatim.
+    parser.add_argument("--terminal-id", required=True)
+    parser.add_argument("--dispatch-id", required=True)
+    parser.add_argument("--instruction", required=True)
+    parser.add_argument("--model", default="sonnet")
+    parser.add_argument("--role", default=None)
+    parser.add_argument("--max-retries", type=int, default=3)
+    parser.add_argument("--no-auto-commit", action="store_true")
+    parser.add_argument("--gate", default="")
+    parser.add_argument("--dispatch-paths", default="")
+    parser.add_argument("--pr-id", default=None)
+    return parser
+
+
+def _dispatch_claude(args: argparse.Namespace) -> int:
+    """Delegate to subprocess_dispatch.deliver_with_recovery (claude path).
+
+    Produces byte-identical NDJSON + receipt as direct subprocess_dispatch
+    invocation — the delegation preserves all argument semantics unchanged.
+    """
+    import subprocess_dispatch as sd
+
+    # OI-1107: fall back to Role: header in instruction, then to documented default.
+    role = args.role
+    if role is None:
+        role = sd._extract_role_from_instruction(args.instruction) or sd._ROLE_FALLBACK
+
+    dispatch_paths: list[str] | None = None
+    if args.dispatch_paths.strip():
+        dispatch_paths = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
+
+    ok = sd.deliver_with_recovery(
+        terminal_id=args.terminal_id,
+        instruction=args.instruction,
+        model=args.model,
+        dispatch_id=args.dispatch_id,
+        role=role,
+        max_retries=args.max_retries,
+        auto_commit=not args.no_auto_commit,
+        gate=args.gate,
+        dispatch_paths=dispatch_paths,
+        pr_id=args.pr_id,
+    )
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args, route to the correct provider handler, return exit code."""
+    parser = _build_parser()
+
+    # argparse exits with code 2 on unrecognised provider values — but provider
+    # is a free-form string (litellm:<model>), not a fixed choices= set, so we
+    # validate manually after parsing.
+    args = parser.parse_args(argv)
+
+    provider = args.provider
+
+    if provider == "claude":
+        return _dispatch_claude(args)
+
+    if provider == "codex":
+        future_pr = _FUTURE_PR_MAP["codex"]
+        print(
+            f"Provider 'codex' spawn handler lands in {future_pr}. "
+            "Use --provider claude for now.",
+            file=sys.stderr,
+        )
+        raise SystemExit(_EX_USAGE)
+
+    if provider == "gemini":
+        future_pr = _FUTURE_PR_MAP["gemini"]
+        print(
+            f"Provider 'gemini' spawn handler lands in {future_pr}. "
+            "Use --provider claude for now.",
+            file=sys.stderr,
+        )
+        raise SystemExit(_EX_USAGE)
+
+    if provider.startswith("litellm:"):
+        print(
+            f"Provider '{provider}' spawn handler lands in PR-4.6.5. "
+            "Use --provider claude for now.",
+            file=sys.stderr,
+        )
+        raise SystemExit(_EX_USAGE)
+
+    # Unknown literal — argparse-style error (exit code 2).
+    parser.error(
+        f"Unknown provider '{provider}'. "
+        "Accepted values: claude, codex, gemini, litellm:<model>."
+    )
+    return 2  # unreachable; parser.error() exits
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Wave 4.6 PR-4.6.1 — provider_dispatch.py entry-point tests.
+
+Covers:
+- Claude provider delegates to subprocess_dispatch with unchanged argv semantics.
+- Codex/Gemini/LiteLLM providers raise SystemExit(64) with PR reference in message.
+- Unknown provider triggers argparse error (SystemExit(2)).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import provider_dispatch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_claude_argv(**overrides) -> list[str]:
+    base = {
+        "--provider": "claude",
+        "--terminal-id": "T1",
+        "--dispatch-id": "test-pr461-smoke",
+        "--instruction": "noop",
+        "--model": "sonnet",
+    }
+    base.update(overrides)
+    argv = []
+    for k, v in base.items():
+        argv.extend([k, v])
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# Test: claude provider delegates to subprocess_dispatch
+# ---------------------------------------------------------------------------
+
+class TestProviderClaudeDelegatesToSubprocessDispatch:
+
+    def test_delegates_on_success(self):
+        """deliver_with_recovery is called and its return value gates exit code."""
+        mock_deliver = MagicMock(return_value=True)
+        mock_extract = MagicMock(return_value=None)
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", mock_extract):
+            result = provider_dispatch.main(_make_claude_argv())
+
+        assert result == 0
+        mock_deliver.assert_called_once()
+
+    def test_delegates_core_kwargs(self):
+        """terminal_id, dispatch_id, instruction forwarded to deliver_with_recovery."""
+        mock_deliver = MagicMock(return_value=True)
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            provider_dispatch.main(_make_claude_argv())
+
+        call_kwargs = mock_deliver.call_args[1]
+        assert call_kwargs["terminal_id"] == "T1"
+        assert call_kwargs["dispatch_id"] == "test-pr461-smoke"
+        assert call_kwargs["instruction"] == "noop"
+
+    def test_failed_deliver_returns_exit_code_1(self):
+        """When deliver_with_recovery returns False, main returns 1."""
+        with patch("subprocess_dispatch.deliver_with_recovery", return_value=False), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            result = provider_dispatch.main(_make_claude_argv())
+        assert result == 1
+
+    def test_no_auto_commit_forwarded(self):
+        """--no-auto-commit flips auto_commit=False in deliver_with_recovery."""
+        mock_deliver = MagicMock(return_value=True)
+        argv = _make_claude_argv() + ["--no-auto-commit"]
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            provider_dispatch.main(argv)
+
+        assert mock_deliver.call_args[1]["auto_commit"] is False
+
+    def test_role_extracted_from_instruction_when_absent(self):
+        """When --role is omitted, role is extracted from instruction body."""
+        mock_deliver = MagicMock(return_value=True)
+        argv = [
+            "--provider", "claude",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-role-extraction",
+            "--instruction", "Role: security-engineer\n\nDo the thing.",
+        ]
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver):
+            provider_dispatch.main(argv)
+
+        assert mock_deliver.call_args[1]["role"] == "security-engineer"
+
+    def test_explicit_role_not_overridden_by_instruction(self):
+        """--role flag takes precedence over Role: header in instruction."""
+        mock_deliver = MagicMock(return_value=True)
+        argv = [
+            "--provider", "claude",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-explicit-role",
+            "--instruction", "Role: backend-developer\n\nTask.",
+            "--role", "architect",
+        ]
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value="backend-developer"):
+            provider_dispatch.main(argv)
+
+        assert mock_deliver.call_args[1]["role"] == "architect"
+
+    def test_dispatch_paths_split_on_comma(self):
+        """--dispatch-paths is split into a list for deliver_with_recovery."""
+        mock_deliver = MagicMock(return_value=True)
+        argv = _make_claude_argv(**{"--dispatch-paths": "scripts/lib,tests"})
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            provider_dispatch.main(argv)
+
+        assert mock_deliver.call_args[1]["dispatch_paths"] == ["scripts/lib", "tests"]
+
+    def test_pr_id_forwarded(self):
+        """--pr-id is forwarded to deliver_with_recovery."""
+        mock_deliver = MagicMock(return_value=True)
+        argv = _make_claude_argv() + ["--pr-id", "488"]
+
+        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            provider_dispatch.main(argv)
+
+        assert mock_deliver.call_args[1]["pr_id"] == "488"
+
+
+# ---------------------------------------------------------------------------
+# Test: codex provider raises SystemExit(64) mentioning PR-4.6.3
+# ---------------------------------------------------------------------------
+
+class TestProviderCodexRaisesNotImplemented:
+
+    def test_exit_code_64(self, capsys):
+        argv = ["--provider", "codex", "--terminal-id", "T1",
+                "--dispatch-id", "test-codex", "--instruction", "noop"]
+        with pytest.raises(SystemExit) as exc_info:
+            provider_dispatch.main(argv)
+        assert exc_info.value.code == 64
+
+    def test_message_mentions_pr_4_6_3(self, capsys):
+        argv = ["--provider", "codex", "--terminal-id", "T1",
+                "--dispatch-id", "test-codex", "--instruction", "noop"]
+        with pytest.raises(SystemExit):
+            provider_dispatch.main(argv)
+        captured = capsys.readouterr()
+        assert "PR-4.6.3" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: gemini provider raises SystemExit(64) mentioning PR-4.6.4
+# ---------------------------------------------------------------------------
+
+class TestProviderGeminiRaisesNotImplemented:
+
+    def test_exit_code_64(self, capsys):
+        argv = ["--provider", "gemini", "--terminal-id", "T1",
+                "--dispatch-id", "test-gemini", "--instruction", "noop"]
+        with pytest.raises(SystemExit) as exc_info:
+            provider_dispatch.main(argv)
+        assert exc_info.value.code == 64
+
+    def test_message_mentions_pr_4_6_4(self, capsys):
+        argv = ["--provider", "gemini", "--terminal-id", "T1",
+                "--dispatch-id", "test-gemini", "--instruction", "noop"]
+        with pytest.raises(SystemExit):
+            provider_dispatch.main(argv)
+        captured = capsys.readouterr()
+        assert "PR-4.6.4" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: litellm:<model> raises SystemExit(64) mentioning PR-4.6.5
+# ---------------------------------------------------------------------------
+
+class TestProviderLitellmRaisesNotImplemented:
+
+    def test_exit_code_64(self, capsys):
+        argv = ["--provider", "litellm:deepseek-v4-pro", "--terminal-id", "T1",
+                "--dispatch-id", "test-litellm", "--instruction", "noop"]
+        with pytest.raises(SystemExit) as exc_info:
+            provider_dispatch.main(argv)
+        assert exc_info.value.code == 64
+
+    def test_message_mentions_pr_4_6_5(self, capsys):
+        argv = ["--provider", "litellm:deepseek-v4-pro", "--terminal-id", "T1",
+                "--dispatch-id", "test-litellm", "--instruction", "noop"]
+        with pytest.raises(SystemExit):
+            provider_dispatch.main(argv)
+        captured = capsys.readouterr()
+        assert "PR-4.6.5" in captured.err
+
+    def test_various_litellm_models(self, capsys):
+        for model in ("litellm:kimi-k2", "litellm:glm-5.1", "litellm:groq:llama3"):
+            argv = ["--provider", model, "--terminal-id", "T1",
+                    "--dispatch-id", "test-litellm", "--instruction", "noop"]
+            with pytest.raises(SystemExit) as exc_info:
+                provider_dispatch.main(argv)
+            assert exc_info.value.code == 64, f"Expected exit 64 for {model}"
+
+
+# ---------------------------------------------------------------------------
+# Test: unknown provider triggers argparse error (exit code 2)
+# ---------------------------------------------------------------------------
+
+class TestProviderUnknownArgparseError:
+
+    def test_exit_code_2(self):
+        argv = ["--provider", "foo", "--terminal-id", "T1",
+                "--dispatch-id", "test-unknown", "--instruction", "noop"]
+        with pytest.raises(SystemExit) as exc_info:
+            provider_dispatch.main(argv)
+        assert exc_info.value.code == 2
+
+    def test_error_message_mentions_provider(self, capsys):
+        argv = ["--provider", "foo", "--terminal-id", "T1",
+                "--dispatch-id", "test-unknown", "--instruction", "noop"]
+        with pytest.raises(SystemExit):
+            provider_dispatch.main(argv)
+        captured = capsys.readouterr()
+        assert "foo" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: importability
+# ---------------------------------------------------------------------------
+
+class TestModuleImportability:
+
+    def test_import_does_not_error(self):
+        import importlib
+        mod = importlib.import_module("provider_dispatch")
+        assert mod.__name__ == "provider_dispatch"
+
+    def test_no_optional_provider_imports_at_module_load(self):
+        """codex/gemini/litellm spawn modules must not be imported at module load."""
+        import sys
+        # Ensure none of the not-yet-existing provider spawn modules are loaded.
+        for mod_name in list(sys.modules.keys()):
+            assert "codex_spawn" not in mod_name, f"codex_spawn imported at module load: {mod_name}"
+            assert "gemini_spawn" not in mod_name, f"gemini_spawn imported at module load: {mod_name}"
+            assert "litellm_spawn" not in mod_name, f"litellm_spawn imported at module load: {mod_name}"


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/provider_dispatch.py` — provider-agnostic dispatch entry accepting `--provider {claude,codex,gemini,litellm:<model>}`.
- `--provider claude` delegates byte-identically to `subprocess_dispatch.deliver_with_recovery`; all existing flags forwarded verbatim.
- `--provider codex/gemini/litellm:*` exit 64 (EX_USAGE) with message referencing the PR that will land the spawn handler (PR-4.6.3 / PR-4.6.4 / PR-4.6.5).
- Unknown provider literal triggers argparse error (exit 2).
- Zero changes to `subprocess_dispatch.py` or `subprocess_dispatch_internals/`.

See: `claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.1`

## Test plan

- [ ] `python3 -m pytest tests/test_provider_dispatch_entry.py -v` — 19 tests, all green
- [ ] `python3 -c "from scripts.lib import provider_dispatch; print(provider_dispatch.__name__)"` — imports cleanly
- [ ] `python3 -m py_compile scripts/lib/provider_dispatch.py` — syntax clean
- [ ] No changes to `subprocess_dispatch.py` (confirmed via `git diff main -- scripts/lib/subprocess_dispatch.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)