### PR TITLE
feat(wave6): PR-6.7 — vnx pool CLI (status/scale/config/reap subcommands)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -166,6 +166,12 @@ Worktree commands:
   worktree-refresh   Update intelligence snapshot from main
   worktree-status    Show worktree isolation status
 
+Pool commands (elastic worker pool management):
+  pool status [--project <id>] [--pool-id <p>] [--json]  Show pool state
+  pool scale --project <id> --to <N>                     Force scale to N workers
+  pool config --project <id> [--min N] [--max N] [--policy <name>] [--cooldown <s>]
+  pool reap --project <id> [--pool-id <p>] [--force]     Reap stale workers
+
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
@@ -1930,6 +1936,9 @@ main() {
       ;;
     demo)
       cmd_demo "$@"
+      ;;
+    pool)
+      PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.commands.pool "$@"
       ;;
     help|-h|--help)
       usage

--- a/docs/operations/POOL_OPERATIONS.md
+++ b/docs/operations/POOL_OPERATIONS.md
@@ -1,0 +1,215 @@
+# Pool Operations Guide
+
+Operator reference for elastic worker pool management via `vnx pool`.
+
+See ADR-018 for the elastic pool architecture and Wave 6 design decisions.
+
+---
+
+## Quick start
+
+Always run `status` first to understand the current pool state before making changes.
+
+```bash
+vnx pool status --project my-project
+```
+
+Example output:
+```
+Pool: default
+Project: my-project
+Current: 2 / policy=queue_depth_v1 (min=1, max=6)
+Queue depth: 0
+Active workers:
+  my-project-P12345-0 (claude) joined=5min ago
+  my-project-P12346-1 (claude) joined=4min ago
+```
+
+With `--json` for machine-readable output:
+
+```bash
+vnx pool status --project my-project --json
+```
+
+```json
+{
+  "pool_id": "default",
+  "project_id": "my-project",
+  "current": 2,
+  "min": 1,
+  "max": 6,
+  "policy": "queue_depth_v1",
+  "queue_depth": 0,
+  "members": [
+    {"terminal_id": "my-project-P12345-0", "provider": "claude"},
+    {"terminal_id": "my-project-P12346-1", "provider": "claude"}
+  ]
+}
+```
+
+---
+
+## Subcommands
+
+### `vnx pool status`
+
+Show the current state of a pool.
+
+```
+vnx pool status [--project <id>] [--pool-id <pool>] [--json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `default` | Project identifier |
+| `--pool-id` | `default` | Pool name within the project |
+| `--json` | off | Emit JSON instead of human-readable output |
+
+**Example:**
+```bash
+vnx pool status --project seocrawler
+vnx pool status --project seocrawler --json | jq .current
+```
+
+---
+
+### `vnx pool scale`
+
+Force the pool to a specific worker count, bypassing the normal scaling policy.
+
+```
+vnx pool scale --project <id> --to <N> [--pool-id <pool>]
+```
+
+The target `N` is validated against the pool's configured `min` and `max`. Scale requests outside this range are rejected.
+
+**Example — scale up to 4 workers:**
+```bash
+vnx pool scale --project seocrawler --to 4
+```
+
+```
+Decision: scale_up delta=2
+Spawned: 2 ['seocrawler-P98765-0', 'seocrawler-P98765-1']
+Reaped: 0 []
+```
+
+**Example — scale down to 1 worker:**
+```bash
+vnx pool scale --project seocrawler --to 1
+```
+
+---
+
+### `vnx pool config`
+
+Update pool configuration. Changes take effect on the next tick.
+
+```
+vnx pool config --project <id> [--min N] [--max N] [--policy <name>] [--cooldown <s>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--min N` | Minimum worker floor |
+| `--max N` | Maximum worker ceiling |
+| `--policy <name>` | Scaling policy: `fixed`, `queue_depth_v1`, `cost_aware_v1` |
+| `--cooldown <s>` | Seconds to wait between scaling events |
+
+**Example — raise the ceiling and lower cooldown:**
+```bash
+vnx pool config --project seocrawler --max 8 --cooldown 30
+```
+
+```
+Updated config for 'default': {'max_workers': 8, 'cooldown_seconds': 30.0}
+```
+
+Verify the change took effect:
+```bash
+vnx pool status --project seocrawler
+```
+
+---
+
+### `vnx pool reap`
+
+Identify and remove stale or stuck workers.
+
+Default behavior (without `--force`) is a **dry-run** that shows candidates without removing them.
+
+```
+vnx pool reap --project <id> [--pool-id <pool>] [--force]
+```
+
+**Dry-run (default):**
+```bash
+vnx pool reap --project seocrawler
+```
+
+```
+WARN: --force not specified. Reap candidates (dry-run):
+  would reap: seocrawler-P11111-0 reason=heartbeat_stale=250s>180s
+```
+
+**Actually reap:**
+```bash
+vnx pool reap --project seocrawler --force
+```
+
+```
+Reaped 1 workers
+  seocrawler-P11111-0 (heartbeat_stale=250s>180s)
+```
+
+---
+
+## Troubleshooting
+
+### Project ID typo
+
+If `status` fails with a RuntimeError about missing `pool_config` rows, the project ID is wrong or the pool has not been bootstrapped. Run the migration from ADR-018 and insert a `pool_config` row for your project.
+
+```bash
+# Check which projects have pool_config rows
+sqlite3 .vnx-data/state/runtime_coordination.db \
+  "SELECT project_id, pool_id, min_workers, max_workers FROM pool_config;"
+```
+
+### Config drift after manual DB edits
+
+If pool behavior does not match the expected config, verify with:
+
+```bash
+vnx pool status --project <id> --json
+```
+
+Then reconcile via `vnx pool config --project <id> --min ... --max ...`.
+
+### Workers not being reaped
+
+Run `vnx pool reap --project <id>` (dry-run) to see candidates. If the list is empty but you expect stale workers, check that their `last_heartbeat_at` in `terminal_leases` is actually missing or old. The reap threshold is 180s by default.
+
+If candidates appear but `--force` is not cleaning them, check the pool event log:
+
+```bash
+tail -f .vnx-data/events/pool_events.ndjson | python3 -m json.tool
+```
+
+### Force-reap followed by status shows old workers
+
+`reap_dead()` marks members as `released_at IS NOT NULL`. The next `status` call queries only unreleased members, so old entries will not appear. If they do, there may be duplicate membership rows — investigate with:
+
+```bash
+sqlite3 .vnx-data/state/runtime_coordination.db \
+  "SELECT * FROM worker_pool_membership WHERE released_at IS NULL;"
+```
+
+---
+
+## Reference
+
+- ADR-018: Elastic Worker Pool design
+- Wave 6 architecture: `claudedocs/wave6-workers-n-architecture.md`
+- Pool event log: `.vnx-data/events/pool_events.ndjson`
+- Schema: `schemas/migrations/0020_elastic_worker_pool.sql`

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -433,3 +433,41 @@ class PoolStateRepository:
             raise
         finally:
             conn.close()
+
+    def update_config(self, pool_id: str, updates: Dict) -> None:
+        """Update pool_config fields. Keys map to PoolConfig field names."""
+        _FIELD_MAP = {
+            "min_workers": "min_workers",
+            "max_workers": "max_workers",
+            "scaling_policy": "scale_policy",
+            "cooldown_seconds": "cooldown_seconds",
+        }
+        cols: List[str] = []
+        vals: List = []
+        for key, value in updates.items():
+            col = _FIELD_MAP.get(key)
+            if col is None:
+                raise ValueError(f"Unknown config field: {key}")
+            cols.append(f"{col} = ?")
+            vals.append(value)
+
+        if not cols:
+            return
+
+        now_iso = _iso_now(time.time())
+        cols.append("updated_at = ?")
+        vals.append(now_iso)
+        vals.extend([self.project_id, pool_id])
+
+        sql = f"UPDATE pool_config SET {', '.join(cols)} WHERE project_id = ? AND pool_id = ?"
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(sql, vals)
+            conn.commit()
+            log.debug("update_config: pool=%s updates=%s", pool_id, updates)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -471,3 +471,8 @@ class PoolStateRepository:
             raise
         finally:
             conn.close()
+        self._emit_ledger("pool.config.updated", {
+            "pool_id": pool_id,
+            "updates": updates,
+            "now": time.time(),
+        })

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -63,6 +63,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "smoke", "package-check",
     "dispatch", "gate",
     "snapshot", "restore", "quiesce-check",
+    "pool",
 })
 
 TIER_DEMO_ONLY: FrozenSet[str] = frozenset({

--- a/tests/test_pool_state_repo.py
+++ b/tests/test_pool_state_repo.py
@@ -175,3 +175,25 @@ def test_ledger_file_atomic_append(tmp_path):
         assert "event_type" in ev
         assert "timestamp" in ev
         assert "payload" in ev
+
+
+# ---------------------------------------------------------------------------
+# 6. update_config emits pool.config.updated ledger event (ADR-005)
+# ---------------------------------------------------------------------------
+
+def test_update_config_emits_ledger_event(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    updates = {"min_workers": 2, "max_workers": 8, "cooldown_seconds": 90}
+    repo.update_config("default", updates)
+
+    events = _read_ledger_events(db)
+    config_events = [e for e in events if e["event_type"] == "pool.config.updated"]
+    assert len(config_events) == 1
+    ev = config_events[0]
+    assert ev["payload"]["pool_id"] == "default"
+    assert ev["payload"]["updates"] == updates
+    assert "now" in ev["payload"]
+    assert "timestamp" in ev

--- a/tests/test_vnx_pool_cli.py
+++ b/tests/test_vnx_pool_cli.py
@@ -1,0 +1,381 @@
+"""test_vnx_pool_cli.py — Unit tests for vnx pool CLI subcommands.
+
+Tests drive the CLI functions directly (cmd_* and main(argv=...)) with
+PoolManager mocked so no real SQLite DB or subprocess is required.
+
+Wave 6 PR-6.7 — vnx pool CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# Ensure vnx_cli and scripts/lib are importable.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState  # noqa: E402
+from pool_manager import ExecResult  # noqa: E402
+from pool_reaper import ReapTarget  # noqa: E402
+from vnx_cli.commands.pool import (  # noqa: E402
+    cmd_config,
+    cmd_reap,
+    cmd_scale,
+    cmd_status,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+def _make_config(
+    pool_id: str = "default",
+    min_workers: int = 1,
+    max_workers: int = 6,
+    policy: str = "queue_depth_v1",
+) -> PoolConfig:
+    return PoolConfig(
+        pool_id=pool_id,
+        min_workers=min_workers,
+        max_workers=max_workers,
+        scaling_policy=policy,
+        provider_mix=["claude"],
+        cooldown_seconds=60.0,
+    )
+
+
+def _make_state(queue_depth: int = 0) -> PoolState:
+    return PoolState(queue_depth=queue_depth, last_scaled_at=None, now=1000.0)
+
+
+def _make_member(tid: str = "T1", provider: str = "claude") -> Membership:
+    return Membership(
+        membership_id="m-001",
+        terminal_id=tid,
+        provider=provider,
+        pool_role="backend-developer",
+        status="active",
+        joined_at=900.0,
+        last_heartbeat=990.0,
+    )
+
+
+def _make_exec_result(
+    spawned: List[str] = None,
+    reaped: List[str] = None,
+    errors: List[str] = None,
+) -> ExecResult:
+    decision = PoolDecision(action="noop", delta=0, reason="test")
+    return ExecResult(
+        decision=decision,
+        spawned=spawned or [],
+        reaped=reaped or [],
+        errors=errors or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# status tests
+# ---------------------------------------------------------------------------
+
+class TestCmdStatus:
+    def _args(self, project: str = "test-proj", pool_id=None, json_out=False):
+        args = MagicMock()
+        args.project = project
+        args.pool_id = pool_id
+        args.json = json_out
+        return args
+
+    def test_status_outputs_pool_state(self, capsys):
+        member = _make_member("WORKER-1")
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(queue_depth=3), [member])
+            rc = cmd_status(self._args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Pool: default" in out
+        assert "queue_depth_v1" in out
+        assert "WORKER-1" in out
+        assert "Queue depth: 3" in out
+
+    def test_status_json_format(self, capsys):
+        member = _make_member("WORKER-2", provider="litellm")
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(max_workers=4), _make_state(), [member])
+            rc = cmd_status(self._args(json_out=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["pool_id"] == "default"
+        assert data["max"] == 4
+        assert data["current"] == 1
+        assert data["members"][0]["terminal_id"] == "WORKER-2"
+        assert data["members"][0]["provider"] == "litellm"
+
+    def test_status_works_without_project(self, capsys):
+        """--project defaults to 'default'; no error when omitted."""
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            rc = main(argv=["status"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Project: default" in out
+
+    def test_status_with_pool_id_passed_to_manager(self):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(pool_id="batch"), _make_state(), [])
+            main(argv=["status", "--project", "proj-a", "--pool-id", "batch"])
+        MockMgr.assert_called_once_with(project_id="proj-a", pool_id="batch")
+
+    def test_status_empty_pool(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            rc = cmd_status(self._args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Current: 0" in out
+
+
+# ---------------------------------------------------------------------------
+# scale tests
+# ---------------------------------------------------------------------------
+
+class TestCmdScale:
+    def _args(self, project="proj", pool_id=None, to=3):
+        args = MagicMock()
+        args.project = project
+        args.pool_id = pool_id
+        args.to = to
+        return args
+
+    def test_scale_invokes_execute_with_correct_decision(self, capsys):
+        members = [_make_member("T1"), _make_member("T2")]
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(min_workers=1, max_workers=6), _make_state(), members)
+            mgr.execute.return_value = _make_exec_result(spawned=["T3"])
+            rc = cmd_scale(self._args(to=3))
+        assert rc == 0
+        call_args = mgr.execute.call_args[0][0]
+        assert call_args.action == "scale_up"
+        assert call_args.delta == 1
+        assert "operator request" in call_args.reason
+
+    def test_scale_rejects_target_outside_range(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (
+                _make_config(min_workers=1, max_workers=4), _make_state(), []
+            )
+            rc = cmd_scale(self._args(to=10))
+        assert rc == 1
+        assert "outside" in capsys.readouterr().err
+
+    def test_scale_below_min_rejected(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (
+                _make_config(min_workers=2, max_workers=6), _make_state(), [_make_member()]
+            )
+            rc = cmd_scale(self._args(to=0))
+        assert rc == 1
+
+    def test_scale_zero_delta_skips(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (
+                _make_config(), _make_state(), [_make_member("T1"), _make_member("T2")]
+            )
+            rc = cmd_scale(self._args(to=2))
+        assert rc == 0
+        mgr.execute.assert_not_called()
+        assert "nothing to do" in capsys.readouterr().out
+
+    def test_scale_down_uses_scale_down_action(self, capsys):
+        members = [_make_member("T1"), _make_member("T2"), _make_member("T3")]
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(min_workers=1, max_workers=6), _make_state(), members)
+            mgr.execute.return_value = _make_exec_result(reaped=["m-003"])
+            rc = cmd_scale(self._args(to=2))
+        assert rc == 0
+        call_args = mgr.execute.call_args[0][0]
+        assert call_args.action == "scale_down"
+        assert call_args.delta == -1
+
+    def test_scale_errors_return_nonzero(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            mgr.execute.return_value = _make_exec_result(spawned=[], errors=["spawn failed"])
+            rc = cmd_scale(self._args(to=1))
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# config tests
+# ---------------------------------------------------------------------------
+
+class TestCmdConfig:
+    def _args(self, project="proj", pool_id=None, min=None, max=None, policy=None, cooldown=None):
+        args = MagicMock()
+        args.project = project
+        args.pool_id = pool_id
+        args.min = min
+        args.max = max
+        args.policy = policy
+        args.cooldown = cooldown
+        return args
+
+    def test_config_updates_min_max_policy_cooldown(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(min=2, max=8, policy="cost_aware_v1", cooldown=30.0))
+        assert rc == 0
+        mgr.repo.update_config.assert_called_once_with(
+            "default",
+            {"min_workers": 2, "max_workers": 8, "scaling_policy": "cost_aware_v1", "cooldown_seconds": 30.0},
+        )
+
+    def test_config_no_changes(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args())
+        assert rc == 0
+        mgr.repo.update_config.assert_not_called()
+        assert "No changes" in capsys.readouterr().out
+
+    def test_config_unknown_pool_returns_error(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = None
+            rc = cmd_config(self._args(max=8))
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_config_partial_update(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(max=10))
+        assert rc == 0
+        mgr.repo.update_config.assert_called_once_with("default", {"max_workers": 10})
+
+
+# ---------------------------------------------------------------------------
+# reap tests
+# ---------------------------------------------------------------------------
+
+class TestCmdReap:
+    def _args(self, project="proj", pool_id=None, force=False):
+        args = MagicMock()
+        args.project = project
+        args.pool_id = pool_id
+        args.force = force
+        return args
+
+    def test_reap_dry_run_default(self, capsys):
+        member = _make_member("STUCK-1")
+        member_stale = Membership(
+            membership_id="m-stale",
+            terminal_id="STUCK-1",
+            provider="claude",
+            pool_role="backend-developer",
+            status="active",
+            joined_at=0.0,
+            last_heartbeat=0.0,
+        )
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [member_stale])
+            rc = cmd_reap(self._args(force=False))
+        assert rc == 0
+        mgr.reap_dead.assert_not_called()
+        out = capsys.readouterr().out
+        assert "dry-run" in out or "WARN" in out
+
+    def test_reap_force_actually_reaps(self, capsys):
+        targets = [
+            ReapTarget(
+                membership_id="m-001",
+                terminal_id="T-DEAD",
+                pid=None,
+                reason="heartbeat_stale=250s>180s",
+            )
+        ]
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.reap_dead.return_value = targets
+            rc = cmd_reap(self._args(force=True))
+        assert rc == 0
+        mgr.reap_dead.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Reaped 1" in out
+        assert "T-DEAD" in out
+
+    def test_reap_dry_run_empty_when_no_candidates(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            rc = cmd_reap(self._args(force=False))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no candidates" in out
+
+    def test_reap_force_empty_result(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.reap_dead.return_value = []
+            rc = cmd_reap(self._args(force=True))
+        assert rc == 0
+        assert "Reaped 0" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# argparse / routing tests
+# ---------------------------------------------------------------------------
+
+class TestArgparseBehavior:
+    def test_project_required_for_scale(self):
+        with pytest.raises(SystemExit) as exc:
+            main(argv=["scale", "--to", "3"])
+        assert exc.value.code != 0
+
+    def test_project_required_for_config(self):
+        with pytest.raises(SystemExit) as exc:
+            main(argv=["config", "--max", "5"])
+        assert exc.value.code != 0
+
+    def test_project_required_for_reap(self):
+        with pytest.raises(SystemExit) as exc:
+            main(argv=["reap"])
+        assert exc.value.code != 0
+
+    def test_to_required_for_scale(self):
+        with pytest.raises(SystemExit) as exc:
+            main(argv=["scale", "--project", "proj"])
+        assert exc.value.code != 0
+
+    def test_unknown_subcommand_exits_nonzero(self):
+        with pytest.raises(SystemExit) as exc:
+            main(argv=["bogus-cmd"])
+        assert exc.value.code != 0

--- a/tests/test_vnx_pool_cli.py
+++ b/tests/test_vnx_pool_cli.py
@@ -280,6 +280,54 @@ class TestCmdConfig:
         assert rc == 0
         mgr.repo.update_config.assert_called_once_with("default", {"max_workers": 10})
 
+    def test_config_rejects_negative_min(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(min=-1))
+        assert rc == 1
+        assert "--min must be >= 0" in capsys.readouterr().err
+        mgr.repo.update_config.assert_not_called()
+
+    def test_config_rejects_negative_max(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(max=-5))
+        assert rc == 1
+        assert "--max must be >= 0" in capsys.readouterr().err
+        mgr.repo.update_config.assert_not_called()
+
+    def test_config_rejects_invalid_policy(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(policy="nonexistent_policy"))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "invalid policy" in err
+        assert "nonexistent_policy" in err
+        mgr.repo.update_config.assert_not_called()
+
+    def test_config_rejects_negative_cooldown(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = cmd_config(self._args(cooldown=-10.0))
+        assert rc == 1
+        assert "--cooldown must be >= 0" in capsys.readouterr().err
+        mgr.repo.update_config.assert_not_called()
+
+    def test_config_rejects_min_greater_than_max(self, capsys):
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config(min_workers=2, max_workers=6)
+            rc = cmd_config(self._args(min=8, max=4))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "min" in err and "max" in err and "invariant" in err
+        mgr.repo.update_config.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # reap tests

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -97,6 +97,9 @@ def cmd_scale(args: argparse.Namespace) -> int:
     return 0 if not result.errors else 1
 
 
+_VALID_POLICIES = frozenset({"fixed", "queue_depth_v1", "queue_aware", "cost_aware_v1"})
+
+
 def cmd_config(args: argparse.Namespace) -> int:
     """Update pool config fields (min/max/policy/cooldown)."""
     mgr = _make_manager(args.project, args.pool_id)
@@ -108,17 +111,41 @@ def cmd_config(args: argparse.Namespace) -> int:
 
     updates = {}
     if args.min is not None:
+        if args.min < 0:
+            print("ERROR: --min must be >= 0", file=sys.stderr)
+            return 1
         updates["min_workers"] = args.min
     if args.max is not None:
+        if args.max < 0:
+            print("ERROR: --max must be >= 0", file=sys.stderr)
+            return 1
         updates["max_workers"] = args.max
     if args.policy is not None:
+        if args.policy not in _VALID_POLICIES:
+            print(
+                f"ERROR: invalid policy {args.policy!r}; valid: {sorted(_VALID_POLICIES)}",
+                file=sys.stderr,
+            )
+            return 1
         updates["scaling_policy"] = args.policy
     if args.cooldown is not None:
+        if args.cooldown < 0:
+            print("ERROR: --cooldown must be >= 0", file=sys.stderr)
+            return 1
         updates["cooldown_seconds"] = args.cooldown
 
     if not updates:
         print("No changes")
         return 0
+
+    final_min = updates.get("min_workers", config.min_workers)
+    final_max = updates.get("max_workers", config.max_workers)
+    if final_min > final_max:
+        print(
+            f"ERROR: min ({final_min}) > max ({final_max}); invariant violated",
+            file=sys.stderr,
+        )
+        return 1
 
     mgr.repo.update_config(pool_id, updates)
     print(f"Updated config for {pool_id!r}: {updates}")

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -1,0 +1,199 @@
+"""vnx pool — Pool management CLI for elastic worker pools.
+
+Usage:
+    vnx pool status [--project <id>] [--pool-id <pool>] [--json]
+    vnx pool scale --project <id> --to <N> [--pool-id <pool>]
+    vnx pool config --project <id> [--min N] [--max N] [--policy <name>] [--cooldown <s>]
+    vnx pool reap --project <id> [--pool-id <pool>] [--force]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+
+# Bootstrap scripts/lib into path so pool_manager etc. are importable.
+_LIB_DIR = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from pool_manager import ExecResult, PoolManager  # noqa: E402
+from pool_state_repo import PoolStateRepository  # noqa: E402
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show current pool state for a project."""
+    mgr = _make_manager(args.project, args.pool_id)
+    config, state, members = mgr.load_state()
+
+    active = [m for m in members if m.status == "active"]
+    if args.json:
+        print(json.dumps({
+            "pool_id": config.pool_id,
+            "project_id": args.project,
+            "current": len(active),
+            "min": config.min_workers,
+            "max": config.max_workers,
+            "policy": config.scaling_policy,
+            "queue_depth": state.queue_depth,
+            "members": [
+                {"terminal_id": m.terminal_id, "provider": m.provider}
+                for m in active
+            ],
+        }, indent=2))
+    else:
+        print(f"Pool: {config.pool_id}")
+        print(f"Project: {args.project}")
+        print(
+            f"Current: {len(active)} / policy={config.scaling_policy}"
+            f" (min={config.min_workers}, max={config.max_workers})"
+        )
+        print(f"Queue depth: {state.queue_depth}")
+        if active:
+            print("Active workers:")
+            for m in active:
+                print(f"  {m.terminal_id} ({m.provider}) joined={_fmt_age(m.joined_at)}")
+    return 0
+
+
+def cmd_scale(args: argparse.Namespace) -> int:
+    """Force scale pool to a specific worker count."""
+    from pool_decision_engine import PoolDecision  # noqa: E402
+
+    mgr = _make_manager(args.project, args.pool_id)
+    config, _, members = mgr.load_state()
+    current = len([m for m in members if m.status == "active"])
+    target = args.to
+
+    if target < config.min_workers or target > config.max_workers:
+        print(
+            f"ERROR: target {target} outside [{config.min_workers}, {config.max_workers}]",
+            file=sys.stderr,
+        )
+        return 1
+
+    delta = target - current
+    if delta == 0:
+        print(f"Already at {target}; nothing to do")
+        return 0
+
+    action = "scale_up" if delta > 0 else "scale_down"
+    decision = PoolDecision(
+        action=action,
+        delta=delta,
+        reason=f"operator request --to {target}",
+    )
+    result: ExecResult = mgr.execute(decision)
+    print(f"Decision: {decision.action} delta={delta}")
+    print(f"Spawned: {len(result.spawned)} {result.spawned}")
+    print(f"Reaped: {len(result.reaped)} {result.reaped}")
+    if result.errors:
+        for e in result.errors:
+            print(f"  ERROR: {e}", file=sys.stderr)
+    return 0 if not result.errors else 1
+
+
+def cmd_config(args: argparse.Namespace) -> int:
+    """Update pool config fields (min/max/policy/cooldown)."""
+    mgr = _make_manager(args.project, args.pool_id)
+    pool_id = args.pool_id or "default"
+    config = mgr.repo.get_config(pool_id)
+    if not config:
+        print(f"ERROR: pool {pool_id!r} not found for project {args.project!r}", file=sys.stderr)
+        return 1
+
+    updates = {}
+    if args.min is not None:
+        updates["min_workers"] = args.min
+    if args.max is not None:
+        updates["max_workers"] = args.max
+    if args.policy is not None:
+        updates["scaling_policy"] = args.policy
+    if args.cooldown is not None:
+        updates["cooldown_seconds"] = args.cooldown
+
+    if not updates:
+        print("No changes")
+        return 0
+
+    mgr.repo.update_config(pool_id, updates)
+    print(f"Updated config for {pool_id!r}: {updates}")
+    return 0
+
+
+def cmd_reap(args: argparse.Namespace) -> int:
+    """Reap stale workers; dry-run by default unless --force."""
+    mgr = _make_manager(args.project, args.pool_id)
+
+    if not args.force:
+        from pool_reaper import ReapConfig, identify_reap_targets  # noqa: E402
+        _config, _state, members = mgr.load_state()
+        targets = identify_reap_targets(members, time.time(), ReapConfig())
+        print("WARN: --force not specified. Reap candidates (dry-run):")
+        for t in targets:
+            print(f"  would reap: {t.terminal_id} reason={t.reason}")
+        if not targets:
+            print("  (no candidates)")
+        return 0
+
+    reaped = mgr.reap_dead()
+    print(f"Reaped {len(reaped)} workers")
+    for t in reaped:
+        print(f"  {t.terminal_id} ({t.reason})")
+    return 0
+
+
+def _make_manager(project: str, pool_id: Optional[str]) -> PoolManager:
+    return PoolManager(project_id=project, pool_id=pool_id or "default")
+
+
+def _fmt_age(timestamp: float) -> str:
+    age_s = time.time() - timestamp
+    if age_s < 60:
+        return f"{age_s:.0f}s ago"
+    if age_s < 3600:
+        return f"{age_s / 60:.0f}min ago"
+    return f"{age_s / 3600:.1f}h ago"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="vnx pool — manage elastic worker pools")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_status = sub.add_parser("status", help="show pool state")
+    p_status.add_argument("--project", default="default")
+    p_status.add_argument("--pool-id", dest="pool_id", default=None)
+    p_status.add_argument("--json", action="store_true")
+    p_status.set_defaults(func=cmd_status)
+
+    p_scale = sub.add_parser("scale", help="force scale pool to N workers")
+    p_scale.add_argument("--project", required=True)
+    p_scale.add_argument("--to", type=int, required=True)
+    p_scale.add_argument("--pool-id", dest="pool_id", default=None)
+    p_scale.set_defaults(func=cmd_scale)
+
+    p_config = sub.add_parser("config", help="update pool config")
+    p_config.add_argument("--project", required=True)
+    p_config.add_argument("--pool-id", dest="pool_id", default=None)
+    p_config.add_argument("--min", type=int, dest="min")
+    p_config.add_argument("--max", type=int, dest="max")
+    p_config.add_argument("--policy", dest="policy")
+    p_config.add_argument("--cooldown", type=float, dest="cooldown")
+    p_config.set_defaults(func=cmd_config)
+
+    p_reap = sub.add_parser("reap", help="reap stale workers (dry-run by default)")
+    p_reap.add_argument("--project", required=True)
+    p_reap.add_argument("--pool-id", dest="pool_id", default=None)
+    p_reap.add_argument("--force", action="store_true", help="actually reap (default: dry-run)")
+    p_reap.set_defaults(func=cmd_reap)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -94,6 +94,17 @@ def main() -> None:
         help="project directory (default: current directory)",
     )
 
+    # pool subcommand — delegates to vnx_cli.commands.pool for sub-subcommand parsing
+    pool_parser = subparsers.add_parser(
+        "pool",
+        help="manage elastic worker pools (status/scale/config/reap)",
+    )
+    pool_parser.add_argument(
+        "pool_args",
+        nargs=argparse.REMAINDER,
+        help="pool subcommand and arguments",
+    )
+
     args = parser.parse_args()
 
     if args.command == "init":
@@ -111,6 +122,10 @@ def main() -> None:
     elif args.command == "dispatch-agent":
         from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
         sys.exit(vnx_dispatch_agent(args))
+
+    elif args.command == "pool":
+        from vnx_cli.commands.pool import main as pool_main
+        sys.exit(pool_main(argv=getattr(args, "pool_args", None) or None))
 
     else:
         parser.print_help()


### PR DESCRIPTION
## Summary

- Adds `vnx pool` CLI with 4 subcommands: `status`, `scale`, `config`, `reap`
- Implements `update_config()` on `PoolStateRepository` (required by `vnx pool config`)
- Routes `pool` through both `bin/vnx` (bash shim) and `vnx_cli/main.py` (Python entry point)
- Adds operator guide at `docs/operations/POOL_OPERATIONS.md`

## Architecture

`vnx_cli/commands/pool.py` owns all pool argparse logic. Both entry points delegate to `pool.main(argv=...)`:
- `bin/vnx`: `exec python3 -m vnx_cli.commands.pool "$@"` (bash shim path)
- `vnx_cli/main.py`: `pool_main(argv=args.pool_args)` (Python package path)

`update_config()` in `PoolStateRepository` maps PoolConfig field names → DB column names (`scaling_policy` → `scale_policy`) and uses `BEGIN IMMEDIATE` atomic writes.

Reap is dry-run by default (`--force` required for actual reap). Scale validates target against `[min, max]` before dispatching a `PoolDecision` to `PoolManager.execute()`.

## References

- ADR-018: Elastic Worker Pool
- Wave 6 architecture: `claudedocs/wave6-workers-n-architecture.md`

## Test plan

- [x] 24 unit tests in `tests/test_vnx_pool_cli.py` — all pass
- [x] 63 existing pool tests pass with no regressions
- [x] `bash -n bin/vnx` syntax OK
- [x] No `.vnx-data/state/` in docstrings (CI Legacy gate)
- [x] No TODO/FIXME in implementation
- [x] All functions ≤70 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)