### PR TITLE
feat(wave4.6): PR-4.6.4 — gemini_spawn handler extracted from gemini_adapter

### DIFF
--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -29,6 +29,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from _streaming_drainer import StreamingDrainerMixin
 from canonical_event import CanonicalEvent
 from provider_adapter import AdapterResult, Capability, ProviderAdapter
+from provider_spawns.gemini_spawn import (  # noqa: E402
+    normalize_gemini_event,
+    spawn_gemini,
+    _extract_gemini_usage_metadata as _spawn_extract_usage_metadata,
+    _extract_gemini_token_count as _spawn_extract_token_count,
+)
 from vertex_ai_runner import collect_file_contents
 
 logger = logging.getLogger(__name__)
@@ -84,16 +90,14 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         return shutil.which("gemini") is not None
 
     def execute(self, instruction: str, context: dict) -> AdapterResult:
-        """Run a Gemini review and return structured findings.
+        """Run a Gemini review. Delegates spawn+stream to spawn_gemini() (Wave 4.6 PR-4.6.4).
 
-        Routes through streaming drainer when VNX_GEMINI_STREAM=1,
-        otherwise uses the legacy buffered path.
+        Behavior is byte-identical to the pre-refactor inline path.
         """
         model = os.environ.get("VNX_GEMINI_MODEL", _DEFAULT_MODEL)
         terminal_id = context.get("terminal_id", self._terminal_id)
         dispatch_id = context.get("dispatch_id", "unknown")
         changed_files = context.get("changed_files", [])
-
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
 
@@ -101,15 +105,56 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
         dispatch_meta = context.get("dispatch_metadata", {})
         prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
 
-        if _gemini_stream_enabled():
-            return self._execute_streaming(
-                prompt=prompt,
-                model=model,
-                terminal_id=terminal_id,
-                dispatch_id=dispatch_id,
-                context=context,
+        chunk_timeout = float(os.environ.get(
+            "VNX_GEMINI_STALL_THRESHOLD", context.get("chunk_timeout", _DEFAULT_STALL_THRESHOLD)
+        ))
+        total_deadline = float(os.environ.get(
+            "VNX_GEMINI_TIMEOUT", context.get("total_deadline", _DEFAULT_TIMEOUT)
+        ))
+        event_store = context.get("event_store")
+
+        collected_events: list[dict] = []
+        findings_parts: list[str] = []
+
+        def _collect(tid: str, ev_dict: dict, dispatch_id: str = dispatch_id) -> None:
+            collected_events.append(ev_dict)
+            ev_type = ev_dict.get("event_type") or ev_dict.get("type", "")
+            if ev_type in ("text", "complete", "result"):
+                data = ev_dict.get("data")
+                text = data if isinstance(data, str) else (data or {}).get("text", "")
+                if text:
+                    findings_parts.append(text)
+
+        t0 = time.monotonic()
+        spawn_result = spawn_gemini(
+            prompt=prompt, model=model,
+            dispatch_id=dispatch_id, terminal_id=terminal_id,
+            event_writer=_collect,
+            chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+            event_store=event_store,
+        )
+        duration = time.monotonic() - t0
+
+        if spawn_result.timed_out:
+            return AdapterResult(
+                status="timeout",
+                output=f"Gemini CLI exceeded {int(total_deadline)}s timeout",
+                events=collected_events, event_count=len(collected_events),
+                duration_seconds=duration, committed=False, commit_hash=None,
+                report_path=None, provider="gemini", model=model,
             )
-        return self._execute_legacy(prompt=prompt, model=model)
+
+        if spawn_result.token_usage:
+            self._write_token_cache(spawn_result.token_usage)
+
+        findings = "\n\n".join(findings_parts) if findings_parts else spawn_result.completion_text
+        status = "done" if spawn_result.returncode == 0 else "failed"
+        return AdapterResult(
+            status=status, output=findings, events=collected_events,
+            event_count=len(collected_events), duration_seconds=duration,
+            committed=False, commit_hash=None, report_path=None,
+            provider="gemini", model=model,
+        )
 
     def stream_events(self, instruction: str, context: dict) -> Iterator[dict]:
         """Stream Gemini events live (VNX_GEMINI_STREAM=1) or yield a single
@@ -185,89 +230,12 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
             proc.wait()
 
     # ------------------------------------------------------------------
-    # StreamingDrainerMixin: event normalizer
+    # StreamingDrainerMixin: event normalizer — delegates to standalone
     # ------------------------------------------------------------------
 
     def _normalize(self, raw: dict) -> CanonicalEvent:
-        """Map a raw Gemini stream-json event to a CanonicalEvent (Tier-1).
-
-        Gemini --output-format stream-json emits NDJSON where each line has a
-        "type" field. Mapping:
-
-          session_start / init      → init
-          message / text            → text (content in "text" or "content")
-          tool_call / tool_use      → tool_use (function name + args)
-          tool_result / tool_response → tool_result (output)
-          result / done / complete  → complete (with optional token_count)
-          error                     → error
-
-        Unknown types fall through to error with raw_type preserved.
-        """
-        terminal_id = self._current_terminal_id
-        dispatch_id = self._current_dispatch_id
-
-        def make(event_type: str, data: dict) -> CanonicalEvent:
-            return CanonicalEvent(
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                provider="gemini",
-                event_type=event_type,
-                data=data,
-                observability_tier=_TIER_STREAMING,
-            )
-
-        etype = raw.get("type", "")
-
-        # ── init ──────────────────────────────────────────────────────────
-        if etype in ("session_start", "init"):
-            return make("init", {"raw_type": etype})
-
-        # ── text / message ────────────────────────────────────────────────
-        if etype in ("message", "text", "content"):
-            text = raw.get("text") or raw.get("content") or raw.get("message") or ""
-            return make("text", {"text": str(text)})
-
-        # ── tool_use / tool_call ──────────────────────────────────────────
-        if etype in ("tool_use", "tool_call", "function_call"):
-            name = raw.get("name") or raw.get("function_name") or raw.get("tool", "")
-            args = raw.get("args") or raw.get("input") or raw.get("arguments") or {}
-            if not isinstance(args, dict):
-                args = {"raw": str(args)}
-            return make("tool_use", {"name": str(name), "args": args})
-
-        # ── tool_result / tool_response ───────────────────────────────────
-        if etype in ("tool_result", "tool_response", "function_response"):
-            output = raw.get("output") or raw.get("result") or raw.get("content") or ""
-            return make("tool_result", {"output": str(output)})
-
-        # ── result / done / complete ──────────────────────────────────────
-        if etype in ("result", "done", "complete", "finish"):
-            data: dict = {}
-            text = raw.get("text") or raw.get("content") or raw.get("output") or ""
-            if text:
-                data["text"] = str(text)
-            token_count = self._extract_gemini_token_count(raw)
-            if token_count:
-                data["token_count"] = token_count
-            return make("complete", data)
-
-        # ── error ─────────────────────────────────────────────────────────
-        if etype == "error":
-            msg = raw.get("message") or raw.get("error") or raw.get("text") or ""
-            return make("error", {"message": str(msg) if msg else str(raw)[:200]})
-
-        # ── usageMetadata (token telemetry emitted mid-stream) ────────────
-        if "usageMetadata" in raw:
-            token_count = self._extract_gemini_token_count(raw)
-            if token_count:
-                return make("text", {"text": "", "token_count": token_count})
-
-        # ── unknown → error ───────────────────────────────────────────────
-        return make("error", {
-            "reason": f"unrecognized gemini event type: {etype!r}",
-            "raw_type": etype,
-            "raw": str(raw)[:300],
-        })
+        """Delegate to normalize_gemini_event (single canonical implementation)."""
+        return normalize_gemini_event(raw, self._current_terminal_id, self._current_dispatch_id)
 
     # ------------------------------------------------------------------
     # Private: streaming execute path
@@ -495,41 +463,13 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
 
     @staticmethod
     def _extract_gemini_token_count(raw: dict) -> Optional[dict]:
-        """Extract and normalize token counts from a Gemini stream event dict."""
-        usage_meta = raw.get("usageMetadata")
-        if isinstance(usage_meta, dict):
-            result = GeminiAdapter._extract_usage_metadata(usage_meta)
-            if result:
-                return result
-        # Also check top-level promptTokenCount (some stream shapes)
-        if "promptTokenCount" in raw or "candidatesTokenCount" in raw:
-            result = GeminiAdapter._extract_usage_metadata(raw)
-            if result:
-                return result
-        return None
+        """Delegate to standalone _extract_gemini_token_count (gemini_spawn owns logic)."""
+        return _spawn_extract_token_count(raw)
 
     @staticmethod
     def _extract_usage_metadata(data: dict) -> Optional[dict]:
