### PR TITLE
feat(wave7): PR-7.1 — DeepSeek V4 lane via LiteLLM subprocess bridge

### DIFF
--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -1,0 +1,58 @@
+# Provider API keys (Wave 7+)
+
+Wave 7 introduces non-Claude provider lanes via the LiteLLM bridge (Path B, ADR-015).
+Each provider requires an API key set as an env var before dispatch.
+
+| Provider | Env var | Where to get | Pricing | Status |
+|---|---|---|---|---|
+| Anthropic Claude | ANTHROPIC_API_KEY (or OAuth via subscription) | console.anthropic.com | Sonnet 4.6 $3/$15 | default |
+| DeepSeek | DEEPSEEK_API_KEY | platform.deepseek.com | V3.2 $0.28/$0.40 | Wave 7 PR-7.1 |
+| Moonshot (Kimi) | MOONSHOT_API_KEY | platform.moonshot.cn | K2-0905 $0.60/$2.50 | Wave 7 PR-7.2 |
+| Z.AI (GLM) | ZHIPU_API_KEY | open.bigmodel.cn | GLM-5.1 est. $0.50/$2.50 | Wave 7 PR-7.3 |
+
+Pricing shown as input/output per MTok. Sonnet 4.6 reference included for cost comparison.
+
+## Provisioning
+
+Set keys via shell export or `.env` before invoking `provider_dispatch.py`:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+Keys are consumed by `_litellm_runner.py` subprocess — they never reach VNX worker code.
+The repo-level secret scan (`scripts/lib/secret_scanner.py`) covers leak prevention.
+
+## Model registry
+
+`scripts/lib/providers/wave7_models.yaml` is the SSOT for model names, pricing, and feature
+flags. `provider_dispatch.py` uses it to resolve the LiteLLM model string for each
+sub-provider. Override the resolved model via `VNX_LITELLM_MODEL` env var.
+
+## Feature flags
+
+Each sub-provider is off by default. Enable via env var:
+
+```bash
+export VNX_ROUTING_DEEPSEEK=1   # enables DeepSeek V4 lane
+export VNX_ROUTING_KIMI=1       # enables Kimi lane (PR-7.2)
+export VNX_ROUTING_GLM=1        # enables GLM lane (PR-7.3)
+```
+
+Without feature flags, `provider_dispatch.py` still routes `litellm:deepseek`
+dispatches — the flags control automatic routing policy (PR-7.4, not yet shipped).
+
+## DeepSeek V4 (PR-7.1)
+
+- LiteLLM model string: `deepseek/deepseek-v3.2`
+- Context: 163,840 tokens
+- Tool calls: yes, streaming: yes
+- Dispatch: `--provider litellm:deepseek`
+- Missing `DEEPSEEK_API_KEY` → immediate exit(64) before subprocess spawn
+
+## Related
+
+- ADR-015: Wave 7 Path B decision + Path D deferral
+- `scripts/lib/providers/wave7_models.yaml`: full model registry
+- `scripts/lib/providers/provider_registry.py`: registry loader
+- `scripts/lib/adapters/_litellm_runner.py`: subprocess sidecar that performs the actual API call

--- a/scripts/lib/adapters/_litellm_runner.py
+++ b/scripts/lib/adapters/_litellm_runner.py
@@ -15,8 +15,11 @@ BILLING SAFETY: No Anthropic SDK imports. Uses litellm library only.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
+
+log = logging.getLogger(__name__)
 
 _EXIT_OK = 0
 _EXIT_CREDS = 1
@@ -68,8 +71,9 @@ def _emit_usage(usage: object) -> None:
     else:
         try:
             usage_dict = dict(usage)  # type: ignore[call-overload]
-        except Exception:
-            return
+        except AttributeError as e:
+            log.warning("_litellm_runner: usage serialization fallback: %s", e)
+            usage_dict = {"input_tokens": 0, "output_tokens": 0, "usage_serialization_failed": True}
     _emit({"event_type": "usage_complete", "usage": usage_dict})
 
 
@@ -99,7 +103,6 @@ def main() -> int:
         return _EXIT_ERR
 
     # Silence litellm's own logging to avoid polluting stdout
-    import logging
     logging.getLogger("litellm").setLevel(logging.CRITICAL)
     litellm.suppress_debug_info = True
 

--- a/scripts/lib/adapters/_litellm_runner.py
+++ b/scripts/lib/adapters/_litellm_runner.py
@@ -15,16 +15,62 @@ BILLING SAFETY: No Anthropic SDK imports. Uses litellm library only.
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 _EXIT_OK = 0
 _EXIT_CREDS = 1
 _EXIT_ERR = 2
 
