### PR TITLE
refactor(intelligence): split intelligence_selector.py (2511 LOC) per source module

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -262,7 +262,8 @@ class IntelligenceSelector:
                 event_id = _append_event(conn, event_type=event_type, entity_type="dispatch", entity_id=result.dispatch_id, actor="intelligence_selector", reason=reason, metadata=result.to_event_metadata())
                 conn.commit()
             return event_id
-        except Exception:
+        except Exception as exc:
+            logger.warning("emit_event: failed to append coordination event for dispatch %s: %s", result.dispatch_id, exc)
             return None
 
     def record_injection(self, result: InjectionResult, coord_state_dir=None) -> None:

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -1,69 +1,39 @@
 #!/usr/bin/env python3
 """
-VNX Intelligence Selector — Bounded injection for dispatch-create and resume paths.
+VNX Intelligence Selector — orchestrator for bounded dispatch injection.
 
-Implements the FP-C Intelligence Contract (docs/core/31_FPC_INTELLIGENCE_CONTRACT.md):
-  - Selection algorithm (Section 2.3): one item per class, highest confidence wins
-  - Payload bounds (Section 2.2): max 3 items, max 2000 chars total for standard classes
-    (proven_pattern, failure_prevention, recent_comparable); direct-injection classes
-    (code_anchor, prior_round_finding, adr_relevant, operator_memory) carry up to 1500 chars
-    each and the combined payload limit is raised to 4000 chars to allow multiple such items.
-  - Evidence thresholds: proven_pattern >= 0.6, failure_prevention >= 0.5, recent_comparable >= 0.4
-  - Task-class-aware filtering via scope_tags and task_class_filter
-  - Injection and suppression events emitted to coordination_events
+Implements FP-C Intelligence Contract (docs/core/31_FPC_INTELLIGENCE_CONTRACT.md).
+Per-source query logic lives in scripts/lib/intelligence_sources/.
+This module coordinates budgets, applies selection, records audit.
 
-Governance:
-  G-R5: Injection bounded to max 3 items, only at dispatch-create or resume
-  G-R6: Every item carries confidence, evidence_count, last_seen, scope_tags
-  G-R7: Recommendations are advisory-only (measured but not auto-applied)
+Governance: G-R5 (max 3 items), G-R6 (confidence+evidence+scope), G-R7 (advisory-only).
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import os
 import sqlite3
-import uuid
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
+
+from intelligence_sources import (  # noqa: F401  (re-exported for backward compat)
+    CONFIDENCE_THRESHOLDS, EVIDENCE_THRESHOLDS, ITEM_CLASS_PRIORITY,
+    MAX_CODE_ANCHOR_CHARS, MAX_CONTENT_CHARS_PER_ITEM, MAX_GOVERNANCE_PER_BATCH,
+    MAX_ITEMS_PER_INJECTION, MAX_PAYLOAD_CHARS, PATTERN_CATEGORY_GOVERNANCE,
+    VALID_INJECTION_POINTS,
+    IntelligenceItem, SuppressionRecord,
+    InjectionResult, IntelligenceContext,
+    _new_id, _now_utc, _table_has_column,
+    apply_candidate_diversity, resolve_task_class,
+    query_proven_patterns, query_failure_prevention, query_recent_comparable,
+    build_adr_item, build_schema_section_item,
+    build_code_anchor_item, build_operator_memory_item, build_prior_round_item,
+    record_injection_audit, record_pattern_usage,
+)
+from intelligence_sources import stamp_source_dispatch_ids as _stamp
 
 logger = logging.getLogger(__name__)
-
-try:
-    import shadow_verifier as _shadow_verifier
-    import shadow_logger as _shadow_logger
-except ImportError:
-    _shadow_verifier = None  # type: ignore[assignment]
-    _shadow_logger = None  # type: ignore[assignment]
-
-try:
-    import prior_round_injector as _prior_round_injector
-except ImportError:
-    _prior_round_injector = None  # type: ignore[assignment]
-
-try:
-    import adr_indexer as _adr_indexer
-except ImportError:
-    _adr_indexer = None  # type: ignore[assignment]
-
-try:
-    import code_anchor_finder as _code_anchor_finder
-except ImportError:
-    _code_anchor_finder = None  # type: ignore[assignment]
-
-try:
-    import operator_memory_indexer as _operator_memory_indexer
-except ImportError:
-    _operator_memory_indexer = None  # type: ignore[assignment]
-
-try:
-    import schema_section_indexer as _schema_section_indexer
-except ImportError:
-    _schema_section_indexer = None  # type: ignore[assignment]
 
 try:
     from vnx_paths import resolve_central_data_dir as _resolve_central_data_dir
@@ -72,457 +42,30 @@ except ImportError:
 
 try:
     from project_scope import current_project_id, project_filter_enabled
-except ImportError:  # pragma: no cover - lib path bootstrap
+except ImportError:
     import sys as _sys
-    from pathlib import Path as _Path
-    _sys.path.insert(0, str(_Path(__file__).resolve().parent))
+    _sys.path.insert(0, str(Path(__file__).resolve().parent))
     from project_scope import current_project_id, project_filter_enabled
 
-# ---------------------------------------------------------------------------
-# Constants from FP-C Intelligence Contract
-# ---------------------------------------------------------------------------
+# Direct injection source table: (item_class, cumulative_drop_order)
+_DIRECT_SOURCES = [
+    ("prior_round_finding", ["prior_round_finding"]),
+    ("adr_relevant",        ["prior_round_finding", "adr_relevant"]),
+    ("code_anchor",         ["prior_round_finding", "adr_relevant", "code_anchor"]),
+    ("operator_memory",     ["prior_round_finding", "adr_relevant", "code_anchor", "operator_memory"]),
+    ("schema_section",      ["prior_round_finding", "adr_relevant", "code_anchor", "operator_memory", "schema_section"]),
+]
 
-MAX_ITEMS_PER_INJECTION = 3
-MAX_CONTENT_CHARS_PER_ITEM = 500
-MAX_PAYLOAD_CHARS = 4000
-MIN_EVIDENCE_COUNT = 1
-MAX_CODE_ANCHOR_CHARS = 1500
-
-# Item classes that carry pre-formatted sections and must not be clipped to the
-# 500-char standard limit.  These are direct-injection classes whose full content
-# (up to MAX_CODE_ANCHOR_CHARS) the worker is expected to read verbatim.
-_DIRECT_INJECTION_CLASSES = frozenset({
-    "code_anchor",
-    "prior_round_finding",
-    "adr_relevant",
-    "operator_memory",
-    "schema_section",
-})
-
-# Per-class confidence thresholds (Section 1.2 / 2.3)
-CONFIDENCE_THRESHOLDS = {
-    "proven_pattern": 0.6,
-    "failure_prevention": 0.5,
-    "recent_comparable": 0.4,
-}
-
-# Per-class minimum evidence counts
-EVIDENCE_THRESHOLDS = {
-    "proven_pattern": 2,
-    "failure_prevention": 1,
-    "recent_comparable": 1,
-}
-
-# Selection priority order (highest first) — used for payload overflow trimming
-ITEM_CLASS_PRIORITY = ["proven_pattern", "failure_prevention", "recent_comparable"]
-
-# Pattern categories (see schemas/migrations/0011_add_pattern_category.sql).
-# Diversity rules consume these to demote governance signals out of the
-# proven_pattern slot and avoid repeating identical content across a batch.
-PATTERN_CATEGORY_CODE = "code"
-PATTERN_CATEGORY_GOVERNANCE = "governance"
-PATTERN_CATEGORY_PROCESS = "process"
-PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE = "antipattern_evidence"
-
-# Maximum governance items per batch — they win the proven_pattern slot only
-# when no real code pattern is available, and never appear more than once
-# across a single injection.
-MAX_GOVERNANCE_PER_BATCH = 1
-
-# Confidence multiplier applied to governance proven_patterns so that, all else
-# equal, a code pattern with the same raw confidence wins. Pure penalty —
-# governance patterns are still allowed when they're the only candidates above
-# threshold.
-GOVERNANCE_CONFIDENCE_PENALTY = 0.7
-
-# Recent comparable window
-RECENT_COMPARABLE_DAYS = 14
-
-# Valid injection points
-VALID_INJECTION_POINTS = frozenset({"dispatch_create", "dispatch_resume"})
-
-# Valid task classes (from FP-C Execution Contracts)
-VALID_TASK_CLASSES = frozenset({
-    "coding_interactive",
-    "research_structured",
-    "docs_synthesis",
-    "ops_watchdog",
-    "channel_response",
-})
-
-# Skill-to-task-class mapping (from 30_FPC_EXECUTION_CONTRACTS.md Section 1.1)
-SKILL_TO_TASK_CLASS = {
-    "backend-developer": "coding_interactive",
-    "frontend-developer": "coding_interactive",
-    "api-developer": "coding_interactive",
-    "python-optimizer": "coding_interactive",
-    "supabase-expert": "coding_interactive",
-    "monitoring-specialist": "coding_interactive",
-    "vnx-manager": "coding_interactive",
-    "debugger": "coding_interactive",
-    "test-engineer": "coding_interactive",
-    "quality-engineer": "coding_interactive",
-    "architect": "research_structured",
-    "reviewer": "research_structured",
-    "planner": "research_structured",
-    "data-analyst": "research_structured",
-    "performance-profiler": "research_structured",
-    "security-engineer": "research_structured",
-    "t0-orchestrator": "research_structured",
-    "excel-reporter": "docs_synthesis",
-    "technical-writer": "docs_synthesis",
-}
-
-
-# ---------------------------------------------------------------------------
-# Data classes
-# ---------------------------------------------------------------------------
-
-@dataclass
-class IntelligenceItem:
-    """A single intelligence item conforming to the FP-C schema."""
-    item_id: str
-    item_class: str
-    title: str
-    content: str
-    confidence: float
-    evidence_count: int
-    last_seen: str
-    scope_tags: List[str]
-    source_refs: List[str] = field(default_factory=list)
-    task_class_filter: List[str] = field(default_factory=list)
-    pattern_category: str = PATTERN_CATEGORY_CODE
-    content_hash: str = ""
-
-    def to_dict(self) -> Dict[str, Any]:
-        content_cap = (
-            MAX_CODE_ANCHOR_CHARS
-            if self.item_class in _DIRECT_INJECTION_CLASSES
-            else MAX_CONTENT_CHARS_PER_ITEM
-        )
-        return {
-            "item_id": self.item_id,
-            "item_class": self.item_class,
-            "title": self.title,
-            "content": self.content[:content_cap],
-            "confidence": self.confidence,
-            "evidence_count": self.evidence_count,
-            "last_seen": self.last_seen,
-            "scope_tags": self.scope_tags,
-            "source_refs": self.source_refs,
-            "task_class_filter": self.task_class_filter,
-            "pattern_category": self.pattern_category,
-            "content_hash": self.content_hash,
-        }
-
-
-def _normalize_for_hash(text: str) -> str:
-    return " ".join((text or "").lower().split())
-
-
-def _content_hash(*parts: str) -> str:
-    joined = "\n".join(_normalize_for_hash(p) for p in parts)
-    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
-
-
-def classify_pattern_category(title: str, description: str) -> str:
-    """Mirror of pattern_dedup.classify_pattern, kept local to avoid import cycle.
-
-    Order matters: governance gate-pass shape wins over generic process tokens.
-    """
-    haystack = f"{_normalize_for_hash(title)} :: {_normalize_for_hash(description)}"
-    if "gate " in haystack and "passed" in haystack:
-        return PATTERN_CATEGORY_GOVERNANCE
-    if any(token in haystack for token in (
-        "receipt processor",
-        "dispatch lifecycle",
-        "lease release",
-    )):
-        return PATTERN_CATEGORY_PROCESS
-    return PATTERN_CATEGORY_CODE
-
-
-@dataclass
-class SuppressionRecord:
-    """Records why an item class slot was not filled."""
-    item_class: str
-    reason: str
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {"item_class": self.item_class, "reason": self.reason}
-
-
-@dataclass
-class InjectionResult:
-    """Complete result of an intelligence selection run."""
-    injection_point: str
-    injected_at: str
-    items: List[IntelligenceItem]
-    suppressed: List[SuppressionRecord]
-    task_class: str
-    dispatch_id: str
-
-    @property
-    def items_injected(self) -> int:
-        return len(self.items)
-
-    @property
-    def items_suppressed(self) -> int:
-        return len(self.suppressed)
-
-    @property
-    def payload_chars(self) -> int:
-        return len(json.dumps(self.to_payload_dict()))
-
-    def to_payload_dict(self) -> Dict[str, Any]:
-        """Return the intelligence_payload for bundle.json."""
-        return {
-            "injection_point": self.injection_point,
-            "injected_at": self.injected_at,
-            "items": [item.to_dict() for item in self.items],
-            "suppressed": [s.to_dict() for s in self.suppressed],
-        }
-
-    def to_event_metadata(self) -> Dict[str, Any]:
-        """Return metadata for the coordination event."""
-        return {
-            "injection_point": self.injection_point,
-            "task_class": self.task_class,
-            "items_injected": self.items_injected,
-            "items_suppressed": self.items_suppressed,
-            "suppression_reasons": [s.reason for s in self.suppressed],
-            "payload_chars": self.payload_chars,
-            "item_ids": [item.item_id for item in self.items],
-        }
-
-
-# ---------------------------------------------------------------------------
-# IntelligenceContext — per-provider serialization container
-# ---------------------------------------------------------------------------
-
-def _format_items_markdown(items: List["IntelligenceItem"]) -> str:
-    """Group items by class and render as full markdown sections."""
-    by_class: Dict[str, List["IntelligenceItem"]] = {}
-    for item in items:
-        by_class.setdefault(item.item_class, []).append(item)
-    parts: List[str] = []
-    if "failure_prevention" in by_class:
-        parts.append("### Antipatterns to avoid")
-        for item in by_class["failure_prevention"]:
-            parts.append(f"- **[CRITICAL] {item.title}**: {item.content}")
-        parts.append("")
-    if "proven_pattern" in by_class:
-        parts.append("### Proven success patterns")
-        for item in by_class["proven_pattern"]:
-            parts.append(f"- **{item.title}**: {item.content}")
-        parts.append("")
-    if "recent_comparable" in by_class:
-        parts.append("### Tag warnings")
-        for item in by_class["recent_comparable"]:
-            parts.append(f"- **{item.title}**: {item.content}")
-        parts.append("")
-    return "\n".join(parts)
-
-
-def _format_items_compact(items: List["IntelligenceItem"]) -> str:
-    """Compact numbered format for providers where brevity is preferred."""
-    lines: List[str] = ["## Intelligence Context"]
-    for i, item in enumerate(items, 1):
-        cls = item.item_class.replace("_", " ").title()
-        lines.append(f"{i}. [{cls}] **{item.title}**: {item.content}")
-    return "\n".join(lines)
-
-
-@dataclass
-class IntelligenceContext:
-    """Provider-agnostic container for an intelligence injection result."""
-    result: InjectionResult
-    dispatch_id: str
-
-    def serialize_for(self, provider: str) -> str:
-        """Return provider-specific markdown for the prompt intelligence section.
-
-        Returns an empty string when the result contains no items.
-        Providers:
-          - 'codex': compact numbered list (brevity-first)
-          - 'gemini', 'litellm', others: full markdown sections with headers
-        """
-        if not self.result.items:
-            return ""
-        if provider == "codex":
-            return _format_items_compact(self.result.items)
-        return _format_items_markdown(self.result.items)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _now_utc() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
-
-
-def _new_id() -> str:
-    return str(uuid.uuid4())
-
-
-def _stable_item_id(prefix: str, source_key: str) -> str:
-    """Build a deterministic, content-derived item_id.
-
-    Patterns offered to multiple dispatches must share the SAME item_id so that
-    pattern_usage rows aggregate (one row per underlying pattern) instead of
-    fragmenting into a fresh row per offering.  Random UUIDs broke that
-    invariant — see codex regate finding for PR #311.
-
-    The id encodes the originating table via *prefix* (e.g. ``sp`` for
-    success_patterns, ``ap`` for antipatterns, ``pr`` for prevention_rules,
-    ``dm`` for dispatch_metadata) and a stable per-row key (the row PK or
-    dispatch_id).
-    """
-    safe_key = str(source_key).strip().lower().replace(" ", "_")
-    return f"intel_{prefix}_{safe_key}"
-
-
-# Length of the content_hash prefix stored in success_patterns.content_hash
-# (CFX-5 / migration 0012). Matches scripts/lib/pattern_dedup.CONTENT_HASH_PREFIX_LEN.
-SUCCESS_PATTERN_CONTENT_HASH_LEN = 16
-
-
-def _short_content_hash(*parts: str) -> str:
-    """16-char prefix of the normalized SHA-256, matching the on-row column.
-
-    Used to derive a *content-addressable* canonical id for success_patterns
-    rows that lack a stored ``content_hash`` (e.g. legacy rows on databases
-    where migration 0012 has been applied but ``backfill_content_hash`` has
-    not yet run).
-    """
-    return _content_hash(*parts)[:SUCCESS_PATTERN_CONTENT_HASH_LEN]
-
-
-def _item_hash(item_id: str) -> str:
-    """SHA1 of item_id, matching learning_loop.hash_pattern() convention."""
-    import hashlib
-    return hashlib.sha1(item_id.encode("utf-8")).hexdigest()
-
-
-def resolve_task_class(
-    task_class: Optional[str] = None,
-    skill_name: Optional[str] = None,
-) -> str:
-    """Resolve task class from explicit value or skill name. Defaults to coding_interactive."""
-    if task_class and task_class in VALID_TASK_CLASSES:
-        return task_class
-    if skill_name:
-        return SKILL_TO_TASK_CLASS.get(skill_name, "coding_interactive")
-    return "coding_interactive"
-
-
-def _scope_matches(item_scope_tags: List[str], query_scope_tags: List[str]) -> bool:
-    """Check if an item's scope tags overlap with the query scope tags.
-
-    Empty item scope = matches everything. Empty query scope = matches everything.
-    """
-    if not item_scope_tags or not query_scope_tags:
-        return True
-    return bool(set(item_scope_tags) & set(query_scope_tags))
-
-
-def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
-    """PRAGMA-based column probe on an arbitrary connection.
-
-    Mirrors :meth:`IntelligenceSelector._has_column` for write paths that
-    operate on the coordination DB rather than the lazily-cached quality DB.
-    """
-    try:
-        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    except sqlite3.Error:
-        return False
-    for row in rows:
-        name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
-        if name == column:
-            return True
-    return False
-
-
-def _project_scope_clause(column_present: bool) -> tuple[str, tuple]:
-    """Return the ``AND project_id = ?`` fragment + bind params, or empty.
-
-    Two safety gates:
-      1. The caller has detected the ``project_id`` column on the target
-         table. Pre-Phase-0 DBs (or stripped-down test fixtures) skip the
-         filter so reads do not crash.
-      2. ``project_filter_enabled()`` is true (it is unless
-         ``VNX_PROJECT_FILTER`` is set to a falsy value). This is the
-         opt-out for cross-tenant analytics queries.
-    """
-    if not column_present or not project_filter_enabled():
-        return "", ()
-    return "AND project_id = ?", (current_project_id(),)
-
-
-def _task_class_matches(item_filter: List[str], task_class: str) -> bool:
-    """Check if an item's task_class_filter allows the given task class.
-
-    Empty filter = matches all task classes.
-    """
-    if not item_filter:
-        return True
-    return task_class in item_filter
-
-
-# ---------------------------------------------------------------------------
-# SQL templates used by shadow comparisons (passed to shadow_verifier.compare)
-# ---------------------------------------------------------------------------
-
-_PROVEN_PATTERNS_SQL_TEMPLATE = (
-    "SELECT id, title, description, confidence_score, usage_count "
-    "FROM success_patterns "
-    "WHERE (valid_until IS NULL OR valid_until > datetime('now')) "
-    "ORDER BY confidence_score DESC LIMIT 20"
-)
-
-_FAILURE_PREVENTION_SQL_TEMPLATE = (
-    "SELECT id, title, description, severity, occurrence_count "
-    "FROM antipatterns "
-    "WHERE occurrence_count >= 1 "
-    "AND (valid_until IS NULL OR valid_until > datetime('now')) "
-    "ORDER BY occurrence_count DESC LIMIT 5"
-)
-
-_RECENT_COMPARABLE_SQL_TEMPLATE = (
-    "SELECT dispatch_id, terminal, track, role, skill_name, gate, "
-    "outcome_status, dispatched_at "
-    "FROM dispatch_metadata "
-    "WHERE dispatched_at >= ? AND outcome_status IS NOT NULL "
-    "ORDER BY dispatched_at DESC LIMIT 20"
-)
-
-
-# ---------------------------------------------------------------------------
-# Intelligence Selector
-# ---------------------------------------------------------------------------
 
 class IntelligenceSelector:
-    """Selects bounded, evidence-backed intelligence items for dispatch injection.
+    """Selects bounded, evidence-backed intelligence items for dispatch injection."""
 
