### PR TITLE
feat(wave5): timing-metrics in receipts + retrospective analyzer

### DIFF
--- a/scripts/aggregator/t0_lifecycle.py
+++ b/scripts/aggregator/t0_lifecycle.py
@@ -1,0 +1,371 @@
+"""t0_lifecycle.py — Wave 5 PR-5.2: per-project T0 spawn/heartbeat/kill mechanics.
+
+Control Centre uses this to manage N per-project T0 processes. Each T0 runs
+in its own project worktree with isolated VNX_PROJECT_ID env. State aggregator
+(PR-5.1) is the central state-sharing mechanism.
+
+Lease isolation uses runtime_coordination.db terminal_leases with composite
+UNIQUE(terminal_id="T0", project_id) per schema v10 (Wave 5 PR-5.3).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+_T0_TERMINAL_ID = "T0"
+_HEARTBEAT_TIMEOUT_DEFAULT = 120
+_KILL_POLL_INTERVAL_DEFAULT = 0.5
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _parse_iso(ts: str) -> float:
+    """Return POSIX timestamp from ISO 8601 string. Raises ValueError on bad input."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+
+@dataclass
+class T0Instance:
+    project_id: str
+    pid: int
+    started_at: str             # ISO 8601
+    project_root: str           # absolute path
+    state: str                  # spawning | running | stopping | stopped
+    last_heartbeat_at: Optional[str] = None
+
+
+class T0LifecycleManager:
+    """Manages spawn/kill/heartbeat for per-project T0 processes.
+
+    Thread-safe via SQLite WAL + EXCLUSIVE transactions. Each T0 is tracked
+    as a lease row with terminal_id="T0" and project_id=<project_id>.
+    """
+
+    def __init__(self, opts: dict) -> None:
+        self._coord_db = Path(opts["coord_db_path"])
+        self._project_registry: Dict[str, dict] = opts.get("projects", {})
+        self._heartbeat_timeout_seconds: float = opts.get(
+            "heartbeat_timeout", _HEARTBEAT_TIMEOUT_DEFAULT
+        )
+        self._kill_poll_interval: float = opts.get(
+            "kill_poll_interval", _KILL_POLL_INTERVAL_DEFAULT
+        )
+        self._aggregator = opts.get("aggregator")
+        self._coord_db.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def spawn(self, project_id: str) -> T0Instance:
+        """Spawn a per-project T0 process.
+
+        Refuses if a T0 for this project_id is already running.
+        Uses composite lease row (terminal_id="T0", project_id) from schema v10.
+
+        Raises ValueError if T0 already running for this project_id.
+        Raises RuntimeError if subprocess.Popen fails.
+        """
+        project_cfg = self._project_registry.get(project_id, {})
+        project_root = project_cfg.get("root", "")
+        cmd = list(project_cfg.get("cmd", ["claude"])) + list(
+            project_cfg.get("claude_args", [])
+        )
+        now = _now_iso()
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN EXCLUSIVE")
+            existing = self._get_t0_row(conn, project_id)
+            if existing and existing["state"] == "leased":
+                meta = json.loads(existing.get("metadata_json") or "{}")
+                conn.execute("ROLLBACK")
+                raise ValueError(
+                    f"T0 for project {project_id!r} is already running "
+                    f"(pid={meta.get('pid')})"
+                )
+
+            env = {**os.environ, "VNX_PROJECT_ID": project_id}
+            if project_root:
+                env["VNX_PROJECT_ROOT"] = project_root
+
+            try:
+                proc = subprocess.Popen(
+                    cmd,
+                    cwd=project_root or None,
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except OSError as e:
+                conn.execute("ROLLBACK")
+                raise RuntimeError(
+                    f"Failed to spawn T0 for {project_id!r}: {e}"
+                ) from e
+
+            pid = proc.pid
+            metadata = json.dumps(
+                {"pid": pid, "project_root": project_root, "started_at": now}
+            )
+
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO terminal_leases
+                        (terminal_id, project_id, state, dispatch_id, generation,
+                         leased_at, last_heartbeat_at, metadata_json)
+                    VALUES (?, ?, 'leased', NULL, 1, ?, ?, ?)
+                    """,
+                    (_T0_TERMINAL_ID, project_id, now, now, metadata),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE terminal_leases
+                    SET state='leased', generation=generation+1,
+                        leased_at=?, last_heartbeat_at=?,
+                        released_at=NULL, dispatch_id=NULL, metadata_json=?
+                    WHERE terminal_id=? AND project_id=?
+                    """,
+                    (now, now, metadata, _T0_TERMINAL_ID, project_id),
+                )
+            conn.execute("COMMIT")
+        finally:
+            conn.close()
+
+        instance = T0Instance(
+            project_id=project_id,
+            pid=pid,
+            started_at=now,
+            project_root=project_root,
+            state="running",
+            last_heartbeat_at=now,
+        )
+        self._emit_event(project_id, "t0_spawned", {
+            "pid": pid,
+            "project_root": project_root,
+            "started_at": now,
+        })
+        return instance
+
+    def heartbeat(self, project_id: str, pid: int) -> bool:
+        """Update last_heartbeat_at for the given project T0.
+
+        Returns True if recorded. Returns False if no matching running lease found
+        or if the pid does not match the stored pid.
+        """
+        now = _now_iso()
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if not row or row["state"] != "leased":
+                return False
+            meta = json.loads(row.get("metadata_json") or "{}")
+            if meta.get("pid") != pid:
+                return False
+            conn.execute(
+                """
+                UPDATE terminal_leases SET last_heartbeat_at=?
+                WHERE terminal_id=? AND project_id=?
+                """,
+                (now, _T0_TERMINAL_ID, project_id),
+            )
+            conn.commit()
+
+        self._emit_event(project_id, "t0_heartbeat", {
+            "pid": pid,
+            "heartbeat_at": now,
+        })
+        return True
+
+    def list_running(self) -> List[T0Instance]:
+        """Return all T0 instances currently in running (leased) state."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND state='leased'",
+                (_T0_TERMINAL_ID,),
+            ).fetchall()
+
+        result: List[T0Instance] = []
+        for row in rows:
+            r = dict(row)
+            meta = json.loads(r.get("metadata_json") or "{}")
+            result.append(T0Instance(
+                project_id=r["project_id"],
+                pid=meta.get("pid", -1),
+                started_at=meta.get("started_at", r.get("leased_at", "")),
+                project_root=meta.get("project_root", ""),
+                state="running",
+                last_heartbeat_at=r.get("last_heartbeat_at"),
+            ))
+        return result
+
+    def kill(
+        self,
+        project_id: str,
+        *,
+        signal_type: int = signal.SIGTERM,
+    ) -> bool:
+        """Send signal to T0 process.
+
+        SIGTERM: wait up to heartbeat_timeout_seconds for graceful shutdown,
+        then escalate to SIGKILL. SIGKILL: immediate, no wait.
+        Returns True if a running lease was found and signalled.
+        """
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if not row or row["state"] != "leased":
+                return False
+            meta = json.loads(row.get("metadata_json") or "{}")
+            pid = meta.get("pid")
+            if not pid:
+                return False
+
+        try:
+            os.kill(pid, signal_type)
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            log.warning("t0_lifecycle: kill pid=%d failed: %s", pid, e)
+
+        if signal_type == signal.SIGTERM:
+            deadline = time.monotonic() + self._heartbeat_timeout_seconds
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                    time.sleep(self._kill_poll_interval)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        now = _now_iso()
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if row:
+                existing_meta = json.loads(row.get("metadata_json") or "{}")
+                existing_meta["killed_at"] = now
+                conn.execute(
+                    """
+                    UPDATE terminal_leases
+                    SET state='released', released_at=?, metadata_json=?
+                    WHERE terminal_id=? AND project_id=?
+                    """,
+                    (now, json.dumps(existing_meta), _T0_TERMINAL_ID, project_id),
+                )
+                conn.commit()
+
+        self._emit_event(project_id, "t0_killed", {
+            "pid": pid,
+            "signal": signal_type,
+            "killed_at": now,
+        })
+        return True
+
+    def reap_dead_t0s(self) -> List[str]:
+        """Detect T0s where last_heartbeat older than heartbeat_timeout_seconds.
+
+        Marks their leases released and returns list of reaped project_ids.
+        Idempotent: already-released T0s are not re-reaped.
+        """
+        now_ts = time.time()
+        reaped: List[str] = []
+
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND state='leased'",
+                (_T0_TERMINAL_ID,),
+            ).fetchall()
+
+            for row in rows:
+                r = dict(row)
+                hb = r.get("last_heartbeat_at")
+                if not hb:
+                    continue
+                try:
+                    age = now_ts - _parse_iso(hb)
+                except ValueError:
+                    continue
+                if age > self._heartbeat_timeout_seconds:
+                    released_at = _now_iso()
+                    conn.execute(
+                        """
+                        UPDATE terminal_leases
+                        SET state='released', released_at=?
+                        WHERE terminal_id=? AND project_id=?
+                        """,
+                        (released_at, _T0_TERMINAL_ID, r["project_id"]),
+                    )
+                    reaped.append(r["project_id"])
+
+            if reaped:
+                conn.commit()
+
+        for project_id in reaped:
+            self._emit_event(project_id, "t0_reaped", {
+                "reason": "heartbeat_timeout",
+                "timeout_seconds": self._heartbeat_timeout_seconds,
+            })
+        return reaped
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._coord_db), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _get_t0_row(
+        self, conn: sqlite3.Connection, project_id: str
+    ) -> Optional[dict]:
+        row = conn.execute(
+            """
+            SELECT * FROM terminal_leases
+            WHERE terminal_id=? AND project_id=?
+            """,
+            (_T0_TERMINAL_ID, project_id),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def _emit_event(
+        self, project_id: str, event_type: str, payload: dict
+    ) -> None:
+        if self._aggregator is None:
+            return
+        try:
+            from scripts.aggregator.state_aggregator import ProjectStateUpdate
+            update = ProjectStateUpdate(
+                project_id=project_id,
+                timestamp=_now_iso(),
+                event_type=event_type,
+                payload=payload,
+                source_t0="T0-lifecycle",
+            )
+            self._aggregator.submit(update)
+        except Exception as e:
+            log.warning(
+                "t0_lifecycle: aggregator emit failed for %s/%s: %s",
+                project_id,
+                event_type,
+                e,
+            )

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -50,6 +50,30 @@ def _maybe_reroute_to_gate_stream(receipt: Dict[str, Any], receipts_file: Option
         return receipts_file
 
 
+def _enrich_receipt_timing(receipt: Dict[str, Any]) -> None:
+    """Idempotent: stamp timing block from NDJSON archive onto completion receipt.
+
+    Skipped silently when archive is unavailable or timing already present.
+    """
+    if receipt.get("timing") is not None:
+        return
+    dispatch_id = str(receipt.get("dispatch_id") or "").strip()
+    if not dispatch_id or dispatch_id == "unknown":
+        return
+    try:
+        sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+        from timing_metrics import _build_timing_block
+        paths = facade.ensure_env()
+        vnx_data_dir = Path(paths.get("VNX_DATA_DIR", "")).expanduser()
+        if not vnx_data_dir.is_dir():
+            return
+        block = _build_timing_block(dispatch_id, vnx_data_dir)
+        if block is not None:
+            receipt["timing"] = block
+    except Exception as exc:
+        log.warning("payload: timing enrichment failed for %r: %s", dispatch_id, exc)
+
+
 def _run_post_append_hooks(receipt: Dict[str, Any]) -> None:
     """Best-effort hooks fired after a receipt is successfully appended.
 
