### PR TITLE
feat(wave5): PR-5.x — timing-metrics in receipts + retrospective analyzer

### DIFF
--- a/scripts/aggregator/t0_lifecycle.py
+++ b/scripts/aggregator/t0_lifecycle.py
@@ -1,0 +1,371 @@
+"""t0_lifecycle.py — Wave 5 PR-5.2: per-project T0 spawn/heartbeat/kill mechanics.
+
+Control Centre uses this to manage N per-project T0 processes. Each T0 runs
+in its own project worktree with isolated VNX_PROJECT_ID env. State aggregator
+(PR-5.1) is the central state-sharing mechanism.
+
+Lease isolation uses runtime_coordination.db terminal_leases with composite
+UNIQUE(terminal_id="T0", project_id) per schema v10 (Wave 5 PR-5.3).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+_T0_TERMINAL_ID = "T0"
+_HEARTBEAT_TIMEOUT_DEFAULT = 120
+_KILL_POLL_INTERVAL_DEFAULT = 0.5
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _parse_iso(ts: str) -> float:
+    """Return POSIX timestamp from ISO 8601 string. Raises ValueError on bad input."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+
+@dataclass
+class T0Instance:
+    project_id: str
+    pid: int
+    started_at: str             # ISO 8601
+    project_root: str           # absolute path
+    state: str                  # spawning | running | stopping | stopped
+    last_heartbeat_at: Optional[str] = None
+
+
+class T0LifecycleManager:
+    """Manages spawn/kill/heartbeat for per-project T0 processes.
+
+    Thread-safe via SQLite WAL + EXCLUSIVE transactions. Each T0 is tracked
+    as a lease row with terminal_id="T0" and project_id=<project_id>.
+    """
+
+    def __init__(self, opts: dict) -> None:
+        self._coord_db = Path(opts["coord_db_path"])
+        self._project_registry: Dict[str, dict] = opts.get("projects", {})
+        self._heartbeat_timeout_seconds: float = opts.get(
+            "heartbeat_timeout", _HEARTBEAT_TIMEOUT_DEFAULT
+        )
+        self._kill_poll_interval: float = opts.get(
+            "kill_poll_interval", _KILL_POLL_INTERVAL_DEFAULT
+        )
+        self._aggregator = opts.get("aggregator")
+        self._coord_db.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def spawn(self, project_id: str) -> T0Instance:
+        """Spawn a per-project T0 process.
+
+        Refuses if a T0 for this project_id is already running.
+        Uses composite lease row (terminal_id="T0", project_id) from schema v10.
+
+        Raises ValueError if T0 already running for this project_id.
+        Raises RuntimeError if subprocess.Popen fails.
+        """
+        project_cfg = self._project_registry.get(project_id, {})
+        project_root = project_cfg.get("root", "")
+        cmd = list(project_cfg.get("cmd", ["claude"])) + list(
+            project_cfg.get("claude_args", [])
+        )
+        now = _now_iso()
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN EXCLUSIVE")
+            existing = self._get_t0_row(conn, project_id)
+            if existing and existing["state"] == "leased":
+                meta = json.loads(existing.get("metadata_json") or "{}")
+                conn.execute("ROLLBACK")
+                raise ValueError(
+                    f"T0 for project {project_id!r} is already running "
+                    f"(pid={meta.get('pid')})"
+                )
+
+            env = {**os.environ, "VNX_PROJECT_ID": project_id}
+            if project_root:
+                env["VNX_PROJECT_ROOT"] = project_root
+
+            try:
+                proc = subprocess.Popen(
+                    cmd,
+                    cwd=project_root or None,
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except OSError as e:
+                conn.execute("ROLLBACK")
+                raise RuntimeError(
+                    f"Failed to spawn T0 for {project_id!r}: {e}"
+                ) from e
+
+            pid = proc.pid
+            metadata = json.dumps(
+                {"pid": pid, "project_root": project_root, "started_at": now}
+            )
+
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO terminal_leases
+                        (terminal_id, project_id, state, dispatch_id, generation,
+                         leased_at, last_heartbeat_at, metadata_json)
+                    VALUES (?, ?, 'leased', NULL, 1, ?, ?, ?)
+                    """,
+                    (_T0_TERMINAL_ID, project_id, now, now, metadata),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE terminal_leases
+                    SET state='leased', generation=generation+1,
+                        leased_at=?, last_heartbeat_at=?,
+                        released_at=NULL, dispatch_id=NULL, metadata_json=?
+                    WHERE terminal_id=? AND project_id=?
+                    """,
+                    (now, now, metadata, _T0_TERMINAL_ID, project_id),
+                )
+            conn.execute("COMMIT")
+        finally:
+            conn.close()
+
+        instance = T0Instance(
+            project_id=project_id,
+            pid=pid,
+            started_at=now,
+            project_root=project_root,
+            state="running",
+            last_heartbeat_at=now,
+        )
+        self._emit_event(project_id, "t0_spawned", {
+            "pid": pid,
+            "project_root": project_root,
+            "started_at": now,
+        })
+        return instance
+
+    def heartbeat(self, project_id: str, pid: int) -> bool:
+        """Update last_heartbeat_at for the given project T0.
+
+        Returns True if recorded. Returns False if no matching running lease found
+        or if the pid does not match the stored pid.
+        """
+        now = _now_iso()
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if not row or row["state"] != "leased":
+                return False
+            meta = json.loads(row.get("metadata_json") or "{}")
+            if meta.get("pid") != pid:
+                return False
+            conn.execute(
+                """
+                UPDATE terminal_leases SET last_heartbeat_at=?
+                WHERE terminal_id=? AND project_id=?
+                """,
+                (now, _T0_TERMINAL_ID, project_id),
+            )
+            conn.commit()
+
+        self._emit_event(project_id, "t0_heartbeat", {
+            "pid": pid,
+            "heartbeat_at": now,
+        })
+        return True
+
+    def list_running(self) -> List[T0Instance]:
+        """Return all T0 instances currently in running (leased) state."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND state='leased'",
+                (_T0_TERMINAL_ID,),
+            ).fetchall()
+
+        result: List[T0Instance] = []
+        for row in rows:
+            r = dict(row)
+            meta = json.loads(r.get("metadata_json") or "{}")
+            result.append(T0Instance(
+                project_id=r["project_id"],
+                pid=meta.get("pid", -1),
+                started_at=meta.get("started_at", r.get("leased_at", "")),
+                project_root=meta.get("project_root", ""),
+                state="running",
+                last_heartbeat_at=r.get("last_heartbeat_at"),
+            ))
+        return result
+
+    def kill(
+        self,
+        project_id: str,
+        *,
+        signal_type: int = signal.SIGTERM,
+    ) -> bool:
+        """Send signal to T0 process.
+
+        SIGTERM: wait up to heartbeat_timeout_seconds for graceful shutdown,
+        then escalate to SIGKILL. SIGKILL: immediate, no wait.
+        Returns True if a running lease was found and signalled.
+        """
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if not row or row["state"] != "leased":
+                return False
+            meta = json.loads(row.get("metadata_json") or "{}")
+            pid = meta.get("pid")
+            if not pid:
+                return False
+
+        try:
+            os.kill(pid, signal_type)
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            log.warning("t0_lifecycle: kill pid=%d failed: %s", pid, e)
+
+        if signal_type == signal.SIGTERM:
+            deadline = time.monotonic() + self._heartbeat_timeout_seconds
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                    time.sleep(self._kill_poll_interval)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        now = _now_iso()
+        with self._connect() as conn:
+            row = self._get_t0_row(conn, project_id)
+            if row:
+                existing_meta = json.loads(row.get("metadata_json") or "{}")
+                existing_meta["killed_at"] = now
+                conn.execute(
+                    """
+                    UPDATE terminal_leases
+                    SET state='released', released_at=?, metadata_json=?
+                    WHERE terminal_id=? AND project_id=?
+                    """,
+                    (now, json.dumps(existing_meta), _T0_TERMINAL_ID, project_id),
+                )
+                conn.commit()
+
+        self._emit_event(project_id, "t0_killed", {
+            "pid": pid,
+            "signal": signal_type,
+            "killed_at": now,
+        })
+        return True
+
+    def reap_dead_t0s(self) -> List[str]:
+        """Detect T0s where last_heartbeat older than heartbeat_timeout_seconds.
+
+        Marks their leases released and returns list of reaped project_ids.
+        Idempotent: already-released T0s are not re-reaped.
+        """
+        now_ts = time.time()
+        reaped: List[str] = []
+
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND state='leased'",
+                (_T0_TERMINAL_ID,),
+            ).fetchall()
+
+            for row in rows:
+                r = dict(row)
+                hb = r.get("last_heartbeat_at")
+                if not hb:
+                    continue
+                try:
+                    age = now_ts - _parse_iso(hb)
+                except ValueError:
+                    continue
+                if age > self._heartbeat_timeout_seconds:
+                    released_at = _now_iso()
+                    conn.execute(
+                        """
+                        UPDATE terminal_leases
+                        SET state='released', released_at=?
+                        WHERE terminal_id=? AND project_id=?
+                        """,
+                        (released_at, _T0_TERMINAL_ID, r["project_id"]),
+                    )
+                    reaped.append(r["project_id"])
+
+            if reaped:
+                conn.commit()
+
+        for project_id in reaped:
+            self._emit_event(project_id, "t0_reaped", {
+                "reason": "heartbeat_timeout",
+                "timeout_seconds": self._heartbeat_timeout_seconds,
+            })
+        return reaped
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._coord_db), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _get_t0_row(
+        self, conn: sqlite3.Connection, project_id: str
+    ) -> Optional[dict]:
+        row = conn.execute(
+            """
+            SELECT * FROM terminal_leases
+            WHERE terminal_id=? AND project_id=?
+            """,
+            (_T0_TERMINAL_ID, project_id),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def _emit_event(
+        self, project_id: str, event_type: str, payload: dict
+    ) -> None:
+        if self._aggregator is None:
+            return
+        try:
+            from scripts.aggregator.state_aggregator import ProjectStateUpdate
+            update = ProjectStateUpdate(
+                project_id=project_id,
+                timestamp=_now_iso(),
+                event_type=event_type,
+                payload=payload,
+                source_t0="T0-lifecycle",
+            )
+            self._aggregator.submit(update)
+        except Exception as e:
+            log.warning(
+                "t0_lifecycle: aggregator emit failed for %s/%s: %s",
+                project_id,
+                event_type,
+                e,
+            )

--- a/scripts/lib/append_receipt_internals/enrichment.py
+++ b/scripts/lib/append_receipt_internals/enrichment.py
@@ -7,7 +7,9 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .common import _emit, _utc_now_iso, facade
+import sys
+
+from .common import _emit, _utc_now_iso, facade, SCRIPTS_DIR
 from .validation import _is_completion_event, _is_subprocess_intermediate_completion
 
 
@@ -183,6 +185,31 @@ def _enrich_oi_delta(enriched: Dict[str, Any], state_dir: Path) -> None:
         _emit("WARN", "oi_delta_enrichment_failed", error=str(exc))
 
 
+def _enrich_timing(enriched: Dict[str, Any], state_dir: Path) -> None:
+    """Add timing block from event archive (idempotent, best-effort).
+
+    Skipped when timing is already present or dispatch_id missing.
+    state_dir is .vnx-data/state; parent is the vnx_data_dir.
+    """
+    if enriched.get("timing") is not None:
+        return
+    dispatch_id = str(
+        enriched.get("dispatch_id")
+        or (enriched.get("metadata") or {}).get("dispatch_id")
+        or ""
+    ).strip()
+    if not dispatch_id:
+        return
+    try:
+        sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+        from timing_metrics import _build_timing_block
+        timing = _build_timing_block(dispatch_id, state_dir.parent)
+        if timing is not None:
+            enriched["timing"] = timing
+    except Exception as exc:
+        _emit("WARN", "timing_enrichment_failed", error=str(exc))
+
+
 def _enrich_cqs(enriched: Dict[str, Any], state_dir: Path) -> None:
     try:
         db_path = state_dir / "quality_intelligence.db"
@@ -265,6 +292,7 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
 
     _enrich_quality_advisory(enriched, receipt, repo_root)
     _enrich_oi_delta(enriched, state_dir)
+    _enrich_timing(enriched, state_dir)
 
     if "open_items_created" not in enriched:
         enriched["open_items_created"] = facade._count_quality_violations_against_store(enriched)

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -32,6 +32,40 @@ import logging
 log = logging.getLogger(__name__)
 
 
+def _enrich_timing_block(receipt: Dict[str, Any]) -> None:
+    """Idempotent: stamp timing block on completion receipts if archive exists.
+
+    Skips if timing already present or dispatch_id missing. Never raises.
+    """
+    if receipt.get("timing") is not None:
+        return
+    dispatch_id = str(receipt.get("dispatch_id") or "").strip()
+    if not dispatch_id:
+        return
+    event_type = str(receipt.get("event_type") or receipt.get("event") or "").lower()
+    COMPLETION_EVENTS = {
+        "task_complete", "task_completed", "completion", "complete",
+        "task_failed", "task_timeout",
+    }
+    if event_type not in COMPLETION_EVENTS:
+        return
+    try:
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+        from timing_metrics import _build_timing_block
+    except ImportError:
+        return
+    try:
+        paths = facade.ensure_env()
+        vnx_data_dir = Path(paths.get("VNX_DATA_DIR", ""))
+        if not vnx_data_dir or not vnx_data_dir.exists():
+            return
+    except Exception:
+        return
+    timing = _build_timing_block(dispatch_id, vnx_data_dir)
+    if timing is not None:
+        receipt["timing"] = timing
+
+
 def _maybe_reroute_to_gate_stream(receipt: Dict[str, Any], receipts_file: Optional[str]) -> Optional[str]:
     """Route ghost gate receipts (dispatch_id="unknown" + gate event) to gate_events.ndjson."""
     if receipts_file is not None or not facade.should_route_to_gate_stream(receipt):
@@ -79,6 +113,10 @@ def _run_post_append_hooks(receipt: Dict[str, Any]) -> None:
         facade._trigger_receipt_classifier(receipt)
     except Exception as exc:
         log.warning("payload: receipt classifier hook failed: %s", exc)
+    try:
+        _enrich_timing_block(receipt)
+    except Exception as exc:
+        log.warning("payload: timing enrichment hook failed: %s", exc)
 
 
 def _stamp_observability_tier(receipt: Dict[str, Any]) -> None:

--- a/scripts/lib/timing_metrics.py
+++ b/scripts/lib/timing_metrics.py
@@ -1,0 +1,174 @@
+"""timing_metrics.py — Wave 5 PR-5.x: effective time + parallel detection.
+
+Two use-cases:
+- Forward: append_receipt enriches new receipts with timing block
+- Retrospective: pr_timing_report CLI analyzes archived event-streams
+
+Effective time = sum of inter-event gaps capped at threshold_seconds.
+Long gaps (gates running, waiting on review) don't count as active work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ACTIVE_THRESHOLD_SECONDS = float(
+    os.environ.get("VNX_TIMING_ACTIVE_THRESHOLD_SECONDS", "10.0")
+)
+
+
+@dataclass
+class TimingMetrics:
+    dispatch_id: str
+    walltime_seconds: float
+    effective_seconds: float
+    event_count: int
+    started_at: str
+    ended_at: str
+    parallel_dispatch_ids: List[str]
+    parallel_seconds: float
+
+
+def compute_effective_time(
+    ndjson_path: Path,
+    threshold_seconds: float = DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+) -> Tuple[float, float, int, str, str]:
+    """Parse NDJSON event-stream, return (walltime, effective_time, event_count, started_iso, ended_iso).
+
+    Effective = sum of min(t_next - t_curr, threshold) for consecutive timestamps.
+    Walltime = last event ts - first event ts.
+    Raises OSError on unreadable file; json.JSONDecodeError never silently swallowed.
+    """
+    timestamps: List[Tuple[float, str]] = []
+    with open(ndjson_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                log.debug("timing_metrics: skipping malformed JSON line in %s", ndjson_path)
+                continue
+            ts = obj.get("timestamp")
+            if not ts:
+                continue
+            try:
+                t = datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+                timestamps.append((t, ts))
+            except ValueError:
+                log.debug("timing_metrics: unparseable timestamp %r in %s", ts, ndjson_path)
+
+    if len(timestamps) < 2:
+        return 0.0, 0.0, len(timestamps), "", ""
+
+    timestamps.sort()
+    walltime = timestamps[-1][0] - timestamps[0][0]
+    effective = sum(
+        min(timestamps[i + 1][0] - timestamps[i][0], threshold_seconds)
+        for i in range(len(timestamps) - 1)
+    )
+    return walltime, effective, len(timestamps), timestamps[0][1], timestamps[-1][1]
+
+
+def detect_parallel_dispatches(
+    target_dispatch_id: str,
+    target_started: float,
+    target_ended: float,
+    candidate_archives: List[Path],
+) -> Tuple[List[str], float]:
+    """Find other dispatches whose [start, end] windows overlap with the target.
+
+    Returns (list of overlapping dispatch_ids, total overlap seconds).
+    Overlap intervals are summed naively; no deduplication of union periods.
+    """
+    overlaps: List[str] = []
+    total_overlap = 0.0
+    for archive in candidate_archives:
+        if target_dispatch_id in archive.stem:
+            continue
+        try:
+            _, _, _, started, ended = compute_effective_time(archive)
+        except OSError as exc:
+            log.debug("timing_metrics: skipping unreadable archive %s: %s", archive, exc)
+            continue
+        if not started or not ended:
+            continue
+        try:
+            t_start = datetime.fromisoformat(started.replace("Z", "+00:00")).timestamp()
+            t_end = datetime.fromisoformat(ended.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            continue
+        overlap_start = max(target_started, t_start)
+        overlap_end = min(target_ended, t_end)
+        if overlap_end > overlap_start:
+            overlaps.append(archive.stem)
+            total_overlap += overlap_end - overlap_start
+    return overlaps, total_overlap
+
+
+def analyze_dispatch(
+    dispatch_id: str,
+    archive_root: Path,
+    threshold_seconds: float = DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+) -> Optional[TimingMetrics]:
+    """Find NDJSON archive for dispatch_id, compute metrics, detect parallel dispatches."""
+    candidates = list(archive_root.rglob(f"{dispatch_id}*.ndjson"))
+    if not candidates:
+        return None
+    ndjson_path = candidates[0]
+
+    try:
+        wt, eff, n_events, started, ended = compute_effective_time(ndjson_path, threshold_seconds)
+    except OSError as exc:
+        log.warning("timing_metrics: failed to read archive %s: %s", ndjson_path, exc)
+        return None
+
+    if not started:
+        return None
+
+    try:
+        t_start = datetime.fromisoformat(started.replace("Z", "+00:00")).timestamp()
+        t_end = datetime.fromisoformat(ended.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+    all_archives = list(archive_root.rglob("*.ndjson"))
+    parallel_ids, parallel_secs = detect_parallel_dispatches(
+        dispatch_id, t_start, t_end, all_archives
+    )
+
+    return TimingMetrics(
+        dispatch_id=dispatch_id,
+        walltime_seconds=wt,
+        effective_seconds=eff,
+        event_count=n_events,
+        started_at=started,
+        ended_at=ended,
+        parallel_dispatch_ids=parallel_ids,
+        parallel_seconds=parallel_secs,
+    )
+
+
+def _build_timing_block(dispatch_id: str, vnx_data_dir: Path) -> Optional[Dict]:
+    """Build a timing dict for embedding in a completion receipt (best-effort).
+
+    Returns None when no archive exists or metrics cannot be computed.
+    Safe to call on any dispatch; missing archive is the expected case
+    for non-subprocess-routed terminals.
+    """
+    archive_root = vnx_data_dir / "events" / "archive"
+    if not archive_root.exists():
+        return None
+    metrics = analyze_dispatch(dispatch_id, archive_root)
+    if metrics is None:
+        return None
+    return asdict(metrics)

--- a/scripts/pr_timing_report.py
+++ b/scripts/pr_timing_report.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""pr_timing_report.py — Wave 5 PR-5.x: retrospective timing analysis.
+
+Usage:
+  python3 scripts/pr_timing_report.py --pr 522
+  python3 scripts/pr_timing_report.py --since 2026-05-15
+  python3 scripts/pr_timing_report.py --dispatch 20260516-wave5-pr1-aggregator
+  python3 scripts/pr_timing_report.py --since 2026-05-15 --output claudedocs/timing-report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Resolve project root for imports
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE / "lib"))
+
+from timing_metrics import TimingMetrics, analyze_dispatch, DEFAULT_ACTIVE_THRESHOLD_SECONDS
+
+
+COST_BENCHMARK_HOURLY = 125.0  # € per hour (Vincent's internal benchmark)
+
+
+def _vnx_data_dir() -> Path:
+    env_val = os.environ.get("VNX_DATA_DIR", "")
+    if env_val:
+        candidate = Path(env_val)
+        if candidate.exists():
+            return candidate
+    default = _HERE.parent / ".vnx-data"
+    return default
+
+
+def _archive_root(data_dir: Path) -> Path:
+    return data_dir / "events" / "archive"
+
+
+def _receipts_path(data_dir: Path) -> Path:
+    return data_dir / "state" / "t0_receipts.ndjson"
+
+
+def _load_receipts(receipts_path: Path) -> List[Dict]:
+    if not receipts_path.exists():
+        return []
+    receipts: List[Dict] = []
+    with open(receipts_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                receipts.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return receipts
+
+
+def _dispatch_ids_for_pr(pr_number: str, receipts: List[Dict]) -> List[str]:
+    """Map a PR number to its dispatch IDs by scanning receipts."""
+    norm = str(pr_number).lstrip("PR-pr").strip()
+    seen: List[str] = []
+    seen_set: set = set()
+    targets = {f"PR-{norm}", norm, f"pr-{norm}"}
+    for r in receipts:
+        pr_id = str(r.get("pr_id") or r.get("pr") or "")
+        dispatch_id = str(r.get("dispatch_id") or "").strip()
+        if not dispatch_id or dispatch_id in seen_set:
+            continue
+        if pr_id in targets or pr_id.lstrip("PR-pr") == norm:
+            seen.append(dispatch_id)
+            seen_set.add(dispatch_id)
+    return seen
+
+
+def _dispatch_ids_since(since_iso: str, receipts: List[Dict]) -> List[str]:
+    """Return dispatch IDs whose receipts have timestamps >= since_iso."""
+    try:
+        cutoff = datetime.fromisoformat(since_iso).replace(tzinfo=timezone.utc)
+    except ValueError:
+        sys.exit(f"Invalid date format for --since: {since_iso!r}. Use YYYY-MM-DD.")
+    seen: List[str] = []
+    seen_set: set = set()
+    for r in receipts:
+        ts_raw = str(r.get("timestamp") or "").strip()
+        dispatch_id = str(r.get("dispatch_id") or "").strip()
+        if not dispatch_id or dispatch_id in seen_set:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.astimezone(timezone.utc) >= cutoff:
+            seen.append(dispatch_id)
+            seen_set.add(dispatch_id)
+    return seen
+
+
+def _format_seconds(secs: float) -> str:
+    if secs < 60:
+        return f"{secs:.0f}s"
+    if secs < 3600:
+        return f"{secs / 60:.0f}m"
+    return f"{secs / 3600:.1f}h"
+
+
+def _effective_rate(effective_seconds: float) -> str:
+    if effective_seconds <= 0:
+        return "n/a"
+    hours = effective_seconds / 3600
+    rate = COST_BENCHMARK_HOURLY / hours if hours > 0 else 0
+    return f"€{rate:.0f}/u"
+
+
+def _build_dispatch_block(
+    dispatch_id: str,
+    archive_root: Path,
+    threshold: float,
+) -> Optional[TimingMetrics]:
+    return analyze_dispatch(dispatch_id, archive_root, threshold)
+
+
+def _render_pr_section(
+    pr_label: str,
+    dispatch_ids: List[str],
+    metrics_list: List[TimingMetrics],
+) -> str:
+    lines: List[str] = []
+    lines.append(f"PR {pr_label}")
+
+    if not metrics_list:
+        lines.append("  No archived event streams found for this PR.")
+        return "\n".join(lines)
+
+    total_walltime = sum(m.walltime_seconds for m in metrics_list)
+    total_effective = sum(m.effective_seconds for m in metrics_list)
+    total_events = sum(m.event_count for m in metrics_list)
+    all_parallel = list({p for m in metrics_list for p in m.parallel_dispatch_ids})
+    total_parallel_secs = sum(m.parallel_seconds for m in metrics_list)
+
+    active_ratio = (total_effective / total_walltime * 100) if total_walltime > 0 else 0
+    lines.append(f"  Dispatches: {len(metrics_list)}")
+    lines.append(f"  Walltime sum: {_format_seconds(total_walltime)}")
+    lines.append(f"  Effective sum: {_format_seconds(total_effective)}")
+    lines.append(f"  Active ratio: {active_ratio:.0f}%")
+    if all_parallel:
+        lines.append(f"  Parallel with: {', '.join(all_parallel[:5])}")
+    lines.append(f"  Parallel seconds: {total_parallel_secs:.0f}s")
+    lines.append(f"  Effective rate: {_effective_rate(total_effective)} "
+                 f"(at €{COST_BENCHMARK_HOURLY:.0f}/u-benchmark, {active_ratio:.0f}% effective)")
+    return "\n".join(lines)
+
+
+def _render_aggregate(all_metrics: List[TimingMetrics]) -> str:
+    if not all_metrics:
+        return "No metrics available."
+    total_wt = sum(m.walltime_seconds for m in all_metrics)
+    total_eff = sum(m.effective_seconds for m in all_metrics)
+    ratio = (total_eff / total_wt * 100) if total_wt > 0 else 0
+    lines = [
+        "",
+        "## Aggregate",
+        f"  Total dispatches analyzed: {len(all_metrics)}",
+        f"  Total walltime: {_format_seconds(total_wt)}",
+        f"  Total effective: {_format_seconds(total_eff)}",
+        f"  Overall active ratio: {ratio:.0f}%",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Retrospective timing report for VNX dispatches / PRs."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", metavar="NUMBER", help="Single PR number to analyze")
+    group.add_argument("--since", metavar="DATE", help="Analyze all dispatches since YYYY-MM-DD")
+    group.add_argument("--dispatch", metavar="DISPATCH_ID", help="Single dispatch ID to analyze")
+    parser.add_argument("--output", metavar="PATH", help="Write markdown report to file")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+        help=f"Active gap cap in seconds (default: {DEFAULT_ACTIVE_THRESHOLD_SECONDS})",
+    )
+    args = parser.parse_args()
+
+    data_dir = _vnx_data_dir()
+    archive_root = _archive_root(data_dir)
+    receipts = _load_receipts(_receipts_path(data_dir))
+
+    sections: List[str] = []
+    all_metrics: List[TimingMetrics] = []
+
+    if args.dispatch:
+        m = _build_dispatch_block(args.dispatch, archive_root, args.threshold)
+        metrics_list = [m] if m else []
+        all_metrics.extend(metrics_list)
+        sections.append(_render_pr_section(f"dispatch/{args.dispatch}", [args.dispatch], metrics_list))
+
+    elif args.pr:
+        dispatch_ids = _dispatch_ids_for_pr(args.pr, receipts)
+        if not dispatch_ids:
+            print(f"No dispatch IDs found for PR {args.pr} in receipts.")
+        metrics_list = [
+            m for d in dispatch_ids
+            for m in [_build_dispatch_block(d, archive_root, args.threshold)]
+            if m is not None
+        ]
+        all_metrics.extend(metrics_list)
+        sections.append(_render_pr_section(f"#{args.pr}", dispatch_ids, metrics_list))
+
+    elif args.since:
+        dispatch_ids = _dispatch_ids_since(args.since, receipts)
+        by_pr: Dict[str, Tuple[List[str], List[TimingMetrics]]] = {}
+        for did in dispatch_ids:
+            pr_id = "unknown"
+            for r in receipts:
+                if str(r.get("dispatch_id") or "") == did:
+                    pr_id = str(r.get("pr_id") or r.get("pr") or "unknown")
+                    break
+            m = _build_dispatch_block(did, archive_root, args.threshold)
+            ids_list, metrics_list = by_pr.setdefault(pr_id, ([], []))
+            ids_list.append(did)
+            if m is not None:
+                metrics_list.append(m)
+                all_metrics.append(m)
+        for pr_id, (ids_list, metrics_list) in sorted(by_pr.items()):
+            sections.append(_render_pr_section(f"#{pr_id}", ids_list, metrics_list))
+
+    output_lines = "\n".join(sections) + _render_aggregate(all_metrics)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output_lines + "\n", encoding="utf-8")
+        print(f"Report written to {out_path}")
+    else:
+        print(output_lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/t0_lifecycle_cli.py
+++ b/scripts/t0_lifecycle_cli.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""t0_lifecycle_cli.py — Operator CLI for per-project T0 lifecycle management.
+
+Wave 5 PR-5.2. Wraps T0LifecycleManager with an argparse interface.
+
+Usage:
+    python3 scripts/t0_lifecycle_cli.py spawn --project-id vnx-dev --project-root /path/to/repo
+    python3 scripts/t0_lifecycle_cli.py heartbeat --project-id vnx-dev --pid 12345
+    python3 scripts/t0_lifecycle_cli.py list
+    python3 scripts/t0_lifecycle_cli.py kill --project-id vnx-dev
+    python3 scripts/t0_lifecycle_cli.py reap
+
+Config resolution (in priority order):
+    1. --coord-db CLI flag
+    2. VNX_STATE_DIR env var  → <VNX_STATE_DIR>/runtime_coordination.db
+    3. Default: .vnx-data/state/runtime_coordination.db (relative to cwd)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+
+# Allow running from project root or scripts/ directory
+_HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = _HERE.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.aggregator.t0_lifecycle import T0LifecycleManager
+
+
+def _resolve_coord_db(args: argparse.Namespace) -> Path:
+    if getattr(args, "coord_db", None):
+        return Path(args.coord_db)
+    state_dir = os.environ.get("VNX_STATE_DIR")
+    if state_dir:
+        return Path(state_dir) / "runtime_coordination.db"
+    return Path.cwd() / ".vnx-data" / "state" / "runtime_coordination.db"
+
+
+def _build_manager(
+    coord_db: Path,
+    project_id: str = "",
+    project_root: str = "",
+    claude_args: list | None = None,
+) -> T0LifecycleManager:
+    projects: dict = {}
+    if project_id:
+        projects[project_id] = {
+            "root": project_root,
+            "claude_args": claude_args or [],
+        }
+    return T0LifecycleManager({
+        "coord_db_path": str(coord_db),
+        "projects": projects,
+    })
+
+
+def cmd_spawn(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    claude_args = args.claude_args.split() if args.claude_args else []
+    mgr = _build_manager(
+        coord_db,
+        project_id=args.project_id,
+        project_root=args.project_root or "",
+        claude_args=claude_args,
+    )
+    try:
+        instance = mgr.spawn(args.project_id)
+    except ValueError as e:
+        print(f"[error] {e}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"[error] {e}", file=sys.stderr)
+        return 1
+    print(json.dumps({
+        "project_id": instance.project_id,
+        "pid": instance.pid,
+        "state": instance.state,
+        "started_at": instance.started_at,
+        "project_root": instance.project_root,
+    }, indent=2))
+    return 0
+
+
+def cmd_heartbeat(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = _build_manager(coord_db, project_id=args.project_id)
+    recorded = mgr.heartbeat(args.project_id, args.pid)
+    if recorded:
+        print(f"[ok] heartbeat recorded for project={args.project_id} pid={args.pid}")
+        return 0
+    print(f"[warn] no running T0 found for project={args.project_id} pid={args.pid}", file=sys.stderr)
+    return 1
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = T0LifecycleManager({"coord_db_path": str(coord_db)})
+    instances = mgr.list_running()
+    if not instances:
+        print("No running T0 instances.")
+        return 0
+    for inst in instances:
+        print(json.dumps({
+            "project_id": inst.project_id,
+            "pid": inst.pid,
+            "state": inst.state,
+            "started_at": inst.started_at,
+            "last_heartbeat_at": inst.last_heartbeat_at,
+        }))
+    return 0
+
+
+def cmd_kill(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = _build_manager(coord_db, project_id=args.project_id)
+    sig = signal.SIGKILL if args.force else signal.SIGTERM
+    killed = mgr.kill(args.project_id, signal_type=sig)
+    if killed:
+        sig_name = "SIGKILL" if args.force else "SIGTERM"
+        print(f"[ok] sent {sig_name} to T0 for project={args.project_id}")
+        return 0
+    print(f"[warn] no running T0 found for project={args.project_id}", file=sys.stderr)
+    return 1
+
+
+def cmd_reap(args: argparse.Namespace) -> int:
+    coord_db = _resolve_coord_db(args)
+    mgr = T0LifecycleManager({"coord_db_path": str(coord_db)})
+    reaped = mgr.reap_dead_t0s()
+    if reaped:
+        print(f"[ok] reaped {len(reaped)} stale T0(s): {', '.join(reaped)}")
+    else:
+        print("[ok] no stale T0s found")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="VNX per-project T0 lifecycle management (Wave 5 PR-5.2)"
+    )
+    parser.add_argument(
+        "--coord-db",
+        default=None,
+        help="Path to runtime_coordination.db (overrides VNX_STATE_DIR)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sp_spawn = sub.add_parser("spawn", help="Spawn a per-project T0 process")
+    sp_spawn.add_argument("--project-id", required=True)
+    sp_spawn.add_argument("--project-root", default="", help="Absolute path to project worktree")
+    sp_spawn.add_argument("--claude-args", default="", help="Space-separated extra args for claude")
+    sp_spawn.set_defaults(func=cmd_spawn)
+
+    sp_hb = sub.add_parser("heartbeat", help="Record heartbeat for a running T0")
+    sp_hb.add_argument("--project-id", required=True)
+    sp_hb.add_argument("--pid", required=True, type=int)
+    sp_hb.set_defaults(func=cmd_heartbeat)
+
+    sp_list = sub.add_parser("list", help="List all running T0 instances")
+    sp_list.set_defaults(func=cmd_list)
+
+    sp_kill = sub.add_parser("kill", help="Kill a running T0 (graceful SIGTERM, then SIGKILL)")
+    sp_kill.add_argument("--project-id", required=True)
+    sp_kill.add_argument("--force", action="store_true", help="Skip SIGTERM, send SIGKILL directly")
+    sp_kill.set_defaults(func=cmd_kill)
+
+    sp_reap = sub.add_parser("reap", help="Reap stale T0s (heartbeat older than timeout)")
+    sp_reap.set_defaults(func=cmd_reap)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_t0_lifecycle.py
+++ b/tests/test_t0_lifecycle.py
@@ -1,0 +1,510 @@
+"""Tests for scripts/aggregator/t0_lifecycle.py (Wave 5 PR-5.2).
+
+Coverage:
+  - spawn creates lease + returns T0Instance with valid pid
+  - spawn refuses if project T0 already running (ValueError)
+  - heartbeat updates last_heartbeat_at timestamp
+  - kill SIGTERM — graceful shutdown, lease released
+  - kill SIGTERM escalation to SIGKILL when process unresponsive
+  - reap_dead_t0s detects stale heartbeats
+  - list_running returns correct subset after spawn/kill
+  - StateAggregator receives t0_spawned lifecycle event
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Project root in path for package imports
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.aggregator.state_aggregator import ProjectStateUpdate, StateAggregator
+from scripts.aggregator.t0_lifecycle import T0LifecycleManager, _T0_TERMINAL_ID
+
+_SCRIPTS_LIB = _PROJECT_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(_SCRIPTS_LIB))
+
+
+# Minimal schema for tests — only the terminal_leases table that T0LifecycleManager uses.
+# The full init_schema chain (v1→v10) fails on fresh DBs because v10 depends on the
+# schemas/migrations/0010 ALTER TABLE that init_schema doesn't apply.
+_MINIMAL_SCHEMA_SQL = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS terminal_leases (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT,
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(terminal_id, project_id)
+);
+"""
+
+
+def _init_test_db(db_path: Path) -> None:
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_MINIMAL_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_conn(db_path: Path):
+    import sqlite3
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Base test case
+# ---------------------------------------------------------------------------
+
+
+class _LifecycleBase(unittest.TestCase):
+    """Creates temp dirs, initialises schema, builds a T0LifecycleManager."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.state_dir = Path(self._tmpdir.name)
+        self.coord_db = self.state_dir / "runtime_coordination.db"
+        _init_test_db(self.coord_db)
+
+        self.vnx_data_dir = self.state_dir / "vnx-data"
+        self.vnx_data_dir.mkdir()
+        self.aggregator = StateAggregator(self.vnx_data_dir)
+
+        self.mgr = self._make_mgr()
+
+    def _make_mgr(self, **extra) -> T0LifecycleManager:
+        opts = {
+            "coord_db_path": str(self.coord_db),
+            "projects": {
+                "proj-a": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "proj-b": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "proj-c": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+                "test-proj": {"root": str(self.state_dir), "cmd": ["sleep", "60"]},
+            },
+            "heartbeat_timeout": 120,
+            "aggregator": self.aggregator,
+        }
+        opts.update(extra)
+        return T0LifecycleManager(opts)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _lease_row(self, project_id: str) -> dict | None:
+        conn = _get_conn(self.coord_db)
+        try:
+            row = conn.execute(
+                "SELECT * FROM terminal_leases WHERE terminal_id=? AND project_id=?",
+                (_T0_TERMINAL_ID, project_id),
+            ).fetchone()
+        finally:
+            conn.close()
+        return dict(row) if row else None
+
+    def _aggregator_events(self, event_type: str | None = None) -> list[dict]:
+        events_path = self.vnx_data_dir / "events" / "state_aggregator.ndjson"
+        if not events_path.exists():
+            return []
+        records = []
+        for line in events_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if event_type is None or rec.get("event_type") == event_type:
+                records.append(rec)
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Test: spawn creates lease + process
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCreatesLeaseAndProcess(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_creates_lease_and_process(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99001
+        mock_popen.return_value = mock_proc
+
+        instance = self.mgr.spawn("test-proj")
+
+        self.assertEqual(instance.project_id, "test-proj")
+        self.assertEqual(instance.pid, 99001)
+        self.assertEqual(instance.state, "running")
+        self.assertIsNotNone(instance.started_at)
+        self.assertIsNotNone(instance.last_heartbeat_at)
+
+        row = self._lease_row("test-proj")
+        self.assertIsNotNone(row)
+        self.assertEqual(row["state"], "leased")
+        self.assertEqual(row["terminal_id"], _T0_TERMINAL_ID)
+        self.assertEqual(row["project_id"], "test-proj")
+
+        meta = json.loads(row["metadata_json"])
+        self.assertEqual(meta["pid"], 99001)
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_sets_vnx_project_id_env(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        call_kwargs = mock_popen.call_args[1]
+        env = call_kwargs.get("env", {})
+        self.assertEqual(env.get("VNX_PROJECT_ID"), "test-proj")
+
+
+# ---------------------------------------------------------------------------
+# Test: spawn refuses if already running
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnRefusesIfAlreadyRunning(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_spawn_refuses_if_already_running(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 88001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.mgr.spawn("test-proj")
+
+        self.assertIn("test-proj", str(ctx.exception))
+        self.assertIn("already running", str(ctx.exception))
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_second_spawn_different_project_succeeds(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 88100
+        mock_popen.return_value = mock_proc
+
+        inst_a = self.mgr.spawn("proj-a")
+        inst_b = self.mgr.spawn("proj-b")
+
+        self.assertEqual(inst_a.project_id, "proj-a")
+        self.assertEqual(inst_b.project_id, "proj-b")
+
+
+# ---------------------------------------------------------------------------
+# Test: heartbeat updates timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatUpdatesTimestamp(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_heartbeat_updates_timestamp(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 77001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        row_before = self._lease_row("test-proj")
+
+        time.sleep(0.01)
+        recorded = self.mgr.heartbeat("test-proj", 77001)
+
+        self.assertTrue(recorded)
+        row_after = self._lease_row("test-proj")
+        self.assertGreater(
+            row_after["last_heartbeat_at"],
+            row_before["last_heartbeat_at"],
+        )
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_heartbeat_wrong_pid_returns_false(self, mock_popen: MagicMock) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 77002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        result = self.mgr.heartbeat("test-proj", 99999)
+        self.assertFalse(result)
+
+    def test_heartbeat_no_lease_returns_false(self) -> None:
+        result = self.mgr.heartbeat("test-proj", 12345)
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# Test: kill SIGTERM graceful
+# ---------------------------------------------------------------------------
+
+
+class TestKillSigtermGraceful(_LifecycleBase):
+    def test_kill_sigterm_graceful(self) -> None:
+        import subprocess as sp
+        # Short timeout so the test completes in <1s even if zombie detection is imperfect
+        mgr = self._make_mgr(heartbeat_timeout=0.3, kill_poll_interval=0.05)
+        proc = sp.Popen(
+            ["sleep", "60"],
+            stdout=sp.DEVNULL,
+            stderr=sp.DEVNULL,
+        )
+        pid = proc.pid
+
+        now = "2026-05-16T12:00:00.000+00:00"
+        meta = json.dumps({"pid": pid, "project_root": "", "started_at": now})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, 'test-proj', 'leased', NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, now, now, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        killed = mgr.kill("test-proj", signal_type=signal.SIGTERM)
+
+        self.assertTrue(killed)
+        # Reap zombie and verify the process is gone (SIGTERM or SIGKILL escalation)
+        try:
+            proc.wait(timeout=2)
+        except sp.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        self.assertIsNotNone(proc.returncode, "Process should have terminated")
+
+        row = self._lease_row("test-proj")
+        self.assertEqual(row["state"], "released")
+
+
+# ---------------------------------------------------------------------------
+# Test: kill escalates to SIGKILL when unresponsive
+# ---------------------------------------------------------------------------
+
+
+class TestKillSigkillEscalation(_LifecycleBase):
+    def test_kill_sigkill_force_when_unresponsive(self) -> None:
+        mgr = self._make_mgr(
+            heartbeat_timeout=0.5,
+            kill_poll_interval=0.05,
+        )
+        # Spawn a process that ignores SIGTERM
+        import subprocess as sp
+        proc = sp.Popen(
+            [
+                "python3",
+                "-c",
+                "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)",
+            ],
+            stdout=sp.DEVNULL,
+            stderr=sp.DEVNULL,
+        )
+        pid = proc.pid
+
+        now = "2026-05-16T12:00:00.000+00:00"
+        meta = json.dumps({"pid": pid, "project_root": "", "started_at": now})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, 'test-proj', 'leased', NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, now, now, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        killed = mgr.kill("test-proj", signal_type=signal.SIGTERM)
+
+        self.assertTrue(killed)
+        # Process must be dead (SIGKILL escalation fired)
+        proc.wait(timeout=2)
+        self.assertIsNotNone(proc.returncode)
+
+        row = self._lease_row("test-proj")
+        self.assertEqual(row["state"], "released")
+
+
+# ---------------------------------------------------------------------------
+# Test: reap dead T0s
+# ---------------------------------------------------------------------------
+
+
+class TestReapDeadT0s(_LifecycleBase):
+    def _insert_lease(
+        self,
+        project_id: str,
+        *,
+        last_heartbeat_at: str,
+        state: str = "leased",
+    ) -> None:
+        meta = json.dumps({"pid": 0, "project_root": ""})
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, dispatch_id, generation,
+                     leased_at, last_heartbeat_at, metadata_json)
+                VALUES (?, ?, ?, NULL, 1, ?, ?, ?)
+                """,
+                (_T0_TERMINAL_ID, project_id, state, last_heartbeat_at, last_heartbeat_at, meta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_reap_dead_t0s_finds_stale(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        now = datetime.now(timezone.utc)
+        # Stale: 2 hours ago → definitely older than 60s timeout
+        stale_ts = (now - timedelta(hours=2)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-a", last_heartbeat_at=stale_ts)
+        # Fresh: 10 seconds ago → not older than 60s timeout
+        fresh_ts = (now - timedelta(seconds=10)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-b", last_heartbeat_at=fresh_ts)
+
+        reaped = mgr.reap_dead_t0s()
+
+        self.assertIn("proj-a", reaped)
+        self.assertNotIn("proj-b", reaped)
+
+        row_a = self._lease_row("proj-a")
+        row_b = self._lease_row("proj-b")
+        self.assertEqual(row_a["state"], "released")
+        self.assertEqual(row_b["state"], "leased")
+
+    def test_reap_dead_t0s_idempotent(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(timespec="milliseconds")
+        self._insert_lease("proj-a", last_heartbeat_at=stale_ts)
+
+        first = mgr.reap_dead_t0s()
+        second = mgr.reap_dead_t0s()
+
+        self.assertIn("proj-a", first)
+        self.assertEqual(second, [])
+
+    def test_reap_no_stale_returns_empty(self) -> None:
+        mgr = self._make_mgr(heartbeat_timeout=60)
+        reaped = mgr.reap_dead_t0s()
+        self.assertEqual(reaped, [])
+
+
+# ---------------------------------------------------------------------------
+# Test: list_running returns active subset
+# ---------------------------------------------------------------------------
+
+
+class TestListRunningReturnsActive(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_list_running_returns_active(self, mock_popen: MagicMock) -> None:
+        pids = iter([11001, 11002, 11003])
+
+        def _make_mock(*args, **kwargs):
+            m = MagicMock()
+            m.pid = next(pids)
+            return m
+
+        mock_popen.side_effect = _make_mock
+
+        self.mgr.spawn("proj-a")
+        self.mgr.spawn("proj-b")
+        self.mgr.spawn("proj-c")
+
+        running = self.mgr.list_running()
+        self.assertEqual(len(running), 3)
+        project_ids = {i.project_id for i in running}
+        self.assertEqual(project_ids, {"proj-a", "proj-b", "proj-c"})
+
+        # Kill proj-b via DB (bypass actual process to avoid real signal)
+        conn = _get_conn(self.coord_db)
+        try:
+            conn.execute(
+                "UPDATE terminal_leases SET state='released' WHERE terminal_id=? AND project_id=?",
+                (_T0_TERMINAL_ID, "proj-b"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        running_after = self.mgr.list_running()
+        self.assertEqual(len(running_after), 2)
+        remaining = {i.project_id for i in running_after}
+        self.assertNotIn("proj-b", remaining)
+
+
+# ---------------------------------------------------------------------------
+# Test: StateAggregator receives lifecycle events
+# ---------------------------------------------------------------------------
+
+
+class TestStateAggregatorReceivesLifecycleEvents(_LifecycleBase):
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_state_aggregator_receives_lifecycle_events(
+        self, mock_popen: MagicMock
+    ) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 55001
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+
+        events = self._aggregator_events("t0_spawned")
+        self.assertGreaterEqual(len(events), 1)
+        evt = events[0]
+        self.assertEqual(evt["event_type"], "t0_spawned")
+        self.assertEqual(evt["sub_provider"], "test-proj")
+        data = evt["data"]
+        self.assertEqual(data["pid"], 55001)
+
+    @patch("scripts.aggregator.t0_lifecycle.subprocess.Popen")
+    def test_state_aggregator_receives_heartbeat_event(
+        self, mock_popen: MagicMock
+    ) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 55002
+        mock_popen.return_value = mock_proc
+
+        self.mgr.spawn("test-proj")
+        self.mgr.heartbeat("test-proj", 55002)
+
+        hb_events = self._aggregator_events("t0_heartbeat")
+        # Both spawn-time heartbeat state and explicit heartbeat call
+        self.assertGreaterEqual(len(hb_events), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timing_metrics.py
+++ b/tests/test_timing_metrics.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Tests for timing_metrics.py — Wave 5 PR-5.x."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from timing_metrics import (
+    DEFAULT_ACTIVE_THRESHOLD_SECONDS,
+    TimingMetrics,
+    _build_timing_block,
+    analyze_dispatch,
+    compute_effective_time,
+    detect_parallel_dispatches,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_ndjson(path: Path, events: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _ts(offset_seconds: float, base: datetime | None = None) -> str:
+    """ISO-8601 timestamp at base + offset."""
+    if base is None:
+        base = datetime(2026, 5, 16, 10, 0, 0, tzinfo=timezone.utc)
+    t = base.timestamp() + offset_seconds
+    return datetime.fromtimestamp(t, tz=timezone.utc).isoformat()
+
+
+def _events(*offsets: float) -> list:
+    return [{"timestamp": _ts(o), "type": "tool_use"} for o in offsets]
+
+
+# ---------------------------------------------------------------------------
+# compute_effective_time
+# ---------------------------------------------------------------------------
+
+class TestComputeEffectiveTime:
+    def test_caps_long_gaps(self, tmp_path: Path) -> None:
+        """Events at 0, 30, 35, 65s → gaps of 30, 5, 30 → effective = 10+5+10 = 25."""
+        ndjson = tmp_path / "dispatch.ndjson"
+        _write_ndjson(ndjson, _events(0, 30, 35, 65))
+        _, effective, count, started, ended = compute_effective_time(ndjson, threshold_seconds=10.0)
+        assert count == 4
+        assert effective == pytest.approx(25.0, abs=0.1)
+
+    def test_walltime_includes_full_span(self, tmp_path: Path) -> None:
+        """Walltime = last - first regardless of gap sizes."""
+        ndjson = tmp_path / "dispatch.ndjson"
+        _write_ndjson(ndjson, _events(0, 30, 35, 65))
+        walltime, _, _, started, ended = compute_effective_time(ndjson, threshold_seconds=10.0)
+        assert walltime == pytest.approx(65.0, abs=0.1)
+        assert started != ""
+        assert ended != ""
+
+    def test_small_gaps_not_capped(self, tmp_path: Path) -> None:
+        """Gaps smaller than threshold pass through unchanged."""
+        ndjson = tmp_path / "dispatch.ndjson"
+        _write_ndjson(ndjson, _events(0, 3, 7, 9))
+        _, effective, _, _, _ = compute_effective_time(ndjson, threshold_seconds=10.0)
+        assert effective == pytest.approx(9.0, abs=0.1)
+
+    def test_single_event_returns_zeros(self, tmp_path: Path) -> None:
+        ndjson = tmp_path / "single.ndjson"
+        _write_ndjson(ndjson, _events(0))
+        wt, eff, count, started, ended = compute_effective_time(ndjson)
+        assert wt == 0.0
+        assert eff == 0.0
+        assert count == 1
+        assert started == ""
+
+    def test_empty_file_returns_zeros(self, tmp_path: Path) -> None:
+        ndjson = tmp_path / "empty.ndjson"
+        ndjson.write_text("", encoding="utf-8")
+        wt, eff, count, started, ended = compute_effective_time(ndjson)
+        assert wt == 0.0
+        assert eff == 0.0
+        assert count == 0
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        ndjson = tmp_path / "partial.ndjson"
+        with ndjson.open("w") as f:
+            f.write(json.dumps({"timestamp": _ts(0)}) + "\n")
+            f.write("not valid json\n")
+            f.write(json.dumps({"timestamp": _ts(10)}) + "\n")
+        wt, _, count, _, _ = compute_effective_time(ndjson, threshold_seconds=10.0)
+        assert count == 2
+        assert wt == pytest.approx(10.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# detect_parallel_dispatches
+# ---------------------------------------------------------------------------
+
+class TestDetectParallelDispatches:
+    def _make_archive(self, tmp_path: Path, name: str, start_offset: float, end_offset: float) -> Path:
+        p = tmp_path / f"{name}.ndjson"
+        _write_ndjson(p, _events(start_offset, end_offset))
+        return p
+
+    def test_finds_overlapping_dispatches(self, tmp_path: Path) -> None:
+        """Target: 0-100s. Dispatch A: 50-150s (overlaps). Dispatch B: 200-300s (no overlap)."""
+        target_start = datetime(2026, 5, 16, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+        target_end = target_start + 100
+
+        arch_a = self._make_archive(tmp_path, "dispatch-A", 50, 150)
+        arch_b = self._make_archive(tmp_path, "dispatch-B", 200, 300)
+
+        overlaps, _ = detect_parallel_dispatches(
+            "target-dispatch",
+            target_start,
+            target_end,
+            [arch_a, arch_b],
+        )
+        assert "dispatch-A" in overlaps
+        assert "dispatch-B" not in overlaps
+
+    def test_parallel_seconds_correct(self, tmp_path: Path) -> None:
+        """Target 0-100s, overlap with A at 50-100 = 50 seconds parallel."""
+        target_start = datetime(2026, 5, 16, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+        target_end = target_start + 100
+
+        arch_a = self._make_archive(tmp_path, "dispatch-C", 50, 100)
+
+        _, parallel_secs = detect_parallel_dispatches(
+            "target-dispatch",
+            target_start,
+            target_end,
+            [arch_a],
+        )
+        assert parallel_secs == pytest.approx(50.0, abs=0.5)
+
+    def test_excludes_self(self, tmp_path: Path) -> None:
+        """Target dispatch file is never counted as overlapping itself."""
+        target_start = datetime(2026, 5, 16, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+        target_end = target_start + 100
+
+        self_archive = tmp_path / "target-dispatch-T1.ndjson"
+        _write_ndjson(self_archive, _events(0, 90))
+
+        overlaps, _ = detect_parallel_dispatches(
+            "target-dispatch",
+            target_start,
+            target_end,
+            [self_archive],
+        )
+        assert overlaps == []
+
+
+# ---------------------------------------------------------------------------
+# analyze_dispatch
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeDispatch:
+    def test_missing_archive_returns_none(self, tmp_path: Path) -> None:
+        result = analyze_dispatch("nonexistent-dispatch-id", tmp_path)
+        assert result is None
+
+    def test_returns_timing_metrics(self, tmp_path: Path) -> None:
+        ndjson = tmp_path / "T1" / "my-dispatch-id.ndjson"
+        _write_ndjson(ndjson, _events(0, 5, 10, 70))
+        result = analyze_dispatch("my-dispatch-id", tmp_path)
+        assert isinstance(result, TimingMetrics)
+        assert result.dispatch_id == "my-dispatch-id"
+        assert result.event_count == 4
+        assert result.walltime_seconds == pytest.approx(70.0, abs=0.1)
+        # 5+5+10(cap) = 20 effective with default 10s threshold
+        assert result.effective_seconds == pytest.approx(20.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# _build_timing_block
+# ---------------------------------------------------------------------------
+
+class TestBuildTimingBlock:
+    def test_no_archive_dir_returns_none(self, tmp_path: Path) -> None:
+        result = _build_timing_block("some-dispatch", tmp_path)
+        assert result is None
+
+    def test_missing_dispatch_in_archive_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "events" / "archive").mkdir(parents=True)
+        result = _build_timing_block("missing-dispatch", tmp_path)
+        assert result is None
+
+    def test_returns_dict_with_dispatch_id(self, tmp_path: Path) -> None:
+        archive_dir = tmp_path / "events" / "archive" / "T1"
+        ndjson = archive_dir / "test-dispatch-id.ndjson"
+        _write_ndjson(ndjson, _events(0, 5, 15))
+        result = _build_timing_block("test-dispatch-id", tmp_path)
+        assert isinstance(result, dict)
+        assert result["dispatch_id"] == "test-dispatch-id"
+        assert "walltime_seconds" in result
+        assert "effective_seconds" in result
+        assert "parallel_dispatch_ids" in result
+
+
+# ---------------------------------------------------------------------------
+# PR report aggregation
+# ---------------------------------------------------------------------------
+
+class TestPrReportAggregation:
+    def test_aggregates_multiple_dispatches(self, tmp_path: Path) -> None:
+        """PR with 3 dispatches → totals sum correctly."""
+        archive_dir = tmp_path / "T1"
+        dispatches = ["disp-alpha", "disp-beta", "disp-gamma"]
+        expected_walltimes = [60.0, 120.0, 30.0]
+        for name, duration in zip(dispatches, expected_walltimes):
+            _write_ndjson(archive_dir / f"{name}.ndjson", _events(0, duration))
+
+        metrics_list = [
+            analyze_dispatch(did, tmp_path)
+            for did in dispatches
+        ]
+        assert all(m is not None for m in metrics_list)
+
+        total_walltime = sum(m.walltime_seconds for m in metrics_list)  # type: ignore[union-attr]
+        assert total_walltime == pytest.approx(210.0, abs=1.0)
+
+        total_effective = sum(m.effective_seconds for m in metrics_list)  # type: ignore[union-attr]
+        # Each dispatch has a single gap capped at 10s → 10+10+10 = 30
+        assert total_effective == pytest.approx(30.0, abs=1.0)


### PR DESCRIPTION
## Summary

- **Forward use-case**: `_enrich_timing` wired into `_enrich_completion_receipt` pipeline — completion receipts now include a `timing` block (walltime, effective time, parallel detection) when a subprocess-routed event archive exists. Idempotent: skips if `timing` key already present.
- **Retrospective use-case**: `scripts/pr_timing_report.py` CLI reads archived NDJSON event streams and generates per-PR timing reports with walltime, effective time, active ratio, parallel detection, and aggregate totals. Supports `--pr`, `--since`, `--dispatch`, `--output`.
- **Core module**: `scripts/lib/timing_metrics.py` — pure functions (`compute_effective_time`, `detect_parallel_dispatches`, `analyze_dispatch`, `_build_timing_block`). Active threshold configurable via `VNX_TIMING_ACTIVE_THRESHOLD_SECONDS` env var (default 10s).

## Design

Effective time = sum of inter-event gaps capped at threshold. Long pauses (review gates, human approval) do not inflate active work metrics. Walltime includes the full span regardless of gaps.

## Test plan

- [ ] `pytest tests/test_timing_metrics.py -v` — 15 tests, all green
- [ ] `python3 scripts/pr_timing_report.py --help` — CLI loads and prints usage
- [ ] `python3 scripts/pr_timing_report.py --dispatch <id>` — runs against live `.vnx-data/events/archive/`

## Reference

Wave 5 design doc: `.vnx/docs/wave5/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)