### PR TITLE
feat(wave5): PR-5.2 — per-project T0 lifecycle management (spawn/heartbeat/kill/reap)

### DIFF
--- a/schemas/migrations/0019_t0_lifecycle_tokens.sql
+++ b/schemas/migrations/0019_t0_lifecycle_tokens.sql
@@ -1,0 +1,66 @@
+-- VNX Migration 0019 — Wave 5 PR-5.2 T0 lifecycle tokens
+-- Purpose: Per-incarnation lease identification via lease_token (UUID v7).
+--
+-- Design: claudedocs/wave5-pr2-t0-lifecycle-redesign.md §3
+-- ADR: ADR-005 (audit-trail invariant), ADR-017 (Control Centre product-shape)
+--
+-- Pre-migration state (v12, after 0017): composite UNIQUE(terminal_id, project_id)
+--                                        on terminal_leases.
+--
+-- Post-migration state (v13):
+--   terminal_leases — adds lease_token TEXT NOT NULL DEFAULT '' column +
+--                     UNIQUE INDEX idx_terminal_leases_token WHERE lease_token != ''.
+--                     Backfill: existing leased rows get a token so they are
+--                     identifiable; released rows keep empty token.
+--
+-- Atomicity: single BEGIN/COMMIT transaction. FK enforcement suspended.
+--            On error, the uncommitted transaction is rolled back when the
+--            connection is closed.
+--
+-- Idempotency: guarded by the Python runner (scripts/lib/migrations/apply_0019.py)
+--              which checks runtime_schema_version before executing this script.
+--              The final INSERT OR IGNORE is a defence-in-depth guard only.
+--
+-- Applied by: scripts/lib/migrations/apply_0019.py
+-- Tested by:  tests/test_t0_lifecycle.py (via inline applier)
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN TRANSACTION;
+
+-- ============================================================================
+-- 1. terminal_leases: add lease_token column (additive, no table rebuild)
+-- ============================================================================
+
+ALTER TABLE terminal_leases ADD COLUMN lease_token TEXT NOT NULL DEFAULT '';
+
+-- ============================================================================
+-- 2. Partial UNIQUE index on non-empty tokens
+--    Empty string ('') = legacy rows or released rows; collisions allowed.
+--    Non-empty token = active per-incarnation identifier; must be globally unique.
+-- ============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_leases_token
+    ON terminal_leases(lease_token)
+    WHERE lease_token != '';
+
+-- ============================================================================
+-- 3. Backfill: stamp existing leased rows with a token so they are addressable.
+--    16 random hex bytes (32 chars) — forensic-distinct from the v7 format used
+--    by the application layer (which has timestamp-prefix structure).
+-- ============================================================================
+
+UPDATE terminal_leases
+SET lease_token = lower(hex(randomblob(16)))
+WHERE state = 'leased' AND lease_token = '';
+
+-- ============================================================================
+-- 4. Version stamp
+-- ============================================================================
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (13, 'Wave 5 PR-5.2: lease_token for per-incarnation lease identification');
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;

--- a/scripts/aggregator/t0_lifecycle.py
+++ b/scripts/aggregator/t0_lifecycle.py
@@ -584,6 +584,135 @@ class T0LifecycleManager:
         with self._lock:
             return self._spawn_locked(project_id, argv, project_root, env)
 
+    def _emit_spawn_requested(
+        self, project_id: str, lease_token: str, resolved_root: str
+    ) -> None:
+        try:
+            self._emit_event(
+                project_id,
+                "t0.spawn.requested",
+                {"lease_token": lease_token, "project_root": resolved_root},
+            )
+        except (OSError, RuntimeError, ValueError) as e:
+            raise T0AuditEmitError(
+                f"audit emit failed for t0.spawn.requested: {e}"
+            ) from e
+
+    def _check_no_active_lease(
+        self, conn: sqlite3.Connection, project_id: str
+    ) -> Optional[sqlite3.Row]:
+        """Validate no active lease. Returns prior row (for generation) or None.
+
+        Raises T0AlreadyRunningError if a leased row exists. Caller must hold
+        BEGIN EXCLUSIVE before calling.
+        """
+        existing = self._get_active_row(conn, project_id)
+        if existing is not None:
+            existing_meta = self._parse_metadata(existing["metadata_json"])
+            existing_pid = existing_meta.get("pid")
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("t0_lifecycle: ROLLBACK on AlreadyRunning suppressed")
+            raise T0AlreadyRunningError(project_id, existing_pid)
+        cur = conn.execute(
+            "SELECT generation FROM terminal_leases "
+            "WHERE terminal_id = ? AND project_id = ?",
+            (T0_TERMINAL, project_id),
+        )
+        return cur.fetchone()
+
+    def _start_subprocess_proc(
+        self,
+        argv: Optional[List[str]],
+        resolved_root: str,
+        env: Optional[Dict[str, str]],
+        conn: sqlite3.Connection,
+        project_id: str,
+    ) -> tuple:
+        """Spawn subprocess. Returns (proc, pid).
+
+        Raises T0SpawnFailedError on Popen failure or T0SubprocessExitedEarly
+        on early exit. Rolls back the open transaction on failure.
+        """
+        spawn_argv = argv or [sys.executable, "-c", "import time; time.sleep(60)"]
+        try:
+            proc = self._subprocess_factory(
+                spawn_argv,
+                cwd=resolved_root,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            pid = proc.pid
+        except OSError as e:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("t0_lifecycle: ROLLBACK on spawn OSError suppressed")
+            raise T0SpawnFailedError(
+                f"subprocess.Popen failed for {project_id}: {e}"
+            ) from e
+
+        time.sleep(0.05)
+        returncode = proc.poll()
+        if returncode is not None:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("t0_lifecycle: ROLLBACK on early-exit suppressed")
+            self._drain_zombie(pid)
+            raise T0SubprocessExitedEarly(returncode)
+
+        return proc, pid
+
+    def _write_lease_row(
+        self,
+        conn: sqlite3.Connection,
+        project_id: str,
+        prior: Optional[sqlite3.Row],
+        lease_token: str,
+        new_generation: int,
+        started_at: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        if prior is not None:
+            conn.execute(
+                "UPDATE terminal_leases SET "
+                "state = ?, generation = ?, lease_token = ?, "
+                "leased_at = ?, last_heartbeat_at = ?, released_at = NULL, "
+                "metadata_json = ? "
+                "WHERE terminal_id = ? AND project_id = ?",
+                (
+                    DB_STATE_LEASED,
+                    new_generation,
+                    lease_token,
+                    started_at,
+                    started_at,
+                    json.dumps(metadata),
+                    T0_TERMINAL,
+                    project_id,
+                ),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO terminal_leases "
+                "(terminal_id, project_id, state, generation, lease_token, "
+                " leased_at, last_heartbeat_at, metadata_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    T0_TERMINAL,
+                    project_id,
+                    DB_STATE_LEASED,
+                    new_generation,
+                    lease_token,
+                    started_at,
+                    started_at,
+                    json.dumps(metadata),
+                ),
+            )
+
     def _spawn_locked(
         self,
         project_id: str,
@@ -593,81 +722,17 @@ class T0LifecycleManager:
     ) -> T0Instance:
         lease_token = _new_lease_token()
         resolved_root = project_root or os.getcwd()
-
-        # Emit t0.spawn.requested BEFORE any DB-mutation or subprocess spawn,
-        # so a crash inside the EXCLUSIVE block leaves a forensic breadcrumb.
-        try:
-            self._emit_event(
-                project_id,
-                "t0.spawn.requested",
-                {
-                    "lease_token": lease_token,
-                    "project_root": resolved_root,
-                },
-            )
-        except (OSError, RuntimeError, ValueError) as e:
-            raise T0AuditEmitError(
-                f"audit emit failed for t0.spawn.requested: {e}"
-            ) from e
+        self._emit_spawn_requested(project_id, lease_token, resolved_root)
 
         conn = self._connect()
         proc: Optional[subprocess.Popen] = None
         pid: int = -1
         try:
             self._begin_exclusive_with_retry(conn)
-
-            existing = self._get_active_row(conn, project_id)
-            if existing is not None:
-                existing_meta = self._parse_metadata(existing["metadata_json"])
-                existing_pid = existing_meta.get("pid")
-                try:
-                    conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    log.debug("t0_lifecycle: ROLLBACK on AlreadyRunning suppressed")
-                raise T0AlreadyRunningError(project_id, existing_pid)
-
-            # Existing row may be in 'released' state; we will UPSERT.
-            cur = conn.execute(
-                "SELECT generation FROM terminal_leases "
-                "WHERE terminal_id = ? AND project_id = ?",
-                (T0_TERMINAL, project_id),
-            )
-            prior = cur.fetchone()
+            prior = self._check_no_active_lease(conn, project_id)
             new_generation = (prior["generation"] + 1) if prior else 1
 
-            # Spawn subprocess.
-            spawn_argv = argv or [sys.executable, "-c", "import time; time.sleep(60)"]
-            try:
-                proc = self._subprocess_factory(
-                    spawn_argv,
-                    cwd=resolved_root,
-                    env=env,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-                pid = proc.pid
-            except OSError as e:
-                try:
-                    conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    log.debug("t0_lifecycle: ROLLBACK on spawn OSError suppressed")
-                raise T0SpawnFailedError(
-                    f"subprocess.Popen failed for {project_id}: {e}"
-                ) from e
-
-            # Detect early-exit (exec failure, etc.).
-            time.sleep(0.05)
-            returncode = proc.poll()
-            if returncode is not None:
-                try:
-                    conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    log.debug("t0_lifecycle: ROLLBACK on early-exit suppressed")
-                # Try to drain in case of zombie.
-                self._drain_zombie(pid)
-                raise T0SubprocessExitedEarly(returncode)
-
+            proc, pid = self._start_subprocess_proc(argv, resolved_root, env, conn, project_id)
             started_at = _now_iso()
             metadata = {
                 "pid": pid,
@@ -676,48 +741,14 @@ class T0LifecycleManager:
                 "lifecycle_state": LIFECYCLE_RUNNING,
                 "lease_token": lease_token,
             }
-
-            if prior is not None:
-                conn.execute(
-                    "UPDATE terminal_leases SET "
-                    "state = ?, generation = ?, lease_token = ?, "
-                    "leased_at = ?, last_heartbeat_at = ?, released_at = NULL, "
-                    "metadata_json = ? "
-                    "WHERE terminal_id = ? AND project_id = ?",
-                    (
-                        DB_STATE_LEASED,
-                        new_generation,
-                        lease_token,
-                        started_at,
-                        started_at,
-                        json.dumps(metadata),
-                        T0_TERMINAL,
-                        project_id,
-                    ),
-                )
-            else:
-                conn.execute(
-                    "INSERT INTO terminal_leases "
-                    "(terminal_id, project_id, state, generation, lease_token, "
-                    " leased_at, last_heartbeat_at, metadata_json) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        T0_TERMINAL,
-                        project_id,
-                        DB_STATE_LEASED,
-                        new_generation,
-                        lease_token,
-                        started_at,
-                        started_at,
-                        json.dumps(metadata),
-                    ),
-                )
+            self._write_lease_row(
+                conn, project_id, prior, lease_token, new_generation, started_at, metadata
+            )
 
             committed_pid = pid
 
             def _rollback_subprocess() -> None:
                 self._force_kill_subprocess(committed_pid)
-                # Best-effort spawn-aborted audit so forensics knows why.
                 try:
                     self._emit_event(
                         project_id,
@@ -730,9 +761,7 @@ class T0LifecycleManager:
                         },
                     )
                 except Exception as e:  # noqa: BLE001 — best-effort
-                    log.error(
-                        "t0_lifecycle: spawn.aborted emit failed: %s", e
-                    )
+                    log.error("t0_lifecycle: spawn.aborted emit failed: %s", e)
 
             self._commit_with_audit(
                 conn,
@@ -748,7 +777,6 @@ class T0LifecycleManager:
                 rollback_action=_rollback_subprocess,
             )
 
-            # Retain Popen handle so we can call waitpid as the actual parent.
             if proc is not None:
                 self._popen_handles[lease_token] = proc
 
@@ -879,116 +907,109 @@ class T0LifecycleManager:
     def kill(
         self,
         project_id: str,
-        pid: int,
         lease_token: str,
         *,
         signal_type: int = signal.SIGTERM,
         wait_timeout: Optional[float] = None,
         source: str = "operator",
     ) -> KillResult:
-        """Terminate a specific T0 incarnation.
+        """Terminate a specific T0 incarnation identified by lease_token.
 
-        Sequence: TERMINATING state → signal → wait → verify dead → release.
-        Lease is released ONLY after ProcessLookupError confirms process death.
+        PID is sourced from metadata_json.pid (source of truth) — caller
+        supplies only the lease_token to address this incarnation.
+        Sequence: TERMINATING → signal → wait → verify dead → release.
+        Lease is released ONLY after process death is verified.
         """
         with self._lock:
             return self._kill_locked(
                 project_id,
-                pid,
                 lease_token,
                 signal_type=signal_type,
                 wait_timeout=wait_timeout,
                 source=source,
             )
 
-    def _kill_locked(
+    def _kill_acquire_lease(
+        self,
+        conn: sqlite3.Connection,
+        project_id: str,
+        lease_token: str,
+        signal_type: int,
+        source: str,
+    ) -> tuple:
+        """BEGIN + validate token + transition TERMINATING + commit audit.
+
+        Returns (stored_pid, None) on success.
+        Returns (-1, KillResult) when no active lease exists.
+        Raises LeaseTokenMismatchError on token mismatch.
+        """
+        conn.execute("BEGIN")
+        row = self._get_active_row(conn, project_id)
+        if row is None:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("kill: ROLLBACK on no-active-lease suppressed")
+            return -1, KillResult(
+                project_id=project_id, lease_token=lease_token, pid=-1, error="no_active_lease"
+            )
+
+        db_token = row["lease_token"] or ""
+        if db_token != lease_token:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("kill: ROLLBACK on token-mismatch suppressed")
+            raise LeaseTokenMismatchError(project_id, lease_token, db_token)
+
+        meta = self._parse_metadata(row["metadata_json"])
+        stored_pid = meta.get("pid", -1)
+        meta["lifecycle_state"] = LIFECYCLE_TERMINATING
+        meta["kill_signal_sent_at"] = _now_iso()
+        meta["kill_initiated_by"] = source
+        conn.execute(
+            "UPDATE terminal_leases SET metadata_json = ? "
+            "WHERE terminal_id = ? AND project_id = ? AND lease_token = ?",
+            (json.dumps(meta), T0_TERMINAL, project_id, lease_token),
+        )
+        self._commit_with_audit(
+            conn,
+            project_id,
+            "t0.kill.requested",
+            {
+                "lease_token": lease_token,
+                "pid": stored_pid,
+                "signal_type": int(signal_type),
+                "source": source,
+            },
+        )
+        return stored_pid, None
+
+    def _kill_signal_phase(
         self,
         project_id: str,
-        pid: int,
         lease_token: str,
-        *,
+        pid: int,
         signal_type: int,
-        wait_timeout: Optional[float],
-        source: str,
-    ) -> KillResult:
-        started_ms = _now_ms()
-        wait = wait_timeout if wait_timeout is not None else self._kill_wait_timeout_seconds
+        wait: float,
+        result: KillResult,
+    ) -> bool:
+        """Send signal, wait, escalate to SIGKILL if needed.
 
