### PR TITLE
feat(pr-d5-e): unified report schema enforcement

### DIFF
--- a/schemas/unified_report_v1.json
+++ b/schemas/unified_report_v1.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vnx-orchestration/schemas/unified_report_v1.json",
+  "title": "Unified Report Frontmatter v1",
+  "description": "JSONSchema for the YAML frontmatter that every unified report (PR-D5-F onward) must declare. PR-D5-E ships this schema + validator; PR-D5-F wires it into governance_emit.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "dispatch_id",
+    "provider",
+    "sub_provider",
+    "model",
+    "terminal_id",
+    "pool_id",
+    "role",
+    "task_class",
+    "pr_id",
+    "duration_seconds",
+    "exit_code",
+    "token_usage",
+    "cost_usd",
+    "route_decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Frontmatter schema version. Currently fixed at 1.",
+      "const": 1
+    },
+    "dispatch_id": {
+      "description": "Stable dispatch identifier, matches dispatch metadata footer.",
+      "type": "string",
+      "minLength": 1
+    },
+    "provider": {
+      "description": "Top-level provider family (claude|codex|gemini|kimi|litellm).",
+      "type": "string",
+      "minLength": 1
+    },
+    "sub_provider": {
+      "description": "Sub-provider routing label (e.g. anthropic, openai, google, moonshot, deepseek, glm). Use 'none' when not applicable.",
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "description": "Concrete model identifier reported by the adapter.",
+      "type": "string",
+      "minLength": 1
+    },
+    "terminal_id": {
+      "description": "Terminal slot identifier (e.g. T0, T1, W4).",
+      "type": "string",
+      "minLength": 1
+    },
+    "pool_id": {
+      "description": "Worker pool identifier (interactive|headless|hybrid|<custom>).",
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "description": "Role profile that executed the dispatch (e.g. backend-developer, architect).",
+      "type": "string",
+      "minLength": 1
+    },
+    "task_class": {
+      "description": "Coarse task classification used by routing (implementation|review|gate|test|docs|...).",
+      "type": "string",
+      "minLength": 1
+    },
+    "pr_id": {
+      "description": "PR identifier (PR-D5-E) or 'none' if not PR-scoped work.",
+      "type": "string",
+      "minLength": 1
+    },
+    "duration_seconds": {
+      "description": "Wall-clock execution duration in seconds.",
+      "type": "number",
+      "minimum": 0
+    },
+    "exit_code": {
+      "description": "Adapter exit code (0 = success).",
+      "type": "integer"
+    },
+    "token_usage": {
+      "description": "Token accounting reported by the adapter.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input", "output", "cache_read"],
+      "properties": {
+        "input": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cache_read": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "cost_usd": {
+      "description": "Estimated USD cost for the dispatch.",
+      "type": "number",
+      "minimum": 0
+    },
+    "route_decision": {
+      "description": "Routing metadata captured at dispatch time (provider/model selection rationale).",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["strategy", "selected_provider", "selected_model"],
+      "properties": {
+        "strategy": {
+          "description": "Routing strategy label (e.g. default, override, fallback).",
+          "type": "string",
+          "minLength": 1
+        },
+        "selected_provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "selected_model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/scripts/guardrails/verify_report_schema.sh
+++ b/scripts/guardrails/verify_report_schema.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# verify_report_schema.sh — guardrail wrapper around unified_report_schema validator.
+#
+# Usage: verify_report_schema.sh <unified_report.md> [<more.md> ...]
+#
+# Exits 0 when every file's YAML frontmatter validates against
+# schemas/unified_report_v1.json. Exits 1 with a 'missing field: X' or
+# 'invalid type: X' message on the first failure.
+#
+# PR-D5-E ships this guardrail; PR-D5-F wires governance_emit to enforce it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $(basename "$0") <unified_report.md> [<more.md> ...]" >&2
+  exit 2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+for report in "$@"; do
+  if [ ! -f "$report" ]; then
+    echo "verify_report_schema: report not found: $report" >&2
+    exit 1
+  fi
+
+  REPO_ROOT_ENV="$REPO_ROOT" REPORT_PATH="$report" \
+    "$PYTHON_BIN" - <<'PY'
+import os
+import sys
+
+repo_root = os.environ["REPO_ROOT_ENV"]
+report_path = os.environ["REPORT_PATH"]
+
+sys.path.insert(0, os.path.join(repo_root, "scripts", "lib"))
+
+try:
+    from unified_report_schema import SchemaViolation, validate_file  # type: ignore
+except ImportError as exc:
+    sys.stderr.write(
+        f"verify_report_schema: cannot import validator ({exc}).\n"
+        "Install dependencies: pip install jsonschema pyyaml\n"
+    )
+    sys.exit(1)
+
+try:
+    validate_file(report_path)
+except SchemaViolation as exc:
+    sys.stderr.write(
+        f"verify_report_schema: {report_path}: {exc}\n"
+    )
+    sys.exit(1)
+except Exception as exc:  # surfaces unexpected runtime errors
+    sys.stderr.write(
+        f"verify_report_schema: {report_path}: unexpected error: {exc}\n"
+    )
+    sys.exit(1)
+
+print(f"verify_report_schema: {report_path}: ok")
+PY
+
+done
+
+exit 0

--- a/scripts/lib/unified_report_schema.py
+++ b/scripts/lib/unified_report_schema.py
@@ -1,0 +1,192 @@
+"""unified_report_schema.py — JSONSchema validator for unified report frontmatter.
+
+Used by PR-D5-E guardrail (scripts/guardrails/verify_report_schema.sh) and (from
+PR-D5-F onwards) by governance_emit when writing the unified report.
+
+Public surface:
+    SchemaViolation
+    SCHEMA_VERSION
+    SCHEMA_PATH
+    load_schema()
+    extract_frontmatter(text) -> (frontmatter_text, body)
+    parse_frontmatter(text) -> dict
+    validate_frontmatter(text) -> dict
+    validate_file(path) -> dict
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import yaml
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+SCHEMA_VERSION = 1
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2] / "schemas" / "unified_report_v1.json"
+)
+
+
+class SchemaViolation(ValueError):
+    """Raised when a unified report frontmatter fails schema validation."""
+
+
+_SCHEMA_CACHE: Optional[Dict[str, Any]] = None
+_VALIDATOR_CACHE: Optional[Draft202012Validator] = None
+
+
+def load_schema(schema_path: Path = SCHEMA_PATH) -> Dict[str, Any]:
+    """Load the unified-report schema JSON. Cached on first call."""
+    global _SCHEMA_CACHE
+    if _SCHEMA_CACHE is None or schema_path != SCHEMA_PATH:
+        try:
+            with open(schema_path, "r", encoding="utf-8") as fh:
+                schema = json.load(fh)
+        except FileNotFoundError as exc:
+            raise SchemaViolation(
+                f"schema file not found: {schema_path}"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise SchemaViolation(
+                f"schema file is not valid JSON ({schema_path}): {exc}"
+            ) from exc
+        if schema_path == SCHEMA_PATH:
+            _SCHEMA_CACHE = schema
+        return schema
+    return _SCHEMA_CACHE
+
+
+def _get_validator() -> Draft202012Validator:
+    global _VALIDATOR_CACHE
+    if _VALIDATOR_CACHE is None:
+        schema = load_schema()
+        Draft202012Validator.check_schema(schema)
+        _VALIDATOR_CACHE = Draft202012Validator(schema)
+    return _VALIDATOR_CACHE
+
+
+def extract_frontmatter(text: str) -> Tuple[str, str]:
+    """Split a markdown document into (frontmatter_text, body).
+
+    Frontmatter is recognised only when the document starts with a ``---``
+    fence on the first non-empty line and is closed by a second ``---`` fence.
+
+    Raises SchemaViolation when no frontmatter block is present or when the
+    fence is not closed.
+    """
+    if text is None:
+        raise SchemaViolation("report text is empty: no frontmatter block")
+
+    lines = text.splitlines()
+    idx = 0
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+
+    if idx >= len(lines) or lines[idx].strip() != "---":
+        raise SchemaViolation(
+            "missing YAML frontmatter: report must start with '---' fence"
+        )
+
+    start = idx + 1
+    end: Optional[int] = None
+    for j in range(start, len(lines)):
+        if lines[j].strip() == "---":
+            end = j
+            break
+
+    if end is None:
+        raise SchemaViolation(
+            "unterminated YAML frontmatter: closing '---' fence not found"
+        )
+
+    frontmatter_text = "\n".join(lines[start:end])
+    body = "\n".join(lines[end + 1 :])
+    return frontmatter_text, body
+
+
+def parse_frontmatter(text: str) -> Dict[str, Any]:
+    """Extract + YAML-parse the frontmatter mapping.
+
+    Raises SchemaViolation when the YAML is invalid or not a mapping.
+    """
+    frontmatter_text, _body = extract_frontmatter(text)
+    try:
+        data = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        raise SchemaViolation(f"invalid YAML in frontmatter: {exc}") from exc
+
+    if data is None:
+        raise SchemaViolation("empty YAML frontmatter")
+    if not isinstance(data, dict):
+        raise SchemaViolation(
+            f"frontmatter must be a YAML mapping, got {type(data).__name__}"
+        )
+    return data
+
+
+def _format_error(err: ValidationError) -> str:
+    path = list(err.absolute_path)
+    pointer = ".".join(str(p) for p in path) if path else "<root>"
+    validator = err.validator
+
+    if validator == "required":
+        missing = err.message.split("'")[1] if "'" in err.message else err.message
+        return f"missing field: {missing}"
+
+    if validator == "type":
+        expected = err.validator_value
+        return f"invalid type: {pointer} (expected {expected})"
+
+    if validator == "const":
+        return (
+            f"invalid type: {pointer} (must equal {err.validator_value!r}, "
+            f"got {err.instance!r})"
+        )
+
+    if validator == "additionalProperties":
+        return f"invalid type: {pointer} ({err.message})"
+
+    if validator == "minimum":
+        return (
+            f"invalid type: {pointer} (must be >= {err.validator_value}, "
+            f"got {err.instance!r})"
+        )
+
+    if validator == "minLength":
+        return f"invalid type: {pointer} (must be non-empty string)"
+
+    return f"invalid type: {pointer} ({err.message})"
+
+
+def validate_frontmatter(text: str) -> Dict[str, Any]:
+    """Validate unified-report frontmatter found in *text*.
+
+    Returns the parsed frontmatter mapping on success.
+
+    Raises:
+        SchemaViolation: when the frontmatter is missing, malformed, or fails
+            JSONSchema validation. The first violation is surfaced with a
+            human-readable message such as "missing field: provider" or
+            "invalid type: cost_usd (expected number)".
+    """
+    data = parse_frontmatter(text)
+    validator = _get_validator()
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        raise SchemaViolation(_format_error(errors[0]))
+    return data
+
+
+def validate_file(path: Path) -> Dict[str, Any]:
+    """Read *path* from disk and validate its frontmatter."""
+    path = Path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SchemaViolation(f"report file not found: {path}") from exc
+    except OSError as exc:
+        raise SchemaViolation(f"cannot read report {path}: {exc}") from exc
+    return validate_frontmatter(text)

--- a/tests/test_unified_report_schema.py
+++ b/tests/test_unified_report_schema.py
@@ -1,0 +1,333 @@
+"""Tests for unified_report_schema validator (PR-D5-E)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/lib is added to sys.path by tests/conftest.py
+from unified_report_schema import (  # type: ignore  # noqa: E402
+    SCHEMA_PATH,
+    SchemaViolation,
+    extract_frontmatter,
+    load_schema,
+    parse_frontmatter,
+    validate_file,
+    validate_frontmatter,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARDRAIL = REPO_ROOT / "scripts" / "guardrails" / "verify_report_schema.sh"
+
+
+def _valid_frontmatter() -> dict:
+    """Minimal-valid frontmatter mapping for the v1 schema."""
+    return {
+        "schema_version": 1,
+        "dispatch_id": "20260517-pr-d5-e-test",
+        "provider": "claude",
+        "sub_provider": "anthropic",
+        "model": "claude-opus-4-7",
+        "terminal_id": "W4",
+        "pool_id": "headless",
+        "role": "backend-developer",
+        "task_class": "implementation",
+        "pr_id": "PR-D5-E",
+        "duration_seconds": 12.5,
+        "exit_code": 0,
+        "token_usage": {"input": 1234, "output": 567, "cache_read": 89},
+        "cost_usd": 0.0421,
+        "route_decision": {
+            "strategy": "default",
+            "selected_provider": "claude",
+            "selected_model": "claude-opus-4-7",
+            "reason": "primary route",
+        },
+    }
+
+
+def _render_report(frontmatter: dict, body: str = "Report body.") -> str:
+    """Render a unified report markdown string with the given frontmatter."""
+    import yaml
+
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False).strip()
+    return f"---\n{yaml_text}\n---\n\n{body}\n"
+
+
+# ---------------------------------------------------------------------------
+# Schema file
+# ---------------------------------------------------------------------------
+
+
+def test_schema_file_loads_and_is_draft_2020_12():
+    schema = load_schema()
+    assert schema["$schema"].endswith("2020-12/schema")
+    assert schema["title"] == "Unified Report Frontmatter v1"
+    assert schema["properties"]["schema_version"]["const"] == 1
+
+
+def test_schema_path_resolves_to_repo_schemas_dir():
+    assert SCHEMA_PATH.exists(), f"schema missing at {SCHEMA_PATH}"
+    assert SCHEMA_PATH.name == "unified_report_v1.json"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_frontmatter_splits_correctly():
+    text = "---\nkey: value\n---\n\nbody line\n"
+    fm, body = extract_frontmatter(text)
+    assert "key: value" in fm
+    assert "body line" in body
+
+
+def test_extract_frontmatter_missing_fence_raises():
+    with pytest.raises(SchemaViolation, match="missing YAML frontmatter"):
+        extract_frontmatter("# just a heading\nno frontmatter here\n")
+
+
+def test_extract_frontmatter_unterminated_raises():
+    with pytest.raises(SchemaViolation, match="unterminated YAML frontmatter"):
+        extract_frontmatter("---\nkey: value\nno closing fence\n")
+
+
+def test_extract_frontmatter_empty_text_raises():
+    with pytest.raises(SchemaViolation, match="missing YAML frontmatter"):
+        extract_frontmatter("")
+
+
+def test_parse_frontmatter_non_mapping_raises():
+    text = "---\n- just\n- a\n- list\n---\n"
+    with pytest.raises(SchemaViolation, match="mapping"):
+        parse_frontmatter(text)
+
+
+def test_parse_frontmatter_invalid_yaml_raises():
+    text = "---\nkey: [unterminated\n---\n"
+    with pytest.raises(SchemaViolation, match="invalid YAML"):
+        parse_frontmatter(text)
+
+
+# ---------------------------------------------------------------------------
+# validate_frontmatter — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_validate_frontmatter_accepts_minimal_valid_payload():
+    text = _render_report(_valid_frontmatter())
+    data = validate_frontmatter(text)
+    assert data["dispatch_id"] == "20260517-pr-d5-e-test"
+    assert data["schema_version"] == 1
+
+
+def test_validate_frontmatter_allows_unknown_top_level_keys():
+    fm = _valid_frontmatter()
+    fm["custom_extension_field"] = "future-use"
+    text = _render_report(fm)
+    data = validate_frontmatter(text)
+    assert data["custom_extension_field"] == "future-use"
+
+
+# ---------------------------------------------------------------------------
+# validate_frontmatter — required-field violations
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_FIELDS = [
+    "schema_version",
+    "dispatch_id",
+    "provider",
+    "sub_provider",
+    "model",
+    "terminal_id",
+    "pool_id",
+    "role",
+    "task_class",
+    "pr_id",
+    "duration_seconds",
+    "exit_code",
+    "token_usage",
+    "cost_usd",
+    "route_decision",
+]
+
+
+@pytest.mark.parametrize("field", REQUIRED_FIELDS)
+def test_missing_required_field_reports_missing_field(field):
+    fm = _valid_frontmatter()
+    fm.pop(field)
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation) as excinfo:
+        validate_frontmatter(text)
+    assert "missing field" in str(excinfo.value)
+    assert field in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# validate_frontmatter — type violations
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_schema_version_const_rejected():
+    fm = _valid_frontmatter()
+    fm["schema_version"] = 2
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation, match="schema_version"):
+        validate_frontmatter(text)
+
+
+def test_invalid_cost_usd_type_rejected():
+    fm = _valid_frontmatter()
+    fm["cost_usd"] = "not-a-number"
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation) as excinfo:
+        validate_frontmatter(text)
+    msg = str(excinfo.value)
+    assert "invalid type" in msg
+    assert "cost_usd" in msg
+
+
+def test_negative_duration_rejected():
+    fm = _valid_frontmatter()
+    fm["duration_seconds"] = -1.0
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation, match="duration_seconds"):
+        validate_frontmatter(text)
+
+
+def test_non_integer_exit_code_rejected():
+    fm = _valid_frontmatter()
+    fm["exit_code"] = 0.5
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation, match="exit_code"):
+        validate_frontmatter(text)
+
+
+def test_token_usage_missing_subfield_rejected():
+    fm = _valid_frontmatter()
+    fm["token_usage"] = {"input": 1, "output": 2}  # cache_read missing
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation) as excinfo:
+        validate_frontmatter(text)
+    msg = str(excinfo.value)
+    assert "missing field" in msg and "cache_read" in msg
+
+
+def test_token_usage_wrong_subfield_type_rejected():
+    fm = _valid_frontmatter()
+    fm["token_usage"] = {"input": "lots", "output": 2, "cache_read": 0}
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation) as excinfo:
+        validate_frontmatter(text)
+    msg = str(excinfo.value)
+    assert "invalid type" in msg
+    assert "token_usage" in msg
+
+
+def test_route_decision_missing_subfield_rejected():
+    fm = _valid_frontmatter()
+    fm["route_decision"] = {"strategy": "default", "selected_provider": "claude"}
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation) as excinfo:
+        validate_frontmatter(text)
+    msg = str(excinfo.value)
+    assert "missing field" in msg
+    assert "selected_model" in msg
+
+
+def test_empty_provider_string_rejected():
+    fm = _valid_frontmatter()
+    fm["provider"] = ""
+    text = _render_report(fm)
+    with pytest.raises(SchemaViolation, match="provider"):
+        validate_frontmatter(text)
+
+
+# ---------------------------------------------------------------------------
+# validate_file
+# ---------------------------------------------------------------------------
+
+
+def test_validate_file_accepts_valid_report(tmp_path: Path):
+    report = tmp_path / "report.md"
+    report.write_text(_render_report(_valid_frontmatter()), encoding="utf-8")
+    data = validate_file(report)
+    assert data["schema_version"] == 1
+
+
+def test_validate_file_missing_path_raises(tmp_path: Path):
+    missing = tmp_path / "does_not_exist.md"
+    with pytest.raises(SchemaViolation, match="not found"):
+        validate_file(missing)
+
+
+# ---------------------------------------------------------------------------
+# Bash guardrail wrapper — black-box integration
+# ---------------------------------------------------------------------------
+
+
+def _run_guardrail(report_path: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.setdefault("PYTHON_BIN", sys.executable)
+    return subprocess.run(
+        ["bash", str(GUARDRAIL), str(report_path)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_guardrail_exits_zero_on_valid_report(tmp_path: Path):
+    assert GUARDRAIL.exists(), f"guardrail missing: {GUARDRAIL}"
+    report = tmp_path / "valid_report.md"
+    report.write_text(_render_report(_valid_frontmatter()), encoding="utf-8")
+    result = _run_guardrail(report)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_guardrail_exits_one_on_missing_field(tmp_path: Path):
+    fm = _valid_frontmatter()
+    fm.pop("provider")
+    report = tmp_path / "missing_provider.md"
+    report.write_text(_render_report(fm), encoding="utf-8")
+    result = _run_guardrail(report)
+    assert result.returncode == 1
+    assert "missing field" in result.stderr
+    assert "provider" in result.stderr
+
+
+def test_guardrail_exits_one_on_type_violation(tmp_path: Path):
+    fm = _valid_frontmatter()
+    fm["cost_usd"] = "free"
+    report = tmp_path / "bad_cost.md"
+    report.write_text(_render_report(fm), encoding="utf-8")
+    result = _run_guardrail(report)
+    assert result.returncode == 1
+    assert "invalid type" in result.stderr
+    assert "cost_usd" in result.stderr
+
+
+def test_guardrail_exits_one_when_report_missing(tmp_path: Path):
+    result = _run_guardrail(tmp_path / "nope.md")
+    assert result.returncode == 1
+    assert "not found" in result.stderr
+
+
+def test_guardrail_usage_when_no_args():
+    env = os.environ.copy()
+    env.setdefault("PYTHON_BIN", sys.executable)
+    result = subprocess.run(
+        ["bash", str(GUARDRAIL)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 2
+    assert "usage" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- Adds the v1 frontmatter contract every unified report must satisfy: `schemas/unified_report_v1.json` (Draft 2020-12 JSONSchema, ~140 LOC).
- Adds the Python validator `scripts/lib/unified_report_schema.py` exposing `SchemaViolation`, `validate_frontmatter(text)`, `validate_file(path)` with human-readable error messages (`missing field: X`, `invalid type: X`).
- Adds the bash guardrail `scripts/guardrails/verify_report_schema.sh` (sets up REPO_ROOT, imports the validator, exits 1 with the violation message). Bash syntax-checked (`bash -n`).
- 40-test pytest suite (`tests/test_unified_report_schema.py`): schema load, frontmatter extraction edge cases, parametrised missing-required-field coverage for all 15 top-level fields, type / const / minimum violations, nested `token_usage` + `route_decision` validation, and 5 black-box guardrail subprocess tests.

## Scope
- **Not wired into `governance_emit.py`** — that lands in PR-D5-F.
- No changes to existing producers; this PR only ships the contract + enforcement helpers.

## Test plan
- [x] `pytest tests/test_unified_report_schema.py -x` — 40 passed in 0.54s
- [x] `bash -n scripts/guardrails/verify_report_schema.sh`
- [x] Manual sanity: guardrail rejects current `templates/unified_report_template.md` (no frontmatter) with `missing YAML frontmatter` and exit 1

Dispatch-ID: 20260517-pr-d5-e-unified-schema