-        """Extract usageMetadata from a parsed Gemini response dict.
-
-        Handles both top-level and nested usageMetadata. Field names follow the
-        Gemini REST API: promptTokenCount (input) and candidatesTokenCount (output).
-        """
-        usage_meta = data.get("usageMetadata")
-        if isinstance(usage_meta, dict):
-            data = usage_meta
-        prompt_t = data.get("promptTokenCount", 0) or 0
-        candidates_t = data.get("candidatesTokenCount", 0) or 0
-        if not isinstance(prompt_t, int) or not isinstance(candidates_t, int):
-            return None
-        if prompt_t == 0 and candidates_t == 0:
-            return None
-        return {
-            "input_tokens": prompt_t,
-            "output_tokens": candidates_t,
-            "cache_creation_tokens": 0,
-            "cache_read_tokens": 0,
-        }
+        """Delegate to standalone _extract_gemini_usage_metadata (gemini_spawn owns logic)."""
+        return _spawn_extract_usage_metadata(data)
 
     @staticmethod
     def _parse_token_usage_from_response(raw: str) -> Optional[dict]:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6 PR-4.6.1).
+"""provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6).
 
 Routes dispatch execution to the appropriate provider spawn handler based on
-``--provider``.  In PR-4.6.1 only the ``claude`` provider is wired; all other
-providers raise NotImplementedError with exit code 64 (EX_USAGE) until their
-respective spawn handlers land in subsequent PRs.
+``--provider``. PR-4.6.1: claude wired. PR-4.6.3: codex wired. PR-4.6.4: gemini wired.
+All other providers raise SystemExit(64) until their handlers land.
 
-See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.1
+See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md
 
 BILLING SAFETY: this module does NOT import the Anthropic SDK.  Claude dispatch
 delegates entirely to ``subprocess_dispatch.py`` which invokes ``claude -p`` via
@@ -23,14 +22,11 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
-# Providers whose spawn handlers exist in this PR.
-_IMPLEMENTED_PROVIDERS = {"claude"}
+# Providers whose spawn handlers exist.
+_IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini"}
 
 # Mapping: provider literal -> which future PR delivers its handler.
-_FUTURE_PR_MAP = {
-    "codex": "PR-4.6.3",
-    "gemini": "PR-4.6.4",
-}
+_FUTURE_PR_MAP: dict = {}
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -93,6 +89,51 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _dispatch_codex(args: argparse.Namespace) -> int:
+    """Route to spawn_codex for codex-provider dispatches.
+
+    Builds a minimal context dict from CLI args and delegates to spawn_codex().
+    Prompt is the raw instruction — file-content injection and intelligence context
+    are the caller's responsibility (same contract as the claude path).
+    """
+    from provider_spawns.codex_spawn import spawn_codex
+    import os
+
+    model = os.environ.get("VNX_CODEX_MODEL", "")
+
+    result = spawn_codex(
+        prompt=args.instruction,
+        model=model,
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+    )
+    return 0 if result.returncode == 0 else 1
+
+
+def _dispatch_gemini(args: argparse.Namespace) -> int:
+    """Route to spawn_gemini for gemini-provider dispatches (PR-4.6.4).
+
+    Prompt is the raw instruction; file-content injection is caller's responsibility.
+    """
+    import os
+    from provider_spawns.gemini_spawn import spawn_gemini
+
+    model = os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+    result = spawn_gemini(
+        prompt=args.instruction,
+        model=model,
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+    )
+    if result.error:
+        print(f"spawn_gemini failed: {result.error}", file=sys.stderr)
+        return 1
+    if result.timed_out:
+        print("spawn_gemini timed out", file=sys.stderr)
+        return 1
+    return 0 if result.returncode == 0 else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse args, route to the correct provider handler, return exit code."""
     parser = _build_parser()
@@ -108,22 +149,10 @@ def main(argv: list[str] | None = None) -> int:
         return _dispatch_claude(args)
 
     if provider == "codex":
-        future_pr = _FUTURE_PR_MAP["codex"]
-        print(
-            f"Provider 'codex' spawn handler lands in {future_pr}. "
-            "Use --provider claude for now.",
-            file=sys.stderr,
-        )
-        raise SystemExit(_EX_USAGE)
+        return _dispatch_codex(args)
 
     if provider == "gemini":
