### PR TITLE
feat(wave6): PR-6.4 — pluggable scaling policies (queue_depth_v1 + cost_aware_v1)

### DIFF
--- a/scripts/lib/cost_tracker.py
+++ b/scripts/lib/cost_tracker.py
@@ -20,7 +20,7 @@ def recent_cost_per_hour(
 ) -> float:
     """Estimate hourly cost based on recent receipts.
 
-    Reads .vnx-data/state/t0_receipts.ndjson (last ~200 lines), filters by
+    Reads t0_receipts.ndjson from VNX_STATE_DIR (last ~200 lines), filters by
     timestamp window and provider, then computes avg cost_usd per dispatch
     multiplied by estimated dispatches/hour per worker.
 

--- a/scripts/lib/cost_tracker.py
+++ b/scripts/lib/cost_tracker.py
@@ -1,0 +1,108 @@
+"""cost_tracker — Read recent dispatch costs from t0_receipts.ndjson.
+
+Used by cost_aware scaling policy to estimate hourly burn rate.
+Reads only the last N receipts (default 200) for performance.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List
+
+
+def recent_cost_per_hour(
+    workers: int,
+    provider_mix: List[str],
+    window_minutes: int = 60,
+) -> float:
+    """Estimate hourly cost based on recent receipts.
+
+    Reads .vnx-data/state/t0_receipts.ndjson (last ~200 lines), filters by
+    timestamp window and provider, then computes avg cost_usd per dispatch
+    multiplied by estimated dispatches/hour per worker.
+
+    Returns 0.0 if receipt file is absent or empty.
+    """
+    receipts_path = _resolve_receipts_path()
+    if not receipts_path.exists():
+        return 0.0
+
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=window_minutes)
+
+    costs_by_provider: Dict[str, List[float]] = {}
+    for line in _read_last_lines(receipts_path, n=200):
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        cost = r.get("cost_usd")
+        if cost is None:
+            continue
+
+        raw_ts = r.get("timestamp", "")
+        try:
+            ts = datetime.fromisoformat(raw_ts.rstrip("Z")).replace(tzinfo=timezone.utc)
+        except (ValueError, AttributeError):
+            continue
+
+        if ts < cutoff:
+            continue
+
+        provider = (r.get("provider") or "claude")
+        costs_by_provider.setdefault(provider, []).append(float(cost))
+
+    if not costs_by_provider:
+        return 0.0
+
+    avg_costs = {p: sum(cs) / len(cs) for p, cs in costs_by_provider.items()}
+
+    DISPATCHES_PER_HOUR = 6.0
+    distribution = _distribute_workers(workers, provider_mix or ["claude"] * workers)
+
+    hourly = 0.0
+    fallback_avg = avg_costs.get("claude", 0.0)
+    for provider, count in distribution.items():
+        avg_cost = avg_costs.get(provider, fallback_avg)
+        hourly += avg_cost * DISPATCHES_PER_HOUR * count
+
+    return hourly
+
+
+def _resolve_receipts_path() -> Path:
+    """Resolve path via VNX_STATE_DIR or default."""
+    state_dir = os.environ.get("VNX_STATE_DIR", ".vnx-data/state")
+    return Path(state_dir) / "t0_receipts.ndjson"
+
+
+def _read_last_lines(path: Path, n: int) -> List[str]:
+    """Read last N non-empty lines efficiently."""
+    with path.open("rb") as f:
+        f.seek(0, 2)
+        end_pos = f.tell()
+        if end_pos == 0:
+            return []
+
+        # Estimate: NDJSON receipt lines average ~400 bytes; read enough to hold n lines.
+        read_bytes = min(end_pos, n * 400)
+        f.seek(end_pos - read_bytes)
+        raw = f.read(read_bytes).decode("utf-8", errors="replace")
+        lines = raw.splitlines()
+
+        # Drop potentially partial first line when we didn't start from file beginning.
+        if end_pos > read_bytes:
+            lines = lines[1:]
+
+        return [ln for ln in lines[-n:] if ln.strip()]
+
+
+def _distribute_workers(total: int, mix: List[str]) -> Dict[str, int]:
+    """Distribute workers over provider mix round-robin."""
+    distribution: Dict[str, int] = {}
+    for i in range(total):
+        provider = mix[i % len(mix)]
+        distribution[provider] = distribution.get(provider, 0) + 1
+    return distribution

