### PR TITLE
fix(wiring): activate 4 dead-code modules from Wave 8 fast-path

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -191,14 +191,22 @@ def _init_and_check_db(state_dir: Path) -> bool:
     if not db_path.exists():
         return False
     try:
-        import sqlite3
         with sqlite3.connect(str(db_path)) as conn:
             tables = {r[0] for r in conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()}
-            return "terminal_leases" in tables
+            if "terminal_leases" not in tables:
+                return False
     except Exception:
         return False
+    # PR-6.5d fallback: DB exists but coordination_db init failed (e.g. locked).
+    # Still attempt auto_apply with the known path so pending migrations run.
+    try:
+        from migrations.auto_apply import auto_apply
+        auto_apply(db_path)
+    except Exception as e:
+        log.warning("migration auto_apply (fallback path) failed: %s", e)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -106,25 +106,56 @@ def emit_dispatch_receipt(
     return receipt_path
 
 
-def _validate_report_frontmatter(content: str, dispatch_id: str) -> None:
-    """Validate unified-report frontmatter. Shadow-mode by default.
+def _validate_report_via_shell(report_path: Path, dispatch_id: str) -> None:
+    """Shell fallback: invoke verify_report_schema.sh when Python jsonschema unavailable."""
+    import subprocess
 
-    Logs SchemaViolation as a warning. Raises only when VNX_SCHEMA_STRICT=1.
+    script = Path(__file__).resolve().parent.parent / "guardrails" / "verify_report_schema.sh"
+    if not script.exists():
+        logger.debug("governance_emit: shell validator %s not found, skipping", script)
+        return
+    try:
+        result = subprocess.run(
+            ["bash", str(script), str(report_path)],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            msg = (result.stdout or result.stderr or "unknown error").strip()
+            if os.environ.get("VNX_SCHEMA_STRICT") == "1":
+                raise ValueError(f"schema validation failed (shell): {msg}")
+            logger.warning(
+                "governance_emit: schema violation via shell (shadow-mode) dispatch=%s: %s",
+                dispatch_id, msg,
+            )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("governance_emit: shell validator error dispatch=%s: %s", dispatch_id, exc)
+
+
+def _validate_report_frontmatter(content: str, dispatch_id: str, report_path: Optional[Path] = None) -> None:
+    """Validate unified-report frontmatter via UnifiedReportValidator (PR-D5-E/F).
+
+    Uses Python jsonschema when available (UnifiedReportValidator class), falls
+    back to shell wrapper (verify_report_schema.sh) when jsonschema is missing.
+    Shadow-mode by default (log violations). Raises only when VNX_SCHEMA_STRICT=1.
     """
     try:
-        from unified_report_schema import validate_frontmatter, SchemaViolation
+        from unified_report_schema import UnifiedReportValidator, SchemaViolation
     except ImportError:
-        logger.debug("governance_emit: unified_report_schema not available, skipping validation")
+        if report_path is not None:
+            _validate_report_via_shell(report_path, dispatch_id)
+        else:
+            logger.debug("governance_emit: unified_report_schema not available, skipping validation")
         return
 
-    try:
-        validate_frontmatter(content)
-    except SchemaViolation as exc:
+    validator = UnifiedReportValidator()
+    result = validator.validate(content)
+    if not result.valid:
+        violation_msg = result.errors[0] if result.errors else "unknown schema violation"
         if os.environ.get("VNX_SCHEMA_STRICT") == "1":
-            raise
+            raise SchemaViolation(violation_msg)
         logger.warning(
             "governance_emit: schema violation (shadow-mode) dispatch=%s: %s",
-            dispatch_id, exc,
+            dispatch_id, violation_msg,
         )
 
 
@@ -184,7 +215,7 @@ def emit_unified_report(
             allow_unicode=True,
         )
         content = f"---\n{frontmatter_yaml}---\n\n{body}"
-        _validate_report_frontmatter(content, dispatch_id)
+        _validate_report_frontmatter(content, dispatch_id, report_path=report_path)
     else:
         content = body
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -775,35 +775,33 @@ def main(argv: list[str] | None = None) -> int:
 
     provider = args.provider
 
-    # PR-SR-4: smart_router auto-route (opt-in via --auto-route).
+    # PR-SR-3/4: smart_router.route() end-to-end pipeline (opt-in via --auto-route).
     if getattr(args, "auto_route", False):
         try:
-            from smart_router import decide as _smart_route, parse_route_model_id, write_route_decision  # noqa: PLC0415
+            from smart_router import route as _smart_route  # noqa: PLC0415
 
             _dp = None
             if args.dispatch_paths.strip():
                 _dp = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
 
-            _route_decision = _smart_route(
+            _state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+            _routing_result = _smart_route(
                 instruction=args.instruction,
+                dispatch_id=args.dispatch_id,
+                state_dir=_state_dir,
                 role=args.role,
                 dispatch_paths=_dp,
             )
-            if _route_decision.primary:
-                _routed_provider, _routed_model = parse_route_model_id(
-                    _route_decision.primary.model_id,
-                )
-                provider = _routed_provider
-                args.provider = _routed_provider
-                args.model = _routed_model
+            if _routing_result.routed:
+                provider = _routing_result.provider
+                args.provider = _routing_result.provider
+                args.model = _routing_result.model
                 os.environ["VNX_ROUTE_STRATEGY"] = "smart_router"
-                os.environ["VNX_TASK_CLASS"] = _route_decision.task_class
+                os.environ["VNX_TASK_CLASS"] = _routing_result.decision.task_class
 
-            _state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
-            write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
             logger.info(
                 "smart_router: auto-route provider=%s model=%s (task_class=%s)",
-                provider, args.model, _route_decision.task_class,
+                provider, args.model, _routing_result.decision.task_class,
             )
         except Exception as _route_exc:
             logger.warning(

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -307,3 +307,52 @@ def write_route_decision(
         "outcome": None,
     }
     append_locked(path, record)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end routing pipeline (PR-SR-3)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RoutingResult:
+    """Full result of the route() end-to-end pipeline."""
+    decision: RouteDecision
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    routed: bool = False
+
+
+def route(
+    instruction: str,
+    dispatch_id: str,
+    state_dir: Path,
+    *,
+    role: Optional[str] = None,
+    dispatch_paths: Optional[Sequence[str]] = None,
+    recommendations_path: Optional[Path] = None,
+) -> RoutingResult:
+    """End-to-end smart routing pipeline: classify → decide → resolve → persist.
+
+    Combines classify_task, decide, parse_route_model_id, and write_route_decision
+    into a single call. Returns RoutingResult with the selected provider/model and
+    the underlying RouteDecision.
+
+    This is the function provider_dispatch should call under --auto-route.
+    """
+    decision = decide(
+        instruction=instruction,
+        role=role,
+        dispatch_paths=dispatch_paths,
+        recommendations_path=recommendations_path,
+    )
+
+    result = RoutingResult(decision=decision)
+
+    if decision.primary:
+        provider, model = parse_route_model_id(decision.primary.model_id)
+        result.provider = provider
+        result.model = model
+        result.routed = True
+
+    write_route_decision(dispatch_id, decision, state_dir=state_dir)
+    return result

--- a/scripts/lib/unified_report_schema.py
+++ b/scripts/lib/unified_report_schema.py
@@ -190,3 +190,49 @@ def validate_file(path: Path) -> Dict[str, Any]:
     except OSError as exc:
         raise SchemaViolation(f"cannot read report {path}: {exc}") from exc
     return validate_frontmatter(text)
+
+
+class UnifiedReportValidator:
+    """Stateful validator for unified report frontmatter (PR-D5-E).
+
+    Provides a class-based API around the module-level validation functions.
+    Caches the jsonschema validator instance for repeated calls within the
+    same process (e.g. batch validation in CI or governance_emit hot path).
+
+    Usage:
+        validator = UnifiedReportValidator()
+        result = validator.validate(report_text)
+        # result.valid is True/False, result.errors lists violation messages
+    """
+
+    class Result:
+        __slots__ = ("valid", "errors", "frontmatter")
+
+        def __init__(
+            self,
+            valid: bool,
+            errors: "list[str]",
+            frontmatter: "Dict[str, Any] | None",
+        ):
+            self.valid = valid
+            self.errors = errors
+            self.frontmatter = frontmatter
+
+    def __init__(self, schema_path: "Path | None" = None):
+        self._schema_path = schema_path or SCHEMA_PATH
+
+    def validate(self, text: str) -> "UnifiedReportValidator.Result":
+        """Validate report text. Returns Result with valid/errors/frontmatter."""
+        try:
+            fm = validate_frontmatter(text)
+            return self.Result(valid=True, errors=[], frontmatter=fm)
+        except SchemaViolation as exc:
+            return self.Result(valid=False, errors=[str(exc)], frontmatter=None)
+
+    def validate_path(self, path: Path) -> "UnifiedReportValidator.Result":
+        """Validate a report file on disk."""
+        try:
+            fm = validate_file(path)
+            return self.Result(valid=True, errors=[], frontmatter=fm)
+        except SchemaViolation as exc:
+            return self.Result(valid=False, errors=[str(exc)], frontmatter=None)

--- a/tests/test_wiring_completeness.py
+++ b/tests/test_wiring_completeness.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Tests for Wave 8 dead-code wiring completeness.
+
+Verifies that all 4 modules identified in the audit are properly wired
+through at least one real call-path:
+  1. PR-6.5d: auto_apply() runs from build_t0_state fallback path
+  2. PR-D5-E: UnifiedReportValidator class is importable and usable from governance_emit
+  3. PR-D5-F: VNX_SCHEMA_STRICT toggle in emit_unified_report (shadow-mode + strict)
+  4. PR-SR-3: smart_router.route() is called from provider_dispatch --auto-route
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: PR-6.5d — auto_apply wired in build_t0_state fallback path
+# ---------------------------------------------------------------------------
+
+class TestAutoApplyWiring:
+    """Verify auto_apply is reachable from build_t0_state even when
+    coordination_db import fails (fallback path)."""
+
+    def test_auto_apply_called_in_fallback_path(self, tmp_path):
+        """When coordination_db init_schema raises, fallback path still calls auto_apply."""
+        import build_t0_state as bts
+
+        db_path = tmp_path / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE terminal_leases (id TEXT PRIMARY KEY, state TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+        auto_apply_called_with = []
+
+        def mock_auto_apply(path):
+            auto_apply_called_with.append(path)
+            return []
+
+        def mock_init_schema(sd):
+            raise sqlite3.OperationalError("database is locked")
+
+        with patch("build_t0_state.init_schema", mock_init_schema, create=True):
+            with patch(
+                "migrations.auto_apply.auto_apply", mock_auto_apply
+            ):
+                result = bts._init_and_check_db(tmp_path)
+
+        assert result is True
+        assert len(auto_apply_called_with) == 1
+        assert auto_apply_called_with[0] == db_path
+
+    def test_auto_apply_failure_does_not_block(self, tmp_path):
+        """auto_apply raising in fallback path must not prevent DB check from passing."""
+        db_path = tmp_path / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE terminal_leases (id TEXT PRIMARY KEY, state TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+        with patch.dict(sys.modules, {"coordination_db": None}):
+            with patch(
+                "migrations.auto_apply.auto_apply",
+                side_effect=RuntimeError("migration exploded"),
+            ):
+                import build_t0_state as bts
+
+                result = bts._init_and_check_db(tmp_path)
+
+        assert result is True
+
+    def test_auto_apply_import_available(self):
+        """Verify the auto_apply module is importable from scripts/lib/migrations/."""
+        from migrations.auto_apply import auto_apply
+
+        assert callable(auto_apply)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: PR-D5-E — UnifiedReportValidator class wired in governance_emit
+# ---------------------------------------------------------------------------
+
+class TestUnifiedReportValidatorWiring:
+    """Verify UnifiedReportValidator exists and is used by governance_emit."""
+
+    def test_class_importable(self):
+        """UnifiedReportValidator is importable from unified_report_schema."""
+        from unified_report_schema import UnifiedReportValidator
+
+        validator = UnifiedReportValidator()
+        assert hasattr(validator, "validate")
+        assert hasattr(validator, "validate_path")
+
+    def test_validator_accepts_valid_frontmatter(self, tmp_path):
+        """UnifiedReportValidator.validate returns valid=True for conformant content."""
+        from unified_report_schema import UnifiedReportValidator
+
+        valid_fm = {
+            "schema_version": 1,
+            "dispatch_id": "test-dispatch-001",
+            "provider": "claude",
+            "sub_provider": "none",
+            "model": "sonnet",
+            "terminal_id": "T1",
+            "pool_id": "headless",
+            "role": "backend-developer",
+            "task_class": "implementation",
+            "pr_id": "none",
+            "duration_seconds": 42.5,
+            "exit_code": 0,
+            "token_usage": {"input": 1000, "output": 500, "cache_read": 0},
+            "cost_usd": 0.01,
+            "route_decision": {
+                "strategy": "default",
+                "selected_provider": "claude",
+                "selected_model": "sonnet",
+            },
+        }
+        import yaml
+
+        fm_yaml = yaml.dump(valid_fm, default_flow_style=False)
+        content = f"---\n{fm_yaml}---\n\n# Report body\n"
+
+        validator = UnifiedReportValidator()
+        result = validator.validate(content)
+        assert result.valid is True
+        assert result.errors == []
+        assert result.frontmatter is not None
+
+    def test_validator_rejects_invalid_frontmatter(self):
+        """UnifiedReportValidator.validate returns valid=False for missing fields."""
+        from unified_report_schema import UnifiedReportValidator
+
+        content = "---\nschema_version: 1\n---\n\n# Missing fields\n"
+        validator = UnifiedReportValidator()
+        result = validator.validate(content)
+        assert result.valid is False
+        assert len(result.errors) > 0
+
+    def test_governance_emit_uses_validator_class(self, tmp_path):
+        """governance_emit._validate_report_frontmatter uses UnifiedReportValidator."""
+        import yaml
+
+        from governance_emit import _validate_report_frontmatter
+
+        valid_fm = {
+            "schema_version": 1,
+            "dispatch_id": "test-dispatch-002",
+            "provider": "claude",
+            "sub_provider": "none",
+            "model": "sonnet",
+            "terminal_id": "T1",
+            "pool_id": "headless",
+            "role": "backend-developer",
+            "task_class": "implementation",
+            "pr_id": "none",
+            "duration_seconds": 10.0,
+            "exit_code": 0,
+            "token_usage": {"input": 100, "output": 50, "cache_read": 0},
+            "cost_usd": 0.001,
+            "route_decision": {
+                "strategy": "default",
+                "selected_provider": "claude",
+                "selected_model": "sonnet",
+            },
+        }
+        fm_yaml = yaml.dump(valid_fm, default_flow_style=False)
+        content = f"---\n{fm_yaml}---\n\n# Body\n"
+
+        _validate_report_frontmatter(content, "test-dispatch-002")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: PR-D5-F — VNX_SCHEMA_STRICT toggle in emit_unified_report
+# ---------------------------------------------------------------------------
+
+class TestSchemaStrictToggle:
+    """Verify VNX_SCHEMA_STRICT controls raise vs shadow-mode behavior."""
+
+    def test_shadow_mode_logs_violation(self, tmp_path, caplog):
+        """Default (VNX_SCHEMA_STRICT unset): violations logged, not raised."""
+        import logging
+
+        from governance_emit import _validate_report_frontmatter
+
+        content = "---\nschema_version: 1\n---\n\n# Missing fields\n"
+
+        env_patch = {"VNX_SCHEMA_STRICT": ""}
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("VNX_SCHEMA_STRICT", None)
+            with caplog.at_level(logging.WARNING):
+                _validate_report_frontmatter(content, "test-shadow")
+
+        assert any("schema violation (shadow-mode)" in r.message for r in caplog.records)
+
+    def test_strict_mode_raises(self):
+        """VNX_SCHEMA_STRICT=1: violations raise SchemaViolation."""
+        from unified_report_schema import SchemaViolation
+
+        from governance_emit import _validate_report_frontmatter
+
+        content = "---\nschema_version: 1\n---\n\n# Missing fields\n"
+
+        with patch.dict(os.environ, {"VNX_SCHEMA_STRICT": "1"}):
+            with pytest.raises(SchemaViolation):
+                _validate_report_frontmatter(content, "test-strict")
+
+    def test_emit_unified_report_validates_with_frontmatter(self, tmp_path):
+        """emit_unified_report calls validation when frontmatter is provided."""
+        from governance_emit import emit_unified_report
+
+        frontmatter = {
+            "schema_version": 1,
+            "dispatch_id": "test-emit-001",
+            "provider": "claude",
+            "sub_provider": "none",
+            "model": "sonnet",
+            "terminal_id": "T1",
+            "pool_id": "headless",
+            "role": "backend-developer",
+            "task_class": "implementation",
+            "pr_id": "none",
+            "duration_seconds": 5.0,
+            "exit_code": 0,
+            "token_usage": {"input": 100, "output": 50, "cache_read": 0},
+            "cost_usd": 0.001,
+            "route_decision": {
+                "strategy": "default",
+                "selected_provider": "claude",
+                "selected_model": "sonnet",
+            },
+        }
+
+        report_path = emit_unified_report(
+            dispatch_id="test-emit-001",
+            terminal_id="T1",
+            provider="claude",
+            instruction="test instruction",
+            response_text="test response",
+            findings=[],
+            duration_seconds=5.0,
+            data_dir=tmp_path,
+            frontmatter=frontmatter,
+        )
+
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert content.startswith("---\n")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: PR-SR-3 — smart_router.route() wired in provider_dispatch --auto-route
+# ---------------------------------------------------------------------------
+
+class TestSmartRouterRouteWiring:
+    """Verify smart_router.route() exists and is called by provider_dispatch."""
+
+    def test_route_function_exists(self):
+        """smart_router.route() is importable and callable."""
+        from smart_router import route, RoutingResult
+
+        assert callable(route)
+
+    def test_route_returns_routing_result(self, tmp_path):
+        """smart_router.route() returns a RoutingResult with provider+model."""
+        from smart_router import route, RoutingResult
+
+        recs_yaml = tmp_path / "routing_recommendations.yaml"
+        recs_yaml.write_text(
+            "routing_by_task:\n"
+            "  01_code_generation:\n"
+            "  - model_id: claude-sonnet-4-6\n"
+            "    composite_score: 8.0\n"
+            "    avg_duration_seconds: 500\n"
+            "  - model_id: deepseek-v4-pro\n"
+            "    composite_score: 5.0\n"
+            "    avg_duration_seconds: 200\n",
+            encoding="utf-8",
+        )
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = route(
+            instruction="implement a new module for batch processing",
+            dispatch_id="test-route-001",
+            state_dir=state_dir,
+            role="backend-developer",
+            recommendations_path=recs_yaml,
+        )
+
+        assert isinstance(result, RoutingResult)
+        assert result.routed is True
+        assert result.provider == "claude"
+        assert result.model == "sonnet"
+        assert result.decision.task_class == "01_code_generation"
+
+    def test_route_writes_decision_ndjson(self, tmp_path):
+        """smart_router.route() persists the decision to route_decisions.ndjson."""
+        from smart_router import route
+
+        recs_yaml = tmp_path / "routing_recommendations.yaml"
+        recs_yaml.write_text(
+            "routing_by_task:\n"
+            "  05_debugging:\n"
+            "  - model_id: claude-opus-4-6\n"
+            "    composite_score: 9.0\n"
+            "    avg_duration_seconds: 300\n",
+            encoding="utf-8",
+        )
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        route(
+            instruction="debug the failing test in module X",
+            dispatch_id="test-route-002",
+            state_dir=state_dir,
+            recommendations_path=recs_yaml,
+        )
+
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        assert ndjson_path.exists()
+        lines = ndjson_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["dispatch_id"] == "test-route-002"
+        assert record["task_class"] == "05_debugging"
+        assert record["chosen_route"]["model_id"] == "claude-opus-4-6"
+
+    def test_provider_dispatch_auto_route_calls_smart_router_route(self, tmp_path):
+        """provider_dispatch main() with --auto-route calls smart_router.route()."""
+        from smart_router import RoutingResult, RouteDecision, RouteCandidate
+
+        mock_result = RoutingResult(
+            decision=RouteDecision(
+                task_class="01_code_generation",
+                primary=RouteCandidate(
+                    model_id="claude-sonnet-4-6",
+                    composite_score=8.0,
+                    avg_duration_seconds=500,
+                ),
+                fallback=None,
+                reason="test",
+            ),
+            provider="claude",
+            model="sonnet",
+            routed=True,
+        )
+
+        with patch("smart_router.route", return_value=mock_result) as mock_route:
+            with patch.dict(os.environ, {"VNX_STATE_DIR": str(tmp_path)}):
+                import provider_dispatch as pd_mod
+
+                with patch.object(pd_mod, "_dispatch_claude", return_value=0):
+                    with patch("env_loader.load_env"):
+                        with patch("constraint_enforcer.enforce"):
+                            try:
+                                pd_mod.main([
+                                    "--provider", "claude",
+                                    "--terminal-id", "T1",
+                                    "--dispatch-id", "test-auto-001",
+                                    "--instruction", "implement feature X",
+                                    "--auto-route",
+                                ])
+                            except SystemExit:
+                                pass
+
+            mock_route.assert_called_once()
+            call_kwargs = mock_route.call_args
+            assert "dispatch_id" in (call_kwargs.kwargs or {}) or len(call_kwargs.args) > 1
+            if call_kwargs.kwargs:
+                assert call_kwargs.kwargs["dispatch_id"] == "test-auto-001"


### PR DESCRIPTION
## Summary
- Wire `auto_apply()` fallback path in `build_t0_state._init_and_check_db()` so DB migrations run even when `coordination_db` init fails
- Create `UnifiedReportValidator` class in `unified_report_schema.py` and wire as Python primary validator in `governance_emit` with shell fallback
- VNX_SCHEMA_STRICT toggle via `UnifiedReportValidator`: raises on `=1`, logs shadow-mode violations by default
- Add `smart_router.route()` end-to-end pipeline function; wire in `provider_dispatch.py --auto-route` replacing manual inline steps

## Test plan
- [x] 14 tests in `tests/test_wiring_completeness.py` (all pass)
- [x] 109 existing tests in `test_build_t0_state`, `test_smart_router*` pass
- [x] 127 existing tests in `test_governance_emit*`, `test_provider_dispatch*` pass
- [x] 40 existing tests in `test_unified_report_schema*` pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)