### PR TITLE
chore(hardening): narrow silent-except in intelligence_selector.py (10 findings, OI-1437)

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -571,8 +571,8 @@ class IntelligenceSelector:
             return
         try:
             maybe_reconcile(self._quality_db_path)
-        except Exception:
-            pass
+        except (sqlite3.Error, OSError) as e:
+            logger.debug("Reconciliation step skipped: %s", e)
 
     def _get_central_qi_conn(self) -> Optional[sqlite3.Connection]:
         """Open a fresh independent connection to the central quality_intelligence.db.
@@ -1012,8 +1012,8 @@ class IntelligenceSelector:
                         ),
                     )
                 conn.commit()
-        except Exception:
-            pass
+        except sqlite3.Error as e:
+            logger.warning("Failed to record injection audit: %s", e)
 
         # Write per-item pattern_usage rows so feedback loop can query by dispatch_id
         if result.items and self._quality_db_path is not None and self._quality_db_path.exists():
@@ -1023,8 +1023,8 @@ class IntelligenceSelector:
         # safe when _record_pattern_usage already did a partial stamp internally.
         try:
             self.stamp_source_dispatch_ids(result)
-        except Exception:
-            pass
+        except (sqlite3.Error, OSError) as e:
+            logger.debug("Failed to stamp source_dispatch_ids: %s", e)
 
     def _record_pattern_usage(self, result: InjectionResult) -> None:
         """Write one pattern_usage row per injected item so feedback can find them later.
@@ -1148,8 +1148,8 @@ class IntelligenceSelector:
                     )
                 self._stamp_source_dispatch_id(db, item, result.dispatch_id)
             db.commit()
