### PR TITLE
fix(wave7): claude cost tracking + kimi audit-gap status + redact prompt in logs

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -418,7 +418,9 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
     )
     end_time = datetime.now(timezone.utc)
 
-    # Read token_usage side-channel written by deliver_via_subprocess → spawn_claude.
+    # Read token_usage from delivery side-channel (populated by spawn_claude).
+    # recovery._resolve_token_usage_and_cost uses .get() to leave the entry
+    # available for this governance-receipt path; we .pop() here to clean up.
     _claude_token_usage = None
     try:
         from subprocess_dispatch_internals.delivery import _dispatch_token_usage as _tu_cache
@@ -713,8 +715,8 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
             "kimi dispatch completed but %d event_writer failures occurred — audit gap",
             result.event_writer_failures,
         )
-        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "failure")
-        return 1
+        _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
+        return 2
     _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success")
     return 0
 

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -391,7 +391,11 @@ def spawn_kimi(
     cwd_str = str(cwd) if cwd is not None else None
 
     cmd = _build_kimi_cmd(prompt, model, cwd)
-    logger.info("kimi_spawn: launching %s", " ".join(cmd[:6]))
+    logger.info(
+        "kimi_spawn: launching kimi -p <%d chars> -m %s",
+        len(prompt),
+        cmd[cmd.index("-m") + 1] if "-m" in cmd else "default",
+    )
 
     proc, err_result = _start_kimi_subprocess(cmd, env, cwd_str)
     if err_result is not None:

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -119,8 +119,12 @@ def _resolve_active_dispatch_file(dispatch_id: str):
 def _resolve_token_usage_and_cost(
     dispatch_id: str, sub_result, model: "str | None",
 ) -> tuple[dict | None, float | None]:
-    """Pop token_usage from the delivery side-channel, normalize, and compute cost."""
-    raw_usage = _dispatch_token_usage.pop(dispatch_id, None)
+    """Read token_usage from the delivery side-channel, normalize, and compute cost.
+
+    Uses .get() (not .pop()) so the entry remains available for the governance
+    receipt emitted by _dispatch_claude in provider_dispatch.py.
+    """
+    raw_usage = _dispatch_token_usage.get(dispatch_id, None)
     if raw_usage is None:
         raw_usage = getattr(sub_result, "token_usage", None) if sub_result else None
     if not isinstance(raw_usage, dict) or not raw_usage:

--- a/tests/test_wave7_fixes.py
+++ b/tests/test_wave7_fixes.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""test_wave7_fixes.py — regression tests for 3 Wave 7 blockers.
+
+Fix 1: Claude cost tracking — side-channel uses .get() in recovery so
+       _dispatch_claude can still .pop() the token_usage for governance receipt.
+Fix 2: Kimi audit-gap status — event_writer_failures emit status='success' + rc=2,
+       aligned with codex/gemini/litellm.
+Fix 3: kimi_spawn prompt redaction — log line must not contain prompt text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: Claude cost side-channel survives recovery consumption
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCostSideChannel:
+    """_dispatch_token_usage must survive _resolve_token_usage_and_cost(.get)
+    so _dispatch_claude can .pop() it for the governance receipt."""
+
+    def test_resolve_uses_get_not_pop(self):
+        """After _resolve_token_usage_and_cost, the entry remains in the dict."""
+        from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+
+        dispatch_id = "test-cost-channel-001"
+        fake_usage = {"input_tokens": 1500, "output_tokens": 300, "cache_read_input_tokens": 200}
+        _dispatch_token_usage[dispatch_id] = fake_usage
+
+        try:
+            with patch(
+                "subprocess_dispatch_internals.recovery._extract_token_usage",
+                return_value={"input": 1500, "output": 300, "cache_hit": 200},
+            ), patch(
+                "subprocess_dispatch_internals.recovery._compute_cost",
+                return_value=0.0123,
+            ):
+                from subprocess_dispatch_internals.recovery import _resolve_token_usage_and_cost
+
+                token_usage, cost_usd = _resolve_token_usage_and_cost(
+                    dispatch_id, None, "claude-sonnet-4-6",
+                )
+
+            assert token_usage is not None, "token_usage should be extracted"
+            assert dispatch_id in _dispatch_token_usage, (
+                "entry must survive .get() — _dispatch_claude needs it"
+            )
+        finally:
+            _dispatch_token_usage.pop(dispatch_id, None)
+
+    def test_dispatch_claude_pops_after_recovery(self):
+        """_dispatch_claude should be able to .pop() the entry after deliver_with_recovery."""
+        from subprocess_dispatch_internals.delivery import _dispatch_token_usage
+
+        dispatch_id = "test-cost-pop-002"
+        fake_usage = {"input_tokens": 800, "output_tokens": 120, "cache_read_input_tokens": 50}
+        _dispatch_token_usage[dispatch_id] = fake_usage
+
+        try:
+            popped = _dispatch_token_usage.pop(dispatch_id, None)
+            assert popped == fake_usage
+            assert dispatch_id not in _dispatch_token_usage
+        finally:
+            _dispatch_token_usage.pop(dispatch_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: Kimi audit-gap aligns with codex/gemini/litellm (success + rc=2)
+# ---------------------------------------------------------------------------
+
+
+class TestKimiAuditGapStatus:
+    """_dispatch_kimi must emit status='success' + return 2 when dispatch
+    succeeded but event_writer had failures (audit-gap)."""
+
+    def _make_kimi_result(self, *, event_writer_failures=0, returncode=0):
+        return SimpleNamespace(
+            completion_text="done",
+            token_usage={"input_tokens": 100, "output_tokens": 50},
+            event_writer_failures=event_writer_failures,
+            returncode=returncode,
+            timed_out=False,
+            error=None,
+        )
+
+    def test_audit_gap_returns_2_with_success(self):
+        """event_writer_failures > 0 → status='success', return 2."""
+        result = self._make_kimi_result(event_writer_failures=3)
+
+        governance_calls = []
+
+        def capture_governance(args, provider, model, res, start, end, status):
+            governance_calls.append(status)
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
+             patch("event_store.EventStore", return_value=MagicMock(append=MagicMock())), \
+             patch("provider_dispatch._emit_governance", side_effect=capture_governance), \
+             patch.dict(os.environ, {"VNX_KIMI_MODEL": "k2-test"}):
+
+            from provider_dispatch import _dispatch_kimi
+
+            args = argparse.Namespace(
+                dispatch_id="test-kimi-audit-001",
+                terminal_id="T1",
+                instruction="test instruction",
+                provider="kimi",
+                model="k2-test",
+                pr_id=None,
+            )
+            rc = _dispatch_kimi(args)
+
+        assert rc == 2, f"expected rc=2 for audit-gap, got {rc}"
+        assert governance_calls == ["success"], (
+            f"expected status='success', got {governance_calls}"
+        )
+
+    def test_clean_dispatch_returns_0(self):
+        """No event_writer_failures → status='success', return 0."""
+        result = self._make_kimi_result(event_writer_failures=0)
+
+        governance_calls = []
+
+        def capture_governance(args, provider, model, res, start, end, status):
+            governance_calls.append(status)
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
+             patch("event_store.EventStore", return_value=MagicMock(append=MagicMock())), \
+             patch("provider_dispatch._emit_governance", side_effect=capture_governance), \
+             patch.dict(os.environ, {"VNX_KIMI_MODEL": "k2-test"}):
+
+            from provider_dispatch import _dispatch_kimi
+
+            args = argparse.Namespace(
+                dispatch_id="test-kimi-clean-002",
+                terminal_id="T1",
+                instruction="test instruction",
+                provider="kimi",
+                model="k2-test",
+                pr_id=None,
+            )
+            rc = _dispatch_kimi(args)
+
+        assert rc == 0, f"expected rc=0 for clean dispatch, got {rc}"
+        assert governance_calls == ["success"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: kimi_spawn prompt redaction in log
+# ---------------------------------------------------------------------------
+
+
+class TestKimiPromptRedaction:
+    """spawn_kimi log must NOT contain prompt text."""
+
+    def test_log_redacts_prompt_with_model(self, caplog):
+        """Log should show char count and model, not the prompt itself."""
+        secret_prompt = "SECRET_INSTRUCTION_DO_NOT_LEAK_THIS_CONTENT"
+
+        with patch(
+            "provider_spawns.kimi_spawn._start_kimi_subprocess",
+            return_value=(None, SimpleNamespace(
+                completion_text="",
+                token_usage=None,
+                event_writer_failures=0,
+                returncode=127,
+                timed_out=False,
+                error="kimi binary not found",
+                events_written=0,
+                stopped_early=False,
+            )),
+        ), caplog.at_level(logging.INFO, logger="provider_spawns.kimi_spawn"):
+            from provider_spawns.kimi_spawn import spawn_kimi
+
+            spawn_kimi(
+                prompt=secret_prompt,
+                model="k2-test",
+                dispatch_id="test-redact-001",
+                terminal_id="T1",
+            )
+
+        log_text = caplog.text
+        assert secret_prompt not in log_text, (
+            f"prompt leaked into log: {log_text!r}"
+        )
+        assert str(len(secret_prompt)) in log_text, (
+            "log should contain prompt char count"
+        )
+        assert "k2-test" in log_text, "log should contain model name"
+
+    def test_log_redacts_prompt_without_model(self, caplog):
+        """When no model is specified, log should show 'default'."""
+        secret_prompt = "ANOTHER_SECRET_PROMPT_VALUE"
+
+        with patch(
+            "provider_spawns.kimi_spawn._start_kimi_subprocess",
+            return_value=(None, SimpleNamespace(
+                completion_text="",
+                token_usage=None,
+                event_writer_failures=0,
+                returncode=127,
+                timed_out=False,
+                error="kimi binary not found",
+                events_written=0,
+                stopped_early=False,
+            )),
+        ), caplog.at_level(logging.INFO, logger="provider_spawns.kimi_spawn"):
+            from provider_spawns.kimi_spawn import spawn_kimi
+
+            spawn_kimi(
+                prompt=secret_prompt,
+                model=None,
+                dispatch_id="test-redact-002",
+                terminal_id="T1",
+            )
+
+        log_text = caplog.text
+        assert secret_prompt not in log_text
+        assert "default" in log_text
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider consistency: all 4 non-claude providers use same audit-gap pattern
+# ---------------------------------------------------------------------------
+
+
+class TestAuditGapConsistency:
+    """All non-claude providers must use status='success' + rc=2 for audit-gap."""
+
+    def test_codex_gemini_litellm_kimi_patterns_match(self):
+        """Verify the source code has consistent event_writer_failures handling."""
+        import inspect
+        import provider_dispatch
+
+        source = inspect.getsource(provider_dispatch)
+
+        for provider in ("codex", "gemini", "litellm", "kimi"):
+            # Find the event_writer_failures block for each provider
+            marker = f"{provider} dispatch completed but %d event_writer failures"
+            assert marker in source, f"missing audit-gap log for {provider}"
+
+        # All four blocks should emit "success" for audit-gap, never "failure"
+        lines = source.split("\n")
+        for i, line in enumerate(lines):
+            if "event_writer failures occurred" in line:
+                context = "\n".join(lines[max(0, i - 2):i + 5])
+                assert '"failure"' not in context or '"success"' in context, (
+                    f"audit-gap block near line {i} may emit 'failure' instead of 'success':\n{context}"
+                )

--- a/tests/test_worker_receipt_bridge.py
+++ b/tests/test_worker_receipt_bridge.py
@@ -281,7 +281,9 @@ class TestResolveTokenUsageAndCost:
 
         assert token_usage == {"input": 2000, "output": 900, "cache_hit": 150}
         assert cost_usd == 0.05
-        assert "test-side-001" not in _dispatch_token_usage
+        # .get() leaves entry for _dispatch_claude governance receipt; clean up
+        assert "test-side-001" in _dispatch_token_usage
+        _dispatch_token_usage.pop("test-side-001", None)
 
     def test_falls_back_to_sub_result_token_usage(self):
         from subprocess_dispatch_internals.recovery import _resolve_token_usage_and_cost


### PR DESCRIPTION
## Summary
- **Claude cost tracking**: `_resolve_token_usage_and_cost` in recovery.py consumed the side-channel dict via `.pop()` before `_dispatch_claude` could read it for the governance receipt — always resulted in `$0.00`. Changed to `.get()` so both receipt paths get the data.
- **Kimi audit-gap status**: `_dispatch_kimi` emitted `status='failure'` + `rc=1` when dispatch succeeded but event_writer had failures. Aligned with codex/gemini/litellm pattern: `status='success'` + `rc=2`.
- **Prompt redaction in kimi_spawn logs**: `logger.info` logged `cmd[:6]` which is adjacent to the prompt arg. Replaced with redacted format showing only char count and model name.

## Test plan
- [x] 7 new regression tests in `tests/test_wave7_fixes.py` (side-channel survival, audit-gap rc=2/rc=0, prompt redaction with/without model, cross-provider consistency)
- [x] Updated existing `test_worker_receipt_bridge.py` to match `.get()` semantics
- [x] 71 targeted tests pass (wave7 smoke, receipt bridge, append receipt)
- [x] 40 existing Wave 7 smoke tests pass (kimi, deepseek, glm)

Dispatch-ID: 20260517-fix-wave7-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)