### PR TITLE
feat(wave4.6): PR-4.6.3 — codex_spawn handler extracted from codex_adapter

### DIFF
--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -28,6 +28,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from _streaming_drainer import StreamingDrainerMixin
 from canonical_event import CanonicalEvent
 from provider_adapter import AdapterResult, Capability, ProviderAdapter
+from provider_spawns.codex_spawn import (  # noqa: E402
+    normalize_codex_event,
+    spawn_codex,
+    _extract_token_count_payload as _spawn_extract_token_count_payload,
+    _normalize_token_count as _spawn_normalize_token_count,
+)
 from vertex_ai_runner import collect_file_contents
 
 logger = logging.getLogger(__name__)
@@ -77,8 +83,8 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
     def execute(self, instruction: str, context: dict) -> AdapterResult:
         """Run a Codex review with inline file contents and return findings.
 
-        Spawns `codex exec --json`, drains stdout via StreamingDrainerMixin for
-        live Tier-1 events, collects text findings, and returns AdapterResult.
+        Delegates spawn+stream to spawn_codex() (Wave 4.6 PR-4.6.3).
+        Behavior is byte-identical to the pre-refactor inline path.
         """
         model = (
             os.environ.get("VNX_CODEX_HEADLESS_MODEL")
@@ -101,100 +107,40 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
         role = context.get("role")
         dispatch_meta = context.get("dispatch_metadata", {})
         prompt = self._build_prompt(instruction, changed_files, role=role, dispatch_metadata=dispatch_meta)
-        cmd = self._build_cmd(model)
 
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
 
         t0 = time.monotonic()
-        try:
-            proc = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                start_new_session=True,
-            )
-        except OSError as exc:
-            return AdapterResult(
-                status="failed",
-                output=str(exc),
-                events=[],
-                event_count=0,
-                duration_seconds=0.0,
-                committed=False,
-                commit_hash=None,
-                report_path=None,
-                provider="codex",
-                model=model,
-            )
 
-        if proc.stdin:
-            try:
-                proc.stdin.write(prompt.encode("utf-8"))
-                proc.stdin.close()
-            except BrokenPipeError:
-                return AdapterResult(
-                    status="failed",
-                    output="stdin write failed (BrokenPipeError): codex process exited early",
-                    events=[],
-                    event_count=0,
-                    duration_seconds=0.0,
-                    committed=False,
-                    commit_hash=None,
-                    report_path=None,
-                    provider="codex",
-                    model=model,
-                )
+        collected_events: list[dict] = []
 
-        events: list[dict] = []
-        findings_parts: list[str] = []
-        last_token_usage: Optional[dict] = None
+        def _collect_event(tid: str, event_dict: dict, dispatch_id: str = dispatch_id) -> None:
+            collected_events.append(event_dict)
 
-        for canonical_event in self.drain_stream(
-            proc,
-            terminal_id,
-            dispatch_id,
-            event_store,
+        spawn_result = spawn_codex(
+            prompt=prompt,
+            model=model,
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            event_writer=_collect_event,
+            event_store=event_store,
             chunk_timeout=chunk_timeout,
             total_deadline=total_deadline,
-        ):
-            events.append(canonical_event.to_dict())
-            if canonical_event.event_type == "text":
-                text = canonical_event.data.get("text", "")
-                if text:
-                    findings_parts.append(text)
-                tc = canonical_event.data.get("token_count")
-                if tc:
-                    last_token_usage = tc
-            elif canonical_event.event_type == "complete":
-                tc = canonical_event.data.get("token_count")
-                if tc:
-                    last_token_usage = tc
-                text = canonical_event.data.get("text", "")
-                if text:
-                    findings_parts.append(text)
-
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+        )
 
         duration = time.monotonic() - t0
 
-        if last_token_usage:
-            self._write_token_cache(last_token_usage)
+        if spawn_result.token_usage:
+            self._write_token_cache(spawn_result.token_usage)
 