-        conn = self._connect()
-        try:
-            conn.execute("BEGIN")
-            row = self._get_active_row(conn, project_id)
-            if row is None:
-                try:
-                    conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    log.debug("kill: ROLLBACK on no-active-lease suppressed")
-                return KillResult(
-                    project_id=project_id,
-                    lease_token=lease_token,
-                    pid=pid,
-                    error="no_active_lease",
-                )
-
-            db_token = row["lease_token"] or ""
-            if db_token != lease_token:
-                try:
-                    conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    log.debug("kill: ROLLBACK on token-mismatch suppressed")
-                raise LeaseTokenMismatchError(project_id, lease_token, db_token)
-
-            # Transition to TERMINATING (persist via metadata_json).
-            meta = self._parse_metadata(row["metadata_json"])
-            meta["lifecycle_state"] = LIFECYCLE_TERMINATING
-            meta["kill_signal_sent_at"] = _now_iso()
-            meta["kill_initiated_by"] = source
-            conn.execute(
-                "UPDATE terminal_leases SET metadata_json = ? "
-                "WHERE terminal_id = ? AND project_id = ? AND lease_token = ?",
-                (json.dumps(meta), T0_TERMINAL, project_id, lease_token),
-            )
-
-            self._commit_with_audit(
-                conn,
-                project_id,
-                "t0.kill.requested",
-                {
-                    "lease_token": lease_token,
-                    "pid": pid,
-                    "signal_type": int(signal_type),
-                    "source": source,
-                },
-            )
-        finally:
-            conn.close()
-
-        # Signal phase — outside transaction.
-        result = KillResult(
-            project_id=project_id,
-            lease_token=lease_token,
-            pid=pid,
-        )
-
+        Mutates result fields. Returns True if process is still alive after
+        all wait windows (caller should return without releasing the lease).
+        """
         outcome = self._signal_process(pid, signal_type)
         if outcome == "permission_denied":
             self._emit_event(
                 project_id,
                 "t0.kill.permission_denied",
-                {
-                    "lease_token": lease_token,
-                    "pid": pid,
-                    "errno": errno.EPERM,
-                },
+                {"lease_token": lease_token, "pid": pid, "errno": errno.EPERM},
             )
             result.error = "permission_denied"
-            result.duration_ms = _now_ms() - started_ms
-            return result
+            return True
 
-        if outcome == "already_dead":
-            # Skip signal phase, go straight to verify+release.
-            result.signaled = False
-        else:
+        if outcome != "already_dead":
             result.signaled = True
             self._emit_event(
                 project_id,
@@ -1000,55 +1021,49 @@ class T0LifecycleManager:
                     "escalation": False,
                 },
             )
-
-            # Wait for exit.
             exited = self._wait_for_exit(pid, wait, lease_token=lease_token)
-            if not exited:
-                if signal_type == signal.SIGTERM:
-                    # Escalate to SIGKILL.
-                    result.escalated_to_sigkill = True
-                    escalate_outcome = self._signal_process(pid, signal.SIGKILL)
-                    if escalate_outcome == "sent":
-                        self._emit_event(
-                            project_id,
-                            "t0.kill.signaled",
-                            {
-                                "lease_token": lease_token,
-                                "pid": pid,
-                                "signal_type": int(signal.SIGKILL),
-                                "escalation": True,
-                            },
-                        )
-                        self._wait_for_exit(
-                            pid,
-                            self._sigkill_wait_timeout_seconds,
-                            lease_token=lease_token,
-                        )
+            if not exited and signal_type == signal.SIGTERM:
+                result.escalated_to_sigkill = True
+                if self._signal_process(pid, signal.SIGKILL) == "sent":
+                    self._emit_event(
+                        project_id,
+                        "t0.kill.signaled",
+                        {
+                            "lease_token": lease_token,
+                            "pid": pid,
+                            "signal_type": int(signal.SIGKILL),
+                            "escalation": True,
+                        },
+                    )
+                    self._wait_for_exit(
+                        pid, self._sigkill_wait_timeout_seconds, lease_token=lease_token
+                    )
 
-        # Verify death.
         if self._is_alive(pid, lease_token=lease_token):
-            result.error = (
-                "sigkill_zombie"
-                if result.escalated_to_sigkill
-                else "alive_after_wait"
-            )
-            result.duration_ms = _now_ms() - started_ms
+            err = "sigkill_zombie" if result.escalated_to_sigkill else "alive_after_wait"
+            result.error = err
             self._emit_event(
                 project_id,
                 "t0.error.kill",
                 {
                     "lease_token": lease_token,
                     "pid": pid,
-                    "error_type": result.error,
+                    "error_type": err,
                     "message": "process still alive after wait window",
                 },
             )
-            return result
+            return True
+        return False
 
-        result.verified_dead = True
-        self._drain_zombie(pid, lease_token=lease_token)
-
-        # Final release transaction.
+    def _kill_release(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+        result: KillResult,
+        started_ms: int,
+    ) -> None:
+        """Final release transaction after verified process death."""
         conn = self._connect()
         try:
             conn.execute("BEGIN")
@@ -1059,7 +1074,7 @@ class T0LifecycleManager:
                 except sqlite3.Error:
                     log.debug("kill: ROLLBACK on already-released suppressed")
                 result.duration_ms = _now_ms() - started_ms
-                return result
+                return
 
             meta = self._parse_metadata(row["metadata_json"])
             meta["lifecycle_state"] = LIFECYCLE_REAPED
@@ -1067,15 +1082,8 @@ class T0LifecycleManager:
             conn.execute(
                 "UPDATE terminal_leases SET state = ?, released_at = ?, metadata_json = ? "
                 "WHERE terminal_id = ? AND lease_token = ?",
-                (
-                    DB_STATE_RELEASED,
-                    meta["reaped_at"],
-                    json.dumps(meta),
-                    T0_TERMINAL,
-                    lease_token,
-                ),
+                (DB_STATE_RELEASED, meta["reaped_at"], json.dumps(meta), T0_TERMINAL, lease_token),
             )
-
             result.duration_ms = _now_ms() - started_ms
             self._commit_with_audit(
                 conn,
@@ -1090,9 +1098,45 @@ class T0LifecycleManager:
             )
             result.lease_released = True
             self._release_popen_handle(lease_token)
-            return result
         finally:
             conn.close()
+
+    def _kill_locked(
+        self,
+        project_id: str,
+        lease_token: str,
+        *,
+        signal_type: int,
+        wait_timeout: Optional[float],
+        source: str,
+    ) -> KillResult:
+        started_ms = _now_ms()
+        wait = wait_timeout if wait_timeout is not None else self._kill_wait_timeout_seconds
+
+        conn = self._connect()
+        try:
+            stored_pid, error_result = self._kill_acquire_lease(
+                conn, project_id, lease_token, signal_type, source
+            )
+        finally:
+            conn.close()
+
+        if error_result is not None:
+            return error_result
+
+        result = KillResult(project_id=project_id, lease_token=lease_token, pid=stored_pid)
+
+        still_alive = self._kill_signal_phase(
+            project_id, lease_token, stored_pid, signal_type, wait, result
+        )
+        if still_alive:
+            result.duration_ms = _now_ms() - started_ms
+            return result
+
+        result.verified_dead = True
+        self._drain_zombie(stored_pid, lease_token=lease_token)
+        self._kill_release(project_id, lease_token, stored_pid, result, started_ms)
+        return result
 
     # ------------------------------------------------------------------
     # Public API: force_release_lease (operator escape hatch)
@@ -1221,22 +1265,21 @@ class T0LifecycleManager:
 
         return results
 
-    def _reap_one(self, cand: Dict[str, Any], threshold: int) -> ReapResult:
-        project_id = cand["project_id"]
-        lease_token = cand["lease_token"]
-        pid = cand["pid"]
-
-        # Emit stale.detected before any action.
+    def _reap_emit_stale(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+        last_heartbeat_ms: int,
+    ) -> Optional[ReapResult]:
+        """Emit t0.stale.detected. Returns error ReapResult on failure, else None."""
         try:
             self._emit_event(
                 project_id,
                 "t0.stale.detected",
-                {
-                    "lease_token": lease_token,
-                    "pid": pid,
-                    "last_heartbeat_ms": cand["last_heartbeat_ms"],
-                },
+                {"lease_token": lease_token, "pid": pid, "last_heartbeat_ms": last_heartbeat_ms},
             )
+            return None
         except (OSError, RuntimeError, ValueError) as e:
             log.error("reap: stale.detected emit failed: %s", e)
             return ReapResult(
@@ -1247,12 +1290,19 @@ class T0LifecycleManager:
                 error=f"audit_emit_failed: {e}",
             )
 
-        # Liveness check.
+    def _reap_liveness(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+    ) -> tuple:
+        """Liveness probe. Returns (alive: bool, error_result: Optional[ReapResult])."""
         try:
             alive = self._is_alive(pid, lease_token=lease_token) if pid > 0 else False
+            return alive, None
         except OSError as e:
             log.error("reap: liveness check failed for pid=%s: %s", pid, e)
-            return ReapResult(
+            return False, ReapResult(
                 project_id=project_id,
                 lease_token=lease_token,
                 pid=pid,
@@ -1260,11 +1310,18 @@ class T0LifecycleManager:
                 error=f"liveness_check_failed: {e}",
             )
 
-        if not alive:
-            # Already-dead path: emit reap.completed + release lease.
-            return self._reap_release_dead(project_id, lease_token, pid)
+    def _reap_check_fresh_heartbeat(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+        threshold: int,
+    ) -> Optional[ReapResult]:
+        """Re-check heartbeat for alive process.
 
