### PR TITLE
docs(adr-003): clarify API-key + CLI permitted; SDK still banned

### DIFF
--- a/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
+++ b/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
@@ -68,6 +68,22 @@ VNX's value proposition depends on a Claude credential model the operator alread
 - A CI gate against `import anthropic` / `import claude_agent_sdk` is required before this ADR can be considered fully enforced. Tracked as a Wave 0 task in the strategic replan.
 - Future SDK feature parity (e.g. Anthropic ships a new prompt-cache control surface) is implemented over the CLI subprocess output stream, not via SDK adoption.
 
+## Amendment (2026-05-15): API-key + CLI explicitly permitted
+
+After the June 15 2026 Anthropic Agent SDK credit changes, the operator commissioned strategic research (`claudedocs/agent-sdk-vs-claude-p-cli-strategic-comparison-2026-05-15.md`) comparing Agent SDK direct-API usage against `claude -p` subprocess on the same API key. The verdict: stay with `claude -p` subprocess for the governed worker dispatch path; Agent SDK can be a follow-up provider option for non-governed use cases.
+
+This amendment makes the routing matrix explicit:
+
+| Transport | Auth | Status | Reason |
+|---|---|---|---|
+| `claude -p` subprocess | OAuth subscription | **Permitted (current default)** | Lowest cost on Pro/Max tiers; ADR-005/010/013 invariants intact |
+| `claude -p` subprocess | API key | **Permitted (per-token billing)** | Identical audit surface as OAuth subscription path; switch is operator economic choice |
+| Agent SDK (in-process) | OAuth | **Banned** | OAuth credential abuse risk + SDK in-process loop breaks ADR-005/010/013 invariants |
+| Agent SDK (in-process) | API key | **Banned for governed worker dispatch** | API-key resolves the licensing concern but SDK still runs the agent loop in-process — incompatible with NDJSON capture, subprocess isolation, and PID-per-worker pools |
+| Anthropic Managed Agents | n/a | **Banned** (per ADR-004) | Vendor lock-in conflict with self-hosted positioning |
+
+The Wave 4.6 finalization PR may introduce Agent SDK as an opt-in fifth provider-spawn handler for **non-governed** use cases (sandbox experiments, fast iteration without audit requirements). That path uses API-key only and is mutually exclusive with the worker-dispatch governed-pad; it is not a replacement for `claude -p` subprocess.
+
 ## See also
 
 - ADR-004 — VNX positioning as self-hosted alternative to Anthropic Managed Agents


### PR DESCRIPTION
## Summary

- Inserts `## Amendment (2026-05-15): API-key + CLI explicitly permitted` section into ADR-003, between `## Implementation note` and `## See also`
- Routing matrix makes explicit that `claude -p` subprocess with an API key is **permitted** (identical audit surface to OAuth; operator economic choice)
- Agent SDK in-process remains **banned for governed worker dispatch** regardless of auth method — SDK runs the agent loop in-process, breaking ADR-005 NDJSON audit, ADR-010 subprocess isolation, and ADR-013 PID-per-worker pools
- Notes Wave 4.6 opt-in fifth provider path (non-governed, API-key only, mutually exclusive with worker-dispatch governed-pad)

## Background

Operator commissioned Opus strategic research (`claudedocs/agent-sdk-vs-claude-p-cli-strategic-comparison-2026-05-15.md`) after June 15 2026 Anthropic Agent SDK credit changes. Conclusion: stay with `claude -p` subprocess (Option A) + add Agent SDK as opt-in fifth provider in Wave 4.6 (Option C). ADR-003 previously only covered the OAuth + SDK ban; this amendment closes the gap for API-key + CLI combinations.

## Scope

Docs-only. One file changed: `docs/governance/decisions/ADR-003-oauth-only-claude-routing.md` (+16 lines).

## Test plan

- [ ] Section appears between `## Implementation note` and `## See also`
- [ ] Existing content unchanged
- [ ] Routing matrix renders correctly in GitHub Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)