### PR TITLE
fix(pool): integration-fix PR-6.5a tests after PR-6.5b worktree-create

### DIFF
--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -194,6 +194,8 @@ class PoolStateRepository:
                 last_heartbeat = _from_iso(row["last_heartbeat_at"])
                 joined_ts = _from_iso(row["joined_at"]) or 0.0
                 raw_pid = row["worker_pid"]
+                if raw_pid is None:
+                    raw_pid = meta.get("pid")
                 pid = int(raw_pid) if raw_pid is not None else None
                 members.append(
                     Membership(

--- a/tests/pool/test_spawn_integration.py
+++ b/tests/pool/test_spawn_integration.py
@@ -1,0 +1,229 @@
+"""test_spawn_integration.py — End-to-end integration test for pool spawn flow.
+
+Validates the full lifecycle: worktree create → Popen → PID capture →
+membership record → reaper PID validation → worktree cleanup.
+
+All subprocess calls (git worktree, claude CLI) are mocked at the boundary,
+but the internal wiring between pool_manager, pool_worktree_manager,
+pool_state_repo, and pool_reaper runs unpatched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_manager import (
+    ExecResult,
+    PoolManager,
+    SpawnResult,
+    _spawn_via_provider_dispatch,
+)
+from pool_reaper import ReapConfig, ReapTarget
+from pool_state_repo import PoolStateRepository
+from pool_state_fixtures import create_test_db_file
+
+
+def _setup_db(tmp_path: Path, min_workers: int = 0, max_workers: int = 4) -> Path:
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "events").mkdir(parents=True, exist_ok=True)
+    return create_test_db_file(
+        db_path,
+        min_workers=min_workers,
+        max_workers=max_workers,
+        target_workers=max(min_workers, 1),
+    )
+
+
+class TestSpawnIntegrationFullFlow:
+    """End-to-end: worktree create → Popen → PID in DB → reaper validates PID."""
+
+    @patch("pool_worktree_manager.create_worker_worktree")
+    @patch("pool_manager.subprocess.Popen")
+    @patch("pool_manager.os.kill")
+    def test_full_spawn_flow_worktree_to_receipt(self, mock_kill, mock_popen, mock_wt, tmp_path):
+        wt_path = tmp_path / "worktrees" / "pool-T1"
+        wt_path.mkdir(parents=True)
+        mock_wt.return_value = wt_path
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 88888
+        mock_popen.return_value = mock_proc
+
+        result = _spawn_via_provider_dispatch(
+            "vnx-dev", "default", "T1", "claude", "backend-developer"
+        )
+
+        assert result.success is True
+        assert result.pid == 88888
+        assert result.terminal_id == "T1"
+
+        mock_wt.assert_called_once_with("T1")
+        mock_popen.assert_called_once()
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["cwd"] == str(wt_path)
+        assert call_kwargs["start_new_session"] is True
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--terminal-id" in cmd
+        assert "--dispatch-id" in cmd
+        assert "--role" in cmd
+        assert "backend-developer" in cmd
+
+    @patch("pool_worktree_manager.create_worker_worktree")
+    @patch("pool_manager.subprocess.Popen")
+    @patch("pool_manager.os.kill")
+    def test_spawn_pid_persists_through_membership_and_reaper(
+        self, mock_kill, mock_popen, mock_wt, tmp_path
+    ):
+        mock_wt.return_value = tmp_path / "worktrees" / "pool-T1"
+        mock_proc = MagicMock()
+        mock_proc.pid = 55555
+        mock_popen.return_value = mock_proc
+
+        db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES (?, ?, ?)",
+            ("d-int-001", "vnx-dev", "queued"),
+        )
+        conn.commit()
+        conn.close()
+
+        mgr = PoolManager(
+            "vnx-dev", "default", db_path,
+            spawn_fn=_spawn_via_provider_dispatch,
+        )
+        result = mgr.tick()
+
+        assert len(result.spawned) >= 1
+
+        repo = PoolStateRepository(db_path, "vnx-dev")
+        members = repo.list_members("default")
+        assert len(members) >= 1
+        spawned_member = next(m for m in members if m.pid == 55555)
+        assert spawned_member.provider == "claude"
+
+    @patch("pool_worktree_manager.create_worker_worktree")
+    @patch("pool_manager.subprocess.Popen")
+    @patch("pool_manager.os.kill")
+    def test_reaper_uses_pid_from_spawn_for_kill(
+        self, mock_kill, mock_popen, mock_wt, tmp_path
+    ):
+        mock_wt.return_value = tmp_path / "worktrees" / "pool-T1"
+        mock_proc = MagicMock()
+        mock_proc.pid = 44444
+        mock_popen.return_value = mock_proc
+
+        db_path = _setup_db(tmp_path)
+        repo = PoolStateRepository(db_path, "vnx-dev")
+        repo.add_member("default", "T1", "claude", "backend-developer", 100.0, pid=44444)
+
+        mgr = PoolManager("vnx-dev", "default", db_path, spawn_fn=lambda *a: SpawnResult("x", True))
+        mgr.reap_config = ReapConfig(
+            heartbeat_stale_threshold_s=10.0,
+            warmup_window_s=5.0,
+        )
+
+        with patch.object(mgr, "_kill_subprocess") as mock_kill_sub:
+            with patch("pool_worktree_manager.reap_worker_worktree"):
+                reaped = mgr.reap_dead()
+
+        assert len(reaped) >= 1
+        kill_call = mock_kill_sub.call_args_list[0]
+        assert kill_call[0][0] == "T1"
+        assert kill_call[0][1] == 44444
+
+    @patch("pool_worktree_manager.reap_worker_worktree")
+    @patch("pool_worktree_manager.create_worker_worktree")
+    @patch("pool_manager.subprocess.Popen")
+    @patch("pool_manager.os.kill")
+    def test_full_lifecycle_spawn_and_reap(
+        self, mock_kill, mock_popen, mock_wt, mock_reap_wt, tmp_path
+    ):
+        mock_wt.return_value = tmp_path / "worktrees" / "pool-T1"
+        mock_proc = MagicMock()
+        mock_proc.pid = 33333
+        mock_popen.return_value = mock_proc
+
+        db_path = _setup_db(tmp_path, min_workers=0, max_workers=4)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES (?, ?, ?)",
+            ("d-lifecycle-001", "vnx-dev", "queued"),
+        )
+        conn.commit()
+        conn.close()
+
+        mgr = PoolManager(
+            "vnx-dev", "default", db_path,
+            spawn_fn=_spawn_via_provider_dispatch,
+        )
+        spawn_result = mgr.tick()
+        assert len(spawn_result.spawned) >= 1
+
+        repo = PoolStateRepository(db_path, "vnx-dev")
+        members = repo.list_members("default")
+        assert len(members) >= 1
+        member = members[0]
+        assert member.pid == 33333
+
+        mgr.reap_config = ReapConfig(
+            heartbeat_stale_threshold_s=0.001,
+            warmup_window_s=0.0,
+        )
+
+        mock_kill.side_effect = [None, ProcessLookupError]
+
+        with patch("pool_manager.time.sleep"):
+            reaped = mgr.reap_dead()
+
+        assert len(reaped) >= 1
+        mock_reap_wt.assert_called()
+
+    def test_worktree_failure_does_not_leave_orphan_membership(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES (?, ?, ?)",
+            ("d-orphan-001", "vnx-dev", "queued"),
+        )
+        conn.commit()
+        conn.close()
+
+        call_count = {"n": 0}
+
+        def spawn_fn_worktree_fails(project_id, pool_id, terminal_id, provider, role):
+            call_count["n"] += 1
+            return SpawnResult(
+                terminal_id=terminal_id,
+                success=False,
+                error="worktree creation failed: git error",
+            )
+
+        mgr = PoolManager("vnx-dev", "default", db_path, spawn_fn=spawn_fn_worktree_fails)
+        result = mgr.tick()
+
+        assert len(result.spawned) == 0
+        assert len(result.errors) >= 1
+        assert "worktree creation failed" in result.errors[0]
+
+        repo = PoolStateRepository(db_path, "vnx-dev")
+        members = repo.list_members("default")
+        assert len(members) == 0

--- a/tests/pool/test_subprocess_spawn.py
+++ b/tests/pool/test_subprocess_spawn.py
@@ -106,9 +106,11 @@ class TestSpawnResult:
 # ---------------------------------------------------------------------------
 
 class TestSpawnViaProviderDispatch:
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_successful_spawn_captures_pid(self, mock_kill, mock_popen):
+    def test_successful_spawn_captures_pid(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 54321
         mock_popen.return_value = mock_proc
@@ -120,6 +122,7 @@ class TestSpawnViaProviderDispatch:
         assert result.success is True
         assert result.pid == 54321
         assert result.terminal_id == "T1"
+        mock_wt.assert_called_once_with("T1")
         mock_popen.assert_called_once()
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
@@ -127,10 +130,13 @@ class TestSpawnViaProviderDispatch:
         assert "T1" in cmd
         assert "--role" in cmd
         assert "backend-developer" in cmd
+        assert call_args[1]["cwd"] == "/tmp/fake-worktree"
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_spawn_uses_start_new_session(self, mock_kill, mock_popen):
+    def test_spawn_uses_start_new_session(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 100
         mock_popen.return_value = mock_proc
@@ -142,8 +148,10 @@ class TestSpawnViaProviderDispatch:
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
-    def test_spawn_failure_on_oserror(self, mock_popen):
+    def test_spawn_failure_on_oserror(self, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_popen.side_effect = OSError("No such file or directory")
 
         result = _spawn_via_provider_dispatch(
@@ -154,9 +162,11 @@ class TestSpawnViaProviderDispatch:
         assert "Popen failed" in result.error
         assert result.pid is None
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_spawn_failure_when_process_dies_immediately(self, mock_kill, mock_popen):
+    def test_spawn_failure_when_process_dies_immediately(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 99999
         mock_popen.return_value = mock_proc
@@ -170,9 +180,11 @@ class TestSpawnViaProviderDispatch:
         assert "died immediately" in result.error
         assert result.pid == 99999
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_spawn_command_includes_dispatch_id(self, mock_kill, mock_popen):
+    def test_spawn_command_includes_dispatch_id(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 200
         mock_popen.return_value = mock_proc
@@ -186,9 +198,11 @@ class TestSpawnViaProviderDispatch:
         dispatch_id_idx = cmd.index("--dispatch-id") + 1
         assert cmd[dispatch_id_idx].startswith("pool-spawn-T1-")
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_spawn_command_includes_instruction(self, mock_kill, mock_popen):
+    def test_spawn_command_includes_instruction(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 300
         mock_popen.return_value = mock_proc
@@ -202,6 +216,18 @@ class TestSpawnViaProviderDispatch:
         instr_idx = cmd.index("--instruction") + 1
         assert "T2" in cmd[instr_idx]
         assert "my-pool" in cmd[instr_idx]
+
+    @patch("pool_worktree_manager.create_worker_worktree")
+    def test_spawn_failure_on_worktree_error(self, mock_wt):
+        mock_wt.side_effect = RuntimeError("git worktree add failed")
+
+        result = _spawn_via_provider_dispatch(
+            "vnx-dev", "default", "T1", "claude", "backend-developer"
+        )
+
+        assert result.success is False
+        assert "worktree creation failed" in result.error
+        assert result.pid is None
 
 
 # ---------------------------------------------------------------------------
@@ -368,8 +394,10 @@ class TestReaperPidValidation:
 # ---------------------------------------------------------------------------
 
 class TestSpawnNegativePaths:
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
-    def test_spawn_popen_file_not_found(self, mock_popen):
+    def test_spawn_popen_file_not_found(self, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_popen.side_effect = FileNotFoundError("python3 not found")
 
         result = _spawn_via_provider_dispatch(
@@ -379,9 +407,11 @@ class TestSpawnNegativePaths:
         assert result.success is False
         assert "Popen failed" in result.error
 
+    @patch("pool_worktree_manager.create_worker_worktree")
     @patch("pool_manager.subprocess.Popen")
     @patch("pool_manager.os.kill")
-    def test_spawn_with_empty_role(self, mock_kill, mock_popen):
+    def test_spawn_with_empty_role(self, mock_kill, mock_popen, mock_wt):
+        mock_wt.return_value = Path("/tmp/fake-worktree")
         mock_proc = MagicMock()
         mock_proc.pid = 400
         mock_popen.return_value = mock_proc


### PR DESCRIPTION
## Summary
- PR-6.5b (#566) introduced `create_worker_worktree()` before `subprocess.Popen` in `_spawn_via_provider_dispatch`, breaking 12 existing tests from PR-6.5a (#558)
- Fixed by mocking the worktree creation step in unit tests and adding a metadata_json pid fallback in `list_members()` for the write/read gap between `add_member()` (stores pid in metadata_json) and `list_members()` (reads from terminal_leases.worker_pid JOIN)
- Added end-to-end integration test (`tests/pool/test_spawn_integration.py`) covering full lifecycle: worktree create → Popen → PID persistence → reaper PID validation → worktree cleanup

## Changes
- `scripts/lib/pool_state_repo.py`: Added metadata_json pid fallback when `terminal_leases.worker_pid` is NULL
- `tests/pool/test_subprocess_spawn.py`: Added `@patch("pool_worktree_manager.create_worker_worktree")` to 8 spawn tests + 1 new worktree-failure test
- `tests/pool/test_spawn_integration.py`: 5 new e2e tests

## Test plan
- [x] All 12 originally-failing tests now pass
- [x] 1 new worktree-failure unit test passes
- [x] 5 new integration tests pass
- [x] Full pool test suite: 204 tests pass (`pytest tests/pool/ tests/test_pool_*.py`)
- [ ] CI green

Dispatch-ID: 20260517-fix-pr-6.5a-tests-integration