### PR TITLE
feat(wave7): vnx.env loader + DeepSeek V4-Pro/V4-Flash model registry update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ testing/
 .env
 .env.*
 
+# VNX provider secrets
+vnx.env
+.vnx/vnx.env
+
 # macOS
 .DS_Store
 

--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -6,7 +6,7 @@ Each provider requires an API key set as an env var before dispatch.
 | Provider | Env var | Where to get | Pricing | Status |
 |---|---|---|---|---|
 | Anthropic Claude | ANTHROPIC_API_KEY (or OAuth via subscription) | console.anthropic.com | Sonnet 4.6 $3/$15 | default |
-| DeepSeek | DEEPSEEK_API_KEY | platform.deepseek.com | V3.2 $0.28/$0.40 | Wave 7 PR-7.1 |
+| DeepSeek | DEEPSEEK_API_KEY | platform.deepseek.com | V4-Pro $0.435/$0.87, V4-Flash $0.14/$0.28 | Wave 7 PR-7.1 |
 | Moonshot (Kimi) | MOONSHOT_API_KEY | platform.moonshot.cn | K2-0905 $0.60/$2.50 | Wave 7 PR-7.2 |
 | Z.AI (GLM) via OpenRouter | OPENROUTER_API_KEY | openrouter.ai | GLM-5.1 $0.50/$2.50 (pass-through) | Wave 7 PR-7.3 |
 
@@ -19,11 +19,20 @@ Pricing shown as input/output per MTok. Sonnet 4.6 reference included for cost c
 
 ## Provisioning
 
-Set keys via shell export or `.env` before invoking `provider_dispatch.py`:
+Set keys via shell export, or store them in `vnx.env` at repo root (gitignored):
 
 ```bash
+# Option A: shell export (wins over file)
 export DEEPSEEK_API_KEY="sk-..."
+
+# Option B: file-based (loaded automatically by provider_dispatch.py)
+# Copy vnx.env.example to vnx.env and fill in your keys.
+cp vnx.env.example vnx.env
 ```
+
+`vnx.env` is loaded by `scripts/lib/env_loader.py` at the start of every
+`provider_dispatch.py` invocation. Shell env always wins over file values.
+A user-level file at `~/.vnx/vnx.env` is also supported as a fallback.
 
 Keys are consumed by `_litellm_runner.py` subprocess — they never reach VNX worker code.
 The repo-level secret scan (`scripts/lib/secret_scanner.py`) covers leak prevention.