-        findings = "\n\n".join(findings_parts) if findings_parts else ""
-        rc = proc.returncode
-        status = "done" if rc == 0 else "failed"
+        status = "done" if spawn_result.returncode == 0 else "failed"
 
         return AdapterResult(
             status=status,
-            output=findings,
-            events=events,
-            event_count=len(events),
+            output=spawn_result.completion_text,
+            events=collected_events,
+            event_count=len(collected_events),
             duration_seconds=duration,
             committed=False,
             commit_hash=None,
@@ -272,143 +218,8 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
     # ------------------------------------------------------------------
 
     def _normalize(self, raw: dict) -> CanonicalEvent:
-        """Map a raw Codex NDJSON event to a CanonicalEvent (Tier-1).
-
-        Handles three Codex event shapes:
-        1. New-style top-level: {"type": "thread.started"|"turn.completed"|"item.*", ...}
-        2. Wrapped: {"event_msg": {"payload": {"type": "session_start"|"agent_message"|..., ...}}}
-        3. Legacy: {"type": "agent_message"|"result"|"message", "content": "..."}
-
-        Mapping:
-          thread.started / session_start             → init
-          agent_message (direct or item.completed)   → text
-          item.started/updated [command_execution]   → tool_use
-          item.completed [command_execution]          → tool_result
-          error                                       → error
-          turn.completed / result / message           → complete
-          token_count (intermediate telemetry)        → text (token_count in data)
-          unknown                                     → error
-        """
-        terminal_id = self._current_terminal_id
-        dispatch_id = self._current_dispatch_id
-
-        def make(event_type: str, data: dict) -> CanonicalEvent:
-            return CanonicalEvent(
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                provider="codex",
-                event_type=event_type,
-                data=data,
-                observability_tier=1,
-            )
-
-        # Resolve effective payload: unwrap event_msg.payload when present.
-        top_etype = raw.get("type", "")
-        payload: dict = raw
-        event_msg = raw.get("event_msg")
-        if isinstance(event_msg, dict):
-            inner = event_msg.get("payload")
-            if isinstance(inner, dict):
-                payload = inner
-            elif isinstance(event_msg.get("type"), str):
-                payload = event_msg
-
-        etype = payload.get("type", "") if isinstance(payload, dict) else ""
-
-        # New-style item.* / thread.* / turn.* events use the top-level type.
-        if top_etype and (
-            top_etype.startswith("item.")
-            or top_etype.startswith("thread.")
-            or top_etype.startswith("turn.")
-        ):
-            etype = top_etype
-            payload = raw
-
-        item: dict = {}
-        raw_item = raw.get("item") or (payload.get("item") if payload is not raw else None)
-        if isinstance(raw_item, dict):
-            item = raw_item
-        item_type = item.get("type", "")
-
-        # ── thread.started / session_start → init ──────────────────────
-        if etype in ("thread.started", "session_start"):
-            return make("init", {"raw_type": etype})
-
-        # ── agent_message (direct) → text ──────────────────────────────
-        if etype == "agent_message":
-            content = payload.get("text", payload.get("content", payload.get("message", "")))
-            return make("text", {"text": str(content)})
-
-        # ── item.completed [agent_message] → text ──────────────────────
-        if etype == "item.completed" and item_type == "agent_message":
-            content = item.get("content", "")
-            if isinstance(content, list):
-                texts = [
-                    block.get("text", "")
-                    for block in content
-                    if isinstance(block, dict)
-                ]
-                content = "\n".join(t for t in texts if t)
-            return make("text", {"text": str(content)})
-
-        # ── item.started / item.updated [command_execution] → tool_use ─
-        if etype in ("item.started", "item.updated") and item_type == "command_execution":
-            cmd_str = item.get("command", item.get("cmd", item.get("args", "")))
-            if isinstance(cmd_str, list):
-                cmd_str = " ".join(str(a) for a in cmd_str)
-            return make("tool_use", {"command": str(cmd_str), "raw_type": etype})
-
-        # ── item.completed [command_execution] → tool_result ───────────
-        if etype == "item.completed" and item_type == "command_execution":
-            output = item.get("output", item.get("result", ""))
-            exit_code = item.get("exit_code", 0)
-            return make("tool_result", {"output": str(output), "exit_code": exit_code})
-
-        # ── error → error ───────────────────────────────────────────────
-        if etype == "error":
-            msg = payload.get("message", payload.get("error", payload.get("text", "")))
-            return make("error", {"message": str(msg) if msg else str(payload)[:200]})
-
-        # ── turn.completed → complete (with token_count from event) ─────
-        if etype == "turn.completed":
-            tc_payload = CodexAdapter._extract_token_count_payload(raw)
-            token_count = CodexAdapter._normalize_token_count(tc_payload) if tc_payload else None
-            data: dict = {}
-            if token_count:
-                data["token_count"] = token_count
-            return make("complete", data)
-
-        # ── result / message → complete ─────────────────────────────────
-        if etype in ("result", "message"):
-            content = payload.get("content", payload.get("text", payload.get("output", "")))
-            tc_payload = CodexAdapter._extract_token_count_payload(raw)
-            token_count = CodexAdapter._normalize_token_count(tc_payload) if tc_payload else None
-            # Also check OpenAI-style usage block on result events
-            if token_count is None:
-                usage = raw.get("usage") or payload.get("usage")
-                if isinstance(usage, dict):
-                    token_count = CodexAdapter._normalize_token_count({
-                        "input_tokens": usage.get("input_tokens") or usage.get("prompt_tokens", 0),
-                        "output_tokens": usage.get("output_tokens") or usage.get("completion_tokens", 0),
-                    })
-            data = {"text": str(content)} if content else {}
-            if token_count:
-                data["token_count"] = token_count
-            return make("complete", data)
-
-        # ── intermediate token_count → text (with token data) ───────────
-        tc_payload = CodexAdapter._extract_token_count_payload(raw)
-        if tc_payload is not None:
-            token_count = CodexAdapter._normalize_token_count(tc_payload)
-            if token_count:
-                return make("text", {"text": "", "token_count": token_count})
-
-        # ── unknown event type → error ───────────────────────────────────
-        return make("error", {
-            "reason": f"unrecognized codex event type: {etype!r}",
-            "raw_type": etype,
-            "raw": str(raw)[:300],
-        })
+        """Delegate to normalize_codex_event (single implementation in codex_spawn)."""
+        return normalize_codex_event(raw, self._current_terminal_id, self._current_dispatch_id)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -432,80 +243,13 @@ class CodexAdapter(StreamingDrainerMixin, ProviderAdapter):
 
     @staticmethod
     def _extract_token_count_payload(event: dict) -> Optional[dict]:
-        """Locate a `token_count` payload nested inside a Codex NDJSON event.
-
-        Codex `exec --json` emits records where the actual event body lives under
-        one of several wrapper keys, e.g.:
-
-            {"event_msg": {"payload": {"type": "token_count",
-                                        "input_tokens": N,
-                                        "cached_input_tokens": M,
-                                        "output_tokens": K, ...}}}
-
-            {"msg": {"type": "token_count", "input_tokens": N, ...}}
-
-            {"item": {"type": "token_count", ...}}
-
-        Returns the inner payload dict when type == "token_count", else None.
-        """
-        if not isinstance(event, dict):
-            return None
-        # event_msg.payload (current `codex exec` shape)
-        em = event.get("event_msg")
-        if isinstance(em, dict):
-            payload = em.get("payload")
-            if isinstance(payload, dict) and payload.get("type") == "token_count":
-                return payload
-            if em.get("type") == "token_count":
-                return em
-        # msg-wrapped variant
-        msg = event.get("msg")
-        if isinstance(msg, dict) and msg.get("type") == "token_count":
-            return msg
-        # item-wrapped variant
-        item = event.get("item")
-        if isinstance(item, dict) and item.get("type") == "token_count":
-            return item
-        # top-level token_count
-        if event.get("type") == "token_count":
-            return event
-        return None
+        """Shim: delegates to codex_spawn._extract_token_count_payload."""
+        return _spawn_extract_token_count_payload(event)
 
     @staticmethod
     def _normalize_token_count(payload: dict) -> Optional[dict]:
-        """Normalize a Codex token_count payload to the canonical token_usage dict.
-
-        Codex variants we accept:
-        - input_tokens / output_tokens (preferred)
-        - prompt_tokens / completion_tokens (OpenAI-compat key names)
-        Cache breakdown (best-effort, both names supported):
-        - cached_input_tokens / cache_read_tokens
-        - cache_creation_input_tokens / cache_creation_tokens
-        """
-        if not isinstance(payload, dict):
-            return None
-        input_t = payload.get("input_tokens")
-        if input_t is None:
-            input_t = payload.get("prompt_tokens", 0)
-        output_t = payload.get("output_tokens")
-        if output_t is None:
-            output_t = payload.get("completion_tokens", 0)
-        if not isinstance(input_t, int) or not isinstance(output_t, int):
-            return None
-        if input_t == 0 and output_t == 0:
-            return None
-        cache_read = payload.get("cached_input_tokens")
-        if cache_read is None:
-            cache_read = payload.get("cache_read_tokens", 0)
-        cache_creation = payload.get("cache_creation_input_tokens")
-        if cache_creation is None:
-            cache_creation = payload.get("cache_creation_tokens", 0)
-        return {
-            "input_tokens": int(input_t),
-            "output_tokens": int(output_t),
-            "cache_creation_tokens": int(cache_creation) if isinstance(cache_creation, int) else 0,
-            "cache_read_tokens": int(cache_read) if isinstance(cache_read, int) else 0,
-        }
+        """Shim: delegates to codex_spawn._normalize_token_count."""
+        return _spawn_normalize_token_count(payload)
 
     @staticmethod
     def _parse_token_usage_from_output(raw: str) -> Optional[dict]:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -15,10 +15,13 @@ subprocess only.
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+
+logger = logging.getLogger(__name__)
 
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
@@ -95,9 +98,21 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
     """Route to spawn_codex for codex-provider dispatches (PR-4.6.3).
 
     Prompt is the raw instruction; file-content injection is caller's responsibility.
+    Wires EventStore as event_writer so codex dispatches produce a NDJSON audit trail
+    identical to the claude path (provider-agnostic audit completeness, ADR-005).
     """
     import os
     from provider_spawns.codex_spawn import spawn_codex
+
+    event_store = None
+    try:
+        from event_store import EventStore
+        event_store = EventStore()
+    except Exception as _es_exc:
+        logger.warning(
+            "_dispatch_codex: EventStore unavailable; NDJSON audit sink skipped: %s",
+            _es_exc,
+        )
 
     model = os.environ.get("VNX_CODEX_MODEL", "")
     result = spawn_codex(
@@ -105,6 +120,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         model=model,
         dispatch_id=args.dispatch_id,
         terminal_id=args.terminal_id,
+        event_writer=event_store.append if event_store is not None else None,
     )
     if result.error:
         print(f"spawn_codex failed: {result.error}", file=sys.stderr)

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6 PR-4.6.1).
+"""provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6).
 
 Routes dispatch execution to the appropriate provider spawn handler based on
-``--provider``.  In PR-4.6.1 only the ``claude`` provider is wired; all other
-providers raise NotImplementedError with exit code 64 (EX_USAGE) until their
-respective spawn handlers land in subsequent PRs.
+``--provider``. PR-4.6.1: claude wired. PR-4.6.3: codex wired. All other
+providers raise SystemExit(64) until their handlers land in subsequent PRs.
 
-See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md §PR-4.6.1
+See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md
 
 BILLING SAFETY: this module does NOT import the Anthropic SDK.  Claude dispatch
 delegates entirely to ``subprocess_dispatch.py`` which invokes ``claude -p`` via
@@ -23,12 +22,11 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
-# Providers whose spawn handlers exist in this PR.
-_IMPLEMENTED_PROVIDERS = {"claude"}
+# Providers whose spawn handlers exist.
+_IMPLEMENTED_PROVIDERS = {"claude", "codex"}
 
 # Mapping: provider literal -> which future PR delivers its handler.
 _FUTURE_PR_MAP = {
-    "codex": "PR-4.6.3",
     "gemini": "PR-4.6.4",
 }
 
@@ -93,6 +91,30 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _dispatch_codex(args: argparse.Namespace) -> int:
+    """Route to spawn_codex for codex-provider dispatches (PR-4.6.3).
+
+    Prompt is the raw instruction; file-content injection is caller's responsibility.
+    """
+    import os
+    from provider_spawns.codex_spawn import spawn_codex
+
+    model = os.environ.get("VNX_CODEX_MODEL", "")
+    result = spawn_codex(
+        prompt=args.instruction,
+        model=model,
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+    )
+    if result.error:
+        print(f"spawn_codex failed: {result.error}", file=sys.stderr)
+        return 1
+    if result.timed_out:
+        print("spawn_codex timed out", file=sys.stderr)
+        return 1
+    return 0 if result.returncode == 0 else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse args, route to the correct provider handler, return exit code."""
     parser = _build_parser()
@@ -108,13 +130,7 @@ def main(argv: list[str] | None = None) -> int:
         return _dispatch_claude(args)
 
     if provider == "codex":
-        future_pr = _FUTURE_PR_MAP["codex"]
-        print(
-            f"Provider 'codex' spawn handler lands in {future_pr}. "
-            "Use --provider claude for now.",
-            file=sys.stderr,
-        )
-        raise SystemExit(_EX_USAGE)
+        return _dispatch_codex(args)
 
     if provider == "gemini":
         future_pr = _FUTURE_PR_MAP["gemini"]

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -2,8 +2,8 @@
 """provider_dispatch.py — Provider-agnostic dispatch entry-point (Wave 4.6).
 
 Routes dispatch execution to the appropriate provider spawn handler based on
-``--provider``. PR-4.6.1: claude wired. PR-4.6.3: codex wired. All other
-providers raise SystemExit(64) until their handlers land in subsequent PRs.
+``--provider``. PR-4.6.1: claude wired. PR-4.6.3: codex wired. PR-4.6.4: gemini wired.
+All other providers raise SystemExit(64) until their handlers land.
 
 See: claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md
 
@@ -26,12 +26,10 @@ logger = logging.getLogger(__name__)
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
 # Providers whose spawn handlers exist.
-_IMPLEMENTED_PROVIDERS = {"claude", "codex"}
+_IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini"}
 
 # Mapping: provider literal -> which future PR delivers its handler.
-_FUTURE_PR_MAP = {
-    "gemini": "PR-4.6.4",
-}
+_FUTURE_PR_MAP: dict = {}
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -128,7 +126,50 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
     if result.timed_out:
         print("spawn_codex timed out", file=sys.stderr)
         return 1
-    return 0 if result.returncode == 0 else 1
+    if result.returncode != 0:
+        return 1
+    if result.event_writer_failures > 0:
+        logger.error(
+            "codex dispatch completed but %d event_writer failures occurred — audit gap",
+            result.event_writer_failures,
+        )
+        return 2
+    return 0
+
+
+def _dispatch_gemini(args: argparse.Namespace) -> int:
+    """Route to spawn_gemini for gemini-provider dispatches (PR-4.6.4).
+
+    Prompt is the raw instruction; file-content injection is caller's responsibility.
+    """
+    import os
+    from event_store import EventStore
+    from provider_spawns.gemini_spawn import spawn_gemini
+
+    model = os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+    event_store = EventStore()
+    result = spawn_gemini(
+        prompt=args.instruction,
+        model=model,
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+        event_writer=event_store.append,
+    )
+    if result.error:
+        print(f"spawn_gemini failed: {result.error}", file=sys.stderr)
+        return 1
+    if result.timed_out:
+        print("spawn_gemini timed out", file=sys.stderr)
+        return 1
+    if result.returncode != 0:
+        return 1
+    if result.event_writer_failures > 0:
+        logger.error(
+            "gemini dispatch completed but %d event_writer failures occurred — audit gap",
+            result.event_writer_failures,
+        )
+        return 2
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -149,13 +190,7 @@ def main(argv: list[str] | None = None) -> int:
         return _dispatch_codex(args)
 
     if provider == "gemini":
-        future_pr = _FUTURE_PR_MAP["gemini"]
-        print(
-            f"Provider 'gemini' spawn handler lands in {future_pr}. "
-            "Use --provider claude for now.",
-            file=sys.stderr,
-        )
-        raise SystemExit(_EX_USAGE)
+        return _dispatch_gemini(args)
 
     if provider.startswith("litellm:"):
         print(

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -55,6 +55,9 @@ class CodexSpawnResult:
     token_usage: Optional[Dict[str, Any]] = None
     # Set when an exception terminated the stream read.
     error: Optional[str] = None
+    # Number of times event_writer callback raised an exception.
+    # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
+    event_writer_failures: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -337,10 +340,11 @@ def _process_one_event(
     HealthStatus: Any,
     SLOW_THRESHOLD: float,
     last_stuck_log: float,
-) -> Tuple[bool, float]:
+    events_written: int = 0,
+) -> Tuple[bool, float, bool]:
     """Process one canonical event: health tick, event_writer, on_event.
 