-        future_pr = _FUTURE_PR_MAP["gemini"]
-        print(
-            f"Provider 'gemini' spawn handler lands in {future_pr}. "
-            "Use --provider claude for now.",
-            file=sys.stderr,
-        )
-        raise SystemExit(_EX_USAGE)
+        return _dispatch_gemini(args)
 
     if provider.startswith("litellm:"):
         print(

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -116,14 +116,17 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
     Prompt is the raw instruction; file-content injection is caller's responsibility.
     """
     import os
+    from event_store import EventStore
     from provider_spawns.gemini_spawn import spawn_gemini
 
     model = os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+    event_store = EventStore()
     result = spawn_gemini(
         prompt=args.instruction,
         model=model,
         dispatch_id=args.dispatch_id,
         terminal_id=args.terminal_id,
+        event_writer=event_store.append,
     )
     if result.error:
         print(f"spawn_gemini failed: {result.error}", file=sys.stderr)

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -1,0 +1,576 @@
+"""gemini_spawn.py — Gemini-specific spawn handler extracted from gemini_adapter.
+
+Extracted in Wave 4.6 PR-4.6.4. This module owns the "pure spawn+stream" slice:
+
+  1. Spawn ``gemini --model <model> --output-format stream-json`` (or json) via
+     subprocess.Popen with stdin pipe for the prompt.
+  2. Read NDJSON / buffered-JSON output; normalize to CanonicalEvent objects via
+     the standalone ``normalize_gemini_event`` function.
+  3. Tick health_monitor on each event.
+  4. Invoke optional on_event callback per event (return False to stop early).
+
+Callers handle: lease/manifest/receipt/event-archive/retry.
+
+BILLING SAFETY: only ``subprocess.Popen(["gemini", ...])`` is invoked. No SDK,
+no LiteLLM, no direct API calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import select as _select_mod
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Optional
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1])
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from canonical_event import CanonicalEvent  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_TIER_STREAMING = 1
+_TIER_LEGACY = 3
+
+
+# ---------------------------------------------------------------------------
+# Token extraction helpers (single implementation; gemini_adapter delegates here)
+# ---------------------------------------------------------------------------
+
+def _extract_gemini_usage_metadata(data: dict) -> Optional[dict]:
+    """Extract token counts from a parsed Gemini dict.
+
+    Handles both top-level and nested usageMetadata. Returns None when
+    both prompt and candidates counts are zero.
+    """
+    usage_meta = data.get("usageMetadata")
+    if isinstance(usage_meta, dict):
+        data = usage_meta
+    prompt_t = data.get("promptTokenCount", 0) or 0
+    candidates_t = data.get("candidatesTokenCount", 0) or 0
+    if not isinstance(prompt_t, int) or not isinstance(candidates_t, int):
+        return None
+    if prompt_t == 0 and candidates_t == 0:
+        return None
+    return {
+        "input_tokens": prompt_t,
+        "output_tokens": candidates_t,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+    }
+
+
+def _extract_gemini_token_count(raw: dict) -> Optional[dict]:
+    """Locate and normalize token counts from a Gemini stream event dict."""
+    usage_meta = raw.get("usageMetadata")
+    if isinstance(usage_meta, dict):
+        result = _extract_gemini_usage_metadata(usage_meta)
+        if result:
+            return result
+    if "promptTokenCount" in raw or "candidatesTokenCount" in raw:
+        result = _extract_gemini_usage_metadata(raw)
+        if result:
+            return result
+    return None
+
+
+def _parse_gemini_response(raw: str) -> str:
+    """Extract findings text from a buffered JSON response; fall back to raw text."""
+    stripped = raw.strip()
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict):
+            for key in ("response", "text", "content", "output"):
+                if key in parsed:
+                    return str(parsed[key])
+        return stripped
+    except (json.JSONDecodeError, ValueError):
+        return stripped
+
+
+def _parse_gemini_token_usage(raw: str) -> Optional[dict]:
+    """Parse token counts from Gemini CLI stdout (JSON or NDJSON format)."""
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict):
+            result = _extract_gemini_usage_metadata(parsed)
+            if result:
+                return result
+    except json.JSONDecodeError:
+        pass
+    for line in stripped.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+            if isinstance(parsed, dict):
+                result = _extract_gemini_usage_metadata(parsed)
+                if result:
+                    return result
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Normalizer — single canonical implementation
+# ---------------------------------------------------------------------------
+
+def normalize_gemini_event(raw: dict, terminal_id: str, dispatch_id: str) -> CanonicalEvent:
+    """Map a raw Gemini stream-json event to a CanonicalEvent (Tier-1).
+
+    Both _GeminiNormalizerHost (used by spawn_gemini streaming path) and
+    GeminiAdapter._normalize delegate here to guarantee byte identity.
+    """
+    def make(event_type: str, data: dict) -> CanonicalEvent:
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="gemini",
+            event_type=event_type,
+            data=data,
+            observability_tier=_TIER_STREAMING,
+        )
+
+    etype = raw.get("type", "")
+
+    if etype in ("session_start", "init"):
+        return make("init", {"raw_type": etype})
+
+    if etype in ("message", "text", "content"):
+        text = raw.get("text") or raw.get("content") or raw.get("message") or ""
+        return make("text", {"text": str(text)})
+
+    if etype in ("tool_use", "tool_call", "function_call"):
+        name = raw.get("name") or raw.get("function_name") or raw.get("tool", "")
+        args = raw.get("args") or raw.get("input") or raw.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"raw": str(args)}
+        return make("tool_use", {"name": str(name), "args": args})
+
+    if etype in ("tool_result", "tool_response", "function_response"):
+        output = raw.get("output") or raw.get("result") or raw.get("content") or ""
+        return make("tool_result", {"output": str(output)})
+
+    if etype in ("result", "done", "complete", "finish"):
+        data: dict = {}
+        text = raw.get("text") or raw.get("content") or raw.get("output") or ""
+        if text:
+            data["text"] = str(text)
+        token_count = _extract_gemini_token_count(raw)
+        if token_count:
+            data["token_count"] = token_count
+        return make("complete", data)
+
+    if etype == "error":
+        msg = raw.get("message") or raw.get("error") or raw.get("text") or ""
+        return make("error", {"message": str(msg) if msg else str(raw)[:200]})
+
+    if "usageMetadata" in raw:
+        token_count = _extract_gemini_token_count(raw)
+        if token_count:
+            return make("text", {"text": "", "token_count": token_count})
+
+    return make("error", {
+        "reason": f"unrecognized gemini event type: {etype!r}",
+        "raw_type": etype,
+        "raw": str(raw)[:300],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Internal normalizer host (composes StreamingDrainerMixin for drain_stream)
+# ---------------------------------------------------------------------------
+
+class _GeminiNormalizerHost(StreamingDrainerMixin):
+    """Minimal state holder so StreamingDrainerMixin can call normalize_gemini_event."""
+
+    provider_name = "gemini"
+    provider_observability_tier = _TIER_STREAMING
+
+    def __init__(self, terminal_id: str, dispatch_id: str) -> None:
+        self._current_terminal_id = terminal_id
+        self._current_dispatch_id = dispatch_id
+
+    def _normalize(self, raw: dict) -> CanonicalEvent:
+        return normalize_gemini_event(raw, self._current_terminal_id, self._current_dispatch_id)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GeminiSpawnResult:
+    """Return value from spawn_gemini(); carries spawn outcome to the caller."""
+
+    returncode: int
+    completion_text: str
+    events_written: int
+    session_id: Optional[str]
+    timed_out: bool
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Main spawn function
+# ---------------------------------------------------------------------------
+
+def spawn_gemini(
+    prompt: str,
+    model: str,
+    dispatch_id: str,
+    terminal_id: str,
+    *,
+    event_writer: Optional[Callable[..., None]] = None,
+    health_monitor: Optional[Any] = None,
+    on_event: Optional[Callable[[Any], Optional[bool]]] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    cwd: Optional[Any] = None,
+    chunk_timeout: float = 60.0,
+    total_deadline: float = 600.0,
+    event_store: Optional[Any] = None,
+    **kwargs: Any,
+) -> GeminiSpawnResult:
+    """Spawn ``gemini`` and consume the event stream.
+
+    Routes through streaming drainer (NDJSON, Tier-1) when VNX_GEMINI_STREAM=1;
+    otherwise uses the legacy buffered-JSON path (Tier-3, single result event).
+    Returns GeminiSpawnResult on completion. Caller manages lease/manifest/receipt.
+
+    Parameters
+    ----------
+    prompt:
+        Fully assembled dispatch instruction written to gemini stdin.
+    model:
+        Gemini model identifier, e.g. ``"gemini-2.5-pro"``.
+    dispatch_id, terminal_id:
+        Identifiers forwarded to the normalizer and EventStore.
+    event_writer:
+        Optional callback ``(terminal_id, event_dict, dispatch_id=...)`` called
+        for every normalized event. Used by GeminiAdapter.execute() to collect events.
+    health_monitor:
+        Optional WorkerHealthMonitor; ``health_monitor.update(event)`` called per event.
+    on_event:
+        Optional per-event callback ``(CanonicalEvent) -> bool|None``. Return
+        ``False`` to stop the stream early.
+    extra_env:
+        Additional environment variables merged into the subprocess environment.
+    cwd:
+        Working directory for the gemini subprocess.
+    chunk_timeout:
+        Max seconds between consecutive output lines (streaming path only).
+    total_deadline:
+        Max total seconds for the entire dispatch.
+    event_store:
+        EventStore instance for live persistence; None = skip.
+    **kwargs:
+        Accepted for forward-compatibility; ignored.
+
+    Raises
+    ------
+    FileNotFoundError:
+        When the ``gemini`` binary is not found on PATH.  Propagated immediately
+        so callers can distinguish a missing binary from a transient failure.
+    """
+    try:
+        chunk_timeout = float(os.environ.get("VNX_GEMINI_STALL_THRESHOLD", chunk_timeout))
+    except (TypeError, ValueError):
+        pass
+    try:
+        total_deadline = float(os.environ.get("VNX_GEMINI_TIMEOUT", total_deadline))
+    except (TypeError, ValueError):
+        pass
+
+    env = {**os.environ, **(extra_env or {})}
+    cwd_str = str(cwd) if cwd is not None else None
+
+    if os.environ.get("VNX_GEMINI_STREAM", "0").strip() == "1":
+        return _spawn_streaming(
+            prompt=prompt, model=model,
+            dispatch_id=dispatch_id, terminal_id=terminal_id,
+            event_writer=event_writer, health_monitor=health_monitor,
+            on_event=on_event, env=env, cwd_str=cwd_str,
+            chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+            event_store=event_store,
+        )
+    return _spawn_legacy(
+        prompt=prompt, model=model,
+        dispatch_id=dispatch_id, terminal_id=terminal_id,
+        event_writer=event_writer, env=env, cwd_str=cwd_str,
+        total_deadline=total_deadline,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming path
+# ---------------------------------------------------------------------------
+
+def _spawn_streaming(
+    *,
+    prompt: str,
+    model: str,
+    dispatch_id: str,
+    terminal_id: str,
+    event_writer: Optional[Callable],
+    health_monitor: Optional[Any],
+    on_event: Optional[Callable],
+    env: Optional[Dict],
+    cwd_str: Optional[str],
+    chunk_timeout: float,
+    total_deadline: float,
+    event_store: Optional[Any],
+) -> GeminiSpawnResult:
+    """Spawn ``gemini --output-format stream-json`` and drain the NDJSON event stream."""
+    cmd = ["gemini", "--model", model, "--output-format", "stream-json"]
+    try:
+        proc = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, start_new_session=True,
+            env=env, cwd=cwd_str,
+        )
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        return GeminiSpawnResult(
+            returncode=1, completion_text="", events_written=0,
+            session_id=None, timed_out=False, error=str(exc),
+        )
+
+    if proc.stdin:
+        try:
+            proc.stdin.write(prompt.encode("utf-8"))
+            proc.stdin.close()
+        except BrokenPipeError as exc:
+            return GeminiSpawnResult(
+                returncode=1, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                error=f"stdin write failed (BrokenPipeError): {exc}",
+            )
+
+    host = _GeminiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+    events_written = 0
+    completion_text = ""
+    token_usage: Optional[Dict[str, Any]] = None
+    stopped_early = False
+    timed_out = False
+
+    for canonical_event in host.drain_stream(
+        proc, terminal_id, dispatch_id, event_store,
+        chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+    ):
+        events_written += 1
+        evt_type = canonical_event.event_type
+
+        if evt_type == "complete":
+            completion_text = canonical_event.data.get("text", "")
+            tc = canonical_event.data.get("token_count")
+            if tc:
+                token_usage = tc
+        elif evt_type == "text":
+            tc = canonical_event.data.get("token_count")
+            if tc:
+                token_usage = tc
+        elif evt_type == "error":
+            reason = (canonical_event.data.get("reason") or "").lower()
+            if "timeout" in reason or "deadline" in reason:
+                timed_out = True
+
+        if health_monitor is not None:
+            health_monitor.update(canonical_event)
+
+        if event_writer is not None:
+            try:
+                event_writer(terminal_id, canonical_event.to_dict(), dispatch_id=dispatch_id)
+            except Exception as _exc:
+                logger.debug("spawn_gemini: event_writer raised: %s", _exc)
+
+        if on_event is not None:
+            if on_event(canonical_event) is False:
+                stopped_early = True
+                try:
+                    proc.kill()
+                except OSError as _ke:
+                    logger.debug("spawn_gemini: kill after on_event=False failed: %s", _ke)
+                break
+
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+    rc = proc.returncode if proc.returncode is not None else 1
+    return GeminiSpawnResult(
+        returncode=rc, completion_text=completion_text, events_written=events_written,
+        session_id=None, timed_out=timed_out, stopped_early=stopped_early,
+        token_usage=token_usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy buffered path
+# ---------------------------------------------------------------------------
+
+def _spawn_legacy(
+    *,
+    prompt: str,
+    model: str,
+    dispatch_id: str,
+    terminal_id: str,
+    event_writer: Optional[Callable],
+    env: Optional[Dict],
+    cwd_str: Optional[str],
+    total_deadline: float,
+) -> GeminiSpawnResult:
+    """Spawn ``gemini --output-format json`` and collect a single buffered response."""
+    cmd = ["gemini", "--model", model, "--output-format", "json"]
+    try:
+        proc = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, start_new_session=True,
+            env=env, cwd=cwd_str,
+        )
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        return GeminiSpawnResult(
+            returncode=1, completion_text="", events_written=0,
+            session_id=None, timed_out=False, error=str(exc),
+        )
+
+    if proc.stdin:
+        try:
+            proc.stdin.write(prompt.encode("utf-8"))
+            proc.stdin.close()
+        except BrokenPipeError as exc:
+            return GeminiSpawnResult(
+                returncode=1, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                error=f"stdin write failed (BrokenPipeError): {exc}",
+            )
+
+    timeout_int = max(1, int(total_deadline))
+    stdout, stderr, status = _drain_buffered(proc, timeout_int)
+
+    if status == "timeout":
+        _kill_proc(proc)
+        return GeminiSpawnResult(
+            returncode=1, completion_text="", events_written=0,
+            session_id=None, timed_out=True,
+            error=f"gemini CLI exceeded {timeout_int}s timeout",
+        )
+
+    if proc.returncode != 0:
+        return GeminiSpawnResult(
+            returncode=proc.returncode, completion_text="",
+            events_written=0, session_id=None, timed_out=False,
+            error=(stderr or stdout)[:500],
+        )
+
+    text = _parse_gemini_response(stdout)
+    token_usage = _parse_gemini_token_usage(stdout)
+    synthetic = {"type": "result", "data": text, "observability_tier": _TIER_LEGACY}
+
+    if event_writer is not None:
+        try:
+            event_writer(terminal_id, synthetic, dispatch_id=dispatch_id)
+        except Exception as _exc:
+            logger.debug("spawn_gemini: event_writer (legacy) raised: %s", _exc)
+
+    return GeminiSpawnResult(
+        returncode=0, completion_text=text, events_written=1,
+        session_id=None, timed_out=False, token_usage=token_usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _drain_buffered(proc: subprocess.Popen, timeout: int) -> tuple:
+    """Read stdout/stderr with a wall-clock timeout; returns (stdout, stderr, status)."""
+    stdout_parts: list = []
+    stderr_parts: list = []
+    start = time.monotonic()
+    stdout_fd = proc.stdout.fileno() if proc.stdout else -1
+    stderr_fd = proc.stderr.fileno() if proc.stderr else -1
+    fd_map: dict = {}
+    if stdout_fd >= 0:
+        fd_map[stdout_fd] = "stdout"
+    if stderr_fd >= 0:
+        fd_map[stderr_fd] = "stderr"
+    raw_fds = list(fd_map)
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= timeout:
+            return (
+                b"".join(stdout_parts).decode("utf-8", errors="replace"),
+                b"".join(stderr_parts).decode("utf-8", errors="replace"),
+                "timeout",
+            )
+        remaining = max(timeout - elapsed, 0.1)
+        try:
+            readable, _, _ = _select_mod.select(raw_fds, [], [], min(remaining, 1.0))
+        except (ValueError, OSError):
+            break
+        for fd_num in readable:
+            try:
+                chunk = os.read(fd_num, 4096)
+            except OSError:
+                chunk = b""
+            if chunk:
+                if fd_map.get(fd_num) == "stdout":
+                    stdout_parts.append(chunk)
+                else:
+                    stderr_parts.append(chunk)
+        if proc.poll() is not None:
+            for fd_num in raw_fds:
+                try:
+                    while True:
+                        rem = os.read(fd_num, 4096)
+                        if not rem:
+                            break
+                        if fd_map.get(fd_num) == "stdout":
+                            stdout_parts.append(rem)
+                        else:
+                            stderr_parts.append(rem)
+                except OSError:
+                    pass
+            break
+
+    return (
+        b"".join(stdout_parts).decode("utf-8", errors="replace"),
+        b"".join(stderr_parts).decode("utf-8", errors="replace"),
+        "ok",
+    )
+
+
+def _kill_proc(proc: subprocess.Popen) -> None:
+    """Send SIGTERM then SIGKILL to process group."""
+    import signal as _signal
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, _signal.SIGTERM)
+        time.sleep(0.2)
+        os.killpg(pgid, _signal.SIGKILL)
+    except OSError:
+        try:
+            proc.kill()
+        except OSError:
+            pass

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -281,11 +281,8 @@ def spawn_gemini(
     **kwargs:
         Accepted for forward-compatibility; ignored.
 
-    Raises
-    ------
-    FileNotFoundError:
-        When the ``gemini`` binary is not found on PATH.  Propagated immediately
-        so callers can distinguish a missing binary from a transient failure.
+    A missing gemini binary returns returncode=127 with result.error set;
+    it does NOT raise FileNotFoundError. Check result.error to detect spawn failures.
     """
     try:
         chunk_timeout = float(os.environ.get("VNX_GEMINI_STALL_THRESHOLD", chunk_timeout))
@@ -317,38 +314,42 @@ def spawn_gemini(
 
 
 # ---------------------------------------------------------------------------
-# Streaming path
+# Subprocess spawn helpers
 # ---------------------------------------------------------------------------
 
-def _spawn_streaming(
-    *,
-    prompt: str,
-    model: str,
-    dispatch_id: str,
-    terminal_id: str,
-    event_writer: Optional[Callable],
-    health_monitor: Optional[Any],
-    on_event: Optional[Callable],
+def _build_gemini_cmd(model: str, output_format: str) -> list:
+    """Build the gemini argv list for the given model and output format."""
+    return ["gemini", "--model", model, "--output-format", output_format]
+
+
+def _start_gemini_subprocess(
+    cmd: list,
     env: Optional[Dict],
     cwd_str: Optional[str],
-    chunk_timeout: float,
-    total_deadline: float,
-    event_store: Optional[Any],
-) -> GeminiSpawnResult:
-    """Spawn ``gemini --output-format stream-json`` and drain the NDJSON event stream."""
-    cmd = ["gemini", "--model", model, "--output-format", "stream-json"]
+    prompt: str,
+) -> "tuple[subprocess.Popen | None, GeminiSpawnResult | None]":
+    """Start the gemini subprocess and write prompt to stdin.
+
+    Returns (proc, None) on success, or (None, GeminiSpawnResult) on spawn failure.
+    All subprocess-boundary errors convert to structured results; none are re-raised.
+    """
     try:
         proc = subprocess.Popen(
             cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, start_new_session=True,
             env=env, cwd=cwd_str,
         )
-    except FileNotFoundError:
-        raise
+    except FileNotFoundError as exc:
+        return None, GeminiSpawnResult(
+            returncode=127, completion_text="", events_written=0,
+            session_id=None, timed_out=False, stopped_early=False,
+            token_usage=None, error=f"gemini binary not found: {exc}",
+        )
     except OSError as exc:
-        return GeminiSpawnResult(
-            returncode=1, completion_text="", events_written=0,
-            session_id=None, timed_out=False, error=str(exc),
+        return None, GeminiSpawnResult(
+            returncode=126, completion_text="", events_written=0,
+            session_id=None, timed_out=False, stopped_early=False,
+            token_usage=None, error=f"failed to spawn gemini: {exc}",
         )
 
     if proc.stdin:
@@ -356,13 +357,28 @@ def _spawn_streaming(
             proc.stdin.write(prompt.encode("utf-8"))
             proc.stdin.close()
         except BrokenPipeError as exc:
-            return GeminiSpawnResult(
+            return None, GeminiSpawnResult(
                 returncode=1, completion_text="", events_written=0,
                 session_id=None, timed_out=False,
                 error=f"stdin write failed (BrokenPipeError): {exc}",
             )
 
-    host = _GeminiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+    return proc, None
+
+
+def _consume_gemini_stream(
+    proc: subprocess.Popen,
+    host: "_GeminiNormalizerHost",
+    on_event: Optional[Callable],
+    health_monitor: Optional[Any],
+    event_writer: Optional[Callable],
+    terminal_id: str,
+    dispatch_id: str,
+    event_store: Optional[Any],
+    chunk_timeout: float,
+    total_deadline: float,
+) -> "tuple[str, int, Optional[Dict[str, Any]], bool, bool]":
+    """Drain the NDJSON stream; return (completion_text, events_written, token_usage, timed_out, stopped_early)."""
     events_written = 0
     completion_text = ""
     token_usage: Optional[Dict[str, Any]] = None
@@ -408,17 +424,68 @@ def _spawn_streaming(
                     logger.debug("spawn_gemini: kill after on_event=False failed: %s", _ke)
                 break
 
+    return completion_text, events_written, token_usage, timed_out, stopped_early
+
+
+def _finalize_gemini_result(
+    proc: subprocess.Popen,
+    completion_text: str,
+    events_written: int,
+    token_usage: Optional[Dict[str, Any]],
+    timed_out: bool,
+    stopped_early: bool,
+) -> GeminiSpawnResult:
+    """Wait for process exit and return a GeminiSpawnResult."""
     try:
         proc.wait(timeout=10)
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait()
-
     rc = proc.returncode if proc.returncode is not None else 1
     return GeminiSpawnResult(
         returncode=rc, completion_text=completion_text, events_written=events_written,
         session_id=None, timed_out=timed_out, stopped_early=stopped_early,
         token_usage=token_usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming path
+# ---------------------------------------------------------------------------
+
+def _spawn_streaming(
+    *,
+    prompt: str,
+    model: str,
+    dispatch_id: str,
+    terminal_id: str,
+    event_writer: Optional[Callable],
+    health_monitor: Optional[Any],
+    on_event: Optional[Callable],
+    env: Optional[Dict],
+    cwd_str: Optional[str],
+    chunk_timeout: float,
+    total_deadline: float,
+    event_store: Optional[Any],
+) -> GeminiSpawnResult:
+    """Spawn ``gemini --output-format stream-json`` and drain the NDJSON event stream."""
+    cmd = _build_gemini_cmd(model, "stream-json")
+    proc, err_result = _start_gemini_subprocess(cmd, env, cwd_str, prompt)
+    if err_result is not None:
+        return err_result
+
+    host = _GeminiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+    completion_text, events_written, token_usage, timed_out, stopped_early = _consume_gemini_stream(
+        proc=proc, host=host, on_event=on_event,
+        health_monitor=health_monitor, event_writer=event_writer,
+        terminal_id=terminal_id, dispatch_id=dispatch_id,
+        event_store=event_store, chunk_timeout=chunk_timeout,
+        total_deadline=total_deadline,
+    )
+    return _finalize_gemini_result(
+        proc=proc, completion_text=completion_text,
+        events_written=events_written, token_usage=token_usage,
+        timed_out=timed_out, stopped_early=stopped_early,
     )
 
 
@@ -438,31 +505,10 @@ def _spawn_legacy(
     total_deadline: float,
 ) -> GeminiSpawnResult:
     """Spawn ``gemini --output-format json`` and collect a single buffered response."""
-    cmd = ["gemini", "--model", model, "--output-format", "json"]
-    try:
-        proc = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, start_new_session=True,
-            env=env, cwd=cwd_str,
-        )
-    except FileNotFoundError:
-        raise
-    except OSError as exc:
-        return GeminiSpawnResult(
-            returncode=1, completion_text="", events_written=0,
-            session_id=None, timed_out=False, error=str(exc),
-        )
-
-    if proc.stdin:
-        try:
-            proc.stdin.write(prompt.encode("utf-8"))
-            proc.stdin.close()
-        except BrokenPipeError as exc:
-            return GeminiSpawnResult(
-                returncode=1, completion_text="", events_written=0,
-                session_id=None, timed_out=False,
-                error=f"stdin write failed (BrokenPipeError): {exc}",
-            )
+    cmd = _build_gemini_cmd(model, "json")
+    proc, err_result = _start_gemini_subprocess(cmd, env, cwd_str, prompt)
+    if err_result is not None:
+        return err_result
 
     timeout_int = max(1, int(total_deadline))
     stdout, stderr, status = _drain_buffered(proc, timeout_int)

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -224,6 +224,9 @@ class GeminiSpawnResult:
     stopped_early: bool = False
     token_usage: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    # Number of times event_writer callback raised an exception.
+    # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
+    event_writer_failures: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -377,13 +380,14 @@ def _consume_gemini_stream(
     event_store: Optional[Any],
     chunk_timeout: float,
     total_deadline: float,
-) -> "tuple[str, int, Optional[Dict[str, Any]], bool, bool]":
-    """Drain the NDJSON stream; return (completion_text, events_written, token_usage, timed_out, stopped_early)."""
+) -> "tuple[str, int, Optional[Dict[str, Any]], bool, bool, int]":
+    """Drain the NDJSON stream; return (completion_text, events_written, token_usage, timed_out, stopped_early, event_writer_failures)."""
     events_written = 0
     completion_text = ""
     token_usage: Optional[Dict[str, Any]] = None
     stopped_early = False
     timed_out = False
+    _event_writer_failures = 0
 
     for canonical_event in host.drain_stream(
         proc, terminal_id, dispatch_id, event_store,
@@ -410,10 +414,16 @@ def _consume_gemini_stream(
             health_monitor.update(canonical_event)
 
         if event_writer is not None:
+            # event_writer is caller-supplied (typically NDJSON ledger).
+            # Failures are ADR-005 audit gaps — log as ERROR + count for caller inspection.
             try:
                 event_writer(terminal_id, canonical_event.to_dict(), dispatch_id=dispatch_id)
             except Exception as _exc:
-                logger.debug("spawn_gemini: event_writer raised: %s", _exc)
+                logger.error(
+                    "spawn_gemini: event_writer callback failed (dispatch=%s, event_count=%d): %s",
+                    dispatch_id, events_written, _exc,
+                )
+                _event_writer_failures += 1
 
         if on_event is not None:
             if on_event(canonical_event) is False:
@@ -424,7 +434,7 @@ def _consume_gemini_stream(
                     logger.debug("spawn_gemini: kill after on_event=False failed: %s", _ke)
                 break
 
-    return completion_text, events_written, token_usage, timed_out, stopped_early
+    return completion_text, events_written, token_usage, timed_out, stopped_early, _event_writer_failures
 
 
 def _finalize_gemini_result(
@@ -434,6 +444,7 @@ def _finalize_gemini_result(
     token_usage: Optional[Dict[str, Any]],
     timed_out: bool,
     stopped_early: bool,
+    event_writer_failures: int = 0,
 ) -> GeminiSpawnResult:
     """Wait for process exit and return a GeminiSpawnResult."""
     try:
@@ -445,7 +456,7 @@ def _finalize_gemini_result(
     return GeminiSpawnResult(
         returncode=rc, completion_text=completion_text, events_written=events_written,
         session_id=None, timed_out=timed_out, stopped_early=stopped_early,
-        token_usage=token_usage,
+        token_usage=token_usage, event_writer_failures=event_writer_failures,
     )
 
 
@@ -475,7 +486,7 @@ def _spawn_streaming(
         return err_result
 
     host = _GeminiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
-    completion_text, events_written, token_usage, timed_out, stopped_early = _consume_gemini_stream(
+    completion_text, events_written, token_usage, timed_out, stopped_early, _event_writer_failures = _consume_gemini_stream(
         proc=proc, host=host, on_event=on_event,
         health_monitor=health_monitor, event_writer=event_writer,
         terminal_id=terminal_id, dispatch_id=dispatch_id,
@@ -486,6 +497,7 @@ def _spawn_streaming(
         proc=proc, completion_text=completion_text,
         events_written=events_written, token_usage=token_usage,
         timed_out=timed_out, stopped_early=stopped_early,
+        event_writer_failures=_event_writer_failures,
     )
 
 
@@ -532,15 +544,23 @@ def _spawn_legacy(
     token_usage = _parse_gemini_token_usage(stdout)
     synthetic = {"type": "result", "data": text, "observability_tier": _TIER_LEGACY}
 
+    _event_writer_failures = 0
     if event_writer is not None:
+        # event_writer is caller-supplied (typically NDJSON ledger).
+        # Failures are ADR-005 audit gaps — log as ERROR + count for caller inspection.
         try:
             event_writer(terminal_id, synthetic, dispatch_id=dispatch_id)
         except Exception as _exc:
-            logger.debug("spawn_gemini: event_writer (legacy) raised: %s", _exc)
+            logger.error(
+                "spawn_gemini: event_writer callback failed (dispatch=%s, event_count=%d): %s",
+                dispatch_id, 1, _exc,
+            )
+            _event_writer_failures += 1
 
     return GeminiSpawnResult(
         returncode=0, completion_text=text, events_written=1,
         session_id=None, timed_out=False, token_usage=token_usage,
+        event_writer_failures=_event_writer_failures,
     )
 
 

--- a/tests/test_gemini_spawn_byte_identity.py
+++ b/tests/test_gemini_spawn_byte_identity.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Wave 4.6 PR-4.6.4 — byte-identity tests for gemini_spawn.
+
+Verifies that spawn_gemini (streaming path) produces the same normalized events
+as calling GeminiAdapter._normalize directly on the same raw fixture events.
+Uses a recorded NDJSON fixture replayed via mocked drain_stream.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_LIB / "adapters"))
+
+from canonical_event import CanonicalEvent
+from provider_spawns.gemini_spawn import (
+    normalize_gemini_event,
+    GeminiSpawnResult,
+    spawn_gemini,
+)
+from adapters.gemini_adapter import GeminiAdapter
+
+
+# ---------------------------------------------------------------------------
+# Recorded fixture — deterministic NDJSON stream (record once, replay always)
+# ---------------------------------------------------------------------------
+
+# Each dict is a raw Gemini stream-json event as the CLI would emit.
+FIXTURE_STREAM_EVENTS = [
+    {"type": "session_start"},
+    {"type": "text", "text": "## Security Review\n\nFound 0 critical issues."},
+    {"type": "text", "text": " No SQL injection vectors detected."},
+    {
+        "type": "done",
+        "text": "Review complete.",
+        "usageMetadata": {"promptTokenCount": 200, "candidatesTokenCount": 80},
+    },
+]
+
+EXPECTED_EVENT_TYPES = ["init", "text", "text", "complete"]
+
+EXPECTED_PAYLOADS = [
+    {"raw_type": "session_start"},
+    {"text": "## Security Review\n\nFound 0 critical issues."},
+    {"text": " No SQL injection vectors detected."},
+    {
+        "text": "Review complete.",
+        "token_count": {
+            "input_tokens": 200,
+            "output_tokens": 80,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _strip_nondeterministic(ev_dict: dict) -> dict:
+    """Remove timestamp and event_id (generated fresh per call)."""
+    return {k: v for k, v in ev_dict.items() if k not in ("timestamp", "event_id")}
+
+
+def _fixture_canonical_events(terminal_id: str, dispatch_id: str) -> list:
+    """Convert raw fixture dicts to CanonicalEvents via normalize_gemini_event."""
+    return [normalize_gemini_event(raw, terminal_id, dispatch_id) for raw in FIXTURE_STREAM_EVENTS]
+
+
+# ---------------------------------------------------------------------------
+# Test: normalize_gemini_event produces expected canonical shapes
+# ---------------------------------------------------------------------------
+
+class TestNormalizerFixtureShapes:
+    """The standalone normalizer maps the recorded fixture to expected shapes."""
+
+    def test_event_types_match_expected(self):
+        events = _fixture_canonical_events("T3", "d1")
+        types = [e.event_type for e in events]
+        assert types == EXPECTED_EVENT_TYPES
+
+    def test_init_event_data(self):
+        events = _fixture_canonical_events("T3", "d1")
+        assert events[0].data == {"raw_type": "session_start"}
+
+    def test_text_events_preserve_content(self):
+        events = _fixture_canonical_events("T3", "d1")
+        assert events[1].data["text"] == "## Security Review\n\nFound 0 critical issues."
+        assert events[2].data["text"] == " No SQL injection vectors detected."
+
+    def test_complete_event_includes_token_count(self):
+        events = _fixture_canonical_events("T3", "d1")
+        complete = events[3]
+        assert complete.event_type == "complete"
+        assert complete.data.get("text") == "Review complete."
+        tc = complete.data.get("token_count", {})
+        assert tc.get("input_tokens") == 200
+        assert tc.get("output_tokens") == 80
+        assert tc.get("cache_creation_tokens") == 0
+
+    def test_all_events_have_gemini_provider(self):
+        events = _fixture_canonical_events("T3", "d1")
+        assert all(e.provider == "gemini" for e in events)
+
+    def test_all_events_tier_1(self):
+        events = _fixture_canonical_events("T3", "d1")
+        assert all(e.observability_tier == 1 for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Test: GeminiAdapter._normalize delegates to normalize_gemini_event (byte identity)
+# ---------------------------------------------------------------------------
+
+class TestAdapterNormalizerDelegatesIdentity:
+    """GeminiAdapter._normalize and normalize_gemini_event produce identical output."""
+
+    def test_byte_identity_per_event(self):
+        """GeminiAdapter._normalize output == normalize_gemini_event output (excl. non-det fields)."""
+        adapter = GeminiAdapter("T3")
+        adapter._current_terminal_id = "T3"
+        adapter._current_dispatch_id = "d1"
+
+        for raw in FIXTURE_STREAM_EVENTS:
+            via_adapter = adapter._normalize(raw).to_dict()
+            via_standalone = normalize_gemini_event(raw, "T3", "d1").to_dict()
+
+            assert _strip_nondeterministic(via_adapter) == _strip_nondeterministic(via_standalone), (
+                f"Mismatch for raw={raw!r}:\n"
+                f"  adapter:    {via_adapter}\n"
+                f"  standalone: {via_standalone}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: spawn_gemini streaming path fires event_writer with correct shapes
+# ---------------------------------------------------------------------------
+
+class TestSpawnGeminiStreamingEventWriter:
+    """spawn_gemini fires event_writer with to_dict() of normalized canonical events."""
+
+    def _run_spawn_with_fixture(self) -> list[dict]:
+        """Run spawn_gemini with fixture events injected via mocked drain_stream."""
+        import io
+
+        class _FakeProc:
+            stdin = io.BytesIO()
+            stdout = io.BytesIO(b"")
+            stderr = io.BytesIO(b"")
+            returncode = 0
+            pid = 12345
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+            def poll(self):
+                return 0
+
+        fixture_events = _fixture_canonical_events("T3", "d-fixture-01")
+        collected: list[dict] = []
+
+        def _writer(tid: str, ev_dict: dict, dispatch_id: str = "") -> None:
+            collected.append(ev_dict)
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter(fixture_events),
+             ):
+            spawn_gemini(
+                prompt="test prompt",
+                model="gemini-2.5-pro",
+                dispatch_id="d-fixture-01",
+                terminal_id="T3",
+                event_writer=_writer,
+            )
+
+        return collected
+
+    def test_event_count_matches_fixture(self):
+        collected = self._run_spawn_with_fixture()
+        assert len(collected) == len(FIXTURE_STREAM_EVENTS)
+
+    def test_event_types_match_expected(self):
+        collected = self._run_spawn_with_fixture()
+        types = [ev.get("event_type") for ev in collected]
+        assert types == EXPECTED_EVENT_TYPES
+
+    def test_events_match_standalone_normalizer(self):
+        """Events collected via event_writer == normalize_gemini_event().to_dict() per event."""
+        collected = self._run_spawn_with_fixture()
+        for i, (collected_ev, raw) in enumerate(zip(collected, FIXTURE_STREAM_EVENTS)):
+            expected = normalize_gemini_event(raw, "T3", "d-fixture-01").to_dict()
+            assert _strip_nondeterministic(collected_ev) == _strip_nondeterministic(expected), (
+                f"Event {i} mismatch: {collected_ev!r} != {expected!r}"
+            )
+
+    def test_completion_text_extracted(self):
+        """spawn_gemini extracts completion_text from the complete event."""
+        import io
+
+        class _FakeProc:
+            stdin = io.BytesIO()
+            stdout = io.BytesIO(b"")
+            stderr = io.BytesIO(b"")
+            returncode = 0
+            pid = 12345
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+            def poll(self):
+                return 0
+
+        fixture_events = _fixture_canonical_events("T3", "d1")
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter(fixture_events),
+             ):
+            result = spawn_gemini(
+                prompt="test", model="gemini-2.5-pro",
+                dispatch_id="d1", terminal_id="T3",
+            )
+
+        assert result.completion_text == "Review complete."
+        assert result.returncode == 0
+        assert result.timed_out is False
+
+
+# ---------------------------------------------------------------------------
+# Test: legacy path produces synthetic result event
+# ---------------------------------------------------------------------------
+
+class TestLegacyPathSyntheticEvent:
+
+    def test_legacy_fires_single_result_event(self):
+        """Legacy path emits a single synthetic {'type': 'result', 'data': text, ...} event."""
+        import io
+
+        class _FakeProc:
+            stdin = io.BytesIO()
+            stdout = io.BytesIO(b'{"response": "Legacy review findings."}')
+            stderr = io.BytesIO(b"")
+            returncode = 0
+            pid = 12345
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+            def poll(self):
+                return 0
+
+        collected: list[dict] = []
+
+        def _writer(tid, ev_dict, dispatch_id=""):
+            collected.append(ev_dict)
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "0"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._drain_buffered",
+                 return_value=('{"response": "Legacy review findings."}', "", "ok"),
+             ):
+            result = spawn_gemini(
+                prompt="test", model="gemini-2.5-pro",
+                dispatch_id="d1", terminal_id="T3",
+                event_writer=_writer,
+            )
+
+        assert len(collected) == 1
+        assert collected[0]["type"] == "result"
+        assert collected[0]["data"] == "Legacy review findings."
+        assert result.completion_text == "Legacy review findings."
+        assert result.events_written == 1

--- a/tests/test_gemini_spawn_fail_closed.py
+++ b/tests/test_gemini_spawn_fail_closed.py
@@ -241,6 +241,40 @@ class TestOnEventFalseStopsStreamEarly:
 
 
 # ---------------------------------------------------------------------------
+# Test: event_writer failure → logged as ERROR + counted in result
+# ---------------------------------------------------------------------------
+
+class TestEventWriterFailureLoggedAndCounted:
+
+    def test_event_writer_failure_is_logged_as_error_and_counted(self, caplog):
+        """event_writer always raising → result.event_writer_failures > 0 + ERROR in caplog."""
+        import logging
+
+        events = [
+            _make_canonical("text", {"text": "hello"}),
+        ]
+
+        def bad_writer(*args, **kwargs):
+            raise RuntimeError("simulated audit write failure")
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter(events),
+             ), \
+             caplog.at_level(logging.ERROR, logger="provider_spawns.gemini_spawn"):
+            result = spawn_gemini(
+                "prompt", "gemini-2.5-pro", "d1", "T3",
+                event_writer=bad_writer,
+            )
+
+        assert result.event_writer_failures > 0
+        error_msgs = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("event_writer" in m for m in error_msgs)
+
+
+# ---------------------------------------------------------------------------
 # Test: BrokenPipeError on stdin write → structured failure
 # ---------------------------------------------------------------------------
 

--- a/tests/test_gemini_spawn_fail_closed.py
+++ b/tests/test_gemini_spawn_fail_closed.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Wave 4.6 PR-4.6.4 — fail-closed tests for spawn_gemini.
+
+Covers:
+- spawn_gemini raises FileNotFoundError when `gemini` binary is missing.
+- chunk_timeout breach (simulated via drain_stream error event) returns timed_out=True.
+- on_event returning False stops the stream early and sets stopped_early=True.
+- BrokenPipeError on stdin write returns a structured failure, not an exception.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_LIB / "adapters"))
+
+from provider_spawns.gemini_spawn import spawn_gemini, GeminiSpawnResult
+from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeStdin:
+    """Minimal stdin that succeeds or raises on write."""
+
+    def __init__(self, raise_broken_pipe: bool = False) -> None:
+        self._broken = raise_broken_pipe
+
+    def write(self, data: bytes) -> None:
+        if self._broken:
+            raise BrokenPipeError("fake broken pipe")
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in."""
+
+    def __init__(
+        self,
+        returncode: int = 0,
+        raise_broken_pipe: bool = False,
+    ) -> None:
+        self.stdin = _FakeStdin(raise_broken_pipe=raise_broken_pipe)
+        self.stdout = io.BytesIO(b"")
+        self.stderr = io.BytesIO(b"")
+        self.returncode = returncode
+        self.pid = 99999
+
+    def wait(self, timeout=None) -> int:
+        return self.returncode
+
+    def kill(self) -> None:
+        pass
+
+    def poll(self) -> int:
+        return self.returncode
+
+
+def _make_canonical(event_type: str, data: dict) -> CanonicalEvent:
+    return CanonicalEvent(
+        dispatch_id="d1",
+        terminal_id="T3",
+        provider="gemini",
+        event_type=event_type,
+        data=data,
+        observability_tier=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: binary missing → FileNotFoundError raised (fail closed)
+# ---------------------------------------------------------------------------
+
+class TestBinaryMissingRaisesFileNotFoundError:
+
+    def test_streaming_path_raises_fnfe(self):
+        """spawn_gemini re-raises FileNotFoundError when gemini binary absent (streaming)."""
+        with patch("subprocess.Popen", side_effect=FileNotFoundError("No such file: gemini")), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}):
+            with pytest.raises(FileNotFoundError):
+                spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+    def test_legacy_path_raises_fnfe(self):
+        """spawn_gemini re-raises FileNotFoundError when gemini binary absent (legacy)."""
+        with patch("subprocess.Popen", side_effect=FileNotFoundError("No such file: gemini")), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "0"}):
+            with pytest.raises(FileNotFoundError):
+                spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+    def test_generic_oserror_returns_structured_failure(self):
+        """Non-FileNotFoundError OSError returns GeminiSpawnResult with error, not raised."""
+        with patch("subprocess.Popen", side_effect=OSError("permission denied")), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+        assert result.returncode != 0
+        assert result.error is not None
+        assert "permission denied" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Test: chunk_timeout → timed_out=True
+# ---------------------------------------------------------------------------
+
+class TestChunkTimeoutReturnsTrueFlag:
+
+    def test_streaming_timeout_event_sets_timed_out(self):
+        """Synthetic timeout error event from drain_stream sets timed_out=True."""
+        timeout_event = _make_canonical(
+            "error",
+            {"reason": "chunk timeout 60.0s exceeded"},
+        )
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter([timeout_event]),
+             ):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+        assert result.timed_out is True
+
+    def test_total_deadline_event_sets_timed_out(self):
+        """Synthetic deadline error event from drain_stream sets timed_out=True."""
+        deadline_event = _make_canonical(
+            "error",
+            {"reason": "total deadline 600s exceeded"},
+        )
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter([deadline_event]),
+             ):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+        assert result.timed_out is True
+
+    def test_legacy_timeout_returns_timed_out(self):
+        """Legacy path: _drain_buffered returning 'timeout' status sets timed_out=True."""
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "0"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._drain_buffered",
+                 return_value=("", "", "timeout"),
+             ):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+        assert result.timed_out is True
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Test: on_event returning False stops stream early
+# ---------------------------------------------------------------------------
+
+class TestOnEventFalseStopsStreamEarly:
+
+    def test_stopped_early_set_after_on_event_false(self):
+        """on_event returning False sets stopped_early=True after first event."""
+        events = [
+            _make_canonical("text", {"text": "partial output"}),
+            _make_canonical("complete", {"text": "should not reach here"}),
+        ]
+        calls = []
+
+        def on_event(ev: CanonicalEvent):
+            calls.append(ev.event_type)
+            return False  # stop after first event
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter(events),
+             ):
+            result = spawn_gemini(
+                "prompt", "gemini-2.5-pro", "d1", "T3",
+                on_event=on_event,
+            )
+
+        assert result.stopped_early is True
+        assert len(calls) == 1
+        assert calls[0] == "text"
+
+    def test_on_event_true_continues_stream(self):
+        """on_event returning True (or None) does not stop the stream."""
+        events = [
+            _make_canonical("text", {"text": "part 1"}),
+            _make_canonical("complete", {"text": "done"}),
+        ]
+        calls = []
+
+        def on_event(ev: CanonicalEvent):
+            calls.append(ev.event_type)
+            return True  # continue
+
+        with patch("subprocess.Popen", return_value=_FakeProc()), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}), \
+             patch(
+                 "provider_spawns.gemini_spawn._GeminiNormalizerHost.drain_stream",
+                 return_value=iter(events),
+             ):
+            result = spawn_gemini(
+                "prompt", "gemini-2.5-pro", "d1", "T3",
+                on_event=on_event,
+            )
+
+        assert result.stopped_early is False
+        assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: BrokenPipeError on stdin write → structured failure
+# ---------------------------------------------------------------------------
+
+class TestBrokenPipeReturnsStructuredFailure:
+
+    def test_streaming_broken_pipe_returns_error_result(self):
+        """BrokenPipeError on stdin.write returns GeminiSpawnResult with error."""
+        with patch("subprocess.Popen", return_value=_FakeProc(raise_broken_pipe=True)), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+        assert result.returncode != 0
+        assert "BrokenPipeError" in (result.error or "")
+
+    def test_legacy_broken_pipe_returns_error_result(self):
+        """BrokenPipeError on stdin.write (legacy path) returns GeminiSpawnResult."""
+        with patch("subprocess.Popen", return_value=_FakeProc(raise_broken_pipe=True)), \
+             patch.dict(os.environ, {"VNX_GEMINI_STREAM": "0"}):
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+
+        assert result.returncode != 0
+        assert "BrokenPipeError" in (result.error or "")