--- a/scripts/lib/pool_decision_engine.py
+++ b/scripts/lib/pool_decision_engine.py
@@ -4,13 +4,21 @@ No SQLite, no filesystem, no subprocess. Pure functions over PoolState +
 PoolConfig + Membership list. Returns PoolDecision.
 
 Wave 6 PR-6.3 — ADR-018 elastic worker pool.
+Wave 6 PR-6.4 — Pluggable policy registry via pool_scaling_policies.
 """
 
 from __future__ import annotations
 
 import math
+import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Literal, Optional
+
+# Ensure pool_scaling_policies sub-package is importable.
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
 
 
 @dataclass(frozen=True)
@@ -18,10 +26,11 @@ class PoolConfig:
     pool_id: str
     min_workers: int
     max_workers: int
-    scaling_policy: str          # "fixed" | "queue_aware"
+    scaling_policy: str          # "fixed" | "queue_aware" | "queue_depth_v1" | "cost_aware_v1"
     provider_mix: List[str]      # e.g. ["claude", "claude", "litellm:deepseek"]
     cooldown_seconds: float = 60.0
     heartbeat_stale_seconds: float = 300.0
+    cost_ceiling_usd: Optional[float] = None  # used by cost_aware_v1
 
 
 @dataclass(frozen=True)
@@ -61,9 +70,11 @@ def decide(
     Evaluation order:
     1. Stale heartbeats -> reap with targets
     2. Cooldown active -> noop with cooldown_remaining
-    3. Scaling policy: fixed | queue_aware
-    4. Clamp delta to [min - current, max - current]
+    3. Policy registry lookup (fixed | queue_aware | queue_depth_v1 | cost_aware_v1)
+    4. Compute delta and return scale_up / scale_down / noop
     """
+    from pool_scaling_policies import POLICIES  # lazy import avoids circular dep
+
     active = [m for m in members if m.status == "active"]
     current = len(active)
 
@@ -88,12 +99,14 @@ def decide(
                 cooldown_remaining_s=remaining,
             )
 
-    target = _compute_target(config, state)
-    if target is None:
+    policy_fn = POLICIES.get(config.scaling_policy)
+    if policy_fn is None:
         return PoolDecision(
             action="noop",
-            reason=f"unknown scaling policy: {config.scaling_policy}",
+            reason=f"unknown policy: {config.scaling_policy}",
         )
+
+    target = policy_fn(config, state, members)
 
     delta = target - current
     if delta > 0:
@@ -112,15 +125,6 @@ def decide(
             targets=targets,
         )
     return PoolDecision(action="noop", reason="at target")
-
-
-def _compute_target(config: PoolConfig, state: PoolState) -> Optional[int]:
-    if config.scaling_policy == "fixed":
-        return config.min_workers
-    if config.scaling_policy == "queue_aware":
-        raw = _ceil_div(state.queue_depth, 2) if state.queue_depth > 0 else config.min_workers
-        return max(config.min_workers, min(raw, config.max_workers))
-    return None
 
 
 def _is_stale(member: Membership, now: float, threshold: float) -> bool:

