### PR TITLE
feat(wave7): PR-7.6 — provider governance unification (receipt + unified report for all providers)

### DIFF
--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -1,0 +1,169 @@
+"""governance_emit.py — Shared governance receipt + unified report emitter (Wave 7 PR-7.6).
+
+Used by both subprocess_dispatch.py (claude path) and provider_dispatch.py (multi-provider
+path) so every dispatch writes a governance-enriched receipt and unified report.
+
+ADR-005: NDJSON audit completeness. ADR-016: unified events.
+
+Hard rules (PRD provider-governance-unification):
+  - Provider field MUST match _PROVIDER_RE — raises ValueError on mismatch.
+  - Receipt write MUST NOT silently fail — raises RuntimeError on OSError.
+  - NDJSON append uses fcntl.flock(LOCK_EX) for concurrent safety.
+  - Unified report uses tmp + os.replace for atomic write.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_RE = re.compile(r"^(claude|codex|gemini|litellm:[a-z][a-z0-9_-]*)$")
+
+
+def _validate_provider(provider: str) -> None:
+    """Raise ValueError when provider doesn't match required pattern."""
+    if not _PROVIDER_RE.match(provider or ""):
+        raise ValueError(
+            f"Invalid provider {provider!r}. "
+            "Must match ^(claude|codex|gemini|litellm:[a-z][a-z0-9_-]*)$"
+        )
+
+
+def emit_dispatch_receipt(
+    dispatch_id: str,
+    terminal_id: str,
+    provider: str,
+    model: str,
+    pr_id: Optional[str],
+    status: str,
+    completion_pct: int,
+    risk: float,
+    findings: List[Dict[str, Any]],
+    duration_seconds: float,
+    token_usage: Dict[str, int],
+    cost_usd: Optional[float],
+    state_dir: Path,
+) -> Path:
+    """Atomic-append to t0_receipts.ndjson. fcntl.flock for concurrent safety.
+
+    Returns the receipt file path on success.
+
+    Raises:
+        ValueError: provider field doesn't match required pattern
+        RuntimeError: write failed
+    """
+    _validate_provider(provider)
+
+    now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    recorded_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    receipt: Dict[str, Any] = {
+        "dispatch_id": dispatch_id,
+        "terminal_id": terminal_id,
+        "provider": provider,
+        "model": model,
+        "status": status,
+        "completion_pct": completion_pct,
+        "risk": risk,
+        "duration_seconds": round(float(duration_seconds), 3),
+        "token_usage": token_usage,
+        "cost_usd": cost_usd,
+        "findings": findings,
+        "pr_id": pr_id,
+        "timestamp": now_ts,
+        "recorded_at": recorded_ts,
+    }
+
+    receipt_path = Path(state_dir) / "t0_receipts.ndjson"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(receipt, separators=(",", ":")) + "\n"
+
+    try:
+        with open(receipt_path, "a", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            try:
+                fh.write(line)
+                fh.flush()
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+    except OSError as exc:
+        raise RuntimeError(
+            f"governance_emit: receipt write failed for dispatch={dispatch_id}: {exc}"
+        ) from exc
+
+    logger.info(
+        "governance_emit: receipt written dispatch=%s provider=%s status=%s",
+        dispatch_id, provider, status,
+    )
+    return receipt_path
+
+
+def emit_unified_report(
+    dispatch_id: str,
+    terminal_id: str,
+    provider: str,
+    instruction: str,
+    response_text: str,
+    findings: List[Dict[str, Any]],
+    duration_seconds: float,
+    data_dir: Path,
+) -> Path:
+    """Atomic write to unified_reports/<dispatch_id>_report.md. Returns path.
+
+    Idempotent: returns the existing path without modifying it when the report
+    already exists (worker may have written a richer report).
+
+    Raises:
+        RuntimeError: write failed
+    """
+    reports_dir = Path(data_dir) / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / f"{dispatch_id}_report.md"
+    if report_path.exists():
+        return report_path
+
+    if findings:
+        findings_lines = "\n".join(
+            f"- [{f.get('severity', 'info').upper()}] {f.get('message', str(f))}"
+            for f in findings
+        )
+    else:
+        findings_lines = "None"
+
+    content = (
+        f"# Dispatch {dispatch_id}\n\n"
+        f"- Provider: {provider}\n"
+        f"- Terminal: {terminal_id}\n"
+        f"- Duration: {duration_seconds:.1f}s\n\n"
+        f"## Instruction\n\n{instruction or '(not captured)'}\n\n"
+        f"## Response\n\n{response_text or '(no response captured)'}\n\n"
+        f"## Findings\n\n{findings_lines}\n"
+    )
+
+    tmp_path = report_path.with_suffix(".md.tmp")
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        os.replace(tmp_path, report_path)
+    except OSError as exc:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise RuntimeError(
+            f"governance_emit: unified report write failed for dispatch={dispatch_id}: {exc}"
+        ) from exc
+
+    logger.info(
+        "governance_emit: unified report written dispatch=%s provider=%s path=%s",
+        dispatch_id, provider, report_path,
+    )
+    return report_path

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -58,6 +61,106 @@ _SUB_PROVIDER_DEFAULT_ALIAS: dict = {
     "moonshot": "kimi-k2-0905-default",
     "zai": "glm-5.1-default",
 }
+
+
+def _extract_response_text(result: Any) -> str:
+    """Return completion_text from any spawn result, or empty string."""
+    return (getattr(result, "completion_text", None) or "")
+
+
+def _extract_token_usage(result: Any) -> Dict[str, int]:
+    """Normalize token_usage from any spawn result to {input, output, cache_hit}."""
+    raw = getattr(result, "token_usage", None)
+    if not isinstance(raw, dict):
+        return {"input": 0, "output": 0, "cache_hit": 0}
+    return {
+        "input": int(raw.get("input_tokens", raw.get("input", 0)) or 0),
+        "output": int(raw.get("output_tokens", raw.get("output", 0)) or 0),
+        "cache_hit": int(raw.get("cache_read_tokens", raw.get("cache_hit", 0)) or 0),
+    }
+
+
+def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Optional[float]:
+    """Compute cost_usd from wave7_models.yaml pricing. Returns None on lookup miss."""
+    if not token_usage or (token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0):
+        return None
+    if not provider.startswith("litellm:"):
+        return None
+    sub = provider.split(":", 1)[1] if ":" in provider else ""
+    try:
+        from providers import provider_registry as _reg
+        registry = _reg.load()
+        cfg = registry.get(sub)
+        if cfg is None or not cfg.models:
+            return None
+        model_key = model.split("/")[-1] if "/" in model else model
+        entry = cfg.models.get(model_key)
+        if entry is None:
+            entry = next(iter(cfg.models.values()), None)
+        if entry is None:
+            return None
+        cost_in = (token_usage.get("input", 0) / 1_000_000) * float(entry.cost_input_per_mtok)
+        cost_out = (token_usage.get("output", 0) / 1_000_000) * float(entry.cost_output_per_mtok)
+        return round(cost_in + cost_out, 8)
+    except Exception as exc:
+        logger.debug("_compute_cost: lookup failed for provider=%s model=%s: %s", provider, model, exc)
+        return None
+
+
+def _emit_governance(
+    args: argparse.Namespace,
+    provider: str,
+    model_used: str,
+    result: Any,
+    start_time: datetime,
+    end_time: datetime,
+    status: str,
+) -> None:
+    """Emit dispatch receipt + unified report after every spawn handler call."""
+    from governance_emit import emit_dispatch_receipt, emit_unified_report
+
+    state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+    duration = (end_time - start_time).total_seconds()
+    token_usage = _extract_token_usage(result)
+    cost_usd = _compute_cost(provider, model_used, token_usage)
+
+    try:
+        receipt_path = emit_dispatch_receipt(
+            dispatch_id=args.dispatch_id,
+            terminal_id=args.terminal_id,
+            provider=provider,
+            model=model_used,
+            pr_id=getattr(args, "pr_id", None),
+            status=status,
+            completion_pct=100 if status == "success" else 0,
+            risk=0.0,
+            findings=[],
+            duration_seconds=duration,
+            token_usage=token_usage,
+            cost_usd=cost_usd,
+            state_dir=state_dir,
+        )
+        print(f"Receipt: {receipt_path}", file=sys.stderr)
+    except (ValueError, RuntimeError) as exc:
+        logger.error("governance_emit: receipt failed dispatch=%s: %s", args.dispatch_id, exc)
+        raise SystemExit(1) from exc
+
+    try:
+        report_path = emit_unified_report(
+            dispatch_id=args.dispatch_id,
+            terminal_id=args.terminal_id,
+            provider=provider,
+            instruction=args.instruction,
+            response_text=_extract_response_text(result),
+            findings=[],
+            duration_seconds=duration,
+            data_dir=data_dir,
+        )
+        print(f"Report: {report_path}", file=sys.stderr)
+    except RuntimeError as exc:
+        logger.error("governance_emit: unified report failed dispatch=%s: %s", args.dispatch_id, exc)
+        raise SystemExit(1) from exc
 
 
 def _build_lane_key(base_sub: str, model_alias: "str | None") -> str:
@@ -115,6 +218,7 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
     if args.dispatch_paths.strip():
         dispatch_paths = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
 
+    start_time = datetime.now(timezone.utc)
     ok = sd.deliver_with_recovery(
         terminal_id=args.terminal_id,
         instruction=args.instruction,
@@ -127,6 +231,14 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
         dispatch_paths=dispatch_paths,
         pr_id=args.pr_id,
     )
+    end_time = datetime.now(timezone.utc)
+
+    class _ClaudeResult:
+        completion_text = ""
+        token_usage = None
+
+    status = "success" if ok else "failure"
+    _emit_governance(args, "claude", args.model, _ClaudeResult(), start_time, end_time, status)
     return 0 if ok else 1
 
 
@@ -137,7 +249,6 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
     Wires EventStore as event_writer so codex dispatches produce a NDJSON audit trail
     identical to the claude path (provider-agnostic audit completeness, ADR-005).
     """
-    import os
     from provider_spawns.codex_spawn import spawn_codex
 
     event_store = None
@@ -151,6 +262,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         )
 
     model = os.environ.get("VNX_CODEX_MODEL", "")
+    start_time = datetime.now(timezone.utc)
     result = spawn_codex(
         prompt=args.instruction,
         model=model,
@@ -158,20 +270,27 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         terminal_id=args.terminal_id,
         event_writer=event_store.append if event_store is not None else None,
     )
+    end_time = datetime.now(timezone.utc)
+
     if result.error:
+        _emit_governance(args, "codex", model, result, start_time, end_time, "failure")
         print(f"spawn_codex failed: {result.error}", file=sys.stderr)
         return 1
     if result.timed_out:
+        _emit_governance(args, "codex", model, result, start_time, end_time, "timeout")
         print("spawn_codex timed out", file=sys.stderr)
         return 1
     if result.returncode != 0:
+        _emit_governance(args, "codex", model, result, start_time, end_time, "failure")
         return 1
     if result.event_writer_failures > 0:
         logger.error(
             "codex dispatch completed but %d event_writer failures occurred — audit gap",
             result.event_writer_failures,
         )
+        _emit_governance(args, "codex", model, result, start_time, end_time, "success")
         return 2
+    _emit_governance(args, "codex", model, result, start_time, end_time, "success")
     return 0
 
 
@@ -247,7 +366,6 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     or "anthropic/claude-sonnet-4-6" fallback. Wires EventStore for NDJSON audit.
     DeepSeek requires DEEPSEEK_API_KEY env var (fast-fail before subprocess spawn).
     """
-    import os
     from provider_spawns.litellm_spawn import spawn_litellm
 
     event_store = None
@@ -315,6 +433,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
             lane_key,
         )
 
