### PR TITLE
feat(wave7): PR-7.2 — Kimi K2.6 + K2-0905 lane via LiteLLM Moonshot endpoint

### DIFF
--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -50,6 +50,20 @@ dispatches — the flags control automatic routing policy (PR-7.4, not yet shipp
 - Dispatch: `--provider litellm:deepseek`
 - Missing `DEEPSEEK_API_KEY` → immediate exit(64) before subprocess spawn
 
+## Kimi K2 via Moonshot (PR-7.2)
+
+Two model tiers available under `--provider litellm:moonshot`:
+
+| Alias | LiteLLM name | Input/MTok | Output/MTok | Task classes |
+|---|---|---|---|---|
+| kimi-k2-0905-default | moonshot/kimi-k2-0905-preview | $0.60 | $2.50 | coding, review, analysis |
+| kimi-k2-6 | moonshot/kimi-k2.6 | $0.95 | $4.00 | coding-premium |
+
+- Default lane: `kimi-k2-0905-preview` (~5x cheaper than Claude Sonnet 4.6 output)
+- Dispatch: `--provider litellm:moonshot` (default) or `--provider litellm:moonshot:kimi-k2-6` (premium)
+- Missing `MOONSHOT_API_KEY` → immediate exit(64) before subprocess spawn
+- Context: 8,192 tokens (both models); streaming + tool calls supported
+
 ## Related
 
 - ADR-015: Wave 7 Path B decision + Path D deferral

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -36,7 +36,7 @@ _FUTURE_PR_MAP: dict = {}
 _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "bedrock": "bedrock/claude-sonnet-4-6",
     "deepseek": "deepseek/deepseek-v3.2",
-    "kimi": "openai/moonshot-v1-32k",
+    "moonshot": "moonshot/kimi-k2-0905-preview",
     "glm-5.1": "zhipuai/glm-4",
     "ollama": "ollama/llama3",
     "anthropic": "anthropic/claude-sonnet-4-6",
@@ -45,6 +45,7 @@ _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
 # Env vars required per sub-provider (fast-fail before subprocess spawn)
 _SUB_PROVIDER_KEY_REQS: dict = {
     "deepseek": "DEEPSEEK_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
 }
 
 
@@ -166,6 +167,29 @@ def _resolve_deepseek_model() -> str:
     return _LITELLM_SUB_PROVIDER_DEFAULTS["deepseek"]
 
 
+def _resolve_moonshot_model(model_alias: "str | None" = None) -> str:
+    """Load Moonshot model litellm_name from registry.
+
+    When model_alias is given (e.g. 'kimi-k2-6'), looks up that specific model key.
+    Defaults to 'kimi-k2-0905-default' (cost-effective lane) when alias is absent.
+    Falls back to hardcoded default when registry is unavailable.
+    """
+    from providers import provider_registry as _reg
+    try:
+        registry = _reg.load()
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("provider_dispatch: registry resolve failed for moonshot: %s", e)
+        raise RuntimeError(f"provider registry resolution failed: {e}") from e
+    cfg = registry.get("moonshot")
+    if cfg is None or not cfg.enabled or not cfg.models:
+        return _LITELLM_SUB_PROVIDER_DEFAULTS["moonshot"]
+    target_key = model_alias or "kimi-k2-0905-default"
+    if target_key in cfg.models:
+        return cfg.models[target_key].litellm_name
+    # alias not found — fall back to first available model
+    return next(iter(cfg.models.values())).litellm_name
+
+
 def _dispatch_litellm(args: argparse.Namespace) -> int:
     """Route to spawn_litellm for litellm-provider dispatches (PR-4.6.5).
 
@@ -190,24 +214,31 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     parts = args.provider.split(":", 1)
     sub_provider = parts[1] if len(parts) > 1 else ""
 
+    # Normalize sub-sub-routing: litellm:moonshot:kimi-k2-6 -> base=moonshot, alias=kimi-k2-6
+    sub_parts = sub_provider.split(":", 1)
+    base_sub = sub_parts[0]
+    model_alias = sub_parts[1] if len(sub_parts) > 1 else None
+
     # Fast-fail for providers that require an explicit API key
-    required_key = _SUB_PROVIDER_KEY_REQS.get(sub_provider)
+    required_key = _SUB_PROVIDER_KEY_REQS.get(base_sub)
     if required_key and not os.environ.get(required_key):
         print(
-            f"litellm:{sub_provider} requires {required_key} env var",
+            f"litellm:{base_sub} requires {required_key} env var",
             file=sys.stderr,
         )
         return _EX_USAGE
 
     env_model = os.environ.get("VNX_LITELLM_MODEL", "")
-    if sub_provider == "deepseek":
+    if base_sub == "deepseek":
         model = env_model or _resolve_deepseek_model()
+    elif base_sub == "moonshot":
+        model = env_model or _resolve_moonshot_model(model_alias)
     elif env_model:
         model = env_model
-    elif sub_provider and sub_provider in _LITELLM_SUB_PROVIDER_DEFAULTS:
-        model = _LITELLM_SUB_PROVIDER_DEFAULTS[sub_provider]
-    elif sub_provider:
-        model = f"{sub_provider}/default"
+    elif base_sub and base_sub in _LITELLM_SUB_PROVIDER_DEFAULTS:
+        model = _LITELLM_SUB_PROVIDER_DEFAULTS[base_sub]
+    elif base_sub:
+        model = f"{base_sub}/default"
     else:
         model = "anthropic/claude-sonnet-4-6"
 
@@ -216,7 +247,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         model=model,
         dispatch_id=args.dispatch_id,
         terminal_id=args.terminal_id,
-        sub_provider=sub_provider or None,
+        sub_provider=base_sub or None,
         event_writer=event_store.append if event_store is not None else None,
     )
     if result.error:

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -13,9 +13,25 @@ providers:
         supports_tool_calls: true
         task_classes: ["coding", "review", "analysis"]
   moonshot:
-    enabled: false  # PR-7.2 will enable
+    enabled: true
     api_key_env: MOONSHOT_API_KEY
-    models: {}
+    models:
+      kimi-k2-0905-default:
+        litellm_name: "moonshot/kimi-k2-0905-preview"
+        cost_input_per_mtok: 0.60
+        cost_output_per_mtok: 2.50
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review", "analysis"]
+      kimi-k2-6:
+        litellm_name: "moonshot/kimi-k2.6"
+        cost_input_per_mtok: 0.95
+        cost_output_per_mtok: 4.00
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding-premium"]
   zai:
     enabled: false  # PR-7.3 will enable
     api_key_env: ZHIPU_API_KEY

--- a/tests/test_wave7_deepseek_smoke.py
+++ b/tests/test_wave7_deepseek_smoke.py
@@ -164,8 +164,9 @@ class TestWave7ModelsYamlValid:
 
         registry = provider_registry.load()
 
+        # moonshot enabled by PR-7.2; zai still pending PR-7.3
         assert "moonshot" in registry, "moonshot provider missing from registry"
-        assert registry["moonshot"].enabled is False, "moonshot must be disabled (PR-7.2)"
+        assert registry["moonshot"].enabled is True, "moonshot must be enabled after PR-7.2"
 
         assert "zai" in registry, "zai provider missing from registry"
         assert registry["zai"].enabled is False, "zai must be disabled (PR-7.3)"
@@ -179,10 +180,11 @@ class TestWave7ModelsYamlValid:
             f"unexpected litellm_name from default: {model.litellm_name!r}"
         )
 
-    def test_get_default_model_returns_none_for_disabled(self):
+    def test_get_default_model_returns_none_for_still_disabled(self):
         from providers import provider_registry
 
-        model = provider_registry.get_default_model("moonshot")
+        # zai is still disabled until PR-7.3
+        model = provider_registry.get_default_model("zai")
         assert model is None, (
-            f"expected None for disabled moonshot provider, got {model!r}"
+            f"expected None for disabled zai provider, got {model!r}"
         )

--- a/tests/test_wave7_kimi_smoke.py
+++ b/tests/test_wave7_kimi_smoke.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""test_wave7_kimi_smoke.py — Wave 7 PR-7.2 Kimi K2 smoke tests.
+
+Verifies Kimi K2 lane via LiteLLM Moonshot endpoint (no real API calls):
+
+  test_provider_dispatch_routes_moonshot  — litellm:moonshot routes to
+      spawn_litellm with model containing 'moonshot'
+  test_kimi_requires_api_key             — missing MOONSHOT_API_KEY → non-zero exit
+  test_kimi_model_alias_resolution       — kimi-k2-0905-default resolves to
+      moonshot/kimi-k2-0905-preview; kimi-k2-6 resolves to moonshot/kimi-k2.6
+  test_wave7_models_yaml_moonshot_valid  — moonshot entry has valid schema + 2 models
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns.litellm_spawn import LiteLLMSpawnResult
+
+
+# ---------------------------------------------------------------------------
+# Test 1: provider_dispatch routes litellm:moonshot to spawn_litellm
+# ---------------------------------------------------------------------------
+
+class TestProviderDispatchRoutesMoonshot:
+    """provider_dispatch.main routes --provider litellm:moonshot to spawn_litellm."""
+
+    def test_provider_dispatch_routes_moonshot(self):
+        mock_result = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="ok",
+            events_written=2,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=None,
+            event_writer_failures=0,
+        )
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=mock_result) as mock_spawn:
+            with patch.dict(os.environ, {"MOONSHOT_API_KEY": "sk-test-moonshot"}):
+                from provider_dispatch import main
+                rc = main([
+                    "--provider", "litellm:moonshot",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-dispatch-moonshot",
+                    "--instruction", "Reply with one word.",
+                ])
+
+        assert rc == 0, f"expected exit 0, got {rc}"
+        assert mock_spawn.called, "spawn_litellm was not called"
+        call_kwargs = mock_spawn.call_args
+        model = (call_kwargs[1] if call_kwargs[1] else {}).get("model") or (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else ""
+        )
+        assert "moonshot" in model, (
+            f"expected model containing 'moonshot', got {model!r}"
+        )
+
+    def test_provider_dispatch_routes_moonshot_premium_alias(self):
+        mock_result = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="ok",
+            events_written=1,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=None,
+            event_writer_failures=0,
+        )
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=mock_result) as mock_spawn:
+            with patch.dict(os.environ, {"MOONSHOT_API_KEY": "sk-test-moonshot"}):
+                from provider_dispatch import main
+                rc = main([
+                    "--provider", "litellm:moonshot:kimi-k2-6",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-dispatch-moonshot-k26",
+                    "--instruction", "Reply with one word.",
+                ])
+
+        assert rc == 0, f"expected exit 0, got {rc}"
+        assert mock_spawn.called, "spawn_litellm was not called"
+        call_kwargs = mock_spawn.call_args
+        model = (call_kwargs[1] if call_kwargs[1] else {}).get("model") or (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else ""
+        )
+        assert "kimi-k2.6" in model, (
+            f"expected model containing 'kimi-k2.6', got {model!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: missing MOONSHOT_API_KEY returns non-zero exit code
+# ---------------------------------------------------------------------------
+
+class TestKimiRequiresApiKey:
+    """provider_dispatch exits non-zero when MOONSHOT_API_KEY is not set."""
+
+    def test_kimi_requires_api_key(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "MOONSHOT_API_KEY"}
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from provider_dispatch import main
+            rc = main([
+                "--provider", "litellm:moonshot",
+                "--terminal-id", "T1",
+                "--dispatch-id", "test-no-key",
+                "--instruction", "test",
+            ])
+
+        assert rc != 0, "expected non-zero exit when MOONSHOT_API_KEY is missing"
+
+    def test_kimi_runner_validates_moonshot_api_key(self):
+        from adapters import _litellm_runner as runner
+
+        env_without_key = {k: v for k, v in os.environ.items() if k != "MOONSHOT_API_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            ok, msg = runner._validate_provider_key("moonshot/kimi-k2-0905-preview")
+        assert ok is False, f"expected ok=False without key, got ok={ok}"
+        assert "MOONSHOT_API_KEY" in msg, f"expected MOONSHOT_API_KEY in msg, got: {msg!r}"
+
+    def test_kimi_runner_passes_with_api_key(self):
+        from adapters import _litellm_runner as runner
+
+        with patch.dict(os.environ, {"MOONSHOT_API_KEY": "sk-test-key"}):
+            ok, msg = runner._validate_provider_key("moonshot/kimi-k2.6")
+        assert ok is True, f"expected ok=True with key, got ok={ok}"
+        assert msg == "", f"expected empty msg, got: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: model alias resolution
+# ---------------------------------------------------------------------------
+
+class TestKimiModelAliasResolution:
+    """_resolve_moonshot_model correctly maps aliases to litellm model strings."""
+
+    def test_default_resolves_to_k2_0905_preview(self):
+        from provider_dispatch import _resolve_moonshot_model
+        model = _resolve_moonshot_model()
+        assert model == "moonshot/kimi-k2-0905-preview", (
+            f"expected moonshot/kimi-k2-0905-preview as default, got {model!r}"
+        )
+
+    def test_kimi_k2_0905_alias_resolves(self):
+        from provider_dispatch import _resolve_moonshot_model
+        model = _resolve_moonshot_model("kimi-k2-0905-default")
+        assert model == "moonshot/kimi-k2-0905-preview", (
+            f"kimi-k2-0905-default should resolve to moonshot/kimi-k2-0905-preview, got {model!r}"
+        )
+
+    def test_kimi_k2_6_alias_resolves(self):
+        from provider_dispatch import _resolve_moonshot_model
+        model = _resolve_moonshot_model("kimi-k2-6")
+        assert model == "moonshot/kimi-k2.6", (
+            f"kimi-k2-6 should resolve to moonshot/kimi-k2.6, got {model!r}"
+        )
+
+    def test_unknown_alias_falls_back_to_first_model(self):
+        from provider_dispatch import _resolve_moonshot_model
+        model = _resolve_moonshot_model("nonexistent-alias")
+        # Falls back to first model in registry (kimi-k2-0905-default)
+        assert model.startswith("moonshot/"), (
+            f"unknown alias should fall back to a moonshot/ model, got {model!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: wave7_models.yaml has valid moonshot entries
+# ---------------------------------------------------------------------------
+
+class TestWave7ModelsYamlMoonshotValid:
+    """wave7_models.yaml contains a valid, enabled moonshot entry."""
+
+    def test_wave7_models_yaml_moonshot_valid(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+
+        assert "moonshot" in registry, "moonshot provider missing from registry"
+
+        moonshot = registry["moonshot"]
+        assert moonshot.enabled is True, "moonshot.enabled must be True after PR-7.2"
+        assert moonshot.api_key_env == "MOONSHOT_API_KEY", (
+            f"unexpected api_key_env: {moonshot.api_key_env!r}"
+        )
+        assert len(moonshot.models) == 2, (
+            f"expected 2 moonshot models, got {len(moonshot.models)}"
+        )
+
+    def test_kimi_k2_0905_model_schema(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+        model = registry["moonshot"].models["kimi-k2-0905-default"]
+
+        assert model.litellm_name == "moonshot/kimi-k2-0905-preview", (
+            f"unexpected litellm_name: {model.litellm_name!r}"
+        )
+        assert model.cost_input_per_mtok == pytest.approx(0.60)
+        assert model.cost_output_per_mtok == pytest.approx(2.50)
+        assert model.max_tokens == 8192
+        assert model.supports_streaming is True
+        assert model.supports_tool_calls is True
+        assert "coding" in model.task_classes
+
+    def test_kimi_k2_6_model_schema(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+        model = registry["moonshot"].models["kimi-k2-6"]
+
+        assert model.litellm_name == "moonshot/kimi-k2.6", (
+            f"unexpected litellm_name: {model.litellm_name!r}"
+        )
+        assert model.cost_input_per_mtok == pytest.approx(0.95)
+        assert model.cost_output_per_mtok == pytest.approx(4.00)
+        assert model.max_tokens == 8192
+        assert model.supports_streaming is True
+        assert model.supports_tool_calls is True
+        assert "coding-premium" in model.task_classes
+
+    def test_get_default_model_returns_moonshot(self):
+        from providers import provider_registry
+
+        model = provider_registry.get_default_model("moonshot")
+        assert model is not None, "get_default_model('moonshot') returned None"
+        assert "moonshot" in model.litellm_name, (
+            f"unexpected litellm_name from default: {model.litellm_name!r}"
+        )


### PR DESCRIPTION
## Summary

- Enables Moonshot (Kimi) provider via LiteLLM bridge (ADR-015 Path B)
- Two model tiers: `kimi-k2-0905-preview` (default, $0.60/$2.50/MTok) and `kimi-k2.6` (premium, $0.95/$4.00/MTok)
- Sub-sub-routing: `--provider litellm:moonshot` (default lane) or `--provider litellm:moonshot:kimi-k2-6` (premium)
- `MOONSHOT_API_KEY` required — fast-fail before subprocess spawn

## Changes

- `scripts/lib/providers/wave7_models.yaml`: moonshot enabled, 2 model entries
- `scripts/lib/provider_dispatch.py`: `_resolve_moonshot_model()`, moonshot key check, sub-sub-routing normalization
- `docs/operations/PROVIDER_API_KEYS.md`: Kimi section added
- `tests/test_wave7_kimi_smoke.py`: 13 smoke tests (routing, key validation, alias resolution, YAML schema)
- `tests/test_wave7_deepseek_smoke.py`: updated assertions reflecting moonshot now enabled

## Design references

- ADR-015: Wave 7 Path B decision (merged)
- `claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md`: wave7 design doc

## Merge note

Depends on PR-7.1 (DeepSeek) for `wave7_models.yaml` foundation. If PR-7.1 is not yet merged when this PR lands, the moonshot entry will be added on top of the PR-7.1 deepseek entry — no conflict. If PR-7.1 merges first, rebase this branch on main before merging.

## Test plan

- [ ] `pytest tests/test_wave7_kimi_smoke.py` — 13/13 green
- [ ] `pytest tests/test_wave7_deepseek_smoke.py` — 9/9 green (no regressions)
- [ ] Codex gate: standard B3
- [ ] Gemini review: standard B3

🤖 Generated with [Claude Code](https://claude.com/claude-code)