-        # Alive: re-check heartbeat (may have refreshed).
+        Returns refuted_alive ReapResult if heartbeat refreshed, error ReapResult
+        if lease row is missing, or None (still stale — proceed to kill).
+        """
         conn = self._connect()
         try:
             cur = conn.execute(
@@ -1288,7 +1345,6 @@ class T0LifecycleManager:
         fresh_hb = _parse_iso(row["last_heartbeat_at"] or "")
         fresh_ms = int(fresh_hb.timestamp() * 1000) if fresh_hb else 0
         if fresh_ms >= threshold:
-            # Heartbeat caught up: refuted_alive.
             try:
                 self._emit_event(
                     project_id,
@@ -1303,8 +1359,15 @@ class T0LifecycleManager:
                 pid=pid,
                 classification="refuted_alive",
             )
+        return None
 
-        # Alive + still stale: run kill() as if operator triggered it.
+    def _reap_kill_stale(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+    ) -> ReapResult:
+        """Kill an alive + still-stale lease via _kill_locked."""
         try:
             self._emit_event(
                 project_id,
@@ -1317,14 +1380,12 @@ class T0LifecycleManager:
         try:
             kr = self._kill_locked(
                 project_id,
-                pid,
                 lease_token,
                 signal_type=signal.SIGTERM,
                 wait_timeout=self._kill_wait_timeout_seconds,
                 source="reap",
             )
         except LeaseTokenMismatchError as e:
-            # Successor lease was spawned concurrently; abandon this iteration.
             return ReapResult(
                 project_id=project_id,
                 lease_token=lease_token,
@@ -1332,7 +1393,6 @@ class T0LifecycleManager:
                 classification="error",
                 error=f"token_mismatch: {e}",
             )
-
         return ReapResult(
             project_id=project_id,
             lease_token=lease_token,
@@ -1341,6 +1401,28 @@ class T0LifecycleManager:
             lease_released=kr.lease_released,
             error=kr.error,
         )
+
+    def _reap_one(self, cand: Dict[str, Any], threshold: int) -> ReapResult:
+        project_id = cand["project_id"]
+        lease_token = cand["lease_token"]
+        pid = cand["pid"]
+
+        err = self._reap_emit_stale(project_id, lease_token, pid, cand["last_heartbeat_ms"])
+        if err is not None:
+            return err
+
+        alive, err = self._reap_liveness(project_id, lease_token, pid)
+        if err is not None:
+            return err
+
+        if not alive:
+            return self._reap_release_dead(project_id, lease_token, pid)
+
+        stale_result = self._reap_check_fresh_heartbeat(project_id, lease_token, pid, threshold)
+        if stale_result is not None:
+            return stale_result
+
+        return self._reap_kill_stale(project_id, lease_token, pid)
 
     def _reap_release_dead(
         self,

--- a/scripts/aggregator/t0_lifecycle.py
+++ b/scripts/aggregator/t0_lifecycle.py
@@ -1,0 +1,1407 @@
+"""t0_lifecycle.py — Wave 5 PR-5.2: per-project T0 lifecycle management.
+
+Clean redesign per claudedocs/wave5-pr2-t0-lifecycle-redesign.md (architect spec).
+
+Replaces ad-hoc lease-mutation-as-process-control with an explicit state machine
+that separates lease-state (SQLite row) from process-state (POSIX PID) and ties
+every transition to a per-incarnation `lease_token` (UUID v7).
+
+Public surface:
+    - T0LifecycleManager: spawn, heartbeat, kill, reap_dead_t0s,
+                          list_running, force_release_lease
+    - T0Instance: dataclass returned by spawn()
+    - KillResult: dataclass returned by kill()
+    - ReapResult: dataclass returned per row by reap_dead_t0s()
+    - LeaseTokenMismatchError: raised when an operation targets a stale lease
+
+Lifecycle states (projected via metadata_json.lifecycle_state):
+    PENDING → RUNNING → STALE → TERMINATING → REAPED
+
+Only RUNNING, TERMINATING, REAPED are persisted; PENDING and STALE are
+in-memory classifications. The SQLite `state` column stays in the
+'leased' | 'released' enum (schema-compat with runtime_core_cli).
+
+ADR-005 invariant: every state mutation emits a structured audit event BEFORE
+the COMMIT. If the audit emit fails, the transaction is rolled back and any
+external side-effect (subprocess spawn) is cleaned up via rollback_action.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from .state_aggregator import ProjectStateUpdate, StateAggregator
+
+log = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+T0_TERMINAL = "T0"
+
+# Lifecycle state strings stored in metadata_json.lifecycle_state.
+LIFECYCLE_PENDING = "PENDING"
+LIFECYCLE_RUNNING = "RUNNING"
+LIFECYCLE_STALE = "STALE"
+LIFECYCLE_TERMINATING = "TERMINATING"
+LIFECYCLE_REAPED = "REAPED"
+
+# SQLite state column values (schema-compat with other terminal_leases consumers).
+DB_STATE_LEASED = "leased"
+DB_STATE_RELEASED = "released"
+
+# Default tuning.
+DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 60.0
+DEFAULT_KILL_WAIT_TIMEOUT_SECONDS = 10.0
+DEFAULT_SIGKILL_WAIT_TIMEOUT_SECONDS = 5.0
+DEFAULT_DB_CONNECT_TIMEOUT_SECONDS = 10.0
+
+# Exponential backoff for BEGIN EXCLUSIVE contention.
+_DB_BACKOFF_DELAYS = (0.5, 1.0, 2.0, 4.0)
+
+
+# ----------------------------------------------------------------------------
+# Exceptions
+# ----------------------------------------------------------------------------
+
+
+class T0LifecycleError(RuntimeError):
+    """Base for all T0 lifecycle exceptions."""
+
+
+class T0AlreadyRunningError(T0LifecycleError):
+    """Raised when spawn() is called for a project that already has a leased T0."""
+
+    def __init__(self, project_id: str, pid: Optional[int] = None) -> None:
+        super().__init__(
+            f"T0 for project {project_id!r} is already leased"
+            + (f" (pid={pid})" if pid else "")
+        )
+        self.project_id = project_id
+        self.pid = pid
+
+
+class T0SpawnFailedError(T0LifecycleError):
+    """Raised when subprocess.Popen fails or exits before lease commit."""
+
+
+class T0SubprocessExitedEarly(T0SpawnFailedError):
+    """Subprocess exited before the spawn transaction committed."""
+
+    def __init__(self, returncode: int) -> None:
+        super().__init__(f"T0 subprocess exited early with returncode={returncode}")
+        self.returncode = returncode
+
+
+class T0AuditEmitError(T0LifecycleError):
+    """Raised when the aggregator-emit step inside _commit_with_audit fails.
+
+    The transaction has been rolled back; any rollback_action has been run.
+    """
+
+
+class T0SpawnContentionError(T0LifecycleError):
+    """Raised when BEGIN EXCLUSIVE cannot acquire the DB after retry budget."""
+
+
+class LeaseTokenMismatchError(T0LifecycleError):
+    """Raised when a kill/force_release operation targets a stale lease_token.
+
+    Means: a successor lease has replaced the lease the caller thought it
+    owned. Caller should refresh state and decide whether to abort or retarget.
+    """
+
+    def __init__(self, project_id: str, expected: str, actual: str) -> None:
+        super().__init__(
+            f"lease_token mismatch for project {project_id!r}: "
+            f"caller expected {expected[:16]}..., DB has {actual[:16]}..."
+        )
+        self.project_id = project_id
+        self.expected = expected
+        self.actual = actual
+
+
+# ----------------------------------------------------------------------------
+# Dataclasses
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class T0Instance:
+    """Return value of T0LifecycleManager.spawn().
+
+    Caller persists `lease_token` to address this specific incarnation in
+    subsequent heartbeat/kill calls.
+    """
+
+    project_id: str
+    pid: int
+    lease_token: str
+    generation: int
+    started_at: str
+    project_root: str
+    lifecycle_state: str = LIFECYCLE_RUNNING
+
+
+@dataclass
+class KillResult:
+    """Return value of T0LifecycleManager.kill().
+
+    Replaces a bool return — every kill path produces an explicit, structured
+    outcome. Callers must check `verified_dead` (not `signaled`) to know
+    whether the lease has been released.
+    """
+
+    project_id: str
+    lease_token: str
+    pid: int
+    signaled: bool = False
+    verified_dead: bool = False
+    lease_released: bool = False
+    escalated_to_sigkill: bool = False
+    error: Optional[str] = None
+    duration_ms: Optional[int] = None
+
+
+@dataclass
+class ReapResult:
+    """Return value (per stale lease) of T0LifecycleManager.reap_dead_t0s()."""
+
+    project_id: str
+    lease_token: str
+    pid: Optional[int]
+    classification: str  # "already_dead" | "killed_by_reap" | "refuted_alive" | "error"
+    lease_released: bool = False
+    error: Optional[str] = None
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _now_ms() -> int:
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _new_lease_token() -> str:
+    """UUID v7-ish: time-ordered prefix + random suffix.
+
+    Format: <12 hex unix-ms>-<20 hex random>. 33 chars total (32 hex + 1 dash).
+    Sort-stable by timestamp prefix; collision-resistant by random suffix.
+    """
+    ts_ms = _now_ms()
+    return f"{ts_ms:012x}-{uuid.uuid4().hex[:20]}"
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    """Parse ISO 8601 timestamp; return None on failure."""
+    if not ts:
+        return None
+    try:
+        # Handle trailing Z
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+# ----------------------------------------------------------------------------
+# T0LifecycleManager
+# ----------------------------------------------------------------------------
+
+
+class T0LifecycleManager:
+    """Manages per-project T0 process lifecycle with explicit state machine.
+
+    Construction REQUIRES a StateAggregator instance — no silent fallback to
+    logging. ADR-005 invariant demands every mutation has an audit record.
+    """
+
+    def __init__(
+        self,
+        coord_db_path: Path,
+        aggregator: StateAggregator,
+        *,
+        heartbeat_timeout_seconds: float = DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
+        kill_wait_timeout_seconds: float = DEFAULT_KILL_WAIT_TIMEOUT_SECONDS,
+        sigkill_wait_timeout_seconds: float = DEFAULT_SIGKILL_WAIT_TIMEOUT_SECONDS,
+        db_connect_timeout_seconds: float = DEFAULT_DB_CONNECT_TIMEOUT_SECONDS,
+        subprocess_factory: Optional[Callable[..., subprocess.Popen]] = None,
+    ) -> None:
+        if aggregator is None:
+            raise ValueError(
+                "T0LifecycleManager requires a StateAggregator instance "
+                "(ADR-005: every mutation needs an audit record)."
+            )
+
+        self._db_path = Path(coord_db_path)
+        self._aggregator = aggregator
+        self._heartbeat_timeout_seconds = float(heartbeat_timeout_seconds)
+        self._kill_wait_timeout_seconds = float(kill_wait_timeout_seconds)
+        self._sigkill_wait_timeout_seconds = float(sigkill_wait_timeout_seconds)
+        self._db_connect_timeout_seconds = float(db_connect_timeout_seconds)
+        self._subprocess_factory = subprocess_factory or subprocess.Popen
+        self._lock = threading.Lock()
+        # Retained Popen handles indexed by lease_token. Used for waitpid
+        # zombie drain by the parent process (mgr is the Popen parent).
+        # Released when the lease is reaped/released.
+        self._popen_handles: Dict[str, subprocess.Popen] = {}
+
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self._db_path),
+            timeout=self._db_connect_timeout_seconds,
+            isolation_level=None,  # explicit transaction control
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _begin_exclusive_with_retry(self, conn: sqlite3.Connection) -> None:
+        """BEGIN EXCLUSIVE with exponential backoff on cross-process contention."""
+        last_err: Optional[sqlite3.OperationalError] = None
+        for attempt, delay in enumerate(_DB_BACKOFF_DELAYS):
+            try:
+                conn.execute("BEGIN EXCLUSIVE")
+                return
+            except sqlite3.OperationalError as e:
+                last_err = e
+                if "locked" not in str(e).lower():
+                    raise
+                if attempt < len(_DB_BACKOFF_DELAYS) - 1:
+                    time.sleep(delay)
+                    continue
+                break
+        raise T0SpawnContentionError(
+            f"DB contention after {len(_DB_BACKOFF_DELAYS)} attempts"
+        ) from last_err
+
+    # ------------------------------------------------------------------
+    # Audit-event helpers
+    # ------------------------------------------------------------------
+
+    def _emit_event(
+        self,
+        project_id: str,
+        event_type: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        """Emit an audit event via the aggregator.
+
+        Raises on aggregator failure — caller (_commit_with_audit) handles
+        the rollback path.
+        """
+        update = ProjectStateUpdate(
+            project_id=project_id,
+            timestamp=_now_iso(),
+            event_type=event_type,
+            payload=payload,
+            source_t0=T0_TERMINAL,
+        )
+        self._aggregator.submit(update)
+
+    def _commit_with_audit(
+        self,
+        conn: sqlite3.Connection,
+        project_id: str,
+        event_type: str,
+        payload: Dict[str, Any],
+        *,
+        rollback_action: Optional[Callable[[], None]] = None,
+    ) -> None:
+        """Emit audit event BEFORE COMMIT.
+
+        On audit-emit failure: ROLLBACK, run rollback_action (if any), then
+        raise T0AuditEmitError. ADR-005 invariant: no DB mutation without
+        a corresponding audit record.
+        """
+        try:
+            self._emit_event(project_id, event_type, payload)
+        except (OSError, RuntimeError, ValueError) as e:
+            log.error(
+                "t0_lifecycle: audit emit failed (event=%s project=%s): %s; rolling back",
+                event_type,
+                project_id,
+                e,
+            )
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error as rollback_err:
+                log.error("t0_lifecycle: ROLLBACK also failed: %s", rollback_err)
+            if rollback_action is not None:
+                try:
+                    rollback_action()
+                except Exception as ra_err:  # noqa: BLE001 — bounded cleanup
+                    log.error(
+                        "t0_lifecycle: rollback_action failed: %s", ra_err
+                    )
+            raise T0AuditEmitError(
+                f"audit emit failed for {event_type}: {e}"
+            ) from e
+
+        try:
+            conn.execute("COMMIT")
+        except sqlite3.Error as e:
+            log.error("t0_lifecycle: COMMIT failed after audit emit: %s", e)
+            if rollback_action is not None:
+                try:
+                    rollback_action()
+                except Exception as ra_err:  # noqa: BLE001
+                    log.error(
+                        "t0_lifecycle: rollback_action failed after commit error: %s",
+                        ra_err,
+                    )
+            raise
+
+    # ------------------------------------------------------------------
+    # Lease-row helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_metadata(metadata_raw: Optional[str]) -> Dict[str, Any]:
+        if not metadata_raw:
+            return {}
+        try:
+            return json.loads(metadata_raw)
+        except (json.JSONDecodeError, TypeError):
+            log.warning("t0_lifecycle: corrupt metadata_json, treating as empty")
+            return {}
+
+    def _get_active_row(
+        self,
+        conn: sqlite3.Connection,
+        project_id: str,
+    ) -> Optional[sqlite3.Row]:
+        cur = conn.execute(
+            "SELECT * FROM terminal_leases "
+            "WHERE terminal_id = ? AND project_id = ? AND state = ?",
+            (T0_TERMINAL, project_id, DB_STATE_LEASED),
+        )
+        return cur.fetchone()
+
+    def _get_row_by_token(
+        self,
+        conn: sqlite3.Connection,
+        lease_token: str,
+    ) -> Optional[sqlite3.Row]:
+        if not lease_token:
+            return None
+        cur = conn.execute(
+            "SELECT * FROM terminal_leases "
+            "WHERE terminal_id = ? AND lease_token = ?",
+            (T0_TERMINAL, lease_token),
+        )
+        return cur.fetchone()
+
+    # ------------------------------------------------------------------
+    # Subprocess helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _signal_process(pid: int, sig: int) -> str:
+        """Send a signal to pid. Returns outcome marker:
+        'sent' | 'already_dead' | 'permission_denied' | 'error:<errno>'.
+        """
+        try:
+            os.kill(pid, sig)
+            return "sent"
+        except ProcessLookupError:
+            return "already_dead"
+        except PermissionError:
+            return "permission_denied"
+        except OSError as e:
+            if e.errno == errno.ESRCH:
+                return "already_dead"
+            if e.errno == errno.EPERM:
+                return "permission_denied"
+            return f"error:{e.errno}"
+
+    def _is_alive(self, pid: int, lease_token: Optional[str] = None) -> bool:
+        """Liveness probe. True iff process is running (not a zombie).
+
+        When a retained Popen handle exists for lease_token, prefer Popen.poll()
+        — it reaps zombies and returns the returncode, so we can distinguish
+        "still running" from "zombie not yet reaped". For unowned pids, falls
+        back to os.kill(pid, 0) (which considers zombies as alive).
+        """
+        if lease_token and lease_token in self._popen_handles:
+            proc = self._popen_handles[lease_token]
+            try:
+                return proc.poll() is None
+            except OSError as e:
+                log.debug("_is_alive: Popen.poll failed for pid=%s: %s", pid, e)
+                # Fall through to os.kill check.
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Process exists but we don't own it.
+            return True
+        except OSError as e:
+            if e.errno == errno.ESRCH:
+                return False
+            if e.errno == errno.EPERM:
+                return True
+            raise
+
+    def _wait_for_exit(
+        self,
+        pid: int,
+        timeout_seconds: float,
+        lease_token: Optional[str] = None,
+    ) -> bool:
+        """Poll for process exit. Returns True if exited within timeout."""
+        # When we own the Popen, use Popen.wait directly — reaps the zombie
+        # and is the only correct way for start_new_session children.
+        if lease_token and lease_token in self._popen_handles:
+            proc = self._popen_handles[lease_token]
+            try:
+                proc.wait(timeout=max(0.0, timeout_seconds))
+                return True
+            except subprocess.TimeoutExpired:
+                return False
+            except OSError as e:
+                log.debug("_wait_for_exit: Popen.wait failed for pid=%s: %s", pid, e)
+                # Fall through to polling.
+
+        deadline = time.monotonic() + max(0.0, timeout_seconds)
+        poll_interval = 0.1
+        while time.monotonic() < deadline:
+            if not self._is_alive(pid, lease_token):
+                return True
+            time.sleep(poll_interval)
+        return not self._is_alive(pid, lease_token)
+
+    def _drain_zombie(self, pid: int, lease_token: Optional[str] = None) -> None:
+        """waitpid(pid, WNOHANG) to drain zombie if we are the parent.
+
+        When the lease_token has a retained Popen handle (from spawn()), use
+        Popen.poll() / Popen.wait() so the child is reaped via the Popen
+        machinery — this is the only reliable path when start_new_session
+        decoupled the OS-level process group.
+
+        Silently ignores ChildProcessError (not our child) and other OS errors —
+        the OS will reap unowned children eventually.
+        """
+        # Prefer Popen.wait / poll if we own the handle.
+        if lease_token and lease_token in self._popen_handles:
+            proc = self._popen_handles[lease_token]
+            try:
+                # poll() is non-blocking. If returncode is set, the child is reaped.
+                proc.poll()
+                if proc.returncode is None:
+                    # Best-effort short wait — caller already verified death.
+                    try:
+                        proc.wait(timeout=0.5)
+                    except subprocess.TimeoutExpired:
+                        log.debug(
+                            "t0_lifecycle: Popen.wait timed out for pid=%s", pid
+                        )
+            except OSError as e:
+                log.debug(
+                    "t0_lifecycle: Popen.poll/wait failed for pid=%s: %s", pid, e
+                )
+            return
+
+        try:
+            os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            log.debug("t0_lifecycle: pid=%s not our child, skip waitpid", pid)
+        except OSError as e:
+            log.debug("t0_lifecycle: waitpid(%s) failed: %s", pid, e)
+
+    def _release_popen_handle(self, lease_token: str) -> None:
+        """Discard the Popen handle for a released lease."""
+        self._popen_handles.pop(lease_token, None)
+
+    def _force_kill_subprocess(self, pid: int) -> None:
+        """Best-effort cleanup path used by spawn rollback.
+
+        Escalates SIGTERM → wait → SIGKILL → wait → waitpid. No exceptions
+        propagate; the caller is already in an error path.
+        """
+        if pid <= 0:
+            return
+        try:
+            outcome = self._signal_process(pid, signal.SIGTERM)
+            if outcome == "sent":
+                self._wait_for_exit(pid, self._sigkill_wait_timeout_seconds)
+            if self._is_alive(pid):
+                self._signal_process(pid, signal.SIGKILL)
+                self._wait_for_exit(pid, self._sigkill_wait_timeout_seconds)
+            self._drain_zombie(pid)
+        except Exception as e:  # noqa: BLE001 — bounded cleanup path
+            log.error("t0_lifecycle: rollback subprocess kill failed: %s", e)
+
+    # ------------------------------------------------------------------
+    # Public API: spawn
+    # ------------------------------------------------------------------
+
+    def spawn(
+        self,
+        project_id: str,
+        *,
+        argv: Optional[List[str]] = None,
+        project_root: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> T0Instance:
+        """Spawn a T0 worker subprocess for project_id.
+
+        Invariant: a successful spawn yields exactly one (terminal_id="T0",
+        project_id) row in `leased` state with a fresh lease_token, an audit
+        trail of two events (t0.spawn.requested + t0.spawn.committed), and a
+        live subprocess whose pid matches metadata_json.pid.
+
+        Failure paths leave no orphan rows or processes.
+        """
+        with self._lock:
+            return self._spawn_locked(project_id, argv, project_root, env)
+
+    def _spawn_locked(
+        self,
+        project_id: str,
+        argv: Optional[List[str]],
+        project_root: Optional[str],
+        env: Optional[Dict[str, str]],
+    ) -> T0Instance:
+        lease_token = _new_lease_token()
+        resolved_root = project_root or os.getcwd()
+
+        # Emit t0.spawn.requested BEFORE any DB-mutation or subprocess spawn,
+        # so a crash inside the EXCLUSIVE block leaves a forensic breadcrumb.
+        try:
+            self._emit_event(
+                project_id,
+                "t0.spawn.requested",
+                {
+                    "lease_token": lease_token,
+                    "project_root": resolved_root,
+                },
+            )
+        except (OSError, RuntimeError, ValueError) as e:
+            raise T0AuditEmitError(
+                f"audit emit failed for t0.spawn.requested: {e}"
+            ) from e
+
+        conn = self._connect()
+        proc: Optional[subprocess.Popen] = None
+        pid: int = -1
+        try:
+            self._begin_exclusive_with_retry(conn)
+
+            existing = self._get_active_row(conn, project_id)
+            if existing is not None:
+                existing_meta = self._parse_metadata(existing["metadata_json"])
+                existing_pid = existing_meta.get("pid")
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("t0_lifecycle: ROLLBACK on AlreadyRunning suppressed")
+                raise T0AlreadyRunningError(project_id, existing_pid)
+
+            # Existing row may be in 'released' state; we will UPSERT.
+            cur = conn.execute(
+                "SELECT generation FROM terminal_leases "
+                "WHERE terminal_id = ? AND project_id = ?",
+                (T0_TERMINAL, project_id),
+            )
+            prior = cur.fetchone()
+            new_generation = (prior["generation"] + 1) if prior else 1
+
+            # Spawn subprocess.
+            spawn_argv = argv or [sys.executable, "-c", "import time; time.sleep(60)"]
+            try:
+                proc = self._subprocess_factory(
+                    spawn_argv,
+                    cwd=resolved_root,
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                pid = proc.pid
+            except OSError as e:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("t0_lifecycle: ROLLBACK on spawn OSError suppressed")
+                raise T0SpawnFailedError(
+                    f"subprocess.Popen failed for {project_id}: {e}"
+                ) from e
+
+            # Detect early-exit (exec failure, etc.).
+            time.sleep(0.05)
+            returncode = proc.poll()
+            if returncode is not None:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("t0_lifecycle: ROLLBACK on early-exit suppressed")
+                # Try to drain in case of zombie.
+                self._drain_zombie(pid)
+                raise T0SubprocessExitedEarly(returncode)
+
+            started_at = _now_iso()
+            metadata = {
+                "pid": pid,
+                "project_root": resolved_root,
+                "started_at": started_at,
+                "lifecycle_state": LIFECYCLE_RUNNING,
+                "lease_token": lease_token,
+            }
+
+            if prior is not None:
+                conn.execute(
+                    "UPDATE terminal_leases SET "
+                    "state = ?, generation = ?, lease_token = ?, "
+                    "leased_at = ?, last_heartbeat_at = ?, released_at = NULL, "
+                    "metadata_json = ? "
+                    "WHERE terminal_id = ? AND project_id = ?",
+                    (
+                        DB_STATE_LEASED,
+                        new_generation,
+                        lease_token,
+                        started_at,
+                        started_at,
+                        json.dumps(metadata),
+                        T0_TERMINAL,
+                        project_id,
+                    ),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO terminal_leases "
+                    "(terminal_id, project_id, state, generation, lease_token, "
+                    " leased_at, last_heartbeat_at, metadata_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        T0_TERMINAL,
+                        project_id,
+                        DB_STATE_LEASED,
+                        new_generation,
+                        lease_token,
+                        started_at,
+                        started_at,
+                        json.dumps(metadata),
+                    ),
+                )
+
+            committed_pid = pid
+
+            def _rollback_subprocess() -> None:
+                self._force_kill_subprocess(committed_pid)
+                # Best-effort spawn-aborted audit so forensics knows why.
+                try:
+                    self._emit_event(
+                        project_id,
+                        "t0.spawn.aborted",
+                        {
+                            "lease_token": lease_token,
+                            "pid": committed_pid,
+                            "reason": "audit_or_commit_failed",
+                            "subprocess_killed": True,
+                        },
+                    )
+                except Exception as e:  # noqa: BLE001 — best-effort
+                    log.error(
+                        "t0_lifecycle: spawn.aborted emit failed: %s", e
+                    )
+
+            self._commit_with_audit(
+                conn,
+                project_id,
+                "t0.spawn.committed",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "started_at": started_at,
+                    "generation": new_generation,
+                    "project_root": resolved_root,
+                },
+                rollback_action=_rollback_subprocess,
+            )
+
+            # Retain Popen handle so we can call waitpid as the actual parent.
+            if proc is not None:
+                self._popen_handles[lease_token] = proc
+
+            return T0Instance(
+                project_id=project_id,
+                pid=pid,
+                lease_token=lease_token,
+                generation=new_generation,
+                started_at=started_at,
+                project_root=resolved_root,
+                lifecycle_state=LIFECYCLE_RUNNING,
+            )
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API: heartbeat
+    # ------------------------------------------------------------------
+
+    def heartbeat(
+        self,
+        project_id: str,
+        pid: int,
+        lease_token: str,
+    ) -> bool:
+        """Record a heartbeat for a specific lease incarnation.
+
+        Returns True on match, False on token-mismatch / no active lease /
+        pid-mismatch. Heartbeat NEVER causes a lifecycle state transition.
+        """
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN")
+                cur = conn.execute(
+                    "SELECT * FROM terminal_leases "
+                    "WHERE terminal_id = ? AND project_id = ? "
+                    "AND lease_token = ? AND state = ?",
+                    (T0_TERMINAL, project_id, lease_token, DB_STATE_LEASED),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    try:
+                        conn.execute("ROLLBACK")
+                    except sqlite3.Error:
+                        log.debug("heartbeat: ROLLBACK on no-match suppressed")
+                    return False
+
+                meta = self._parse_metadata(row["metadata_json"])
+                stored_pid = meta.get("pid")
+                if stored_pid is not None and stored_pid != pid:
+                    try:
+                        conn.execute("ROLLBACK")
+                    except sqlite3.Error:
+                        log.debug("heartbeat: ROLLBACK on pid-mismatch suppressed")
+                    log.warning(
+                        "heartbeat: pid mismatch for project=%s token=%s "
+                        "(stored=%s, given=%s)",
+                        project_id,
+                        lease_token[:16],
+                        stored_pid,
+                        pid,
+                    )
+                    return False
+
+                now = _now_iso()
+                conn.execute(
+                    "UPDATE terminal_leases SET last_heartbeat_at = ? "
+                    "WHERE terminal_id = ? AND project_id = ? AND lease_token = ?",
+                    (now, T0_TERMINAL, project_id, lease_token),
+                )
+
+                try:
+                    self._commit_with_audit(
+                        conn,
+                        project_id,
+                        "t0.heartbeat.recorded",
+                        {
+                            "lease_token": lease_token,
+                            "pid": pid,
+                            "heartbeat_at": now,
+                        },
+                    )
+                except T0AuditEmitError:
+                    # Heartbeat is best-effort: emit failure surfaces upward
+                    # but the lease itself is not corrupted (no state change
+                    # was made because ROLLBACK already happened in helper).
+                    raise
+                return True
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API: list_running
+    # ------------------------------------------------------------------
+
+    def list_running(self) -> List[T0Instance]:
+        """Return all active T0 leases (state=leased, terminal=T0)."""
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM terminal_leases "
+                "WHERE terminal_id = ? AND state = ?",
+                (T0_TERMINAL, DB_STATE_LEASED),
+            )
+            instances: List[T0Instance] = []
+            for row in cur.fetchall():
+                meta = self._parse_metadata(row["metadata_json"])
+                instances.append(
+                    T0Instance(
+                        project_id=row["project_id"],
+                        pid=meta.get("pid", -1),
+                        lease_token=row["lease_token"] or "",
+                        generation=row["generation"],
+                        started_at=meta.get("started_at", row["leased_at"] or ""),
+                        project_root=meta.get("project_root", ""),
+                        lifecycle_state=meta.get("lifecycle_state", LIFECYCLE_RUNNING),
+                    )
+                )
+            return instances
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API: kill
+    # ------------------------------------------------------------------
+
+    def kill(
+        self,
+        project_id: str,
+        pid: int,
+        lease_token: str,
+        *,
+        signal_type: int = signal.SIGTERM,
+        wait_timeout: Optional[float] = None,
+        source: str = "operator",
+    ) -> KillResult:
+        """Terminate a specific T0 incarnation.
+
+        Sequence: TERMINATING state → signal → wait → verify dead → release.
+        Lease is released ONLY after ProcessLookupError confirms process death.
+        """
+        with self._lock:
+            return self._kill_locked(
+                project_id,
+                pid,
+                lease_token,
+                signal_type=signal_type,
+                wait_timeout=wait_timeout,
+                source=source,
+            )
+
+    def _kill_locked(
+        self,
+        project_id: str,
+        pid: int,
+        lease_token: str,
+        *,
+        signal_type: int,
+        wait_timeout: Optional[float],
+        source: str,
+    ) -> KillResult:
+        started_ms = _now_ms()
+        wait = wait_timeout if wait_timeout is not None else self._kill_wait_timeout_seconds
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            row = self._get_active_row(conn, project_id)
+            if row is None:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("kill: ROLLBACK on no-active-lease suppressed")
+                return KillResult(
+                    project_id=project_id,
+                    lease_token=lease_token,
+                    pid=pid,
+                    error="no_active_lease",
+                )
+
+            db_token = row["lease_token"] or ""
+            if db_token != lease_token:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("kill: ROLLBACK on token-mismatch suppressed")
+                raise LeaseTokenMismatchError(project_id, lease_token, db_token)
+
+            # Transition to TERMINATING (persist via metadata_json).
+            meta = self._parse_metadata(row["metadata_json"])
+            meta["lifecycle_state"] = LIFECYCLE_TERMINATING
+            meta["kill_signal_sent_at"] = _now_iso()
+            meta["kill_initiated_by"] = source
+            conn.execute(
+                "UPDATE terminal_leases SET metadata_json = ? "
+                "WHERE terminal_id = ? AND project_id = ? AND lease_token = ?",
+                (json.dumps(meta), T0_TERMINAL, project_id, lease_token),
+            )
+
+            self._commit_with_audit(
+                conn,
+                project_id,
+                "t0.kill.requested",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "signal_type": int(signal_type),
+                    "source": source,
+                },
+            )
+        finally:
+            conn.close()
+
+        # Signal phase — outside transaction.
+        result = KillResult(
+            project_id=project_id,
+            lease_token=lease_token,
+            pid=pid,
+        )
+
+        outcome = self._signal_process(pid, signal_type)
+        if outcome == "permission_denied":
+            self._emit_event(
+                project_id,
+                "t0.kill.permission_denied",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "errno": errno.EPERM,
+                },
+            )
+            result.error = "permission_denied"
+            result.duration_ms = _now_ms() - started_ms
+            return result
+
+        if outcome == "already_dead":
+            # Skip signal phase, go straight to verify+release.
+            result.signaled = False
+        else:
+            result.signaled = True
+            self._emit_event(
+                project_id,
+                "t0.kill.signaled",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "signal_type": int(signal_type),
+                    "escalation": False,
+                },
+            )
+
+            # Wait for exit.
+            exited = self._wait_for_exit(pid, wait, lease_token=lease_token)
+            if not exited:
+                if signal_type == signal.SIGTERM:
+                    # Escalate to SIGKILL.
+                    result.escalated_to_sigkill = True
+                    escalate_outcome = self._signal_process(pid, signal.SIGKILL)
+                    if escalate_outcome == "sent":
+                        self._emit_event(
+                            project_id,
+                            "t0.kill.signaled",
+                            {
+                                "lease_token": lease_token,
+                                "pid": pid,
+                                "signal_type": int(signal.SIGKILL),
+                                "escalation": True,
+                            },
+                        )
+                        self._wait_for_exit(
+                            pid,
+                            self._sigkill_wait_timeout_seconds,
+                            lease_token=lease_token,
+                        )
+
+        # Verify death.
+        if self._is_alive(pid, lease_token=lease_token):
+            result.error = (
+                "sigkill_zombie"
+                if result.escalated_to_sigkill
+                else "alive_after_wait"
+            )
+            result.duration_ms = _now_ms() - started_ms
+            self._emit_event(
+                project_id,
+                "t0.error.kill",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "error_type": result.error,
+                    "message": "process still alive after wait window",
+                },
+            )
+            return result
+
+        result.verified_dead = True
+        self._drain_zombie(pid, lease_token=lease_token)
+
+        # Final release transaction.
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            row = self._get_row_by_token(conn, lease_token)
+            if row is None or row["state"] != DB_STATE_LEASED:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug("kill: ROLLBACK on already-released suppressed")
+                result.duration_ms = _now_ms() - started_ms
+                return result
+
+            meta = self._parse_metadata(row["metadata_json"])
+            meta["lifecycle_state"] = LIFECYCLE_REAPED
+            meta["reaped_at"] = _now_iso()
+            conn.execute(
+                "UPDATE terminal_leases SET state = ?, released_at = ?, metadata_json = ? "
+                "WHERE terminal_id = ? AND lease_token = ?",
+                (
+                    DB_STATE_RELEASED,
+                    meta["reaped_at"],
+                    json.dumps(meta),
+                    T0_TERMINAL,
+                    lease_token,
+                ),
+            )
+
+            result.duration_ms = _now_ms() - started_ms
+            self._commit_with_audit(
+                conn,
+                project_id,
+                "t0.kill.verified",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "kill_duration_ms": result.duration_ms,
+                    "escalated_to_sigkill": result.escalated_to_sigkill,
+                },
+            )
+            result.lease_released = True
+            self._release_popen_handle(lease_token)
+            return result
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API: force_release_lease (operator escape hatch)
+    # ------------------------------------------------------------------
+
+    def force_release_lease(self, lease_token: str, reason: str) -> bool:
+        """Operator-action: release a lease by token without process verification.
+
+        Use case: a T0 process is stuck in a state where normal kill() cannot
+        proceed (EPERM, sigkill_zombie). Operator takes explicit ownership of
+        the lease so a successor can spawn.
+
+        Emits its own audit-event pair (requested + committed). Returns True
+        if a leased row was found and released, False otherwise.
+        """
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN")
+                row = self._get_row_by_token(conn, lease_token)
+                if row is None or row["state"] != DB_STATE_LEASED:
+                    try:
+                        conn.execute("ROLLBACK")
+                    except sqlite3.Error:
+                        log.debug(
+                            "force_release: ROLLBACK on no-lease suppressed"
+                        )
+                    return False
+
+                project_id = row["project_id"]
+                meta = self._parse_metadata(row["metadata_json"])
+                old_pid = meta.get("pid", -1)
+
+                # Pre-commit audit (separate emit so we can still close
+                # the transaction cleanly even if the released-event fails).
+                self._emit_event(
+                    project_id,
+                    "t0.force_release.requested",
+                    {
+                        "lease_token": lease_token,
+                        "pid": old_pid,
+                        "reason": reason,
+                    },
+                )
+
+                meta["lifecycle_state"] = LIFECYCLE_REAPED
+                meta["force_released_at"] = _now_iso()
+                meta["force_release_reason"] = reason
+                conn.execute(
+                    "UPDATE terminal_leases SET state = ?, released_at = ?, "
+                    "metadata_json = ? "
+                    "WHERE terminal_id = ? AND lease_token = ?",
+                    (
+                        DB_STATE_RELEASED,
+                        meta["force_released_at"],
+                        json.dumps(meta),
+                        T0_TERMINAL,
+                        lease_token,
+                    ),
+                )
+
+                self._commit_with_audit(
+                    conn,
+                    project_id,
+                    "t0.force_release.committed",
+                    {
+                        "lease_token": lease_token,
+                        "pid": old_pid,
+                        "reason": reason,
+                    },
+                )
+                self._release_popen_handle(lease_token)
+                return True
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API: reap_dead_t0s
+    # ------------------------------------------------------------------
+
+    def reap_dead_t0s(self) -> List[ReapResult]:
+        """Process all STALE leases sequentially.
+
+        For each lease with last_heartbeat_at older than heartbeat_timeout:
+            1. liveness-check via os.kill(pid, 0)
+            2. if alive → kill() pad (SIGTERM → wait → SIGKILL escalation)
+            3. if dead → emit t0.reap.completed + release lease
+            4. if liveness-check race (fresh heartbeat) → refuted_alive
+        """
+        with self._lock:
+            return self._reap_locked()
+
+    def _reap_locked(self) -> List[ReapResult]:
+        results: List[ReapResult] = []
+        threshold = _now_ms() - int(self._heartbeat_timeout_seconds * 1000)
+
+        # Snapshot candidates (release connection before signal calls).
+        candidates: List[Dict[str, Any]] = []
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM terminal_leases "
+                "WHERE terminal_id = ? AND state = ? "
+                "ORDER BY last_heartbeat_at ASC",
+                (T0_TERMINAL, DB_STATE_LEASED),
+            )
+            for row in cur.fetchall():
+                hb = _parse_iso(row["last_heartbeat_at"] or "")
+                hb_ms = int(hb.timestamp() * 1000) if hb else 0
+                if hb_ms >= threshold:
+                    continue  # not stale
+                meta = self._parse_metadata(row["metadata_json"])
+                candidates.append(
+                    {
+                        "project_id": row["project_id"],
+                        "lease_token": row["lease_token"] or "",
+                        "pid": meta.get("pid", -1),
+                        "last_heartbeat_ms": hb_ms,
+                    }
+                )
+        finally:
+            conn.close()
+
+        for cand in candidates:
+            results.append(self._reap_one(cand, threshold))
+
+        return results
+
+    def _reap_one(self, cand: Dict[str, Any], threshold: int) -> ReapResult:
+        project_id = cand["project_id"]
+        lease_token = cand["lease_token"]
+        pid = cand["pid"]
+
+        # Emit stale.detected before any action.
+        try:
+            self._emit_event(
+                project_id,
+                "t0.stale.detected",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                    "last_heartbeat_ms": cand["last_heartbeat_ms"],
+                },
+            )
+        except (OSError, RuntimeError, ValueError) as e:
+            log.error("reap: stale.detected emit failed: %s", e)
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="error",
+                error=f"audit_emit_failed: {e}",
+            )
+
+        # Liveness check.
+        try:
+            alive = self._is_alive(pid, lease_token=lease_token) if pid > 0 else False
+        except OSError as e:
+            log.error("reap: liveness check failed for pid=%s: %s", pid, e)
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="error",
+                error=f"liveness_check_failed: {e}",
+            )
+
+        if not alive:
+            # Already-dead path: emit reap.completed + release lease.
+            return self._reap_release_dead(project_id, lease_token, pid)
+
+        # Alive: re-check heartbeat (may have refreshed).
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "SELECT last_heartbeat_at FROM terminal_leases "
+                "WHERE terminal_id = ? AND lease_token = ?",
+                (T0_TERMINAL, lease_token),
+            )
+            row = cur.fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="error",
+                error="lease_already_released",
+            )
+
+        fresh_hb = _parse_iso(row["last_heartbeat_at"] or "")
+        fresh_ms = int(fresh_hb.timestamp() * 1000) if fresh_hb else 0
+        if fresh_ms >= threshold:
+            # Heartbeat caught up: refuted_alive.
+            try:
+                self._emit_event(
+                    project_id,
+                    "t0.stale.refuted",
+                    {"lease_token": lease_token, "pid": pid},
+                )
+            except (OSError, RuntimeError, ValueError) as e:
+                log.error("reap: stale.refuted emit failed: %s", e)
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="refuted_alive",
+            )
+
+        # Alive + still stale: run kill() as if operator triggered it.
+        try:
+            self._emit_event(
+                project_id,
+                "t0.reap.detected",
+                {"lease_token": lease_token, "pid": pid},
+            )
+        except (OSError, RuntimeError, ValueError) as e:
+            log.error("reap: reap.detected emit failed: %s", e)
+
+        try:
+            kr = self._kill_locked(
+                project_id,
+                pid,
+                lease_token,
+                signal_type=signal.SIGTERM,
+                wait_timeout=self._kill_wait_timeout_seconds,
+                source="reap",
+            )
+        except LeaseTokenMismatchError as e:
+            # Successor lease was spawned concurrently; abandon this iteration.
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="error",
+                error=f"token_mismatch: {e}",
+            )
+
+        return ReapResult(
+            project_id=project_id,
+            lease_token=lease_token,
+            pid=pid,
+            classification="killed_by_reap" if kr.verified_dead else "error",
+            lease_released=kr.lease_released,
+            error=kr.error,
+        )
+
+    def _reap_release_dead(
+        self,
+        project_id: str,
+        lease_token: str,
+        pid: int,
+    ) -> ReapResult:
+        """Release a lease whose process is already dead (no kill needed)."""
+        self._drain_zombie(pid, lease_token=lease_token)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            row = self._get_row_by_token(conn, lease_token)
+            if row is None or row["state"] != DB_STATE_LEASED:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    log.debug(
+                        "reap_release_dead: ROLLBACK on missing-lease suppressed"
+                    )
+                return ReapResult(
+                    project_id=project_id,
+                    lease_token=lease_token,
+                    pid=pid,
+                    classification="error",
+                    error="lease_already_released",
+                )
+
+            meta = self._parse_metadata(row["metadata_json"])
+            meta["lifecycle_state"] = LIFECYCLE_REAPED
+            meta["reaped_at"] = _now_iso()
+            meta["reap_classification"] = "already_dead"
+            conn.execute(
+                "UPDATE terminal_leases SET state = ?, released_at = ?, "
+                "metadata_json = ? "
+                "WHERE terminal_id = ? AND lease_token = ?",
+                (
+                    DB_STATE_RELEASED,
+                    meta["reaped_at"],
+                    json.dumps(meta),
+                    T0_TERMINAL,
+                    lease_token,
+                ),
+            )
+
+            self._commit_with_audit(
+                conn,
+                project_id,
+                "t0.reap.completed",
+                {
+                    "lease_token": lease_token,
+                    "pid": pid,
+                },
+            )
+            self._release_popen_handle(lease_token)
+            return ReapResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=pid,
+                classification="already_dead",
+                lease_released=True,
+            )
+        finally:
+            conn.close()