+    start_time = datetime.now(timezone.utc)
     result = spawn_litellm(
         prompt=args.instruction,
         model=model,
@@ -325,20 +444,27 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         tool_call_shape=_tool_call_shape,
         event_writer=event_store.append if event_store is not None else None,
     )
+    end_time = datetime.now(timezone.utc)
+
     if result.error:
+        _emit_governance(args, args.provider, model, result, start_time, end_time, "failure")
         print(f"spawn_litellm failed: {result.error}", file=sys.stderr)
         return 1
     if result.timed_out:
+        _emit_governance(args, args.provider, model, result, start_time, end_time, "timeout")
         print("spawn_litellm timed out", file=sys.stderr)
         return 1
     if result.returncode != 0:
+        _emit_governance(args, args.provider, model, result, start_time, end_time, "failure")
         return 1
     if result.event_writer_failures > 0:
         logger.error(
             "litellm dispatch completed but %d event_writer failures occurred — audit gap",
             result.event_writer_failures,
         )
+        _emit_governance(args, args.provider, model, result, start_time, end_time, "success")
         return 2
+    _emit_governance(args, args.provider, model, result, start_time, end_time, "success")
     return 0
 
 
@@ -347,12 +473,12 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
 
     Prompt is the raw instruction; file-content injection is caller's responsibility.
     """
-    import os
     from event_store import EventStore
     from provider_spawns.gemini_spawn import spawn_gemini
 
     model = os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
     event_store = EventStore()
+    start_time = datetime.now(timezone.utc)
     result = spawn_gemini(
         prompt=args.instruction,
         model=model,
@@ -360,20 +486,27 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         terminal_id=args.terminal_id,
         event_writer=event_store.append,
     )
+    end_time = datetime.now(timezone.utc)
+
     if result.error:
+        _emit_governance(args, "gemini", model, result, start_time, end_time, "failure")
         print(f"spawn_gemini failed: {result.error}", file=sys.stderr)
         return 1
     if result.timed_out:
+        _emit_governance(args, "gemini", model, result, start_time, end_time, "timeout")
         print("spawn_gemini timed out", file=sys.stderr)
         return 1
     if result.returncode != 0:
+        _emit_governance(args, "gemini", model, result, start_time, end_time, "failure")
         return 1
     if result.event_writer_failures > 0:
         logger.error(
             "gemini dispatch completed but %d event_writer failures occurred — audit gap",
             result.event_writer_failures,
         )
+        _emit_governance(args, "gemini", model, result, start_time, end_time, "success")
         return 2
+    _emit_governance(args, "gemini", model, result, start_time, end_time, "success")
     return 0
 
 

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -83,6 +83,7 @@ from subprocess_dispatch_internals.receipt_writer import (
     _ensure_unified_report,
     _write_receipt,
 )
+from governance_emit import emit_dispatch_receipt, emit_unified_report  # noqa: F401 — re-exported for callers
 from subprocess_dispatch_internals.recovery import deliver_with_recovery
 from subprocess_dispatch_internals.skill_injection import (
     _build_intelligence_section,
@@ -137,6 +138,8 @@ __all__ = [
     "_ensure_unified_report",
     "_auto_commit_changes",
     "_auto_stash_changes",
+    "emit_dispatch_receipt",
+    "emit_unified_report",
     "_capture_dispatch_parameters",
     "_capture_dispatch_outcome",
     "_update_pattern_confidence",

--- a/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
+++ b/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
@@ -1,4 +1,12 @@
-"""receipt_writer — receipt persistence + auto-commit/auto-stash for dispatches."""
+"""receipt_writer — receipt persistence + auto-commit/auto-stash for dispatches.
+
+DEPRECATED (Wave 7 PR-7.6): _write_receipt is subprocess-adapter-specific and
+retained for backward compatibility. New code should call
+``governance_emit.emit_dispatch_receipt`` / ``governance_emit.emit_unified_report``
+for the canonical governance receipt format (includes provider, model, token_usage).
+``emit_dispatch_receipt`` is re-exported below for callers already importing from
+this internal module path.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +22,16 @@ from .path_utils import _get_dirty_files
 from .state_paths import _default_state_dir
 
 logger = logging.getLogger(__name__)