-    Sources data from quality_intelligence.db tables:
-      - success_patterns   → proven_pattern items
-      - antipatterns        → failure_prevention items
-      - prevention_rules   → failure_prevention items
-      - dispatch_metadata  → recent_comparable items
-    """
-
-    def __init__(
-        self,
-        quality_db_path: Optional[Path] = None,
-        coord_db_state_dir: Optional[Path] = None,
-    ) -> None:
+    def __init__(self, quality_db_path=None, coord_db_state_dir=None) -> None:
         self._quality_db_path = quality_db_path
         self._coord_state_dir = coord_db_state_dir
         self._quality_db: Optional[sqlite3.Connection] = None
 
     def _get_quality_db(self) -> Optional[sqlite3.Connection]:
-        """Lazy-connect to quality_intelligence.db."""
         if self._quality_db is not None:
             return self._quality_db
         if self._quality_db_path is None or not self._quality_db_path.exists():
@@ -540,48 +83,19 @@ class IntelligenceSelector:
             self._quality_db = None
 
     def _has_column(self, table: str, column: str) -> bool:
-        """Cheap PRAGMA-based feature detection for migrations not yet applied."""
         db = self._get_quality_db()
-        if db is None:
-            return False
-        try:
-            rows = db.execute(f"PRAGMA table_info({table})").fetchall()
-        except sqlite3.Error:
-            return False
-        for row in rows:
-            name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
-            if name == column:
-                return True
-        return False
+        return _table_has_column(db, table, column) if db is not None else False
 
     def _maybe_reconcile_confidence(self) -> None:
-        """Run reconcile if the cached timestamp is older than the TTL.
-
-        Best-effort safety net: failures are swallowed so a broken reconcile
-        never blocks dispatch creation.  The reconcile opens its own SQLite
-        connection and commits before returning, so subsequent SELECT
-        statements on ``self._quality_db`` observe the new values without
-        needing to re-open the cached reader connection.
-        """
         if self._quality_db_path is None:
             return
         try:
             from confidence_reconcile import maybe_reconcile
-        except ImportError:
-            return
-        try:
             maybe_reconcile(self._quality_db_path)
-        except (sqlite3.Error, OSError) as e:
+        except (ImportError, sqlite3.Error, OSError) as e:
             logger.debug("Reconciliation step skipped: %s", e)
 
     def _get_central_qi_conn(self) -> Optional[sqlite3.Connection]:
-        """Open a fresh independent connection to the central quality_intelligence.db.
-
-        Verifier-independence principle (Wave 1 design §4): this connection is
-        opened via resolve_central_data_dir — never reusing self._quality_db —
-        so schema bugs in the per-project path cannot blind the comparator.
-        Returns None when project_id cannot be resolved or the DB does not exist.
-        """
         if _resolve_central_data_dir is None:
             return None
         try:
@@ -597,1864 +111,185 @@ class IntelligenceSelector:
         except Exception:
             return None
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+    def _query_candidates(self, task_class: str, scope_tags: List[str]) -> Dict[str, List[IntelligenceItem]]:
+        """Query all standard-class candidates from quality_intelligence.db."""
+        db = self._get_quality_db()
+        result: Dict[str, List[IntelligenceItem]] = {"proven_pattern": [], "failure_prevention": [], "recent_comparable": []}
+        if db is None:
+            return result
+        kw = dict(has_column_fn=self._has_column, central_conn_fn=self._get_central_qi_conn)
+        result["proven_pattern"] = query_proven_patterns(db, task_class, scope_tags, reconcile_fn=self._maybe_reconcile_confidence, **kw)
+        result["failure_prevention"] = query_failure_prevention(db, task_class, scope_tags, **kw)
+        result["recent_comparable"] = query_recent_comparable(db, task_class, scope_tags, **kw)
+        return result
 
     def select(
         self,
         dispatch_id: str,
         injection_point: str,
         *,
-        task_class: Optional[str] = None,
-        skill_name: Optional[str] = None,
-        scope_tags: Optional[List[str]] = None,
-        track: Optional[str] = None,
-        gate: Optional[str] = None,
-        pr_id: Optional[str] = None,
-        dispatch_paths: Optional[List[str]] = None,
-        instruction_text: Optional[str] = None,
+        task_class=None, skill_name=None, scope_tags=None,
+        track=None, gate=None, pr_id=None,
+        dispatch_paths=None, instruction_text=None,
     ) -> InjectionResult:
-        """Run the bounded selection algorithm and return an InjectionResult.
-
-        Args:
-            dispatch_id:     Dispatch being created or resumed.
-            injection_point: Must be 'dispatch_create' or 'dispatch_resume'.
-            task_class:      Explicit task class (overrides skill_name derivation).
-            skill_name:      Skill name for task class derivation.
-            scope_tags:      Scope tags for filtering (skill, track, gate, etc.).
-            track:           Track label (added to scope_tags automatically).
-            gate:            Gate identifier (added to scope_tags automatically).
-
-        Returns:
-            InjectionResult with 0-3 items and suppression records.
-        """
+        """Run the bounded selection algorithm and return an InjectionResult."""
         if injection_point not in VALID_INJECTION_POINTS:
-            raise ValueError(
-                f"Invalid injection_point: {injection_point!r}. "
-                f"Must be one of {sorted(VALID_INJECTION_POINTS)}"
-            )
-
+            raise ValueError(f"Invalid injection_point: {injection_point!r}. Must be one of {sorted(VALID_INJECTION_POINTS)}")
         resolved_class = resolve_task_class(task_class, skill_name)
-
-        # Build scope tags from all available context
         effective_scope: List[str] = list(scope_tags or [])
-        if skill_name and skill_name not in effective_scope:
-            effective_scope.append(skill_name)
-        if track:
-            tag = f"Track-{track}" if not track.startswith("Track-") else track
-            if tag not in effective_scope:
+        for tag in [skill_name, (f"Track-{track}" if track and not track.startswith("Track-") else track), gate, resolved_class]:
+            if tag and tag not in effective_scope:
                 effective_scope.append(tag)
-        if gate and gate not in effective_scope:
-            effective_scope.append(gate)
-        if resolved_class not in effective_scope:
-            effective_scope.append(resolved_class)
 
-        # Query candidates per class
-        candidates = self._query_candidates(resolved_class, effective_scope)
+        candidates = apply_candidate_diversity(self._query_candidates(resolved_class, effective_scope), resolved_class)
+        selected, suppressed = self._select_standard_classes(candidates)
+        selected = self._enforce_payload_limit(selected, suppressed, list(reversed(ITEM_CLASS_PRIORITY)))
 
-        # Apply pre-selection diversity: collapse byte-identical content_hash
-        # candidates and demote governance signals so they don't drown out
-        # real code patterns (audit 2026-04-30: 54/55 byte-identical injections).
-        candidates = self._apply_candidate_diversity(candidates, resolved_class)
+        now_ts = _now_utc()
+        paths = dispatch_paths or []
+        direct = {
+            "prior_round_finding": build_prior_round_item(pr_id or "", paths, now_ts) if pr_id else None,
+            "adr_relevant": build_adr_item(dispatch_id, paths, now_ts) if paths else None,
+            "code_anchor": build_code_anchor_item(dispatch_id, paths, instruction_text or "", now_ts) if (paths and instruction_text) else None,
+            "operator_memory": build_operator_memory_item(dispatch_id, skill_name, paths, instruction_text or "", now_ts) if (skill_name or paths or instruction_text) else None,
+            "schema_section": build_schema_section_item(dispatch_id, paths, instruction_text or "", now_ts) if (paths or instruction_text) else None,
+        }
+        for class_name, extra_drop in _DIRECT_SOURCES:
+            item = direct.get(class_name)
+            if item is not None:
+                selected.append(item)
+                selected = self._enforce_payload_limit(selected, suppressed, list(reversed(ITEM_CLASS_PRIORITY)) + extra_drop)
 
-        # Select best item per class
+        return InjectionResult(injection_point=injection_point, injected_at=now_ts, items=selected, suppressed=suppressed, task_class=resolved_class, dispatch_id=dispatch_id)
+
+    def _select_standard_classes(self, candidates):
         selected: List[IntelligenceItem] = []
         suppressed: List[SuppressionRecord] = []
         seen_hashes: set = set()
         governance_used = 0
-
         for item_class in ITEM_CLASS_PRIORITY:
             class_candidates = candidates.get(item_class, [])
             if not class_candidates:
-                suppressed.append(SuppressionRecord(
-                    item_class=item_class,
-                    reason="no candidates available",
-                ))
+                suppressed.append(SuppressionRecord(item_class=item_class, reason="no candidates available"))
                 continue
-
             threshold = CONFIDENCE_THRESHOLDS[item_class]
             evidence_min = EVIDENCE_THRESHOLDS[item_class]
-
-            # Filter by thresholds
-            eligible = [
-                c for c in class_candidates
-                if c.confidence >= threshold and c.evidence_count >= evidence_min
-            ]
-
+            eligible = [c for c in class_candidates if c.confidence >= threshold and c.evidence_count >= evidence_min]
             if not eligible:
                 best_conf = max(c.confidence for c in class_candidates)
-                suppressed.append(SuppressionRecord(
-                    item_class=item_class,
-                    reason=f"confidence {best_conf:.2f} below threshold {threshold}",
-                ))
+                suppressed.append(SuppressionRecord(item_class=item_class, reason=f"confidence {best_conf:.2f} below threshold {threshold}"))
                 continue
-
-            # Diversity filters: drop already-seen content hashes and respect
-            # the per-batch governance cap.
-            diverse = []
-            dropped_dup = 0
-            dropped_gov = 0
+            diverse, dropped_dup, dropped_gov = [], 0, 0
             for cand in eligible:
                 if cand.content_hash and cand.content_hash in seen_hashes:
                     dropped_dup += 1
-                    continue
-                if (
-                    cand.pattern_category == PATTERN_CATEGORY_GOVERNANCE
-                    and governance_used >= MAX_GOVERNANCE_PER_BATCH
-                ):
+                elif cand.pattern_category == PATTERN_CATEGORY_GOVERNANCE and governance_used >= MAX_GOVERNANCE_PER_BATCH:
                     dropped_gov += 1
-                    continue
-                diverse.append(cand)
-
+                else:
+                    diverse.append(cand)
             if not diverse:
-                reason_parts = []
-                if dropped_dup:
-                    reason_parts.append(
-                        f"{dropped_dup} duplicates removed by content hash"
-                    )
-                if dropped_gov:
-                    reason_parts.append(
-                        f"{dropped_gov} governance items past per-batch cap"
-                    )
-                reason = (
-                    "; ".join(reason_parts)
-                    if reason_parts
-                    else "no diverse candidates remain"
-                )
-                suppressed.append(SuppressionRecord(
-                    item_class=item_class,
-                    reason=f"diversity filter dropped all eligible items ({reason})",
-                ))
+                parts = ([f"{dropped_dup} duplicates removed by content hash"] if dropped_dup else []) + ([f"{dropped_gov} governance items past per-batch cap"] if dropped_gov else [])
+                suppressed.append(SuppressionRecord(item_class=item_class, reason=f"diversity filter dropped all eligible items ({'; '.join(parts) or 'no diverse candidates remain'})"))
                 continue
-
             best = max(diverse, key=lambda c: c.confidence)
             selected.append(best)
             if best.content_hash:
                 seen_hashes.add(best.content_hash)
             if best.pattern_category == PATTERN_CATEGORY_GOVERNANCE:
                 governance_used += 1
+        return selected, suppressed
 
-        # Enforce payload size limit (Section 2.3 step 6)
-        selected = self._enforce_payload_limit(selected, suppressed)
-
-        # Wave 5 P0: inject prior-round review findings when pr_id is present.
-        # Added after standard enforcement so prior findings ride above the
-        # standard class budget and are only dropped as last resort.
-        if pr_id and _prior_round_injector is not None:
-            prior_findings = _prior_round_injector.fetch_prior_findings(
-                pr_id,
-                dispatch_paths=dispatch_paths or [],
-                max_chars=MAX_PAYLOAD_CHARS,
-            )
-            if prior_findings:
-                now_ts = _now_utc()
-                prior_item = IntelligenceItem(
-                    item_id=f"intel_prf_{pr_id}",
-                    item_class="prior_round_finding",
-                    title=f"Prior-round review findings on PR #{pr_id}",
-                    content=_prior_round_injector.format_findings_section(prior_findings),
-                    confidence=1.0,
-                    evidence_count=len(prior_findings),
-                    last_seen=now_ts,
-                    scope_tags=[],
-                    source_refs=[f"pr-{pr_id}-{f.gate}" for f in prior_findings],
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_CODE,
-                    content_hash="",
-                )
-                selected.insert(0, prior_item)
-                selected = self._enforce_payload_limit_with_prior(selected, suppressed)
-
-        # Wave 5 P1: inject relevant ADR sections when dispatch_paths overlap ADR references.
-        # Added after prior_round enforcement so ADR context rides above standard class budget.
-        if dispatch_paths and _adr_indexer is not None:
-            relevant_adrs = _adr_indexer.fetch_relevant_adrs(
-                dispatch_paths,
-                max_chars=1500,
-            )
-            if relevant_adrs:
-                now_ts = _now_utc()
-                adr_item = IntelligenceItem(
-                    item_id=f"intel_adr_{'_'.join(a.adr_id for a in relevant_adrs[:3])}",
-                    item_class="adr_relevant",
-                    title=f"Relevant ADRs for {len(dispatch_paths)} touched files",
-                    content=_adr_indexer.format_adrs_section(relevant_adrs),
-                    confidence=1.0,
-                    evidence_count=len(relevant_adrs),
-                    last_seen=now_ts,
-                    scope_tags=[],
-                    source_refs=[a.adr_id for a in relevant_adrs],
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_CODE,
-                    content_hash="",
-                )
-                selected.append(adr_item)
-                selected = self._enforce_payload_limit_with_adr(selected, suppressed)
-
-        # Wave 5 P2: inject code anchors (file:line snippets) when dispatch_paths and
-        # instruction_text are both present. Provides current-state grounding so workers
-        # don't need to grep before acting. Added after ADR enforcement; code_anchor is
-        # the most specific evidence so it survives payload trimming until last resort.
-        if dispatch_paths and instruction_text and _code_anchor_finder is not None:
-            anchors = _code_anchor_finder.fetch_code_anchors(
-                dispatch_paths,
-                instruction_text,
-                max_chars=MAX_CODE_ANCHOR_CHARS,
-            )
-            if anchors:
-                now_ts = _now_utc()
-                anchor_item = IntelligenceItem(
-                    item_id=f"intel_ca_{dispatch_id}",
-                    item_class="code_anchor",
-                    title=f"Code anchors for {len(dispatch_paths)} touched files",
-                    content=_code_anchor_finder.format_code_anchors_section(anchors),
-                    confidence=1.0,
-                    evidence_count=len(anchors),
-                    last_seen=now_ts,
-                    scope_tags=[],
-                    source_refs=[
-                        f"{a.file_path}:{a.line_start}-{a.line_end}" for a in anchors
-                    ],
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_CODE,
-                    content_hash="",
-                )
-                selected.append(anchor_item)
-                selected = self._enforce_payload_limit_with_code_anchor(selected, suppressed)
-
-        # Wave 5 P3: inject operator memories (curated wisdom) when role, dispatch_paths,
-        # or instruction_text are present. Provides accumulated operator feedback so workers
-        # inherit hard-won lessons without discovering them the hard way.
-        if (skill_name or dispatch_paths or instruction_text) and _operator_memory_indexer is not None:
-            memories = _operator_memory_indexer.fetch_relevant_memories(
-                skill_name,
-                dispatch_paths or [],
-                instruction_text or "",
-                max_chars=MAX_CODE_ANCHOR_CHARS,
-            )
-            if memories:
-                now_ts = _now_utc()
-                memory_item = IntelligenceItem(
-                    item_id=f"intel_om_{dispatch_id}",
-                    item_class="operator_memory",
-                    title=f"Relevant operator memories ({len(memories)})",
-                    content=_operator_memory_indexer.format_memories_section(memories),
-                    confidence=1.0,
-                    evidence_count=len(memories),
-                    last_seen=now_ts,
-                    scope_tags=[],
-                    source_refs=[m.name for m in memories],
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_CODE,
-                    content_hash="",
-                )
-                selected.append(memory_item)
-                selected = self._enforce_payload_limit_with_operator_memory(selected, suppressed)
-
-        # Wave 5 P4: inject schema sections (DDL grounding for DB workers) when dispatch
-        # touches schema/migration/importer paths or instruction mentions known table names.
-        # Pre-grounds the worker on the actual CREATE TABLE / ALTER TABLE statements so
-        # they don't need to grep schemas/ before acting.
-        if (dispatch_paths or instruction_text) and _schema_section_indexer is not None:
-            schema_sections = _schema_section_indexer.fetch_relevant_schema_sections(
-                dispatch_paths or [],
-                instruction_text or "",
-                max_chars=MAX_CODE_ANCHOR_CHARS,
-            )
-            if schema_sections:
-                now_ts = _now_utc()
-                unique_tables = len({s.table_name for s in schema_sections})
-                schema_item = IntelligenceItem(
-                    item_id=f"intel_ss_{dispatch_id}",
-                    item_class="schema_section",
-                    title=f"Schema sections for {unique_tables} touched table(s)",
-                    content=_schema_section_indexer.format_schema_sections(schema_sections),
-                    confidence=1.0,
-                    evidence_count=len(schema_sections),
-                    last_seen=now_ts,
-                    scope_tags=[],
-                    source_refs=[f"{s.file_path}:{s.table_name}" for s in schema_sections],
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_CODE,
-                    content_hash="",
-                )
-                selected.append(schema_item)
-                selected = self._enforce_payload_limit_with_schema_section(selected, suppressed)
-
-        now = _now_utc()
-        result = InjectionResult(
-            injection_point=injection_point,
-            injected_at=now,
-            items=selected,
-            suppressed=suppressed,
-            task_class=resolved_class,
-            dispatch_id=dispatch_id,
+    def _query_proven_patterns(self, db, task_class: str, scope_tags: List[str]) -> List[IntelligenceItem]:
+        return query_proven_patterns(
+            db, task_class, scope_tags,
+            has_column_fn=self._has_column,
+            central_conn_fn=self._get_central_qi_conn,
+            reconcile_fn=self._maybe_reconcile_confidence,
+            project_id_fn=current_project_id,
         )
 
-        return result
+    def _query_failure_prevention(self, db, task_class: str, scope_tags: List[str]) -> List[IntelligenceItem]:
+        return query_failure_prevention(
+            db, task_class, scope_tags,
+            has_column_fn=self._has_column,
+            central_conn_fn=self._get_central_qi_conn,
+            project_id_fn=current_project_id,
+        )
 
-    def emit_event(
-        self,
-        result: InjectionResult,
-        coord_state_dir: Optional[Path] = None,
-    ) -> Optional[str]:
-        """Emit an injection or suppression coordination event.
+    def _query_recent_comparable(self, db, task_class: str, scope_tags: List[str]) -> List[IntelligenceItem]:
+        return query_recent_comparable(
+            db, task_class, scope_tags,
+            has_column_fn=self._has_column,
+            central_conn_fn=self._get_central_qi_conn,
+            project_id_fn=current_project_id,
+        )
 
-        Returns the event_id or None if no coord DB available.
-        """
+    def _enforce_payload_limit(self, selected, suppressed, drop_order=None) -> List[IntelligenceItem]:
+        """Drop lowest-priority classes until payload fits within MAX_PAYLOAD_CHARS."""
+        if drop_order is None:
+            drop_order = list(reversed(ITEM_CLASS_PRIORITY))
+        if not selected:
+            return selected
+        def _size():
+            return len(json.dumps({"injection_point": "x", "injected_at": "x", "items": [i.to_dict() for i in selected], "suppressed": [s.to_dict() for s in suppressed]}))
+        if _size() <= MAX_PAYLOAD_CHARS:
+            return selected
+        for drop_class in drop_order:
+            if not any(i.item_class == drop_class for i in selected):
+                continue
+            sz = _size()
+            selected = [i for i in selected if i.item_class != drop_class]
+            suppressed.append(SuppressionRecord(item_class=drop_class, reason=f"dropped to enforce payload limit ({sz} > {MAX_PAYLOAD_CHARS} chars)"))
+            if _size() <= MAX_PAYLOAD_CHARS:
+                break
+        return selected
+
+    def emit_event(self, result: InjectionResult, coord_state_dir=None) -> Optional[str]:
+        """Emit an injection or suppression coordination event."""
         if not result.dispatch_id or not str(result.dispatch_id).strip():
             raise ValueError("emit_event: dispatch_id required for audit attribution")
         state_dir = coord_state_dir or self._coord_state_dir
         if state_dir is None:
             return None
-
         try:
             from runtime_coordination import get_connection, _append_event
         except ImportError:
             return None
-
-        if result.items_injected > 0:
-            event_type = "intelligence_injection"
-            reason = f"injected {result.items_injected} items at {result.injection_point}"
-        else:
-            event_type = "intelligence_suppression"
-            reason = "no items met minimum thresholds"
-
+        event_type = "intelligence_injection" if result.items_injected > 0 else "intelligence_suppression"
+        reason = f"injected {result.items_injected} items at {result.injection_point}" if result.items_injected > 0 else "no items met minimum thresholds"
         try:
             with get_connection(state_dir) as conn:
-                event_id = _append_event(
-                    conn,
-                    event_type=event_type,
-                    entity_type="dispatch",
-                    entity_id=result.dispatch_id,
-                    actor="intelligence_selector",
-                    reason=reason,
-                    metadata=result.to_event_metadata(),
-                )
+                event_id = _append_event(conn, event_type=event_type, entity_type="dispatch", entity_id=result.dispatch_id, actor="intelligence_selector", reason=reason, metadata=result.to_event_metadata())
                 conn.commit()
             return event_id
         except Exception:
             return None
 
-    def record_injection(
-        self,
-        result: InjectionResult,
-        coord_state_dir: Optional[Path] = None,
-    ) -> None:
-        """Record injection decision in the intelligence_injections audit table.
-
-        Also writes per-item rows to pattern_usage in quality_intelligence.db so
-        the feedback loop can look up which patterns were offered for a dispatch.
-        """
+    def record_injection(self, result: InjectionResult, coord_state_dir=None) -> None:
+        """Record injection decision in intelligence_injections audit table."""
         if not result.dispatch_id or not str(result.dispatch_id).strip():
             raise ValueError("record_injection: dispatch_id required for audit attribution")
         state_dir = coord_state_dir or self._coord_state_dir
-        if state_dir is None:
-            return
-
-        try:
-            from runtime_coordination import get_connection
-        except ImportError:
-            return
-
-        injection_id = _new_id()
-        items_json = json.dumps([item.to_dict() for item in result.items])
-        suppressed_json = json.dumps([s.to_dict() for s in result.suppressed])
-        project_id = current_project_id()
-
-        try:
-            with get_connection(state_dir) as conn:
-                has_project = _table_has_column(
-                    conn, "intelligence_injections", "project_id"
-                )
-                if has_project:
-                    conn.execute(
-                        """
-                        INSERT INTO intelligence_injections
-                            (injection_id, dispatch_id, injection_point, task_class,
-                             items_injected, items_suppressed, payload_chars,
-                             items_json, suppressed_json, project_id)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            injection_id,
-                            result.dispatch_id,
-                            result.injection_point,
-                            result.task_class,
-                            result.items_injected,
-                            result.items_suppressed,
-                            result.payload_chars,
-                            items_json,
-                            suppressed_json,
-                            project_id,
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        """
-                        INSERT INTO intelligence_injections
-                            (injection_id, dispatch_id, injection_point, task_class,
-                             items_injected, items_suppressed, payload_chars,
-                             items_json, suppressed_json)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            injection_id,
-                            result.dispatch_id,
-                            result.injection_point,
-                            result.task_class,
-                            result.items_injected,
-                            result.items_suppressed,
-                            result.payload_chars,
-                            items_json,
-                            suppressed_json,
-                        ),
-                    )
-                conn.commit()
-        except sqlite3.Error as e:
-            logger.warning("Failed to record injection audit: %s", e)
-
-        # Write per-item pattern_usage rows so feedback loop can query by dispatch_id
+        if state_dir is not None:
+            record_injection_audit(result, state_dir, current_project_id())
         if result.items and self._quality_db_path is not None and self._quality_db_path.exists():
-            self._record_pattern_usage(result)
-
-        # Ensure source_dispatch_ids is stamped for all callers — idempotent, so
-        # safe when _record_pattern_usage already did a partial stamp internally.
+            record_pattern_usage(result, self._get_quality_db(), self._has_column)
         try:
-            self.stamp_source_dispatch_ids(result)
+            _stamp(result, self._get_quality_db())
         except (sqlite3.Error, OSError) as e:
             logger.debug("Failed to stamp source_dispatch_ids: %s", e)
 
-    def _record_pattern_usage(self, result: InjectionResult) -> None:
-        """Write one pattern_usage row per injected item so feedback can find them later.
-
-        Identity model:
-          - ``pattern_id`` is the *stable* per-pattern id derived from the
-            originating row (see :func:`_stable_item_id`).  The same pattern
-            offered to multiple dispatches collapses onto the same row via
-            ON CONFLICT(pattern_id) DO UPDATE.  This restores deduplication —
-            random ids fragmented one underlying pattern across many rows.
-          - ``pattern_hash`` is SHA1(item_id), following the convention used by
-            ``learning_loop.hash_pattern``.  Hash and pattern_id must NOT be
-            the same string; consumers may rely on the hash to detect
-            content-level identity independently of the id.
-
-        Per-dispatch attribution is recorded in the ``dispatch_pattern_offered``
-        junction table (one row per dispatch+pattern pair) so that concurrent
-        dispatches offering the same pattern do not overwrite each other.
-        """
-        db = self._get_quality_db()
-        if db is None:
-            return
-        now = _now_utc()
-        project_id = current_project_id()
-        pu_has_project = self._has_column("pattern_usage", "project_id")
-        dpo_has_project = self._has_column("dispatch_pattern_offered", "project_id")
-        try:
-            db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
-                    dispatch_id   TEXT NOT NULL,
-                    pattern_id    TEXT NOT NULL,
-                    pattern_title TEXT NOT NULL,
-                    offered_at    TEXT NOT NULL,
-                    PRIMARY KEY (dispatch_id, pattern_id)
-                )
-                """
-            )
-            # Re-probe after CREATE — a freshly created table won't have project_id.
-            dpo_has_project = self._has_column("dispatch_pattern_offered", "project_id")
-            for item in result.items:
-                pattern_hash = _item_hash(item.item_id)
-                if pu_has_project:
-                    db.execute(
-                        """
-                        INSERT INTO pattern_usage
-                            (pattern_id, pattern_title, pattern_hash, used_count,
-                             ignored_count, success_count, failure_count,
-                             last_offered, confidence, created_at, updated_at,
-                             project_id)
-                        VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?, ?)
-                        ON CONFLICT(pattern_id) DO UPDATE SET
-                            pattern_title = excluded.pattern_title,
-                            pattern_hash  = excluded.pattern_hash,
-                            last_offered  = excluded.last_offered,
-                            updated_at    = excluded.updated_at
-                        """,
-                        (
-                            item.item_id,
-                            item.title[:255],
-                            pattern_hash,
-                            now,
-                            item.confidence,
-                            now,
-                            now,
-                            project_id,
-                        ),
-                    )
-                else:
-                    db.execute(
-                        """
-                        INSERT INTO pattern_usage
-                            (pattern_id, pattern_title, pattern_hash, used_count,
-                             ignored_count, success_count, failure_count,
-                             last_offered, confidence, created_at, updated_at)
-                        VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?)
-                        ON CONFLICT(pattern_id) DO UPDATE SET
-                            pattern_title = excluded.pattern_title,
-                            pattern_hash  = excluded.pattern_hash,
-                            last_offered  = excluded.last_offered,
-                            updated_at    = excluded.updated_at
-                        """,
-                        (
-                            item.item_id,
-                            item.title[:255],
-                            pattern_hash,
-                            now,
-                            item.confidence,
-                            now,
-                            now,
-                        ),
-                    )
-                if dpo_has_project:
-                    db.execute(
-                        """
-                        INSERT INTO dispatch_pattern_offered
-                            (dispatch_id, pattern_id, pattern_title, offered_at,
-                             project_id)
-                        VALUES (?, ?, ?, ?, ?)
-                        ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET
-                            offered_at = excluded.offered_at
-                        """,
-                        (
-                            result.dispatch_id,
-                            item.item_id,
-                            item.title[:255],
-                            now,
-                            project_id,
-                        ),
-                    )
-                else:
-                    db.execute(
-                        """
-                        INSERT INTO dispatch_pattern_offered
-                            (dispatch_id, pattern_id, pattern_title, offered_at)
-                        VALUES (?, ?, ?, ?)
-                        ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET
-                            offered_at = excluded.offered_at
-                        """,
-                        (result.dispatch_id, item.item_id, item.title[:255], now),
-                    )
-                self._stamp_source_dispatch_id(db, item, result.dispatch_id)
-            db.commit()
-        except sqlite3.Error as e:
-            logger.warning("Failed to record pattern usage: %s", e)
-
     def stamp_source_dispatch_ids(self, result: InjectionResult) -> int:
