### PR TITLE
feat(wave6): PR-6.3 — PoolManager core (decision engine + state repo + manager)

### DIFF
--- a/scripts/lib/pool_decision_engine.py
+++ b/scripts/lib/pool_decision_engine.py
@@ -1,0 +1,133 @@
+"""pool_decision_engine.py — Pure decision functions for elastic worker pools.
+
+No SQLite, no filesystem, no subprocess. Pure functions over PoolState +
+PoolConfig + Membership list. Returns PoolDecision.
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+
+@dataclass(frozen=True)
+class PoolConfig:
+    pool_id: str
+    min_workers: int
+    max_workers: int
+    scaling_policy: str          # "fixed" | "queue_aware"
+    provider_mix: List[str]      # e.g. ["claude", "claude", "litellm:deepseek"]
+    cooldown_seconds: float = 60.0
+    heartbeat_stale_seconds: float = 300.0
+
+
+@dataclass(frozen=True)
+class Membership:
+    membership_id: str
+    terminal_id: str
+    provider: str
+    pool_role: str
+    status: str                  # "pending" | "active" | "draining" | "reaped"
+    joined_at: float             # unix timestamp
+    last_heartbeat: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class PoolState:
+    queue_depth: int             # pending dispatches
+    last_scaled_at: Optional[float]  # cooldown anchor
+    now: float                   # current time for testability
+
+
+@dataclass(frozen=True)
+class PoolDecision:
+    action: Literal["noop", "scale_up", "scale_down", "reap"]
+    delta: int = 0
+    reason: str = ""
+    targets: List[str] = field(default_factory=list)
+    cooldown_remaining_s: float = 0.0
+
+
+def decide(
+    config: PoolConfig,
+    state: PoolState,
+    members: List[Membership],
+) -> PoolDecision:
+    """Pure decision: given current state, what should the pool do?
+
+    Evaluation order:
+    1. Stale heartbeats -> reap with targets
+    2. Cooldown active -> noop with cooldown_remaining
+    3. Scaling policy: fixed | queue_aware
+    4. Clamp delta to [min - current, max - current]
+    """
+    active = [m for m in members if m.status == "active"]
+    current = len(active)
+
+    stale = [m for m in active if _is_stale(m, state.now, config.heartbeat_stale_seconds)]
+    if stale:
+        return PoolDecision(
+            action="reap",
+            targets=[m.membership_id for m in stale],
+            reason=(
+                f"{len(stale)} workers heartbeat-stale "
+                f"(>{config.heartbeat_stale_seconds}s)"
+            ),
+        )
+
+    if state.last_scaled_at is not None:
+        elapsed = state.now - state.last_scaled_at
+        if elapsed < config.cooldown_seconds:
+            remaining = config.cooldown_seconds - elapsed
+            return PoolDecision(
+                action="noop",
+                reason=f"cooldown active ({elapsed:.1f}s / {config.cooldown_seconds}s)",
+                cooldown_remaining_s=remaining,
+            )
+
+    target = _compute_target(config, state)
+    if target is None:
+        return PoolDecision(
+            action="noop",
+            reason=f"unknown scaling policy: {config.scaling_policy}",
+        )
+
+    delta = target - current
+    if delta > 0:
+        return PoolDecision(
+            action="scale_up",
+            delta=delta,
+            reason=f"target={target} from queue_depth={state.queue_depth}",
+        )
+    if delta < 0:
+        sorted_active = sorted(active, key=lambda m: m.joined_at)
+        targets = [m.membership_id for m in sorted_active[: abs(delta)]]
+        return PoolDecision(
+            action="scale_down",
+            delta=delta,
+            reason=f"target={target} current={current}",
+            targets=targets,
+        )
+    return PoolDecision(action="noop", reason="at target")
+
+
+def _compute_target(config: PoolConfig, state: PoolState) -> Optional[int]:
+    if config.scaling_policy == "fixed":
+        return config.min_workers
+    if config.scaling_policy == "queue_aware":
+        raw = _ceil_div(state.queue_depth, 2) if state.queue_depth > 0 else config.min_workers
+        return max(config.min_workers, min(raw, config.max_workers))
+    return None
+
+
+def _is_stale(member: Membership, now: float, threshold: float) -> bool:
+    if member.last_heartbeat is None:
+        return (now - member.joined_at) > threshold
+    return (now - member.last_heartbeat) > threshold
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return math.ceil(a / b)

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -47,7 +47,7 @@ SpawnFn = Callable[[str, str, str, str, str], SpawnResult]
 
 
 def _default_db_path(project_id: str) -> Path:
-    """Resolve default DB path: .vnx-data/state/runtime_coordination.db."""
+    """Resolve default DB path under VNX_STATE_DIR (via vnx_paths.resolve_state_dir)."""
     try:
         from project_root import resolve_project_root  # type: ignore
         root = resolve_project_root(__file__)
@@ -105,7 +105,7 @@ class PoolManager:
         project_id:  VNX project identifier.
         pool_id:     Pool name (default "default").
         db_path:     Path to runtime_coordination.db.
-                     Defaults to .vnx-data/state/runtime_coordination.db.
+                     Defaults to <state-dir>/runtime_coordination.db where <state-dir> = VNX_STATE_DIR or vnx_paths default.
         spawn_fn:    Injected for testability. Signature matches SpawnFn.
     """
 

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -1,0 +1,309 @@
+"""pool_manager.py — Elastic worker pool manager.
+
+Called from T0-tick. Reads state via PoolStateRepository, computes decision via
+pool_decision_engine.decide(), executes spawns/reaps, records the decision.
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+# Ensure scripts/lib is importable regardless of invocation path.
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from pool_decision_engine import (  # noqa: E402
+    Membership,
+    PoolConfig,
+    PoolDecision,
+    PoolState,
+    decide,
+)
+from pool_state_repo import PoolStateRepository  # noqa: E402
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Spawn protocol
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SpawnResult:
+    terminal_id: str
+    success: bool
+    error: str = ""
+
+
+SpawnFn = Callable[[str, str, str, str, str], SpawnResult]
+
+
+def _default_db_path(project_id: str) -> Path:
+    """Resolve default DB path: .vnx-data/state/runtime_coordination.db."""
+    try:
+        from project_root import resolve_project_root  # type: ignore
+        root = resolve_project_root(__file__)
+        return root / ".vnx-data" / "state" / "runtime_coordination.db"
+    except Exception:
+        return Path.cwd() / ".vnx-data" / "state" / "runtime_coordination.db"
+
+
+def _spawn_via_provider_dispatch(
+    project_id: str,
+    pool_id: str,
+    terminal_id: str,
+    provider: str,
+    role: str,
+) -> SpawnResult:
+    """Delegate to Wave 4.6 provider spawn handlers.
+
+    Provider-mix integration is completed in PR-6.5. For PR-6.3 this
+    records the spawn intent and returns success so that PoolManager can
+    insert the membership row. Actual subprocess spawning is wired in PR-6.5.
+    """
+    log.info(
+        "spawn: project=%s pool=%s terminal=%s provider=%s role=%s",
+        project_id,
+        pool_id,
+        terminal_id,
+        provider,
+        role,
+    )
+    return SpawnResult(terminal_id=terminal_id, success=True)
+
+
+# ---------------------------------------------------------------------------
+# ExecResult
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecResult:
+    decision: PoolDecision
+    spawned: List[str] = field(default_factory=list)   # terminal_ids spawned
+    reaped: List[str] = field(default_factory=list)    # membership_ids reaped
+    errors: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# PoolManager
+# ---------------------------------------------------------------------------
+
+class PoolManager:
+    """Orchestrator: read -> decide -> execute -> record.
+
+    Instantiate with project_id and pool_id. Call tick() from T0.
+
+    Args:
+        project_id:  VNX project identifier.
+        pool_id:     Pool name (default "default").
+        db_path:     Path to runtime_coordination.db.
+                     Defaults to .vnx-data/state/runtime_coordination.db.
+        spawn_fn:    Injected for testability. Signature matches SpawnFn.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        pool_id: str = "default",
+        db_path: Optional[Path] = None,
+        *,
+        spawn_fn: Optional[SpawnFn] = None,
+    ) -> None:
+        self.project_id = project_id
+        self.pool_id = pool_id
+        db = db_path or _default_db_path(project_id)
+        self.repo = PoolStateRepository(db, project_id)
+        self._spawn_fn: SpawnFn = spawn_fn or _spawn_via_provider_dispatch
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load_state(self) -> Tuple[PoolConfig, PoolState, List[Membership]]:
+        """Load config + state + members for this pool."""
+        now = time.time()
+        config = self.repo.get_config(self.pool_id)
+        if config is None:
+            raise RuntimeError(
+                f"No pool_config row for project={self.project_id} pool={self.pool_id}. "
+                "Run migration 0020 and bootstrap first."
+            )
+        state = self.repo.get_state(self.pool_id, now)
+        members = self.repo.list_members(self.pool_id)
+        return config, state, members
+
+    def decide(self) -> PoolDecision:
+        """Read state and return a pure decision. No side effects."""
+        config, state, members = self.load_state()
+        return decide(config, state, members)
+
+    def execute(self, decision: PoolDecision) -> ExecResult:
+        """Apply decision: spawn new workers or reap stale ones.
+
+        Per-target outcome tracking: if 1 of 3 spawns fails, the other 2
+        still succeed. Membership rows are only created on successful spawn.
+        """
+        result = ExecResult(decision=decision)
+        now = time.time()
+
+        if decision.action == "scale_up":
+            result = self._execute_scale_up(decision, now)
+        elif decision.action == "scale_down":
+            result = self._execute_scale_down(decision, now)
+        elif decision.action == "reap":
+            result = self._execute_reap(decision, now)
+        else:
+            # noop — nothing to do
+            pass
+
+        return result
+
+    def tick(self) -> ExecResult:
+        """Full T0-tick cycle: decide + execute + record.
+
+        Called once per T0 tick. Records the decision in the DB and updates
+        last_scaled_at only when workers were actually spawned or reaped.
+        """
+        config, state, members = self.load_state()
+        decision = decide(config, state, members)
+
+        result = self.execute(decision)
+
+        now = time.time()
+        self.repo.record_decision(self.pool_id, decision, now)
+
+        if result.spawned or result.reaped:
+            self.repo.update_last_scaled_at(self.pool_id, now)
+            current_size = self.repo.get_current_size(self.pool_id)
+            self.repo.update_pool_size(self.pool_id, current_size)
+
+        log.info(
+            "tick: pool=%s action=%s spawned=%d reaped=%d errors=%d reason=%s",
+            self.pool_id,
+            decision.action,
+            len(result.spawned),
+            len(result.reaped),
+            len(result.errors),
+            decision.reason,
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Private execution helpers
+    # ------------------------------------------------------------------
+
+    def _next_terminal_id(self) -> str:
+        current_size = self.repo.get_current_size(self.pool_id)
+        slot = current_size + 1
+        prefix = self.project_id.split("-")[0] if "-" in self.project_id else self.project_id
+        return f"{prefix[:3].upper()}-{slot}"
+
+    def _provider_for_slot(self, config: PoolConfig, slot_index: int) -> str:
+        mix = config.provider_mix
+        if not mix:
+            return "claude"
+        return mix[slot_index % len(mix)]
+
+    def _execute_scale_up(self, decision: PoolDecision, now: float) -> ExecResult:
+        result = ExecResult(decision=decision)
+        config, _, _ = self.load_state()
+
+        for i in range(abs(decision.delta)):
+            terminal_id = f"{self.project_id}-P{int(now * 1000) % 100000}-{i}"
+            provider = self._provider_for_slot(config, i)
+            role = config.provider_mix[0] if config.provider_mix else "backend-developer"
+            # role comes from pool config role_mix; provider_mix has providers
+            # For PR-6.3, derive role from worker_registry if available
+            role = _resolve_role(config, i)
+
+            try:
+                spawn_result = self._spawn_fn(
+                    self.project_id,
+                    self.pool_id,
+                    terminal_id,
+                    provider,
+                    role,
+                )
+                if spawn_result.success:
+                    self.repo.add_member(
+                        self.pool_id, terminal_id, provider, role, now
+                    )
+                    result.spawned.append(terminal_id)
+                    log.info(
+                        "scale_up: spawned terminal=%s provider=%s",
+                        terminal_id,
+                        provider,
+                    )
+                else:
+                    err = f"spawn failed for terminal={terminal_id}: {spawn_result.error}"
+                    result.errors.append(err)
+                    log.warning("scale_up: %s", err)
+            except Exception as exc:
+                err = f"spawn exception for terminal={terminal_id}: {exc}"
+                result.errors.append(err)
+                log.exception("scale_up: unexpected spawn error terminal=%s", terminal_id)
+
+        return result
+
+    def _execute_scale_down(self, decision: PoolDecision, now: float) -> ExecResult:
+        result = ExecResult(decision=decision)
+
+        for membership_id in decision.targets:
+            try:
+                self.repo.mark_member_reaped(
+                    membership_id, "scale_down", now
+                )
+                result.reaped.append(membership_id)
+                log.info("scale_down: reaped membership=%s", membership_id)
+            except Exception as exc:
+                err = f"reap error for membership={membership_id}: {exc}"
+                result.errors.append(err)
+                log.exception("scale_down: reap error membership=%s", membership_id)
+
+        return result
+
+    def _execute_reap(self, decision: PoolDecision, now: float) -> ExecResult:
+        result = ExecResult(decision=decision)
+
+        for membership_id in decision.targets:
+            try:
+                self.repo.mark_member_reaped(
+                    membership_id, "heartbeat_stale", now
+                )
+                result.reaped.append(membership_id)
+                log.info("reap: reaped stale membership=%s", membership_id)
+            except Exception as exc:
+                err = f"reap error for membership={membership_id}: {exc}"
+                result.errors.append(err)
+                log.exception("reap: error membership=%s", membership_id)
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_role(config: PoolConfig, slot_index: int) -> str:
+    """Derive role for a slot from provider_mix naming convention.
+
+    Provider_mix entries like 'claude:backend-developer' carry the role.
+    Plain entries like 'claude' get role 'backend-developer' as default.
+    Full role resolution via role_mix is implemented in PR-6.5.
+    """
+    mix = config.provider_mix
+    if not mix:
+        return "backend-developer"
+    entry = mix[slot_index % len(mix)]
+    if ":" in entry:
+        parts = entry.split(":", 1)
+        return parts[1] if parts[1] else "backend-developer"
+    return "backend-developer"

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -79,9 +79,16 @@ class PoolStateRepository:
         self.project_id = project_id
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+        # isolation_level=None: full autocommit; all transactions are explicit BEGIN … COMMIT.
+        # Without this, Python's sqlite3 implicit transaction management can conflict with
+        # our explicit BEGIN IMMEDIATE calls when two threads race on the same DB.
+        conn = sqlite3.connect(str(self.db_path), timeout=30.0, isolation_level=None)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode = WAL")
+        # Belt-and-suspenders: set busy_timeout via PRAGMA in addition to the connect-level
+        # timeout so SQLite retries on SQLITE_BUSY regardless of how the busy handler was
+        # previously configured on this connection.
+        conn.execute("PRAGMA busy_timeout = 30000")
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -1,0 +1,403 @@
+"""pool_state_repo.py — SQLite repository for pool state queries.
+
+Read methods are cacheable; write methods are atomic via BEGIN IMMEDIATE.
+No business logic — pure persistence against schema v14 tables:
+  pool_config, worker_pools, worker_pool_membership, terminal_leases.
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# UUID v7 — time-ordered unique IDs for membership_id / decision_id
+# ---------------------------------------------------------------------------
+
+def _uuid7() -> str:
+    """Generate a UUID v7 (time-ordered) compatible with Python < 3.14."""
+    ts_ms = int(time.time() * 1000)
+    rand_bytes = os.urandom(10)
+    rand_int = int.from_bytes(rand_bytes, "big")  # 80 bits of randomness
+
+    rand_a = (rand_int >> 68) & 0xFFF        # top 12 bits -> rand_a field
+    rand_b = rand_int & 0x3FFFFFFFFFFFFFFF   # low 62 bits -> rand_b field
+
+    val = (
+        ((ts_ms & 0xFFFFFFFFFFFF) << 80)
+        | (0x7 << 76)      # version = 7
+        | (rand_a << 64)   # rand_a (12 bits)
+        | (0b10 << 62)     # variant = 10
+        | rand_b           # rand_b (62 bits)
+    )
+    h = f"{val:032x}"
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:]}"
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+def _iso_now(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _from_iso(s: Optional[str]) -> Optional[float]:
+    if s is None:
+        return None
+    try:
+        s_clean = s.rstrip("Z")
+        dt = datetime.fromisoformat(s_clean).replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# PoolStateRepository
+# ---------------------------------------------------------------------------
+
+class PoolStateRepository:
+    """SQLite read/write adapter for pool tables. No business logic."""
+
+    def __init__(self, db_path: Path, project_id: str) -> None:
+        self.db_path = db_path
+        self.project_id = project_id
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    # ------------------------------------------------------------------
+    # Read methods
+    # ------------------------------------------------------------------
+
+    def get_config(self, pool_id: str) -> Optional[PoolConfig]:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT pool_id, min_workers, max_workers, scale_policy,
+                       provider_mix_json, cooldown_seconds
+                FROM pool_config
+                WHERE project_id = ? AND pool_id = ?
+                """,
+                (self.project_id, pool_id),
+            ).fetchone()
+            if row is None:
+                return None
+            provider_mix = json.loads(row["provider_mix_json"] or '["claude"]')
+            return PoolConfig(
+                pool_id=row["pool_id"],
+                min_workers=row["min_workers"],
+                max_workers=row["max_workers"],
+                scaling_policy=row["scale_policy"],
+                provider_mix=provider_mix,
+                cooldown_seconds=float(row["cooldown_seconds"]),
+            )
+        finally:
+            conn.close()
+
+    def get_state(self, pool_id: str, now: float) -> PoolState:
+        conn = self._connect()
+        try:
+            pool_row = conn.execute(
+                """
+                SELECT last_scaled_at
+                FROM worker_pools
+                WHERE project_id = ? AND pool_id = ?
+                """,
+                (self.project_id, pool_id),
+            ).fetchone()
+
+            last_scaled_at: Optional[float] = None
+            if pool_row and pool_row["last_scaled_at"]:
+                last_scaled_at = _from_iso(pool_row["last_scaled_at"])
+
+            # Count queued dispatches for this project
+            try:
+                q_row = conn.execute(
+                    """
+                    SELECT COUNT(*) as cnt
+                    FROM dispatches
+                    WHERE project_id = ? AND state = 'queued'
+                    """,
+                    (self.project_id,),
+                ).fetchone()
+                queue_depth = int(q_row["cnt"]) if q_row else 0
+            except sqlite3.OperationalError:
+                # dispatches table may not exist in minimal test setups
+                queue_depth = 0
+
+            return PoolState(
+                queue_depth=queue_depth,
+                last_scaled_at=last_scaled_at,
+                now=now,
+            )
+        finally:
+            conn.close()
+
+    def list_members(self, pool_id: str) -> List[Membership]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                    wpm.id,
+                    wpm.terminal_id,
+                    wpm.provider,
+                    wpm.role,
+                    wpm.joined_at,
+                    wpm.metadata_json,
+                    tl.last_heartbeat_at
+                FROM worker_pool_membership wpm
+                LEFT JOIN terminal_leases tl
+                    ON tl.terminal_id = wpm.terminal_id
+                   AND tl.project_id  = wpm.project_id
+                WHERE wpm.project_id = ?
+                  AND wpm.pool_id    = ?
+                  AND wpm.released_at IS NULL
+                """,
+                (self.project_id, pool_id),
+            ).fetchall()
+
+            members: List[Membership] = []
+            for row in rows:
+                meta = json.loads(row["metadata_json"] or "{}")
+                membership_id = meta.get("membership_id", str(row["id"]))
+                last_heartbeat = _from_iso(row["last_heartbeat_at"])
+                joined_ts = _from_iso(row["joined_at"]) or 0.0
+                members.append(
+                    Membership(
+                        membership_id=membership_id,
+                        terminal_id=row["terminal_id"],
+                        provider=row["provider"],
+                        pool_role=row["role"],
+                        status="active",
+                        joined_at=joined_ts,
+                        last_heartbeat=last_heartbeat,
+                    )
+                )
+            return members
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Write methods — all use BEGIN IMMEDIATE to prevent lost-update
+    # ------------------------------------------------------------------
+
+    def add_member(
+        self,
+        pool_id: str,
+        terminal_id: str,
+        provider: str,
+        role: str,
+        now: float,
+    ) -> str:
+        membership_id = _uuid7()
+        joined_iso = _iso_now(now)
+        meta = json.dumps({"membership_id": membership_id})
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO worker_pool_membership
+                    (terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (terminal_id, self.project_id, pool_id, provider, role, joined_iso, meta),
+            )
+            conn.commit()
+            log.debug(
+                "add_member: pool=%s terminal=%s membership_id=%s",
+                pool_id,
+                terminal_id,
+                membership_id,
+            )
+            return membership_id
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def mark_member_reaped(
+        self,
+        membership_id: str,
+        reason: str,
+        now: float,
+    ) -> None:
+        released_iso = _iso_now(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE worker_pool_membership
+                SET released_at   = ?,
+                    release_reason = ?
+                WHERE json_extract(metadata_json, '$.membership_id') = ?
+                  AND released_at IS NULL
+                """,
+                (released_iso, reason, membership_id),
+            )
+            conn.commit()
+            log.debug("mark_member_reaped: membership_id=%s reason=%s", membership_id, reason)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def update_heartbeat(self, membership_id: str, now: float) -> None:
+        hb_iso = _iso_now(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE terminal_leases
+                SET last_heartbeat_at = ?
+                WHERE (terminal_id, project_id) IN (
+                    SELECT terminal_id, project_id
+                    FROM worker_pool_membership
+                    WHERE json_extract(metadata_json, '$.membership_id') = ?
+                      AND released_at IS NULL
+                )
+                """,
+                (hb_iso, membership_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def update_last_scaled_at(self, pool_id: str, now: float) -> None:
+        scaled_iso = _iso_now(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE worker_pools
+                SET last_scaled_at = ?
+                WHERE project_id = ? AND pool_id = ?
+                """,
+                (scaled_iso, self.project_id, pool_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def record_decision(
+        self,
+        pool_id: str,
+        decision: PoolDecision,
+        now: float,
+    ) -> str:
+        decision_id = _uuid7()
+        scaled_iso = _iso_now(now)
+        decision_json = json.dumps(
+            {
+                "decision_id": decision_id,
+                "action": decision.action,
+                "delta": decision.delta,
+                "reason": decision.reason,
+                "targets": list(decision.targets),
+                "cooldown_remaining_s": decision.cooldown_remaining_s,
+                "recorded_at": scaled_iso,
+            }
+        )
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE worker_pools
+                SET last_decision_json = ?,
+                    last_scale_action  = ?,
+                    last_scaled_at     = CASE
+                        WHEN ? IN ('scale_up', 'scale_down', 'reap') THEN ?
+                        ELSE last_scaled_at
+                    END
+                WHERE project_id = ? AND pool_id = ?
+                """,
+                (
+                    decision_json,
+                    decision.action,
+                    decision.action,
+                    scaled_iso,
+                    self.project_id,
+                    pool_id,
+                ),
+            )
+            conn.commit()
+            log.debug(
+                "record_decision: pool=%s action=%s decision_id=%s",
+                pool_id,
+                decision.action,
+                decision_id,
+            )
+            return decision_id
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def get_current_size(self, pool_id: str) -> int:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) as cnt
+                FROM worker_pool_membership
+                WHERE project_id = ? AND pool_id = ? AND released_at IS NULL
+                """,
+                (self.project_id, pool_id),
+            ).fetchone()
+            return int(row["cnt"]) if row else 0
+        finally:
+            conn.close()
+
+    def update_pool_size(self, pool_id: str, current_size: int) -> None:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE worker_pools
+                SET current_size = ?
+                WHERE project_id = ? AND pool_id = ?
+                """,
+                (current_size, self.project_id, pool_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -9,6 +9,7 @@ Wave 6 PR-6.3 — ADR-018 elastic worker pool.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import math
@@ -17,7 +18,7 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState
 
@@ -210,6 +211,23 @@ class PoolStateRepository:
     # Write methods — all use BEGIN IMMEDIATE to prevent lost-update
     # ------------------------------------------------------------------
 
+    def _emit_ledger(self, event_type: str, payload: Dict) -> None:
+        """Append canonical event to .vnx-data/events/pool_events.ndjson (ADR-005)."""
+        events_dir = self.db_path.parent.parent / "events"
+        events_dir.mkdir(parents=True, exist_ok=True)
+        events_file = events_dir / "pool_events.ndjson"
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "event_type": event_type,
+            "payload": payload,
+        }
+        with open(events_file, "ab") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.write((json.dumps(event) + "\n").encode("utf-8"))
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
     def add_member(
         self,
         pool_id: str,
@@ -239,12 +257,20 @@ class PoolStateRepository:
                 terminal_id,
                 membership_id,
             )
-            return membership_id
         except Exception:
             conn.rollback()
             raise
         finally:
             conn.close()
+        self._emit_ledger("pool.member.added", {
+            "pool_id": pool_id,
+            "membership_id": membership_id,
+            "terminal_id": terminal_id,
+            "provider": provider,
+            "role": role,
+            "now": now,
+        })
+        return membership_id
 
     def mark_member_reaped(
         self,
@@ -273,6 +299,11 @@ class PoolStateRepository:
             raise
         finally:
             conn.close()
+        self._emit_ledger("pool.member.reaped", {
+            "membership_id": membership_id,
+            "reason": reason,
+            "now": now,
+        })
 
     def update_heartbeat(self, membership_id: str, now: float) -> None:
         hb_iso = _iso_now(now)
@@ -345,18 +376,12 @@ class PoolStateRepository:
                 """
                 UPDATE worker_pools
                 SET last_decision_json = ?,
-                    last_scale_action  = ?,
-                    last_scaled_at     = CASE
-                        WHEN ? IN ('scale_up', 'scale_down', 'reap') THEN ?
-                        ELSE last_scaled_at
-                    END
+                    last_scale_action  = ?
                 WHERE project_id = ? AND pool_id = ?
                 """,
                 (
                     decision_json,
                     decision.action,
-                    decision.action,
-                    scaled_iso,
                     self.project_id,
                     pool_id,
                 ),

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+# Test fixtures package

--- a/tests/fixtures/pool_state_fixtures.py
+++ b/tests/fixtures/pool_state_fixtures.py
@@ -1,0 +1,341 @@
+"""pool_state_fixtures.py — Pytest fixtures and factory helpers for pool tests.
+
+Provides:
+- make_config() — PoolConfig factory with sensible defaults
+- make_state() — PoolState factory
+- make_member() — Membership factory
+- pool_db() — in-memory SQLite with schema v14 tables initialized
+- active_member_row() — inserts a live membership row into test DB
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_decision_engine import Membership, PoolConfig, PoolState  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Domain object factories
+# ---------------------------------------------------------------------------
+
+def make_config(
+    pool_id: str = "default",
+    min_workers: int = 1,
+    max_workers: int = 4,
+    scaling_policy: str = "queue_aware",
+    provider_mix: Optional[list] = None,
+    cooldown_seconds: float = 60.0,
+    heartbeat_stale_seconds: float = 300.0,
+) -> PoolConfig:
+    return PoolConfig(
+        pool_id=pool_id,
+        min_workers=min_workers,
+        max_workers=max_workers,
+        scaling_policy=scaling_policy,
+        provider_mix=provider_mix or ["claude"],
+        cooldown_seconds=cooldown_seconds,
+        heartbeat_stale_seconds=heartbeat_stale_seconds,
+    )
+
+
+def make_state(
+    queue_depth: int = 0,
+    last_scaled_at: Optional[float] = None,
+    now: float = 1000.0,
+) -> PoolState:
+    return PoolState(
+        queue_depth=queue_depth,
+        last_scaled_at=last_scaled_at,
+        now=now,
+    )
+
+
+def make_member(
+    membership_id: str = "test-member-001",
+    terminal_id: str = "T1",
+    provider: str = "claude",
+    pool_role: str = "backend-developer",
+    status: str = "active",
+    joined_at: float = 900.0,
+    last_heartbeat: Optional[float] = None,
+) -> Membership:
+    return Membership(
+        membership_id=membership_id,
+        terminal_id=terminal_id,
+        provider=provider,
+        pool_role=pool_role,
+        status=status,
+        joined_at=joined_at,
+        last_heartbeat=last_heartbeat,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQLite test database setup
+# ---------------------------------------------------------------------------
+
+_BASE_SCHEMA = """
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS runtime_schema_version (
+    version     INTEGER PRIMARY KEY,
+    description TEXT,
+    applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+INSERT OR IGNORE INTO runtime_schema_version(version, description)
+VALUES (14, 'test-base-v14');
+
+CREATE TABLE IF NOT EXISTS terminal_leases (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id       TEXT    NOT NULL,
+    project_id        TEXT    NOT NULL,
+    state             TEXT    NOT NULL DEFAULT 'idle',
+    lease_token       TEXT    NOT NULL DEFAULT '',
+    last_heartbeat_at TEXT,
+    UNIQUE(terminal_id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS dispatches (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    project_id  TEXT NOT NULL DEFAULT 'vnx-dev',
+    state       TEXT NOT NULL DEFAULT 'queued',
+    UNIQUE(dispatch_id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS pool_config (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id          TEXT    NOT NULL,
+    pool_id             TEXT    NOT NULL DEFAULT 'default',
+    min_workers         INTEGER NOT NULL DEFAULT 1,
+    max_workers         INTEGER NOT NULL DEFAULT 6,
+    target_workers      INTEGER NOT NULL DEFAULT 3,
+    role_mix_json       TEXT    NOT NULL DEFAULT '["backend-developer"]',
+    provider_mix_json   TEXT    NOT NULL DEFAULT '["claude"]',
+    scale_policy        TEXT    NOT NULL DEFAULT 'queue_depth_v1',
+    cooldown_seconds    INTEGER NOT NULL DEFAULT 120,
+    created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE(project_id, pool_id),
+    CHECK (min_workers >= 0),
+    CHECK (max_workers >= min_workers),
+    CHECK (target_workers >= min_workers AND target_workers <= max_workers)
+);
+
+CREATE TABLE IF NOT EXISTS worker_pools (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id          TEXT    NOT NULL,
+    pool_id             TEXT    NOT NULL DEFAULT 'default',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    current_size        INTEGER NOT NULL DEFAULT 0,
+    target_size         INTEGER NOT NULL DEFAULT 0,
+    healthy_count       INTEGER NOT NULL DEFAULT 0,
+    stuck_count         INTEGER NOT NULL DEFAULT 0,
+    last_scaled_at      TEXT,
+    last_scale_action   TEXT,
+    last_decision_json  TEXT    DEFAULT '{}',
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(project_id, pool_id),
+    FOREIGN KEY (project_id, pool_id) REFERENCES pool_config(project_id, pool_id)
+);
+
+CREATE TABLE IF NOT EXISTS worker_pool_membership (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL,
+    pool_id             TEXT    NOT NULL DEFAULT 'default',
+    provider            TEXT    NOT NULL,
+    role                TEXT    NOT NULL,
+    joined_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    released_at         TEXT,
+    release_reason      TEXT,
+    spawn_generation    INTEGER NOT NULL DEFAULT 1,
+    metadata_json       TEXT    DEFAULT '{}'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_membership_active
+    ON worker_pool_membership(terminal_id, project_id)
+    WHERE released_at IS NULL;
+
+PRAGMA foreign_keys = ON;
+"""
+
+
+def create_test_db(
+    project_id: str = "vnx-dev",
+    pool_id: str = "default",
+    min_workers: int = 1,
+    max_workers: int = 4,
+    target_workers: int = 2,
+    scale_policy: str = "queue_aware",
+    cooldown_seconds: int = 60,
+    provider_mix_json: str = '["claude"]',
+) -> sqlite3.Connection:
+    """Create an in-memory SQLite connection with schema v14 pool tables."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_BASE_SCHEMA)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO pool_config
+            (project_id, pool_id, min_workers, max_workers, target_workers,
+             scale_policy, cooldown_seconds, provider_mix_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            project_id, pool_id, min_workers, max_workers, target_workers,
+            scale_policy, cooldown_seconds, provider_mix_json,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO worker_pools
+            (project_id, pool_id, state, current_size, target_size)
+        VALUES (?, ?, 'idle', 0, ?)
+        """,
+        (project_id, pool_id, target_workers),
+    )
+    conn.commit()
+    return conn
+
+
+def create_test_db_file(
+    db_path: Path,
+    project_id: str = "vnx-dev",
+    pool_id: str = "default",
+    min_workers: int = 1,
+    max_workers: int = 4,
+    target_workers: int = 2,
+    scale_policy: str = "queue_aware",
+    cooldown_seconds: int = 60,
+    provider_mix_json: str = '["claude"]',
+) -> Path:
+    """Initialize a file-backed SQLite DB at db_path with schema v14 pool tables.
+
+    Returns db_path. Used by integration tests that need real file connections
+    (PoolStateRepository._connect() opens/closes per-call).
+    """
+    # Clamp target_workers to satisfy CHECK constraint
+    target_workers = max(target_workers, min_workers)
+    target_workers = min(target_workers, max_workers)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_BASE_SCHEMA)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO pool_config
+            (project_id, pool_id, min_workers, max_workers, target_workers,
+             scale_policy, cooldown_seconds, provider_mix_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            project_id, pool_id, min_workers, max_workers, target_workers,
+            scale_policy, cooldown_seconds, provider_mix_json,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO worker_pools
+            (project_id, pool_id, state, current_size, target_size)
+        VALUES (?, ?, 'idle', 0, ?)
+        """,
+        (project_id, pool_id, target_workers),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def insert_lease(
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    project_id: str = "vnx-dev",
+    last_heartbeat_at: Optional[str] = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO terminal_leases
+            (terminal_id, project_id, state, lease_token, last_heartbeat_at)
+        VALUES (?, ?, 'idle', '', ?)
+        """,
+        (terminal_id, project_id, last_heartbeat_at),
+    )
+    conn.commit()
+
+
+def insert_membership(
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    project_id: str = "vnx-dev",
+    pool_id: str = "default",
+    provider: str = "claude",
+    role: str = "backend-developer",
+    joined_at: Optional[str] = None,
+    membership_id: Optional[str] = None,
+) -> str:
+    import json
+    import uuid as _uuid
+    mid = membership_id or str(_uuid.uuid4())
+    jat = joined_at or "2026-01-01T00:00:00.000000Z"
+    conn.execute(
+        """
+        INSERT INTO worker_pool_membership
+            (terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (terminal_id, project_id, pool_id, provider, role, jat,
+         json.dumps({"membership_id": mid})),
+    )
+    conn.commit()
+    return mid
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def pool_config_default() -> PoolConfig:
+    return make_config()
+
+
+@pytest.fixture()
+def pool_state_empty() -> PoolState:
+    return make_state(queue_depth=0, now=1000.0)
+
+
+@pytest.fixture()
+def pool_state_with_queue() -> PoolState:
+    return make_state(queue_depth=4, now=1000.0)
+
+
+@pytest.fixture()
+def pool_state_cooldown() -> PoolState:
+    return make_state(queue_depth=4, last_scaled_at=980.0, now=1000.0)
+
+
+@pytest.fixture()
+def one_active_member() -> Membership:
+    return make_member(membership_id="m-001", joined_at=900.0, last_heartbeat=990.0)
+
+
+@pytest.fixture()
+def stale_member() -> Membership:
+    return make_member(
+        membership_id="m-stale",
+        joined_at=100.0,
+        last_heartbeat=100.0,  # stale: now=1000, threshold=300 => 900s ago
+    )

--- a/tests/test_pool_decision_engine.py
+++ b/tests/test_pool_decision_engine.py
@@ -1,0 +1,430 @@
+"""test_pool_decision_engine.py — Unit tests for pool_decision_engine.py.
+
+Pure tests: no SQLite, no filesystem, no subprocess.
+Table-driven tests over 8 state combinations plus Hypothesis property test.
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_decision_engine import (  # noqa: E402
+    Membership,
+    PoolConfig,
+    PoolDecision,
+    PoolState,
+    _ceil_div,
+    _is_stale,
+    decide,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures"))
+from pool_state_fixtures import make_config, make_member, make_state  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+def cfg(
+    min_workers: int = 1,
+    max_workers: int = 4,
+    policy: str = "queue_aware",
+    cooldown: float = 60.0,
+    stale: float = 300.0,
+) -> PoolConfig:
+    return make_config(
+        min_workers=min_workers,
+        max_workers=max_workers,
+        scaling_policy=policy,
+        cooldown_seconds=cooldown,
+        heartbeat_stale_seconds=stale,
+    )
+
+
+def st8(
+    queue: int = 0,
+    last_scaled: float = None,
+    now: float = 1000.0,
+) -> PoolState:
+    return make_state(queue_depth=queue, last_scaled_at=last_scaled, now=now)
+
+
+def active(
+    mid: str = "m-1",
+    tid: str = "T1",
+    joined: float = 900.0,
+    heartbeat: float = 990.0,
+) -> Membership:
+    return make_member(
+        membership_id=mid,
+        terminal_id=tid,
+        status="active",
+        joined_at=joined,
+        last_heartbeat=heartbeat,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Table-driven tests — 8 state combinations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "scenario,config,state,members,expected_action,expected_delta",
+    [
+        # 1. Empty pool with queue=4 → ceil(4/2)=2 → scale_up +2
+        (
+            "empty_with_queue",
+            cfg(min_workers=1, max_workers=4, policy="queue_aware"),
+            st8(queue=4, now=1000.0),
+            [],
+            "scale_up",
+            2,
+        ),
+        # 2. Full pool at max with large queue → noop (already at max)
+        (
+            "full_at_max",
+            cfg(min_workers=1, max_workers=2, policy="queue_aware"),
+            st8(queue=10, now=1000.0),
+            [active("m-1", "T1"), active("m-2", "T2")],
+            "noop",
+            0,
+        ),
+        # 3. Pool below min (0 workers), queue=0 → scale_up to min
+        (
+            "below_min_no_queue",
+            cfg(min_workers=2, max_workers=4, policy="queue_aware"),
+            st8(queue=0, now=1000.0),
+            [],
+            "scale_up",
+            2,
+        ),
+        # 4. Stale member present → reap before scaling
+        (
+            "stale_member_reaped_first",
+            cfg(min_workers=1, max_workers=4, policy="queue_aware", stale=300.0),
+            st8(queue=4, now=1000.0),
+            [
+                make_member("m-stale", "T1", joined_at=100.0, last_heartbeat=100.0, status="active"),
+                active("m-fresh", "T2", joined=900.0, heartbeat=990.0),
+            ],
+            "reap",
+            0,
+        ),
+        # 5. Cooldown active → noop with cooldown_remaining
+        (
+            "cooldown_active",
+            cfg(min_workers=1, max_workers=4, policy="queue_aware", cooldown=120.0),
+            st8(queue=4, last_scaled=950.0, now=1000.0),  # 50s elapsed, cooldown=120s
+            [],
+            "noop",
+            0,
+        ),
+        # 6. Fixed policy ignores queue → only scale to min
+        (
+            "fixed_policy_ignores_queue",
+            cfg(min_workers=1, max_workers=4, policy="fixed"),
+            st8(queue=10, now=1000.0),
+            [],
+            "scale_up",
+            1,  # scale_up to min=1
+        ),
+        # 7. Fixed policy at min → noop
+        (
+            "fixed_policy_at_min",
+            cfg(min_workers=1, max_workers=4, policy="fixed"),
+            st8(queue=10, now=1000.0),
+            [active("m-1", "T1")],
+            "noop",
+            0,
+        ),
+        # 8. queue_depth=0, current=min → noop
+        (
+            "at_min_no_queue",
+            cfg(min_workers=1, max_workers=4, policy="queue_aware"),
+            st8(queue=0, now=1000.0),
+            [active("m-1", "T1")],
+            "noop",
+            0,
+        ),
+    ],
+)
+def test_decide_returns_expected(
+    scenario,
+    config,
+    state,
+    members,
+    expected_action,
+    expected_delta,
+):
+    result = decide(config, state, members)
+    assert result.action == expected_action, (
+        f"[{scenario}] expected action={expected_action!r} got {result.action!r}"
+    )
+    if expected_delta != 0:
+        assert result.delta == expected_delta, (
+            f"[{scenario}] expected delta={expected_delta} got {result.delta}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cooldown detail tests
+# ---------------------------------------------------------------------------
+
+def test_cooldown_returns_remaining_time():
+    config = cfg(cooldown=120.0)
+    state = st8(queue=4, last_scaled=900.0, now=1000.0)  # 100s elapsed
+    result = decide(config, state, [])
+    assert result.action == "noop"
+    assert abs(result.cooldown_remaining_s - 20.0) < 0.01
+
+
+def test_cooldown_expired_allows_scale_up():
+    config = cfg(cooldown=60.0)
+    state = st8(queue=4, last_scaled=930.0, now=1000.0)  # 70s elapsed
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+
+
+def test_no_last_scaled_skips_cooldown():
+    config = cfg(cooldown=120.0)
+    state = st8(queue=4, last_scaled=None, now=1000.0)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+
+
+# ---------------------------------------------------------------------------
+# Reap detail tests
+# ---------------------------------------------------------------------------
+
+def test_reap_targets_stale_members_only():
+    config = cfg(stale=300.0)
+    state = st8(queue=0, now=1000.0)
+    members = [
+        make_member("m-stale", "T1", joined_at=100.0, last_heartbeat=100.0, status="active"),
+        active("m-fresh", "T2", joined=900.0, heartbeat=990.0),
+    ]
+    result = decide(config, state, members)
+    assert result.action == "reap"
+    assert result.targets == ["m-stale"]
+
+
+def test_reap_member_with_no_heartbeat_uses_joined_at():
+    config = cfg(stale=300.0)
+    state = st8(queue=0, now=1000.0)
+    members = [
+        make_member("m-no-hb", "T1", joined_at=100.0, last_heartbeat=None, status="active"),
+    ]
+    result = decide(config, state, members)
+    assert result.action == "reap"
+    assert "m-no-hb" in result.targets
+
+
+def test_fresh_member_no_heartbeat_not_reaped():
+    config = cfg(stale=300.0)
+    state = st8(queue=0, now=1000.0)
+    members = [
+        make_member("m-new", "T1", joined_at=800.0, last_heartbeat=None, status="active"),
+    ]
+    result = decide(config, state, members)
+    assert result.action != "reap"
+
+
+# ---------------------------------------------------------------------------
+# Scale-down detail tests
+# ---------------------------------------------------------------------------
+
+def test_scale_down_targets_oldest_first():
+    config = cfg(min_workers=1, max_workers=4, policy="queue_aware")
+    state = st8(queue=0, now=1000.0)  # target = min=1, current=3 → scale_down 2
+    members = [
+        active("m-old", "T1", joined=700.0, heartbeat=990.0),
+        active("m-mid", "T2", joined=800.0, heartbeat=990.0),
+        active("m-new", "T3", joined=900.0, heartbeat=990.0),
+    ]
+    result = decide(config, state, members)
+    assert result.action == "scale_down"
+    assert result.delta == -2
+    # oldest two should be targeted
+    assert "m-old" in result.targets
+    assert "m-mid" in result.targets
+    assert "m-new" not in result.targets
+
+
+def test_scale_down_reason_contains_target():
+    config = cfg(min_workers=1, max_workers=4, policy="queue_aware")
+    state = st8(queue=0, now=1000.0)
+    members = [active("m-1", "T1"), active("m-2", "T2")]
+    result = decide(config, state, members)
+    assert result.action == "scale_down"
+    assert "target=" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Queue-aware scaling calculations
+# ---------------------------------------------------------------------------
+
+def test_queue_aware_ceil_div():
+    config = cfg(min_workers=1, max_workers=8, policy="queue_aware")
+    state = st8(queue=5, now=1000.0)
+    result = decide(config, state, [])
+    # ceil(5/2) = 3 → scale_up +3
+    assert result.action == "scale_up"
+    assert result.delta == 3
+
+
+def test_queue_aware_clamped_to_max():
+    config = cfg(min_workers=1, max_workers=3, policy="queue_aware")
+    state = st8(queue=100, now=1000.0)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+    assert result.delta == 3  # target=3 (max), current=0
+
+
+def test_queue_aware_clamped_to_min_when_queue_zero():
+    config = cfg(min_workers=2, max_workers=6, policy="queue_aware")
+    state = st8(queue=0, now=1000.0)
+    result = decide(config, state, [])
+    # target = min=2 (queue=0 uses min_workers), current=0 → scale_up +2
+    assert result.action == "scale_up"
+    assert result.delta == 2
+
+
+# ---------------------------------------------------------------------------
+# Unknown policy
+# ---------------------------------------------------------------------------
+
+def test_unknown_policy_returns_noop():
+    config = cfg(policy="nonexistent_policy_xyz")
+    state = st8(queue=4, now=1000.0)
+    result = decide(config, state, [])
+    assert result.action == "noop"
+    assert "unknown" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Non-active members are excluded from decisions
+# ---------------------------------------------------------------------------
+
+def test_pending_members_not_counted_as_active():
+    config = cfg(min_workers=1, max_workers=4, policy="queue_aware")
+    state = st8(queue=0, now=1000.0)
+    members = [
+        make_member("m-pending", "T1", status="pending", joined_at=990.0),
+    ]
+    # pending member not counted → current=0 → target=min=1 → scale_up
+    result = decide(config, state, members)
+    assert result.action == "scale_up"
+    assert result.delta == 1
+
+
+def test_reaped_members_excluded():
+    config = cfg(min_workers=1, max_workers=4, policy="queue_aware")
+    state = st8(queue=0, now=1000.0)
+    members = [
+        make_member("m-reaped", "T1", status="reaped", joined_at=500.0, last_heartbeat=100.0),
+        active("m-active", "T2", joined=900.0, heartbeat=990.0),
+    ]
+    result = decide(config, state, members)
+    assert result.action == "noop"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def test_ceil_div_basic():
+    assert _ceil_div(4, 2) == 2
+    assert _ceil_div(5, 2) == 3
+    assert _ceil_div(1, 2) == 1
+    assert _ceil_div(0, 2) == 0
+
+
+def test_is_stale_with_heartbeat():
+    m = make_member(last_heartbeat=600.0, joined_at=500.0)
+    assert _is_stale(m, now=1000.0, threshold=300.0) is True
+    assert _is_stale(m, now=1000.0, threshold=500.0) is False
+
+
+def test_is_stale_without_heartbeat():
+    m = make_member(last_heartbeat=None, joined_at=600.0)
+    assert _is_stale(m, now=1000.0, threshold=300.0) is True
+    m2 = make_member(last_heartbeat=None, joined_at=900.0)
+    assert _is_stale(m2, now=1000.0, threshold=300.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property test: min ≤ current + delta ≤ max
+# ---------------------------------------------------------------------------
+
+_valid_providers = st.sampled_from(["claude", "codex", "gemini"])
+
+
+@settings(max_examples=200)
+@given(
+    min_w=st.integers(min_value=0, max_value=5),
+    max_w=st.integers(min_value=0, max_value=10),
+    current=st.integers(min_value=0, max_value=12),
+    queue=st.integers(min_value=0, max_value=20),
+    policy=st.sampled_from(["fixed", "queue_aware"]),
+    cooldown=st.floats(min_value=0.0, max_value=200.0, allow_nan=False, allow_infinity=False),
+    elapsed_since_scale=st.floats(min_value=0.0, max_value=300.0, allow_nan=False, allow_infinity=False),
+    has_last_scaled=st.booleans(),
+)
+def test_decision_invariant_delta_respects_bounds(
+    min_w, max_w, current, queue, policy, cooldown, elapsed_since_scale, has_last_scaled
+):
+    assume(max_w >= min_w)
+    assume(current <= 12)
+
+    now = 1000.0
+    last_scaled = (now - elapsed_since_scale) if has_last_scaled else None
+
+    config = PoolConfig(
+        pool_id="test",
+        min_workers=min_w,
+        max_workers=max_w,
+        scaling_policy=policy,
+        provider_mix=["claude"],
+        cooldown_seconds=cooldown,
+        heartbeat_stale_seconds=300.0,
+    )
+
+    # Build active members with fresh heartbeats (no stale => no reap path)
+    members = [
+        Membership(
+            membership_id=f"m-{i}",
+            terminal_id=f"T{i}",
+            provider="claude",
+            pool_role="backend-developer",
+            status="active",
+            joined_at=now - 10,
+            last_heartbeat=now - 5,
+        )
+        for i in range(min(current, max_w + 2))
+    ]
+    actual_current = len(members)
+
+    state = PoolState(queue_depth=queue, last_scaled_at=last_scaled, now=now)
+    result = decide(config, state, members)
+
+    if result.action in ("scale_up", "scale_down"):
+        projected = actual_current + result.delta
+        assert projected >= min_w, (
+            f"projected={projected} < min_workers={min_w} "
+            f"(action={result.action} delta={result.delta} current={actual_current})"
+        )
+        assert projected <= max_w, (
+            f"projected={projected} > max_workers={max_w} "
+            f"(action={result.action} delta={result.delta} current={actual_current})"
+        )

--- a/tests/test_pool_manager_integration.py
+++ b/tests/test_pool_manager_integration.py
@@ -412,3 +412,68 @@ def test_scale_down_releases_membership(tmp_path):
 
     if result.decision.action == "scale_down":
         assert released > 0, "Expected released rows after scale_down"
+
+
+# ---------------------------------------------------------------------------
+# 12. Cooldown NOT advanced when all spawns fail (codex R1 regression)
+# ---------------------------------------------------------------------------
+
+def test_cooldown_not_advanced_on_failed_spawn(tmp_path):
+    """Failed spawn must NOT advance the cooldown anchor.
+
+    Before the fix, record_decision() updated last_scaled_at on any scale_up
+    decision — even when all spawns failed. This blocked retry until cooldown
+    expired. The fix makes record_decision() pure audit; only update_last_scaled_at()
+    (gated on result.spawned) may advance the anchor.
+    """
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=2, max_workers=4, cooldown_seconds=300
+    )
+
+    sentinel = "2026-01-01T00:00:00.000000Z"
+    conn = sqlite3.connect(str(db))
+    conn.execute(f"UPDATE worker_pools SET last_scaled_at='{sentinel}'")
+    conn.commit()
+    conn.close()
+
+    mgr = _make_manager(db, spawn_fn=_always_fail)
+    result = mgr.tick()
+
+    assert len(result.spawned) == 0, "No workers should have been spawned"
+    assert len(result.errors) > 0, "Expected spawn errors"
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute("SELECT last_scaled_at FROM worker_pools").fetchone()
+    conn.close()
+
+    assert row[0] == sentinel, (
+        f"last_scaled_at must not advance when all spawns fail; got {row[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13. Cooldown IS advanced when spawn succeeds
+# ---------------------------------------------------------------------------
+
+def test_cooldown_advanced_on_successful_spawn(tmp_path):
+    """Successful spawn must advance the cooldown anchor."""
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=2, max_workers=4, cooldown_seconds=0
+    )
+
+    sentinel = "2026-01-01T00:00:00.000000Z"
+    conn = sqlite3.connect(str(db))
+    conn.execute(f"UPDATE worker_pools SET last_scaled_at='{sentinel}'")
+    conn.commit()
+    conn.close()
+
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    if result.spawned:
+        conn = sqlite3.connect(str(db))
+        row = conn.execute("SELECT last_scaled_at FROM worker_pools").fetchone()
+        conn.close()
+        assert row[0] != sentinel, (
+            "last_scaled_at should advance after successful spawn"
+        )

--- a/tests/test_pool_manager_integration.py
+++ b/tests/test_pool_manager_integration.py
@@ -1,0 +1,414 @@
+"""test_pool_manager_integration.py — Integration tests for PoolManager.
+
+Uses real SQLite file-backed DBs via tmp_path (PoolStateRepository._connect()
+opens/closes per-call, so in-memory shared connections don't work here).
+Spawn function is mocked to avoid subprocess side-effects.
+
+Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import List
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_manager import ExecResult, PoolManager, SpawnResult  # noqa: E402
+from pool_state_fixtures import (  # noqa: E402
+    _BASE_SCHEMA,
+    create_test_db_file,
+    insert_lease,
+    insert_membership,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _always_succeed(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+    return SpawnResult(terminal_id=terminal_id, success=True)
+
+
+def _always_fail(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+    return SpawnResult(terminal_id=terminal_id, success=False, error="mock spawn error")
+
+
+def _make_manager(
+    db_path: Path,
+    project_id: str = "vnx-dev",
+    pool_id: str = "default",
+    spawn_fn=None,
+) -> PoolManager:
+    return PoolManager(
+        project_id=project_id,
+        pool_id=pool_id,
+        db_path=db_path,
+        spawn_fn=spawn_fn or _always_succeed,
+    )
+
+
+def _active_count(db_path: Path, project_id: str = "vnx-dev") -> int:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT COUNT(*) FROM worker_pool_membership WHERE project_id=? AND released_at IS NULL",
+        (project_id,),
+    ).fetchone()
+    conn.close()
+    return row[0]
+
+
+def _last_decision(db_path: Path, project_id: str = "vnx-dev") -> dict:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT last_decision_json FROM worker_pools WHERE project_id=?",
+        (project_id,),
+    ).fetchone()
+    conn.close()
+    if row and row[0]:
+        return json.loads(row[0])
+    return {}
+
+
+def _insert_lease_file(
+    db_path: Path,
+    terminal_id: str,
+    project_id: str = "vnx-dev",
+    last_heartbeat_at=None,
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO terminal_leases
+            (terminal_id, project_id, state, lease_token, last_heartbeat_at)
+        VALUES (?, ?, 'idle', '', ?)
+        """,
+        (terminal_id, project_id, last_heartbeat_at),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_membership_file(
+    db_path: Path,
+    terminal_id: str,
+    project_id: str = "vnx-dev",
+    pool_id: str = "default",
+    provider: str = "claude",
+    role: str = "backend-developer",
+    joined_at: str = "2026-05-01T00:00:00.000000Z",
+    membership_id: str = None,
+) -> str:
+    import uuid as _uuid
+    mid = membership_id or str(_uuid.uuid4())
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO worker_pool_membership
+            (terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (terminal_id, project_id, pool_id, provider, role, joined_at,
+         json.dumps({"membership_id": mid})),
+    )
+    conn.commit()
+    conn.close()
+    return mid
+
+
+# ---------------------------------------------------------------------------
+# 1. Tick records decision in DB
+# ---------------------------------------------------------------------------
+
+def test_tick_records_decision_in_db(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+    mgr = _make_manager(db)
+    mgr.tick()
+
+    d = _last_decision(db)
+    assert "action" in d
+    assert d["action"] in ("scale_up", "scale_down", "noop", "reap")
+    assert "decision_id" in d
+    assert "recorded_at" in d
+
+
+# ---------------------------------------------------------------------------
+# 2. Tick inserts membership on successful spawn
+# ---------------------------------------------------------------------------
+
+def test_tick_inserts_membership_on_successful_spawn(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=2, max_workers=4, cooldown_seconds=0
+    )
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+
+    before = _active_count(db)
+    mgr.tick()
+    after = _active_count(db)
+
+    assert after >= before + 1, (
+        f"Expected membership rows to grow; before={before} after={after}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Tick skips membership on spawn failure
+# ---------------------------------------------------------------------------
+
+def test_tick_skips_membership_on_spawn_failure(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=2, max_workers=4, cooldown_seconds=0
+    )
+    mgr = _make_manager(db, spawn_fn=_always_fail)
+
+    mgr.tick()
+
+    count = _active_count(db)
+    assert count == 0, f"No membership rows should be inserted on spawn failure; got {count}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Tick marks reaped in DB
+# ---------------------------------------------------------------------------
+
+def test_tick_marks_reaped_in_db(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+
+    # Insert a stale lease + membership (heartbeat 900s ago, threshold default=300s)
+    _insert_lease_file(db, "T-stale", last_heartbeat_at="2026-01-01T00:00:00.000000Z")
+    _insert_membership_file(
+        db, "T-stale",
+        joined_at="2026-01-01T00:00:00.000000Z",
+    )
+
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    conn = sqlite3.connect(str(db))
+    reaped = conn.execute(
+        "SELECT released_at FROM worker_pool_membership WHERE released_at IS NOT NULL"
+    ).fetchall()
+    conn.close()
+
+    assert len(reaped) >= 1, "Expected at least one reaped row"
+
+
+# ---------------------------------------------------------------------------
+# 5. Partial spawn failure — per-target outcome tracking
+# ---------------------------------------------------------------------------
+
+def test_partial_spawn_failure_reports_per_target_outcome(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=3, max_workers=6, cooldown_seconds=0
+    )
+
+    call_count = 0
+
+    def partial_spawn(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return SpawnResult(terminal_id=terminal_id, success=True)
+        return SpawnResult(terminal_id=terminal_id, success=False, error="rate limit")
+
+    mgr = _make_manager(db, spawn_fn=partial_spawn)
+    result = mgr.tick()
+
+    assert len(result.spawned) == 1
+    assert len(result.errors) == 2
+    assert _active_count(db) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Cooldown anchor not updated on noop
+# ---------------------------------------------------------------------------
+
+def test_cooldown_anchor_not_updated_on_noop(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+
+    # Seed a single active worker so pool is at min (queue_aware with queue=0 → noop)
+    _insert_lease_file(db, "T1", last_heartbeat_at="2026-05-16T00:00:00.000000Z")
+    _insert_membership_file(db, "T1", joined_at="2026-05-01T00:00:00.000000Z")
+
+    # Manually set last_scaled_at to sentinel
+    conn = sqlite3.connect(str(db))
+    conn.execute("UPDATE worker_pools SET last_scaled_at='2026-01-01T00:00:00.000000Z'")
+    conn.commit()
+    conn.close()
+
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    if result.decision.action == "noop":
+        conn = sqlite3.connect(str(db))
+        row = conn.execute("SELECT last_scaled_at FROM worker_pools").fetchone()
+        conn.close()
+        assert row[0] == "2026-01-01T00:00:00.000000Z", (
+            "last_scaled_at should not change on noop"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Cooldown anchor updated on spawn
+# ---------------------------------------------------------------------------
+
+def test_cooldown_anchor_updated_on_spawn(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=2, max_workers=4, cooldown_seconds=0
+    )
+
+    conn = sqlite3.connect(str(db))
+    before_row = conn.execute("SELECT last_scaled_at FROM worker_pools").fetchone()
+    before = before_row[0]
+    conn.close()
+
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    conn = sqlite3.connect(str(db))
+    after_row = conn.execute("SELECT last_scaled_at FROM worker_pools").fetchone()
+    after = after_row[0]
+    conn.close()
+
+    if result.spawned:
+        assert after != before, "last_scaled_at should update when workers are spawned"
+
+
+# ---------------------------------------------------------------------------
+# 8. Concurrent ticks don't double-scale
+# ---------------------------------------------------------------------------
+
+def test_concurrent_ticks_dont_double_scale(tmp_path):
+    db = tmp_path / "concurrent.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_BASE_SCHEMA)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO pool_config
+            (project_id, pool_id, min_workers, max_workers, target_workers,
+             scale_policy, cooldown_seconds, provider_mix_json)
+        VALUES ('vnx-dev', 'default', 0, 4, 2, 'queue_aware', 120, '["claude"]')
+        """
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO worker_pools (project_id, pool_id) VALUES ('vnx-dev', 'default')"
+    )
+    conn.commit()
+    conn.close()
+
+    spawned_ids: List[str] = []
+    lock = threading.Lock()
+
+    def spawn_fn(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+        with lock:
+            spawned_ids.append(terminal_id)
+        return SpawnResult(terminal_id=terminal_id, success=True)
+
+    errors: List[Exception] = []
+
+    def run_tick():
+        try:
+            mgr = PoolManager(
+                project_id="vnx-dev",
+                pool_id="default",
+                db_path=db,
+                spawn_fn=spawn_fn,
+            )
+            mgr.tick()
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=run_tick)
+    t2 = threading.Thread(target=run_tick)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    count = _active_count(db)
+    assert count <= 4, f"Too many members spawned concurrently: {count}"
+
+
+# ---------------------------------------------------------------------------
+# 9. Noop produces no spawns and no reaps
+# ---------------------------------------------------------------------------
+
+def test_noop_decision_results_in_no_spawns_no_reaps(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+    _insert_lease_file(db, "T1", last_heartbeat_at="2026-05-16T00:00:00.000000Z")
+    _insert_membership_file(db, "T1", joined_at="2026-05-01T00:00:00.000000Z")
+
+    before = _active_count(db)
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    after = _active_count(db)
+    if result.decision.action == "noop":
+        assert after == before
+
+
+# ---------------------------------------------------------------------------
+# 10. Record_decision stores action field
+# ---------------------------------------------------------------------------
+
+def test_record_decision_stores_action(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    mgr.tick()
+
+    d = _last_decision(db)
+    assert d.get("action") in ("scale_up", "scale_down", "noop", "reap")
+
+
+# ---------------------------------------------------------------------------
+# 11. Scale down releases membership rows
+# ---------------------------------------------------------------------------
+
+def test_scale_down_releases_membership(tmp_path):
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0
+    )
+
+    for i in range(3):
+        _insert_lease_file(db, f"T{i}", last_heartbeat_at="2026-05-16T00:00:00.000000Z")
+        _insert_membership_file(
+            db, f"T{i}",
+            joined_at=f"2026-05-0{i+1}T00:00:00.000000Z",
+        )
+
+    mgr = _make_manager(db, spawn_fn=_always_succeed)
+    result = mgr.tick()
+
+    conn = sqlite3.connect(str(db))
+    released = conn.execute(
+        "SELECT COUNT(*) FROM worker_pool_membership WHERE released_at IS NOT NULL"
+    ).fetchone()[0]
+    conn.close()
+
+    if result.decision.action == "scale_down":
+        assert released > 0, "Expected released rows after scale_down"

--- a/tests/test_pool_state_repo.py
+++ b/tests/test_pool_state_repo.py
@@ -1,0 +1,177 @@
+"""test_pool_state_repo.py — Unit tests for PoolStateRepository.
+
+Covers NDJSON ledger emission (ADR-005) for membership mutations.
+
+Wave 6 PR-6.3 — codex R1 fix.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_state_repo import PoolStateRepository  # noqa: E402
+from pool_state_fixtures import create_test_db_file  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_repo(db_path: Path, project_id: str = "vnx-dev") -> PoolStateRepository:
+    return PoolStateRepository(db_path, project_id)
+
+
+def _read_ledger_events(db_path: Path) -> list:
+    """Read all events from pool_events.ndjson next to db_path."""
+    events_file = db_path.parent.parent / "events" / "pool_events.ndjson"
+    if not events_file.exists():
+        return []
+    events = []
+    for line in events_file.read_text().splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# 1. add_member emits pool.member.added ledger event
+# ---------------------------------------------------------------------------
+
+def test_add_member_emits_ledger_event(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    now = time.time()
+    membership_id = repo.add_member("default", "T-test-01", "claude", "backend-developer", now)
+
+    events = _read_ledger_events(db)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event_type"] == "pool.member.added"
+    assert ev["payload"]["membership_id"] == membership_id
+    assert ev["payload"]["terminal_id"] == "T-test-01"
+    assert ev["payload"]["pool_id"] == "default"
+    assert ev["payload"]["provider"] == "claude"
+    assert ev["payload"]["role"] == "backend-developer"
+    assert "timestamp" in ev
+
+
+# ---------------------------------------------------------------------------
+# 2. mark_member_reaped emits pool.member.reaped ledger event
+# ---------------------------------------------------------------------------
+
+def test_mark_reaped_emits_ledger_event(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    now = time.time()
+    membership_id = repo.add_member("default", "T-test-02", "claude", "backend-developer", now)
+
+    # Clear the add event so we can isolate the reap event
+    events_file = db.parent.parent / "events" / "pool_events.ndjson"
+    events_file.write_bytes(b"")
+
+    repo.mark_member_reaped(membership_id, "scale_down", now + 1)
+
+    events = _read_ledger_events(db)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event_type"] == "pool.member.reaped"
+    assert ev["payload"]["membership_id"] == membership_id
+    assert ev["payload"]["reason"] == "scale_down"
+    assert "timestamp" in ev
+
+
+# ---------------------------------------------------------------------------
+# 3. add_member + mark_reaped both emit — two events in sequence
+# ---------------------------------------------------------------------------
+
+def test_add_then_reap_emits_two_events(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    now = time.time()
+    mid = repo.add_member("default", "T-seq-01", "claude", "backend-developer", now)
+    repo.mark_member_reaped(mid, "heartbeat_stale", now + 5)
+
+    events = _read_ledger_events(db)
+    assert len(events) == 2
+    assert events[0]["event_type"] == "pool.member.added"
+    assert events[1]["event_type"] == "pool.member.reaped"
+
+
+# ---------------------------------------------------------------------------
+# 4. Ledger file is created on first emit (no pre-existing file required)
+# ---------------------------------------------------------------------------
+
+def test_ledger_file_created_on_first_emit(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    events_file = db.parent.parent / "events" / "pool_events.ndjson"
+
+    assert not events_file.exists(), "Ledger file should not exist yet"
+
+    repo = _make_repo(db)
+    repo.add_member("default", "T-new", "claude", "backend-developer", time.time())
+
+    assert events_file.exists(), "Ledger file should be created after first emit"
+
+
+# ---------------------------------------------------------------------------
+# 5. Ledger atomic-append: concurrent writers produce valid NDJSON
+# ---------------------------------------------------------------------------
+
+def test_ledger_file_atomic_append(tmp_path):
+    """Concurrent add_member calls must each produce exactly one valid JSON line."""
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+
+    errors: list = []
+    barrier = threading.Barrier(4)
+
+    def add_one(terminal_id: str) -> None:
+        try:
+            barrier.wait()  # all threads start simultaneously
+            repo = _make_repo(db)
+            repo.add_member("default", terminal_id, "claude", "backend-developer", time.time())
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=add_one, args=(f"T-concurrent-{i}",))
+        for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"Concurrent emit errors: {errors}"
+
+    events = _read_ledger_events(db)
+    # Each thread emits one add event; SQLite unique index on (terminal_id, project_id)
+    # may reject duplicates, but each successful DB write must produce a ledger line.
+    add_events = [e for e in events if e["event_type"] == "pool.member.added"]
+    # Verify every event is valid JSON with required fields
+    for ev in add_events:
+        assert "event_type" in ev
+        assert "timestamp" in ev
+        assert "payload" in ev


### PR DESCRIPTION
## Summary

- **pool_decision_engine.py** — Pure decision functions (no I/O): `fixed` + `queue_aware` scaling policies, stale-heartbeat reap, cooldown guard, clamped delta. Fully testable without any DB.
- **pool_state_repo.py** — SQLite repository for schema v14 tables (`pool_config`, `worker_pools`, `worker_pool_membership`). All writes use `BEGIN IMMEDIATE`. UUID v7 for `membership_id` and `decision_id`.
- **pool_manager.py** — `tick()` orchestrator: `load_state → decide → execute → record_decision`. Per-target spawn outcome tracking; membership rows only inserted on successful spawn.

## Architecture references

- ADR-018 (elastic worker pool design freeze)
- Wave 6 workers=N architecture doc `claudedocs/wave6-workers-n-architecture.md` §PR-6.3
- Depends on PR-6.2 schema v14 tables (migration 0020)

## Test results

```
37 passed in 0.37s
- 26 unit tests (test_pool_decision_engine.py): 8 table-driven state combinations + Hypothesis property invariant (200 examples)
- 11 integration tests (test_pool_manager_integration.py): file-backed SQLite, mocked spawn_fn
```

## Test plan

- [ ] All 37 tests pass locally
- [ ] ADR-003 SDK import scan passes (`test_adr_003_no_sdk_imports.py`)
- [ ] No TODO/FIXME in new files
- [ ] `BEGIN IMMEDIATE` on all writes verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)