### PR TITLE
feat(pr-6.5d): migration auto-apply hook in T0 state bootstrap

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -173,8 +173,16 @@ def _count_md(directory: Path) -> int:
 def _init_and_check_db(state_dir: Path) -> bool:
     """Idempotent schema init. Returns True if DB is operational."""
     try:
-        from coordination_db import init_schema
+        from coordination_db import db_path_from_state_dir, init_schema
         init_schema(state_dir)
+        # PR-6.5d: auto-apply any pending numbered migrations (e.g. 0020 pool tables)
+        # before downstream readers touch the DB. Best-effort: a migration error
+        # must not block SessionStart, but surface at WARNING for operator visibility.
+        try:
+            from migrations.auto_apply import auto_apply
+            auto_apply(db_path_from_state_dir(state_dir))
+        except Exception as e:
+            log.warning("migration auto_apply failed: %s", e)
         return True
     except (ImportError, OSError, sqlite3.OperationalError) as e:
         log.debug("coordination_db init failed, falling back: %s", e)

--- a/scripts/lib/migrations/auto_apply.py
+++ b/scripts/lib/migrations/auto_apply.py
@@ -1,0 +1,121 @@
+"""auto_apply.py — Wave 6 PR-6.5d N-worker enablement migration hook.
+
+Bridges the gap between the install-time schema (runtime_coordination.sql +
+project_id_migration.py bringing the DB to v13) and any newer numbered
+migrations under schemas/migrations/. Wired into T0 state bootstrap so the
+runtime_coordination.db acquires new tables (e.g. pool_config from 0020)
+on the first session after a code update — without requiring a separate
+``vnx db migrate`` step.
+
+Mechanism:
+- Tracks position with ``PRAGMA user_version`` on runtime_coordination.db
+  (orthogonal to the legacy ``runtime_schema_version`` row tracker; the
+  PRAGMA is owned by this auto-applier).
+- Discovers ``NNNN_*.sql`` files in schemas/migrations/, sorted ascending.
+- For each NNNN strictly greater than the current user_version, locates the
+  paired runner ``scripts/lib/migrations/apply_NNNN.py`` and invokes its
+  ``apply_migration(db_path, sql_path)``. Migrations without a Python
+  runner are out-of-scope (they target other databases such as
+  quality_intelligence.db, handled by project_id_migration.py and
+  quality_db_init.py) and silently skipped.
+- Logs ``migration NNNN auto-applied`` at INFO when the runner reports the
+  migration was actually applied (vs. an idempotent skip because the
+  legacy version tracker already reflected the change).
+- Errors from runners propagate; the rolled-back transaction is the
+  runner's responsibility. The PRAGMA is only advanced when the runner
+  returns cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DEFAULT_MIGRATIONS_DIR = _REPO_ROOT / "schemas" / "migrations"
+_RUNNERS_DIR = Path(__file__).resolve().parent
+_MIGRATION_NUM_RE = re.compile(r"^(\d{4})_.*\.sql$")
+
+
+def _discover_migrations(migrations_dir: Path) -> List[Tuple[int, Path]]:
+    """Return ``[(NNNN, sql_path)]`` sorted ascending. Excludes ``*_down.sql``."""
+    found: List[Tuple[int, Path]] = []
+    if not migrations_dir.is_dir():
+        return found
+    for path in sorted(migrations_dir.glob("*.sql")):
+        if path.name.endswith("_down.sql"):
+            continue
+        m = _MIGRATION_NUM_RE.match(path.name)
+        if not m:
+            continue
+        found.append((int(m.group(1)), path))
+    return found
+
+
+def _load_runner(runners_dir: Path, number: int):
+    """Import scripts/lib/migrations/apply_NNNN.py from disk; None if absent."""
+    runner_path = runners_dir / f"apply_{number:04d}.py"
+    if not runner_path.exists():
+        return None
+    spec = importlib.util.spec_from_file_location(
+        f"_vnx_migration_runner_{number:04d}", runner_path
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def auto_apply(
+    db_path: Path,
+    migrations_dir: Optional[Path] = None,
+    runners_dir: Optional[Path] = None,
+) -> List[int]:
+    """Apply all migrations newer than the DB's PRAGMA user_version.
+
+    Returns the list of migration numbers that were applied (logged at INFO).
+    A NNNN whose runner reports an idempotent skip is still considered
+    "seen" and bumps user_version, but is not added to the returned list.
+
+    Raises sqlite3.Error (or whatever the runner raises) on failure; the
+    PRAGMA user_version is not advanced when a runner raises.
+    """
+    mig_dir = migrations_dir or _DEFAULT_MIGRATIONS_DIR
+    run_dir = runners_dir or _RUNNERS_DIR
+    applied: List[int] = []
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        current = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    finally:
+        conn.close()
+
+    highest_seen = current
+    for number, sql_path in _discover_migrations(mig_dir):
+        if number <= current:
+            continue
+        runner = _load_runner(run_dir, number)
+        if runner is None:
+            continue
+        was_applied = runner.apply_migration(Path(db_path), sql_path)
+        if was_applied:
+            log.info("migration %04d auto-applied", number)
+            applied.append(number)
+        highest_seen = number
+
+    if highest_seen > current:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(f"PRAGMA user_version = {int(highest_seen)}")
+            conn.commit()
+        finally:
+            conn.close()
+
+    return applied

--- a/tests/migrations/test_auto_apply.py
+++ b/tests/migrations/test_auto_apply.py
@@ -1,0 +1,214 @@
+"""tests/migrations/test_auto_apply.py — Wave 6 PR-6.5d auto-apply hook tests.
+
+Verifies that ``scripts/lib/migrations/auto_apply.auto_apply`` discovers
+NNNN_*.sql migrations, delegates to the apply_NNNN.py runner, advances
+``PRAGMA user_version``, and emits the documented INFO log per applied
+migration. Errors are propagated unchanged.
+
+Fixture DBs are written to ``tmp_path`` (real files; the runners open
+sqlite3 connections by path, so :memory: is not usable). Each test sets
+up the minimum schema state needed by the runner under test
+(runtime_schema_version + terminal_leases for 0020).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from migrations.auto_apply import (  # noqa: E402  (path bootstrap above)
+    _discover_migrations,
+    _load_runner,
+    auto_apply,
+)
+
+_MIGRATIONS_DIR = _REPO_ROOT / "schemas" / "migrations"
+_RUNNERS_DIR = _REPO_ROOT / "scripts" / "lib" / "migrations"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _seed_db_at_v13(db_path: Path) -> None:
+    """Create a runtime_coordination.db with prerequisite tables at v13.
+
+    Mirrors the post-install state expected by apply_0020 (the runner is
+    strict: it refuses to apply unless current_version == 13).
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE runtime_schema_version (
+                version     INTEGER PRIMARY KEY,
+                description TEXT,
+                applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+            INSERT INTO runtime_schema_version(version, description)
+            VALUES (13, 'test seed v13');
+
+            CREATE TABLE terminal_leases (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                terminal_id TEXT    NOT NULL,
+                project_id  TEXT    NOT NULL,
+                state       TEXT    NOT NULL DEFAULT 'free',
+                lease_token TEXT    NOT NULL DEFAULT '',
+                UNIQUE(terminal_id, project_id)
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    finally:
+        conn.close()
+
+
+def _table_exists(db_path: Path, table: str) -> bool:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def test_discover_skips_down_migrations(tmp_path):
+    mig_dir = tmp_path / "migrations"
+    mig_dir.mkdir()
+    (mig_dir / "0020_x.sql").write_text("-- up")
+    (mig_dir / "0020_x_down.sql").write_text("-- down")
+    (mig_dir / "not_a_migration.sql").write_text("-- noop")
+    found = _discover_migrations(mig_dir)
+    assert [n for n, _ in found] == [20]
+
+
+def test_discover_sorts_ascending(tmp_path):
+    mig_dir = tmp_path / "migrations"
+    mig_dir.mkdir()
+    for name in ("0020_a.sql", "0017_b.sql", "0019_c.sql"):
+        (mig_dir / name).write_text("-- noop")
+    nums = [n for n, _ in _discover_migrations(mig_dir)]
+    assert nums == [17, 19, 20]
+
+
+def test_discover_missing_dir_returns_empty(tmp_path):
+    assert _discover_migrations(tmp_path / "does-not-exist") == []
+
+
+# ---------------------------------------------------------------------------
+# Runner loader
+# ---------------------------------------------------------------------------
+
+def test_load_runner_returns_none_when_missing(tmp_path):
+    assert _load_runner(tmp_path, 9999) is None
+
+
+def test_load_runner_loads_real_apply_0020():
+    module = _load_runner(_RUNNERS_DIR, 20)
+    assert module is not None
+    assert hasattr(module, "apply_migration")
+
+
+# ---------------------------------------------------------------------------
+# Apply path (uses real 0020 migration against fixture DB)
+# ---------------------------------------------------------------------------
+
+def test_auto_apply_creates_pool_tables_and_bumps_user_version(tmp_path, caplog):
+    db_path = tmp_path / "runtime_coordination.db"
+    _seed_db_at_v13(db_path)
+    assert _user_version(db_path) == 0
+    assert not _table_exists(db_path, "pool_config")
+
+    with caplog.at_level(logging.INFO, logger="migrations.auto_apply"):
+        applied = auto_apply(db_path)
+
+    assert 20 in applied
+    assert _table_exists(db_path, "pool_config")
+    assert _table_exists(db_path, "worker_pools")
+    assert _table_exists(db_path, "worker_pool_membership")
+    # PRAGMA advances to the highest migration number we tried (20),
+    # regardless of which lower-numbered runners reported idempotent skips.
+    assert _user_version(db_path) == 20
+    assert any("migration 0020 auto-applied" in rec.message for rec in caplog.records)
+
+
+def test_auto_apply_is_idempotent_on_second_run(tmp_path, caplog):
+    db_path = tmp_path / "runtime_coordination.db"
+    _seed_db_at_v13(db_path)
+    auto_apply(db_path)
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="migrations.auto_apply"):
+        applied = auto_apply(db_path)
+
+    assert applied == []
+    assert _user_version(db_path) == 20
+    # No re-application log line on the second run.
+    assert not any("auto-applied" in rec.message for rec in caplog.records)
+
+
+def test_auto_apply_skips_when_user_version_already_high(tmp_path):
+    db_path = tmp_path / "runtime_coordination.db"
+    _seed_db_at_v13(db_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA user_version = 99")
+        conn.commit()
+    finally:
+        conn.close()
+
+    applied = auto_apply(db_path)
+    assert applied == []
+    # Pool tables not created because every migration was below user_version.
+    assert not _table_exists(db_path, "pool_config")
+    assert _user_version(db_path) == 99
+
+
+def test_auto_apply_propagates_runner_error(tmp_path, monkeypatch):
+    """When the underlying runner raises, the exception propagates unchanged
+    and PRAGMA user_version is not advanced. Uses a stub runners_dir whose
+    apply_0020.py deliberately raises sqlite3.Error.
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    _seed_db_at_v13(db_path)
+
+    fake_runners = tmp_path / "fake_runners"
+    fake_runners.mkdir()
+    (fake_runners / "apply_0020.py").write_text(
+        "import sqlite3\n"
+        "def apply_migration(db_path, sql_path):\n"
+        "    raise sqlite3.OperationalError('forced failure for test')\n"
+    )
+
+    # Restrict migrations_dir to only 0020 so we don't pick up unrelated runners.
+    fake_migrations = tmp_path / "fake_migrations"
+    fake_migrations.mkdir()
+    (fake_migrations / "0020_test.sql").write_text("-- placeholder")
+
+    with pytest.raises(sqlite3.OperationalError, match="forced failure"):
+        auto_apply(db_path, migrations_dir=fake_migrations, runners_dir=fake_runners)
+    # PRAGMA must NOT have advanced on failure.
+    assert _user_version(db_path) == 0


