### PR TITLE
fix(receipts): persist token_usage + cost_usd + pr_id for subprocess worker dispatches

### DIFF
--- a/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
+++ b/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
@@ -97,6 +97,9 @@ def _write_receipt(
     commit_hash_after: str = "",
     manifest_path: str | None = None,
     stuck_event_count: int = 0,
+    token_usage: dict | None = None,
+    cost_usd: float | None = None,
+    pr_id: str | None = None,
 ) -> Path:
     """Append a subprocess completion receipt to t0_receipts.ndjson.
 
@@ -116,6 +119,9 @@ def _write_receipt(
         commit_hash_after=commit_hash_after,
         manifest_path=manifest_path,
         stuck_event_count=stuck_event_count,
+        token_usage=token_usage,
+        cost_usd=cost_usd,
+        pr_id=pr_id,
     )
     return _persist_receipt(receipt, dispatch_id, terminal_id, status)
 
@@ -135,6 +141,9 @@ def _build_receipt_payload(
     commit_hash_after: str,
     manifest_path: str | None,
     stuck_event_count: int,
+    token_usage: dict | None = None,
+    cost_usd: float | None = None,
+    pr_id: str | None = None,
 ) -> dict:
     """Assemble the receipt dict from the named fields."""
     receipt = {
@@ -165,6 +174,12 @@ def _build_receipt_payload(
         receipt["commit_missing"] = True
     if stuck_event_count:
         receipt["stuck_event_count"] = stuck_event_count
+    if token_usage is not None:
+        receipt["token_usage"] = token_usage
+    if cost_usd is not None:
+        receipt["cost_usd"] = cost_usd
+    if pr_id is not None:
+        receipt["pr_id"] = pr_id
     return receipt
 
 

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from otel_exporter import emit_dispatch_completion
+from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+from provider_dispatch import _extract_token_usage, _compute_cost
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +116,24 @@ def _resolve_active_dispatch_file(dispatch_id: str):
     return _sd._resolve_active_dispatch_file(dispatch_id)
 
 
+def _resolve_token_usage_and_cost(
+    dispatch_id: str, sub_result, model: "str | None",
+) -> tuple[dict | None, float | None]:
+    """Pop token_usage from the delivery side-channel, normalize, and compute cost."""
+    raw_usage = _dispatch_token_usage.pop(dispatch_id, None)
+    if raw_usage is None:
+        raw_usage = getattr(sub_result, "token_usage", None) if sub_result else None
+    if not isinstance(raw_usage, dict) or not raw_usage:
+        return None, None
+
+    class _UsageHolder:
+        token_usage = raw_usage
+
+    token_usage = _extract_token_usage(_UsageHolder(), "claude")
+    cost_usd = _compute_cost("claude", model or "claude-sonnet-4-6", token_usage)
+    return token_usage, cost_usd
+
+
 def _handle_success(
     *,
     dispatch_id: str,
@@ -130,6 +150,7 @@ def _handle_success(
     pre_sha: str,
     lease_generation: "int | None",
     model: "str | None" = None,
+    pr_id: "str | None" = None,
 ) -> None:
     """Run the success branch: write receipt, feedback, outcome capture, cleanup."""
     import subprocess_dispatch as _sd
@@ -146,6 +167,7 @@ def _handle_success(
         commit_hash_after=commit_hash_after,
         model=model,
     )
+    token_usage, cost_usd = _resolve_token_usage_and_cost(dispatch_id, sub_result, model)
     _sd._ensure_unified_report(dispatch_id, terminal_id, "done")
     _sd._write_receipt(
         dispatch_id, terminal_id, "done",
@@ -158,6 +180,9 @@ def _handle_success(
         commit_hash_after=commit_hash_after,
         manifest_path=sub_result.manifest_path,
         stuck_event_count=monitor.stuck_count,
+        token_usage=token_usage,
+        cost_usd=cost_usd,
+        pr_id=pr_id,
     )
     quality_db = _sd._default_state_dir() / "quality_intelligence.db"
     patt_updated = _sd._update_pattern_confidence(dispatch_id, "success", quality_db)
@@ -201,6 +226,8 @@ def _handle_final_failure(
     pre_sha: str,
     max_retries: int,
     lease_generation: "int | None",
+    model: "str | None" = None,
+    pr_id: "str | None" = None,
 ) -> None:
     """Run the budget-exhausted failure branch: stash, receipt, decay, cleanup."""
     import subprocess_dispatch as _sd
@@ -212,6 +239,7 @@ def _handle_final_failure(
             dispatch_touched_files=sub_result.touched_files,
             manifest_paths=manifest_paths,
         )
+    token_usage, cost_usd = _resolve_token_usage_and_cost(dispatch_id, sub_result, model)
     _sd._write_receipt(
         dispatch_id, terminal_id, "failed",
         event_count=sub_result.event_count,
@@ -221,6 +249,9 @@ def _handle_final_failure(
         commit_hash_before=commit_hash_before,
         manifest_path=sub_result.manifest_path,
         stuck_event_count=monitor.stuck_count,
+        token_usage=token_usage,
+        cost_usd=cost_usd,
+        pr_id=pr_id,
     )
     quality_db = _sd._default_state_dir() / "quality_intelligence.db"
     patt_updated = _sd._update_pattern_confidence(dispatch_id, "failure", quality_db)
@@ -349,6 +380,8 @@ def _backoff_or_fail(
     dispatch_start_ts: str,
     pre_sha: str,
     lease_generation: "int | None",
+    model: "str | None" = None,
+    pr_id: "str | None" = None,
 ) -> None:
     """Sleep with exponential backoff, or run the final-failure branch when exhausted."""
     if attempt < max_retries:
@@ -370,6 +403,8 @@ def _backoff_or_fail(
             pre_sha=pre_sha,
             max_retries=max_retries,
             lease_generation=lease_generation,
+            model=model,
+            pr_id=pr_id,
         )
 
 
@@ -437,6 +472,7 @@ def deliver_with_recovery(
                 pre_sha=pre_sha,
                 lease_generation=lease_generation,
                 model=model,
+                pr_id=pr_id,
             )
             return True
         _backoff_or_fail(
@@ -448,6 +484,8 @@ def deliver_with_recovery(
             commit_hash_before=commit_hash_before,
             dispatch_start_ts=dispatch_start_ts, pre_sha=pre_sha,
             lease_generation=lease_generation,
+            model=model,
+            pr_id=pr_id,
         )
 
     return False

--- a/tests/test_worker_receipt_bridge.py
+++ b/tests/test_worker_receipt_bridge.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Tests for worker→receipt bridge: token_usage, cost_usd, pr_id persistence."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import subprocess_dispatch as sd
+
+
+def _make_append_result(status="appended", path=None):
+    result = MagicMock()
+    result.status = status
+    result.receipts_file = path or Path("/tmp/test-state/t0_receipts.ndjson")
+    return result
+
+
+class TestTokenUsageInReceipt:
+    """token_usage is persisted in subprocess completion receipts."""
+
+    def test_token_usage_included_in_receipt_payload(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        token_usage = {"input": 1500, "output": 800, "cache_hit": 200}
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-tokens-001",
+                terminal_id="T1",
+                status="done",
+                token_usage=token_usage,
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["token_usage"] == {"input": 1500, "output": 800, "cache_hit": 200}
+
+    def test_token_usage_none_omitted_from_receipt(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-tokens-002",
+                terminal_id="T1",
+                status="done",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert "token_usage" not in receipt_arg
+
+    def test_token_usage_in_bare_write_fallback(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        receipt_file = state_dir / "t0_receipts.ndjson"
+
+        token_usage = {"input": 3000, "output": 1200, "cache_hit": 500}
+
+        with patch.dict("sys.modules", {"append_receipt": None}), \
+             patch.object(sd, "_default_state_dir", return_value=state_dir):
+            sd._write_receipt(
+                dispatch_id="test-tokens-003",
+                terminal_id="T2",
+                status="done",
+                token_usage=token_usage,
+            )
+
+        receipt_data = json.loads(receipt_file.read_text().strip())
+        assert receipt_data["token_usage"] == {"input": 3000, "output": 1200, "cache_hit": 500}
+
+
+class TestCostUsdInReceipt:
+    """cost_usd is persisted in subprocess completion receipts."""
+
+    def test_cost_usd_included_in_receipt_payload(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-cost-001",
+                terminal_id="T1",
+                status="done",
+                cost_usd=0.0423,
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["cost_usd"] == 0.0423
+
+    def test_cost_usd_none_omitted_from_receipt(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-cost-002",
+                terminal_id="T1",
+                status="done",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert "cost_usd" not in receipt_arg
+
+    def test_cost_usd_in_bare_write_fallback(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        receipt_file = state_dir / "t0_receipts.ndjson"
+
+        with patch.dict("sys.modules", {"append_receipt": None}), \
+             patch.object(sd, "_default_state_dir", return_value=state_dir):
+            sd._write_receipt(
+                dispatch_id="test-cost-003",
+                terminal_id="T2",
+                status="done",
+                cost_usd=0.156,
+            )
+
+        receipt_data = json.loads(receipt_file.read_text().strip())
+        assert receipt_data["cost_usd"] == 0.156
+
+
+class TestPrIdInReceipt:
+    """pr_id is persisted in subprocess completion receipts."""
+
+    def test_pr_id_included_in_receipt_payload(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-prid-001",
+                terminal_id="T1",
+                status="done",
+                pr_id="PR-565",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["pr_id"] == "PR-565"
+
+    def test_pr_id_none_omitted_from_receipt(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-prid-002",
+                terminal_id="T1",
+                status="done",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert "pr_id" not in receipt_arg
+
+    def test_pr_id_in_bare_write_fallback(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        receipt_file = state_dir / "t0_receipts.ndjson"
+
+        with patch.dict("sys.modules", {"append_receipt": None}), \
+             patch.object(sd, "_default_state_dir", return_value=state_dir):
+            sd._write_receipt(
+                dispatch_id="test-prid-003",
+                terminal_id="T2",
+                status="done",
+                pr_id="PR-566",
+            )
+
+        receipt_data = json.loads(receipt_file.read_text().strip())
+        assert receipt_data["pr_id"] == "PR-566"
+
+
+class TestAllFieldsCombined:
+    """All three fields (token_usage, cost_usd, pr_id) persist together."""
+
+    def test_all_fields_in_single_receipt(self, tmp_path):
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        token_usage = {"input": 5000, "output": 2000, "cache_hit": 1000}
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-combined-001",
+                terminal_id="T1",
+                status="done",
+                event_count=42,
+                committed=True,
+                commit_hash_before="aaa111",
+                commit_hash_after="bbb222",
+                token_usage=token_usage,
+                cost_usd=0.0891,
+                pr_id="PR-567",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["dispatch_id"] == "test-combined-001"
+        assert receipt_arg["status"] == "done"
+        assert receipt_arg["event_count"] == 42
+        assert receipt_arg["committed"] is True
+        assert receipt_arg["token_usage"] == token_usage
+        assert receipt_arg["cost_usd"] == 0.0891
+        assert receipt_arg["pr_id"] == "PR-567"
+
+    def test_backward_compat_no_new_fields(self, tmp_path):
+        """Existing callers without new params still produce valid receipts."""
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-compat-001",
+                terminal_id="T3",
+                status="success",
+                event_count=10,
+                session_id="sess-abc",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["dispatch_id"] == "test-compat-001"
+        assert receipt_arg["event_type"] == "subprocess_completion"
+        assert "token_usage" not in receipt_arg
+        assert "cost_usd" not in receipt_arg
+        assert "pr_id" not in receipt_arg
+
+
+class TestResolveTokenUsageAndCost:
+    """_resolve_token_usage_and_cost extracts from side-channel or sub_result."""
+
+    def test_reads_from_side_channel(self):
+        from subprocess_dispatch_internals.recovery import _resolve_token_usage_and_cost
+        from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+
+        _dispatch_token_usage["test-side-001"] = {
+            "input_tokens": 2000,
+            "output_tokens": 900,
+            "cache_read_input_tokens": 150,
+        }
+
+        sub_result = SimpleNamespace(token_usage=None)
+
+        with patch(
+            "subprocess_dispatch_internals.recovery._compute_cost",
+            return_value=0.05,
+        ):
+            token_usage, cost_usd = _resolve_token_usage_and_cost(
+                "test-side-001", sub_result, "claude-sonnet-4-6"
+            )
+
+        assert token_usage == {"input": 2000, "output": 900, "cache_hit": 150}
+        assert cost_usd == 0.05
+        assert "test-side-001" not in _dispatch_token_usage
+
+    def test_falls_back_to_sub_result_token_usage(self):
+        from subprocess_dispatch_internals.recovery import _resolve_token_usage_and_cost
+        from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+
+        _dispatch_token_usage.pop("test-fallback-001", None)
+
+        sub_result = SimpleNamespace(token_usage={
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 0,
+        })
+
+        with patch(
+            "subprocess_dispatch_internals.recovery._compute_cost",
+            return_value=0.02,
+        ):
+            token_usage, cost_usd = _resolve_token_usage_and_cost(
+                "test-fallback-001", sub_result, "claude-opus-4-6"
+            )
+
+        assert token_usage == {"input": 1000, "output": 500, "cache_hit": 0}
+        assert cost_usd == 0.02
+
+    def test_returns_none_when_no_usage(self):
+        from subprocess_dispatch_internals.recovery import _resolve_token_usage_and_cost
+        from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+
+        _dispatch_token_usage.pop("test-none-001", None)
+        sub_result = SimpleNamespace(token_usage=None)
+
+        token_usage, cost_usd = _resolve_token_usage_and_cost(
+            "test-none-001", sub_result, "claude-sonnet-4-6"
+        )
+
+        assert token_usage is None
+        assert cost_usd is None


### PR DESCRIPTION
## Summary
- Subprocess worker receipts were missing `token_usage`, `cost_usd`, and `pr_id` fields (9 dispatches today produced receipts with `token_usage=0/0`, `cost_usd=None`, empty `pr_id`)
- Wires the existing delivery side-channel (`_dispatch_token_usage`) and `provider_dispatch._extract_token_usage`/`_compute_cost` into the `recovery.py` success/failure handlers
- Backward-compatible: existing callers without the new params produce identical receipts (no new keys when values are None)

## Files changed
- `scripts/lib/subprocess_dispatch_internals/receipt_writer.py` — accept `token_usage`, `cost_usd`, `pr_id` kwargs in `_write_receipt` / `_build_receipt_payload`
- `scripts/lib/subprocess_dispatch_internals/recovery.py` — new `_resolve_token_usage_and_cost()` helper, forward `pr_id`+`model` through handler chain
- `tests/test_worker_receipt_bridge.py` — 14 tests covering canonical path, bare-write fallback, backward compat, side-channel extraction

## Test plan
- [x] `pytest tests/test_worker_receipt_bridge.py` — 14/14 passed
- [x] `pytest tests/test_subprocess_canonical_receipt.py` — 5/5 passed (backward compat)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)