### PR TITLE
feat(wave6): PR-6.5 — provider-mix per pool with lowest-share-first allocation

### DIFF
--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -28,6 +28,10 @@ from pool_decision_engine import (  # noqa: E402
     PoolState,
     decide,
 )
+from pool_provider_allocator import (  # noqa: E402
+    allocate_for_scale_up,
+    select_for_scale_down,
+)
 from pool_state_repo import PoolStateRepository  # noqa: E402
 
 log = logging.getLogger(__name__)
@@ -214,14 +218,17 @@ class PoolManager:
 
     def _execute_scale_up(self, decision: PoolDecision, now: float) -> ExecResult:
         result = ExecResult(decision=decision)
-        config, _, _ = self.load_state()
+        config, _, members = self.load_state()
 
-        for i in range(abs(decision.delta)):
+        allocation = allocate_for_scale_up(
+            members=members,
+            provider_mix=config.provider_mix,
+            delta=abs(decision.delta),
+            fallback_provider="claude",
+        )
+
+        for i, provider in enumerate(allocation.providers):
             terminal_id = f"{self.project_id}-P{int(now * 1000) % 100000}-{i}"
-            provider = self._provider_for_slot(config, i)
-            role = config.provider_mix[0] if config.provider_mix else "backend-developer"
-            # role comes from pool config role_mix; provider_mix has providers
-            # For PR-6.3, derive role from worker_registry if available
             role = _resolve_role(config, i)
 
             try:
@@ -255,8 +262,15 @@ class PoolManager:
 
     def _execute_scale_down(self, decision: PoolDecision, now: float) -> ExecResult:
         result = ExecResult(decision=decision)
+        config, _, members = self.load_state()
 
