### PR TITLE
feat(gate): wiring-gate dead-code detection

### DIFF
--- a/docs/gates/wiring_gate.md
+++ b/docs/gates/wiring_gate.md
@@ -1,0 +1,85 @@
+# Wiring Gate
+
+Dead-code detection gate that catches unwired public definitions added in a PR.
+
+## Problem
+
+26 dead symbols shipped across 92 PRs in the last week. Public functions and classes
+get defined but never called from production code, inflating maintenance surface.
+
+## How it works
+
+1. Fetches the PR diff via `gh pr diff <number>`
+2. AST-parses added lines for new public definitions (`def`/`class` without `_` prefix)
+3. Greps the codebase for callers (excludes `tests/` and the defining file itself)
+4. Flags symbols with zero callers as unwired
+
+## Integration
+
+Add `wiring_gate` to the `--review-stack` option of `review_gate_manager.py`:
+
+```bash
+python3 scripts/review_gate_manager.py request-and-execute \
+  --pr 567 --branch feat/my-feature \
+  --review-stack "gemini_review,codex_gate,wiring_gate"
+```
+
+## Environment
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `VNX_WIRING_GATE_REQUIRED` | `0` | `0` = shadow mode (advisory), `1` = hard-fail (blocking) |
+
+Week 1 runs in shadow mode to calibrate false positives. Set to `1` for enforcement.
+
+## Skip list
+
+File: `.vnx-data/state/wiring_skip.yaml`
+
+```yaml
+library_exports:
+  - emit_governance_receipt
+  - WiringGateResult
+
+decorator_registry:
+  - register_handler
+
+all_reexports:
+  - GateRunner
+
+cli_dispatch:
+  - handle_wiring_command
+```
+
+Categories cover common edge cases where zero callers is intentional:
+- **library_exports**: public API symbols consumed by external callers
+- **decorator_registry**: symbols registered via decorator (runtime discovery)
+- **all_reexports**: symbols exposed through `__all__` for package consumers
+- **cli_dispatch**: entry points reached via CLI argument dispatch dicts
+
+## API
+
+```python
+from wiring_gate import check_pr_wiring, WiringGateResult
+
+result: WiringGateResult = check_pr_wiring(pr_number=567)
+# result.status: "pass" | "fail" | "advisory"
+# result.unwired: List[UnwiredSymbol]
+# result.skipped: List[str]
+# result.total_checked: int
+# result.summary: str
+```
+
+## Gate result schema
+
+```json
+{
+  "status": "advisory",
+  "unwired": [
+    {"name": "orphan_func", "file": "scripts/lib/new.py", "line": 42, "kind": "function"}
+  ],
+  "skipped": ["register_handler"],
+  "total_checked": 8,
+  "summary": "1 unwired symbol(s): orphan_func"
+}
+```

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -22,6 +22,7 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
     "codex_gate": "VNX_CODEX_HEADLESS_ENABLED",
     "claude_github_optional": "VNX_CLAUDE_GITHUB_REVIEW_ENABLED",
     "ci_gate": "VNX_CI_GATE_REQUIRED",
+    "wiring_gate": "VNX_WIRING_GATE_REQUIRED",
 }
 
 _GATE_BINARIES: Dict[str, str] = {
@@ -29,6 +30,7 @@ _GATE_BINARIES: Dict[str, str] = {
     "codex_gate": "codex",
     "claude_github_optional": "gh",
     "ci_gate": "gh",
+    "wiring_gate": "gh",
 }
 
 # Infrastructure/execution failures — NOT semantic gate verdicts.

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -699,7 +699,7 @@ class GateRequestHandlerMixin:
         self, pr_number: int, branch: str, dispatch_id: str = "",
     ) -> Dict[str, Any]:
         from review_gate_manager import _utc_now
-        from wiring_gate import check_pr_wiring
+        from wiring_gate import WiringGateError, check_pr_wiring
 
         available = self._wiring_gate_available()
         requested_at = _utc_now()
@@ -722,7 +722,35 @@ class GateRequestHandlerMixin:
             )
             return payload
 
