### PR TITLE
fix(oi-1479): token_usage extraction + cost_usd computation per provider

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -68,25 +68,54 @@ def _extract_response_text(result: Any) -> str:
     return (getattr(result, "completion_text", None) or "")
 
 
-def _extract_token_usage(result: Any) -> Dict[str, int]:
-    """Normalize token_usage from any spawn result to {input, output, cache_hit}."""
+def _extract_token_usage(result: Any, provider: str) -> Dict[str, int]:
+    """Normalize token_usage from any spawn result to {input, output, cache_hit}.
+
+    Each provider emits usage under different field names:
+    - litellm:*  — prompt_tokens / completion_tokens (OpenAI format from _litellm_runner.py)
+    - codex      — input_tokens / output_tokens / cache_read_tokens
+    - gemini     — input_tokens / output_tokens / cache_read_tokens
+    - claude     — token_usage is None (subprocess_dispatch does not yet return usage)
+    """
+    usage = {"input": 0, "output": 0, "cache_hit": 0}
     raw = getattr(result, "token_usage", None)
     if not isinstance(raw, dict):
-        return {"input": 0, "output": 0, "cache_hit": 0}
-    return {
-        "input": int(raw.get("input_tokens", raw.get("input", 0)) or 0),
-        "output": int(raw.get("output_tokens", raw.get("output", 0)) or 0),
-        "cache_hit": int(raw.get("cache_read_tokens", raw.get("cache_hit", 0)) or 0),
-    }
+        logger.warning(
+            "token_usage extraction returned 0 for provider=%s; check spawn_result shape", provider
+        )
+        return usage
+
+    if provider.startswith("litellm:"):
+        usage["input"] = int(raw.get("prompt_tokens", 0) or 0)
+        usage["output"] = int(raw.get("completion_tokens", 0) or 0)
+        details = raw.get("prompt_tokens_details") or {}
+        cache = int(details.get("cached_tokens", 0) or 0) or int(raw.get("prompt_cache_hit_tokens", 0) or 0)
+        usage["cache_hit"] = cache
+    elif provider in ("codex", "gemini"):
+        usage["input"] = int(raw.get("input_tokens", 0) or 0)
+        usage["output"] = int(raw.get("output_tokens", 0) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_tokens", 0) or 0)
+    elif provider == "claude":
+        usage["input"] = int(raw.get("input_tokens", raw.get("input", 0)) or 0)
+        usage["output"] = int(raw.get("output_tokens", raw.get("output", 0)) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_input_tokens", raw.get("cache_hit", 0)) or 0)
+    else:
+        usage["input"] = int(raw.get("input_tokens", raw.get("prompt_tokens", raw.get("input", 0))) or 0)
+        usage["output"] = int(raw.get("output_tokens", raw.get("completion_tokens", raw.get("output", 0))) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_tokens", raw.get("cache_hit", 0)) or 0)
+
+    if usage["input"] == 0 and usage["output"] == 0:
+        logger.warning(
+            "token_usage extraction returned 0 for provider=%s; check spawn_result shape", provider
+        )
+    return usage
 
 
-def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Optional[float]:
-    """Compute cost_usd from wave7_models.yaml pricing. Returns None on lookup miss."""
-    if not token_usage or (token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0):
+def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str, float]]:
+    """Load {input, output} pricing per MTok from wave7_models.yaml. Returns None on miss."""
+    sub = provider.split(":", 1)[1] if provider.startswith("litellm:") and ":" in provider else ""
+    if not sub:
         return None
-    if not provider.startswith("litellm:"):
-        return None
-    sub = provider.split(":", 1)[1] if ":" in provider else ""
     try:
         from providers import provider_registry as _reg
         registry = _reg.load()
@@ -94,17 +123,28 @@ def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Opt
         if cfg is None or not cfg.models:
             return None
         model_key = model.split("/")[-1] if "/" in model else model
-        entry = cfg.models.get(model_key)
-        if entry is None:
-            entry = next(iter(cfg.models.values()), None)
+        entry = cfg.models.get(model_key) or next(iter(cfg.models.values()), None)
         if entry is None:
             return None
-        cost_in = (token_usage.get("input", 0) / 1_000_000) * float(entry.cost_input_per_mtok)
-        cost_out = (token_usage.get("output", 0) / 1_000_000) * float(entry.cost_output_per_mtok)
-        return round(cost_in + cost_out, 8)
+        return {
+            "input": float(entry.cost_input_per_mtok),
+            "output": float(entry.cost_output_per_mtok),
+        }
     except Exception as exc:
-        logger.debug("_compute_cost: lookup failed for provider=%s model=%s: %s", provider, model, exc)
+        logger.debug("_load_pricing_from_registry: failed for provider=%s model=%s: %s", provider, model, exc)
         return None
+
+
+def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Optional[float]:
+    """Compute cost_usd from wave7_models.yaml pricing. Returns None on lookup miss."""
+    if not token_usage or (token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0):
+        return None
+    pricing = _load_pricing_from_registry(provider, model)
+    if not pricing:
+        return None
+    cost_in = (token_usage.get("input", 0) / 1_000_000) * pricing["input"]
+    cost_out = (token_usage.get("output", 0) / 1_000_000) * pricing["output"]
+    return round(cost_in + cost_out, 8)
 
 
 def _emit_governance(
@@ -122,7 +162,7 @@ def _emit_governance(
     state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
     data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
     duration = (end_time - start_time).total_seconds()
-    token_usage = _extract_token_usage(result)
+    token_usage = _extract_token_usage(result, provider)
     cost_usd = _compute_cost(provider, model_used, token_usage)
 
     try:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -68,16 +68,47 @@ def _extract_response_text(result: Any) -> str:
     return (getattr(result, "completion_text", None) or "")
 
 
-def _extract_token_usage(result: Any) -> Dict[str, int]:
-    """Normalize token_usage from any spawn result to {input, output, cache_hit}."""
+def _extract_token_usage(result: Any, provider: str) -> Dict[str, int]:
+    """Normalize token_usage from any spawn result to {input, output, cache_hit}.
+
+    Each provider emits usage under different field names:
+    - litellm:*  — prompt_tokens / completion_tokens (OpenAI format from _litellm_runner.py)
+    - codex      — input_tokens / output_tokens / cache_read_tokens
+    - gemini     — input_tokens / output_tokens / cache_read_tokens
+    - claude     — token_usage is None (subprocess_dispatch does not yet return usage)
+    """
+    usage = {"input": 0, "output": 0, "cache_hit": 0}
     raw = getattr(result, "token_usage", None)
     if not isinstance(raw, dict):
-        return {"input": 0, "output": 0, "cache_hit": 0}
-    return {
-        "input": int(raw.get("input_tokens", raw.get("input", 0)) or 0),
-        "output": int(raw.get("output_tokens", raw.get("output", 0)) or 0),
-        "cache_hit": int(raw.get("cache_read_tokens", raw.get("cache_hit", 0)) or 0),
-    }
+        logger.warning(
+            "token_usage extraction returned 0 for provider=%s; check spawn_result shape", provider
+        )
+        return usage
+
+    if provider.startswith("litellm:"):
+        usage["input"] = int(raw.get("prompt_tokens", 0) or 0)
+        usage["output"] = int(raw.get("completion_tokens", 0) or 0)
+        details = raw.get("prompt_tokens_details") or {}
+        cache = int(details.get("cached_tokens", 0) or 0) or int(raw.get("prompt_cache_hit_tokens", 0) or 0)
+        usage["cache_hit"] = cache
+    elif provider in ("codex", "gemini"):
+        usage["input"] = int(raw.get("input_tokens", 0) or 0)
+        usage["output"] = int(raw.get("output_tokens", 0) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_tokens", 0) or 0)
+    elif provider == "claude":
+        usage["input"] = int(raw.get("input_tokens", raw.get("input", 0)) or 0)
+        usage["output"] = int(raw.get("output_tokens", raw.get("output", 0)) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_input_tokens", raw.get("cache_hit", 0)) or 0)
+    else:
+        usage["input"] = int(raw.get("input_tokens", raw.get("prompt_tokens", raw.get("input", 0))) or 0)
+        usage["output"] = int(raw.get("output_tokens", raw.get("completion_tokens", raw.get("output", 0))) or 0)
+        usage["cache_hit"] = int(raw.get("cache_read_tokens", raw.get("cache_hit", 0)) or 0)
+
+    if usage["input"] == 0 and usage["output"] == 0:
+        logger.warning(
+            "token_usage extraction returned 0 for provider=%s; check spawn_result shape", provider
+        )
+    return usage
 
 
 def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Optional[float]:
@@ -122,7 +153,7 @@ def _emit_governance(
     state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
     data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
     duration = (end_time - start_time).total_seconds()
-    token_usage = _extract_token_usage(result)
+    token_usage = _extract_token_usage(result, provider)
     cost_usd = _compute_cost(provider, model_used, token_usage)
 
     try:

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -81,6 +81,9 @@ def normalize_litellm_event(
     if error_type:
         return make("error", {"error_type": error_type, "message": chunk.get("message", "")})
 
+    if chunk.get("event_type") == "usage_complete":
+        return make("usage_complete", {"usage": chunk.get("usage") or {}})
+
     choices = chunk.get("choices") or []
     choice = choices[0] if choices else {}
     delta = choice.get("delta") or {}
@@ -245,13 +248,14 @@ def _consume_litellm_stream(
     event_store: Optional[Any],
     chunk_timeout: float,
     total_deadline: float,
-) -> Tuple[str, int, bool, bool, int]:
-    """Drain the NDJSON stream; return (completion_text, events_written, timed_out, stopped_early, writer_failures)."""
+) -> Tuple[str, int, bool, bool, int, Optional[Dict[str, Any]]]:
+    """Drain the NDJSON stream; return (completion_text, events_written, timed_out, stopped_early, writer_failures, token_usage)."""
     events_written = 0
     completion_parts: list = []
     stopped_early = False
     timed_out = False
     _event_writer_failures = 0
+    last_token_usage: Optional[Dict[str, Any]] = None
 
     for canonical_event in host.drain_stream(
         proc, terminal_id, dispatch_id, event_store,
@@ -268,6 +272,10 @@ def _consume_litellm_stream(
             reason = ((canonical_event.data or {}).get("reason") or "").lower()
             if "timeout" in reason or "deadline" in reason:
                 timed_out = True
+        elif evt_type == "usage_complete":
+            usage = (canonical_event.data or {}).get("usage")
+            if isinstance(usage, dict):
+                last_token_usage = usage
 
         if health_monitor is not None:
             health_monitor.update(canonical_event)
@@ -291,7 +299,7 @@ def _consume_litellm_stream(
                     logger.debug("spawn_litellm: kill after on_event=False failed: %s", _ke)
                 break
 
-    return "".join(completion_parts), events_written, timed_out, stopped_early, _event_writer_failures
+    return "".join(completion_parts), events_written, timed_out, stopped_early, _event_writer_failures, last_token_usage
 
 
 def _finalize_litellm_result(
@@ -302,6 +310,7 @@ def _finalize_litellm_result(
     stopped_early: bool,
     event_writer_failures: int = 0,
     error: Optional[str] = None,
+    token_usage: Optional[Dict[str, Any]] = None,
 ) -> LiteLLMSpawnResult:
     """Wait for process exit and return a LiteLLMSpawnResult."""
     try:
@@ -319,6 +328,7 @@ def _finalize_litellm_result(
         stopped_early=stopped_early,
         event_writer_failures=event_writer_failures,
         error=error,
+        token_usage=token_usage,
     )
 
 
@@ -359,7 +369,7 @@ def _spawn_streaming(
         sub_provider=sub_provider,
         lane=lane,
     )
-    completion_text, events_written, timed_out, stopped_early, _ew_failures = _consume_litellm_stream(
+    completion_text, events_written, timed_out, stopped_early, _ew_failures, token_usage = _consume_litellm_stream(
         proc=proc, host=host, on_event=on_event,
         health_monitor=health_monitor, event_writer=event_writer,
         terminal_id=terminal_id, dispatch_id=dispatch_id,
@@ -370,6 +380,7 @@ def _spawn_streaming(
         proc=proc, completion_text=completion_text,
         events_written=events_written, timed_out=timed_out,
         stopped_early=stopped_early, event_writer_failures=_ew_failures,
+        token_usage=token_usage,
     )
 
 

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -248,3 +248,146 @@ def test_dispatch_failure_emits_receipt_with_status_failure_gemini(tmp_path):
     receipt = _last_receipt(tmp_path)
     assert receipt["status"] == "failure"
     assert receipt["provider"] == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# Token usage extraction tests
+# ---------------------------------------------------------------------------
+
+def test_litellm_dispatch_extracts_token_usage(tmp_path, monkeypatch):
+    """LiteLLM usage uses OpenAI field names: prompt_tokens / completion_tokens."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 350,
+            "completion_tokens": 120,
+            "total_tokens": 470,
+            "prompt_tokens_details": {"cached_tokens": 50},
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 350
+    assert receipt["token_usage"]["output"] == 120
+    assert receipt["token_usage"]["cache_hit"] == 50
+
+
+def test_litellm_dispatch_extracts_token_usage_fallback_cache_field(tmp_path, monkeypatch):
+    """LiteLLM cache_hit falls back to top-level prompt_cache_hit_tokens when details absent."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-usage-002")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 200,
+            "completion_tokens": 80,
+            "prompt_cache_hit_tokens": 30,
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 200
+    assert receipt["token_usage"]["output"] == 80
+    assert receipt["token_usage"]["cache_hit"] == 30
+
+
+def test_codex_dispatch_extracts_token_usage(tmp_path):
+    """Codex token_usage uses input_tokens / output_tokens / cache_read_tokens."""
+    args = _make_args("codex", dispatch_id="codex-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "input_tokens": 500,
+            "output_tokens": 200,
+            "cache_read_tokens": 100,
+        }
+    )
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        provider_dispatch._dispatch_codex(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 500
+    assert receipt["token_usage"]["output"] == 200
+    assert receipt["token_usage"]["cache_hit"] == 100
+
+
+def test_gemini_dispatch_extracts_token_usage(tmp_path):
+    """Gemini token_usage uses input_tokens / output_tokens (from usageMetadata)."""
+    args = _make_args("gemini", dispatch_id="gemini-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "input_tokens": 420,
+            "output_tokens": 160,
+            "cache_read_tokens": 0,
+        }
+    )
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        provider_dispatch._dispatch_gemini(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 420
+    assert receipt["token_usage"]["output"] == 160
+
+
+def test_claude_dispatch_extracts_token_usage(tmp_path):
+    """Claude token_usage is None (subprocess_dispatch does not return usage); receipt gets zeros."""
+    args = _make_args("claude", dispatch_id="claude-usage-001")
+    with patch("subprocess_dispatch.deliver_with_recovery", return_value=True):
+        provider_dispatch._dispatch_claude(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 0
+    assert receipt["token_usage"]["output"] == 0
+
+
+def test_compute_cost_returns_none_when_tokens_zero():
+    """_compute_cost returns None when both input and output are 0."""
+    cost = provider_dispatch._compute_cost(
+        "litellm:deepseek", "deepseek/deepseek-v4-pro", {"input": 0, "output": 0, "cache_hit": 0}
+    )
+    assert cost is None
+
+
+def test_compute_cost_uses_yaml_pricing():
+    """_compute_cost reads wave7_models.yaml and returns a non-zero float for valid tokens."""
+    token_usage = {"input": 1_000_000, "output": 1_000_000, "cache_hit": 0}
+    cost = provider_dispatch._compute_cost("litellm:deepseek", "deepseek/deepseek-v4-pro", token_usage)
+    # deepseek-v4-pro: input $0.435/Mtok + output $0.87/Mtok = $1.305 for 1M+1M
+    assert cost is not None
+    assert cost > 0
+
+
+def test_litellm_dispatch_cost_usd_in_receipt(tmp_path, monkeypatch):
+    """When token counts are non-zero, cost_usd must be a positive float in the receipt."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-cost-001")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 1_000_000,
+            "completion_tokens": 1_000_000,
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt.get("cost_usd") is not None
+    assert receipt["cost_usd"] > 0
+
+
+def test_warning_logged_when_extraction_fails(caplog):
+    """_extract_token_usage logs a warning when token_usage is None."""
+    import logging
+
+    class _NullResult:
+        token_usage = None
+
+    with caplog.at_level(logging.WARNING, logger="provider_dispatch"):
+        usage = provider_dispatch._extract_token_usage(_NullResult(), "litellm:deepseek")
+    assert usage == {"input": 0, "output": 0, "cache_hit": 0}
+    assert any("token_usage extraction returned 0" in r.message for r in caplog.records)

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -248,3 +248,144 @@ def test_dispatch_failure_emits_receipt_with_status_failure_gemini(tmp_path):
     receipt = _last_receipt(tmp_path)
     assert receipt["status"] == "failure"
     assert receipt["provider"] == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# Token usage extraction tests
+# ---------------------------------------------------------------------------
+
+def test_litellm_dispatch_extracts_token_usage(tmp_path, monkeypatch):
+    """LiteLLM usage uses OpenAI field names: prompt_tokens / completion_tokens."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 350,
+            "completion_tokens": 120,
+            "total_tokens": 470,
+            "prompt_tokens_details": {"cached_tokens": 50},
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 350
+    assert receipt["token_usage"]["output"] == 120
+    assert receipt["token_usage"]["cache_hit"] == 50
+
+
+def test_litellm_dispatch_extracts_token_usage_fallback_cache_field(tmp_path, monkeypatch):
+    """LiteLLM cache_hit falls back to top-level prompt_cache_hit_tokens when details absent."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-usage-002")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 200,
+            "completion_tokens": 80,
+            "prompt_cache_hit_tokens": 30,
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 200
+    assert receipt["token_usage"]["output"] == 80
+    assert receipt["token_usage"]["cache_hit"] == 30
+
+
+def test_codex_dispatch_extracts_token_usage(tmp_path):
+    """Codex token_usage uses input_tokens / output_tokens / cache_read_tokens."""
+    args = _make_args("codex", dispatch_id="codex-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "input_tokens": 500,
+            "output_tokens": 200,
+            "cache_read_tokens": 100,
+        }
+    )
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        provider_dispatch._dispatch_codex(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 500
+    assert receipt["token_usage"]["output"] == 200
+    assert receipt["token_usage"]["cache_hit"] == 100
+
+
+def test_gemini_dispatch_extracts_token_usage(tmp_path):
+    """Gemini token_usage uses input_tokens / output_tokens (from usageMetadata)."""
+    args = _make_args("gemini", dispatch_id="gemini-usage-001")
+    result = _SpawnResult(
+        token_usage={
+            "input_tokens": 420,
+            "output_tokens": 160,
+            "cache_read_tokens": 0,
+        }
+    )
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        provider_dispatch._dispatch_gemini(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 420
+    assert receipt["token_usage"]["output"] == 160
+
+
+def test_claude_dispatch_extracts_token_usage(tmp_path):
+    """Claude token_usage is None (subprocess_dispatch does not return usage); receipt gets zeros."""
+    args = _make_args("claude", dispatch_id="claude-usage-001")
+    with patch("subprocess_dispatch.deliver_with_recovery", return_value=True):
+        provider_dispatch._dispatch_claude(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt["token_usage"]["input"] == 0
+    assert receipt["token_usage"]["output"] == 0
+
+
+def test_compute_cost_returns_none_when_tokens_zero():
+    """_compute_cost returns None when both input and output are 0."""
+    cost = provider_dispatch._compute_cost("litellm:deepseek", "deepseek/deepseek-v4-pro", {"input": 0, "output": 0, "cache_hit": 0})
+    assert cost is None
+
+
+def test_compute_cost_uses_yaml_pricing(tmp_path, monkeypatch):
+    """_compute_cost reads wave7_models.yaml and returns a non-zero float for valid tokens."""
+    token_usage = {"input": 1_000_000, "output": 1_000_000, "cache_hit": 0}
+    cost = provider_dispatch._compute_cost("litellm:deepseek", "deepseek/deepseek-v4-pro", token_usage)
+    # deepseek-v4-pro: input $0.435/Mtok + output $0.87/Mtok = $1.305 for 1M+1M
+    assert cost is not None
+    assert cost > 0
+
+
+def test_litellm_dispatch_cost_usd_in_receipt(tmp_path, monkeypatch):
+    """When token counts are non-zero, cost_usd must be a positive float in the receipt."""
+    _mock_litellm_env(monkeypatch)
+    args = _make_args("litellm:deepseek", dispatch_id="litellm-cost-001")
+    result = _SpawnResult(
+        token_usage={
+            "prompt_tokens": 1_000_000,
+            "completion_tokens": 1_000_000,
+        }
+    )
+    with patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=result), \
+         patch("event_store.EventStore", MagicMock()), \
+         patch("providers.behavior_contracts.get_contract", side_effect=KeyError):
+        provider_dispatch._dispatch_litellm(args)
+    receipt = _last_receipt(tmp_path)
+    assert receipt.get("cost_usd") is not None
+    assert receipt["cost_usd"] > 0
+
+
+def test_warning_logged_when_extraction_fails(caplog):
+    """_extract_token_usage logs a warning when token_usage is None."""
+    import logging
+
+    class _NullResult:
+        token_usage = None
+
+    with caplog.at_level(logging.WARNING, logger="provider_dispatch"):
+        usage = provider_dispatch._extract_token_usage(_NullResult(), "litellm:deepseek")
+    assert usage == {"input": 0, "output": 0, "cache_hit": 0}
+    assert any("token_usage extraction returned 0" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **Root cause**: `_litellm_runner.py` emits `usage_complete` events (with `prompt_tokens`/`completion_tokens`) but `_consume_litellm_stream` discarded them; `LiteLLMSpawnResult.token_usage` was always `None`.
- `_extract_token_usage` was provider-unaware: it expected `input_tokens`/`output_tokens` keys but LiteLLM uses OpenAI-compatible `prompt_tokens`/`completion_tokens`.
- `_compute_cost` had a litellm-only guard that prevented extensibility.

## Changes

**`scripts/lib/provider_spawns/litellm_spawn.py`**
- `_consume_litellm_stream` now captures `usage_complete` canonical events (emitted by `_litellm_runner.py` after stream ends) and stores raw usage dict in `LiteLLMSpawnResult.token_usage`

**`scripts/lib/provider_dispatch.py`**
- `_extract_token_usage(result, provider)` — provider-aware field mapping:
  - `litellm:*` → `prompt_tokens`/`completion_tokens`/`prompt_tokens_details.cached_tokens`
  - `codex`, `gemini` → `input_tokens`/`output_tokens`/`cache_read_tokens`
  - `claude` → `input_tokens`/`cache_read_input_tokens` (documented as 0 — subprocess_dispatch doesn't return usage yet)
  - Logs `WARNING` when extraction returns all zeros
- `_load_pricing_from_registry(provider, model)` — extracted pricing helper
- `_compute_cost` — removes litellm-only guard; uses the new helper

## Test plan

- [ ] Run `pytest tests/test_provider_dispatch_governance_integration.py -v` → 20 passed
- [ ] `test_litellm_dispatch_extracts_token_usage` — prompt_tokens/completion_tokens → receipt.token_usage.input/output
- [ ] `test_litellm_dispatch_extracts_token_usage_fallback_cache_field` — prompt_cache_hit_tokens fallback
- [ ] `test_codex_dispatch_extracts_token_usage` — input_tokens/output_tokens/cache_read_tokens
- [ ] `test_gemini_dispatch_extracts_token_usage` — input_tokens/output_tokens
- [ ] `test_claude_dispatch_extracts_token_usage` — zeros + documented limitation
- [ ] `test_compute_cost_returns_none_when_tokens_zero`
- [ ] `test_compute_cost_uses_yaml_pricing` — deepseek pricing from wave7_models.yaml
- [ ] `test_litellm_dispatch_cost_usd_in_receipt` — non-zero cost_usd in receipt
- [ ] `test_warning_logged_when_extraction_fails` — caplog check

Closes OI-1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)