### PR TITLE
chore(hardening): narrow silent-except in append_receipt payload.py (5 findings, OI-1437)

### DIFF
--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -28,6 +28,9 @@ from .idempotency import (
 )
 from .validation import _validate_receipt
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def _maybe_reroute_to_gate_stream(receipt: Dict[str, Any], receipts_file: Optional[str]) -> Optional[str]:
     """Route ghost gate receipts (dispatch_id="unknown" + gate event) to gate_events.ndjson."""
@@ -70,12 +73,12 @@ def _run_post_append_hooks(receipt: Dict[str, Any]) -> None:
         _emit("WARN", "dispatch_register_post_hook_failed", error=str(exc))
     try:
         facade._maybe_trigger_state_rebuild(receipt)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("payload: state rebuild hook failed: %s", exc)
     try:
         facade._trigger_receipt_classifier(receipt)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("payload: receipt classifier hook failed: %s", exc)
 
 
 def _stamp_observability_tier(receipt: Dict[str, Any]) -> None:
@@ -97,10 +100,13 @@ def _stamp_observability_tier(receipt: Dict[str, Any]) -> None:
     try:
         sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
         from observability_tier import resolve_effective_tier
+    except ImportError:
+        return
+    try:
         tier = resolve_effective_tier(provider)
         receipt["observability_tier"] = tier
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("payload: failed to resolve observability tier for provider %r: %s", provider, exc)
 
 
 def resolve_central_data_dir(project_id: str) -> Path:
@@ -176,8 +182,8 @@ def _mirror_receipt_to_central(receipt: Dict[str, Any], primary_path: Path) -> N
         return
     try:
         _mirror_receipt_to_central_or_raise(receipt, primary_path)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("payload: central mirror failed for project %r: %s", project_id, exc)
 
 
 def _load_pending_mirrors(queue_path: Path) -> List[Dict[str, Any]]:
@@ -440,6 +446,9 @@ def _maybe_trigger_state_rebuild(receipt: Dict[str, Any]) -> None:
     try:
         sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
         from state_rebuild_trigger import maybe_trigger_state_rebuild
+    except ImportError:
+        return
+    try:
         maybe_trigger_state_rebuild(event_type=event_type)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("payload: state rebuild trigger failed for event %r: %s", event_type, exc)