-        except Exception:
-            pass
+        except sqlite3.Error as e:
+            logger.warning("Failed to record pattern usage: %s", e)
 
     def stamp_source_dispatch_ids(self, result: InjectionResult) -> int:
         """Public injection-time stamping helper (Phase 1.5 PR-2 / OI-1315).
@@ -1860,8 +1860,8 @@ class IntelligenceSelector:
                     pattern_category=pattern_category,
                     content_hash=_content_hash(title, content),
                 ))
-        except Exception:
-            pass
+        except sqlite3.Error as e:
+            logger.debug("Central proven-patterns query failed: %s", e)
         finally:
             conn.close()
         return items
@@ -1942,8 +1942,8 @@ class IntelligenceSelector:
                     pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
                     content_hash=_content_hash(ap_title, content),
                 ))
-        except Exception:
-            pass
+        except sqlite3.Error as e:
+            logger.debug("Central failure-prevention query failed: %s", e)
         finally:
             conn.close()
         return items
@@ -2020,8 +2020,8 @@ class IntelligenceSelector:
                     pattern_category=PATTERN_CATEGORY_PROCESS,
                     content_hash=_content_hash(dm_title, content),
                 ))
-        except Exception:
-            pass
+        except sqlite3.Error as e:
+            logger.debug("Central recent-comparable query failed: %s", e)
         finally:
             conn.close()
         return items
@@ -2061,8 +2061,8 @@ class IntelligenceSelector:
                         cmp, project_id,
                         "IntelligenceSelector._query_proven_patterns",
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Shadow compare (proven_patterns) skipped: %s", e)
         return legacy
 
     def _query_failure_prevention(
@@ -2096,8 +2096,8 @@ class IntelligenceSelector:
                         cmp, project_id,
                         "IntelligenceSelector._query_failure_prevention",
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Shadow compare (failure_prevention) skipped: %s", e)
         return legacy
 
     def _query_recent_comparable(
@@ -2132,8 +2132,8 @@ class IntelligenceSelector:
                         cmp, project_id,
                         "IntelligenceSelector._query_recent_comparable",
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Shadow compare (recent_comparable) skipped: %s", e)
         return legacy
 
     # ------------------------------------------------------------------

--- a/tests/test_intelligence_selector_exception_handling.py
+++ b/tests/test_intelligence_selector_exception_handling.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Regression tests for exception-handling hardening in intelligence_selector.py (OI-1437).
+
+Covers the 10 silent-except sites narrowed in the cleanup PR: every broad
+``except Exception: pass`` is now narrowed and logged. These tests verify
+that (a) the selector runs cleanly in a default env, and (b) DB errors surface
+as log messages instead of being swallowed silently.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_selector import (
+    IntelligenceItem,
+    IntelligenceSelector,
+    InjectionResult,
+)
+
+
+def _make_selector(tmp: str) -> IntelligenceSelector:
+    state_dir = Path(tmp) / "coord"
+    state_dir.mkdir(exist_ok=True)
+    quality_db = Path(tmp) / "quality.db"
+    return IntelligenceSelector(
+        quality_db_path=quality_db,
+        coord_db_state_dir=state_dir,
+    )
+
+
+def _make_item(item_id: str = "test-item") -> IntelligenceItem:
+    return IntelligenceItem(
+        item_id=item_id,
+        item_class="proven_pattern",
+        title="Test pattern",
+        content="Test content",
+        confidence=0.8,
+        evidence_count=3,
+        last_seen="2026-01-01T00:00:00",
+        scope_tags=["test"],
+        task_class_filter=[],
+    )
+
+
+def _make_result(dispatch_id: str = "test-dispatch-001") -> InjectionResult:
+    return InjectionResult(
+        dispatch_id=dispatch_id,
+        injection_point="dispatch_create",
+        injected_at="2026-05-14T00:00:00Z",
+        task_class="backend-developer",
+        items=[_make_item()],
+        suppressed=[],
+    )
+
+
+class TestRunsCleanInDefaultEnv(unittest.TestCase):
+    """Selector constructs and select() runs without unhandled exceptions."""
+
+    def test_construct_selector_no_exception(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            self.assertIsNotNone(sel)
+
+    def test_select_returns_result_without_db(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            result = sel.select(
+                dispatch_id="clean-env-test",
+                injection_point="dispatch_create",
+                task_class="backend-developer",
+                scope_tags=[],
+            )
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result.items, list)
+
+
+class TestCorruptStateLogsWarning(unittest.TestCase):
+    """record_injection with a broken DB logs a warning instead of crashing."""
+
+    def test_corrupt_db_logs_warning(self) -> None:
+        """sqlite3.Error during injection audit write surfaces as log.warning."""
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            result = _make_result()
+
+            # Patch runtime_coordination.get_connection to raise sqlite3.Error
+            import runtime_coordination as _rc
+            with (
+                patch.object(_rc, "get_connection", side_effect=sqlite3.OperationalError("db locked")),
+                self.assertLogs("intelligence_selector", level="WARNING") as cm,
+            ):
+                sel.record_injection(result)
+
+            logged = "\n".join(cm.output)
+            self.assertIn("Failed to record injection audit", logged)
+
+    def test_stamp_source_ids_db_error_logs_debug(self) -> None:
+        """sqlite3.Error in stamp_source_dispatch_ids is caught and logged at DEBUG."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _noop_conn(_state_dir):
+            conn = MagicMock(spec=sqlite3.Connection)
+            conn.execute.return_value = MagicMock()
+            conn.commit.return_value = None
+            yield conn
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            result = _make_result()
+
+            import runtime_coordination as _rc
+            with (
+                patch.object(_rc, "get_connection", side_effect=_noop_conn),
+                patch.object(sel, "stamp_source_dispatch_ids", side_effect=sqlite3.OperationalError("locked")),
+                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
+            ):
+                sel.record_injection(result)
+
+            logged = "\n".join(cm.output)
+            self.assertIn("source_dispatch_ids", logged)
+
+
+class TestCentralDbQueryExceptionSilenced(unittest.TestCase):
+    """Central DB query methods catch sqlite3.Error and return empty list."""
+
+    def _broken_conn(self) -> MagicMock:
+        conn = MagicMock(spec=sqlite3.Connection)
+        conn.execute.side_effect = sqlite3.OperationalError("no such table: success_patterns")
+        conn.close = MagicMock()
+        return conn
+
+    def test_proven_patterns_central_db_error_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
+                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
+                    items = sel._query_proven_patterns_central("backend-developer", [])
+            self.assertEqual(items, [])
+            self.assertTrue(any("proven-patterns" in line for line in cm.output))
+
+    def test_failure_prevention_central_db_error_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
+                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
+                    items = sel._query_failure_prevention_central("backend-developer", [])
+            self.assertEqual(items, [])
+            self.assertTrue(any("failure-prevention" in line for line in cm.output))
+
+    def test_recent_comparable_central_db_error_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
+                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
+                    items = sel._query_recent_comparable_central("backend-developer", [])
+            self.assertEqual(items, [])
+            self.assertTrue(any("recent-comparable" in line for line in cm.output))
+
+
+class TestShadowVerifierExceptionSilenced(unittest.TestCase):
+    """Shadow compare exceptions are caught and logged at DEBUG, not raised."""
+
+    def test_shadow_proven_patterns_exception_logged(self) -> None:
+        import intelligence_selector as _mod
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            broken_verifier = MagicMock()
+            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+            quality_db = sqlite3.connect(":memory:")
+            with (
+                patch.object(_mod, "_shadow_verifier", broken_verifier),
+                patch.object(sel, "_query_proven_patterns_per_project", return_value=[]),
+                patch.object(sel, "_query_proven_patterns_central", return_value=[]),
+                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
+            ):
+                result = sel._query_proven_patterns(quality_db, "backend-developer", [])
+            self.assertEqual(result, [])
+            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+
+    def test_shadow_failure_prevention_exception_logged(self) -> None:
+        import intelligence_selector as _mod
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            broken_verifier = MagicMock()
+            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+            quality_db = sqlite3.connect(":memory:")
+            with (
+                patch.object(_mod, "_shadow_verifier", broken_verifier),
+                patch.object(sel, "_query_failure_prevention_per_project", return_value=[]),
+                patch.object(sel, "_query_failure_prevention_central", return_value=[]),
+                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
+            ):
+                result = sel._query_failure_prevention(quality_db, "backend-developer", [])
+            self.assertEqual(result, [])
+            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+
+    def test_shadow_recent_comparable_exception_logged(self) -> None:
+        import intelligence_selector as _mod
+        with tempfile.TemporaryDirectory() as tmp:
+            sel = _make_selector(tmp)
+            broken_verifier = MagicMock()
+            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+            quality_db = sqlite3.connect(":memory:")
+            with (
+                patch.object(_mod, "_shadow_verifier", broken_verifier),
+                patch.object(sel, "_query_recent_comparable_per_project", return_value=[]),
+                patch.object(sel, "_query_recent_comparable_central", return_value=[]),
+                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
+            ):
+                result = sel._query_recent_comparable(quality_db, "backend-developer", [])
+            self.assertEqual(result, [])
+            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Pure hardening pass on `scripts/lib/intelligence_selector.py` — same pattern as merged PR #491 (`build_t0_state.py`). All 10 broad `except Exception: pass` sites narrowed to specific exception types with logging. No behavior change to produced intelligence output.