-    Returns (stop_requested, updated_last_stuck_log).
+    Returns (stop_requested, updated_last_stuck_log, writer_failed).
     """
     if health_monitor is not None:
         health_monitor.update(canonical_event)
@@ -352,6 +356,7 @@ def _process_one_event(
                     health_monitor.log_stuck_event()
                     last_stuck_log = now
 
+    writer_failed = False
     if event_writer is not None:
         try:
             event_writer(
@@ -360,11 +365,17 @@ def _process_one_event(
                 dispatch_id=dispatch_id,
             )
         except Exception as _exc:
-            logger.debug("spawn_codex: event_writer raised: %s", _exc)
+            # event_writer is caller-supplied (typically writes to NDJSON ledger).
+            # Failures are ADR-005 audit gaps — log as ERROR + count for caller inspection.
+            logger.error(
+                "spawn_codex: event_writer callback failed (dispatch=%s, event_count=%d): %s",
+                dispatch_id, events_written, _exc,
+            )
+            writer_failed = True
 
     if on_event is not None and on_event(canonical_event) is False:
-        return True, last_stuck_log
-    return False, last_stuck_log
+        return True, last_stuck_log, writer_failed
+    return False, last_stuck_log, writer_failed
 
 
 def _wait_proc(proc: subprocess.Popen, timeout: float = 5.0) -> None:
@@ -389,10 +400,11 @@ def _drain_stream(
     total_deadline: float,
     HealthStatus: Any,
     SLOW_THRESHOLD: float,
-) -> Tuple[list, int, Optional[str], bool, bool, Optional[Dict[str, Any]], Optional[str]]:
-    """Drain codex NDJSON stream; return (parts, count, session_id, timed_out, stopped, usage, error)."""
+) -> Tuple[list, int, Optional[str], bool, bool, Optional[Dict[str, Any]], Optional[str], int]:
+    """Drain codex NDJSON stream; return (parts, count, session_id, timed_out, stopped, usage, error, writer_failures)."""
     completion_parts: list = []
     events_written = 0
+    _event_writer_failures = 0
     session_id: Optional[str] = None
     timed_out = False
     stopped_early = False
@@ -420,11 +432,14 @@ def _drain_stream(
                 if "timeout" in (reason or "").lower():
                     timed_out = True
 
-            stop, last_stuck_log = _process_one_event(
+            stop, last_stuck_log, writer_failed = _process_one_event(
                 canonical_event, terminal_id, dispatch_id,
                 health_monitor, event_writer, on_event,
                 HealthStatus, SLOW_THRESHOLD, last_stuck_log,
+                events_written=events_written,
             )
+            if writer_failed:
+                _event_writer_failures += 1
             if stop:
                 stopped_early = True
                 try:
@@ -440,9 +455,9 @@ def _drain_stream(
         except Exception as _kill_exc:
             logger.debug("spawn_codex: kill in error handler failed: %s", _kill_exc)
         _wait_proc(proc)
-        return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, str(exc)
+        return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, str(exc), _event_writer_failures
 
-    return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, None
+    return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, None, _event_writer_failures
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +471,7 @@ def spawn_codex(
     terminal_id: str,
     *,
     event_writer: Optional[Callable[..., None]] = None,
+    event_writer_strict: bool = False,
     health_monitor: Optional[Any] = None,
     on_event: Optional[Callable[[Any], Optional[bool]]] = None,
     extra_env: Optional[Dict[str, str]] = None,
@@ -470,6 +486,9 @@ def spawn_codex(
     Returns CodexSpawnResult on completion (success OR controlled failure).
     Raises FileNotFoundError when the codex binary is absent.
     Caller is responsible for lease/manifest/receipt/event-archive/retry.
+
+    event_writer_strict=True raises RuntimeError if any event_writer call failed,
+    for callers that require strict ADR-005 audit-trail integrity.
     """
     try:
         from worker_health_monitor import HealthStatus, SLOW_THRESHOLD
