### PR TITLE
fix(wave6): config field reads + single heartbeat threshold (3 blockers)

### DIFF
--- a/scripts/lib/pool_decision_engine.py
+++ b/scripts/lib/pool_decision_engine.py
@@ -21,6 +21,9 @@ if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
 
+POOL_HEARTBEAT_STALE_SECONDS: float = 180.0
+
+
 @dataclass(frozen=True)
 class PoolConfig:
     pool_id: str
@@ -29,7 +32,7 @@ class PoolConfig:
     scaling_policy: str          # "fixed" | "queue_aware" | "queue_depth_v1" | "cost_aware_v1"
     provider_mix: List[str]      # e.g. ["claude", "claude", "litellm:deepseek"]
     cooldown_seconds: float = 60.0
-    heartbeat_stale_seconds: float = 300.0
+    heartbeat_stale_seconds: float = POOL_HEARTBEAT_STALE_SECONDS
     cost_ceiling_usd: Optional[float] = None  # used by cost_aware_v1
 
 
@@ -74,7 +77,7 @@ def decide(
     3. Policy registry lookup (fixed | queue_aware | queue_depth_v1 | cost_aware_v1)
     4. Compute delta and return scale_up / scale_down / noop
     """
-    from pool_scaling_policies import POLICIES  # lazy import avoids circular dep
+    from pool_scaling_policies import POLICIES
 
     active = [m for m in members if m.status == "active"]
     current = len(active)

--- a/scripts/lib/pool_reaper.py
+++ b/scripts/lib/pool_reaper.py
@@ -9,6 +9,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
+from pool_decision_engine import POOL_HEARTBEAT_STALE_SECONDS
+
 if TYPE_CHECKING:
     from pool_decision_engine import Membership
 
@@ -23,7 +25,7 @@ class ReapTarget:
 
 @dataclass(frozen=True)
 class ReapConfig:
-    heartbeat_stale_threshold_s: float = 180.0  # operator-tunable; reap after this long silent
+    heartbeat_stale_threshold_s: float = POOL_HEARTBEAT_STALE_SECONDS
     stuck_threshold_s: float = 300.0            # reserved for future processing-stuck detection
     warmup_window_s: float = 120.0              # workers younger than this are exempt
 

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -20,7 +20,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState
+from pool_decision_engine import (
+    POOL_HEARTBEAT_STALE_SECONDS,
+    Membership,
+    PoolConfig,
+    PoolDecision,
+    PoolState,
+)
 
 log = logging.getLogger(__name__)
 
@@ -100,18 +106,35 @@ class PoolStateRepository:
     def get_config(self, pool_id: str) -> Optional[PoolConfig]:
         conn = self._connect()
         try:
-            row = conn.execute(
-                """
-                SELECT pool_id, min_workers, max_workers, scale_policy,
-                       provider_mix_json, cooldown_seconds
-                FROM pool_config
-                WHERE project_id = ? AND pool_id = ?
-                """,
-                (self.project_id, pool_id),
-            ).fetchone()
+            params = (self.project_id, pool_id)
+            try:
+                row = conn.execute(
+                    """
+                    SELECT pool_id, min_workers, max_workers, scale_policy,
+                           provider_mix_json, cooldown_seconds,
+                           cost_ceiling_usd, heartbeat_stale_seconds
+                    FROM pool_config
+                    WHERE project_id = ? AND pool_id = ?
+                    """,
+                    params,
+                ).fetchone()
+            except sqlite3.OperationalError:
+                row = conn.execute(
+                    """
+                    SELECT pool_id, min_workers, max_workers, scale_policy,
+                           provider_mix_json, cooldown_seconds
+                    FROM pool_config
+                    WHERE project_id = ? AND pool_id = ?
+                    """,
+                    params,
+                ).fetchone()
             if row is None:
                 return None
             provider_mix = json.loads(row["provider_mix_json"] or '["claude"]')
+            keys = row.keys()
+            cost_ceiling = row["cost_ceiling_usd"] if "cost_ceiling_usd" in keys else None
+            raw_hb = row["heartbeat_stale_seconds"] if "heartbeat_stale_seconds" in keys else None
+            heartbeat_stale = float(raw_hb) if raw_hb is not None else float(POOL_HEARTBEAT_STALE_SECONDS)
             return PoolConfig(
                 pool_id=row["pool_id"],
                 min_workers=row["min_workers"],
@@ -119,6 +142,8 @@ class PoolStateRepository:
                 scaling_policy=row["scale_policy"],
                 provider_mix=provider_mix,
                 cooldown_seconds=float(row["cooldown_seconds"]),
+                cost_ceiling_usd=cost_ceiling,
+                heartbeat_stale_seconds=heartbeat_stale,
             )
         finally:
             conn.close()
@@ -515,6 +540,8 @@ class PoolStateRepository:
             "max_workers": "max_workers",
             "scaling_policy": "scale_policy",
             "cooldown_seconds": "cooldown_seconds",
+            "cost_ceiling_usd": "cost_ceiling_usd",
+            "heartbeat_stale_seconds": "heartbeat_stale_seconds",
         }
         cols: List[str] = []
         vals: List = []

--- a/tests/fixtures/pool_state_fixtures.py
+++ b/tests/fixtures/pool_state_fixtures.py
@@ -127,6 +127,8 @@ CREATE TABLE IF NOT EXISTS pool_config (
     provider_mix_json   TEXT    NOT NULL DEFAULT '["claude"]',
     scale_policy        TEXT    NOT NULL DEFAULT 'queue_depth_v1',
     cooldown_seconds    INTEGER NOT NULL DEFAULT 120,
+    cost_ceiling_usd    REAL,
+    heartbeat_stale_seconds REAL NOT NULL DEFAULT 180,
     created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     UNIQUE(project_id, pool_id),
@@ -183,6 +185,8 @@ def create_test_db(
     scale_policy: str = "queue_depth_v1",
     cooldown_seconds: int = 60,
     provider_mix_json: str = '["claude"]',
+    cost_ceiling_usd: Optional[float] = None,
+    heartbeat_stale_seconds: float = 180.0,
 ) -> sqlite3.Connection:
     """Create an in-memory SQLite connection with schema v14 pool tables."""
     conn = sqlite3.connect(":memory:")
@@ -192,12 +196,14 @@ def create_test_db(
         """
         INSERT OR IGNORE INTO pool_config
             (project_id, pool_id, min_workers, max_workers, target_workers,
-             scale_policy, cooldown_seconds, provider_mix_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             scale_policy, cooldown_seconds, provider_mix_json,
+             cost_ceiling_usd, heartbeat_stale_seconds)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             project_id, pool_id, min_workers, max_workers, target_workers,
             scale_policy, cooldown_seconds, provider_mix_json,
+            cost_ceiling_usd, heartbeat_stale_seconds,
         ),
     )
     conn.execute(
@@ -222,13 +228,14 @@ def create_test_db_file(
     scale_policy: str = "queue_depth_v1",
     cooldown_seconds: int = 60,
     provider_mix_json: str = '["claude"]',
+    cost_ceiling_usd: Optional[float] = None,
+    heartbeat_stale_seconds: float = 180.0,
 ) -> Path:
     """Initialize a file-backed SQLite DB at db_path with schema v14 pool tables.
 
     Returns db_path. Used by integration tests that need real file connections
     (PoolStateRepository._connect() opens/closes per-call).
     """
-    # Clamp target_workers to satisfy CHECK constraint
     target_workers = max(target_workers, min_workers)
     target_workers = min(target_workers, max_workers)
 
@@ -239,12 +246,14 @@ def create_test_db_file(
         """
         INSERT OR IGNORE INTO pool_config
             (project_id, pool_id, min_workers, max_workers, target_workers,
-             scale_policy, cooldown_seconds, provider_mix_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             scale_policy, cooldown_seconds, provider_mix_json,
+             cost_ceiling_usd, heartbeat_stale_seconds)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             project_id, pool_id, min_workers, max_workers, target_workers,
             scale_policy, cooldown_seconds, provider_mix_json,
+            cost_ceiling_usd, heartbeat_stale_seconds,
         ),
     )
     conn.execute(

--- a/tests/test_pool_blockers_fix.py
+++ b/tests/test_pool_blockers_fix.py
@@ -1,0 +1,249 @@
+"""test_pool_blockers_fix.py — Regression tests for Wave 6 pool cluster 3-blocker fix.
+
+Covers:
+1. _spawn_via_provider_dispatch is real subprocess.Popen (not a stub)
+2. get_config reads cost_ceiling_usd and heartbeat_stale_seconds from DB
+3. Single heartbeat threshold constant (POOL_HEARTBEAT_STALE_SECONDS) used everywhere
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_decision_engine import POOL_HEARTBEAT_STALE_SECONDS, PoolConfig  # noqa: E402
+from pool_reaper import ReapConfig  # noqa: E402
+from pool_state_repo import PoolStateRepository  # noqa: E402
+from pool_state_fixtures import create_test_db_file  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Blocker 1: spawn is a real subprocess.Popen call, not a stub
+# ---------------------------------------------------------------------------
+
+class TestSpawnIsReal:
+    def test_spawn_calls_popen(self):
+        from pool_manager import _spawn_via_provider_dispatch, SpawnResult
+
+        fake_worktree = Path("/tmp/fake-worktree")
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("pool_worktree_manager.create_worker_worktree", return_value=fake_worktree),
+            patch("pool_manager.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("pool_manager.os.kill"),
+        ):
+            result = _spawn_via_provider_dispatch(
+                "proj-1", "default", "T-spawn-1", "claude", "backend-developer",
+            )
+
+        assert isinstance(result, SpawnResult)
+        assert result.success is True
+        assert result.pid == 99999
+        mock_popen.assert_called_once()
+        call_kwargs = mock_popen.call_args
+        assert call_kwargs.kwargs["cwd"] == str(fake_worktree)
+        cmd = call_kwargs.args[0]
+        assert sys.executable in cmd[0]
+        assert "scripts.lib.subprocess_dispatch" in cmd
+
+    def test_spawn_captures_worktree_failure(self):
+        from pool_manager import _spawn_via_provider_dispatch
+
+        with patch(
+            "pool_worktree_manager.create_worker_worktree",
+            side_effect=RuntimeError("no worktree"),
+        ):
+            result = _spawn_via_provider_dispatch(
+                "proj-1", "default", "T-fail", "claude", "backend-developer",
+            )
+
+        assert result.success is False
+        assert "worktree creation failed" in result.error
+
+    def test_spawn_captures_popen_failure(self):
+        from pool_manager import _spawn_via_provider_dispatch
+
+        with (
+            patch("pool_worktree_manager.create_worker_worktree", return_value=Path("/tmp/wt")),
+            patch(
+                "pool_manager.subprocess.Popen",
+                side_effect=OSError("exec failed"),
+            ),
+        ):
+            result = _spawn_via_provider_dispatch(
+                "proj-1", "default", "T-oserr", "claude", "backend-developer",
+            )
+
+        assert result.success is False
+        assert "Popen failed" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Blocker 2: get_config reads cost_ceiling_usd and heartbeat_stale_seconds
+# ---------------------------------------------------------------------------
+
+class TestGetConfigFields:
+    def test_reads_cost_ceiling_usd(self, tmp_path):
+        (tmp_path / "state").mkdir()
+        db = create_test_db_file(
+            tmp_path / "state" / "runtime_coordination.db",
+            cost_ceiling_usd=12.5,
+        )
+        repo = PoolStateRepository(db, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.cost_ceiling_usd == 12.5
+
+    def test_reads_heartbeat_stale_seconds(self, tmp_path):
+        (tmp_path / "state").mkdir()
+        db = create_test_db_file(
+            tmp_path / "state" / "runtime_coordination.db",
+            heartbeat_stale_seconds=90.0,
+        )
+        repo = PoolStateRepository(db, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.heartbeat_stale_seconds == 90.0
+
+    def test_cost_ceiling_defaults_to_none(self, tmp_path):
+        (tmp_path / "state").mkdir()
+        db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+        repo = PoolStateRepository(db, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.cost_ceiling_usd is None
+
+    def test_heartbeat_defaults_to_constant(self, tmp_path):
+        (tmp_path / "state").mkdir()
+        db = create_test_db_file(tmp_path / "state" / "runtime_coordination.db")
+        repo = PoolStateRepository(db, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.heartbeat_stale_seconds == POOL_HEARTBEAT_STALE_SECONDS
+
+    def test_both_fields_round_trip(self, tmp_path):
+        (tmp_path / "state").mkdir()
+        db = create_test_db_file(
+            tmp_path / "state" / "runtime_coordination.db",
+            cost_ceiling_usd=25.0,
+            heartbeat_stale_seconds=120.0,
+        )
+        repo = PoolStateRepository(db, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.cost_ceiling_usd == 25.0
+        assert config.heartbeat_stale_seconds == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Blocker 3: single heartbeat threshold constant
+# ---------------------------------------------------------------------------
+
+class TestHeartbeatThresholdUnified:
+    def test_constant_is_180(self):
+        assert POOL_HEARTBEAT_STALE_SECONDS == 180.0
+
+    def test_pool_config_default_matches_constant(self):
+        config = PoolConfig(
+            pool_id="test",
+            min_workers=1,
+            max_workers=4,
+            scaling_policy="fixed",
+            provider_mix=["claude"],
+        )
+        assert config.heartbeat_stale_seconds == POOL_HEARTBEAT_STALE_SECONDS
+
+    def test_reap_config_default_matches_constant(self):
+        reap_cfg = ReapConfig()
+        assert reap_cfg.heartbeat_stale_threshold_s == POOL_HEARTBEAT_STALE_SECONDS
+
+    def test_both_defaults_are_equal(self):
+        config = PoolConfig(
+            pool_id="test",
+            min_workers=1,
+            max_workers=4,
+            scaling_policy="fixed",
+            provider_mix=["claude"],
+        )
+        reap_cfg = ReapConfig()
+        assert config.heartbeat_stale_seconds == reap_cfg.heartbeat_stale_threshold_s
+
+
+# ---------------------------------------------------------------------------
+# Blocker 2 + 3 combined: get_config fallback on old schema without columns
+# ---------------------------------------------------------------------------
+
+class TestGetConfigOldSchema:
+    def test_fallback_on_missing_columns(self, tmp_path):
+        """get_config gracefully falls back when DB lacks cost/heartbeat columns."""
+        import sqlite3
+
+        (tmp_path / "state").mkdir()
+        db_path = tmp_path / "state" / "runtime_coordination.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS runtime_schema_version (
+                version INTEGER PRIMARY KEY, description TEXT,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+            CREATE TABLE IF NOT EXISTS pool_config (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id TEXT NOT NULL,
+                pool_id TEXT NOT NULL DEFAULT 'default',
+                min_workers INTEGER NOT NULL DEFAULT 1,
+                max_workers INTEGER NOT NULL DEFAULT 6,
+                target_workers INTEGER NOT NULL DEFAULT 3,
+                provider_mix_json TEXT NOT NULL DEFAULT '["claude"]',
+                scale_policy TEXT NOT NULL DEFAULT 'queue_depth_v1',
+                cooldown_seconds INTEGER NOT NULL DEFAULT 120,
+                created_at TEXT, updated_at TEXT,
+                UNIQUE(project_id, pool_id)
+            );
+            CREATE TABLE IF NOT EXISTS worker_pools (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id TEXT NOT NULL, pool_id TEXT NOT NULL DEFAULT 'default',
+                state TEXT NOT NULL DEFAULT 'idle',
+                current_size INTEGER NOT NULL DEFAULT 0,
+                target_size INTEGER NOT NULL DEFAULT 0,
+                healthy_count INTEGER NOT NULL DEFAULT 0,
+                stuck_count INTEGER NOT NULL DEFAULT 0,
+                last_scaled_at TEXT, last_scale_action TEXT,
+                last_decision_json TEXT DEFAULT '{}',
+                metadata_json TEXT DEFAULT '{}',
+                UNIQUE(project_id, pool_id)
+            );
+            INSERT OR IGNORE INTO pool_config (project_id, pool_id, min_workers, max_workers, target_workers)
+            VALUES ('vnx-dev', 'default', 1, 4, 2);
+            INSERT OR IGNORE INTO worker_pools (project_id, pool_id, state, current_size, target_size)
+            VALUES ('vnx-dev', 'default', 'idle', 0, 2);
+        """)
+        conn.commit()
+        conn.close()
+
+        repo = PoolStateRepository(db_path, "vnx-dev")
+        config = repo.get_config("default")
+
+        assert config is not None
+        assert config.cost_ceiling_usd is None
+        assert config.heartbeat_stale_seconds == POOL_HEARTBEAT_STALE_SECONDS


### PR DESCRIPTION
## Summary
- **Blocker 1**: Verified `_spawn_via_provider_dispatch` is already a real `subprocess.Popen` implementation (not a stub). Added 3 regression tests confirming Popen call, worktree failure handling, and OSError handling.
- **Blocker 2**: `get_config()` now reads `cost_ceiling_usd` and `heartbeat_stale_seconds` from the `pool_config` DB table. Graceful fallback for old schemas without these columns (catches `OperationalError`, uses dataclass defaults).
- **Blocker 3**: Single `POOL_HEARTBEAT_STALE_SECONDS = 180` constant in `pool_decision_engine.py`. Both `PoolConfig.heartbeat_stale_seconds` (was 300s) and `ReapConfig.heartbeat_stale_threshold_s` (was 180s) now default from this constant. Eliminates the 180s vs 300s inconsistency.

## Test plan
- [x] `pytest tests/test_pool_blockers_fix.py` — 13 new tests (spawn, config fields, threshold consistency, old-schema fallback)
- [x] `pytest tests/test_pool_state_repo.py tests/test_pool_decision_engine.py tests/test_pool_reaper.py tests/test_pool_manager_integration.py tests/test_pool_tick_reap_decide_execute.py tests/test_scaling_policies.py tests/test_cost_aware_policy.py` — 131 existing tests pass
- [x] `pytest tests/pool/` — 28 spawn integration tests pass
- [x] `pytest tests/test_pool_state_aggregator.py` — 15 aggregator tests pass
- [x] Total: **187 tests passed, 0 failed**

Dispatch-ID: 20260517-fix-wave6-pool-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)