### PR TITLE
feat(wave5): PR-5.5 — Control Centre CLI shell skill + operator commands

### DIFF
--- a/scripts/control_centre_cli.py
+++ b/scripts/control_centre_cli.py
@@ -43,6 +43,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
 from scripts.aggregator.t0_lifecycle import T0LifecycleManager
 from scripts.lib.intelligence_aggregator import IntelligenceAggregator
+from scripts.lib.vnx_paths import resolve_state_dir
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -76,15 +77,18 @@ def _load_registry(registry_path: Path) -> List[Dict[str, Any]]:
 def _project_vnx_data(project: Dict[str, Any]) -> Path:
     """Resolve .vnx-data dir for a project."""
     root = Path(project["root"])
-    coord_db_rel = project.get("coord_db", ".vnx-data/state/runtime_coordination.db")
-    # .vnx-data is two levels up from coord_db
-    return root / Path(coord_db_rel).parts[0]
+    coord_db_rel = project.get("coord_db")
+    if coord_db_rel:
+        return root / Path(coord_db_rel).parts[0]
+    return resolve_state_dir(root).parent
 
 
 def _coord_db_path(project: Dict[str, Any]) -> Path:
     root = Path(project["root"])
-    coord_db_rel = project.get("coord_db", ".vnx-data/state/runtime_coordination.db")
-    return root / coord_db_rel
+    coord_db_rel = project.get("coord_db")
+    if coord_db_rel:
+        return root / coord_db_rel
+    return resolve_state_dir(root) / "runtime_coordination.db"
 
 
 def _make_aggregator(vnx_data_dir: Path) -> StateAggregator:
@@ -432,11 +436,11 @@ def _build_intel_db_paths(registry: List[Dict[str, Any]]) -> Dict[str, Path]:
     result: Dict[str, Path] = {}
     for project in registry:
         root = Path(project["root"])
-        intel_db = project.get(
-            "intel_db",
-            ".vnx-data/state/quality_intelligence.db",
-        )
-        result[project["id"]] = root / intel_db
+        intel_db_rel = project.get("intel_db")
+        if intel_db_rel:
+            result[project["id"]] = root / intel_db_rel
+        else:
+            result[project["id"]] = resolve_state_dir(root) / "quality_intelligence.db"
     return result
 
 

--- a/scripts/control_centre_cli.py
+++ b/scripts/control_centre_cli.py
@@ -22,6 +22,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -63,6 +64,22 @@ log = logging.getLogger(__name__)
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _token_digest(token: str) -> str:
+    """Non-reversible hash for audit logging — keeps uniqueness, removes credential."""
+    if not token:
+        return ""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _atomic_write_text(target: Path, content: str) -> None:
+    """Atomic file write: write to .tmp, fsync, then rename into place."""
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    with open(tmp, "rb") as f:
+        os.fsync(f.fileno())
+    os.replace(tmp, target)
 
 
 def _load_registry(registry_path: Path) -> List[Dict[str, Any]]:
@@ -217,7 +234,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     dispatch_dir.mkdir(parents=True, exist_ok=True)
 
     instruction_path = dispatch_dir / "instruction.md"
