### PR TITLE
feat(pr-6.5e): per-worker .vnx-data/workers/ subdirectory

### DIFF
--- a/scripts/lib/subprocess_dispatch_internals/delivery.py
+++ b/scripts/lib/subprocess_dispatch_internals/delivery.py
@@ -276,6 +276,11 @@ def deliver_via_subprocess(
     resume_session = _load_resume_session(terminal_id)
     extra_env = _build_worker_identity_env(terminal_id)
 
+    # PR-6.5e: per-worker state directory for N-worker isolation.
+    from vnx_paths import resolve_worker_state_dir
+    worker_state_dir = resolve_worker_state_dir(terminal_id)
+    extra_env["VNX_WORKER_STATE_DIR"] = str(worker_state_dir)
+
     heartbeat_stop, heartbeat_thread = _start_heartbeat(
         terminal_id, dispatch_id, lease_generation, heartbeat_interval,
     )

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -226,6 +226,29 @@ def resolve_state_dir(project_root: "Path | None" = None) -> Path:
     return Path(paths["VNX_STATE_DIR"])
 
 
+def resolve_worker_state_dir(terminal_id: str, vnx_data_dir: "Path | None" = None) -> Path:
+    """Return ``.vnx-data/workers/<terminal_id>/`` — per-worker isolated state directory.
+
+    Creates the directory on demand (exist_ok=True). When vnx_data_dir is None,
+    derives it from resolve_paths()["VNX_DATA_DIR"].
+
+    Raises:
+        ValueError: if terminal_id is empty or contains path-traversal characters.
+    """
+    if not terminal_id or not terminal_id.strip():
+        raise ValueError("terminal_id must be non-empty")
+    clean = terminal_id.strip()
+    if "/" in clean or "\\" in clean or ".." in clean:
+        raise ValueError(
+            f"terminal_id must not contain path separators or '..': {terminal_id!r}"
+        )
+    if vnx_data_dir is None:
+        vnx_data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+    worker_dir = vnx_data_dir / "workers" / clean
+    os.makedirs(worker_dir, exist_ok=True)
+    return worker_dir.resolve()
+
+
 def resolve_central_data_dir(project_id: str) -> Path:
     """Return ``~/.vnx-data/<project_id>/`` — the central per-project data directory.
 

--- a/tests/test_worker_state_dir.py
+++ b/tests/test_worker_state_dir.py
@@ -1,0 +1,155 @@
+"""Tests for per-worker .vnx-data/workers/<terminal_id>/ isolation (PR-6.5e)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from vnx_paths import resolve_worker_state_dir
+
+
+@pytest.fixture
+def tmp_vnx_data(tmp_path):
+    """Provide a temporary .vnx-data directory."""
+    vnx_data = tmp_path / ".vnx-data"
+    vnx_data.mkdir()
+    return vnx_data
+
+
+class TestResolveWorkerStateDir:
+    def test_creates_directory_on_demand(self, tmp_vnx_data):
+        result = resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        assert result.exists()
+        assert result.is_dir()
+        assert result == (tmp_vnx_data / "workers" / "T1").resolve()
+
+    def test_isolation_between_terminals(self, tmp_vnx_data):
+        t1 = resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        t2 = resolve_worker_state_dir("T2", vnx_data_dir=tmp_vnx_data)
+        t3 = resolve_worker_state_dir("T3", vnx_data_dir=tmp_vnx_data)
+
+        assert t1 != t2
+        assert t2 != t3
+        assert t1.name == "T1"
+        assert t2.name == "T2"
+        assert t3.name == "T3"
+
+    def test_idempotent_on_existing_dir(self, tmp_vnx_data):
+        first = resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        marker = first / "state.json"
+        marker.write_text("{}")
+        second = resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        assert second == first
+        assert marker.exists()
+
+    def test_worker_writes_isolated(self, tmp_vnx_data):
+        t1_dir = resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        t2_dir = resolve_worker_state_dir("T2", vnx_data_dir=tmp_vnx_data)
+
+        (t1_dir / "dispatch.log").write_text("T1 log entry")
+        (t2_dir / "dispatch.log").write_text("T2 log entry")
+
+        assert (t1_dir / "dispatch.log").read_text() == "T1 log entry"
+        assert (t2_dir / "dispatch.log").read_text() == "T2 log entry"
+
+    def test_rejects_empty_terminal_id(self, tmp_vnx_data):
+        with pytest.raises(ValueError, match="non-empty"):
+            resolve_worker_state_dir("", vnx_data_dir=tmp_vnx_data)
+
+    def test_rejects_whitespace_only_terminal_id(self, tmp_vnx_data):
+        with pytest.raises(ValueError, match="non-empty"):
+            resolve_worker_state_dir("   ", vnx_data_dir=tmp_vnx_data)
+
+    def test_rejects_path_traversal(self, tmp_vnx_data):
+        with pytest.raises(ValueError, match="path separators"):
+            resolve_worker_state_dir("../etc", vnx_data_dir=tmp_vnx_data)
+
+    def test_rejects_slash_in_terminal_id(self, tmp_vnx_data):
+        with pytest.raises(ValueError, match="path separators"):
+            resolve_worker_state_dir("T1/malicious", vnx_data_dir=tmp_vnx_data)
+
+    def test_rejects_backslash_in_terminal_id(self, tmp_vnx_data):
+        with pytest.raises(ValueError, match="path separators"):
+            resolve_worker_state_dir("T1\\bad", vnx_data_dir=tmp_vnx_data)
+
+    def test_uses_resolve_paths_when_no_vnx_data_dir(self, tmp_vnx_data):
+        mock_paths = {"VNX_DATA_DIR": str(tmp_vnx_data)}
+        with patch("vnx_paths.resolve_paths", return_value=mock_paths):
+            result = resolve_worker_state_dir("T2")
+        assert result.exists()
+        assert result == (tmp_vnx_data / "workers" / "T2").resolve()
+
+    def test_parent_workers_dir_created(self, tmp_vnx_data):
+        resolve_worker_state_dir("T1", vnx_data_dir=tmp_vnx_data)
+        workers_dir = tmp_vnx_data / "workers"
+        assert workers_dir.exists()
+        assert workers_dir.is_dir()
+
+
+class TestDeliveryEnvInjection:
+    """Verify that deliver_via_subprocess passes VNX_WORKER_STATE_DIR to spawn_claude."""
+
+    def test_extra_env_contains_worker_state_dir(self, tmp_vnx_data):
+        captured_env = {}
+
+        def fake_spawn_claude(prompt, model, dispatch_id, terminal_id, **kwargs):
+            extra_env = kwargs.get("extra_env")
+            if extra_env:
+                captured_env.update(extra_env)
+            from provider_spawns.claude_spawn import ClaudeSpawnResult
+            return ClaudeSpawnResult(
+                returncode=0,
+                completion={},
+                events_written=0,
+                session_id=None,
+                timed_out=False,
+                _adapter=None,
+            )
+
+        mock_paths = {"VNX_DATA_DIR": str(tmp_vnx_data)}
+
+        with (
+            patch("vnx_paths.resolve_paths", return_value=mock_paths),
+            patch(
+                "provider_spawns.claude_spawn.spawn_claude",
+                side_effect=fake_spawn_claude,
+            ),
+            patch(
+                "subprocess_dispatch_internals.delivery._build_worker_identity_env",
+                return_value={},
+            ),
+            patch(
+                "subprocess_dispatch_internals.delivery._apply_runtime_overrides",
+                return_value=(300.0, 900.0),
+            ),
+            patch(
+                "subprocess_dispatch_internals.delivery._prepare_dispatch",
+                return_value=("instruction", None, None, "/tmp/manifest"),
+            ),
+            patch(
+                "subprocess_dispatch_internals.delivery._load_resume_session",
+                return_value=None,
+            ),
+            patch(
+                "subprocess_dispatch_internals.delivery._start_heartbeat",
+                return_value=(None, None),
+            ),
+        ):
+            from subprocess_dispatch_internals.delivery import deliver_via_subprocess
+
+            deliver_via_subprocess(
+                terminal_id="T1",
+                instruction="test",
+                model="sonnet",
+                dispatch_id="test-dispatch",
+            )
+
+        assert "VNX_WORKER_STATE_DIR" in captured_env
+        expected = str((tmp_vnx_data / "workers" / "T1").resolve())
+        assert captured_env["VNX_WORKER_STATE_DIR"] == expected


### PR DESCRIPTION
## Summary
- Add `resolve_worker_state_dir(terminal_id)` to `scripts/lib/vnx_paths.py` — returns `.vnx-data/workers/<terminal_id>/`, created on demand with `os.makedirs(exist_ok=True)`
- Wire into `subprocess_dispatch_internals/delivery.py` to pass `VNX_WORKER_STATE_DIR` env var to every worker subprocess via `extra_env`
- Path-traversal validation rejects empty, `..`, `/`, and `\` in terminal_id

## Test plan
- [x] 12 tests in `tests/test_worker_state_dir.py` (`pytest tests/test_worker_state_dir.py -x -v` — 12 passed)
- [x] Directory creation on demand
- [x] Isolation between T1/T2/T3
- [x] Idempotency on existing dir
- [x] Write isolation (files in T1 dir don't appear in T2 dir)
- [x] Rejects empty, whitespace-only, path-traversal terminal IDs
- [x] Fallback to `resolve_paths()` when no explicit vnx_data_dir
- [x] Delivery integration: `VNX_WORKER_STATE_DIR` present in `extra_env` passed to `spawn_claude`

Dispatch-ID: 20260517-pr-6.5e-worker-state

🤖 Generated with [Claude Code](https://claude.com/claude-code)