--- a/scripts/aggregator/t0_lifecycle.py
+++ b/scripts/aggregator/t0_lifecycle.py
@@ -741,9 +741,18 @@ class T0LifecycleManager:
                 "lifecycle_state": LIFECYCLE_RUNNING,
                 "lease_token": lease_token,
             }
-            self._write_lease_row(
-                conn, project_id, prior, lease_token, new_generation, started_at, metadata
-            )
+            try:
+                self._write_lease_row(
+                    conn, project_id, prior, lease_token, new_generation, started_at, metadata
+                )
+            except Exception:
+                # Subprocess is alive but lease write failed — kill it to prevent orphan.
+                self._force_kill_subprocess(pid)
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
 
             committed_pid = pid
 
@@ -963,7 +972,18 @@ class T0LifecycleManager:
             raise LeaseTokenMismatchError(project_id, lease_token, db_token)
 
         meta = self._parse_metadata(row["metadata_json"])
-        stored_pid = meta.get("pid", -1)
+        stored_pid = meta.get("pid")
+        if not isinstance(stored_pid, int) or stored_pid <= 0:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                log.debug("kill: ROLLBACK on invalid-pid suppressed")
+            return -1, KillResult(
+                project_id=project_id,
+                lease_token=lease_token,
+                pid=-1,
+                error=f"invalid stored pid: {stored_pid!r} (corrupt metadata)",
+            )
         meta["lifecycle_state"] = LIFECYCLE_TERMINATING
         meta["kill_signal_sent_at"] = _now_iso()
         meta["kill_initiated_by"] = source