## Per-line table

| Line | Exception narrowed to | Action |
|------|----------------------|--------|
| 574 | `(sqlite3.Error, OSError)` | `log.debug` — best-effort reconciliation skip |
| 1015 | `sqlite3.Error` | `log.warning` — injection audit write failure |
| 1026 | `(sqlite3.Error, OSError)` | `log.debug` — stamp source dispatch IDs failure |
| 1151 | `sqlite3.Error` | `log.warning` — pattern usage record failure |
| 1863 | `sqlite3.Error` | `log.debug` — central proven-patterns query failure |
| 1945 | `sqlite3.Error` | `log.debug` — central failure-prevention query failure |
| 2023 | `sqlite3.Error` | `log.debug` — central recent-comparable query failure |
| 2064 | `Exception` | `log.debug` — shadow verifier compare (proven_patterns), external module boundary |
| 2099 | `Exception` | `log.debug` — shadow verifier compare (failure_prevention), external module boundary |
| 2135 | `Exception` | `log.debug` — shadow verifier compare (recent_comparable), external module boundary |

Lines 2064/2099/2135 keep broad `Exception` because they guard calls into external shadow verifier modules where the full exception surface is not controlled — but now log at DEBUG instead of swallowing silently.

## Tests

New: `tests/test_intelligence_selector_exception_handling.py` — 10 tests covering:
- Clean construction + select without DB (`test_runs_clean_in_default_env`)
- `record_injection` with broken coord DB logs WARNING (`test_corrupt_db_logs_warning`)
- `stamp_source_dispatch_ids` error logs DEBUG
- All 3 central DB query methods return empty list and log DEBUG on `sqlite3.Error`
- All 3 shadow verifier compare paths log DEBUG on raised exceptions

Pre-existing failures in `test_intelligence_selector.py` (2 tests, `adr_indexer._INDEX` AttributeError) are unrelated to this PR and were present on `main` before this branch.

## References

- Closes OI-1437 (partial — this PR covers `intelligence_selector.py`)
- Pattern established by #491 (`build_t0_state.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)