--- a/scripts/lib/pool_scaling_policies/__init__.py
+++ b/scripts/lib/pool_scaling_policies/__init__.py
@@ -1,0 +1,27 @@
+"""pool_scaling_policies — Pluggable scaling policies for elastic worker pools.
+
+Policy interface: pure function (config, state, members) -> target_size.
+Registered policies looked up by name in decide().
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure scripts/lib is importable from within this sub-package.
+_LIB_DIR = str(Path(__file__).resolve().parent.parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from .queue_depth_v1 import queue_depth_v1  # noqa: E402
+from .cost_aware_v1 import cost_aware_v1    # noqa: E402
+
+POLICIES = {
+    "fixed": lambda cfg, st, m: cfg.min_workers,
+    "queue_depth_v1": queue_depth_v1,
+    "queue_aware": queue_depth_v1,   # backward-compat alias for PR-6.3
+    "cost_aware_v1": cost_aware_v1,
+}
+
+__all__ = ["POLICIES", "queue_depth_v1", "cost_aware_v1"]

--- a/scripts/lib/pool_scaling_policies/cost_aware_v1.py
+++ b/scripts/lib/pool_scaling_policies/cost_aware_v1.py
@@ -1,0 +1,66 @@
+"""cost_aware_v1 — Queue-aware scaling with cost ceiling.
+
+Falls back to current size if estimated hourly cost would exceed pool_config.cost_ceiling_usd.
+Reads cost data from scripts/lib/cost_tracker.py (which reads from t0_receipts.ndjson per PR-7.6).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List
+
+from .queue_depth_v1 import queue_depth_v1
+
+if TYPE_CHECKING:
+    from pool_decision_engine import Membership, PoolConfig, PoolState
+
+log = logging.getLogger(__name__)
+
+
+def cost_aware_v1(config: "PoolConfig", state: "PoolState", members: "List[Membership]") -> int:
+    """Returns queue_depth_v1 target, clamped by cost ceiling.
+
+    Only blocks scale-UP events. Scale-down is never blocked.
+    When no ceiling is defined or cost_tracker fails, behaves identically to queue_depth_v1.
+    """
+    proposed_target = queue_depth_v1(config, state, members)
+    active_count = len([m for m in members if m.status == "active"])
+
+    # Scale-down never blocked by cost ceiling.
+    if proposed_target <= active_count:
+        return proposed_target
+
+    ceiling = getattr(config, "cost_ceiling_usd", None)
+    if ceiling is None or ceiling <= 0:
+        return proposed_target
+
+    estimated_hourly = _estimate_hourly_cost(
+        members, getattr(config, "provider_mix", []), proposed_target
+    )
+
+    if estimated_hourly > ceiling:
+        log.warning(
+            "cost_aware_v1: estimated_hourly=%.4f > ceiling=%.4f; holding at current=%d",
+            estimated_hourly,
+            ceiling,
+            active_count,
+        )
+        return active_count
+
+    return proposed_target
+
+
+def _estimate_hourly_cost(members: list, provider_mix: list, target_size: int) -> float:
+    """Estimate USD/hour at given pool size.
+
+    Uses recent receipts from cost_tracker for per-provider cost estimates.
+    Falls back to $0.50/hour per worker when cost_tracker is unavailable or has no data
+    (0.0 from cost_tracker means 'no receipts in window', not 'truly free').
+    """
+    conservative = target_size * 0.5
+    try:
+        from cost_tracker import recent_cost_per_hour  # type: ignore[import]
+        result = recent_cost_per_hour(target_size, provider_mix or [])
+        return result if result > 0.0 else conservative
+    except (ImportError, Exception):
+        return conservative