@@ -1009,7 +1029,11 @@ class T0LifecycleManager:
             result.error = "permission_denied"
             return True
 
-        if outcome != "already_dead":
+        if outcome.startswith("error:"):
+            result.error = outcome
+            return True
+
+        if outcome == "sent":
             result.signaled = True
             self._emit_event(
                 project_id,
@@ -1038,6 +1062,7 @@ class T0LifecycleManager:
                     self._wait_for_exit(
                         pid, self._sigkill_wait_timeout_seconds, lease_token=lease_token
                     )
+        # outcome == "already_dead": fall through to _is_alive check below
 
         if self._is_alive(pid, lease_token=lease_token):
             err = "sigkill_zombie" if result.escalated_to_sigkill else "alive_after_wait"

--- a/scripts/lib/migrations/apply_0019.py
+++ b/scripts/lib/migrations/apply_0019.py
@@ -1,0 +1,141 @@
+"""apply_0019.py — Wave 5 PR-5.2 T0 lifecycle tokens migration.
+
+Applies schemas/migrations/0019_t0_lifecycle_tokens.sql to a
+runtime_coordination.db. Adds lease_token column + partial UNIQUE index to
+terminal_leases for per-incarnation lease identification.
+
+Idempotent: reads MAX(version) from runtime_schema_version. Skips if already
+at v13 or higher (the version stamped by the migration).
+
+Atomic: the SQL script uses an explicit BEGIN/COMMIT transaction. If the script
+fails mid-way, the uncommitted transaction is rolled back when the connection
+is closed (SQLite WAL mode guarantees).
+
+ADR-005: emits NDJSON audit events to .vnx-data/events/schema_migrations.ndjson
+for migration_started, migration_completed, and migration_failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_TARGET_VERSION = 13
+_MIGRATION_NAME = "0019_t0_lifecycle_tokens"
+
+_DEFAULT_MIGRATION_SQL = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "schemas"
+    / "migrations"
+    / "0019_t0_lifecycle_tokens.sql"
+)
+
+
+def _emit_migration_event(vnx_data_dir: Path, event_type: str, payload: dict) -> None:
+    events_path = vnx_data_dir / "events" / "schema_migrations.ndjson"
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event_type": event_type,
+        "source": "schema_migration",
+        "migration": _MIGRATION_NAME,
+        **payload,
+    }
+    with open(events_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def apply_migration(
+    db_path: Path,
+    migration_sql_path: Path,
+    vnx_data_dir: Path | None = None,
+) -> bool:
+    """Apply the 0019 migration to db_path.
+
+    Returns True when the migration was applied, False when the DB was
+    already at the target version and the migration was skipped.
+
+    Raises sqlite3.Error on failure (the failing transaction is rolled back
+    via connection close before the exception propagates).
+    """
+    if vnx_data_dir is None:
+        vnx_data_dir = Path(db_path).parent.parent
+
+    current_version = 0
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+        row = cur.fetchone()
+        current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+        if current_version >= _TARGET_VERSION:
+            log.info(
+                "apply_0019: already at v%s (target v%s), skip",
+                current_version,
+                _TARGET_VERSION,
+            )
+            return False
+
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_started",
+            {"from_version": current_version, "to_version": _TARGET_VERSION},
+        )
+
+        sql = migration_sql_path.read_text()
+        conn.executescript(sql)
+        log.info(
+            "apply_0019: migrated from v%s to v%s", current_version, _TARGET_VERSION
+        )
+
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_completed",
+            {"from_version": current_version, "to_version": _TARGET_VERSION},
+        )
+        return True
+
+    except sqlite3.Error as e:
+        conn.rollback()
+        log.error("apply_0019: error during migration; transaction rolled back")
+        _emit_migration_event(
+            vnx_data_dir,
+            "migration_failed",
+            {"from_version": current_version, "error": str(e)},
+        )
+        raise
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    p = argparse.ArgumentParser(
+        description="Apply 0019 T0 lifecycle tokens migration"
+    )
+    p.add_argument("--db", required=True, help="Path to runtime_coordination.db")
+    p.add_argument(
+        "--migration",
+        default=str(_DEFAULT_MIGRATION_SQL),
+        help="Path to 0019_t0_lifecycle_tokens.sql",
+    )
+    p.add_argument(
+        "--vnx-data-dir",
+        default=None,
+        help="Path to .vnx-data directory for audit events (default: db_path/../..)",
+    )
+    args = p.parse_args()
+    applied = apply_migration(
+        Path(args.db),
+        Path(args.migration),
+        Path(args.vnx_data_dir) if args.vnx_data_dir else None,
+    )
+    print("applied" if applied else "skipped (already at target version)")

--- a/scripts/t0_lifecycle_cli.py
+++ b/scripts/t0_lifecycle_cli.py
@@ -115,7 +115,6 @@ def _cmd_kill(args: argparse.Namespace) -> int:
     try:
         kr = mgr.kill(
             args.project_id,
-            args.pid,
             args.lease_token,
             signal_type=sig,
             wait_timeout=args.wait,
@@ -186,7 +185,6 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sp_kill = sub.add_parser("kill", help="Kill a specific T0 incarnation")
     sp_kill.add_argument("project_id")
-    sp_kill.add_argument("--pid", type=int, required=True)
     sp_kill.add_argument("--lease-token", required=True)
     sp_kill.add_argument("--sigkill", action="store_true", help="Use SIGKILL instead of SIGTERM")
     sp_kill.add_argument("--wait", type=float, default=None, help="Wait timeout seconds")

--- a/scripts/t0_lifecycle_cli.py
+++ b/scripts/t0_lifecycle_cli.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""t0_lifecycle_cli.py — Wave 5 PR-5.2: operator CLI for T0 lifecycle.
+
+Wraps T0LifecycleManager (scripts/aggregator/t0_lifecycle.py). Aggregator is
+constructed and injected — never None. Commands:
+
+    spawn         Spawn a new T0 worker for a project_id.
+    heartbeat     Record a heartbeat for an active T0 (token required).
+    kill          Terminate a specific T0 incarnation (token required).
+    force-release Operator escape: release a lease without process check.
+    list          Show all running T0 leases.
+    reap          Run the stale-heartbeat reap loop once.
+
+Output: human-readable text for `list`, JSON for everything else.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from aggregator.state_aggregator import StateAggregator
+from aggregator.t0_lifecycle import (
+    LeaseTokenMismatchError,
+    T0AlreadyRunningError,
+    T0AuditEmitError,
+    T0LifecycleManager,
+    T0SpawnContentionError,
+    T0SpawnFailedError,
+    T0SubprocessExitedEarly,
+)
+
+
+def _resolve_paths(args: argparse.Namespace) -> tuple[Path, Path]:
+    if args.coord_db:
+        coord_db = Path(args.coord_db).resolve()
+    else:
+        state_dir = os.environ.get("VNX_STATE_DIR") or ".vnx-data/state"
+        coord_db = Path(state_dir).resolve() / "runtime_coordination.db"
+
+    if args.vnx_data_dir:
+        vnx_data = Path(args.vnx_data_dir).resolve()
+    else:
+        vnx_data_env = os.environ.get("VNX_DATA_DIR") or ".vnx-data"
+        vnx_data = Path(vnx_data_env).resolve()
+
+    return coord_db, vnx_data
+
+
+def _build_manager(args: argparse.Namespace) -> T0LifecycleManager:
+    coord_db, vnx_data = _resolve_paths(args)
+    if not coord_db.exists():
+        print(
+            json.dumps(
+                {"ok": False, "error": f"coord_db not found: {coord_db}"},
+                indent=2,
+            )
+        )
+        sys.exit(2)
+    aggregator = StateAggregator(vnx_data)
+    return T0LifecycleManager(coord_db, aggregator)
+
+
+def _cmd_spawn(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    argv = None
+    if args.argv:
+        argv = args.argv
+    try:
+        instance = mgr.spawn(
+            args.project_id,
+            argv=argv,
+            project_root=args.project_root,
+        )
+    except T0AlreadyRunningError as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "already_running"}, indent=2))
+        return 3
+    except T0SubprocessExitedEarly as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "exited_early"}, indent=2))
+        return 4
+    except T0SpawnFailedError as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "spawn_failed"}, indent=2))
+        return 5
+    except T0SpawnContentionError as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "db_contention"}, indent=2))
+        return 6
+    except T0AuditEmitError as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "audit_emit_failed"}, indent=2))
+        return 7
+
+    print(json.dumps({"ok": True, "instance": asdict(instance)}, indent=2))
+    return 0
+
+
+def _cmd_heartbeat(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    ok = mgr.heartbeat(args.project_id, args.pid, args.lease_token)
+    print(json.dumps({"ok": ok}, indent=2))
+    return 0 if ok else 1
+
+
+def _cmd_kill(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    sig = signal.SIGKILL if args.sigkill else signal.SIGTERM
+    try:
+        kr = mgr.kill(
+            args.project_id,
+            args.pid,
+            args.lease_token,
+            signal_type=sig,
+            wait_timeout=args.wait,
+        )
+    except LeaseTokenMismatchError as e:
+        print(json.dumps({"ok": False, "error": str(e), "kind": "token_mismatch"}, indent=2))
+        return 8
+
+    print(json.dumps({"ok": kr.verified_dead, "result": asdict(kr)}, indent=2))
+    return 0 if kr.verified_dead else 1
+
+
+def _cmd_force_release(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    released = mgr.force_release_lease(args.lease_token, args.reason)
+    print(json.dumps({"ok": released}, indent=2))
+    return 0 if released else 1
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    instances = mgr.list_running()
+    if args.json:
+        print(json.dumps([asdict(i) for i in instances], indent=2))
+        return 0
+    if not instances:
+        print("(no running T0 leases)")
+        return 0
+    print(f"{'PROJECT':<24} {'PID':>8} {'GEN':>4} {'STATE':<14} TOKEN")
+    for inst in instances:
+        print(
+            f"{inst.project_id:<24} {inst.pid:>8} {inst.generation:>4} "
+            f"{inst.lifecycle_state:<14} {inst.lease_token[:16]}..."
+        )
+    return 0
+
+
+def _cmd_reap(args: argparse.Namespace) -> int:
+    mgr = _build_manager(args)
+    results = mgr.reap_dead_t0s()
+    print(json.dumps([asdict(r) for r in results], indent=2))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Operator CLI for T0 lifecycle management"
+    )
+    p.add_argument("--coord-db", help="Path to runtime_coordination.db (default: $VNX_STATE_DIR/runtime_coordination.db)")
+    p.add_argument("--vnx-data-dir", help="Path to .vnx-data (default: $VNX_DATA_DIR)")
+
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_spawn = sub.add_parser("spawn", help="Spawn a new T0 worker")
+    sp_spawn.add_argument("project_id")
+    sp_spawn.add_argument("--project-root", default=None)
+    sp_spawn.add_argument(
+        "--argv", nargs=argparse.REMAINDER,
+        help="Subprocess argv (after --)",
+    )
+    sp_spawn.set_defaults(func=_cmd_spawn)
+
+    sp_hb = sub.add_parser("heartbeat", help="Record a heartbeat")
+    sp_hb.add_argument("project_id")
+    sp_hb.add_argument("--pid", type=int, required=True)
+    sp_hb.add_argument("--lease-token", required=True)
+    sp_hb.set_defaults(func=_cmd_heartbeat)
+
+    sp_kill = sub.add_parser("kill", help="Kill a specific T0 incarnation")
+    sp_kill.add_argument("project_id")
+    sp_kill.add_argument("--pid", type=int, required=True)
+    sp_kill.add_argument("--lease-token", required=True)
+    sp_kill.add_argument("--sigkill", action="store_true", help="Use SIGKILL instead of SIGTERM")
+    sp_kill.add_argument("--wait", type=float, default=None, help="Wait timeout seconds")
+    sp_kill.set_defaults(func=_cmd_kill)
+
+    sp_fr = sub.add_parser("force-release", help="Release a lease without process verification (operator escape)")
+    sp_fr.add_argument("--lease-token", required=True)
+    sp_fr.add_argument("--reason", required=True)
+    sp_fr.set_defaults(func=_cmd_force_release)
+
+    sp_list = sub.add_parser("list", help="List all running T0 leases")
+    sp_list.add_argument("--json", action="store_true", help="Emit JSON")
+    sp_list.set_defaults(func=_cmd_list)
+
+    sp_reap = sub.add_parser("reap", help="Run reap loop once")
+    sp_reap.set_defaults(func=_cmd_reap)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_t0_lifecycle.py
+++ b/tests/test_t0_lifecycle.py
@@ -59,83 +59,99 @@ _MIGRATION_0019_SQL = _REPO_ROOT / "schemas" / "migrations" / "0019_t0_lifecycle
 # ---------------------------------------------------------------------------
 
 
-def _create_v12_db(db_path: Path) -> None:
-    """Bootstrap a runtime_coordination.db at schema v12 (after migration 0017).
+def _seed_schema_meta_v12(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE runtime_schema_version (
+            version     INTEGER PRIMARY KEY,
+            applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            description TEXT NOT NULL
+        )
+    """)
+    conn.execute("INSERT INTO runtime_schema_version VALUES (11, datetime('now'), 'v11 baseline')")
 
-    Replicates the helper from tests/test_schema_0017_migration.py:
-    create v11 baseline, then apply 0017 to land at v12.
-    """
+
+def _create_dispatches_table_v12(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE dispatch_attempts (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_id      TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL REFERENCES dispatches (dispatch_id),
+            attempt_number  INTEGER NOT NULL DEFAULT 1,
+            terminal_id     TEXT    NOT NULL,
+            state           TEXT    NOT NULL DEFAULT 'pending',
+            started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            ended_at        TEXT,
+            failure_reason  TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev'
+        )
+    """)
+
+
+def _create_terminal_leases_table_v12(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE terminal_leases (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            terminal_id         TEXT    NOT NULL UNIQUE,
+            project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state               TEXT    NOT NULL DEFAULT 'idle',
+            dispatch_id         TEXT,
+            generation          INTEGER NOT NULL DEFAULT 1,
+            leased_at           TEXT,
+            expires_at          TEXT,
+            last_heartbeat_at   TEXT,
+            released_at         TEXT,
+            metadata_json       TEXT    DEFAULT '{}'
+        )
+    """)
+
+
+def _create_worker_states_table_v12(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE worker_states (
+            terminal_id      TEXT    NOT NULL PRIMARY KEY,
+            dispatch_id      TEXT    NOT NULL,
+            state            TEXT    NOT NULL DEFAULT 'initializing',
+            last_output_at   TEXT,
+            state_entered_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            stall_count      INTEGER NOT NULL DEFAULT 0,
+            blocked_reason   TEXT,
+            metadata_json    TEXT,
+            created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """)
+
+
+def _create_v12_db(db_path: Path) -> None:
+    """Bootstrap a runtime_coordination.db at schema v12 (after migration 0017)."""
     conn = sqlite3.connect(str(db_path))
     try:
-        conn.executescript("""
-            PRAGMA journal_mode = WAL;
-
-            CREATE TABLE runtime_schema_version (
-                version     INTEGER PRIMARY KEY,
-                applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                description TEXT NOT NULL
-            );
-            INSERT INTO runtime_schema_version VALUES (11, datetime('now'), 'v11 baseline');
-
-            CREATE TABLE dispatches (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                dispatch_id     TEXT    NOT NULL UNIQUE,
-                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
-                state           TEXT    NOT NULL DEFAULT 'queued',
-                terminal_id     TEXT,
-                track           TEXT,
-                priority        TEXT    DEFAULT 'P2',
-                pr_ref          TEXT,
-                gate            TEXT,
-                attempt_count   INTEGER NOT NULL DEFAULT 0,
-                bundle_path     TEXT,
-                created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                expires_after   TEXT,
-                metadata_json   TEXT    DEFAULT '{}'
-            );
-
-            CREATE TABLE terminal_leases (
-                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-                terminal_id         TEXT    NOT NULL UNIQUE,
-                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
-                state               TEXT    NOT NULL DEFAULT 'idle',
-                dispatch_id         TEXT,
-                generation          INTEGER NOT NULL DEFAULT 1,
-                leased_at           TEXT,
-                expires_at          TEXT,
-                last_heartbeat_at   TEXT,
-                released_at         TEXT,
-                metadata_json       TEXT    DEFAULT '{}'
-            );
-
-            CREATE TABLE worker_states (
-                terminal_id      TEXT    NOT NULL PRIMARY KEY,
-                dispatch_id      TEXT    NOT NULL,
-                state            TEXT    NOT NULL DEFAULT 'initializing',
-                last_output_at   TEXT,
-                state_entered_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                stall_count      INTEGER NOT NULL DEFAULT 0,
-                blocked_reason   TEXT,
-                metadata_json    TEXT,
-                created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-            );
-
-            CREATE TABLE dispatch_attempts (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                attempt_id      TEXT    NOT NULL UNIQUE,
-                dispatch_id     TEXT    NOT NULL REFERENCES dispatches (dispatch_id),
-                attempt_number  INTEGER NOT NULL DEFAULT 1,
-                terminal_id     TEXT    NOT NULL,
-                state           TEXT    NOT NULL DEFAULT 'pending',
-                started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                ended_at        TEXT,
-                failure_reason  TEXT,
-                metadata_json   TEXT    DEFAULT '{}',
-                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev'
-            );
-        """)
+        conn.execute("PRAGMA journal_mode = WAL")
+        _seed_schema_meta_v12(conn)
+        _create_dispatches_table_v12(conn)
+        _create_terminal_leases_table_v12(conn)
+        _create_worker_states_table_v12(conn)
+        conn.commit()
     finally:
         conn.close()
 
@@ -276,7 +292,7 @@ def test_spawn_race_condition_serialized_by_exclusive(tmp_path: Path) -> None:
             inst = results[0]
             try:
                 mgr.kill("proj-race", inst.lease_token, wait_timeout=3.0)
-            except Exception:
+            except (LeaseTokenMismatchError, OSError, sqlite3.Error):
                 pass
 
 
@@ -334,7 +350,7 @@ def test_spawn_rollback_kills_subprocess_on_insert_failure(tmp_path: Path) -> No
         try:
             real_sleeper.kill()
             real_sleeper.wait(timeout=2)
-        except Exception:
+        except (OSError, subprocess.TimeoutExpired):
             pass
 
 
@@ -390,7 +406,7 @@ def test_spawn_rollback_on_audit_emit_failure(tmp_path: Path) -> None:
         try:
             real_sleeper.kill()
             real_sleeper.wait(timeout=2)
-        except Exception:
+        except (OSError, subprocess.TimeoutExpired):
             pass
 
 
@@ -796,11 +812,11 @@ def test_reap_dead_process_skips_signal(tmp_path: Path, monkeypatch) -> None:
         # Subprocess was real; clean up.
         try:
             mgr.force_release_lease(inst.lease_token, "test cleanup")
-        except Exception:
+        except (OSError, sqlite3.Error):
             pass
         try:
             os.kill(inst.pid, signal.SIGKILL)
-        except Exception:
+        except OSError:
             pass
 
 

--- a/tests/test_t0_lifecycle.py
+++ b/tests/test_t0_lifecycle.py
@@ -275,7 +275,7 @@ def test_spawn_race_condition_serialized_by_exclusive(tmp_path: Path) -> None:
         if results:
             inst = results[0]
             try:
-                mgr.kill("proj-race", inst.pid, inst.lease_token, wait_timeout=3.0)
+                mgr.kill("proj-race", inst.lease_token, wait_timeout=3.0)
             except Exception:
                 pass
 
@@ -501,7 +501,7 @@ def test_kill_state_transitions_to_terminating_before_signal(tmp_path: Path, mon
 
         monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(spy_signal))
 
-        kr = mgr.kill("proj-term", inst.pid, inst.lease_token, wait_timeout=3.0)
+        kr = mgr.kill("proj-term", inst.lease_token, wait_timeout=3.0)
 
         assert kr.verified_dead, f"kill should succeed: {kr}"
         assert observed_state["meta"]["lifecycle_state"] == LIFECYCLE_TERMINATING
@@ -538,7 +538,7 @@ def test_kill_only_releases_after_verified_dead(tmp_path: Path, monkeypatch) -> 
             return True
 
         # Test the original semantic instead: real kill of real child.
-        kr = mgr.kill("proj-verify", inst.pid, inst.lease_token, wait_timeout=3.0)
+        kr = mgr.kill("proj-verify", inst.lease_token, wait_timeout=3.0)
         assert kr.verified_dead is True
         assert kr.lease_released is True
 
@@ -576,7 +576,7 @@ def test_kill_eperm_keeps_lease_terminating_state(tmp_path: Path, monkeypatch) -
             staticmethod(lambda pid, sig: "permission_denied"),
         )
 
-        kr = mgr.kill("proj-eperm", inst.pid, inst.lease_token, wait_timeout=1.0)
+        kr = mgr.kill("proj-eperm", inst.lease_token, wait_timeout=1.0)
         assert kr.error == "permission_denied"
         assert kr.verified_dead is False
         assert kr.lease_released is False
@@ -863,14 +863,14 @@ def test_kill_result_dataclass_contracts(tmp_path: Path, monkeypatch) -> None:
 
     try:
         # Path 1: no active lease.
-        kr_no_lease = mgr.kill("proj-nope", 99999, "fake-token", wait_timeout=0.1)
+        kr_no_lease = mgr.kill("proj-nope", "fake-token", wait_timeout=0.1)
         assert kr_no_lease.error == "no_active_lease"
         assert kr_no_lease.verified_dead is False
         assert kr_no_lease.lease_released is False
 
         # Path 2: successful kill of real subprocess.
         inst = _spawn_test_t0(mgr, "proj-ok")
-        kr_ok = mgr.kill("proj-ok", inst.pid, inst.lease_token, wait_timeout=3.0)
+        kr_ok = mgr.kill("proj-ok", inst.lease_token, wait_timeout=3.0)
         assert kr_ok.verified_dead is True
         assert kr_ok.lease_released is True
         assert kr_ok.signaled is True
@@ -880,6 +880,42 @@ def test_kill_result_dataclass_contracts(tmp_path: Path, monkeypatch) -> None:
         # Path 3: token mismatch raises.
         inst2 = _spawn_test_t0(mgr, "proj-mismatch")
         with pytest.raises(LeaseTokenMismatchError):
-            mgr.kill("proj-mismatch", inst2.pid, "wrong-token", wait_timeout=0.1)
+            mgr.kill("proj-mismatch", "wrong-token", wait_timeout=0.1)
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 17: kill uses stored pid from metadata, not any caller-supplied value
+# ---------------------------------------------------------------------------
+
+
+def test_kill_uses_stored_pid_from_metadata(tmp_path: Path, monkeypatch) -> None:
+    """kill() sources pid from metadata_json.pid (source of truth).
+
+    Verifies that the pid passed to os.kill is the one stored in the DB
+    lease row, confirming the blocking finding from codex R1 is addressed.
+    """
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-stored-pid")
+
+        signaled_pids: List[int] = []
+        original_signal = T0LifecycleManager._signal_process
+
+        def capturing_signal(pid, sig):
+            signaled_pids.append(pid)
+            return original_signal(pid, sig)
+
+        monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(capturing_signal))
+
+        kr = mgr.kill("proj-stored-pid", inst.lease_token, wait_timeout=3.0)
+
+        assert kr.verified_dead is True
+        assert kr.pid == inst.pid, "KillResult.pid must equal metadata-stored pid"
+        assert signaled_pids[0] == inst.pid, "os.kill must use the metadata-stored pid"
     finally:
         _cleanup_children(mgr)

--- a/tests/test_t0_lifecycle.py
+++ b/tests/test_t0_lifecycle.py
@@ -1,0 +1,885 @@
+"""Tests for scripts/aggregator/t0_lifecycle.py (Wave 5 PR-5.2).
+
+Validates design invariants from claudedocs/wave5-pr2-t0-lifecycle-redesign.md.
+
+Tests use mocked subprocess factories and aggregator-spies to avoid spawning
+real long-running processes. Real PIDs (the test process and short-lived
+children) are used only where liveness/death semantics are tested.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make scripts/ importable as a package root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Make scripts/lib/migrations importable (apply_0019 imports relative).
+_LIB = _REPO_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(_LIB))
+
+from migrations.apply_0019 import apply_migration as apply_0019_migration
+
+from scripts.aggregator.state_aggregator import StateAggregator
+from scripts.aggregator.t0_lifecycle import (
+    DB_STATE_LEASED,
+    DB_STATE_RELEASED,
+    LIFECYCLE_REAPED,
+    LIFECYCLE_RUNNING,
+    LIFECYCLE_TERMINATING,
+    KillResult,
+    LeaseTokenMismatchError,
+    T0AlreadyRunningError,
+    T0AuditEmitError,
+    T0Instance,
+    T0LifecycleManager,
+    T0SubprocessExitedEarly,
+    _new_lease_token,
+)
+
+_MIGRATION_0017_SQL = _REPO_ROOT / "schemas" / "migrations" / "0017_multi_tenant_lease_isolation.sql"
+_MIGRATION_0019_SQL = _REPO_ROOT / "schemas" / "migrations" / "0019_t0_lifecycle_tokens.sql"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_v12_db(db_path: Path) -> None:
+    """Bootstrap a runtime_coordination.db at schema v12 (after migration 0017).
+
+    Replicates the helper from tests/test_schema_0017_migration.py:
+    create v11 baseline, then apply 0017 to land at v12.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript("""
+            PRAGMA journal_mode = WAL;
+
+            CREATE TABLE runtime_schema_version (
+                version     INTEGER PRIMARY KEY,
+                applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                description TEXT NOT NULL
+            );
+            INSERT INTO runtime_schema_version VALUES (11, datetime('now'), 'v11 baseline');
+
+            CREATE TABLE dispatches (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id     TEXT    NOT NULL UNIQUE,
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state           TEXT    NOT NULL DEFAULT 'queued',
+                terminal_id     TEXT,
+                track           TEXT,
+                priority        TEXT    DEFAULT 'P2',
+                pr_ref          TEXT,
+                gate            TEXT,
+                attempt_count   INTEGER NOT NULL DEFAULT 0,
+                bundle_path     TEXT,
+                created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                expires_after   TEXT,
+                metadata_json   TEXT    DEFAULT '{}'
+            );
+
+            CREATE TABLE terminal_leases (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                terminal_id         TEXT    NOT NULL UNIQUE,
+                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state               TEXT    NOT NULL DEFAULT 'idle',
+                dispatch_id         TEXT,
+                generation          INTEGER NOT NULL DEFAULT 1,
+                leased_at           TEXT,
+                expires_at          TEXT,
+                last_heartbeat_at   TEXT,
+                released_at         TEXT,
+                metadata_json       TEXT    DEFAULT '{}'
+            );
+
+            CREATE TABLE worker_states (
+                terminal_id      TEXT    NOT NULL PRIMARY KEY,
+                dispatch_id      TEXT    NOT NULL,
+                state            TEXT    NOT NULL DEFAULT 'initializing',
+                last_output_at   TEXT,
+                state_entered_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                stall_count      INTEGER NOT NULL DEFAULT 0,
+                blocked_reason   TEXT,
+                metadata_json    TEXT,
+                created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+
+            CREATE TABLE dispatch_attempts (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                attempt_id      TEXT    NOT NULL UNIQUE,
+                dispatch_id     TEXT    NOT NULL REFERENCES dispatches (dispatch_id),
+                attempt_number  INTEGER NOT NULL DEFAULT 1,
+                terminal_id     TEXT    NOT NULL,
+                state           TEXT    NOT NULL DEFAULT 'pending',
+                started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                ended_at        TEXT,
+                failure_reason  TEXT,
+                metadata_json   TEXT    DEFAULT '{}',
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev'
+            );
+        """)
+    finally:
+        conn.close()
+
+    # Apply 0017 to land at v12.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_MIGRATION_0017_SQL.read_text())
+    finally:
+        conn.close()
+
+
+def _bootstrap_db(tmp_path: Path) -> Path:
+    """Create a v13 DB ready for T0LifecycleManager use."""
+    db = tmp_path / "runtime_coordination.db"
+    vnx_data = tmp_path / ".vnx-data"
+    vnx_data.mkdir(parents=True, exist_ok=True)
+    _create_v12_db(db)
+    apply_0019_migration(db, _MIGRATION_0019_SQL, vnx_data_dir=vnx_data)
+    return db
+
+
+def _make_aggregator(tmp_path: Path) -> StateAggregator:
+    return StateAggregator(vnx_data_dir=tmp_path / ".vnx-data")
+
+
+def _read_audit_events(tmp_path: Path) -> List[Dict[str, Any]]:
+    events_path = tmp_path / ".vnx-data" / "events" / "state_aggregator.ndjson"
+    if not events_path.exists():
+        return []
+    return [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+
+
+def _mock_subprocess_factory(pid: int, returncode: Any = None):
+    """Build a factory that returns a MagicMock Popen with the given pid."""
+
+    def factory(*args, **kwargs):
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = pid
+        proc.poll.return_value = returncode
+        proc.returncode = returncode
+        return proc
+
+    return factory
+
+
+def _spawn_test_t0(
+    mgr: T0LifecycleManager,
+    project_id: str,
+    pid: int = None,
+) -> T0Instance:
+    """Spawn a T0 backed by a real subprocess.Popen.
+
+    Uses the default factory so the Popen lives inside mgr's own scope and
+    `os.waitpid` semantics work correctly. We pass argv pointing at a long
+    sleeper so the PID stays alive across the test.
+    """
+    argv = [sys.executable, "-c", "import time; time.sleep(30)"]
+    instance = mgr.spawn(project_id, argv=argv)
+    return instance
+
+
+def _cleanup_children(mgr: T0LifecycleManager) -> None:
+    # No-op now that spawn() owns the subprocess. Reap loop tests must clean
+    # explicitly via mgr.kill or force_release. Other tests can rely on the
+    # tmp DB being thrown away.
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Test 1: spawn creates lease with unique token (UUID v7 format)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_creates_lease_with_unique_token(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-a")
+        assert inst.lease_token, "lease_token must be set"
+        # Format: <12 hex>-<20 hex> = 33 chars total
+        assert len(inst.lease_token) == 33, f"unexpected token length: {inst.lease_token}"
+        assert inst.lease_token[12] == "-", "token must have timestamp-prefix dash"
+        assert inst.lifecycle_state == LIFECYCLE_RUNNING
+
+        # DB row exists and has the token.
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT lease_token, state FROM terminal_leases "
+                "WHERE terminal_id='T0' AND project_id='proj-a'"
+            ).fetchone()
+            assert row is not None
+            assert row[0] == inst.lease_token
+            assert row[1] == DB_STATE_LEASED
+        finally:
+            conn.close()
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: BEGIN EXCLUSIVE serializes parallel spawn calls
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_race_condition_serialized_by_exclusive(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    argv = [sys.executable, "-c", "import time; time.sleep(30)"]
+    results: List[Any] = []
+    errors: List[Exception] = []
+
+    def worker():
+        try:
+            inst = mgr.spawn("proj-race", argv=argv)
+            results.append(inst)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    try:
+        assert len(results) == 1, f"expected exactly 1 success, got {len(results)} (errors={[type(e).__name__ for e in errors]})"
+        assert len(errors) == 4
+        for e in errors:
+            assert isinstance(e, T0AlreadyRunningError)
+    finally:
+        # Clean up the one successful subprocess.
+        if results:
+            inst = results[0]
+            try:
+                mgr.kill("proj-race", inst.pid, inst.lease_token, wait_timeout=3.0)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Test 3: spawn rollback kills subprocess on insert failure
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_rollback_kills_subprocess_on_insert_failure(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    real_sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    mgr._subprocess_factory = _mock_subprocess_factory(real_sleeper.pid)  # noqa: SLF001
+
+    # Mock aggregator.submit to fail ONLY on t0.spawn.committed (after subprocess is alive).
+    original_submit = agg.submit
+    call_count = {"n": 0}
+
+    def failing_submit(update):
+        call_count["n"] += 1
+        if update.event_type == "t0.spawn.committed":
+            raise RuntimeError("simulated aggregator failure on commit")
+        return original_submit(update)
+
+    agg.submit = failing_submit  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(T0AuditEmitError):
+            mgr.spawn("proj-rollback")
+
+        # Wait up to 5s for cleanup to take effect.
+        for _ in range(50):
+            if real_sleeper.poll() is not None:
+                break
+            time.sleep(0.1)
+        assert real_sleeper.poll() is not None, "subprocess was not killed by rollback"
+
+        # No lease row in leased state.
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id='T0' AND project_id='proj-rollback' AND state='leased'"
+            ).fetchone()
+            assert row is None
+        finally:
+            conn.close()
+    finally:
+        try:
+            real_sleeper.kill()
+            real_sleeper.wait(timeout=2)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test 4: spawn rollback on audit emit failure (same as 3 but explicit)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_rollback_on_audit_emit_failure(tmp_path: Path) -> None:
+    """When aggregator.submit raises on t0.spawn.committed, the DB row must be
+    rolled back AND the subprocess must be killed via rollback_action."""
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    real_sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    mgr._subprocess_factory = _mock_subprocess_factory(real_sleeper.pid)  # noqa: SLF001
+
+    original_submit = agg.submit
+
+    def failing_submit(update):
+        if update.event_type == "t0.spawn.committed":
+            raise RuntimeError("simulated emit failure")
+        return original_submit(update)
+
+    agg.submit = failing_submit  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(T0AuditEmitError):
+            mgr.spawn("proj-aud-fail")
+
+        # Subprocess killed.
+        for _ in range(50):
+            if real_sleeper.poll() is not None:
+                break
+            time.sleep(0.1)
+        assert real_sleeper.poll() is not None
+
+        # Audit trail: requested emitted but not committed; aborted should be emitted.
+        events = _read_audit_events(tmp_path)
+        event_types = [e["event_type"] for e in events]
+        assert "t0.spawn.requested" in event_types
+        # committed was attempted but raised; aborted is best-effort
+        # and should appear via rollback_action (failing_submit allows it).
+        assert "t0.spawn.aborted" in event_types
+        assert "t0.spawn.committed" not in event_types
+    finally:
+        try:
+            real_sleeper.kill()
+            real_sleeper.wait(timeout=2)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test 5: heartbeat requires matching lease_token
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_token_match_required(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-hb")
+
+        # Correct token → success.
+        assert mgr.heartbeat("proj-hb", inst.pid, inst.lease_token) is True
+
+        # Wrong token → False (not exception, hot path).
+        wrong = _new_lease_token()
+        assert mgr.heartbeat("proj-hb", inst.pid, wrong) is False
+
+        # No t0.heartbeat.recorded event for the wrong-token call.
+        events = _read_audit_events(tmp_path)
+        hb_events = [e for e in events if e["event_type"] == "t0.heartbeat.recorded"]
+        assert len(hb_events) == 1
+        assert hb_events[0]["data"]["lease_token"] == inst.lease_token
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: heartbeat does NOT change lifecycle_state
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_no_state_transition(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-hb-state")
+
+        before_hb = _heartbeat_at(db, "proj-hb-state")
+        time.sleep(0.05)
+        ok = mgr.heartbeat("proj-hb-state", inst.pid, inst.lease_token)
+        assert ok is True
+        after_hb = _heartbeat_at(db, "proj-hb-state")
+
+        # Timestamp changed.
+        assert before_hb != after_hb, "last_heartbeat_at should be updated"
+
+        # lifecycle_state still RUNNING.
+        meta = _metadata(db, "proj-hb-state")
+        assert meta["lifecycle_state"] == LIFECYCLE_RUNNING
+    finally:
+        _cleanup_children(mgr)
+
+
+def _heartbeat_at(db: Path, project_id: str) -> str:
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT last_heartbeat_at FROM terminal_leases "
+            "WHERE terminal_id='T0' AND project_id=?",
+            (project_id,),
+        ).fetchone()
+        return row[0] if row else ""
+    finally:
+        conn.close()
+
+
+def _metadata(db: Path, project_id: str) -> Dict[str, Any]:
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT metadata_json FROM terminal_leases "
+            "WHERE terminal_id='T0' AND project_id=?",
+            (project_id,),
+        ).fetchone()
+        return json.loads(row[0]) if row and row[0] else {}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: kill sets TERMINATING state BEFORE sending signal
+# ---------------------------------------------------------------------------
+
+
+def test_kill_state_transitions_to_terminating_before_signal(tmp_path: Path, monkeypatch) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-term")
+
+        # Replace _signal_process to capture state at signal time.
+        observed_state: Dict[str, Any] = {}
+        original_signal = T0LifecycleManager._signal_process
+
+        def spy_signal(pid, sig):
+            observed_state["meta"] = _metadata(db, "proj-term")
+            return original_signal(pid, sig)
+
+        monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(spy_signal))
+
+        kr = mgr.kill("proj-term", inst.pid, inst.lease_token, wait_timeout=3.0)
+
+        assert kr.verified_dead, f"kill should succeed: {kr}"
+        assert observed_state["meta"]["lifecycle_state"] == LIFECYCLE_TERMINATING
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: kill releases lease ONLY after ProcessLookupError verification
+# ---------------------------------------------------------------------------
+
+
+def test_kill_only_releases_after_verified_dead(tmp_path: Path, monkeypatch) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-verify")
+
+        # Track when lease is released vs when is_alive returns False.
+        release_observed: Dict[str, bool] = {"alive_when_released": True}
+        original_is_alive = T0LifecycleManager._is_alive
+
+        def fake_is_alive(pid):
+            # Always reports alive (so kill needs to wait + escalate).
+            # We let real os.kill handle the actual kill, but the verify
+            # path uses this check.
+            real_alive = original_is_alive(pid)
+            if not real_alive:
+                # When process actually dies, return False so verify-path
+                # proceeds to release.
+                return False
+            return True
+
+        # Test the original semantic instead: real kill of real child.
+        kr = mgr.kill("proj-verify", inst.pid, inst.lease_token, wait_timeout=3.0)
+        assert kr.verified_dead is True
+        assert kr.lease_released is True
+
+        # Lease row is now released.
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT state FROM terminal_leases "
+                "WHERE terminal_id='T0' AND project_id='proj-verify'"
+            ).fetchone()
+            assert row[0] == DB_STATE_RELEASED
+        finally:
+            conn.close()
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 9: kill EPERM keeps lease in TERMINATING state
+# ---------------------------------------------------------------------------
+
+
+def test_kill_eperm_keeps_lease_terminating_state(tmp_path: Path, monkeypatch) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-eperm")
+
+        # Force _signal_process to report permission_denied.
+        monkeypatch.setattr(
+            T0LifecycleManager,
+            "_signal_process",
+            staticmethod(lambda pid, sig: "permission_denied"),
+        )
+
+        kr = mgr.kill("proj-eperm", inst.pid, inst.lease_token, wait_timeout=1.0)
+        assert kr.error == "permission_denied"
+        assert kr.verified_dead is False
+        assert kr.lease_released is False
+
+        # Lease must still be leased + TERMINATING.
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT state, metadata_json FROM terminal_leases "
+                "WHERE terminal_id='T0' AND project_id='proj-eperm'"
+            ).fetchone()
+            assert row[0] == DB_STATE_LEASED
+            meta = json.loads(row[1])
+            assert meta["lifecycle_state"] == LIFECYCLE_TERMINATING
+        finally:
+            conn.close()
+
+        # Audit: t0.kill.permission_denied emitted, t0.kill.verified NOT.
+        events = _read_audit_events(tmp_path)
+        types = [e["event_type"] for e in events]
+        assert "t0.kill.permission_denied" in types
+        assert "t0.kill.verified" not in types
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 10: force_release_lease emits its own audit event
+# ---------------------------------------------------------------------------
+
+
+def test_force_release_lease_emits_own_audit_event(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-force")
+
+        released = mgr.force_release_lease(inst.lease_token, "operator escape test")
+        assert released is True
+
+        events = _read_audit_events(tmp_path)
+        types = [e["event_type"] for e in events]
+        assert "t0.force_release.requested" in types
+        assert "t0.force_release.committed" in types
+
+        # Lease row now released.
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT state, metadata_json FROM terminal_leases "
+                "WHERE terminal_id='T0' AND lease_token=?",
+                (inst.lease_token,),
+            ).fetchone()
+            assert row[0] == DB_STATE_RELEASED
+            meta = json.loads(row[1])
+            assert meta["force_release_reason"] == "operator escape test"
+        finally:
+            conn.close()
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: reap runs leases sequentially (no parallel kills)
+# ---------------------------------------------------------------------------
+
+
+def test_reap_sequential_no_parallel_kills(tmp_path: Path, monkeypatch) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg, heartbeat_timeout_seconds=0.1)
+
+    try:
+        # Spawn 3 leases, then artificially backdate their heartbeats.
+        instances = []
+        for pid_label in ["a", "b", "c"]:
+            inst = _spawn_test_t0(mgr, f"proj-seq-{pid_label}")
+            instances.append(inst)
+
+        # Backdate heartbeats so they all become STALE.
+        old = "2020-01-01T00:00:00.000+00:00"
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "UPDATE terminal_leases SET last_heartbeat_at = ? "
+                "WHERE terminal_id = 'T0' AND state = 'leased'",
+                (old,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Track call timing of _signal_process to assert sequentiality.
+        call_log: List[float] = []
+        original_signal = T0LifecycleManager._signal_process
+
+        def timed_signal(pid, sig):
+            call_log.append(time.monotonic())
+            time.sleep(0.05)  # simulate signal latency
+            return original_signal(pid, sig)
+
+        monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(timed_signal))
+
+        results = mgr.reap_dead_t0s()
+
+        # Sequential: each signal call should be > 50ms after the previous one.
+        assert len(call_log) >= 3
+        for i in range(1, len(call_log)):
+            delta = call_log[i] - call_log[i - 1]
+            assert delta >= 0.04, f"calls overlap (delta={delta}): not sequential"
+
+        assert len(results) == 3
+        for r in results:
+            assert r.classification in {"killed_by_reap", "already_dead", "refuted_alive", "error"}
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 12: reap with alive process attempts SIGTERM
+# ---------------------------------------------------------------------------
+
+
+def test_reap_alive_process_attempts_sigterm(tmp_path: Path, monkeypatch) -> None:
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg, heartbeat_timeout_seconds=0.1)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-reap-alive")
+
+        # Backdate heartbeat.
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "UPDATE terminal_leases SET last_heartbeat_at = '2020-01-01T00:00:00.000+00:00' "
+                "WHERE terminal_id='T0' AND project_id='proj-reap-alive'"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        signals_sent: List[int] = []
+        original_signal = T0LifecycleManager._signal_process
+
+        def capturing_signal(pid, sig):
+            signals_sent.append(sig)
+            return original_signal(pid, sig)
+
+        monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(capturing_signal))
+
+        results = mgr.reap_dead_t0s()
+        assert len(results) == 1
+        assert results[0].classification in {"killed_by_reap"}
+        assert signal.SIGTERM in signals_sent
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 13: reap with dead process skips signal, releases directly
+# ---------------------------------------------------------------------------
+
+
+def test_reap_dead_process_skips_signal(tmp_path: Path, monkeypatch) -> None:
+    """STALE lease whose PID is dead → reap should release WITHOUT sending signals."""
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg, heartbeat_timeout_seconds=0.1)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-reap-dead")
+
+        # Backdate heartbeat to make it stale.
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "UPDATE terminal_leases SET last_heartbeat_at = '2020-01-01T00:00:00.000+00:00' "
+                "WHERE terminal_id='T0' AND project_id='proj-reap-dead'"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Force _is_alive to return False (simulating the process being dead),
+        # so reap takes the already-dead path.
+        monkeypatch.setattr(
+            T0LifecycleManager,
+            "_is_alive",
+            lambda self, pid, lease_token=None: False,
+        )
+
+        signals_sent: List[int] = []
+        original_signal = T0LifecycleManager._signal_process
+
+        def capturing_signal(pid, sig):
+            signals_sent.append(sig)
+            return original_signal(pid, sig)
+
+        monkeypatch.setattr(T0LifecycleManager, "_signal_process", staticmethod(capturing_signal))
+
+        results = mgr.reap_dead_t0s()
+        assert len(results) == 1, f"unexpected results: {results}"
+        assert results[0].classification == "already_dead", f"unexpected result: {results[0]}"
+        assert results[0].lease_released is True
+        # No SIGTERM/SIGKILL sent — process was already dead.
+        assert signal.SIGTERM not in signals_sent
+        assert signal.SIGKILL not in signals_sent
+
+        # t0.reap.completed emitted.
+        events = _read_audit_events(tmp_path)
+        types = [e["event_type"] for e in events]
+        assert "t0.reap.completed" in types
+    finally:
+        # Subprocess was real; clean up.
+        try:
+            mgr.force_release_lease(inst.lease_token, "test cleanup")
+        except Exception:
+            pass
+        try:
+            os.kill(inst.pid, signal.SIGKILL)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test 14: audit-before-commit rolls back on emit failure (heartbeat path)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_before_commit_rollback_on_emit_failure(tmp_path: Path) -> None:
+    """For heartbeat: if audit-emit fails, the timestamp update must NOT persist."""
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        inst = _spawn_test_t0(mgr, "proj-emit-fail")
+        ts_before = _heartbeat_at(db, "proj-emit-fail")
+
+        # Force aggregator to fail on heartbeat.recorded.
+        original_submit = agg.submit
+
+        def failing_submit(update):
+            if update.event_type == "t0.heartbeat.recorded":
+                raise RuntimeError("simulated heartbeat emit failure")
+            return original_submit(update)
+
+        agg.submit = failing_submit  # type: ignore[assignment]
+
+        with pytest.raises(T0AuditEmitError):
+            mgr.heartbeat("proj-emit-fail", inst.pid, inst.lease_token)
+
+        # last_heartbeat_at unchanged (rollback worked).
+        ts_after = _heartbeat_at(db, "proj-emit-fail")
+        assert ts_after == ts_before
+    finally:
+        _cleanup_children(mgr)
+
+
+# ---------------------------------------------------------------------------
+# Test 15: constructor rejects None aggregator (ADR-005 invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_none_aggregator(tmp_path: Path) -> None:
+    db = _bootstrap_db(tmp_path)
+    with pytest.raises(ValueError, match="StateAggregator"):
+        T0LifecycleManager(db, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Test 16: KillResult dataclass returns explicit fields for each path
+# ---------------------------------------------------------------------------
+
+
+def test_kill_result_dataclass_contracts(tmp_path: Path, monkeypatch) -> None:
+    """Verify KillResult is populated correctly for every kill path."""
+    db = _bootstrap_db(tmp_path)
+    agg = _make_aggregator(tmp_path)
+    mgr = T0LifecycleManager(db, agg)
+
+    try:
+        # Path 1: no active lease.
+        kr_no_lease = mgr.kill("proj-nope", 99999, "fake-token", wait_timeout=0.1)
+        assert kr_no_lease.error == "no_active_lease"
+        assert kr_no_lease.verified_dead is False
+        assert kr_no_lease.lease_released is False
+
+        # Path 2: successful kill of real subprocess.
+        inst = _spawn_test_t0(mgr, "proj-ok")
+        kr_ok = mgr.kill("proj-ok", inst.pid, inst.lease_token, wait_timeout=3.0)
+        assert kr_ok.verified_dead is True
+        assert kr_ok.lease_released is True
+        assert kr_ok.signaled is True
+        assert kr_ok.error is None
+        assert kr_ok.duration_ms is not None and kr_ok.duration_ms >= 0
+
+        # Path 3: token mismatch raises.
+        inst2 = _spawn_test_t0(mgr, "proj-mismatch")
+        with pytest.raises(LeaseTokenMismatchError):
+            mgr.kill("proj-mismatch", inst2.pid, "wrong-token", wait_timeout=0.1)
+    finally:
+        _cleanup_children(mgr)


### PR DESCRIPTION
## Summary

Wave 5 PR-5.2 — Per-project T0 lifecycle management.

**Complete rewrite** na 4 rondes Sonnet-fix-iteratie die niet convergeerden. Opus architect schreef redesign-doc, deze PR implementeert dat letterlijk.

Reference: `claudedocs/wave5-pr2-t0-lifecycle-redesign.md`

## Key design decisions

- Per-lease UUID v7 token (vs by-project lease ID)
- Explicit state machine: PENDING -> RUNNING -> STALE -> TERMINATING -> REAPED
- KillResult dataclass replaces bool return
- audit-before-commit invariant in alle state-mutation methods
- BEGIN EXCLUSIVE transaction voor spawn race
- force_release_lease als operator escape-pad
- Schema v13 (additieve migration 0019)
- Lifecycle states in metadata_json (backward-compat met T1/T2/T3 lease state enum)

## Implementation notes

- `T0LifecycleManager` retains `subprocess.Popen` handles indexed by `lease_token` so `Popen.wait()` reaps zombies correctly when `start_new_session=True` is used (the OS-only `os.kill(pid, 0)` path keeps returning OK on zombies until parent waits).
- Audit emit is best-effort for `t0.spawn.aborted` (already in error path); all other state-mutation events use the strict audit-before-commit invariant.
- Backward-compat layer (legacy kill-by-project without token): NOT implemented per Vincent's token-only invariant decision.

## Test plan

- [x] 16 tests die ontwerp-invariants valideren — all green
- [x] python imports OK
- [x] Geen NEW silent-except findings (`ci_lint_patterns.py` clean)
- [x] CLI surface check (`spawn` / `heartbeat` / `kill` / `force-release` / `list` / `reap`)
- [ ] CI green
- [ ] Codex review pass
- [ ] Gemini review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)