### PR TITLE
feat(benchmark): suite infrastructure (9 models x 7 tasks orchestrator + judge + analyzer)

### DIFF
--- a/scripts/benchmark/analyze_results.py
+++ b/scripts/benchmark/analyze_results.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""analyze_results.py — Aggregate benchmark results into report + routing recommendations.
+
+Output:
+  - claudedocs/benchmark-model-comparison.md  (data tables + insights)
+  - scripts/lib/providers/routing_recommendations.yaml  (cost-routing input data)
+
+Usage:
+    python3 scripts/benchmark/analyze_results.py [--results-dir PATH] [--output-dir PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCHMARK_DIR / "results"
+CLAUDEDOCS_DIR = REPO_ROOT / "claudedocs"
+ROUTING_OUTPUT = REPO_ROOT / "scripts" / "lib" / "providers" / "routing_recommendations.yaml"
+
+
+def load_results(results_dir: Path) -> List[Dict]:
+    records = []
+    for path in sorted(results_dir.glob("*.json")):
+        try:
+            records.append(json.loads(path.read_text()))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return records
+
+
+def _score(record: Dict) -> Optional[float]:
+    scores = (record.get("judge_scores") or {})
+    q = scores.get("quality_score")
+    comp = scores.get("completeness_score")
+    if q is None or comp is None:
+        return None
+    return round((q + comp) / 2, 2)
+
+
+def _cost(record: Dict) -> Optional[float]:
+    return record.get("cost_usd")
+
+
+def _duration(record: Dict) -> float:
+    return record.get("duration_seconds") or 0.0
+
+
+def build_task_summary(records: List[Dict]) -> Dict[str, Dict[str, Dict]]:
+    """Build nested dict: task_id -> model_id -> {score, cost, duration}."""
+    summary: Dict[str, Dict[str, Dict]] = defaultdict(dict)
+    for r in records:
+        task_id = r.get("task_id", "unknown")
+        model_id = r.get("model_id", "unknown")
+        summary[task_id][model_id] = {
+            "score": _score(r),
+            "cost_usd": _cost(r),
+            "duration_seconds": _duration(r),
+            "correctness": (r.get("judge_scores") or {}).get("correctness"),
+        }
+    return summary
+
+
+def build_pareto_frontier(records: List[Dict]) -> List[Dict]:
+    """Compute cost-quality Pareto frontier across all (model, task) pairs."""
+    points = []
+    for r in records:
+        s = _score(r)
+        c = _cost(r)
+        if s is None or c is None:
+            continue
+        points.append({"model_id": r["model_id"], "task_id": r["task_id"], "score": s, "cost_usd": c})
+
+    pareto = []
+    for p in points:
+        dominated = any(
+            other["score"] >= p["score"] and other["cost_usd"] <= p["cost_usd"] and other is not p
+            for other in points
+        )
+        if not dominated:
+            pareto.append(p)
+
+    return sorted(pareto, key=lambda x: x["cost_usd"])
+
+
+def build_routing_recommendations(summary: Dict[str, Dict[str, Dict]]) -> Dict:
+    """For each task class, rank models by composite score and cost."""
+    routing: Dict[str, List[Dict]] = {}
+    for task_id, models in summary.items():
+        ranked = []
+        for model_id, metrics in models.items():
+            ranked.append({
+                "model_id": model_id,
+                "composite_score": metrics["score"],
+                "cost_usd_per_call": metrics["cost_usd"],
+                "avg_duration_seconds": metrics["duration_seconds"],
+            })
+        # Sort: highest score first; tie-break by lowest cost
+        ranked.sort(key=lambda x: (-(x["composite_score"] or 0), (x["cost_usd_per_call"] or float("inf"))))
+        routing[task_id] = ranked
+    return {"routing_by_task": routing}
+
+
+def _md_table(headers: List[str], rows: List[List[str]]) -> str:
+    widths = [max(len(h), max((len(str(r[i])) for r in rows), default=0)) for i, h in enumerate(headers)]
+    sep = "| " + " | ".join("-" * w for w in widths) + " |"
+    header_row = "| " + " | ".join(h.ljust(widths[i]) for i, h in enumerate(headers)) + " |"
+    data_rows = ["| " + " | ".join(str(r[i]).ljust(widths[i]) for i in range(len(headers))) + " |" for r in rows]
+    return "\n".join([header_row, sep] + data_rows)
+
+
+def render_markdown_report(records: List[Dict], summary: Dict, pareto: List[Dict]) -> str:
+    lines = [
+        "# Benchmark Model Comparison Report",
+        "",
+        f"Generated from {len(records)} benchmark results.",
+        "",
+        "## Per-Task Rankings",
+        "",
+    ]
+
+    for task_id in sorted(summary):
+        models_data = summary[task_id]
+        lines.append(f"### {task_id}")
+        headers = ["Model", "Score", "Correctness", "Cost USD", "Duration (s)"]
+        rows = []
+        for model_id in sorted(models_data, key=lambda m: -(models_data[m]["score"] or 0)):
+            m = models_data[model_id]
+            rows.append([
+                model_id,
+                str(m["score"] or "N/A"),
+                "yes" if m["correctness"] else ("no" if m["correctness"] is False else "N/A"),
+                f"{m['cost_usd']:.4f}" if m["cost_usd"] is not None else "N/A",
+                f"{m['duration_seconds']:.1f}",
+            ])
+        lines.append(_md_table(headers, rows))
+        lines.append("")
+
+    lines += [
+        "## Cost-Quality Pareto Frontier",
+        "",
+        "Models where no other model is both cheaper AND better quality.",
+        "",
+    ]
+    if pareto:
+        headers = ["Model", "Task", "Score", "Cost USD"]
+        rows = [[p["model_id"], p["task_id"], str(p["score"]), f"{p['cost_usd']:.4f}"] for p in pareto]
+        lines.append(_md_table(headers, rows))
+    else:
+        lines.append("No Pareto data (missing judge scores or cost data).")
+    lines.append("")
+
+    all_scores: Dict[str, List[float]] = defaultdict(list)
+    all_costs: Dict[str, List[float]] = defaultdict(list)
+    for r in records:
+        s = _score(r)
+        c = _cost(r)
+        mid = r.get("model_id", "unknown")
+        if s is not None:
+            all_scores[mid].append(s)
+        if c is not None:
+            all_costs[mid].append(c)
+
+    lines += ["## Overall Model Summary", ""]
+    headers = ["Model", "Avg Score", "Avg Cost USD", "Tasks Scored"]
+    rows = []
+    for model_id in sorted(all_scores):
+        avg_score = round(sum(all_scores[model_id]) / len(all_scores[model_id]), 2)
+        costs = all_costs.get(model_id, [])
+        avg_cost = round(sum(costs) / len(costs), 4) if costs else None
+        rows.append([
+            model_id,
+            str(avg_score),
+            f"{avg_cost:.4f}" if avg_cost is not None else "N/A",
+            str(len(all_scores[model_id])),
+        ])
+    rows.sort(key=lambda r: -float(r[1]))
+    lines.append(_md_table(headers, rows))
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate benchmark results into report + routing YAML")
+    parser.add_argument("--results-dir", default=None)
+    parser.add_argument("--output-dir", default=None, help="Override claudedocs output directory")
+    args = parser.parse_args()
+
+    results_dir = Path(args.results_dir) if args.results_dir else RESULTS_DIR
+    output_dir = Path(args.output_dir) if args.output_dir else CLAUDEDOCS_DIR
+
+    records = load_results(results_dir)
+    if not records:
+        print(f"No result files found in {results_dir}")
+        return 0
+
+    print(f"Loaded {len(records)} results")
+
+    summary = build_task_summary(records)
+    pareto = build_pareto_frontier(records)
+    routing = build_routing_recommendations(summary)
+    report_md = render_markdown_report(records, summary, pareto)
+
+    report_path = output_dir / "benchmark-model-comparison.md"
+    _atomic_write(report_path, report_md)
+    print(f"Report written to {report_path}")
+
+    routing_path = ROUTING_OUTPUT
+    _atomic_write(routing_path, yaml.dump(routing, default_flow_style=False, allow_unicode=True))
+    print(f"Routing recommendations written to {routing_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/analyze_results.py
+++ b/scripts/benchmark/analyze_results.py
@@ -13,11 +13,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 import yaml
 
@@ -30,11 +33,19 @@ ROUTING_OUTPUT = REPO_ROOT / "scripts" / "lib" / "providers" / "routing_recommen
 
 def load_results(results_dir: Path) -> List[Dict]:
     records = []
+    skipped = []
     for path in sorted(results_dir.glob("*.json")):
         try:
             records.append(json.loads(path.read_text()))
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("analyze: skipping %s: %s", path, e)
+            skipped.append(str(path))
             continue
+    if skipped:
+        print(
+            f"WARNING: skipped {len(skipped)} unreadable result files: {skipped[:3]}{'...' if len(skipped) > 3 else ''}",
+            file=sys.stderr,
+        )
     return records
 
 

--- a/scripts/benchmark/judge_quality.py
+++ b/scripts/benchmark/judge_quality.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""judge_quality.py — Use Claude Opus to score benchmark responses.
+
+For each result file in results/:
+  - Read original task prompt + model response
+  - Call claude -p with judge-prompt: rate quality, correctness, completeness
+  - Parse JSON response, add scores to result file (atomic write)
+
+Usage:
+    python3 scripts/benchmark/judge_quality.py [--results-dir PATH] [--model opus]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCHMARK_DIR / "results"
+PROMPTS_DIR = BENCHMARK_DIR / "prompts"
+
+JUDGE_PROMPT_TEMPLATE = """Score this AI response on three dimensions. Be objective; you're evaluating output quality, not the model's internal reasoning.
+
+Original task:
+{task_prompt}
+
+Response from model "{model_id}":
+{response}
+
+Output ONLY a JSON object with exactly these fields:
+{{
+  "quality_score": <int 1-10>,
+  "correctness": <true|false>,
+  "completeness_score": <int 1-10>,
+  "notable_issues": "<one sentence, or empty string>"
+}}
+
+No markdown, no prose, no code fences. Raw JSON only.
+"""
+
+_FALLBACK_SCORE = {
+    "quality_score": 0,
+    "correctness": False,
+    "completeness_score": 0,
+    "notable_issues": "judge failed to parse",
+}
+
+
+def _load_task_prompt(task_id: str, prompts_dir: Path) -> str:
+    path = prompts_dir / f"{task_id}.txt"
+    return path.read_text() if path.exists() else f"(prompt file not found: {task_id}.txt)"
+
+
+def _call_judge(prompt: str, model: str, timeout: int) -> str:
+    """Invoke claude -p and return stdout. Raises subprocess.TimeoutExpired on timeout."""
+    proc = subprocess.run(
+        ["claude", "-p", "--model", model, prompt],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude returned {proc.returncode}: {proc.stderr[:200]}")
+    return proc.stdout.strip()
+
+
+def _parse_judge_response(raw: str) -> Dict:
+    """Extract JSON object from judge output. Returns fallback dict on parse failure."""
+    raw = raw.strip()
+    # Strip markdown code fences if model wrapped it
+    if raw.startswith("```"):
+        lines = raw.splitlines()
+        inner = [ln for ln in lines if not ln.startswith("```")]
+        raw = "\n".join(inner).strip()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return dict(_FALLBACK_SCORE)
+
+    score: Dict = {}
+    score["quality_score"] = int(data.get("quality_score") or 0)
+    score["correctness"] = bool(data.get("correctness", False))
+    score["completeness_score"] = int(data.get("completeness_score") or 0)
+    score["notable_issues"] = str(data.get("notable_issues") or "")
+    return score
+
+
+def judge_result_file(result_path: Path, prompts_dir: Path, model: str, timeout: int) -> Dict:
+    """Score one result JSON file. Returns the score dict."""
+    data = json.loads(result_path.read_text())
+    task_id = data.get("task_id", "")
+    model_id = data.get("model_id", "")
+    response = data.get("response", "")
+
+    task_prompt = _load_task_prompt(task_id, prompts_dir)
+    judge_prompt = JUDGE_PROMPT_TEMPLATE.format(
+        task_prompt=task_prompt,
+        model_id=model_id,
+        response=response or "(empty response)",
+    )
+
+    try:
+        raw = _call_judge(judge_prompt, model, timeout)
+        score = _parse_judge_response(raw)
+    except Exception as exc:
+        score = dict(_FALLBACK_SCORE)
+        score["notable_issues"] = f"judge error: {exc}"
+
+    data["judge_scores"] = score
+    data["judge_model"] = model
+
+    tmp_path = result_path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2))
+    tmp_path.replace(result_path)
+
+    return score
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Judge benchmark responses via Claude Opus")
+    parser.add_argument("--results-dir", default=None, help="Path to results directory")
+    parser.add_argument("--model", default="opus", help="Claude model to use as judge")
+    parser.add_argument("--timeout", type=int, default=120, help="Per-call timeout in seconds")
+    parser.add_argument("--skip-judged", action="store_true", help="Skip files already containing judge_scores")
+    args = parser.parse_args()
+
+    results_dir = Path(args.results_dir) if args.results_dir else RESULTS_DIR
+    if not results_dir.exists():
+        print(f"Results directory not found: {results_dir}")
+        return 1
+
+    result_files = sorted(results_dir.glob("*.json"))
+    if not result_files:
+        print(f"No result files found in {results_dir}")
+        return 0
+
+    print(f"Judging {len(result_files)} result files with model={args.model}")
+
+    errors = 0
+    for i, path in enumerate(result_files, 1):
+        if args.skip_judged:
+            data = json.loads(path.read_text())
+            if "judge_scores" in data:
+                print(f"  [{i}/{len(result_files)}] skip (already judged): {path.name}")
+                continue
+
+        print(f"  [{i}/{len(result_files)}] {path.name}...")
+        try:
+            score = judge_result_file(path, PROMPTS_DIR, args.model, args.timeout)
+            q = score["quality_score"]
+            c = "correct" if score["correctness"] else "incorrect"
+            comp = score["completeness_score"]
+            print(f"    quality={q}/10 correctness={c} completeness={comp}/10")
+        except Exception as exc:
+            print(f"    ERROR: {exc}")
+            errors += 1
+
+    print(f"\nJudge complete: {len(result_files) - errors} ok, {errors} errors")
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/models.yaml
+++ b/scripts/benchmark/models.yaml
@@ -1,0 +1,48 @@
+models:
+  - id: claude-opus-4-6
+    provider: claude
+    model_arg: opus
+    cost_input_mtok: 15.00
+    cost_output_mtok: 75.00
+
+  - id: claude-sonnet-4-6
+    provider: claude
+    model_arg: sonnet
+    cost_input_mtok: 3.00
+    cost_output_mtok: 15.00
+
+  - id: claude-haiku-4-5
+    provider: claude
+    model_arg: haiku
+    cost_input_mtok: 1.00
+    cost_output_mtok: 5.00
+
+  - id: deepseek-v4-pro
+    provider: litellm:deepseek
+    model_arg: deepseek-v4-pro
+    cost_input_mtok: 0.435
+    cost_output_mtok: 0.87
+
+  - id: deepseek-v4-flash
+    provider: litellm:deepseek
+    model_arg: deepseek-v4-flash
+    cost_input_mtok: 0.14
+    cost_output_mtok: 0.28
+
+  - id: kimi-k2-6
+    provider: litellm:moonshot
+    model_arg: kimi-k2.6
+    cost_input_mtok: 0.95
+    cost_output_mtok: 4.00
+
+  - id: kimi-k2-0905
+    provider: litellm:moonshot
+    model_arg: kimi-k2-0905-preview
+    cost_input_mtok: 0.60
+    cost_output_mtok: 2.50
+
+  - id: glm-5-1
+    provider: litellm:openrouter
+    model_arg: z-ai/glm-5
+    cost_input_mtok: 0.50
+    cost_output_mtok: 2.50

--- a/scripts/benchmark/models.yaml
+++ b/scripts/benchmark/models.yaml
@@ -42,7 +42,7 @@ models:
     cost_output_mtok: 2.50
 
   - id: glm-5-1
-    provider: litellm:openrouter
-    model_arg: z-ai/glm-5
+    provider: litellm:zai
+    model_arg: glm-5
     cost_input_mtok: 0.50
     cost_output_mtok: 2.50

--- a/scripts/benchmark/prompts/01_code_generation.txt
+++ b/scripts/benchmark/prompts/01_code_generation.txt
@@ -1,0 +1,13 @@
+Design a SQLite migration adding a `tenant_id` column to a 50M-row table named `events`.
+
+Requirements:
+- NOT NULL constraint applied AFTER a backfill step (never set NOT NULL on an empty column in a large table)
+- Idempotent: safe to run twice without error or data corruption
+- Audit trail: log migration start, batch count, total rows migrated, and finish timestamp to a `migration_log` table
+- Rollback script: companion SQL that undoes the migration cleanly
+- Concurrent-write tolerant: table remains readable and writable during migration (no full table lock)
+- Batch size: process 10,000 rows per transaction to limit lock duration and WAL growth
+
+Output: two files
+1. `migrate_add_tenant_id.sql` — DDL + batched UPDATE + constraint + audit inserts
+2. `migrate_add_tenant_id_runner.py` — Python script using sqlite3 standard library with BEGIN/COMMIT per batch, progress reporting every 100 batches, and error recovery (resume from last committed row_id)

--- a/scripts/benchmark/prompts/02_code_review.txt
+++ b/scripts/benchmark/prompts/02_code_review.txt
@@ -1,0 +1,77 @@
+Review the following Python script for blocking issues. Identify ALL security vulnerabilities, correctness bugs, and logic errors. For each issue: state the line number, issue type (security/correctness/logic), severity (blocking/warning), and proposed fix.
+
+```python
+import os
+import sqlite3
+import subprocess
+import hashlib
+from pathlib import Path
+
+
+DB_PATH = "/tmp/vnx_cache.db"
+UPLOAD_DIR = "/var/uploads"
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    return conn
+
+
+def fetch_user(conn, username):
+    # Fetch user by username
+    cursor = conn.cursor()
+    query = "SELECT * FROM users WHERE username = '" + username + "'"
+    cursor.execute(query)
+    return cursor.fetchone()
+
+
+def hash_password(password):
+    return hashlib.md5(password.encode()).hexdigest()
+
+
+def authenticate(username, password):
+    conn = get_db()
+    user = fetch_user(conn, username)
+    if user:
+        stored_hash = user[2]
+        input_hash = hash_password(password)
+        if stored_hash == input_hash:
+            return True
+    return False
+
+
+def process_file(filename):
+    # Process uploaded file
+    filepath = os.path.join(UPLOAD_DIR, filename)
+    result = subprocess.run(
+        f"file {filepath}",
+        shell=True,
+        capture_output=True,
+        text=True
+    )
+    return result.stdout
+
+
+def save_report(report_data, output_path):
+    with open(output_path, "w") as f:
+        f.write(str(report_data))
+    os.chmod(output_path, 0o777)
+
+
+def load_config(config_path):
+    import pickle
+    with open(config_path, "rb") as f:
+        return pickle.load(f)
+
+
+def run_analysis(user_input):
+    # Run dynamic analysis
+    result = eval(user_input)
+    return result
+
+
+def cleanup_temp(directory):
+    os.system(f"rm -rf {directory}")
+```
+
+List all blocking issues with line number, issue type, severity, and fix. Do not miss any of the 5 deliberately planted critical issues.

--- a/scripts/benchmark/prompts/03_refactoring.txt
+++ b/scripts/benchmark/prompts/03_refactoring.txt
@@ -1,0 +1,38 @@
+Refactor the following Python function. Requirements: extract sub-functions with clear single responsibilities, improve naming throughout (no abbreviations, no single-letter vars), add type hints (Python 3.10+ style), preserve exact behavior.
+
+```python
+def proc(d, t, cfg):
+    res = []
+    errs = []
+    for i, item in enumerate(d):
+        if item.get('s') != 'active':
+            continue
+        ts = item.get('ts')
+        if ts is None:
+            errs.append({'idx': i, 'msg': 'missing ts', 'id': item.get('id')})
+            continue
+        if ts > t:
+            continue
+        val = item.get('v', 0)
+        lim = cfg.get('max_v', 100)
+        if val > lim:
+            val = lim
+            item['capped'] = True
+        mn = cfg.get('min_v', 0)
+        if val < mn:
+            errs.append({'idx': i, 'msg': 'below min', 'id': item.get('id'), 'val': val})
+            continue
+        m = cfg.get('mult', 1.0)
+        val = val * m
+        if cfg.get('round'):
+            val = round(val, cfg.get('round_dp', 2))
+        res.append({
+            'id': item.get('id'),
+            'v': val,
+            'ts': ts,
+            'src': item.get('src', 'unknown'),
+        })
+    return res, errs
+```
+
+Output the refactored code only. No explanatory prose before or after. The function signature must become `def process_active_items(items: list[dict], cutoff_timestamp: float, config: dict) -> tuple[list[dict], list[dict]]:`.

--- a/scripts/benchmark/prompts/04_documentation.txt
+++ b/scripts/benchmark/prompts/04_documentation.txt
@@ -1,0 +1,102 @@
+Write a README.md for the following Python module. Include: overview paragraph, installation (pip + requirements), API reference for every public function with parameter types and return types, two usage examples (basic + advanced), and a section on error handling.
+
+```python
+"""dispatch_router.py — Route dispatch requests to the correct provider backend."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_PROVIDERS = ("claude", "litellm", "codex", "gemini")
+
+
+@dataclass
+class DispatchResult:
+    success: bool
+    provider: str
+    model: str
+    output: str
+    input_tokens: int
+    output_tokens: int
+    duration_seconds: float
+    error: Optional[str] = None
+
+
+def route(provider: str, model: str, instruction: str, timeout: int = 300) -> DispatchResult:
+    """Route instruction to provider, return structured result.
+
+    Raises ValueError for unsupported provider.
+    Raises TimeoutError if provider exceeds timeout.
+    """
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(f"Unsupported provider: {provider!r}. Must be one of {SUPPORTED_PROVIDERS}")
+    handler = _get_handler(provider)
+    return handler(model=model, instruction=instruction, timeout=timeout)
+
+
+def _get_handler(provider: str):
+    handlers = {
+        "claude": _claude_handler,
+        "litellm": _litellm_handler,
+        "codex": _codex_handler,
+        "gemini": _gemini_handler,
+    }
+    return handlers[provider]
+
+
+def _claude_handler(model: str, instruction: str, timeout: int) -> DispatchResult:
+    import subprocess
+    start = __import__("time").time()
+    proc = subprocess.run(
+        ["claude", "-p", "--model", model, instruction],
+        capture_output=True, text=True, timeout=timeout
+    )
+    duration = __import__("time").time() - start
+    return DispatchResult(
+        success=proc.returncode == 0,
+        provider="claude",
+        model=model,
+        output=proc.stdout,
+        input_tokens=0,
+        output_tokens=0,
+        duration_seconds=duration,
+        error=proc.stderr if proc.returncode != 0 else None,
+    )
+
+
+def _litellm_handler(model: str, instruction: str, timeout: int) -> DispatchResult:
+    raise NotImplementedError("LiteLLM handler: configure via VNX_LITELLM_BASE_URL")
+
+
+def _codex_handler(model: str, instruction: str, timeout: int) -> DispatchResult:
+    raise NotImplementedError("Codex handler: requires CODEX_API_KEY")
+
+
+def _gemini_handler(model: str, instruction: str, timeout: int) -> DispatchResult:
+    raise NotImplementedError("Gemini handler: requires GEMINI_API_KEY")
+
+
+def load_routing_config(config_path: Path) -> dict:
+    """Load routing configuration from JSON file. Returns empty dict if file absent."""
+    if not config_path.exists():
+        return {}
+    return json.loads(config_path.read_text())
+
+
+def select_model(task_class: str, config: dict) -> tuple[str, str]:
+    """Select (provider, model) for a task class from routing config.
+
+    Falls back to ('claude', 'sonnet') if task_class not in config.
+    """
+    routing = config.get("routing", {})
+    entry = routing.get(task_class, {"provider": "claude", "model": "sonnet"})
+    return entry["provider"], entry["model"]
+```
+
+Output only the README.md content. Start directly with the `# dispatch_router` heading.

--- a/scripts/benchmark/prompts/05_debugging.txt
+++ b/scripts/benchmark/prompts/05_debugging.txt
@@ -1,0 +1,51 @@
+Identify the root cause of the following Python error and propose a minimal fix.
+
+Traceback:
+```
+Traceback (most recent call last):
+  File "scripts/lib/pool_state_repo.py", line 187, in update_worker_status
+    self._conn.execute(
+sqlite3.OperationalError: database is locked
+  File "scripts/lib/pool_manager.py", line 94, in tick
+    repo.update_worker_status(worker_id, status)
+  File "scripts/dispatch_loop.py", line 42, in run_forever
+    pool_manager.tick()
+  File "scripts/dispatch_loop.py", line 58, in run_forever
+    time.sleep(0.5)
+```
+
+Relevant code:
+
+```python
+# pool_state_repo.py
+class PoolStateRepo:
+    def __init__(self, db_path: Path):
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+
+    def update_worker_status(self, worker_id: str, status: str) -> None:
+        self._conn.execute(
+            "UPDATE workers SET status=?, updated_at=? WHERE worker_id=?",
+            (status, time.time(), worker_id),
+        )
+        self._conn.commit()
+
+    def get_all_workers(self) -> list[dict]:
+        cursor = self._conn.execute("SELECT * FROM workers")
+        return [dict(row) for row in cursor.fetchall()]
+
+
+# pool_manager.py
+class PoolManager:
+    def __init__(self, db_path: Path):
+        self._repo = PoolStateRepo(db_path)
+        self._repo2 = PoolStateRepo(db_path)  # second connection for reads
+
+    def tick(self):
+        workers = self._repo2.get_all_workers()
+        for w in workers:
+            new_status = self._compute_status(w)
+            self._repo.update_worker_status(w["worker_id"], new_status)
+```
+
+State: root cause + minimal fix + explanation of why the fix works.

--- a/scripts/benchmark/prompts/06_design.txt
+++ b/scripts/benchmark/prompts/06_design.txt
@@ -1,0 +1,17 @@
+Design a system to handle 1,000,000 dispatches per day across 10 projects with cost-routing between three LLM providers: Claude (premium, $3-15/MTok), DeepSeek (mid, $0.14-0.87/MTok), and Kimi (budget, $0.60-4.00/MTok).
+
+Specify:
+
+1. **Architecture** — components, their responsibilities, how they communicate (sync vs async, queue vs direct call)
+2. **Data flow** — a dispatch from creation to completion: what data is written where, at what step, with what guarantees
+3. **Cost routing logic** — how the system decides which provider handles a given dispatch (task type, latency SLO, budget envelope, fallback chain)
+4. **Failure modes** — at least 5 failure scenarios with detection mechanism, recovery strategy, and blast radius
+5. **SLOs** — define p50/p95/p99 latency targets for each tier, throughput floor, error budget, and how violations are detected
+
+Constraints:
+- No proprietary cloud services (no SQS, no Pub/Sub) — self-hosted only
+- State must survive a single-node restart without losing in-flight dispatches
+- Cost tracking must be accurate to ±2% per provider per day
+- The system must support a human approval gate for dispatches above a cost threshold
+
+Format: structured markdown with headers per section. Use concrete numbers. No vague statements like "the system scales horizontally" without specifying what the scaling unit is and at what load.

--- a/scripts/benchmark/prompts/07_translation.txt
+++ b/scripts/benchmark/prompts/07_translation.txt
@@ -1,0 +1,46 @@
+Vertaal de onderstaande Nederlandstalige technische blogpost naar het Engels. Bewaar de opmaak (Markdown headers, bullets, codeblokken). Vertaal technische termen letterlijk (bijv. "dispatch" blijft "dispatch", "governance" blijft "governance", "receipt" blijft "receipt"). Behoud de persoonlijke, directe toon.
+
+---
+
+# Waarom ik geen LangGraph gebruik — en wat ik in plaats daarvan bouw
+
+Twee jaar geleden begon ik met AI-agents bouwen. Het eerste wat iedereen aanraadde: LangGraph.
+
+Ik heb het geprobeerd. Ik begreep het. En daarna heb ik het weggegooid.
+
+## Het fundamentele probleem
+
+LangGraph composeert workers als in-process Runnable nodes. Dat betekent: geen processisolatie, geen echte parallellisatie, en — het ergste — geen audit trail die een financiële audit zou overleven.
+
+In mijn praktijk werk ik voor organisaties die ISO- en ISAE-gecertificeerd zijn. "The model decided" is geen antwoord dat ze accepteren. Ze willen weten *welk model*, *welke versie*, *welke input*, *welke output*, *hoe lang*, en *wie heeft het goedgekeurd*.
+
+LangGraph geeft je dat niet standaard. Je moet het er zelf inbouwen — en dan bouw je eigenlijk een eigen governance-laag bovenop een framework dat daar niet voor ontworpen is.
+
+## Wat ik gebouwd heb
+
+VNX Orchestration is een governance-first runtime. Elke dispatch krijgt een uniek ID. Elke response wordt vastgelegd als NDJSON receipt met:
+
+```json
+{
+  "dispatch_id": "20260514-feat-auth-T1",
+  "model": "claude-sonnet-4-6",
+  "provider": "claude",
+  "input_tokens": 4821,
+  "output_tokens": 1203,
+  "duration_seconds": 14.2,
+  "exit_code": 0,
+  "timestamp": "2026-05-14T09:41:22Z"
+}
+```
+
+Niets gaat de keten uit zonder dat er een receipt is. Niets wordt gemerged zonder dat een gate groen is.
+
+## De afruil
+
+Is het meer werk? Ja. VNX heeft 1.100+ receipts, 860+ sessies geanalyseerd, en 11 agents in productie.
+
+Maar ik slaap goed. En mijn klanten ook.
+
+---
+
+Translate the above to English. Maintain all Markdown formatting exactly as-is. Preserve technical terms in English where they are already English (dispatch, receipt, governance, NDJSON). The blog post uses first-person singular ("ik" → "I", "mijn" → "my") — maintain that throughout.

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import time
 import sys
@@ -51,6 +52,14 @@ def load_tasks(prompts_dir: Optional[Path] = None) -> List[Dict]:
     return tasks
 
 
+def _atomic_write_json(path: Path, obj: object) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2))
+    with open(tmp, "rb") as f:
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
 def run_single(model: Dict, task: Dict, dispatch_id: str) -> Dict:
     """Dispatch single (model, task) pair. Return result dict."""
     start = time.time()