@@ -492,7 +511,7 @@ def spawn_codex(
 
     normalizer = _NormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
 
-    parts, events_written, session_id, timed_out, stopped_early, token_usage, error = _drain_stream(
+    parts, events_written, session_id, timed_out, stopped_early, token_usage, error, _event_writer_failures = _drain_stream(
         normalizer, proc, terminal_id, dispatch_id, event_store,
         health_monitor, event_writer, on_event,
         chunk_timeout, total_deadline, HealthStatus, SLOW_THRESHOLD,
@@ -503,6 +522,12 @@ def spawn_codex(
 
     returncode = proc.returncode if proc.returncode is not None else 1
 
+    if event_writer_strict and _event_writer_failures > 0:
+        raise RuntimeError(
+            f"spawn_codex: event_writer failed {_event_writer_failures} time(s) "
+            f"(dispatch={dispatch_id}) — strict audit mode requires zero failures"
+        )
+
     return CodexSpawnResult(
         returncode=returncode if error is None else (returncode if returncode != 0 else 1),
         completion_text="\n\n".join(parts),
@@ -512,6 +537,7 @@ def spawn_codex(
         stopped_early=stopped_early,
         token_usage=token_usage,
         error=error,
+        event_writer_failures=_event_writer_failures,
     )
 
 

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -293,7 +293,7 @@ def _launch_codex_proc(
     """Start codex subprocess and write prompt to stdin.
 
     Returns (proc, None) on success, or (None, error_result) on failure.
-    Re-raises FileNotFoundError so callers distinguish missing binary.
+    Returns (None, CodexSpawnResult(returncode=127)) when binary is missing.
     """
     cmd = _build_cmd(model)
     env = {**os.environ, **(extra_env or {})}
@@ -309,8 +309,18 @@ def _launch_codex_proc(
             cwd=cwd_str,
             start_new_session=True,
         )
-    except FileNotFoundError:
-        raise
+    except FileNotFoundError as e:
+        return None, CodexSpawnResult(
+            returncode=127,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=f"codex binary not found: {e}",
+            event_writer_failures=0,
+        )
     except OSError as exc:
         return None, CodexSpawnResult(
             returncode=1, completion_text="", events_written=0,
@@ -484,7 +494,7 @@ def spawn_codex(
     """Spawn `codex exec --json` and consume the NDJSON event stream.
 
     Returns CodexSpawnResult on completion (success OR controlled failure).
-    Raises FileNotFoundError when the codex binary is absent.
+    Returns CodexSpawnResult(returncode=127) when the codex binary is absent.
     Caller is responsible for lease/manifest/receipt/event-archive/retry.
 
     event_writer_strict=True raises RuntimeError if any event_writer call failed,

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -1,0 +1,530 @@
+"""codex_spawn.py — Codex-specific spawn handler extracted from codex_adapter.
+
+Extracted in Wave 4.6 PR-4.6.3. This module owns the "pure spawn+stream" slice:
+
+  1. Spawn `codex exec --json` via subprocess.Popen with stdin pipe for prompt.
+  2. Stream stdout NDJSON; normalize to CanonicalEvent dicts via the normalizer
+     logic (single implementation; codex_adapter delegates here for byte identity).
+  3. Tick health_monitor on each event.
+  4. Invoke optional on_event callback per event (return False to stop early).
+
+Callers handle: lease/manifest/receipt/event-archive/retry/changed-files context.
+
+BILLING SAFETY: only subprocess.Popen(["codex", "exec", "--json"]) is invoked.
+No Anthropic SDK, no LiteLLM, no remote-API direct calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1])
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from canonical_event import CanonicalEvent  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CodexSpawnResult:
+    """Return value from spawn_codex(); carries spawn outcome to the caller."""
+
+    returncode: int
+    # Final result text (concatenated agent_message content from the stream).
+    completion_text: str
+    # Number of normalized events processed.
+    events_written: int
+    # codex session identifier from thread.started/session_start event, else None.
+    session_id: Optional[str]
+    # True when chunk_timeout or total_deadline was breached.
+    timed_out: bool
+    # True when on_event returned False (early stream termination).
+    stopped_early: bool = False
+    # Token usage extracted from the stream's final token_count event, else None.
+    token_usage: Optional[Dict[str, Any]] = None
+    # Set when an exception terminated the stream read.
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Normalizer helpers — single implementation; codex_adapter shims delegate here
+# ---------------------------------------------------------------------------
+
+_TOKEN_TEXT_RE = re.compile(
+    r"tokens?:\s*(\d+)\s+input\s*/\s*(\d+)\s+output",
+    re.IGNORECASE,
+)
+
+
+def _extract_token_count_payload(event: dict) -> Optional[dict]:
+    """Locate a `token_count` payload inside a Codex NDJSON event dict."""
+    if not isinstance(event, dict):
+        return None
+    em = event.get("event_msg")
+    if isinstance(em, dict):
+        payload = em.get("payload")
+        if isinstance(payload, dict) and payload.get("type") == "token_count":
+            return payload
+        if em.get("type") == "token_count":
+            return em
+    msg = event.get("msg")
+    if isinstance(msg, dict) and msg.get("type") == "token_count":
+        return msg
+    item = event.get("item")
+    if isinstance(item, dict) and item.get("type") == "token_count":
+        return item
+    if event.get("type") == "token_count":
+        return event
+    return None
+
+
+def _normalize_token_count(payload: dict) -> Optional[dict]:
+    """Normalize a Codex token_count payload to the canonical token_usage dict."""
+    if not isinstance(payload, dict):
+        return None
+    input_t = payload.get("input_tokens")
+    if input_t is None:
+        input_t = payload.get("prompt_tokens", 0)
+    output_t = payload.get("output_tokens")
+    if output_t is None:
+        output_t = payload.get("completion_tokens", 0)
+    if not isinstance(input_t, int) or not isinstance(output_t, int):
+        return None
+    if input_t == 0 and output_t == 0:
+        return None
+    cache_read = payload.get("cached_input_tokens")
+    if cache_read is None:
+        cache_read = payload.get("cache_read_tokens", 0)
+    cache_creation = payload.get("cache_creation_input_tokens")
+    if cache_creation is None:
+        cache_creation = payload.get("cache_creation_tokens", 0)
+    return {
+        "input_tokens": int(input_t),
+        "output_tokens": int(output_t),
+        "cache_creation_tokens": int(cache_creation) if isinstance(cache_creation, int) else 0,
+        "cache_read_tokens": int(cache_read) if isinstance(cache_read, int) else 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Normalizer internals — split to stay ≤70 lines per function
+# ---------------------------------------------------------------------------
+
+def _resolve_codex_event_parts(raw: dict) -> Tuple[str, dict, dict, str]:
+    """Extract (etype, payload, item, item_type) from a raw Codex NDJSON event."""
+    top_etype = raw.get("type", "")
+    payload: dict = raw
+    event_msg = raw.get("event_msg")
+    if isinstance(event_msg, dict):
+        inner = event_msg.get("payload")
+        if isinstance(inner, dict):
+            payload = inner
+        elif isinstance(event_msg.get("type"), str):
+            payload = event_msg
+
+    etype = payload.get("type", "") if isinstance(payload, dict) else ""
+
+    if top_etype and (
+        top_etype.startswith("item.")
+        or top_etype.startswith("thread.")
+        or top_etype.startswith("turn.")
+    ):
+        etype = top_etype
+        payload = raw
+
+    item: dict = {}
+    raw_item = raw.get("item") or (payload.get("item") if payload is not raw else None)
+    if isinstance(raw_item, dict):
+        item = raw_item
+    return etype, payload, item, item.get("type", "")
+
+
+def _normalize_text_events(
+    etype: str,
+    payload: dict,
+    item: dict,
+    item_type: str,
+    make: Callable,
+) -> Optional[CanonicalEvent]:
+    """Handle init, agent_message, item.completed[agent], item.*[command] events."""
+    if etype in ("thread.started", "session_start"):
+        return make("init", {"raw_type": etype})
+    if etype == "agent_message":
+        content = payload.get("text", payload.get("content", payload.get("message", "")))
+        return make("text", {"text": str(content)})
+    if etype == "item.completed" and item_type == "agent_message":
+        content = item.get("content", "")
+        if isinstance(content, list):
+            texts = [b.get("text", "") for b in content if isinstance(b, dict)]
+            content = "\n".join(t for t in texts if t)
+        return make("text", {"text": str(content)})
+    if etype in ("item.started", "item.updated") and item_type == "command_execution":
+        cmd_str = item.get("command", item.get("cmd", item.get("args", "")))
+        if isinstance(cmd_str, list):
+            cmd_str = " ".join(str(a) for a in cmd_str)
+        return make("tool_use", {"command": str(cmd_str), "raw_type": etype})
+    if etype == "item.completed" and item_type == "command_execution":
+        output = item.get("output", item.get("result", ""))
+        return make("tool_result", {"output": str(output), "exit_code": item.get("exit_code", 0)})
+    return None
+
+
+def _normalize_complete_events(
+    etype: str,
+    raw: dict,
+    payload: dict,
+    make: Callable,
+) -> Optional[CanonicalEvent]:
+    """Handle error, turn.completed, result/message, token_count events."""
+    if etype == "error":
+        msg = payload.get("message", payload.get("error", payload.get("text", "")))
+        return make("error", {"message": str(msg) if msg else str(payload)[:200]})
+    if etype == "turn.completed":
+        tc = _extract_token_count_payload(raw)
+        token_count = _normalize_token_count(tc) if tc else None
+        data: dict = {"token_count": token_count} if token_count else {}
+        return make("complete", data)
+    if etype in ("result", "message"):
+        content = payload.get("content", payload.get("text", payload.get("output", "")))
+        tc = _extract_token_count_payload(raw)
+        token_count = _normalize_token_count(tc) if tc else None
+        if token_count is None:
+            usage = raw.get("usage") or payload.get("usage")
+            if isinstance(usage, dict):
+                token_count = _normalize_token_count({
+                    "input_tokens": usage.get("input_tokens") or usage.get("prompt_tokens", 0),
+                    "output_tokens": usage.get("output_tokens") or usage.get("completion_tokens", 0),
+                })
+        data = {"text": str(content)} if content else {}
+        if token_count:
+            data["token_count"] = token_count
+        return make("complete", data)
+    tc = _extract_token_count_payload(raw)
+    if tc is not None:
+        token_count = _normalize_token_count(tc)
+        if token_count:
+            return make("text", {"text": "", "token_count": token_count})
+    return None
+
+
+def normalize_codex_event(raw: dict, terminal_id: str, dispatch_id: str) -> CanonicalEvent:
+    """Map a raw Codex NDJSON event to a CanonicalEvent (Tier-1).
+
+    Single canonical implementation; both _NormalizerHost (used by spawn_codex)
+    and CodexAdapter._normalize (used by stream_events) delegate here.
+    """
+    def make(event_type: str, data: dict) -> CanonicalEvent:
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="codex",
+            event_type=event_type,
+            data=data,
+            observability_tier=1,
+        )
+
+    etype, payload, item, item_type = _resolve_codex_event_parts(raw)
+
+    result = _normalize_text_events(etype, payload, item, item_type, make)
+    if result is not None:
+        return result
+
+    result = _normalize_complete_events(etype, raw, payload, make)
+    if result is not None:
+        return result
+
+    return make("error", {
+        "reason": f"unrecognized codex event type: {etype!r}",
+        "raw_type": etype,
+        "raw": str(raw)[:300],
+    })
+
+
+def _build_cmd(model: str) -> list:
+    """Build the codex exec argv."""
+    cmd = ["codex", "exec", "--json"]
+    if model:
+        cmd += ["-c", f'model="{model}"']
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Internal normalizer host (composes StreamingDrainerMixin for drain_stream)
+# ---------------------------------------------------------------------------
+
+class _NormalizerHost(StreamingDrainerMixin):
+    """Minimal state holder so StreamingDrainerMixin can call normalize_codex_event."""
+
+    provider_name = "codex"
+    provider_observability_tier = 1
+
+    def __init__(self, terminal_id: str, dispatch_id: str) -> None:
+        self._current_terminal_id = terminal_id
+        self._current_dispatch_id = dispatch_id
+
+    def _normalize(self, raw: dict) -> CanonicalEvent:
+        return normalize_codex_event(raw, self._current_terminal_id, self._current_dispatch_id)
+
+
+# ---------------------------------------------------------------------------
+# Spawn helpers — split to stay ≤70 lines per function
+# ---------------------------------------------------------------------------
+
+def _launch_codex_proc(
+    prompt: str,
+    model: str,
+    extra_env: Optional[Dict[str, str]],
+    cwd: Optional[Any],
+) -> Tuple[Optional[subprocess.Popen], Optional[CodexSpawnResult]]:
+    """Start codex subprocess and write prompt to stdin.
+
+    Returns (proc, None) on success, or (None, error_result) on failure.
+    Re-raises FileNotFoundError so callers distinguish missing binary.
+    """
+    cmd = _build_cmd(model)
+    env = {**os.environ, **(extra_env or {})}
+    cwd_str = str(cwd) if cwd is not None else None
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=cwd_str,
+            start_new_session=True,
+        )
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        return None, CodexSpawnResult(
+            returncode=1, completion_text="", events_written=0,
+            session_id=None, timed_out=False, error=str(exc),
+        )
+
+    if proc.stdin:
+        try:
+            proc.stdin.write(prompt.encode("utf-8"))
+            proc.stdin.close()
+        except BrokenPipeError:
+            return None, CodexSpawnResult(
+                returncode=1, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                error="stdin write failed (BrokenPipeError): codex process exited early",
+            )
+    return proc, None
+
+
+def _process_one_event(
+    canonical_event: CanonicalEvent,
+    terminal_id: str,
+    dispatch_id: str,
+    health_monitor: Optional[Any],
+    event_writer: Optional[Callable],
+    on_event: Optional[Callable],
+    HealthStatus: Any,
+    SLOW_THRESHOLD: float,
+    last_stuck_log: float,
+) -> Tuple[bool, float]:
+    """Process one canonical event: health tick, event_writer, on_event.
+
+    Returns (stop_requested, updated_last_stuck_log).
+    """
+    if health_monitor is not None:
+        health_monitor.update(canonical_event)
+        if HealthStatus is not None:
+            now = time.monotonic()
+            if now - last_stuck_log >= SLOW_THRESHOLD:
+                h = health_monitor.health_status()
+                if h.status == HealthStatus.STUCK:
+                    health_monitor.log_stuck_event()
+                    last_stuck_log = now
+
+    if event_writer is not None:
+        try:
+            event_writer(
+                terminal_id,
+                canonical_event.to_dict(),
+                dispatch_id=dispatch_id,
+            )
+        except Exception as _exc:
+            logger.debug("spawn_codex: event_writer raised: %s", _exc)
+
+    if on_event is not None and on_event(canonical_event) is False:
+        return True, last_stuck_log
+    return False, last_stuck_log
+
+
+def _wait_proc(proc: subprocess.Popen, timeout: float = 5.0) -> None:
+    """Wait for proc to exit; kill it on timeout."""
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _drain_stream(
+    normalizer: _NormalizerHost,
+    proc: subprocess.Popen,
+    terminal_id: str,
+    dispatch_id: str,
+    event_store: Optional[Any],
+    health_monitor: Optional[Any],
+    event_writer: Optional[Callable],
+    on_event: Optional[Callable],
+    chunk_timeout: float,
+    total_deadline: float,
+    HealthStatus: Any,
+    SLOW_THRESHOLD: float,
+) -> Tuple[list, int, Optional[str], bool, bool, Optional[Dict[str, Any]], Optional[str]]:
+    """Drain codex NDJSON stream; return (parts, count, session_id, timed_out, stopped, usage, error)."""
+    completion_parts: list = []
+    events_written = 0
+    session_id: Optional[str] = None
+    timed_out = False
+    stopped_early = False
+    last_token_usage: Optional[Dict[str, Any]] = None
+    last_stuck_log = 0.0
+
+    try:
+        for canonical_event in normalizer.drain_stream(
+            proc, terminal_id, dispatch_id, event_store,
+            chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+        ):
+            events_written += 1
+
+            if canonical_event.event_type == "init" and session_id is None:
+                session_id = (canonical_event.data or {}).get("session_id")
+            if canonical_event.event_type in ("text", "complete"):
+                text = (canonical_event.data or {}).get("text", "")
+                if text:
+                    completion_parts.append(text)
+                tc = (canonical_event.data or {}).get("token_count")
+                if tc:
+                    last_token_usage = tc
+            if canonical_event.event_type == "error":
+                reason = (canonical_event.data or {}).get("reason", "")
+                if "timeout" in (reason or "").lower():
+                    timed_out = True
+
+            stop, last_stuck_log = _process_one_event(
+                canonical_event, terminal_id, dispatch_id,
+                health_monitor, event_writer, on_event,
+                HealthStatus, SLOW_THRESHOLD, last_stuck_log,
+            )
+            if stop:
+                stopped_early = True
+                try:
+                    _kill_proc(proc)
+                except Exception as _exc:
+                    logger.debug("spawn_codex: kill after on_event=False failed: %s", _exc)
+                break
+
+    except Exception as exc:
+        logger.error("spawn_codex: stream read failure %s/%s: %s", dispatch_id, terminal_id, exc)
+        try:
+            _kill_proc(proc)
+        except Exception as _kill_exc:
+            logger.debug("spawn_codex: kill in error handler failed: %s", _kill_exc)
+        _wait_proc(proc)
+        return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, str(exc)
+
+    return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, None
+
+
+# ---------------------------------------------------------------------------
+# Main spawn function
+# ---------------------------------------------------------------------------
+
+def spawn_codex(
+    prompt: str,
+    model: str,
+    dispatch_id: str,
+    terminal_id: str,
+    *,
+    event_writer: Optional[Callable[..., None]] = None,
+    health_monitor: Optional[Any] = None,
+    on_event: Optional[Callable[[Any], Optional[bool]]] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    cwd: Optional[Any] = None,
+    event_store: Optional[Any] = None,
+    chunk_timeout: float = 60.0,
+    total_deadline: float = 600.0,
+    **kwargs: Any,
+) -> CodexSpawnResult:
+    """Spawn `codex exec --json` and consume the NDJSON event stream.
+
+    Returns CodexSpawnResult on completion (success OR controlled failure).
+    Raises FileNotFoundError when the codex binary is absent.
+    Caller is responsible for lease/manifest/receipt/event-archive/retry.
+    """
+    try:
+        from worker_health_monitor import HealthStatus, SLOW_THRESHOLD
+    except ImportError:
+        HealthStatus = None  # type: ignore[assignment]
+        SLOW_THRESHOLD = 120.0
+
+    try:
+        chunk_timeout = float(os.environ["VNX_CODEX_STALL_THRESHOLD"])
+    except (KeyError, ValueError):
+        pass
+    try:
+        total_deadline = float(os.environ["VNX_CODEX_TIMEOUT"])
+    except (KeyError, ValueError):
+        pass
+
+    proc, early_result = _launch_codex_proc(prompt, model, extra_env, cwd)
+    if early_result is not None:
+        return early_result
+
+    normalizer = _NormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+
+    parts, events_written, session_id, timed_out, stopped_early, token_usage, error = _drain_stream(
+        normalizer, proc, terminal_id, dispatch_id, event_store,
+        health_monitor, event_writer, on_event,
+        chunk_timeout, total_deadline, HealthStatus, SLOW_THRESHOLD,
+    )
+
+    if error is None:
+        _wait_proc(proc, timeout=10.0)
+
+    returncode = proc.returncode if proc.returncode is not None else 1
+
+    return CodexSpawnResult(
+        returncode=returncode if error is None else (returncode if returncode != 0 else 1),
+        completion_text="\n\n".join(parts),
+        events_written=events_written,
+        session_id=session_id,
+        timed_out=timed_out,
+        stopped_early=stopped_early,
+        token_usage=token_usage,
+        error=error,
+    )
+
+
+def _kill_proc(proc: subprocess.Popen) -> None:
+    """Send SIGTERM then SIGKILL to process group."""
+    import signal as _signal
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, _signal.SIGTERM)
+        time.sleep(0.2)
+        os.killpg(pgid, _signal.SIGKILL)
+    except OSError:
+        try:
+            proc.kill()
+        except OSError:
+            pass

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -549,8 +549,14 @@ def _kill_proc(proc: subprocess.Popen) -> None:
         os.killpg(pgid, _signal.SIGTERM)
         time.sleep(0.2)
         os.killpg(pgid, _signal.SIGKILL)
-    except OSError:
+    except (ProcessLookupError, OSError):
+        proc.kill()
         try:
-            proc.kill()
-        except OSError:
-            pass
+            proc.wait(timeout=2)
+        except (ProcessLookupError, subprocess.TimeoutExpired) as exc:
+            # Process already terminated or wait timed out — both acceptable
+            # at kill-fallback boundary. Log for forensics.
+            logger.warning(
+                "_kill_proc: fallback wait failed (pid=%s): %s",
+                proc.pid, exc,
+            )

--- a/tests/test_codex_spawn_byte_identity.py
+++ b/tests/test_codex_spawn_byte_identity.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""test_codex_spawn_byte_identity.py — Wave 4.6 PR-4.6.3 byte-identity suite.
+
+Verifies structural identity between normalize_codex_event (in codex_spawn)
+and CodexAdapter._normalize (which now delegates to the same function).
+
+Tests:
+  test_normalizer_identity_thread_started     — thread.started → init
+  test_normalizer_identity_agent_message      — agent_message → text
+  test_normalizer_identity_turn_completed     — turn.completed → complete
+  test_normalizer_identity_error_event        — error → error
+  test_normalizer_identity_item_completed     — item.completed [agent_message] → text
+  test_normalizer_identity_token_count        — token_count → text with token_count
+  test_codex_adapter_delegates_to_spawn       — execute() collects same events as spawn_codex
+  test_event_writer_receives_all_events       — event_writer gets dicts for every event
+  test_session_id_extracted_from_init         — session_id from thread.started payload
+  test_completion_text_from_agent_messages    — completion_text joins all agent_message texts
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib" / "adapters"))
+
+from provider_spawns.codex_spawn import (
+    CodexSpawnResult,
+    normalize_codex_event,
+    spawn_codex,
+)
+from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Fixture: known NDJSON raw event dicts (recorded from real codex exec --json)
+# ---------------------------------------------------------------------------
+
+_DISPATCH_ID = "test-byte-identity"
+_TERMINAL_ID = "T1"
+
+_RAW_THREAD_STARTED = {"type": "thread.started"}
+_RAW_AGENT_MSG = {"type": "agent_message", "text": "LGTM. No blocking findings."}
+_RAW_TURN_COMPLETED = {"type": "turn.completed"}
+_RAW_ERROR = {"type": "error", "message": "something went wrong"}
+_RAW_ITEM_COMPLETED_AGENT = {
+    "type": "item.completed",
+    "item": {"type": "agent_message", "content": "Check passed."},
+}
+_RAW_TOKEN_COUNT = {
+    "event_msg": {
+        "payload": {
+            "type": "token_count",
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+    }
+}
+
+_ALL_RAW_EVENTS = [
+    _RAW_THREAD_STARTED,
+    _RAW_AGENT_MSG,
+    _RAW_TURN_COMPLETED,
+]
+
+
+def _normalize_via_spawn(raw: dict) -> CanonicalEvent:
+    return normalize_codex_event(raw, _TERMINAL_ID, _DISPATCH_ID)
+
+
+def _normalize_via_adapter(raw: dict) -> CanonicalEvent:
+    from codex_adapter import CodexAdapter
+    adapter = object.__new__(CodexAdapter)
+    adapter._current_terminal_id = _TERMINAL_ID
+    adapter._current_dispatch_id = _DISPATCH_ID
+    return adapter._normalize(raw)
+
+
+# ---------------------------------------------------------------------------
+# Test 1-6: normalize_codex_event == CodexAdapter._normalize for all shapes
+# ---------------------------------------------------------------------------
+
+class TestNormalizerIdentity:
+    """Both normalization paths must produce structurally identical events."""
+
+    def _assert_identical(self, raw: dict) -> None:
+        via_spawn = _normalize_via_spawn(raw)
+        via_adapter = _normalize_via_adapter(raw)
+        assert via_spawn.event_type == via_adapter.event_type, (
+            f"event_type mismatch for {raw}: {via_spawn.event_type!r} != {via_adapter.event_type!r}"
+        )
+        assert via_spawn.data == via_adapter.data, (
+            f"data mismatch for {raw}: {via_spawn.data} != {via_adapter.data}"
+        )
+        assert via_spawn.provider == via_adapter.provider == "codex"
+        assert via_spawn.dispatch_id == via_adapter.dispatch_id == _DISPATCH_ID
+        assert via_spawn.terminal_id == via_adapter.terminal_id == _TERMINAL_ID
+
+    def test_normalizer_identity_thread_started(self):
+        self._assert_identical(_RAW_THREAD_STARTED)
+
+    def test_normalizer_identity_agent_message(self):
+        self._assert_identical(_RAW_AGENT_MSG)
+
+    def test_normalizer_identity_turn_completed(self):
+        self._assert_identical(_RAW_TURN_COMPLETED)
+
+    def test_normalizer_identity_error_event(self):
+        self._assert_identical(_RAW_ERROR)
+
+    def test_normalizer_identity_item_completed(self):
+        self._assert_identical(_RAW_ITEM_COMPLETED_AGENT)
+
+    def test_normalizer_identity_token_count(self):
+        self._assert_identical(_RAW_TOKEN_COUNT)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: CodexAdapter.execute() collects same events as spawn_codex
+# ---------------------------------------------------------------------------
+
+class TestCodexAdapterDelegatesToSpawn:
+    """execute() is a thin wrapper over spawn_codex; collected events must match."""
+
+    def _build_canonical_events(self) -> List[CanonicalEvent]:
+        return [normalize_codex_event(r, _TERMINAL_ID, _DISPATCH_ID) for r in _ALL_RAW_EVENTS]
+
+    def test_codex_adapter_delegates_to_spawn(self):
+        canonical_events = self._build_canonical_events()
+
+        direct_collected: List[dict] = []
+
+        def _collect(tid, event_dict, dispatch_id=None):
+            direct_collected.append(event_dict)
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(canonical_events),
+            ):
+                result = spawn_codex(
+                    prompt="test instruction",
+                    model="",
+                    dispatch_id=_DISPATCH_ID,
+                    terminal_id=_TERMINAL_ID,
+                    event_writer=_collect,
+                )
+
+        assert result.events_written == len(_ALL_RAW_EVENTS)
+        assert len(direct_collected) == len(_ALL_RAW_EVENTS)
+
+        # Compare event_type and data for each collected event
+        for i, (raw, collected_dict) in enumerate(zip(_ALL_RAW_EVENTS, direct_collected)):
+            expected = normalize_codex_event(raw, _TERMINAL_ID, _DISPATCH_ID)
+            assert collected_dict["event_type"] == expected.event_type, (
+                f"event[{i}] event_type mismatch: "
+                f"{collected_dict['event_type']!r} != {expected.event_type!r}"
+            )
+            assert collected_dict["data"] == expected.data, (
+                f"event[{i}] data mismatch: {collected_dict['data']} != {expected.data}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: event_writer receives dict for every event
+# ---------------------------------------------------------------------------
+
+class TestEventWriterReceivesAllEvents:
+    """event_writer callback is called once per canonical event."""
+
+    def test_event_writer_receives_all_events(self):
+        canonical_events = [
+            normalize_codex_event(r, _TERMINAL_ID, _DISPATCH_ID) for r in _ALL_RAW_EVENTS
+        ]
+        collected: List[dict] = []
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(canonical_events),
+            ):
+                spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id=_DISPATCH_ID,
+                    terminal_id=_TERMINAL_ID,
+                    event_writer=lambda tid, ev, dispatch_id=None: collected.append(ev),
+                )
+
+        assert len(collected) == len(_ALL_RAW_EVENTS), (
+            f"event_writer called {len(collected)} times, expected {len(_ALL_RAW_EVENTS)}"
+        )
+        event_types = [ev["event_type"] for ev in collected]
+        assert "init" in event_types
+        assert "text" in event_types
+        assert "complete" in event_types
+
+
+# ---------------------------------------------------------------------------
+# Test 9: session_id extracted from init event
+# ---------------------------------------------------------------------------
+
+class TestSessionIdExtraction:
+    """session_id is extracted from the init event data when available."""
+
+    def test_session_id_extracted_from_init(self):
+        init_with_session = CanonicalEvent(
+            dispatch_id=_DISPATCH_ID,
+            terminal_id=_TERMINAL_ID,
+            provider="codex",
+            event_type="init",
+            data={"raw_type": "thread.started", "session_id": "sess-codex-42"},
+            observability_tier=1,
+        )
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter([init_with_session]),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id=_DISPATCH_ID,
+                    terminal_id=_TERMINAL_ID,
+                )
+
+        assert result.session_id == "sess-codex-42"
+
+    def test_session_id_none_when_no_init(self):
+        text_event = normalize_codex_event(_RAW_AGENT_MSG, _TERMINAL_ID, _DISPATCH_ID)
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter([text_event]),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id=_DISPATCH_ID,
+                    terminal_id=_TERMINAL_ID,
+                )
+
+        assert result.session_id is None
+
+
+# ---------------------------------------------------------------------------
+# Test 10: completion_text joins agent_message text values
+# ---------------------------------------------------------------------------
+
+class TestCompletionText:
+    """completion_text is built from all text and complete event text values."""
+
+    def test_completion_text_from_agent_messages(self):
+        events = [
+            normalize_codex_event({"type": "agent_message", "text": "Part 1."}, _TERMINAL_ID, _DISPATCH_ID),
+            normalize_codex_event({"type": "agent_message", "text": "Part 2."}, _TERMINAL_ID, _DISPATCH_ID),
+        ]
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id=_DISPATCH_ID,
+                    terminal_id=_TERMINAL_ID,
+                )
+
+        assert "Part 1." in result.completion_text
+        assert "Part 2." in result.completion_text

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -13,6 +13,7 @@ Verifies fail-closed behaviour in spawn_codex():
 from __future__ import annotations
 
 import logging
