### PR TITLE
feat(wave5): PR-5.1 — multi-project state aggregator write-pad

### DIFF
--- a/docs/operations/STATE_AGGREGATOR.md
+++ b/docs/operations/STATE_AGGREGATOR.md
@@ -1,0 +1,66 @@
+# State Aggregator (Wave 5 PR-5.1)
+
+Write-pad for multi-project state updates. Provides per-project facet files,
+central view JSON, and a NDJSON audit trail per ADR-005. Pairs with the
+Phase 6 read-only federation aggregator (`build_central_view.py`).
+
+## Architecture
+
+```
+Project T0 (vnx-dev)  ─┐
+Project T0 (seocrawler)─┤──► StateAggregator.submit() ──► central_state.json
+Control Centre         ─┘                               ──► projects/{id}.json
+                                                        ──► events/state_aggregator.ndjson
+```
+
+`build_central_view.py --read-write-pad <vnx-data-dir>` reads
+`central_state.json` instead of scanning SQLite DBs.
+
+## Usage from Control Centre or project T0
+
+```python
+from pathlib import Path
+from scripts.aggregator.state_aggregator import StateAggregator, ProjectStateUpdate
+
+agg = StateAggregator(vnx_data_dir=Path(".vnx-data"))
+agg.submit(ProjectStateUpdate(
+    project_id="vnx-dev",
+    timestamp="2026-05-16T12:34:56Z",
+    event_type="dispatch_created",
+    payload={"dispatch_id": "20260516-foo", "track": "A"},
+    source_t0="T0-vnx-dev",
+))
+```
+
+Valid `event_type` values: `dispatch_created`, `dispatch_completed`,
+`t0_heartbeat`, `incident`.
+
+## Files written
+
+- `.vnx-data/aggregator/central_state.json` — summary per project (event counts + timestamps)
+- `.vnx-data/aggregator/projects/{project_id}.json` — full facet per project (ring buffer, last 100 events)
+- `.vnx-data/events/state_aggregator.ndjson` — ADR-005 audit trail (append-only)
+
+## Read-write-pad flag in build_central_view.py
+
+```bash
+python3 scripts/aggregator/build_central_view.py \
+    --read-write-pad .vnx-data \
+    --json
+```
+
+Returns `central_state.json` content as JSON. Bypasses SQLite scanning.
+Backwards-compatible: omitting the flag restores default Phase 6 behavior.
+
+## Thread safety
+
+`submit()` acquires a process-level `threading.Lock`. All three writes
+(event append, facet update, central view update) execute atomically within
+the lock. Facet and central view use `os.replace()` (atomic rename) so
+concurrent readers never see a partial write.
+
+## References
+
+- ADR-017: Wave 5 Control Centre architecture
+- `claudedocs/wave5-control-centre-architecture.md`: design details
+- ADR-005: NDJSON audit trail invariant

--- a/scripts/aggregator/build_central_view.py
+++ b/scripts/aggregator/build_central_view.py
@@ -285,12 +285,31 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser.add_argument("--view-db", type=Path, default=None, help="Override view DB path")
     parser.add_argument("--json", action="store_true", help="Emit plan/result as JSON to stdout")
     parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "--read-write-pad",
+        type=Path,
+        default=None,
+        metavar="VNX_DATA_DIR",
+        help=(
+            "Read central state from the Wave 5 write-pad aggregator instead of scanning "
+            "SQLite DBs. Provide the .vnx-data directory written by StateAggregator."
+        ),
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+
+    if args.read_write_pad is not None:
+        from scripts.aggregator.state_aggregator import StateAggregator
+
+        agg = StateAggregator(args.read_write_pad)
+        result = agg.read_central()
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        return 0
 
     registry_path = args.registry or _default_registry_path()
     view_db_path = args.view_db or _default_view_db_path()

--- a/scripts/aggregator/state_aggregator.py
+++ b/scripts/aggregator/state_aggregator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import threading
 import uuid
 from dataclasses import dataclass