@@ -63,11 +72,16 @@ def run_single(model: Dict, task: Dict, dispatch_id: str) -> Dict:
         "--role", "backend-developer",
         "--instruction", task["prompt"],
     ]
-    if model.get("model_arg") and model["provider"] == "claude":
-        cmd.extend(["--model", model["model_arg"]])
+    env = os.environ.copy()
+    if model.get("model_arg"):
+        if model["provider"] == "claude":
+            cmd.extend(["--model", model["model_arg"]])
+        elif model["provider"].startswith("litellm:"):
+            provider_name = model["provider"].split(":", 1)[1]
+            env["VNX_LITELLM_MODEL"] = f"{provider_name}/{model['model_arg']}"
 
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=900)
     except BrokenPipeError:
         return _error_result(model, task, dispatch_id, "BrokenPipeError from provider", time.time() - start)
 
@@ -197,7 +211,7 @@ def main() -> int:
             try:
                 result = run_single(model, task, dispatch_id)
                 result_path = output_dir / f"{model['id']}__{task['id']}.json"
-                result_path.write_text(json.dumps(result, indent=2))
+                _atomic_write_json(result_path, result)
                 cost = result.get("cost_usd")
                 dur = result["duration_seconds"]
                 cost_str = f"${cost:.4f}" if cost is not None else "?"

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""run_benchmark.py — Execute benchmark suite across N models x M tasks.
+
+Usage:
+    python3 scripts/benchmark/run_benchmark.py [--models MODEL_IDS] [--tasks TASK_IDS] [--output PATH]
+    python3 scripts/benchmark/run_benchmark.py --dry-run
+
+For each (model, task):
+  - Dispatch via provider_dispatch.py
+  - Wait for completion
+  - Read receipt from the receipts NDJSON log
+  - Read unified report
+  - Capture: duration_seconds, token_usage, cost_usd, response_text
+  - Save to results/{model_id}__{task_id}.json
+
+INFRASTRUCTURE ONLY — does not execute benchmarks by itself without explicit --run flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = Path(__file__).resolve().parent
+PROMPTS_DIR = BENCHMARK_DIR / "prompts"
+RESULTS_DIR = BENCHMARK_DIR / "results"
+
+
+def load_models(models_yaml: Optional[Path] = None) -> List[Dict]:
+    path = models_yaml or (BENCHMARK_DIR / "models.yaml")
+    config = yaml.safe_load(path.read_text())
+    return config["models"]
+
+
+def load_tasks(prompts_dir: Optional[Path] = None) -> List[Dict]:
+    source = prompts_dir or PROMPTS_DIR
+    tasks = []
+    for prompt_file in sorted(source.glob("*.txt")):
+        tasks.append({
+            "id": prompt_file.stem,
+            "prompt": prompt_file.read_text(),
+        })
+    return tasks
+
+
+def run_single(model: Dict, task: Dict, dispatch_id: str) -> Dict:
+    """Dispatch single (model, task) pair. Return result dict."""
+    start = time.time()
+    cmd = [
+        "python3",
+        str(REPO_ROOT / "scripts" / "lib" / "provider_dispatch.py"),
+        "--provider", model["provider"],
+        "--terminal-id", "T2",
+        "--dispatch-id", dispatch_id,
+        "--role", "backend-developer",
+        "--instruction", task["prompt"],
+    ]
+    if model.get("model_arg") and model["provider"] == "claude":
+        cmd.extend(["--model", model["model_arg"]])
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except BrokenPipeError:
+        return _error_result(model, task, dispatch_id, "BrokenPipeError from provider", time.time() - start)
+
+    duration = time.time() - start
+
+    receipts_path = REPO_ROOT / ".vnx-data" / "receipts" / "t0_receipts.ndjson"
+    receipt = _read_last_receipt(receipts_path, dispatch_id)
+
+    report_path = REPO_ROOT / ".vnx-data" / "unified_reports" / f"{dispatch_id}_report.md"
+    report_text = report_path.read_text() if report_path.exists() else ""
+
+    return {
+        "model_id": model["id"],
+        "task_id": task["id"],
+        "dispatch_id": dispatch_id,
+        "duration_seconds": round(duration, 3),
+        "exit_code": proc.returncode,
+        "stderr": (proc.stderr or "")[:500],
+        "receipt": receipt,
+        "response": _extract_response_from_report(report_text),
+        "cost_usd": _compute_cost_usd(model, receipt),
+    }
+
+
+def _error_result(model: Dict, task: Dict, dispatch_id: str, error: str, duration: float) -> Dict:
+    return {
+        "model_id": model["id"],
+        "task_id": task["id"],
+        "dispatch_id": dispatch_id,
+        "duration_seconds": round(duration, 3),
+        "exit_code": -1,
+        "stderr": error,
+        "receipt": {},
+        "response": "",
+        "cost_usd": None,
+    }
+
+
+def _read_last_receipt(path: Path, dispatch_id: str) -> Dict:
+    if not path.exists():
+        return {}
+    for line in reversed(path.read_text().splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+            if record.get("dispatch_id") == dispatch_id:
+                return record
+        except json.JSONDecodeError:
+            continue
+    return {}
+
+
+def _extract_response_from_report(report: str) -> str:
+    if "## Response" not in report:
+        return ""
+    parts = report.split("## Response", 1)
+    if len(parts) < 2:
+        return ""
+    tail = parts[1]
+    response = tail.split("\n## ", 1)[0] if "\n## " in tail else tail
+    return response.strip()
+
+
+def _compute_cost_usd(model: Dict, receipt: Dict) -> Optional[float]:
+    """Estimate cost from receipt token counts + model pricing."""
+    input_tokens = receipt.get("input_tokens", 0) or 0
+    output_tokens = receipt.get("output_tokens", 0) or 0
+    if not input_tokens and not output_tokens:
+        return None
+    cost_in = (input_tokens / 1_000_000) * model.get("cost_input_mtok", 0)
+    cost_out = (output_tokens / 1_000_000) * model.get("cost_output_mtok", 0)
+    return round(cost_in + cost_out, 6)
+
+
+def _filter_models(models: List[Dict], selector: str) -> List[Dict]:
+    if selector == "all":
+        return models
+    wanted = {m.strip() for m in selector.split(",")}
+    return [m for m in models if m["id"] in wanted]
+
+
+def _filter_tasks(tasks: List[Dict], selector: str) -> List[Dict]:
+    if selector == "all":
+        return tasks
+    wanted = {t.strip() for t in selector.split(",")}
+    return [t for t in tasks if t["id"] in wanted]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="VNX benchmark runner — 9 models x 7 tasks")
+    parser.add_argument("--models", default="all", help="Comma-separated model IDs or 'all'")
+    parser.add_argument("--tasks", default="all", help="Comma-separated task IDs or 'all'")
+    parser.add_argument("--output", default=None, help="Override output directory")
+    parser.add_argument("--dry-run", action="store_true", help="List dispatches without executing")
+    parser.add_argument("--run", action="store_true", help="Actually execute benchmarks")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.run:
+        print("Pass --dry-run to list planned dispatches, or --run to execute.")
+        print("No benchmarks executed (infrastructure-only mode).")
+        return 0
+
+    output_dir = Path(args.output) if args.output else RESULTS_DIR
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    models = _filter_models(load_models(), args.models)
+    tasks = _filter_tasks(load_tasks(), args.tasks)
+
+    total = len(models) * len(tasks)
+    print(f"Benchmark plan: {len(models)} models x {len(tasks)} tasks = {total} dispatches")
+
+    if args.dry_run:
+        for m in models:
+            for t in tasks:
+                print(f"  dispatch: {m['id']} x {t['id']}")
+        return 0
+
+    completed = 0
+    errors = 0
+    for model in models:
+        for task in tasks:
+            ts = int(time.time())
+            dispatch_id = f"bench-{model['id']}-{task['id']}-{ts}"
+            print(f"[{completed + 1}/{total}] {model['id']} x {task['id']}...")
+            try:
+                result = run_single(model, task, dispatch_id)
+                result_path = output_dir / f"{model['id']}__{task['id']}.json"
+                result_path.write_text(json.dumps(result, indent=2))
+                cost = result.get("cost_usd")
+                dur = result["duration_seconds"]
+                cost_str = f"${cost:.4f}" if cost is not None else "?"
+                print(f"  ok {dur:.1f}s cost={cost_str}")
+            except subprocess.TimeoutExpired:
+                print(f"  TIMEOUT after 900s")
+                errors += 1
+            except Exception as exc:
+                print(f"  ERROR: {exc}")
+                errors += 1
+            completed += 1
+
+    print(f"\nDone: {completed - errors}/{total} succeeded, {errors} errors.")
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -329,3 +329,143 @@ def test_pareto_frontier_empty_when_no_costs():
     records[0]["cost_usd"] = None
     pareto = analyze_results.build_pareto_frontier(records)
     assert pareto == []
