### PR TITLE
feat(pr-6.5c): worker heartbeat + PID validation in reaper

### DIFF
--- a/scripts/codex_final_gate.py
+++ b/scripts/codex_final_gate.py
@@ -47,6 +47,11 @@ RUNTIME_PATH_MARKERS = (
 DELETION_FILE_WARN = 5
 DELETION_FILE_HOLD = 20
 
+# Net line deletion thresholds (lines_removed - lines_added across all changed files).
+# Catches PRs that gut file content without fully deleting files.
+NET_LINE_DELETION_WARN = 200
+NET_LINE_DELETION_HOLD = 500
+
 
 def _touches_governance_paths(changed_files: List[str]) -> bool:
     return is_governance_path(changed_files)
@@ -98,6 +103,60 @@ def _count_deleted_files(project_root: Path) -> int:
     return len(files) if files is not None else -1
 
 
+def _parse_numstat_net(numstat_output: str) -> int:
+    """Parse git diff --numstat output, return net line deletion (removed - added).
+
+    Binary files report '-' for both columns and are skipped.
+    """
+    total_added = 0
+    total_removed = 0
+    for line in numstat_output.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] != "-" and parts[1] != "-":
+            try:
+                total_added += int(parts[0])
+                total_removed += int(parts[1])
+            except ValueError:
+                pass
+    return total_removed - total_added
+
+
+def _get_net_line_deletion(project_root: Path) -> Optional[int]:
+    """Return net lines deleted (removed - added) for current PR vs origin/main.
+
+    Returns None on git failure. Complements _get_deleted_files: catches PRs that gut
+    file content without fully deleting files.
+    """
+    for base_ref in ("origin/main", "origin/master"):
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--numstat", f"{base_ref}...HEAD"],
+                cwd=str(project_root),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return _parse_numstat_net(result.stdout)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--numstat", "HEAD~1", "HEAD"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return _parse_numstat_net(result.stdout)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    return None
+
+
 @dataclass(frozen=True)
 class CodexGateEnforcementResult:
     """Result of evaluating whether a Codex final gate is required."""
@@ -111,6 +170,8 @@ class CodexGateEnforcementResult:
     high_risk_by_path: bool
     mass_deletion_count: int = 0
     mass_deletion_warn: bool = False
+    net_line_deletion: int = 0
+    net_line_deletion_warn: bool = False
     warnings: List[str] = field(default_factory=list)
     deleted_files: List[str] = field(default_factory=list)
 
