### PR TITLE
fix(wave6): OI cleanup group 1 (idempotency + regex + ledger + audit)

### DIFF
--- a/scripts/aggregator/build_central_view.py
+++ b/scripts/aggregator/build_central_view.py
@@ -287,10 +287,10 @@ def build_coordination_events_unified(
 ) -> int:
     """Populate coordination_events_unified from per-project t0_receipts.ndjson.
 
-    Safe to call multiple times: the table is created with IF NOT EXISTS.
-    Existing rows are NOT deduplicated across calls; callers that need
-    idempotency should drop+recreate the table before calling.
+    Idempotent: drops and recreates the table on each call so calling twice
+    produces the same row count (OI-1477).
     """
+    con.execute("DROP TABLE IF EXISTS coordination_events_unified")
     con.execute(_COORD_EVENTS_DDL)
 
     inserted = 0

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -337,13 +337,16 @@ class PoolManager:
 
     def _execute_scale_down(self, decision: PoolDecision, now: float) -> ExecResult:
         result = ExecResult(decision=decision)
-        config, _, members = self.load_state()
 
-        membership_ids = select_for_scale_down(
-            members=members,
-            provider_mix=config.provider_mix,
-            delta=decision.delta,
-        )
+        if decision.targets:  # OI-1483: use pre-computed targets from decide()
+            membership_ids = list(decision.targets)
+        else:
+            config, _, members = self.load_state()
+            membership_ids = select_for_scale_down(
+                members=members,
+                provider_mix=config.provider_mix,
+                delta=decision.delta,
+            )
 
         for membership_id in membership_ids:
             try:

--- a/scripts/lib/pool_provider_allocator.py
+++ b/scripts/lib/pool_provider_allocator.py
@@ -100,9 +100,11 @@ def allocate_for_scale_up(
             fallback_used=[fallback_provider] * delta,
         )
 
-    new_size = len(members) + delta
+    # OI-1483: use active-only count for both new_size and current_shares
+    active = [m for m in members if m.status == "active"]
+    new_size = len(active) + delta
     target_shares = compute_target_shares(provider_mix, new_size)
-    current_shares = Counter(m.provider for m in members if m.status == "active")
+    current_shares = Counter(m.provider for m in active)
 
     allocations: List[str] = []
     fallback_used: List[str] = []

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -279,10 +279,11 @@ class PoolStateRepository:
         now: float,
     ) -> None:
         released_iso = _iso_now(now)
+        event_id = _uuid7()  # OI-1484: per-event idempotency key
         conn = self._connect()
         try:
             conn.execute("BEGIN IMMEDIATE")
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE worker_pool_membership
                 SET released_at   = ?,
