### PR TITLE
feat(wave5): PR-5.3 — multi-tenant lease isolation (schema v12)

### DIFF
--- a/schemas/migrations/0017_multi_tenant_lease_isolation.sql
+++ b/schemas/migrations/0017_multi_tenant_lease_isolation.sql
@@ -25,6 +25,12 @@
 --   terminal_leases  — UNIQUE(terminal_id, project_id)
 --   dispatches       — UNIQUE(dispatch_id, project_id)
 --   worker_states    — project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+--
+-- Section order: dispatches rebuilt BEFORE terminal_leases.
+--   terminal_leases carries FK → dispatches(dispatch_id, project_id).
+--   SQLite FK resolution requires the referenced composite UNIQUE to exist
+--   on the referenced table at the time FK enforcement is active. Rebuilding
+--   dispatches first satisfies this constraint regardless of FK pragma state.
 
 PRAGMA foreign_keys = OFF;
 
@@ -38,41 +44,10 @@ ALTER TABLE worker_states ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
 CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
 
 -- ============================================================================
--- 2. terminal_leases: composite UNIQUE(terminal_id, project_id)
---    SQLite cannot ALTER a constraint — requires table rebuild.
--- ============================================================================
-
-CREATE TABLE terminal_leases_v10 (
-    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    terminal_id         TEXT    NOT NULL,
-    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
-    state               TEXT    NOT NULL DEFAULT 'idle',
-    dispatch_id         TEXT,
-    generation          INTEGER NOT NULL DEFAULT 1,
-    leased_at           TEXT,
-    expires_at          TEXT,
-    last_heartbeat_at   TEXT,
-    released_at         TEXT,
-    metadata_json       TEXT    DEFAULT '{}',
-    FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id),
-    UNIQUE(terminal_id, project_id)
-);
-
-INSERT INTO terminal_leases_v10
-    SELECT id, terminal_id, project_id, state, dispatch_id, generation,
-           leased_at, expires_at, last_heartbeat_at, released_at, metadata_json
-    FROM terminal_leases;
-
-DROP TABLE terminal_leases;
-ALTER TABLE terminal_leases_v10 RENAME TO terminal_leases;
-
-CREATE INDEX IF NOT EXISTS idx_lease_state             ON terminal_leases(state);
-CREATE INDEX IF NOT EXISTS idx_lease_dispatch          ON terminal_leases(dispatch_id);
-CREATE INDEX IF NOT EXISTS idx_lease_project           ON terminal_leases(project_id);
-CREATE INDEX IF NOT EXISTS idx_lease_terminal_project  ON terminal_leases(terminal_id, project_id);
-
--- ============================================================================
--- 3. dispatches: composite UNIQUE(dispatch_id, project_id)
+-- 2. dispatches: composite UNIQUE(dispatch_id, project_id)
+--    Rebuilt FIRST because terminal_leases carries a FK → dispatches
+--    (dispatch_id, project_id). The composite UNIQUE must exist on the
+--    referenced table before the referencing table is built.
 --    Composite rather than natural-key only — prevents cross-tenant collision
 --    when dispatch_id prefixes are reused under ADR-007 §3.
 -- ============================================================================