--- a/scripts/lib/pool_scaling_policies/queue_depth_v1.py
+++ b/scripts/lib/pool_scaling_policies/queue_depth_v1.py
@@ -1,0 +1,28 @@
+"""queue_depth_v1 — Scale based on pending dispatches.
+
+target = clamp(min_workers, ceil(queue_depth / 2), max_workers)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from pool_decision_engine import Membership, PoolConfig, PoolState
+
+
+def queue_depth_v1(config: "PoolConfig", state: "PoolState", members: "List[Membership]") -> int:
+    """Returns target pool size based on queue depth.
+
+    Args:
+        config: PoolConfig (min_workers, max_workers, etc)
+        state: PoolState (queue_depth, now, etc)
+        members: List[Membership] (active members)
+
+    Returns:
+        Target pool size (int).
+    """
+    raw_target = -(-state.queue_depth // 2)  # ceil(queue/2) without math import
+    target = max(config.min_workers, raw_target)
+    target = min(target, config.max_workers)
+    return target

--- a/tests/test_cost_aware_policy.py
+++ b/tests/test_cost_aware_policy.py
@@ -1,0 +1,324 @@
+"""test_cost_aware_policy.py — Tests for cost_aware_v1 policy and cost_tracker.
+
+Covers:
+- cost_aware_v1 cost-ceiling hold on scale-up
+- cost_aware_v1 proceeds when below ceiling
+- cost_aware_v1 never blocks scale-down
+- cost_aware_v1 with no ceiling defined
+- cost_aware_v1 with ceiling=0 (disabled)
+- recent_cost_per_hour from real NDJSON file
+- recent_cost_per_hour window filtering
+- recent_cost_per_hour with missing cost_usd fields
+- recent_cost_per_hour on empty file
+- _distribute_workers round-robin distribution
+- VNX_STATE_DIR env override for receipts path
+
+Wave 6 PR-6.4 — ADR-018 pluggable scaling policies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_decision_engine import Membership, PoolConfig, PoolState  # noqa: E402
+from pool_scaling_policies.cost_aware_v1 import cost_aware_v1      # noqa: E402
+from cost_tracker import (                                           # noqa: E402
+    recent_cost_per_hour,
+    _distribute_workers,
+    _read_last_lines,
+    _resolve_receipts_path,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures"))
+from pool_state_fixtures import make_member, make_state  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_cfg(
+    min_workers: int = 1,
+    max_workers: int = 4,
+    policy: str = "cost_aware_v1",
+    cost_ceiling: Optional[float] = None,
+    provider_mix: Optional[List[str]] = None,
+) -> PoolConfig:
+    return PoolConfig(
+        pool_id="default",
+        min_workers=min_workers,
+        max_workers=max_workers,
+        scaling_policy=policy,
+        provider_mix=provider_mix or ["claude"],
+        cooldown_seconds=0.0,
+        heartbeat_stale_seconds=300.0,
+        cost_ceiling_usd=cost_ceiling,
+    )
+
+
+def st8(queue: int = 4) -> PoolState:
+    return make_state(queue_depth=queue, last_scaled_at=None, now=1000.0)
+
+
+def n_active(n: int) -> List[Membership]:
+    return [
+        make_member(
+            membership_id=f"m-{i}",
+            terminal_id=f"T{i}",
+            status="active",
+            joined_at=900.0 + i,
+            last_heartbeat=990.0,
+        )
+        for i in range(n)
+    ]
+
+
+def _write_receipts(path: Path, receipts: List[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for r in receipts:
+            f.write(json.dumps(r) + "\n")
+
+
+def _now_iso(offset_minutes: int = 0) -> str:
+    dt = datetime.now(tz=timezone.utc) + timedelta(minutes=offset_minutes)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+# ---------------------------------------------------------------------------
+# cost_aware_v1: cost-ceiling enforcement
+# ---------------------------------------------------------------------------
+
+def test_cost_aware_holds_when_estimated_exceeds_ceiling():
+    """When estimated hourly cost exceeds ceiling, hold at current size."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=0.01)
+    state = st8(queue=4)  # queue_depth_v1 proposes target=2
+    members = n_active(1)  # current=1 → scaling UP proposed
+
+    # _estimate_hourly_cost falls back to target_size * 0.5 per worker.
+    # proposed_target=2, fallback cost=2*0.5=1.0 > ceiling=0.01 → hold at 1.
+    result = cost_aware_v1(config, state, members)
+    assert result == 1  # held at current active count
+
+
+def test_cost_aware_proceeds_when_below_ceiling():
+    """When estimated cost is within ceiling, scaling proceeds."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=100.0)
+    state = st8(queue=4)   # proposes target=2
+    members = n_active(1)  # current=1
+
+    # fallback cost=2*0.5=1.0 < ceiling=100.0 → proceed
+    result = cost_aware_v1(config, state, members)
+    assert result == 2
+
+
+def test_cost_aware_ignores_ceiling_when_scaling_down():
+    """Scale-down is never blocked, even with a tight ceiling."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=0.001)
+    state = st8(queue=0)   # target=min=1
+    members = n_active(3)  # current=3, scaling DOWN
+
+    result = cost_aware_v1(config, state, members)
+    assert result == 1  # scale-down to min, not held
+
+
+def test_cost_aware_ignores_ceiling_when_already_at_target():
+    """No hold when proposed target == current."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=0.001)
+    state = st8(queue=2)   # ceil(2/2)=1 → target=1
+    members = n_active(1)  # current=1, no change
+
+    result = cost_aware_v1(config, state, members)
+    assert result == 1  # at target, ceiling irrelevant
+
+
+def test_cost_aware_no_ceiling_behaves_like_queue_depth_v1():
+    """When cost_ceiling_usd is None, falls back to queue_depth_v1 target."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=None)
+    state = st8(queue=4)
+    members = n_active(0)
+
+    result = cost_aware_v1(config, state, members)
+    assert result == 2  # queue_depth_v1: ceil(4/2)=2
+
+
+def test_cost_aware_zero_ceiling_bypassed():
+    """cost_ceiling_usd=0 is treated as 'no ceiling defined' (disabled)."""
+    config = make_cfg(min_workers=1, max_workers=4, cost_ceiling=0.0)
+    state = st8(queue=4)
+    members = n_active(0)
+
+    result = cost_aware_v1(config, state, members)
+    assert result == 2  # ceiling=0 → disabled → queue_depth_v1 target
+
+
+# ---------------------------------------------------------------------------
+# recent_cost_per_hour: reading from NDJSON
+# ---------------------------------------------------------------------------
+
+def test_recent_cost_per_hour_returns_zero_when_file_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    result = recent_cost_per_hour(workers=2, provider_mix=["claude"])
+    assert result == 0.0
+
+
+def test_recent_cost_per_hour_returns_zero_for_empty_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipts_path.write_text("")
+    result = recent_cost_per_hour(workers=2, provider_mix=["claude"])
+    assert result == 0.0
+
+
+def test_recent_cost_per_hour_from_receipts(tmp_path, monkeypatch):
+    """Reads cost_usd from recent receipts and computes hourly estimate."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+
+    receipts = [
+        {"timestamp": _now_iso(-5),  "provider": "claude", "cost_usd": 0.10},
+        {"timestamp": _now_iso(-10), "provider": "claude", "cost_usd": 0.20},
+        {"timestamp": _now_iso(-15), "provider": "claude", "cost_usd": 0.30},
+    ]
+    _write_receipts(receipts_path, receipts)
+
+    # avg cost = (0.10 + 0.20 + 0.30) / 3 = 0.20
+    # hourly = 0.20 * 6 dispatches/hr * 1 worker = 1.20
+    result = recent_cost_per_hour(workers=1, provider_mix=["claude"])
+    assert abs(result - 1.20) < 0.01, f"expected ~1.20 got {result}"
+
+
+def test_recent_cost_per_hour_filters_by_window(tmp_path, monkeypatch):
+    """Receipts outside the window_minutes are ignored."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+
+    receipts = [
+        {"timestamp": _now_iso(-5),   "provider": "claude", "cost_usd": 0.10},  # in window
+        {"timestamp": _now_iso(-90),  "provider": "claude", "cost_usd": 9.99},  # outside 60m window
+    ]
+    _write_receipts(receipts_path, receipts)
+
+    result = recent_cost_per_hour(workers=1, provider_mix=["claude"], window_minutes=60)
+    # Only the in-window receipt counts: 0.10 * 6 = 0.60
+    assert abs(result - 0.60) < 0.01, f"expected ~0.60 got {result}"
+
+
+def test_recent_cost_per_hour_handles_missing_cost_usd(tmp_path, monkeypatch):
+    """Lines without cost_usd are silently skipped."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+
+    receipts = [
+        {"timestamp": _now_iso(-5), "provider": "claude"},                        # no cost_usd
+        {"timestamp": _now_iso(-5), "provider": "claude", "cost_usd": None},      # null
+        {"timestamp": _now_iso(-5), "provider": "claude", "cost_usd": 0.20},      # valid
+    ]
+    _write_receipts(receipts_path, receipts)
+
+    result = recent_cost_per_hour(workers=1, provider_mix=["claude"])
+    assert abs(result - 0.20 * 6.0) < 0.01
+
+
+def test_recent_cost_per_hour_multi_provider(tmp_path, monkeypatch):
+    """Per-provider averaging with a mixed provider_mix."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+
+    receipts = [
+        {"timestamp": _now_iso(-5), "provider": "claude",  "cost_usd": 0.10},
+        {"timestamp": _now_iso(-5), "provider": "codex",   "cost_usd": 0.20},
+    ]
+    _write_receipts(receipts_path, receipts)
+
+    # 1 claude worker + 1 codex worker
+    result = recent_cost_per_hour(workers=2, provider_mix=["claude", "codex"])
+    # claude: 0.10 * 6 * 1 = 0.60; codex: 0.20 * 6 * 1 = 1.20; total = 1.80
+    assert abs(result - 1.80) < 0.01, f"expected ~1.80 got {result}"
+
+
+def test_recent_cost_per_hour_state_dir_override(tmp_path, monkeypatch):
+    """VNX_STATE_DIR env var controls where receipts are read from."""
+    custom_dir = tmp_path / "custom_state"
+    monkeypatch.setenv("VNX_STATE_DIR", str(custom_dir))
+    receipts_path = custom_dir / "t0_receipts.ndjson"
+
+    receipts = [{"timestamp": _now_iso(-5), "provider": "claude", "cost_usd": 0.05}]
+    _write_receipts(receipts_path, receipts)
+
+    result = recent_cost_per_hour(workers=1, provider_mix=["claude"])
+    assert result > 0.0
+
+
+# ---------------------------------------------------------------------------
+# _distribute_workers
+# ---------------------------------------------------------------------------
+
+def test_distribute_workers_single_provider():
+    dist = _distribute_workers(3, ["claude"])
+    assert dist == {"claude": 3}
+
+
+def test_distribute_workers_round_robin_equal_split():
+    dist = _distribute_workers(4, ["claude", "codex"])
+    assert dist["claude"] == 2
+    assert dist["codex"] == 2
+
+
+def test_distribute_workers_round_robin_unequal():
+    dist = _distribute_workers(3, ["claude", "codex"])
+    assert dist["claude"] == 2
+    assert dist["codex"] == 1
+
+
+def test_distribute_workers_zero_total():
+    dist = _distribute_workers(0, ["claude"])
+    assert dist == {}
+
+
+def test_distribute_workers_three_providers():
+    dist = _distribute_workers(7, ["claude", "codex", "gemini"])
+    assert sum(dist.values()) == 7
+    assert dist["claude"] == 3    # slots 0, 3, 6
+    assert dist["codex"] == 2     # slots 1, 4
+    assert dist["gemini"] == 2    # slots 2, 5
+
+
+# ---------------------------------------------------------------------------
+# _read_last_lines
+# ---------------------------------------------------------------------------
+
+def test_read_last_lines_returns_last_n(tmp_path):
+    p = tmp_path / "test.ndjson"
+    lines = [f'{{"line": {i}}}' for i in range(50)]
+    p.write_text("\n".join(lines) + "\n")
+    result = _read_last_lines(p, n=10)
+    assert len(result) == 10
+    # Last line should be the 50th entry
+    assert '"line": 49' in result[-1]
+
+
+def test_read_last_lines_empty_file(tmp_path):
+    p = tmp_path / "empty.ndjson"
+    p.write_text("")
+    result = _read_last_lines(p, n=10)
+    assert result == []
+
+
+def test_read_last_lines_fewer_than_n(tmp_path):
+    p = tmp_path / "small.ndjson"
+    p.write_text('{"a": 1}\n{"b": 2}\n')
+    result = _read_last_lines(p, n=100)
+    assert len(result) == 2

--- a/tests/test_scaling_policies.py
+++ b/tests/test_scaling_policies.py
@@ -1,0 +1,227 @@
+"""test_scaling_policies.py — Tests for pluggable scaling policy registry.
+
+Covers: queue_depth_v1, fixed, cost_aware_v1 (no-receipt fallback),
+POLICIES registry, backward-compat alias, and decide() integration.
+
+Wave 6 PR-6.4 — ADR-018 pluggable scaling policies.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_decision_engine import Membership, PoolConfig, PoolState, decide  # noqa: E402
+from pool_scaling_policies import POLICIES, cost_aware_v1, queue_depth_v1  # noqa: E402
+from pool_scaling_policies.queue_depth_v1 import queue_depth_v1 as _q_fn  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures"))
+from pool_state_fixtures import make_config, make_member, make_state  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def cfg(
+    min_workers: int = 1,
+    max_workers: int = 4,
+    policy: str = "queue_depth_v1",
+    cost_ceiling: Optional[float] = None,
+) -> PoolConfig:
+    return PoolConfig(
+        pool_id="default",
+        min_workers=min_workers,
+        max_workers=max_workers,
+        scaling_policy=policy,
+        provider_mix=["claude"],
+        cooldown_seconds=0.0,
+        heartbeat_stale_seconds=300.0,
+        cost_ceiling_usd=cost_ceiling,
+    )
+
+
+def st8(queue: int = 0, now: float = 1000.0) -> PoolState:
+    return make_state(queue_depth=queue, last_scaled_at=None, now=now)
+
+
+def active_member(mid: str = "m-1", tid: str = "T1", joined: float = 900.0) -> Membership:
+    return make_member(membership_id=mid, terminal_id=tid, status="active",
+                       joined_at=joined, last_heartbeat=990.0)
+
+
+def n_active(n: int) -> List[Membership]:
+    return [active_member(mid=f"m-{i}", tid=f"T{i}", joined=900.0 + i)
+            for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Table-driven: pure policy function return values
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("policy,queue,current_n,min_w,max_w,expected_target", [
+    # queue_depth_v1
+    ("queue_depth_v1", 0,   1, 1, 4, 1),   # queue=0 → ceil(0/2)=0 → max(min,0)=1
+    ("queue_depth_v1", 2,   1, 1, 4, 1),   # ceil(2/2)=1 → target=1
+    ("queue_depth_v1", 3,   1, 1, 4, 2),   # ceil(3/2)=2
+    ("queue_depth_v1", 4,   1, 1, 4, 2),   # ceil(4/2)=2
+    ("queue_depth_v1", 5,   1, 1, 4, 3),   # ceil(5/2)=3
+    ("queue_depth_v1", 100, 1, 1, 4, 4),   # capped at max=4
+    ("queue_depth_v1", 0,   0, 2, 6, 2),   # queue=0 below min=2 → target=min=2
+    ("queue_depth_v1", 1,   0, 2, 6, 2),   # ceil(1/2)=1 < min=2 → target=2
+    # fixed
+    ("fixed",          0,   1, 1, 4, 1),   # always min
+    ("fixed",          100, 0, 2, 6, 2),   # always min regardless of queue
+    ("fixed",          50,  4, 3, 8, 3),   # always min=3
+    # queue_aware (alias for queue_depth_v1)
+    ("queue_aware",    4,   0, 1, 4, 2),   # alias works → ceil(4/2)=2
+    ("queue_aware",    0,   1, 1, 4, 1),   # alias at zero queue
+    # cost_aware_v1 — no receipt file, falls back to queue_depth_v1 result
+    ("cost_aware_v1",  4,   0, 1, 4, 2),
+    ("cost_aware_v1",  0,   1, 1, 4, 1),
+])
+def test_policy_returns_expected_target(
+    policy, queue, current_n, min_w, max_w, expected_target
+):
+    config = cfg(min_workers=min_w, max_workers=max_w, policy=policy)
+    state = st8(queue=queue)
+    members = n_active(current_n)
+    policy_fn = POLICIES[policy]
+    result = policy_fn(config, state, members)
+    assert result == expected_target, (
+        f"policy={policy} queue={queue} current={current_n} "
+        f"expected={expected_target} got={result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# POLICIES registry integrity
+# ---------------------------------------------------------------------------
+
+def test_policies_registry_contains_all_required_keys():
+    assert "fixed" in POLICIES
+    assert "queue_depth_v1" in POLICIES
+    assert "queue_aware" in POLICIES
+    assert "cost_aware_v1" in POLICIES
+
+
+def test_queue_aware_alias_is_same_function_as_queue_depth_v1():
+    assert POLICIES["queue_aware"] is POLICIES["queue_depth_v1"]
+
+
+def test_policies_are_callable():
+    for name, fn in POLICIES.items():
+        assert callable(fn), f"POLICIES[{name!r}] is not callable"
+
+
+# ---------------------------------------------------------------------------
+# decide() integration: policy routing via registry
+# ---------------------------------------------------------------------------
+
+def test_decide_with_queue_depth_v1_policy():
+    config = cfg(policy="queue_depth_v1", min_workers=1, max_workers=4)
+    state = st8(queue=4)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+    assert result.delta == 2  # ceil(4/2)=2, current=0
+
+
+def test_decide_with_queue_aware_alias():
+    config = cfg(policy="queue_aware", min_workers=1, max_workers=4)
+    state = st8(queue=4)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+    assert result.delta == 2
+
+
+def test_decide_with_fixed_policy():
+    config = cfg(policy="fixed", min_workers=2, max_workers=6)
+    state = st8(queue=100)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+    assert result.delta == 2  # scale up to min=2 from 0
+
+
+def test_decide_with_fixed_policy_at_min_is_noop():
+    config = cfg(policy="fixed", min_workers=1, max_workers=4)
+    state = st8(queue=100)
+    members = [active_member()]
+    result = decide(config, state, members)
+    assert result.action == "noop"
+
+
+def test_decide_with_cost_aware_v1_no_ceiling():
+    config = cfg(policy="cost_aware_v1", min_workers=1, max_workers=4)
+    state = st8(queue=4)
+    result = decide(config, state, [])
+    assert result.action == "scale_up"
+    assert result.delta == 2  # falls back to queue_depth_v1
+
+
+def test_decide_unknown_policy_returns_noop():
+    config = cfg(policy="nonexistent_xyz")
+    state = st8(queue=10)
+    result = decide(config, state, [])
+    assert result.action == "noop"
+    assert "unknown" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# queue_depth_v1 direct edge cases
+# ---------------------------------------------------------------------------
+
+def test_queue_depth_v1_queue_zero_returns_min():
+    config = cfg(min_workers=3, max_workers=8, policy="queue_depth_v1")
+    state = st8(queue=0)
+    result = _q_fn(config, state, [])
+    assert result == 3
+
+
+def test_queue_depth_v1_queue_one_rounds_up():
+    config = cfg(min_workers=1, max_workers=4, policy="queue_depth_v1")
+    state = st8(queue=1)
+    result = _q_fn(config, state, [])
+    assert result == 1  # ceil(1/2)=1 = min
+
+
+def test_queue_depth_v1_respects_max_workers():
+    config = cfg(min_workers=1, max_workers=2, policy="queue_depth_v1")
+    state = st8(queue=100)
+    result = _q_fn(config, state, [])
+    assert result == 2
+
+
+def test_queue_depth_v1_ignores_member_count_for_target():
+    config = cfg(min_workers=1, max_workers=8, policy="queue_depth_v1")
+    state = st8(queue=6)
+    members_0 = []
+    members_3 = n_active(3)
+    # Target is state-based, not current-size-based
+    assert _q_fn(config, state, members_0) == _q_fn(config, state, members_3) == 3
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: PR-6.3 queue_aware still produces identical results
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("queue,min_w,max_w", [
+    (0,   1, 4),
+    (2,   1, 4),
+    (5,   1, 4),
+    (100, 1, 4),
+    (3,   2, 6),
+])
+def test_queue_aware_and_queue_depth_v1_identical(queue, min_w, max_w):
+    state = st8(queue=queue)
+    members = []
+    cfg_qa = cfg(policy="queue_aware",    min_workers=min_w, max_workers=max_w)
+    cfg_qd = cfg(policy="queue_depth_v1", min_workers=min_w, max_workers=max_w)
+    assert POLICIES["queue_aware"](cfg_qa, state, members) == \
+           POLICIES["queue_depth_v1"](cfg_qd, state, members)


### PR DESCRIPTION
## Summary

- Extracts queue_depth_v1 from inline `decide()` into `pool_scaling_policies` package with a POLICIES registry
- Adds `cost_aware_v1` policy: queue_depth_v1 target clamped by hourly cost ceiling (reads `t0_receipts.ndjson` via `cost_tracker.py`)
- `"queue_aware"` alias preserved for backward compat with PR-6.3
- `cost_ceiling_usd: Optional[float] = None` added to `PoolConfig` (backward compatible)

## Architecture

References ADR-018 (elastic worker pool) and Wave 6 architecture doc.

**Policy interface:** `(config, state, members) -> target_size` pure function.

**POLICIES registry:**
```
fixed          → always min_workers
queue_depth_v1 → ceil(queue/2), clamped to [min, max]
queue_aware    → alias for queue_depth_v1 (PR-6.3 compat)
cost_aware_v1  → queue_depth_v1 target, blocked on scale-UP if hourly estimate > cost_ceiling_usd
```

**cost_tracker:** reads last ~200 lines of `.vnx-data/state/t0_receipts.ndjson`, averages cost_usd per provider within a configurable time window, multiplies by `6 dispatches/hr * worker_count`. Falls back to `$0.50/hr per worker` when no receipt data is available.

## Test plan

- [x] `pytest tests/test_scaling_policies.py` — 33 tests (table-driven policy values, registry integrity, decide() integration, backward-compat alias)
- [x] `pytest tests/test_cost_aware_policy.py` — 21 tests (ceiling enforcement, scale-down never blocked, cost_tracker NDJSON reading, window filtering, _distribute_workers, _read_last_lines)
- [x] `pytest tests/test_pool_decision_engine.py tests/test_pool_manager_integration.py tests/test_pool_state_repo.py` — 44 existing tests, all green (no regressions)
- [x] **Total: 98 tests green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)