### PR TITLE
feat(pr-d5-f): provider spawns emit unified_report v1 frontmatter (shadow-mode)

### DIFF
--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -106,6 +106,28 @@ def emit_dispatch_receipt(
     return receipt_path
 
 
+def _validate_report_frontmatter(content: str, dispatch_id: str) -> None:
+    """Validate unified-report frontmatter. Shadow-mode by default.
+
+    Logs SchemaViolation as a warning. Raises only when VNX_SCHEMA_STRICT=1.
+    """
+    try:
+        from unified_report_schema import validate_frontmatter, SchemaViolation
+    except ImportError:
+        logger.debug("governance_emit: unified_report_schema not available, skipping validation")
+        return
+
+    try:
+        validate_frontmatter(content)
+    except SchemaViolation as exc:
+        if os.environ.get("VNX_SCHEMA_STRICT") == "1":
+            raise
+        logger.warning(
+            "governance_emit: schema violation (shadow-mode) dispatch=%s: %s",
+            dispatch_id, exc,
+        )
+
+
 def emit_unified_report(
     dispatch_id: str,
     terminal_id: str,
@@ -115,11 +137,17 @@ def emit_unified_report(
     findings: List[Dict[str, Any]],
     duration_seconds: float,
     data_dir: Path,
+    *,
+    frontmatter: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Atomic write to unified_reports/<dispatch_id>.md. Returns path.
 
     Idempotent: returns the existing path without modifying it when the report
     already exists (worker may have written a richer report).
+
+    When *frontmatter* is provided, prepends a YAML frontmatter block and
+    validates against unified_report_v1 schema.  Default is shadow-mode (log
+    violations, do not raise).  Set VNX_SCHEMA_STRICT=1 to raise on violation.
 
     Raises:
         RuntimeError: write failed
@@ -139,7 +167,7 @@ def emit_unified_report(
     else:
         findings_lines = "None"
 
-    content = (
+    body = (
         f"# Dispatch {dispatch_id}\n\n"
         f"- Provider: {provider}\n"
         f"- Terminal: {terminal_id}\n"
@@ -148,6 +176,17 @@ def emit_unified_report(
         f"## Response\n\n{response_text or '(no response captured)'}\n\n"
         f"## Findings\n\n{findings_lines}\n"
     )
+
+    if frontmatter:
+        import yaml
+        frontmatter_yaml = yaml.dump(
+            frontmatter, default_flow_style=False, sort_keys=False,
+            allow_unicode=True,
+        )
+        content = f"---\n{frontmatter_yaml}---\n\n{body}"
+        _validate_report_frontmatter(content, dispatch_id)
+    else:
+        content = body
 
     tmp_path = report_path.with_suffix(".md.tmp")
     try:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -242,6 +242,47 @@ def _compute_cost(provider: str, model: str, token_usage: Dict[str, int]) -> Opt
     return round(cost_in + cost_out, 8)
 
 
+def _build_frontmatter(
+    args: argparse.Namespace,
+    provider: str,
+    model_used: str,
+    result: Any,
+    duration: float,
+    token_usage: Dict[str, int],
+    cost_usd: Optional[float],
+) -> Dict[str, Any]:
+    """Build unified_report_v1 frontmatter from dispatch context + spawn result."""
+    from unified_report_schema import SCHEMA_VERSION
+
+    spawn_fm = result.frontmatter_fields() if hasattr(result, "frontmatter_fields") else {}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dispatch_id": args.dispatch_id,
+        "provider": spawn_fm.get("provider", provider.split(":")[0]),
+        "sub_provider": spawn_fm.get("sub_provider", "none"),
+        "model": model_used,
+        "terminal_id": args.terminal_id,
+        "pool_id": os.environ.get("VNX_POOL_ID", "headless"),
+        "role": getattr(args, "role", None) or "backend-developer",
+        "task_class": os.environ.get("VNX_TASK_CLASS", "implementation"),
+        "pr_id": getattr(args, "pr_id", None) or "none",
+        "duration_seconds": round(duration, 3),
+        "exit_code": spawn_fm.get("exit_code", getattr(result, "returncode", 1)),
+        "token_usage": spawn_fm.get("token_usage", {
+            "input": token_usage.get("input", 0),
+            "output": token_usage.get("output", 0),
+            "cache_read": token_usage.get("cache_hit", 0),
+        }),
+        "cost_usd": cost_usd if cost_usd is not None else 0.0,
+        "route_decision": {
+            "strategy": os.environ.get("VNX_ROUTE_STRATEGY", "default"),
+            "selected_provider": provider,
+            "selected_model": model_used,
+        },
+    }
+
+
 def _emit_governance(
     args: argparse.Namespace,
     provider: str,
@@ -281,6 +322,10 @@ def _emit_governance(
         logger.error("governance_emit: receipt failed dispatch=%s: %s", args.dispatch_id, exc)
         raise SystemExit(1) from exc
 
+    frontmatter = _build_frontmatter(
+        args, provider, model_used, result, duration, token_usage, cost_usd,
+    )
+
     try:
         report_path = emit_unified_report(
             dispatch_id=args.dispatch_id,
@@ -291,6 +336,7 @@ def _emit_governance(
             findings=[],
             duration_seconds=duration,
             data_dir=data_dir,
+            frontmatter=frontmatter,
         )
         print(f"Report: {report_path}", file=sys.stderr)
     except RuntimeError as exc:

--- a/scripts/lib/provider_spawns/claude_spawn.py
+++ b/scripts/lib/provider_spawns/claude_spawn.py
@@ -68,6 +68,19 @@ class ClaudeSpawnResult:
     # available.  Not included in repr to avoid verbose output.
     _adapter: Any = field(default=None, repr=False)
 
+    def frontmatter_fields(self) -> Dict[str, Any]:
+        usage = self.token_usage or {}
+        return {
+            "provider": "claude",
+            "sub_provider": "anthropic",
+            "exit_code": self.returncode,
+            "token_usage": {
+                "input": int(usage.get("input_tokens", 0) or 0),
+                "output": int(usage.get("output_tokens", 0) or 0),
+                "cache_read": int(usage.get("cache_read_input_tokens", 0) or 0),
+            },
+        }
+
 
 def spawn_claude(
     prompt: str,

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -59,6 +59,19 @@ class CodexSpawnResult:
     # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
     event_writer_failures: int = 0
 
+    def frontmatter_fields(self) -> Dict[str, Any]:
+        usage = self.token_usage or {}
+        return {
+            "provider": "codex",
+            "sub_provider": "openai",
+            "exit_code": self.returncode,
+            "token_usage": {
+                "input": int(usage.get("input_tokens", 0) or 0),
+                "output": int(usage.get("output_tokens", 0) or 0),
+                "cache_read": int(usage.get("cache_read_tokens", 0) or 0),
+            },
+        }
+
 
 # ---------------------------------------------------------------------------
 # Normalizer helpers — single implementation; codex_adapter shims delegate here

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -228,6 +228,19 @@ class GeminiSpawnResult:
     # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
     event_writer_failures: int = 0
 
+    def frontmatter_fields(self) -> Dict[str, Any]:
+        usage = self.token_usage or {}
+        return {
+            "provider": "gemini",
+            "sub_provider": "google",
+            "exit_code": self.returncode,
+            "token_usage": {
+                "input": int(usage.get("input_tokens", 0) or 0),
+                "output": int(usage.get("output_tokens", 0) or 0),
+                "cache_read": int(usage.get("cache_read_tokens", 0) or 0),
+            },
+        }
+
 
 # ---------------------------------------------------------------------------
 # Main spawn function

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -47,6 +47,19 @@ class KimiSpawnResult:
     error: Optional[str] = None
     event_writer_failures: int = 0
 
+    def frontmatter_fields(self) -> Dict[str, Any]:
+        usage = self.token_usage or {}
+        return {
+            "provider": "kimi",
+            "sub_provider": "moonshot",
+            "exit_code": self.returncode,
+            "token_usage": {
+                "input": int(usage.get("input_tokens", 0) or 0),
+                "output": int(usage.get("output_tokens", 0) or 0),
+                "cache_read": int(usage.get("cache_read_tokens", 0) or 0),
+            },
+        }
+
 
 def normalize_kimi_event(raw: dict, terminal_id: str, dispatch_id: str) -> CanonicalEvent:
     """Map a raw Kimi CLI stream-json event to a CanonicalEvent (Tier-1).

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -155,6 +155,25 @@ class LiteLLMSpawnResult:
     # > 0 indicates audit-trail gaps the caller must investigate per ADR-005.
     event_writer_failures: int = 0
 
+    def frontmatter_fields(self) -> Dict[str, Any]:
+        usage = self.token_usage or {}
+        cache_read = 0
+        details = usage.get("prompt_tokens_details")
+        if isinstance(details, dict):
+            cache_read = int(details.get("cached_tokens", 0) or 0)
+        if not cache_read:
+            cache_read = int(usage.get("prompt_cache_hit_tokens", 0) or 0)
+        return {
+            "provider": "litellm",
+            "sub_provider": "none",
+            "exit_code": self.returncode,
+            "token_usage": {
+                "input": int(usage.get("prompt_tokens", 0) or 0),
+                "output": int(usage.get("completion_tokens", 0) or 0),
+                "cache_read": cache_read,
+            },
+        }
+
 
 # ---------------------------------------------------------------------------
 # Contract enforcement helpers

--- a/scripts/lib/report_assembler.py
+++ b/scripts/lib/report_assembler.py
@@ -428,6 +428,7 @@ def write_report(
 
     try:
         markdown = render_markdown(report)
+        _validate_assembler_output(markdown, dispatch_id)
         md_path.write_text(markdown, encoding="utf-8")
         result.md_path = md_path
     except OSError as exc:
@@ -435,6 +436,25 @@ def write_report(
         md_path = None
 
     return json_path, md_path
+
+
+def _validate_assembler_output(content: str, dispatch_id: str) -> None:
+    """Validate report frontmatter if present. Shadow-mode by default."""
+    if not content or not content.lstrip().startswith("---"):
+        return
+    try:
+        from unified_report_schema import validate_frontmatter, SchemaViolation
+    except ImportError:
+        return
+    try:
+        validate_frontmatter(content)
+    except SchemaViolation as exc:
+        if os.environ.get("VNX_SCHEMA_STRICT") == "1":
+            raise
+        logger.warning(
+            "report_assembler: schema violation (shadow-mode) dispatch=%s: %s",
+            dispatch_id, exc,
+        )
 
 
 def _short_title_from_dispatch_id(dispatch_id: str) -> str:

--- a/tests/test_governance_emit_schema.py
+++ b/tests/test_governance_emit_schema.py
@@ -1,0 +1,236 @@
+"""test_governance_emit_schema.py — Tests for PR-D5-F schema validation in governance_emit.
+
+Covers: frontmatter generation, shadow-mode validation, strict-mode enforcement,
+and backward-compatible behavior (no frontmatter → no validation).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from governance_emit import emit_unified_report, _validate_report_frontmatter
+from unified_report_schema import SchemaViolation, SCHEMA_VERSION
+
+
+@pytest.fixture()
+def tmp_data(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return data_dir
+
+
+def _valid_frontmatter():
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dispatch_id": "test-d5f-001",
+        "provider": "claude",
+        "sub_provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "terminal_id": "T1",
+        "pool_id": "headless",
+        "role": "backend-developer",
+        "task_class": "implementation",
+        "pr_id": "PR-D5-F",
+        "duration_seconds": 42.5,
+        "exit_code": 0,
+        "token_usage": {"input": 1000, "output": 500, "cache_read": 200},
+        "cost_usd": 0.015,
+        "route_decision": {
+            "strategy": "default",
+            "selected_provider": "claude",
+            "selected_model": "claude-sonnet-4-6",
+        },
+    }
+
+
+def _base_report_kwargs(data_dir):
+    return dict(
+        dispatch_id="test-d5f-001",
+        terminal_id="T1",
+        provider="claude",
+        instruction="Do the thing",
+        response_text="Done.",
+        findings=[],
+        duration_seconds=42.5,
+        data_dir=data_dir,
+    )
+
+
+# --- Frontmatter generation ---
+
+
+class TestFrontmatterGeneration:
+    def test_report_with_frontmatter_has_yaml_block(self, tmp_data):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["frontmatter"] = _valid_frontmatter()
+        path = emit_unified_report(**kwargs)
+        content = path.read_text()
+        assert content.startswith("---\n")
+        assert "\n---\n" in content
+
+    def test_report_without_frontmatter_has_no_yaml_block(self, tmp_data):
+        path = emit_unified_report(**_base_report_kwargs(tmp_data))
+        content = path.read_text()
+        assert not content.startswith("---")
+
+    def test_frontmatter_fields_roundtrip(self, tmp_data):
+        kwargs = _base_report_kwargs(tmp_data)
+        fm = _valid_frontmatter()
+        kwargs["frontmatter"] = fm
+        path = emit_unified_report(**kwargs)
+        content = path.read_text()
+        lines = content.split("\n")
+        assert lines[0] == "---"
+        end_idx = None
+        for i in range(1, len(lines)):
+            if lines[i] == "---":
+                end_idx = i
+                break
+        assert end_idx is not None
+        parsed = yaml.safe_load("\n".join(lines[1:end_idx]))
+        assert parsed["schema_version"] == SCHEMA_VERSION
+        assert parsed["dispatch_id"] == "test-d5f-001"
+        assert parsed["provider"] == "claude"
+        assert parsed["token_usage"]["input"] == 1000
+
+    def test_body_preserved_after_frontmatter(self, tmp_data):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["frontmatter"] = _valid_frontmatter()
+        path = emit_unified_report(**kwargs)
+        content = path.read_text()
+        assert "# Dispatch test-d5f-001" in content
+        assert "## Instruction" in content
+        assert "## Response" in content
+
+
+# --- Shadow-mode validation ---
+
+
+class TestShadowMode:
+    def test_invalid_frontmatter_does_not_raise(self, tmp_data, caplog):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-shadow-001"
+        kwargs["frontmatter"] = {"schema_version": 1}
+        with caplog.at_level(logging.WARNING):
+            path = emit_unified_report(**kwargs)
+        assert path.exists()
+        assert "schema violation (shadow-mode)" in caplog.text
+
+    def test_valid_frontmatter_no_warning(self, tmp_data, caplog):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["frontmatter"] = _valid_frontmatter()
+        with caplog.at_level(logging.WARNING):
+            emit_unified_report(**kwargs)
+        assert "schema violation" not in caplog.text
+
+    def test_missing_required_field_logged(self, tmp_data, caplog):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-shadow-missing"
+        fm = _valid_frontmatter()
+        del fm["provider"]
+        kwargs["frontmatter"] = fm
+        with caplog.at_level(logging.WARNING):
+            path = emit_unified_report(**kwargs)
+        assert path.exists()
+        assert "schema violation (shadow-mode)" in caplog.text
+
+
+# --- Strict mode ---
+
+
+class TestStrictMode:
+    def test_raises_on_invalid(self, tmp_data, monkeypatch):
+        monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-strict-001"
+        kwargs["frontmatter"] = {"schema_version": 1}
+        with pytest.raises(SchemaViolation):
+            emit_unified_report(**kwargs)
+
+    def test_passes_on_valid(self, tmp_data, monkeypatch):
+        monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["frontmatter"] = _valid_frontmatter()
+        path = emit_unified_report(**kwargs)
+        assert path.exists()
+
+
+# --- _validate_report_frontmatter standalone ---
+
+
+class TestValidateReportFrontmatter:
+    def test_valid_content(self):
+        fm = _valid_frontmatter()
+        fm_yaml = yaml.dump(fm, default_flow_style=False, sort_keys=False)
+        content = f"---\n{fm_yaml}---\n\n# Body"
+        _validate_report_frontmatter(content, "test-001")
+
+    def test_invalid_shadow_logs(self, caplog):
+        content = "---\nschema_version: 1\n---\n\n# Body"
+        with caplog.at_level(logging.WARNING):
+            _validate_report_frontmatter(content, "test-002")
+        assert "schema violation (shadow-mode)" in caplog.text
+
+    def test_strict_raises(self, monkeypatch):
+        monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+        content = "---\nschema_version: 1\n---\n\n# Body"
+        with pytest.raises(SchemaViolation):
+            _validate_report_frontmatter(content, "test-003")
+
+
+# --- Idempotency preserved ---
+
+
+class TestIdempotency:
+    def test_idempotent_with_frontmatter(self, tmp_data):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["frontmatter"] = _valid_frontmatter()
+        path1 = emit_unified_report(**kwargs)
+        mtime1 = path1.stat().st_mtime
+        kwargs["response_text"] = "Different"
+        path2 = emit_unified_report(**kwargs)
+        assert path1 == path2
+        assert path2.stat().st_mtime == mtime1
+
+    def test_idempotent_without_frontmatter(self, tmp_data):
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-idem-no-fm"
+        path1 = emit_unified_report(**kwargs)
+        path2 = emit_unified_report(**kwargs)
+        assert path1 == path2
+
+
+# --- Integration with unified_report_schema validator ---
+
+
+class TestSchemaIntegration:
+    def test_all_required_fields_present_validates(self, tmp_data, monkeypatch):
+        monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-integration-001"
+        fm = _valid_frontmatter()
+        fm["dispatch_id"] = "test-integration-001"
+        kwargs["frontmatter"] = fm
+        path = emit_unified_report(**kwargs)
+        assert path.exists()
+        from unified_report_schema import validate_file
+        validate_file(path)
+
+    def test_wrong_schema_version_fails_strict(self, tmp_data, monkeypatch):
+        monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+        kwargs = _base_report_kwargs(tmp_data)
+        kwargs["dispatch_id"] = "test-wrong-version"
+        fm = _valid_frontmatter()
+        fm["schema_version"] = 999
+        fm["dispatch_id"] = "test-wrong-version"
+        kwargs["frontmatter"] = fm
+        with pytest.raises(SchemaViolation):
+            emit_unified_report(**kwargs)

--- a/tests/test_provider_spawn_frontmatter.py
+++ b/tests/test_provider_spawn_frontmatter.py
@@ -1,0 +1,306 @@
+"""test_provider_spawn_frontmatter.py — Tests for SpawnResult.frontmatter_fields() (PR-D5-F).
+
+Verifies that all 5 provider spawn modules produce a consistent frontmatter dict
+compatible with the unified_report_v1 schema token_usage shape.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib" / "provider_spawns"))
+
+from provider_spawns.claude_spawn import ClaudeSpawnResult
+from provider_spawns.codex_spawn import CodexSpawnResult
+from provider_spawns.gemini_spawn import GeminiSpawnResult
+from provider_spawns.kimi_spawn import KimiSpawnResult
+from provider_spawns.litellm_spawn import LiteLLMSpawnResult
+
+
+SCHEMA_KEYS = {"provider", "sub_provider", "exit_code", "token_usage"}
+TOKEN_USAGE_KEYS = {"input", "output", "cache_read"}
+
+
+# --- ClaudeSpawnResult ---
+
+
+class TestClaudeFrontmatter:
+    def test_with_full_usage(self):
+        r = ClaudeSpawnResult(
+            returncode=0,
+            completion={"agent_message": "done"},
+            events_written=5,
+            session_id="sess-1",
+            timed_out=False,
+            token_usage={
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200,
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["provider"] == "claude"
+        assert fm["sub_provider"] == "anthropic"
+        assert fm["exit_code"] == 0
+        assert fm["token_usage"] == {"input": 1000, "output": 500, "cache_read": 200}
+
+    def test_without_usage(self):
+        r = ClaudeSpawnResult(
+            returncode=1,
+            completion={},
+            events_written=0,
+            session_id=None,
+            timed_out=True,
+            token_usage=None,
+        )
+        fm = r.frontmatter_fields()
+        assert fm["exit_code"] == 1
+        assert fm["token_usage"] == {"input": 0, "output": 0, "cache_read": 0}
+
+    def test_partial_usage(self):
+        r = ClaudeSpawnResult(
+            returncode=0,
+            completion={},
+            events_written=1,
+            session_id=None,
+            timed_out=False,
+            token_usage={"input_tokens": 50},
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 50, "output": 0, "cache_read": 0}
+
+
+# --- CodexSpawnResult ---
+
+
+class TestCodexFrontmatter:
+    def test_with_full_usage(self):
+        r = CodexSpawnResult(
+            returncode=0,
+            completion_text="result",
+            events_written=10,
+            session_id="codex-sess",
+            timed_out=False,
+            token_usage={
+                "input_tokens": 800,
+                "output_tokens": 300,
+                "cache_read_tokens": 50,
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["provider"] == "codex"
+        assert fm["sub_provider"] == "openai"
+        assert fm["exit_code"] == 0
+        assert fm["token_usage"] == {"input": 800, "output": 300, "cache_read": 50}
+
+    def test_null_usage(self):
+        r = CodexSpawnResult(
+            returncode=127,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            token_usage=None,
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 0, "output": 0, "cache_read": 0}
+
+
+# --- GeminiSpawnResult ---
+
+
+class TestGeminiFrontmatter:
+    def test_with_usage(self):
+        r = GeminiSpawnResult(
+            returncode=0,
+            completion_text="review",
+            events_written=3,
+            session_id=None,
+            timed_out=False,
+            token_usage={
+                "input_tokens": 2000,
+                "output_tokens": 1500,
+                "cache_read_tokens": 0,
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["provider"] == "gemini"
+        assert fm["sub_provider"] == "google"
+        assert fm["token_usage"] == {"input": 2000, "output": 1500, "cache_read": 0}
+
+    def test_no_usage(self):
+        r = GeminiSpawnResult(
+            returncode=1,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=True,
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 0, "output": 0, "cache_read": 0}
+
+
+# --- KimiSpawnResult ---
+
+
+class TestKimiFrontmatter:
+    def test_with_usage(self):
+        r = KimiSpawnResult(
+            returncode=0,
+            completion_text="output",
+            events_written=8,
+            session_id=None,
+            timed_out=False,
+            token_usage={
+                "input_tokens": 600,
+                "output_tokens": 400,
+                "cache_read_tokens": 0,
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["provider"] == "kimi"
+        assert fm["sub_provider"] == "moonshot"
+        assert fm["token_usage"] == {"input": 600, "output": 400, "cache_read": 0}
+
+    def test_null_usage(self):
+        r = KimiSpawnResult(
+            returncode=0,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+            token_usage=None,
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 0, "output": 0, "cache_read": 0}
+
+
+# --- LiteLLMSpawnResult ---
+
+
+class TestLiteLLMFrontmatter:
+    def test_openai_format(self):
+        r = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="done",
+            events_written=12,
+            session_id=None,
+            timed_out=False,
+            token_usage={
+                "prompt_tokens": 1200,
+                "completion_tokens": 700,
+                "prompt_tokens_details": {"cached_tokens": 300},
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["provider"] == "litellm"
+        assert fm["sub_provider"] == "none"
+        assert fm["token_usage"] == {"input": 1200, "output": 700, "cache_read": 300}
+
+    def test_cache_hit_fallback(self):
+        r = LiteLLMSpawnResult(
+            returncode=0,
+            completion_text="done",
+            events_written=5,
+            session_id=None,
+            timed_out=False,
+            token_usage={
+                "prompt_tokens": 500,
+                "completion_tokens": 200,
+                "prompt_cache_hit_tokens": 100,
+            },
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 500, "output": 200, "cache_read": 100}
+
+    def test_null_usage(self):
+        r = LiteLLMSpawnResult(
+            returncode=1,
+            completion_text="",
+            events_written=0,
+            session_id=None,
+            timed_out=False,
+        )
+        fm = r.frontmatter_fields()
+        assert fm["token_usage"] == {"input": 0, "output": 0, "cache_read": 0}
+
+
+# --- Cross-provider consistency ---
+
+
+class TestCrossProviderConsistency:
+    def _all_results(self):
+        return [
+            ClaudeSpawnResult(
+                returncode=0, completion={}, events_written=0,
+                session_id=None, timed_out=False,
+            ),
+            CodexSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+            ),
+            GeminiSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+            ),
+            KimiSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+            ),
+            LiteLLMSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+            ),
+        ]
+
+    def test_all_return_same_keys(self):
+        for r in self._all_results():
+            fm = r.frontmatter_fields()
+            assert set(fm.keys()) == SCHEMA_KEYS, f"{type(r).__name__} keys mismatch"
+            assert set(fm["token_usage"].keys()) == TOKEN_USAGE_KEYS, (
+                f"{type(r).__name__} token_usage keys mismatch"
+            )
+
+    def test_all_token_usage_values_are_ints(self):
+        results_with_usage = [
+            ClaudeSpawnResult(
+                returncode=0, completion={}, events_written=0,
+                session_id=None, timed_out=False,
+                token_usage={"input_tokens": 1, "output_tokens": 2},
+            ),
+            CodexSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                token_usage={"input_tokens": 1, "output_tokens": 2},
+            ),
+            GeminiSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                token_usage={"input_tokens": 1, "output_tokens": 2},
+            ),
+            KimiSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                token_usage={"input_tokens": 1, "output_tokens": 2},
+            ),
+            LiteLLMSpawnResult(
+                returncode=0, completion_text="", events_written=0,
+                session_id=None, timed_out=False,
+                token_usage={"prompt_tokens": 1, "completion_tokens": 2},
+            ),
+        ]
+        for r in results_with_usage:
+            fm = r.frontmatter_fields()
+            for k, v in fm["token_usage"].items():
+                assert isinstance(v, int), (
+                    f"{type(r).__name__}.token_usage[{k}] is {type(v).__name__}, expected int"
+                )
+
+    def test_exit_code_reflects_returncode(self):
+        for r in self._all_results():
+            fm = r.frontmatter_fields()
+            assert fm["exit_code"] == r.returncode


### PR DESCRIPTION
## Summary
- All 5 spawn modules (claude, codex, gemini, kimi, litellm) gain `frontmatter_fields() -> dict` returning normalized `{provider, sub_provider, exit_code, token_usage}` per unified_report_v1 schema
- `governance_emit.emit_unified_report()` accepts optional `frontmatter` kwarg, prepends YAML frontmatter block, validates via `UnifiedReportValidator` in shadow-mode (log, don't raise; `VNX_SCHEMA_STRICT=1` for strict)
- `report_assembler.write_report()` runs same validator on output when frontmatter is present
- `provider_dispatch._emit_governance()` wires everything via `_build_frontmatter()` helper

## Changed files
| File | Change |
|---|---|
| `scripts/lib/provider_spawns/claude_spawn.py` | +`frontmatter_fields()` on `ClaudeSpawnResult` |
| `scripts/lib/provider_spawns/codex_spawn.py` | +`frontmatter_fields()` on `CodexSpawnResult` |
| `scripts/lib/provider_spawns/gemini_spawn.py` | +`frontmatter_fields()` on `GeminiSpawnResult` |
| `scripts/lib/provider_spawns/kimi_spawn.py` | +`frontmatter_fields()` on `KimiSpawnResult` |
| `scripts/lib/provider_spawns/litellm_spawn.py` | +`frontmatter_fields()` on `LiteLLMSpawnResult` |
| `scripts/lib/governance_emit.py` | +`_validate_report_frontmatter()`, updated `emit_unified_report()` |
| `scripts/lib/report_assembler.py` | +`_validate_assembler_output()` in `write_report()` |
| `scripts/lib/provider_dispatch.py` | +`_build_frontmatter()`, wired into `_emit_governance()` |
| `tests/test_provider_spawn_frontmatter.py` | 15 tests across 5 providers + cross-provider consistency |
| `tests/test_governance_emit_schema.py` | 16 tests: frontmatter gen, shadow-mode, strict-mode, idempotency |

## Metrics
- **177 LOC** source changes, **542 LOC** new tests (719 total)
- **31 new tests**, all passing
- **99 total tests** (including PR-D5-E schema tests) pass
- **28 existing governance_emit tests** unchanged and green

## Test plan
- [x] `pytest tests/test_provider_spawn_frontmatter.py` — 15/15 passed
- [x] `pytest tests/test_governance_emit_schema.py` — 16/16 passed
- [x] `pytest tests/test_governance_emit.py` — 28/28 passed (backward compat)
- [x] `pytest tests/test_unified_report_schema.py` — 40/40 passed
- [x] All modified `.py` files pass `py_compile`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)