@@ -49,10 +58,17 @@ dispatches — the flags control automatic routing policy (PR-7.4, not yet shipp
 
 ## DeepSeek V4 (PR-7.1)
 
-- LiteLLM model string: `deepseek/deepseek-v3.2`
-- Context: 163,840 tokens
+Two model tiers available under `--provider litellm:deepseek`:
+
+| Alias | LiteLLM name | Input/MTok | Output/MTok | Max output | Task classes |
+|---|---|---|---|---|---|
+| deepseek-v4-pro (default) | deepseek/deepseek-v4-pro | $0.435 | $0.87 | 384K | coding-premium, review, analysis |
+| deepseek-v4-flash | deepseek/deepseek-v4-flash | $0.14 | $0.28 | 384K | coding, review, analysis |
+
+- Context window: 1M tokens (both models)
 - Tool calls: yes, streaming: yes
-- Dispatch: `--provider litellm:deepseek`
+- Default lane: `deepseek-v4-pro` (~75% discount active; full price $1.74/$3.48)
+- Dispatch: `--provider litellm:deepseek` (default) or `VNX_LITELLM_MODEL=deepseek/deepseek-v4-flash` (flash)
 - Missing `DEEPSEEK_API_KEY` → immediate exit(64) before subprocess spawn
 
 ## Kimi K2 via Moonshot (PR-7.2)

--- a/scripts/lib/env_loader.py
+++ b/scripts/lib/env_loader.py
@@ -1,0 +1,62 @@
+"""env_loader.py — Lightweight .env file loader for VNX provider keys.
+
+Search order (first match wins per key):
+  1. <repo-root>/vnx.env
+  2. ~/.vnx/vnx.env
+
+Shell env always wins over file values. File values fill in missing keys only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_VALID_KEY = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def _parse_env_file(path: Path) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    if not path.is_file():
+        return result
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            logger.warning("env_loader: %s:%d malformed (no =), skipped", path, lineno)
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not _VALID_KEY.match(key):
+            logger.warning("env_loader: %s:%d invalid key %r, skipped", path, lineno, key)
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def load_env(repo_root: Optional[Path] = None, user_home: Optional[Path] = None) -> List[str]:
+    """Populate os.environ from vnx.env files. Returns list of loaded paths."""
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[2]
+    if user_home is None:
+        user_home = Path.home()
+    candidates = [repo_root / "vnx.env", user_home / ".vnx" / "vnx.env"]
+    loaded: List[str] = []
+    for path in candidates:
+        values = _parse_env_file(path)
+        if not values:
+            continue
+        for key, value in values.items():
+            if key not in os.environ:  # shell env wins
+                os.environ[key] = value
+        loaded.append(str(path))
+    return loaded

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -35,7 +35,7 @@ _FUTURE_PR_MAP: dict = {}
 # LiteLLM sub-provider defaults when VNX_LITELLM_MODEL is not set.
 _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "bedrock": "bedrock/claude-sonnet-4-6",
-    "deepseek": "deepseek/deepseek-v3.2",
+    "deepseek": "deepseek/deepseek-v4-pro",
     "moonshot": "moonshot/kimi-k2-0905-preview",
     "zai": "openrouter/z-ai/glm-5",
     "ollama": "ollama/llama3",
@@ -379,6 +379,8 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     """Parse args, route to the correct provider handler, return exit code."""
+    from env_loader import load_env
+    load_env()
     parser = _build_parser()
 
     # argparse exits with code 2 on unrecognised provider values — but provider

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -5,10 +5,20 @@ providers:
     api_key_env: DEEPSEEK_API_KEY
     models:
       deepseek-v4-pro:
-        litellm_name: "deepseek/deepseek-v3.2"
-        cost_input_per_mtok: 0.28
-        cost_output_per_mtok: 0.40
-        max_tokens: 8192
+        litellm_name: "deepseek/deepseek-v4-pro"
+        cost_input_per_mtok: 0.435   # currently 75% discount; full $1.74 input
+        cost_output_per_mtok: 0.87   # full $3.48 output
+        max_tokens: 384000           # 384K output ceiling
+        context_window: 1000000      # 1M context
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding-premium", "review", "analysis"]
+      deepseek-v4-flash:
+        litellm_name: "deepseek/deepseek-v4-flash"
+        cost_input_per_mtok: 0.14    # legacy "chat" model evolved
+        cost_output_per_mtok: 0.28
+        max_tokens: 384000
+        context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
         task_classes: ["coding", "review", "analysis"]

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""test_env_loader.py — Unit tests for scripts/lib/env_loader.py.
+
+Coverage:
+  test_parses_basic_key_value                 — KEY=value sets os.environ
+  test_strips_double_quotes_and_single_quotes — quoted values unquoted
+  test_ignores_comments_and_blank_lines       — # and blank lines skipped
+  test_rejects_invalid_keys                   — lowercase/digit/special skipped
+  test_shell_env_wins_over_file               — pre-existing env var preserved
+  test_repo_root_file_overrides_user_home     — repo root loaded first
+  test_missing_files_silent_no_error          — no exception on absent files
+  test_returns_list_of_loaded_paths           — loaded list contains file paths
+  test_handles_unicode_values                 — non-ASCII values round-trip
+  test_malformed_line_logged_and_skipped      — line without = is warned+skipped
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from env_loader import _parse_env_file, load_env
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_env(tmp_path: Path, content: str) -> Path:
+    f = tmp_path / "vnx.env"
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — basic KEY=value parsing
+# ---------------------------------------------------------------------------
+
+class TestParsesBasicKeyValue:
+    def test_parses_basic_key_value(self, tmp_path):
+        f = _write_env(tmp_path, "MY_KEY=hello\nANOTHER=world\n")
+        result = _parse_env_file(f)
+        assert result["MY_KEY"] == "hello"
+        assert result["ANOTHER"] == "world"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — quote stripping
+# ---------------------------------------------------------------------------
+
+class TestStripsQuotes:
+    def test_strips_double_quotes(self, tmp_path):
+        f = _write_env(tmp_path, 'KEY="my value"\n')
+        result = _parse_env_file(f)
+        assert result["KEY"] == "my value"
+
+    def test_strips_single_quotes(self, tmp_path):
+        f = _write_env(tmp_path, "KEY='my value'\n")
+        result = _parse_env_file(f)
+        assert result["KEY"] == "my value"
+
+    def test_asymmetric_quotes_kept_verbatim(self, tmp_path):
+        f = _write_env(tmp_path, 'KEY="mismatched\'\n')
+        result = _parse_env_file(f)
+        assert result["KEY"] == '"mismatched\''
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — comments and blank lines ignored
+# ---------------------------------------------------------------------------
+
+class TestIgnoresCommentsAndBlanks:
+    def test_ignores_comments_and_blank_lines(self, tmp_path):
+        content = "\n# this is a comment\nVALID=yes\n  # indented comment\n\n"
+        f = _write_env(tmp_path, content)
+        result = _parse_env_file(f)
+        assert list(result.keys()) == ["VALID"]
+        assert result["VALID"] == "yes"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — invalid keys rejected
+# ---------------------------------------------------------------------------
+
+class TestRejectsInvalidKeys:
+    def test_lowercase_key_skipped(self, tmp_path, caplog):
+        f = _write_env(tmp_path, "lowercase_key=val\n")
+        with caplog.at_level(logging.WARNING, logger="env_loader"):
+            result = _parse_env_file(f)
+        assert "lowercase_key" not in result
+        assert any("invalid key" in r.message for r in caplog.records)
+
+    def test_leading_digit_key_skipped(self, tmp_path, caplog):
+        f = _write_env(tmp_path, "1BAD=val\n")
+        with caplog.at_level(logging.WARNING, logger="env_loader"):
+            result = _parse_env_file(f)
+        assert "1BAD" not in result
+
+    def test_special_char_key_skipped(self, tmp_path, caplog):
+        f = _write_env(tmp_path, "BAD-KEY=val\n")
+        with caplog.at_level(logging.WARNING, logger="env_loader"):
+            result = _parse_env_file(f)
+        assert "BAD-KEY" not in result
+
+    def test_valid_key_with_underscore_accepted(self, tmp_path):
+        f = _write_env(tmp_path, "GOOD_KEY_123=val\n")
+        result = _parse_env_file(f)
+        assert result["GOOD_KEY_123"] == "val"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — shell env wins over file
+# ---------------------------------------------------------------------------
+
+class TestShellEnvWinsOverFile:
+    def test_shell_env_wins_over_file(self, tmp_path):
+        f = _write_env(tmp_path, "DEEPSEEK_API_KEY=from-file\n")
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "from-shell"}, clear=False):
+            load_env(repo_root=tmp_path, user_home=tmp_path / "nonexistent_home")
+            assert os.environ["DEEPSEEK_API_KEY"] == "from-shell"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — repo root file loaded first (before user home)
+# ---------------------------------------------------------------------------
+
+class TestRepoRootOverridesUserHome:
+    def test_repo_root_file_overrides_user_home(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        home = tmp_path / "home"
+        (home / ".vnx").mkdir(parents=True)
+
+        (repo_root / "vnx.env").write_text("SOME_KEY=from-repo\n", encoding="utf-8")
+        (home / ".vnx" / "vnx.env").write_text("SOME_KEY=from-home\n", encoding="utf-8")
+
+        clean = {k: v for k, v in os.environ.items() if k != "SOME_KEY"}
+        with patch.dict(os.environ, clean, clear=True):
+            load_env(repo_root=repo_root, user_home=home)
+            assert os.environ["SOME_KEY"] == "from-repo"
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — missing files cause no exception
+# ---------------------------------------------------------------------------
+
+class TestMissingFilesSilent:
+    def test_missing_files_silent_no_error(self, tmp_path):
+        nonexistent = tmp_path / "no_such_dir"
+        loaded = load_env(repo_root=nonexistent, user_home=nonexistent)
+        assert loaded == []
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — returns list of loaded paths
+# ---------------------------------------------------------------------------
+
+class TestReturnsLoadedPaths:
+    def test_returns_list_of_loaded_paths(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / "vnx.env").write_text("LOADED_KEY=yes\n", encoding="utf-8")
+
+        clean = {k: v for k, v in os.environ.items() if k != "LOADED_KEY"}
+        with patch.dict(os.environ, clean, clear=True):
+            loaded = load_env(repo_root=repo_root, user_home=tmp_path / "no_home")
+
+        assert len(loaded) == 1
+        assert "vnx.env" in loaded[0]
+
+    def test_returns_empty_when_no_files(self, tmp_path):
+        loaded = load_env(repo_root=tmp_path / "x", user_home=tmp_path / "y")
+        assert loaded == []
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — unicode values round-trip
+# ---------------------------------------------------------------------------
+
+class TestHandlesUnicodeValues:
+    def test_handles_unicode_values(self, tmp_path):
+        f = _write_env(tmp_path, "UNICODE_KEY=héllo wörld\n")
+        result = _parse_env_file(f)
+        assert result["UNICODE_KEY"] == "héllo wörld"
+
+    def test_handles_unicode_in_quoted_value(self, tmp_path):
+        f = _write_env(tmp_path, 'UNICODE_QUOTED="日本語"\n')
+        result = _parse_env_file(f)
+        assert result["UNICODE_QUOTED"] == "日本語"
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — malformed line (no =) is logged as warning and skipped
+# ---------------------------------------------------------------------------
+
+class TestMalformedLineLoggedAndSkipped:
+    def test_malformed_line_no_equals_logged_and_skipped(self, tmp_path, caplog):
+        content = "VALID=yes\nMALFORMED_LINE_WITHOUT_EQUALS\nALSO_VALID=ok\n"
+        f = _write_env(tmp_path, content)
+        with caplog.at_level(logging.WARNING, logger="env_loader"):
+            result = _parse_env_file(f)
+
+        assert "VALID" in result
+        assert "ALSO_VALID" in result
+        assert "MALFORMED_LINE_WITHOUT_EQUALS" not in result
+        assert any("malformed" in r.message for r in caplog.records)
+
+    def test_malformed_line_warning_includes_line_number(self, tmp_path, caplog):
+        content = "VALID=yes\nBAD_LINE\n"
+        f = _write_env(tmp_path, content)
+        with caplog.at_level(logging.WARNING, logger="env_loader"):
+            _parse_env_file(f)
+
+        warning_msgs = [r.message for r in caplog.records if "malformed" in r.message]
+        assert warning_msgs, "expected at least one malformed warning"

--- a/tests/test_wave7_deepseek_smoke.py
+++ b/tests/test_wave7_deepseek_smoke.py
@@ -9,7 +9,10 @@ Verifies DeepSeek V4 lane via LiteLLM bridge (no real API calls):
   test_runner_validates_deepseek_api_key   — _litellm_runner._validate_provider_key
       returns (False, ...) without key, (True, '') with key
   test_wave7_models_yaml_valid             — wave7_models.yaml parses and deepseek
-      entry has correct schema
+      entry has correct schema (V4-Pro + V4-Flash, no legacy v3.2)
+  test_deepseek_default_model_is_v4_pro    — get_default_model returns V4-Pro
+  test_deepseek_v4_flash_resolves          — V4-Flash model entry in registry
+  test_no_legacy_v3_2_in_registry         — deepseek/deepseek-v3.2 is gone
 """
 
 from __future__ import annotations
@@ -104,14 +107,14 @@ class TestRunnerValidatesDeepSeekApiKey:
         runner = self._load_runner()
         env_without_key = {k: v for k, v in os.environ.items() if k != "DEEPSEEK_API_KEY"}
         with patch.dict(os.environ, env_without_key, clear=True):
-            ok, msg = runner._validate_provider_key("deepseek/deepseek-v3.2")
+            ok, msg = runner._validate_provider_key("deepseek/deepseek-v4-pro")
         assert ok is False, f"expected ok=False, got ok={ok}"
         assert "DEEPSEEK_API_KEY" in msg, f"expected DEEPSEEK_API_KEY in msg, got: {msg!r}"
 
     def test_validate_returns_true_with_key(self):
         runner = self._load_runner()
         with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "sk-test-key"}):