+# Required env var per provider prefix (deepseek/*, moonshot/*, etc.)
+_PROVIDER_KEY_REQS: dict = {
+    "deepseek": "DEEPSEEK_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
+}
+
+# Providers that support stream_options usage reporting via LiteLLM
+_USAGE_STREAM_PROVIDERS = frozenset({"deepseek", "moonshot"})
+
 
 def _emit(obj: dict) -> None:
     sys.stdout.write(json.dumps(obj) + "\n")
     sys.stdout.flush()
+
+
+def _provider_prefix(model: str) -> str:
+    """Return the provider prefix from a LiteLLM model string (e.g. 'deepseek' from 'deepseek/v3.2')."""
+    return model.split("/")[0] if "/" in model else ""
+
+
+def _validate_provider_key(model: str) -> tuple[bool, str]:
+    """Return (ok, error_msg). ok=False when a required API key is absent."""
+    prefix = _provider_prefix(model)
+    key_env = _PROVIDER_KEY_REQS.get(prefix)
+    if key_env and not os.environ.get(key_env):
+        return False, f"missing required env var {key_env!r} for provider '{prefix}'"
+    return True, ""
+
+
+def _completion_kwargs(model: str) -> dict:
+    """Extra keyword args for litellm.completion per provider prefix."""
+    prefix = _provider_prefix(model)
+    if prefix in _USAGE_STREAM_PROVIDERS:
+        return {"stream_options": {"include_usage": True}}
+    return {}
+
+
+def _emit_usage(usage: object) -> None:
+    """Emit a usage_complete event carrying token counts."""
+    if hasattr(usage, "model_dump"):
+        usage_dict = usage.model_dump()
+    elif hasattr(usage, "dict"):
+        usage_dict = usage.dict()
+    else:
+        try:
+            usage_dict = dict(usage)  # type: ignore[call-overload]
+        except Exception:
+            return
+    _emit({"event_type": "usage_complete", "usage": usage_dict})
 
 
 def main() -> int:
@@ -41,6 +87,11 @@ def main() -> int:
         _emit({"error_type": "runner_error", "message": "model field required"})
         return _EXIT_ERR
 
+    ok, err_msg = _validate_provider_key(model)
+    if not ok:
+        _emit({"error_type": "credentials_missing", "message": err_msg})
+        return _EXIT_CREDS
+
     try:
         import litellm  # noqa: PLC0415
     except ImportError as exc:
@@ -52,9 +103,14 @@ def main() -> int:
     logging.getLogger("litellm").setLevel(logging.CRITICAL)
     litellm.suppress_debug_info = True
 
+    extra_kwargs = _completion_kwargs(model)
+    usage_data = None
+
     try:
-        response = litellm.completion(model=model, messages=messages, stream=True)
+        response = litellm.completion(model=model, messages=messages, stream=True, **extra_kwargs)
         for chunk in response:
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage_data = chunk.usage
             try:
                 if hasattr(chunk, "model_dump"):
                     obj = chunk.model_dump()
@@ -65,6 +121,8 @@ def main() -> int:
                 _emit(obj)
             except Exception as exc:
                 _emit({"error_type": "serialize_error", "message": str(exc)})
+        if usage_data is not None:
+            _emit_usage(usage_data)
         return _EXIT_OK
 
     except Exception as exc:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -155,13 +155,14 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
 
 def _resolve_deepseek_model() -> str:
     """Load DeepSeek model litellm_name from registry, fallback to hardcoded default."""
+    from providers import provider_registry as _reg
     try:
-        from providers import provider_registry as _reg
         rec = _reg.get_default_model("deepseek")
-        if rec is not None:
-            return rec.litellm_name
-    except Exception:
-        pass
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("provider_dispatch: registry resolve failed for deepseek: %s", e)
+        raise RuntimeError(f"provider registry resolution failed: {e}") from e
+    if rec is not None:
+        return rec.litellm_name
     return _LITELLM_SUB_PROVIDER_DEFAULTS["deepseek"]
 
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -35,11 +35,16 @@ _FUTURE_PR_MAP: dict = {}
 # LiteLLM sub-provider defaults when VNX_LITELLM_MODEL is not set.
 _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "bedrock": "bedrock/claude-sonnet-4-6",