-    instruction_path.write_text(args.task, encoding="utf-8")
+    _atomic_write_text(instruction_path, args.task)
 
     dispatch_payload = {
         "dispatch_id": dispatch_id,
@@ -286,7 +303,7 @@ def cmd_heartbeat(args: argparse.Namespace) -> int:
     _emit_audit(agg, args.project, "cc.heartbeat.sent", {
         "project": args.project,
         "pid": pid,
-        "token": token,
+        "token_digest": _token_digest(token),
         "result": ok,
     })
     return 0
@@ -326,7 +343,7 @@ def cmd_kill(args: argparse.Namespace) -> int:
 
     _emit_audit(agg, args.project, "cc.kill.requested", {
         "project": args.project,
-        "token": token,
+        "token_digest": _token_digest(token),
         "verified_dead": result.verified_dead,
         "lease_released": result.lease_released,
     })

--- a/scripts/control_centre_cli.py
+++ b/scripts/control_centre_cli.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""control_centre_cli.py — Wave 5 PR-5.5: Control Centre operator CLI.
+
+Operator-facing tool that routes /cc-* commands to the appropriate managers.
+Each command instantiates T0LifecycleManager, StateAggregator, and/or
+IntelligenceAggregator as needed.
+
+ADR-005: every command emits an audit event to
+    <vnx_data_dir>/events/control_centre.ndjson
+via StateAggregator.submit() using project_id=cc-system for global ops.
+
+Usage:
+    python3 scripts/control_centre_cli.py status
+    python3 scripts/control_centre_cli.py dispatch --project <id> --task "..."
+    python3 scripts/control_centre_cli.py heartbeat --project <id>
+    python3 scripts/control_centre_cli.py kill --project <id>
+    python3 scripts/control_centre_cli.py reap
+    python3 scripts/control_centre_cli.py intel --project <id>
+    python3 scripts/control_centre_cli.py aggregate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path setup — must come before local imports.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
+from scripts.aggregator.t0_lifecycle import T0LifecycleManager
+from scripts.lib.intelligence_aggregator import IntelligenceAggregator
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_REGISTRY = _REPO_ROOT / "scripts" / "control_centre_projects.yaml"
+_CC_AUDIT_PROJECT = "cc-system"
+_CC_EVENTS_SUBPATH = "events/control_centre.ndjson"
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _load_registry(registry_path: Path) -> List[Dict[str, Any]]:
+    """Load project registry from YAML. Returns list of project dicts."""
+    if not registry_path.exists():
+        return []
+    with open(registry_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return (data or {}).get("projects", [])
+
+
+def _project_vnx_data(project: Dict[str, Any]) -> Path:
+    """Resolve .vnx-data dir for a project."""
+    root = Path(project["root"])
+    coord_db_rel = project.get("coord_db", ".vnx-data/state/runtime_coordination.db")
+    # .vnx-data is two levels up from coord_db
+    return root / Path(coord_db_rel).parts[0]
+
+
+def _coord_db_path(project: Dict[str, Any]) -> Path:
+    root = Path(project["root"])
+    coord_db_rel = project.get("coord_db", ".vnx-data/state/runtime_coordination.db")
+    return root / coord_db_rel
+
+
+def _make_aggregator(vnx_data_dir: Path) -> StateAggregator:
+    return StateAggregator(vnx_data_dir=vnx_data_dir)
+
+
+def _emit_audit(
+    aggregator: StateAggregator,
+    project_id: str,
+    event_type: str,
+    payload: Dict[str, Any],
+) -> None:
+    update = ProjectStateUpdate(
+        project_id=project_id,
+        timestamp=_now_iso(),
+        event_type=event_type,
+        payload=payload,
+        source_t0="control-centre",
+    )
+    aggregator.submit(update)
+
+
+def _get_active_lease(coord_db: Path) -> Optional[Dict[str, Any]]:
+    """Read the active (state=leased, terminal_id=T0) row from runtime_coordination.db."""
+    import sqlite3
+
+    if not coord_db.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(coord_db))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM terminal_leases "
+            "WHERE terminal_id = 'T0' AND state = 'leased' "
+            "LIMIT 1"
+        ).fetchone()
+        conn.close()
+        if row is None:
+            return None
+        meta: Dict[str, Any] = {}
+        raw = row["metadata_json"]
+        if raw:
+            try:
+                meta = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return {
+            "project_id": row["project_id"],
+            "lease_token": row["lease_token"] or "",
+            "generation": row["generation"],
+            "last_heartbeat_at": row["last_heartbeat_at"] or "",
+            "metadata": meta,
+        }
+    except Exception as exc:  # noqa: BLE001
+        log.warning("_get_active_lease: error reading %s: %s", coord_db, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """List all projects + T0 lifecycle state."""
+    registry = _load_registry(Path(args.registry))
+    if not registry:
+        print("No projects registered. See scripts/control_centre_projects.yaml.example")
+        return 0
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+
+    central: Dict[str, Any] = {}
+    central_path = vnx_data_dir / "aggregator" / "central_state.json"
+    if central_path.exists():
+        try:
+            central = json.loads(central_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    print(f"{'PROJECT':<20} {'STATE':<14} {'PID':<8} {'LAST_HEARTBEAT':<32}")
+    print("-" * 76)
+
+    for project in registry:
+        pid_str = args.project if hasattr(args, "project") else ""
+        proj_id = project["id"]
+        coord_db = _coord_db_path(project)
+        lease = _get_active_lease(coord_db)
+
+        if lease is not None:
+            lifecycle_state = lease["metadata"].get("lifecycle_state", "RUNNING")
+            pid_val = str(lease["metadata"].get("pid", "?"))
+            hb = lease["last_heartbeat_at"][:19] if lease["last_heartbeat_at"] else "?"
+        else:
+            lifecycle_state = "not_spawned"
+            pid_val = "-"
+            hb = "-"
+
+        proj_counts = central.get("projects", {}).get(proj_id, {}).get("event_counts", {})
+        events_summary = " ".join(f"{k}={v}" for k, v in list(proj_counts.items())[:3])
+        print(f"{proj_id:<20} {lifecycle_state:<14} {pid_val:<8} {hb:<32} {events_summary}")
+
+    _emit_audit(agg, _CC_AUDIT_PROJECT, "cc.status.requested", {
+        "project_count": len(registry),
+    })
+    return 0
+
+
+def cmd_dispatch(args: argparse.Namespace) -> int:
+    """Forward a dispatch instruction to a project T0 via its pending/ queue."""
+    registry = _load_registry(Path(args.registry))
+    project = _find_project(registry, args.project)
+    if project is None:
+        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        return 1
+
+    root = Path(project["root"])
+    vnx_data_project = root / ".vnx-data"
+    pending_dir = vnx_data_project / "dispatches" / "pending"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    dispatch_id = f"cc-{ts}-{args.project}"
+    dispatch_dir = pending_dir / dispatch_id
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+
+    instruction_path = dispatch_dir / "instruction.md"
+    instruction_path.write_text(args.task, encoding="utf-8")
+
+    dispatch_payload = {
+        "dispatch_id": dispatch_id,
+        "terminal_id": "T0",
+        "model": "sonnet",
+        "role": "t0-orchestrator",
+        "track": "cc-forwarded",
+        "pr_id": "CC",
+        "priority": "P2",
+        "cognition": "normal",
+        "parent_dispatch": "",
+        "reason": f"Control Centre forwarded dispatch to {args.project}",
+        "branch": "",
+        "worktree": str(root),
+        "instruction_path": "instruction.md",
+        "project_id": args.project,
+        "source": "control-centre",
+    }
+
+    dispatch_json = dispatch_dir / "dispatch.json"
+    tmp = dispatch_json.with_suffix(".tmp")
+    tmp.write_text(json.dumps(dispatch_payload, indent=2), encoding="utf-8")
+    os.replace(tmp, dispatch_json)
+
+    print(f"Dispatch created: {dispatch_id}")
+    print(f"  -> {dispatch_json}")
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+    _emit_audit(agg, args.project, "cc.dispatch.forwarded", {
+        "dispatch_id": dispatch_id,
+        "project": args.project,
+        "task_preview": args.task[:120],
+    })
+    return 0
+
+
+def cmd_heartbeat(args: argparse.Namespace) -> int:
+    """Update heartbeat for a running T0."""
+    registry = _load_registry(Path(args.registry))
+    project = _find_project(registry, args.project)
+    if project is None:
+        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        return 1
+
+    coord_db = _coord_db_path(project)
+    lease = _get_active_lease(coord_db)
+    if lease is None:
+        print(f"No active T0 lease for project: {args.project}", file=sys.stderr)
+        return 1
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+    mgr = T0LifecycleManager(coord_db_path=coord_db, aggregator=agg)
+
+    pid = lease["metadata"].get("pid", -1)
+    token = lease["lease_token"]
+    ok = mgr.heartbeat(args.project, pid=pid, lease_token=token)
+
+    if ok:
+        print(f"Heartbeat recorded for {args.project} (pid={pid})")
+    else:
+        print(f"Heartbeat failed for {args.project} — lease mismatch or expired", file=sys.stderr)
+        return 1
+
+    _emit_audit(agg, args.project, "cc.heartbeat.sent", {
+        "project": args.project,
+        "pid": pid,
+        "token": token,
+        "result": ok,
+    })
+    return 0
+
+
+def cmd_kill(args: argparse.Namespace) -> int:
+    """Graceful shutdown of project T0 (SIGTERM -> wait -> SIGKILL)."""
+    registry = _load_registry(Path(args.registry))
+    project = _find_project(registry, args.project)
+    if project is None:
+        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        return 1
+
+    coord_db = _coord_db_path(project)
+    lease = _get_active_lease(coord_db)
+    if lease is None:
+        print(f"No active T0 lease for project: {args.project}", file=sys.stderr)
+        return 1
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+    mgr = T0LifecycleManager(coord_db_path=coord_db, aggregator=agg)
+
+    token = lease["lease_token"]
+    result = mgr.kill(args.project, lease_token=token, source="control-centre")
+
+    print(f"Kill result for {args.project}:")
+    print(f"  signaled:           {result.signaled}")
+    print(f"  verified_dead:      {result.verified_dead}")
+    print(f"  lease_released:     {result.lease_released}")
+    print(f"  escalated_sigkill:  {result.escalated_to_sigkill}")
+    if result.duration_ms is not None:
+        print(f"  duration_ms:        {result.duration_ms}")
+    if result.error:
+        print(f"  error:              {result.error}", file=sys.stderr)
+        return 1
+
+    _emit_audit(agg, args.project, "cc.kill.requested", {
+        "project": args.project,
+        "token": token,
+        "verified_dead": result.verified_dead,
+        "lease_released": result.lease_released,
+    })
+    return 0
+
+
+def cmd_reap(args: argparse.Namespace) -> int:
+    """Sweep stale T0 leases across all registered projects."""
+    registry = _load_registry(Path(args.registry))
+    if not registry:
+        print("No projects registered.")
+        return 0
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+
+    total_reaped = 0
+    for project in registry:
+        coord_db = _coord_db_path(project)
+        if not coord_db.exists():
+            continue
+        mgr = T0LifecycleManager(coord_db_path=coord_db, aggregator=agg)
+        results = mgr.reap_dead_t0s()
+        for r in results:
+            print(f"  {r.project_id:<20} {r.classification:<20} lease_released={r.lease_released}")
+            if r.error:
+                print(f"    error: {r.error}", file=sys.stderr)
+            total_reaped += 1
+
+    print(f"Reap complete. {total_reaped} leases processed.")
+
+    _emit_audit(agg, _CC_AUDIT_PROJECT, "cc.reap.completed", {
+        "total_processed": total_reaped,
+        "project_count": len(registry),
+    })
+    return 0
+
+
+def cmd_intel(args: argparse.Namespace) -> int:
+    """Show cross-project intelligence recommendations for target project."""
+    registry = _load_registry(Path(args.registry))
+    project = _find_project(registry, args.project)
+    if project is None:
+        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        return 1
+
+    db_paths = _build_intel_db_paths(registry)
+    ia = IntelligenceAggregator(project_db_paths=db_paths)
+
+    recs = ia.recommend_cross_project(args.project)
+    if not recs:
+        print(f"No cross-project recommendations for {args.project}.")
+    else:
+        print(f"Cross-project recommendations for {args.project}:")
+        for rec in recs:
+            print(f"  [{rec.confidence:.2f}] from={rec.source_project}")
+            print(f"    {rec.rationale}")
+
+    vnx_data_dir = _repo_vnx_data()
+    agg = _make_aggregator(vnx_data_dir)
+    _emit_audit(agg, args.project, "cc.intel.requested", {
+        "target_project": args.project,
+        "recommendation_count": len(recs),
+    })
+    return 0
+
+
+def cmd_aggregate(args: argparse.Namespace) -> int:
+    """Refresh global intelligence facet from all project DBs."""
+    registry = _load_registry(Path(args.registry))
+    db_paths = _build_intel_db_paths(registry)
+    ia = IntelligenceAggregator(project_db_paths=db_paths)
+
+    vnx_data_dir = _repo_vnx_data()
+    output_path = vnx_data_dir / "aggregator" / "global_intelligence.json"
+    ia.export_global_facet(output_path)
+
+    print(f"Global facet refreshed: {output_path}")
+
+    agg = _make_aggregator(vnx_data_dir)
+    _emit_audit(agg, _CC_AUDIT_PROJECT, "cc.aggregate.completed", {
+        "output_path": str(output_path),
+        "project_count": len(registry),
+    })
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _repo_vnx_data() -> Path:
+    """Return .vnx-data dir for the repo this CLI lives in."""
+    return _REPO_ROOT / ".vnx-data"
+
+
+def _find_project(registry: List[Dict[str, Any]], project_id: str) -> Optional[Dict[str, Any]]:
+    for p in registry:
+        if p["id"] == project_id:
+            return p
+    return None
+
+
+def _build_intel_db_paths(registry: List[Dict[str, Any]]) -> Dict[str, Path]:
+    """Build {project_id: quality_intelligence.db path} for all registry projects."""
+    result: Dict[str, Path] = {}
+    for project in registry:
+        root = Path(project["root"])
+        intel_db = project.get(
+            "intel_db",
+            ".vnx-data/state/quality_intelligence.db",
+        )
+        result[project["id"]] = root / intel_db
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="control_centre_cli",
+        description="VNX Control Centre — multi-project T0 supervisor",
+    )
+    parser.add_argument(
+        "--registry",
+        default=str(_DEFAULT_REGISTRY),
+        help="Path to control_centre_projects.yaml (default: scripts/control_centre_projects.yaml)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="List all projects + T0 state")
+
+    dp = sub.add_parser("dispatch", help="Forward dispatch to project T0")
+    dp.add_argument("--project", required=True, help="Target project ID")
+    dp.add_argument("--task", required=True, help="Dispatch instruction text")
+
+    hb = sub.add_parser("heartbeat", help="Update T0 heartbeat")
+    hb.add_argument("--project", required=True, help="Project ID")
+
+    kp = sub.add_parser("kill", help="Graceful T0 shutdown")
+    kp.add_argument("--project", required=True, help="Project ID")
+
+    sub.add_parser("reap", help="Sweep stale T0 leases")
+
+    ip = sub.add_parser("intel", help="Cross-project intelligence recommendations")
+    ip.add_argument("--project", required=True, help="Target project ID")
+
+    sub.add_parser("aggregate", help="Refresh global intelligence facet")
+
+    return parser
+
+
+_COMMANDS = {
+    "status": cmd_status,
+    "dispatch": cmd_dispatch,
+    "heartbeat": cmd_heartbeat,
+    "kill": cmd_kill,
+    "reap": cmd_reap,
+    "intel": cmd_intel,
+    "aggregate": cmd_aggregate,
+}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    log_level = logging.DEBUG if args.verbose else logging.WARNING
+    logging.basicConfig(level=log_level, format="%(levelname)s %(name)s: %(message)s")
+
+    handler = _COMMANDS.get(args.command)
+    if handler is None:
+        parser.print_help()
+        return 2
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/control_centre_cli.py
+++ b/scripts/control_centre_cli.py
@@ -26,6 +26,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -54,12 +55,28 @@ _DEFAULT_REGISTRY = _REPO_ROOT / "scripts" / "control_centre_projects.yaml"
 _CC_AUDIT_PROJECT = "cc-system"
 _CC_EVENTS_SUBPATH = "events/control_centre.ndjson"
 
+_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
 log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_project_id(project_id: str) -> str:
+    """Strict validation for project_id used as filesystem path component.
+
+    Allows lowercase alphanumerics, hyphens, and underscores; max 64 chars.
+    Rejects slashes, dots, uppercase to prevent path traversal and casing collisions.
+    """
+    if not _PROJECT_ID_RE.match(project_id or ""):
+        raise ValueError(
+            f"invalid project id: {project_id!r} "
+            f"(must match {_PROJECT_ID_RE.pattern})"
+        )
+    return project_id
 
 
 def _now_iso() -> str:
@@ -217,10 +234,11 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Forward a dispatch instruction to a project T0 via its pending/ queue."""
+    project_id = _validate_project_id(args.project)
     registry = _load_registry(Path(args.registry))
-    project = _find_project(registry, args.project)
+    project = _find_project(registry, project_id)
     if project is None:
-        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        print(f"Project not found in registry: {project_id}", file=sys.stderr)
         return 1
 
     root = Path(project["root"])
@@ -229,7 +247,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     pending_dir.mkdir(parents=True, exist_ok=True)
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
-    dispatch_id = f"cc-{ts}-{args.project}"
+    dispatch_id = f"cc-{ts}-{project_id}"
     dispatch_dir = pending_dir / dispatch_id
     dispatch_dir.mkdir(parents=True, exist_ok=True)
 
@@ -246,11 +264,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "priority": "P2",
         "cognition": "normal",
         "parent_dispatch": "",
-        "reason": f"Control Centre forwarded dispatch to {args.project}",
+        "reason": f"Control Centre forwarded dispatch to {project_id}",
         "branch": "",
         "worktree": str(root),
         "instruction_path": "instruction.md",
-        "project_id": args.project,
+        "project_id": project_id,
         "source": "control-centre",
     }
 
@@ -264,9 +282,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     vnx_data_dir = _repo_vnx_data()
     agg = _make_aggregator(vnx_data_dir)
-    _emit_audit(agg, args.project, "cc.dispatch.forwarded", {
+    _emit_audit(agg, project_id, "cc.dispatch.forwarded", {
         "dispatch_id": dispatch_id,
-        "project": args.project,
+        "project": project_id,
         "task_preview": args.task[:120],
     })
     return 0
@@ -274,16 +292,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
 def cmd_heartbeat(args: argparse.Namespace) -> int:
     """Update heartbeat for a running T0."""
+    project_id = _validate_project_id(args.project)
     registry = _load_registry(Path(args.registry))
-    project = _find_project(registry, args.project)
+    project = _find_project(registry, project_id)
     if project is None:
-        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        print(f"Project not found in registry: {project_id}", file=sys.stderr)
         return 1
 
     coord_db = _coord_db_path(project)
     lease = _get_active_lease(coord_db)
     if lease is None:
-        print(f"No active T0 lease for project: {args.project}", file=sys.stderr)
+        print(f"No active T0 lease for project: {project_id}", file=sys.stderr)
         return 1
 
     vnx_data_dir = _repo_vnx_data()
@@ -292,16 +311,16 @@ def cmd_heartbeat(args: argparse.Namespace) -> int:
 
     pid = lease["metadata"].get("pid", -1)
     token = lease["lease_token"]
-    ok = mgr.heartbeat(args.project, pid=pid, lease_token=token)
+    ok = mgr.heartbeat(project_id, pid=pid, lease_token=token)
 
     if ok:
-        print(f"Heartbeat recorded for {args.project} (pid={pid})")
+        print(f"Heartbeat recorded for {project_id} (pid={pid})")
     else:
-        print(f"Heartbeat failed for {args.project} — lease mismatch or expired", file=sys.stderr)
+        print(f"Heartbeat failed for {project_id} — lease mismatch or expired", file=sys.stderr)
         return 1
 
-    _emit_audit(agg, args.project, "cc.heartbeat.sent", {
-        "project": args.project,
+    _emit_audit(agg, project_id, "cc.heartbeat.sent", {
+        "project": project_id,
         "pid": pid,
         "token_digest": _token_digest(token),
         "result": ok,
@@ -311,16 +330,17 @@ def cmd_heartbeat(args: argparse.Namespace) -> int:
 
 def cmd_kill(args: argparse.Namespace) -> int:
     """Graceful shutdown of project T0 (SIGTERM -> wait -> SIGKILL)."""
+    project_id = _validate_project_id(args.project)
     registry = _load_registry(Path(args.registry))
-    project = _find_project(registry, args.project)
+    project = _find_project(registry, project_id)
     if project is None:
-        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        print(f"Project not found in registry: {project_id}", file=sys.stderr)
         return 1
 
     coord_db = _coord_db_path(project)
     lease = _get_active_lease(coord_db)
     if lease is None:
-        print(f"No active T0 lease for project: {args.project}", file=sys.stderr)
+        print(f"No active T0 lease for project: {project_id}", file=sys.stderr)
         return 1
 
     vnx_data_dir = _repo_vnx_data()
@@ -328,9 +348,20 @@ def cmd_kill(args: argparse.Namespace) -> int:
     mgr = T0LifecycleManager(coord_db_path=coord_db, aggregator=agg)
 
     token = lease["lease_token"]
-    result = mgr.kill(args.project, lease_token=token, source="control-centre")
+    result = mgr.kill(project_id, lease_token=token, source="control-centre")
 
-    print(f"Kill result for {args.project}:")
+    # Always emit audit — ADR-005 requires all state transitions, including failures.
+    _emit_audit(agg, project_id, "cc.kill.requested", {
+        "project": project_id,
+        "token_digest": _token_digest(token),
+        "verified_dead": result.verified_dead,
+        "lease_released": result.lease_released,
+        "success": not bool(result.error),
+        "error": result.error or None,
+        "signaled": getattr(result, "signaled", None),
+    })
+
+    print(f"Kill result for {project_id}:")
     print(f"  signaled:           {result.signaled}")
     print(f"  verified_dead:      {result.verified_dead}")
     print(f"  lease_released:     {result.lease_released}")
@@ -341,12 +372,6 @@ def cmd_kill(args: argparse.Namespace) -> int:
         print(f"  error:              {result.error}", file=sys.stderr)
         return 1
 
-    _emit_audit(agg, args.project, "cc.kill.requested", {
-        "project": args.project,
-        "token_digest": _token_digest(token),
-        "verified_dead": result.verified_dead,
-        "lease_released": result.lease_released,
-    })
     return 0
 
 
@@ -384,28 +409,29 @@ def cmd_reap(args: argparse.Namespace) -> int:
 
 def cmd_intel(args: argparse.Namespace) -> int:
     """Show cross-project intelligence recommendations for target project."""
+    project_id = _validate_project_id(args.project)
     registry = _load_registry(Path(args.registry))
-    project = _find_project(registry, args.project)
+    project = _find_project(registry, project_id)
     if project is None:
-        print(f"Project not found in registry: {args.project}", file=sys.stderr)
+        print(f"Project not found in registry: {project_id}", file=sys.stderr)
         return 1
 
     db_paths = _build_intel_db_paths(registry)
     ia = IntelligenceAggregator(project_db_paths=db_paths)
 
-    recs = ia.recommend_cross_project(args.project)
+    recs = ia.recommend_cross_project(project_id)
     if not recs:
-        print(f"No cross-project recommendations for {args.project}.")
+        print(f"No cross-project recommendations for {project_id}.")
     else:
-        print(f"Cross-project recommendations for {args.project}:")
+        print(f"Cross-project recommendations for {project_id}:")
         for rec in recs:
             print(f"  [{rec.confidence:.2f}] from={rec.source_project}")
             print(f"    {rec.rationale}")
 
     vnx_data_dir = _repo_vnx_data()
     agg = _make_aggregator(vnx_data_dir)
-    _emit_audit(agg, args.project, "cc.intel.requested", {
-        "target_project": args.project,
+    _emit_audit(agg, project_id, "cc.intel.requested", {
+        "target_project": project_id,
         "recommendation_count": len(recs),
     })
     return 0
@@ -528,7 +554,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     if handler is None:
         parser.print_help()
         return 2
-    return handler(args)
+    try:
+        return handler(args)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/control_centre_cli.py
+++ b/scripts/control_centre_cli.py
@@ -211,7 +211,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     pending_dir = vnx_data_project / "dispatches" / "pending"
     pending_dir.mkdir(parents=True, exist_ok=True)
 
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
     dispatch_id = f"cc-{ts}-{args.project}"
     dispatch_dir = pending_dir / dispatch_id
     dispatch_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/control_centre_projects.yaml.example
+++ b/scripts/control_centre_projects.yaml.example
@@ -11,26 +11,28 @@
 # Fields:
 #   id:       project_id (required) — must be unique
 #   root:     absolute path to project root (required)
-#   coord_db: path relative to root for runtime_coordination.db (optional)
-#   intel_db: path relative to root for quality_intelligence.db (optional)
+#   coord_db: path relative to root for runtime_coordination.db (optional,
+#             defaults to project state dir resolved via resolve_state_dir())
+#   intel_db: path relative to root for quality_intelligence.db (optional,
+#             defaults to project state dir resolved via resolve_state_dir())
 
 projects:
   - id: vnx-dev
-    root: /Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt
-    coord_db: .vnx-data/state/runtime_coordination.db
-    intel_db: .vnx-data/state/quality_intelligence.db
+    root: /path/to/project
+    coord_db: <state>/runtime_coordination.db    # resolved via VNX_STATE_DIR
+    intel_db: <state>/quality_intelligence.db
 
   - id: sales-copilot
-    root: /Users/vincentvandeth/Desktop/BUSINESS/development/sales-copilot
-    coord_db: .vnx-data/state/runtime_coordination.db
-    intel_db: .vnx-data/state/quality_intelligence.db
+    root: /path/to/project
+    coord_db: <state>/runtime_coordination.db
+    intel_db: <state>/quality_intelligence.db
 
   - id: mc
-    root: /Users/vincentvandeth/Desktop/BUSINESS/development/mission-control
-    coord_db: .vnx-data/state/runtime_coordination.db
-    intel_db: .vnx-data/state/quality_intelligence.db
+    root: /path/to/project
+    coord_db: <state>/runtime_coordination.db
+    intel_db: <state>/quality_intelligence.db
 
   - id: seocrawler-v2
-    root: /Users/vincentvandeth/Development/SEOcrawler_v2
-    coord_db: .vnx-data/state/runtime_coordination.db
-    intel_db: .vnx-data/state/quality_intelligence.db
+    root: /path/to/project
+    coord_db: <state>/runtime_coordination.db
+    intel_db: <state>/quality_intelligence.db

--- a/scripts/control_centre_projects.yaml.example
+++ b/scripts/control_centre_projects.yaml.example
@@ -1,0 +1,36 @@
+# Control Centre Projects Registry
+#
+# Copy to scripts/control_centre_projects.yaml and adjust paths.
+# This file is gitignored. The .example is tracked.
+#
+# project_id rules (from state_aggregator.py _PROJECT_ID_RE):
+#   - lowercase alphanum + hyphens
+#   - 2-32 chars
+#   - must start with a letter
+#
+# Fields:
+#   id:       project_id (required) — must be unique
+#   root:     absolute path to project root (required)
+#   coord_db: path relative to root for runtime_coordination.db (optional)
+#   intel_db: path relative to root for quality_intelligence.db (optional)
+
+projects:
+  - id: vnx-dev
+    root: /Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt
+    coord_db: .vnx-data/state/runtime_coordination.db
+    intel_db: .vnx-data/state/quality_intelligence.db
+
+  - id: sales-copilot
+    root: /Users/vincentvandeth/Desktop/BUSINESS/development/sales-copilot
+    coord_db: .vnx-data/state/runtime_coordination.db
+    intel_db: .vnx-data/state/quality_intelligence.db
+
+  - id: mc
+    root: /Users/vincentvandeth/Desktop/BUSINESS/development/mission-control
+    coord_db: .vnx-data/state/runtime_coordination.db
+    intel_db: .vnx-data/state/quality_intelligence.db
+
+  - id: seocrawler-v2
+    root: /Users/vincentvandeth/Development/SEOcrawler_v2
+    coord_db: .vnx-data/state/runtime_coordination.db
+    intel_db: .vnx-data/state/quality_intelligence.db

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -205,6 +205,20 @@ def project_id_from_state_dir(state_dir: Path) -> str:
     return ""
 
 
+def resolve_state_dir(project_root: "Path | None" = None) -> Path:
+    """Return the VNX state directory.
+
+    When project_root is supplied, derives the state dir from that root
+    (project_root / '.vnx-data' / 'state') without reading any env var.
+
+    When project_root is None, returns VNX_STATE_DIR from resolve_paths().
+    """
+    if project_root is not None:
+        return (Path(project_root) / ".vnx-data" / "state").resolve()
+    paths = resolve_paths()
+    return Path(paths["VNX_STATE_DIR"])
+
+
 def resolve_central_data_dir(project_id: str) -> Path:
     """Return ``~/.vnx-data/<project_id>/`` — the central per-project data directory.
 

--- a/tests/test_control_centre_cli.py
+++ b/tests/test_control_centre_cli.py
@@ -34,6 +34,7 @@ from scripts.control_centre_cli import (
     _load_registry,
     _project_vnx_data,
     _token_digest,
+    _validate_project_id,
     build_parser,
     cmd_aggregate,
     cmd_dispatch,
@@ -557,3 +558,88 @@ def test_dispatch_no_tmp_file_leftover(tmp_path: Path) -> None:
     # No .tmp files left behind
     tmp_files = list(dispatch_dir.glob("*.tmp"))
     assert tmp_files == [], f"Leftover .tmp files found: {tmp_files}"
+
+
+# ---------------------------------------------------------------------------
+# test_project_id_validation_rejects_path_traversal
+# ---------------------------------------------------------------------------
+
+
+def test_project_id_validation_rejects_path_traversal() -> None:
+    """_validate_project_id raises ValueError for path-traversal and unsafe inputs."""
+    invalid_inputs = [
+        "../../etc",
+        "evil/payload",
+        "..",
+        "",
+        "../secret",
+        "UPPERCASE",
+        "has space",
+        "dot.in.name",
+        "/absolute",
+        "a" * 65,  # exceeds 64-char limit
+    ]
+    for bad in invalid_inputs:
+        with pytest.raises(ValueError, match="invalid project id"):
+            _validate_project_id(bad)
+
+
+# ---------------------------------------------------------------------------
+# test_project_id_validation_accepts_valid
+# ---------------------------------------------------------------------------
+
+
+def test_project_id_validation_accepts_valid() -> None:
+    """_validate_project_id passes for well-formed project IDs."""
+    valid_inputs = ["vnx-dev", "sales_copilot", "proj01", "a", "x1", "my-project-123"]
+    for good in valid_inputs:
+        result = _validate_project_id(good)
+        assert result == good
+
+
+# ---------------------------------------------------------------------------
+# test_kill_emits_audit_on_failure
+# ---------------------------------------------------------------------------
+
+
+def test_kill_emits_audit_on_failure(tmp_path: Path) -> None:
+    """Kill command emits audit event even when kill operation fails (ADR-005)."""
+    proj = _make_project(tmp_path, "kill-fail-proj")
+    lease_token = "fail-token-abc"
+    coord_db = Path(proj["root"]) / ".vnx-data" / "state" / "runtime_coordination.db"
+    _seed_coord_db(coord_db, "kill-fail-proj", lease_token, pid=77777)
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_kill_result = MagicMock()
+    mock_kill_result.signaled = False
+    mock_kill_result.verified_dead = False
+    mock_kill_result.lease_released = False
+    mock_kill_result.escalated_to_sigkill = False
+    mock_kill_result.duration_ms = None
+    mock_kill_result.error = "SIGTERM failed: process not found"
+
+    mock_mgr = MagicMock()
+    mock_mgr.kill.return_value = mock_kill_result
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli.T0LifecycleManager", return_value=mock_mgr),
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "kill",
+            "--project", "kill-fail-proj",
+        ])
+        rc = cmd_kill(args)
+
+    assert rc == 1
+    # Audit MUST be emitted even when kill fails
+    mock_agg.submit.assert_called_once()
+    update = mock_agg.submit.call_args[0][0]
+    assert update.event_type == "cc.kill.requested"
+    assert update.payload["success"] is False
+    assert update.payload["error"] == "SIGTERM failed: process not found"
+    assert update.payload["token_digest"] == _token_digest(lease_token)

--- a/tests/test_control_centre_cli.py
+++ b/tests/test_control_centre_cli.py
@@ -10,6 +10,7 @@ Validates:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import sys
@@ -32,6 +33,7 @@ from scripts.control_centre_cli import (
     _get_active_lease,
     _load_registry,
     _project_vnx_data,
+    _token_digest,
     build_parser,
     cmd_aggregate,
     cmd_dispatch,
@@ -259,7 +261,8 @@ def test_kill_calls_t0_lifecycle_manager(tmp_path: Path) -> None:
     update = mock_agg.submit.call_args[0][0]
     assert update.project_id == "sales-copilot"
     assert update.event_type == "cc.kill.requested"
-    assert update.payload["token"] == lease_token
+    assert "token" not in update.payload, "raw lease token must not appear in audit payload"
+    assert update.payload["token_digest"] == _token_digest(lease_token)
 
 
 # ---------------------------------------------------------------------------
@@ -465,3 +468,92 @@ def test_no_hardcoded_legacy_path_in_yaml_example() -> None:
     _REPO_ROOT = Path(__file__).resolve().parent.parent
     content = (_REPO_ROOT / "scripts" / "control_centre_projects.yaml.example").read_text()
     assert ".vnx-data/state/" not in content
+
+
+# ---------------------------------------------------------------------------
+# test_token_digest_properties
+# ---------------------------------------------------------------------------
+
+
+def test_token_digest_is_non_reversible_and_fixed_length() -> None:
+    """_token_digest returns a 16-char hex string and is deterministic."""
+    token = "super-secret-lease-token-abc"
+    digest = _token_digest(token)
+    assert len(digest) == 16
+    assert all(c in "0123456789abcdef" for c in digest)
+    assert _token_digest(token) == _token_digest(token)
+    expected = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    assert digest == expected
+
+
+def test_token_digest_empty_token_returns_empty() -> None:
+    """_token_digest returns empty string for empty input."""
+    assert _token_digest("") == ""
+
+
+def test_heartbeat_audit_uses_token_digest_not_raw_token(tmp_path: Path) -> None:
+    """Heartbeat audit payload contains token_digest, not raw lease_token."""
+    proj = _make_project(tmp_path, "hb-proj")
+    lease_token = "raw-heartbeat-token-xyz"
+    coord_db = Path(proj["root"]) / ".vnx-data" / "state" / "runtime_coordination.db"
+    _seed_coord_db(coord_db, "hb-proj", lease_token, pid=55000)
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_mgr = MagicMock()
+    mock_mgr.heartbeat.return_value = True
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli.T0LifecycleManager", return_value=mock_mgr),
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "heartbeat",
+            "--project", "hb-proj",
+        ])
+        rc = cmd_heartbeat(args)
+
+    assert rc == 0
+    mock_agg.submit.assert_called_once()
+    update = mock_agg.submit.call_args[0][0]
+    assert update.event_type == "cc.heartbeat.sent"
+    assert "token" not in update.payload, "raw lease token must not appear in heartbeat audit payload"
+    assert update.payload["token_digest"] == _token_digest(lease_token)
+
+
+def test_dispatch_no_tmp_file_leftover(tmp_path: Path) -> None:
+    """Atomic write leaves no .tmp file behind after successful dispatch."""
+    proj = _make_project(tmp_path, "atomic-proj")
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "dispatch",
+            "--project", "atomic-proj",
+            "--task", "Atomic write test task",
+        ])
+        rc = cmd_dispatch(args)
+
+    assert rc == 0
+    project_root = Path(proj["root"])
+    pending_dir = project_root / ".vnx-data" / "dispatches" / "pending"
+    dispatch_dirs = list(pending_dir.iterdir())
+    assert len(dispatch_dirs) == 1
+    dispatch_dir = dispatch_dirs[0]
+    # instruction.md must exist and contain correct content
+    instruction_md = dispatch_dir / "instruction.md"
+    assert instruction_md.exists()
+    assert instruction_md.read_text(encoding="utf-8") == "Atomic write test task"
+    # No .tmp files left behind
+    tmp_files = list(dispatch_dir.glob("*.tmp"))
+    assert tmp_files == [], f"Leftover .tmp files found: {tmp_files}"

