### PR TITLE
feat(wave7): PR-7.3 — GLM-5.1 lane via OpenRouter (z.AI direct deferred)

### DIFF
--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -8,7 +8,12 @@ Each provider requires an API key set as an env var before dispatch.
 | Anthropic Claude | ANTHROPIC_API_KEY (or OAuth via subscription) | console.anthropic.com | Sonnet 4.6 $3/$15 | default |
 | DeepSeek | DEEPSEEK_API_KEY | platform.deepseek.com | V3.2 $0.28/$0.40 | Wave 7 PR-7.1 |
 | Moonshot (Kimi) | MOONSHOT_API_KEY | platform.moonshot.cn | K2-0905 $0.60/$2.50 | Wave 7 PR-7.2 |
-| Z.AI (GLM) | ZHIPU_API_KEY | open.bigmodel.cn | GLM-5.1 est. $0.50/$2.50 | Wave 7 PR-7.3 |
+| Z.AI (GLM) via OpenRouter | OPENROUTER_API_KEY | openrouter.ai | GLM-5.1 $0.50/$2.50 (pass-through) | Wave 7 PR-7.3 |
+
+**Note on GLM legacy versions:** GLM-4.5 and GLM-4.6 are deprecated. Only GLM-5.1 is
+accepted by the `litellm:zai` route. Passing `--model glm-4.5` or `--model glm-4.6`
+raises an error. Direct Zhipu API integration (no OpenRouter margin) is deferred to
+Wave 7.3.1 — see `scripts/lib/providers/z_ai_custom_provider.py`.
 
 Pricing shown as input/output per MTok. Sonnet 4.6 reference included for cost comparison.
 
@@ -63,6 +68,20 @@ Two model tiers available under `--provider litellm:moonshot`:
 - Dispatch: `--provider litellm:moonshot` (default) or `--provider litellm:moonshot:kimi-k2-6` (premium)
 - Missing `MOONSHOT_API_KEY` → immediate exit(64) before subprocess spawn
 - Context: 8,192 tokens (both models); streaming + tool calls supported
+
+## GLM-5.1 via OpenRouter / Z.AI (PR-7.3)
+
+GLM-5.1 routes through OpenRouter as `openrouter/z-ai/glm-5`:
+
+| Alias | LiteLLM name | Input/MTok | Output/MTok | Task classes |
+|---|---|---|---|---|
+| glm-5.1-default | openrouter/z-ai/glm-5 | $0.50 | $2.50 | coding, review |
+
+- Dispatch: `--provider litellm:zai`
+- Missing `OPENROUTER_API_KEY` → immediate exit(64) before subprocess spawn
+- Deprecated models GLM-4.5 and GLM-4.6 → ValueError on dispatch (explicit legacy guard)
+- Context: 8,192 tokens; streaming + tool calls supported
+- Direct Zhipu integration deferred to Wave 7.3.1 (see `z_ai_custom_provider.py`)
 
 ## Related
 

--- a/scripts/lib/adapters/_litellm_runner.py
+++ b/scripts/lib/adapters/_litellm_runner.py
@@ -25,14 +25,15 @@ _EXIT_OK = 0
 _EXIT_CREDS = 1
 _EXIT_ERR = 2
 
-# Required env var per provider prefix (deepseek/*, moonshot/*, etc.)
+# Required env var per provider prefix (deepseek/*, moonshot/*, openrouter/*, etc.)
 _PROVIDER_KEY_REQS: dict = {
     "deepseek": "DEEPSEEK_API_KEY",
     "moonshot": "MOONSHOT_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",  # z.AI via OpenRouter (PR-7.3)
 }
 
 # Providers that support stream_options usage reporting via LiteLLM
-_USAGE_STREAM_PROVIDERS = frozenset({"deepseek", "moonshot"})
+_USAGE_STREAM_PROVIDERS = frozenset({"deepseek", "moonshot", "openrouter"})
 
 
 def _emit(obj: dict) -> None:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -37,7 +37,7 @@ _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "bedrock": "bedrock/claude-sonnet-4-6",
     "deepseek": "deepseek/deepseek-v3.2",
     "moonshot": "moonshot/kimi-k2-0905-preview",