-    "deepseek": "deepseek/deepseek-v3",
+    "deepseek": "deepseek/deepseek-v3.2",
     "kimi": "openai/moonshot-v1-32k",
     "glm-5.1": "zhipuai/glm-4",
     "ollama": "ollama/llama3",
     "anthropic": "anthropic/claude-sonnet-4-6",
+}
+
+# Env vars required per sub-provider (fast-fail before subprocess spawn)
+_SUB_PROVIDER_KEY_REQS: dict = {
+    "deepseek": "DEEPSEEK_API_KEY",
 }
 
 
@@ -148,12 +153,25 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_deepseek_model() -> str:
+    """Load DeepSeek model litellm_name from registry, fallback to hardcoded default."""
+    try:
+        from providers import provider_registry as _reg
+        rec = _reg.get_default_model("deepseek")
+        if rec is not None:
+            return rec.litellm_name
+    except Exception:
+        pass
+    return _LITELLM_SUB_PROVIDER_DEFAULTS["deepseek"]
+
+
 def _dispatch_litellm(args: argparse.Namespace) -> int:
     """Route to spawn_litellm for litellm-provider dispatches (PR-4.6.5).
 
     Accepts --provider litellm:<sub_provider>, e.g. litellm:deepseek.
-    Model resolved via VNX_LITELLM_MODEL env var, sub_provider default, or
-    "anthropic/claude-sonnet-4-6" fallback. Wires EventStore for NDJSON audit.
+    Model resolved via VNX_LITELLM_MODEL env var, registry lookup, sub_provider default,
+    or "anthropic/claude-sonnet-4-6" fallback. Wires EventStore for NDJSON audit.
+    DeepSeek requires DEEPSEEK_API_KEY env var (fast-fail before subprocess spawn).
     """
     import os
     from provider_spawns.litellm_spawn import spawn_litellm
@@ -171,8 +189,19 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     parts = args.provider.split(":", 1)
     sub_provider = parts[1] if len(parts) > 1 else ""
 
+    # Fast-fail for providers that require an explicit API key
+    required_key = _SUB_PROVIDER_KEY_REQS.get(sub_provider)
+    if required_key and not os.environ.get(required_key):
+        print(
+            f"litellm:{sub_provider} requires {required_key} env var",
+            file=sys.stderr,
+        )
+        return _EX_USAGE
+
     env_model = os.environ.get("VNX_LITELLM_MODEL", "")
-    if env_model:
+    if sub_provider == "deepseek":
+        model = env_model or _resolve_deepseek_model()
+    elif env_model:
         model = env_model
     elif sub_provider and sub_provider in _LITELLM_SUB_PROVIDER_DEFAULTS:
         model = _LITELLM_SUB_PROVIDER_DEFAULTS[sub_provider]

--- a/scripts/lib/providers/__init__.py
+++ b/scripts/lib/providers/__init__.py
@@ -1,0 +1,1 @@
+# Wave 7 provider registry package

--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -8,11 +8,14 @@ BILLING SAFETY: read-only data loader; no Anthropic SDK, no API calls.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
+
+log = logging.getLogger(__name__)
 
 _REGISTRY_PATH = Path(__file__).parent / "wave7_models.yaml"
 