-        result = check_pr_wiring(pr_number)
+        try:
+            result = check_pr_wiring(pr_number)
+        except WiringGateError as exc:
+            payload = {
+                "gate": "wiring_gate",
+                "status": "fail",
+                "provider": "ast_grep",
+                "branch": branch,
+                "pr_number": pr_number,
+                "requested_at": requested_at,
+                "completed_at": _utc_now(),
+                "summary": f"Wiring gate error: {exc}",
+                "blocking_findings": [{
+                    "severity": "blocking",
+                    "title": "Wiring gate subprocess failure",
+                    "description": str(exc),
+                }],
+                "blocking_count": 1,
+                "advisory_count": 0,
+                "total_checked": 0,
+                "skipped_symbols": [],
+            }
+            if dispatch_id:
+                payload["dispatch_id"] = dispatch_id
+            self._request_path("wiring_gate", pr_number).write_text(
+                json.dumps(payload, indent=2), encoding="utf-8",
+            )
+            return payload
+
         payload = {
             "gate": "wiring_gate",
             "status": result.status,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -88,6 +88,8 @@ class GateRequestHandlerMixin:
             return payload
         if gate == "ci_gate":
             return self._request_ci_gate(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+        if gate == "wiring_gate":
+            return self._request_wiring_gate(pr_number, branch, dispatch_id)
         return {"gate": gate, "status": "blocked", "reason": "unknown_review_gate"}
 
     def request_reviews(
@@ -688,4 +690,64 @@ class GateRequestHandlerMixin:
         request_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
         self._emit_ci_gate_contract_receipt(contract, mode, dispatch_id, payload["status"])
+        return payload
+
+    def _wiring_gate_available(self) -> bool:
+        return shutil.which("gh") is not None
+
+    def _request_wiring_gate(
+        self, pr_number: int, branch: str, dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        from review_gate_manager import _utc_now
+        from wiring_gate import check_pr_wiring
+
+        available = self._wiring_gate_available()
+        requested_at = _utc_now()
+
+        if not available:
+            payload: Dict[str, Any] = {
+                "gate": "wiring_gate",
+                "status": "not_executable",
+                "provider": "gh_cli",
+                "branch": branch,
+                "pr_number": pr_number,
+                "requested_at": requested_at,
+                "reason": "provider_not_installed",
+                "reason_detail": "gh binary not found in PATH",
+            }
+            if dispatch_id:
+                payload["dispatch_id"] = dispatch_id
+            self._request_path("wiring_gate", pr_number).write_text(
+                json.dumps(payload, indent=2), encoding="utf-8",
+            )
+            return payload
+
+        result = check_pr_wiring(pr_number)
+        payload = {
+            "gate": "wiring_gate",
+            "status": result.status,
+            "provider": "ast_grep",
+            "branch": branch,
+            "pr_number": pr_number,
+            "requested_at": requested_at,
+            "completed_at": _utc_now(),
+            "summary": result.summary,
+            "blocking_findings": [
+                {
+                    "severity": "blocking" if result.status == "fail" else "advisory",
+                    "title": f"Unwired {s.kind}: {s.name}",
+                    "description": f"{s.file}:{s.line} — zero callers outside definition file",
+                }
+                for s in result.unwired
+            ],
+            "blocking_count": len(result.unwired) if result.status == "fail" else 0,
+            "advisory_count": len(result.unwired) if result.status == "advisory" else 0,
+            "total_checked": result.total_checked,
+            "skipped_symbols": result.skipped,
+        }
+        if dispatch_id:
+            payload["dispatch_id"] = dispatch_id
+        self._request_path("wiring_gate", pr_number).write_text(
+            json.dumps(payload, indent=2), encoding="utf-8",
+        )
         return payload

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -717,9 +717,10 @@ class GateRequestHandlerMixin:
             }
             if dispatch_id:
                 payload["dispatch_id"] = dispatch_id
-            self._request_path("wiring_gate", pr_number).write_text(
-                json.dumps(payload, indent=2), encoding="utf-8",
-            )
+            _path = self._request_path("wiring_gate", pr_number)
+            _tmp = _path.with_suffix(".tmp")
+            _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(_tmp, _path)
             return payload
 
         try:
@@ -746,9 +747,10 @@ class GateRequestHandlerMixin:
             }
             if dispatch_id:
                 payload["dispatch_id"] = dispatch_id
-            self._request_path("wiring_gate", pr_number).write_text(
-                json.dumps(payload, indent=2), encoding="utf-8",
-            )
+            _path = self._request_path("wiring_gate", pr_number)
+            _tmp = _path.with_suffix(".tmp")
+            _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(_tmp, _path)
             return payload
 
         payload = {
@@ -775,7 +777,8 @@ class GateRequestHandlerMixin:
         }
         if dispatch_id:
             payload["dispatch_id"] = dispatch_id
-        self._request_path("wiring_gate", pr_number).write_text(
-            json.dumps(payload, indent=2), encoding="utf-8",
-        )
+        _path = self._request_path("wiring_gate", pr_number)
+        _tmp = _path.with_suffix(".tmp")
+        _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.replace(_tmp, _path)
         return payload

--- a/scripts/lib/wiring_gate.py
+++ b/scripts/lib/wiring_gate.py
@@ -1,0 +1,234 @@
+"""wiring_gate.py — Dead-code detection gate for PR diffs.
+
+AST-parses new public definitions (functions, classes) added in a PR diff,
+then greps the codebase for callers. Definitions with zero callers outside
+their own file (excluding tests) are flagged as unwired dead code.
+
+Skip-list: .vnx-data/state/wiring_skip.yaml supports library-exports,
+decorator-registry entries, __all__ re-exports, and CLI dispatch-dicts.
+
+Env: VNX_WIRING_GATE_REQUIRED (default "0" = shadow/advisory, "1" = blocking).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+
+@dataclass(frozen=True)
+class UnwiredSymbol:
+    name: str
+    file: str
+    line: int
+    kind: str  # "function" or "class"
+
+
+@dataclass
+class WiringGateResult:
+    status: str  # "pass", "fail", "advisory"
+    unwired: List[UnwiredSymbol] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+    total_checked: int = 0
+    summary: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "unwired": [
+                {"name": s.name, "file": s.file, "line": s.line, "kind": s.kind}
+                for s in self.unwired
+            ],
+            "skipped": self.skipped,
+            "total_checked": self.total_checked,
+            "summary": self.summary,
+        }
+
+
+def _load_skip_list(state_dir: Optional[Path] = None) -> set:
+    if state_dir is None:
+        state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+    skip_path = state_dir / "wiring_skip.yaml"
+    if not skip_path.exists():
+        return set()
+    try:
+        data = yaml.safe_load(skip_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    symbols = set()
+    for key in ("library_exports", "decorator_registry", "all_reexports", "cli_dispatch"):
+        entries = data.get(key, [])
+        if isinstance(entries, list):
+            symbols.update(str(e) for e in entries)
+    return symbols
+
+
+def _get_pr_diff_files(pr_number: int) -> str:
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number), "--name-only"],
+            capture_output=True, text=True, timeout=15, check=True,
+        )
+        return proc.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def _get_pr_diff(pr_number: int) -> str:
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number)],
+            capture_output=True, text=True, timeout=30, check=True,
+        )
+        return proc.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def _extract_added_python_files(diff_names: str) -> List[str]:
+    return [
+        f.strip() for f in diff_names.splitlines()
+        if f.strip().endswith(".py")
+    ]
+
+
+_ADDED_DEF_RE = re.compile(r"^\+(?:def|class)\s+([A-Za-z]\w*)")
+
+
+def _extract_new_public_defs(diff_text: str) -> List[dict]:
+    defs = []
+    current_file = None
+    line_in_new = 0
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git"):
+            match = re.search(r" b/(.+)$", line)
+            current_file = match.group(1) if match else None
+            line_in_new = 0
+            continue
+        if line.startswith("@@"):
+            m = hunk_re.match(line)
+            if m:
+                line_in_new = int(m.group(1)) - 1
+            continue
+        if current_file and current_file.endswith(".py"):
+            if line.startswith("+") and not line.startswith("+++"):
+                line_in_new += 1
+                m = _ADDED_DEF_RE.match(line)
+                if m:
+                    name = m.group(1)
+                    if not name.startswith("_"):
+                        kind = "class" if line[1:].strip().startswith("class") else "function"
+                        defs.append({
+                            "name": name,
+                            "file": current_file,
+                            "line": line_in_new,
+                            "kind": kind,
+                        })
+            elif line.startswith("-"):
+                pass  # deleted lines don't advance new-file counter
+            else:
+                line_in_new += 1
+    return defs
+
+
+def _grep_callers(symbol_name: str, def_file: str) -> int:
+    try:
+        proc = subprocess.run(
+            [
+                "grep", "-r", "--include=*.py",
+                "-l", symbol_name, ".",
+            ],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return 1  # assume wired on grep failure (safe default)
+
+    if proc.returncode not in (0, 1):
+        return 1
+
+    callers = 0
+    for hit_file in proc.stdout.splitlines():
+        hit_file = hit_file.strip().lstrip("./")
+        if hit_file == def_file:
+            continue
+        if hit_file.startswith("tests/") or "/tests/" in hit_file or hit_file.startswith("test_"):
+            continue
+        callers += 1
+    return callers
+
+
+def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> WiringGateResult:
+    """Check a PR for unwired (dead) public definitions.
+
+    Returns WiringGateResult with status:
+      - "pass": all new public defs have callers
+      - "fail": unwired defs found AND VNX_WIRING_GATE_REQUIRED=1
+      - "advisory": unwired defs found but gate is in shadow mode
+    """
+    skip_list = _load_skip_list(state_dir)
+    required = os.environ.get("VNX_WIRING_GATE_REQUIRED", "0") == "1"
+
+    diff_text = _get_pr_diff(pr_number)
+    if not diff_text:
+        return WiringGateResult(
+            status="pass", total_checked=0,
+            summary="No diff available or empty PR",
+        )
+
+    new_defs = _extract_new_public_defs(diff_text)
+    if not new_defs:
+        return WiringGateResult(
+            status="pass", total_checked=0,
+            summary="No new public definitions in PR diff",
+        )
+
+    unwired: List[UnwiredSymbol] = []
+    skipped: List[str] = []
+
+    for d in new_defs:
+        if d["name"] in skip_list:
+            skipped.append(d["name"])
+            continue
+        caller_count = _grep_callers(d["name"], d["file"])
+        if caller_count == 0:
+            unwired.append(UnwiredSymbol(
+                name=d["name"],
+                file=d["file"],
+                line=d["line"],
+                kind=d["kind"],
+            ))
+
+    total_checked = len(new_defs) - len(skipped)
+
+    if not unwired:
+        return WiringGateResult(
+            status="pass",
+            unwired=[],
+            skipped=skipped,
+            total_checked=total_checked,
+            summary=f"All {total_checked} new public definitions are wired",
+        )
+
+    status = "fail" if required else "advisory"
+    names = ", ".join(s.name for s in unwired[:5])
+    tail = f" (+{len(unwired) - 5} more)" if len(unwired) > 5 else ""
+    summary = f"{len(unwired)} unwired symbol(s): {names}{tail}"
+
+    return WiringGateResult(
+        status=status,
+        unwired=unwired,
+        skipped=skipped,
+        total_checked=total_checked,
+        summary=summary,
+    )

--- a/scripts/lib/wiring_gate.py
+++ b/scripts/lib/wiring_gate.py
@@ -23,6 +23,10 @@ from typing import List, Optional
 import yaml
 
 
+class WiringGateError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class UnwiredSymbol:
     name: str
@@ -33,7 +37,7 @@ class UnwiredSymbol:
 
 @dataclass
 class WiringGateResult:
-    status: str  # "pass", "fail", "advisory"
+    status: str  # "pass", "fail", "advisory", "error"
     unwired: List[UnwiredSymbol] = field(default_factory=list)
     skipped: List[str] = field(default_factory=list)
     total_checked: int = 0
@@ -78,9 +82,11 @@ def _get_pr_diff_files(pr_number: int) -> str:
             ["gh", "pr", "diff", str(pr_number), "--name-only"],
             capture_output=True, text=True, timeout=15, check=True,
         )
-        return proc.stdout
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
-        return ""
+    except subprocess.TimeoutExpired as e:
+        raise WiringGateError(f"gh pr diff --name-only timed out for PR #{pr_number}") from e
+    except (subprocess.CalledProcessError, OSError) as e:
+        raise WiringGateError(f"gh pr diff --name-only failed for PR #{pr_number}: {e}") from e
+    return proc.stdout
 
 
 def _get_pr_diff(pr_number: int) -> str:
@@ -89,9 +95,11 @@ def _get_pr_diff(pr_number: int) -> str:
             ["gh", "pr", "diff", str(pr_number)],
             capture_output=True, text=True, timeout=30, check=True,
         )
-        return proc.stdout
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
-        return ""
+    except subprocess.TimeoutExpired as e:
+        raise WiringGateError(f"gh pr diff timed out for PR #{pr_number}") from e
+    except (subprocess.CalledProcessError, OSError) as e:
+        raise WiringGateError(f"gh pr diff failed for PR #{pr_number}: {e}") from e
+    return proc.stdout
 
 
 def _extract_added_python_files(diff_names: str) -> List[str]:
@@ -101,10 +109,80 @@ def _extract_added_python_files(diff_names: str) -> List[str]:
     ]
 
 
-_ADDED_DEF_RE = re.compile(r"^\+(?:def|class)\s+([A-Za-z]\w*)")
+_ADDED_DEF_RE = re.compile(r"^\+(?:async\s+)?(?:def|class)\s+([A-Za-z]\w*)")
 
 
-def _extract_new_public_defs(diff_text: str) -> List[dict]:
+def _extract_added_source_per_file(diff_text: str) -> dict[str, tuple[str, dict[int, int]]]:
+    """Extract full added source per .py file from a unified diff.
+
+    Returns {filepath: (source_text, {source_line: diff_line})} where source_text
+    is the reconstructed new-file content from added lines, and the mapping allows
+    translating AST lineno back to the actual file line in the PR.
+    """
+    files: dict[str, tuple[list[str], dict[int, int]]] = {}
+    current_file: Optional[str] = None
+    line_in_new = 0
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git"):
+            match = re.search(r" b/(.+)$", line)
+            current_file = match.group(1) if match else None
+            line_in_new = 0
+            continue
+        if line.startswith("@@"):
+            m = hunk_re.match(line)
+            if m:
+                line_in_new = int(m.group(1)) - 1
+            continue
+        if current_file and current_file.endswith(".py"):
+            if line.startswith("+") and not line.startswith("+++"):
+                line_in_new += 1
+                if current_file not in files:
+                    files[current_file] = ([], {})
+                src_lines, line_map = files[current_file]
+                src_lines.append(line[1:])  # strip leading '+'
+                line_map[len(src_lines)] = line_in_new
+            elif line.startswith("-"):
+                pass
+            else:
+                line_in_new += 1
+
+    return {fp: ("\n".join(lines), lmap) for fp, (lines, lmap) in files.items()}
+
+
+def _extract_defs_via_ast(source: str, filepath: str, line_map: dict[int, int]) -> List[dict]:
+    """Parse source with AST and extract public top-level function/class defs."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    defs = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                diff_line = line_map.get(node.lineno, node.lineno)
+                defs.append({
+                    "name": node.name,
+                    "file": filepath,
+                    "line": diff_line,
+                    "kind": "function",
+                })
+        elif isinstance(node, ast.ClassDef):
+            if not node.name.startswith("_"):
+                diff_line = line_map.get(node.lineno, node.lineno)
+                defs.append({
+                    "name": node.name,
+                    "file": filepath,
+                    "line": diff_line,
+                    "kind": "class",
+                })
+    return defs
+
+
+def _extract_defs_via_regex(diff_text: str) -> List[dict]:
+    """Fallback regex-based extraction when AST parse fails."""
     defs = []
     current_file = None
     line_in_new = 0
@@ -136,13 +214,41 @@ def _extract_new_public_defs(diff_text: str) -> List[dict]:
                             "kind": kind,
                         })
             elif line.startswith("-"):