-    "glm-5.1": "zhipuai/glm-4",
+    "zai": "openrouter/z-ai/glm-5",
     "ollama": "ollama/llama3",
     "anthropic": "anthropic/claude-sonnet-4-6",
 }
@@ -46,7 +46,11 @@ _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
 _SUB_PROVIDER_KEY_REQS: dict = {
     "deepseek": "DEEPSEEK_API_KEY",
     "moonshot": "MOONSHOT_API_KEY",
+    "zai": "OPENROUTER_API_KEY",
 }
+
+# GLM model names that are LEGACY — rejected on zai dispatch (PR-7.3)
+_DEPRECATED_ZAI_MODELS = frozenset({"glm-4.5", "glm-4.6"})
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -190,6 +194,34 @@ def _resolve_moonshot_model(model_alias: "str | None" = None) -> str:
     return next(iter(cfg.models.values())).litellm_name
 
 
+def _validate_zai_model_not_legacy(model: str) -> None:
+    """Raise ValueError when model names a deprecated GLM version."""
+    model_lower = (model or "").lower().strip()
+    if model_lower in _DEPRECATED_ZAI_MODELS:
+        raise ValueError(f"GLM-4.5/4.6 are LEGACY, use GLM-5.1 (got: {model!r})")
+
+
+def _resolve_zai_model(model_alias: "str | None" = None) -> str:
+    """Load GLM-5.1 litellm_name from registry via OpenRouter.
+
+    Defaults to 'glm-5.1-default' (openrouter/z-ai/glm-5) when alias is absent.
+    Falls back to hardcoded default when registry is unavailable.
+    """
+    from providers import provider_registry as _reg
+    try:
+        registry = _reg.load()
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("provider_dispatch: registry resolve failed for zai: %s", e)
+        raise RuntimeError(f"provider registry resolution failed: {e}") from e
+    cfg = registry.get("zai")
+    if cfg is None or not cfg.enabled or not cfg.models:
+        return _LITELLM_SUB_PROVIDER_DEFAULTS["zai"]
+    target_key = model_alias or "glm-5.1-default"
+    if target_key in cfg.models:
+        return cfg.models[target_key].litellm_name
+    return next(iter(cfg.models.values())).litellm_name
+
+
 def _dispatch_litellm(args: argparse.Namespace) -> int:
     """Route to spawn_litellm for litellm-provider dispatches (PR-4.6.5).
 
@@ -233,6 +265,11 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         model = env_model or _resolve_deepseek_model()
     elif base_sub == "moonshot":
         model = env_model or _resolve_moonshot_model(model_alias)
+    elif base_sub == "zai":
+        _validate_zai_model_not_legacy(args.model)
+        if model_alias:
+            _validate_zai_model_not_legacy(model_alias)
+        model = env_model or _resolve_zai_model(model_alias)
     elif env_model:
         model = env_model
     elif base_sub and base_sub in _LITELLM_SUB_PROVIDER_DEFAULTS:

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -33,6 +33,18 @@ providers:
         supports_tool_calls: true
         task_classes: ["coding-premium"]
   zai:
-    enabled: false  # PR-7.3 will enable
-    api_key_env: ZHIPU_API_KEY
-    models: {}
+    enabled: true
+    api_key_env: OPENROUTER_API_KEY  # via OpenRouter, not direct Zhipu
+    direct_provider_note: "Native Zhipu integration deferred; PR-7.3 uses OpenRouter fallback"
+    models:
+      glm-5.1-default:
+        litellm_name: "openrouter/z-ai/glm-5"
+        cost_input_per_mtok: 0.50  # OpenRouter pass-through cost
+        cost_output_per_mtok: 2.50
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review"]
+        deprecated_models:  # explicit guard against legacy
+          - "glm-4.5"
+          - "glm-4.6"

--- a/scripts/lib/providers/z_ai_custom_provider.py
+++ b/scripts/lib/providers/z_ai_custom_provider.py
@@ -1,0 +1,10 @@
+"""z_ai_custom_provider.py — Direct Zhipu API integration via litellm.CustomLLM.
+
+DEFERRED. PR-7.3 uses OpenRouter fallback for GLM-5.1.
+Direct integration will land in Wave 7.3.1 follow-up if usage warrants the
+investment over OpenRouter's 5-10% margin.
+
+See: claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md
+"""
+
+# Intentionally empty — placeholder for Wave 7.3.1 follow-up.

--- a/tests/test_wave7_deepseek_smoke.py
+++ b/tests/test_wave7_deepseek_smoke.py
@@ -159,17 +159,16 @@ class TestWave7ModelsYamlValid:
         assert model.supports_tool_calls is True
         assert "coding" in model.task_classes
 
-    def test_inactive_providers_disabled(self):
+    def test_active_providers_enabled(self):
         from providers import provider_registry
 
         registry = provider_registry.load()
 
-        # moonshot enabled by PR-7.2; zai still pending PR-7.3
         assert "moonshot" in registry, "moonshot provider missing from registry"
         assert registry["moonshot"].enabled is True, "moonshot must be enabled after PR-7.2"
 
         assert "zai" in registry, "zai provider missing from registry"
-        assert registry["zai"].enabled is False, "zai must be disabled (PR-7.3)"
+        assert registry["zai"].enabled is True, "zai must be enabled after PR-7.3"
 
     def test_get_default_model_returns_deepseek(self):
         from providers import provider_registry
@@ -180,11 +179,11 @@ class TestWave7ModelsYamlValid:
             f"unexpected litellm_name from default: {model.litellm_name!r}"
         )
 
-    def test_get_default_model_returns_none_for_still_disabled(self):
+    def test_get_default_model_returns_zai_after_pr73(self):
         from providers import provider_registry
 
-        # zai is still disabled until PR-7.3
         model = provider_registry.get_default_model("zai")
-        assert model is None, (
-            f"expected None for disabled zai provider, got {model!r}"
+        assert model is not None, "get_default_model('zai') should return a model after PR-7.3"
+        assert "openrouter" in model.litellm_name, (
+            f"expected openrouter in litellm_name, got {model.litellm_name!r}"
         )

--- a/tests/test_wave7_glm_smoke.py
+++ b/tests/test_wave7_glm_smoke.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""test_wave7_glm_smoke.py — Wave 7 PR-7.3 GLM-5.1 smoke tests.
+
+Verifies GLM-5.1 lane via LiteLLM OpenRouter endpoint (no real API calls):
+
+  test_provider_dispatch_routes_zai_via_openrouter — litellm:zai routes to
+      spawn_litellm with model containing 'openrouter'
+  test_zai_requires_openrouter_key                 — missing OPENROUTER_API_KEY → non-zero exit
+  test_glm45_legacy_rejected                       — --model glm-4.5 raises ValueError
+  test_glm_model_alias_resolution                  — glm-5.1-default resolves to
+      openrouter/z-ai/glm-5
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns.litellm_spawn import LiteLLMSpawnResult
+
+
+# ---------------------------------------------------------------------------
+# Test 1: provider_dispatch routes litellm:zai to spawn_litellm via OpenRouter
+# ---------------------------------------------------------------------------
+
+class TestProviderDispatchRoutesZaiViaOpenRouter:
+    """provider_dispatch.main routes --provider litellm:zai to spawn_litellm with openrouter model."""
+
+    def test_provider_dispatch_routes_zai_via_openrouter(self):
+        mock_result = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="ok",
+            events_written=2,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=None,
+            event_writer_failures=0,
+        )
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=mock_result) as mock_spawn:
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-test-key"}):
+                from provider_dispatch import main
+                rc = main([
+                    "--provider", "litellm:zai",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-dispatch-zai",
+                    "--instruction", "Reply with one word.",
+                ])
+
+        assert rc == 0, f"expected exit 0, got {rc}"
+        assert mock_spawn.called, "spawn_litellm was not called"
+        call_kwargs = mock_spawn.call_args
+        model = (call_kwargs[1] if call_kwargs[1] else {}).get("model") or (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else ""
+        )
+        assert "openrouter" in model, (
+            f"expected model containing 'openrouter', got {model!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: missing OPENROUTER_API_KEY returns non-zero exit code
+# ---------------------------------------------------------------------------
+
+class TestZaiRequiresOpenRouterKey:
+    """provider_dispatch exits non-zero when OPENROUTER_API_KEY is not set."""
+
+    def test_zai_requires_openrouter_key(self):
+        clean_env = {k: v for k, v in os.environ.items() if k != "OPENROUTER_API_KEY"}
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            from provider_dispatch import main
+            rc = main([
+                "--provider", "litellm:zai",
+                "--terminal-id", "T1",
+                "--dispatch-id", "test-no-key",
+                "--instruction", "test",
+            ])
+
+        assert rc != 0, "expected non-zero exit when OPENROUTER_API_KEY is missing"
+
+    def test_zai_runner_validates_openrouter_api_key(self):
+        from adapters import _litellm_runner as runner
+
+        env_without_key = {k: v for k, v in os.environ.items() if k != "OPENROUTER_API_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            ok, msg = runner._validate_provider_key("openrouter/z-ai/glm-5")
+        assert ok is False, f"expected ok=False without key, got ok={ok}"
+        assert "OPENROUTER_API_KEY" in msg, f"expected OPENROUTER_API_KEY in msg, got: {msg!r}"
+
+    def test_zai_runner_passes_with_api_key(self):
+        from adapters import _litellm_runner as runner
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-test"}):
+            ok, msg = runner._validate_provider_key("openrouter/z-ai/glm-5")
+        assert ok is True, f"expected ok=True with key, got ok={ok}"
+        assert msg == "", f"expected empty msg, got: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: deprecated GLM-4.5/4.6 models are rejected
+# ---------------------------------------------------------------------------
+
+class TestGlmLegacyRejected:
+    """Passing deprecated GLM model names raises ValueError."""
+
+    def test_glm45_legacy_rejected(self):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-test"}):
+            from provider_dispatch import main
+            with pytest.raises(ValueError, match="GLM-4.5/4.6 are LEGACY"):
+                main([
+                    "--provider", "litellm:zai",
+                    "--model", "glm-4.5",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-legacy",
+                    "--instruction", "test",
+                ])
+
+    def test_glm46_legacy_rejected(self):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-test"}):
+            from provider_dispatch import main
+            with pytest.raises(ValueError, match="GLM-4.5/4.6 are LEGACY"):
+                main([
+                    "--provider", "litellm:zai",
+                    "--model", "glm-4.6",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "test-legacy-46",
+                    "--instruction", "test",
+                ])
+
+    def test_validate_zai_model_not_legacy_raises_for_deprecated(self):
+        from provider_dispatch import _validate_zai_model_not_legacy
+
+        with pytest.raises(ValueError, match="GLM-4.5/4.6 are LEGACY"):
+            _validate_zai_model_not_legacy("glm-4.5")
+
+    def test_validate_zai_model_not_legacy_passes_for_current(self):
+        from provider_dispatch import _validate_zai_model_not_legacy
+
+        _validate_zai_model_not_legacy("glm-5.1-default")
+        _validate_zai_model_not_legacy("sonnet")
+        _validate_zai_model_not_legacy("")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: model alias resolution
+# ---------------------------------------------------------------------------
+
+class TestGlmModelAliasResolution:
+    """_resolve_zai_model correctly maps aliases to litellm model strings."""
+
+    def test_default_resolves_to_openrouter_glm5(self):
+        from provider_dispatch import _resolve_zai_model
+        model = _resolve_zai_model()
+        assert model == "openrouter/z-ai/glm-5", (
+            f"expected openrouter/z-ai/glm-5 as default, got {model!r}"
+        )
+
+    def test_glm51_default_alias_resolves(self):
+        from provider_dispatch import _resolve_zai_model
+        model = _resolve_zai_model("glm-5.1-default")
+        assert model == "openrouter/z-ai/glm-5", (
+            f"glm-5.1-default should resolve to openrouter/z-ai/glm-5, got {model!r}"
+        )
+
+    def test_unknown_alias_falls_back_to_first_model(self):
+        from provider_dispatch import _resolve_zai_model
+        model = _resolve_zai_model("nonexistent-alias")
+        assert "openrouter" in model, (
+            f"unknown alias should fall back to an openrouter model, got {model!r}"
+        )
+
+    def test_wave7_models_yaml_zai_valid(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+
+        assert "zai" in registry, "zai provider missing from registry"
+        zai = registry["zai"]
+        assert zai.enabled is True, "zai.enabled must be True after PR-7.3"
+        assert zai.api_key_env == "OPENROUTER_API_KEY", (
+            f"unexpected api_key_env: {zai.api_key_env!r}"
+        )
+        assert len(zai.models) == 1, (
+            f"expected 1 zai model, got {len(zai.models)}"
+        )
+
+    def test_glm51_default_model_schema(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+        model = registry["zai"].models["glm-5.1-default"]
+
+        assert model.litellm_name == "openrouter/z-ai/glm-5", (
+            f"unexpected litellm_name: {model.litellm_name!r}"
+        )
+        assert model.cost_input_per_mtok == pytest.approx(0.50)
+        assert model.cost_output_per_mtok == pytest.approx(2.50)
+        assert model.max_tokens == 8192
+        assert model.supports_streaming is True
+        assert model.supports_tool_calls is True
+        assert "coding" in model.task_classes
+        assert "review" in model.task_classes
+
+    def test_get_default_model_returns_zai_model(self):
+        from providers import provider_registry
+
+        model = provider_registry.get_default_model("zai")
+        assert model is not None, "get_default_model('zai') returned None after PR-7.3"
+        assert "openrouter" in model.litellm_name, (
+            f"expected openrouter in litellm_name, got {model.litellm_name!r}"
+        )


### PR DESCRIPTION
## Summary

- Adds `litellm:zai` sub-provider routing GLM-5.1 through OpenRouter (`openrouter/z-ai/glm-5`) — no CustomLLM subclass needed for MVP
- Explicit legacy guard: `--model glm-4.5` or `--model glm-4.6` raises `ValueError("GLM-4.5/4.6 are LEGACY, use GLM-5.1")` before any subprocess spawn
- `OPENROUTER_API_KEY` fast-fail mirrors pattern from DeepSeek/Moonshot lanes

## Design decisions

Per ADR-015 and `claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md`, direct Zhipu integration via `litellm.CustomLLM` is deferred. OpenRouter fallback ships immediately (works out-of-the-box, no custom provider code). Direct integration deferred to Wave 7.3.1 if usage warrants the investment over OpenRouter's margin — placeholder at `scripts/lib/providers/z_ai_custom_provider.py`.

## Files changed

| File | Change |
|---|---|
| `scripts/lib/providers/wave7_models.yaml` | `zai` block enabled with GLM-5.1-default → OpenRouter model string |
| `scripts/lib/provider_dispatch.py` | `_validate_zai_model_not_legacy`, `_resolve_zai_model`, zai branch in `_dispatch_litellm` |
| `scripts/lib/adapters/_litellm_runner.py` | `openrouter` added to key requirements + usage stream providers |
| `scripts/lib/providers/z_ai_custom_provider.py` | Deferred stub, docstring only |
| `docs/operations/PROVIDER_API_KEYS.md` | OpenRouter row + GLM-5.1 section + legacy deprecation note |
| `tests/test_wave7_glm_smoke.py` | 14 new tests |
| `tests/test_wave7_deepseek_smoke.py` | Updated 2 assertions now that zai is enabled |

## Test plan

- [x] `pytest tests/test_wave7_glm_smoke.py` — 14/14 green
- [x] `pytest tests/test_wave7_deepseek_smoke.py tests/test_wave7_kimi_smoke.py` — 22/22 green (no regressions)
- [x] Total: 36/36 across all Wave 7 smoke suites

## Gates

codex_gate + gemini_review. Standard B3 1-retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)