-        """Public injection-time stamping helper (Phase 1.5 PR-2 / OI-1315).
+        """Public injection-time stamping helper (Phase 1.5 PR-2 / OI-1315)."""
+        return _stamp(result, self._get_quality_db())
 
-        Iterates ``result.items`` and stamps each one's source row
-        ``source_dispatch_ids`` JSON array with ``result.dispatch_id``. Each
-        item is wrapped in its own try/except so a single failure does NOT
-        leave subsequent items unstamped. Idempotent — already-present
-        dispatch_ids are skipped.
 
-        This is invoked from the ``record_injection()`` call site in
-        ``subprocess_dispatch_internals.skill_injection`` so that even when
-        ``_record_pattern_usage`` partially fails (or the quality DB is
-        absent), source_dispatch_ids is still populated reliably for
-        receipt-driven confidence updates of FRESHLY injected patterns.
 
-        Returns the count of rows successfully stamped.
-        """
-        if not result.items or not result.dispatch_id:
-            return 0
-        db = self._get_quality_db()
-        if db is None:
-            return 0
-        stamped = 0
-        for item in result.items:
-            try:
-                if self._stamp_source_dispatch_id(db, item, result.dispatch_id):
-                    stamped += 1
-            except Exception:
-                continue
-        try:
-            db.commit()
-        except sqlite3.Error:
-            pass
-        return stamped
-
-    def _stamp_source_dispatch_id(
-        self,
-        db: sqlite3.Connection,
-        item: IntelligenceItem,
-        dispatch_id: str,
-    ) -> bool:
-        """Append dispatch_id to source_dispatch_ids on the item's source row.
-
-        This restores the injection-time linkage that
-        ``intelligence_persist.update_confidence_from_outcome`` relies on
-        (``WHERE source_dispatch_ids LIKE '%dispatch_id%'``). Without it,
-        failure decay never finds patterns offered to the failing dispatch
-        unless ``pattern_extractor`` clusters them post-hoc.
-
-        Idempotent: a dispatch_id already present in the JSON array is not
-        re-appended. Pre-existing entries are preserved (we extend, never
-        clobber). The list is capped at the most recent 20 entries to match
-        the ``intelligence_persist._append_to_json_list`` convention.
-
-        Currently stamps:
-          - ``proven_pattern`` items   → ``success_patterns.source_dispatch_ids``
-          - ``failure_prevention`` items from antipatterns
-            → ``antipatterns.source_dispatch_ids`` (when item_id has ``intel_ap_`` prefix)
-
-        Returns ``True`` when the row's source_dispatch_ids was modified
-        (or already contained ``dispatch_id``); ``False`` when the item is
-        ineligible or the row could not be located/updated.
-        """
-        if not dispatch_id:
-            return False
-
-        item_id = item.item_id or ""
-        if item.item_class == "proven_pattern" and item_id.startswith("intel_sp_"):
-            table = "success_patterns"
-            row_key = item_id[len("intel_sp_"):]
-        elif item.item_class == "failure_prevention" and item_id.startswith("intel_ap_"):
-            table = "antipatterns"
-            row_key = item_id[len("intel_ap_"):]
-        else:
-            return False
-
-        try:
-            row_id = int(row_key)
-        except (ValueError, TypeError):
-            return False
-
-        try:
-            row = db.execute(
-                f"SELECT source_dispatch_ids FROM {table} WHERE id = ?",
-                (row_id,),
-            ).fetchone()
-        except sqlite3.Error:
-            return False
-
-        if row is None:
-            return False
-
-        existing_json = row["source_dispatch_ids"] if isinstance(row, sqlite3.Row) else row[0]
-        ids: List[str] = []
-        if existing_json:
-            try:
-                parsed = json.loads(existing_json)
-                if isinstance(parsed, list):
-                    ids = [str(x) for x in parsed]
-            except (json.JSONDecodeError, TypeError):
-                ids = []
-
-        if dispatch_id in ids:
-            return True
-
-        ids.append(dispatch_id)
-        ids = ids[-20:]
-        try:
-            db.execute(
-                f"UPDATE {table} SET source_dispatch_ids = ? WHERE id = ?",
-                (json.dumps(ids), row_id),
-            )
-        except sqlite3.Error:
-            return False
-        return True
-
-    # ------------------------------------------------------------------
-    # Diversity helpers
-    # ------------------------------------------------------------------
-
-    def _apply_candidate_diversity(
-        self,
-        candidates: Dict[str, List[IntelligenceItem]],
-        task_class: str,
-    ) -> Dict[str, List[IntelligenceItem]]:
-        """Collapse same-hash duplicates and re-rank governance vs. code.
-
-        Within each class:
-          * Patterns sharing a content_hash collapse to the single highest-
-            confidence representative. This protects the selector from
-            offering the same governance gate-pass payload N times under
-            different ids (the failure mode the audit caught).
-          * Governance-category proven_patterns get a confidence penalty so
-            that, all else equal, a real code pattern wins. The penalty is
-            applied to a copy so that downstream consumers reading
-            ``IntelligenceItem.confidence`` see the effective ranking score.
-        """
-        adjusted: Dict[str, List[IntelligenceItem]] = {}
-        for cls, items in candidates.items():
-            collapsed: Dict[str, IntelligenceItem] = {}
-            unhashed: List[IntelligenceItem] = []
-            for item in items:
-                if not item.content_hash:
-                    unhashed.append(item)
-                    continue
-                existing = collapsed.get(item.content_hash)
-                if existing is None or item.confidence > existing.confidence:
-                    collapsed[item.content_hash] = item
-            merged = list(collapsed.values()) + unhashed
-
-            if cls == "proven_pattern":
-                merged = [
-                    self._apply_governance_penalty(item, task_class)
-                    for item in merged
-                ]
-
-            merged.sort(key=lambda i: i.confidence, reverse=True)
-            adjusted[cls] = merged
-        return adjusted
-
-    def _apply_governance_penalty(
-        self,
-        item: IntelligenceItem,
-        task_class: str,
-    ) -> IntelligenceItem:
-        """Down-weight governance proven_patterns for code-context dispatches."""
-        if item.pattern_category != PATTERN_CATEGORY_GOVERNANCE:
-            return item
-        if task_class != "coding_interactive":
-            return item
-        return IntelligenceItem(
-            item_id=item.item_id,
-            item_class=item.item_class,
-            title=item.title,
-            content=item.content,
-            confidence=item.confidence * GOVERNANCE_CONFIDENCE_PENALTY,
-            evidence_count=item.evidence_count,
-            last_seen=item.last_seen,
-            scope_tags=item.scope_tags,
-            source_refs=item.source_refs,
-            task_class_filter=item.task_class_filter,
-            pattern_category=item.pattern_category,
-            content_hash=item.content_hash,
-        )
-
-    # ------------------------------------------------------------------
-    # Candidate query methods
-    # ------------------------------------------------------------------
-
-    def _query_candidates(
-        self,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> Dict[str, List[IntelligenceItem]]:
-        """Query all candidate items from quality_intelligence.db, grouped by class."""
-        db = self._get_quality_db()
-        result: Dict[str, List[IntelligenceItem]] = {
-            "proven_pattern": [],
-            "failure_prevention": [],
-            "recent_comparable": [],
-        }
-        if db is None:
-            return result
-
-        result["proven_pattern"] = self._query_proven_patterns(db, task_class, scope_tags)
-        result["failure_prevention"] = self._query_failure_prevention(db, task_class, scope_tags)
-        result["recent_comparable"] = self._query_recent_comparable(db, task_class, scope_tags)
-
-        return result
-
-    def _query_proven_patterns_per_project(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query success_patterns for proven_pattern candidates (per-project DB)."""
-        # Safety net: if the daily learning_loop reconcile has not run
-        # recently, sync pattern_usage learning state into
-        # success_patterns.confidence_score before reading it.
-        self._maybe_reconcile_confidence()
-
-        items: List[IntelligenceItem] = []
-        has_pattern_cat = self._has_column("success_patterns", "pattern_category")
-        has_content_hash_col = self._has_column("success_patterns", "content_hash")
-        has_project_id_col = self._has_column("success_patterns", "project_id")
-        select_cols = (
-            "id, title, description, category, confidence_score, "
-            "usage_count, source_dispatch_ids, first_seen, last_used"
-        )
-        if has_pattern_cat:
-            select_cols += ", pattern_category"
-        if has_content_hash_col:
-            select_cols += ", content_hash"
-        if has_project_id_col:
-            select_cols += ", project_id"
-        scope_clause, scope_params = _project_scope_clause(has_project_id_col)
-        active_project_id = current_project_id() if has_project_id_col else None
-        try:
-            rows = db.execute(
-                f"""
-                SELECT {select_cols}
-                FROM success_patterns
-                WHERE (valid_until IS NULL OR valid_until > datetime('now'))
-                  {scope_clause}
-                ORDER BY confidence_score DESC
-                LIMIT 20
-                """,
-                scope_params,
-            ).fetchall()
-        except Exception:
-            return items
-
-        canonical_id_cache: Dict[Any, Any] = {}
-
-        for row in rows:
-            row_d = dict(row)
-            category = row_d.get("category", "")
-            pattern_scope = [category] if category else []
-
-            if not _scope_matches(pattern_scope, scope_tags):
-                continue
-
-            title = (row_d.get("title") or "Proven pattern")[:120]
-            content = (row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
-
-            # Resolve the canonical row id for this pattern's content. CFX-5:
-            # when the same content lives under multiple rows (legacy
-            # duplication or pre-dedup state), every row emits the *same*
-            # item_id so pattern_usage aggregates instead of fragmenting.
-            # Phase 1.5 PR-2: lookup is project-scoped so two tenants with
-            # the same pattern text do NOT collide onto a single canonical id.
-            stored_short_hash = (
-                row_d.get("content_hash") if has_content_hash_col else None
-            )
-            short_hash = stored_short_hash or _short_content_hash(title, content)
-            row_project_id = (
-                row_d.get("project_id") if has_project_id_col else None
-            )
-            canonical_key = self._resolve_canonical_id(
-                db,
-                short_hash,
-                fallback_id=row_d.get("id"),
-                cache=canonical_id_cache,
-                has_content_hash_col=has_content_hash_col,
-                has_project_id_col=has_project_id_col,
-                project_id=row_project_id or active_project_id,
-            )
-
-            # Phase 1.5 PR-2 — Fix 2/3: when canonical_key differs from this
-            # row's id (i.e. this row is a duplicate that remapped to a
-            # canonical sibling), emit the CANONICAL row's confidence,
-            # usage_count, source_dispatch_ids, title, description, and
-            # last_used so downstream pattern_usage / _stamp_source_dispatch_id
-            # writes target the canonical row's data — not stale duplicate
-            # values that would silently desynchronize the canonical row.
-            canonical_row_d = row_d
-            if canonical_key and canonical_key != str(row_d.get("id") or ""):
-                fetched = self._fetch_canonical_row(
-                    db, canonical_key, select_cols=select_cols
-                )
-                if fetched is not None:
-                    canonical_row_d = fetched
-
-            # Phase 1.5 PR-2 fix-forward: pattern_scope (and the underlying
-            # ``category``) must come from the canonical row, same as
-            # title/content/confidence/pattern_category already do. Otherwise a
-            # higher-confidence duplicate with a different category silently
-            # tags the emitted IntelligenceItem with a wrong scope.
-            canonical_category = canonical_row_d.get("category", "") or ""
-            pattern_scope = [canonical_category] if canonical_category else []
-
-            # OI-1340: re-evaluate scope after canonical remap. A duplicate row
-            # may have passed the pre-remap scope check but remapped to a
-            # canonical sibling whose category does NOT match the requested scope.
-            if not _scope_matches(pattern_scope, scope_tags):
-                continue
-
-            source_refs = []
-            if canonical_row_d.get("source_dispatch_ids"):
-                try:
-                    source_refs = json.loads(canonical_row_d["source_dispatch_ids"])
-                except (json.JSONDecodeError, TypeError):
-                    pass
-
-            canonical_title = (canonical_row_d.get("title") or title)[:120]
-            canonical_content = (canonical_row_d.get("description") or content)[:MAX_CONTENT_CHARS_PER_ITEM]
-            last_seen = (
-                canonical_row_d.get("last_used")
-                or canonical_row_d.get("first_seen")
-                or _now_utc()
-            )
-
-            stored_cat = canonical_row_d.get("pattern_category")
-            pattern_category = stored_cat or classify_pattern_category(
-                canonical_title, canonical_content
-            )
-
-            items.append(IntelligenceItem(
-                item_id=_stable_item_id("sp", canonical_key),
-                item_class="proven_pattern",
-                title=canonical_title,
-                content=canonical_content,
-                confidence=float(canonical_row_d.get("confidence_score", 0.0)),
-                evidence_count=int(canonical_row_d.get("usage_count", 0)),
-                last_seen=last_seen,
-                scope_tags=pattern_scope,
-                source_refs=source_refs[:5],
-                task_class_filter=[],
-                pattern_category=pattern_category,
-                content_hash=_content_hash(canonical_title, canonical_content),
-            ))
-
-        return items
-
-    def _resolve_canonical_id(
-        self,
-        db: sqlite3.Connection,
-        short_hash: str,
-        *,
-        fallback_id: Any,
-        cache: Dict[Any, Any],
-        has_content_hash_col: bool,
-        has_project_id_col: bool = False,
-        project_id: Optional[str] = None,
-    ) -> str:
-        """Return the canonical (smallest-id) row key for a given content hash.
-
-        Multi-tenant safety (Phase 1.5 PR-2 / OI-1315 / OI-1321):
-          When ``project_id`` is present on ``success_patterns``, the canonical
-          lookup MUST be scoped to the same project. Two projects with the
-          same pattern text would otherwise collapse onto a single id, which
-          contaminates pattern_usage / source_dispatch_ids across tenants.
-
-        Consult the on-row ``content_hash`` index when available so that
-        ``intel_sp_<id>`` collapses across duplicate rows within a project.
-        When the column is absent (pre-migration 0012) or no row matches the
-        hash yet, fall back to the row's own primary key — preserving the
-        legacy ``intel_sp_<id>`` format and the backward-compatibility
-        guarantee in the dispatch.
-        """
-        fallback_key = str(fallback_id) if fallback_id is not None else ""
-        if not short_hash or not has_content_hash_col:
-            return fallback_key
-        cache_key = (project_id, short_hash) if has_project_id_col else short_hash
-        if cache_key in cache:
-            return cache[cache_key]
-        try:
-            if has_project_id_col and project_filter_enabled():
-                row = db.execute(
-                    "SELECT MIN(id) FROM success_patterns "
-                    "WHERE content_hash = ? AND project_id = ?",
-                    (short_hash, project_id),
-                ).fetchone()
-            else:
-                row = db.execute(
-                    "SELECT MIN(id) FROM success_patterns WHERE content_hash = ?",
-                    (short_hash,),
-                ).fetchone()
-        except sqlite3.Error:
-            cache[cache_key] = fallback_key
-            return fallback_key
-        canonical_id = None
-        if row is not None:
-            canonical_id = row[0] if not isinstance(row, sqlite3.Row) else row[0]
-        if canonical_id is None:
-            cache[cache_key] = fallback_key
-            return fallback_key
-        canonical_key = str(canonical_id)
-        cache[cache_key] = canonical_key
-        return canonical_key
-
-    def _fetch_canonical_row(
-        self,
-        db: sqlite3.Connection,
-        canonical_id: Any,
-        *,
-        select_cols: str,
-    ) -> Optional[Dict[str, Any]]:
-        """Fetch the canonical row's data for use after a duplicate remap.
-
-        Returns the row as a dict, or ``None`` if the lookup fails. The caller
-        passes in the same ``select_cols`` projection used for the bulk query
-        so the returned shape is consistent with ``row_d`` lookups elsewhere.
-        """
-        if canonical_id in (None, ""):
-            return None
-        try:
-            row = db.execute(
-                f"SELECT {select_cols} FROM success_patterns WHERE id = ?",
-                (canonical_id,),
-            ).fetchone()
-        except sqlite3.Error:
-            return None
-        if row is None:
-            return None
-        return dict(row)
-
-    def _query_failure_prevention_per_project(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query antipatterns and prevention_rules for failure_prevention candidates (per-project DB)."""
-        items: List[IntelligenceItem] = []
-
-        # Query antipatterns
-        ap_scope_clause, ap_scope_params = _project_scope_clause(
-            self._has_column("antipatterns", "project_id")
-        )
-        try:
-            rows = db.execute(
-                f"""
-                SELECT id, title, description, category, severity,
-                       why_problematic, better_alternative,
-                       occurrence_count, first_seen, last_seen
-                FROM antipatterns
-                WHERE occurrence_count >= 1
-                  AND (valid_until IS NULL OR valid_until > datetime('now'))
-                  {ap_scope_clause}
-                ORDER BY
-                    CASE severity
-                        WHEN 'critical' THEN 4
-                        WHEN 'high' THEN 3
-                        WHEN 'medium' THEN 2
-                        WHEN 'low' THEN 1
-                        ELSE 0
-                    END DESC,
-                    occurrence_count DESC
-                LIMIT 5
-                """,
-                ap_scope_params,
-            ).fetchall()
-        except Exception:
-            rows = []
-
-        severity_confidence = {"critical": 0.9, "high": 0.75, "medium": 0.6, "low": 0.5}
-
-        for row in rows:
-            row_d = dict(row)
-            category = row_d.get("category", "")
-            pattern_scope = [category] if category else []
-
-            if not _scope_matches(pattern_scope, scope_tags):
-                continue
-
-            content_parts = []
-            if row_d.get("why_problematic"):
-                content_parts.append(row_d["why_problematic"])
-            if row_d.get("better_alternative"):
-                content_parts.append(f"Instead: {row_d['better_alternative']}")
-            content = " ".join(content_parts)[:MAX_CONTENT_CHARS_PER_ITEM]
-
-            severity = row_d.get("severity", "medium")
-            confidence = severity_confidence.get(severity, 0.5)
-
-            ap_title = (row_d.get("title") or "Failure prevention")[:120]
-            items.append(IntelligenceItem(
-                item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
-                item_class="failure_prevention",
-                title=ap_title,
-                content=content,
-                confidence=confidence,
-                evidence_count=int(row_d.get("occurrence_count", 1)),
-                last_seen=row_d.get("last_seen") or row_d.get("first_seen") or _now_utc(),
-                scope_tags=pattern_scope,
-                source_refs=[f"antipattern_{row_d['id']}"],
-                task_class_filter=[],
-                pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
-                content_hash=_content_hash(ap_title, content),
-            ))
-
-        # Query prevention_rules
-        pr_scope_clause, pr_scope_params = _project_scope_clause(
-            self._has_column("prevention_rules", "project_id")
-        )
-        try:
-            rule_rows = db.execute(
-                f"""
-                SELECT id, tag_combination, rule_type, description,
-                       recommendation, confidence, triggered_count, last_triggered
-                FROM prevention_rules
-                WHERE (valid_until IS NULL OR valid_until > datetime('now'))
-                  {pr_scope_clause}
-                ORDER BY confidence DESC
-                LIMIT 10
-                """,
-                pr_scope_params,
-            ).fetchall()
-        except Exception:
-            rule_rows = []
-
-        for row in rule_rows:
-            row_d = dict(row)
-            tag_combo = row_d.get("tag_combination", "") or ""
-            if not tag_combo:
-                rule_scope = []
-            else:
-                try:
-                    parsed = json.loads(tag_combo)
-                    rule_scope = parsed if isinstance(parsed, list) else ([str(parsed)] if parsed else [])
-                except (json.JSONDecodeError, TypeError):
-                    rule_scope = [t.strip() for t in tag_combo.split(",") if t.strip()]
-
-            if not _scope_matches(rule_scope, scope_tags):
-                continue
-
-            content = (row_d.get("recommendation") or row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
-
-            pr_title = (row_d.get("description") or "Prevention rule")[:120]
-            items.append(IntelligenceItem(
-                item_id=_stable_item_id("pr", str(row_d.get("id", ""))),
-                item_class="failure_prevention",
-                title=pr_title,
-                content=content,
-                confidence=float(row_d.get("confidence", 0.5)),
-                evidence_count=max(1, int(row_d.get("triggered_count", 1))),
-                last_seen=row_d.get("last_triggered") or _now_utc(),
-                scope_tags=rule_scope,
-                source_refs=[f"prevention_rule_{row_d['id']}"],
-                task_class_filter=[],
-                pattern_category=PATTERN_CATEGORY_PROCESS,
-                content_hash=_content_hash(pr_title, content),
-            ))
-
-        return items
-
-    def _query_recent_comparable_per_project(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query dispatch_metadata for recent_comparable candidates (per-project DB)."""
-        items: List[IntelligenceItem] = []
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)).isoformat()
-
-        dm_scope_clause, dm_scope_params = _project_scope_clause(
-            self._has_column("dispatch_metadata", "project_id")
-        )
-        try:
-            rows = db.execute(
-                f"""
-                SELECT dispatch_id, terminal, track, role, skill_name, gate,
-                       outcome_status, dispatched_at, pattern_count,
-                       prevention_rule_count
-                FROM dispatch_metadata
-                WHERE dispatched_at >= ?
-                  AND outcome_status IS NOT NULL
-                  {dm_scope_clause}
-                ORDER BY dispatched_at DESC
-                LIMIT 20
-                """,
-                (cutoff, *dm_scope_params),
-            ).fetchall()
-        except Exception:
-            return items
-
-        for row in rows:
-            row_d = dict(row)
-            dispatch_scope = []
-            if row_d.get("skill_name"):
-                dispatch_scope.append(row_d["skill_name"])
-            if row_d.get("gate"):
-                dispatch_scope.append(row_d["gate"])
-            if row_d.get("track"):
-                dispatch_scope.append(f"Track-{row_d['track']}")
-
-            if not _scope_matches(dispatch_scope, scope_tags):
-                continue
-
-            outcome = row_d.get("outcome_status", "unknown")
-            skill = row_d.get("skill_name") or row_d.get("role") or "unknown"
-            gate = row_d.get("gate") or ""
-
-            content = (
-                f"Dispatch {row_d['dispatch_id']} ({skill}, {gate}) "
-                f"completed with status: {outcome}. "
-                f"Patterns used: {row_d.get('pattern_count', 0)}, "
-                f"Prevention rules: {row_d.get('prevention_rule_count', 0)}."
-            )[:MAX_CONTENT_CHARS_PER_ITEM]
-
-            confidence = 0.7 if outcome == "success" else 0.45
-
-            dm_title = f"Recent: {skill} dispatch ({outcome})"[:120]
-            items.append(IntelligenceItem(
-                item_id=_stable_item_id("dm", str(row_d.get("dispatch_id", ""))),
-                item_class="recent_comparable",
-                title=dm_title,
-                content=content,
-                confidence=confidence,
-                evidence_count=1,
-                last_seen=row_d.get("dispatched_at") or _now_utc(),
-                scope_tags=dispatch_scope,
-                source_refs=[row_d["dispatch_id"]],
-                task_class_filter=[],
-                pattern_category=PATTERN_CATEGORY_PROCESS,
-                content_hash=_content_hash(dm_title, content),
-            ))
-
-        return items
-
-    # ------------------------------------------------------------------
-    # Central DB query methods (Wave 1 shadow reads)
-    # ------------------------------------------------------------------
-
-    def _query_proven_patterns_central(
-        self,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query success_patterns from central DB (independent connection, project_id-scoped)."""
-        items: List[IntelligenceItem] = []
-        conn = self._get_central_qi_conn()
-        if conn is None:
-            return items
-        try:
-            project_id = current_project_id()
-            has_pattern_cat = _table_has_column(conn, "success_patterns", "pattern_category")
-            has_content_hash_col = _table_has_column(conn, "success_patterns", "content_hash")
-            has_project_id_col = _table_has_column(conn, "success_patterns", "project_id")
-            select_cols = (
-                "id, title, description, category, confidence_score, "
-                "usage_count, source_dispatch_ids, first_seen, last_used"
-            )
-            if has_pattern_cat:
-                select_cols += ", pattern_category"
-            if has_content_hash_col:
-                select_cols += ", content_hash"
-            if has_project_id_col:
-                select_cols += ", project_id"
-            if has_project_id_col and project_id:
-                rows = conn.execute(
-                    f"""SELECT {select_cols} FROM success_patterns
-                    WHERE (valid_until IS NULL OR valid_until > datetime('now'))
-                    AND project_id = ?
-                    ORDER BY confidence_score DESC LIMIT 20""",
-                    (project_id,),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    f"""SELECT {select_cols} FROM success_patterns
-                    WHERE (valid_until IS NULL OR valid_until > datetime('now'))
-                    ORDER BY confidence_score DESC LIMIT 20"""
-                ).fetchall()
-            for row in rows:
-                row_d = dict(row)
-                category = row_d.get("category", "")
-                pattern_scope = [category] if category else []
-                if not _scope_matches(pattern_scope, scope_tags):
-                    continue
-                title = (row_d.get("title") or "Proven pattern")[:120]
-                content = (row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
-                stored_cat = row_d.get("pattern_category")
-                pattern_category = stored_cat or classify_pattern_category(title, content)
-                items.append(IntelligenceItem(
-                    item_id=_stable_item_id("sp", str(row_d.get("id", ""))),
-                    item_class="proven_pattern",
-                    title=title,
-                    content=content,
-                    confidence=float(row_d.get("confidence_score", 0.0)),
-                    evidence_count=int(row_d.get("usage_count", 0)),
-                    last_seen=row_d.get("last_used") or row_d.get("first_seen") or _now_utc(),
-                    scope_tags=pattern_scope,
-                    task_class_filter=[],
-                    pattern_category=pattern_category,
-                    content_hash=_content_hash(title, content),
-                ))
-        except sqlite3.Error as e:
-            logger.debug("Central proven-patterns query failed: %s", e)
-        finally:
-            conn.close()
-        return items
-
-    def _query_failure_prevention_central(
-        self,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query antipatterns from central DB (independent connection, project_id-scoped)."""
-        items: List[IntelligenceItem] = []
-        conn = self._get_central_qi_conn()
-        if conn is None:
-            return items
-        try:
-            project_id = current_project_id()
-            has_project_id = _table_has_column(conn, "antipatterns", "project_id")
-            severity_confidence = {"critical": 0.9, "high": 0.75, "medium": 0.6, "low": 0.5}
-            if has_project_id and project_id:
-                rows = conn.execute(
-                    """SELECT id, title, description, category, severity,
-                           why_problematic, better_alternative,
-                           occurrence_count, first_seen, last_seen
-                    FROM antipatterns
-                    WHERE occurrence_count >= 1
-                      AND (valid_until IS NULL OR valid_until > datetime('now'))
-                      AND project_id = ?
-                    ORDER BY
-                        CASE severity
-                            WHEN 'critical' THEN 4 WHEN 'high' THEN 3
-                            WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0
-                        END DESC,
-                        occurrence_count DESC
-                    LIMIT 5""",
-                    (project_id,),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    """SELECT id, title, description, category, severity,
-                           why_problematic, better_alternative,
-                           occurrence_count, first_seen, last_seen
-                    FROM antipatterns
-                    WHERE occurrence_count >= 1
-                      AND (valid_until IS NULL OR valid_until > datetime('now'))
-                    ORDER BY
-                        CASE severity
-                            WHEN 'critical' THEN 4 WHEN 'high' THEN 3
-                            WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0
-                        END DESC,
-                        occurrence_count DESC
-                    LIMIT 5"""
-                ).fetchall()
-            for row in rows:
-                row_d = dict(row)
-                category = row_d.get("category", "")
-                pattern_scope = [category] if category else []
-                if not _scope_matches(pattern_scope, scope_tags):
-                    continue
-                content_parts = []
-                if row_d.get("why_problematic"):
-                    content_parts.append(row_d["why_problematic"])
-                if row_d.get("better_alternative"):
-                    content_parts.append(f"Instead: {row_d['better_alternative']}")
-                content = " ".join(content_parts)[:MAX_CONTENT_CHARS_PER_ITEM]
-                severity = row_d.get("severity", "medium")
-                confidence = severity_confidence.get(severity, 0.5)
-                ap_title = (row_d.get("title") or "Failure prevention")[:120]
-                items.append(IntelligenceItem(
-                    item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
-                    item_class="failure_prevention",
-                    title=ap_title,
-                    content=content,
-                    confidence=confidence,
-                    evidence_count=int(row_d.get("occurrence_count", 1)),
-                    last_seen=row_d.get("last_seen") or row_d.get("first_seen") or _now_utc(),
-                    scope_tags=pattern_scope,
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
-                    content_hash=_content_hash(ap_title, content),
-                ))
-        except sqlite3.Error as e:
-            logger.debug("Central failure-prevention query failed: %s", e)
-        finally:
-            conn.close()
-        return items
-
-    def _query_recent_comparable_central(
-        self,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """Query dispatch_metadata from central DB (independent connection, project_id-scoped)."""
-        items: List[IntelligenceItem] = []
-        conn = self._get_central_qi_conn()
-        if conn is None:
-            return items
-        try:
-            project_id = current_project_id()
-            cutoff = (datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)).isoformat()
-            has_project_id = _table_has_column(conn, "dispatch_metadata", "project_id")
-            if has_project_id and project_id:
-                rows = conn.execute(
-                    """SELECT dispatch_id, terminal, track, role, skill_name, gate,
-                           outcome_status, dispatched_at, pattern_count,
-                           prevention_rule_count
-                    FROM dispatch_metadata
-                    WHERE dispatched_at >= ?
-                      AND outcome_status IS NOT NULL
-                      AND project_id = ?
-                    ORDER BY dispatched_at DESC LIMIT 20""",
-                    (cutoff, project_id),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    """SELECT dispatch_id, terminal, track, role, skill_name, gate,
-                           outcome_status, dispatched_at, pattern_count,
-                           prevention_rule_count
-                    FROM dispatch_metadata
-                    WHERE dispatched_at >= ?
-                      AND outcome_status IS NOT NULL
-                    ORDER BY dispatched_at DESC LIMIT 20""",
-                    (cutoff,),
-                ).fetchall()
-            for row in rows:
-                row_d = dict(row)
-                dispatch_scope = []
-                if row_d.get("skill_name"):
-                    dispatch_scope.append(row_d["skill_name"])
-                if row_d.get("gate"):
-                    dispatch_scope.append(row_d["gate"])
-                if row_d.get("track"):
-                    dispatch_scope.append(f"Track-{row_d['track']}")
-                if not _scope_matches(dispatch_scope, scope_tags):
-                    continue
-                outcome = row_d.get("outcome_status", "unknown")
-                skill = row_d.get("skill_name") or row_d.get("role") or "unknown"
-                gate = row_d.get("gate") or ""
-                content = (
-                    f"Dispatch {row_d['dispatch_id']} ({skill}, {gate}) "
-                    f"completed with status: {outcome}. "
-                    f"Patterns used: {row_d.get('pattern_count', 0)}, "
-                    f"Prevention rules: {row_d.get('prevention_rule_count', 0)}."
-                )[:MAX_CONTENT_CHARS_PER_ITEM]
-                confidence = 0.7 if outcome == "success" else 0.45
-                dm_title = f"Recent: {skill} dispatch ({outcome})"[:120]
-                items.append(IntelligenceItem(
-                    item_id=_stable_item_id("dm", str(row_d.get("dispatch_id", ""))),
-                    item_class="recent_comparable",
-                    title=dm_title,
-                    content=content,
-                    confidence=confidence,
-                    evidence_count=1,
-                    last_seen=row_d.get("dispatched_at") or _now_utc(),
-                    scope_tags=dispatch_scope,
-                    task_class_filter=[],
-                    pattern_category=PATTERN_CATEGORY_PROCESS,
-                    content_hash=_content_hash(dm_title, content),
-                ))
-        except sqlite3.Error as e:
-            logger.debug("Central recent-comparable query failed: %s", e)
-        finally:
-            conn.close()
-        return items
-
-    # ------------------------------------------------------------------
-    # Shadow-aware dispatcher methods (Wave 1 — 3-state VNX_USE_CENTRAL_DB)
-    # ------------------------------------------------------------------
-
-    def _query_proven_patterns(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """3-state dispatcher: per-project | central | shadow (metric 3, success_patterns)."""
-        flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
-        if flag == "":
-            return self._query_proven_patterns_per_project(db, task_class, scope_tags)
-        if flag == "1":
-            return self._query_proven_patterns_central(task_class, scope_tags)
-        # flag == "shadow": per-project authoritative; central observed-only
-        legacy = self._query_proven_patterns_per_project(db, task_class, scope_tags)
-        central = self._query_proven_patterns_central(task_class, scope_tags)
-        if _shadow_verifier is not None:
-            project_id = current_project_id()
-            try:
-                cmp = _shadow_verifier.compare(
-                    [item.to_dict() for item in legacy],
-                    [item.to_dict() for item in central],
-                    project_id=project_id,
-                    read_site="IntelligenceSelector._query_proven_patterns",
-                    sql_template=_PROVEN_PATTERNS_SQL_TEMPLATE,
-                    metric_id=3,
-                )
-                if cmp.divergences and _shadow_logger is not None:
-                    _shadow_logger.write_comparison_result(
-                        cmp, project_id,
-                        "IntelligenceSelector._query_proven_patterns",
-                    )
-            except Exception as e:
-                logger.debug("Shadow compare (proven_patterns) skipped: %s", e)
-        return legacy
-
-    def _query_failure_prevention(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """3-state dispatcher: per-project | central | shadow (metric 3, antipatterns)."""
-        flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
-        if flag == "":
-            return self._query_failure_prevention_per_project(db, task_class, scope_tags)
-        if flag == "1":
-            return self._query_failure_prevention_central(task_class, scope_tags)
-        # flag == "shadow"
-        legacy = self._query_failure_prevention_per_project(db, task_class, scope_tags)
-        central = self._query_failure_prevention_central(task_class, scope_tags)
-        if _shadow_verifier is not None:
-            project_id = current_project_id()
-            try:
-                cmp = _shadow_verifier.compare(
-                    [item.to_dict() for item in legacy],
-                    [item.to_dict() for item in central],
-                    project_id=project_id,
-                    read_site="IntelligenceSelector._query_failure_prevention",
-                    sql_template=_FAILURE_PREVENTION_SQL_TEMPLATE,
-                    metric_id=3,
-                )
-                if cmp.divergences and _shadow_logger is not None:
-                    _shadow_logger.write_comparison_result(
-                        cmp, project_id,
-                        "IntelligenceSelector._query_failure_prevention",
-                    )
-            except Exception as e:
-                logger.debug("Shadow compare (failure_prevention) skipped: %s", e)
-        return legacy
-
-    def _query_recent_comparable(
-        self,
-        db: sqlite3.Connection,
-        task_class: str,
-        scope_tags: List[str],
-    ) -> List[IntelligenceItem]:
-        """3-state dispatcher: per-project | central | shadow (metric 4, dispatch_metadata)."""
-        flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
-        if flag == "":
-            return self._query_recent_comparable_per_project(db, task_class, scope_tags)
-        if flag == "1":
-            return self._query_recent_comparable_central(task_class, scope_tags)
-        # flag == "shadow"
-        legacy = self._query_recent_comparable_per_project(db, task_class, scope_tags)
-        central = self._query_recent_comparable_central(task_class, scope_tags)
-        if _shadow_verifier is not None:
-            project_id = current_project_id()
-            try:
-                cmp = _shadow_verifier.compare(
-                    [item.to_dict() for item in legacy],
-                    [item.to_dict() for item in central],
-                    project_id=project_id,
-                    read_site="IntelligenceSelector._query_recent_comparable",
-                    sql_template=_RECENT_COMPARABLE_SQL_TEMPLATE,
-                    metric_id=4,
-                    table="dispatch_metadata",
-                )
-                if cmp.divergences and _shadow_logger is not None:
-                    _shadow_logger.write_comparison_result(
-                        cmp, project_id,
-                        "IntelligenceSelector._query_recent_comparable",
-                    )
-            except Exception as e:
-                logger.debug("Shadow compare (recent_comparable) skipped: %s", e)
-        return legacy
-
-    # ------------------------------------------------------------------
-    # Payload enforcement
-    # ------------------------------------------------------------------
-
-    def _enforce_payload_limit(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Enforce MAX_PAYLOAD_CHARS by dropping lowest-priority items first.
-
-        Drop order (per contract Section 2.3 step 6):
-          1. recent_comparable
-          2. failure_prevention
-          3. proven_pattern (last resort)
-        """
-        if not selected:
-            return selected
-
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        # Drop in reverse priority order
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY))
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-    def _enforce_payload_limit_with_prior(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Re-enforce payload limit after a prior_round_finding item has been prepended.
-
-        Drops standard classes first (recent_comparable → failure_prevention →
-        proven_pattern) and only removes prior_round_finding as last resort,
-        since it is direct evidence with confidence 1.0.
-        """
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + ["prior_round_finding"]
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-    def _enforce_payload_limit_with_adr(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Re-enforce payload limit after an adr_relevant item has been appended.
-
-        Drops standard classes first (recent_comparable → failure_prevention →
-        proven_pattern → prior_round_finding) and only removes adr_relevant as
-        last resort since it is direct governance evidence with confidence 1.0.
-        """
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + ["prior_round_finding", "adr_relevant"]
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-    def _enforce_payload_limit_with_code_anchor(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Re-enforce payload limit after a code_anchor item has been appended.
-
-        Drops standard classes first (recent_comparable → failure_prevention →
-        proven_pattern → prior_round_finding → adr_relevant) and only removes
-        code_anchor as last resort since it is direct file evidence with confidence 1.0.
-        """
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + [
-            "prior_round_finding", "adr_relevant", "code_anchor"
-        ]
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-    def _enforce_payload_limit_with_operator_memory(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Re-enforce payload limit after an operator_memory item has been appended.
-
-        Drops standard classes first (recent_comparable → failure_prevention →
-        proven_pattern → prior_round_finding → adr_relevant → code_anchor) and
-        only removes operator_memory as last resort since it carries operator-curated
-        lessons with confidence 1.0.
-        """
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + [
-            "prior_round_finding", "adr_relevant", "code_anchor", "operator_memory"
-        ]
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-    def _enforce_payload_limit_with_schema_section(
-        self,
-        selected: List[IntelligenceItem],
-        suppressed: List[SuppressionRecord],
-    ) -> List[IntelligenceItem]:
-        """Re-enforce payload limit after a schema_section item has been appended.
-
-        Drops standard classes first (recent_comparable -> failure_prevention ->
-        proven_pattern -> prior_round_finding -> adr_relevant -> code_anchor ->
-        operator_memory) and only removes schema_section as last resort since it
-        carries direct DDL evidence with confidence 1.0.
-        """
-        payload_size = len(json.dumps({
-            "injection_point": "dispatch_create",
-            "injected_at": _now_utc(),
-            "items": [item.to_dict() for item in selected],
-            "suppressed": [s.to_dict() for s in suppressed],
-        }))
-
-        if payload_size <= MAX_PAYLOAD_CHARS:
-            return selected
-
-        drop_order = list(reversed(ITEM_CLASS_PRIORITY)) + [
-            "prior_round_finding", "adr_relevant", "code_anchor", "operator_memory", "schema_section"
-        ]
-        for drop_class in drop_order:
-            to_drop = [i for i in selected if i.item_class == drop_class]
-            if not to_drop:
-                continue
-
-            selected = [i for i in selected if i.item_class != drop_class]
-            suppressed.append(SuppressionRecord(
-                item_class=drop_class,
-                reason=f"dropped to enforce payload limit ({payload_size} > {MAX_PAYLOAD_CHARS} chars)",
-            ))
-
-            payload_size = len(json.dumps({
-                "injection_point": "dispatch_create",
-                "injected_at": _now_utc(),
-                "items": [item.to_dict() for item in selected],
-                "suppressed": [s.to_dict() for s in suppressed],
-            }))
-
-            if payload_size <= MAX_PAYLOAD_CHARS:
-                break
-
-        return selected
-
-
-# ---------------------------------------------------------------------------
-# Module-level convenience
-# ---------------------------------------------------------------------------
-
-def select_intelligence(
-    dispatch_id: str,
-    injection_point: str,
-    *,
-    quality_db_path: Optional[Path] = None,
-    coord_state_dir: Optional[Path] = None,
-    task_class: Optional[str] = None,
-    skill_name: Optional[str] = None,
-    scope_tags: Optional[List[str]] = None,
-    track: Optional[str] = None,
-    gate: Optional[str] = None,
-) -> InjectionResult:
+def select_intelligence(dispatch_id, injection_point, *, quality_db_path=None, coord_state_dir=None, task_class=None, skill_name=None, scope_tags=None, track=None, gate=None) -> InjectionResult:
     """Convenience function: select, emit event, record injection, return result."""
-    selector = IntelligenceSelector(
-        quality_db_path=quality_db_path,
-        coord_db_state_dir=coord_state_dir,
-    )
+    selector = IntelligenceSelector(quality_db_path=quality_db_path, coord_db_state_dir=coord_state_dir)
     try:
-        result = selector.select(
-            dispatch_id=dispatch_id,
-            injection_point=injection_point,
-            task_class=task_class,
-            skill_name=skill_name,
-            scope_tags=scope_tags,
-            track=track,
-            gate=gate,
-        )
+        result = selector.select(dispatch_id=dispatch_id, injection_point=injection_point, task_class=task_class, skill_name=skill_name, scope_tags=scope_tags, track=track, gate=gate)
         selector.emit_event(result)
         selector.record_injection(result)
         return result
@@ -2462,42 +297,17 @@ def select_intelligence(
         selector.close()
 
 
-def build_intelligence_context(
-    *,
-    dispatch_id: str = "",
-    role: str = "",
-    pr_id: Optional[str] = None,
-    dispatch_paths: Optional[List[str]] = None,
-    quality_db_path: Optional[Path] = None,
-    coord_state_dir: Optional[Path] = None,
-) -> Optional[IntelligenceContext]:
+def build_intelligence_context(*, dispatch_id="", role="", pr_id=None, dispatch_paths=None, quality_db_path=None, coord_state_dir=None) -> Optional[IntelligenceContext]:
     """Build an IntelligenceContext for adapter prompt assembly.
 
-    Returns None immediately when dispatch_id is empty or whitespace — no
-    audit rows are written (intelligence_injections / coordination_events).
-    Callers must supply a real dispatch_id for injection and audit to fire.
-
-    On success, returns an IntelligenceContext whose serialize_for(provider)
-    method yields provider-specific markdown (or '' when no items selected).
+    Returns None immediately when dispatch_id is empty (no audit rows written).
     """
     if not dispatch_id or not str(dispatch_id).strip():
-        logger.debug(
-            "build_intelligence_context: empty dispatch_id, skipping injection (no audit write)"
-        )
+        logger.debug("build_intelligence_context: empty dispatch_id, skipping injection (no audit write)")
         return None
-
-    selector = IntelligenceSelector(
-        quality_db_path=quality_db_path,
-        coord_db_state_dir=coord_state_dir,
-    )
+    selector = IntelligenceSelector(quality_db_path=quality_db_path, coord_db_state_dir=coord_state_dir)
     try:
-        result = selector.select(
-            dispatch_id=dispatch_id,
-            injection_point="dispatch_create",
-            skill_name=role or "",
-            dispatch_paths=dispatch_paths or [],
-            pr_id=pr_id,
-        )
+        result = selector.select(dispatch_id=dispatch_id, injection_point="dispatch_create", skill_name=role or "", dispatch_paths=dispatch_paths or [], pr_id=pr_id)
         try:
             selector.emit_event(result, coord_state_dir=coord_state_dir)
         except Exception as exc:

--- a/scripts/lib/intelligence_sources/__init__.py
+++ b/scripts/lib/intelligence_sources/__init__.py
@@ -1,0 +1,70 @@
+"""
+intelligence_sources — per-source intelligence query and injection modules.
+
+Public re-exports for backward compatibility through intelligence_selector.py.
+"""
+from ._common import (
+    CONFIDENCE_THRESHOLDS,
+    EVIDENCE_THRESHOLDS,
+    GOVERNANCE_CONFIDENCE_PENALTY,
+    ITEM_CLASS_PRIORITY,
+    MAX_CODE_ANCHOR_CHARS,
+    MAX_CONTENT_CHARS_PER_ITEM,
+    MAX_GOVERNANCE_PER_BATCH,
+    MAX_ITEMS_PER_INJECTION,
+    MAX_PAYLOAD_CHARS,
+    MIN_EVIDENCE_COUNT,
+    PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+    PATTERN_CATEGORY_CODE,
+    PATTERN_CATEGORY_GOVERNANCE,
+    PATTERN_CATEGORY_PROCESS,
+    RECENT_COMPARABLE_DAYS,
+    SKILL_TO_TASK_CLASS,
+    SUCCESS_PATTERN_CONTENT_HASH_LEN,
+    VALID_INJECTION_POINTS,
+    VALID_TASK_CLASSES,
+    IntelligenceItem,
+    SuppressionRecord,
+    _content_hash,
+    _item_hash,
+    _new_id,
+    _normalize_for_hash,
+    _now_utc,
+    _project_scope_clause,
+    _scope_matches,
+    _short_content_hash,
+    _stable_item_id,
+    _table_has_column,
+    _task_class_matches,
+    _apply_governance_penalty,
+    apply_candidate_diversity,
+    classify_pattern_category,
+    resolve_task_class,
+)
+from ._models import InjectionResult, IntelligenceContext
+from ._recording import record_injection_audit, record_pattern_usage, stamp_source_dispatch_ids
+from .proven_pattern import query_proven_patterns
+from .failure_prevention import query_failure_prevention
+from .recent_comparable import query_recent_comparable
+from .adr_relevant import build_adr_item, build_schema_section_item
+from .code_anchor import build_code_anchor_item, build_operator_memory_item, build_prior_round_item
+
+__all__ = [
+    "CONFIDENCE_THRESHOLDS", "EVIDENCE_THRESHOLDS", "GOVERNANCE_CONFIDENCE_PENALTY",
+    "ITEM_CLASS_PRIORITY", "MAX_CODE_ANCHOR_CHARS", "MAX_CONTENT_CHARS_PER_ITEM",
+    "MAX_GOVERNANCE_PER_BATCH", "MAX_ITEMS_PER_INJECTION", "MAX_PAYLOAD_CHARS",
+    "MIN_EVIDENCE_COUNT", "PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE", "PATTERN_CATEGORY_CODE",
+    "PATTERN_CATEGORY_GOVERNANCE", "PATTERN_CATEGORY_PROCESS", "RECENT_COMPARABLE_DAYS",
+    "SKILL_TO_TASK_CLASS", "SUCCESS_PATTERN_CONTENT_HASH_LEN", "VALID_INJECTION_POINTS",
+    "VALID_TASK_CLASSES",
+    "IntelligenceItem", "SuppressionRecord", "InjectionResult", "IntelligenceContext",
+    "_content_hash", "_item_hash", "_new_id", "_normalize_for_hash",
+    "_now_utc", "_project_scope_clause", "_scope_matches",
+    "_short_content_hash", "_stable_item_id", "_table_has_column", "_task_class_matches",
+    "_apply_governance_penalty", "apply_candidate_diversity", "classify_pattern_category",
+    "resolve_task_class",
+    "record_injection_audit", "record_pattern_usage", "stamp_source_dispatch_ids",
+    "query_proven_patterns", "query_failure_prevention", "query_recent_comparable",
+    "build_adr_item", "build_schema_section_item",
+    "build_code_anchor_item", "build_operator_memory_item", "build_prior_round_item",
+]

--- a/scripts/lib/intelligence_sources/_common.py
+++ b/scripts/lib/intelligence_sources/_common.py
@@ -1,0 +1,296 @@
+"""
+Shared types, constants, and utilities for intelligence_sources modules.
+
+Extracted from intelligence_selector.py (2511 LOC → per-source split).
+All public symbols are re-exported via intelligence_selector.py for backward compat.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from project_scope import current_project_id, project_filter_enabled
+except ImportError:
+    import sys as _sys
+    from pathlib import Path as _Path
+    _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+    from project_scope import current_project_id, project_filter_enabled
+
+# ---------------------------------------------------------------------------
+# FP-C Intelligence Contract constants
+# ---------------------------------------------------------------------------
+
+MAX_ITEMS_PER_INJECTION = 3
+MAX_CONTENT_CHARS_PER_ITEM = 500
+MAX_PAYLOAD_CHARS = 4000
+MIN_EVIDENCE_COUNT = 1
+MAX_CODE_ANCHOR_CHARS = 1500
+
+_DIRECT_INJECTION_CLASSES = frozenset({
+    "code_anchor",
+    "prior_round_finding",
+    "adr_relevant",
+    "operator_memory",
+    "schema_section",
+})
+
+CONFIDENCE_THRESHOLDS = {
+    "proven_pattern": 0.6,
+    "failure_prevention": 0.5,
+    "recent_comparable": 0.4,
+}
+
+EVIDENCE_THRESHOLDS = {
+    "proven_pattern": 2,
+    "failure_prevention": 1,
+    "recent_comparable": 1,
+}
+
+ITEM_CLASS_PRIORITY = ["proven_pattern", "failure_prevention", "recent_comparable"]
+
+PATTERN_CATEGORY_CODE = "code"
+PATTERN_CATEGORY_GOVERNANCE = "governance"
+PATTERN_CATEGORY_PROCESS = "process"
+PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE = "antipattern_evidence"
+
+MAX_GOVERNANCE_PER_BATCH = 1
+GOVERNANCE_CONFIDENCE_PENALTY = 0.7
+RECENT_COMPARABLE_DAYS = 14
+
+VALID_INJECTION_POINTS = frozenset({"dispatch_create", "dispatch_resume"})
+
+VALID_TASK_CLASSES = frozenset({
+    "coding_interactive",
+    "research_structured",
+    "docs_synthesis",
+    "ops_watchdog",
+    "channel_response",
+})
+
+SKILL_TO_TASK_CLASS = {
+    "backend-developer": "coding_interactive",
+    "frontend-developer": "coding_interactive",
+    "api-developer": "coding_interactive",
+    "python-optimizer": "coding_interactive",
+    "supabase-expert": "coding_interactive",
+    "monitoring-specialist": "coding_interactive",
+    "vnx-manager": "coding_interactive",
+    "debugger": "coding_interactive",
+    "test-engineer": "coding_interactive",
+    "quality-engineer": "coding_interactive",
+    "architect": "research_structured",
+    "reviewer": "research_structured",
+    "planner": "research_structured",
+    "data-analyst": "research_structured",
+    "performance-profiler": "research_structured",
+    "security-engineer": "research_structured",
+    "t0-orchestrator": "research_structured",
+    "excel-reporter": "docs_synthesis",
+    "technical-writer": "docs_synthesis",
+}
+
+SUCCESS_PATTERN_CONTENT_HASH_LEN = 16
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class IntelligenceItem:
+    """A single intelligence item conforming to the FP-C schema."""
+    item_id: str
+    item_class: str
+    title: str
+    content: str
+    confidence: float
+    evidence_count: int
+    last_seen: str
+    scope_tags: List[str]
+    source_refs: List[str] = field(default_factory=list)
+    task_class_filter: List[str] = field(default_factory=list)
+    pattern_category: str = PATTERN_CATEGORY_CODE
+    content_hash: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        content_cap = (
+            MAX_CODE_ANCHOR_CHARS
+            if self.item_class in _DIRECT_INJECTION_CLASSES
+            else MAX_CONTENT_CHARS_PER_ITEM
+        )
+        return {
+            "item_id": self.item_id,
+            "item_class": self.item_class,
+            "title": self.title,
+            "content": self.content[:content_cap],
+            "confidence": self.confidence,
+            "evidence_count": self.evidence_count,
+            "last_seen": self.last_seen,
+            "scope_tags": self.scope_tags,
+            "source_refs": self.source_refs,
+            "task_class_filter": self.task_class_filter,
+            "pattern_category": self.pattern_category,
+            "content_hash": self.content_hash,
+        }
+
+
+@dataclass
+class SuppressionRecord:
+    """Records why an item class slot was not filled."""
+    item_class: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"item_class": self.item_class, "reason": self.reason}
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _normalize_for_hash(text: str) -> str:
+    return " ".join((text or "").lower().split())
+
+
+def _content_hash(*parts: str) -> str:
+    joined = "\n".join(_normalize_for_hash(p) for p in parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _short_content_hash(*parts: str) -> str:
+    return _content_hash(*parts)[:SUCCESS_PATTERN_CONTENT_HASH_LEN]
+
+
+def _item_hash(item_id: str) -> str:
+    return hashlib.sha1(item_id.encode("utf-8")).hexdigest()
+
+
+def _stable_item_id(prefix: str, source_key: str) -> str:
+    """Build a deterministic, content-derived item_id.
+
+    The id encodes the originating table via prefix (e.g. sp, ap, pr, dm)
+    and a stable per-row key so pattern_usage rows aggregate instead of
+    fragmenting across dispatches.
+    """
+    safe_key = str(source_key).strip().lower().replace(" ", "_")
+    return f"intel_{prefix}_{safe_key}"
+
+
+def classify_pattern_category(title: str, description: str) -> str:
+    """Mirror of pattern_dedup.classify_pattern, kept local to avoid import cycle."""
+    haystack = f"{_normalize_for_hash(title)} :: {_normalize_for_hash(description)}"
+    if "gate " in haystack and "passed" in haystack:
+        return PATTERN_CATEGORY_GOVERNANCE
+    if any(token in haystack for token in (
+        "receipt processor",
+        "dispatch lifecycle",
+        "lease release",
+    )):
+        return PATTERN_CATEGORY_PROCESS
+    return PATTERN_CATEGORY_CODE
+
+
+def resolve_task_class(
+    task_class: Optional[str] = None,
+    skill_name: Optional[str] = None,
+) -> str:
+    """Resolve task class from explicit value or skill name. Defaults to coding_interactive."""
+    if task_class and task_class in VALID_TASK_CLASSES:
+        return task_class
+    if skill_name:
+        return SKILL_TO_TASK_CLASS.get(skill_name, "coding_interactive")
+    return "coding_interactive"
+
+
+def _scope_matches(item_scope_tags: List[str], query_scope_tags: List[str]) -> bool:
+    """Empty item scope = matches everything. Empty query scope = matches everything."""
+    if not item_scope_tags or not query_scope_tags:
+        return True
+    return bool(set(item_scope_tags) & set(query_scope_tags))
+
+
+def _task_class_matches(item_filter: List[str], task_class: str) -> bool:
+    """Empty filter = matches all task classes."""
+    if not item_filter:
+        return True
+    return task_class in item_filter
+
+
+def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """PRAGMA-based column probe."""
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    except sqlite3.Error:
+        return False
+    for row in rows:
+        name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
+        if name == column:
+            return True
+    return False
+
+
+def _project_scope_clause(column_present: bool) -> Tuple[str, tuple]:
+    """Return the AND project_id = ? fragment + bind params, or empty."""
+    if not column_present or not project_filter_enabled():
+        return "", ()
+    return "AND project_id = ?", (current_project_id(),)
+
+
+
+def apply_candidate_diversity(
+    candidates: Dict[str, List["IntelligenceItem"]],
+    task_class: str,
+) -> Dict[str, List["IntelligenceItem"]]:
+    """Collapse same-hash duplicates and re-rank governance vs. code patterns."""
+    adjusted: Dict[str, List["IntelligenceItem"]] = {}
+    for cls, items in candidates.items():
+        collapsed: Dict[str, "IntelligenceItem"] = {}
+        unhashed: List["IntelligenceItem"] = []
+        for item in items:
+            if not item.content_hash:
+                unhashed.append(item)
+                continue
+            existing = collapsed.get(item.content_hash)
+            if existing is None or item.confidence > existing.confidence:
+                collapsed[item.content_hash] = item
+        merged = list(collapsed.values()) + unhashed
+        if cls == "proven_pattern":
+            merged = [_apply_governance_penalty(item, task_class) for item in merged]
+        merged.sort(key=lambda i: i.confidence, reverse=True)
+        adjusted[cls] = merged
+    return adjusted
+
+
+def _apply_governance_penalty(item: "IntelligenceItem", task_class: str) -> "IntelligenceItem":
+    """Down-weight governance proven_patterns for code-context dispatches."""
+    if item.pattern_category != PATTERN_CATEGORY_GOVERNANCE:
+        return item
+    if task_class != "coding_interactive":
+        return item
+    return IntelligenceItem(
+        item_id=item.item_id,
+        item_class=item.item_class,
+        title=item.title,
+        content=item.content,
+        confidence=item.confidence * GOVERNANCE_CONFIDENCE_PENALTY,
+        evidence_count=item.evidence_count,
+        last_seen=item.last_seen,
+        scope_tags=item.scope_tags,
+        source_refs=item.source_refs,
+        task_class_filter=item.task_class_filter,
+        pattern_category=item.pattern_category,
+        content_hash=item.content_hash,
+    )

--- a/scripts/lib/intelligence_sources/_models.py
+++ b/scripts/lib/intelligence_sources/_models.py
@@ -1,0 +1,103 @@
+"""
+InjectionResult, IntelligenceContext, and markdown formatters.
+
+Split from intelligence_selector.py (2511 LOC → per-source modules).
+Re-exported via intelligence_selector for backward compatibility.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from ._common import IntelligenceItem, SuppressionRecord
+
+
+def _format_items_markdown(items: List[IntelligenceItem]) -> str:
+    """Group items by class and render as full markdown sections."""
+    by_class: Dict[str, List[IntelligenceItem]] = {}
+    for item in items:
+        by_class.setdefault(item.item_class, []).append(item)
+    parts: List[str] = []
+    if "failure_prevention" in by_class:
+        parts.append("### Antipatterns to avoid")
+        for item in by_class["failure_prevention"]:
+            parts.append(f"- **[CRITICAL] {item.title}**: {item.content}")
+        parts.append("")
+    if "proven_pattern" in by_class:
+        parts.append("### Proven success patterns")
+        for item in by_class["proven_pattern"]:
+            parts.append(f"- **{item.title}**: {item.content}")
+        parts.append("")
+    if "recent_comparable" in by_class:
+        parts.append("### Tag warnings")
+        for item in by_class["recent_comparable"]:
+            parts.append(f"- **{item.title}**: {item.content}")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _format_items_compact(items: List[IntelligenceItem]) -> str:
+    """Compact numbered format for providers where brevity is preferred."""
+    lines: List[str] = ["## Intelligence Context"]
+    for i, item in enumerate(items, 1):
+        cls = item.item_class.replace("_", " ").title()
+        lines.append(f"{i}. [{cls}] **{item.title}**: {item.content}")
+    return "\n".join(lines)
+
+
+@dataclass
+class InjectionResult:
+    """Complete result of an intelligence selection run."""
+    injection_point: str
+    injected_at: str
+    items: List[IntelligenceItem]
+    suppressed: List[SuppressionRecord]
+    task_class: str
+    dispatch_id: str
+
+    @property
+    def items_injected(self) -> int:
+        return len(self.items)
+
+    @property
+    def items_suppressed(self) -> int:
+        return len(self.suppressed)
+
+    @property
+    def payload_chars(self) -> int:
+        return len(json.dumps(self.to_payload_dict()))
+
+    def to_payload_dict(self) -> Dict[str, Any]:
+        return {
+            "injection_point": self.injection_point,
+            "injected_at": self.injected_at,
+            "items": [item.to_dict() for item in self.items],
+            "suppressed": [s.to_dict() for s in self.suppressed],
+        }
+
+    def to_event_metadata(self) -> Dict[str, Any]:
+        return {
+            "injection_point": self.injection_point,
+            "task_class": self.task_class,
+            "items_injected": self.items_injected,
+            "items_suppressed": self.items_suppressed,
+            "suppression_reasons": [s.reason for s in self.suppressed],
+            "payload_chars": self.payload_chars,
+            "item_ids": [item.item_id for item in self.items],
+        }
+
+
+@dataclass
+class IntelligenceContext:
+    """Provider-agnostic container for an intelligence injection result."""
+    result: InjectionResult
+    dispatch_id: str
+
+    def serialize_for(self, provider: str) -> str:
+        """Return provider-specific markdown for the prompt intelligence section."""
+        if not self.result.items:
+            return ""
+        if provider == "codex":
+            return _format_items_compact(self.result.items)
+        return _format_items_markdown(self.result.items)

--- a/scripts/lib/intelligence_sources/_recording.py
+++ b/scripts/lib/intelligence_sources/_recording.py
@@ -120,12 +120,13 @@ def stamp_source_dispatch_ids(
         try:
             if _stamp_source_dispatch_id(db, item, result.dispatch_id):
                 stamped += 1
-        except Exception:
+        except Exception as exc:
+            logger.warning("stamp_source_dispatch_ids: failed to stamp item %s: %s", getattr(item, "item_id", "?"), exc)
             continue
     try:
         db.commit()
-    except sqlite3.Error:
-        pass
+    except sqlite3.Error as exc:
+        logger.warning("stamp_source_dispatch_ids: commit failed: %s", exc)
     return stamped
 
 

--- a/scripts/lib/intelligence_sources/_recording.py
+++ b/scripts/lib/intelligence_sources/_recording.py
@@ -1,0 +1,228 @@
+"""
+Intelligence injection recording helpers.
+
+Writes to:
+  - intelligence_injections (coord DB) — audit trail
+  - pattern_usage (quality DB) — feedback loop
+  - dispatch_pattern_offered (quality DB) — per-dispatch offering junction
+  - success_patterns / antipatterns source_dispatch_ids (quality DB) — decay linkage
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from ._common import (
+    IntelligenceItem,
+    _item_hash,
+    _new_id,
+    _now_utc,
+    _table_has_column,
+)
+
+if TYPE_CHECKING:
+    from ._models import InjectionResult
+
+try:
+    from project_scope import current_project_id
+except ImportError:
+    from project_scope import current_project_id  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def record_injection_audit(
+    result: "InjectionResult",
+    state_dir: object,
+    project_id: Optional[str],
+) -> None:
+    """Insert one row into intelligence_injections in the coord DB."""
+    try:
+        from runtime_coordination import get_connection
+    except ImportError:
+        return
+    injection_id = _new_id()
+    items_json = json.dumps([item.to_dict() for item in result.items])
+    suppressed_json = json.dumps([s.to_dict() for s in result.suppressed])
+    try:
+        with get_connection(state_dir) as conn:
+            has_project = _table_has_column(conn, "intelligence_injections", "project_id")
+            if has_project:
+                conn.execute(
+                    """INSERT INTO intelligence_injections
+                        (injection_id, dispatch_id, injection_point, task_class,
+                         items_injected, items_suppressed, payload_chars,
+                         items_json, suppressed_json, project_id)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (injection_id, result.dispatch_id, result.injection_point,
+                     result.task_class, result.items_injected, result.items_suppressed,
+                     result.payload_chars, items_json, suppressed_json, project_id),
+                )
+            else:
+                conn.execute(
+                    """INSERT INTO intelligence_injections
+                        (injection_id, dispatch_id, injection_point, task_class,
+                         items_injected, items_suppressed, payload_chars,
+                         items_json, suppressed_json)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (injection_id, result.dispatch_id, result.injection_point,
+                     result.task_class, result.items_injected, result.items_suppressed,
+                     result.payload_chars, items_json, suppressed_json),
+                )
+            conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("Failed to record injection audit: %s", e)
+
+
+def record_pattern_usage(
+    result: "InjectionResult",
+    db: sqlite3.Connection,
+    has_column_fn: Callable[[str, str], bool],
+) -> None:
+    """Write pattern_usage + dispatch_pattern_offered rows for the feedback loop."""
+    if db is None:
+        return
+    now = _now_utc()
+    project_id = current_project_id()
+    pu_has_project = has_column_fn("pattern_usage", "project_id")
+    dpo_has_project = has_column_fn("dispatch_pattern_offered", "project_id")
+    try:
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+                dispatch_id   TEXT NOT NULL,
+                pattern_id    TEXT NOT NULL,
+                pattern_title TEXT NOT NULL,
+                offered_at    TEXT NOT NULL,
+                PRIMARY KEY (dispatch_id, pattern_id)
+            )"""
+        )
+        dpo_has_project = has_column_fn("dispatch_pattern_offered", "project_id")
+        for item in result.items:
+            _upsert_pattern_usage(db, item, now, project_id, pu_has_project)
+            _upsert_dispatch_pattern_offered(db, item, result.dispatch_id, now, project_id, dpo_has_project)
+            _stamp_source_dispatch_id(db, item, result.dispatch_id)
+        db.commit()
+    except sqlite3.Error as e:
+        logger.warning("Failed to record pattern usage: %s", e)
+
+
+def stamp_source_dispatch_ids(
+    result: "InjectionResult",
+    db: Optional[sqlite3.Connection],
+) -> int:
+    """Public injection-time stamping: append dispatch_id to source row JSON arrays."""
+    if not result.items or not result.dispatch_id or db is None:
+        return 0
+    stamped = 0
+    for item in result.items:
+        try:
+            if _stamp_source_dispatch_id(db, item, result.dispatch_id):
+                stamped += 1
+        except Exception:
+            continue
+    try:
+        db.commit()
+    except sqlite3.Error:
+        pass
+    return stamped
+
+
+def _upsert_pattern_usage(db, item, now, project_id, has_project):
+    pattern_hash = _item_hash(item.item_id)
+    if has_project:
+        db.execute(
+            """INSERT INTO pattern_usage
+                (pattern_id, pattern_title, pattern_hash, used_count,
+                 ignored_count, success_count, failure_count,
+                 last_offered, confidence, created_at, updated_at, project_id)
+               VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?, ?)
+               ON CONFLICT(pattern_id) DO UPDATE SET
+                pattern_title = excluded.pattern_title,
+                pattern_hash  = excluded.pattern_hash,
+                last_offered  = excluded.last_offered,
+                updated_at    = excluded.updated_at""",
+            (item.item_id, item.title[:255], pattern_hash, now, item.confidence, now, now, project_id),
+        )
+    else:
+        db.execute(
+            """INSERT INTO pattern_usage
+                (pattern_id, pattern_title, pattern_hash, used_count,
+                 ignored_count, success_count, failure_count,
+                 last_offered, confidence, created_at, updated_at)
+               VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?, ?)
+               ON CONFLICT(pattern_id) DO UPDATE SET
+                pattern_title = excluded.pattern_title,
+                pattern_hash  = excluded.pattern_hash,
+                last_offered  = excluded.last_offered,
+                updated_at    = excluded.updated_at""",
+            (item.item_id, item.title[:255], pattern_hash, now, item.confidence, now, now),
+        )
+
+
+def _upsert_dispatch_pattern_offered(db, item, dispatch_id, now, project_id, has_project):
+    if has_project:
+        db.execute(
+            """INSERT INTO dispatch_pattern_offered
+                (dispatch_id, pattern_id, pattern_title, offered_at, project_id)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET
+                offered_at = excluded.offered_at""",
+            (dispatch_id, item.item_id, item.title[:255], now, project_id),
+        )
+    else:
+        db.execute(
+            """INSERT INTO dispatch_pattern_offered
+                (dispatch_id, pattern_id, pattern_title, offered_at)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(dispatch_id, pattern_id) DO UPDATE SET
+                offered_at = excluded.offered_at""",
+            (dispatch_id, item.item_id, item.title[:255], now),
+        )
+
+
+def _stamp_source_dispatch_id(db, item, dispatch_id: str) -> bool:
+    """Append dispatch_id to source_dispatch_ids on the originating pattern row."""
+    if not dispatch_id:
+        return False
+    item_id = item.item_id or ""
+    if item.item_class == "proven_pattern" and item_id.startswith("intel_sp_"):
+        table, row_key = "success_patterns", item_id[len("intel_sp_"):]
+    elif item.item_class == "failure_prevention" and item_id.startswith("intel_ap_"):
+        table, row_key = "antipatterns", item_id[len("intel_ap_"):]
+    else:
+        return False
+    try:
+        row_id = int(row_key)
+    except (ValueError, TypeError):
+        return False
+    try:
+        row = db.execute(
+            f"SELECT source_dispatch_ids FROM {table} WHERE id = ?", (row_id,)
+        ).fetchone()
+    except sqlite3.Error:
+        return False
+    if row is None:
+        return False
+    existing_json = row["source_dispatch_ids"] if isinstance(row, sqlite3.Row) else row[0]
+    ids: List[str] = []
+    if existing_json:
+        try:
+            parsed = json.loads(existing_json)
+            if isinstance(parsed, list):
+                ids = [str(x) for x in parsed]
+        except (json.JSONDecodeError, TypeError):
+            ids = []
+    if dispatch_id in ids:
+        return True
+    ids.append(dispatch_id)
+    ids = ids[-20:]
+    try:
+        db.execute(
+            f"UPDATE {table} SET source_dispatch_ids = ? WHERE id = ?",
+            (json.dumps(ids), row_id),
+        )
+    except sqlite3.Error:
+        return False
+    return True

--- a/scripts/lib/intelligence_sources/adr_relevant.py
+++ b/scripts/lib/intelligence_sources/adr_relevant.py
@@ -1,0 +1,100 @@
+"""
+adr_relevant source — auto-match ADRs to touched files + schema section grounding.
+
+Two direct-injection item builders:
+  - build_adr_item: fetches relevant ADR sections via adr_indexer
+  - build_schema_section_item: fetches relevant CREATE TABLE blocks via schema_section_indexer
+
+Both produce IntelligenceItem with class 'adr_relevant' / 'schema_section', confidence 1.0.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ._common import (
+    MAX_CODE_ANCHOR_CHARS,
+    PATTERN_CATEGORY_CODE,
+    IntelligenceItem,
+    _now_utc,
+)
+
+try:
+    import adr_indexer as _adr_indexer
+except ImportError:
+    _adr_indexer = None  # type: ignore[assignment]
+
+try:
+    import schema_section_indexer as _schema_section_indexer
+except ImportError:
+    _schema_section_indexer = None  # type: ignore[assignment]
+
+
+def build_adr_item(
+    dispatch_id: str,
+    dispatch_paths: List[str],
+    now_ts: str,
+    max_chars: int = MAX_CODE_ANCHOR_CHARS,
+) -> Optional[IntelligenceItem]:
+    """Return an adr_relevant IntelligenceItem, or None when no ADRs match.
+
+    Delegates to adr_indexer.fetch_relevant_adrs. Returns None when the
+    indexer is unavailable or no ADRs are relevant to the dispatch paths.
+    """
+    if not dispatch_paths or _adr_indexer is None:
+        return None
+    relevant_adrs = _adr_indexer.fetch_relevant_adrs(dispatch_paths, max_chars=max_chars)
+    if not relevant_adrs:
+        return None
+    return IntelligenceItem(
+        item_id=f"intel_adr_{'_'.join(a.adr_id for a in relevant_adrs[:3])}",
+        item_class="adr_relevant",
+        title=f"Relevant ADRs for {len(dispatch_paths)} touched files",
+        content=_adr_indexer.format_adrs_section(relevant_adrs),
+        confidence=1.0,
+        evidence_count=len(relevant_adrs),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[a.adr_id for a in relevant_adrs],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )
+
+
+def build_schema_section_item(
+    dispatch_id: str,
+    dispatch_paths: List[str],
+    instruction_text: str,
+    now_ts: str,
+    max_chars: int = MAX_CODE_ANCHOR_CHARS,
+) -> Optional[IntelligenceItem]:
+    """Return a schema_section IntelligenceItem, or None when no schemas match.
+
+    Delegates to schema_section_indexer.fetch_relevant_schema_sections.
+    Pre-grounds the worker on actual CREATE TABLE / ALTER TABLE statements
+    so they don't need to grep schemas/ before acting.
+    """
+    if (not dispatch_paths and not instruction_text) or _schema_section_indexer is None:
+        return None
+    schema_sections = _schema_section_indexer.fetch_relevant_schema_sections(
+        dispatch_paths or [],
+        instruction_text or "",
+        max_chars=max_chars,
+    )
+    if not schema_sections:
+        return None
+    unique_tables = len({s.table_name for s in schema_sections})
+    return IntelligenceItem(
+        item_id=f"intel_ss_{dispatch_id}",
+        item_class="schema_section",
+        title=f"Schema sections for {unique_tables} touched table(s)",
+        content=_schema_section_indexer.format_schema_sections(schema_sections),
+        confidence=1.0,
+        evidence_count=len(schema_sections),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[f"{s.file_path}:{s.table_name}" for s in schema_sections],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )

--- a/scripts/lib/intelligence_sources/code_anchor.py
+++ b/scripts/lib/intelligence_sources/code_anchor.py
@@ -1,0 +1,150 @@
+"""
+code_anchor source — code-snippet grounding + operator memory + prior-round findings.
+
+Three direct-injection item builders that provide current-state grounding:
+  - build_prior_round_item: prior review gate findings for the current PR
+  - build_code_anchor_item: file:line snippets matching dispatch keywords
+  - build_operator_memory_item: curated operator lessons relevant to this dispatch
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ._common import (
+    MAX_CODE_ANCHOR_CHARS,
+    PATTERN_CATEGORY_CODE,
+    IntelligenceItem,
+)
+
+try:
+    import prior_round_injector as _prior_round_injector
+except ImportError:
+    _prior_round_injector = None  # type: ignore[assignment]
+
+try:
+    import code_anchor_finder as _code_anchor_finder
+except ImportError:
+    _code_anchor_finder = None  # type: ignore[assignment]
+
+try:
+    import operator_memory_indexer as _operator_memory_indexer
+except ImportError:
+    _operator_memory_indexer = None  # type: ignore[assignment]
+
+
+def build_prior_round_item(
+    pr_id: str,
+    dispatch_paths: List[str],
+    now_ts: str,
+    max_chars: int = MAX_CODE_ANCHOR_CHARS,
+) -> Optional[IntelligenceItem]:
+    """Return a prior_round_finding IntelligenceItem, or None when no findings exist.
+
+    Fetches prior review-gate findings for the given PR. Confidence is always
+    1.0 since these are direct evidence from a completed gate run.
+    """
+    if not pr_id or _prior_round_injector is None:
+        return None
+    prior_findings = _prior_round_injector.fetch_prior_findings(
+        pr_id,
+        dispatch_paths=dispatch_paths,
+        max_chars=max_chars,
+    )
+    if not prior_findings:
+        return None
+    return IntelligenceItem(
+        item_id=f"intel_prf_{pr_id}",
+        item_class="prior_round_finding",
+        title=f"Prior-round review findings on PR #{pr_id}",
+        content=_prior_round_injector.format_findings_section(prior_findings),
+        confidence=1.0,
+        evidence_count=len(prior_findings),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[f"pr-{pr_id}-{f.gate}" for f in prior_findings],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )
+
+
+def build_code_anchor_item(
+    dispatch_id: str,
+    dispatch_paths: List[str],
+    instruction_text: str,
+    now_ts: str,
+    max_chars: int = MAX_CODE_ANCHOR_CHARS,
+) -> Optional[IntelligenceItem]:
+    """Return a code_anchor IntelligenceItem, or None when no anchors match.
+
+    Extracts file:line snippets from dispatch_paths matching keywords in
+    instruction_text. Provides current-state grounding so workers don't
+    need to grep before acting.
+    """
+    if not dispatch_paths or not instruction_text or _code_anchor_finder is None:
+        return None
+    anchors = _code_anchor_finder.fetch_code_anchors(
+        dispatch_paths,
+        instruction_text,
+        max_chars=max_chars,
+    )
+    if not anchors:
+        return None
+    return IntelligenceItem(
+        item_id=f"intel_ca_{dispatch_id}",
+        item_class="code_anchor",
+        title=f"Code anchors for {len(dispatch_paths)} touched files",
+        content=_code_anchor_finder.format_code_anchors_section(anchors),
+        confidence=1.0,
+        evidence_count=len(anchors),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[
+            f"{a.file_path}:{a.line_start}-{a.line_end}" for a in anchors
+        ],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )
+
+
+def build_operator_memory_item(
+    dispatch_id: str,
+    skill_name: Optional[str],
+    dispatch_paths: List[str],
+    instruction_text: str,
+    now_ts: str,
+    max_chars: int = MAX_CODE_ANCHOR_CHARS,
+) -> Optional[IntelligenceItem]:
+    """Return an operator_memory IntelligenceItem, or None when no memories match.
+
+    Fetches curated operator lessons relevant to the current skill, paths,
+    and instruction text. Provides accumulated operator feedback so workers
+    inherit hard-won lessons without discovering them the hard way.
+    """
+    if not (skill_name or dispatch_paths or instruction_text):
+        return None
+    if _operator_memory_indexer is None:
+        return None
+    memories = _operator_memory_indexer.fetch_relevant_memories(
+        skill_name,
+        dispatch_paths,
+        instruction_text,
+        max_chars=max_chars,
+    )
+    if not memories:
+        return None
+    return IntelligenceItem(
+        item_id=f"intel_om_{dispatch_id}",
+        item_class="operator_memory",
+        title=f"Relevant operator memories ({len(memories)})",
+        content=_operator_memory_indexer.format_memories_section(memories),
+        confidence=1.0,
+        evidence_count=len(memories),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[m.name for m in memories],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )

--- a/scripts/lib/intelligence_sources/failure_prevention.py
+++ b/scripts/lib/intelligence_sources/failure_prevention.py
@@ -132,7 +132,8 @@ def _query_antipatterns(
             """,
             ap_scope_params,
         ).fetchall()
-    except Exception:
+    except Exception as exc:
+        logger.warning("failure_prevention antipatterns query failed: %s", exc)
         return items
     for row in rows:
         row_d = dict(row)
@@ -189,7 +190,8 @@ def _query_prevention_rules(
             """,
             pr_scope_params,
         ).fetchall()
-    except Exception:
+    except Exception as exc:
+        logger.warning("failure_prevention prevention_rules query failed: %s", exc)
         return items
     for row in rule_rows:
         row_d = dict(row)

--- a/scripts/lib/intelligence_sources/failure_prevention.py
+++ b/scripts/lib/intelligence_sources/failure_prevention.py
@@ -1,0 +1,309 @@
+"""
+failure_prevention source — antipattern evidence + prevention rules.
+
+Handles per-project DB query (antipatterns + prevention_rules tables),
+central DB query, and shadow comparison dispatch.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from typing import Callable, List, Optional
+
+from ._common import (
+    MAX_CONTENT_CHARS_PER_ITEM,
+    PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+    PATTERN_CATEGORY_PROCESS,
+    IntelligenceItem,
+    _content_hash,
+    _now_utc,
+    _project_scope_clause,
+    _scope_matches,
+    _stable_item_id,
+    _table_has_column,
+)
+try:
+    from project_scope import current_project_id
+except ImportError:
+    from project_scope import current_project_id  # type: ignore
+
+try:
+    import shadow_verifier as _shadow_verifier
+    import shadow_logger as _shadow_logger
+except ImportError:
+    _shadow_verifier = None  # type: ignore[assignment]
+    _shadow_logger = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+_FAILURE_PREVENTION_SQL_TEMPLATE = (
+    "SELECT id, title, description, severity, occurrence_count "
+    "FROM antipatterns "
+    "WHERE occurrence_count >= 1 "
+    "AND (valid_until IS NULL OR valid_until > datetime('now')) "
+    "ORDER BY occurrence_count DESC LIMIT 5"
+)
+
+_SEVERITY_CONFIDENCE = {"critical": 0.9, "high": 0.75, "medium": 0.6, "low": 0.5}
+
+
+def query_failure_prevention(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    *,
+    has_column_fn: Callable[[str, str], bool],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """3-state dispatcher: per-project | central | shadow (metric 3, antipatterns)."""
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _query_per_project(db, task_class, scope_tags, has_column_fn)
+    if flag == "1":
+        return _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    legacy = _query_per_project(db, task_class, scope_tags, has_column_fn)
+    central = _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    if _shadow_verifier is not None:
+        project_id = current_project_id()
+        try:
+            cmp = _shadow_verifier.compare(
+                [item.to_dict() for item in legacy],
+                [item.to_dict() for item in central],
+                project_id=project_id,
+                read_site="IntelligenceSelector._query_failure_prevention",
+                sql_template=_FAILURE_PREVENTION_SQL_TEMPLATE,
+                metric_id=3,
+            )
+            if cmp.divergences and _shadow_logger is not None:
+                _shadow_logger.write_comparison_result(
+                    cmp, project_id,
+                    "IntelligenceSelector._query_failure_prevention",
+                )
+        except Exception as e:
+            logger.debug("Shadow compare (failure_prevention) skipped: %s", e)
+    return legacy
+
+
+def _query_per_project(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    has_column_fn: Callable[[str, str], bool],
+) -> List[IntelligenceItem]:
+    """Query antipatterns and prevention_rules tables."""
+    items = _query_antipatterns(db, scope_tags, has_column_fn)
+    items += _query_prevention_rules(db, scope_tags, has_column_fn)
+    return items
+
+
+def _query_antipatterns(
+    db: sqlite3.Connection,
+    scope_tags: List[str],
+    has_column_fn: Callable[[str, str], bool],
+) -> List[IntelligenceItem]:
+    """Query antipatterns table for failure_prevention candidates."""
+    items: List[IntelligenceItem] = []
+    ap_scope_clause, ap_scope_params = _project_scope_clause(
+        has_column_fn("antipatterns", "project_id")
+    )
+    try:
+        rows = db.execute(
+            f"""
+            SELECT id, title, description, category, severity,
+                   why_problematic, better_alternative,
+                   occurrence_count, first_seen, last_seen
+            FROM antipatterns
+            WHERE occurrence_count >= 1
+              AND (valid_until IS NULL OR valid_until > datetime('now'))
+              {ap_scope_clause}
+            ORDER BY
+                CASE severity
+                    WHEN 'critical' THEN 4
+                    WHEN 'high' THEN 3
+                    WHEN 'medium' THEN 2
+                    WHEN 'low' THEN 1
+                    ELSE 0
+                END DESC,
+                occurrence_count DESC
+            LIMIT 5
+            """,
+            ap_scope_params,
+        ).fetchall()
+    except Exception:
+        return items
+    for row in rows:
+        row_d = dict(row)
+        category = row_d.get("category", "")
+        pattern_scope = [category] if category else []
+        if not _scope_matches(pattern_scope, scope_tags):
+            continue
+        content_parts = []
+        if row_d.get("why_problematic"):
+            content_parts.append(row_d["why_problematic"])
+        if row_d.get("better_alternative"):
+            content_parts.append(f"Instead: {row_d['better_alternative']}")
+        content = " ".join(content_parts)[:MAX_CONTENT_CHARS_PER_ITEM]
+        severity = row_d.get("severity", "medium")
+        confidence = _SEVERITY_CONFIDENCE.get(severity, 0.5)
+        ap_title = (row_d.get("title") or "Failure prevention")[:120]
+        items.append(IntelligenceItem(
+            item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
+            item_class="failure_prevention",
+            title=ap_title,
+            content=content,
+            confidence=confidence,
+            evidence_count=int(row_d.get("occurrence_count", 1)),
+            last_seen=row_d.get("last_seen") or row_d.get("first_seen") or _now_utc(),
+            scope_tags=pattern_scope,
+            source_refs=[f"antipattern_{row_d['id']}"],
+            task_class_filter=[],
+            pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+            content_hash=_content_hash(ap_title, content),
+        ))
+    return items
+
+
+def _query_prevention_rules(
+    db: sqlite3.Connection,
+    scope_tags: List[str],
+    has_column_fn: Callable[[str, str], bool],
+) -> List[IntelligenceItem]:
+    """Query prevention_rules table for failure_prevention candidates."""
+    items: List[IntelligenceItem] = []
+    pr_scope_clause, pr_scope_params = _project_scope_clause(
+        has_column_fn("prevention_rules", "project_id")
+    )
+    try:
+        rule_rows = db.execute(
+            f"""
+            SELECT id, tag_combination, rule_type, description,
+                   recommendation, confidence, triggered_count, last_triggered
+            FROM prevention_rules
+            WHERE (valid_until IS NULL OR valid_until > datetime('now'))
+              {pr_scope_clause}
+            ORDER BY confidence DESC
+            LIMIT 10
+            """,
+            pr_scope_params,
+        ).fetchall()
+    except Exception:
+        return items
+    for row in rule_rows:
+        row_d = dict(row)
+        tag_combo = row_d.get("tag_combination", "") or ""
+        if not tag_combo:
+            rule_scope: List[str] = []
+        else:
+            try:
+                parsed = json.loads(tag_combo)
+                rule_scope = parsed if isinstance(parsed, list) else (
+                    [str(parsed)] if parsed else []
+                )
+            except (json.JSONDecodeError, TypeError):
+                rule_scope = [t.strip() for t in tag_combo.split(",") if t.strip()]
+        if not _scope_matches(rule_scope, scope_tags):
+            continue
+        content = (row_d.get("recommendation") or row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
+        pr_title = (row_d.get("description") or "Prevention rule")[:120]
+        items.append(IntelligenceItem(
+            item_id=_stable_item_id("pr", str(row_d.get("id", ""))),
+            item_class="failure_prevention",
+            title=pr_title,
+            content=content,
+            confidence=float(row_d.get("confidence", 0.5)),
+            evidence_count=max(1, int(row_d.get("triggered_count", 1))),
+            last_seen=row_d.get("last_triggered") or _now_utc(),
+            scope_tags=rule_scope,
+            source_refs=[f"prevention_rule_{row_d['id']}"],
+            task_class_filter=[],
+            pattern_category=PATTERN_CATEGORY_PROCESS,
+            content_hash=_content_hash(pr_title, content),
+        ))
+    return items
+
+
+_CENTRAL_AP_COLS = (
+    "id, title, description, category, severity, "
+    "why_problematic, better_alternative, "
+    "occurrence_count, first_seen, last_seen"
+)
+_CENTRAL_AP_ORDER = (
+    "CASE severity WHEN 'critical' THEN 4 WHEN 'high' THEN 3 "
+    "WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC, "
+    "occurrence_count DESC"
+)
+_CENTRAL_AP_WHERE = (
+    "occurrence_count >= 1 AND (valid_until IS NULL OR valid_until > datetime('now'))"
+)
+
+
+def _central_row_to_item(row_d: dict, scope_tags: List[str]) -> Optional[IntelligenceItem]:
+    """Convert a central-DB antipatterns row dict to IntelligenceItem, or None if filtered."""
+    category = row_d.get("category", "")
+    pattern_scope = [category] if category else []
+    if not _scope_matches(pattern_scope, scope_tags):
+        return None
+    content_parts = []
+    if row_d.get("why_problematic"):
+        content_parts.append(row_d["why_problematic"])
+    if row_d.get("better_alternative"):
+        content_parts.append(f"Instead: {row_d['better_alternative']}")
+    content = " ".join(content_parts)[:MAX_CONTENT_CHARS_PER_ITEM]
+    severity = row_d.get("severity", "medium")
+    confidence = _SEVERITY_CONFIDENCE.get(severity, 0.5)
+    ap_title = (row_d.get("title") or "Failure prevention")[:120]
+    return IntelligenceItem(
+        item_id=_stable_item_id("ap", str(row_d.get("id", ""))),
+        item_class="failure_prevention",
+        title=ap_title,
+        content=content,
+        confidence=confidence,
+        evidence_count=int(row_d.get("occurrence_count", 1)),
+        last_seen=row_d.get("last_seen") or row_d.get("first_seen") or _now_utc(),
+        scope_tags=pattern_scope,
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+        content_hash=_content_hash(ap_title, content),
+    )
+
+
+def _query_central(
+    task_class: str,
+    scope_tags: List[str],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    *,
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """Query antipatterns from central DB (independent connection, project_id-scoped)."""
+    items: List[IntelligenceItem] = []
+    conn = central_conn_fn()
+    if conn is None:
+        return items
+    try:
+        project_id = (project_id_fn or current_project_id)()
+        has_project_id = _table_has_column(conn, "antipatterns", "project_id")
+        if has_project_id and project_id:
+            rows = conn.execute(
+                f"SELECT {_CENTRAL_AP_COLS} FROM antipatterns "
+                f"WHERE {_CENTRAL_AP_WHERE} AND project_id = ? "
+                f"ORDER BY {_CENTRAL_AP_ORDER} LIMIT 5",
+                (project_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                f"SELECT {_CENTRAL_AP_COLS} FROM antipatterns "
+                f"WHERE {_CENTRAL_AP_WHERE} "
+                f"ORDER BY {_CENTRAL_AP_ORDER} LIMIT 5"
+            ).fetchall()
+        for row in rows:
+            item = _central_row_to_item(dict(row), scope_tags)
+            if item is not None:
+                items.append(item)
+    except sqlite3.Error as e:
+        logger.debug("Central failure-prevention query failed: %s", e)
+    finally:
+        conn.close()
+    return items

--- a/scripts/lib/intelligence_sources/proven_pattern.py
+++ b/scripts/lib/intelligence_sources/proven_pattern.py
@@ -1,0 +1,304 @@
+"""
+proven_pattern source — success_patterns lookup + scoring.
+
+Handles per-project DB query, central DB query, and shadow comparison dispatch.
+Canonical-ID resolution and diversity/governance helpers live in _common.py.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from typing import Any, Callable, Dict, List, Optional
+
+from ._common import (
+    MAX_CONTENT_CHARS_PER_ITEM,
+    IntelligenceItem,
+    _content_hash,
+    _now_utc,
+    _project_scope_clause,
+    _scope_matches,
+    _short_content_hash,
+    _stable_item_id,
+    _table_has_column,
+    classify_pattern_category,
+)
+try:
+    from project_scope import current_project_id, project_filter_enabled
+except ImportError:
+    from project_scope import current_project_id, project_filter_enabled  # type: ignore
+
+try:
+    import shadow_verifier as _shadow_verifier
+    import shadow_logger as _shadow_logger
+except ImportError:
+    _shadow_verifier = None  # type: ignore[assignment]
+    _shadow_logger = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_canonical_id(db, short_hash, *, fallback_id, cache, has_content_hash_col, has_project_id_col=False, project_id=None):
+    """Return the canonical (smallest-id) row key for a given content hash."""
+    fallback_key = str(fallback_id) if fallback_id is not None else ""
+    if not short_hash or not has_content_hash_col:
+        return fallback_key
+    cache_key = (project_id, short_hash) if has_project_id_col else short_hash
+    if cache_key in cache:
+        return cache[cache_key]
+    try:
+        if has_project_id_col and project_filter_enabled():
+            row = db.execute("SELECT MIN(id) FROM success_patterns WHERE content_hash = ? AND project_id = ?", (short_hash, project_id)).fetchone()
+        else:
+            row = db.execute("SELECT MIN(id) FROM success_patterns WHERE content_hash = ?", (short_hash,)).fetchone()
+    except sqlite3.Error:
+        cache[cache_key] = fallback_key
+        return fallback_key
+    canonical_id = row[0] if row is not None else None
+    if canonical_id is None:
+        cache[cache_key] = fallback_key
+        return fallback_key
+    canonical_key = str(canonical_id)
+    cache[cache_key] = canonical_key
+    return canonical_key
+
+
+def _fetch_canonical_row(db, canonical_id, *, select_cols):
+    """Fetch the canonical row's data after a duplicate-remap lookup."""
+    if canonical_id in (None, ""):
+        return None
+    try:
+        row = db.execute(f"SELECT {select_cols} FROM success_patterns WHERE id = ?", (canonical_id,)).fetchone()
+    except sqlite3.Error:
+        return None
+    return dict(row) if row is not None else None
+
+
+_PROVEN_PATTERNS_SQL_TEMPLATE = (
+    "SELECT id, title, description, confidence_score, usage_count "
+    "FROM success_patterns "
+    "WHERE (valid_until IS NULL OR valid_until > datetime('now')) "
+    "ORDER BY confidence_score DESC LIMIT 20"
+)
+
+
+def query_proven_patterns(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    *,
+    has_column_fn: Callable[[str, str], bool],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    reconcile_fn: Callable[[], None],
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """3-state dispatcher: per-project | central | shadow (metric 3, success_patterns)."""
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _query_per_project(db, task_class, scope_tags, has_column_fn, reconcile_fn)
+    if flag == "1":
+        return _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    legacy = _query_per_project(db, task_class, scope_tags, has_column_fn, reconcile_fn)
+    central = _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    _maybe_shadow_compare(legacy, central, task_class)
+    return legacy
+
+
+def _maybe_shadow_compare(legacy, central, task_class):
+    if _shadow_verifier is None:
+        return
+    project_id = current_project_id()
+    try:
+        cmp = _shadow_verifier.compare(
+            [item.to_dict() for item in legacy],
+            [item.to_dict() for item in central],
+            project_id=project_id,
+            read_site="IntelligenceSelector._query_proven_patterns",
+            sql_template=_PROVEN_PATTERNS_SQL_TEMPLATE,
+            metric_id=3,
+        )
+        if cmp.divergences and _shadow_logger is not None:
+            _shadow_logger.write_comparison_result(
+                cmp, project_id, "IntelligenceSelector._query_proven_patterns",
+            )
+    except Exception as e:
+        logger.debug("Shadow compare (proven_patterns) skipped: %s", e)
+
+
+def _query_per_project(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    has_column_fn: Callable[[str, str], bool],
+    reconcile_fn: Callable[[], None],
+) -> List[IntelligenceItem]:
+    """Query success_patterns from the per-project DB."""
+    reconcile_fn()
+    items: List[IntelligenceItem] = []
+    has_pattern_cat = has_column_fn("success_patterns", "pattern_category")
+    has_content_hash_col = has_column_fn("success_patterns", "content_hash")
+    has_project_id_col = has_column_fn("success_patterns", "project_id")
+    select_cols = (
+        "id, title, description, category, confidence_score, "
+        "usage_count, source_dispatch_ids, first_seen, last_used"
+    )
+    if has_pattern_cat:
+        select_cols += ", pattern_category"
+    if has_content_hash_col:
+        select_cols += ", content_hash"
+    if has_project_id_col:
+        select_cols += ", project_id"
+    scope_clause, scope_params = _project_scope_clause(has_project_id_col)
+    active_project_id = current_project_id() if has_project_id_col else None
+    try:
+        rows = db.execute(
+            f"""SELECT {select_cols} FROM success_patterns
+            WHERE (valid_until IS NULL OR valid_until > datetime('now'))
+              {scope_clause}
+            ORDER BY confidence_score DESC LIMIT 20""",
+            scope_params,
+        ).fetchall()
+    except Exception:
+        return items
+    canonical_cache: Dict[Any, Any] = {}
+    for row in rows:
+        item = _per_project_row_to_item(
+            row, scope_tags, select_cols, db,
+            has_content_hash_col, has_project_id_col, active_project_id, canonical_cache,
+        )
+        if item is not None:
+            items.append(item)
+    return items
+
+
+def _per_project_row_to_item(
+    row: Any, scope_tags: List[str], select_cols: str, db: sqlite3.Connection,
+    has_content_hash_col: bool, has_project_id_col: bool,
+    active_project_id: Optional[str], canonical_cache: Dict[Any, Any],
+) -> Optional[IntelligenceItem]:
+    """Convert a per-project success_patterns row to IntelligenceItem."""
+    row_d = dict(row)
+    category = row_d.get("category", "")
+    if not _scope_matches([category] if category else [], scope_tags):
+        return None
+    title = (row_d.get("title") or "Proven pattern")[:120]
+    content = (row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
+    stored_short_hash = row_d.get("content_hash") if has_content_hash_col else None
+    short_hash = stored_short_hash or _short_content_hash(title, content)
+    row_project_id = row_d.get("project_id") if has_project_id_col else None
+    canonical_key = _resolve_canonical_id(
+        db, short_hash, fallback_id=row_d.get("id"), cache=canonical_cache,
+        has_content_hash_col=has_content_hash_col, has_project_id_col=has_project_id_col,
+        project_id=row_project_id or active_project_id,
+    )
+    canonical_row_d = row_d
+    if canonical_key and canonical_key != str(row_d.get("id") or ""):
+        fetched = _fetch_canonical_row(db, canonical_key, select_cols=select_cols)
+        if fetched is not None:
+            canonical_row_d = fetched
+    canonical_category = canonical_row_d.get("category", "") or ""
+    if not _scope_matches([canonical_category] if canonical_category else [], scope_tags):
+        return None
+    source_refs = []
+    if canonical_row_d.get("source_dispatch_ids"):
+        try:
+            import json
+            source_refs = json.loads(canonical_row_d["source_dispatch_ids"])
+        except (ValueError, TypeError):
+            pass
+    canonical_title = (canonical_row_d.get("title") or title)[:120]
+    canonical_content = (canonical_row_d.get("description") or content)[:MAX_CONTENT_CHARS_PER_ITEM]
+    last_seen = canonical_row_d.get("last_used") or canonical_row_d.get("first_seen") or _now_utc()
+    stored_cat = canonical_row_d.get("pattern_category")
+    pattern_category = stored_cat or classify_pattern_category(canonical_title, canonical_content)
+    return IntelligenceItem(
+        item_id=_stable_item_id("sp", canonical_key),
+        item_class="proven_pattern",
+        title=canonical_title,
+        content=canonical_content,
+        confidence=float(canonical_row_d.get("confidence_score", 0.0)),
+        evidence_count=int(canonical_row_d.get("usage_count", 0)),
+        last_seen=last_seen,
+        scope_tags=[canonical_category] if canonical_category else [],
+        source_refs=source_refs[:5],
+        task_class_filter=[],
+        pattern_category=pattern_category,
+        content_hash=_content_hash(canonical_title, canonical_content),
+    )
+
+
+def _query_central(
+    task_class: str,
+    scope_tags: List[str],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    *,
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """Query success_patterns from central DB (independent connection, project-scoped)."""
+    items: List[IntelligenceItem] = []
+    conn = central_conn_fn()
+    if conn is None:
+        return items
+    try:
+        project_id = (project_id_fn or current_project_id)()
+        has_pattern_cat = _table_has_column(conn, "success_patterns", "pattern_category")
+        has_content_hash_col = _table_has_column(conn, "success_patterns", "content_hash")
+        has_project_id_col = _table_has_column(conn, "success_patterns", "project_id")
+        select_cols = (
+            "id, title, description, category, confidence_score, "
+            "usage_count, source_dispatch_ids, first_seen, last_used"
+        )
+        if has_pattern_cat:
+            select_cols += ", pattern_category"
+        if has_content_hash_col:
+            select_cols += ", content_hash"
+        if has_project_id_col:
+            select_cols += ", project_id"
+        if has_project_id_col and project_id:
+            rows = conn.execute(
+                f"""SELECT {select_cols} FROM success_patterns
+                WHERE (valid_until IS NULL OR valid_until > datetime('now'))
+                  AND project_id = ?
+                ORDER BY confidence_score DESC LIMIT 20""",
+                (project_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                f"""SELECT {select_cols} FROM success_patterns
+                WHERE (valid_until IS NULL OR valid_until > datetime('now'))
+                ORDER BY confidence_score DESC LIMIT 20"""
+            ).fetchall()
+        for row in rows:
+            item = _central_row_to_item(row, scope_tags)
+            if item is not None:
+                items.append(item)
+    except sqlite3.Error as e:
+        logger.debug("Central proven-patterns query failed: %s", e)
+    finally:
+        conn.close()
+    return items
+
+
+def _central_row_to_item(row: Any, scope_tags: List[str]) -> Optional[IntelligenceItem]:
+    """Convert a central-DB success_patterns row to IntelligenceItem (no canonical remap)."""
+    row_d = dict(row)
+    category = row_d.get("category", "")
+    if not _scope_matches([category] if category else [], scope_tags):
+        return None
+    title = (row_d.get("title") or "Proven pattern")[:120]
+    content = (row_d.get("description") or "")[:MAX_CONTENT_CHARS_PER_ITEM]
+    stored_cat = row_d.get("pattern_category")
+    pattern_category = stored_cat or classify_pattern_category(title, content)
+    return IntelligenceItem(
+        item_id=_stable_item_id("sp", str(row_d.get("id", ""))),
+        item_class="proven_pattern",
+        title=title,
+        content=content,
+        confidence=float(row_d.get("confidence_score", 0.0)),
+        evidence_count=int(row_d.get("usage_count", 0)),
+        last_seen=row_d.get("last_used") or row_d.get("first_seen") or _now_utc(),
+        scope_tags=[category] if category else [],
+        task_class_filter=[],
+        pattern_category=pattern_category,
+        content_hash=_content_hash(title, content),
+    )

--- a/scripts/lib/intelligence_sources/proven_pattern.py
+++ b/scripts/lib/intelligence_sources/proven_pattern.py
@@ -158,7 +158,8 @@ def _query_per_project(
             ORDER BY confidence_score DESC LIMIT 20""",
             scope_params,
         ).fetchall()
-    except Exception:
+    except Exception as exc:
+        logger.warning("proven_pattern per-project query failed: %s", exc)
         return items
     canonical_cache: Dict[Any, Any] = {}
     for row in rows:

--- a/scripts/lib/intelligence_sources/recent_comparable.py
+++ b/scripts/lib/intelligence_sources/recent_comparable.py
@@ -115,7 +115,8 @@ def _query_per_project(
             """,
             (cutoff, *dm_scope_params),
         ).fetchall()
-    except Exception:
+    except Exception as exc:
+        logger.warning("recent_comparable per-project query failed: %s", exc)
         return items
     for row in rows:
         item = _row_to_intelligence_item(row, scope_tags)

--- a/scripts/lib/intelligence_sources/recent_comparable.py
+++ b/scripts/lib/intelligence_sources/recent_comparable.py
@@ -1,0 +1,218 @@
+"""
+recent_comparable source — recent dispatch similarity ranking.
+
+Queries dispatch_metadata to surface recently successful/failed dispatches
+that share skill, gate, or track context with the current dispatch.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Callable, List, Optional
+
+from ._common import (
+    MAX_CONTENT_CHARS_PER_ITEM,
+    PATTERN_CATEGORY_PROCESS,
+    RECENT_COMPARABLE_DAYS,
+    IntelligenceItem,
+    _content_hash,
+    _now_utc,
+    _project_scope_clause,
+    _scope_matches,
+    _stable_item_id,
+    _table_has_column,
+)
+try:
+    from project_scope import current_project_id
+except ImportError:
+    from project_scope import current_project_id  # type: ignore
+
+try:
+    import shadow_verifier as _shadow_verifier
+    import shadow_logger as _shadow_logger
+except ImportError:
+    _shadow_verifier = None  # type: ignore[assignment]
+    _shadow_logger = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+_RECENT_COMPARABLE_SQL_TEMPLATE = (
+    "SELECT dispatch_id, terminal, track, role, skill_name, gate, "
+    "outcome_status, dispatched_at "
+    "FROM dispatch_metadata "
+    "WHERE dispatched_at >= ? AND outcome_status IS NOT NULL "
+    "ORDER BY dispatched_at DESC LIMIT 20"
+)
+
+
+def query_recent_comparable(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    *,
+    has_column_fn: Callable[[str, str], bool],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """3-state dispatcher: per-project | central | shadow (metric 4, dispatch_metadata)."""
+    flag = os.environ.get("VNX_USE_CENTRAL_DB", "")
+    if flag == "":
+        return _query_per_project(db, task_class, scope_tags, has_column_fn)
+    if flag == "1":
+        return _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    legacy = _query_per_project(db, task_class, scope_tags, has_column_fn)
+    central = _query_central(task_class, scope_tags, central_conn_fn, project_id_fn=project_id_fn)
+    if _shadow_verifier is not None:
+        project_id = current_project_id()
+        try:
+            cmp = _shadow_verifier.compare(
+                [item.to_dict() for item in legacy],
+                [item.to_dict() for item in central],
+                project_id=project_id,
+                read_site="IntelligenceSelector._query_recent_comparable",
+                sql_template=_RECENT_COMPARABLE_SQL_TEMPLATE,
+                metric_id=4,
+                table="dispatch_metadata",
+            )
+            if cmp.divergences and _shadow_logger is not None:
+                _shadow_logger.write_comparison_result(
+                    cmp, project_id,
+                    "IntelligenceSelector._query_recent_comparable",
+                )
+        except Exception as e:
+            logger.debug("Shadow compare (recent_comparable) skipped: %s", e)
+    return legacy
+
+
+def _query_per_project(
+    db: sqlite3.Connection,
+    task_class: str,
+    scope_tags: List[str],
+    has_column_fn: Callable[[str, str], bool],
+) -> List[IntelligenceItem]:
+    """Query dispatch_metadata for recent_comparable candidates."""
+    items: List[IntelligenceItem] = []
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)
+    ).isoformat()
+    dm_scope_clause, dm_scope_params = _project_scope_clause(
+        has_column_fn("dispatch_metadata", "project_id")
+    )
+    try:
+        rows = db.execute(
+            f"""
+            SELECT dispatch_id, terminal, track, role, skill_name, gate,
+                   outcome_status, dispatched_at, pattern_count,
+                   prevention_rule_count
+            FROM dispatch_metadata
+            WHERE dispatched_at >= ?
+              AND outcome_status IS NOT NULL
+              {dm_scope_clause}
+            ORDER BY dispatched_at DESC
+            LIMIT 20
+            """,
+            (cutoff, *dm_scope_params),
+        ).fetchall()
+    except Exception:
+        return items
+    for row in rows:
+        item = _row_to_intelligence_item(row, scope_tags)
+        if item is not None:
+            items.append(item)
+    return items
+
+
+def _row_to_intelligence_item(
+    row: object,
+    scope_tags: List[str],
+) -> Optional[IntelligenceItem]:
+    """Convert a dispatch_metadata row to IntelligenceItem, or None if filtered out."""
+    row_d = dict(row)  # type: ignore[call-overload]
+    dispatch_scope = []
+    if row_d.get("skill_name"):
+        dispatch_scope.append(row_d["skill_name"])
+    if row_d.get("gate"):
+        dispatch_scope.append(row_d["gate"])
+    if row_d.get("track"):
+        dispatch_scope.append(f"Track-{row_d['track']}")
+    if not _scope_matches(dispatch_scope, scope_tags):
+        return None
+    outcome = row_d.get("outcome_status", "unknown")
+    skill = row_d.get("skill_name") or row_d.get("role") or "unknown"
+    gate = row_d.get("gate") or ""
+    content = (
+        f"Dispatch {row_d['dispatch_id']} ({skill}, {gate}) "
+        f"completed with status: {outcome}. "
+        f"Patterns used: {row_d.get('pattern_count', 0)}, "
+        f"Prevention rules: {row_d.get('prevention_rule_count', 0)}."
+    )[:MAX_CONTENT_CHARS_PER_ITEM]
+    confidence = 0.7 if outcome == "success" else 0.45
+    dm_title = f"Recent: {skill} dispatch ({outcome})"[:120]
+    return IntelligenceItem(
+        item_id=_stable_item_id("dm", str(row_d.get("dispatch_id", ""))),
+        item_class="recent_comparable",
+        title=dm_title,
+        content=content,
+        confidence=confidence,
+        evidence_count=1,
+        last_seen=row_d.get("dispatched_at") or _now_utc(),
+        scope_tags=dispatch_scope,
+        source_refs=[row_d["dispatch_id"]],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_PROCESS,
+        content_hash=_content_hash(dm_title, content),
+    )
+
+
+def _query_central(
+    task_class: str,
+    scope_tags: List[str],
+    central_conn_fn: Callable[[], Optional[sqlite3.Connection]],
+    *,
+    project_id_fn: Optional[Callable[[], Optional[str]]] = None,
+) -> List[IntelligenceItem]:
+    """Query dispatch_metadata from central DB (independent connection, project_id-scoped)."""
+    items: List[IntelligenceItem] = []
+    conn = central_conn_fn()
+    if conn is None:
+        return items
+    try:
+        project_id = (project_id_fn or current_project_id)()
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)
+        ).isoformat()
+        has_project_id = _table_has_column(conn, "dispatch_metadata", "project_id")
+        if has_project_id and project_id:
+            rows = conn.execute(
+                """SELECT dispatch_id, terminal, track, role, skill_name, gate,
+                       outcome_status, dispatched_at, pattern_count,
+                       prevention_rule_count
+                FROM dispatch_metadata
+                WHERE dispatched_at >= ?
+                  AND outcome_status IS NOT NULL
+                  AND project_id = ?
+                ORDER BY dispatched_at DESC LIMIT 20""",
+                (cutoff, project_id),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT dispatch_id, terminal, track, role, skill_name, gate,
+                       outcome_status, dispatched_at, pattern_count,
+                       prevention_rule_count
+                FROM dispatch_metadata
+                WHERE dispatched_at >= ?
+                  AND outcome_status IS NOT NULL
+                ORDER BY dispatched_at DESC LIMIT 20""",
+                (cutoff,),
+            ).fetchall()
+        for row in rows:
+            item = _row_to_intelligence_item(row, scope_tags)
+            if item is not None:
+                items.append(item)
+    except sqlite3.Error as e:
+        logger.debug("Central recent-comparable query failed: %s", e)
+    finally:
+        conn.close()
+    return items

--- a/tests/test_intelligence_selector_exception_handling.py
+++ b/tests/test_intelligence_selector_exception_handling.py
@@ -2,10 +2,8 @@
 """
 Regression tests for exception-handling hardening in intelligence_selector.py (OI-1437).
 
-Covers the 10 silent-except sites narrowed in the cleanup PR: every broad
-``except Exception: pass`` is now narrowed and logged. These tests verify
-that (a) the selector runs cleanly in a default env, and (b) DB errors surface
-as log messages instead of being swallowed silently.
+Updated for the per-source module split: internal query methods moved to
+intelligence_sources submodules, so tests now reach them directly.
 """
 
 from __future__ import annotations
@@ -62,6 +60,13 @@ def _make_result(dispatch_id: str = "test-dispatch-001") -> InjectionResult:
     )
 
 
+def _broken_central_conn() -> MagicMock:
+    conn = MagicMock(spec=sqlite3.Connection)
+    conn.execute.side_effect = sqlite3.OperationalError("no such table: success_patterns")
+    conn.close = MagicMock()
+    return conn
+
+
 class TestRunsCleanInDefaultEnv(unittest.TestCase):
     """Selector constructs and select() runs without unhandled exceptions."""
 
@@ -84,7 +89,7 @@ class TestRunsCleanInDefaultEnv(unittest.TestCase):
 
 
 class TestCorruptStateLogsWarning(unittest.TestCase):
-    """record_injection with a broken DB logs a warning instead of crashing."""
+    """record_injection with a broken DB logs instead of crashing."""
 
     def test_corrupt_db_logs_warning(self) -> None:
         """sqlite3.Error during injection audit write surfaces as log.warning."""
@@ -92,11 +97,10 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
             sel = _make_selector(tmp)
             result = _make_result()
 
-            # Patch runtime_coordination.get_connection to raise sqlite3.Error
             import runtime_coordination as _rc
             with (
                 patch.object(_rc, "get_connection", side_effect=sqlite3.OperationalError("db locked")),
-                self.assertLogs("intelligence_selector", level="WARNING") as cm,
+                self.assertLogs("intelligence_sources._recording", level="WARNING") as cm,
             ):
                 sel.record_injection(result)
 
@@ -104,7 +108,7 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
             self.assertIn("Failed to record injection audit", logged)
 
     def test_stamp_source_ids_db_error_logs_debug(self) -> None:
-        """sqlite3.Error in stamp_source_dispatch_ids is caught and logged at DEBUG."""
+        """sqlite3.Error in _stamp is caught and logged at DEBUG by intelligence_selector."""
         from contextlib import contextmanager
 
         @contextmanager
@@ -119,9 +123,10 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
             result = _make_result()
 
             import runtime_coordination as _rc
+            import intelligence_selector as _is_mod
             with (
                 patch.object(_rc, "get_connection", side_effect=_noop_conn),
-                patch.object(sel, "stamp_source_dispatch_ids", side_effect=sqlite3.OperationalError("locked")),
+                patch.object(_is_mod, "_stamp", side_effect=sqlite3.OperationalError("locked")),
                 self.assertLogs("intelligence_selector", level="DEBUG") as cm,
             ):
                 sel.record_injection(result)
@@ -131,98 +136,131 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
 
 
 class TestCentralDbQueryExceptionSilenced(unittest.TestCase):
-    """Central DB query methods catch sqlite3.Error and return empty list."""
-
-    def _broken_conn(self) -> MagicMock:
-        conn = MagicMock(spec=sqlite3.Connection)
-        conn.execute.side_effect = sqlite3.OperationalError("no such table: success_patterns")
-        conn.close = MagicMock()
-        return conn
+    """Central DB query functions catch sqlite3.Error and return empty list."""
 
     def test_proven_patterns_central_db_error_returns_empty(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
-                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
-                    items = sel._query_proven_patterns_central("backend-developer", [])
-            self.assertEqual(items, [])
-            self.assertTrue(any("proven-patterns" in line for line in cm.output))
+        from intelligence_sources.proven_pattern import _query_central
+        with self.assertLogs("intelligence_sources.proven_pattern", level="DEBUG") as cm:
+            items = _query_central(
+                "backend-developer", [],
+                lambda: _broken_central_conn(),
+                project_id_fn=lambda: None,
+            )
+        self.assertEqual(items, [])
+        self.assertTrue(any("proven-patterns" in line for line in cm.output))
 
     def test_failure_prevention_central_db_error_returns_empty(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
-                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
-                    items = sel._query_failure_prevention_central("backend-developer", [])
-            self.assertEqual(items, [])
-            self.assertTrue(any("failure-prevention" in line for line in cm.output))
+        from intelligence_sources.failure_prevention import _query_central
+        with self.assertLogs("intelligence_sources.failure_prevention", level="DEBUG") as cm:
+            items = _query_central(
+                "backend-developer", [],
+                lambda: _broken_central_conn(),
+                project_id_fn=lambda: None,
+            )
+        self.assertEqual(items, [])
+        self.assertTrue(any("failure-prevention" in line for line in cm.output))
 
     def test_recent_comparable_central_db_error_returns_empty(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            with patch.object(sel, "_get_central_qi_conn", return_value=self._broken_conn()):
-                with self.assertLogs("intelligence_selector", level="DEBUG") as cm:
-                    items = sel._query_recent_comparable_central("backend-developer", [])
-            self.assertEqual(items, [])
-            self.assertTrue(any("recent-comparable" in line for line in cm.output))
+        from intelligence_sources.recent_comparable import _query_central
+        with self.assertLogs("intelligence_sources.recent_comparable", level="DEBUG") as cm:
+            items = _query_central(
+                "backend-developer", [],
+                lambda: _broken_central_conn(),
+                project_id_fn=lambda: None,
+            )
+        self.assertEqual(items, [])
+        self.assertTrue(any("recent-comparable" in line for line in cm.output))
 
 
 class TestShadowVerifierExceptionSilenced(unittest.TestCase):
     """Shadow compare exceptions are caught and logged at DEBUG, not raised."""
 
+    def _make_per_project_db(self) -> sqlite3.Connection:
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.executescript("""
+            CREATE TABLE success_patterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT, description TEXT, category TEXT,
+                confidence_score REAL DEFAULT 0.0, usage_count INTEGER DEFAULT 0,
+                source_dispatch_ids TEXT, first_seen DATETIME, last_used DATETIME,
+                valid_until DATETIME DEFAULT NULL
+            );
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+                role TEXT, skill_name TEXT, gate TEXT,
+                outcome_status TEXT, dispatched_at DATETIME,
+                pattern_count INTEGER DEFAULT 0, prevention_rule_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE antipatterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT, description TEXT, category TEXT,
+                severity TEXT DEFAULT 'medium', occurrence_count INTEGER DEFAULT 0,
+                why_problematic TEXT, better_alternative TEXT,
+                first_seen DATETIME, last_seen DATETIME,
+                valid_until DATETIME DEFAULT NULL
+            );
+        """)
+        return db
+
     def test_shadow_proven_patterns_exception_logged(self) -> None:
-        import intelligence_selector as _mod
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            broken_verifier = MagicMock()
-            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
-            quality_db = sqlite3.connect(":memory:")
-            with (
-                patch.object(_mod, "_shadow_verifier", broken_verifier),
-                patch.object(sel, "_query_proven_patterns_per_project", return_value=[]),
-                patch.object(sel, "_query_proven_patterns_central", return_value=[]),
-                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
-                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
-            ):
-                result = sel._query_proven_patterns(quality_db, "backend-developer", [])
-            self.assertEqual(result, [])
-            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+        import intelligence_sources.proven_pattern as _mod
+        db = self._make_per_project_db()
+        broken_verifier = MagicMock()
+        broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+        with (
+            patch.object(_mod, "_shadow_verifier", broken_verifier),
+            patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+            self.assertLogs("intelligence_sources.proven_pattern", level="DEBUG") as cm,
+        ):
+            result = _mod.query_proven_patterns(
+                db, "backend-developer", [],
+                has_column_fn=lambda t, c: False,
+                central_conn_fn=lambda: None,
+                reconcile_fn=lambda: None,
+            )
+        db.close()
+        self.assertEqual(result, [])
+        self.assertTrue(any("Shadow compare" in line for line in cm.output))
 
     def test_shadow_failure_prevention_exception_logged(self) -> None:
-        import intelligence_selector as _mod
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            broken_verifier = MagicMock()
-            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
-            quality_db = sqlite3.connect(":memory:")
-            with (
-                patch.object(_mod, "_shadow_verifier", broken_verifier),
-                patch.object(sel, "_query_failure_prevention_per_project", return_value=[]),
-                patch.object(sel, "_query_failure_prevention_central", return_value=[]),
-                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
-                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
-            ):
-                result = sel._query_failure_prevention(quality_db, "backend-developer", [])
-            self.assertEqual(result, [])
-            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+        import intelligence_sources.failure_prevention as _mod
+        db = self._make_per_project_db()
+        broken_verifier = MagicMock()
+        broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+        with (
+            patch.object(_mod, "_shadow_verifier", broken_verifier),
+            patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+            self.assertLogs("intelligence_sources.failure_prevention", level="DEBUG") as cm,
+        ):
+            result = _mod.query_failure_prevention(
+                db, "backend-developer", [],
+                has_column_fn=lambda t, c: False,
+                central_conn_fn=lambda: None,
+            )
+        db.close()
+        self.assertEqual(result, [])
+        self.assertTrue(any("Shadow compare" in line for line in cm.output))
 
     def test_shadow_recent_comparable_exception_logged(self) -> None:
-        import intelligence_selector as _mod
-        with tempfile.TemporaryDirectory() as tmp:
-            sel = _make_selector(tmp)
-            broken_verifier = MagicMock()
-            broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
-            quality_db = sqlite3.connect(":memory:")
-            with (
-                patch.object(_mod, "_shadow_verifier", broken_verifier),
-                patch.object(sel, "_query_recent_comparable_per_project", return_value=[]),
-                patch.object(sel, "_query_recent_comparable_central", return_value=[]),
-                patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
-                self.assertLogs("intelligence_selector", level="DEBUG") as cm,
-            ):
-                result = sel._query_recent_comparable(quality_db, "backend-developer", [])
-            self.assertEqual(result, [])
-            self.assertTrue(any("Shadow compare" in line for line in cm.output))
+        import intelligence_sources.recent_comparable as _mod
+        db = self._make_per_project_db()
+        broken_verifier = MagicMock()
+        broken_verifier.compare.side_effect = RuntimeError("shadow verifier exploded")
+        with (
+            patch.object(_mod, "_shadow_verifier", broken_verifier),
+            patch.dict("os.environ", {"VNX_USE_CENTRAL_DB": "shadow"}),
+            self.assertLogs("intelligence_sources.recent_comparable", level="DEBUG") as cm,
+        ):
+            result = _mod.query_recent_comparable(
+                db, "backend-developer", [],
+                has_column_fn=lambda t, c: False,
+                central_conn_fn=lambda: None,
+            )
+        db.close()
+        self.assertEqual(result, [])
+        self.assertTrue(any("Shadow compare" in line for line in cm.output))
 
 
 if __name__ == "__main__":

--- a/tests/test_intelligence_sources/test_adr_relevant.py
+++ b/tests/test_intelligence_sources/test_adr_relevant.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Tests for intelligence_sources/adr_relevant.py"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources.adr_relevant import build_adr_item, build_schema_section_item
+from intelligence_sources._common import PATTERN_CATEGORY_CODE
+
+
+class _MockADR:
+    def __init__(self, adr_id, title, content):
+        self.adr_id = adr_id
+        self.title = title
+        self.content = content
+
+
+class _MockSchemaSection:
+    def __init__(self, table_name, file_path, sql):
+        self.table_name = table_name
+        self.file_path = file_path
+        self.sql = sql
+
+
+class TestBuildAdrItem(unittest.TestCase):
+    def test_returns_none_when_no_paths(self):
+        item = build_adr_item("d-001", [], "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_indexer_unavailable(self):
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = None
+        try:
+            item = build_adr_item("d-001", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._adr_indexer = original
+
+    def test_returns_none_when_no_matching_adrs(self):
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = []
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._adr_indexer = original
+
+    def test_returns_item_when_adrs_match(self):
+        adr = _MockADR("ADR-001", "Use SQLite", "Use SQLite for persistence.")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = [adr]
+        mock_indexer.format_adrs_section.return_value = "## ADR-001\nUse SQLite"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertIsNotNone(item)
+            self.assertEqual(item.item_class, "adr_relevant")
+        finally:
+            _mod._adr_indexer = original
+
+    def test_item_has_high_confidence(self):
+        adr = _MockADR("ADR-002", "ADR title", "ADR content.")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = [adr]
+        mock_indexer.format_adrs_section.return_value = "## ADR-002"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertEqual(item.confidence, 1.0)
+        finally:
+            _mod._adr_indexer = original
+
+    def test_source_refs_contain_adr_ids(self):
+        adrs = [_MockADR("ADR-001", "T1", "C1"), _MockADR("ADR-002", "T2", "C2")]
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = adrs
+        mock_indexer.format_adrs_section.return_value = "ADR content"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertIn("ADR-001", item.source_refs)
+            self.assertIn("ADR-002", item.source_refs)
+        finally:
+            _mod._adr_indexer = original
+
+    def test_evidence_count_equals_adr_count(self):
+        adrs = [_MockADR(f"ADR-{i}", f"T{i}", f"C{i}") for i in range(3)]
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = adrs
+        mock_indexer.format_adrs_section.return_value = "ADR content"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["f.py"], "2026-01-01T00:00:00Z")
+            self.assertEqual(item.evidence_count, 3)
+        finally:
+            _mod._adr_indexer = original
+
+    def test_pattern_category_is_code(self):
+        adr = _MockADR("ADR-001", "T", "C")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_adrs.return_value = [adr]
+        mock_indexer.format_adrs_section.return_value = "C"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._adr_indexer
+        _mod._adr_indexer = mock_indexer
+        try:
+            item = build_adr_item("d-001", ["f.py"], "2026-01-01T00:00:00Z")
+            self.assertEqual(item.pattern_category, PATTERN_CATEGORY_CODE)
+        finally:
+            _mod._adr_indexer = original
+
+
+class TestBuildSchemaSectionItem(unittest.TestCase):
+    def test_returns_none_when_no_paths_and_no_text(self):
+        item = build_schema_section_item("d-001", [], "", "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_indexer_unavailable(self):
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._schema_section_indexer
+        _mod._schema_section_indexer = None
+        try:
+            item = build_schema_section_item("d-001", ["schemas/foo.sql"], "CREATE TABLE", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._schema_section_indexer = original
+
+    def test_returns_none_when_no_sections_match(self):
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_schema_sections.return_value = []
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._schema_section_indexer
+        _mod._schema_section_indexer = mock_indexer
+        try:
+            item = build_schema_section_item("d-001", ["schemas/foo.sql"], "ALTER TABLE", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._schema_section_indexer = original
+
+    def test_returns_item_when_sections_match(self):
+        section = _MockSchemaSection("users", "schemas/users.sql", "CREATE TABLE users (id INT)")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_schema_sections.return_value = [section]
+        mock_indexer.format_schema_sections.return_value = "## users\nCREATE TABLE users (id INT)"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._schema_section_indexer
+        _mod._schema_section_indexer = mock_indexer
+        try:
+            item = build_schema_section_item("d-001", ["schemas/users.sql"], "users", "2026-01-01T00:00:00Z")
+            self.assertIsNotNone(item)
+            self.assertEqual(item.item_class, "schema_section")
+        finally:
+            _mod._schema_section_indexer = original
+
+    def test_evidence_count_equals_section_count(self):
+        sections = [
+            _MockSchemaSection("t1", "f.sql", "CREATE TABLE t1 ()"),
+            _MockSchemaSection("t2", "f.sql", "CREATE TABLE t2 ()"),
+        ]
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_schema_sections.return_value = sections
+        mock_indexer.format_schema_sections.return_value = "content"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._schema_section_indexer
+        _mod._schema_section_indexer = mock_indexer
+        try:
+            item = build_schema_section_item("d-001", ["f.sql"], "t1 t2", "2026-01-01T00:00:00Z")
+            self.assertEqual(item.evidence_count, 2)
+        finally:
+            _mod._schema_section_indexer = original
+
+    def test_item_has_full_confidence(self):
+        section = _MockSchemaSection("t", "f.sql", "CREATE TABLE t ()")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_schema_sections.return_value = [section]
+        mock_indexer.format_schema_sections.return_value = "content"
+        import intelligence_sources.adr_relevant as _mod
+        original = _mod._schema_section_indexer
+        _mod._schema_section_indexer = mock_indexer
+        try:
+            item = build_schema_section_item("d-001", ["f.sql"], "t", "2026-01-01T00:00:00Z")
+            self.assertEqual(item.confidence, 1.0)
+        finally:
+            _mod._schema_section_indexer = original

--- a/tests/test_intelligence_sources/test_code_anchor.py
+++ b/tests/test_intelligence_sources/test_code_anchor.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Tests for intelligence_sources/code_anchor.py"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources.code_anchor import (
+    build_code_anchor_item,
+    build_operator_memory_item,
+    build_prior_round_item,
+)
+from intelligence_sources._common import PATTERN_CATEGORY_CODE
+
+
+class _MockFinding:
+    def __init__(self, gate, summary):
+        self.gate = gate
+        self.summary = summary
+
+
+class _MockAnchor:
+    def __init__(self, file_path, line_start, line_end, snippet):
+        self.file_path = file_path
+        self.line_start = line_start
+        self.line_end = line_end
+        self.snippet = snippet
+
+
+class _MockMemory:
+    def __init__(self, name, content):
+        self.name = name
+        self.content = content
+
+
+class TestBuildPriorRoundItem(unittest.TestCase):
+    def test_returns_none_when_no_pr_id(self):
+        item = build_prior_round_item("", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_injector_unavailable(self):
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._prior_round_injector
+        _mod._prior_round_injector = None
+        try:
+            item = build_prior_round_item("pr-42", ["scripts/lib/foo.py"], "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._prior_round_injector = original
+
+    def test_returns_none_when_no_findings(self):
+        mock_injector = MagicMock()
+        mock_injector.fetch_prior_findings.return_value = []
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._prior_round_injector
+        _mod._prior_round_injector = mock_injector
+        try:
+            item = build_prior_round_item("pr-42", [], "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._prior_round_injector = original
+
+    def test_returns_item_when_findings_exist(self):
+        finding = _MockFinding("codex_gate", "Missing null guard")
+        mock_injector = MagicMock()
+        mock_injector.fetch_prior_findings.return_value = [finding]
+        mock_injector.format_findings_section.return_value = "## Finding\nMissing null guard"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._prior_round_injector
+        _mod._prior_round_injector = mock_injector
+        try:
+            item = build_prior_round_item("pr-42", [], "2026-01-01T00:00:00Z")
+            self.assertIsNotNone(item)
+            self.assertEqual(item.item_class, "prior_round_finding")
+        finally:
+            _mod._prior_round_injector = original
+
+    def test_item_confidence_is_one(self):
+        finding = _MockFinding("codex_gate", "F1")
+        mock_injector = MagicMock()
+        mock_injector.fetch_prior_findings.return_value = [finding]
+        mock_injector.format_findings_section.return_value = "content"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._prior_round_injector
+        _mod._prior_round_injector = mock_injector
+        try:
+            item = build_prior_round_item("pr-42", [], "2026-01-01T00:00:00Z")
+            self.assertEqual(item.confidence, 1.0)
+        finally:
+            _mod._prior_round_injector = original
+
+    def test_item_id_includes_pr_id(self):
+        finding = _MockFinding("g", "f")
+        mock_injector = MagicMock()
+        mock_injector.fetch_prior_findings.return_value = [finding]
+        mock_injector.format_findings_section.return_value = "c"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._prior_round_injector
+        _mod._prior_round_injector = mock_injector
+        try:
+            item = build_prior_round_item("pr-99", [], "2026-01-01T00:00:00Z")
+            self.assertIn("pr-99", item.item_id)
+        finally:
+            _mod._prior_round_injector = original
+
+
+class TestBuildCodeAnchorItem(unittest.TestCase):
+    def test_returns_none_when_no_paths(self):
+        item = build_code_anchor_item("d-001", [], "fix null", "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_no_instruction(self):
+        item = build_code_anchor_item("d-001", ["scripts/lib/foo.py"], "", "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_finder_unavailable(self):
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._code_anchor_finder
+        _mod._code_anchor_finder = None
+        try:
+            item = build_code_anchor_item("d-001", ["scripts/lib/foo.py"], "fix null guard", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._code_anchor_finder = original
+
+    def test_returns_none_when_no_anchors_match(self):
+        mock_finder = MagicMock()
+        mock_finder.fetch_code_anchors.return_value = []
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._code_anchor_finder
+        _mod._code_anchor_finder = mock_finder
+        try:
+            item = build_code_anchor_item("d-001", ["scripts/lib/foo.py"], "instruction", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._code_anchor_finder = original
+
+    def test_returns_item_when_anchors_match(self):
+        anchor = _MockAnchor("scripts/lib/foo.py", 10, 20, "def foo(): pass")
+        mock_finder = MagicMock()
+        mock_finder.fetch_code_anchors.return_value = [anchor]
+        mock_finder.format_code_anchors_section.return_value = "## scripts/lib/foo.py:10-20\ndef foo(): pass"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._code_anchor_finder
+        _mod._code_anchor_finder = mock_finder
+        try:
+            item = build_code_anchor_item("d-001", ["scripts/lib/foo.py"], "fix foo", "2026-01-01T00:00:00Z")
+            self.assertIsNotNone(item)
+            self.assertEqual(item.item_class, "code_anchor")
+        finally:
+            _mod._code_anchor_finder = original
+
+    def test_item_confidence_is_one(self):
+        anchor = _MockAnchor("f.py", 1, 5, "code")
+        mock_finder = MagicMock()
+        mock_finder.fetch_code_anchors.return_value = [anchor]
+        mock_finder.format_code_anchors_section.return_value = "content"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._code_anchor_finder
+        _mod._code_anchor_finder = mock_finder
+        try:
+            item = build_code_anchor_item("d-001", ["f.py"], "fix", "2026-01-01T00:00:00Z")
+            self.assertEqual(item.confidence, 1.0)
+        finally:
+            _mod._code_anchor_finder = original
+
+    def test_source_refs_contain_line_ranges(self):
+        anchor = _MockAnchor("foo.py", 10, 20, "code")
+        mock_finder = MagicMock()
+        mock_finder.fetch_code_anchors.return_value = [anchor]
+        mock_finder.format_code_anchors_section.return_value = "content"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._code_anchor_finder
+        _mod._code_anchor_finder = mock_finder
+        try:
+            item = build_code_anchor_item("d-001", ["foo.py"], "fix", "2026-01-01T00:00:00Z")
+            self.assertIn("foo.py:10-20", item.source_refs)
+        finally:
+            _mod._code_anchor_finder = original
+
+
+class TestBuildOperatorMemoryItem(unittest.TestCase):
+    def test_returns_none_when_no_inputs(self):
+        item = build_operator_memory_item("d-001", None, [], "", "2026-01-01T00:00:00Z")
+        self.assertIsNone(item)
+
+    def test_returns_none_when_indexer_unavailable(self):
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = None
+        try:
+            item = build_operator_memory_item("d-001", "architect", ["f.py"], "instruction", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._operator_memory_indexer = original
+
+    def test_returns_none_when_no_memories_match(self):
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_memories.return_value = []
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = mock_indexer
+        try:
+            item = build_operator_memory_item("d-001", "architect", [], "instruction", "2026-01-01T00:00:00Z")
+            self.assertIsNone(item)
+        finally:
+            _mod._operator_memory_indexer = original
+
+    def test_returns_item_when_memories_match(self):
+        memory = _MockMemory("feedback_atomic_writes", "Always use atomic writes")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_memories.return_value = [memory]
+        mock_indexer.format_memories_section.return_value = "## Operator memories\nAlways use atomic writes"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = mock_indexer
+        try:
+            item = build_operator_memory_item("d-001", "architect", [], "fix atomic", "2026-01-01T00:00:00Z")
+            self.assertIsNotNone(item)
+            self.assertEqual(item.item_class, "operator_memory")
+        finally:
+            _mod._operator_memory_indexer = original
+
+    def test_source_refs_contain_memory_names(self):
+        memories = [_MockMemory("mem_a", "A"), _MockMemory("mem_b", "B")]
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_memories.return_value = memories
+        mock_indexer.format_memories_section.return_value = "content"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = mock_indexer
+        try:
+            item = build_operator_memory_item("d-001", "architect", [], "fix", "2026-01-01T00:00:00Z")
+            self.assertIn("mem_a", item.source_refs)
+            self.assertIn("mem_b", item.source_refs)
+        finally:
+            _mod._operator_memory_indexer = original
+
+    def test_item_confidence_is_one(self):
+        memory = _MockMemory("m", "content")
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_memories.return_value = [memory]
+        mock_indexer.format_memories_section.return_value = "content"
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = mock_indexer
+        try:
+            item = build_operator_memory_item("d-001", "architect", [], "fix", "2026-01-01T00:00:00Z")
+            self.assertEqual(item.confidence, 1.0)
+        finally:
+            _mod._operator_memory_indexer = original
+
+    def test_skill_name_only_triggers_lookup(self):
+        mock_indexer = MagicMock()
+        mock_indexer.fetch_relevant_memories.return_value = []
+        import intelligence_sources.code_anchor as _mod
+        original = _mod._operator_memory_indexer
+        _mod._operator_memory_indexer = mock_indexer
+        try:
+            build_operator_memory_item("d-001", "architect", [], "", "2026-01-01T00:00:00Z")
+            mock_indexer.fetch_relevant_memories.assert_called_once()
+        finally:
+            _mod._operator_memory_indexer = original

--- a/tests/test_intelligence_sources/test_failure_prevention.py
+++ b/tests/test_intelligence_sources/test_failure_prevention.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for intelligence_sources/failure_prevention.py"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources.failure_prevention import (
+    _query_antipatterns,
+    _query_central,
+    _query_per_project,
+    _query_prevention_rules,
+    query_failure_prevention,
+)
+from intelligence_sources._common import (
+    PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE,
+    PATTERN_CATEGORY_PROCESS,
+)
+
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS antipatterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            why_problematic TEXT, better_alternative TEXT,
+            occurrence_count INTEGER DEFAULT 0, severity TEXT DEFAULT 'medium',
+            source_dispatch_ids TEXT, first_seen DATETIME, last_seen DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+        CREATE TABLE IF NOT EXISTS prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT, rule_type TEXT, description TEXT,
+            recommendation TEXT, confidence REAL DEFAULT 0.0,
+            created_at TEXT, triggered_count INTEGER DEFAULT 0,
+            last_triggered TEXT,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed_antipattern(conn, title="Bad pattern", category="architect",
+                       severity="high", occurrence_count=3,
+                       why="Wrong approach", better="Better approach"):
+    cur = conn.execute(
+        """INSERT INTO antipatterns (title, description, category, severity,
+           why_problematic, better_alternative, occurrence_count, first_seen, last_seen)
+           VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+        (title, title, category, severity, why, better, occurrence_count),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _seed_rule(conn, description="Rule", recommendation="Do this", confidence=0.7,
+               tag_combination=None, triggered_count=2):
+    cur = conn.execute(
+        """INSERT INTO prevention_rules (tag_combination, rule_type, description,
+           recommendation, confidence, created_at, triggered_count, last_triggered)
+           VALUES (?, 'tag', ?, ?, ?, datetime('now'), ?, datetime('now'))""",
+        (tag_combination, description, recommendation, confidence, triggered_count),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _no_column(table, col):
+    return False
+
+
+class TestQueryAntipatterns(unittest.TestCase):
+    def test_empty_db_returns_empty(self):
+        db = _make_db()
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_returns_antipattern_item(self):
+        db = _make_db()
+        _seed_antipattern(db, title="Cowboy commit")
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertEqual(len(items), 1)
+        self.assertIn("Cowboy commit", items[0].title)
+        db.close()
+
+    def test_item_class_is_failure_prevention(self):
+        db = _make_db()
+        _seed_antipattern(db)
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertEqual(items[0].item_class, "failure_prevention")
+        db.close()
+
+    def test_pattern_category_is_antipattern_evidence(self):
+        db = _make_db()
+        _seed_antipattern(db)
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertEqual(items[0].pattern_category, PATTERN_CATEGORY_ANTIPATTERN_EVIDENCE)
+        db.close()
+
+    def test_critical_severity_gets_high_confidence(self):
+        db = _make_db()
+        _seed_antipattern(db, severity="critical")
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertGreaterEqual(items[0].confidence, 0.9)
+        db.close()
+
+    def test_expired_antipattern_excluded(self):
+        db = _make_db()
+        db.execute(
+            """INSERT INTO antipatterns (title, occurrence_count, severity,
+               valid_until, first_seen, last_seen)
+               VALUES ('Expired', 2, 'high', datetime('now', '-1 day'), datetime('now'), datetime('now'))"""
+        )
+        db.commit()
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_scope_filter_applied(self):
+        db = _make_db()
+        _seed_antipattern(db, category="reviewer", severity="critical")
+        items = _query_antipatterns(db, ["architect"], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_content_builds_why_and_better(self):
+        db = _make_db()
+        _seed_antipattern(db, why="This is wrong", better="Do this instead")
+        items = _query_antipatterns(db, [], _no_column)
+        self.assertIn("This is wrong", items[0].content)
+        self.assertIn("Do this instead", items[0].content)
+        db.close()
+
+
+class TestQueryPreventionRules(unittest.TestCase):
+    def test_empty_db_returns_empty(self):
+        db = _make_db()
+        items = _query_prevention_rules(db, [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_returns_rule_item(self):
+        db = _make_db()
+        _seed_rule(db, description="Don't mock the DB")
+        items = _query_prevention_rules(db, [], _no_column)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+    def test_item_class_is_failure_prevention(self):
+        db = _make_db()
+        _seed_rule(db)
+        items = _query_prevention_rules(db, [], _no_column)
+        self.assertEqual(items[0].item_class, "failure_prevention")
+        db.close()
+
+    def test_pattern_category_is_process(self):
+        db = _make_db()
+        _seed_rule(db)
+        items = _query_prevention_rules(db, [], _no_column)
+        self.assertEqual(items[0].pattern_category, PATTERN_CATEGORY_PROCESS)
+        db.close()
+
+    def test_json_array_tag_combination_parsed(self):
+        db = _make_db()
+        import json
+        _seed_rule(db, tag_combination=json.dumps(["architect", "coding_interactive"]))
+        items = _query_prevention_rules(db, ["architect"], _no_column)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+    def test_comma_separated_tag_combination_parsed(self):
+        db = _make_db()
+        _seed_rule(db, tag_combination="architect,coding_interactive")
+        items = _query_prevention_rules(db, ["architect"], _no_column)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+    def test_no_matching_scope_returns_empty(self):
+        db = _make_db()
+        _seed_rule(db, tag_combination=json.dumps(["reviewer"]))
+        items = _query_prevention_rules(db, ["architect"], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_empty_tag_combination_matches_all(self):
+        db = _make_db()
+        _seed_rule(db, tag_combination=None)
+        items = _query_prevention_rules(db, ["architect"], _no_column)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+
+class TestQueryFailurePrevention(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def test_unset_env_uses_per_project(self):
+        db = _make_db()
+        _seed_antipattern(db, title="Per-project AP")
+        items = query_failure_prevention(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+        )
+        self.assertTrue(any("Per-project AP" in i.title for i in items))
+        db.close()
+
+    def test_central_env_returns_central(self):
+        os.environ["VNX_USE_CENTRAL_DB"] = "1"
+        central_db = sqlite3.connect(":memory:")
+        central_db.row_factory = sqlite3.Row
+        central_db.executescript("""
+            CREATE TABLE antipatterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT, title TEXT, description TEXT,
+                why_problematic TEXT, better_alternative TEXT,
+                occurrence_count INTEGER DEFAULT 0, severity TEXT DEFAULT 'medium',
+                first_seen DATETIME, last_seen DATETIME,
+                valid_until DATETIME DEFAULT NULL, project_id TEXT
+            );
+        """)
+        central_db.execute(
+            """INSERT INTO antipatterns (title, description, category, severity,
+               why_problematic, better_alternative, occurrence_count,
+               first_seen, last_seen, project_id)
+               VALUES ('Central AP', 'x', 'architect', 'high', 'Bad', 'Better', 3,
+               datetime('now'), datetime('now'), 'proj-c')"""
+        )
+        central_db.commit()
+        per_db = _make_db()
+        items = query_failure_prevention(
+            per_db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: central_db,
+            project_id_fn=lambda: "proj-c",
+        )
+        self.assertTrue(any("Central AP" in i.title for i in items))
+        per_db.close()
+        central_db.close()
+
+    def test_returns_both_antipatterns_and_rules(self):
+        db = _make_db()
+        _seed_antipattern(db, title="AP item")
+        _seed_rule(db, description="Rule item", tag_combination=None)
+        items = query_failure_prevention(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+        )
+        classes = {i.item_class for i in items}
+        self.assertIn("failure_prevention", classes)
+        db.close()

--- a/tests/test_intelligence_sources/test_proven_pattern.py
+++ b/tests/test_intelligence_sources/test_proven_pattern.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Tests for intelligence_sources/proven_pattern.py"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources.proven_pattern import (
+    _query_central,
+    _query_per_project,
+    query_proven_patterns,
+)
+from intelligence_sources._common import (
+    IntelligenceItem,
+    PATTERN_CATEGORY_GOVERNANCE,
+    PATTERN_CATEGORY_CODE,
+)
+
+
+def _make_db(path=":memory:") -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            confidence_score REAL DEFAULT 0.0, usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT, first_seen DATETIME, last_used DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _make_db_with_extras(path=":memory:") -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT, category TEXT, title TEXT, description TEXT,
+            confidence_score REAL DEFAULT 0.0, usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT, first_seen DATETIME, last_used DATETIME,
+            valid_from DATETIME DEFAULT NULL, valid_until DATETIME DEFAULT NULL,
+            content_hash TEXT, project_id TEXT, pattern_category TEXT
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed(conn, title="Test pattern", description="Description", category="architect",
+          confidence=0.8, usage_count=5, valid_until=None):
+    cur = conn.execute(
+        """INSERT INTO success_patterns (title, description, category, confidence_score,
+           usage_count, first_seen)
+           VALUES (?, ?, ?, ?, ?, datetime('now'))""",
+        (title, description, category, confidence, usage_count),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _no_reconcile():
+    pass
+
+
+def _no_column(table, col):
+    return False
+
+
+class TestQueryPerProject(unittest.TestCase):
+    def test_empty_db_returns_empty(self):
+        db = _make_db()
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_single_pattern_returned(self):
+        db = _make_db()
+        _seed(db, title="Use structured output", confidence=0.85, usage_count=5)
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertEqual(len(items), 1)
+        self.assertIn("structured output", items[0].title)
+        db.close()
+
+    def test_item_class_is_proven_pattern(self):
+        db = _make_db()
+        _seed(db)
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertEqual(items[0].item_class, "proven_pattern")
+        db.close()
+
+    def test_confidence_preserved(self):
+        db = _make_db()
+        _seed(db, confidence=0.73)
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertAlmostEqual(items[0].confidence, 0.73)
+        db.close()
+
+    def test_expired_patterns_excluded(self):
+        db = _make_db()
+        db.execute(
+            """INSERT INTO success_patterns (title, description, confidence_score,
+               usage_count, valid_until, first_seen)
+               VALUES ('Expired', 'x', 0.9, 5, datetime('now', '-1 day'), datetime('now'))"""
+        )
+        db.commit()
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_scope_filter_no_match(self):
+        db = _make_db()
+        _seed(db, category="reviewer", confidence=0.9)
+        items = _query_per_project(db, "coding_interactive", ["architect"], _no_column, _no_reconcile)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_scope_filter_match(self):
+        db = _make_db()
+        _seed(db, category="architect", confidence=0.9)
+        items = _query_per_project(db, "research_structured", ["architect"], _no_column, _no_reconcile)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+    def test_sorted_by_confidence_desc(self):
+        db = _make_db()
+        _seed(db, title="Low", confidence=0.5)
+        _seed(db, title="High", confidence=0.9)
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertGreater(items[0].confidence, items[1].confidence)
+        db.close()
+
+    def test_reconcile_called(self):
+        called = []
+        def _reconcile():
+            called.append(True)
+        db = _make_db()
+        _query_per_project(db, "coding_interactive", [], _no_column, _reconcile)
+        self.assertEqual(len(called), 1)
+        db.close()
+
+    def test_source_refs_parsed_from_json(self):
+        db = _make_db()
+        import json
+        db.execute(
+            """INSERT INTO success_patterns (title, description, confidence_score,
+               usage_count, source_dispatch_ids, first_seen)
+               VALUES ('P', 'D', 0.8, 3, ?, datetime('now'))""",
+            (json.dumps(["d-001", "d-002"]),),
+        )
+        db.commit()
+        items = _query_per_project(db, "coding_interactive", [], _no_column, _no_reconcile)
+        self.assertIn("d-001", items[0].source_refs)
+        db.close()
+
+
+class TestQueryCentral(unittest.TestCase):
+    def test_none_connection_returns_empty(self):
+        items = _query_central("coding_interactive", [], lambda: None)
+        self.assertEqual(items, [])
+
+    def test_central_item_returned(self):
+        db = _make_db_with_extras()
+        db.execute(
+            """INSERT INTO success_patterns (title, description, category, confidence_score,
+               usage_count, first_seen, project_id)
+               VALUES ('Central pattern', 'Desc', 'architect', 0.85, 5, datetime('now'), 'proj-1')"""
+        )
+        db.commit()
+        project_id_fn = lambda: "proj-1"
+        items = _query_central("coding_interactive", [], lambda: db, project_id_fn=project_id_fn)
+        self.assertEqual(len(items), 1)
+        self.assertIn("Central pattern", items[0].title)
+        db.close()
+
+    def test_project_id_filter_applied(self):
+        db = _make_db_with_extras()
+        db.execute(
+            """INSERT INTO success_patterns (title, description, category, confidence_score,
+               usage_count, first_seen, project_id)
+               VALUES ('Proj1 pattern', 'D', 'architect', 0.85, 5, datetime('now'), 'proj-1')"""
+        )
+        db.execute(
+            """INSERT INTO success_patterns (title, description, category, confidence_score,
+               usage_count, first_seen, project_id)
+               VALUES ('Proj2 pattern', 'D', 'architect', 0.85, 5, datetime('now'), 'proj-2')"""
+        )
+        db.commit()
+        items = _query_central("coding_interactive", [], lambda: db, project_id_fn=lambda: "proj-1")
+        self.assertEqual(len(items), 1)
+        self.assertIn("Proj1 pattern", items[0].title)
+        db.close()
+
+    def test_item_class_is_proven_pattern(self):
+        db = _make_db_with_extras()
+        db.execute(
+            """INSERT INTO success_patterns (title, description, category, confidence_score,
+               usage_count, first_seen, project_id)
+               VALUES ('Pattern', 'D', 'architect', 0.8, 3, datetime('now'), 'p')"""
+        )
+        db.commit()
+        items = _query_central("coding_interactive", [], lambda: db, project_id_fn=lambda: "p")
+        self.assertTrue(all(i.item_class == "proven_pattern" for i in items))
+        db.close()
+
+
+class TestQueryProvenPatterns(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def test_unset_env_uses_per_project(self):
+        db = _make_db()
+        _seed(db, title="Per-project", confidence=0.9)
+        items = query_proven_patterns(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+            reconcile_fn=_no_reconcile,
+        )
+        self.assertEqual(len(items), 1)
+        self.assertIn("Per-project", items[0].title)
+        db.close()
+
+    def test_central_env_returns_central(self):
+        os.environ["VNX_USE_CENTRAL_DB"] = "1"
+        db = _make_db_with_extras()
+        db.execute(
+            """INSERT INTO success_patterns (title, description, category, confidence_score,
+               usage_count, first_seen, project_id)
+               VALUES ('Central', 'D', 'architect', 0.85, 5, datetime('now'), 'proj-x')"""
+        )
+        db.commit()
+        per_project_db = _make_db()
+        items = query_proven_patterns(
+            per_project_db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: db,
+            reconcile_fn=_no_reconcile,
+            project_id_fn=lambda: "proj-x",
+        )
+        self.assertTrue(any("Central" in i.title for i in items))
+        per_project_db.close()
+        db.close()
+
+    def test_shadow_env_returns_per_project(self):
+        os.environ["VNX_USE_CENTRAL_DB"] = "shadow"
+        db = _make_db()
+        _seed(db, title="Per-project shadow", confidence=0.9)
+        items = query_proven_patterns(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+            reconcile_fn=_no_reconcile,
+        )
+        self.assertTrue(any("Per-project shadow" in i.title for i in items))
+        db.close()

--- a/tests/test_intelligence_sources/test_recent_comparable.py
+++ b/tests/test_intelligence_sources/test_recent_comparable.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Tests for intelligence_sources/recent_comparable.py"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources.recent_comparable import (
+    _query_central,
+    _query_per_project,
+    _row_to_intelligence_item,
+    query_recent_comparable,
+)
+from intelligence_sources._common import PATTERN_CATEGORY_PROCESS, RECENT_COMPARABLE_DAYS
+
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT,
+            outcome_status TEXT, dispatched_at DATETIME,
+            pattern_count INTEGER DEFAULT 0,
+            prevention_rule_count INTEGER DEFAULT 0
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed_dispatch(conn, dispatch_id="d-001", skill_name="architect",
+                   outcome="success", days_ago=1, gate=""):
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    conn.execute(
+        """INSERT INTO dispatch_metadata
+           (dispatch_id, skill_name, gate, outcome_status, dispatched_at,
+            pattern_count, prevention_rule_count)
+           VALUES (?, ?, ?, ?, ?, 2, 1)""",
+        (dispatch_id, skill_name, gate, outcome, ts),
+    )
+    conn.commit()
+
+
+def _no_column(table, col):
+    return False
+
+
+class TestRowToIntelligenceItem(unittest.TestCase):
+    def _make_row(self, dispatch_id="d-001", skill_name="architect",
+                  gate="", track=None, outcome_status="success",
+                  pattern_count=2, prevention_rule_count=1):
+        ts = datetime.now(timezone.utc).isoformat()
+        return {
+            "dispatch_id": dispatch_id,
+            "skill_name": skill_name,
+            "gate": gate,
+            "track": track,
+            "outcome_status": outcome_status,
+            "dispatched_at": ts,
+            "pattern_count": pattern_count,
+            "prevention_rule_count": prevention_rule_count,
+        }
+
+    def test_returns_intelligence_item(self):
+        row = self._make_row()
+        item = _row_to_intelligence_item(row, [])
+        self.assertIsNotNone(item)
+        self.assertEqual(item.item_class, "recent_comparable")
+
+    def test_success_gets_higher_confidence(self):
+        success_row = self._make_row(outcome_status="success")
+        failure_row = self._make_row(outcome_status="failed")
+        success_item = _row_to_intelligence_item(success_row, [])
+        failure_item = _row_to_intelligence_item(failure_row, [])
+        self.assertGreater(success_item.confidence, failure_item.confidence)
+
+    def test_scope_filter_no_match(self):
+        row = self._make_row(skill_name="reviewer")
+        item = _row_to_intelligence_item(row, ["architect"])
+        self.assertIsNone(item)
+
+    def test_scope_filter_match_by_skill(self):
+        row = self._make_row(skill_name="architect")
+        item = _row_to_intelligence_item(row, ["architect"])
+        self.assertIsNotNone(item)
+
+    def test_pattern_category_is_process(self):
+        row = self._make_row()
+        item = _row_to_intelligence_item(row, [])
+        self.assertEqual(item.pattern_category, PATTERN_CATEGORY_PROCESS)
+
+    def test_content_includes_outcome(self):
+        row = self._make_row(outcome_status="success")
+        item = _row_to_intelligence_item(row, [])
+        self.assertIn("success", item.content)
+
+    def test_dispatch_id_in_source_refs(self):
+        row = self._make_row(dispatch_id="d-abc-123")
+        item = _row_to_intelligence_item(row, [])
+        self.assertIn("d-abc-123", item.source_refs)
+
+    def test_track_added_to_scope_tags(self):
+        row = self._make_row(track="A")
+        item = _row_to_intelligence_item(row, [])
+        self.assertIn("Track-A", item.scope_tags)
+
+
+class TestQueryPerProject(unittest.TestCase):
+    def test_empty_db_returns_empty(self):
+        db = _make_db()
+        items = _query_per_project(db, "coding_interactive", [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_recent_dispatch_returned(self):
+        db = _make_db()
+        _seed_dispatch(db, dispatch_id="d-recent", days_ago=1)
+        items = _query_per_project(db, "coding_interactive", [], _no_column)
+        self.assertEqual(len(items), 1)
+        db.close()
+
+    def test_old_dispatch_excluded(self):
+        db = _make_db()
+        _seed_dispatch(db, dispatch_id="d-old", days_ago=RECENT_COMPARABLE_DAYS + 5)
+        items = _query_per_project(db, "coding_interactive", [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_pending_status_excluded(self):
+        db = _make_db()
+        ts = datetime.now(timezone.utc).isoformat()
+        db.execute(
+            """INSERT INTO dispatch_metadata (dispatch_id, skill_name, dispatched_at)
+               VALUES ('d-pending', 'architect', ?)""",
+            (ts,),
+        )
+        db.commit()
+        items = _query_per_project(db, "coding_interactive", [], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+    def test_scope_filter_applied(self):
+        db = _make_db()
+        _seed_dispatch(db, skill_name="reviewer")
+        items = _query_per_project(db, "coding_interactive", ["architect"], _no_column)
+        self.assertEqual(items, [])
+        db.close()
+
+
+class TestQueryRecentComparable(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+
+    def test_unset_env_uses_per_project(self):
+        db = _make_db()
+        _seed_dispatch(db, dispatch_id="d-pp", skill_name="architect")
+        items = query_recent_comparable(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+        )
+        ids = [i.source_refs[0] for i in items if i.source_refs]
+        self.assertIn("d-pp", ids)
+        db.close()
+
+    def test_central_env_returns_central(self):
+        os.environ["VNX_USE_CENTRAL_DB"] = "1"
+        central_db = sqlite3.connect(":memory:")
+        central_db.row_factory = sqlite3.Row
+        ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        central_db.executescript(f"""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT UNIQUE, terminal TEXT, track TEXT,
+                role TEXT, skill_name TEXT, gate TEXT,
+                outcome_status TEXT, dispatched_at DATETIME,
+                pattern_count INTEGER DEFAULT 0, prevention_rule_count INTEGER DEFAULT 0,
+                project_id TEXT
+            );
+            INSERT INTO dispatch_metadata
+               (dispatch_id, skill_name, gate, outcome_status, dispatched_at, project_id)
+               VALUES ('central-d-001', 'architect', '', 'success', '{ts}', 'proj-r');
+        """)
+        central_db.commit()
+        per_db = _make_db()
+        items = query_recent_comparable(
+            per_db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: central_db,
+            project_id_fn=lambda: "proj-r",
+        )
+        ids = [i.source_refs[0] for i in items if i.source_refs]
+        self.assertIn("central-d-001", ids)
+        per_db.close()
+        central_db.close()
+
+    def test_shadow_env_returns_per_project(self):
+        os.environ["VNX_USE_CENTRAL_DB"] = "shadow"
+        db = _make_db()
+        _seed_dispatch(db, dispatch_id="d-shadow-pp")
+        items = query_recent_comparable(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+        )
+        ids = [i.source_refs[0] for i in items if i.source_refs]
+        self.assertIn("d-shadow-pp", ids)
+        db.close()
+
+    def test_no_dispatch_returns_empty(self):
+        db = _make_db()
+        items = query_recent_comparable(
+            db, "coding_interactive", [],
+            has_column_fn=_no_column,
+            central_conn_fn=lambda: None,
+        )
+        self.assertEqual(items, [])
+        db.close()


### PR DESCRIPTION
## Summary
- `intelligence_selector.py` reduced from 2511 LOC → 321 LOC (orchestrator-only)
- New package `scripts/lib/intelligence_sources/` with 7 modules separating concerns by source type
- 87 new tests in `tests/test_intelligence_sources/` covering all 5 query sources

## Motivation
2026-05-17 audit identified `intelligence_selector.py` as the largest hot-spot: 32 methods, a 291-line `select()`, and 2511 total LOC. This made the file unmaintainable and violated module size governance.

## Changes

### New package: `scripts/lib/intelligence_sources/`
| File | LOC | Responsibility |
|------|-----|----------------|
| `_common.py` | 296 | Shared types, constants, utility functions |
| `_models.py` | 103 | InjectionResult, IntelligenceContext, markdown formatters |
| `_recording.py` | 228 | Injection audit + pattern_usage recording |
| `proven_pattern.py` | 304 | success_patterns query + canonical-ID resolution |
| `failure_prevention.py` | 309 | antipatterns + prevention_rules query |
| `recent_comparable.py` | 218 | dispatch_metadata similarity ranking |
| `adr_relevant.py` | 100 | ADR + schema section direct-injection builders |
| `code_anchor.py` | 150 | Code anchors + operator memory + prior-round builders |
| `__init__.py` | 70 | Re-exports for backward compat |

### `intelligence_selector.py` (321 LOC, was 2511)
Orchestrator-only: coordinates per-source budgets, enforces payload cap, records audit. Public API (`build_intelligence_context`, `select_intelligence`, `IntelligenceSelector.select`) unchanged.

### Exception handling tests updated
`test_intelligence_selector_exception_handling.py` updated to target submodule loggers and functions after internal `_query_*_central` methods moved to per-source modules.

## Test results
- **136 passed** (49 previously passing + 87 new)
- **31 failed** — unchanged pre-existing failures (same set as main branch, DB migration issue unrelated to this PR)
- All functions ≤ 70 LOC ✓

## Known deviation
`intelligence_selector.py` at 321 LOC vs 300 LOC target. The 21-line delta comes from 3 backward-compat wrapper methods (`_query_proven_patterns`, `_query_failure_prevention`, `_query_recent_comparable`) that the existing test suite calls directly on `IntelligenceSelector`.

## References
2026-05-17 audit + operator dispatch `20260517-intelligence-selector-refactor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)