@@ -80,8 +83,12 @@ def get_default_model(
     """Return the first model entry for *sub_provider*, or None if not found/disabled."""
     try:
         registry = load(registry_path)
-    except Exception:
-        return None
+    except FileNotFoundError as e:
+        log.error("provider_registry: file missing at %s: %s", registry_path or _REGISTRY_PATH, e)
+        raise
+    except yaml.YAMLError as e:
+        log.error("provider_registry: malformed yaml at %s: %s", registry_path or _REGISTRY_PATH, e)
+        raise ValueError(f"malformed wave7_models.yaml: {e}") from e
     cfg = registry.get(sub_provider)
     if cfg is None or not cfg.enabled or not cfg.models:
         return None

--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -1,0 +1,88 @@
+"""provider_registry.py — Wave 7 model registry loader.
+
+Reads wave7_models.yaml and exposes typed records for provider dispatch
+and cost-routing. Used by provider_dispatch.py to resolve model names
+without hardcoded strings.
+
+BILLING SAFETY: read-only data loader; no Anthropic SDK, no API calls.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+_REGISTRY_PATH = Path(__file__).parent / "wave7_models.yaml"
+
+
+@dataclass
+class ProviderModel:
+    litellm_name: str
+    cost_input_per_mtok: float
+    cost_output_per_mtok: float
+    max_tokens: int
+    supports_streaming: bool
+    supports_tool_calls: bool
+    task_classes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ProviderConfig:
+    enabled: bool
+    api_key_env: str
+    models: Dict[str, ProviderModel] = field(default_factory=dict)
+
+
+def _parse_model(data: dict) -> ProviderModel:
+    return ProviderModel(
+        litellm_name=str(data["litellm_name"]),
+        cost_input_per_mtok=float(data["cost_input_per_mtok"]),
+        cost_output_per_mtok=float(data["cost_output_per_mtok"]),
+        max_tokens=int(data["max_tokens"]),
+        supports_streaming=bool(data["supports_streaming"]),
+        supports_tool_calls=bool(data["supports_tool_calls"]),
+        task_classes=list(data.get("task_classes") or []),
+    )
+
+
+def _parse_provider(data: dict) -> ProviderConfig:
+    models: Dict[str, ProviderModel] = {}
+    for model_key, model_data in (data.get("models") or {}).items():
+        models[model_key] = _parse_model(model_data)
+    return ProviderConfig(
+        enabled=bool(data.get("enabled", False)),
+        api_key_env=str(data.get("api_key_env") or ""),
+        models=models,
+    )
+
+
+def load(registry_path: Optional[Path] = None) -> Dict[str, ProviderConfig]:
+    """Parse wave7_models.yaml and return a dict of provider configs.
+
+    Raises FileNotFoundError when registry_path does not exist.
+    Raises yaml.YAMLError on malformed YAML.
+    """
+    path = Path(registry_path) if registry_path is not None else _REGISTRY_PATH
+    with open(path) as fh:
+        raw = yaml.safe_load(fh)
+    result: Dict[str, ProviderConfig] = {}
+    for provider_key, provider_data in (raw or {}).get("providers", {}).items():
+        result[str(provider_key)] = _parse_provider(provider_data or {})
+    return result
+
+
+def get_default_model(
+    sub_provider: str,
+    registry_path: Optional[Path] = None,
+) -> Optional[ProviderModel]:
+    """Return the first model entry for *sub_provider*, or None if not found/disabled."""
+    try:
+        registry = load(registry_path)
+    except Exception:
+        return None
+    cfg = registry.get(sub_provider)
+    if cfg is None or not cfg.enabled or not cfg.models:
+        return None
+    return next(iter(cfg.models.values()))

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -1,0 +1,22 @@
+# Wave 7 model registry — LiteLLM-compatible model names + cost/MTok
+providers:
+  deepseek:
+    enabled: true
+    api_key_env: DEEPSEEK_API_KEY
+    models:
+      deepseek-v4-pro:
+        litellm_name: "deepseek/deepseek-v3.2"
+        cost_input_per_mtok: 0.28
+        cost_output_per_mtok: 0.40
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review", "analysis"]
+  moonshot:
+    enabled: false  # PR-7.2 will enable
+    api_key_env: MOONSHOT_API_KEY
+    models: {}
+  zai:
+    enabled: false  # PR-7.3 will enable
+    api_key_env: ZHIPU_API_KEY
+    models: {}

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -205,33 +205,59 @@ class TestProviderGeminiRouted:
 
 
 # ---------------------------------------------------------------------------
-# Test: litellm:<model> raises SystemExit(64) mentioning PR-4.6.5
+# Test: litellm:<model> routes to _dispatch_litellm (PR-4.6.5 implemented)
 # ---------------------------------------------------------------------------
 
-class TestProviderLitellmRaisesNotImplemented:
+class TestProviderLitellmRouted:
 
-    def test_exit_code_64(self, capsys):
-        argv = ["--provider", "litellm:deepseek-v4-pro", "--terminal-id", "T1",
-                "--dispatch-id", "test-litellm", "--instruction", "noop"]
-        with pytest.raises(SystemExit) as exc_info:
-            provider_dispatch.main(argv)
-        assert exc_info.value.code == 64
+    def test_litellm_routes_to_dispatch_litellm(self):
+        """--provider litellm:deepseek calls _dispatch_litellm and returns 0 on success."""
+        argv = ["--provider", "litellm:deepseek", "--terminal-id", "T1",
+                "--dispatch-id", "test-litellm-routed", "--instruction", "noop"]
+        with patch("provider_dispatch._dispatch_litellm", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+        assert rc == 0
+        mock_dispatch.assert_called_once()
 
-    def test_message_mentions_pr_4_6_5(self, capsys):
-        argv = ["--provider", "litellm:deepseek-v4-pro", "--terminal-id", "T1",
-                "--dispatch-id", "test-litellm", "--instruction", "noop"]
-        with pytest.raises(SystemExit):
-            provider_dispatch.main(argv)
-        captured = capsys.readouterr()
-        assert "PR-4.6.5" in captured.err
+    def test_bare_litellm_routes_to_dispatch_litellm(self):
+        """--provider litellm (no sub-provider) also routes to _dispatch_litellm."""
+        argv = ["--provider", "litellm", "--terminal-id", "T1",
+                "--dispatch-id", "test-litellm-bare", "--instruction", "noop"]
+        with patch("provider_dispatch._dispatch_litellm", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(argv)
+        assert rc == 0
+        mock_dispatch.assert_called_once()
 
-    def test_various_litellm_models(self, capsys):
-        for model in ("litellm:kimi-k2", "litellm:glm-5.1", "litellm:groq:llama3"):
-            argv = ["--provider", model, "--terminal-id", "T1",
-                    "--dispatch-id", "test-litellm", "--instruction", "noop"]
-            with pytest.raises(SystemExit) as exc_info:
-                provider_dispatch.main(argv)
-            assert exc_info.value.code == 64, f"Expected exit 64 for {model}"
+    def test_various_litellm_sub_providers_route(self):
+        """Various litellm:<sub> values all route to _dispatch_litellm."""
+        for provider_str in ("litellm:kimi-k2", "litellm:glm-5.1", "litellm:bedrock"):
+            argv = ["--provider", provider_str, "--terminal-id", "T1",
+                    "--dispatch-id", "test-litellm-sub", "--instruction", "noop"]
+            with patch("provider_dispatch._dispatch_litellm", return_value=0) as mock_dispatch:
+                rc = provider_dispatch.main(argv)
+            assert rc == 0, f"Expected 0 for {provider_str}"
+            mock_dispatch.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: registry resolution failure raises RuntimeError (codex R1 fix)
+# ---------------------------------------------------------------------------
+
+class TestRegistryResolutionFailure:
+
+    def test_provider_dispatch_raises_on_registry_failure(self):
+        """_resolve_deepseek_model() raises RuntimeError when registry load fails."""
+        with patch("providers.provider_registry.get_default_model",
+                   side_effect=FileNotFoundError("wave7_models.yaml missing")):
+            with pytest.raises(RuntimeError, match="registry resolution failed"):
+                provider_dispatch._resolve_deepseek_model()
+
+    def test_provider_dispatch_raises_on_malformed_registry(self):
+        """_resolve_deepseek_model() raises RuntimeError when registry is malformed yaml."""
+        with patch("providers.provider_registry.get_default_model",
+                   side_effect=ValueError("malformed wave7_models.yaml: mapping error")):
+            with pytest.raises(RuntimeError, match="registry resolution failed"):
+                provider_dispatch._resolve_deepseek_model()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_registry_exceptions.py
+++ b/tests/test_provider_registry_exceptions.py
@@ -1,0 +1,66 @@
+"""Tests for provider_registry exception narrowing (codex R1 fix).
+
+Verifies that get_default_model() fails-fast on missing or malformed registry
+files instead of silently returning None.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from providers import provider_registry
+
+
+class TestProviderRegistryRaisesOnMissingFile:
+
+    def test_raises_file_not_found(self, tmp_path):
+        """get_default_model raises FileNotFoundError when registry file is absent."""
+        missing = tmp_path / "nonexistent.yaml"
+        with pytest.raises(FileNotFoundError):
+            provider_registry.get_default_model("deepseek", registry_path=missing)
+
+    def test_does_not_return_none_on_missing_file(self, tmp_path):
+        """get_default_model must not silently swallow FileNotFoundError."""
+        missing = tmp_path / "nonexistent.yaml"
+        try:
+            result = provider_registry.get_default_model("deepseek", registry_path=missing)
+            pytest.fail(f"Expected FileNotFoundError, got {result!r}")
+        except FileNotFoundError:
+            pass  # expected
+
+
+class TestProviderRegistryRaisesOnMalformedYaml:
+
+    def test_provider_registry_raises_on_malformed_yaml(self, tmp_path):
+        """get_default_model raises ValueError wrapping YAMLError on malformed content."""
+        malformed = tmp_path / "bad.yaml"
+        malformed.write_text("providers:\n  bad: :::invalid:::\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="malformed wave7_models.yaml"):
+            provider_registry.get_default_model("deepseek", registry_path=malformed)
+
+    def test_malformed_yaml_does_not_return_none(self, tmp_path):
+        """get_default_model must not silently swallow yaml parse errors."""
+        malformed = tmp_path / "bad.yaml"
+        malformed.write_text("providers:\n  bad: :::invalid:::\n", encoding="utf-8")
+        try:
+            result = provider_registry.get_default_model("deepseek", registry_path=malformed)
+            pytest.fail(f"Expected ValueError, got {result!r}")
+        except ValueError:
+            pass  # expected
+
+
+class TestProviderRegistryHappyPath:
+
+    def test_returns_none_for_unknown_provider(self, tmp_path):
+        """get_default_model returns None when provider is not in registry (no exception)."""
+        registry_yaml = tmp_path / "models.yaml"
+        registry_yaml.write_text(
+            "providers:\n  deepseek:\n    enabled: false\n    api_key_env: DEEPSEEK_API_KEY\n    models: {}\n",
+            encoding="utf-8",
+        )
+        result = provider_registry.get_default_model("nonexistent", registry_path=registry_yaml)
+        assert result is None

--- a/tests/test_wave7_deepseek_smoke.py
+++ b/tests/test_wave7_deepseek_smoke.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""test_wave7_deepseek_smoke.py — Wave 7 PR-7.1 DeepSeek smoke tests.
+
+Verifies DeepSeek V4 lane via LiteLLM bridge (no real API calls):
+
+  test_provider_dispatch_routes_deepseek   — litellm:deepseek routes to
+      spawn_litellm with model containing 'deepseek'
+  test_deepseek_requires_api_key           — missing DEEPSEEK_API_KEY → non-zero exit
+  test_runner_validates_deepseek_api_key   — _litellm_runner._validate_provider_key
+      returns (False, ...) without key, (True, '') with key
+  test_wave7_models_yaml_valid             — wave7_models.yaml parses and deepseek
+      entry has correct schema
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns.litellm_spawn import LiteLLMSpawnResult
+
+
+# ---------------------------------------------------------------------------
+# Test 1: provider_dispatch routes litellm:deepseek to spawn_litellm
+# ---------------------------------------------------------------------------
+
+class TestProviderDispatchRoutesDeepSeek:
+    """provider_dispatch.main routes --provider litellm:deepseek to spawn_litellm."""
+
+    def test_provider_dispatch_routes_deepseek(self):
+        mock_result = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="ok",
+            events_written=2,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=None,
+            event_writer_failures=0,
+        )
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=mock_result) as mock_spawn:
+            with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "sk-test-key"}):
+                from provider_dispatch import main
+                rc = main([
+                    "--provider", "litellm:deepseek",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-dispatch-deepseek",
+                    "--instruction", "Reply with one word.",
+                ])
+
+        assert rc == 0, f"expected exit 0, got {rc}"
+        assert mock_spawn.called, "spawn_litellm was not called"
+        call_kwargs = mock_spawn.call_args
+        model = (call_kwargs[1] if call_kwargs[1] else {}).get("model") or (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else ""
+        )
+        assert "deepseek" in model, (
+            f"expected model containing 'deepseek', got {model!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: missing DEEPSEEK_API_KEY returns non-zero exit code
+# ---------------------------------------------------------------------------
+
+class TestDeepSeekRequiresApiKey:
+    """provider_dispatch exits non-zero when DEEPSEEK_API_KEY is not set."""
+
+    def test_deepseek_requires_api_key(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "DEEPSEEK_API_KEY"}
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from provider_dispatch import main
+            rc = main([
+                "--provider", "litellm:deepseek",
+                "--terminal-id", "T1",
+                "--dispatch-id", "test-no-key",
+                "--instruction", "test",
+            ])
+
+        assert rc != 0, "expected non-zero exit when DEEPSEEK_API_KEY is missing"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: _litellm_runner._validate_provider_key validates DEEPSEEK_API_KEY
+# ---------------------------------------------------------------------------
+
+class TestRunnerValidatesDeepSeekApiKey:
+    """_litellm_runner._validate_provider_key returns (False, msg) when key absent."""
+
+    def _load_runner(self):
+        from adapters import _litellm_runner as runner
+        return runner
+
+    def test_validate_returns_false_without_key(self):
+        runner = self._load_runner()
+        env_without_key = {k: v for k, v in os.environ.items() if k != "DEEPSEEK_API_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            ok, msg = runner._validate_provider_key("deepseek/deepseek-v3.2")
+        assert ok is False, f"expected ok=False, got ok={ok}"
+        assert "DEEPSEEK_API_KEY" in msg, f"expected DEEPSEEK_API_KEY in msg, got: {msg!r}"
+
+    def test_validate_returns_true_with_key(self):
+        runner = self._load_runner()
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "sk-test-key"}):
+            ok, msg = runner._validate_provider_key("deepseek/deepseek-v3.2")
+        assert ok is True, f"expected ok=True, got ok={ok}"
+        assert msg == "", f"expected empty msg, got: {msg!r}"
+
+    def test_validate_passes_for_non_keyed_provider(self):
+        runner = self._load_runner()
+        clean_env = {k: v for k, v in os.environ.items() if k not in ("DEEPSEEK_API_KEY", "MOONSHOT_API_KEY")}
+        with patch.dict(os.environ, clean_env, clear=True):
+            ok, msg = runner._validate_provider_key("anthropic/claude-sonnet-4-6")
+        assert ok is True, f"anthropic provider should not require key check, got ok={ok}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: wave7_models.yaml parses with valid deepseek entry
+# ---------------------------------------------------------------------------
+
+class TestWave7ModelsYamlValid:
+    """wave7_models.yaml contains a valid deepseek entry conforming to schema."""
+
+    def test_wave7_models_yaml_valid(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+
+        assert "deepseek" in registry, "deepseek provider missing from registry"
+
+        deepseek = registry["deepseek"]
+        assert deepseek.enabled is True, "deepseek.enabled must be True"
+        assert deepseek.api_key_env == "DEEPSEEK_API_KEY", (
+            f"unexpected api_key_env: {deepseek.api_key_env!r}"
+        )
+        assert deepseek.models, "deepseek.models must not be empty"
+        assert "deepseek-v4-pro" in deepseek.models, "deepseek-v4-pro model entry missing"
+
+        model = deepseek.models["deepseek-v4-pro"]
+        assert model.litellm_name == "deepseek/deepseek-v3.2", (
+            f"unexpected litellm_name: {model.litellm_name!r}"
+        )
+        assert model.cost_input_per_mtok == pytest.approx(0.28), (
+            f"unexpected input cost: {model.cost_input_per_mtok}"
+        )
+        assert model.cost_output_per_mtok == pytest.approx(0.40), (
+            f"unexpected output cost: {model.cost_output_per_mtok}"
+        )
+        assert model.supports_streaming is True
+        assert model.supports_tool_calls is True
+        assert "coding" in model.task_classes
+
+    def test_inactive_providers_disabled(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+
+        assert "moonshot" in registry, "moonshot provider missing from registry"
+        assert registry["moonshot"].enabled is False, "moonshot must be disabled (PR-7.2)"
+
+        assert "zai" in registry, "zai provider missing from registry"
+        assert registry["zai"].enabled is False, "zai must be disabled (PR-7.3)"
+
+    def test_get_default_model_returns_deepseek(self):
+        from providers import provider_registry
+
+        model = provider_registry.get_default_model("deepseek")
+        assert model is not None, "get_default_model('deepseek') returned None"
+        assert "deepseek" in model.litellm_name, (
+            f"unexpected litellm_name from default: {model.litellm_name!r}"
+        )
+
+    def test_get_default_model_returns_none_for_disabled(self):
+        from providers import provider_registry
+
+        model = provider_registry.get_default_model("moonshot")
+        assert model is None, (
+            f"expected None for disabled moonshot provider, got {model!r}"
+        )

--- a/tests/unit/test_litellm_runner_usage.py
+++ b/tests/unit/test_litellm_runner_usage.py
@@ -1,0 +1,86 @@
+"""Unit tests for _litellm_runner usage serialization fallback (codex R1 fix).
+
+Verifies that _emit_usage() emits a placeholder dict with warning log
+instead of silently returning when usage serialization fails.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "lib" / "adapters"))
+
+import _litellm_runner
+
+
+class _BrokenUsage:
+    """Object where dict() raises AttributeError (has keys() that raises AttributeError)."""
+    def keys(self):
+        raise AttributeError("usage object has no valid keys")
+
+
+class _ModelDumpUsage:
+    """Object with model_dump() — happy path."""
+    def model_dump(self) -> dict:
+        return {"input_tokens": 10, "output_tokens": 5}
+
+
+class _DictUsage:
+    """Object with dict() — happy path via .dict()."""
+    def dict(self) -> dict:
+        return {"input_tokens": 20, "output_tokens": 8}
+
+
+class TestEmitUsageFallback:
+
+    def test_litellm_runner_emits_placeholder_on_usage_failure(self, caplog):
+        """_emit_usage emits placeholder dict + warning log when dict(usage) raises AttributeError."""
+        emitted: list[dict] = []
+
+        with patch.object(_litellm_runner, "_emit", side_effect=emitted.append):
+            with caplog.at_level(logging.WARNING, logger="_litellm_runner"):
+                _litellm_runner._emit_usage(_BrokenUsage())
+
+        assert len(emitted) == 1, f"Expected 1 emitted event, got {len(emitted)}"
+        event = emitted[0]
+        assert event["event_type"] == "usage_complete"
+        assert event["usage"]["usage_serialization_failed"] is True
+        assert event["usage"]["input_tokens"] == 0
+        assert event["usage"]["output_tokens"] == 0
+
+    def test_litellm_runner_logs_warning_on_usage_failure(self, caplog):
+        """_emit_usage logs a WARNING when usage serialization falls back to placeholder."""
+        with patch.object(_litellm_runner, "_emit", lambda _: None):
+            with caplog.at_level(logging.WARNING, logger="_litellm_runner"):
+                _litellm_runner._emit_usage(_BrokenUsage())
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_records, "Expected at least one WARNING log record"
+        assert "usage serialization fallback" in warning_records[0].message
+
+    def test_emit_usage_happy_path_model_dump(self):
+        """_emit_usage emits real usage dict when model_dump() is available."""
+        emitted: list[dict] = []
+
+        with patch.object(_litellm_runner, "_emit", side_effect=emitted.append):
+            _litellm_runner._emit_usage(_ModelDumpUsage())
+
+        assert len(emitted) == 1
+        assert emitted[0]["usage"]["input_tokens"] == 10
+        assert emitted[0]["usage"]["output_tokens"] == 5
+
+    def test_emit_usage_happy_path_dict_method(self):
+        """_emit_usage emits real usage dict when .dict() is available."""
+        emitted: list[dict] = []
+
+        with patch.object(_litellm_runner, "_emit", side_effect=emitted.append):
+            _litellm_runner._emit_usage(_DictUsage())
+
+        assert len(emitted) == 1
+        assert emitted[0]["usage"]["input_tokens"] == 20
+        assert emitted[0]["usage"]["output_tokens"] == 8


### PR DESCRIPTION
## Summary

- Activates DeepSeek V4 (`deepseek/deepseek-v3.2`) as the first non-Claude worker lane via the LiteLLM subprocess bridge (ADR-015 Path B, depends on PR-7.0 merged)
- `scripts/lib/providers/wave7_models.yaml` — shared model registry for PR-7.1/7.2/7.3 (DeepSeek entry live; moonshot/zai stubs disabled)
- `scripts/lib/providers/provider_registry.py` — typed YAML loader with `get_default_model()` for dispatch-time resolution
- `scripts/lib/provider_dispatch.py` — DEEPSEEK_API_KEY fast-fail before subprocess spawn; registry-based model resolution; default corrected from `v3` to `v3.2`
- `scripts/lib/adapters/_litellm_runner.py` — `_validate_provider_key()` (defense-in-depth API key check inside runner), `_completion_kwargs()` (stream_options usage tracking), `_emit_usage()` (usage_complete event from final chunk)
- `docs/operations/PROVIDER_API_KEYS.md` — operator-facing key provisioning reference
- `tests/test_wave7_deepseek_smoke.py` — 9 tests: routing, API key validation at dispatch + runner levels, YAML schema correctness

## Design constraints upheld

- No LiteLLM imports in VNX worker code (ADR-010 compliance)
- No Anthropic SDK imports (ADR-003 compliance)
- Default routing unchanged — DeepSeek lane only activates on `--provider litellm:deepseek`
- Feature flag `VNX_ROUTING_DEEPSEEK` reserved for routing policy (PR-7.4)

## Related

- ADR-015: `docs/governance/decisions/ADR-015-wave7-litellm-path-b.md`
- Design doc: `claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md`
- Dispatch-ID: `20260515-wave7-pr1-deepseek`

## Test plan

- [x] `pytest tests/test_wave7_deepseek_smoke.py -v` — 9/9 passed
- [x] `pytest tests/test_litellm_spawn_fail_closed.py tests/test_litellm_spawn_byte_identity.py` — 20/20 baseline unchanged
- [ ] Gates: codex_gate + gemini_review (standard B3 1-retry per dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)