--- a/tests/test_payload_exception_handling.py
+++ b/tests/test_payload_exception_handling.py
@@ -1,0 +1,186 @@
+"""Regression tests: silent-except hardening in append_receipt_internals/payload.py (OI-1437).
+
+Covers the 5 findings narrowed in chore/cleanup-payload-silent-except:
+1. _run_post_append_hooks: state rebuild hook — logs warning, does not raise
+2. _run_post_append_hooks: classifier hook — logs warning, does not raise
+3. _stamp_observability_tier: resolve failure — logs warning, does not raise
+4. _mirror_receipt_to_central: mirror failure — logs warning, does not raise
+5. _maybe_trigger_state_rebuild: trigger failure — logs warning, does not raise
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import append_receipt_internals.payload as payload_mod
+from append_receipt_internals.common import register_facade, _facade_modules
+
+
+def _make_receipt(dispatch_id: str = "d-test", project_id: str = "proj-x") -> dict:
+    return {
+        "dispatch_id": dispatch_id,
+        "project_id": project_id,
+        "event_type": "task_complete",
+        "status": "success",
+        "terminal": "T1",
+    }
+
+
+@pytest.fixture
+def stub_facade():
+    """Register a stub facade module with MagicMock hooks; clean up after test.
+
+    _FacadeProxy prefers Mock-typed values over real ones, so these mocks
+    take precedence over any previously-registered real facade module.
+    """
+    mod = types.ModuleType("_test_payload_stub")
+    mod._register_quality_open_items = MagicMock()
+    mod._update_confidence_from_receipt = MagicMock()
+    mod._emit_dispatch_register = MagicMock()
+    mod._maybe_trigger_state_rebuild = MagicMock()
+    mod._trigger_receipt_classifier = MagicMock()
+    register_facade(mod)
+    yield mod
+    if mod in _facade_modules:
+        _facade_modules.remove(mod)
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 + 2 — _run_post_append_hooks: state-rebuild and classifier
+# ---------------------------------------------------------------------------
+
+def test_runs_clean_with_valid_payload(stub_facade, caplog):
+    """Baseline: _run_post_append_hooks succeeds when hooks behave normally."""
+    receipt = _make_receipt()
+    with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+        payload_mod._run_post_append_hooks(receipt)
+    assert not caplog.records, "No warnings expected on clean run"
+
+
+def test_state_rebuild_hook_failure_logs_warning(stub_facade, caplog):
+    """Finding 1: state rebuild hook failure logs warning, never silently swallows."""
+    stub_facade._maybe_trigger_state_rebuild.side_effect = RuntimeError("state rebuild exploded")
+    receipt = _make_receipt()
+    with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+        payload_mod._run_post_append_hooks(receipt)
+    assert any("state rebuild hook failed" in r.message for r in caplog.records), (
+        "Expected 'state rebuild hook failed' warning; got: " + str([r.message for r in caplog.records])
+    )
+
+
+def test_classifier_hook_failure_logs_warning(stub_facade, caplog):
+    """Finding 2: classifier hook failure logs warning, never silently swallows."""
+    stub_facade._trigger_receipt_classifier.side_effect = ValueError("classifier crashed")
+    receipt = _make_receipt()
+    with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+        payload_mod._run_post_append_hooks(receipt)
+    assert any("receipt classifier hook failed" in r.message for r in caplog.records), (
+        "Expected 'receipt classifier hook failed' warning; got: " + str([r.message for r in caplog.records])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — _stamp_observability_tier: resolve failure
+# ---------------------------------------------------------------------------
+
+def test_stamp_observability_tier_import_error_is_silent(caplog):
+    """Finding 3 (import path): ImportError → silent return, no warning expected."""
+    receipt = {"provider": "some-provider"}
+
+    with patch.dict("sys.modules", {"observability_tier": None}):
+        with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+            payload_mod._stamp_observability_tier(receipt)
+
+    assert "observability_tier" not in receipt
+    assert not caplog.records, "ImportError path must not log (expected miss)"
+
+
+def test_stamp_observability_tier_resolve_failure_logs_warning(caplog):
+    """Finding 3 (resolve path): resolve_effective_tier exception → logs warning."""
+    receipt = {"provider": "bad-provider"}
+
+    fake_module = MagicMock()
+    fake_module.resolve_effective_tier.side_effect = ValueError("unknown provider")
+
+    with patch.dict("sys.modules", {"observability_tier": fake_module}):
+        with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+            payload_mod._stamp_observability_tier(receipt)
+
+    assert "observability_tier" not in receipt
+    assert any("failed to resolve observability tier" in r.message for r in caplog.records), (
+        "Expected observability tier warning; got: " + str([r.message for r in caplog.records])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — _mirror_receipt_to_central: corrupt prior-receipt state
+# ---------------------------------------------------------------------------
+
+def test_corrupt_prior_state_logs_warning(tmp_path, caplog):
+    """Finding 4: _mirror_receipt_to_central failure logs warning, does not raise."""
+    receipt = _make_receipt(project_id="proj-warn")
+    primary_path = tmp_path / "receipts.ndjson"
+
+    with patch.object(payload_mod, "_mirror_receipt_to_central_or_raise",
+                      side_effect=OSError("central disk full")), \
+         patch.object(payload_mod, "resolve_central_data_dir",
+                      return_value=tmp_path / "central"):
+        with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+            payload_mod._mirror_receipt_to_central(receipt, primary_path)
+
+    assert any("central mirror failed" in r.message for r in caplog.records), (
+        "Expected 'central mirror failed' warning; got: " + str([r.message for r in caplog.records])
+    )
+
+
+def test_mirror_receipt_to_central_never_raises(tmp_path):
+    """Finding 4: _mirror_receipt_to_central must never raise regardless of error."""
+    receipt = _make_receipt(project_id="proj-safe")
+    primary_path = tmp_path / "receipts.ndjson"
+
+    with patch.object(payload_mod, "_mirror_receipt_to_central_or_raise",
+                      side_effect=Exception("catastrophic failure")):
+        payload_mod._mirror_receipt_to_central(receipt, primary_path)
+
+
+# ---------------------------------------------------------------------------
+# Finding 5 — _maybe_trigger_state_rebuild: trigger failure
+# ---------------------------------------------------------------------------
+
+def test_state_rebuild_trigger_failure_logs_warning(caplog):
+    """Finding 5: maybe_trigger_state_rebuild exception → logs warning, does not raise."""
+    receipt = _make_receipt()
+    receipt["event_type"] = "task_complete"
+
+    fake_module = MagicMock()
+    fake_module.maybe_trigger_state_rebuild.side_effect = RuntimeError("rebuild service down")
+
+    with patch.dict("sys.modules", {"state_rebuild_trigger": fake_module}):
+        with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+            payload_mod._maybe_trigger_state_rebuild(receipt)
+
+    assert any("state rebuild trigger failed" in r.message for r in caplog.records), (
+        "Expected 'state rebuild trigger failed' warning; got: " + str([r.message for r in caplog.records])
+    )
+
+
+def test_state_rebuild_trigger_import_error_is_silent(caplog):
+    """Finding 5 (import path): ImportError → silent return, no warning expected."""
+    receipt = _make_receipt()
+    receipt["event_type"] = "task_complete"
+
+    with patch.dict("sys.modules", {"state_rebuild_trigger": None}):
+        with caplog.at_level(logging.WARNING, logger="append_receipt_internals.payload"):
+            payload_mod._maybe_trigger_state_rebuild(receipt)
+
+    assert not caplog.records, "ImportError path must not log (expected miss)"


### PR DESCRIPTION
## Summary

Receipt hot path hardening — pure narrowing + logging, no behavior changes.

`payload.py` is on every receipt write path. Silent excepts here mean missing
NDJSON lines with no trace, which creates undetectable governance evidence gaps.
All 5 sites now emit `log.warning` so failures surface without blocking the writer.

Chose `log.warning` over `log.debug` because this is a hot path: any exception
during receipt emission is a signal worth seeing in logs.

## Per-line table

| Line (before) | Site | Change |
|---|---|---|
| 73 | `_run_post_append_hooks` → `_maybe_trigger_state_rebuild` | `except Exception: pass` → `except Exception as exc: log.warning(...)` |
| 77 | `_run_post_append_hooks` → `_trigger_receipt_classifier` | `except Exception: pass` → `except Exception as exc: log.warning(...)` |
| 97-103 | `_stamp_observability_tier` import + resolve | Split into `except ImportError: return` + `except Exception as exc: log.warning(...)` |
| 179 | `_mirror_receipt_to_central` | `except Exception: pass` → `except Exception as exc: log.warning(...)` |
| 444 | `_maybe_trigger_state_rebuild` trigger | Split into `except ImportError: return` + `except Exception as exc: log.warning(...)` |

## Test plan

- [x] `python3 scripts/ci_lint_patterns.py | grep "payload.py"` returns nothing
- [x] 105 pre-existing append_receipt tests pass (no regressions)
- [x] 9 new tests in `tests/test_payload_exception_handling.py` — one per finding + negative paths
- [x] New tests verify: warning logged on hook failure, ImportError silently returns, mirror failure logs, trigger failure logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)