### PR TITLE
feat(wave7): PR-7.7 — Kimi CLI as 5th provider (OAuth via kimi login)

### DIFF
--- a/scripts/lib/canonical_event.py
+++ b/scripts/lib/canonical_event.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-VALID_PROVIDERS = frozenset({"claude", "codex", "gemini", "litellm", "ollama"})
+VALID_PROVIDERS = frozenset({"claude", "codex", "gemini", "kimi", "litellm", "ollama"})
 VALID_EVENT_TYPES = frozenset({"init", "text", "tool_use", "tool_result", "thinking", "complete", "error"})
 VALID_TIERS = frozenset({1, 2, 3})
 
@@ -204,6 +204,8 @@ class CanonicalEvent:
             return _from_codex_event(raw, dispatch_id, terminal_id)
         if provider == "gemini":
             return _from_gemini_event(raw, dispatch_id, terminal_id)
+        if provider == "kimi":
+            return _from_kimi_event(raw, dispatch_id, terminal_id)
         if provider == "litellm":
             return _from_litellm_event(raw, dispatch_id, terminal_id, sub_provider=sub_provider)
         # ollama fallback
@@ -376,6 +378,53 @@ def _from_litellm_event(
     if delta.get("role") == "assistant" and not delta.get("content"):
         return make("init", {"model": str(raw.get("model") or "")})
     return make("text", {"content": delta.get("content") or ""})
+
+
+def _from_kimi_event(
+    raw: Dict[str, Any],
+    dispatch_id: str,
+    terminal_id: str,
+) -> CanonicalEvent:
+    """Map a raw Kimi CLI stream-json event dict to a CanonicalEvent (Tier-1)."""
+    def make(et: str, d: Dict[str, Any]) -> CanonicalEvent:
+        return CanonicalEvent(
+            dispatch_id=dispatch_id, terminal_id=terminal_id,
+            provider="kimi", event_type=et, data=d, observability_tier=1,
+        )
+
+    event_type = (raw.get("event_type") or raw.get("type") or "")
+
+    if event_type in ("assistant_text", "text"):
+        return make("text", {"text": str(raw.get("content", ""))})
+    if event_type == "tool_call":
+        return make("tool_use", {
+            "name": str(raw.get("name", "")),
+            "input": raw.get("input", {}),
+            "id": str(raw.get("id", "")),
+        })
+    if event_type == "tool_result":
+        return make("tool_result", {
+            "tool_use_id": str(raw.get("tool_call_id", "")),
+            "content": str(raw.get("output", "")),
+        })
+    if event_type == "usage_complete":
+        usage = raw.get("usage") or {}
+        token_count = {
+            "input_tokens": int((usage.get("prompt_tokens") or 0)),
+            "output_tokens": int((usage.get("completion_tokens") or 0)),
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+        return make("text", {"text": "", "token_count": token_count})
+    if event_type == "complete":
+        return make("complete", {})
+    if event_type == "error":
+        msg = raw.get("message") or raw.get("error") or ""
+        return make("error", {"message": str(msg) if msg else str(raw)[:200]})
+    return make("error", {
+        "reason": f"unrecognized kimi event_type: {event_type!r}",
+        "raw": str(raw)[:300],
+    })
 
 
 def _from_ollama_event(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-_PROVIDER_RE = re.compile(r"^(claude|codex|gemini|litellm:[a-z][a-z0-9_-]*)$")
+_PROVIDER_RE = re.compile(r"^(claude|codex|gemini|kimi|litellm:[a-z][a-z0-9_-]*)$")
 
 
 def _validate_provider(provider: str) -> None:
@@ -33,7 +33,7 @@ def _validate_provider(provider: str) -> None:
     if not _PROVIDER_RE.match(provider or ""):
         raise ValueError(
             f"Invalid provider {provider!r}. "
-            "Must match ^(claude|codex|gemini|litellm:[a-z][a-z0-9_-]*)$"
+            "Must match ^(claude|codex|gemini|kimi|litellm:[a-z][a-z0-9_-]*)$"
         )
 
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -320,10 +320,11 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         from event_store import EventStore
         event_store = EventStore()
     except Exception as _es_exc:
-        logger.warning(
-            "_dispatch_codex: EventStore unavailable; NDJSON audit sink skipped: %s",
+        logger.error(
+            "_dispatch_codex: EventStore init failed; cannot proceed without audit sink (ADR-005): %s",
             _es_exc,
         )
+        return 1
 
     model = os.environ.get("VNX_CODEX_MODEL", "")
     start_time = datetime.now(timezone.utc)
@@ -437,10 +438,11 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         from event_store import EventStore
         event_store = EventStore()
     except Exception as _es_exc:
-        logger.warning(
-            "_dispatch_litellm: EventStore unavailable; NDJSON audit sink skipped: %s",
+        logger.error(
+            "_dispatch_litellm: EventStore init failed; cannot proceed without audit sink (ADR-005): %s",
             _es_exc,
         )
+        return 1
 
     parts = args.provider.split(":", 1)
     sub_provider = parts[1] if len(parts) > 1 else ""
@@ -546,10 +548,11 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         from event_store import EventStore
         event_store = EventStore()
     except Exception as _es_exc:
-        logger.warning(
-            "_dispatch_kimi: EventStore unavailable; NDJSON audit sink skipped: %s",
+        logger.error(
+            "_dispatch_kimi: EventStore init failed; cannot proceed without audit sink (ADR-005): %s",
             _es_exc,
         )
+        return 1
 
     model = os.environ.get("VNX_KIMI_MODEL", "") or None
     model_label = model or "default"

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
 # Providers whose spawn handlers exist.
-_IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini", "litellm"}
+_IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini", "kimi", "litellm"}
 
 # Mapping: provider literal -> which future PR delivers its handler.
 _FUTURE_PR_MAP: dict = {}
@@ -91,7 +91,7 @@ def _extract_token_usage(result: Any, provider: str) -> Dict[str, int]:
         details = raw.get("prompt_tokens_details") or {}
         cache = int(details.get("cached_tokens", 0) or 0) or int(raw.get("prompt_cache_hit_tokens", 0) or 0)
         usage["cache_hit"] = cache
-    elif provider in ("codex", "gemini"):
+    elif provider in ("codex", "gemini", "kimi"):
         usage["input"] = int(raw.get("input_tokens", 0) or 0)
         usage["output"] = int(raw.get("output_tokens", 0) or 0)
         usage["cache_hit"] = int(raw.get("cache_read_tokens", 0) or 0)
@@ -135,10 +135,34 @@ def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str,
         return None
 
 
+def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, int]) -> Optional[float]:
+    """Compute cost via wave7_models.yaml kimi_cli section for kimi provider."""
+    if not token_usage or (token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0):
+        return None
+    try:
+        from providers import provider_registry as _reg
+        registry = _reg.load()
+        cfg = registry.get("kimi_cli")
+        if cfg is None or not cfg.models:
+            return None
+        target_key = (model or "").strip() or "kimi-default"
+        entry = cfg.models.get(target_key) or next(iter(cfg.models.values()), None)
+        if entry is None:
+            return None
+        cost_in = (token_usage.get("input", 0) / 1_000_000) * entry.cost_input_per_mtok
+        cost_out = (token_usage.get("output", 0) / 1_000_000) * entry.cost_output_per_mtok
+        return round(cost_in + cost_out, 8)
+    except Exception as exc:
+        logger.debug("_compute_kimi_cost failed: %s", exc)
+        return None
+
+
 def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Optional[float]:
     """Compute cost_usd from wave7_models.yaml pricing. Returns None on lookup miss."""
     if not token_usage or (token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0):
         return None
+    if provider == "kimi":
+        return _compute_kimi_cost(model, token_usage)
     pricing = _load_pricing_from_registry(provider, model)
     if not pricing:
         return None
@@ -223,8 +247,8 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help=(
             "Provider to use for dispatch. "
-            "Accepted values: claude, codex, gemini, litellm:<model>. "
-            "Example: --provider claude, --provider litellm:deepseek-v4-pro"
+            "Accepted values: claude, codex, gemini, kimi, litellm:<model>. "
+            "Example: --provider claude, --provider kimi, --provider litellm:deepseek-v4-pro"
         ),
     )
     # Forward all existing subprocess_dispatch.py flags verbatim.
@@ -508,6 +532,59 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     return 0
 
 
+def _dispatch_kimi(args: argparse.Namespace) -> int:
+    """Route to spawn_kimi for kimi-provider dispatches (Wave 7.7).
+
+    Auth via ``kimi login`` (OAuth). No API key env var required.
+    Model resolved via VNX_KIMI_MODEL env var or kimi config default.
+    Wires EventStore as event_writer so kimi dispatches produce a NDJSON audit trail.
+    """
+    from provider_spawns.kimi_spawn import spawn_kimi
+
+    event_store = None
+    try:
+        from event_store import EventStore
+        event_store = EventStore()
+    except Exception as _es_exc:
+        logger.warning(
+            "_dispatch_kimi: EventStore unavailable; NDJSON audit sink skipped: %s",
+            _es_exc,
+        )
+
+    model = os.environ.get("VNX_KIMI_MODEL", "") or None
+    model_label = model or "default"
+    start_time = datetime.now(timezone.utc)
+    result = spawn_kimi(
+        prompt=args.instruction,
+        model=model,
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+        event_writer=event_store.append if event_store is not None else None,
+    )
+    end_time = datetime.now(timezone.utc)
+
+    if result.error:
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "failure")
+        print(f"spawn_kimi failed: {result.error}", file=sys.stderr)
+        return 1
+    if result.timed_out:
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "timeout")
+        print("spawn_kimi timed out", file=sys.stderr)
+        return 1
+    if result.returncode != 0:
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "failure")
+        return 1
+    if result.event_writer_failures > 0:
+        logger.error(
+            "kimi dispatch completed but %d event_writer failures occurred — audit gap",
+            result.event_writer_failures,
+        )
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
+        return 2
+    _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
+    return 0
+
+
 def _dispatch_gemini(args: argparse.Namespace) -> int:
     """Route to spawn_gemini for gemini-provider dispatches (PR-4.6.4).
 
@@ -572,13 +649,16 @@ def main(argv: list[str] | None = None) -> int:
     if provider == "gemini":
         return _dispatch_gemini(args)
 
+    if provider == "kimi":
+        return _dispatch_kimi(args)
+
     if provider.startswith("litellm:") or provider == "litellm":
         return _dispatch_litellm(args)
 
     # Unknown literal — argparse-style error (exit code 2).
     parser.error(
         f"Unknown provider '{provider}'. "
-        "Accepted values: claude, codex, gemini, litellm:<model>."
+        "Accepted values: claude, codex, gemini, kimi, litellm:<model>."
     )
     return 2  # unreachable; parser.error() exits
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -582,8 +582,8 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
             "kimi dispatch completed but %d event_writer failures occurred — audit gap",
             result.event_writer_failures,
         )
-        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
-        return 2
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "failure")
+        return 1
     _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
     return 0
 

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -1,0 +1,340 @@
+"""kimi_spawn.py — Kimi CLI subprocess spawn handler (Wave 7.7).
+
+Owns: spawn + stream-json parsing + canonical event normalization.
+Caller (provider_dispatch.py) handles: receipt, unified report, lease, etc.
+
+Kimi CLI invocation:
+    kimi --print --output-format stream-json --yolo -p "<prompt>"
+
+Authentication: OAuth via `kimi login` (operator-managed). No API key in spawn.
+
+BILLING SAFETY: only subprocess.Popen(["kimi", ...]) is invoked.
+No Anthropic SDK, no LiteLLM, no direct API calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1])
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from canonical_event import CanonicalEvent  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KimiSpawnResult:
+    """Return value from spawn_kimi(); carries spawn outcome to the caller."""
+
+    returncode: int
+    completion_text: str
+    events_written: int
+    session_id: Optional[str]
+    timed_out: bool
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+
+def normalize_kimi_event(raw: dict, terminal_id: str, dispatch_id: str) -> CanonicalEvent:
+    """Map a raw Kimi CLI stream-json event to a CanonicalEvent (Tier-1).
+
+    Kimi CLI emits events with an ``event_type`` key (not ``type``):
+      {"event_type": "assistant_text", "content": "..."}
+      {"event_type": "tool_call", "name": "...", "input": {...}, "id": "..."}
+      {"event_type": "tool_result", "tool_call_id": "...", "output": "..."}
+      {"event_type": "usage_complete", "usage": {"prompt_tokens": N, "completion_tokens": N}}
+      {"event_type": "complete"}
+      {"event_type": "error", "message": "..."}
+
+    ``usage_complete`` is mapped to a "text" event with ``token_count`` data so
+    the spawn loop can extract token usage from the standard event stream.
+    Unknown event_type values map to error events (never returns None).
+    """
+    def make(event_type: str, data: dict) -> CanonicalEvent:
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            provider="kimi",
+            event_type=event_type,
+            data=data,
+            observability_tier=1,
+        )
+
+    event_type = (raw.get("event_type") or raw.get("type") or "")
+
+    if event_type in ("assistant_text", "text"):
+        return make("text", {"text": str(raw.get("content", ""))})
+
+    if event_type == "tool_call":
+        return make("tool_use", {
+            "name": str(raw.get("name", "")),
+            "input": raw.get("input", {}),
+            "id": str(raw.get("id", "")),
+        })
+
+    if event_type == "tool_result":
+        return make("tool_result", {
+            "tool_use_id": str(raw.get("tool_call_id", "")),
+            "content": str(raw.get("output", "")),
+        })
+
+    if event_type == "usage_complete":
+        usage = raw.get("usage") or {}
+        token_count = {
+            "input_tokens": int((usage.get("prompt_tokens") or 0)),
+            "output_tokens": int((usage.get("completion_tokens") or 0)),
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+        return make("text", {"text": "", "token_count": token_count})
+
+    if event_type == "complete":
+        return make("complete", {})
+
+    if event_type == "error":
+        msg = raw.get("message") or raw.get("error") or ""
+        return make("error", {"message": str(msg) if msg else str(raw)[:200]})
+
+    logger.warning("kimi_spawn: unknown event_type %r, mapping to error", event_type)
+    return make("error", {
+        "reason": f"unrecognized kimi event_type: {event_type!r}",
+        "raw_type": event_type,
+        "raw": str(raw)[:300],
+    })
+
+
+class _KimiNormalizerHost(StreamingDrainerMixin):
+    """Minimal state holder so StreamingDrainerMixin can call normalize_kimi_event."""
+
+    provider_name = "kimi"
+    provider_observability_tier = 1
+
+    def __init__(self, terminal_id: str, dispatch_id: str) -> None:
+        self._current_terminal_id = terminal_id
+        self._current_dispatch_id = dispatch_id
+
+    def _normalize(self, raw: dict) -> CanonicalEvent:
+        return normalize_kimi_event(raw, self._current_terminal_id, self._current_dispatch_id)
+
+
+def _build_kimi_cmd(prompt: str, model: Optional[str], work_dir: Optional[Any]) -> list:
+    """Build the kimi argv list."""
+    cmd = ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p", prompt]
+    if model:
+        cmd.extend(["-m", model])
+    if work_dir:
+        cmd.extend(["-w", str(work_dir)])
+    return cmd
+
+
+def _start_kimi_subprocess(
+    cmd: list,
+    env: Dict[str, str],
+    cwd_str: Optional[str],
+) -> "tuple[subprocess.Popen | None, KimiSpawnResult | None]":
+    """Start the kimi subprocess (no stdin — prompt passed via -p flag).
+
+    Returns (proc, None) on success, or (None, KimiSpawnResult) on spawn failure.
+    All subprocess-boundary errors convert to structured results; none are re-raised.
+    """
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            env=env,
+            cwd=cwd_str,
+        )
+    except FileNotFoundError as exc:
+        return None, KimiSpawnResult(
+            returncode=127,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=f"kimi CLI not found: {exc}. Install: `uv tool install kimi-cli` and run `kimi login`.",
+        )
+    except OSError as exc:
+        return None, KimiSpawnResult(
+            returncode=126,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage=None,
+            error=f"failed to spawn kimi: {exc}",
+        )
+    return proc, None
+
+
+def _consume_kimi_stream(
+    proc: subprocess.Popen,
+    host: _KimiNormalizerHost,
+    on_event: Optional[Callable],
+    health_monitor: Optional[Any],
+    event_writer: Optional[Callable],
+    terminal_id: str,
+    dispatch_id: str,
+    event_store: Optional[Any],
+    chunk_timeout: float,
+    total_deadline: float,
+) -> "tuple[str, int, Optional[Dict], bool, bool, int]":
+    """Drain the stream; return (completion_text, events_written, token_usage, timed_out, stopped_early, failures)."""
+    events_written = 0
+    completion_parts: list = []
+    token_usage: Optional[Dict[str, Any]] = None
+    stopped_early = False
+    timed_out = False
+    _event_writer_failures = 0
+
+    for canonical_event in host.drain_stream(
+        proc, terminal_id, dispatch_id, event_store,
+        chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+    ):
+        events_written += 1
+        evt_type = canonical_event.event_type
+
+        if evt_type in ("text", "complete"):
+            text = (canonical_event.data or {}).get("text", "")
+            if text:
+                completion_parts.append(text)
+            tc = (canonical_event.data or {}).get("token_count")
+            if tc:
+                token_usage = tc
+        elif evt_type == "error":
+            reason = ((canonical_event.data or {}).get("reason") or "").lower()
+            if "timeout" in reason or "deadline" in reason:
+                timed_out = True
+
+        if health_monitor is not None:
+            health_monitor.update(canonical_event)
+
+        if event_writer is not None:
+            try:
+                event_writer(terminal_id, canonical_event.to_dict(), dispatch_id=dispatch_id)
+            except Exception as _exc:
+                logger.error(
+                    "spawn_kimi: event_writer callback failed (dispatch=%s, event_count=%d): %s",
+                    dispatch_id, events_written, _exc,
+                )
+                _event_writer_failures += 1
+
+        if on_event is not None:
+            if on_event(canonical_event) is False:
+                stopped_early = True
+                try:
+                    proc.kill()
+                except OSError as _ke:
+                    logger.debug("spawn_kimi: kill after on_event=False failed: %s", _ke)
+                break
+
+    return "".join(completion_parts), events_written, token_usage, timed_out, stopped_early, _event_writer_failures
+
+
+def _finalize_kimi_result(
+    proc: subprocess.Popen,
+    completion_text: str,
+    events_written: int,
+    token_usage: Optional[Dict[str, Any]],
+    timed_out: bool,
+    stopped_early: bool,
+    event_writer_failures: int,
+) -> KimiSpawnResult:
+    """Wait for process exit and return a KimiSpawnResult."""
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    rc = proc.returncode if proc.returncode is not None else 1
+    return KimiSpawnResult(
+        returncode=rc,
+        completion_text=completion_text,
+        events_written=events_written,
+        session_id=None,
+        timed_out=timed_out,
+        stopped_early=stopped_early,
+        token_usage=token_usage,
+        event_writer_failures=event_writer_failures,
+    )
+
+
+def spawn_kimi(
+    prompt: str,
+    model: Optional[str] = None,
+    dispatch_id: str = "",
+    terminal_id: str = "",
+    *,
+    event_writer: Optional[Callable[..., None]] = None,
+    health_monitor: Optional[Any] = None,
+    on_event: Optional[Callable[[Any], Optional[bool]]] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    cwd: Optional[Any] = None,
+    chunk_timeout: float = 60.0,
+    total_deadline: float = 900.0,
+    event_store: Optional[Any] = None,
+    **kwargs: Any,
+) -> KimiSpawnResult:
+    """Spawn ``kimi --print --output-format stream-json --yolo -p <prompt>``.
+
+    Returns KimiSpawnResult on completion (success OR controlled failure).
+    Returns KimiSpawnResult(returncode=127) when the kimi binary is absent.
+    Caller is responsible for lease/manifest/receipt/event-archive/retry.
+
+    event_writer signature: ``(terminal_id, event_dict, dispatch_id=...)`` called
+    per normalized event. Failures are counted in result.event_writer_failures.
+
+    Auth: OAuth via ``kimi login`` (operator-managed). No API key required.
+    """
+    try:
+        chunk_timeout = float(os.environ.get("VNX_KIMI_STALL_THRESHOLD", chunk_timeout))
+    except (TypeError, ValueError):
+        pass
+    try:
+        total_deadline = float(os.environ.get("VNX_KIMI_TIMEOUT", total_deadline))
+    except (TypeError, ValueError):
+        pass
+
+    env = {**os.environ, **(extra_env or {})}
+    cwd_str = str(cwd) if cwd is not None else None
+
+    cmd = _build_kimi_cmd(prompt, model, cwd)
+    logger.info("kimi_spawn: launching %s", " ".join(cmd[:6]))
+
+    proc, err_result = _start_kimi_subprocess(cmd, env, cwd_str)
+    if err_result is not None:
+        return err_result
+
+    host = _KimiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
+    completion_text, events_written, token_usage, timed_out, stopped_early, _event_writer_failures = (
+        _consume_kimi_stream(
+            proc=proc, host=host, on_event=on_event,
+            health_monitor=health_monitor, event_writer=event_writer,
+            terminal_id=terminal_id, dispatch_id=dispatch_id,
+            event_store=event_store, chunk_timeout=chunk_timeout,
+            total_deadline=total_deadline,
+        )
+    )
+    return _finalize_kimi_result(
+        proc=proc, completion_text=completion_text,
+        events_written=events_written, token_usage=token_usage,
+        timed_out=timed_out, stopped_early=stopped_early,
+        event_writer_failures=_event_writer_failures,
+    )

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -324,6 +324,9 @@ def spawn_kimi(
     ``event_writer`` is called per-event in _consume_kimi_stream. Passing both
     causes every event to be written twice.
     """
+    if event_store is not None and event_writer is not None:
+        raise ValueError("Pass either event_store OR event_writer, not both")
+
     try:
         chunk_timeout = float(os.environ.get("VNX_KIMI_STALL_THRESHOLD", chunk_timeout))
     except (TypeError, ValueError):

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -195,14 +195,15 @@ def _consume_kimi_stream(
     event_store: Optional[Any],
     chunk_timeout: float,
     total_deadline: float,
-) -> "tuple[str, int, Optional[Dict], bool, bool, int]":
-    """Drain the stream; return (completion_text, events_written, token_usage, timed_out, stopped_early, failures)."""
+) -> "tuple[str, int, Optional[Dict], bool, bool, int, list]":
+    """Drain the stream; return (completion_text, events_written, token_usage, timed_out, stopped_early, failures, errors_captured)."""
     events_written = 0
     completion_parts: list = []
     token_usage: Optional[Dict[str, Any]] = None
     stopped_early = False
     timed_out = False
     _event_writer_failures = 0
+    errors_captured: list = []
 
     for canonical_event in host.drain_stream(
         proc, terminal_id, dispatch_id, event_store,
@@ -219,9 +220,12 @@ def _consume_kimi_stream(
             if tc:
                 token_usage = tc
         elif evt_type == "error":
-            reason = ((canonical_event.data or {}).get("reason") or "").lower()
+            data = canonical_event.data or {}
+            reason = (data.get("reason") or "").lower()
             if "timeout" in reason or "deadline" in reason:
                 timed_out = True
+            msg = data.get("message") or data.get("reason") or str(data)[:200]
+            errors_captured.append(str(msg))
 
         if health_monitor is not None:
             health_monitor.update(canonical_event)
@@ -245,7 +249,7 @@ def _consume_kimi_stream(
                     logger.debug("spawn_kimi: kill after on_event=False failed: %s", _ke)
                 break
 
-    return "".join(completion_parts), events_written, token_usage, timed_out, stopped_early, _event_writer_failures
+    return "".join(completion_parts), events_written, token_usage, timed_out, stopped_early, _event_writer_failures, errors_captured
 
 
 def _finalize_kimi_result(
@@ -256,6 +260,7 @@ def _finalize_kimi_result(
     timed_out: bool,
     stopped_early: bool,
     event_writer_failures: int,
+    errors_captured: Optional[list] = None,
 ) -> KimiSpawnResult:
     """Wait for process exit and return a KimiSpawnResult."""
     try:
@@ -264,6 +269,16 @@ def _finalize_kimi_result(
         proc.kill()
         proc.wait()
     rc = proc.returncode if proc.returncode is not None else 1
+
+    if errors_captured:
+        error: Optional[str] = "\n".join(errors_captured)
+        if rc == 0:
+            rc = 1  # error event overrides false-success zero exit code
+    elif rc != 0:
+        error = f"kimi exited with code {rc}"
+    else:
+        error = None
+
     return KimiSpawnResult(
         returncode=rc,
         completion_text=completion_text,
@@ -273,6 +288,7 @@ def _finalize_kimi_result(
         stopped_early=stopped_early,
         token_usage=token_usage,
         event_writer_failures=event_writer_failures,
+        error=error,
     )
 
 
@@ -302,6 +318,11 @@ def spawn_kimi(
     per normalized event. Failures are counted in result.event_writer_failures.
 
     Auth: OAuth via ``kimi login`` (operator-managed). No API key required.
+
+    DUPLICATE-WRITE CONTRACT: pass either ``event_writer`` OR ``event_store``, not
+    both. ``event_store`` is forwarded to drain_stream (writes via drainer);
+    ``event_writer`` is called per-event in _consume_kimi_stream. Passing both
+    causes every event to be written twice.
     """
     try:
         chunk_timeout = float(os.environ.get("VNX_KIMI_STALL_THRESHOLD", chunk_timeout))
@@ -323,7 +344,7 @@ def spawn_kimi(
         return err_result
 
     host = _KimiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
-    completion_text, events_written, token_usage, timed_out, stopped_early, _event_writer_failures = (
+    completion_text, events_written, token_usage, timed_out, stopped_early, _event_writer_failures, errors_captured = (
         _consume_kimi_stream(
             proc=proc, host=host, on_event=on_event,
             health_monitor=health_monitor, event_writer=event_writer,
@@ -337,4 +358,5 @@ def spawn_kimi(
         events_written=events_written, token_usage=token_usage,
         timed_out=timed_out, stopped_early=stopped_early,
         event_writer_failures=_event_writer_failures,
+        errors_captured=errors_captured,
     )

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -58,3 +58,23 @@ providers:
         deprecated_models:  # explicit guard against legacy
           - "glm-4.5"
           - "glm-4.6"
+  kimi_cli:
+    enabled: true
+    api_key_env: ""  # no API key; OAuth via `kimi login`
+    models:
+      kimi-default:
+        litellm_name: ""  # kimi CLI direct; not via LiteLLM
+        cost_input_per_mtok: 0.60   # estimate based on moonshot K2 pricing
+        cost_output_per_mtok: 2.50
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review", "analysis"]
+      kimi-k2-6:
+        litellm_name: ""  # kimi CLI direct; not via LiteLLM
+        cost_input_per_mtok: 0.95
+        cost_output_per_mtok: 4.00
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding-premium"]

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -256,6 +256,49 @@ class TestSpawnKimiIntegration(unittest.TestCase):
         self.assertEqual(result.token_usage["input_tokens"], 200)
         self.assertEqual(result.token_usage["output_tokens"], 75)
 
+    def test_error_event_propagated_to_result_error_field(self):
+        """Error events emitted by kimi CLI must surface in result.error."""
+        events = [
+            {"event_type": "assistant_text", "content": "Partial"},
+            {"event_type": "error", "message": "upstream model returned 503"},
+            {"event_type": "complete"},
+        ]
+        result = self._run_with_events(events)
+        self.assertIsNotNone(result.error)
+        self.assertIn("503", result.error)
+
+    def test_error_event_overrides_zero_exit_code(self):
+        """An error event with exit_code=0 must set result.error and returncode != 0."""
+        events = [
+            {"event_type": "error", "message": "auth token expired"},
+        ]
+        result = self._run_with_events(events, returncode=0)
+        self.assertIsNotNone(result.error)
+        self.assertIn("auth token expired", result.error)
+        self.assertNotEqual(result.returncode, 0)
+
+
+class TestDispatchKimiEventStoreFailure(unittest.TestCase):
+    """Tests for _dispatch_kimi EventStore audit-invariant enforcement (ADR-005)."""
+
+    def test_event_store_init_failure_returns_nonzero(self):
+        """_dispatch_kimi must return non-zero when EventStore fails to initialize."""
+        import argparse
+        _PARENT_LIB = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+        if _PARENT_LIB not in sys.path:
+            sys.path.insert(0, _PARENT_LIB)
+        import provider_dispatch as pd
+
+        args = argparse.Namespace(
+            instruction="test prompt",
+            dispatch_id="d-es-fail",
+            terminal_id="T1",
+            pr_id=None,
+        )
+        with patch("event_store.EventStore", side_effect=RuntimeError("db locked")):
+            rc = pd._dispatch_kimi(args)
+        self.assertNotEqual(rc, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -1,0 +1,261 @@
+"""Tests for kimi_spawn.py — Kimi CLI subprocess spawn handler (Wave 7.7)."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Make sure scripts/lib is on the path
+_LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from provider_spawns.kimi_spawn import (  # noqa: E402
+    KimiSpawnResult,
+    _build_kimi_cmd,
+    normalize_kimi_event,
+    spawn_kimi,
+)
+
+
+def _make_stdout(*events: dict) -> io.BytesIO:
+    """Build a bytes stream of NDJSON events."""
+    lines = "".join(json.dumps(e) + "\n" for e in events)
+    return io.BytesIO(lines.encode())
+
+
+def _mock_proc(stdout_events: list, returncode: int = 0) -> MagicMock:
+    """Return a mock subprocess.Popen with the given events in stdout."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.poll.return_value = returncode
+    data = b"".join((json.dumps(e) + "\n").encode() for e in stdout_events)
+    proc.stdout = io.BytesIO(data)
+    proc.stderr = io.BytesIO(b"")
+    proc.wait = MagicMock(return_value=returncode)
+    return proc
+
+
+class TestBuildKimiCmd(unittest.TestCase):
+    def test_constructs_correct_argv_no_model(self):
+        cmd = _build_kimi_cmd("hello world", None, None)
+        self.assertEqual(cmd[:6], ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p"])
+        self.assertEqual(cmd[6], "hello world")
+
+    def test_passes_model_when_specified(self):
+        cmd = _build_kimi_cmd("prompt", "kimi-k2-6", None)
+        self.assertIn("-m", cmd)
+        self.assertEqual(cmd[cmd.index("-m") + 1], "kimi-k2-6")
+
+    def test_skips_model_when_none(self):
+        cmd = _build_kimi_cmd("prompt", None, None)
+        self.assertNotIn("-m", cmd)
+
+    def test_passes_work_dir_when_specified(self):
+        cmd = _build_kimi_cmd("prompt", None, Path("/tmp/work"))
+        self.assertIn("-w", cmd)
+        self.assertEqual(cmd[cmd.index("-w") + 1], "/tmp/work")
+
+    def test_skips_work_dir_when_none(self):
+        cmd = _build_kimi_cmd("prompt", None, None)
+        self.assertNotIn("-w", cmd)
+
+
+class TestNormalizeKimiEvent(unittest.TestCase):
+    def _make_raw(self, **kwargs) -> dict:
+        return kwargs
+
+    def test_normalize_assistant_text_event(self):
+        raw = {"event_type": "assistant_text", "content": "Hello!"}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "text")
+        self.assertEqual(event.data["text"], "Hello!")
+        self.assertEqual(event.provider, "kimi")
+
+    def test_normalize_text_event_alias(self):
+        raw = {"event_type": "text", "content": "World"}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "text")
+        self.assertEqual(event.data["text"], "World")
+
+    def test_normalize_tool_call_event(self):
+        raw = {
+            "event_type": "tool_call",
+            "name": "read_file",
+            "input": {"path": "/tmp/x.txt"},
+            "id": "tc-123",
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "tool_use")
+        self.assertEqual(event.data["name"], "read_file")
+        self.assertEqual(event.data["input"], {"path": "/tmp/x.txt"})
+        self.assertEqual(event.data["id"], "tc-123")
+
+    def test_normalize_tool_result_event(self):
+        raw = {
+            "event_type": "tool_result",
+            "tool_call_id": "tc-123",
+            "output": "file contents here",
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "tool_result")
+        self.assertEqual(event.data["tool_use_id"], "tc-123")
+        self.assertEqual(event.data["content"], "file contents here")
+
+    def test_normalize_usage_complete_extracted_as_text_with_token_count(self):
+        raw = {
+            "event_type": "usage_complete",
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "text")
+        self.assertEqual(event.data["text"], "")
+        tc = event.data.get("token_count", {})
+        self.assertEqual(tc["input_tokens"], 100)
+        self.assertEqual(tc["output_tokens"], 50)
+        self.assertEqual(tc["cache_creation_tokens"], 0)
+        self.assertEqual(tc["cache_read_tokens"], 0)
+
+    def test_normalize_complete_event(self):
+        raw = {"event_type": "complete"}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "complete")
+
+    def test_normalize_error_event(self):
+        raw = {"event_type": "error", "message": "something went wrong"}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "error")
+        self.assertEqual(event.data["message"], "something went wrong")
+
+    def test_normalize_unknown_event_type_maps_to_error(self):
+        raw = {"event_type": "weird_event", "data": "xyz"}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "error")
+        self.assertIn("reason", event.data)
+        self.assertIn("weird_event", event.data["reason"])
+
+    def test_event_has_correct_dispatch_and_terminal(self):
+        raw = {"event_type": "complete"}
+        event = normalize_kimi_event(raw, "T2", "my-dispatch")
+        self.assertEqual(event.terminal_id, "T2")
+        self.assertEqual(event.dispatch_id, "my-dispatch")
+        self.assertEqual(event.observability_tier, 1)
+
+
+class TestSpawnKimiSubprocess(unittest.TestCase):
+    def test_returns_127_when_cli_missing(self):
+        with patch("subprocess.Popen", side_effect=FileNotFoundError("kimi not found")):
+            result = spawn_kimi("test prompt", dispatch_id="d1", terminal_id="T1")
+        self.assertEqual(result.returncode, 127)
+        self.assertIsNotNone(result.error)
+        self.assertIn("not found", result.error.lower())
+        self.assertEqual(result.events_written, 0)
+
+    def test_spawn_kimi_constructs_correct_argv(self):
+        captured_cmd = []
+
+        def fake_popen(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            raise FileNotFoundError("not testing real spawn")
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            spawn_kimi("my prompt", dispatch_id="d1", terminal_id="T1")
+
+        self.assertIn("kimi", captured_cmd)
+        self.assertIn("--print", captured_cmd)
+        self.assertIn("--output-format", captured_cmd)
+        self.assertIn("stream-json", captured_cmd)
+        self.assertIn("--yolo", captured_cmd)
+        self.assertIn("-p", captured_cmd)
+        self.assertIn("my prompt", captured_cmd)
+
+    def test_spawn_kimi_passes_model_flag_when_specified(self):
+        captured_cmd = []
+
+        def fake_popen(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            raise FileNotFoundError("not testing real spawn")
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            spawn_kimi("prompt", model="kimi-k2-6", dispatch_id="d1", terminal_id="T1")
+
+        self.assertIn("-m", captured_cmd)
+        self.assertEqual(captured_cmd[captured_cmd.index("-m") + 1], "kimi-k2-6")
+
+    def test_spawn_kimi_skips_model_flag_when_none(self):
+        captured_cmd = []
+
+        def fake_popen(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            raise FileNotFoundError("not testing real spawn")
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            spawn_kimi("prompt", model=None, dispatch_id="d1", terminal_id="T1")
+
+        self.assertNotIn("-m", captured_cmd)
+
+
+class TestSpawnKimiIntegration(unittest.TestCase):
+    """Integration-style tests using a real pipe so drain_stream.fileno() works."""
+
+    def _run_with_events(self, events: list, returncode: int = 0) -> KimiSpawnResult:
+        """Run spawn_kimi with a real-pipe-backed fake process emitting the given events."""
+        data = b"".join((json.dumps(e) + "\n").encode() for e in events)
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            try:
+                os.write(write_fd, data)
+            finally:
+                os.close(write_fd)
+
+        writer_thread = threading.Thread(target=_writer, daemon=True)
+        writer_thread.start()
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = returncode
+        fake_proc.poll.return_value = returncode
+        fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=returncode)
+        fake_proc.kill = MagicMock()
+
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi("prompt", dispatch_id="d1", terminal_id="T1")
+        finally:
+            writer_thread.join(timeout=5)
+        return result
+
+    def test_response_text_concatenation(self):
+        events = [
+            {"event_type": "assistant_text", "content": "Hello "},
+            {"event_type": "assistant_text", "content": "world!"},
+            {"event_type": "complete"},
+        ]
+        result = self._run_with_events(events)
+        self.assertIn("Hello", result.completion_text)
+        self.assertIn("world!", result.completion_text)
+
+    def test_captures_usage_field(self):
+        events = [
+            {"event_type": "assistant_text", "content": "Done."},
+            {"event_type": "usage_complete", "usage": {"prompt_tokens": 200, "completion_tokens": 75}},
+            {"event_type": "complete"},
+        ]
+        result = self._run_with_events(events)
+        self.assertIsNotNone(result.token_usage)
+        self.assertEqual(result.token_usage["input_tokens"], 200)
+        self.assertEqual(result.token_usage["output_tokens"], 75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -77,7 +77,7 @@ class TestDispatchKimiSuccess(unittest.TestCase):
         result = self._make_success_result()
 
         with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
-             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
              patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
              patch("governance_emit.emit_unified_report") as mock_report:
             mock_receipt.return_value = Path("/tmp/receipts.ndjson")
@@ -97,7 +97,7 @@ class TestDispatchKimiSuccess(unittest.TestCase):
         result = self._make_success_result()
 
         with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
-             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
              patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
              patch("governance_emit.emit_unified_report") as mock_report:
             mock_receipt.return_value = Path("/tmp/receipts.ndjson")
@@ -121,7 +121,7 @@ class TestDispatchKimiSuccess(unittest.TestCase):
         )
 
         with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=fail_result), \
-             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
              patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
              patch("governance_emit.emit_unified_report") as mock_report:
             mock_receipt.return_value = Path("/tmp/receipts.ndjson")
@@ -129,6 +129,51 @@ class TestDispatchKimiSuccess(unittest.TestCase):
             exit_code = pd._dispatch_kimi(args)
 
         self.assertEqual(exit_code, 1)
+        mock_receipt.assert_called_once()
+        call_kwargs = mock_receipt.call_args.kwargs
+        self.assertEqual(call_kwargs.get("status"), "failure")
+
+    def test_event_store_init_failure_returns_nonzero(self):
+        import provider_dispatch as pd
+
+        args = _build_args()
+
+        with patch("event_store.EventStore", side_effect=Exception("db unavailable")), \
+             patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
+             patch("governance_emit.emit_unified_report") as mock_report:
+            exit_code = pd._dispatch_kimi(args)
+
+        self.assertNotEqual(exit_code, 0)
+        # No success receipt may be emitted when audit sink is unavailable
+        for call in mock_receipt.call_args_list:
+            self.assertNotEqual(call.kwargs.get("status"), "success")
+
+    def test_event_writer_failures_emits_failure_receipt(self):
+        import provider_dispatch as pd
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        args = _build_args()
+        audit_gap_result = KimiSpawnResult(
+            returncode=0,
+            completion_text="done",
+            events_written=5,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage={"input_tokens": 100, "output_tokens": 40, "cache_read_tokens": 0, "cache_creation_tokens": 0},
+            error=None,
+            event_writer_failures=3,
+        )
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=audit_gap_result), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
+             patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
+             patch("governance_emit.emit_unified_report") as mock_report:
+            mock_receipt.return_value = Path("/tmp/receipts.ndjson")
+            mock_report.return_value = Path("/tmp/report.md")
+            exit_code = pd._dispatch_kimi(args)
+
+        self.assertNotEqual(exit_code, 0)
         mock_receipt.assert_called_once()
         call_kwargs = mock_receipt.call_args.kwargs
         self.assertEqual(call_kwargs.get("status"), "failure")

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -1,0 +1,182 @@
+"""Tests for the kimi provider routing in provider_dispatch.py (Wave 7.7)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+
+def _build_args(**overrides):
+    """Build a minimal argparse.Namespace for dispatch tests."""
+    import argparse
+
+    defaults = {
+        "provider": "kimi",
+        "terminal_id": "T1",
+        "dispatch_id": "test-dispatch-kimi-01",
+        "instruction": "Say hi",
+        "model": "default",
+        "max_retries": 3,
+        "no_auto_commit": False,
+        "gate": "",
+        "dispatch_paths": "",
+        "pr_id": None,
+        "role": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestProviderDispatchKimiArgParser(unittest.TestCase):
+    def test_provider_kimi_accepted_in_arg_parser(self):
+        import provider_dispatch as pd
+
+        parser = pd._build_parser()
+        args = parser.parse_args([
+            "--provider", "kimi",
+            "--terminal-id", "T1",
+            "--dispatch-id", "d1",
+            "--instruction", "test",
+        ])
+        self.assertEqual(args.provider, "kimi")
+
+    def test_parser_help_mentions_kimi(self):
+        import provider_dispatch as pd
+
+        parser = pd._build_parser()
+        help_text = parser.format_help()
+        self.assertIn("kimi", help_text)
+
+
+class TestDispatchKimiSuccess(unittest.TestCase):
+    def _make_success_result(self):
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        return KimiSpawnResult(
+            returncode=0,
+            completion_text="Hello from Kimi!",
+            events_written=3,
+            session_id=None,
+            timed_out=False,
+            stopped_early=False,
+            token_usage={"input_tokens": 50, "output_tokens": 20, "cache_read_tokens": 0, "cache_creation_tokens": 0},
+            error=None,
+            event_writer_failures=0,
+        )
+
+    def test_dispatch_kimi_emits_receipt_with_provider_kimi(self):
+        import provider_dispatch as pd
+
+        args = _build_args()
+        result = self._make_success_result()
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
+             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
+             patch("governance_emit.emit_unified_report") as mock_report:
+            mock_receipt.return_value = Path("/tmp/receipts.ndjson")
+            mock_report.return_value = Path("/tmp/report.md")
+            exit_code = pd._dispatch_kimi(args)
+
+        self.assertEqual(exit_code, 0)
+        mock_receipt.assert_called_once()
+        # provider is always passed as keyword arg
+        call_kwargs = mock_receipt.call_args.kwargs
+        self.assertEqual(call_kwargs.get("provider"), "kimi")
+
+    def test_dispatch_kimi_emits_unified_report(self):
+        import provider_dispatch as pd
+
+        args = _build_args()
+        result = self._make_success_result()
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
+             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
+             patch("governance_emit.emit_unified_report") as mock_report:
+            mock_receipt.return_value = Path("/tmp/receipts.ndjson")
+            mock_report.return_value = Path("/tmp/report.md")
+            pd._dispatch_kimi(args)
+
+        mock_report.assert_called_once()
+
+    def test_dispatch_kimi_failure_emits_receipt_with_status_failure(self):
+        import provider_dispatch as pd
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        args = _build_args()
+        fail_result = KimiSpawnResult(
+            returncode=1,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            error="kimi exited with code 1",
+        )
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=fail_result), \
+             patch("event_store.EventStore", side_effect=Exception("no store")), \
+             patch("governance_emit.emit_dispatch_receipt") as mock_receipt, \
+             patch("governance_emit.emit_unified_report") as mock_report:
+            mock_receipt.return_value = Path("/tmp/receipts.ndjson")
+            mock_report.return_value = Path("/tmp/report.md")
+            exit_code = pd._dispatch_kimi(args)
+
+        self.assertEqual(exit_code, 1)
+        mock_receipt.assert_called_once()
+        call_kwargs = mock_receipt.call_args.kwargs
+        self.assertEqual(call_kwargs.get("status"), "failure")
+
+
+class TestComputeKimiCost(unittest.TestCase):
+    def test_cost_computed_when_usage_present(self):
+        import provider_dispatch as pd
+
+        token_usage = {"input": 1_000_000, "output": 500_000, "cache_hit": 0}
+        # Without registry (isolated): returns None gracefully
+        with patch("provider_dispatch._compute_kimi_cost") as mock_cost:
+            mock_cost.return_value = 0.00185
+            cost = pd._compute_cost("kimi", "kimi-default", token_usage)
+        self.assertEqual(cost, 0.00185)
+
+    def test_compute_kimi_cost_returns_none_on_zero_usage(self):
+        import provider_dispatch as pd
+
+        cost = pd._compute_kimi_cost("kimi-default", {"input": 0, "output": 0, "cache_hit": 0})
+        self.assertIsNone(cost)
+
+    def test_compute_kimi_cost_returns_none_when_registry_missing(self):
+        import provider_dispatch as pd
+
+        with patch("provider_dispatch._compute_kimi_cost", wraps=pd._compute_kimi_cost):
+            # Patch load to raise FileNotFoundError
+            with patch("providers.provider_registry.load", side_effect=FileNotFoundError):
+                cost = pd._compute_kimi_cost("kimi-default", {"input": 100, "output": 50, "cache_hit": 0})
+        self.assertIsNone(cost)
+
+    def test_extract_token_usage_kimi_uses_input_output_keys(self):
+        import provider_dispatch as pd
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        result = KimiSpawnResult(
+            returncode=0,
+            completion_text="",
+            events_written=1,
+            session_id=None,
+            timed_out=False,
+            token_usage={"input_tokens": 300, "output_tokens": 120, "cache_read_tokens": 5, "cache_creation_tokens": 0},
+        )
+        usage = pd._extract_token_usage(result, "kimi")
+        self.assertEqual(usage["input"], 300)
+        self.assertEqual(usage["output"], 120)
+        self.assertEqual(usage["cache_hit"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Integrates Moonshot's Kimi CLI (`/Users/vincentvandeth/.local/bin/kimi`, v1.44.0) as VNX's 5th provider alongside claude/codex/gemini/litellm
- Auth via `kimi login` OAuth — no API key in env required; fully operator-managed credential
- Full governance stack: NDJSON audit trail via EventStore, receipt + unified report via governance_emit, token usage extraction, cost tracking from wave7_models.yaml

## Changes

| File | Change |
|------|--------|
| `scripts/lib/provider_spawns/kimi_spawn.py` | NEW — spawn handler, stream-json normalizer, `_KimiNormalizerHost` (StreamingDrainerMixin), `KimiSpawnResult` |
| `scripts/lib/provider_dispatch.py` | `_dispatch_kimi`, `_compute_kimi_cost`, kimi token usage branch, parser + main() routing |
| `scripts/lib/canonical_event.py` | "kimi" in `VALID_PROVIDERS`, `_from_kimi_event` mapper, dispatch in `from_provider_event` |
| `scripts/lib/governance_emit.py` | `_PROVIDER_RE` extended to include `kimi` |
| `scripts/lib/providers/wave7_models.yaml` | `kimi_cli` section with `kimi-default` + `kimi-k2-6` pricing |
| `tests/test_kimi_spawn.py` | NEW — 20 tests (normalizer, argv, FileNotFoundError, real-pipe integration) |
| `tests/test_provider_dispatch_kimi.py` | NEW — 9 tests (routing, receipt/report emission, cost, token extraction) |

## Test plan

- [x] `pytest tests/test_kimi_spawn.py tests/test_provider_dispatch_kimi.py` — 29/29 pass
- [x] `pytest tests/test_governance_emit.py tests/test_canonical_event.py` — 89/89 pass (includes parametrized "kimi" provider tests)
- [x] No regressions in governance_emit or canonical_event test suites
- [x] `VALID_PROVIDERS` frozenset includes "kimi" — verified by existing parametrized tests
- [x] `_PROVIDER_RE` accepts "kimi" — verified by governance_emit receipt write path

## Wave 7 context

Same pattern as codex_spawn / gemini_spawn (B3 cycle). Upstream: [MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli).

Dispatch-ID: 20260517-wave7-7-kimi-cli-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)