### PR TITLE
chore(hardening): narrow silent-except in api_intelligence.py (6 findings, OI-1437)

### DIFF
--- a/dashboard/api_intelligence.py
+++ b/dashboard/api_intelligence.py
@@ -127,8 +127,8 @@ def _shadow_write_cmp(cmp: object, project_id: str, read_site: str) -> None:
     if _shadow_logger is not None and getattr(cmp, "divergences", None):
         try:
             _shadow_logger.write_comparison_result(cmp, project_id, read_site)  # type: ignore[union-attr]
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.debug("shadow_write_cmp failed at %s: %s", read_site, e)
 
 
 def _open_qi_ro(db_path: Path) -> "sqlite3.Connection":
@@ -296,8 +296,8 @@ def _intelligence_get_patterns(params: dict) -> dict:
                 table="antipatterns",
             )
             _shadow_write_cmp(cmp, project_id, "dashboard.api.intelligence_patterns.antipatterns")
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.debug("shadow verification failed for patterns: %s", e)
 
     return {"success_patterns": legacy_sp, "antipatterns": legacy_ap}
 
@@ -346,8 +346,8 @@ def _intelligence_get_injections(params: dict) -> dict:
             # Table may not exist yet
             pass
         con.close()
-    except Exception:
-        pass
+    except sqlite3.Error as e:
+        _logger.warning("Failed to query coordination_events from %s: %s", db_path, e)
 
     return {"injections": injections}
 
@@ -770,8 +770,8 @@ def _intelligence_get_confidence_trends(params: dict) -> dict:
                 table="antipatterns",
             )
             _shadow_write_cmp(cmp, project_id, "dashboard.api.confidence_trends.antipatterns")
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.debug("shadow verification failed for confidence_trends: %s", e)
 
     return {"trends": _aggregate_trends(legacy_sp_rows, legacy_ap_rows)}
 
@@ -983,8 +983,8 @@ def _intelligence_get_learning_summary() -> tuple[dict, int]:
                 sql_template=_LEARNING_ANTI_COUNT_SQL,
             )
             _shadow_write_cmp(cmp, project_id, "dashboard.api.learning_summary.antipatterns_count")
-        except Exception:
-            pass
+        except Exception as e:
+            _logger.debug("shadow verification failed for learning_summary: %s", e)
 
     return _compute_learning_metrics(legacy_events, legacy_prev), 200
 
@@ -1284,7 +1284,7 @@ def _dispatch_get_events(dispatch_id: str) -> tuple[dict, int]:
                 if first_ts is None:
                     first_ts = ts_val
                 ts_offset = round(ts_val - first_ts, 1)
-            except Exception:
+            except ValueError:
                 pass
 
         if ev_type == "tool_use":