+
+# Re-export shared module surface so callers can migrate at their own pace.
+try:
+    import sys as _sys
+    _lib_dir = str(Path(__file__).resolve().parents[1])
+    if _lib_dir not in _sys.path:
+        _sys.path.insert(0, _lib_dir)
+    from governance_emit import emit_dispatch_receipt, emit_unified_report  # noqa: F401
+except ImportError:
+    pass  # governance_emit not yet on path — callers will import directly
 
 
 def _ensure_unified_report(

--- a/tests/test_governance_emit.py
+++ b/tests/test_governance_emit.py
@@ -1,0 +1,302 @@
+"""test_governance_emit.py — Unit tests for governance_emit module (Wave 7 PR-7.6).
+
+Tests cover provider validation, atomic write patterns, concurrent safety,
+and all public function contracts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from governance_emit import (
+    _validate_provider,
+    emit_dispatch_receipt,
+    emit_unified_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_state(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    return state_dir
+
+
+@pytest.fixture()
+def tmp_data(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return data_dir
+
+
+def _base_receipt_kwargs(state_dir):
+    return dict(
+        dispatch_id="test-dispatch-001",
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-4-6",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"input": 100, "output": 50, "cache_hit": 0},
+        cost_usd=None,
+        state_dir=state_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider validation tests
+# ---------------------------------------------------------------------------
+
+def test_provider_field_validates_claude():
+    _validate_provider("claude")
+
+
+def test_provider_field_validates_codex():
+    _validate_provider("codex")
+
+
+def test_provider_field_validates_gemini():
+    _validate_provider("gemini")
+
+
+def test_provider_field_validates_litellm_deepseek():
+    _validate_provider("litellm:deepseek")
+
+
+def test_provider_field_validates_litellm_moonshot():
+    _validate_provider("litellm:moonshot")
+
+
+def test_provider_field_validates_litellm_zai():
+    _validate_provider("litellm:zai")
+
+
+def test_provider_field_validates_litellm_with_hyphen():
+    _validate_provider("litellm:my-provider")
+
+
+def test_provider_field_rejects_unknown_openai():
+    with pytest.raises(ValueError, match="Invalid provider"):
+        _validate_provider("openai")
+
+
+def test_provider_field_rejects_litellm_with_space():
+    with pytest.raises(ValueError, match="Invalid provider"):
+        _validate_provider("litellm:foo bar")
+
+
+def test_provider_field_rejects_empty():
+    with pytest.raises(ValueError, match="Invalid provider"):
+        _validate_provider("")
+
+
+def test_provider_field_rejects_uppercase():
+    with pytest.raises(ValueError, match="Invalid provider"):
+        _validate_provider("Claude")
+
+
+# ---------------------------------------------------------------------------
+# Receipt emit tests
+# ---------------------------------------------------------------------------
+
+def test_emit_returns_path(tmp_state):
+    path = emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    assert isinstance(path, Path)
+    assert path.exists()
+
+
+def test_receipt_written_to_correct_file(tmp_state):
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    receipt_path = tmp_state / "t0_receipts.ndjson"
+    assert receipt_path.exists()
+
+
+def test_receipt_json_structure(tmp_state):
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    receipt_path = tmp_state / "t0_receipts.ndjson"
+    line = receipt_path.read_text().strip()
+    data = json.loads(line)
+    assert data["dispatch_id"] == "test-dispatch-001"
+    assert data["terminal_id"] == "T1"
+    assert data["provider"] == "claude"
+    assert data["model"] == "claude-sonnet-4-6"
+    assert data["status"] == "success"
+    assert data["completion_pct"] == 100
+
+
+def test_receipt_includes_token_usage_when_provided(tmp_state):
+    kwargs = _base_receipt_kwargs(tmp_state)
+    kwargs["token_usage"] = {"input": 215, "output": 47, "cache_hit": 0}
+    emit_dispatch_receipt(**kwargs)
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["token_usage"] == {"input": 215, "output": 47, "cache_hit": 0}
+
+
+def test_receipt_cost_usd_nullable_when_provider_does_not_report(tmp_state):
+    kwargs = _base_receipt_kwargs(tmp_state)
+    kwargs["cost_usd"] = None
+    emit_dispatch_receipt(**kwargs)
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["cost_usd"] is None
+
+
+def test_recorded_at_timestamp_present(tmp_state):
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert "recorded_at" in data
+    assert data["recorded_at"].endswith("Z")
+    assert "timestamp" in data
+
+
+def test_receipt_written_atomically(tmp_state, monkeypatch):
+    """Verify that the NDJSON append does not write a partial line (flock held)."""
+    lines_written = []
+
+    original_open = open
+
+    def patched_open(path, mode="r", **kwargs):
+        fh = original_open(path, mode, **kwargs)
+        return fh
+
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    receipt_path = tmp_state / "t0_receipts.ndjson"
+    content = receipt_path.read_text()
+    for line in content.splitlines():
+        if line.strip():
+            obj = json.loads(line)
+            lines_written.append(obj)
+    assert len(lines_written) == 1
+    assert lines_written[0]["dispatch_id"] == "test-dispatch-001"
+
+
+def test_receipt_append_concurrent_safe(tmp_state):
+    """Multiple threads appending concurrently should each write exactly one valid line."""
+    errors = []
+    results = []
+
+    def write_one(i):
+        try:
+            kwargs = _base_receipt_kwargs(tmp_state)
+            kwargs["dispatch_id"] = f"concurrent-{i:03d}"
+            path = emit_dispatch_receipt(**kwargs)
+            results.append(path)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write_one, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Concurrent writes raised: {errors}"
+    receipt_path = tmp_state / "t0_receipts.ndjson"
+    lines = [l for l in receipt_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == 10
+    ids = {json.loads(l)["dispatch_id"] for l in lines}
+    assert len(ids) == 10
+
+
+def test_write_failure_raises_runtimeerror(tmp_state):
+    """If the receipt file can't be written, RuntimeError is raised."""
+    receipt_path = tmp_state / "t0_receipts.ndjson"
+    receipt_path.write_text("existing\n")
+    receipt_path.chmod(0o444)
+    try:
+        with pytest.raises(RuntimeError, match="receipt write failed"):
+            emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    finally:
+        receipt_path.chmod(0o644)
+
+
+def test_provider_validation_raises_before_write(tmp_state):
+    kwargs = _base_receipt_kwargs(tmp_state)
+    kwargs["provider"] = "bad-provider"
+    with pytest.raises(ValueError, match="Invalid provider"):
+        emit_dispatch_receipt(**kwargs)
+    assert not (tmp_state / "t0_receipts.ndjson").exists()
+
+
+# ---------------------------------------------------------------------------
+# Unified report tests
+# ---------------------------------------------------------------------------
+
+def _base_report_kwargs(data_dir):
+    return dict(
+        dispatch_id="test-dispatch-002",
+        terminal_id="T2",
+        provider="litellm:deepseek",
+        instruction="Do the thing",
+        response_text="Done.",
+        findings=[],
+        duration_seconds=4.2,
+        data_dir=data_dir,
+    )
+
+
+def test_unified_report_markdown_format(tmp_data):
+    path = emit_unified_report(**_base_report_kwargs(tmp_data))
+    content = path.read_text()
+    assert "# Dispatch test-dispatch-002" in content
+    assert "## Instruction" in content
+    assert "## Response" in content
+    assert "## Findings" in content
+
+
+def test_unified_report_includes_provider_in_header(tmp_data):
+    path = emit_unified_report(**_base_report_kwargs(tmp_data))
+    content = path.read_text()
+    assert "Provider: litellm:deepseek" in content
+
+
+def test_unified_report_created_at_correct_path(tmp_data):
+    emit_unified_report(**_base_report_kwargs(tmp_data))
+    expected = tmp_data / "unified_reports" / "test-dispatch-002_report.md"
+    assert expected.exists()
+
+
+def test_unified_report_returns_path(tmp_data):
+    path = emit_unified_report(**_base_report_kwargs(tmp_data))
+    assert isinstance(path, Path)
+    assert path.exists()
+
+
+def test_unified_report_idempotent(tmp_data):
+    kwargs = _base_report_kwargs(tmp_data)
+    path1 = emit_unified_report(**kwargs)
+    original_mtime = path1.stat().st_mtime
+    kwargs["response_text"] = "Different response"
+    path2 = emit_unified_report(**kwargs)
+    assert path1 == path2
+    assert path2.stat().st_mtime == original_mtime
+
+
+def test_unified_report_includes_response_text(tmp_data):
+    kwargs = _base_report_kwargs(tmp_data)
+    kwargs["response_text"] = "My specific response"
+    path = emit_unified_report(**kwargs)
+    assert "My specific response" in path.read_text()
+
+
+def test_unified_report_includes_findings(tmp_data):
+    kwargs = _base_report_kwargs(tmp_data)
+    kwargs["findings"] = [{"severity": "warning", "message": "Something smells"}]
+    path = emit_unified_report(**kwargs)
+    assert "Something smells" in path.read_text()
+    assert "WARNING" in path.read_text()

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -1,0 +1,250 @@
+"""test_provider_dispatch_governance_integration.py — Integration tests for
+provider_dispatch.py governance emit hooks (Wave 7 PR-7.6).
+
+Each test mocks the spawn function and verifies that:
+  - t0_receipts.ndjson gets a new line with the correct `provider` field
+  - unified_reports/<dispatch_id>_report.md is created
+  - Failure/timeout dispatches produce a receipt with status != "success"
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import provider_dispatch
+
+
+# ---------------------------------------------------------------------------
+# Shared result stub
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _SpawnResult:
+    returncode: int = 0
+    completion_text: str = "OK"
+    events_written: int = 5
+    session_id: Optional[str] = None
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+
+def _make_args(provider, dispatch_id="test-integ-001", data_root=None):
+    args = MagicMock()
+    args.provider = provider
+    args.dispatch_id = dispatch_id
+    args.terminal_id = "T1"
+    args.instruction = "Do the integration test thing"
+    args.model = "sonnet"
+    args.pr_id = None
+    args.dispatch_paths = ""
+    args.no_auto_commit = True
+    args.max_retries = 1
+    args.gate = ""
+    args.role = None
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Parametrized fixture to redirect state / data dirs
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_env_dirs(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    return state_dir, data_dir
+
+
+# ---------------------------------------------------------------------------
+# Helper: read last receipt from ndjson
+# ---------------------------------------------------------------------------
+
+def _last_receipt(tmp_path):
+    state_dir = tmp_path / "state"
+    receipt_path = state_dir / "t0_receipts.ndjson"
+    if not receipt_path.exists():
+        return None
+    lines = [l for l in receipt_path.read_text().splitlines() if l.strip()]
+    return json.loads(lines[-1]) if lines else None
+
+
+def _report_exists(tmp_path, dispatch_id):
+    data_dir = tmp_path / "data"
+    return (data_dir / "unified_reports" / f"{dispatch_id}_report.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Claude dispatch test (subprocess_dispatch delegation)
+# ---------------------------------------------------------------------------
+
+def test_claude_dispatch_produces_receipt(tmp_path):
+    args = _make_args("claude", dispatch_id="claude-integ-001")
+    with patch("subprocess_dispatch.deliver_with_recovery", return_value=True):
+        rc = provider_dispatch._dispatch_claude(args)
+    assert rc == 0
+    receipt = _last_receipt(tmp_path)
+    assert receipt is not None
+    assert receipt["provider"] == "claude"
+    assert receipt["status"] == "success"
+
+
+def test_claude_dispatch_failure_produces_receipt(tmp_path):
+    args = _make_args("claude", dispatch_id="claude-fail-001")
+    with patch("subprocess_dispatch.deliver_with_recovery", return_value=False):
+        rc = provider_dispatch._dispatch_claude(args)
+    assert rc == 1
+    receipt = _last_receipt(tmp_path)
+    assert receipt is not None
+    assert receipt["provider"] == "claude"
+    assert receipt["status"] == "failure"
+
+
+# ---------------------------------------------------------------------------
+# Codex dispatch tests
+# ---------------------------------------------------------------------------
+
+def test_codex_dispatch_produces_receipt(tmp_path):
+    args = _make_args("codex", dispatch_id="codex-integ-001")
+    result = _SpawnResult(completion_text="codex output")
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_codex(args)
+    assert rc == 0
+    receipt = _last_receipt(tmp_path)
+    assert receipt is not None
+    assert receipt["provider"] == "codex"
+
+
+def test_codex_dispatch_failure_emits_receipt_with_status_failure(tmp_path):
+    args = _make_args("codex", dispatch_id="codex-fail-001")
+    result = _SpawnResult(returncode=1, error="codex blew up")
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_codex(args)
+    assert rc == 1
+    receipt = _last_receipt(tmp_path)
+    assert receipt["provider"] == "codex"
+    assert receipt["status"] == "failure"
+
+
+# ---------------------------------------------------------------------------
+# Gemini dispatch tests
+# ---------------------------------------------------------------------------
+
+def test_gemini_dispatch_produces_receipt(tmp_path):
+    args = _make_args("gemini", dispatch_id="gemini-integ-001")
+    result = _SpawnResult(completion_text="gemini output")
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_gemini(args)
+    assert rc == 0
+    receipt = _last_receipt(tmp_path)
+    assert receipt is not None
+    assert receipt["provider"] == "gemini"
+
+
+def test_gemini_dispatch_timeout_produces_receipt(tmp_path):
+    args = _make_args("gemini", dispatch_id="gemini-timeout-001")
+    result = _SpawnResult(returncode=1, timed_out=True)
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_gemini(args)
+    assert rc == 1
+    receipt = _last_receipt(tmp_path)
+    assert receipt["provider"] == "gemini"
+    assert receipt["status"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM dispatch tests
+# ---------------------------------------------------------------------------
+
+def _mock_litellm_env(monkeypatch, sub="deepseek"):
+    monkeypatch.setenv("VNX_LITELLM_MODEL", "deepseek/deepseek-v4-pro")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "fake-key")
+
+
+def test_litellm_deepseek_dispatch_produces_receipt(tmp_path, monkeypatch):
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-ds-001")
+    result = _SpawnResult(
+        completion_text="deepseek response",
+        token_usage={"input_tokens": 100, "output_tokens": 40, "cache_read_tokens": 0},
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        rc = provider_dispatch._dispatch_litellm(args)
+    assert rc == 0
+    receipt = _last_receipt(tmp_path)
+    assert receipt is not None
+    assert receipt["provider"] == "litellm:deepseek"
+
+
+def test_receipt_contains_correct_provider_field_for_each_provider(tmp_path, monkeypatch):
+    _mock_litellm_env(monkeypatch)
+    dispatch_id = "litellm-provider-field-001"
+    args = _make_args("litellm:deepseek", dispatch_id=dispatch_id)
+    result = _SpawnResult()
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["provider"] == "litellm:deepseek"
+    assert receipt["dispatch_id"] == dispatch_id
+
+
+# ---------------------------------------------------------------------------
+# Unified report tests
+# ---------------------------------------------------------------------------
+
+def test_unified_report_created_for_claude(tmp_path):
+    args = _make_args("claude", dispatch_id="claude-report-001")
+    with patch("subprocess_dispatch.deliver_with_recovery", return_value=True):
+        provider_dispatch._dispatch_claude(args)
+    assert _report_exists(tmp_path, "claude-report-001")
+
+
+def test_unified_report_created_for_each_provider(tmp_path, monkeypatch):
+    _mock_litellm_env(monkeypatch)
+    dispatch_id = "litellm-report-001"
+    args = _make_args("litellm:deepseek", dispatch_id=dispatch_id)
+    result = _SpawnResult(completion_text="litellm response text")
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    assert _report_exists(tmp_path, dispatch_id)
+    report_path = tmp_path / "data" / "unified_reports" / f"{dispatch_id}_report.md"
+    content = report_path.read_text()
+    assert "Provider: litellm:deepseek" in content
+    assert "litellm response text" in content
+
+
+def test_dispatch_failure_emits_receipt_with_status_failure_gemini(tmp_path):
+    args = _make_args("gemini", dispatch_id="gemini-fail-002")
+    result = _SpawnResult(returncode=1, error="gemini failed")
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_gemini(args)
+    assert rc == 1
+    receipt = _last_receipt(tmp_path)
+    assert receipt["status"] == "failure"
+    assert receipt["provider"] == "gemini"


### PR DESCRIPTION
## Summary

- **Gap closed**: codex/gemini/litellm dispatches now write to `t0_receipts.ndjson` and `unified_reports/` — previously these paths produced NDJSON event streams but emitted no governance trail. A DeepSeek test-dispatch on 2026-05-16 19:50 was the concrete motivation: tokens on T2.ndjson, nothing in receipts or reports.
- **New shared module** `scripts/lib/governance_emit.py`: two public functions (`emit_dispatch_receipt`, `emit_unified_report`) with provider field validation (`^(claude|codex|gemini|litellm:[a-z][a-z0-9_-]*)$`), atomic NDJSON append with `fcntl.flock`, atomic report write via `tmp + os.replace`, fail-fast on write error.
- **All four handlers** in `provider_dispatch.py` now call `_emit_governance()` after every spawn (success, failure, and timeout). `subprocess_dispatch.py` re-exports the shared interface. `receipt_writer.py` deprecated with re-export shim.

## Test plan

- [x] `pytest tests/test_governance_emit.py` — 28 tests: provider validation for all valid/invalid values, concurrent-safe append (10 threads), atomic write, NULL cost_usd, markdown format, idempotency
- [x] `pytest tests/test_provider_dispatch_governance_integration.py` — 11 tests: each provider produces receipt + report, failure/timeout dispatches produce correct status field
- [x] Full test suite: 39 new tests green, no regressions in existing tests (pre-existing collection errors unaffected)

Cross-refs: PRD `claudedocs/prd-provider-governance-unification.md`, ADR-005, ADR-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)