### PR TITLE
refactor(cleanup_worker_exit): decompose 104-line function — close OI-1448

### DIFF
--- a/scripts/lib/cleanup_worker_exit.py
+++ b/scripts/lib/cleanup_worker_exit.py
@@ -380,6 +380,93 @@ def _archive_event_store_step(
         )
 
 
+def _normalize_exit_status(exit_status: str, dispatch_id: str) -> str:
+    """Validate exit_status; emit WARN and normalise to 'failure' if unknown."""
+    if exit_status not in VALID_EXIT_STATUSES:
+        _emit(
+            "WARN",
+            "unknown_exit_status",
+            exit_status=exit_status,
+            dispatch_id=dispatch_id,
+        )
+        return "failure"
+    return exit_status
+
+
+def _run_cleanup_steps(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    exit_status: str,
+    lease_generation: Optional[int],
+    dispatch_file: Optional[Path],
+    state_dir: Path,
+    result: CleanupResult,
+) -> None:
+    """Run all five cleanup steps in order; each step is best-effort."""
+    _release_lease_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        lease_generation=lease_generation,
+        exit_status=exit_status,
+        state_dir=state_dir,
+        result=result,
+    )
+    _transition_worker_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        exit_status=exit_status,
+        state_dir=state_dir,
+        result=result,
+    )
+    _move_dispatch_file_step(
+        dispatch_file=dispatch_file,
+        exit_status=exit_status,
+        result=result,
+    )
+    _append_audit_event_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        exit_status=exit_status,
+        result=result,
+    )
+    _archive_event_store_step(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        result=result,
+    )
+
+
+def _emit_health_beacon(
+    *,
+    terminal_id: str,
+    dispatch_id: str,
+    exit_status: str,
+    resolved_state_dir: Path,
+    result: CleanupResult,
+) -> None:
+    """Best-effort HealthBeacon heartbeat; swallows import/OS/runtime errors."""
+    try:
+        from health_beacon import HealthBeacon  # noqa: PLC0415
+        HealthBeacon(
+            resolved_state_dir.parent,
+            "cleanup_worker_exit",
+            expected_interval_seconds=None,
+        ).heartbeat(
+            status="ok" if not result.errors else "fail",
+            details={
+                "terminal_id": terminal_id,
+                "dispatch_id": dispatch_id,
+                "exit_status": exit_status,
+                "lease_released": result.lease_released,
+                "worker_transitioned": result.worker_transitioned,
+                "errors": list(result.errors),
+            },
+        )
+    except (ImportError, OSError, RuntimeError) as exc:
+        _emit("WARN", "health_beacon_failed", error=str(exc))
+
+
 def cleanup_worker_exit(
     *,
     terminal_id: str,
@@ -415,74 +502,25 @@ def cleanup_worker_exit(
     Returns:
         CleanupResult — never raises.
     """
-    if exit_status not in VALID_EXIT_STATUSES:
-        _emit(
-            "WARN",
-            "unknown_exit_status",
-            exit_status=exit_status,
-            dispatch_id=dispatch_id,
-        )
-        exit_status = "failure"
-
-    result = CleanupResult()
+    exit_status = _normalize_exit_status(exit_status, dispatch_id)
     resolved_state_dir = state_dir if state_dir is not None else _resolve_state_dir()
-
-    _release_lease_step(
+    result = CleanupResult()
+    _run_cleanup_steps(
         terminal_id=terminal_id,
         dispatch_id=dispatch_id,
+        exit_status=exit_status,
         lease_generation=lease_generation,
-        exit_status=exit_status,
-        state_dir=resolved_state_dir,
-        result=result,
-    )
-
-    _transition_worker_step(
-        terminal_id=terminal_id,
-        dispatch_id=dispatch_id,
-        exit_status=exit_status,
-        state_dir=resolved_state_dir,
-        result=result,
-    )
-
-    _move_dispatch_file_step(
         dispatch_file=dispatch_file,
-        exit_status=exit_status,
+        state_dir=resolved_state_dir,
         result=result,
     )
-
-    _append_audit_event_step(
+    _emit_health_beacon(
         terminal_id=terminal_id,
         dispatch_id=dispatch_id,
         exit_status=exit_status,
+        resolved_state_dir=resolved_state_dir,
         result=result,
     )
-
-    _archive_event_store_step(
-        terminal_id=terminal_id,
-        dispatch_id=dispatch_id,
-        result=result,
-    )
-
-    try:
-        from health_beacon import HealthBeacon
-        HealthBeacon(
-            resolved_state_dir.parent,
-            "cleanup_worker_exit",
-            expected_interval_seconds=None,
-        ).heartbeat(
-            status="ok" if not result.errors else "fail",
-            details={
-                "terminal_id": terminal_id,
-                "dispatch_id": dispatch_id,
-                "exit_status": exit_status,
-                "lease_released": result.lease_released,
-                "worker_transitioned": result.worker_transitioned,
-                "errors": list(result.errors),
-            },
-        )
-    except (ImportError, OSError, RuntimeError) as exc:
-        _emit("WARN", "health_beacon_failed", error=str(exc))
-
     return result
 
 


### PR DESCRIPTION
## Summary

- `cleanup_worker_exit()` was 104 lines, exceeding the 70-line blocking threshold (OI-1448)
- Extracted three helpers; orchestrator is now 61 lines
- Pure structural refactor: no behaviour change, no step reordering, identical side-effects

## Before / After

| Function | Before | After |
|---|---|---|
| `cleanup_worker_exit` | 104 lines | 61 lines |
| `_normalize_exit_status` | — | 13 lines (new) |
| `_run_cleanup_steps` | — | 44 lines (new) |
| `_emit_health_beacon` | — | 30 lines (new) |

## Helper layout

- **`_normalize_exit_status(exit_status, dispatch_id)`** — validates against `VALID_EXIT_STATUSES`, emits WARN and returns `"failure"` if unknown
- **`_run_cleanup_steps(...)`** — sequenced calls to the five pre-existing step helpers (`_release_lease_step`, `_transition_worker_step`, `_move_dispatch_file_step`, `_append_audit_event_step`, `_archive_event_store_step`)
- **`_emit_health_beacon(...)`** — HealthBeacon heartbeat block with `(ImportError, OSError, RuntimeError)` narrowed except

## Closes

OI-1448: Function exceeds blocking threshold: 104 lines (max 70)

## Test plan

- [x] `pytest tests/test_cleanup_worker_exit.py tests/test_cleanup_worker_exit_exception_handling.py -v` → 12/12 passed
- [x] `python3 scripts/ci_lint_patterns.py` → 27 findings (unchanged, no new findings)
- [x] Function line counts verified programmatically: all new helpers ≤44 lines, orchestrator 61 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)