--- a/tests/test_gemini_spawn_fail_closed.py
+++ b/tests/test_gemini_spawn_fail_closed.py
@@ -80,24 +80,28 @@ def _make_canonical(event_type: str, data: dict) -> CanonicalEvent:
 
 
 # ---------------------------------------------------------------------------
-# Test: binary missing → FileNotFoundError raised (fail closed)
+# Test: binary missing → structured GeminiSpawnResult (returncode=127)
 # ---------------------------------------------------------------------------
 
-class TestBinaryMissingRaisesFileNotFoundError:
+class TestBinaryMissingReturnsStructuredResult:
 
-    def test_streaming_path_raises_fnfe(self):
-        """spawn_gemini re-raises FileNotFoundError when gemini binary absent (streaming)."""
+    def test_streaming_path_returns_structured_result_on_fnfe(self):
+        """spawn_gemini returns GeminiSpawnResult(returncode=127) when gemini binary absent (streaming)."""
         with patch("subprocess.Popen", side_effect=FileNotFoundError("No such file: gemini")), \
              patch.dict(os.environ, {"VNX_GEMINI_STREAM": "1"}):
-            with pytest.raises(FileNotFoundError):
-                spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+        assert isinstance(result, GeminiSpawnResult)
+        assert result.returncode == 127
+        assert "not found" in (result.error or "").lower()
 