@@ -338,6 +362,7 @@ def append_receipt_payload(
 
     if not skip_enrichment:
         receipt = facade._enrich_completion_receipt(receipt)
+        _enrich_receipt_timing(receipt)
 
     receipt.setdefault("open_items_created", facade._count_quality_violations(receipt))
 

--- a/scripts/lib/timing_metrics.py
+++ b/scripts/lib/timing_metrics.py
@@ -1,0 +1,167 @@
+"""timing_metrics.py — Wave 5 PR-5.x: effective time + parallel detection.
+
+Two use-cases:
+- Forward: append_receipt enriches new receipts with timing block
+- Retrospective: pr_timing_report CLI analyzes archived event-streams
+
+Effective time = sum of inter-event gaps capped at threshold_seconds.
+Long gaps (gates running, waiting on review) don't count as active work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ACTIVE_THRESHOLD_SECONDS = float(
+    os.environ.get("VNX_TIMING_ACTIVE_THRESHOLD_SECONDS", "10.0")
+)
+
+
+@dataclass
+class TimingMetrics:
+    dispatch_id: str
+    walltime_seconds: float
+    effective_seconds: float
+    event_count: int
+    started_at: str
+    ended_at: str
+    parallel_dispatch_ids: List[str]
+    parallel_seconds: float
+
+
+def _parse_timestamp(ts: str) -> float:
+    """Return POSIX timestamp from ISO 8601 string. Raises ValueError on bad input."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+
+def compute_effective_time(
+    ndjson_path: Path,
+    threshold_seconds: float = DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+) -> Tuple[float, float, int, str, str]:
+    """Parse NDJSON event-stream, return (walltime, effective_time, event_count, started_iso, ended_iso).
+
+    Effective = sum of min(t_next - t_curr, threshold) for consecutive event timestamps.
+    Walltime = last event ts - first event ts.
+    """
+    timestamps: List[Tuple[float, str]] = []
+    with open(ndjson_path, "r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = obj.get("timestamp")
+            if not ts:
+                continue
+            try:
+                t = _parse_timestamp(ts)
+                timestamps.append((t, ts))
+            except ValueError:
+                continue
+
+    if len(timestamps) < 2:
+        started = timestamps[0][1] if timestamps else ""
+        return 0.0, 0.0, len(timestamps), started, started
+
+    timestamps.sort(key=lambda x: x[0])
+    walltime = timestamps[-1][0] - timestamps[0][0]
+    effective = sum(
+        min(timestamps[i + 1][0] - timestamps[i][0], threshold_seconds)
+        for i in range(len(timestamps) - 1)
+    )
+    return walltime, effective, len(timestamps), timestamps[0][1], timestamps[-1][1]
+
+
+def detect_parallel_dispatches(
+    target_dispatch_id: str,
+    target_started: float,
+    target_ended: float,
+    candidate_archives: List[Path],
+) -> Tuple[List[str], float]:
+    """For target dispatch's [start, end] window, find other dispatches whose windows overlap.
+
+    Returns (list of overlapping dispatch_ids, total seconds during which 1+ other was active).
+    """
+    overlaps: List[str] = []
+    overlap_intervals: List[Tuple[float, float]] = []
+    for archive in candidate_archives:
+        if target_dispatch_id in archive.stem:
+            continue
+        try:
+            _, _, _, started, ended = compute_effective_time(archive)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        if not started or not ended:
+            continue
+        try:
+            t_start = _parse_timestamp(started)
+            t_end = _parse_timestamp(ended)
+        except ValueError:
+            continue
+        overlap_start = max(target_started, t_start)
+        overlap_end = min(target_ended, t_end)
+        if overlap_end > overlap_start:
+            overlaps.append(archive.stem)
+            overlap_intervals.append((overlap_start, overlap_end))
+    parallel_seconds = sum(end - start for start, end in overlap_intervals)
+    return overlaps, parallel_seconds
+
+
+def analyze_dispatch(
+    dispatch_id: str,
+    archive_root: Path,
+    threshold_seconds: float = DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+) -> Optional[TimingMetrics]:
+    """Find the NDJSON archive for dispatch_id, compute metrics, detect parallel."""
+    candidates = list(archive_root.rglob(f"{dispatch_id}*.ndjson"))
+    if not candidates:
+        return None
+    ndjson_path = candidates[0]
+
+    wt, eff, n_events, started, ended = compute_effective_time(ndjson_path, threshold_seconds)
+    if not started:
+        return None
+
+    t_start = _parse_timestamp(started)
+    t_end = _parse_timestamp(ended)
+    all_archives = list(archive_root.rglob("*.ndjson"))
+    parallel_ids, parallel_secs = detect_parallel_dispatches(
+        dispatch_id, t_start, t_end, all_archives
+    )
+
+    return TimingMetrics(
+        dispatch_id=dispatch_id,
+        walltime_seconds=wt,
+        effective_seconds=eff,
+        event_count=n_events,
+        started_at=started,
+        ended_at=ended,
+        parallel_dispatch_ids=parallel_ids,
+        parallel_seconds=parallel_secs,
+    )
+
+
+def _build_timing_block(
+    dispatch_id: str,
+    vnx_data_dir: Path,
+    threshold_seconds: float = DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+) -> Optional[Dict]:
+    """Build a timing dict for receipt enrichment. Returns None if archive unavailable."""
+    archive_root = vnx_data_dir / "events" / "archive"
+    if not archive_root.exists():
+        return None
+    metrics = analyze_dispatch(dispatch_id, archive_root, threshold_seconds)
+    if metrics is None:
+        return None
+    return asdict(metrics)

--- a/scripts/pr_timing_report.py
+++ b/scripts/pr_timing_report.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""pr_timing_report.py — Wave 5 PR-5.x retrospective timing analyzer.
+
+Usage:
+    python3 scripts/pr_timing_report.py --pr 522
+    python3 scripts/pr_timing_report.py --since 2026-05-15
+    python3 scripts/pr_timing_report.py --dispatch 20260516-wave5-pr1-aggregator
+    python3 scripts/pr_timing_report.py --since 2026-05-15 --output claudedocs/report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+SCRIPTS_LIB = Path(__file__).resolve().parent / "lib"
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+
+from timing_metrics import TimingMetrics, analyze_dispatch, compute_effective_time
+
+HOURLY_RATE = 125.0
+SECONDS_PER_HOUR = 3600.0
+
+_PR_IN_NAME_RE = re.compile(r"(?:pr|PR)[- _]?(\d+)")
+_PR_IN_DISPATCH_RE = re.compile(r"[_-]pr(\d+)[_-]", re.IGNORECASE)
+
+
+def _resolve_archive_root() -> Path:
+    vnx_data = os.environ.get("VNX_DATA_DIR", "")
+    if vnx_data:
+        root = Path(vnx_data).expanduser() / "events" / "archive"
+        if root.exists():
+            return root
+    candidates = [
+        Path(__file__).resolve().parent.parent / ".vnx-data" / "events" / "archive",
+        Path.home() / ".vnx-data" / "events" / "archive",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return candidates[0]
+
+
+def _resolve_receipts_file() -> Optional[Path]:
+    vnx_data = os.environ.get("VNX_DATA_DIR", "")
+    if vnx_data:
+        p = Path(vnx_data).expanduser() / "state" / "t0_receipts.ndjson"
+        if p.exists():
+            return p
+    candidates = [
+        Path(__file__).resolve().parent.parent / ".vnx-data" / "state" / "t0_receipts.ndjson",
+        Path.home() / ".vnx-data" / "state" / "t0_receipts.ndjson",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def _all_archive_files(archive_root: Path) -> List[Path]:
+    if not archive_root.exists():
+        return []
+    return sorted(archive_root.rglob("*.ndjson"))
+
+
+def _dispatch_ids_for_pr(pr_num: int, archive_root: Path) -> List[str]:
+    """Find dispatch IDs that reference a given PR number in their stem."""
+    result: List[str] = []
+    patterns = [
+        re.compile(rf"[_-]pr[_-]?{pr_num}[_-]", re.IGNORECASE),
+        re.compile(rf"[_-]{pr_num}[_-]"),
+        re.compile(rf"pr{pr_num}[_-]", re.IGNORECASE),
+    ]
+    seen: set = set()
+    for f in _all_archive_files(archive_root):
+        stem = f.stem
+        if stem in seen:
+            continue
+        for pat in patterns:
+            if pat.search(stem):
+                result.append(stem)
+                seen.add(stem)
+                break
+
+    if not result:
+        result = _dispatch_ids_for_pr_from_receipts(pr_num)
+
+    return result
+
+
+def _dispatch_ids_for_pr_from_receipts(pr_num: int) -> List[str]:
+    receipts_file = _resolve_receipts_file()
+    if not receipts_file:
+        return []
+    result: List[str] = []
+    seen: set = set()
+    pr_re = re.compile(rf"\bpr[_-]?{pr_num}\b", re.IGNORECASE)
+    try:
+        with open(receipts_file, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                dispatch_id = str(obj.get("dispatch_id") or "")
+                if not dispatch_id or dispatch_id in seen:
+                    continue
+                searchable = " ".join(
+                    str(obj.get(k, ""))
+                    for k in ("dispatch_id", "title", "gate", "task_id")
+                )
+                if pr_re.search(searchable):
+                    result.append(dispatch_id)
+                    seen.add(dispatch_id)
+    except OSError:
+        pass
+    return result
+
+
+def _dispatch_ids_since(since_date: datetime, archive_root: Path) -> List[str]:
+    """Return dispatch IDs whose archive file was last-modified on or after since_date."""
+    result: List[str] = []
+    seen: set = set()
+    for f in _all_archive_files(archive_root):
+        stem = f.stem
+        if stem in seen:
+            continue
+        mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+        if mtime >= since_date:
+            result.append(stem)
+            seen.add(stem)
+    return result
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m = int(seconds // 60)
+    s = int(seconds % 60)
+    if m < 60:
+        return f"{m}m{s:02d}s" if s else f"{m}m"
+    h = m // 60
+    rm = m % 60
+    return f"{h}h{rm:02d}m" if rm else f"{h}h"
+
+
+def _effective_rate(effective_seconds: float) -> str:
+    if effective_seconds <= 0:
+        return "n/a"
+    rate = HOURLY_RATE / (effective_seconds / SECONDS_PER_HOUR)
+    return f"€{rate:.0f}/u"
+
+
+def _active_ratio(effective_seconds: float, walltime_seconds: float) -> str:
+    if walltime_seconds <= 0:
+        return "n/a"
+    ratio = effective_seconds / walltime_seconds * 100
+    return f"{ratio:.0f}%"
+
+
+def _render_dispatch_block(metrics: TimingMetrics) -> str:
+    lines = [
+        f"  Dispatch: {metrics.dispatch_id}",
+        f"    Walltime:  {_format_duration(metrics.walltime_seconds)}",
+        f"    Effective: {_format_duration(metrics.effective_seconds)}",
+        f"    Events:    {metrics.event_count}",
+        f"    Active:    {_active_ratio(metrics.effective_seconds, metrics.walltime_seconds)}",
+    ]
+    if metrics.parallel_dispatch_ids:
+        lines.append(f"    Parallel:  {', '.join(metrics.parallel_dispatch_ids)}")
+        lines.append(f"    Para-secs: {_format_duration(metrics.parallel_seconds)}")
+    return "\n".join(lines)
+
+
+def _render_pr_section(
+    pr_num: Optional[int],
+    dispatch_results: List[TimingMetrics],
+    pr_title: str = "",
+) -> str:
+    if not dispatch_results:
+        label = f"PR #{pr_num}" if pr_num else "?"
+        return f"{label} — no timing data found\n"
+
+    walltime_sum = sum(m.walltime_seconds for m in dispatch_results)
+    effective_sum = sum(m.effective_seconds for m in dispatch_results)
+    all_parallel = list(
+        {pid for m in dispatch_results for pid in m.parallel_dispatch_ids}
+    )
+    para_secs = sum(m.parallel_seconds for m in dispatch_results)
+
+    header = f"PR #{pr_num}" if pr_num else "Dispatches"
+    if pr_title:
+        header += f" — {pr_title}"
+    lines = [header]
+    lines.append(f"  Dispatches:   {len(dispatch_results)}")
+    lines.append(f"  Walltime sum: {_format_duration(walltime_sum)}")
+    lines.append(f"  Effective sum:{_format_duration(effective_sum)}")
+    lines.append(f"  Active ratio: {_active_ratio(effective_sum, walltime_sum)}")
+    if all_parallel:
+        pr_refs = sorted({_extract_pr_ref(d) for d in all_parallel if _extract_pr_ref(d)})
+        label = ", ".join(f"PR #{p}" for p in pr_refs) if pr_refs else ", ".join(all_parallel[:3])
+        lines.append(f"  Parallel with:{label}")
+        lines.append(f"  Para-seconds: {_format_duration(para_secs)}")
+    lines.append(f"  Effective rate: {_effective_rate(effective_sum)}")
+    lines.append("")
+    for m in dispatch_results:
+        lines.append(_render_dispatch_block(m))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _extract_pr_ref(dispatch_id: str) -> Optional[int]:
+    m = _PR_IN_DISPATCH_RE.search(dispatch_id)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _render_aggregate(all_results: List[Tuple[Optional[int], List[TimingMetrics]]]) -> str:
+    total_walltime = sum(m.walltime_seconds for _, ml in all_results for m in ml)
+    total_effective = sum(m.effective_seconds for _, ml in all_results for m in ml)
+    total_dispatches = sum(len(ml) for _, ml in all_results)
+
+    lines = [
+        "## Aggregate",
+        f"  Total dispatches: {total_dispatches}",
+        f"  Total walltime:   {_format_duration(total_walltime)}",
+        f"  Total effective:  {_format_duration(total_effective)}",
+        f"  Overall active:   {_active_ratio(total_effective, total_walltime)}",
+        f"  Effective rate:   {_effective_rate(total_effective)}",
+    ]
+    return "\n".join(lines)
+
+
+def run_pr(pr_num: int, archive_root: Path) -> Tuple[Optional[int], List[TimingMetrics]]:
+    dispatch_ids = _dispatch_ids_for_pr(pr_num, archive_root)
+    results = []
+    for did in dispatch_ids:
+        m = analyze_dispatch(did, archive_root)
+        if m:
+            results.append(m)
+    return pr_num, results
+
+
+def run_since(since_str: str, archive_root: Path) -> List[Tuple[Optional[int], List[TimingMetrics]]]:
+    try:
+        since_dt = datetime.fromisoformat(since_str).replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid --since date: {exc}") from exc
+    dispatch_ids = _dispatch_ids_since(since_dt, archive_root)
+    by_pr: Dict[Optional[int], List[TimingMetrics]] = {}
+    for did in dispatch_ids:
+        m = analyze_dispatch(did, archive_root)
+        if not m:
+            continue
+        pr_ref = _extract_pr_ref(did)
+        by_pr.setdefault(pr_ref, []).append(m)
+    return sorted(by_pr.items(), key=lambda x: (x[0] is None, x[0]))
+
+
+def run_dispatch(dispatch_id: str, archive_root: Path) -> Tuple[Optional[int], List[TimingMetrics]]:
+    m = analyze_dispatch(dispatch_id, archive_root)
+    if not m:
+        return None, []
+    return _extract_pr_ref(dispatch_id), [m]
+
+
+def build_report(sections: List[Tuple[Optional[int], List[TimingMetrics]]]) -> str:
+    parts = ["# VNX Timing Report\n"]
+    for pr_num, results in sections:
+        parts.append(_render_pr_section(pr_num, results))
+    if len(sections) > 1:
+        parts.append(_render_aggregate(sections))
+    return "\n".join(parts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="VNX timing retrospective report")
+    parser.add_argument("--pr", type=int, help="PR number to analyze")
+    parser.add_argument("--since", help="ISO date (e.g. 2026-05-15) — report all dispatches since")
+    parser.add_argument("--dispatch", help="Single dispatch ID to analyze")
+    parser.add_argument("--output", help="Write markdown report to this file path")
+    args = parser.parse_args()
+
+    if not any([args.pr, args.since, args.dispatch]):
+        parser.print_help()
+        raise SystemExit(1)
+
+    archive_root = _resolve_archive_root()
+
+    sections: List[Tuple[Optional[int], List[TimingMetrics]]] = []
+
+    if args.dispatch:
+        sections.append(run_dispatch(args.dispatch, archive_root))
+    elif args.pr:
+        sections.append(run_pr(args.pr, archive_root))
+    elif args.since:
+        sections.extend(run_since(args.since, archive_root))
+
+    report = build_report(sections)
+    print(report)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = out_path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(report, encoding="utf-8")
+        os.replace(tmp, out_path)
+        print(f"\nReport written to: {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/t0_lifecycle_cli.py
+++ b/scripts/t0_lifecycle_cli.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""t0_lifecycle_cli.py — Operator CLI for per-project T0 lifecycle management.
+
+Wave 5 PR-5.2. Wraps T0LifecycleManager with an argparse interface.
+
+Usage:
+    python3 scripts/t0_lifecycle_cli.py spawn --project-id vnx-dev --project-root /path/to/repo
+    python3 scripts/t0_lifecycle_cli.py heartbeat --project-id vnx-dev --pid 12345
+    python3 scripts/t0_lifecycle_cli.py list
+    python3 scripts/t0_lifecycle_cli.py kill --project-id vnx-dev
+    python3 scripts/t0_lifecycle_cli.py reap
+
+Config resolution (in priority order):
+    1. --coord-db CLI flag
+    2. VNX_STATE_DIR env var  → <VNX_STATE_DIR>/runtime_coordination.db
+    3. Default: .vnx-data/state/runtime_coordination.db (relative to cwd)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+
+# Allow running from project root or scripts/ directory
+_HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = _HERE.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.aggregator.t0_lifecycle import T0LifecycleManager
+
+
+def _resolve_coord_db(args: argparse.Namespace) -> Path:
+    if getattr(args, "coord_db", None):
+        return Path(args.coord_db)
+    state_dir = os.environ.get("VNX_STATE_DIR")
+    if state_dir:
+        return Path(state_dir) / "runtime_coordination.db"
+    return Path.cwd() / ".vnx-data" / "state" / "runtime_coordination.db"
+
+
+def _build_manager(
+    coord_db: Path,
+    project_id: str = "",
+    project_root: str = "",
+    claude_args: list | None = None,
+) -> T0LifecycleManager:
+    projects: dict = {}
+    if project_id:
+        projects[project_id] = {
+            "root": project_root,
+            "claude_args": claude_args or [],
+        }
+    return T0LifecycleManager({
+        "coord_db_path": str(coord_db),
+        "projects": projects,
+    })
+
+
+def cmd_spawn(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    claude_args = args.claude_args.split() if args.claude_args else []
+    mgr = _build_manager(
+        coord_db,
+        project_id=args.project_id,
+        project_root=args.project_root or "",
+        claude_args=claude_args,
+    )
+    try:
+        instance = mgr.spawn(args.project_id)
+    except ValueError as e:
+        print(f"[error] {e}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"[error] {e}", file=sys.stderr)
+        return 1
+    print(json.dumps({
+        "project_id": instance.project_id,
+        "pid": instance.pid,
+        "state": instance.state,
+        "started_at": instance.started_at,
+        "project_root": instance.project_root,
+    }, indent=2))
+    return 0
+
+
+def cmd_heartbeat(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = _build_manager(coord_db, project_id=args.project_id)
+    recorded = mgr.heartbeat(args.project_id, args.pid)
+    if recorded:
+        print(f"[ok] heartbeat recorded for project={args.project_id} pid={args.pid}")
+        return 0
+    print(f"[warn] no running T0 found for project={args.project_id} pid={args.pid}", file=sys.stderr)
+    return 1
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = T0LifecycleManager({"coord_db_path": str(coord_db)})
+    instances = mgr.list_running()
+    if not instances:
+        print("No running T0 instances.")
+        return 0
+    for inst in instances:
+        print(json.dumps({
+            "project_id": inst.project_id,
+            "pid": inst.pid,
+            "state": inst.state,
+            "started_at": inst.started_at,
+            "last_heartbeat_at": inst.last_heartbeat_at,
+        }))
+    return 0
+
+
+def cmd_kill(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = _build_manager(coord_db, project_id=args.project_id)
+    sig = signal.SIGKILL if args.force else signal.SIGTERM
+    killed = mgr.kill(args.project_id, signal_type=sig)
+    if killed:
+        sig_name = "SIGKILL" if args.force else "SIGTERM"
+        print(f"[ok] sent {sig_name} to T0 for project={args.project_id}")
+        return 0
+    print(f"[warn] no running T0 found for project={args.project_id}", file=sys.stderr)
+    return 1
+
+
+def cmd_reap(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = T0LifecycleManager({"coord_db_path": str(coord_db)})
+    reaped = mgr.reap_dead_t0s()
+    if reaped:
+        print(f"[ok] reaped {len(reaped)} stale T0(s): {', '.join(reaped)}")
+    else:
+        print("[ok] no stale T0s found")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="VNX per-project T0 lifecycle management (Wave 5 PR-5.2)"
+    )
+    parser.add_argument(
+        "--coord-db",
+        default=None,
+        help="Path to runtime_coordination.db (overrides VNX_STATE_DIR)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sp_spawn = sub.add_parser("spawn", help="Spawn a per-project T0 process")
+    sp_spawn.add_argument("--project-id", required=True)
+    sp_spawn.add_argument("--project-root", default="", help="Absolute path to project worktree")
+    sp_spawn.add_argument("--claude-args", default="", help="Space-separated extra args for claude")
+    sp_spawn.set_defaults(func=cmd_spawn)
+
+    sp_hb = sub.add_parser("heartbeat", help="Record heartbeat for a running T0")
+    sp_hb.add_argument("--project-id", required=True)
+    sp_hb.add_argument("--pid", required=True, type=int)
+    sp_hb.set_defaults(func=cmd_heartbeat)
+
+    sp_list = sub.add_parser("list", help="List all running T0 instances")
+    sp_list.set_defaults(func=cmd_list)
+
+    sp_kill = sub.add_parser("kill", help="Kill a running T0 (graceful SIGTERM, then SIGKILL)")
+    sp_kill.add_argument("--project-id", required=True)
+    sp_kill.add_argument("--force", action="store_true", help="Skip SIGTERM, send SIGKILL directly")
+    sp_kill.set_defaults(func=cmd_kill)
+
+    sp_reap = sub.add_parser("reap", help="Reap stale T0s (heartbeat older than timeout)")
+    sp_reap.set_defaults(func=cmd_reap)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_t0_lifecycle.py
+++ b/tests/test_t0_lifecycle.py
@@ -1,0 +1,510 @@
+"""Tests for scripts/aggregator/t0_lifecycle.py (Wave 5 PR-5.2).
+
+Coverage:
+  - spawn creates lease + returns T0Instance with valid pid
+  - spawn refuses if project T0 already running (ValueError)
+  - heartbeat updates last_heartbeat_at timestamp
+  - kill SIGTERM — graceful shutdown, lease released
+  - kill SIGTERM escalation to SIGKILL when process unresponsive
+  - reap_dead_t0s detects stale heartbeats
+  - list_running returns correct subset after spawn/kill
+  - StateAggregator receives t0_spawned lifecycle event
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Project root in path for package imports
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
+from scripts.aggregator.t0_lifecycle import T0LifecycleManager, _T0_TERMINAL_ID
+
+_SCRIPTS_LIB = _PROJECT_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(_SCRIPTS_LIB))
+
+
+# Minimal schema for tests — only the terminal_leases table that T0LifecycleManager uses.
+# The full init_schema chain (v1→v10) fails on fresh DBs because v10 depends on the
+# schemas/migrations/0010 ALTER TABLE that init_schema doesn't apply.
+_MINIMAL_SCHEMA_SQL = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS terminal_leases (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT,
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(terminal_id, project_id)
+);
+"""
+
+
+def _init_test_db(db_path: Path) -> None:
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_MINIMAL_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_conn(db_path: Path):
+    import sqlite3
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Base test case
+# ---------------------------------------------------------------------------
+
+
+class _LifecycleBase(unittest.TestCase):
+    """Creates temp dirs, initialises schema, builds a T0LifecycleManager."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.state_dir = Path(self._tmpdir.name)
+        self.coord_db = self.state_dir / "runtime_coordination.db"
+        _init_test_db(self.coord_db)
+
+        self.vnx_data_dir = self.state_dir / "vnx-data"
+        self.vnx_data_dir.mkdir()
+        self.aggregator = StateAggregator(self.vnx_data_dir)
+
+        self.mgr = self._make_mgr()
+
+    def _make_mgr(self, **extra) -> T0LifecycleManager:
+        opts = {
+            "coord_db_path": str(self.coord_db),
+            "projects": {
+                "proj-a": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "proj-b": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "proj-c": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "test-proj": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+            },
+            "heartbeat_timeout": 120,
+            "aggregator": self.aggregator,
+        }
+        opts.update(extra)
+        return T0LifecycleManager(opts)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _lease_row(self, project_id: str) -> dict | None:
+        conn = _get_conn(self.coord_db)
+        try:
+            row = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND project_id=?",
+                (_T0_TERMINAL_ID, project_id),
+            ).fetchone()
+        finally:
+            conn.close()
+        return dict(row) if row else None
+
+    def _aggregator_events(self, event_type: str | None = None) -> list[dict]:
+        events_path = self.vnx_data_dir / "events" / "state_aggregator.ndjson"
+        if not events_path.exists():
+            return []
+        records = []
+        for line in events_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if event_type is None or rec.get("event_type") == event_type:
+                records.append(rec)
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Test: spawn creates lease + process
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCreatesLeaseAndProcess(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_creates_lease_and_process(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99001
+        mock_popen.return_value = mock_proc
+
+        instance = self.mgr.spawn("test-proj")
+
+        self.assertEqual(instance.project_id, "test-proj")
+        self.assertEqual(instance.pid, 99001)
+        self.assertEqual(instance.state, "running")
+        self.assertIsNotNone(instance.started_at)
+        self.assertIsNotNone(instance.last_heartbeat_at)
+
+        row = self._lease_row("test-proj")
+        self.assertIsNotNone(row)
+        self.assertEqual(row["state"], "leased")
+        self.assertEqual(row["terminal_id"], _T0_TERMINAL_ID)
+        self.assertEqual(row["project_id"], "test-proj")
+
+        meta = json.loads(row["metadata_json"])
+        self.assertEqual(meta["pid"], 99001)
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_sets_vnx_project_id_env(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        call_kwargs = mock_popen.call_args[1]
+        env = call_kwargs.get("env", {})
+        self.assertEqual(env.get("VNX_PROJECT_ID"), "test-proj")
+
+
+# ---------------------------------------------------------------------------
+# Test: spawn refuses if already running
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnRefusesIfAlreadyRunning(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_refuses_if_already_running(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 88001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.mgr.spawn("test-proj")
+
+        self.assertIn("test-proj", str(ctx.exception))
+        self.assertIn("already running", str(ctx.exception))
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_second_spawn_different_project_succeeds(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 88100
+        mock_popen.return_value = mock_proc
+
+        inst_a = self.mgr.spawn("proj-a")
+        inst_b = self.mgr.spawn("proj-b")
+
+        self.assertEqual(inst_a.project_id, "proj-a")
+        self.assertEqual(inst_b.project_id, "proj-b")
+
+
+# ---------------------------------------------------------------------------
+# Test: heartbeat updates timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatUpdatesTimestamp(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_heartbeat_updates_timestamp(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 77001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        row_before = self._lease_row("test-proj")
+
+        time.sleep(0.01)
+        recorded = self.mgr.heartbeat("test-proj", 77001)
+
+        self.assertTrue(recorded)
+        row_after = self._lease_row("test-proj")
+        self.assertGreater(
+            row_after["last_heartbeat_at"],
+            row_before["last_heartbeat_at"],
+        )
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_heartbeat_wrong_pid_returns_false(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 77002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        result = self.mgr.heartbeat("test-proj", 99999)
+        self.assertFalse(result)
+
+    def test_heartbeat_no_lease_returns_false(self) -> None:
+        result = self.mgr.heartbeat("test-proj", 12345)
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# Test: kill SIGTERM graceful
+# ---------------------------------------------------------------------------
+
+
+class TestKillSigtermGraceful(_LifecycleBase):
+    def test_kill_sigterm_graceful(self) -> None:
+        import subprocess as sp
+        # Short timeout so the test completes in <1s even if zombie detection is imperfect
+        mgr = self._make_mgr(heartbeat_timeout=0.3, kill_poll_interval=0.05)
+        proc = sp.Popen(
+            ["sleep", "60"],
+            stdout=sp.DEVNULL,
+            stderr=sp.DEVNULL,
+        )
+        pid = proc.pid
+
+        now = "2026-05-16T12:00:00.000+00:00"
+        meta = json.dumps({"pid": pid, "project_root": "", "started_at": now})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, 'test-proj', 'leased', NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, now, now, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        killed = mgr.kill("test-proj", signal_type=signal.SIGTERM)
+
+        self.assertTrue(killed)
+        # Reap zombie and verify the process is gone (SIGTERM or SIGKILL escalation)
+        try:
+            proc.wait(timeout=2)
+        except sp.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        self.assertIsNotNone(proc.returncode, "Process should have terminated")
+
+        row = self._lease_row("test-proj")
+        self.assertEqual(row["state"], "released")
+
+
+# ---------------------------------------------------------------------------
+# Test: kill escalates to SIGKILL when unresponsive
+# ---------------------------------------------------------------------------
+
+
+class TestKillSigkillEscalation(_LifecycleBase):
+    def test_kill_sigkill_force_when_unresponsive(self) -> None:
+        mgr = self._make_mgr(
+            heartbeat_timeout=0.5,
+            kill_poll_interval=0.05,
+        )
+        # Spawn a process that ignores SIGTERM
+        import subprocess as sp
+        proc = sp.Popen(
+            [
+                "python3",
+                "-c",
+                "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)",
+            ],
+            stdout=sp.DEVNULL,
+            stderr=sp.DEVNULL,
+        )
+        pid = proc.pid
+
+        now = "2026-05-16T12:00:00.000+00:00"
+        meta = json.dumps({"pid": pid, "project_root": "", "started_at": now})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, 'test-proj', 'leased', NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, now, now, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        killed = mgr.kill("test-proj", signal_type=signal.SIGTERM)
+
+        self.assertTrue(killed)
+        # Process must be dead (SIGKILL escalation fired)
+        proc.wait(timeout=2)
+        self.assertIsNotNone(proc.returncode)
+
+        row = self._lease_row("test-proj")
+        self.assertEqual(row["state"], "released")
+
+
+# ---------------------------------------------------------------------------
+# Test: reap dead T0s
+# ---------------------------------------------------------------------------
+
+
+class TestReapDeadT0s(_LifecycleBase):
+    def _insert_lease(
+        self,
+        project_id: str,
+        *,
+        last_heartbeat_at: str,
+        state: str = "leased",
+    ) -> None:
+        meta = json.dumps({"pid": 0, "project_root": ""})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, ?, ?, NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, project_id, state, last_heartbeat_at, last_heartbeat_at, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_reap_dead_t0s_finds_stale(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        now = datetime.now(timezone.utc)
+        # Stale: 2 hours ago → definitely older than 60s timeout
+        stale_ts = (now - timedelta(hours=2)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-a", last_heartbeat_at=stale_ts)
+        # Fresh: 10 seconds ago → not older than 60s timeout
+        fresh_ts = (now - timedelta(seconds=10)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-b", last_heartbeat_at=fresh_ts)
+
+        reaped = mgr.reap_dead_t0s()
+
+        self.assertIn("proj-a", reaped)
+        self.assertNotIn("proj-b", reaped)
+
+        row_a = self._lease_row("proj-a")
+        row_b = self._lease_row("proj-b")
+        self.assertEqual(row_a["state"], "released")
+        self.assertEqual(row_b["state"], "leased")
+
+    def test_reap_dead_t0s_idempotent(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-a", last_heartbeat_at=stale_ts)
+
+        first = mgr.reap_dead_t0s()
+        second = mgr.reap_dead_t0s()
+
+        self.assertIn("proj-a", first)
+        self.assertEqual(second, [])
+
+    def test_reap_no_stale_returns_empty(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        reaped = mgr.reap_dead_t0s()
+        self.assertEqual(reaped, [])
+
+
+# ---------------------------------------------------------------------------
+# Test: list_running returns active subset
+# ---------------------------------------------------------------------------
+
+
+class TestListRunningReturnsActive(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_list_running_returns_active(self, mock_popen: MagicMock) -> None:
+        pids = iter([11001, 11002, 11003])
+
+        def _make_mock(*args, **kwargs):
+            m = MagicMock()
+            m.pid = next(pids)
+            return m
+
+        mock_popen.side_effect = _make_mock
+
+        self.mgr.spawn("proj-a")
+        self.mgr.spawn("proj-b")
+        self.mgr.spawn("proj-c")
+
+        running = self.mgr.list_running()
+        self.assertEqual(len(running), 3)
+        project_ids = {i.project_id for i in running}
+        self.assertEqual(project_ids, {"proj-a", "proj-b", "proj-c"})
+
+        # Kill proj-b via DB (bypass actual process to avoid real signal)
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                "UPDATE terminal_leases SET state='released' WHERE terminal_id=? AND project_id=?",
+                (_T0_TERMINAL_ID, "proj-b"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        running_after = self.mgr.list_running()
+        self.assertEqual(len(running_after), 2)
+        remaining = {i.project_id for i in running_after}
+        self.assertNotIn("proj-b", remaining)
+
+
+# ---------------------------------------------------------------------------
+# Test: StateAggregator receives lifecycle events
+# ---------------------------------------------------------------------------
+
+
+class TestStateAggregatorReceivesLifecycleEvents(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_state_aggregator_receives_lifecycle_events(
+        self, mock_popen: MagicMock
+    ) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 55001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        events = self._aggregator_events("t0_spawned")
+        self.assertGreaterEqual(len(events), 1)
+        evt = events[0]
+        self.assertEqual(evt["event_type"], "t0_spawned")
+        self.assertEqual(evt["sub_provider"], "test-proj")
+        data = evt["data"]
+        self.assertEqual(data["pid"], 55001)
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_state_aggregator_receives_heartbeat_event(
+        self, mock_popen: MagicMock
+    ) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 55002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        self.mgr.heartbeat("test-proj", 55002)
+
+        hb_events = self._aggregator_events("t0_heartbeat")
+        # Both spawn-time heartbeat state and explicit heartbeat call
+        self.assertGreaterEqual(len(hb_events), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timing_metrics.py
+++ b/tests/test_timing_metrics.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Tests for Wave 5 PR-5.x: timing_metrics module."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from timing_metrics import (
+    TimingMetrics,
+    _build_timing_block,
+    analyze_dispatch,
+    compute_effective_time,
+    detect_parallel_dispatches,
+)
+
+
+def _write_ndjson(path: Path, events: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+
+
+def _make_events(timestamps_iso: list) -> list:
+    return [{"type": "assistant", "timestamp": ts} for ts in timestamps_iso]
+
+
+class TestComputeEffectiveTime(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+
+    def test_caps_long_gaps(self):
+        """Events with 30s + 5s + 30s gaps → effective = 10+5+10 = 25s (cap 10)."""
+        events = _make_events([
+            "2026-05-16T10:00:00+00:00",
+            "2026-05-16T10:00:30+00:00",
+            "2026-05-16T10:00:35+00:00",
+            "2026-05-16T10:01:05+00:00",
+        ])
+        f = self.tmp / "test.ndjson"
+        _write_ndjson(f, events)
+        _, eff, n, _, _ = compute_effective_time(f, threshold_seconds=10.0)
+        self.assertAlmostEqual(eff, 25.0, places=1)
+        self.assertEqual(n, 4)
+
+    def test_walltime_includes_full_span(self):
+        """Walltime = last - first regardless of internal gaps."""
+        events = _make_events([
+            "2026-05-16T10:00:00+00:00",
+            "2026-05-16T10:00:30+00:00",
+            "2026-05-16T10:30:00+00:00",
+        ])
+        f = self.tmp / "test2.ndjson"
+        _write_ndjson(f, events)
+        wt, eff, n, started, ended = compute_effective_time(f, threshold_seconds=10.0)
+        self.assertAlmostEqual(wt, 1800.0, places=1)
+        self.assertAlmostEqual(eff, 20.0, places=1)
+        self.assertEqual(n, 3)
+        self.assertIn("10:00:00", started)
+        self.assertIn("10:30:00", ended)
+
+    def test_single_event_returns_zeros(self):
+        """Single event → walltime=0, effective=0."""
+        events = _make_events(["2026-05-16T10:00:00+00:00"])
+        f = self.tmp / "single.ndjson"
+        _write_ndjson(f, events)
+        wt, eff, n, started, ended = compute_effective_time(f)
+        self.assertEqual(wt, 0.0)
+        self.assertEqual(eff, 0.0)
+        self.assertEqual(n, 1)
+        self.assertEqual(started, ended)
+
+    def test_skips_lines_with_no_timestamp(self):
+        """Lines without timestamp field are silently ignored."""
+        events = [
+            {"type": "system"},
+            {"type": "assistant", "timestamp": "2026-05-16T10:00:00+00:00"},
+            {"type": "result", "timestamp": "2026-05-16T10:00:08+00:00"},
+        ]
+        f = self.tmp / "mixed.ndjson"
+        _write_ndjson(f, events)
+        wt, eff, n, _, _ = compute_effective_time(f, threshold_seconds=10.0)
+        self.assertEqual(n, 2)
+        self.assertAlmostEqual(wt, 8.0, places=1)
+        self.assertAlmostEqual(eff, 8.0, places=1)
+
+
+class TestDetectParallelDispatches(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+
+    def _create_archive(self, name: str, start: str, end: str) -> Path:
+        """Create a minimal archive with two events at start and end."""
+        f = self.tmp / f"{name}.ndjson"
+        events = _make_events([start, end])
+        _write_ndjson(f, events)
+        return f
+
+    def test_finds_overlapping(self):
+        """3 dispatches, 2 overlap with target → list has 2 entries."""
+        target_start = "2026-05-16T10:00:00+00:00"
+        target_end = "2026-05-16T10:10:00+00:00"
+        overlap1 = self._create_archive("overlap-1", "2026-05-16T10:05:00+00:00", "2026-05-16T10:15:00+00:00")
+        overlap2 = self._create_archive("overlap-2", "2026-05-16T09:55:00+00:00", "2026-05-16T10:03:00+00:00")
+        no_overlap = self._create_archive("no-overlap", "2026-05-16T11:00:00+00:00", "2026-05-16T11:30:00+00:00")
+
+        from datetime import datetime
+        t_start = datetime.fromisoformat(target_start.replace("Z", "+00:00")).timestamp()
+        t_end = datetime.fromisoformat(target_end.replace("Z", "+00:00")).timestamp()
+
+        ids, secs = detect_parallel_dispatches(
+            "target-dispatch", t_start, t_end,
+            [overlap1, overlap2, no_overlap]
+        )
+        self.assertEqual(len(ids), 2)
+        self.assertIn("overlap-1", ids)
+        self.assertIn("overlap-2", ids)
+        self.assertNotIn("no-overlap", ids)
+
+    def test_parallel_seconds_correct(self):
+        """Assert sum-of-overlaps is correct."""
+        target_start = "2026-05-16T10:00:00+00:00"
+        target_end = "2026-05-16T10:10:00+00:00"
+        # Overlaps from T+5m to T+10m → 300s
+        arch = self._create_archive("overlap-a", "2026-05-16T10:05:00+00:00", "2026-05-16T10:20:00+00:00")
+
+        from datetime import datetime
+        t_start = datetime.fromisoformat(target_start.replace("Z", "+00:00")).timestamp()
+        t_end = datetime.fromisoformat(target_end.replace("Z", "+00:00")).timestamp()
+
+        _, secs = detect_parallel_dispatches("tgt", t_start, t_end, [arch])
+        self.assertAlmostEqual(secs, 300.0, places=0)
+
+    def test_excludes_target_itself(self):
+        """Archive matching target dispatch_id is excluded from candidates."""
+        target_start = "2026-05-16T10:00:00+00:00"
+        target_end = "2026-05-16T10:10:00+00:00"
+        self_arch = self._create_archive("my-dispatch-id", "2026-05-16T10:00:00+00:00", "2026-05-16T10:10:00+00:00")
+
+        from datetime import datetime
+        t_start = datetime.fromisoformat(target_start.replace("Z", "+00:00")).timestamp()
+        t_end = datetime.fromisoformat(target_end.replace("Z", "+00:00")).timestamp()
+
+        ids, _ = detect_parallel_dispatches("my-dispatch-id", t_start, t_end, [self_arch])
+        self.assertEqual(ids, [])
+
+
+class TestAnalyzeDispatch(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+
+    def test_missing_archive_returns_none(self):
+        """dispatch_id not in archive → returns None."""
+        archive_root = self.tmp / "archive"
+        archive_root.mkdir(parents=True)
+        result = analyze_dispatch("nonexistent-dispatch-id", archive_root)
+        self.assertIsNone(result)
+
+    def test_returns_timing_metrics(self):
+        """Valid archive returns a populated TimingMetrics."""
+        archive_root = self.tmp / "T1"
+        archive_root.mkdir(parents=True)
+        f = archive_root / "test-dispatch-abc.ndjson"
+        events = _make_events([
+            "2026-05-16T10:00:00+00:00",
+            "2026-05-16T10:00:05+00:00",
+            "2026-05-16T10:00:09+00:00",
+        ])
+        _write_ndjson(f, events)
+        result = analyze_dispatch("test-dispatch-abc", self.tmp, threshold_seconds=10.0)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.dispatch_id, "test-dispatch-abc")
+        self.assertAlmostEqual(result.walltime_seconds, 9.0, places=1)
+        self.assertAlmostEqual(result.effective_seconds, 9.0, places=1)
+        self.assertEqual(result.event_count, 3)
+
+
+class TestPRReportAggregation(unittest.TestCase):
+    """Tests for the pr_timing_report CLI aggregation logic."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+    def _make_dispatch(self, name: str, events: list) -> Path:
+        f = self.tmp / f"{name}.ndjson"
+        _write_ndjson(f, events)
+        return f
+
+    def test_aggregates_multiple_dispatches(self):
+        """PR with 3 dispatches → totals are sum of all three."""
+        import importlib
+        spec = importlib.util.spec_from_file_location(
+            "pr_timing_report",
+            Path(__file__).resolve().parent.parent / "scripts" / "pr_timing_report.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        archive_root = self.tmp / "archive"
+        archive_root.mkdir(parents=True)
+
+        dispatches = []
+        for i, (start, end) in enumerate([
+            ("2026-05-16T10:00:00+00:00", "2026-05-16T10:00:08+00:00"),
+            ("2026-05-16T11:00:00+00:00", "2026-05-16T11:00:06+00:00"),
+            ("2026-05-16T12:00:00+00:00", "2026-05-16T12:00:04+00:00"),
+        ]):
+            f = archive_root / f"wave5-pr522-dispatch-{i}.ndjson"
+            _write_ndjson(f, _make_events([start, end]))
+            m = analyze_dispatch(f.stem, archive_root)
+            if m:
+                dispatches.append(m)
+
+        self.assertEqual(len(dispatches), 3)
+        total_walltime = sum(m.walltime_seconds for m in dispatches)
+        total_effective = sum(m.effective_seconds for m in dispatches)
+        self.assertAlmostEqual(total_walltime, 18.0, places=0)
+        self.assertAlmostEqual(total_effective, 18.0, places=0)
+
+
+class TestBuildTimingBlock(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.tmp = Path(self._tmpdir)
+
+    def test_returns_none_when_no_archive(self):
+        """_build_timing_block returns None when archive dir missing."""
+        result = _build_timing_block("any-dispatch", self.tmp / "nonexistent")
+        self.assertIsNone(result)
+
+    def test_returns_dict_when_archive_found(self):
+        """_build_timing_block returns a dict with expected keys when archive exists."""
+        # vnx_data_dir layout: <vnx_data>/events/archive/T1/<dispatch>.ndjson
+        vnx_data = self.tmp / "vnx-data"
+        archive = vnx_data / "events" / "archive" / "T1"
+        archive.mkdir(parents=True)
+        f = archive / "my-dispatch-xyz.ndjson"
+        _write_ndjson(f, _make_events([
+            "2026-05-16T10:00:00+00:00",
+            "2026-05-16T10:00:05+00:00",
+        ]))
+        result = _build_timing_block("my-dispatch-xyz", vnx_data)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("dispatch_id", result)
+        self.assertIn("walltime_seconds", result)
+        self.assertIn("effective_seconds", result)
+        self.assertAlmostEqual(result["walltime_seconds"], 5.0, places=1)
+        self.assertEqual(result["dispatch_id"], "my-dispatch-xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Forward: `append_receipt` enriches new completion-receipts with timing block:
`walltime_seconds`, `effective_seconds`, `parallel_dispatch_ids`, `parallel_seconds`.
Effective time = sum of inter-event gaps capped at threshold (default 10s).

Retrospective: `scripts/pr_timing_report.py` CLI reads archived event-streams and
computes per-PR or per-dispatch metrics for already-merged work. Use cases:
`--pr 522`, `--since 2026-05-15`, `--dispatch <id>`, `--output <path>`.

Recovery dispatch: files were written by an earlier T2 dispatch (20260516-wave5-timing)
that stalled before push/PR due to shared-worktree race.

## Test plan

- [x] `pytest tests/test_timing_metrics.py -v` — 12/12 passed
- [x] `python3 -c "from scripts.lib.timing_metrics import ..."` — imports valid
- [x] `python3 -c "import scripts.pr_timing_report"` — imports valid
- [x] No new lint findings from `ci_lint_patterns.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)