### PR TITLE
feat(pr-sr-3): smart_router classifier + recommendation lookup

### DIFF
--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -1,0 +1,253 @@
+"""smart_router.py — Task classifier + recommendation lookup for cost-aware routing.
+
+Pure-function module. Classifies dispatch instructions into one of 7 task classes
+via heuristic regex + tag matching, then looks up ranked model recommendations
+from routing_recommendations.yaml.
+
+No side effects beyond reading the YAML file. No wiring into provider_dispatch —
+that is PR-SR-4 scope.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import yaml
+
+_RECOMMENDATIONS_PATH = Path(__file__).parent / "providers" / "routing_recommendations.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RouteCandidate:
+    """Single model recommendation for a task class."""
+    model_id: str
+    composite_score: float
+    avg_duration_seconds: float
+    cost_usd_per_call: Optional[float] = None
+
+
+@dataclass
+class RouteDecision:
+    """Result of classify + recommend."""
+    task_class: str
+    primary: Optional[RouteCandidate]
+    fallback: Optional[RouteCandidate]
+    reason: str
+    constraints_applied: List[str] = field(default_factory=list)
+    cost_estimate: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Task class definitions — heuristic patterns
+# ---------------------------------------------------------------------------
+
+_TASK_CLASS_PATTERNS: List[tuple[str, re.Pattern]] = [
+    ("05_debugging", re.compile(
+        r"(?i)(?:"
+        r"(?:^|\W)debug\b|fix\s+(?:bug|issue|error|crash|regression)"
+        r"|diagnos|troubleshoot"
+        r"|investigate\s+(?:the\s+)?(?:bug|issue|error|failure|regression|crash|flak)"
+        r"|root[\s_-]?cause|bisect|stack[\s_-]?trace"
+        r")",
+    )),
+    ("02_code_review", re.compile(
+        r"(?i)(?:"
+        r"(?:code|peer|security)[\s_-]?review"
+        r"|(?:^|\W)(?:review|audit)\s+(?:the\s+)?(?:PR|code|module|changes|security|auth)"
+        r"|inspect\s+code|check\s+(?:code|quality|style)"
+        r"|(?:^|\W)lint(?:ing)?\b|static[\s_-]?analysis|gate[\s_-]?check"
+        r")",
+    )),
+    ("06_design", re.compile(
+        r"(?i)(?:"
+        r"(?:^|\W)design\b|(?:^|\W)architect\b"
+        r"|plan\s+(?:the\s+)?(?:system|feature|module|migration)"
+        r"|(?:^|\W)rfc\b|design[\s_-]?doc|system[\s_-]?design|api[\s_-]?design"
+        r"|technical[\s_-]?spec|blueprint|schema[\s_-]?design"
+        r")",
+    )),
+    ("07_translation", re.compile(
+        r"(?i)(?:"
+        r"translat|(?:^|\W)i18n\b|(?:^|\W)l10n\b|localiz"
+        r"|port\s+(?:to|from)\s+\w+"
+        r"|convert\s+(?:to|from)\s+\w+"
+        r"|migrat(?:e|ion)\s+(?:to|from)\s+\w+"
+        r")",
+    )),
+    ("04_documentation", re.compile(
+        r"(?i)(?:"
+        r"(?:^|\W)document(?:ation)?\b"
+        r"|write\s+(?:(?:a|the|an)\s+)?(?:docs|documentation|readme|adr|changelog)"
+        r"|update\s+(?:the\s+)?(?:docs|documentation|readme|adr|changelog)"
+        r"|(?:add|write)\s+(?:(?:a|the)\s+)?docstring"
+        r"|jsdoc|typedoc|api[\s_-]?doc"
+        r")",
+    )),
+    ("03_refactoring", re.compile(
+        r"(?i)(?:"
+        r"refactor|restructure|reorganize|split\s+(?:module|file|class)"
+        r"|extract\s+(?:function|class|module|method)"
+        r"|(?:^|\W)rename\b|move\s+(?:code|function|class|module)"
+        r"|dedup|consolidat|simplif|clean\s*up"
+        r")",
+    )),
+    ("01_code_generation", re.compile(
+        r"(?i)(?:"
+        r"implement|create\s+(?:new\s+)?(?:module|class|function|endpoint|feature|script)"
+        r"|add\s+(?:new\s+)?(?:support|handler|adapter|route|command)"
+        r"|(?:^|\W)build\b|scaffold|bootstrap|generate\s+code"
+        r"|write\s+(?:(?:a|the)\s+)?(?:module|class|function|script)"
+        r")",
+    )),
+]
+
+TASK_CLASSES: Dict[str, re.Pattern] = {tc: pat for tc, pat in _TASK_CLASS_PATTERNS}
+
+ROLE_TO_TASK_CLASS: Dict[str, str] = {
+    "backend-developer": "01_code_generation",
+    "frontend-developer": "01_code_generation",
+    "api-developer": "01_code_generation",
+    "python-optimizer": "01_code_generation",
+    "supabase-expert": "01_code_generation",
+    "test-engineer": "01_code_generation",
+    "quality-engineer": "02_code_review",
+    "reviewer": "02_code_review",
+    "security-engineer": "02_code_review",
+    "architect": "06_design",
+    "planner": "06_design",
+    "technical-writer": "04_documentation",
+    "debugger": "05_debugging",
+    "performance-profiler": "05_debugging",
+}
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+def classify_task(
+    instruction: str,
+    role: Optional[str] = None,
+    dispatch_paths: Optional[Sequence[str]] = None,
+) -> str:
+    """Classify a dispatch instruction into one of the 7 task classes.
+
+    Priority:
+      1. Instruction text matched against heuristic regex patterns (first match wins,
+         ordered by task class number — code_gen checked before review, etc.)
+      2. Role-based fallback if no regex matches
+      3. Default: 01_code_generation (safest default — most dispatches are code work)
+
+    dispatch_paths is reserved for future signal enrichment (e.g. docs-only paths
+    → documentation class) but not used in the heuristic yet.
+    """
+    normalized = (instruction or "").strip()
+
+    for task_class, pattern in _TASK_CLASS_PATTERNS:
+        if pattern.search(normalized):
+            return task_class
+
+    if role:
+        role_key = role.strip().lstrip("/").lower()
+        mapped = ROLE_TO_TASK_CLASS.get(role_key)
+        if mapped:
+            return mapped
+
+    return "01_code_generation"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations loader
+# ---------------------------------------------------------------------------
+
+def _load_recommendations(
+    path: Optional[Path] = None,
+) -> Dict[str, List[RouteCandidate]]:
+    """Load routing_recommendations.yaml and return parsed candidates per task class."""
+    yaml_path = path or _RECOMMENDATIONS_PATH
+    if not yaml_path.exists():
+        raise FileNotFoundError(
+            f"routing_recommendations.yaml not found at {yaml_path}"
+        )
+
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or "routing_by_task" not in raw:
+        raise ValueError(
+            f"Malformed routing_recommendations.yaml: missing 'routing_by_task' key"
+        )
+
+    result: Dict[str, List[RouteCandidate]] = {}
+    for task_class, entries in raw["routing_by_task"].items():
+        candidates = []
+        for entry in (entries or []):
+            candidates.append(RouteCandidate(
+                model_id=str(entry["model_id"]),
+                composite_score=float(entry["composite_score"]),
+                avg_duration_seconds=float(entry["avg_duration_seconds"]),
+                cost_usd_per_call=entry.get("cost_usd_per_call"),
+            ))
+        candidates.sort(key=lambda c: c.composite_score, reverse=True)
+        result[task_class] = candidates
+
+    return result
+
+
+def recommend(
+    task_class: str,
+    *,
+    recommendations_path: Optional[Path] = None,
+) -> List[RouteCandidate]:
+    """Return ranked RouteCandidate list for a task class.
+
+    Returns empty list if the task class has no recommendations.
+    """
+    recs = _load_recommendations(recommendations_path)
+    return recs.get(task_class, [])
+
+
+# ---------------------------------------------------------------------------
+# Full decision
+# ---------------------------------------------------------------------------
+
+def decide(
+    instruction: str,
+    role: Optional[str] = None,
+    dispatch_paths: Optional[Sequence[str]] = None,
+    *,
+    recommendations_path: Optional[Path] = None,
+) -> RouteDecision:
+    """Classify instruction and build a RouteDecision with primary + fallback.
+
+    Combines classify_task and recommend into a single call that returns a
+    RouteDecision with the top-scoring candidate as primary and the second-best
+    as fallback.
+    """
+    task_class = classify_task(instruction, role=role, dispatch_paths=dispatch_paths)
+    candidates = recommend(task_class, recommendations_path=recommendations_path)
+
+    primary = candidates[0] if candidates else None
+    fallback = candidates[1] if len(candidates) > 1 else None
+
+    parts = [f"task_class={task_class}"]
+    if primary:
+        parts.append(f"primary={primary.model_id} (score={primary.composite_score})")
+    if fallback:
+        parts.append(f"fallback={fallback.model_id} (score={fallback.composite_score})")
+    if not candidates:
+        parts.append("no recommendations available")
+
+    cost_estimate = primary.cost_usd_per_call if primary else None
+
+    return RouteDecision(
+        task_class=task_class,
+        primary=primary,
+        fallback=fallback,
+        reason="; ".join(parts),
+        cost_estimate=cost_estimate,
+    )

--- a/tests/test_smart_router.py
+++ b/tests/test_smart_router.py
@@ -1,0 +1,379 @@
+"""Tests for smart_router — task classifier + recommendation lookup.
+
+Covers all 7 task classes from routing_recommendations.yaml, role-based fallback,
+ambiguous inputs, missing recommendations, and the full decide() flow.
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from smart_router import (
+    RouteCandidate,
+    RouteDecision,
+    classify_task,
+    decide,
+    recommend,
+    _load_recommendations,
+    TASK_CLASSES,
+    ROLE_TO_TASK_CLASS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def recommendations_yaml(tmp_path):
+    """Minimal routing_recommendations.yaml for isolated tests."""
+    data = {
+        "routing_by_task": {
+            "01_code_generation": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
+                 "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
+                {"model_id": "claude-opus-4-6", "composite_score": 7.5,
+                 "avg_duration_seconds": 330.0, "cost_usd_per_call": None},
+            ],
+            "02_code_review": [
+                {"model_id": "claude-opus-4-6", "composite_score": 10.0,
+                 "avg_duration_seconds": 90.9, "cost_usd_per_call": None},
+                {"model_id": "claude-sonnet-4-6", "composite_score": 9.5,
+                 "avg_duration_seconds": 72.5, "cost_usd_per_call": None},
+            ],
+            "03_refactoring": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.5,
+                 "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
+            ],
+            "04_documentation": [
+                {"model_id": "deepseek-v4-flash", "composite_score": 8.5,
+                 "avg_duration_seconds": 12.6, "cost_usd_per_call": None},
+            ],
+            "05_debugging": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 7.5,
+                 "avg_duration_seconds": 148.8, "cost_usd_per_call": None},
+            ],
+            "06_design": [
+                {"model_id": "claude-haiku-4-5", "composite_score": 9.5,
+                 "avg_duration_seconds": 151.9, "cost_usd_per_call": None},
+                {"model_id": "claude-opus-4-6", "composite_score": 9.0,
+                 "avg_duration_seconds": 273.3, "cost_usd_per_call": None},
+            ],
+            "07_translation": [
+                {"model_id": "deepseek-v4-flash", "composite_score": 8.5,
+                 "avg_duration_seconds": 4.25, "cost_usd_per_call": None},
+            ],
+        }
+    }
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def empty_recommendations_yaml(tmp_path):
+    """YAML with routing_by_task but no entries for any class."""
+    data = {"routing_by_task": {}}
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# classify_task — 7 task classes
+# ---------------------------------------------------------------------------
+
+class TestClassifyCodeGeneration:
+
+    @pytest.mark.parametrize("instruction", [
+        "Implement the smart router module",
+        "Create new endpoint for user registration",
+        "Add support for WebSocket connections",
+        "Build the migration script",
+        "Scaffold the provider adapter",
+        "Generate code for the CLI parser",
+        "Write a module for cost tracking",
+    ])
+    def test_code_generation_instructions(self, instruction):
+        assert classify_task(instruction) == "01_code_generation"
+
+
+class TestClassifyCodeReview:
+
+    @pytest.mark.parametrize("instruction", [
+        "Review the PR for security issues",
+        "Audit the authentication module",
+        "Run a code review on the dispatch logic",
+        "Check code quality of the router",
+        "Perform static analysis on the adapter",
+        "Gate check: lint + type-check before merge",
+    ])
+    def test_code_review_instructions(self, instruction):
+        assert classify_task(instruction) == "02_code_review"
+
+
+class TestClassifyRefactoring:
+
+    @pytest.mark.parametrize("instruction", [
+        "Refactor the dispatch router into smaller functions",
+        "Split module intelligence_selector.py per source",
+        "Extract function from the monolithic handler",
+        "Rename the legacy adapter class",
+        "Consolidate duplicate error handlers",
+        "Clean up the dead code in cost_tracker",
+    ])
+    def test_refactoring_instructions(self, instruction):
+        assert classify_task(instruction) == "03_refactoring"
+
+
+class TestClassifyDocumentation:
+
+    @pytest.mark.parametrize("instruction", [
+        "Document the API endpoints",
+        "Write docs for the new router module",
+        "Update the README with installation instructions",
+        "Add docstrings to the provider registry",
+        "Write an ADR for the routing decision",
+        "Update changelog for v0.6.0",
+    ])
+    def test_documentation_instructions(self, instruction):
+        assert classify_task(instruction) == "04_documentation"
+
+
+class TestClassifyDebugging:
+
+    @pytest.mark.parametrize("instruction", [
+        "Debug the failing gate check",
+        "Fix bug in the cost tracker parsing",
+        "Diagnose the flaky test in CI",
+        "Troubleshoot the broken WebSocket connection",
+        "Investigate the regression in dispatch timing",
+        "Root cause analysis for the NDJSON corruption",
+    ])
+    def test_debugging_instructions(self, instruction):
+        assert classify_task(instruction) == "05_debugging"
+
+
+class TestClassifyDesign:
+
+    @pytest.mark.parametrize("instruction", [
+        "Design the new routing architecture",
+        "Plan the migration from tmux to headless",
+        "Write an RFC for the feedback loop system",
+        "Create a technical spec for the cost router",
+        "System design for multi-tenant dispatch",
+        "API design for the external webhook integration",
+    ])
+    def test_design_instructions(self, instruction):
+        assert classify_task(instruction) == "06_design"
+
+
+class TestClassifyTranslation:
+
+    @pytest.mark.parametrize("instruction", [
+        "Translate the UI strings to Dutch",
+        "Add i18n support for error messages",
+        "Localize the dashboard for German users",
+        "Port to Python from the existing TypeScript module",
+        "Convert to YAML from the JSON config",
+    ])
+    def test_translation_instructions(self, instruction):
+        assert classify_task(instruction) == "07_translation"
+
+
+# ---------------------------------------------------------------------------
+# classify_task — role fallback
+# ---------------------------------------------------------------------------
+
+class TestClassifyRoleFallback:
+
+    def test_role_backend_developer_falls_back_to_code_gen(self):
+        assert classify_task("do the thing", role="backend-developer") == "01_code_generation"
+
+    def test_role_reviewer_falls_back_to_code_review(self):
+        assert classify_task("check this", role="reviewer") == "02_code_review"
+
+    def test_role_architect_falls_back_to_design(self):
+        assert classify_task("think about this", role="architect") == "06_design"
+
+    def test_role_debugger_falls_back_to_debugging(self):
+        assert classify_task("look at the logs", role="debugger") == "05_debugging"
+
+    def test_role_technical_writer_falls_back_to_documentation(self):
+        assert classify_task("handle the docs", role="technical-writer") == "04_documentation"
+
+    def test_instruction_takes_priority_over_role(self):
+        assert classify_task("Refactor the module", role="backend-developer") == "03_refactoring"
+
+
+# ---------------------------------------------------------------------------
+# classify_task — edge cases
+# ---------------------------------------------------------------------------
+
+class TestClassifyEdgeCases:
+
+    def test_empty_instruction_no_role_defaults_to_code_gen(self):
+        assert classify_task("") == "01_code_generation"
+
+    def test_none_instruction_defaults_to_code_gen(self):
+        assert classify_task(None) == "01_code_generation"
+
+    def test_ambiguous_instruction_uses_first_match(self):
+        result = classify_task("Implement and review the new adapter")
+        assert result == "01_code_generation"
+
+    def test_unknown_role_defaults_to_code_gen(self):
+        assert classify_task("do something", role="underwater-welder") == "01_code_generation"
+
+    def test_role_with_leading_slash(self):
+        assert classify_task("do the thing", role="/backend-developer") == "01_code_generation"
+
+    def test_role_case_insensitive(self):
+        assert classify_task("do the thing", role="Backend-Developer") == "01_code_generation"
+
+    def test_dispatch_paths_accepted_but_unused(self):
+        result = classify_task("do the thing", dispatch_paths=["scripts/lib/foo.py"])
+        assert result == "01_code_generation"
+
+
+# ---------------------------------------------------------------------------
+# recommend
+# ---------------------------------------------------------------------------
+
+class TestRecommend:
+
+    def test_returns_candidates_sorted_by_score(self, recommendations_yaml):
+        candidates = recommend("01_code_generation", recommendations_path=recommendations_yaml)
+        assert len(candidates) == 2
+        assert candidates[0].composite_score >= candidates[1].composite_score
+
+    def test_candidates_are_route_candidate_type(self, recommendations_yaml):
+        candidates = recommend("02_code_review", recommendations_path=recommendations_yaml)
+        assert all(isinstance(c, RouteCandidate) for c in candidates)
+
+    def test_returns_empty_for_unknown_task_class(self, recommendations_yaml):
+        candidates = recommend("99_nonexistent", recommendations_path=recommendations_yaml)
+        assert candidates == []
+
+    def test_returns_empty_for_empty_yaml(self, empty_recommendations_yaml):
+        candidates = recommend("01_code_generation", recommendations_path=empty_recommendations_yaml)
+        assert candidates == []
+
+    def test_all_7_task_classes_have_recommendations(self):
+        """Verify the real routing_recommendations.yaml covers all 7 classes."""
+        recs = _load_recommendations()
+        for tc in TASK_CLASSES:
+            assert tc in recs, f"Missing recommendations for {tc}"
+            assert len(recs[tc]) > 0, f"Empty recommendations for {tc}"
+
+    def test_raises_on_missing_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.yaml"
+        with pytest.raises(FileNotFoundError):
+            recommend("01_code_generation", recommendations_path=missing)
+
+    def test_raises_on_malformed_yaml(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("not_routing_by_task: true", encoding="utf-8")
+        with pytest.raises(ValueError, match="routing_by_task"):
+            recommend("01_code_generation", recommendations_path=bad)
+
+
+# ---------------------------------------------------------------------------
+# decide (full flow)
+# ---------------------------------------------------------------------------
+
+class TestDecide:
+
+    def test_returns_route_decision(self, recommendations_yaml):
+        decision = decide(
+            "Implement the cost tracker",
+            recommendations_path=recommendations_yaml,
+        )
+        assert isinstance(decision, RouteDecision)
+        assert decision.task_class == "01_code_generation"
+        assert decision.primary is not None
+        assert decision.primary.model_id == "claude-sonnet-4-6"
+        assert decision.fallback is not None
+        assert decision.fallback.model_id == "claude-opus-4-6"
+
+    def test_decision_with_single_candidate(self, recommendations_yaml):
+        decision = decide(
+            "Refactor the handler into three modules",
+            recommendations_path=recommendations_yaml,
+        )
+        assert decision.task_class == "03_refactoring"
+        assert decision.primary is not None
+        assert decision.fallback is None
+
+    def test_decision_for_design_via_role(self, recommendations_yaml):
+        decision = decide(
+            "think about the system",
+            role="architect",
+            recommendations_path=recommendations_yaml,
+        )
+        assert decision.task_class == "06_design"
+        assert decision.primary.model_id == "claude-haiku-4-5"
+
+    def test_decision_with_no_recommendations(self, empty_recommendations_yaml):
+        decision = decide(
+            "Debug the broken gate",
+            recommendations_path=empty_recommendations_yaml,
+        )
+        assert decision.task_class == "05_debugging"
+        assert decision.primary is None
+        assert decision.fallback is None
+        assert "no recommendations" in decision.reason
+
+    def test_reason_contains_task_class(self, recommendations_yaml):
+        decision = decide(
+            "Review the security audit results",
+            recommendations_path=recommendations_yaml,
+        )
+        assert "02_code_review" in decision.reason
+
+    def test_dispatch_paths_forwarded(self, recommendations_yaml):
+        decision = decide(
+            "update the tests",
+            dispatch_paths=["tests/"],
+            recommendations_path=recommendations_yaml,
+        )
+        assert isinstance(decision, RouteDecision)
+
+
+# ---------------------------------------------------------------------------
+# RouteCandidate / RouteDecision dataclass sanity
+# ---------------------------------------------------------------------------
+
+class TestDataclasses:
+
+    def test_route_candidate_fields(self):
+        c = RouteCandidate(
+            model_id="test-model",
+            composite_score=8.5,
+            avg_duration_seconds=100.0,
+            cost_usd_per_call=0.05,
+        )
+        assert c.model_id == "test-model"
+        assert c.composite_score == 8.5
+        assert c.avg_duration_seconds == 100.0
+        assert c.cost_usd_per_call == 0.05
+
+    def test_route_candidate_cost_defaults_to_none(self):
+        c = RouteCandidate(model_id="m", composite_score=1.0, avg_duration_seconds=1.0)
+        assert c.cost_usd_per_call is None
+
+    def test_route_decision_constraints_defaults_to_empty(self):
+        d = RouteDecision(
+            task_class="01_code_generation",
+            primary=None,
+            fallback=None,
+            reason="test",
+        )
+        assert d.constraints_applied == []
+        assert d.cost_estimate is None


### PR DESCRIPTION
## Summary
- Pure-function module `scripts/lib/smart_router.py` (253 LOC) that classifies dispatch instructions into 7 task classes via heuristic regex + role-based fallback, then looks up ranked model recommendations from `routing_recommendations.yaml`
- Exports: `classify_task()`, `recommend()`, `decide()`, `RouteCandidate`, `RouteDecision` dataclasses
- **Not wired** into provider_dispatch — that is PR-SR-4 scope

## Task classes recognized
| Class | Signal examples |
|---|---|
| `01_code_generation` | implement, create module, add support, build, scaffold |
| `02_code_review` | review PR, audit, lint, static analysis, gate check |
| `03_refactoring` | refactor, split module, extract function, rename, cleanup |
| `04_documentation` | document, write docs/readme/adr, update changelog |
| `05_debugging` | debug, fix bug, diagnose, troubleshoot, root cause |
| `06_design` | design, architect, plan migration, RFC, technical spec |
| `07_translation` | translate, i18n, localize, port to/from, convert to/from |

## Test plan
- [x] 71 tests in `tests/test_smart_router.py` — all green
- [x] Parametrized tests for all 7 task classes (42 instruction variants)
- [x] Role-based fallback (6 tests)
- [x] Edge cases: empty/None input, ambiguous, unknown role, leading slash, case insensitive
- [x] Recommendation loading: sorted scores, empty YAML, missing file, malformed YAML
- [x] Full `decide()` flow: primary + fallback, single candidate, no recommendations
- [x] Dataclass field defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)