@@ -292,6 +293,12 @@ class PoolStateRepository:
                 """,
                 (released_iso, reason, membership_id),
             )
+            if cursor.rowcount == 0:  # OI-1482: no row matched — skip ledger emit
+                conn.rollback()
+                log.warning(
+                    "mark_member_reaped: no row matched for membership_id=%s", membership_id
+                )
+                return
             conn.commit()
             log.debug("mark_member_reaped: membership_id=%s reason=%s", membership_id, reason)
         except Exception:
@@ -299,11 +306,17 @@ class PoolStateRepository:
             raise
         finally:
             conn.close()
-        self._emit_ledger("pool.member.reaped", {
-            "membership_id": membership_id,
-            "reason": reason,
-            "now": now,
-        })
+        try:  # OI-1484: wrap ledger emit; DB mutation is authoritative
+            self._emit_ledger("pool.member.reaped", {
+                "event_id": event_id,
+                "membership_id": membership_id,
+                "reason": reason,
+                "now": now,
+            })
+        except Exception:
+            log.error(
+                "mark_member_reaped: ledger emit failed for membership_id=%s", membership_id
+            )
 
     def update_heartbeat(self, membership_id: str, now: float) -> None:
         hb_iso = _iso_now(now)
@@ -393,12 +406,22 @@ class PoolStateRepository:
                 decision.action,
                 decision_id,
             )
-            return decision_id
         except Exception:
             conn.rollback()
             raise
         finally:
             conn.close()
+        self._emit_ledger("pool.decision.recorded", {  # OI-1482: emit ledger after commit
+            "pool_id": pool_id,
+            "decision_id": decision_id,
+            "action": decision.action,
+            "delta": decision.delta,
+            "reason": decision.reason,
+            "targets": list(decision.targets),
+            "cooldown_remaining_s": decision.cooldown_remaining_s,
+            "now": now,
+        })
+        return decision_id
 
     def get_current_size(self, pool_id: str) -> int:
         conn = self._connect()

--- a/scripts/lib/worker_registry.py
+++ b/scripts/lib/worker_registry.py
@@ -15,7 +15,7 @@ Public API:
 - resolve_alias(alias) -> Optional[Worker]
 
 Validation:
-- terminal_id matches r"^[A-Za-z][A-Za-z0-9]*[0-9]+$" or is a plain letter+digit combo
+- terminal_id matches r"^T[0-9]+$" (T followed by one or more digits)
 - role validated against validate_skill.py --list output
 - provider in {claude, codex, gemini, litellm:<sub>}
 - aliases unique across all workers
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_TERMINAL_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*$")
+_TERMINAL_ID_RE = re.compile(r"^T[0-9]+$")
 _VALID_SCALING_POLICIES = frozenset({"fixed", "queue_aware"})
 _VALID_PROVIDERS_BASE = frozenset({"claude", "codex", "gemini"})
 # System roles that are valid but not listed in validate_skill.py (non-worker roles).
@@ -238,7 +238,7 @@ def _validate_terminal_id(terminal_id: str) -> None:
     if not _TERMINAL_ID_RE.match(terminal_id):
         raise ValueError(
             f"Invalid terminal_id {terminal_id!r}. "
-            "Must start with a letter, followed by alphanumeric chars."
+            "Must match ^T[0-9]+$ (e.g. T0, T1, T2, T99)."
         )
 
 

--- a/tests/fixtures/pool_state_fixtures.py
+++ b/tests/fixtures/pool_state_fixtures.py
@@ -34,7 +34,7 @@ def make_config(
     pool_id: str = "default",
     min_workers: int = 1,
     max_workers: int = 4,
-    scaling_policy: str = "queue_aware",
+    scaling_policy: str = "queue_depth_v1",
     provider_mix: Optional[list] = None,
     cooldown_seconds: float = 60.0,
     heartbeat_stale_seconds: float = 300.0,
@@ -179,7 +179,7 @@ def create_test_db(
     min_workers: int = 1,
     max_workers: int = 4,
     target_workers: int = 2,
-    scale_policy: str = "queue_aware",
+    scale_policy: str = "queue_depth_v1",
     cooldown_seconds: int = 60,
     provider_mix_json: str = '["claude"]',
 ) -> sqlite3.Connection:
@@ -218,7 +218,7 @@ def create_test_db_file(
     min_workers: int = 1,
     max_workers: int = 4,
     target_workers: int = 2,
-    scale_policy: str = "queue_aware",
+    scale_policy: str = "queue_depth_v1",
     cooldown_seconds: int = 60,
     provider_mix_json: str = '["claude"]',
 ) -> Path:

--- a/tests/test_aggregator_build_central_view.py
+++ b/tests/test_aggregator_build_central_view.py
@@ -19,7 +19,9 @@ import pytest
 
 from scripts.aggregator.build_central_view import (
     UNIFIED_TABLES,
+    ProjectEntry,
     attach_readonly,
+    build_coordination_events_unified,
     load_registry,
     main,
     materialize_views,
@@ -365,6 +367,46 @@ def test_unified_tables_constants_consistent():
 # ---------------------------------------------------------------------------
 # CLI wiring
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# OI-1477: build_coordination_events_unified idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_build_coordination_events_idempotent(tmp_path: Path):
+    """OI-1477: calling build_coordination_events_unified twice yields the same row count."""
+    # Create a project with a t0_receipts.ndjson that has 3 events.
+    proj_path = tmp_path / "proj1"
+    state_dir = proj_path / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    receipt_lines = [
+        '{"dispatch_id": "d1", "event_type": "dispatch_created", "timestamp": "2026-01-01T00:00:00Z", "project_id": "vnx-dev"}',
+        '{"dispatch_id": "d1", "event_type": "dispatch_completed", "timestamp": "2026-01-01T00:01:00Z", "project_id": "vnx-dev"}',
+        '{"dispatch_id": "d2", "event_type": "t0_heartbeat", "timestamp": "2026-01-01T00:02:00Z", "project_id": "vnx-dev"}',
+    ]
+    (state_dir / "t0_receipts.ndjson").write_text("\n".join(receipt_lines))
+    projects = [ProjectEntry(name="proj1", path=proj_path, project_id="vnx-dev")]
+
+    view_db = tmp_path / "agg.db"
+    con = sqlite3.connect(view_db)
+    try:
+        build_coordination_events_unified(con, projects)
+        first_count = con.execute(
+            "SELECT COUNT(*) FROM coordination_events_unified"
+        ).fetchone()[0]
+
+        build_coordination_events_unified(con, projects)
+        second_count = con.execute(
+            "SELECT COUNT(*) FROM coordination_events_unified"
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert first_count == 3, f"Expected 3 rows on first call, got {first_count}"
+    assert second_count == first_count, (
+        f"Idempotency violated: first={first_count}, second={second_count}"
+    )
 
 
 def test_cli_dry_run_exits_zero_and_prints_plan(four_project_fixture, tmp_path: Path, capsys):

--- a/tests/test_pool_provider_allocator.py
+++ b/tests/test_pool_provider_allocator.py
@@ -284,6 +284,41 @@ class TestEdgeCases:
         assert counts.get("claude", 0) == 5
         assert counts.get("codex", 0) == 5
 
+
+# ---------------------------------------------------------------------------
+# OI-1483: allocate_for_scale_up uses active-only count (not all members)
+# ---------------------------------------------------------------------------
+
+class TestActiveOnlyCount:
+    def test_reaped_members_excluded_from_new_size(self):
+        """OI-1483: new_size = len(active) + delta, not len(all) + delta."""
+        reset_counter()
+        # 2 active + 1 reaped; delta=1 -> new_size=3, not 4
+        active1 = m("claude", t=1.0, status="active", mid="a1")
+        active2 = m("codex", t=2.0, status="active", mid="a2")
+        reaped1 = m("claude", t=0.5, status="reaped", mid="r1")
+
+        mix = ["claude", "codex"]
+        result = allocate_for_scale_up([active1, active2, reaped1], mix, delta=1)
+        # new_size=3; target={claude:2,codex:1}; current_active={claude:1,codex:1}
+        # claude gap=1, codex gap=0 -> allocate claude
+        assert len(result.providers) == 1
+        assert result.providers[0] == "claude"
+
+    def test_pending_members_excluded_from_current_shares(self):
+        """OI-1483: pending/draining members don't count toward current_shares."""
+        reset_counter()
+        active_claude = m("claude", t=1.0, status="active", mid="ac1")
+        pending_codex = m("codex", t=2.0, status="pending", mid="pc1")
+
+        mix = ["claude", "codex"]
+        # Only active=1 (claude), new_size=3 (1+delta=2), target={claude:2, codex:1}
+        # current_shares={claude:1}; gaps: claude=1, codex=1 -> allocate both
+        result = allocate_for_scale_up([active_claude, pending_codex], mix, delta=2)
+        assert len(result.providers) == 2
+        # codex should appear since pending_codex is not counted in current_shares
+        assert "codex" in result.providers
+
     def test_allocation_result_is_pure_no_side_effects(self):
         """Calling allocate twice with same args returns same result."""
         reset_counter()