### PR DESCRIPTION
## Summary

- New `scripts/lib/migrations/auto_apply.py` (~110 LOC w/ docstring) — walks `schemas/migrations/NNNN_*.sql`, tracks position with `PRAGMA user_version` on `runtime_coordination.db`, delegates each pending migration to the existing `apply_NNNN.py` runner.
- Wired into `scripts/build_t0_state.py::_init_and_check_db` right after `init_schema()` so new tables (e.g. PR-6.2 `pool_config` / `worker_pools` / `worker_pool_membership` from 0020) materialize on first SessionStart after a code update — no separate `vnx db migrate` step.
- `tests/migrations/test_auto_apply.py` covers discovery, runner loading, end-to-end apply + PRAGMA bump, idempotency, no-op when caught up, and error propagation (with PRAGMA not advancing).

## Why now

Wave 6 N-worker enablement: PR-6.5d needs the pool tables to be present whenever T0 boots, otherwise `vnx pool status` returns empty / errors on a fresh worktree post-pull.

## Design

- `PRAGMA user_version` is owned solely by this auto-applier and is orthogonal to the legacy `runtime_schema_version` row tracker. The existing `apply_NNNN.py` runners still do their own strict pre-version checks (e.g. `apply_0020` refuses unless DB is at v13) and transactional rollback. This hook is just the scheduler.
- Migrations without a paired `apply_NNNN.py` are silently skipped — they target `quality_intelligence.db` or `global_intelligence.db` and are handled by `project_id_migration.py` / `quality_db_init.py`.
- Errors propagate from `auto_apply` per spec. The `build_t0_state` call site wraps in a try/except so a migration failure logs at WARNING but never blocks SessionStart.

## Test plan

- [x] 9 new unit tests pass (`tests/migrations/test_auto_apply.py`)
- [x] Existing `tests/test_schema_0020_migration.py` (37 tests) still green
- [x] End-to-end sandbox: seed v13 DB → run `auto_apply` → `pool_config` + `worker_pools` query returns `vnx-dev/default` bootstrap rows
- [ ] CI green on Linux runners
- [ ] codex_gate + gemini_review pass