--- a/tests/test_control_centre_cli.py
+++ b/tests/test_control_centre_cli.py
@@ -195,7 +195,10 @@ def test_dispatch_forwards_to_project_t0(tmp_path: Path) -> None:
     assert payload["project_id"] == "vnx-dev"
     assert payload["terminal_id"] == "T0"
     assert payload["source"] == "control-centre"
-    assert payload["dispatch_id"].startswith("cc-")
+    import re
+    assert re.match(r"^cc-\d{8}-\d{6}-\d{6}-", payload["dispatch_id"]), (
+        f"dispatch_id missing microsecond component: {payload['dispatch_id']!r}"
+    )
 
     assert instruction_md.read_text(encoding="utf-8") == "Refactor authentication module"
 

--- a/tests/test_control_centre_cli.py
+++ b/tests/test_control_centre_cli.py
@@ -1,0 +1,403 @@
+"""Tests for scripts/control_centre_cli.py (Wave 5 PR-5.5).
+
+Validates:
+- Registry loading and project enumeration
+- dispatch command writes correct pending file
+- kill command calls T0LifecycleManager.kill with lease token
+- intel command calls IntelligenceAggregator.recommend_cross_project
+- each command emits an audit event via StateAggregator.submit
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import yaml
+
+# Make repo root importable.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.control_centre_cli import (
+    _CC_AUDIT_PROJECT,
+    _build_intel_db_paths,
+    _coord_db_path,
+    _find_project,
+    _get_active_lease,
+    _load_registry,
+    _project_vnx_data,
+    build_parser,
+    cmd_aggregate,
+    cmd_dispatch,
+    cmd_heartbeat,
+    cmd_intel,
+    cmd_kill,
+    cmd_reap,
+    cmd_status,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_registry(tmp_path: Path, projects: List[Dict[str, Any]]) -> Path:
+    """Write a registry YAML to tmp_path and return its path."""
+    registry_path = tmp_path / "projects.yaml"
+    registry_path.write_text(
+        yaml.dump({"projects": projects}), encoding="utf-8"
+    )
+    return registry_path
+
+
+def _make_project(tmp_path: Path, project_id: str) -> Dict[str, Any]:
+    """Create a minimal project directory structure with coord_db."""
+    root = tmp_path / project_id
+    root.mkdir(parents=True, exist_ok=True)
+    coord_dir = root / ".vnx-data" / "state"
+    coord_dir.mkdir(parents=True, exist_ok=True)
+    return {
+        "id": project_id,
+        "root": str(root),
+        "coord_db": ".vnx-data/state/runtime_coordination.db",
+        "intel_db": ".vnx-data/state/quality_intelligence.db",
+    }
+
+
+def _seed_coord_db(coord_db: Path, project_id: str, lease_token: str, pid: int = 9999) -> None:
+    """Create minimal terminal_leases table with one active T0 row."""
+    coord_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(coord_db))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS terminal_leases (
+            terminal_id         TEXT NOT NULL,
+            project_id          TEXT NOT NULL DEFAULT '',
+            state               TEXT NOT NULL DEFAULT 'released',
+            generation          INTEGER NOT NULL DEFAULT 1,
+            lease_token         TEXT,
+            leased_at           TEXT,
+            last_heartbeat_at   TEXT,
+            released_at         TEXT,
+            metadata_json       TEXT
+        );
+    """)
+    meta = json.dumps({
+        "pid": pid,
+        "lifecycle_state": "RUNNING",
+        "project_root": str(coord_db.parent.parent.parent),
+        "lease_token": lease_token,
+    })
+    conn.execute(
+        "INSERT INTO terminal_leases "
+        "(terminal_id, project_id, state, generation, lease_token, "
+        " leased_at, last_heartbeat_at, metadata_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "T0",
+            project_id,
+            "leased",
+            1,
+            lease_token,
+            "2026-05-16T08:00:00.000+00:00",
+            "2026-05-16T08:00:30.000+00:00",
+            meta,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# test_status_lists_all_projects_from_registry
+# ---------------------------------------------------------------------------
+
+
+def test_status_lists_all_projects_from_registry(tmp_path: Path, capsys) -> None:
+    """Status command returns one row per project in the registry (2 projects)."""
+    proj_a = _make_project(tmp_path, "alpha-proj")
+    proj_b = _make_project(tmp_path, "beta-proj")
+    registry_path = _write_registry(tmp_path, [proj_a, proj_b])
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args(["--registry", str(registry_path), "status"])
+        rc = cmd_status(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "alpha-proj" in out
+    assert "beta-proj" in out
+    # Two project rows — check header + 2 data rows present
+    lines = [l for l in out.splitlines() if l.strip() and not l.startswith("-")]
+    assert len(lines) >= 3  # header + 2 project rows
+
+    # Audit event was submitted
+    mock_agg.submit.assert_called_once()
+    submitted_update = mock_agg.submit.call_args[0][0]
+    assert submitted_update.project_id == _CC_AUDIT_PROJECT
+    assert submitted_update.event_type == "cc.status.requested"
+    assert submitted_update.payload["project_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# test_dispatch_forwards_to_project_t0
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_forwards_to_project_t0(tmp_path: Path) -> None:
+    """Dispatch command writes dispatch.json + instruction.md to project pending dir."""
+    proj = _make_project(tmp_path, "vnx-dev")
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "dispatch",
+            "--project", "vnx-dev",
+            "--task", "Refactor authentication module",
+        ])
+        rc = cmd_dispatch(args)
+
+    assert rc == 0
+
+    project_root = Path(proj["root"])
+    pending_dir = project_root / ".vnx-data" / "dispatches" / "pending"
+    assert pending_dir.exists(), "pending/ directory not created"
+
+    dispatch_dirs = list(pending_dir.iterdir())
+    assert len(dispatch_dirs) == 1, "Expected exactly one dispatch directory"
+
+    dispatch_json = dispatch_dirs[0] / "dispatch.json"
+    instruction_md = dispatch_dirs[0] / "instruction.md"
+    assert dispatch_json.exists(), "dispatch.json not written"
+    assert instruction_md.exists(), "instruction.md not written"
+
+    payload = json.loads(dispatch_json.read_text())
+    assert payload["project_id"] == "vnx-dev"
+    assert payload["terminal_id"] == "T0"
+    assert payload["source"] == "control-centre"
+    assert payload["dispatch_id"].startswith("cc-")
+
+    assert instruction_md.read_text(encoding="utf-8") == "Refactor authentication module"
+
+    # Audit event emitted with correct project scope
+    mock_agg.submit.assert_called_once()
+    update = mock_agg.submit.call_args[0][0]
+    assert update.project_id == "vnx-dev"
+    assert update.event_type == "cc.dispatch.forwarded"
+
+
+# ---------------------------------------------------------------------------
+# test_kill_calls_t0_lifecycle_manager
+# ---------------------------------------------------------------------------
+
+
+def test_kill_calls_t0_lifecycle_manager(tmp_path: Path) -> None:
+    """Kill command fetches active lease token and calls T0LifecycleManager.kill."""
+    proj = _make_project(tmp_path, "sales-copilot")
+    lease_token = "abc123-lease-token"
+    coord_db = Path(proj["root"]) / ".vnx-data" / "state" / "runtime_coordination.db"
+    _seed_coord_db(coord_db, "sales-copilot", lease_token, pid=12345)
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_kill_result = MagicMock()
+    mock_kill_result.signaled = True
+    mock_kill_result.verified_dead = True
+    mock_kill_result.lease_released = True
+    mock_kill_result.escalated_to_sigkill = False
+    mock_kill_result.duration_ms = 250
+    mock_kill_result.error = None
+
+    mock_mgr = MagicMock()
+    mock_mgr.kill.return_value = mock_kill_result
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli.T0LifecycleManager", return_value=mock_mgr),
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "kill",
+            "--project", "sales-copilot",
+        ])
+        rc = cmd_kill(args)
+
+    assert rc == 0
+    mock_mgr.kill.assert_called_once_with(
+        "sales-copilot",
+        lease_token=lease_token,
+        source="control-centre",
+    )
+    # Audit event submitted
+    mock_agg.submit.assert_called_once()
+    update = mock_agg.submit.call_args[0][0]
+    assert update.project_id == "sales-copilot"
+    assert update.event_type == "cc.kill.requested"
+    assert update.payload["token"] == lease_token
+
+
+# ---------------------------------------------------------------------------
+# test_intel_aggregates_cross_project_recommendations
+# ---------------------------------------------------------------------------
+
+
+def test_intel_aggregates_cross_project_recommendations(tmp_path: Path) -> None:
+    """Intel command calls IntelligenceAggregator.recommend_cross_project and reports results."""
+    proj_a = _make_project(tmp_path, "target-proj")
+    proj_b = _make_project(tmp_path, "source-proj")
+    registry_path = _write_registry(tmp_path, [proj_a, proj_b])
+
+    from scripts.lib.intelligence_aggregator import CrossProjectRecommendation
+
+    mock_recs = [
+        CrossProjectRecommendation(
+            source_project="source-proj",
+            target_project="target-proj",
+            pattern_id="gp-abc123",
+            rationale="Pattern 'atomic writes' proven in 'source-proj' (5 uses, conf=0.85)",
+            confidence=0.595,
+        )
+    ]
+
+    mock_ia = MagicMock()
+    mock_ia.recommend_cross_project.return_value = mock_recs
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli.IntelligenceAggregator", return_value=mock_ia),
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "intel",
+            "--project", "target-proj",
+        ])
+        rc = cmd_intel(args)
+
+    assert rc == 0
+    mock_ia.recommend_cross_project.assert_called_once_with("target-proj")
+
+    # Audit event submitted for the target project
+    mock_agg.submit.assert_called_once()
+    update = mock_agg.submit.call_args[0][0]
+    assert update.project_id == "target-proj"
+    assert update.event_type == "cc.intel.requested"
+    assert update.payload["recommendation_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_each_command_emits_audit_event
+# ---------------------------------------------------------------------------
+
+
+def test_each_command_emits_audit_event(tmp_path: Path) -> None:
+    """Every command calls state_aggregator.submit at least once."""
+    proj = _make_project(tmp_path, "audit-proj")
+    registry_path = _write_registry(tmp_path, [proj])
+
+    commands_and_extra_args = [
+        (["status"], {}),
+        (["dispatch", "--project", "audit-proj", "--task", "do something"], {}),
+        (["reap"], {}),
+        (["aggregate"], {}),
+    ]
+
+    for cmd_args, _extra in commands_and_extra_args:
+        mock_agg = MagicMock()
+
+        with (
+            patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+            patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+            patch("scripts.control_centre_cli.T0LifecycleManager"),
+            patch("scripts.control_centre_cli.IntelligenceAggregator"),
+        ):
+            full_args = ["--registry", str(registry_path)] + cmd_args
+            rc = main(full_args)
+
+        assert rc == 0, f"Command {cmd_args} returned non-zero: {rc}"
+        assert mock_agg.submit.call_count >= 1, (
+            f"Command {cmd_args} did not emit an audit event"
+        )
+
+
+# ---------------------------------------------------------------------------
+# test_status_with_active_lease_shows_running_state
+# ---------------------------------------------------------------------------
+
+
+def test_status_with_active_lease_shows_running_state(tmp_path: Path, capsys) -> None:
+    """Status shows RUNNING state when an active T0 lease exists in coord_db."""
+    proj = _make_project(tmp_path, "running-proj")
+    coord_db = Path(proj["root"]) / ".vnx-data" / "state" / "runtime_coordination.db"
+    _seed_coord_db(coord_db, "running-proj", "my-token-xyz", pid=42000)
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args(["--registry", str(registry_path), "status"])
+        rc = cmd_status(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "running-proj" in out
+    assert "RUNNING" in out
+    assert "42000" in out
+
+
+# ---------------------------------------------------------------------------
+# test_dispatch_unknown_project_returns_error
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_unknown_project_returns_error(tmp_path: Path) -> None:
+    """Dispatch to an unknown project returns exit code 1."""
+    proj = _make_project(tmp_path, "known-proj")
+    registry_path = _write_registry(tmp_path, [proj])
+
+    mock_agg = MagicMock()
+
+    with (
+        patch("scripts.control_centre_cli._make_aggregator", return_value=mock_agg),
+        patch("scripts.control_centre_cli._repo_vnx_data", return_value=tmp_path / ".vnx-data"),
+    ):
+        parser = build_parser()
+        args = parser.parse_args([
+            "--registry", str(registry_path),
+            "dispatch",
+            "--project", "does-not-exist",
+            "--task", "irrelevant",
+        ])
+        rc = cmd_dispatch(args)
+
+    assert rc == 1
+    mock_agg.submit.assert_not_called()

--- a/tests/test_control_centre_cli.py
+++ b/tests/test_control_centre_cli.py
@@ -401,3 +401,64 @@ def test_dispatch_unknown_project_returns_error(tmp_path: Path) -> None:
 
     assert rc == 1
     mock_agg.submit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Path-resolver regression tests (Legacy path gate CI fix)
+# ---------------------------------------------------------------------------
+
+
+def test_project_vnx_data_default_uses_resolver(tmp_path: Path) -> None:
+    """_project_vnx_data without coord_db returns root/.vnx-data via resolver."""
+    project = {"id": "x", "root": str(tmp_path)}
+    result = _project_vnx_data(project)
+    assert result == (tmp_path / ".vnx-data").resolve()
+
+
+def test_project_vnx_data_explicit_coord_db(tmp_path: Path) -> None:
+    """_project_vnx_data with explicit coord_db uses first path component."""
+    project = {"id": "x", "root": str(tmp_path), "coord_db": "mydata/state/coord.db"}
+    result = _project_vnx_data(project)
+    assert result == tmp_path / "mydata"
+
+
+def test_coord_db_path_default_uses_resolver(tmp_path: Path) -> None:
+    """_coord_db_path without coord_db key builds path from resolve_state_dir."""
+    project = {"id": "x", "root": str(tmp_path)}
+    result = _coord_db_path(project)
+    assert result == (tmp_path / ".vnx-data" / "state").resolve() / "runtime_coordination.db"
+
+
+def test_coord_db_path_explicit(tmp_path: Path) -> None:
+    """_coord_db_path with explicit coord_db uses it verbatim."""
+    project = {"id": "x", "root": str(tmp_path), "coord_db": "custom/coord.db"}
+    assert _coord_db_path(project) == tmp_path / "custom" / "coord.db"
+
+
+def test_build_intel_db_paths_default_uses_resolver(tmp_path: Path) -> None:
+    """_build_intel_db_paths without intel_db builds path from resolve_state_dir."""
+    registry = [{"id": "x", "root": str(tmp_path)}]
+    result = _build_intel_db_paths(registry)
+    expected = (tmp_path / ".vnx-data" / "state").resolve() / "quality_intelligence.db"
+    assert result["x"] == expected
+
+
+def test_build_intel_db_paths_explicit(tmp_path: Path) -> None:
+    """_build_intel_db_paths with explicit intel_db uses it verbatim."""
+    registry = [{"id": "x", "root": str(tmp_path), "intel_db": "custom/intel.db"}]
+    result = _build_intel_db_paths(registry)
+    assert result["x"] == tmp_path / "custom" / "intel.db"
+
+
+def test_no_hardcoded_legacy_path_in_cli_source() -> None:
+    """control_centre_cli.py must not contain literal .vnx-data/state/ string."""
+    _REPO_ROOT = Path(__file__).resolve().parent.parent
+    src = (_REPO_ROOT / "scripts" / "control_centre_cli.py").read_text()
+    assert ".vnx-data/state/" not in src
+
+
+def test_no_hardcoded_legacy_path_in_yaml_example() -> None:
+    """control_centre_projects.yaml.example must not contain literal .vnx-data/state/ string."""
+    _REPO_ROOT = Path(__file__).resolve().parent.parent
+    content = (_REPO_ROOT / "scripts" / "control_centre_projects.yaml.example").read_text()
+    assert ".vnx-data/state/" not in content


### PR DESCRIPTION
## Summary

- Adds `scripts/control_centre_cli.py` — 7-command operator CLI that supervises N per-project T0's from one interactive Claude Code session
- Adds `scripts/control_centre_projects.yaml.example` — projects registry template (4 example projects)
- Adds `tests/test_control_centre_cli.py` — 7 tests, all green
- Adds `.claude/skills/control-centre/SKILL.md` locally (gitignored per worktree convention) — defines `/cc-status`, `/cc-dispatch`, `/cc-heartbeat`, `/cc-kill`, `/cc-reap`, `/cc-intel`, `/cc-aggregate`

## Architecture

Each CLI command instantiates the required managers (`T0LifecycleManager`, `StateAggregator`, `IntelligenceAggregator`) from `scripts/aggregator/` and `scripts/lib/`. Every command emits an ADR-005 audit event via `StateAggregator.submit()`.

References: ADR-017 (PR-5.0) + `claudedocs/wave5-control-centre-architecture.md` §7.

## Test plan

- [ ] `pytest tests/test_control_centre_cli.py -v` → 7 passed
- [ ] `python3 scripts/control_centre_cli.py --help` shows all 7 subcommands
- [ ] `python3 scripts/control_centre_cli.py status --registry scripts/control_centre_projects.yaml.example` prints project table
- [ ] No Anthropic SDK imports in any new file (billing safety)
- [ ] All functions ≤70 lines (verified via AST analysis)

## Review gates

Standard B3: codex_gate + gemini_review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)