+import subprocess
 import sys
 from pathlib import Path
 from typing import List
@@ -22,7 +23,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from provider_spawns.codex_spawn import CodexSpawnResult, spawn_codex
+from provider_spawns.codex_spawn import CodexSpawnResult, _kill_proc, spawn_codex
 from canonical_event import CanonicalEvent
 
 
@@ -396,3 +397,81 @@ class TestEventWriterFailureLogged:
 
         assert result.event_writer_failures == 0
         assert len(collected) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 7 (R2): _kill_proc fallback wait failure is logged, not silently swallowed
+# ---------------------------------------------------------------------------
+
+class TestKillProcFallbackWaitFailure:
+    """R2 fix: fallback wait exceptions in _kill_proc must be logged as WARNING."""
+
+    def _make_proc(self, pid: int = 42) -> MagicMock:
+        proc = MagicMock(spec=subprocess.Popen)
+        type(proc).pid = MagicMock(return_value=pid)
+        proc.pid = pid
+        return proc
+
+    def test_kill_proc_fallback_wait_failure_is_logged(self, caplog):
+        """When proc.wait(timeout=2) raises ProcessLookupError, WARNING is emitted."""
+        proc = self._make_proc(pid=1234)
+        proc.wait.side_effect = ProcessLookupError("process already gone")
+
+        with patch("os.getpgid", side_effect=OSError("no pgid")), \
+             caplog.at_level(logging.WARNING, logger="provider_spawns.codex_spawn"):
+            _kill_proc(proc)
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("fallback wait failed" in m for m in warning_msgs), (
+            f"Expected WARNING containing 'fallback wait failed', got: {warning_msgs}"
+        )
+
+    def test_kill_proc_fallback_wait_failure_includes_pid(self, caplog):
+        """WARNING log must include the pid for forensics."""
+        proc = self._make_proc(pid=5678)
+        proc.wait.side_effect = ProcessLookupError("gone")
+
+        with patch("os.getpgid", side_effect=OSError("no pgid")), \
+             caplog.at_level(logging.WARNING, logger="provider_spawns.codex_spawn"):
+            _kill_proc(proc)
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("5678" in m for m in warning_msgs), (
+            f"pid 5678 not in WARNING messages: {warning_msgs}"
+        )
+
+    def test_kill_proc_timeout_expired_is_logged(self, caplog):
+        """When proc.wait(timeout=2) raises TimeoutExpired, WARNING is emitted."""
+        proc = self._make_proc(pid=99)
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="codex", timeout=2)
+
+        with patch("os.getpgid", side_effect=OSError("no pgid")), \
+             caplog.at_level(logging.WARNING, logger="provider_spawns.codex_spawn"):
+            _kill_proc(proc)
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("fallback wait failed" in m for m in warning_msgs), (
+            f"Expected WARNING containing 'fallback wait failed', got: {warning_msgs}"
+        )
+
+    def test_kill_proc_returns_normally_on_process_lookup_error(self):
+        """_kill_proc must not propagate ProcessLookupError from proc.wait()."""
+        proc = self._make_proc(pid=11)
+        proc.wait.side_effect = ProcessLookupError("already gone")
+
+        with patch("os.getpgid", side_effect=OSError("no pgid")):
+            try:
+                _kill_proc(proc)
+            except Exception as exc:
+                pytest.fail(f"_kill_proc propagated unexpectedly: {exc!r}")
+
+    def test_kill_proc_returns_normally_on_timeout_expired(self):
+        """_kill_proc must not propagate TimeoutExpired from proc.wait()."""
+        proc = self._make_proc(pid=22)
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="codex", timeout=2)
+
+        with patch("os.getpgid", side_effect=OSError("no pgid")):
+            try:
+                _kill_proc(proc)
+            except Exception as exc:
+                pytest.fail(f"_kill_proc propagated unexpectedly: {exc!r}")

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""test_codex_spawn_fail_closed.py — Wave 4.6 PR-4.6.3 fail-closed suite.
+"""test_codex_spawn_fail_closed.py — Wave 4.6 PR-4.6.3/R3 fail-closed suite.
 
 Verifies fail-closed behaviour in spawn_codex():
 
-  test_missing_binary_raises_file_not_found — FileNotFoundError propagates
+  test_spawn_returns_structured_result_when_binary_missing — missing binary → structured result (returncode=127)
   test_broken_pipe_returns_failed_result    — BrokenPipeError → error result
   test_chunk_timeout_returns_timed_out      — chunk_timeout breach → timed_out=True
   test_on_event_false_stops_stream_early    — on_event=False → stopped_early=True
@@ -29,23 +29,36 @@ from canonical_event import CanonicalEvent
 
 
 # ---------------------------------------------------------------------------
-# Test 1: missing binary raises FileNotFoundError
+# Test 1: missing binary returns structured CodexSpawnResult (R3 fix)
 # ---------------------------------------------------------------------------
 
 class TestCodexSpawnMissingBinary:
-    """spawn_codex raises FileNotFoundError when codex binary is absent."""
+    """spawn_codex returns structured result (returncode=127) when codex binary is absent."""
 
-    def test_missing_binary_raises_file_not_found(self):
+    def test_spawn_returns_structured_result_when_binary_missing(self):
         with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
             MockPopen.side_effect = FileNotFoundError("codex: not found")
 
-            with pytest.raises(FileNotFoundError):
-                spawn_codex(
-                    prompt="test",
-                    model="",
-                    dispatch_id="test-missing-binary",
-                    terminal_id="T1",
-                )
+            result = spawn_codex(
+                prompt="test",
+                model="",
+                dispatch_id="test-missing-binary",
+                terminal_id="T1",
+            )
+
+        assert isinstance(result, CodexSpawnResult), (
+            f"Expected CodexSpawnResult, got {type(result)}"
+        )
+        assert result.returncode == 127, (
+            f"Expected returncode=127 for missing binary, got {result.returncode}"
+        )
+        assert result.error is not None, "Expected error field to be set"
+        assert "not found" in (result.error or "").lower(), (
+            f"Expected 'not found' in error message, got: {result.error!r}"
+        )
+        assert result.events_written == 0
+        assert result.timed_out is False
+        assert result.completion_text == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""test_codex_spawn_fail_closed.py — Wave 4.6 PR-4.6.3 fail-closed suite.
+
+Verifies fail-closed behaviour in spawn_codex():
+
+  test_missing_binary_raises_file_not_found — FileNotFoundError propagates
+  test_broken_pipe_returns_failed_result    — BrokenPipeError → error result
+  test_chunk_timeout_returns_timed_out      — chunk_timeout breach → timed_out=True
+  test_on_event_false_stops_stream_early    — on_event=False → stopped_early=True
+  test_normal_completion_unchanged          — happy path returncode==0 (regression)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns.codex_spawn import CodexSpawnResult, spawn_codex
+from canonical_event import CanonicalEvent
+
+
+
+# ---------------------------------------------------------------------------
+# Test 1: missing binary raises FileNotFoundError
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnMissingBinary:
+    """spawn_codex raises FileNotFoundError when codex binary is absent."""
+
+    def test_missing_binary_raises_file_not_found(self):
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            MockPopen.side_effect = FileNotFoundError("codex: not found")
+
+            with pytest.raises(FileNotFoundError):
+                spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id="test-missing-binary",
+                    terminal_id="T1",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: BrokenPipeError on stdin write → error result
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnBrokenPipe:
+    """spawn_codex returns CodexSpawnResult with error when stdin write fails."""
+
+    def test_broken_pipe_returns_failed_result(self):
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 1
+            proc.wait = MagicMock(return_value=1)
+            proc.poll = MagicMock(return_value=1)
+
+            stdin_mock = MagicMock()
+            stdin_mock.write.side_effect = BrokenPipeError("pipe broken")
+            proc.stdin = stdin_mock
+
+            MockPopen.return_value = proc
+
+            result = spawn_codex(
+                prompt="test",
+                model="",
+                dispatch_id="test-broken-pipe",
+                terminal_id="T1",
+            )
+
+        assert isinstance(result, CodexSpawnResult)
+        assert result.returncode == 1
+        assert result.error is not None
+        assert "BrokenPipeError" in result.error
+        assert result.events_written == 0
+        assert result.timed_out is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3: chunk_timeout breach → timed_out=True
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnTimeout:
+    """spawn_codex returns timed_out=True when drain_stream signals timeout."""
+
+    def test_chunk_timeout_returns_timed_out(self):
+        """When drain_stream emits a timeout error event, timed_out=True."""
+        timeout_event = CanonicalEvent(
+            dispatch_id="test-timeout",
+            terminal_id="T1",
+            provider="codex",
+            event_type="error",
+            data={"reason": "chunk timeout 60s exceeded"},
+            observability_tier=1,
+        )
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = -15
+            proc.wait = MagicMock(return_value=-15)
+            proc.poll = MagicMock(return_value=-15)
+            stdin_mock = MagicMock()
+            proc.stdin = stdin_mock
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter([timeout_event]),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id="test-timeout",
+                    terminal_id="T1",
+                    chunk_timeout=1.0,
+                    total_deadline=5.0,
+                )
+
+        assert result.timed_out is True, (
+            f"expected timed_out=True after timeout error event, got {result.timed_out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: on_event=False stops stream early
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnOnEventStop:
+    """spawn_codex sets stopped_early=True when on_event returns False."""
+
+    def test_on_event_false_stops_stream_early(self):
+        call_count = 0
+
+        def _stop_after_first(event: CanonicalEvent):
+            nonlocal call_count
+            call_count += 1
+            return False
+
+        init_event = CanonicalEvent(
+            dispatch_id="test-stop",
+            terminal_id="T1",
+            provider="codex",
+            event_type="init",
+            data={"raw_type": "thread.started"},
+            observability_tier=1,
+        )
+        text_event = CanonicalEvent(
+            dispatch_id="test-stop",
+            terminal_id="T1",
+            provider="codex",
+            event_type="text",
+            data={"text": "should not reach here"},
+            observability_tier=1,
+        )
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            stdin_mock = MagicMock()
+            proc.stdin = stdin_mock
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter([init_event, text_event]),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id="test-stop",
+                    terminal_id="T1",
+                    on_event=_stop_after_first,
+                )
+
+        assert result.stopped_early is True
+        assert call_count == 1
+        assert result.events_written == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 5: happy-path regression
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnNormalCompletion:
+    """Happy path: successful drain returns returncode==0 and populates result."""
+
+    def test_normal_completion_unchanged(self):
+        events = [
+            CanonicalEvent(
+                dispatch_id="test-ok",
+                terminal_id="T1",
+                provider="codex",
+                event_type="init",
+                data={"raw_type": "thread.started"},
+                observability_tier=1,
+            ),
+            CanonicalEvent(
+                dispatch_id="test-ok",
+                terminal_id="T1",
+                provider="codex",
+                event_type="text",
+                data={"text": "Analysis complete."},
+                observability_tier=1,
+            ),
+            CanonicalEvent(
+                dispatch_id="test-ok",
+                terminal_id="T1",
+                provider="codex",
+                event_type="complete",
+                data={},
+                observability_tier=1,
+            ),
+        ]
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            stdin_mock = MagicMock()
+            proc.stdin = stdin_mock
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                result = spawn_codex(
+                    prompt="Reply OK.",
+                    model="",
+                    dispatch_id="test-ok",
+                    terminal_id="T1",
+                )
+
+        assert isinstance(result, CodexSpawnResult)
+        assert result.returncode == 0
+        assert result.events_written == 3
+        assert result.timed_out is False
+        assert result.stopped_early is False
+        assert result.error is None
+        assert "Analysis complete." in result.completion_text

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -12,6 +12,7 @@ Verifies fail-closed behaviour in spawn_codex():
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from typing import List
@@ -250,3 +251,148 @@ class TestCodexSpawnNormalCompletion:
         assert result.stopped_early is False
         assert result.error is None
         assert "Analysis complete." in result.completion_text
+
+
+# ---------------------------------------------------------------------------
+# Test 6: event_writer failure is logged as ERROR and counted
+# ---------------------------------------------------------------------------
+
+class TestEventWriterFailureLogged:
+    """ADR-005: event_writer failures logged at ERROR level and counted in result."""
+
+    def _make_proc(self, MockPopen: MagicMock) -> MagicMock:
+        proc = MagicMock()
+        proc.pid = 99
+        proc.returncode = 0
+        proc.wait = MagicMock(return_value=0)
+        proc.poll = MagicMock(return_value=0)
+        proc.stdin = MagicMock()
+        MockPopen.return_value = proc
+        return proc
+
+    def test_event_writer_failure_is_logged_as_error_and_counted(self, caplog):
+        """When event_writer always raises, result.event_writer_failures > 0 and ERROR logged."""
+        events = [
+            CanonicalEvent(
+                dispatch_id="test-ew-fail",
+                terminal_id="T1",
+                provider="codex",
+                event_type="text",
+                data={"text": "hello"},
+                observability_tier=1,
+            ),
+            CanonicalEvent(
+                dispatch_id="test-ew-fail",
+                terminal_id="T1",
+                provider="codex",
+                event_type="complete",
+                data={},
+                observability_tier=1,
+            ),
+        ]
+
+        def _failing_writer(tid, event_dict, dispatch_id=None):
+            raise OSError("ndjson ledger unavailable")
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            self._make_proc(MockPopen)
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                with caplog.at_level(logging.ERROR, logger="provider_spawns.codex_spawn"):
+                    result = spawn_codex(
+                        prompt="test",
+                        model="",
+                        dispatch_id="test-ew-fail",
+                        terminal_id="T1",
+                        event_writer=_failing_writer,
+                    )
+
+        assert result.event_writer_failures == 2, (
+            f"expected 2 writer failures (one per event), got {result.event_writer_failures}"
+        )
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) >= 1, "expected at least one ERROR log record"
+        assert any(
+            "event_writer callback failed" in r.message for r in error_records
+        ), f"ERROR log missing 'event_writer callback failed': {[r.message for r in error_records]}"
+
+    def test_event_writer_strict_raises_on_failure(self):
+        """event_writer_strict=True raises RuntimeError when event_writer fails."""
+        events = [
+            CanonicalEvent(
+                dispatch_id="test-strict",
+                terminal_id="T1",
+                provider="codex",
+                event_type="text",
+                data={"text": "hi"},
+                observability_tier=1,
+            ),
+        ]
+
+        def _failing_writer(tid, event_dict, dispatch_id=None):
+            raise ValueError("write failed")
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                with pytest.raises(RuntimeError, match="event_writer failed"):
+                    spawn_codex(
+                        prompt="test",
+                        model="",
+                        dispatch_id="test-strict",
+                        terminal_id="T1",
+                        event_writer=_failing_writer,
+                        event_writer_strict=True,
+                    )
+
+    def test_no_failures_result_field_zero(self):
+        """event_writer_failures=0 when writer never raises (regression guard)."""
+        events = [
+            CanonicalEvent(
+                dispatch_id="test-ok-ew",
+                terminal_id="T1",
+                provider="codex",
+                event_type="text",
+                data={"text": "ok"},
+                observability_tier=1,
+            ),
+        ]
+
+        collected: List[dict] = []
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 0
+            proc.wait = MagicMock(return_value=0)
+            proc.poll = MagicMock(return_value=0)
+            proc.stdin = MagicMock()
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id="test-ok-ew",
+                    terminal_id="T1",
+                    event_writer=lambda tid, ev, dispatch_id=None: collected.append(ev),
+                )
+
+        assert result.event_writer_failures == 0
+        assert len(collected) == 1

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Wave 4.6 PR-4.6.1 — provider_dispatch.py entry-point tests.
+"""Wave 4.6 PR-4.6.3 — provider_dispatch.py entry-point tests.
 
 Covers:
 - Claude provider delegates to subprocess_dispatch with unchanged argv semantics.