-                pass  # deleted lines don't advance new-file counter
+                pass
             else:
                 line_in_new += 1
     return defs
 
 
-def _grep_callers(symbol_name: str, def_file: str) -> int:
+def _extract_new_public_defs(diff_text: str) -> List[dict]:
+    """Extract new public definitions from diff. Uses AST as primary, regex as fallback."""
+    file_sources = _extract_added_source_per_file(diff_text)
+
+    all_defs: List[dict] = []
+    ast_failed_files: set[str] = set()
+
+    for filepath, (source, line_map) in file_sources.items():
+        ast_defs = _extract_defs_via_ast(source, filepath, line_map)
+        if ast_defs:
+            all_defs.extend(ast_defs)
+        else:
+            ast_failed_files.add(filepath)
+
+    if ast_failed_files:
+        regex_defs = _extract_defs_via_regex(diff_text)
+        for d in regex_defs:
+            if d["file"] in ast_failed_files:
+                all_defs.append(d)
+
+    return all_defs
+
+
+def _grep_callers(symbol_name: str, def_file: str) -> Optional[int]:
+    """Count non-test callers of symbol outside its definition file.
+
+    Returns None on grep failure (unknown state) — callers must treat
+    None as blocking rather than assuming the symbol is wired.
+    """
     try:
         proc = subprocess.run(
             [
@@ -152,10 +258,10 @@ def _grep_callers(symbol_name: str, def_file: str) -> int:
             capture_output=True, text=True, timeout=10, check=False,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return 1  # assume wired on grep failure (safe default)
+        return None
 
     if proc.returncode not in (0, 1):
-        return 1
+        return None
 
     callers = 0
     for hit_file in proc.stdout.splitlines():
@@ -175,6 +281,10 @@ def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> Wiri
       - "pass": all new public defs have callers
       - "fail": unwired defs found AND VNX_WIRING_GATE_REQUIRED=1
       - "advisory": unwired defs found but gate is in shadow mode
+      - "error": subprocess failure fetching diff (gate cannot determine wiring)
+
+    Raises WiringGateError if the diff cannot be fetched — the gate runner
+    must catch this and mark the gate outcome as FAILED, never PASS with 0 checks.
     """
     skip_list = _load_skip_list(state_dir)
     required = os.environ.get("VNX_WIRING_GATE_REQUIRED", "0") == "1"
@@ -183,7 +293,7 @@ def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> Wiri
     if not diff_text:
         return WiringGateResult(
             status="pass", total_checked=0,
-            summary="No diff available or empty PR",
+            summary="Empty PR diff (no changes)",
         )
 
     new_defs = _extract_new_public_defs(diff_text)
@@ -195,13 +305,22 @@ def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> Wiri
 
     unwired: List[UnwiredSymbol] = []
     skipped: List[str] = []
+    grep_failures: List[str] = []
 
     for d in new_defs:
         if d["name"] in skip_list:
             skipped.append(d["name"])
             continue
         caller_count = _grep_callers(d["name"], d["file"])
-        if caller_count == 0:
+        if caller_count is None:
+            grep_failures.append(d["name"])
+            unwired.append(UnwiredSymbol(
+                name=d["name"],
+                file=d["file"],
+                line=d["line"],
+                kind=d["kind"],
+            ))
+        elif caller_count == 0:
             unwired.append(UnwiredSymbol(
                 name=d["name"],
                 file=d["file"],
@@ -210,6 +329,19 @@ def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> Wiri
             ))
 
     total_checked = len(new_defs) - len(skipped)
+
+    if grep_failures:
+        status = "fail"
+        names = ", ".join(grep_failures[:5])
+        tail = f" (+{len(grep_failures) - 5} more)" if len(grep_failures) > 5 else ""
+        summary = f"grep failed for {len(grep_failures)} symbol(s) (treated as blocking): {names}{tail}"
+        return WiringGateResult(
+            status=status,
+            unwired=unwired,
+            skipped=skipped,
+            total_checked=total_checked,
+            summary=summary,
+        )
 
     if not unwired:
         return WiringGateResult(

--- a/tests/test_wiring_gate.py
+++ b/tests/test_wiring_gate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for wiring_gate.py — dead-code detection gate."""
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+from wiring_gate import (
+    WiringGateResult,
+    _extract_new_public_defs,
+    _load_skip_list,
+    check_pr_wiring,
+)
+
+
+SAMPLE_DIFF = textwrap.dedent("""\
+    diff --git a/scripts/lib/new_module.py b/scripts/lib/new_module.py
+    new file mode 100644
+    --- /dev/null
+    +++ b/scripts/lib/new_module.py
+    @@ -0,0 +1,12 @@
+    +\"\"\"New module.\"\"\"
+    +
+    +def public_helper():
+    +    pass
+    +
+    +def _private_helper():
+    +    pass
+    +
+    +class PublicWidget:
+    +    pass
+    +
+    +class _InternalWidget:
+    +    pass
+""")
+
+DIFF_NO_DEFS = textwrap.dedent("""\
+    diff --git a/README.md b/README.md
+    --- a/README.md
+    +++ b/README.md
+    @@ -1,3 +1,4 @@
+     # Project
+    +Added a line.
+""")
+
+
+class TestExtractNewPublicDefs:
+    def test_extracts_public_skips_private(self):
+        defs = _extract_new_public_defs(SAMPLE_DIFF)
+        names = [d["name"] for d in defs]
+        assert "public_helper" in names
+        assert "PublicWidget" in names
+        assert "_private_helper" not in names
+        assert "_InternalWidget" not in names
+
+    def test_assigns_correct_kind(self):
+        defs = _extract_new_public_defs(SAMPLE_DIFF)
+        by_name = {d["name"]: d for d in defs}
+        assert by_name["public_helper"]["kind"] == "function"
+        assert by_name["PublicWidget"]["kind"] == "class"
+
+    def test_no_defs_in_non_python(self):
+        defs = _extract_new_public_defs(DIFF_NO_DEFS)
+        assert defs == []
+
+    def test_records_file_path(self):
+        defs = _extract_new_public_defs(SAMPLE_DIFF)
+        for d in defs:
+            assert d["file"] == "scripts/lib/new_module.py"
+
+
+class TestLoadSkipList:
+    def test_empty_when_no_file(self, tmp_path):
+        result = _load_skip_list(tmp_path)
+        assert result == set()
+
+    def test_loads_all_categories(self, tmp_path):
+        skip_file = tmp_path / "wiring_skip.yaml"
+        skip_file.write_text(textwrap.dedent("""\
+            library_exports:
+              - emit_governance_receipt
+            decorator_registry:
+              - register_handler
+            all_reexports:
+              - WiringGateResult
+            cli_dispatch:
+              - handle_wiring
+        """))
+        result = _load_skip_list(tmp_path)
+        assert result == {
+            "emit_governance_receipt",
+            "register_handler",
+            "WiringGateResult",
+            "handle_wiring",
+        }
+
+    def test_handles_malformed_yaml(self, tmp_path):
+        skip_file = tmp_path / "wiring_skip.yaml"
+        skip_file.write_text("not: [valid: yaml: {{")
+        result = _load_skip_list(tmp_path)
+        assert result == set()
+
+
+class TestCheckPrWiring:
+    @patch("wiring_gate._get_pr_diff", return_value="")
+    def test_empty_diff_passes(self, mock_diff):
+        result = check_pr_wiring(999)
+        assert result.status == "pass"
+        assert result.total_checked == 0
+
+    @patch("wiring_gate._get_pr_diff", return_value=DIFF_NO_DEFS)
+    def test_no_new_defs_passes(self, mock_diff):
+        result = check_pr_wiring(999)
+        assert result.status == "pass"
+
+    @patch("wiring_gate._grep_callers", return_value=0)
+    @patch("wiring_gate._get_pr_diff", return_value=SAMPLE_DIFF)
+    def test_unwired_advisory_by_default(self, mock_diff, mock_grep, monkeypatch):
+        monkeypatch.setenv("VNX_WIRING_GATE_REQUIRED", "0")
+        result = check_pr_wiring(123)
+        assert result.status == "advisory"
+        assert len(result.unwired) == 2
+
+    @patch("wiring_gate._grep_callers", return_value=0)
+    @patch("wiring_gate._get_pr_diff", return_value=SAMPLE_DIFF)
+    def test_unwired_blocks_when_required(self, mock_diff, mock_grep, monkeypatch):
+        monkeypatch.setenv("VNX_WIRING_GATE_REQUIRED", "1")
+        result = check_pr_wiring(123)
+        assert result.status == "fail"
+        assert len(result.unwired) == 2
+
+    @patch("wiring_gate._grep_callers", return_value=3)
+    @patch("wiring_gate._get_pr_diff", return_value=SAMPLE_DIFF)
+    def test_all_wired_passes(self, mock_diff, mock_grep):
+        result = check_pr_wiring(123)
+        assert result.status == "pass"
+        assert result.unwired == []
+
+    @patch("wiring_gate._grep_callers", return_value=0)
+    @patch("wiring_gate._get_pr_diff", return_value=SAMPLE_DIFF)
+    def test_skip_list_excludes_symbols(self, mock_diff, mock_grep, tmp_path):
+        skip_file = tmp_path / "wiring_skip.yaml"
+        skip_file.write_text("library_exports:\n  - public_helper\n  - PublicWidget\n")
+        result = check_pr_wiring(123, state_dir=tmp_path)
+        assert result.status == "pass"
+        assert set(result.skipped) == {"public_helper", "PublicWidget"}
+
+    def test_result_to_dict(self):
+        from wiring_gate import UnwiredSymbol
+        result = WiringGateResult(
+            status="advisory",
+            unwired=[UnwiredSymbol("foo", "bar.py", 10, "function")],
+            skipped=["baz"],
+            total_checked=5,
+            summary="1 unwired symbol(s): foo",
+        )
+        d = result.to_dict()
+        assert d["status"] == "advisory"
+        assert d["unwired"][0]["name"] == "foo"
+        assert d["skipped"] == ["baz"]

--- a/tests/test_wiring_gate.py
+++ b/tests/test_wiring_gate.py
@@ -2,6 +2,7 @@
 """Tests for wiring_gate.py — dead-code detection gate."""
 
 import os
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -14,8 +15,10 @@ sys.path.insert(0, str(VNX_ROOT / "scripts"))
 sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
 
 from wiring_gate import (
+    WiringGateError,
     WiringGateResult,
     _extract_new_public_defs,
+    _grep_callers,
     _load_skip_list,
     check_pr_wiring,
 )
@@ -39,6 +42,24 @@ SAMPLE_DIFF = textwrap.dedent("""\
     +    pass
     +
     +class _InternalWidget:
+    +    pass
+""")
+
+SAMPLE_DIFF_ASYNC = textwrap.dedent("""\
+    diff --git a/scripts/lib/async_module.py b/scripts/lib/async_module.py
+    new file mode 100644
+    --- /dev/null
+    +++ b/scripts/lib/async_module.py
+    @@ -0,0 +1,9 @@
+    +\"\"\"Async module.\"\"\"
+    +
+    +async def fetch_data():
+    +    pass
+    +
+    +async def _internal_fetch():
+    +    pass
+    +
+    +def sync_helper():
     +    pass
 """)
 
@@ -166,3 +187,70 @@ class TestCheckPrWiring:
         assert d["status"] == "advisory"
         assert d["unwired"][0]["name"] == "foo"
         assert d["skipped"] == ["baz"]
+
+    @patch("wiring_gate._get_pr_diff", side_effect=WiringGateError("gh pr diff failed"))
+    def test_diff_failure_raises_wiring_gate_error(self, mock_diff):
+        with pytest.raises(WiringGateError, match="gh pr diff failed"):
+            check_pr_wiring(999)
+
+    @patch("wiring_gate._grep_callers", return_value=None)
+    @patch("wiring_gate._get_pr_diff", return_value=SAMPLE_DIFF)
+    def test_grep_failure_blocks_as_fail(self, mock_diff, mock_grep):
+        result = check_pr_wiring(123)
+        assert result.status == "fail"
+        assert len(result.unwired) == 2
+        assert "grep failed" in result.summary
+
+
+class TestAsyncDefExtraction:
+    def test_extracts_async_def(self):
+        defs = _extract_new_public_defs(SAMPLE_DIFF_ASYNC)
+        names = [d["name"] for d in defs]
+        assert "fetch_data" in names
+        assert "sync_helper" in names
+        assert "_internal_fetch" not in names
+
+    def test_async_def_kind_is_function(self):
+        defs = _extract_new_public_defs(SAMPLE_DIFF_ASYNC)
+        by_name = {d["name"]: d for d in defs}
+        assert by_name["fetch_data"]["kind"] == "function"
+
+
+class TestGetPrDiffRaisesOnError:
+    @patch("wiring_gate.subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 30))
+    def test_timeout_raises(self, mock_run):
+        from wiring_gate import _get_pr_diff
+        with pytest.raises(WiringGateError, match="timed out"):
+            _get_pr_diff(123)
+
+    @patch("wiring_gate.subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh"))
+    def test_called_process_error_raises(self, mock_run):
+        from wiring_gate import _get_pr_diff
+        with pytest.raises(WiringGateError, match="failed"):
+            _get_pr_diff(123)
+
+    @patch("wiring_gate.subprocess.run", side_effect=OSError("no gh binary"))
+    def test_os_error_raises(self, mock_run):
+        from wiring_gate import _get_pr_diff
+        with pytest.raises(WiringGateError, match="failed"):
+            _get_pr_diff(123)
+
+
+class TestGrepCallersReturnsNone:
+    @patch("wiring_gate.subprocess.run", side_effect=subprocess.TimeoutExpired("grep", 10))
+    def test_timeout_returns_none(self, mock_run):
+        result = _grep_callers("some_func", "some_file.py")
+        assert result is None
+
+    @patch("wiring_gate.subprocess.run", side_effect=OSError("no grep"))
+    def test_os_error_returns_none(self, mock_run):
+        result = _grep_callers("some_func", "some_file.py")
+        assert result is None
+
+    @patch("wiring_gate.subprocess.run")
+    def test_bad_returncode_returns_none(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["grep"], returncode=2, stdout="", stderr="error"
+        )
+        result = _grep_callers("some_func", "some_file.py")
+        assert result is None


### PR DESCRIPTION
## Summary
- New `wiring_gate` (~120 LOC) AST-parses PR diffs for new public definitions, greps callers, flags unwired symbols
- Integrates with `review_gate_manager.py` as a stack option (`--review-stack "...,wiring_gate"`)
- Shadow mode (advisory) by default via `VNX_WIRING_GATE_REQUIRED=0`, hard-fail when set to `1`
- Skip-list support via `.vnx-data/state/wiring_skip.yaml` (library-exports, decorator-registry, __all__ re-exports, CLI dispatch-dicts)

## Test plan
- [x] 14 unit tests in `tests/test_wiring_gate.py` — all pass
- [ ] Integration test: run against an actual PR with known dead symbols
- [ ] Week 1 shadow-mode soak: verify false-positive rate before enabling enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)