### PR TITLE
feat(pr-6.5b): per-worker git worktree manager

### DIFF
--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -76,7 +76,7 @@ def _spawn_via_provider_dispatch(
     """Spawn a worker CC session via subprocess.Popen.
 
     Launches ``scripts.lib.subprocess_dispatch`` as a detached child process
-    and captures its PID for lifecycle management (heartbeat, reap).
+    in an isolated git worktree, and captures its PID for lifecycle management.
     """
     log.info(
         "spawn: project=%s pool=%s terminal=%s provider=%s role=%s",
@@ -86,6 +86,16 @@ def _spawn_via_provider_dispatch(
         provider,
         role,
     )
+
+    try:
+        from pool_worktree_manager import create_worker_worktree  # noqa: E402
+        worktree_path = create_worker_worktree(terminal_id)
+    except Exception as exc:
+        return SpawnResult(
+            terminal_id=terminal_id,
+            success=False,
+            error=f"worktree creation failed: {exc}",
+        )
 
     dispatch_id = f"pool-spawn-{terminal_id}-{int(time.time() * 1000) % 100000}"
     cmd = [
@@ -102,6 +112,7 @@ def _spawn_via_provider_dispatch(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,
+            cwd=str(worktree_path),
         )
     except OSError as exc:
         return SpawnResult(
@@ -243,6 +254,16 @@ class PoolManager:
                 log.error(
                     "reap: membership release failed for %s: %s",
                     target.membership_id,
+                    exc,
+                )
+
+            try:
+                from pool_worktree_manager import reap_worker_worktree  # noqa: E402
+                reap_worker_worktree(target.terminal_id)
+            except Exception as exc:
+                log.warning(
+                    "reap: worktree cleanup failed for %s: %s",
+                    target.terminal_id,
                     exc,
                 )
 

--- a/scripts/lib/pool_worktree_manager.py
+++ b/scripts/lib/pool_worktree_manager.py
@@ -124,8 +124,8 @@ def reap_worker_worktree(
                 capture_output=True,
                 text=True,
             )
-        except subprocess.CalledProcessError:
-            pass
+        except subprocess.CalledProcessError as exc:
+            log.warning("worktree prune failed: %s", exc)
 
     _delete_worktree_branch(terminal_id, root)
 
@@ -142,5 +142,5 @@ def _delete_worktree_branch(terminal_id: str, project_root: Path) -> None:
             text=True,
         )
         log.info("branch deleted: %s", branch_name)
-    except subprocess.CalledProcessError:
-        pass
+    except subprocess.CalledProcessError as exc:
+        log.warning("branch deletion failed for %s: %s", branch_name, exc)

--- a/scripts/lib/pool_worktree_manager.py
+++ b/scripts/lib/pool_worktree_manager.py
@@ -7,10 +7,13 @@ concurrent subprocess workers operate on independent file trees.
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
+
+_TERMINAL_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +26,16 @@ def _resolve_project_root() -> Path:
         return Path.cwd()
 
 
+def _validate_terminal_id(terminal_id: str) -> None:
+    if not _TERMINAL_ID_RE.fullmatch(terminal_id):
+        raise ValueError(
+            f"invalid terminal_id {terminal_id!r}: "
+            "must match ^[A-Za-z0-9_-]{1,32}$"
+        )
+
+
 def _worktree_dir(project_root: Path, terminal_id: str) -> Path:
+    _validate_terminal_id(terminal_id)
     return project_root / ".vnx-data" / "worktrees" / f"pool-{terminal_id}"
 
 
@@ -115,7 +127,13 @@ def reap_worker_worktree(
             "git worktree remove failed: %s; cleaning up directory",
             (exc.stderr or "").strip(),
         )
-        shutil.rmtree(str(wt_path), ignore_errors=True)
+        if wt_path.is_symlink() or not wt_path.is_dir():
+            raise RuntimeError(
+                f"refusing cleanup: {wt_path} is a symlink or not a directory"
+            )
+        resolved = wt_path.resolve()
+        resolved.relative_to(root)
+        shutil.rmtree(str(resolved), ignore_errors=True)
         try:
             subprocess.run(
                 ["git", "worktree", "prune"],

--- a/scripts/lib/pool_worktree_manager.py
+++ b/scripts/lib/pool_worktree_manager.py
@@ -1,0 +1,146 @@
+"""pool_worktree_manager.py — Per-worker git worktree create/reap.
+
+Wave 6 PR-6.5b — Each pool worker gets an isolated git worktree so
+concurrent subprocess workers operate on independent file trees.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+def _resolve_project_root() -> Path:
+    try:
+        from project_root import resolve_project_root  # type: ignore[attr-defined]
+        return Path(resolve_project_root(__file__))
+    except Exception:
+        return Path.cwd()
+
+
+def _worktree_dir(project_root: Path, terminal_id: str) -> Path:
+    return project_root / ".vnx-data" / "worktrees" / f"pool-{terminal_id}"
+
+
+def create_worker_worktree(
+    terminal_id: str,
+    base_branch: str = "main",
+    *,
+    project_root: Optional[Path] = None,
+) -> Path:
+    """Create an isolated git worktree for a pool worker.
+
+    Idempotent: returns existing worktree path if already present.
+    """
+    root = (project_root or _resolve_project_root()).resolve()
+    wt_path = _worktree_dir(root, terminal_id)
+
+    if wt_path.is_dir():
+        log.info("worktree already exists: %s", wt_path)
+        return wt_path
+
+    wt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    branch_name = f"pool/{terminal_id}"
+
+    try:
+        subprocess.run(
+            [
+                "git", "worktree", "add",
+                str(wt_path),
+                "-b", branch_name,
+                f"origin/{base_branch}",
+            ],
+            cwd=str(root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if "already exists" in (exc.stderr or ""):
+            try:
+                subprocess.run(
+                    [
+                        "git", "worktree", "add",
+                        str(wt_path),
+                        branch_name,
+                    ],
+                    cwd=str(root),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as exc2:
+                raise RuntimeError(
+                    f"git worktree add failed for {terminal_id}: {exc2.stderr}"
+                ) from exc2
+        else:
+            raise RuntimeError(
+                f"git worktree add failed for {terminal_id}: {exc.stderr}"
+            ) from exc
+
+    log.info("worktree created: %s (branch %s)", wt_path, branch_name)
+    return wt_path.resolve()
+
+
+def reap_worker_worktree(
+    terminal_id: str,
+    *,
+    project_root: Optional[Path] = None,
+) -> None:
+    """Remove a pool worker's git worktree. Idempotent."""
+    root = (project_root or _resolve_project_root()).resolve()
+    wt_path = _worktree_dir(root, terminal_id)
+
+    if not wt_path.exists():
+        log.info("worktree already absent: %s", wt_path)
+        return
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(wt_path)],
+            cwd=str(root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        log.info("worktree removed: %s", wt_path)
+    except subprocess.CalledProcessError as exc:
+        log.warning(
+            "git worktree remove failed: %s; cleaning up directory",
+            (exc.stderr or "").strip(),
+        )
+        shutil.rmtree(str(wt_path), ignore_errors=True)
+        try:
+            subprocess.run(
+                ["git", "worktree", "prune"],
+                cwd=str(root),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+
+    _delete_worktree_branch(terminal_id, root)
+
+
+def _delete_worktree_branch(terminal_id: str, project_root: Path) -> None:
+    """Best-effort delete the pool/{terminal_id} branch after worktree removal."""
+    branch_name = f"pool/{terminal_id}"
+    try:
+        subprocess.run(
+            ["git", "branch", "-D", branch_name],
+            cwd=str(project_root),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        log.info("branch deleted: %s", branch_name)
+    except subprocess.CalledProcessError:
+        pass

--- a/tests/test_pool_worktree_manager.py
+++ b/tests/test_pool_worktree_manager.py
@@ -24,6 +24,7 @@ if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
 from pool_worktree_manager import (
+    _validate_terminal_id,
     _worktree_dir,
     create_worker_worktree,
     reap_worker_worktree,
@@ -310,3 +311,95 @@ def test_reaper_calls_worktree_cleanup(tmp_path):
         assert "REAP-T1" in terminal_ids_reaped
         reap_calls = [c[0][0] for c in mock_reap.call_args_list]
         assert "REAP-T1" in reap_calls
+
+
+# ---------------------------------------------------------------------------
+# 13. Security: terminal_id validation rejects path traversal
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_id", [
+    "../etc/passwd",
+    "../../root",
+    "foo/bar",
+    "a" * 33,
+    "",
+    "hello world",
+    "T1; rm -rf /",
+    "pool\x00null",
+])
+def test_validate_terminal_id_rejects_malicious(bad_id):
+    with pytest.raises(ValueError, match="invalid terminal_id"):
+        _validate_terminal_id(bad_id)
+
+
+@pytest.mark.parametrize("good_id", [
+    "T1",
+    "ABC-1",
+    "worker_3",
+    "a" * 32,
+    "T0",
+    "my-worker-99",
+])
+def test_validate_terminal_id_accepts_valid(good_id):
+    _validate_terminal_id(good_id)
+
+
+def test_create_rejects_traversal_id(tmp_path):
+    with pytest.raises(ValueError, match="invalid terminal_id"):
+        create_worker_worktree("../../../etc", project_root=tmp_path)
+
+
+def test_reap_rejects_traversal_id(tmp_path):
+    with pytest.raises(ValueError, match="invalid terminal_id"):
+        reap_worker_worktree("../../../etc", project_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 14. Security: cleanup fallback refuses symlink targets
+# ---------------------------------------------------------------------------
+
+def test_reap_fallback_refuses_symlink_inside_root(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    wt_dir = local / ".vnx-data" / "worktrees" / "pool-SYM1"
+    wt_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    target = local / "real_target"
+    target.mkdir()
+    wt_dir.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="refusing cleanup.*symlink"):
+        reap_worker_worktree("SYM1", project_root=local)
+
+    assert target.is_dir()
+
+
+def test_reap_fallback_refuses_symlink_outside_root(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    wt_dir = local / ".vnx-data" / "worktrees" / "pool-SYM2"
+    wt_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    target = tmp_path / "outside_target"
+    target.mkdir()
+    wt_dir.symlink_to(target)
+
+    with pytest.raises((ValueError, RuntimeError)):
+        reap_worker_worktree("SYM2", project_root=local)
+
+    assert target.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# 15. Security: cleanup fallback refuses paths outside project root
+# ---------------------------------------------------------------------------
+
+def test_reap_fallback_refuses_outside_root(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    wt_dir = local / ".vnx-data" / "worktrees" / "pool-ESC1"
+    wt_dir.parent.mkdir(parents=True, exist_ok=True)
+    wt_dir.symlink_to(outside)
+
+    with pytest.raises((ValueError, RuntimeError)):
+        reap_worker_worktree("ESC1", project_root=local)

--- a/tests/test_pool_worktree_manager.py
+++ b/tests/test_pool_worktree_manager.py
@@ -1,0 +1,312 @@
+"""test_pool_worktree_manager.py — Tests for per-worker git worktree manager.
+
+Covers:
+  - create_worker_worktree: idempotent creation, branch naming, error handling
+  - reap_worker_worktree: idempotent removal, directory cleanup on git failure
+  - Integration with real git repos in tempdir
+  - Wiring verification: spawn passes cwd, reaper calls reap
+
+Wave 6 PR-6.5b.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from pool_worktree_manager import (
+    _worktree_dir,
+    create_worker_worktree,
+    reap_worker_worktree,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: set up a real git repo with a bare "origin" remote
+# ---------------------------------------------------------------------------
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    """Create a bare origin + local clone with an initial commit.
+
+    Returns the local clone path (the 'project root').
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(bare), str(local)],
+        check=True, capture_output=True,
+    )
+
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "main"],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(
+        ["git", "-C", str(local), "add", "README.md"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "commit", "-m", "initial"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+
+    return local
+
+
+# ---------------------------------------------------------------------------
+# 1. _worktree_dir builds correct path
+# ---------------------------------------------------------------------------
+
+def test_worktree_dir_path():
+    root = Path("/proj")
+    assert _worktree_dir(root, "ABC-1") == root / ".vnx-data" / "worktrees" / "pool-ABC-1"
+
+
+# ---------------------------------------------------------------------------
+# 2. create_worker_worktree — idempotent when directory exists
+# ---------------------------------------------------------------------------
+
+def test_create_idempotent_existing_dir(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    wt = root / ".vnx-data" / "worktrees" / "pool-T1"
+    wt.mkdir(parents=True)
+
+    result = create_worker_worktree("T1", project_root=root)
+    assert result == wt
+
+
+# ---------------------------------------------------------------------------
+# 3. create_worker_worktree — real git worktree
+# ---------------------------------------------------------------------------
+
+def test_create_real_worktree(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = create_worker_worktree("W1", base_branch="main", project_root=local)
+
+    assert wt.is_dir()
+    assert (wt / "README.md").is_file()
+    assert "pool-W1" in str(wt)
+
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", "pool/W1"],
+        text=True,
+    ).strip()
+    assert "pool/W1" in branches
+
+
+# ---------------------------------------------------------------------------
+# 4. create_worker_worktree — idempotent real (second call returns same path)
+# ---------------------------------------------------------------------------
+
+def test_create_real_idempotent(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    first = create_worker_worktree("W2", project_root=local)
+    second = create_worker_worktree("W2", project_root=local)
+
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# 5. create_worker_worktree — branch already exists (re-attach)
+# ---------------------------------------------------------------------------
+
+def test_create_branch_already_exists(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    subprocess.run(
+        ["git", "-C", str(local), "branch", "pool/W3", "origin/main"],
+        check=True, capture_output=True,
+    )
+
+    wt = create_worker_worktree("W3", project_root=local)
+    assert wt.is_dir()
+    assert (wt / "README.md").is_file()
+
+
+# ---------------------------------------------------------------------------
+# 6. create_worker_worktree — bad base_branch raises RuntimeError
+# ---------------------------------------------------------------------------
+
+def test_create_bad_base_branch(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    with pytest.raises(RuntimeError, match="git worktree add failed"):
+        create_worker_worktree("W4", base_branch="nonexistent", project_root=local)
+
+
+# ---------------------------------------------------------------------------
+# 7. reap_worker_worktree — idempotent when absent
+# ---------------------------------------------------------------------------
+
+def test_reap_idempotent_absent(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    reap_worker_worktree("NOPE", project_root=local)
+
+
+# ---------------------------------------------------------------------------
+# 8. reap_worker_worktree — removes real worktree
+# ---------------------------------------------------------------------------
+
+def test_reap_real_worktree(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = create_worker_worktree("W5", project_root=local)
+    assert wt.is_dir()
+
+    reap_worker_worktree("W5", project_root=local)
+
+    assert not wt.exists()
+
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", "pool/W5"],
+        text=True,
+    ).strip()
+    assert branches == ""
+
+
+# ---------------------------------------------------------------------------
+# 9. reap_worker_worktree — falls back to rmtree + prune when git fails
+# ---------------------------------------------------------------------------
+
+def test_reap_fallback_rmtree(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    wt_dir = local / ".vnx-data" / "worktrees" / "pool-FAKE"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / "dummy.txt").write_text("x")
+
+    reap_worker_worktree("FAKE", project_root=local)
+
+    assert not wt_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 10. reap after create — full lifecycle
+# ---------------------------------------------------------------------------
+
+def test_create_then_reap_lifecycle(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = create_worker_worktree("LC1", project_root=local)
+    assert wt.is_dir()
+    assert (wt / "README.md").is_file()
+
+    reap_worker_worktree("LC1", project_root=local)
+    assert not wt.exists()
+
+    wt2 = create_worker_worktree("LC1", project_root=local)
+    assert wt2.is_dir()
+    assert (wt2 / "README.md").is_file()
+
+
+# ---------------------------------------------------------------------------
+# 11. Spawn wiring: _spawn_via_provider_dispatch passes cwd
+# ---------------------------------------------------------------------------
+
+def test_spawn_passes_worktree_cwd(tmp_path):
+    wt_path = tmp_path / ".vnx-data" / "worktrees" / "pool-WT-1"
+    wt_path.mkdir(parents=True)
+
+    import pool_manager as pm_mod
+
+    captured_kwargs = {}
+
+    class FakePopen:
+        def __init__(self, cmd, **kw):
+            captured_kwargs.update(kw)
+            self.pid = 99999
+
+    with patch("pool_worktree_manager.create_worker_worktree", return_value=wt_path):
+        with patch.object(pm_mod.subprocess, "Popen", FakePopen):
+            with patch("os.kill"):
+                result = pm_mod._spawn_via_provider_dispatch(
+                    "proj", "default", "WT-1", "claude", "backend-developer",
+                )
+
+    assert "cwd" in captured_kwargs
+    assert captured_kwargs["cwd"] == str(wt_path)
+
+
+# ---------------------------------------------------------------------------
+# 12. Reaper wiring: reap_dead calls reap_worker_worktree
+# ---------------------------------------------------------------------------
+
+def test_reaper_calls_worktree_cleanup(tmp_path):
+    _FIXTURES = Path(__file__).resolve().parent / "fixtures"
+    if str(_FIXTURES) not in sys.path:
+        sys.path.insert(0, str(_FIXTURES))
+
+    import json
+    import sqlite3
+    from pool_state_fixtures import _BASE_SCHEMA, create_test_db_file
+
+    db = create_test_db_file(
+        tmp_path / "test.db", min_workers=1, max_workers=4, cooldown_seconds=0,
+    )
+
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """INSERT OR IGNORE INTO terminal_leases
+           (terminal_id, project_id, state, lease_token, last_heartbeat_at)
+           VALUES ('REAP-T1', 'vnx-dev', 'idle', '', '2020-01-01T00:00:00.000000Z')""",
+    )
+    conn.execute(
+        """INSERT INTO worker_pool_membership
+           (terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json)
+           VALUES ('REAP-T1', 'vnx-dev', 'default', 'claude', 'backend-developer',
+                   '2020-01-01T00:00:00.000000Z', ?)""",
+        (json.dumps({"membership_id": "m-reap-1"}),),
+    )
+    conn.commit()
+    conn.close()
+
+    from pool_manager import PoolManager, SpawnResult
+
+    def noop_spawn(*_a, **_kw):
+        return SpawnResult(terminal_id="x", success=True)
+
+    mgr = PoolManager(
+        project_id="vnx-dev", pool_id="default", db_path=db, spawn_fn=noop_spawn,
+    )
+
+    with patch("pool_worktree_manager.reap_worker_worktree") as mock_reap:
+        with patch("pool_manager.reap_worker_worktree", mock_reap, create=True):
+            targets = mgr.reap_dead()
+
+    if targets:
+        terminal_ids_reaped = [t.terminal_id for t in targets]
+        assert "REAP-T1" in terminal_ids_reaped
+        reap_calls = [c[0][0] for c in mock_reap.call_args_list]
+        assert "REAP-T1" in reap_calls


### PR DESCRIPTION
## Summary
- Adds `scripts/lib/pool_worktree_manager.py` with `create_worker_worktree()` and `reap_worker_worktree()` — idempotent git worktree lifecycle for pool workers
- Wires worktree creation into `_spawn_via_provider_dispatch` (passes `cwd=worktree_path` to subprocess.Popen)
- Wires worktree cleanup into `reap_dead()` (calls `reap_worker_worktree` after membership release)
- 12 tests covering path construction, real git lifecycle, idempotency, error fallbacks, and wiring verification

## Test plan
- [x] `pytest tests/test_pool_worktree_manager.py -v` — 12/12 passed
- [x] `pytest tests/test_pool_manager_integration.py tests/test_pool_reaper.py tests/test_pool_decision_engine.py tests/test_pool_state_repo.py -v` — 67/67 passed (zero regressions)
- [ ] CI green

Dispatch-ID: 20260517-pr-6.5b-worktree-mgr

🤖 Generated with [Claude Code](https://claude.com/claude-code)