-- Codex/Gemini/LiteLLM providers raise SystemExit(64) with PR reference in message.
+- Codex provider routes to _dispatch_codex (PR-4.6.3 wired).
+- Gemini/LiteLLM providers raise SystemExit(64) with PR reference in message.
 - Unknown provider triggers argparse error (SystemExit(2)).
 """
 
@@ -145,25 +146,32 @@ class TestProviderClaudeDelegatesToSubprocessDispatch:
 
 
 # ---------------------------------------------------------------------------
-# Test: codex provider raises SystemExit(64) mentioning PR-4.6.3
+# Test: codex provider is routed to _dispatch_codex (PR-4.6.3 implemented)
 # ---------------------------------------------------------------------------
 
-class TestProviderCodexRaisesNotImplemented:
+class TestProviderCodexRouted:
 
-    def test_exit_code_64(self, capsys):
+    def test_codex_routes_to_dispatch_codex(self):
+        """--provider codex calls _dispatch_codex and returns 0 on success."""
         argv = ["--provider", "codex", "--terminal-id", "T1",
-                "--dispatch-id", "test-codex", "--instruction", "noop"]
-        with pytest.raises(SystemExit) as exc_info:
-            provider_dispatch.main(argv)
-        assert exc_info.value.code == 64
+                "--dispatch-id", "test-codex-routed", "--instruction", "noop"]
 
-    def test_message_mentions_pr_4_6_3(self, capsys):
+        with patch("provider_dispatch._dispatch_codex", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_codex_does_not_raise_system_exit_64(self):
+        """--provider codex must no longer raise SystemExit(64)."""
         argv = ["--provider", "codex", "--terminal-id", "T1",
-                "--dispatch-id", "test-codex", "--instruction", "noop"]
-        with pytest.raises(SystemExit):
-            provider_dispatch.main(argv)
-        captured = capsys.readouterr()
-        assert "PR-4.6.3" in captured.err
+                "--dispatch-id", "test-codex-ok", "--instruction", "noop"]
+
+        with patch("provider_dispatch._dispatch_codex", return_value=0):
+            try:
+                rc = provider_dispatch.main(argv)
+            except SystemExit as exc:
+                pytest.fail(f"provider codex raised SystemExit({exc.code}): should be routed now")
 
 
 # ---------------------------------------------------------------------------
@@ -252,10 +260,23 @@ class TestModuleImportability:
         assert mod.__name__ == "provider_dispatch"
 
     def test_no_optional_provider_imports_at_module_load(self):
-        """codex/gemini/litellm spawn modules must not be imported at module load."""
+        """provider_dispatch itself must not trigger spawn module imports at load time."""
+        import importlib
         import sys
-        # Ensure none of the not-yet-existing provider spawn modules are loaded.
-        for mod_name in list(sys.modules.keys()):
+
+        # Remove spawn modules and provider_dispatch from sys.modules so we can
+        # observe what loading provider_dispatch alone pulls in.
+        to_remove = [
+            k for k in sys.modules
+            if any(s in k for s in ("codex_spawn", "gemini_spawn", "litellm_spawn", "provider_dispatch"))
+        ]
+        for k in to_remove:
+            del sys.modules[k]
+
+        importlib.import_module("provider_dispatch")
+
+        # None of the optional spawn modules should have been imported as side effects.
+        for mod_name in sys.modules:
             assert "codex_spawn" not in mod_name, f"codex_spawn imported at module load: {mod_name}"
             assert "gemini_spawn" not in mod_name, f"gemini_spawn imported at module load: {mod_name}"
             assert "litellm_spawn" not in mod_name, f"litellm_spawn imported at module load: {mod_name}"

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Wave 4.6 PR-4.6.3 — provider_dispatch.py entry-point tests.
+"""Wave 4.6 PR-4.6.3/R3 — provider_dispatch.py entry-point tests.
 
 Covers:
 - Claude provider delegates to subprocess_dispatch with unchanged argv semantics.
 - Codex provider routes to _dispatch_codex (PR-4.6.3 wired).