-            ok, msg = runner._validate_provider_key("deepseek/deepseek-v3.2")
+            ok, msg = runner._validate_provider_key("deepseek/deepseek-v4-pro")
         assert ok is True, f"expected ok=True, got ok={ok}"
         assert msg == "", f"expected empty msg, got: {msg!r}"
 
@@ -146,18 +149,19 @@ class TestWave7ModelsYamlValid:
         assert "deepseek-v4-pro" in deepseek.models, "deepseek-v4-pro model entry missing"
 
         model = deepseek.models["deepseek-v4-pro"]
-        assert model.litellm_name == "deepseek/deepseek-v3.2", (
+        assert model.litellm_name == "deepseek/deepseek-v4-pro", (
             f"unexpected litellm_name: {model.litellm_name!r}"
         )
-        assert model.cost_input_per_mtok == pytest.approx(0.28), (
+        assert model.cost_input_per_mtok == pytest.approx(0.435), (
             f"unexpected input cost: {model.cost_input_per_mtok}"
         )
-        assert model.cost_output_per_mtok == pytest.approx(0.40), (
+        assert model.cost_output_per_mtok == pytest.approx(0.87), (
             f"unexpected output cost: {model.cost_output_per_mtok}"
         )
+        assert model.max_tokens == 384000, f"unexpected max_tokens: {model.max_tokens}"
         assert model.supports_streaming is True
         assert model.supports_tool_calls is True
-        assert "coding" in model.task_classes
+        assert "coding-premium" in model.task_classes
 
     def test_active_providers_enabled(self):
         from providers import provider_registry
@@ -186,4 +190,77 @@ class TestWave7ModelsYamlValid:
         assert model is not None, "get_default_model('zai') should return a model after PR-7.3"
         assert "openrouter" in model.litellm_name, (
             f"expected openrouter in litellm_name, got {model.litellm_name!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: default model resolved by provider_dispatch is V4-Pro
+# ---------------------------------------------------------------------------
+
+class TestDeepSeekDefaultModelIsV4Pro:
+    """get_default_model('deepseek') resolves to V4-Pro litellm name."""
+
+    def test_deepseek_default_model_is_v4_pro(self):
+        from providers import provider_registry
+
+        model = provider_registry.get_default_model("deepseek")
+        assert model is not None, "get_default_model('deepseek') returned None"
+        assert model.litellm_name == "deepseek/deepseek-v4-pro", (
+            f"expected deepseek/deepseek-v4-pro, got {model.litellm_name!r}"
+        )
+
+    def test_provider_dispatch_default_is_v4_pro(self):
+        from provider_dispatch import _LITELLM_SUB_PROVIDER_DEFAULTS
+        assert _LITELLM_SUB_PROVIDER_DEFAULTS["deepseek"] == "deepseek/deepseek-v4-pro", (
+            f"hardcoded default should be v4-pro, got: {_LITELLM_SUB_PROVIDER_DEFAULTS['deepseek']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: V4-Flash model resolves correctly
+# ---------------------------------------------------------------------------
+
+class TestDeepSeekV4FlashResolves:
+    """deepseek-v4-flash model is present and has correct litellm_name."""
+
+    def test_deepseek_v4_flash_resolves_correctly(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+        deepseek = registry["deepseek"]
+        assert "deepseek-v4-flash" in deepseek.models, (
+            "deepseek-v4-flash model entry missing from registry"
+        )
+        flash = deepseek.models["deepseek-v4-flash"]
+        assert flash.litellm_name == "deepseek/deepseek-v4-flash", (
+            f"unexpected flash litellm_name: {flash.litellm_name!r}"
+        )
+        assert flash.cost_input_per_mtok == pytest.approx(0.14)
+        assert flash.cost_output_per_mtok == pytest.approx(0.28)
+        assert flash.max_tokens == 384000
+        assert flash.supports_streaming is True
+        assert flash.supports_tool_calls is True
+
+
+# ---------------------------------------------------------------------------
+# Test 7: legacy deepseek/deepseek-v3.2 is NOT in registry
+# ---------------------------------------------------------------------------
+
+class TestNoLegacyV3_2InRegistry:
+    """deepseek/deepseek-v3.2 litellm name must be absent from registry."""
+
+    def test_no_legacy_v3_2_in_registry(self):
+        from providers import provider_registry
+
+        registry = provider_registry.load()
+        deepseek = registry.get("deepseek")
+        assert deepseek is not None, "deepseek provider missing"
+        legacy_name = "deepseek/deepseek-v3.2"
+        found = [
+            alias
+            for alias, model in deepseek.models.items()
+            if model.litellm_name == legacy_name
+        ]
+        assert not found, (
+            f"legacy litellm_name {legacy_name!r} still present in models: {found}"
         )

--- a/vnx.env.example
+++ b/vnx.env.example
@@ -1,0 +1,28 @@
+# VNX Provider API Keys (Wave 7+)
+# Copy to `vnx.env` (gitignored) and fill in your keys.
+# Shell env vars always override values in this file.
+
+# === Anthropic Claude (default) ===
+# Not needed when using Claude Code subscription/OAuth.
+# ANTHROPIC_API_KEY=
+
+# === DeepSeek V4 (PR-7.1) — V4-Pro $0.435/$0.87, V4-Flash $0.14/$0.28 per MTok ===
+# Get key: https://platform.deepseek.com
+# DEEPSEEK_API_KEY=sk-...
+
+# === Moonshot / Kimi K2 (PR-7.2) — $0.60/$2.50 per MTok ===
+# Get key: https://platform.moonshot.cn
+# MOONSHOT_API_KEY=sk-...
+
+# === OpenRouter / GLM-5.1 (PR-7.3) — $0.50/$2.50 per MTok ===
+# Get key: https://openrouter.ai
+# OPENROUTER_API_KEY=sk-or-...
+
+# === Routing policy feature flags (PR-7.4, opt-in) ===
+# VNX_ROUTING_POLICY_ENABLED=1
+# VNX_ROUTING_DEEPSEEK=1
+# VNX_ROUTING_KIMI=1
+# VNX_ROUTING_GLM=1
+
+# === Per-provider model override (optional) ===
+# VNX_LITELLM_MODEL=deepseek/deepseek-v4-pro


### PR DESCRIPTION
## Summary

- **env-loader** (`scripts/lib/env_loader.py`): lightweight `.env` file parser with no third-party deps. Loads `vnx.env` from repo root or `~/.vnx/vnx.env`. Shell env always wins — file values only fill missing keys.
- **provider_dispatch.py**: calls `load_env()` at start of `main()` so API keys are available before any sub-provider check
- **vnx.env.example**: committed operator onboarding file with placeholder keys for all Wave 7 providers + feature flags
- **DeepSeek V4 registry** (`wave7_models.yaml`): replaces legacy `deepseek/deepseek-v3.2` with V4-Pro ($0.435/$0.87 per MTok, 384K output, 1M context) and V4-Flash ($0.14/$0.28). V4-Pro is now the default lane. Legacy v3.2 name is gone.
- **Docs** (`PROVIDER_API_KEYS.md`): updated DeepSeek section with V4 pricing + env-file provisioning instructions

## Test plan

- [x] `pytest tests/test_env_loader.py` — 18 tests: parse, quote-strip, comments, invalid keys, shell-wins, search-order, missing files, loaded-paths list, unicode, malformed-line warning
- [x] `pytest tests/test_wave7_deepseek_smoke.py` — 13 tests: V4-Pro default, V4-Flash present, legacy v3.2 absent, provider_dispatch routing, API key enforcement
- [x] `pytest tests/test_provider_dispatch_entry.py tests/test_provider_registry_exceptions.py tests/test_wave7_kimi_smoke.py tests/test_wave7_glm_smoke.py` — 53 tests, zero regressions

**Total: 31 new/updated + 53 regression = 84 tests green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)