+
+
+# ---------------------------------------------------------------------------
+# test_atomic_write_creates_tmp_then_replace
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_creates_tmp_then_replace(tmp_path: Path):
+    target = tmp_path / "result.json"
+    obj = {"model_id": "claude-sonnet-4-6", "task_id": "01_alpha", "cost_usd": 0.01}
+    run_benchmark._atomic_write_json(target, obj)
+    assert target.exists()
+    # tmp file must be gone after replace
+    assert not (tmp_path / "result.json.tmp").exists()
+    loaded = json.loads(target.read_text())
+    assert loaded["model_id"] == "claude-sonnet-4-6"
+
+
+def test_atomic_write_overwrites_existing(tmp_path: Path):
+    target = tmp_path / "result.json"
+    target.write_text(json.dumps({"old": True}))
+    run_benchmark._atomic_write_json(target, {"new": True})
+    loaded = json.loads(target.read_text())
+    assert loaded == {"new": True}
+
+
+# ---------------------------------------------------------------------------
+# test_litellm_model_arg_passed_via_env
+# ---------------------------------------------------------------------------
+
+def test_litellm_model_arg_passed_via_env(tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path):
+    model = run_benchmark.load_models(tmp_models_yaml)[1]  # deepseek-v4-pro, provider=litellm:deepseek
+    assert model["provider"] == "litellm:deepseek"
+    task = run_benchmark.load_tasks(tmp_prompts)[0]
+    dispatch_id = "bench-test-litellm-456"
+
+    receipts_dir = tmp_path / ".vnx-data" / "receipts"
+    receipts_dir.mkdir(parents=True)
+    (receipts_dir / "t0_receipts.ndjson").write_text("")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = ""
+    fake_proc.stderr = ""
+
+    captured_env = {}
+
+    def fake_run(cmd, env=None, **kwargs):
+        captured_env.update(env or {})
+        return fake_proc
+
+    with patch("subprocess.run", side_effect=fake_run), \
+         patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+        run_benchmark.run_single(model, task, dispatch_id)
+
+    assert "VNX_LITELLM_MODEL" in captured_env
+    assert captured_env["VNX_LITELLM_MODEL"] == "deepseek/deepseek-v4-pro"
+
+
+def test_claude_model_arg_passed_via_cmd_not_env(tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path):
+    model = run_benchmark.load_models(tmp_models_yaml)[0]  # claude-sonnet-4-6
+    assert model["provider"] == "claude"
+    task = run_benchmark.load_tasks(tmp_prompts)[0]
+    dispatch_id = "bench-test-claude-789"
+
+    receipts_dir = tmp_path / ".vnx-data" / "receipts"
+    receipts_dir.mkdir(parents=True)
+    (receipts_dir / "t0_receipts.ndjson").write_text("")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = ""
+    fake_proc.stderr = ""
+
+    captured_cmd = []
+    captured_env = {}
+
+    def fake_run(cmd, env=None, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(env or {})
+        return fake_proc
+
+    with patch("subprocess.run", side_effect=fake_run), \
+         patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+        run_benchmark.run_single(model, task, dispatch_id)
+
+    assert "--model" in captured_cmd
+    assert "VNX_LITELLM_MODEL" not in captured_env
+
+
+# ---------------------------------------------------------------------------
+# test_glm_uses_zai_provider
+# ---------------------------------------------------------------------------
+
+def test_glm_uses_zai_provider():
+    models = run_benchmark.load_models()
+    glm = next((m for m in models if m["id"] == "glm-5-1"), None)
+    assert glm is not None, "glm-5-1 not found in models.yaml"
+    assert glm["provider"] == "litellm:zai", f"Expected litellm:zai, got {glm['provider']}"
+    assert glm["model_arg"] == "glm-5", f"Expected glm-5, got {glm['model_arg']}"
+
+
+# ---------------------------------------------------------------------------
+# test_analyze_warns_on_malformed_files
+# ---------------------------------------------------------------------------
+
+def test_analyze_warns_on_malformed_files(tmp_path: Path, capsys):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    # One valid file
+    good = _make_result_record("claude-sonnet-4-6", "01_alpha", 0.01, 8)
+    (results_dir / "claude-sonnet-4-6__01_alpha.json").write_text(json.dumps(good))
+
+    # One malformed file
+    (results_dir / "broken__01_alpha.json").write_text("this is not valid json {{{")
+
+    records = analyze_results.load_results(results_dir)
+
+    captured = capsys.readouterr()
+    assert len(records) == 1
+    assert records[0]["model_id"] == "claude-sonnet-4-6"
+    assert "WARNING" in captured.err
+    assert "1 unreadable result" in captured.err
+
+
+def test_analyze_warns_on_unreadable_file(tmp_path: Path, capsys):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    good = _make_result_record("model-a", "task1", 0.01, 7)
+    (results_dir / "model-a__task1.json").write_text(json.dumps(good))
+
+    bad_path = results_dir / "bad__task1.json"
+    bad_path.write_text("")  # OSError equivalent: empty → JSONDecodeError
+
+    records = analyze_results.load_results(results_dir)
+    captured = capsys.readouterr()
+
+    assert len(records) == 1
+    assert "WARNING" in captured.err

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,0 +1,331 @@
+"""Tests for scripts/benchmark/ suite: loader, runner, judge, analyzer."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Helpers to import benchmark modules without installed package
+# ---------------------------------------------------------------------------
+
+import sys
+BENCHMARK_DIR = Path(__file__).resolve().parents[1] / "scripts" / "benchmark"
+if str(BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARK_DIR))
+
+import run_benchmark
+import judge_quality
+import analyze_results
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_prompts(tmp_path: Path) -> Path:
+    p = tmp_path / "prompts"
+    p.mkdir()
+    (p / "01_alpha.txt").write_text("Do task alpha.")
+    (p / "02_beta.txt").write_text("Do task beta.")
+    return p
+
+
+@pytest.fixture()
+def tmp_models_yaml(tmp_path: Path) -> Path:
+    data = {
+        "models": [
+            {
+                "id": "claude-sonnet-4-6",
+                "provider": "claude",
+                "model_arg": "sonnet",
+                "cost_input_mtok": 3.00,
+                "cost_output_mtok": 15.00,
+            },
+            {
+                "id": "deepseek-v4-pro",
+                "provider": "litellm:deepseek",
+                "model_arg": "deepseek-v4-pro",
+                "cost_input_mtok": 0.435,
+                "cost_output_mtok": 0.87,
+            },
+        ]
+    }
+    path = tmp_path / "models.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+@pytest.fixture()
+def tmp_results(tmp_path: Path) -> Path:
+    d = tmp_path / "results"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# test_load_models_yaml
+# ---------------------------------------------------------------------------
+
+def test_load_models_yaml_valid(tmp_models_yaml: Path):
+    models = run_benchmark.load_models(tmp_models_yaml)
+    assert len(models) == 2
+    assert models[0]["id"] == "claude-sonnet-4-6"
+    assert models[1]["cost_input_mtok"] == 0.435
+
+
+def test_load_models_yaml_fields_present(tmp_models_yaml: Path):
+    models = run_benchmark.load_models(tmp_models_yaml)
+    required = {"id", "provider", "model_arg", "cost_input_mtok", "cost_output_mtok"}
+    for m in models:
+        assert required.issubset(m.keys()), f"Missing fields in {m}"
+
+
+def test_load_models_yaml_missing_file(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        run_benchmark.load_models(tmp_path / "nonexistent.yaml")
+
+
+# ---------------------------------------------------------------------------
+# test_load_tasks_from_prompts_dir
+# ---------------------------------------------------------------------------
+
+def test_load_tasks_from_prompts_dir_count(tmp_prompts: Path):
+    tasks = run_benchmark.load_tasks(tmp_prompts)
+    assert len(tasks) == 2
+
+
+def test_load_tasks_from_prompts_dir_ids(tmp_prompts: Path):
+    tasks = run_benchmark.load_tasks(tmp_prompts)
+    ids = [t["id"] for t in tasks]
+    assert "01_alpha" in ids
+    assert "02_beta" in ids
+
+
+def test_load_tasks_from_prompts_dir_prompt_content(tmp_prompts: Path):
+    tasks = run_benchmark.load_tasks(tmp_prompts)
+    by_id = {t["id"]: t for t in tasks}
+    assert "Do task alpha." in by_id["01_alpha"]["prompt"]
+
+
+def test_load_tasks_from_prompts_dir_sorted(tmp_prompts: Path):
+    tasks = run_benchmark.load_tasks(tmp_prompts)
+    assert tasks[0]["id"] == "01_alpha"
+    assert tasks[1]["id"] == "02_beta"
+
+
+# ---------------------------------------------------------------------------
+# test_run_single_captures_receipt
+# ---------------------------------------------------------------------------
+
+def _make_receipt_ndjson(dispatch_id: str) -> str:
+    record = {
+        "dispatch_id": dispatch_id,
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "exit_code": 0,
+    }
+    return json.dumps(record) + "\n"
+
+
+def test_run_single_captures_receipt(tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path):
+    model = run_benchmark.load_models(tmp_models_yaml)[0]
+    task = run_benchmark.load_tasks(tmp_prompts)[0]
+    dispatch_id = "bench-test-dispatch-123"
+
+    receipts_dir = tmp_path / ".vnx-data" / "receipts"
+    receipts_dir.mkdir(parents=True)
+    receipt_path = receipts_dir / "t0_receipts.ndjson"
+    receipt_path.write_text(_make_receipt_ndjson(dispatch_id))
+
+    reports_dir = tmp_path / ".vnx-data" / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_path = reports_dir / f"{dispatch_id}_report.md"
+    report_path.write_text("## Response\nThis is the model output.\n## Metadata\nsome meta")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = ""
+    fake_proc.stderr = ""
+
+    with patch("subprocess.run", return_value=fake_proc) as mock_run, \
+         patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+        result = run_benchmark.run_single(model, task, dispatch_id)
+
+    assert result["dispatch_id"] == dispatch_id
+    assert result["model_id"] == model["id"]
+    assert result["task_id"] == task["id"]
+    assert result["receipt"]["input_tokens"] == 1000
+    assert "This is the model output." in result["response"]
+    mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# test_extract_response_from_report
+# ---------------------------------------------------------------------------
+
+def test_extract_response_from_report_basic():
+    report = "# Title\n## Response\nHello world.\n## Metadata\nsome info"
+    result = run_benchmark._extract_response_from_report(report)
+    assert result == "Hello world."
+
+
+def test_extract_response_from_report_no_section():
+    report = "# Title\nNo response header here."
+    result = run_benchmark._extract_response_from_report(report)
+    assert result == ""
+
+
+def test_extract_response_from_report_trailing_content():
+    report = "## Response\nLine 1.\nLine 2.\n## NextSection\nother"
+    result = run_benchmark._extract_response_from_report(report)
+    assert "Line 1." in result
+    assert "other" not in result
+
+
+# ---------------------------------------------------------------------------
+# test_judge_quality_parses_opus_response
+# ---------------------------------------------------------------------------
+
+def test_judge_quality_parses_valid_json():
+    raw = '{"quality_score": 8, "correctness": true, "completeness_score": 7, "notable_issues": ""}'
+    score = judge_quality._parse_judge_response(raw)
+    assert score["quality_score"] == 8
+    assert score["correctness"] is True
+    assert score["completeness_score"] == 7
+    assert score["notable_issues"] == ""
+
+
+def test_judge_quality_parses_fenced_json():
+    raw = '```json\n{"quality_score": 5, "correctness": false, "completeness_score": 6, "notable_issues": "missing examples"}\n```'
+    score = judge_quality._parse_judge_response(raw)
+    assert score["quality_score"] == 5
+    assert score["correctness"] is False
+
+
+def test_judge_quality_fallback_on_invalid():
+    score = judge_quality._parse_judge_response("not valid json at all {{{")
+    assert score["quality_score"] == 0
+    assert score["correctness"] is False
+    assert "judge failed" in score["notable_issues"]
+
+
+def test_judge_quality_missing_fields_defaults():
+    raw = '{"quality_score": 9}'
+    score = judge_quality._parse_judge_response(raw)
+    assert score["quality_score"] == 9
+    assert score["completeness_score"] == 0
+
+
+# ---------------------------------------------------------------------------
+# test_analyze_results_writes_markdown
+# ---------------------------------------------------------------------------
+
+def _make_result_record(model_id: str, task_id: str, cost: float, score: float) -> dict:
+    return {
+        "model_id": model_id,
+        "task_id": task_id,
+        "duration_seconds": 10.0,
+        "cost_usd": cost,
+        "response": "some response",
+        "receipt": {},
+        "judge_scores": {
+            "quality_score": int(score),
+            "correctness": True,
+            "completeness_score": int(score),
+            "notable_issues": "",
+        },
+    }
+
+
+def test_analyze_results_writes_markdown(tmp_path: Path):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    output_dir = tmp_path / "claudedocs"
+
+    records = [
+        _make_result_record("claude-sonnet-4-6", "01_code_gen", 0.01, 8),
+        _make_result_record("deepseek-v4-pro", "01_code_gen", 0.001, 6),
+    ]
+    for r in records:
+        path = results_dir / f"{r['model_id']}__{r['task_id']}.json"
+        path.write_text(json.dumps(r))
+
+    with patch.object(analyze_results, "ROUTING_OUTPUT", tmp_path / "routing.yaml"), \
+         patch.object(analyze_results, "CLAUDEDOCS_DIR", output_dir):
+        result = analyze_results.main.__wrapped__ if hasattr(analyze_results.main, "__wrapped__") else None
+
+    loaded = analyze_results.load_results(results_dir)
+    summary = analyze_results.build_task_summary(loaded)
+    pareto = analyze_results.build_pareto_frontier(loaded)
+    report = analyze_results.render_markdown_report(loaded, summary, pareto)
+
+    assert "# Benchmark Model Comparison Report" in report
+    assert "claude-sonnet-4-6" in report
+    assert "deepseek-v4-pro" in report
+    assert "01_code_gen" in report
+
+
+# ---------------------------------------------------------------------------
+# test_analyze_results_writes_yaml_recommendations
+# ---------------------------------------------------------------------------
+
+def test_analyze_results_writes_yaml_recommendations(tmp_path: Path):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    records = [
+        _make_result_record("claude-sonnet-4-6", "01_alpha", 0.01, 8),
+        _make_result_record("deepseek-v4-pro", "01_alpha", 0.001, 6),
+        _make_result_record("claude-sonnet-4-6", "02_beta", 0.02, 9),
+    ]
+    for r in records:
+        path = results_dir / f"{r['model_id']}__{r['task_id']}.json"
+        path.write_text(json.dumps(r))
+
+    loaded = analyze_results.load_results(results_dir)
+    summary = analyze_results.build_task_summary(loaded)
+    routing = analyze_results.build_routing_recommendations(summary)
+
+    routing_path = tmp_path / "routing.yaml"
+    analyze_results._atomic_write(routing_path, yaml.dump(routing, default_flow_style=False, allow_unicode=True))
+
+    assert routing_path.exists()
+    data = yaml.safe_load(routing_path.read_text())
+    assert "routing_by_task" in data
+    assert "01_alpha" in data["routing_by_task"]
+    # Highest score model should rank first
+    first = data["routing_by_task"]["01_alpha"][0]
+    assert first["model_id"] == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# test_pareto_frontier
+# ---------------------------------------------------------------------------
+
+def test_pareto_frontier_excludes_dominated():
+    records = [
+        _make_result_record("model-a", "task1", 0.01, 9),
+        _make_result_record("model-b", "task1", 0.01, 7),  # dominated: same cost, lower score
+    ]
+    pareto = analyze_results.build_pareto_frontier(records)
+    model_ids = {p["model_id"] for p in pareto}
+    assert "model-a" in model_ids
+    # model-b is dominated by model-a (same cost, lower score) — must not appear
+    assert "model-b" not in model_ids
+
+
+def test_pareto_frontier_empty_when_no_costs():
+    records = [_make_result_record("model-a", "task1", 0.0, 8)]
+    records[0]["cost_usd"] = None
+    pareto = analyze_results.build_pareto_frontier(records)
+    assert pareto == []


### PR DESCRIPTION
## Summary

- Ships `scripts/benchmark/` with full orchestrator, judge, and analyzer infrastructure for benchmarking 8 models across 7 task classes (56 total dispatches)
- Dry-run verified: `python3 scripts/benchmark/run_benchmark.py --dry-run` lists all 56 planned dispatches
- 19 tests passing — covers model/task loading, receipt capture, response extraction, judge parsing, markdown/YAML output, and Pareto frontier

## What's included

| File | Purpose |
|---|---|
| `scripts/benchmark/run_benchmark.py` | Orchestrator: dispatches via `provider_dispatch.py`, captures receipts + reports, writes per-pair JSON results |
| `scripts/benchmark/judge_quality.py` | Opus judge: scores each result on quality (1-10), correctness (bool), completeness (1-10) — atomic write |
| `scripts/benchmark/analyze_results.py` | Aggregator: per-task rankings, cost-quality Pareto frontier, routing recommendations YAML |
| `scripts/benchmark/models.yaml` | 8 models: claude-opus/sonnet/haiku, deepseek-v4-pro/flash, kimi-k2-6/k2-0905, glm-5-1 |
| `scripts/benchmark/prompts/01-07` | 7 task classes: code_generation, code_review, refactoring, documentation, debugging, design, translation |
| `tests/test_benchmark_suite.py` | 19 tests covering all modules |

## Test plan

- [x] `pytest tests/test_benchmark_suite.py -x -v` — 19/19 passed
- [x] `python3 scripts/benchmark/run_benchmark.py --dry-run` — 56 dispatches listed
- [x] No `.vnx-data/state/` literal in docstrings (CI legacy gate)
- [x] No TODO/FIXME

## Notes

INFRASTRUCTURE ONLY. Benchmarks do not execute without explicit `--run` flag. Live execution is a separate manual step post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)