-- Gemini/LiteLLM providers raise SystemExit(64) with PR reference in message.
+- Gemini provider routes to _dispatch_gemini (PR-4.6.4 wired).
+- LiteLLM provider raises SystemExit(64) with PR reference in message.
 - Unknown provider triggers argparse error (SystemExit(2)).
 """
 
@@ -175,25 +176,32 @@ class TestProviderCodexRouted:
 
 
 # ---------------------------------------------------------------------------
-# Test: gemini provider raises SystemExit(64) mentioning PR-4.6.4
+# Test: gemini provider is routed to _dispatch_gemini (PR-4.6.4 implemented)
 # ---------------------------------------------------------------------------
 
-class TestProviderGeminiRaisesNotImplemented:
+class TestProviderGeminiRouted:
 
-    def test_exit_code_64(self, capsys):
+    def test_gemini_routes_to_dispatch_gemini(self):
+        """--provider gemini calls _dispatch_gemini and returns 0 on success."""
         argv = ["--provider", "gemini", "--terminal-id", "T1",
-                "--dispatch-id", "test-gemini", "--instruction", "noop"]
-        with pytest.raises(SystemExit) as exc_info:
-            provider_dispatch.main(argv)
-        assert exc_info.value.code == 64
+                "--dispatch-id", "test-gemini-routed", "--instruction", "noop"]
 
-    def test_message_mentions_pr_4_6_4(self, capsys):
+        with patch("provider_dispatch._dispatch_gemini", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_gemini_does_not_raise_system_exit_64(self):
+        """--provider gemini must no longer raise SystemExit(64)."""
         argv = ["--provider", "gemini", "--terminal-id", "T1",
-                "--dispatch-id", "test-gemini", "--instruction", "noop"]
-        with pytest.raises(SystemExit):
-            provider_dispatch.main(argv)
-        captured = capsys.readouterr()
-        assert "PR-4.6.4" in captured.err
+                "--dispatch-id", "test-gemini-ok", "--instruction", "noop"]
+
+        with patch("provider_dispatch._dispatch_gemini", return_value=0):
+            try:
+                rc = provider_dispatch.main(argv)
+            except SystemExit as exc:
+                pytest.fail(f"provider gemini raised SystemExit({exc.code}): should be routed now")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New module**: `scripts/lib/provider_spawns/codex_spawn.py` — owns the spawn+stream+normalizer slice for Codex, mirroring `claude_spawn.py` structure with `CodexSpawnResult` dataclass and `spawn_codex()` function
- **Refactored**: `CodexAdapter.execute()` delegates to `spawn_codex()` internally — byte-identical output, no behavior change
- **Wired**: `provider_dispatch.py` routes `--provider codex` to `spawn_codex` via `_dispatch_codex()`; `codex` promoted from `_FUTURE_PR_MAP` to `_IMPLEMENTED_PROVIDERS`

## Design reference

`claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md` §PR-4.6.3

## Extracted from

`CodexAdapter.execute()` (lines 83–145) and `CodexAdapter._normalize()` (lines 218–253) in `codex_adapter.py`. The normalizer logic (`normalize_codex_event`, `_resolve_codex_event_parts`, `_normalize_text_events`, `_normalize_complete_events`) now lives in `codex_spawn.py` as the single implementation; `CodexAdapter._normalize` and the static helper shims delegate back to it.

## Tests

- `tests/test_codex_spawn_fail_closed.py` (5 tests): missing binary raises `FileNotFoundError`, `BrokenPipeError` → error result, chunk_timeout → `timed_out=True`, `on_event=False` → `stopped_early=True`, happy path regression
- `tests/test_codex_spawn_byte_identity.py` (11 tests): normalizer identity for all 6 event shapes, adapter delegates correctly, event_writer receives all events, session_id extraction, completion_text assembly

**Total: 35 tests pass (16 new + 19 existing provider_dispatch tests)**

## Test plan

- [x] `pytest tests/test_codex_spawn_fail_closed.py tests/test_codex_spawn_byte_identity.py -v` — 16/16 passed
- [x] `pytest tests/test_codex_spawn_fail_closed.py tests/test_codex_spawn_byte_identity.py tests/test_provider_dispatch_entry.py -v` — 35/35 passed
- [x] `python3 scripts/ci_lint_patterns.py` — exit 0, no new findings
- [x] All files ≤800 lines; no new function >70 lines (pre-existing `_parse_token_usage_from_output` at 79 lines unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)