@@ -107,9 +82,10 @@ CREATE INDEX IF NOT EXISTS idx_dispatch_created  ON dispatches(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
 
 -- ============================================================================
--- 3.5. dispatch_attempts: fix broken FK after dispatches composite UNIQUE
---      REFERENCES dispatches(dispatch_id) is now invalid — upgrade to composite.
---      project_id already present (added by migration 0010).
+-- 3. dispatch_attempts: fix broken FK after dispatches composite UNIQUE
+--    REFERENCES dispatches(dispatch_id) is now invalid — upgrade to composite.
+--    project_id already present (added by migration 0010).
+--    Rebuilt after dispatches so the new composite FK target already exists.
 -- ============================================================================
 
 CREATE TABLE dispatch_attempts_v10 (
@@ -141,7 +117,43 @@ CREATE INDEX IF NOT EXISTS idx_attempt_terminal  ON dispatch_attempts(terminal_i
 CREATE INDEX IF NOT EXISTS idx_attempt_project   ON dispatch_attempts(project_id);
 
 -- ============================================================================
--- 4. Version stamp
+-- 4. terminal_leases: composite UNIQUE(terminal_id, project_id)
+--    SQLite cannot ALTER a constraint — requires table rebuild.
+--    Rebuilt AFTER dispatches so FK → dispatches(dispatch_id, project_id)
+--    targets an already-existing composite UNIQUE constraint.
+-- ============================================================================
+
+CREATE TABLE terminal_leases_v10 (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT,
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    metadata_json       TEXT    DEFAULT '{}',
+    FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id),
+    UNIQUE(terminal_id, project_id)
+);
+
+INSERT INTO terminal_leases_v10
+    SELECT id, terminal_id, project_id, state, dispatch_id, generation,
+           leased_at, expires_at, last_heartbeat_at, released_at, metadata_json
+    FROM terminal_leases;
+
+DROP TABLE terminal_leases;
+ALTER TABLE terminal_leases_v10 RENAME TO terminal_leases;
+
+CREATE INDEX IF NOT EXISTS idx_lease_state             ON terminal_leases(state);
+CREATE INDEX IF NOT EXISTS idx_lease_dispatch          ON terminal_leases(dispatch_id);
+CREATE INDEX IF NOT EXISTS idx_lease_project           ON terminal_leases(project_id);
+CREATE INDEX IF NOT EXISTS idx_lease_terminal_project  ON terminal_leases(terminal_id, project_id);
+
+-- ============================================================================
+-- 5. Version stamp
 -- ============================================================================
 
 INSERT OR IGNORE INTO runtime_schema_version (version, description)

--- a/schemas/migrations/0017_multi_tenant_lease_isolation.sql
+++ b/schemas/migrations/0017_multi_tenant_lease_isolation.sql
@@ -1,0 +1,117 @@
+-- VNX Migration 0017 — Wave 5 PR-5.3 multi-tenant lease isolation
+-- Purpose: Composite UNIQUE constraints on tenant-scoped hot tables;
+--          project_id added to worker_states (missed in v9 Feature 12 PR-1).
+--
+-- Design: claudedocs/wave5-control-centre-architecture.md §6 PR-5.3
+-- ADR: ADR-017 Control Centre product-shape architecture
+--
+-- Atomicity: single BEGIN/COMMIT transaction; FK enforcement suspended for
+--            table-rebuild steps. On error, the uncommitted transaction is
+--            rolled back when the connection is closed.
+--
+-- Idempotency: guarded by the Python runner (scripts/lib/migrations/apply_0017.py)
+--              which checks runtime_schema_version before executing this script.
+--              The final INSERT OR IGNORE is a defence-in-depth guard only.
+--
+-- Applied by: scripts/lib/migrations/apply_0017.py
+-- Tested by:  tests/test_schema_0017_migration.py
+--
+-- Pre-migration state (v11, after 0010 + 0015):
+--   terminal_leases  — has project_id, UNIQUE(terminal_id) only
+--   dispatches       — has project_id, UNIQUE(dispatch_id) only
+--   worker_states    — no project_id column
+--
+-- Post-migration state (v12):
+--   terminal_leases  — UNIQUE(terminal_id, project_id)
+--   dispatches       — UNIQUE(dispatch_id, project_id)
+--   worker_states    — project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN TRANSACTION;
+
+-- ============================================================================
+-- 1. worker_states: add project_id (missed in v9)
+-- ============================================================================
+
+ALTER TABLE worker_states ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
+
+-- ============================================================================
+-- 2. terminal_leases: composite UNIQUE(terminal_id, project_id)
+--    SQLite cannot ALTER a constraint — requires table rebuild.
+-- ============================================================================
+
+CREATE TABLE terminal_leases_v10 (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT,
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(terminal_id, project_id)
+);
+
+INSERT INTO terminal_leases_v10
+    SELECT id, terminal_id, project_id, state, dispatch_id, generation,
+           leased_at, expires_at, last_heartbeat_at, released_at, metadata_json
+    FROM terminal_leases;
+
+DROP TABLE terminal_leases;
+ALTER TABLE terminal_leases_v10 RENAME TO terminal_leases;
+
+CREATE INDEX IF NOT EXISTS idx_lease_state             ON terminal_leases(state);
+CREATE INDEX IF NOT EXISTS idx_lease_dispatch          ON terminal_leases(dispatch_id);
+CREATE INDEX IF NOT EXISTS idx_lease_project           ON terminal_leases(project_id);
+CREATE INDEX IF NOT EXISTS idx_lease_terminal_project  ON terminal_leases(terminal_id, project_id);
+
+-- ============================================================================
+-- 3. dispatches: composite UNIQUE(dispatch_id, project_id)
+--    Composite rather than natural-key only — prevents cross-tenant collision
+--    when dispatch_id prefixes are reused under ADR-007 §3.
+-- ============================================================================
+
+CREATE TABLE dispatches_v10 (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state           TEXT    NOT NULL DEFAULT 'queued',
+    terminal_id     TEXT,
+    track           TEXT,
+    priority        TEXT    DEFAULT 'P2',
+    pr_ref          TEXT,
+    gate            TEXT,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    bundle_path     TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_after   TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    UNIQUE(dispatch_id, project_id)
+);
+
+INSERT INTO dispatches_v10 SELECT * FROM dispatches;
+
+DROP TABLE dispatches;
+ALTER TABLE dispatches_v10 RENAME TO dispatches;
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_state    ON dispatches(state, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_terminal ON dispatches(terminal_id, state);
+CREATE INDEX IF NOT EXISTS idx_dispatch_created  ON dispatches(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
+
+-- ============================================================================
+-- 4. Version stamp
+-- ============================================================================
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (12, 'Wave 5 PR-5.3: composite UNIQUE on terminal_leases + dispatches; project_id on worker_states');
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;

--- a/schemas/migrations/0017_multi_tenant_lease_isolation.sql
+++ b/schemas/migrations/0017_multi_tenant_lease_isolation.sql
@@ -54,6 +54,7 @@ CREATE TABLE terminal_leases_v10 (
     last_heartbeat_at   TEXT,
     released_at         TEXT,
     metadata_json       TEXT    DEFAULT '{}',
+    FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id),
     UNIQUE(terminal_id, project_id)
 );
 
@@ -104,6 +105,40 @@ CREATE INDEX IF NOT EXISTS idx_dispatch_state    ON dispatches(state, updated_at
 CREATE INDEX IF NOT EXISTS idx_dispatch_terminal ON dispatches(terminal_id, state);
 CREATE INDEX IF NOT EXISTS idx_dispatch_created  ON dispatches(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
+
+-- ============================================================================
+-- 3.5. dispatch_attempts: fix broken FK after dispatches composite UNIQUE
+--      REFERENCES dispatches(dispatch_id) is now invalid — upgrade to composite.
+--      project_id already present (added by migration 0010).
+-- ============================================================================
+
+CREATE TABLE dispatch_attempts_v10 (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    attempt_id      TEXT    NOT NULL UNIQUE,
+    dispatch_id     TEXT    NOT NULL,
+    attempt_number  INTEGER NOT NULL DEFAULT 1,
+    terminal_id     TEXT    NOT NULL,
+    state           TEXT    NOT NULL DEFAULT 'pending',
+    started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    ended_at        TEXT,
+    failure_reason  TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id)
+);
+
+INSERT INTO dispatch_attempts_v10
+    SELECT id, attempt_id, dispatch_id, attempt_number, terminal_id,
+           state, started_at, ended_at, failure_reason, metadata_json, project_id
+    FROM dispatch_attempts;
+
+DROP TABLE dispatch_attempts;
+ALTER TABLE dispatch_attempts_v10 RENAME TO dispatch_attempts;
+
+CREATE INDEX IF NOT EXISTS idx_attempt_dispatch  ON dispatch_attempts(dispatch_id, attempt_number);
+CREATE INDEX IF NOT EXISTS idx_attempt_state     ON dispatch_attempts(state, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_attempt_terminal  ON dispatch_attempts(terminal_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_attempt_project   ON dispatch_attempts(project_id);
 
 -- ============================================================================
 -- 4. Version stamp

--- a/schemas/runtime_coordination_v10.sql
+++ b/schemas/runtime_coordination_v10.sql
@@ -29,13 +29,14 @@ CREATE TABLE IF NOT EXISTS terminal_leases (
     terminal_id         TEXT    NOT NULL,
     project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
     state               TEXT    NOT NULL DEFAULT 'idle',
-    dispatch_id         TEXT    REFERENCES dispatches (dispatch_id),
+    dispatch_id         TEXT,
     generation          INTEGER NOT NULL DEFAULT 1,
     leased_at           TEXT,
     expires_at          TEXT,
     last_heartbeat_at   TEXT,
     released_at         TEXT,
     metadata_json       TEXT    DEFAULT '{}',
+    FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id),
     UNIQUE(terminal_id, project_id)
 );
 

--- a/schemas/runtime_coordination_v10.sql
+++ b/schemas/runtime_coordination_v10.sql
@@ -1,0 +1,108 @@
+-- VNX Runtime Coordination Schema — v10 baseline (Wave 5 PR-5.3)
+-- Purpose: Multi-tenant lease isolation — composite UNIQUE constraints on
+--          terminal_leases and dispatches; project_id on worker_states.
+-- Applies on top of: v9 (Feature 12 PR-1) + migrations 0010 + 0015.
+--
+-- Design: claudedocs/wave5-control-centre-architecture.md §6 PR-5.3
+-- Applied by migration: schemas/migrations/0017_multi_tenant_lease_isolation.sql
+--
+-- Key changes from v9:
+--   terminal_leases — UNIQUE(terminal_id) replaced by UNIQUE(terminal_id, project_id)
+--   dispatches      — UNIQUE(dispatch_id) replaced by UNIQUE(dispatch_id, project_id)
+--   worker_states   — project_id column added (missed in v9)
+--
+-- This file documents the target schema structure. For fresh DB creation,
+-- apply runtime_coordination.sql then all migrations 0010 through 0017.
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+-- ============================================================================
+-- TERMINAL LEASES (v10 — composite UNIQUE)
+-- ============================================================================
+-- One row per (terminal, project) pair. Multiple projects can each have a
+-- row for T1/T2/T3 without collision. The composite UNIQUE enforces that
+-- the same terminal cannot be leased by two dispatches in the same project.
+
+CREATE TABLE IF NOT EXISTS terminal_leases (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT    REFERENCES dispatches (dispatch_id),
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(terminal_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lease_state            ON terminal_leases(state);
+CREATE INDEX IF NOT EXISTS idx_lease_dispatch         ON terminal_leases(dispatch_id);
+CREATE INDEX IF NOT EXISTS idx_lease_project          ON terminal_leases(project_id);
+CREATE INDEX IF NOT EXISTS idx_lease_terminal_project ON terminal_leases(terminal_id, project_id);
+
+-- ============================================================================
+-- DISPATCHES (v10 — composite UNIQUE)
+-- ============================================================================
+-- UNIQUE(dispatch_id, project_id) rather than UNIQUE(dispatch_id) alone.
+-- Prevents cross-project collision under ADR-007 §3 identifier-reuse rules.
+
+CREATE TABLE IF NOT EXISTS dispatches (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state           TEXT    NOT NULL DEFAULT 'queued',
+    terminal_id     TEXT,
+    track           TEXT,
+    priority        TEXT    DEFAULT 'P2',
+    pr_ref          TEXT,
+    gate            TEXT,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    bundle_path     TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_after   TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    UNIQUE(dispatch_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_state    ON dispatches(state, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_terminal ON dispatches(terminal_id, state);
+CREATE INDEX IF NOT EXISTS idx_dispatch_created  ON dispatches(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
+
+-- ============================================================================
+-- WORKER STATES (v10 — project_id added)
+-- ============================================================================
+-- project_id was missing from the v9 schema (Feature 12 PR-1). Added here
+-- with DEFAULT 'vnx-dev' to preserve backward compatibility.
+
+CREATE TABLE IF NOT EXISTS worker_states (
+    terminal_id      TEXT    NOT NULL,
+    dispatch_id      TEXT    NOT NULL,
+    project_id       TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state            TEXT    NOT NULL DEFAULT 'initializing',
+    last_output_at   TEXT,
+    state_entered_at TEXT    NOT NULL,
+    stall_count      INTEGER NOT NULL DEFAULT 0,
+    blocked_reason   TEXT,
+    metadata_json    TEXT,
+    created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+
+    PRIMARY KEY (terminal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_state   ON worker_states(state);
+CREATE INDEX IF NOT EXISTS idx_worker_dispatch ON worker_states(dispatch_id);
+CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
+
+-- ============================================================================
+-- SCHEMA VERSION
+-- ============================================================================
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (12, 'Wave 5 PR-5.3: composite UNIQUE on terminal_leases + dispatches; project_id on worker_states');

--- a/scripts/lib/migrations/__init__.py
+++ b/scripts/lib/migrations/__init__.py
@@ -1,0 +1,1 @@
+# VNX migration runner package

--- a/scripts/lib/migrations/apply_0017.py
+++ b/scripts/lib/migrations/apply_0017.py
@@ -1,0 +1,89 @@
+"""apply_0017.py — Wave 5 PR-5.3 multi-tenant lease isolation migration.
+
+Applies schemas/migrations/0017_multi_tenant_lease_isolation.sql to a
+runtime_coordination.db. Adds composite UNIQUE constraints on terminal_leases
+and dispatches; adds project_id to worker_states.
+
+Idempotent: reads MAX(version) from runtime_schema_version. Skips if already
+at v12 or higher (the version stamped by the migration).
+
+Atomic: the SQL script uses an explicit BEGIN/COMMIT transaction. If the script
+fails mid-way, the uncommitted transaction is rolled back when the connection
+is closed (SQLite WAL mode guarantees).
+
+Tested via tests/test_schema_0017_migration.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_TARGET_VERSION = 12
+
+_DEFAULT_MIGRATION_SQL = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "schemas"
+    / "migrations"
+    / "0017_multi_tenant_lease_isolation.sql"
+)
+
+
+def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
+    """Apply the 0017 migration to db_path.
+
+    Returns True when the migration was applied, False when the DB was
+    already at the target version and the migration was skipped.
+
+    Raises sqlite3.Error on failure (the failing transaction is rolled back
+    via connection close before the exception propagates).
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+        row = cur.fetchone()
+        current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+        if current_version >= _TARGET_VERSION:
+            log.info(
+                "apply_0017: already at v%s (target v%s), skip",
+                current_version,
+                _TARGET_VERSION,
+            )
+            return False
+
+        sql = migration_sql_path.read_text()
+        conn.executescript(sql)
+        log.info(
+            "apply_0017: migrated from v%s to v%s", current_version, _TARGET_VERSION
+        )
+        return True
+
+    except sqlite3.Error:
+        conn.rollback()
+        log.error("apply_0017: error during migration; transaction rolled back")
+        raise
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    p = argparse.ArgumentParser(
+        description="Apply 0017 multi-tenant lease isolation migration"
+    )
+    p.add_argument("--db", required=True, help="Path to runtime_coordination.db")
+    p.add_argument(
+        "--migration",
+        default=str(_DEFAULT_MIGRATION_SQL),
+        help="Path to 0017_multi_tenant_lease_isolation.sql",
+    )
+    args = p.parse_args()
+    applied = apply_migration(Path(args.db), Path(args.migration))
+    print("applied" if applied else "skipped (already at target version)")

--- a/scripts/lib/migrations/apply_0017.py
+++ b/scripts/lib/migrations/apply_0017.py
@@ -2,7 +2,7 @@
 
 Applies schemas/migrations/0017_multi_tenant_lease_isolation.sql to a
 runtime_coordination.db. Adds composite UNIQUE constraints on terminal_leases
-and dispatches; adds project_id to worker_states.
+and dispatches; adds project_id to worker_states; fixes dispatch_attempts FK.
 
 Idempotent: reads MAX(version) from runtime_schema_version. Skips if already
 at v12 or higher (the version stamped by the migration).
@@ -11,14 +11,19 @@ Atomic: the SQL script uses an explicit BEGIN/COMMIT transaction. If the script
 fails mid-way, the uncommitted transaction is rolled back when the connection
 is closed (SQLite WAL mode guarantees).
 
+ADR-005: emits NDJSON audit events to .vnx-data/events/schema_migrations.ndjson
+for migration_started, migration_completed, and migration_failed.
+
 Tested via tests/test_schema_0017_migration.py.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -33,7 +38,25 @@ _DEFAULT_MIGRATION_SQL = (
 )
 
 
-def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
+def _emit_migration_event(vnx_data_dir: Path, event_type: str, payload: dict) -> None:
+    events_path = vnx_data_dir / "events" / "schema_migrations.ndjson"
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event_type": event_type,
+        "source": "schema_migration",
+        "migration": "0017_multi_tenant_lease_isolation",
+        **payload,
+    }
+    with open(events_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def apply_migration(
+    db_path: Path,
+    migration_sql_path: Path,
+    vnx_data_dir: Path | None = None,
+) -> bool:
     """Apply the 0017 migration to db_path.
 
     Returns True when the migration was applied, False when the DB was
@@ -42,6 +65,10 @@ def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
     Raises sqlite3.Error on failure (the failing transaction is rolled back
     via connection close before the exception propagates).
     """
+    if vnx_data_dir is None:
+        vnx_data_dir = Path(db_path).parent.parent
+
+    current_version = 0
     conn = sqlite3.connect(str(db_path))
     try:
         cur = conn.cursor()
@@ -57,16 +84,33 @@ def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
             )
             return False
 
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_started",
+            {"from_version": current_version, "to_version": _TARGET_VERSION},
+        )
+
         sql = migration_sql_path.read_text()
         conn.executescript(sql)
         log.info(
             "apply_0017: migrated from v%s to v%s", current_version, _TARGET_VERSION
         )
+
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_completed",
+            {"from_version": current_version, "to_version": _TARGET_VERSION},
+        )
         return True
 
-    except sqlite3.Error:
+    except sqlite3.Error as e:
         conn.rollback()
         log.error("apply_0017: error during migration; transaction rolled back")
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_failed",
+            {"from_version": current_version, "error": str(e)},
+        )
         raise
 
     finally:
@@ -84,6 +128,15 @@ if __name__ == "__main__":
         default=str(_DEFAULT_MIGRATION_SQL),
         help="Path to 0017_multi_tenant_lease_isolation.sql",
     )
+    p.add_argument(
+        "--vnx-data-dir",
+        default=None,
+        help="Path to .vnx-data directory for audit events (default: db_path/../..)",
+    )
     args = p.parse_args()
-    applied = apply_migration(Path(args.db), Path(args.migration))
+    applied = apply_migration(
+        Path(args.db),
+        Path(args.migration),
+        Path(args.vnx_data_dir) if args.vnx_data_dir else None,
+    )
     print("applied" if applied else "skipped (already at target version)")

--- a/tests/test_schema_0017_migration.py
+++ b/tests/test_schema_0017_migration.py
@@ -298,6 +298,40 @@ PRAGMA foreign_keys = ON;
     assert "error" in failed
 
 
+def test_migration_order_creates_dispatches_before_leases(tmp_path: Path) -> None:
+    """Migration must rebuild dispatches before terminal_leases.
+
+    terminal_leases carries FK → dispatches(dispatch_id, project_id).
+    If terminal_leases is rebuilt first, that FK references a composite key
+    that does not yet exist, causing IntegrityError when FK enforcement is
+    active during the INSERT phase.
+
+    This test exercises that failure mode by stripping the migration's own
+    PRAGMA foreign_keys = OFF so FK enforcement stays ON throughout. With
+    correct ordering (dispatches first) the migration completes without error.
+    """
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+
+    raw_sql = MIGRATION_SQL.read_text()
+    # Remove the FK-off guard so SQLite enforces FK constraints during the run.
+    # This exposes ordering bugs: if terminal_leases is rebuilt before
+    # dispatches, the INSERT into terminal_leases_v10 will fail with
+    # IntegrityError because the composite UNIQUE on dispatches doesn't exist yet.
+    sql_with_fk_on = raw_sql.replace("PRAGMA foreign_keys = OFF;", "PRAGMA foreign_keys = ON;")
+
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.executescript(sql_with_fk_on)
+    finally:
+        conn.close()
+
+    # Verify migration reached the expected end-state.
+    assert _max_version(db) == 12
+    assert _has_composite_unique(db, "dispatches", frozenset({"dispatch_id", "project_id"}))
+    assert _has_composite_unique(db, "terminal_leases", frozenset({"terminal_id", "project_id"}))
+
+
 def test_composite_fk_referencing_dispatches(tmp_path: Path) -> None:
     db = tmp_path / "coord.db"
     _create_pre_migration_db(db)

--- a/tests/test_schema_0017_migration.py
+++ b/tests/test_schema_0017_migration.py
@@ -1,11 +1,13 @@
 """Tests for migration 0017 — multi-tenant lease isolation (schema v12).
 
 Covers: apply from pre-migration state, idempotency, rollback on error,
-composite UNIQUE enforcement, and worker_states.project_id presence.
+composite UNIQUE enforcement, worker_states.project_id presence,
+ADR-005 audit event emission, and composite FK correctness.
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 from pathlib import Path
@@ -36,6 +38,7 @@ def _create_pre_migration_db(db_path: Path) -> None:
 
     terminal_leases and dispatches have project_id (from 0010) but only
     single-column UNIQUE constraints. worker_states has no project_id.
+    dispatch_attempts has project_id (from 0010) with single-column FK.
     """
     conn = sqlite3.connect(str(db_path))
     try:
@@ -98,6 +101,20 @@ def _create_pre_migration_db(db_path: Path) -> None:
                 created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
             );
+
+            CREATE TABLE dispatch_attempts (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                attempt_id      TEXT    NOT NULL UNIQUE,
+                dispatch_id     TEXT    NOT NULL REFERENCES dispatches (dispatch_id),
+                attempt_number  INTEGER NOT NULL DEFAULT 1,
+                terminal_id     TEXT    NOT NULL,
+                state           TEXT    NOT NULL DEFAULT 'pending',
+                started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                ended_at        TEXT,
+                failure_reason  TEXT,
+                metadata_json   TEXT    DEFAULT '{}',
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev'
+            );
         """)
     finally:
         conn.close()
@@ -131,6 +148,17 @@ def _max_version(db_path: Path) -> int:
         conn.close()
 
 
+def _read_ndjson_events(events_path: Path) -> list[dict]:
+    if not events_path.exists():
+        return []
+    events = []
+    for line in events_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -139,7 +167,7 @@ def test_apply_migration_from_v9_succeeds(tmp_path: Path) -> None:
     db = tmp_path / "coord.db"
     _create_pre_migration_db(db)
 
-    result = apply_migration(db, MIGRATION_SQL)
+    result = apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
 
     assert result is True
     assert _max_version(db) == 12
@@ -151,8 +179,8 @@ def test_apply_migration_idempotent(tmp_path: Path) -> None:
     db = tmp_path / "coord.db"
     _create_pre_migration_db(db)
 
-    first = apply_migration(db, MIGRATION_SQL)
-    second = apply_migration(db, MIGRATION_SQL)
+    first = apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
+    second = apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
 
     assert first is True
     assert second is False
@@ -174,7 +202,7 @@ PRAGMA foreign_keys = ON;
 """)
 
     with pytest.raises(sqlite3.OperationalError):
-        apply_migration(db, corrupt_sql)
+        apply_migration(db, corrupt_sql, vnx_data_dir=tmp_path)
 
     # worker_states must not have project_id (transaction rolled back)
     conn = sqlite3.connect(str(db))
@@ -191,7 +219,7 @@ PRAGMA foreign_keys = ON;
 def test_terminal_leases_unique_constraint(tmp_path: Path) -> None:
     db = tmp_path / "coord.db"
     _create_pre_migration_db(db)
-    apply_migration(db, MIGRATION_SQL)
+    apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
 
     conn = sqlite3.connect(str(db))
     try:
@@ -220,7 +248,7 @@ def test_terminal_leases_unique_constraint(tmp_path: Path) -> None:
 def test_worker_states_has_project_id_after_migration(tmp_path: Path) -> None:
     db = tmp_path / "coord.db"
     _create_pre_migration_db(db)
-    apply_migration(db, MIGRATION_SQL)
+    apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
 
     conn = sqlite3.connect(str(db))
     try:
@@ -228,3 +256,94 @@ def test_worker_states_has_project_id_after_migration(tmp_path: Path) -> None:
     finally:
         conn.close()
     assert "project_id" in cols
+
+
+def test_migration_emits_started_completed_events(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+
+    apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
+
+    events_path = tmp_path / "events" / "schema_migrations.ndjson"
+    events = _read_ndjson_events(events_path)
+    assert len(events) == 2
+    assert events[0]["event_type"] == "migration_started"
+    assert events[1]["event_type"] == "migration_completed"
+    assert events[0]["migration"] == "0017_multi_tenant_lease_isolation"
+    assert events[1]["migration"] == "0017_multi_tenant_lease_isolation"
+
+
+def test_migration_emits_failed_event_on_rollback(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    corrupt_sql = tmp_path / "corrupt.sql"
+    _create_pre_migration_db(db)
+
+    corrupt_sql.write_text("""
+PRAGMA foreign_keys = OFF;
+BEGIN TRANSACTION;
+ALTER TABLE worker_states ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+THIS IS NOT VALID SQL AND WILL CAUSE AN ERROR;
+COMMIT;
+PRAGMA foreign_keys = ON;
+""")
+
+    with pytest.raises(sqlite3.OperationalError):
+        apply_migration(db, corrupt_sql, vnx_data_dir=tmp_path)
+
+    events_path = tmp_path / "events" / "schema_migrations.ndjson"
+    events = _read_ndjson_events(events_path)
+    event_types = [e["event_type"] for e in events]
+    assert "migration_failed" in event_types
+    failed = next(e for e in events if e["event_type"] == "migration_failed")
+    assert "error" in failed
+
+
+def test_composite_fk_referencing_dispatches(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+    apply_migration(db, MIGRATION_SQL, vnx_data_dir=tmp_path)
+
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state)"
+            " VALUES ('d1', 'proj-a', 'queued')"
+        )
+        conn.commit()
+
+        # terminal_leases: valid (dispatch_id, project_id) pair → success
+        conn.execute(
+            "INSERT INTO terminal_leases"
+            " (terminal_id, project_id, state, dispatch_id, generation)"
+            " VALUES ('T4', 'proj-a', 'leased', 'd1', 1)"
+        )
+        conn.commit()
+
+        # terminal_leases: unknown dispatch_id → IntegrityError
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO terminal_leases"
+                " (terminal_id, project_id, state, dispatch_id, generation)"
+                " VALUES ('T5', 'proj-a', 'leased', 'nonexistent', 1)"
+            )
+            conn.commit()
+
+        # dispatch_attempts: valid (dispatch_id, project_id) pair → success
+        conn.execute(
+            "INSERT INTO dispatch_attempts"
+            " (attempt_id, dispatch_id, project_id, terminal_id)"
+            " VALUES ('a1', 'd1', 'proj-a', 'T1')"
+        )
+        conn.commit()
+
+        # dispatch_attempts: unknown dispatch → IntegrityError
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO dispatch_attempts"
+                " (attempt_id, dispatch_id, project_id, terminal_id)"
+                " VALUES ('a2', 'nonexistent', 'proj-a', 'T1')"
+            )
+            conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_schema_0017_migration.py
+++ b/tests/test_schema_0017_migration.py
@@ -1,0 +1,230 @@
+"""Tests for migration 0017 — multi-tenant lease isolation (schema v12).
+
+Covers: apply from pre-migration state, idempotency, rollback on error,
+composite UNIQUE enforcement, and worker_states.project_id presence.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/lib importable
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from migrations.apply_0017 import apply_migration
+
+MIGRATION_SQL = (
+    Path(__file__).resolve().parent.parent
+    / "schemas"
+    / "migrations"
+    / "0017_multi_tenant_lease_isolation.sql"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_pre_migration_db(db_path: Path) -> None:
+    """Build a minimal DB that represents the pre-0017 state (v11).
+
+    terminal_leases and dispatches have project_id (from 0010) but only
+    single-column UNIQUE constraints. worker_states has no project_id.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript("""
+            PRAGMA journal_mode = WAL;
+
+            CREATE TABLE runtime_schema_version (
+                version     INTEGER PRIMARY KEY,
+                applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                description TEXT NOT NULL
+            );
+            INSERT INTO runtime_schema_version VALUES (1, datetime('now'), 'initial');
+            INSERT INTO runtime_schema_version VALUES (9, datetime('now'), 'worker_states');
+            INSERT INTO runtime_schema_version VALUES (10, datetime('now'), 'project_id phase 0');
+            INSERT INTO runtime_schema_version VALUES (11, datetime('now'), 'project_id phase 4');
+
+            CREATE TABLE dispatches (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id     TEXT    NOT NULL UNIQUE,
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state           TEXT    NOT NULL DEFAULT 'queued',
+                terminal_id     TEXT,
+                track           TEXT,
+                priority        TEXT    DEFAULT 'P2',
+                pr_ref          TEXT,
+                gate            TEXT,
+                attempt_count   INTEGER NOT NULL DEFAULT 0,
+                bundle_path     TEXT,
+                created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                expires_after   TEXT,
+                metadata_json   TEXT    DEFAULT '{}'
+            );
+
+            CREATE TABLE terminal_leases (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                terminal_id         TEXT    NOT NULL UNIQUE,
+                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state               TEXT    NOT NULL DEFAULT 'idle',
+                dispatch_id         TEXT,
+                generation          INTEGER NOT NULL DEFAULT 1,
+                leased_at           TEXT,
+                expires_at          TEXT,
+                last_heartbeat_at   TEXT,
+                released_at         TEXT,
+                metadata_json       TEXT    DEFAULT '{}'
+            );
+            INSERT INTO terminal_leases (terminal_id, state, generation)
+                VALUES ('T1', 'idle', 1), ('T2', 'idle', 1), ('T3', 'idle', 1);
+
+            CREATE TABLE worker_states (
+                terminal_id      TEXT    NOT NULL PRIMARY KEY,
+                dispatch_id      TEXT    NOT NULL,
+                state            TEXT    NOT NULL DEFAULT 'initializing',
+                last_output_at   TEXT,
+                state_entered_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                stall_count      INTEGER NOT NULL DEFAULT 0,
+                blocked_reason   TEXT,
+                metadata_json    TEXT,
+                created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+        """)
+    finally:
+        conn.close()
+
+
+def _has_composite_unique(db_path: Path, table: str, columns: frozenset) -> bool:
+    """Return True if the table has a UNIQUE index over exactly the given columns."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        indices = conn.execute(f"PRAGMA index_list({table})").fetchall()
+        for idx in indices:
+            # index_list row: (seq, name, unique, origin, partial)
+            if not idx[2]:  # unique flag
+                continue
+            info = conn.execute(f"PRAGMA index_info({idx[1]})").fetchall()
+            # index_info row: (seqno, cid, name)
+            idx_cols = frozenset(row[2] for row in info)
+            if idx_cols == columns:
+                return True
+    finally:
+        conn.close()
+    return False
+
+
+def _max_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute("SELECT MAX(version) FROM runtime_schema_version").fetchone()
+        return int(row[0]) if (row and row[0] is not None) else 0
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_apply_migration_from_v9_succeeds(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+
+    result = apply_migration(db, MIGRATION_SQL)
+
+    assert result is True
+    assert _max_version(db) == 12
+    assert _has_composite_unique(db, "terminal_leases", frozenset({"terminal_id", "project_id"}))
+    assert _has_composite_unique(db, "dispatches", frozenset({"dispatch_id", "project_id"}))
+
+
+def test_apply_migration_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+
+    first = apply_migration(db, MIGRATION_SQL)
+    second = apply_migration(db, MIGRATION_SQL)
+
+    assert first is True
+    assert second is False
+    assert _max_version(db) == 12
+
+
+def test_apply_migration_rollback_on_error(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    corrupt_sql = tmp_path / "corrupt.sql"
+    _create_pre_migration_db(db)
+
+    corrupt_sql.write_text("""
+PRAGMA foreign_keys = OFF;
+BEGIN TRANSACTION;
+ALTER TABLE worker_states ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev';
+THIS IS NOT VALID SQL AND WILL CAUSE AN ERROR;
+COMMIT;
+PRAGMA foreign_keys = ON;
+""")
+
+    with pytest.raises(sqlite3.OperationalError):
+        apply_migration(db, corrupt_sql)
+
+    # worker_states must not have project_id (transaction rolled back)
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(worker_states)")}
+    finally:
+        conn.close()
+    assert "project_id" not in cols
+
+    # DB version unchanged
+    assert _max_version(db) == 11
+
+
+def test_terminal_leases_unique_constraint(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+    apply_migration(db, MIGRATION_SQL)
+
+    conn = sqlite3.connect(str(db))
+    try:
+        # (T1, proj-a) and (T1, proj-b) in the same table are allowed
+        conn.execute(
+            "INSERT INTO terminal_leases (terminal_id, project_id, state, generation)"
+            " VALUES ('T1', 'proj-a', 'idle', 1)"
+        )
+        conn.execute(
+            "INSERT INTO terminal_leases (terminal_id, project_id, state, generation)"
+            " VALUES ('T1', 'proj-b', 'idle', 1)"
+        )
+        conn.commit()
+
+        # Duplicate (T1, proj-a) must raise IntegrityError
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO terminal_leases (terminal_id, project_id, state, generation)"
+                " VALUES ('T1', 'proj-a', 'idle', 2)"
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def test_worker_states_has_project_id_after_migration(tmp_path: Path) -> None:
+    db = tmp_path / "coord.db"
+    _create_pre_migration_db(db)
+    apply_migration(db, MIGRATION_SQL)
+
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(worker_states)")}
+    finally:
+        conn.close()
+    assert "project_id" in cols


### PR DESCRIPTION
## Summary

- Adds composite `UNIQUE(terminal_id, project_id)` to `terminal_leases` and `UNIQUE(dispatch_id, project_id)` to `dispatches` via SQLite table-rebuild (migration 0017)
- Adds `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` to `worker_states` (missed in v9 Feature 12 PR-1)
- Idempotent Python runner skips if `MAX(runtime_schema_version) >= 12`; rolls back atomically on any error

Implements ADR-017 §6 + [wave5-control-centre-architecture.md §6 PR-5.3](claudedocs/wave5-control-centre-architecture.md). Required before PR-5.5 (Control Centre interactive layer) can safely spawn multiple per-project T0s into a shared `runtime_coordination.db`.

## Files changed

| File | Purpose |
|------|---------|
| `schemas/migrations/0017_multi_tenant_lease_isolation.sql` | Atomic migration SQL (PRAGMA FK OFF + BEGIN/COMMIT) |
| `schemas/runtime_coordination_v10.sql` | Clean v10 delta baseline (table structures post-migration) |
| `scripts/lib/migrations/apply_0017.py` | Idempotent Python runner with version guard and rollback |
| `tests/test_schema_0017_migration.py` | 5 tests: apply, idempotency, rollback-on-error, composite UNIQUE enforcement, worker_states.project_id |

## Test plan

- [x] `pytest tests/test_schema_0017_migration.py -v` — 5/5 passed
- [x] `python3 scripts/ci_lint_patterns.py` — 0 new findings
- [x] Migration is idempotent (second apply returns False, DB unchanged)
- [x] Composite UNIQUE enforced: `(T1, proj-a)` and `(T1, proj-b)` both insert; duplicate `(T1, proj-a)` raises IntegrityError
- [x] Rollback on error: corrupt SQL leaves worker_states without project_id column

## Design notes

- Version 12 (not 10) used in `runtime_schema_version` — migration 0010 already occupies v10; using 12 avoids the collision while the branch name "schema-v10" refers to the product design version label
- `PRAGMA foreign_keys = OFF` during table-rebuild; restored to ON after COMMIT
- `INSERT INTO dispatches_v10 SELECT * FROM dispatches` — column order preserved; works because dispatches schema was already fixed at v10 shape via migration 0010

🤖 Generated with [Claude Code](https://claude.com/claude-code)