### PR TITLE
fix(bench): BENCH terminal-id + stdin judge + anon model-id (3 blockers)

### DIFF
--- a/scripts/benchmark/judge_quality.py
+++ b/scripts/benchmark/judge_quality.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
@@ -29,7 +30,7 @@ JUDGE_PROMPT_TEMPLATE = """Score this AI response on three dimensions. Be object
 Original task:
 {task_prompt}
 
-Response from model "{model_id}":
+Response from {anon_label}:
 {response}
 
 Output ONLY a JSON object with exactly these fields:
@@ -51,22 +52,37 @@ _FALLBACK_SCORE = {
 }
 
 
+def anonymize_model_id(model_id: str) -> str:
+    """Deterministic anonymized label so judge cannot recognize the model."""
+    short_hash = hashlib.sha256(model_id.encode()).hexdigest()[:8]
+    return f"X-anon-{short_hash}"
+
+
 def _load_task_prompt(task_id: str, prompts_dir: Path) -> str:
     path = prompts_dir / f"{task_id}.txt"
     return path.read_text() if path.exists() else f"(prompt file not found: {task_id}.txt)"
 
 
 def _call_judge(prompt: str, model: str, timeout: int) -> str:
-    """Invoke claude -p and return stdout. Raises subprocess.TimeoutExpired on timeout."""
-    proc = subprocess.run(
-        ["claude", "-p", "--model", model, prompt],
-        capture_output=True,
+    """Invoke claude -p with prompt on stdin (avoids ARG_MAX and process-table exposure)."""
+    proc = subprocess.Popen(
+        ["claude", "-p", "--model", model],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=timeout,
     )
+    try:
+        stdout, stderr = proc.communicate(input=prompt, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        raise
+    except BrokenPipeError:
+        raise RuntimeError("BrokenPipeError: claude process terminated before accepting prompt")
     if proc.returncode != 0:
-        raise RuntimeError(f"claude returned {proc.returncode}: {proc.stderr[:200]}")
-    return proc.stdout.strip()
+        raise RuntimeError(f"claude returned {proc.returncode}: {(stderr or '')[:200]}")
+    return stdout.strip()
 
 
 def _parse_judge_response(raw: str) -> Dict:
@@ -98,9 +114,10 @@ def judge_result_file(result_path: Path, prompts_dir: Path, model: str, timeout:
     response = data.get("response", "")
 
     task_prompt = _load_task_prompt(task_id, prompts_dir)
+    anon_label = anonymize_model_id(model_id)
     judge_prompt = JUDGE_PROMPT_TEMPLATE.format(
         task_prompt=task_prompt,
-        model_id=model_id,
+        anon_label=anon_label,
         response=response or "(empty response)",
     )
 

--- a/scripts/benchmark/models.yaml
+++ b/scripts/benchmark/models.yaml
@@ -35,12 +35,6 @@ models:
     cost_input_mtok: 0.95
     cost_output_mtok: 4.00
 
-  - id: kimi-k2-0905
-    provider: litellm:moonshot
-    model_arg: kimi-k2-0905-preview
-    cost_input_mtok: 0.60
-    cost_output_mtok: 2.50
-
   - id: glm-5-1
     provider: litellm:zai
     model_arg: glm-5

--- a/scripts/benchmark/prompts/02_code_review.txt
+++ b/scripts/benchmark/prompts/02_code_review.txt
@@ -74,4 +74,4 @@ def cleanup_temp(directory):
     os.system(f"rm -rf {directory}")
 ```
 
-List all blocking issues with line number, issue type, severity, and fix. Do not miss any of the 5 deliberately planted critical issues.
+List all blocking issues with line number, issue type, severity, and fix.

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -60,14 +60,14 @@ def _atomic_write_json(path: Path, obj: object) -> None:
     os.replace(tmp, path)
 
 
-def run_single(model: Dict, task: Dict, dispatch_id: str) -> Dict:
+def run_single(model: Dict, task: Dict, dispatch_id: str, terminal_id: str = "BENCH") -> Dict:
     """Dispatch single (model, task) pair. Return result dict."""
     start = time.time()
     cmd = [
         "python3",
         str(REPO_ROOT / "scripts" / "lib" / "provider_dispatch.py"),
         "--provider", model["provider"],
-        "--terminal-id", "T2",
+        "--terminal-id", terminal_id,
         "--dispatch-id", dispatch_id,
         "--role", "backend-developer",
         "--instruction", task["prompt"],
@@ -177,6 +177,7 @@ def main() -> int:
     parser.add_argument("--models", default="all", help="Comma-separated model IDs or 'all'")
     parser.add_argument("--tasks", default="all", help="Comma-separated task IDs or 'all'")
     parser.add_argument("--output", default=None, help="Override output directory")
+    parser.add_argument("--terminal-id", default="BENCH", help="Terminal ID for governance state (default: BENCH)")
     parser.add_argument("--dry-run", action="store_true", help="List dispatches without executing")
     parser.add_argument("--run", action="store_true", help="Actually execute benchmarks")
     args = parser.parse_args()
@@ -209,7 +210,7 @@ def main() -> int:
             dispatch_id = f"bench-{model['id']}-{task['id']}-{ts}"
             print(f"[{completed + 1}/{total}] {model['id']} x {task['id']}...")
             try:
-                result = run_single(model, task, dispatch_id)
+                result = run_single(model, task, dispatch_id, terminal_id=args.terminal_id)
                 result_path = output_dir / f"{model['id']}__{task['id']}.json"
                 _atomic_write_json(result_path, result)
                 cost = result.get("cost_usd")

--- a/tests/test_benchmark_fixes.py
+++ b/tests/test_benchmark_fixes.py
@@ -1,0 +1,321 @@
+"""Regression tests for the 3 benchmark blockers + 2 quick-wins.
+
+Dispatch-ID: 20260517-fix-benchmark-cluster
+
+Covers:
+  1. run_benchmark.run_single uses 'BENCH' terminal-id (not 'T2')
+  2. judge_quality._call_judge streams prompt via stdin (not CLI arg)
+  3. judge_quality.anonymize_model_id produces stable anonymized label
+  4. models.yaml no longer contains duplicate kimi-k2-0905 entry
+  5. prompts/02_code_review.txt no longer leaks expected issue count
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import yaml
+
+import sys
+BENCHMARK_DIR = Path(__file__).resolve().parents[1] / "scripts" / "benchmark"
+if str(BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARK_DIR))
+
+import run_benchmark
+import judge_quality
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_prompts(tmp_path: Path) -> Path:
+    p = tmp_path / "prompts"
+    p.mkdir()
+    (p / "01_alpha.txt").write_text("Do task alpha.")
+    return p
+
+
+@pytest.fixture()
+def tmp_models_yaml(tmp_path: Path) -> Path:
+    data = {
+        "models": [
+            {
+                "id": "claude-sonnet-4-6",
+                "provider": "claude",
+                "model_arg": "sonnet",
+                "cost_input_mtok": 3.00,
+                "cost_output_mtok": 15.00,
+            },
+        ]
+    }
+    path = tmp_path / "models.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 1: terminal-id defaults to BENCH, not T2
+# ---------------------------------------------------------------------------
+
+class TestTerminalIdBench:
+    def test_run_single_uses_bench_terminal_id_by_default(
+        self, tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path,
+    ):
+        model = run_benchmark.load_models(tmp_models_yaml)[0]
+        task = run_benchmark.load_tasks(tmp_prompts)[0]
+        dispatch_id = "bench-fix-tid-001"
+
+        receipts_dir = tmp_path / ".vnx-data" / "receipts"
+        receipts_dir.mkdir(parents=True)
+        (receipts_dir / "t0_receipts.ndjson").write_text("")
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.stdout = ""
+        fake_proc.stderr = ""
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return fake_proc
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+            run_benchmark.run_single(model, task, dispatch_id)
+
+        tid_idx = captured_cmd.index("--terminal-id")
+        assert captured_cmd[tid_idx + 1] == "BENCH"
+
+    def test_run_single_accepts_custom_terminal_id(
+        self, tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path,
+    ):
+        model = run_benchmark.load_models(tmp_models_yaml)[0]
+        task = run_benchmark.load_tasks(tmp_prompts)[0]
+        dispatch_id = "bench-fix-tid-002"
+
+        receipts_dir = tmp_path / ".vnx-data" / "receipts"
+        receipts_dir.mkdir(parents=True)
+        (receipts_dir / "t0_receipts.ndjson").write_text("")
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.stdout = ""
+        fake_proc.stderr = ""
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return fake_proc
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+            run_benchmark.run_single(model, task, dispatch_id, terminal_id="CUSTOM")
+
+        tid_idx = captured_cmd.index("--terminal-id")
+        assert captured_cmd[tid_idx + 1] == "CUSTOM"
+
+    def test_t2_never_appears_in_default_cmd(
+        self, tmp_path: Path, tmp_prompts: Path, tmp_models_yaml: Path,
+    ):
+        model = run_benchmark.load_models(tmp_models_yaml)[0]
+        task = run_benchmark.load_tasks(tmp_prompts)[0]
+        dispatch_id = "bench-fix-tid-003"
+
+        receipts_dir = tmp_path / ".vnx-data" / "receipts"
+        receipts_dir.mkdir(parents=True)
+        (receipts_dir / "t0_receipts.ndjson").write_text("")
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.stdout = ""
+        fake_proc.stderr = ""
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return fake_proc
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch.object(run_benchmark, "REPO_ROOT", tmp_path):
+            run_benchmark.run_single(model, task, dispatch_id)
+
+        assert "T2" not in captured_cmd
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 2: judge prompt via stdin (not CLI arg)
+# ---------------------------------------------------------------------------
+
+class TestJudgeStdinPrompt:
+    def test_call_judge_uses_stdin_not_argv(self):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ('{"quality_score": 8}', "")
+        mock_proc.returncode = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            result = judge_quality._call_judge("test prompt content", "opus", 120)
+
+        args_list = mock_popen.call_args[0][0]
+        assert "test prompt content" not in args_list
+        assert args_list == ["claude", "-p", "--model", "opus"]
+
+        mock_proc.communicate.assert_called_once_with(
+            input="test prompt content", timeout=120,
+        )
+
+    def test_call_judge_stdin_prevents_process_table_exposure(self):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ('{"result": "ok"}', "")
+        mock_proc.returncode = 0
+
+        large_prompt = "A" * 300_000
+
+        with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            judge_quality._call_judge(large_prompt, "opus", 120)
+
+        args_list = mock_popen.call_args[0][0]
+        for arg in args_list:
+            assert len(arg) < 1000
+
+    def test_call_judge_handles_broken_pipe(self):
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = BrokenPipeError("pipe gone")
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with pytest.raises(RuntimeError, match="BrokenPipeError"):
+                judge_quality._call_judge("prompt", "opus", 120)
+
+    def test_call_judge_handles_timeout(self):
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = subprocess.TimeoutExpired(
+            cmd="claude", timeout=120,
+        )
+        mock_proc.kill = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with pytest.raises(subprocess.TimeoutExpired):
+                judge_quality._call_judge("prompt", "opus", 120)
+        mock_proc.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 3: anonymized model_id in judge prompt
+# ---------------------------------------------------------------------------
+
+class TestAnonymizedModelId:
+    def test_anonymize_produces_stable_hash(self):
+        label1 = judge_quality.anonymize_model_id("claude-opus-4-6")
+        label2 = judge_quality.anonymize_model_id("claude-opus-4-6")
+        assert label1 == label2
+
+    def test_anonymize_hides_real_model_name(self):
+        label = judge_quality.anonymize_model_id("claude-opus-4-6")
+        assert "claude" not in label.lower()
+        assert "opus" not in label.lower()
+
+    def test_anonymize_format_matches_spec(self):
+        label = judge_quality.anonymize_model_id("deepseek-v4-pro")
+        assert re.match(r"^X-anon-[0-9a-f]{8}$", label)
+
+    def test_different_models_get_different_labels(self):
+        a = judge_quality.anonymize_model_id("claude-opus-4-6")
+        b = judge_quality.anonymize_model_id("deepseek-v4-pro")
+        assert a != b
+
+    def test_judge_prompt_template_contains_anon_not_model_id(self):
+        assert "{anon_label}" in judge_quality.JUDGE_PROMPT_TEMPLATE
+        assert "{model_id}" not in judge_quality.JUDGE_PROMPT_TEMPLATE
+
+    def test_judge_result_file_stores_real_model_id(self, tmp_path: Path):
+        result_data = {
+            "model_id": "claude-opus-4-6",
+            "task_id": "01_alpha",
+            "response": "some response text",
+        }
+        result_file = tmp_path / "claude-opus-4-6__01_alpha.json"
+        result_file.write_text(json.dumps(result_data))
+
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "01_alpha.txt").write_text("Do task alpha.")
+
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (
+            '{"quality_score": 7, "correctness": true, "completeness_score": 6, "notable_issues": ""}',
+            "",
+        )
+        mock_proc.returncode = 0
+
+        captured_stdin = []
+
+        def fake_popen(cmd, **kwargs):
+            return mock_proc
+
+        original_communicate = mock_proc.communicate
+
+        def capture_communicate(input=None, timeout=None):
+            captured_stdin.append(input)
+            return original_communicate(input=input, timeout=timeout)
+
+        mock_proc.communicate = capture_communicate
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            score = judge_quality.judge_result_file(result_file, prompts_dir, "opus", 120)
+
+        assert len(captured_stdin) == 1
+        prompt_sent = captured_stdin[0]
+        assert "claude-opus-4-6" not in prompt_sent
+        assert "X-anon-" in prompt_sent
+
+        saved = json.loads(result_file.read_text())
+        assert saved["model_id"] == "claude-opus-4-6"
+        assert saved["judge_scores"]["quality_score"] == 7
+
+
+# ---------------------------------------------------------------------------
+# QUICK-WIN: kimi-k2-0905 duplicate dropped from models.yaml
+# ---------------------------------------------------------------------------
+
+class TestModelsYamlDeduplicated:
+    def test_no_kimi_k2_0905_entry(self):
+        models = run_benchmark.load_models()
+        ids = [m["id"] for m in models]
+        assert "kimi-k2-0905" not in ids
+
+    def test_kimi_k2_6_still_present(self):
+        models = run_benchmark.load_models()
+        ids = [m["id"] for m in models]
+        assert "kimi-k2-6" in ids
+
+    def test_total_model_count_after_dedup(self):
+        models = run_benchmark.load_models()
+        assert len(models) == 7
+
+
+# ---------------------------------------------------------------------------
+# QUICK-WIN: count-leak removed from prompts/02_code_review.txt
+# ---------------------------------------------------------------------------
+
+class TestCountLeakRemoved:
+    def test_no_count_leak_in_code_review_prompt(self):
+        prompt_path = BENCHMARK_DIR / "prompts" / "02_code_review.txt"
+        content = prompt_path.read_text()
+        assert "5 deliberately planted" not in content
+        assert "Do not miss any of the" not in content
+
+    def test_code_review_prompt_still_requests_issues(self):
+        prompt_path = BENCHMARK_DIR / "prompts" / "02_code_review.txt"
+        content = prompt_path.read_text()
+        assert "blocking issues" in content
+        assert "line number" in content