--- a/tests/test_pool_state_repo.py
+++ b/tests/test_pool_state_repo.py
@@ -197,3 +197,72 @@ def test_update_config_emits_ledger_event(tmp_path):
     assert ev["payload"]["updates"] == updates
     assert "now" in ev["payload"]
     assert "timestamp" in ev
+
+
+# ---------------------------------------------------------------------------
+# 7. record_decision emits pool.decision.recorded ledger event (OI-1482)
+# ---------------------------------------------------------------------------
+
+def test_record_decision_emits_ledger_event(tmp_path):
+    from pool_decision_engine import PoolDecision  # noqa: E402
+
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    decision = PoolDecision(action="scale_up", delta=2, reason="queue backlog")
+    repo.record_decision("default", decision, time.time())
+
+    events = _read_ledger_events(db)
+    decision_events = [e for e in events if e["event_type"] == "pool.decision.recorded"]
+    assert len(decision_events) == 1
+    ev = decision_events[0]
+    assert ev["payload"]["pool_id"] == "default"
+    assert ev["payload"]["action"] == "scale_up"
+    assert ev["payload"]["delta"] == 2
+    assert "decision_id" in ev["payload"]
+    assert "timestamp" in ev
+
+
+# ---------------------------------------------------------------------------
+# 8. mark_member_reaped no-op when membership_id has no matching row (OI-1482)
+# ---------------------------------------------------------------------------
+
+def test_mark_reaped_no_match_no_ledger_emit(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    events_file = db.parent.parent / "events" / "pool_events.ndjson"
+
+    # Call with a non-existent membership_id
+    repo.mark_member_reaped("nonexistent-membership-id", "scale_down", time.time())
+
+    # No ledger event should be emitted for a no-op UPDATE
+    if events_file.exists():
+        events = _read_ledger_events(db)
+        reap_events = [e for e in events if e["event_type"] == "pool.member.reaped"]
+        assert reap_events == [], "No reap event should be emitted when no row matched"
+
+
+# ---------------------------------------------------------------------------
+# 9. mark_member_reaped includes event_id in ledger payload (OI-1484)
+# ---------------------------------------------------------------------------
+
+def test_mark_reaped_event_id_in_payload(tmp_path):
+    (tmp_path / "state").mkdir()
+    db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+    repo = _make_repo(db)
+
+    now = time.time()
+    membership_id = repo.add_member("default", "T-oi1484-01", "claude", "backend-developer", now)
+
+    events_file = db.parent.parent / "events" / "pool_events.ndjson"
+    events_file.write_bytes(b"")
+
+    repo.mark_member_reaped(membership_id, "heartbeat_stale", now + 1)
+
+    events = _read_ledger_events(db)
+    reap_events = [e for e in events if e["event_type"] == "pool.member.reaped"]
+    assert len(reap_events) == 1
+    assert "event_id" in reap_events[0]["payload"], "event_id must be present for idempotency"

--- a/tests/test_worker_registry.py
+++ b/tests/test_worker_registry.py
@@ -315,8 +315,9 @@ class TestTerminalIdValidation:
         with pytest.raises(ValueError, match="Invalid terminal_id"):
             _registry_from_yaml(bad_yaml)
 
-    def test_valid_custom_prefix_terminal_id(self):
-        ok_yaml = textwrap.dedent("""\
+    def test_custom_prefix_terminal_id_rejected(self):
+        """OI-1478: strict ^T[0-9]+$ rejects custom prefixes like WORKER1."""
+        bad_yaml = textwrap.dedent("""\
             schema_version: 1
             workers:
               - terminal_id: WORKER1
@@ -332,8 +333,52 @@ class TestTerminalIdValidation:
                 scaling_policy: fixed
                 provider_mix: []
         """)
-        reg = _registry_from_yaml(ok_yaml)
-        assert reg.by_id("WORKER1") is not None
+        with pytest.raises(ValueError, match="Invalid terminal_id"):
+            _registry_from_yaml(bad_yaml)
+
+    def test_non_t_prefix_rejected(self):
+        """OI-1478: IDs like 'Foo', 'Bar', 'A1' must be rejected."""
+        for bad_id in ("Foo", "Bar", "A1", "T", "t0"):
+            bad_yaml = textwrap.dedent(f"""\
+                schema_version: 1
+                workers:
+                  - terminal_id: {bad_id!r}
+                    role: backend-developer
+                    provider: claude
+                    model: sonnet
+                    pool_id: p
+                    aliases: []
+                pools:
+                  - pool_id: p
+                    min_workers: 1
+                    max_workers: 1
+                    scaling_policy: fixed
+                    provider_mix: []
+            """)
+            with pytest.raises(ValueError, match="Invalid terminal_id"):
+                _registry_from_yaml(bad_yaml)
+
+    def test_valid_t_format_terminal_ids(self):
+        """OI-1478: backward-compat — T0, T1, T2, T3, T99 all valid."""
+        for tid in ("T0", "T1", "T2", "T3", "T99"):
+            ok_yaml = textwrap.dedent(f"""\
+                schema_version: 1
+                workers:
+                  - terminal_id: {tid!r}
+                    role: backend-developer
+                    provider: claude
+                    model: sonnet
+                    pool_id: p
+                    aliases: []
+                pools:
+                  - pool_id: p
+                    min_workers: 1
+                    max_workers: 1
+                    scaling_policy: fixed
+                    provider_mix: []
+            """)
+            reg = _registry_from_yaml(ok_yaml)
+            assert reg.by_id(tid) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -506,7 +551,7 @@ class TestOperatorYamlOverride:
         operator_yaml.write_text(textwrap.dedent("""\
             schema_version: 1
             workers:
-              - terminal_id: A1
+              - terminal_id: T5
                 role: backend-developer
                 provider: claude
                 model: haiku
@@ -524,7 +569,7 @@ class TestOperatorYamlOverride:
         reg = _load_registry(repo_root=tmp_path)
         workers = reg.list_workers()
         assert len(workers) == 1
-        assert workers[0].terminal_id == "A1"
+        assert workers[0].terminal_id == "T5"
 
     def test_missing_yaml_falls_back_to_hardcoded_default(self, tmp_path: Path):
         reg = _load_registry(repo_root=tmp_path)

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -88,6 +88,10 @@ def cmd_scale(args: argparse.Namespace) -> int:
         reason=f"operator request --to {target}",
     )
     result: ExecResult = mgr.execute(decision)
+    now = time.time()
+    mgr.repo.record_decision(mgr.pool_id, decision, now)  # OI-1485: audit trail
+    if result.spawned or result.reaped:
+        mgr.repo.update_last_scaled_at(mgr.pool_id, now)  # OI-1485: cooldown anchor
     print(f"Decision: {decision.action} delta={delta}")
     print(f"Spawned: {len(result.spawned)} {result.spawned}")
     print(f"Reaped: {len(result.reaped)} {result.reaped}")


### PR DESCRIPTION
## Summary

Six advisory OIs from Wave 6 PR-6.1–6.7, bundled as a single cohesive cleanup.

- **OI-1477** — `build_coordination_events_unified` made idempotent: drops and recreates table on each call, preventing duplicate rows on repeated `materialize_views()` invocations
- **OI-1478** — `_TERMINAL_ID_RE` tightened from `^[A-Za-z][A-Za-z0-9]*$` to `^T[0-9]+$` per contract docs; T0–T3 remain valid; "WORKER1", "Foo", "A1" now raise `ValueError`
- **OI-1482** — `record_decision()` now emits `pool.decision.recorded` ledger event after commit (was an audit gap); `mark_member_reaped()` checks `cursor.rowcount` and skips ledger emit when UPDATE matches no row; fixture `scaling_policy` default aligned to `queue_depth_v1` (matches DDL default)
- **OI-1483** — `allocate_for_scale_up()` computes `new_size` and `current_shares` from active-only members (was inconsistent: all members for size, active-only for shares); `_execute_scale_down()` uses `decision.targets` when pre-computed by `decide()` instead of re-selecting
- **OI-1484** — `mark_member_reaped()` adds per-event `event_id` (UUID v7) to ledger payload for idempotency detection; ledger emit wrapped in `try/except` so DB mutation (authoritative) survives transient file-write failures
- **OI-1485** — `cmd_scale` now calls `record_decision()` + `update_last_scaled_at()` after `execute()` so manual scale operations produce an audit entry and cooldown anchor (previously bypassed `tick()` bookkeeping)

## Test plan

- [ ] `pytest tests/test_aggregator_build_central_view.py` — 14 tests, OI-1477 idempotency test added
- [ ] `pytest tests/test_worker_registry.py` — 48 tests, OI-1478 strict regex tests added
- [ ] `pytest tests/test_pool_state_repo.py` — 9 tests, OI-1482/1484 ledger + event_id tests added
- [ ] `pytest tests/test_pool_provider_allocator.py` — 37 tests, OI-1483 active-only count tests added
- [ ] `pytest tests/test_pool_manager_integration.py tests/test_state_aggregator.py tests/test_pool_state_aggregator.py` — 36 tests pass (no regressions)
- [ ] Total: 144 tests pass across all affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)