--- a/tests/test_api_intelligence_exception_handling.py
+++ b/tests/test_api_intelligence_exception_handling.py
@@ -1,0 +1,90 @@
+"""Regression tests for OI-1437 exception-narrowing in api_intelligence.py.
+
+Verifies that narrowed except clauses (PR-5 of the hardening series):
+- Return graceful defaults on missing state files (not silent crashes)
+- Log a warning when a DB file is corrupt (sqlite3.Error path, line ~349)
+
+Reference: chore(hardening) PR-5, merged PRs #491-#493.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+import api_intelligence
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sd(tmp_path: Path, db_path: Path | None = None) -> types.SimpleNamespace:
+    sd = types.SimpleNamespace()
+    sd.DB_PATH = db_path if db_path is not None else (tmp_path / "missing.db")
+    sd.REPORTS_DIR = tmp_path / "unified_reports"
+    sd.RECEIPTS_PATH = tmp_path / "t0_receipts.ndjson"
+    sd.DISPATCHES_DIR = tmp_path / "dispatches"
+    sd.VNX_DATA_DIR = tmp_path
+    return sd
+
+
+# ---------------------------------------------------------------------------
+# test_endpoint_handles_missing_state_file
+# ---------------------------------------------------------------------------
+
+def test_endpoint_handles_missing_state_file(tmp_path: Path) -> None:
+    """_intelligence_get_injections returns an empty list when DB_PATH is absent.
+
+    Ensures the endpoint produces a graceful default (not a 500 or an uncaught
+    exception) when the state file does not exist yet.
+    """
+    sd = _make_sd(tmp_path)  # db_path defaults to non-existent path
+    assert not sd.DB_PATH.exists(), "precondition: DB must not exist"
+
+    with patch.object(api_intelligence, "_sd", return_value=sd):
+        result = api_intelligence._intelligence_get_injections({})
+
+    assert result == {"injections": []}, (
+        f"expected graceful empty response, got {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_endpoint_logs_corrupt_json (DB-level corruption → sqlite3.Error warning)
+# ---------------------------------------------------------------------------
+
+def test_endpoint_logs_corrupt_json(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """_intelligence_get_injections logs a warning when DB file is corrupt.
+
+    A file filled with non-SQLite bytes triggers sqlite3.DatabaseError (a
+    subclass of sqlite3.Error). The narrowed except clause at line ~349 must
+    log at WARNING level and return an empty list rather than swallowing
+    silently.
+    """
+    corrupt_db = tmp_path / "corrupt.db"
+    corrupt_db.write_bytes(b"not a sqlite3 database -- garbage content\xff\xfe")
+
+    sd = _make_sd(tmp_path, db_path=corrupt_db)
+
+    with caplog.at_level(logging.WARNING, logger="api_intelligence"):
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_injections({})
+
+    assert result == {"injections": []}, (
+        f"expected graceful empty response on corrupt DB, got {result!r}"
+    )
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("coordination_events" in m for m in warning_msgs), (
+        f"expected a warning mentioning 'coordination_events', got: {warning_msgs!r}"
+    )


### PR DESCRIPTION
## Summary

Narrows 6 silent `except Exception: pass` blocks in `dashboard/api_intelligence.py` as part of the OI-1437 hardening series (same pattern as merged PRs #491, #492, #493).

## Per-line table

| Line | Site | Exception narrowed to | Action |
|------|------|-----------------------|--------|
| 130 | `_shadow_write_cmp` – shadow NDJSON write | `Exception as e` | `log.debug` (best-effort shadow write; external module) |
| 299 | `_intelligence_get_patterns` – shadow verify block | `Exception as e` | `log.debug` (shadow verifier; non-load-bearing) |
| 349 | `_intelligence_get_injections` – DB open/query | `sqlite3.Error as e` | `log.warning` + return empty list |
| 773 | `_intelligence_get_confidence_trends` – shadow verify block | `Exception as e` | `log.debug` (shadow verifier; non-load-bearing) |
| 986 | `_intelligence_get_learning_summary` – shadow verify block | `Exception as e` | `log.debug` (shadow verifier; non-load-bearing) |
| 1287 | `_dispatch_get_events` – ISO timestamp parse | `ValueError` | silent skip (optional offset enrichment) |

No behavior changes. Shadow verification blocks remain best-effort; the injections endpoint now surfaces DB errors at WARNING level instead of dropping them silently.

## New tests (`tests/test_api_intelligence_exception_handling.py`)

- `test_endpoint_handles_missing_state_file` — `_intelligence_get_injections` returns `{"injections": []}` when `DB_PATH` is absent
- `test_endpoint_logs_corrupt_json` — corrupt non-SQLite file at `DB_PATH` triggers `sqlite3.Error`, logs a WARNING mentioning `coordination_events`, returns empty list

## Pre-existing failures

`test_api_intelligence.py::TestPatternsEndpoint::test_returns_success_patterns` and `test_returns_antipatterns` fail on main before this PR (verified). Not introduced here.

## References

- OI-1437 silent-except backlog
- Merged pattern: #491 (`build_t0_state.py`), #492 (`intelligence_selector.py`), #493 (`gather_intelligence.py`)