-        for membership_id in decision.targets:
+        membership_ids = select_for_scale_down(
+            members=members,
+            provider_mix=config.provider_mix,
+            delta=decision.delta,
+        )
+
+        for membership_id in membership_ids:
             try:
                 self.repo.mark_member_reaped(
                     membership_id, "scale_down", now

--- a/scripts/lib/pool_provider_allocator.py
+++ b/scripts/lib/pool_provider_allocator.py
@@ -1,0 +1,175 @@
+"""pool_provider_allocator.py — Provider-mix allocation for elastic pools.
+
+Pure function (no I/O). Given current pool members + provider_mix + target_delta,
+returns ordered list of providers for new workers.
+
+Algorithm: lowest-share-first (highest gap from target wins each slot).
+For provider_mix=["claude","claude","codex"], target=4, current=[]:
+  Allocations:
+  - claude (target=2, current=0, gap=2) -> 1st spawn
+  - claude (target=2, current=1, gap=1) -> 2nd spawn
+  - codex (target=1, current=0, gap=1) -> 3rd spawn (tie resolved by dict order)
+  - claude or codex (both at target) -> 4th spawn falls back to fallback_provider
+
+Provider-binding is immutable per worker lifetime — this module only
+decides providers for NEW workers; existing members are never reassigned.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from pool_decision_engine import Membership  # noqa: E402
+
+
+@dataclass(frozen=True)
+class AllocationResult:
+    providers: List[str]       # ordered list, len == delta for scale_up
+    fallback_used: List[str]   # providers chosen via fallback when mix saturated
+
+
+def compute_target_shares(provider_mix: List[str], pool_size: int) -> Dict[str, int]:
+    """For a pool of given size, what is the target count per provider?
+
+    Args:
+        provider_mix: e.g. ["claude", "claude", "codex"] — defines proportions
+        pool_size: total workers in pool
+
+    Returns:
+        {provider: count} summing to pool_size
+    """
+    if not provider_mix:
+        return {}
+    mix_size = len(provider_mix)
+    mix_counter = Counter(provider_mix)
+    target: Dict[str, int] = {}
+    remaining = pool_size
+    sorted_providers = sorted(mix_counter.items(), key=lambda x: -x[1])
+
+    for i, (provider, mix_count) in enumerate(sorted_providers):
+        if i == len(sorted_providers) - 1:
+            target[provider] = remaining
+        else:
+            count = int(round(pool_size * mix_count / mix_size))
+            target[provider] = count
+            remaining -= count
+
+    total = sum(target.values())
+    if total != pool_size:
+        diff = pool_size - total
+        first = sorted_providers[0][0]
+        target[first] = target[first] + diff
+
+    return target
+
+
+def allocate_for_scale_up(
+    members: List[Membership],
+    provider_mix: List[str],
+    delta: int,
+    fallback_provider: str = "claude",
+) -> AllocationResult:
+    """Decide which providers to spawn for scale-up.
+
+    Strategy: pick providers with the largest gap (target - current).
+    Provider-binding is immutable — existing members keep their provider.
+
+    Args:
+        members: current pool members (provider from .provider, status from .status)
+        provider_mix: pool configuration list
+        delta: number of new workers to spawn (positive)
+        fallback_provider: used when mix is empty or all targets saturated
+
+    Returns:
+        AllocationResult with ordered providers list (len == delta).
+    """
+    if delta <= 0:
+        return AllocationResult(providers=[], fallback_used=[])
+
+    if not provider_mix:
+        return AllocationResult(
+            providers=[fallback_provider] * delta,
+            fallback_used=[fallback_provider] * delta,
+        )
+
+    new_size = len(members) + delta
+    target_shares = compute_target_shares(provider_mix, new_size)
+    current_shares = Counter(m.provider for m in members if m.status == "active")
+
+    allocations: List[str] = []
+    fallback_used: List[str] = []
+    pending: Dict[str, int] = dict(current_shares)
+
+    for _ in range(delta):
+        gaps = {p: target_shares.get(p, 0) - pending.get(p, 0) for p in target_shares}
+        positive = {p: g for p, g in gaps.items() if g > 0}
+
+        if positive:
+            chosen = max(positive.items(), key=lambda x: (x[1], -ord(x[0][0])))[0]
+        else:
+            chosen = fallback_provider
+            fallback_used.append(chosen)
+
+        allocations.append(chosen)
+        pending[chosen] = pending.get(chosen, 0) + 1
+
+    return AllocationResult(providers=allocations, fallback_used=fallback_used)
+
+
+def select_for_scale_down(
+    members: List[Membership],
+    provider_mix: List[str],
+    delta: int,
+) -> List[str]:
+    """Return membership_ids to release on scale-down.
+
+    Strategy: release oldest worker of the provider with the highest excess
+    over its target share. Falls back to overall oldest when all providers
+    are at or below target.
+
+    Args:
+        members: current pool members
+        provider_mix: pool configuration list
+        delta: negative int (number of workers to remove)
+
+    Returns:
+        List of membership_ids to reap, len == abs(delta).
+    """
+    if delta >= 0:
+        return []
+
+    active = [m for m in members if m.status == "active"]
+    new_size = len(active) + delta
+    target_shares = compute_target_shares(provider_mix, max(new_size, 0)) if provider_mix else {}
+    current_shares = Counter(m.provider for m in active)
+    excess = {p: current_shares.get(p, 0) - target_shares.get(p, 0) for p in current_shares}
+
+    candidates: List[Membership] = []
+    while len(candidates) < abs(delta):
+        positive_excess = {p: e for p, e in excess.items() if e > 0}
+        chosen_provider: Optional[str] = None
+        if positive_excess:
+            chosen_provider = max(positive_excess.items(), key=lambda x: x[1])[0]
+
+        pool = (
+            [m for m in active if m.provider == chosen_provider]
+            if chosen_provider
+            else list(active)
+        )
+        pool = [m for m in pool if m not in candidates]
+        if not pool:
+            break
+        oldest = min(pool, key=lambda m: m.joined_at)
+        candidates.append(oldest)
+        if chosen_provider:
+            excess[chosen_provider] = excess[chosen_provider] - 1
+
+    return [m.membership_id for m in candidates]

--- a/tests/test_pool_provider_allocator.py
+++ b/tests/test_pool_provider_allocator.py
@@ -1,0 +1,293 @@
+"""Tests for pool_provider_allocator — provider-mix allocation logic."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from pool_decision_engine import Membership
+from pool_provider_allocator import (
+    AllocationResult,
+    allocate_for_scale_up,
+    compute_target_shares,
+    select_for_scale_down,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_mid_counter = 0
+
+
+def m(provider: str, t: float = 0.0, status: str = "active", mid: str | None = None) -> Membership:
+    global _mid_counter
+    _mid_counter += 1
+    return Membership(
+        membership_id=mid or f"mid_{provider}_{int(t)}_{_mid_counter}",
+        terminal_id=f"T-{provider}-{int(t)}-{_mid_counter}",
+        provider=provider,
+        pool_role="backend-developer",
+        status=status,
+        joined_at=t,
+    )
+
+
+def reset_counter() -> None:
+    global _mid_counter
+    _mid_counter = 0
+
+
+# ---------------------------------------------------------------------------
+# compute_target_shares
+# ---------------------------------------------------------------------------
+
+class TestComputeTargetShares:
+    def test_balanced_two_providers_even_pool(self):
+        result = compute_target_shares(["claude", "codex"], 4)
+        assert result == {"claude": 2, "codex": 2}
+
+    def test_two_thirds_one_third_split(self):
+        result = compute_target_shares(["claude", "claude", "codex"], 6)
+        assert result == {"claude": 4, "codex": 2}
+
+    def test_acceptance_criterion(self):
+        """Explicit acceptance test from dispatch spec."""
+        assert compute_target_shares(["claude", "claude", "codex"], 6) == {"claude": 4, "codex": 2}
+
+    def test_empty_mix_returns_empty(self):
+        assert compute_target_shares([], 10) == {}
+
+    def test_single_provider(self):
+        result = compute_target_shares(["claude"], 5)
+        assert result == {"claude": 5}
+
+    def test_sum_equals_pool_size(self):
+        for pool_size in [1, 2, 3, 5, 7, 10, 13]:
+            result = compute_target_shares(["claude", "claude", "codex"], pool_size)
+            assert sum(result.values()) == pool_size, f"pool_size={pool_size}, result={result}"
+
+    def test_sum_equals_pool_size_even_split(self):
+        for pool_size in [1, 2, 3, 4, 5, 6, 7]:
+            result = compute_target_shares(["claude", "codex"], pool_size)
+            assert sum(result.values()) == pool_size
+
+    def test_three_providers(self):
+        result = compute_target_shares(["claude", "codex", "litellm:deepseek"], 6)
+        assert sum(result.values()) == 6
+        assert result.get("claude", 0) >= 1
+        assert result.get("codex", 0) >= 1
+        assert result.get("litellm:deepseek", 0) >= 1
+
+    def test_litellm_deepseek_in_mix(self):
+        result = compute_target_shares(["claude", "litellm:deepseek"], 4)
+        assert result == {"claude": 2, "litellm:deepseek": 2}
+
+    def test_pool_size_zero(self):
+        result = compute_target_shares(["claude", "codex"], 0)
+        assert sum(result.values()) == 0
+
+
+# ---------------------------------------------------------------------------
+# allocate_for_scale_up — parametrized table tests
+# ---------------------------------------------------------------------------
+
+class TestAllocateForScaleUpParametrized:
+    @pytest.mark.parametrize("mix,members_setup,delta,expected_providers", [
+        # Empty pool — pure mix allocation
+        (["claude", "claude", "codex"], [], 3, ["claude", "claude", "codex"]),
+        # Balanced 50-50 over 4 slots
+        (["claude", "codex"], [], 4, ["claude", "codex", "claude", "codex"]),
+        # Single provider mix
+        (["claude"], [], 3, ["claude", "claude", "claude"]),
+        # delta=0 returns empty
+        (["claude", "codex"], [], 0, []),
+    ])
+    def test_allocation(self, mix, members_setup, delta, expected_providers):
+        reset_counter()
+        members = [m(p) for p in members_setup]
+        result = allocate_for_scale_up(members, mix, delta)
+        assert result.providers == expected_providers
+
+    def test_existing_claude_then_codex_allocated(self):
+        """With 1 existing claude, delta=2: fills codex gap then balances."""
+        reset_counter()
+        # mix=["claude","codex"], new_size=3, target={claude:2,codex:1}
+        # pending starts at {claude:1}
+        # step1: claude gap=1, codex gap=1 -> tie -> claude (dict order)
+        # step2: codex gap=1 -> codex
+        members = [m("claude", t=5.0)]
+        result = allocate_for_scale_up(members, ["claude", "codex"], delta=2)
+        assert len(result.providers) == 2
+        assert result.providers.count("claude") + result.providers.count("codex") == 2
+
+    def test_provider_binding_immutable(self):
+        """Existing members keep their provider; allocator never touches them."""
+        reset_counter()
+        existing = [m("claude", t=1.0), m("codex", t=2.0)]
+        result = allocate_for_scale_up(existing, ["claude", "codex"], delta=2)
+        # Only 2 NEW providers are returned
+        assert len(result.providers) == 2
+        # The existing members' providers are unchanged (function is pure; no mutation)
+
+    def test_result_length_equals_delta(self):
+        for delta in [1, 2, 3, 5]:
+            result = allocate_for_scale_up([], ["claude", "codex"], delta)
+            assert len(result.providers) == delta
+
+    def test_all_providers_from_mix_or_fallback(self):
+        mix = ["claude", "litellm:deepseek"]
+        result = allocate_for_scale_up([], mix, delta=6)
+        for p in result.providers:
+            assert p in mix or p == "claude"
+
+
+class TestAllocateForScaleUpFallback:
+    def test_empty_mix_all_fallback(self):
+        result = allocate_for_scale_up([], [], 3)
+        assert result.providers == ["claude", "claude", "claude"]
+        assert result.fallback_used == ["claude", "claude", "claude"]
+
+    def test_empty_mix_custom_fallback(self):
+        result = allocate_for_scale_up([], [], 2, fallback_provider="codex")
+        assert result.providers == ["codex", "codex"]
+        assert result.fallback_used == ["codex", "codex"]
+
+    def test_negative_delta_returns_empty(self):
+        result = allocate_for_scale_up([], ["claude"], -1)
+        assert result.providers == []
+        assert result.fallback_used == []
+
+    def test_no_fallback_used_in_normal_allocation(self):
+        result = allocate_for_scale_up([], ["claude", "codex"], 4)
+        assert result.fallback_used == []
+
+
+# ---------------------------------------------------------------------------
+# allocate_for_scale_up — provider counts
+# ---------------------------------------------------------------------------
+
+class TestAllocateProviderCounts:
+    def test_two_claude_two_codex_for_target_four(self):
+        """Acceptance criterion: provider_mix=["claude","codex"] target=4 → 2+2."""
+        result = allocate_for_scale_up([], ["claude", "codex"], delta=4)
+        counts = {}
+        for p in result.providers:
+            counts[p] = counts.get(p, 0) + 1
+        assert counts.get("claude", 0) == 2
+        assert counts.get("codex", 0) == 2
+
+    def test_two_claude_one_codex_for_target_three(self):
+        result = allocate_for_scale_up([], ["claude", "claude", "codex"], delta=3)
+        counts = {}
+        for p in result.providers:
+            counts[p] = counts.get(p, 0) + 1
+        assert counts.get("claude", 0) == 2
+        assert counts.get("codex", 0) == 1
+
+    def test_litellm_deepseek_mixed_spawn(self):
+        """Mock-spawn with 1 claude + 1 litellm:deepseek works."""
+        result = allocate_for_scale_up([], ["claude", "litellm:deepseek"], delta=2)
+        assert len(result.providers) == 2
+        assert "claude" in result.providers
+        assert "litellm:deepseek" in result.providers
+
+
+# ---------------------------------------------------------------------------
+# select_for_scale_down
+# ---------------------------------------------------------------------------
+
+class TestSelectForScaleDown:
+    def test_noop_on_zero_delta(self):
+        reset_counter()
+        members = [m("claude", t=1), m("codex", t=2)]
+        result = select_for_scale_down(members, ["claude", "codex"], 0)
+        assert result == []
+
+    def test_noop_on_positive_delta(self):
+        reset_counter()
+        members = [m("claude", t=1)]
+        result = select_for_scale_down(members, ["claude"], 1)
+        assert result == []
+
+    def test_release_oldest_of_highest_excess(self):
+        """Scale-down releases oldest worker of the provider with highest excess."""
+        reset_counter()
+        m1 = m("claude", t=1.0, mid="mid_c_1")
+        m2 = m("claude", t=2.0, mid="mid_c_2")
+        m3 = m("codex", t=3.0, mid="mid_x_3")
+        # mix=["claude","codex"], current=2 claude+1 codex, new_size=2
+        # target for new_size=2: {claude:1,codex:1}
+        # excess: {claude:1,codex:0} -> release oldest claude
+        result = select_for_scale_down([m1, m2, m3], ["claude", "codex"], -1)
+        assert result == ["mid_c_1"]
+
+    def test_release_count_matches_abs_delta(self):
+        reset_counter()
+        members = [m("claude", t=i) for i in range(5)]
+        result = select_for_scale_down(members, ["claude"], -3)
+        assert len(result) == 3
+
+    def test_release_oldest_when_tied_excess(self):
+        """When all providers have equal (zero) excess, release oldest overall."""
+        reset_counter()
+        m1 = m("claude", t=1.0, mid="oldest")
+        m2 = m("codex", t=5.0, mid="newer")
+        # new_size=1, mix=["claude","codex"], target={claude:1,codex:0} or {0,1}?
+        # Actually: new_size=2+(-1)=1; target=compute_target_shares(["claude","codex"],1)
+        # -> mix_size=2, sorted=[("claude",1),("codex",1)], claude(not last): round(1*1/2)=round(0.5)=0
+        # Wait, round(0.5)=0 in Python (round-half-to-even). remaining=1-0=1. codex(last)=1.
+        # target={"claude":0,"codex":1}. excess={claude:1-0=1, codex:1-1=0}.
+        # highest excess = claude(1). release oldest claude = m1.
+        result = select_for_scale_down([m1, m2], ["claude", "codex"], -1)
+        # claude has excess=1, so oldest claude is released
+        assert "oldest" in result
+
+    def test_scale_down_empty_mix(self):
+        """With empty mix, fallback to oldest overall."""
+        reset_counter()
+        m1 = m("claude", t=1.0, mid="old")
+        m2 = m("codex", t=2.0, mid="new")
+        result = select_for_scale_down([m1, m2], [], -1)
+        assert result == ["old"]
+
+    def test_only_active_members_considered(self):
+        """Reaped/pending members should not be candidates."""
+        reset_counter()
+        active = m("claude", t=1.0, mid="active_one", status="active")
+        reaped = m("claude", t=0.5, mid="reaped_one", status="reaped")
+        result = select_for_scale_down([active, reaped], ["claude"], -1)
+        assert result == ["active_one"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_member_scale_up(self):
+        reset_counter()
+        result = allocate_for_scale_up([], ["claude"], 1)
+        assert result.providers == ["claude"]
+
+    def test_large_delta_consistent_counts(self):
+        """For a balanced mix over 10 workers, counts should be roughly equal."""
+        result = allocate_for_scale_up([], ["claude", "codex"], 10)
+        counts = {}
+        for p in result.providers:
+            counts[p] = counts.get(p, 0) + 1
+        assert counts.get("claude", 0) == 5
+        assert counts.get("codex", 0) == 5
+
+    def test_allocation_result_is_pure_no_side_effects(self):
+        """Calling allocate twice with same args returns same result."""
+        reset_counter()
+        members = [m("claude", t=1.0)]
+        r1 = allocate_for_scale_up(members, ["claude", "codex"], 3)
+        r2 = allocate_for_scale_up(members, ["claude", "codex"], 3)
+        assert r1.providers == r2.providers

--- a/tests/test_pool_provider_mix_integration.py
+++ b/tests/test_pool_provider_mix_integration.py
@@ -1,0 +1,274 @@
+"""Integration tests for provider-mix allocation via PoolManager mock-spawn."""
+
+from __future__ import annotations
+
+import sys
+import time
+import tempfile
+import sqlite3
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState
+from pool_manager import PoolManager, SpawnResult, ExecResult
+from pool_provider_allocator import allocate_for_scale_up, select_for_scale_down
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_membership(mid: str, provider: str, t: float, status: str = "active") -> Membership:
+    return Membership(
+        membership_id=mid,
+        terminal_id=f"T-{mid}",
+        provider=provider,
+        pool_role="backend-developer",
+        status=status,
+        joined_at=t,
+    )
+
+
+def _spawn_ok(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+    return SpawnResult(terminal_id=terminal_id, success=True)
+
+
+def _spawn_fail(project_id, pool_id, terminal_id, provider, role) -> SpawnResult:
+    return SpawnResult(terminal_id=terminal_id, success=False, error="mock failure")
+
+
+# ---------------------------------------------------------------------------
+# Pure allocator integration — no DB needed
+# ---------------------------------------------------------------------------
+
+class TestProviderMixClaudeCodex:
+    def test_target_4_gives_two_each(self):
+        """provider_mix=["claude","codex"] target=4 → 2 claude + 2 codex spawned."""
+        result = allocate_for_scale_up([], ["claude", "codex"], delta=4)
+        counts = {p: result.providers.count(p) for p in set(result.providers)}
+        assert counts.get("claude", 0) == 2
+        assert counts.get("codex", 0) == 2
+
+    def test_target_6_three_each(self):
+        result = allocate_for_scale_up([], ["claude", "codex"], delta=6)
+        counts = {p: result.providers.count(p) for p in set(result.providers)}
+        assert counts.get("claude", 0) == 3
+        assert counts.get("codex", 0) == 3
+
+    def test_target_1_uses_first_provider(self):
+        result = allocate_for_scale_up([], ["claude", "codex"], delta=1)
+        assert len(result.providers) == 1
+        assert result.providers[0] in ("claude", "codex")
+
+    def test_scale_up_then_scale_down_net_zero(self):
+        """Scale up to 4, then down by 2: net 2 workers."""
+        up = allocate_for_scale_up([], ["claude", "codex"], delta=4)
+        # Simulate members from those spawns
+        members = [
+            _make_membership(f"mid_{i}", p, float(i))
+            for i, p in enumerate(up.providers)
+        ]
+        down_ids = select_for_scale_down(members, ["claude", "codex"], -2)
+        assert len(down_ids) == 2
+
+
+class TestProviderMixLitellmDeepseek:
+    def test_claude_litellm_deepseek_two_each(self):
+        """Mock-spawn with 1 claude + 1 litellm:deepseek works."""
+        result = allocate_for_scale_up([], ["claude", "litellm:deepseek"], delta=2)
+        assert len(result.providers) == 2
+        assert "claude" in result.providers
+        assert "litellm:deepseek" in result.providers
+
+    def test_litellm_deepseek_heavy_mix(self):
+        """["litellm:deepseek","litellm:deepseek","claude"] → 2:1 ratio."""
+        result = allocate_for_scale_up(
+            [], ["litellm:deepseek", "litellm:deepseek", "claude"], delta=3
+        )
+        counts = {p: result.providers.count(p) for p in set(result.providers)}
+        assert counts.get("litellm:deepseek", 0) == 2
+        assert counts.get("claude", 0) == 1
+
+    def test_providers_in_result_are_valid_strings(self):
+        result = allocate_for_scale_up([], ["claude", "litellm:deepseek"], delta=4)
+        for p in result.providers:
+            assert isinstance(p, str)
+            assert len(p) > 0
+
+
+class TestProviderMixWithExistingMembers:
+    def test_rebalances_toward_target(self):
+        """With 2 existing claude workers and mix ["claude","codex"], next spawn fills codex."""
+        existing = [
+            _make_membership("c1", "claude", 1.0),
+            _make_membership("c2", "claude", 2.0),
+        ]
+        result = allocate_for_scale_up(existing, ["claude", "codex"], delta=2)
+        # new_size=4, target={claude:2,codex:2}; current={claude:2}, need 2 codex
+        assert result.providers.count("codex") == 2
+        assert result.providers.count("claude") == 0
+
+    def test_immutable_provider_binding(self):
+        """Existing members keep their provider after scale_up call."""
+        m1 = _make_membership("m1", "claude", 1.0)
+        m2 = _make_membership("m2", "codex", 2.0)
+        original_providers = [m1.provider, m2.provider]
+        _ = allocate_for_scale_up([m1, m2], ["claude", "codex"], delta=2)
+        # Immutability: dataclasses are frozen; providers unchanged
+        assert m1.provider == original_providers[0]
+        assert m2.provider == original_providers[1]
+
+    def test_mixed_status_members_only_active_counted(self):
+        """Reaped members don't count toward current_shares."""
+        active = _make_membership("a1", "claude", 1.0, status="active")
+        reaped = _make_membership("r1", "claude", 0.5, status="reaped")
+        # Only 1 active claude; new_size=1+2=3, target={claude:2,codex:1}
+        result = allocate_for_scale_up([active, reaped], ["claude", "codex"], delta=2)
+        # pending starts as {claude:1}; step1 gap=1:1 tie -> claude; step2 codex gap=1 -> codex
+        assert len(result.providers) == 2
+
+
+class TestScaleDownProviderAware:
+    def test_release_oldest_of_highest_excess_provider(self):
+        """scale_down releases oldest worker of highest-excess provider."""
+        m1 = _make_membership("m1", "claude", 1.0)
+        m2 = _make_membership("m2", "claude", 2.0)
+        m3 = _make_membership("m3", "codex", 3.0)
+        # mix=["claude","codex"], current=2+1, new_size=2, target={claude:1,codex:1}
+        # excess: {claude:1,codex:0} -> release oldest claude = m1
+        result = select_for_scale_down([m1, m2, m3], ["claude", "codex"], -1)
+        assert result == ["m1"]
+
+    def test_scale_down_two_releases_correct_pair(self):
+        """Scale down by 2 releases 2 oldest of overrepresented provider."""
+        members = [
+            _make_membership("c1", "claude", 1.0),
+            _make_membership("c2", "claude", 2.0),
+            _make_membership("c3", "claude", 3.0),
+            _make_membership("x1", "codex", 4.0),
+        ]
+        # mix=["claude","codex"], current=3+1, new_size=2, target={claude:1,codex:1}
+        # excess: {claude:2,codex:0} -> release c1, then c2
+        result = select_for_scale_down(members, ["claude", "codex"], -2)
+        assert set(result) == {"c1", "c2"}
+
+    def test_empty_provider_mix_scale_down_oldest_first(self):
+        """Empty mix falls back to global oldest-first."""
+        members = [
+            _make_membership("old", "claude", 1.0),
+            _make_membership("new", "codex", 10.0),
+        ]
+        result = select_for_scale_down(members, [], -1)
+        assert result == ["old"]
+
+
+class TestPoolManagerMockSpawn:
+    def _build_manager_with_db(self) -> tuple[PoolManager, Path]:
+        """Build a PoolManager backed by a real in-memory SQLite DB."""
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        db_path = Path(tmp.name)
+        tmp.close()
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE pool_config (
+                project_id TEXT,
+                pool_id TEXT,
+                min_workers INTEGER,
+                max_workers INTEGER,
+                scale_policy TEXT,
+                provider_mix_json TEXT,
+                cooldown_seconds REAL,
+                PRIMARY KEY (project_id, pool_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE worker_pools (
+                project_id TEXT,
+                pool_id TEXT,
+                current_size INTEGER DEFAULT 0,
+                last_scaled_at TEXT,
+                last_decision_json TEXT,
+                last_scale_action TEXT,
+                PRIMARY KEY (project_id, pool_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE worker_pool_membership (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                terminal_id TEXT,
+                project_id TEXT,
+                pool_id TEXT,
+                provider TEXT,
+                role TEXT,
+                joined_at TEXT,
+                released_at TEXT,
+                release_reason TEXT,
+                metadata_json TEXT DEFAULT '{}'
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE terminal_leases (
+                terminal_id TEXT,
+                project_id TEXT,
+                last_heartbeat_at TEXT,
+                PRIMARY KEY (terminal_id, project_id)
+            )
+        """)
+        conn.execute(
+            "INSERT INTO pool_config VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("proj-test", "default", 0, 4, "queue_depth_v1", '["claude","codex"]', 0.0),
+        )
+        conn.execute(
+            "INSERT INTO worker_pools VALUES (?, ?, ?, ?, ?, ?)",
+            ("proj-test", "default", 0, None, None, None),
+        )
+        conn.commit()
+        conn.close()
+
+        mgr = PoolManager(
+            project_id="proj-test",
+            pool_id="default",
+            db_path=db_path,
+            spawn_fn=_spawn_ok,
+        )
+        return mgr, db_path
+
+    def test_execute_scale_up_spawns_correct_providers(self):
+        mgr, db_path = self._build_manager_with_db()
+        decision = PoolDecision(action="scale_up", delta=4, reason="test")
+        result = mgr.execute(decision)
+        assert len(result.errors) == 0
+        assert len(result.spawned) == 4
+
+        # Verify provider distribution via repo
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT provider FROM worker_pool_membership WHERE project_id=? AND released_at IS NULL",
+            ("proj-test",),
+        ).fetchall()
+        conn.close()
+        providers = [r[0] for r in rows]
+        assert providers.count("claude") == 2
+        assert providers.count("codex") == 2
+
+    def test_execute_scale_up_with_spawn_failure(self):
+        mgr, db_path = self._build_manager_with_db()
+        mgr._spawn_fn = _spawn_fail
+        decision = PoolDecision(action="scale_up", delta=2, reason="test")
+        result = mgr.execute(decision)
+        assert len(result.spawned) == 0
+        assert len(result.errors) == 2
+
+    def test_noop_decision_no_spawns(self):
+        mgr, db_path = self._build_manager_with_db()
+        decision = PoolDecision(action="noop", reason="at target")
+        result = mgr.execute(decision)
+        assert result.spawned == []
+        assert result.reaped == []
+        assert result.errors == []


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/pool_provider_allocator.py` — pure (no I/O) allocator implementing lowest-share-first algorithm; `compute_target_shares` maps provider_mix proportions to pool size; `allocate_for_scale_up` iterates highest-gap-first; `select_for_scale_down` releases oldest worker of highest-excess provider
- Updates `scripts/lib/pool_manager.py` to use the allocator in `_execute_scale_up` and `_execute_scale_down`; provider-binding immutable per worker lifetime; empty mix falls back to `"claude"`
- References ADR-018 elastic worker pool; part of Wave 6 architecture (`claudedocs/wave6-workers-n-architecture.md`)

## Test plan

- [ ] `pytest tests/test_pool_provider_allocator.py` — 35 unit tests: `compute_target_shares`, `allocate_for_scale_up` (table-driven + fallback), `select_for_scale_down`, edge cases
- [ ] `pytest tests/test_pool_provider_mix_integration.py` — 16 integration tests: claude+codex balance, litellm:deepseek mix, existing members rebalancing, DB-backed manager mock-spawn
- [ ] Existing pool tests: `pytest tests/test_pool_decision_engine.py tests/test_pool_manager_integration.py tests/test_pool_state_repo.py` — 44 tests, all green
- [ ] Total: 95 tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)