@@ -23,7 +24,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+try:
+    import fcntl as _fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _fcntl = None  # type: ignore[assignment]
+    _HAS_FCNTL = False
+
 log = logging.getLogger(__name__)
+
+_PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9-]{1,31}$")
 
 VALID_EVENT_TYPES = frozenset({
     "dispatch_created",
@@ -35,6 +45,19 @@ VALID_EVENT_TYPES = frozenset({
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _validate_project_id(project_id: str) -> str:
+    """Strict project_id validation. Raises ValueError on invalid input.
+
+    Pattern: lowercase alphanum + hyphens, 2-32 chars, starts with letter.
+    Matches scripts/lib/vnx_paths.py:208-225 strictness.
+    """
+    if not _PROJECT_ID_RE.match(project_id or ""):
+        raise ValueError(
+            f"Invalid project_id {project_id!r}: must match {_PROJECT_ID_RE.pattern}"
+        )
+    return project_id
 
 
 @dataclass
@@ -57,17 +80,31 @@ class StateAggregator:
         self._central_path = vnx_data_dir / "aggregator" / "central_state.json"
         self._facet_dir = vnx_data_dir / "aggregator" / "projects"
         self._events_path = vnx_data_dir / "events" / "state_aggregator.ndjson"
+        self._lock_path = vnx_data_dir / "aggregator" / ".central_state.lock"
         self._lock = threading.Lock()
         self._central_path.parent.mkdir(parents=True, exist_ok=True)
         self._facet_dir.mkdir(parents=True, exist_ok=True)
         self._events_path.parent.mkdir(parents=True, exist_ok=True)
+        if not _HAS_FCNTL:
+            log.warning(
+                "state_aggregator: fcntl unavailable on Windows. "
+                "Multi-process safety NOT guaranteed. Use single-process deployment."
+            )
 
     def submit(self, update: ProjectStateUpdate) -> None:
         """Submit a state update. Atomic: emit event + update facet + central view."""
-        with self._lock:
-            self._emit_event(update)
-            self._update_project_facet(update)
-            self._update_central_view(update)
+        _validate_project_id(update.project_id)
+        with self._lock:                                    # thread-lock
+            with open(self._lock_path, "w") as lockf:      # cross-process lock
+                if _HAS_FCNTL:
+                    _fcntl.flock(lockf.fileno(), _fcntl.LOCK_EX)
+                try:
+                    self._emit_event(update)
+                    self._update_project_facet(update)
+                    self._update_central_view(update)
+                finally:
+                    if _HAS_FCNTL:
+                        _fcntl.flock(lockf.fileno(), _fcntl.LOCK_UN)
 
     def _emit_event(self, update: ProjectStateUpdate) -> None:
         record = {

--- a/scripts/aggregator/state_aggregator.py
+++ b/scripts/aggregator/state_aggregator.py
@@ -1,0 +1,135 @@
+"""state_aggregator.py — Wave 5 PR-5.1: multi-project state aggregator write-pad.
+
+Receives state-update events from N project T0's and central Control Centre.
+Aggregates into central state.json + per-project facet files. Read-pad remains
+build_central_view.py (Phase 6) — now fed by this write-pad.
+
+ADR-005: every state mutation emits a structured NDJSON record to
+.vnx-data/events/state_aggregator.ndjson. Aggregator events use
+provider="aggregator" (domain-specific; not a CanonicalEvent stream-provider)
+so we emit raw NDJSON dicts matching the canonical shape instead of
+instantiating CanonicalEvent (which enforces a closed provider set).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+log = logging.getLogger(__name__)
+
+VALID_EVENT_TYPES = frozenset({
+    "dispatch_created",
+    "dispatch_completed",
+    "t0_heartbeat",
+    "incident",
+})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+@dataclass
+class ProjectStateUpdate:
+    project_id: str
+    timestamp: str
+    event_type: str
+    payload: Dict[str, Any]
+    source_t0: Optional[str] = None
+
+
+class StateAggregator:
+    """Append-only write-pad with per-project facet + central view.
+
+    Thread-safe within process; atomic file writes for multi-process safety.
+    """
+
+    def __init__(self, vnx_data_dir: Path) -> None:
+        self._data_dir = vnx_data_dir
+        self._central_path = vnx_data_dir / "aggregator" / "central_state.json"
+        self._facet_dir = vnx_data_dir / "aggregator" / "projects"
+        self._events_path = vnx_data_dir / "events" / "state_aggregator.ndjson"
+        self._lock = threading.Lock()
+        self._central_path.parent.mkdir(parents=True, exist_ok=True)
+        self._facet_dir.mkdir(parents=True, exist_ok=True)
+        self._events_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def submit(self, update: ProjectStateUpdate) -> None:
+        """Submit a state update. Atomic: emit event + update facet + central view."""
+        with self._lock:
+            self._emit_event(update)
+            self._update_project_facet(update)
+            self._update_central_view(update)
+
+    def _emit_event(self, update: ProjectStateUpdate) -> None:
+        record = {
+            "event_id": str(uuid.uuid4()),
+            "dispatch_id": (update.payload or {}).get("dispatch_id", ""),
+            "terminal_id": update.source_t0 or "",
+            "provider": "aggregator",
+            "sub_provider": update.project_id,
+            "event_type": update.event_type,
+            "timestamp": update.timestamp or _now_iso(),
+            "schema_version": 1,
+            "data": update.payload,
+        }
+        with open(self._events_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+    def _update_project_facet(self, update: ProjectStateUpdate) -> None:
+        facet_path = self._facet_dir / f"{update.project_id}.json"
+        facet = self._read_facet(facet_path)
+        facet["last_updated"] = update.timestamp
+        facet.setdefault("events", []).append({
+            "event_type": update.event_type,
+            "timestamp": update.timestamp,
+            "payload": update.payload,
+        })
+        facet["events"] = facet["events"][-100:]
+        tmp = facet_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(facet, indent=2), encoding="utf-8")
+        os.replace(tmp, facet_path)
+
+    def _update_central_view(self, update: ProjectStateUpdate) -> None:
+        central: Dict[str, Any] = {}
+        if self._central_path.exists():
+            try:
+                central = json.loads(self._central_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as e:
+                log.error("state_aggregator: central_state.json corrupt, regenerating: %s", e)
+                central = {}
+        central.setdefault("projects", {})
+        proj = central["projects"].setdefault(update.project_id, {
+            "first_seen": update.timestamp,
+            "event_counts": {},
+        })
+        proj["last_seen"] = update.timestamp
+        proj["event_counts"][update.event_type] = (
+            proj["event_counts"].get(update.event_type, 0) + 1
+        )
+        central["last_aggregated"] = update.timestamp
+        tmp = self._central_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(central, indent=2), encoding="utf-8")
+        os.replace(tmp, self._central_path)
+
+    def _read_facet(self, facet_path: Path) -> Dict[str, Any]:
+        if facet_path.exists():
+            try:
+                return json.loads(facet_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as e:
+                log.error("state_aggregator: facet %s corrupt, regenerating: %s", facet_path, e)
+        return {}
+
+    def read_central(self) -> Dict[str, Any]:
+        """Read-only access to central state. Phase 6 aggregator may call this."""
+        if not self._central_path.exists():
+            return {"projects": {}}
+        return json.loads(self._central_path.read_text(encoding="utf-8"))

--- a/tests/test_state_aggregator.py
+++ b/tests/test_state_aggregator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import sys
 import threading
 from pathlib import Path
@@ -144,6 +145,48 @@ def test_canonical_event_emitted_per_submit(tmp_path: Path) -> None:
         assert "event_id" in record
         assert record["schema_version"] == 1
         assert record["provider"] == "aggregator"
+
+
+def test_invalid_project_id_rejected(tmp_path: Path) -> None:
+    agg = StateAggregator(vnx_data_dir=tmp_path)
+    with pytest.raises(ValueError, match="Invalid project_id"):
+        agg.submit(ProjectStateUpdate(
+            project_id="../etc",
+            timestamp="2026-05-16T12:00:00Z",
+            event_type="dispatch_created",
+            payload={},
+        ))
+
+
+def _mp_worker(data_dir: str, project_id: str, n: int) -> None:
+    _root = str(Path(__file__).resolve().parent.parent)
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
+    from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
+    agg = StateAggregator(vnx_data_dir=Path(data_dir))
+    for i in range(n):
+        agg.submit(ProjectStateUpdate(
+            project_id=project_id,
+            timestamp=f"2026-05-16T12:00:{i:02d}Z",
+            event_type="dispatch_created",
+            payload={"i": i},
+        ))
+
+
+def test_concurrent_processes_no_lost_updates(tmp_path: Path) -> None:
+    procs = [
+        multiprocessing.Process(target=_mp_worker, args=(str(tmp_path), "vnx-dev", 20))
+        for _ in range(5)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+        assert p.exitcode == 0, f"worker process exited with {p.exitcode}"
+
+    agg = StateAggregator(vnx_data_dir=tmp_path)
+    central = agg.read_central()
+    assert central["projects"]["vnx-dev"]["event_counts"]["dispatch_created"] == 100
 
 
 def test_phase6_read_pad_compatibility(tmp_path: Path) -> None:

--- a/tests/test_state_aggregator.py
+++ b/tests/test_state_aggregator.py
@@ -1,0 +1,164 @@
+"""Tests for scripts/aggregator/state_aggregator.py (Wave 5 PR-5.1)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agg(tmp_path: Path) -> StateAggregator:
+    return StateAggregator(vnx_data_dir=tmp_path / ".vnx-data")
+
+
+def _make_update(
+    project_id: str = "test-proj",
+    event_type: str = "dispatch_created",
+    dispatch_id: str = "disp-001",
+    source_t0: str | None = "T0-test",
+) -> ProjectStateUpdate:
+    return ProjectStateUpdate(
+        project_id=project_id,
+        timestamp="2026-05-16T12:00:00.000+00:00",
+        event_type=event_type,
+        payload={"dispatch_id": dispatch_id, "track": "A"},
+        source_t0=source_t0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_submit_writes_central_facet_event(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    vnx = tmp_path / ".vnx-data"
+    agg.submit(_make_update())
+
+    central_path = vnx / "aggregator" / "central_state.json"
+    facet_path = vnx / "aggregator" / "projects" / "test-proj.json"
+    events_path = vnx / "events" / "state_aggregator.ndjson"
+
+    assert central_path.exists(), "central_state.json not written"
+    assert facet_path.exists(), "project facet not written"
+    assert events_path.exists(), "events NDJSON not written"
+
+    central = json.loads(central_path.read_text())
+    assert "test-proj" in central["projects"]
+    assert central["projects"]["test-proj"]["event_counts"]["dispatch_created"] == 1
+
+    facet = json.loads(facet_path.read_text())
+    assert len(facet["events"]) == 1
+    assert facet["events"][0]["event_type"] == "dispatch_created"
+
+    lines = [ln for ln in events_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["provider"] == "aggregator"
+    assert record["event_type"] == "dispatch_created"
+    assert record["sub_provider"] == "test-proj"
+
+
+def test_submit_atomic_under_concurrent_writes(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    errors: list[Exception] = []
+
+    def _worker(n: int) -> None:
+        try:
+            for i in range(10):
+                agg.submit(_make_update(
+                    project_id=f"proj-{n}",
+                    event_type="t0_heartbeat",
+                    dispatch_id=f"disp-{n}-{i}",
+                ))
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(n,)) for n in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent submit raised: {errors}"
+
+    events_path = tmp_path / ".vnx-data" / "events" / "state_aggregator.ndjson"
+    lines = [ln for ln in events_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 100, f"expected 100 events, got {len(lines)}"
+
+    central = (tmp_path / ".vnx-data" / "aggregator" / "central_state.json")
+    data = json.loads(central.read_text())
+    total_events = sum(
+        sum(counts.values())
+        for counts in (p["event_counts"] for p in data["projects"].values())
+    )
+    assert total_events == 100
+
+
+def test_corrupt_central_recovers(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    central_path = tmp_path / ".vnx-data" / "aggregator" / "central_state.json"
+    central_path.parent.mkdir(parents=True, exist_ok=True)
+    central_path.write_text("{ not valid json }", encoding="utf-8")
+
+    agg.submit(_make_update())
+
+    data = json.loads(central_path.read_text())
+    assert "test-proj" in data["projects"]
+
+
+def test_ring_buffer_caps_at_100(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    for i in range(200):
+        agg.submit(_make_update(dispatch_id=f"disp-{i}"))
+
+    facet_path = tmp_path / ".vnx-data" / "aggregator" / "projects" / "test-proj.json"
+    facet = json.loads(facet_path.read_text())
+    assert len(facet["events"]) == 100
+
+
+def test_canonical_event_emitted_per_submit(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    for i in range(7):
+        agg.submit(_make_update(dispatch_id=f"disp-{i}"))
+
+    events_path = tmp_path / ".vnx-data" / "events" / "state_aggregator.ndjson"
+    lines = [ln for ln in events_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 7
+
+    for line in lines:
+        record = json.loads(line)
+        assert "event_id" in record
+        assert record["schema_version"] == 1
+        assert record["provider"] == "aggregator"
+
+
+def test_phase6_read_pad_compatibility(tmp_path: Path) -> None:
+    agg = _make_agg(tmp_path)
+    agg.submit(_make_update(project_id="vnx-dev", event_type="dispatch_created"))
+    agg.submit(_make_update(project_id="seocrawler", event_type="dispatch_completed"))
+
+    from scripts.aggregator.build_central_view import main
+
+    vnx_data_dir = tmp_path / ".vnx-data"
+    rc = main(["--read-write-pad", str(vnx_data_dir)])
+    assert rc == 0
+
+    result = agg.read_central()
+    assert "vnx-dev" in result["projects"]
+    assert "seocrawler" in result["projects"]
+    assert result["projects"]["vnx-dev"]["event_counts"]["dispatch_created"] == 1
+    assert result["projects"]["seocrawler"]["event_counts"]["dispatch_completed"] == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/aggregator/state_aggregator.py` with `StateAggregator` class: thread-safe write-pad that receives `ProjectStateUpdate` events from N project T0s and the Control Centre, aggregating into `central_state.json` + per-project facets + ADR-005 NDJSON audit trail
- Adds `--read-write-pad <vnx-data-dir>` flag to `build_central_view.py` (backwards-compatible; default behaviour unchanged) enabling the Phase 6 read-pad to consume write-pad output
- Adds `docs/operations/STATE_AGGREGATOR.md` with usage, file layout, and thread-safety notes
- 6 new tests covering: all-three-files written, 10-thread × 10-submit concurrency, corrupt-central recovery, ring buffer cap (100), NDJSON count integrity, and Phase 6 compatibility via `--read-write-pad`

## References

- ADR-017: Wave 5 Control Centre architecture (`docs/governance/decisions/ADR-017-wave5-control-centre.md`)
- `claudedocs/wave5-control-centre-architecture.md` — Wave 5 design doc
- Phase 6 baseline: `scripts/aggregator/build_central_view.py` (PR #412)

## Test plan

- [x] `pytest tests/test_state_aggregator.py -v` → 6/6 passed
- [x] `pytest tests/test_aggregator_build_central_view.py tests/test_aggregator_schema_drift.py -v` → 19/19 passed (no regressions)
- [x] Atomic writes verified: tmp + os.replace() throughout
- [x] Thread safety verified: threading.Lock wraps all three writes per submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)