-    def test_legacy_path_raises_fnfe(self):
-        """spawn_gemini re-raises FileNotFoundError when gemini binary absent (legacy)."""
+    def test_legacy_path_returns_structured_result_on_fnfe(self):
+        """spawn_gemini returns GeminiSpawnResult(returncode=127) when gemini binary absent (legacy)."""
         with patch("subprocess.Popen", side_effect=FileNotFoundError("No such file: gemini")), \
              patch.dict(os.environ, {"VNX_GEMINI_STREAM": "0"}):
-            with pytest.raises(FileNotFoundError):
-                spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+            result = spawn_gemini("prompt", "gemini-2.5-pro", "d1", "T3")
+        assert isinstance(result, GeminiSpawnResult)
+        assert result.returncode == 127
+        assert "not found" in (result.error or "").lower()
 
     def test_generic_oserror_returns_structured_failure(self):
         """Non-FileNotFoundError OSError returns GeminiSpawnResult with error, not raised."""
@@ -107,6 +111,19 @@ class TestBinaryMissingRaisesFileNotFoundError:
         assert result.returncode != 0
         assert result.error is not None
         assert "permission denied" in (result.error or "")
+
+    def test_spawn_returns_structured_result_when_binary_missing(self):
+        """With a PATH containing no gemini binary, spawn_gemini returns returncode=127, not FileNotFoundError."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as empty_bin:
+            result = spawn_gemini(
+                "prompt", "gemini-2.5-pro", "d1", "T3",
+                extra_env={"PATH": empty_bin},
+            )
+        assert isinstance(result, GeminiSpawnResult)
+        assert result.returncode == 127
+        assert result.error is not None
+        assert "not found" in (result.error or "").lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -145,47 +145,74 @@ class TestProviderClaudeDelegatesToSubprocessDispatch:
 
 
 # ---------------------------------------------------------------------------
-# Test: codex provider raises SystemExit(64) mentioning PR-4.6.3
+# Test: codex provider is routed to spawn_codex (PR-4.6.3 implemented)
 # ---------------------------------------------------------------------------
 
-class TestProviderCodexRaisesNotImplemented:
+class TestProviderCodexRouted:
 
-    def test_exit_code_64(self, capsys):
+    def test_codex_routes_to_spawn_codex(self):
+        """--provider codex calls spawn_codex and returns 0 on success."""
+        from unittest.mock import MagicMock
+        from provider_spawns.codex_spawn import CodexSpawnResult
+
+        mock_result = CodexSpawnResult(
+            returncode=0,
+            completion_text="ok",
+            events_written=1,
+            session_id=None,
+            timed_out=False,
+        )
+
         argv = ["--provider", "codex", "--terminal-id", "T1",
-                "--dispatch-id", "test-codex", "--instruction", "noop"]
-        with pytest.raises(SystemExit) as exc_info:
-            provider_dispatch.main(argv)
-        assert exc_info.value.code == 64
+                "--dispatch-id", "test-codex-routed", "--instruction", "noop"]
 
-    def test_message_mentions_pr_4_6_3(self, capsys):
+        with patch("provider_dispatch._dispatch_codex", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_codex_does_not_raise_system_exit_64(self):
+        """--provider codex must no longer raise SystemExit(64)."""
+        from provider_spawns.codex_spawn import CodexSpawnResult
+
         argv = ["--provider", "codex", "--terminal-id", "T1",
-                "--dispatch-id", "test-codex", "--instruction", "noop"]
-        with pytest.raises(SystemExit):
-            provider_dispatch.main(argv)
-        captured = capsys.readouterr()
-        assert "PR-4.6.3" in captured.err
+                "--dispatch-id", "test-codex-ok", "--instruction", "noop"]
+
+        with patch("provider_dispatch._dispatch_codex", return_value=0):
+            try:
+                rc = provider_dispatch.main(argv)
+            except SystemExit as exc:
+                pytest.fail(f"provider codex raised SystemExit({exc.code}): should be routed now")
 
 
 # ---------------------------------------------------------------------------
-# Test: gemini provider raises SystemExit(64) mentioning PR-4.6.4
+# Test: gemini provider is routed to spawn_gemini (PR-4.6.4 implemented)
 # ---------------------------------------------------------------------------
 
-class TestProviderGeminiRaisesNotImplemented:
+class TestProviderGeminiRouted:
 
-    def test_exit_code_64(self, capsys):
-        argv = ["--provider", "gemini", "--terminal-id", "T1",
-                "--dispatch-id", "test-gemini", "--instruction", "noop"]
-        with pytest.raises(SystemExit) as exc_info:
-            provider_dispatch.main(argv)
-        assert exc_info.value.code == 64
+    def test_gemini_routes_to_dispatch_gemini(self):
+        """--provider gemini calls _dispatch_gemini and returns 0 on success."""
+        argv = ["--provider", "gemini", "--terminal-id", "T3",
+                "--dispatch-id", "test-gemini-routed", "--instruction", "noop"]
 
-    def test_message_mentions_pr_4_6_4(self, capsys):
-        argv = ["--provider", "gemini", "--terminal-id", "T1",
-                "--dispatch-id", "test-gemini", "--instruction", "noop"]
-        with pytest.raises(SystemExit):
-            provider_dispatch.main(argv)
-        captured = capsys.readouterr()
-        assert "PR-4.6.4" in captured.err
+        with patch("provider_dispatch._dispatch_gemini", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_gemini_does_not_raise_system_exit_64(self):
+        """--provider gemini must no longer raise SystemExit(64)."""
+        argv = ["--provider", "gemini", "--terminal-id", "T3",
+                "--dispatch-id", "test-gemini-ok", "--instruction", "noop"]
+
+        with patch("provider_dispatch._dispatch_gemini", return_value=0):
+            try:
+                rc = provider_dispatch.main(argv)
+            except SystemExit as exc:
+                pytest.fail(f"provider gemini raised SystemExit({exc.code}): should be routed now")
 
 
 # ---------------------------------------------------------------------------
@@ -252,10 +279,9 @@ class TestModuleImportability:
         assert mod.__name__ == "provider_dispatch"
 
     def test_no_optional_provider_imports_at_module_load(self):
-        """codex/gemini/litellm spawn modules must not be imported at module load."""
+        """litellm_spawn (not yet implemented) must not be imported at module load."""
         import sys
-        # Ensure none of the not-yet-existing provider spawn modules are loaded.
+        # codex_spawn (PR-4.6.3) and gemini_spawn (PR-4.6.4) are now implemented.
+        # litellm_spawn is a future PR and must not exist yet.
         for mod_name in list(sys.modules.keys()):
-            assert "codex_spawn" not in mod_name, f"codex_spawn imported at module load: {mod_name}"
-            assert "gemini_spawn" not in mod_name, f"gemini_spawn imported at module load: {mod_name}"
-            assert "litellm_spawn" not in mod_name, f"litellm_spawn imported at module load: {mod_name}"
+            assert "litellm_spawn" not in mod_name, f"litellm_spawn imported unexpectedly: {mod_name}"


### PR DESCRIPTION
## Summary

- **New module** `scripts/lib/provider_spawns/gemini_spawn.py`: `GeminiSpawnResult` dataclass + `spawn_gemini()` entrypoint, streaming path (NDJSON via `_GeminiNormalizerHost`/`StreamingDrainerMixin`) and legacy buffered-JSON path, single canonical `normalize_gemini_event()` function, token-extraction helpers (`_extract_gemini_usage_metadata`, `_extract_gemini_token_count`).
- **`gemini_adapter.py`** refactored: `GeminiAdapter.execute()` delegates to `spawn_gemini()`; `_normalize()` delegates to `normalize_gemini_event()`. Byte-identical behavior — no functional change to callers.
- **`provider_dispatch.py`**: `gemini` added to `_IMPLEMENTED_PROVIDERS`; `_dispatch_gemini()` routes `--provider gemini` to `spawn_gemini()`.
- **`test_provider_dispatch_entry.py`**: `TestProviderGeminiRaisesNotImplemented` → `TestProviderGeminiRouted`; import-guard updated to `litellm_spawn`-only.

Design doc reference: `claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.4`
Extracted from: `gemini_adapter.py` (inline `_execute_streaming`, `_execute_legacy`, normalizer helpers)

## Tests breakdown

| File | Tests | Result |
|---|---|---|
| `tests/test_gemini_spawn_fail_closed.py` | 10 | ✅ green |
| `tests/test_gemini_spawn_byte_identity.py` | 12 | ✅ green |
| `tests/test_provider_dispatch_entry.py` | 19 | ✅ green |
| **Total** | **41** | **all pass** |

Key gate: `TestAdapterNormalizerDelegatesIdentity::test_byte_identity_per_event` confirms `GeminiAdapter._normalize()` and `normalize_gemini_event()` produce identical output (excluding non-deterministic fields).

`python3 scripts/ci_lint_patterns.py` — 0 new findings in PR-4.6.4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)