### PR TITLE
feat(wave7): PR-7.5 — provider behavior contracts (capabilities + tool-shape + cache-control)

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -52,6 +52,23 @@ _SUB_PROVIDER_KEY_REQS: dict = {
 # GLM model names that are LEGACY — rejected on zai dispatch (PR-7.3)
 _DEPRECATED_ZAI_MODELS = frozenset({"glm-4.5", "glm-4.6"})
 
+# Default model alias per sub-provider — used to build lane key for contract lookup
+_SUB_PROVIDER_DEFAULT_ALIAS: dict = {
+    "deepseek": "deepseek-v4-pro",
+    "moonshot": "kimi-k2-0905-default",
+    "zai": "glm-5.1-default",
+}
+
+
+def _build_lane_key(base_sub: str, model_alias: "str | None") -> str:
+    """Build a behavior_contracts lane key from sub-provider parts.
+
+    e.g. ("deepseek", None) -> "litellm:deepseek:deepseek-v4-pro"
+         ("moonshot", "kimi-k2-6") -> "litellm:moonshot:kimi-k2-6"
+    """
+    alias = model_alias or _SUB_PROVIDER_DEFAULT_ALIAS.get(base_sub, "default")
+    return f"litellm:{base_sub}:{alias}"
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -279,12 +296,33 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     else:
         model = "anthropic/claude-sonnet-4-6"
 
+    lane_key = _build_lane_key(base_sub, model_alias)
+    _contract = None
+    _tool_call_shape = None
+    try:
+        from providers.behavior_contracts import get_contract as _get_contract
+        _contract = _get_contract(lane_key)
+        _tool_call_shape = _contract.tool_call_shape
+        logger.debug(
+            "_dispatch_litellm: lane=%s cache_control=%s tool_shape=%s",
+            lane_key,
+            _contract.cache_control_supported,
+            _tool_call_shape,
+        )
+    except KeyError:
+        logger.warning(
+            "_dispatch_litellm: no behavior contract for lane %r — proceeding without contract enforcement",
+            lane_key,
+        )
+
     result = spawn_litellm(
         prompt=args.instruction,
         model=model,
         dispatch_id=args.dispatch_id,
         terminal_id=args.terminal_id,
         sub_provider=base_sub or None,
+        lane=lane_key,
+        tool_call_shape=_tool_call_shape,
         event_writer=event_store.append if event_store is not None else None,
     )
     if result.error:

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -50,13 +50,21 @@ def normalize_litellm_event(
     chunk: Dict[str, Any],
     terminal_id: str,
     dispatch_id: str,
+    *,
+    sub_provider: Optional[str] = None,
+    lane: Optional[str] = None,
 ) -> CanonicalEvent:
     """Map an OpenAI-shaped NDJSON chunk to a CanonicalEvent (Tier-1).
 
     Both _LiteLLMNormalizerHost (used by spawn_litellm) and
     LiteLLMAdapter._normalize delegate here to guarantee byte identity.
     Priority: error_type -> tool_calls -> finish_reason -> init -> text.
+    sub_provider and lane are stored in CanonicalEvent for ADR-016 audit enrichment.
     """
+    provider_meta: Dict[str, Any] = {}
+    if lane is not None:
+        provider_meta["lane"] = lane
+
     def make(etype: str, data: dict) -> CanonicalEvent:
         return CanonicalEvent(
             dispatch_id=dispatch_id,
@@ -65,6 +73,8 @@ def normalize_litellm_event(
             event_type=etype,
             data=data,
             observability_tier=_TIER_STREAMING,
+            sub_provider=sub_provider,
+            provider_meta=provider_meta,
         )
 
     error_type = chunk.get("error_type")
@@ -98,12 +108,27 @@ class _LiteLLMNormalizerHost(StreamingDrainerMixin):
     provider_name = "litellm"
     provider_observability_tier = _TIER_STREAMING
 
-    def __init__(self, terminal_id: str, dispatch_id: str) -> None:
+    def __init__(
+        self,
+        terminal_id: str,
+        dispatch_id: str,
+        *,
+        sub_provider: Optional[str] = None,
+        lane: Optional[str] = None,
+    ) -> None:
         self._current_terminal_id = terminal_id
         self._current_dispatch_id = dispatch_id
+        self._sub_provider = sub_provider
+        self._lane = lane
 
     def _normalize(self, raw: Dict[str, Any]) -> CanonicalEvent:
-        return normalize_litellm_event(raw, self._current_terminal_id, self._current_dispatch_id)
+        return normalize_litellm_event(
+            raw,
+            self._current_terminal_id,
+            self._current_dispatch_id,
+            sub_provider=self._sub_provider,
+            lane=self._lane,
+        )
 
 
 
@@ -126,6 +151,26 @@ class LiteLLMSpawnResult:
     # Number of times event_writer callback raised an exception.
     # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
     event_writer_failures: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Contract enforcement helpers
+# ---------------------------------------------------------------------------
+
+def _validate_tool_shape(prompt: str, tool_call_shape: Optional[str]) -> None:
+    """Raise ValueError when prompt embeds tool definitions in the wrong format.
+
+    Detects Anthropic-format tool markers (input_schema) in prompts destined
+    for openai_tools lanes — a mismatch that would produce silent call failures.
+    Only fires when tool_call_shape is explicitly provided by a BehaviorContract.
+    """
+    if not tool_call_shape:
+        return
+    if tool_call_shape == "openai_tools" and '"input_schema"' in prompt:
+        raise ValueError(
+            f"Prompt embeds Anthropic tool format (input_schema) but lane "
+            f"contract expects {tool_call_shape!r} — tool calls would fail"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +341,8 @@ def _spawn_streaming(
     total_deadline: float,
     event_store: Optional[Any],
     runner_path: str,
+    sub_provider: Optional[str] = None,
+    lane: Optional[str] = None,
 ) -> LiteLLMSpawnResult:
     """Spawn _litellm_runner.py and drain the NDJSON event stream."""
     payload_json = json.dumps({
@@ -306,7 +353,12 @@ def _spawn_streaming(
     if err_result is not None:
         return err_result
 
-    host = _LiteLLMNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+    host = _LiteLLMNormalizerHost(
+        terminal_id=terminal_id,
+        dispatch_id=dispatch_id,
+        sub_provider=sub_provider,
+        lane=lane,
+    )
     completion_text, events_written, timed_out, stopped_early, _ew_failures = _consume_litellm_stream(
         proc=proc, host=host, on_event=on_event,
         health_monitor=health_monitor, event_writer=event_writer,
@@ -332,6 +384,8 @@ def spawn_litellm(
     terminal_id: str,
     *,
     sub_provider: Optional[str] = None,
+    lane: Optional[str] = None,
+    tool_call_shape: Optional[str] = None,
     event_writer: Optional[Callable[..., None]] = None,
     health_monitor: Optional[Any] = None,
     on_event: Optional[Callable[[Any], Optional[bool]]] = None,
@@ -352,6 +406,10 @@ def spawn_litellm(
     model must be a full LiteLLM model string, e.g. "bedrock/claude-sonnet-4-6".
     When model is empty, falls back to VNX_LITELLM_MODEL env var or a sub_provider
     default, then to "anthropic/claude-sonnet-4-6".
+
+    lane and tool_call_shape are sourced from BehaviorContract (Wave 7 PR-7.5).
+    tool_call_shape triggers pre-spawn validation for format mismatch detection.
+    sub_provider and lane are propagated to audit events per ADR-016.
     """
     try:
         chunk_timeout = float(os.environ.get("VNX_LITELLM_STALL_THRESHOLD", chunk_timeout))
@@ -361,6 +419,14 @@ def spawn_litellm(
         total_deadline = float(os.environ.get("VNX_LITELLM_TIMEOUT", total_deadline))
     except (TypeError, ValueError):
         pass
+
+    try:
+        _validate_tool_shape(prompt, tool_call_shape)
+    except ValueError as exc:
+        return LiteLLMSpawnResult(
+            returncode=64, completion_text="", events_written=0,
+            session_id=None, timed_out=False, error=str(exc),
+        )
 
     if not model:
         env_model = os.environ.get("VNX_LITELLM_MODEL", "")
@@ -387,4 +453,6 @@ def spawn_litellm(
         total_deadline=total_deadline,
         event_store=event_store,
         runner_path=_runner,
+        sub_provider=sub_provider,
+        lane=lane,
     )

--- a/scripts/lib/providers/behavior_contracts.py
+++ b/scripts/lib/providers/behavior_contracts.py
@@ -1,0 +1,134 @@
+"""behavior_contracts.py — Wave 7 provider behavior contracts.
+
+Codifies what each provider lane supports + how its outputs are normalized.
+Used by routing_policy + spawn handlers to set capability flags + apply
+provider-specific output normalization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Set
+
+
+@dataclass(frozen=True)
+class BehaviorContract:
+    provider: str               # claude | litellm | claude_sdk
+    sub_provider: str           # "" for claude, "deepseek"|"moonshot"|"zai" for litellm
+    supports_streaming: bool
+    supports_tool_calls: bool
+    tool_call_shape: str        # "anthropic_tools" | "openai_functions" | "openai_tools"
+    cache_control_supported: bool
+    audit_shape: str            # "canonical_event" (all use ADR-016 shape)
+    max_context_tokens: int
+    max_output_tokens: int
+
+
+# Static contract registry — loaded once, used everywhere
+CONTRACTS: Dict[str, BehaviorContract] = {
+    "claude/sonnet-4-6": BehaviorContract(
+        provider="claude",
+        sub_provider="",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="anthropic_tools",
+        cache_control_supported=True,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,
+        max_output_tokens=8192,
+    ),
+    "claude/haiku-4-5": BehaviorContract(
+        provider="claude",
+        sub_provider="",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="anthropic_tools",
+        cache_control_supported=True,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,
+        max_output_tokens=8192,
+    ),
+    "claude/opus": BehaviorContract(
+        provider="claude",
+        sub_provider="",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="anthropic_tools",
+        cache_control_supported=True,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,
+        max_output_tokens=8192,
+    ),
+    "litellm:deepseek:deepseek-v4-pro": BehaviorContract(
+        provider="litellm",
+        sub_provider="deepseek",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="openai_tools",  # DeepSeek follows OpenAI tools shape
+        cache_control_supported=False,    # no native cache control via LiteLLM
+        audit_shape="canonical_event",
+        max_context_tokens=128_000,
+        max_output_tokens=8192,
+    ),
+    "litellm:moonshot:kimi-k2-0905-default": BehaviorContract(
+        provider="litellm",
+        sub_provider="moonshot",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="openai_tools",
+        cache_control_supported=False,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,  # Kimi's claim to fame
+        max_output_tokens=8192,
+    ),
+    "litellm:moonshot:kimi-k2-6": BehaviorContract(
+        provider="litellm",
+        sub_provider="moonshot",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="openai_tools",
+        cache_control_supported=False,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,
+        max_output_tokens=8192,
+    ),
+    "litellm:zai:glm-5.1-default": BehaviorContract(
+        provider="litellm",
+        sub_provider="zai",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="openai_tools",  # via OpenRouter
+        cache_control_supported=False,
+        audit_shape="canonical_event",
+        max_context_tokens=128_000,
+        max_output_tokens=8192,
+    ),
+    "claude_sdk/sonnet-4-6": BehaviorContract(
+        provider="claude_sdk",
+        sub_provider="",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="anthropic_tools",
+        cache_control_supported=True,
+        audit_shape="canonical_event",
+        max_context_tokens=200_000,
+        max_output_tokens=8192,
+    ),
+}
+
+
+def get_contract(lane: str) -> BehaviorContract:
+    """Retrieve contract for a lane. Raises KeyError on unknown lane."""
+    if lane not in CONTRACTS:
+        raise KeyError(f"Unknown provider lane: {lane}. Known: {sorted(CONTRACTS.keys())}")
+    return CONTRACTS[lane]
+
+
+def get_lanes_by_provider(provider: str) -> Set[str]:
+    """Return all lane-keys for a given provider."""
+    return {lane for lane, c in CONTRACTS.items() if c.provider == provider}
+
+
+def validate_audit_shape_uniform() -> bool:
+    """Invariant: ALL contracts have audit_shape='canonical_event' per ADR-016."""
+    return all(c.audit_shape == "canonical_event" for c in CONTRACTS.values())

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Wave 7 PR-7.5 — behavior_contracts.py tests.
+
+Covers:
+- All routing_policy.yaml lanes have a corresponding BehaviorContract.
+- ADR-016 invariant: all contracts use audit_shape='canonical_event'.
+- Unknown lane raises KeyError.
+- DeepSeek uses openai_tools shape.
+- Claude lanes use anthropic_tools shape.
+- LiteLLM lanes have cache_control_supported=False.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from providers.behavior_contracts import (
+    CONTRACTS,
+    BehaviorContract,
+    get_contract,
+    get_lanes_by_provider,
+    validate_audit_shape_uniform,
+)
+
+_ROUTING_POLICY_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts" / "lib" / "providers" / "routing_policy.yaml"
+)
+
+
+def _load_routing_lanes() -> list[str]:
+    """Extract all explicit lane values from routing_policy.yaml."""
+    with open(_ROUTING_POLICY_PATH) as fh:
+        data = yaml.safe_load(fh)
+    lanes = []
+    if data.get("default_lane"):
+        lanes.append(data["default_lane"])
+    for rule in data.get("rules") or []:
+        if rule.get("lane"):
+            lanes.append(rule["lane"])
+    return lanes
+
+
+class TestAllKnownLanesHaveContracts:
+    def test_routing_policy_lanes_covered(self):
+        """Every lane referenced in routing_policy.yaml must have a BehaviorContract."""
+        routing_lanes = _load_routing_lanes()
+        missing = [lane for lane in routing_lanes if lane not in CONTRACTS]
+        assert missing == [], f"Lanes in routing_policy.yaml missing contracts: {missing}"
+
+    def test_eight_contracts_registered(self):
+        """Registry has exactly 8 contracts (all current lanes)."""
+        assert len(CONTRACTS) == 8, (
+            f"Expected 8 contracts, got {len(CONTRACTS)}. "
+            f"Keys: {sorted(CONTRACTS.keys())}"
+        )
+
+
+class TestAuditShapeUniform:
+    def test_validate_audit_shape_uniform_returns_true(self):
+        """validate_audit_shape_uniform() is True — ADR-016 invariant holds."""
+        assert validate_audit_shape_uniform() is True
+
+    def test_all_contracts_have_canonical_event_audit_shape(self):
+        """Every individual contract has audit_shape='canonical_event'."""
+        for lane, contract in CONTRACTS.items():
+            assert contract.audit_shape == "canonical_event", (
+                f"Lane {lane!r} has audit_shape={contract.audit_shape!r}, expected 'canonical_event'"
+            )
+
+
+class TestGetContractUnknownLaneRaises:
+    def test_raises_key_error_for_unknown_lane(self):
+        """get_contract raises KeyError for an unregistered lane."""
+        with pytest.raises(KeyError, match="Unknown provider lane"):
+            get_contract("litellm:unknown:model-xyz")
+
+    def test_error_message_contains_known_lanes(self):
+        """KeyError message lists the known lanes for diagnostics."""
+        with pytest.raises(KeyError) as exc_info:
+            get_contract("bad-lane")
+        assert "Known:" in str(exc_info.value)
+
+
+class TestDeepSeekUsesOpenAIToolsShape:
+    def test_deepseek_tool_call_shape(self):
+        """DeepSeek V4 lane uses openai_tools shape (not Anthropic format)."""
+        contract = get_contract("litellm:deepseek:deepseek-v4-pro")
+        assert contract.tool_call_shape == "openai_tools"
+
+    def test_deepseek_is_litellm_provider(self):
+        contract = get_contract("litellm:deepseek:deepseek-v4-pro")
+        assert contract.provider == "litellm"
+        assert contract.sub_provider == "deepseek"
+
+
+class TestClaudeUsesAnthropicToolsShape:
+    def test_sonnet_tool_call_shape(self):
+        """Sonnet 4.6 lane uses anthropic_tools shape."""
+        contract = get_contract("claude/sonnet-4-6")
+        assert contract.tool_call_shape == "anthropic_tools"
+
+    def test_haiku_tool_call_shape(self):
+        contract = get_contract("claude/haiku-4-5")
+        assert contract.tool_call_shape == "anthropic_tools"
+
+    def test_opus_tool_call_shape(self):
+        contract = get_contract("claude/opus")
+        assert contract.tool_call_shape == "anthropic_tools"
+
+    def test_claude_lanes_count(self):
+        """Exactly 3 claude provider lanes registered."""
+        claude_lanes = get_lanes_by_provider("claude")
+        assert len(claude_lanes) == 3
+
+
+class TestLiteLLMLanesNoCacheControl:
+    def test_deepseek_no_cache_control(self):
+        contract = get_contract("litellm:deepseek:deepseek-v4-pro")
+        assert contract.cache_control_supported is False
+
+    def test_kimi_k2_0905_no_cache_control(self):
+        contract = get_contract("litellm:moonshot:kimi-k2-0905-default")
+        assert contract.cache_control_supported is False
+
+    def test_kimi_k2_6_no_cache_control(self):
+        contract = get_contract("litellm:moonshot:kimi-k2-6")
+        assert contract.cache_control_supported is False
+
+    def test_glm_no_cache_control(self):
+        contract = get_contract("litellm:zai:glm-5.1-default")
+        assert contract.cache_control_supported is False
+
+    def test_all_litellm_lanes_no_cache_control(self):
+        """Invariant: no LiteLLM lane supports cache_control (LiteLLM limitation)."""
+        litellm_lanes = get_lanes_by_provider("litellm")
+        failing = [
+            lane for lane in litellm_lanes
+            if CONTRACTS[lane].cache_control_supported
+        ]
+        assert failing == [], f"LiteLLM lanes with cache_control=True: {failing}"
+
+
+class TestClaudeLanesCacheControl:
+    def test_claude_lanes_support_cache_control(self):
+        """All claude lanes support cache_control (native Claude feature)."""
+        claude_lanes = get_lanes_by_provider("claude")
+        failing = [
+            lane for lane in claude_lanes
+            if not CONTRACTS[lane].cache_control_supported
+        ]
+        assert failing == [], f"Claude lanes with cache_control=False: {failing}"
+
+
+class TestGetLanesByProvider:
+    def test_returns_set_for_known_provider(self):
+        lanes = get_lanes_by_provider("litellm")
+        assert isinstance(lanes, set)
+        assert len(lanes) > 0
+
+    def test_returns_empty_set_for_unknown_provider(self):
+        lanes = get_lanes_by_provider("ollama")
+        assert lanes == set()
+
+
+class TestContractDataIntegrity:
+    def test_all_max_tokens_positive(self):
+        for lane, c in CONTRACTS.items():
+            assert c.max_context_tokens > 0, f"{lane}: max_context_tokens <= 0"
+            assert c.max_output_tokens > 0, f"{lane}: max_output_tokens <= 0"
+
+    def test_valid_tool_call_shapes(self):
+        valid_shapes = {"anthropic_tools", "openai_functions", "openai_tools"}
+        for lane, c in CONTRACTS.items():
+            assert c.tool_call_shape in valid_shapes, (
+                f"{lane}: unknown tool_call_shape {c.tool_call_shape!r}"
+            )
+
+    def test_kimi_large_context_window(self):
+        """Kimi lanes have 200K context (their differentiated capability)."""
+        k1 = get_contract("litellm:moonshot:kimi-k2-0905-default")
+        k2 = get_contract("litellm:moonshot:kimi-k2-6")
+        assert k1.max_context_tokens == 200_000
+        assert k2.max_context_tokens == 200_000

--- a/tests/test_provider_dispatch_contract_integration.py
+++ b/tests/test_provider_dispatch_contract_integration.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Wave 7 PR-7.5 — provider_dispatch contract integration tests.
+
+Covers:
+- _build_lane_key constructs correct lane keys for all known sub-providers.
+- Dispatching to deepseek lane passes cache_control_supported=False (via contract).
+- spawn_litellm receives lane + tool_call_shape from contract.
+- Mismatched tool shape triggers structured error (not raised exception).
+- normalize_litellm_event enriches CanonicalEvent with sub_provider + lane.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import provider_dispatch
+from provider_dispatch import _build_lane_key
+from providers.behavior_contracts import get_contract
+from provider_spawns.litellm_spawn import (
+    LiteLLMSpawnResult,
+    _validate_tool_shape,
+    normalize_litellm_event,
+    spawn_litellm,
+)
+
+
+# ---------------------------------------------------------------------------
+# _build_lane_key
+# ---------------------------------------------------------------------------
+
+class TestBuildLaneKey:
+    def test_deepseek_default_alias(self):
+        assert _build_lane_key("deepseek", None) == "litellm:deepseek:deepseek-v4-pro"
+
+    def test_deepseek_explicit_alias(self):
+        assert _build_lane_key("deepseek", "deepseek-v4-pro") == "litellm:deepseek:deepseek-v4-pro"
+
+    def test_moonshot_default_alias(self):
+        assert _build_lane_key("moonshot", None) == "litellm:moonshot:kimi-k2-0905-default"
+
+    def test_moonshot_kimi_k2_6(self):
+        assert _build_lane_key("moonshot", "kimi-k2-6") == "litellm:moonshot:kimi-k2-6"
+
+    def test_zai_default_alias(self):
+        assert _build_lane_key("zai", None) == "litellm:zai:glm-5.1-default"
+
+    def test_unknown_sub_provider_uses_default_sentinel(self):
+        result = _build_lane_key("bedrock", None)
+        assert result == "litellm:bedrock:default"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch disables cache_control for deepseek
+# ---------------------------------------------------------------------------
+
+class TestDispatchDisablesCacheControlForDeepSeek:
+    def test_deepseek_contract_says_no_cache_control(self):
+        """The contract for the deepseek lane explicitly marks cache_control=False."""
+        contract = get_contract("litellm:deepseek:deepseek-v4-pro")
+        assert contract.cache_control_supported is False
+
+    def test_dispatch_litellm_passes_lane_to_spawn(self):
+        """_dispatch_litellm passes lane= to spawn_litellm when deepseek is selected."""
+        captured_kwargs: dict = {}
+
+        def fake_spawn(**kwargs):
+            captured_kwargs.update(kwargs)
+            return LiteLLMSpawnResult(
+                returncode=0, completion_text="ok", events_written=1,
+                session_id=None, timed_out=False,
+            )
+
+        argv = [
+            "--provider", "litellm:deepseek",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-contract-01",
+            "--instruction", "echo hello",
+        ]
+
+        # spawn_litellm is a local import inside _dispatch_litellm — patch at module level
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", fake_spawn), \
+             patch.dict("os.environ", {"DEEPSEEK_API_KEY": "test-key"}):
+            provider_dispatch.main(argv)
+
+        assert "lane" in captured_kwargs, "spawn_litellm was not called with lane= kwarg"
+        assert captured_kwargs["lane"] == "litellm:deepseek:deepseek-v4-pro"
+
+    def test_dispatch_litellm_passes_tool_shape_to_spawn(self):
+        """_dispatch_litellm passes tool_call_shape from contract to spawn_litellm."""
+        captured_kwargs: dict = {}
+
+        def fake_spawn(**kwargs):
+            captured_kwargs.update(kwargs)
+            return LiteLLMSpawnResult(
+                returncode=0, completion_text="ok", events_written=1,
+                session_id=None, timed_out=False,
+            )
+
+        argv = [
+            "--provider", "litellm:deepseek",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-contract-02",
+            "--instruction", "echo hello",
+        ]
+
+        # spawn_litellm is a local import inside _dispatch_litellm — patch at module level
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", fake_spawn), \
+             patch.dict("os.environ", {"DEEPSEEK_API_KEY": "test-key"}):
+            provider_dispatch.main(argv)
+
+        assert captured_kwargs.get("tool_call_shape") == "openai_tools"
+
+
+# ---------------------------------------------------------------------------
+# Tool shape validation
+# ---------------------------------------------------------------------------
+
+class TestDispatchValidatesToolShape:
+    def test_validate_tool_shape_noop_when_no_shape(self):
+        """No-op when tool_call_shape is None (contract not found path)."""
+        _validate_tool_shape("any prompt content", None)  # must not raise
+
+    def test_validate_tool_shape_noop_for_anthropic_tools(self):
+        """anthropic_tools shape does not reject any prompt content."""
+        prompt_with_input_schema = 'tool: {"input_schema": {"type": "object"}}'
+        _validate_tool_shape(prompt_with_input_schema, "anthropic_tools")  # must not raise
+
+    def test_validate_tool_shape_raises_for_openai_lane_with_anthropic_markers(self):
+        """Prompt with Anthropic tool markers rejected for openai_tools lanes."""
+        bad_prompt = 'Use this tool: {"input_schema": {"type": "object", "properties": {}}}'
+        with pytest.raises(ValueError, match="input_schema"):
+            _validate_tool_shape(bad_prompt, "openai_tools")
+
+    def test_validate_tool_shape_allows_clean_prompt_for_openai_lane(self):
+        """Normal prompt without tool markers passes openai_tools validation."""
+        clean_prompt = "Refactor the authentication module and add tests."
+        _validate_tool_shape(clean_prompt, "openai_tools")  # must not raise
+
+    def test_spawn_litellm_returns_structured_error_on_shape_mismatch(self):
+        """spawn_litellm returns error result (not raised exception) on tool shape mismatch."""
+        bad_prompt = 'call tool with {"input_schema": {"type": "object"}}'
+        result = spawn_litellm(
+            prompt=bad_prompt,
+            model="deepseek/deepseek-v3.2",
+            dispatch_id="test-shape-mismatch",
+            terminal_id="T1",
+            tool_call_shape="openai_tools",
+        )
+        assert result.error is not None
+        assert "input_schema" in result.error
+        assert result.returncode == 64
+
+
+# ---------------------------------------------------------------------------
+# normalize_litellm_event audit enrichment
+# ---------------------------------------------------------------------------
+
+class TestNormalizeLiteLLMEventAuditEnrichment:
+    def _text_chunk(self) -> dict:
+        return {
+            "choices": [{"delta": {"content": "hello"}, "finish_reason": None}]
+        }
+
+    def test_sub_provider_propagated_to_canonical_event(self):
+        event = normalize_litellm_event(
+            self._text_chunk(), "T1", "dispatch-001",
+            sub_provider="deepseek",
+        )
+        assert event.sub_provider == "deepseek"
+
+    def test_lane_propagated_to_provider_meta(self):
+        event = normalize_litellm_event(
+            self._text_chunk(), "T1", "dispatch-001",
+            lane="litellm:deepseek:deepseek-v4-pro",
+        )
+        assert event.provider_meta.get("lane") == "litellm:deepseek:deepseek-v4-pro"
+
+    def test_both_enrichment_fields_set(self):
+        event = normalize_litellm_event(
+            self._text_chunk(), "T1", "dispatch-001",
+            sub_provider="moonshot",
+            lane="litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert event.sub_provider == "moonshot"
+        assert event.provider_meta.get("lane") == "litellm:moonshot:kimi-k2-0905-default"
+
+    def test_no_enrichment_when_not_provided(self):
+        """Existing callers without sub_provider/lane get None/empty — backward compat."""
+        event = normalize_litellm_event(self._text_chunk(), "T1", "dispatch-001")
+        assert event.sub_provider is None
+        assert event.provider_meta == {}
+
+    def test_provider_is_always_litellm(self):
+        event = normalize_litellm_event(
+            self._text_chunk(), "T1", "dispatch-001",
+            sub_provider="zai", lane="litellm:zai:glm-5.1-default",
+        )
+        assert event.provider == "litellm"


### PR DESCRIPTION
## Summary

- Introduces `scripts/lib/providers/behavior_contracts.py` — a static 8-lane registry (`BehaviorContract` dataclass) covering all Wave 7 provider lanes including Claude, LiteLLM/DeepSeek, Moonshot/Kimi, and z.AI/GLM
- Wires contract lookup into `provider_dispatch._dispatch_litellm`: resolves lane key via `_build_lane_key()`, reads contract, passes `lane` + `tool_call_shape` to `spawn_litellm`
- Updates `litellm_spawn.py`: adds `_validate_tool_shape()` pre-spawn guard (rejects Anthropic-format tool markers on openai_tools lanes), enriches `CanonicalEvent` with `sub_provider` + `lane` in `provider_meta` per ADR-016
- 42 new tests (23 + 19) covering ADR-016 invariant, lane coverage cross-check vs routing_policy.yaml, unknown-lane KeyError, per-provider tool shape, cache-control limitation, dispatch integration, and audit enrichment backward compat

## References

- ADR-015: LiteLLM Path B integration
- ADR-016: Canonical audit event shape (all 8 contracts have `audit_shape="canonical_event"`)
- Wave 7 design doc: `claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md`

## Wave 7 status

This PR completes Wave 7 core: 5/5 implementation PRs (PR-7.0 through PR-7.5). PR-7.6 (sandbox research) remains optional.

## Test plan

- [x] `pytest tests/test_behavior_contracts.py` — 23 passed
- [x] `pytest tests/test_provider_dispatch_contract_integration.py` — 19 passed
- [x] Full provider + wave7 regression suite (157 tests) — 0 failures
- [x] `test_context_assembler.py` failure is pre-existing (unrelated import error, not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)