@@ -160,6 +221,8 @@ def enforce_codex_gate(
     deleted_files: List[str] = []
     deleted_count = 0
     mass_deletion_warn = False
+    net_line_deletion = 0
+    net_line_deletion_warn = False
     warnings_list: List[str] = []
     if project_root is not None:
         raw = _get_deleted_files(project_root)
@@ -172,6 +235,15 @@ def enforce_codex_gate(
             mass_deletion_warn = True
             warnings_list.append("mass_deletion_warning")
 
+        raw_net = _get_net_line_deletion(project_root)
+        if raw_net is not None:
+            net_line_deletion = raw_net
+        if net_line_deletion >= NET_LINE_DELETION_HOLD:
+            reasons.append("net_line_deletion")
+        elif net_line_deletion >= NET_LINE_DELETION_WARN:
+            net_line_deletion_warn = True
+            warnings_list.append("net_line_deletion_warning")
+
     return CodexGateEnforcementResult(
         required=len(reasons) > 0,
         reasons=reasons,
@@ -182,6 +254,8 @@ def enforce_codex_gate(
         high_risk_by_path=high_risk_path,
         mass_deletion_count=deleted_count,
         mass_deletion_warn=mass_deletion_warn,
+        net_line_deletion=net_line_deletion,
+        net_line_deletion_warn=net_line_deletion_warn,
         warnings=warnings_list,
         deleted_files=deleted_files,
     )
@@ -424,20 +498,28 @@ def _apply_mass_deletion_warning(
     enforcement: CodexGateEnforcementResult,
     findings: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Prepend a WARN-level finding when mass-deletion threshold is reached.
+    """Prepend WARN-level findings for file-count and net-line-count deletion thresholds.
 
-    WARN does not make the gate required; it surfaces as an advisory finding.
+    WARN does not make the gate required; findings surface as advisory in the receipt.
     """
-    if not enforcement.mass_deletion_warn:
-        return findings
-    warning = {
-        "severity": "warning",
-        "message": (
-            f"Net deletion warning: {enforcement.mass_deletion_count} file(s) deleted "
-            f"(>= {DELETION_FILE_WARN} threshold) — verify intentional scope reduction"
-        ),
-    }
-    return [warning] + findings
+    prefixed: List[Dict[str, Any]] = list(findings)
+    if enforcement.net_line_deletion_warn:
+        prefixed.insert(0, {
+            "severity": "warning",
+            "message": (
+                f"Net line deletion warning: {enforcement.net_line_deletion} net lines deleted "
+                f"(>= {NET_LINE_DELETION_WARN} threshold) — verify intentional scope reduction"
+            ),
+        })
+    if enforcement.mass_deletion_warn:
+        prefixed.insert(0, {
+            "severity": "warning",
+            "message": (
+                f"Net deletion warning: {enforcement.mass_deletion_count} file(s) deleted "
+                f"(>= {DELETION_FILE_WARN} threshold) — verify intentional scope reduction"
+            ),
+        })
+    return prefixed
 
 
 def _atomic_write_text(target: Path, content: str) -> None:
@@ -626,8 +708,10 @@ def _cmd_render_prompt(args: argparse.Namespace) -> int:
         print(json.dumps({"ok": False, "error": str(exc)}))
         return EXIT_IO
 
+    deleted_files = _get_deleted_files(SCRIPT_DIR.parent)
+
     try:
-        prompt = render_codex_prompt(contract)
+        prompt = render_codex_prompt(contract, deleted_files=deleted_files)
     except ValueError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))
         return EXIT_VALIDATION

--- a/scripts/lib/pool_decision_engine.py
+++ b/scripts/lib/pool_decision_engine.py
@@ -42,6 +42,7 @@ class Membership:
     status: str                  # "pending" | "active" | "draining" | "reaped"
     joined_at: float             # unix timestamp
     last_heartbeat: Optional[float] = None
+    pid: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -35,7 +35,7 @@ from pool_provider_allocator import (  # noqa: E402
     allocate_for_scale_up,
     select_for_scale_down,
 )
-from pool_reaper import ReapConfig, ReapTarget, identify_reap_targets  # noqa: E402
+from pool_reaper import ReapConfig, ReapTarget, identify_dead_pid_targets, identify_reap_targets  # noqa: E402
 from pool_state_repo import PoolStateRepository  # noqa: E402
 
 log = logging.getLogger(__name__)
@@ -178,13 +178,26 @@ class PoolManager:
     def reap_dead(self) -> List[ReapTarget]:
         """Identify + kill + release stuck/stale workers.
 
+        Two detection paths run in sequence:
+        1. PID validation — os.kill(pid, 0) probe; dead process = immediate reap
+        2. Heartbeat staleness — existing threshold-based detection
+
         Returns list of successfully reaped targets for audit/observability.
         Kill failures do not block membership release — process may already be gone.
         """
         _config, _state, members = self.load_state()
         now = time.time()
 
-        targets = identify_reap_targets(members, now, self.reap_config)
+        pid_targets = identify_dead_pid_targets(members)
+        heartbeat_targets = identify_reap_targets(members, now, self.reap_config)
+
+        seen_ids: set[str] = set()
+        targets: List[ReapTarget] = []
+        for t in pid_targets + heartbeat_targets:
+            if t.membership_id not in seen_ids:
+                seen_ids.add(t.membership_id)
+                targets.append(t)
+
         reaped: List[ReapTarget] = []
 
         for target in targets:

--- a/scripts/lib/pool_reaper.py
+++ b/scripts/lib/pool_reaper.py
@@ -5,6 +5,7 @@ Pure detection module. Actual SIGTERM/SIGKILL via cleanup_worker_exit.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -54,7 +55,7 @@ def identify_reap_targets(
                 targets.append(ReapTarget(
                     membership_id=m.membership_id,
                     terminal_id=m.terminal_id,
-                    pid=getattr(m, "pid", None),
+                    pid=m.pid,
                     reason=(
                         f"never_heartbeat_age={worker_age:.0f}s"
                         f">{config.heartbeat_stale_threshold_s:.0f}s"
@@ -66,10 +67,46 @@ def identify_reap_targets(
                 targets.append(ReapTarget(
                     membership_id=m.membership_id,
                     terminal_id=m.terminal_id,
-                    pid=getattr(m, "pid", None),
+                    pid=m.pid,
                     reason=(
                         f"heartbeat_stale={stale_age:.0f}s"
                         f">{config.heartbeat_stale_threshold_s:.0f}s"
                     ),
                 ))
+    return targets
+
+
+def is_pid_alive(pid: Optional[int]) -> bool:
+    """Check if a process with the given PID is still running.
+
+    Returns False for None, pid <= 0, or dead processes.
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def identify_dead_pid_targets(
+    members: "List[Membership]",
+) -> List[ReapTarget]:
+    """Identify active members whose worker PID is no longer alive."""
+    targets: List[ReapTarget] = []
+    for m in members:
+        if m.status != "active":
+            continue
+        if m.pid is None or m.pid <= 0:
+            continue
+        if not is_pid_alive(m.pid):
+            targets.append(ReapTarget(
+                membership_id=m.membership_id,
+                terminal_id=m.terminal_id,
+                pid=m.pid,
+                reason=f"pid_dead={m.pid}",
+            ))
     return targets

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -174,7 +174,8 @@ class PoolStateRepository:
                     wpm.role,
                     wpm.joined_at,
                     wpm.metadata_json,
-                    tl.last_heartbeat_at
+                    tl.last_heartbeat_at,
+                    tl.worker_pid
                 FROM worker_pool_membership wpm
                 LEFT JOIN terminal_leases tl
                     ON tl.terminal_id = wpm.terminal_id
@@ -192,6 +193,8 @@ class PoolStateRepository:
                 membership_id = meta.get("membership_id", str(row["id"]))
                 last_heartbeat = _from_iso(row["last_heartbeat_at"])
                 joined_ts = _from_iso(row["joined_at"]) or 0.0
+                raw_pid = row["worker_pid"]
+                pid = int(raw_pid) if raw_pid is not None else None
                 members.append(
                     Membership(
                         membership_id=membership_id,
@@ -201,6 +204,7 @@ class PoolStateRepository:
                         status="active",
                         joined_at=joined_ts,
                         last_heartbeat=last_heartbeat,
+                        pid=pid,
                     )
                 )
             return members
@@ -317,6 +321,46 @@ class PoolStateRepository:
             log.error(
                 "mark_member_reaped: ledger emit failed for membership_id=%s", membership_id
             )
+
+    def store_worker_pid(self, terminal_id: str, pid: int) -> None:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE terminal_leases
+                SET worker_pid = ?
+                WHERE terminal_id = ? AND project_id = ?
+                """,
+                (pid, terminal_id, self.project_id),
+            )
+            conn.commit()
+            log.debug("store_worker_pid: terminal=%s pid=%d", terminal_id, pid)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def update_heartbeat_by_terminal(self, terminal_id: str, now: float) -> None:
+        hb_iso = _iso_now(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE terminal_leases
+                SET last_heartbeat_at = ?
+                WHERE terminal_id = ? AND project_id = ?
+                """,
+                (hb_iso, terminal_id, self.project_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def update_heartbeat(self, membership_id: str, now: float) -> None:
         hb_iso = _iso_now(now)

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -146,8 +146,27 @@ __all__ = [
 ]
 
 
+def _pool_heartbeat_loop(
+    terminal_id: str,
+    project_id: str,
+    db_path: "Path",
+    stop_event: "threading.Event",
+    interval: float = 15.0,
+) -> None:
+    """Update terminal_leases.last_heartbeat_at every *interval* seconds."""
+    import threading as _thr
+    while not stop_event.wait(timeout=interval):
+        try:
+            from pool_state_repo import PoolStateRepository
+            repo = PoolStateRepository(db_path, project_id)
+            repo.update_heartbeat_by_terminal(terminal_id, time.time())
+        except Exception:
+            pass
+
+
 if __name__ == "__main__":
     import argparse
+    import threading
 
     parser = argparse.ArgumentParser(description="Deliver dispatch via SubprocessAdapter")
     parser.add_argument("--terminal-id", required=True)
@@ -235,16 +254,40 @@ if __name__ == "__main__":
                 _routing_exc, args.model,
             )
 
-    ok = deliver_with_recovery(
-        terminal_id=args.terminal_id,
-        instruction=args.instruction,
-        model=_effective_model,
-        dispatch_id=args.dispatch_id,
-        role=args.role,
-        max_retries=args.max_retries,
-        auto_commit=not args.no_auto_commit,
-        gate=args.gate,
-        dispatch_paths=_dispatch_paths,
-        pr_id=args.pr_id,
+    _state_dir = _default_state_dir()
+    _db_path = _state_dir / "runtime_coordination.db"
+    _project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+
+    try:
+        from pool_state_repo import PoolStateRepository
+        _pid_repo = PoolStateRepository(_db_path, _project_id)
+        _pid_repo.store_worker_pid(args.terminal_id, os.getpid())
+    except Exception:
+        pass
+
+    _hb_stop = threading.Event()
+    _hb_thread = threading.Thread(
+        target=_pool_heartbeat_loop,
+        args=(args.terminal_id, _project_id, _db_path, _hb_stop),
+        daemon=True,
     )
+    _hb_thread.start()
+
+    try:
+        ok = deliver_with_recovery(
+            terminal_id=args.terminal_id,
+            instruction=args.instruction,
+            model=_effective_model,
+            dispatch_id=args.dispatch_id,
+            role=args.role,
+            max_retries=args.max_retries,
+            auto_commit=not args.no_auto_commit,
+            gate=args.gate,
+            dispatch_paths=_dispatch_paths,
+            pr_id=args.pr_id,
+        )
+    finally:
+        _hb_stop.set()
+        _hb_thread.join(timeout=5)
+
     sys.exit(0 if ok else 1)

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -160,7 +160,9 @@ def _pool_heartbeat_loop(
             from pool_state_repo import PoolStateRepository
             repo = PoolStateRepository(db_path, project_id)
             repo.update_heartbeat_by_terminal(terminal_id, time.time())
-        except Exception:
+        except Exception as exc:
+            import logging as _log_mod
+            _log_mod.getLogger(__name__).warning("heartbeat update failed: %s", exc)
             pass
 
 
@@ -262,7 +264,9 @@ if __name__ == "__main__":
         from pool_state_repo import PoolStateRepository
         _pid_repo = PoolStateRepository(_db_path, _project_id)
         _pid_repo.store_worker_pid(args.terminal_id, os.getpid())
-    except Exception:
+    except Exception as exc:
+        import logging as _log_mod
+        _log_mod.getLogger(__name__).warning("PID persistence failed: %s", exc)
         pass
 
     _hb_stop = threading.Event()

--- a/tests/fixtures/pool_state_fixtures.py
+++ b/tests/fixtures/pool_state_fixtures.py
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS terminal_leases (
     state             TEXT    NOT NULL DEFAULT 'idle',
     lease_token       TEXT    NOT NULL DEFAULT '',
     last_heartbeat_at TEXT,
+    worker_pid        INTEGER,
     UNIQUE(terminal_id, project_id)
 );
 

--- a/tests/test_codex_final_gate_mass_deletion.py
+++ b/tests/test_codex_final_gate_mass_deletion.py
@@ -21,7 +21,10 @@ sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
 from codex_final_gate import (
     DELETION_FILE_HOLD,
     DELETION_FILE_WARN,
+    NET_LINE_DELETION_HOLD,
+    NET_LINE_DELETION_WARN,
     CodexFinalGateReceipt,
+    _parse_numstat_net,
     _persist_result,
     check_gate_clearance,
     enforce_codex_gate,
@@ -288,3 +291,173 @@ class TestPersistResultAtomicWrite:
                     _persist_result(receipt, output_path, contract)
 
         assert not output_path.exists(), "canonical file must not exist when os.replace fails"
+
+
+class TestParseNumstatNet:
+    """Unit tests for _parse_numstat_net helper."""
+
+    def test_basic_net_deletion(self):
+        output = "10\t50\tsome/file.py\n5\t20\tother/file.py\n"
+        assert _parse_numstat_net(output) == (50 + 20) - (10 + 5)
+
+    def test_net_addition(self):
+        output = "100\t10\tsome/file.py\n"
+        assert _parse_numstat_net(output) == 10 - 100
+
+    def test_binary_files_skipped(self):
+        output = "-\t-\tbinary.png\n10\t30\ttext.py\n"
+        assert _parse_numstat_net(output) == 30 - 10
+
+    def test_empty_output_returns_zero(self):
+        assert _parse_numstat_net("") == 0
+
+    def test_no_tabs_skipped(self):
+        output = "just_a_filename\n10\t30\tfile.py\n"
+        assert _parse_numstat_net(output) == 30 - 10
+
+
+def _mock_numstat(net_removed: int):
+    """Return a mock subprocess.run result reporting net_removed as a single deletion."""
+    mock = MagicMock()
+    mock.returncode = 0
+    mock.stdout = f"0\t{net_removed}\tsome/file.py\n"
+    return mock
+
+
+class TestNetLineDeletion:
+    """enforce_codex_gate must detect net line deletion and flag appropriately."""
+
+    def test_hold_level_triggers_gate(self, tmp_path):
+        contract = _make_contract()
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),   # _get_deleted_files → no deleted files
+            _mock_numstat(NET_LINE_DELETION_HOLD + 100),  # _get_net_line_deletion → HOLD
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.net_line_deletion >= NET_LINE_DELETION_HOLD
+        assert "net_line_deletion" in result.reasons
+        assert result.required is True
+
+    def test_warn_level_sets_flag_not_required(self, tmp_path):
+        contract = _make_contract()
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),
+            _mock_numstat(NET_LINE_DELETION_WARN + 50),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.net_line_deletion_warn is True
+        assert "net_line_deletion" not in result.reasons
+        assert result.required is False
+
+    def test_below_warn_no_flag(self, tmp_path):
+        contract = _make_contract()
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),
+            _mock_numstat(NET_LINE_DELETION_WARN - 10),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.net_line_deletion_warn is False
+        assert "net_line_deletion" not in result.reasons
+
+    def test_net_addition_ignored(self, tmp_path):
+        """PR that adds more lines than it removes must not trigger net_line_deletion."""
+        contract = _make_contract()
+        mock_net_add = MagicMock()
+        mock_net_add.returncode = 0
+        mock_net_add.stdout = f"500\t10\tsome/file.py\n"  # +490 net lines
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),
+            mock_net_add,
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.net_line_deletion_warn is False
+        assert "net_line_deletion" not in result.reasons
+
+    def test_warn_injects_finding_in_receipt(self, tmp_path):
+        """evaluate_and_record injects a warning finding when net_line_deletion_warn is active."""
+        contract = _make_contract(
+            pr_id="PR-netline",
+            pr_title="Big line reduction",
+            deliverables=[Deliverable(description="refactor module", category="refactor")],
+            review_stack=["codex_gate"],
+            content_hash="netline123",
+        )
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),
+            _mock_numstat(NET_LINE_DELETION_WARN + 50),
+        ]):
+            with patch("codex_final_gate.emit_governance_receipt"):
+                receipt = evaluate_and_record(contract, project_root=tmp_path)
+
+        line_warn_findings = [
+            f for f in receipt.findings
+            if f.get("severity") == "warning" and "Net line deletion warning" in f.get("message", "")
+        ]
+        assert len(line_warn_findings) == 1
+        assert str(NET_LINE_DELETION_WARN) in line_warn_findings[0]["message"]
+
+    def test_git_failure_returns_zero_net(self, tmp_path):
+        """Git failure on numstat must not crash — net_line_deletion stays 0."""
+        contract = _make_contract()
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            MagicMock(returncode=0, stdout=""),  # _get_deleted_files succeeds
+            MagicMock(returncode=1, stdout=""),  # _get_net_line_deletion origin/main fails
+            MagicMock(returncode=1, stdout=""),  # _get_net_line_deletion origin/master fails
+            MagicMock(returncode=1, stdout=""),  # _get_net_line_deletion HEAD~1 fails
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.net_line_deletion == 0
+        assert result.net_line_deletion_warn is False
+
+
+class TestRenderPromptIncludesDeletionAlert:
+    """_cmd_render_prompt must inject Net-Deletion Alert when deleted files exist."""
+
+    def _write_contract(self, tmp_path):
+        contract = _make_contract(
+            pr_id="PR-render",
+            pr_title="Render test",
+            deliverables=[Deliverable(description="cleanup old module", category="infrastructure")],
+            review_stack=["codex_gate"],
+            content_hash="render456",
+        )
+        path = tmp_path / "contract.json"
+        path.write_text(contract.to_json(), encoding="utf-8")
+        return path
+
+    def test_deleted_files_appear_in_rendered_prompt(self, tmp_path, capsys):
+        from codex_final_gate import main as cgf_main
+
+        contract_path = self._write_contract(tmp_path)
+        deleted = ["old/module.py", "old/helper.py"]
+        mock_git = MagicMock()
+        mock_git.returncode = 0
+        mock_git.stdout = "\n".join(deleted) + "\n"
+
+        with patch("codex_final_gate.subprocess.run", return_value=mock_git):
+            exit_code = cgf_main(["render-prompt", "--contract", str(contract_path)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Net-Deletion Alert" in captured.out
+        assert "old/module.py" in captured.out
+
+    def test_no_deleted_files_no_alert_section(self, tmp_path, capsys):
+        from codex_final_gate import main as cgf_main
+
+        contract_path = self._write_contract(tmp_path)
+        mock_git = MagicMock()
+        mock_git.returncode = 0
+        mock_git.stdout = ""
+
+        with patch("codex_final_gate.subprocess.run", return_value=mock_git):
+            exit_code = cgf_main(["render-prompt", "--contract", str(contract_path)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Net-Deletion Alert" not in captured.out

--- a/tests/test_pool_provider_mix_integration.py
+++ b/tests/test_pool_provider_mix_integration.py
@@ -217,6 +217,7 @@ class TestPoolManagerMockSpawn:
                 terminal_id TEXT,
                 project_id TEXT,
                 last_heartbeat_at TEXT,
+                worker_pid INTEGER,
                 PRIMARY KEY (terminal_id, project_id)
             )
         """)

--- a/tests/test_worker_heartbeat.py
+++ b/tests/test_worker_heartbeat.py
@@ -366,3 +366,32 @@ def test_pool_manager_reap_dead_catches_dead_pid(tmp_path):
     assert len(reaped) == 1
     assert reaped[0].membership_id == "m-dead-pid"
     assert "pid_dead" in reaped[0].reason
+
+
+# ---------------------------------------------------------------------------
+# 8. Silent-except regression: heartbeat loop logs on failure
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_loop_logs_warning_on_exception(tmp_path, caplog):
+    import logging
+
+    from subprocess_dispatch import _pool_heartbeat_loop
+
+    bad_db = tmp_path / "nonexistent" / "db.sqlite3"
+    stop = threading.Event()
+
+    with caplog.at_level(logging.WARNING):
+        t = threading.Thread(
+            target=_pool_heartbeat_loop,
+            args=("T1", "vnx-dev", bad_db, stop),
+            kwargs={"interval": 0.05},
+            daemon=True,
+        )
+        t.start()
+        time.sleep(0.15)
+        stop.set()
+        t.join(timeout=2)
+
+    assert any("heartbeat update failed" in r.message for r in caplog.records)
+
+

--- a/tests/test_worker_heartbeat.py
+++ b/tests/test_worker_heartbeat.py
@@ -1,0 +1,368 @@
+"""test_worker_heartbeat.py — Worker heartbeat + PID validation tests.
+
+Covers:
+- Pool heartbeat loop updates terminal_leases.last_heartbeat_at
+- store_worker_pid writes PID to terminal_leases
+- update_heartbeat_by_terminal updates last_heartbeat_at by terminal_id
+- PID validation: is_pid_alive returns False for dead PIDs
+- identify_dead_pid_targets reaps members with dead PIDs
+- identify_dead_pid_targets skips members with alive PIDs
+- PID <= 0 safety: never probed via os.kill
+
+Wave 6 PR-6.5c — Worker heartbeat + PID validation in reaper.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import threading
+import time
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_decision_engine import Membership
+from pool_reaper import identify_dead_pid_targets, is_pid_alive
+from pool_state_repo import PoolStateRepository
+from pool_state_fixtures import create_test_db_file, insert_lease
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_repo(db_path: Path, project_id: str = "vnx-dev") -> PoolStateRepository:
+    return PoolStateRepository(db_path, project_id)
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    (tmp_path / "state").mkdir()
+    return create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+
+
+def _read_heartbeat(db_path: Path, terminal_id: str) -> str | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT last_heartbeat_at FROM terminal_leases WHERE terminal_id = ?",
+        (terminal_id,),
+    ).fetchone()
+    conn.close()
+    return row["last_heartbeat_at"] if row else None
+
+
+def _read_pid(db_path: Path, terminal_id: str) -> int | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT worker_pid FROM terminal_leases WHERE terminal_id = ?",
+        (terminal_id,),
+    ).fetchone()
+    conn.close()
+    if row is None:
+        return None
+    return int(row["worker_pid"]) if row["worker_pid"] is not None else None
+
+
+def _member_with_pid(
+    membership_id: str = "m-001",
+    terminal_id: str = "T1",
+    pid: int | None = None,
+    status: str = "active",
+    joined_at: float = 0.0,
+    last_heartbeat: float | None = None,
+) -> Membership:
+    return Membership(
+        membership_id=membership_id,
+        terminal_id=terminal_id,
+        provider="claude",
+        pool_role="backend-developer",
+        status=status,
+        joined_at=joined_at,
+        last_heartbeat=last_heartbeat,
+        pid=pid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. store_worker_pid writes PID to terminal_leases
+# ---------------------------------------------------------------------------
+
+def test_store_worker_pid(tmp_path):
+    db = _setup_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token) "
+        "VALUES ('T1', 'vnx-dev', 'active', 'tok-1')",
+    )
+    conn.commit()
+    conn.close()
+
+    repo = _make_repo(db)
+    repo.store_worker_pid("T1", 12345)
+
+    stored_pid = _read_pid(db, "T1")
+    assert stored_pid == 12345
+
+
+# ---------------------------------------------------------------------------
+# 2. update_heartbeat_by_terminal updates last_heartbeat_at
+# ---------------------------------------------------------------------------
+
+def test_update_heartbeat_by_terminal(tmp_path):
+    db = _setup_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token) "
+        "VALUES ('T1', 'vnx-dev', 'active', 'tok-1')",
+    )
+    conn.commit()
+    conn.close()
+
+    repo = _make_repo(db)
+    now = time.time()
+    repo.update_heartbeat_by_terminal("T1", now)
+
+    hb = _read_heartbeat(db, "T1")
+    assert hb is not None
+    assert "T" not in hb or "Z" in hb  # ISO format
+
+
+def test_update_heartbeat_by_terminal_overwrites_previous(tmp_path):
+    db = _setup_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token, last_heartbeat_at) "
+        "VALUES ('T1', 'vnx-dev', 'active', 'tok-1', '2020-01-01T00:00:00.000000Z')",
+    )
+    conn.commit()
+    conn.close()
+
+    repo = _make_repo(db)
+    now = time.time()
+    repo.update_heartbeat_by_terminal("T1", now)
+
+    hb = _read_heartbeat(db, "T1")
+    assert hb is not None
+    assert "2020" not in hb
+
+
+# ---------------------------------------------------------------------------
+# 3. Pool heartbeat loop integration
+# ---------------------------------------------------------------------------
+
+def test_pool_heartbeat_loop_updates_heartbeat(tmp_path):
+    db = _setup_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token) "
+        "VALUES ('T1', 'vnx-dev', 'active', 'tok-1')",
+    )
+    conn.commit()
+    conn.close()
+
+    sys.path.insert(0, str(_LIB_DIR))
+    from subprocess_dispatch import _pool_heartbeat_loop
+
+    stop = threading.Event()
+    t = threading.Thread(
+        target=_pool_heartbeat_loop,
+        args=("T1", "vnx-dev", db, stop),
+        kwargs={"interval": 0.1},
+        daemon=True,
+    )
+    t.start()
+    time.sleep(0.35)
+    stop.set()
+    t.join(timeout=2)
+
+    hb = _read_heartbeat(db, "T1")
+    assert hb is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. is_pid_alive
+# ---------------------------------------------------------------------------
+
+def test_is_pid_alive_returns_true_for_self():
+    assert is_pid_alive(os.getpid()) is True
+
+
+def test_is_pid_alive_returns_false_for_none():
+    assert is_pid_alive(None) is False
+
+
+def test_is_pid_alive_returns_false_for_zero():
+    assert is_pid_alive(0) is False
+
+
+def test_is_pid_alive_returns_false_for_negative():
+    assert is_pid_alive(-1) is False
+
+
+def test_is_pid_alive_returns_false_for_dead_pid():
+    with unittest.mock.patch("pool_reaper.os.kill", side_effect=ProcessLookupError):
+        assert is_pid_alive(99999) is False
+
+
+def test_is_pid_alive_returns_true_on_permission_error():
+    with unittest.mock.patch("pool_reaper.os.kill", side_effect=PermissionError):
+        assert is_pid_alive(99999) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. identify_dead_pid_targets
+# ---------------------------------------------------------------------------
+
+def test_dead_pid_produces_reap_target():
+    m = _member_with_pid(pid=99999)
+    with unittest.mock.patch("pool_reaper.os.kill", side_effect=ProcessLookupError):
+        targets = identify_dead_pid_targets([m])
+    assert len(targets) == 1
+    assert targets[0].membership_id == "m-001"
+    assert "pid_dead" in targets[0].reason
+
+
+def test_alive_pid_not_reaped():
+    m = _member_with_pid(pid=os.getpid())
+    targets = identify_dead_pid_targets([m])
+    assert targets == []
+
+
+def test_no_pid_member_skipped():
+    m = _member_with_pid(pid=None)
+    targets = identify_dead_pid_targets([m])
+    assert targets == []
+
+
+def test_zero_pid_member_skipped():
+    m = _member_with_pid(pid=0)
+    targets = identify_dead_pid_targets([m])
+    assert targets == []
+
+
+def test_negative_pid_member_skipped():
+    m = _member_with_pid(pid=-1)
+    targets = identify_dead_pid_targets([m])
+    assert targets == []
+
+
+def test_non_active_member_with_dead_pid_skipped():
+    m = _member_with_pid(pid=99999, status="draining")
+    with unittest.mock.patch("pool_reaper.os.kill", side_effect=ProcessLookupError):
+        targets = identify_dead_pid_targets([m])
+    assert targets == []
+
+
+def test_mixed_alive_and_dead_pids():
+    alive = _member_with_pid(membership_id="alive", pid=os.getpid())
+    dead = _member_with_pid(membership_id="dead", pid=99999)
+
+    def selective_kill(pid, sig):
+        if pid == 99999:
+            raise ProcessLookupError
+        return None
+
+    with unittest.mock.patch("pool_reaper.os.kill", side_effect=selective_kill):
+        targets = identify_dead_pid_targets([alive, dead])
+    assert len(targets) == 1
+    assert targets[0].membership_id == "dead"
+
+
+# ---------------------------------------------------------------------------
+# 6. list_members includes pid from terminal_leases
+# ---------------------------------------------------------------------------
+
+def test_list_members_includes_pid(tmp_path):
+    db = _setup_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token, worker_pid) "
+        "VALUES ('T-pid-01', 'vnx-dev', 'active', 'tok-1', 42)",
+    )
+    import json
+    conn.execute(
+        "INSERT INTO worker_pool_membership "
+        "(terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json) "
+        "VALUES ('T-pid-01', 'vnx-dev', 'default', 'claude', 'backend-developer', "
+        "'2026-01-01T00:00:00.000000Z', ?)",
+        (json.dumps({"membership_id": "m-pid-01"}),),
+    )
+    conn.commit()
+    conn.close()
+
+    repo = _make_repo(db)
+    members = repo.list_members("default")
+    assert len(members) == 1
+    assert members[0].pid == 42
+
+
+def test_list_members_pid_none_when_not_set(tmp_path):
+    db = _setup_db(tmp_path)
+    repo = _make_repo(db)
+    now = time.time()
+    repo.add_member("default", "T-nopid-01", "claude", "backend-developer", now)
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT OR IGNORE INTO terminal_leases (terminal_id, project_id, state, lease_token) "
+        "VALUES ('T-nopid-01', 'vnx-dev', 'active', 'tok-1')",
+    )
+    conn.commit()
+    conn.close()
+
+    members = repo.list_members("default")
+    assert len(members) == 1
+    assert members[0].pid is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Reaper integration: dead PID triggers reap via PoolManager
+# ---------------------------------------------------------------------------
+
+def test_pool_manager_reap_dead_catches_dead_pid(tmp_path):
+    from pool_manager import PoolManager, SpawnResult
+
+    db = _setup_db(tmp_path)
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id, state, lease_token, worker_pid, last_heartbeat_at) "
+        "VALUES ('T-dead', 'vnx-dev', 'active', 'tok-1', 99999, ?)",
+        (time.strftime("%Y-%m-%dT%H:%M:%S.000000Z", time.gmtime()),),
+    )
+    import json
+    conn.execute(
+        "INSERT INTO worker_pool_membership "
+        "(terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json) "
+        "VALUES ('T-dead', 'vnx-dev', 'default', 'claude', 'backend-developer', "
+        "'2026-01-01T00:00:00.000000Z', ?)",
+        (json.dumps({"membership_id": "m-dead-pid"}),),
+    )
+    conn.commit()
+    conn.close()
+
+    mgr = PoolManager(
+        project_id="vnx-dev",
+        pool_id="default",
+        db_path=db,
+        spawn_fn=lambda *a: SpawnResult(terminal_id=a[2], success=True),
+    )
+
+    with unittest.mock.patch("os.kill", side_effect=ProcessLookupError):
+        reaped = mgr.reap_dead()
+
+    assert len(reaped) == 1
+    assert reaped[0].membership_id == "m-dead-pid"
+    assert "pid_dead" in reaped[0].reason


### PR DESCRIPTION
## Summary
- Adds 15s pool heartbeat thread to `subprocess_dispatch.py` entrypoint that updates `terminal_leases.last_heartbeat_at` directly by terminal_id
- Stores worker PID in `terminal_leases.worker_pid` column on dispatch startup via `pool_state_repo.store_worker_pid()`
- Pool reaper now runs two detection paths in sequence: PID validation (`os.kill(pid, 0)` probe for dead processes) then heartbeat staleness (existing threshold-based detection)
- Adds `pid` field to `Membership` dataclass, propagated through `list_members` JOIN

## Files changed (8 files, +156/-16 LOC)
- `scripts/lib/pool_decision_engine.py` — `pid: Optional[int]` field on Membership
- `scripts/lib/pool_state_repo.py` — `store_worker_pid()`, `update_heartbeat_by_terminal()`, pid in `list_members()`
- `scripts/lib/pool_reaper.py` — `is_pid_alive()`, `identify_dead_pid_targets()`
- `scripts/lib/pool_manager.py` — dual-path reaping (PID + heartbeat) in `reap_dead()`
- `scripts/lib/subprocess_dispatch.py` — `_pool_heartbeat_loop()`, PID store + heartbeat thread in entrypoint
- `tests/fixtures/pool_state_fixtures.py` — `worker_pid` column in test schema
- `tests/test_pool_provider_mix_integration.py` — `worker_pid` column in inline schema
- `tests/test_worker_heartbeat.py` — 20 new tests

## Test plan
- [x] `pytest tests/test_worker_heartbeat.py` — 20/20 passed
- [x] `pytest tests/test_pool_reaper.py tests/test_pool_state_repo.py tests/test_pool_manager_integration.py tests/test_pool_decision_engine.py tests/test_pool_provider_mix_integration.py` — 103/103 passed, zero regressions
- [x] `pytest tests/test_pool_tick_reap_decide_execute.py` — 9/9 passed (1 pre-existing flaky concurrent SQLite test excluded)
- [ ] CI green

Dispatch-ID: 20260517-pr-6.5c-heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)