### PR DESCRIPTION
## Summary
- **Blocker 1**: `run_benchmark.py` hardcoded terminal-id `T2`, poisoning governance state. Now defaults to `BENCH` with `--terminal-id` CLI override.
- **Blocker 2**: `judge_quality.py` passed judge prompt as positional CLI arg (ARG_MAX + process-table exposure). Now streams via `subprocess.Popen` stdin.
- **Blocker 3**: `judge_quality.py` passed real `model_id` to Claude judge, enabling self-recognition bias. Now uses `anonymize_model_id()` with `X-anon-{sha256[:8]}` labels; real model_id preserved in result file.
- **Quick-win**: Dropped duplicate `kimi-k2-0905` from `models.yaml` (same endpoint as `kimi-k2-6`).
- **Quick-win**: Removed `5 deliberately planted critical issues` count-leak from `prompts/02_code_review.txt`.

## Files changed
- `scripts/benchmark/run_benchmark.py` — `--terminal-id` param, default `BENCH`
- `scripts/benchmark/judge_quality.py` — stdin prompt, `anonymize_model_id()`, BrokenPipe/timeout handling
- `scripts/benchmark/models.yaml` — removed kimi-k2-0905 entry (7 models, was 8)
- `scripts/benchmark/prompts/02_code_review.txt` — removed count-leak line
- `tests/test_benchmark_fixes.py` — 18 regression tests covering all 5 fixes

## Test plan
- [x] `pytest tests/test_benchmark_fixes.py -x -v` — 18/18 passed
- [x] `pytest tests/test_benchmark_suite.py -x -v` — 26/26 passed (zero regressions)
- [ ] CI green
- [ ] Codex gate
- [ ] Gemini review

Dispatch-ID: 20260517-fix-benchmark-cluster