### PR TITLE
fix(governance): atomic OI saves + WAL migrations + closure_verifier self-reference loop

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1608,8 +1608,8 @@ def main() -> int:
             pass  # best-effort — must not block SessionStart
         elapsed = time.monotonic() - t_start
         _build_succeeded = True
-    except Exception:
-        pass  # SessionStart hook must never block session
+    except Exception as exc:
+        log.warning("build_t0_state failed (SessionStart continues): %s", exc)
 
     if _build_succeeded:
         try:

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -959,14 +959,23 @@ def _detect_gate_report_contradictions(
     return checks
 
 
+_CLOSURE_OUTPUT_RE = re.compile(r"^\s*-?\s*\[(FAIL|PASS|WARN)\]\s")
+
+
 def _count_report_blocking_indicators(content: str) -> int:
     """Count blocking-severity indicators in a normalized report.
 
     Looks for patterns that indicate blocking findings in headless review reports.
+    Excludes lines written by the closure verifier itself (``- [FAIL] ...``)
+    to prevent a self-reference loop where the verifier's own output is
+    counted as a blocking indicator on re-read.
     """
-    import re
+    filtered_lines = [
+        line for line in content.splitlines()
+        if not _CLOSURE_OUTPUT_RE.match(line)
+    ]
+    filtered = "\n".join(filtered_lines)
     count = 0
-    # Standard blocking patterns in normalized reports
     blocking_patterns = [
         r"\[BLOCKING\]",
         r"\*\*Severity\*\*:\s*blocking",
@@ -975,7 +984,7 @@ def _count_report_blocking_indicators(content: str) -> int:
         r"Status:\s*FAIL",
     ]
     for pattern in blocking_patterns:
-        count += len(re.findall(pattern, content, re.IGNORECASE))
+        count += len(re.findall(pattern, filtered, re.IGNORECASE))
     return count
 
 

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -102,6 +102,25 @@ def get_connection(
         conn.close()
 
 
+@contextmanager
+def get_connection_for_db(
+    db_path: str | Path,
+    *,
+    timeout: float = 10.0,
+) -> Generator[sqlite3.Connection, None, None]:
+    """Like get_connection but accepts a direct DB file path instead of state_dir."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=timeout)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        yield conn
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -150,7 +169,11 @@ def _append_event(
 # ---------------------------------------------------------------------------
 
 def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -> None:
-    """Initialize (or migrate) the runtime coordination database. Idempotent."""
+    """Initialize (or migrate) the runtime coordination database. Idempotent.
+
+    Uses a single connection for the entire init+migration sequence to
+    prevent TOCTOU races between version check and migration apply.
+    """
     if schema_sql_path is None:
         here = Path(__file__).resolve()
         schema_sql_path = here.parent.parent.parent / "schemas" / "runtime_coordination.sql"
@@ -164,8 +187,7 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
         conn.executescript(schema_sql)
         conn.commit()
 
-    current_version = 1
-    with get_connection(state_dir) as conn:
+        current_version = 1
         try:
             row = conn.execute(
                 "SELECT MAX(version) FROM runtime_schema_version"
@@ -175,20 +197,19 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
         except sqlite3.OperationalError:
             pass
 
-    schemas_dir = schema_sql_path.parent
-    version = 2
-    while True:
-        migration = schemas_dir / f"runtime_coordination_v{version}.sql"
-        if not migration.exists():
-            break
-        if version <= current_version:
-            version += 1
-            continue
-        migration_sql = migration.read_text(encoding="utf-8")
-        with get_connection(state_dir) as conn:
+        schemas_dir = schema_sql_path.parent
+        version = 2
+        while True:
+            migration = schemas_dir / f"runtime_coordination_v{version}.sql"
+            if not migration.exists():
+                break
+            if version <= current_version:
+                version += 1
+                continue
+            migration_sql = migration.read_text(encoding="utf-8")
             conn.executescript(migration_sql)
             conn.commit()
-        version += 1
+            version += 1
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -63,7 +63,7 @@ def emit_dispatch_receipt(
     _validate_provider(provider)
 
     now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    recorded_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    recorded_ts = now_ts
 
     receipt: Dict[str, Any] = {
         "dispatch_id": dispatch_id,

--- a/scripts/lib/migrations/apply_0017.py
+++ b/scripts/lib/migrations/apply_0017.py
@@ -23,8 +23,14 @@ import argparse
 import json
 import logging
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+from coordination_db import get_connection_for_db
 
 log = logging.getLogger(__name__)
 
@@ -69,52 +75,50 @@ def apply_migration(
         vnx_data_dir = Path(db_path).parent.parent
 
     current_version = 0
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cur = conn.cursor()
-        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
-        row = cur.fetchone()
-        current_version = int(row[0]) if (row and row[0] is not None) else 0
 
-        if current_version >= _TARGET_VERSION:
-            log.info(
-                "apply_0017: already at v%s (target v%s), skip",
-                current_version,
-                _TARGET_VERSION,
+    with get_connection_for_db(db_path) as conn:
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+            row = cur.fetchone()
+            current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+            if current_version >= _TARGET_VERSION:
+                log.info(
+                    "apply_0017: already at v%s (target v%s), skip",
+                    current_version,
+                    _TARGET_VERSION,
+                )
+                return False
+
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_started",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
             )
-            return False
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_started",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
+            sql = migration_sql_path.read_text()
+            conn.executescript(sql)
+            log.info(
+                "apply_0017: migrated from v%s to v%s", current_version, _TARGET_VERSION
+            )
 
-        sql = migration_sql_path.read_text()
-        conn.executescript(sql)
-        log.info(
-            "apply_0017: migrated from v%s to v%s", current_version, _TARGET_VERSION
-        )
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_completed",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
+            )
+            return True
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_completed",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
-        return True
-
-    except sqlite3.Error as e:
-        conn.rollback()
-        log.error("apply_0017: error during migration; transaction rolled back")
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_failed",
-            {"from_version": current_version, "error": str(e)},
-        )
-        raise
-
-    finally:
-        conn.close()
+        except sqlite3.Error as e:
+            conn.rollback()
+            log.error("apply_0017: error during migration; transaction rolled back")
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_failed",
+                {"from_version": current_version, "error": str(e)},
+            )
+            raise
 
 
 if __name__ == "__main__":

--- a/scripts/lib/migrations/apply_0019.py
+++ b/scripts/lib/migrations/apply_0019.py
@@ -21,8 +21,14 @@ import argparse
 import json
 import logging
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+from coordination_db import get_connection_for_db
 
 log = logging.getLogger(__name__)
 
@@ -68,52 +74,50 @@ def apply_migration(
         vnx_data_dir = Path(db_path).parent.parent
 
     current_version = 0
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cur = conn.cursor()
-        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
-        row = cur.fetchone()
-        current_version = int(row[0]) if (row and row[0] is not None) else 0
 
-        if current_version >= _TARGET_VERSION:
-            log.info(
-                "apply_0019: already at v%s (target v%s), skip",
-                current_version,
-                _TARGET_VERSION,
+    with get_connection_for_db(db_path) as conn:
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+            row = cur.fetchone()
+            current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+            if current_version >= _TARGET_VERSION:
+                log.info(
+                    "apply_0019: already at v%s (target v%s), skip",
+                    current_version,
+                    _TARGET_VERSION,
+                )
+                return False
+
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_started",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
             )
-            return False
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_started",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
+            sql = migration_sql_path.read_text()
+            conn.executescript(sql)
+            log.info(
+                "apply_0019: migrated from v%s to v%s", current_version, _TARGET_VERSION
+            )
 
-        sql = migration_sql_path.read_text()
-        conn.executescript(sql)
-        log.info(
-            "apply_0019: migrated from v%s to v%s", current_version, _TARGET_VERSION
-        )
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_completed",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
+            )
+            return True
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_completed",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
-        return True
-
-    except sqlite3.Error as e:
-        conn.rollback()
-        log.error("apply_0019: error during migration; transaction rolled back")
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_failed",
-            {"from_version": current_version, "error": str(e)},
-        )
-        raise
-
-    finally:
-        conn.close()
+        except sqlite3.Error as e:
+            conn.rollback()
+            log.error("apply_0019: error during migration; transaction rolled back")
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_failed",
+                {"from_version": current_version, "error": str(e)},
+            )
+            raise
 
 
 if __name__ == "__main__":

--- a/scripts/lib/migrations/apply_0020.py
+++ b/scripts/lib/migrations/apply_0020.py
@@ -28,6 +28,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+from coordination_db import get_connection_for_db
+
 log = logging.getLogger(__name__)
 
 _TARGET_VERSION = 14
@@ -69,56 +74,54 @@ def apply_migration(
         vnx_data_dir = Path(db_path).parent.parent
 
     current_version = 0
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cur = conn.cursor()
-        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
-        row = cur.fetchone()
-        current_version = int(row[0]) if (row and row[0] is not None) else 0
 
-        if current_version == _TARGET_VERSION:
-            log.info("apply_0020: already at v%s; idempotent skip", _TARGET_VERSION)
-            return False
-        if current_version != _TARGET_VERSION - 1:
-            msg = (
-                f"ERROR: up-migration requires schema v{_TARGET_VERSION - 1}; "
-                f"got v{current_version}. Refusing to apply."
+    with get_connection_for_db(db_path) as conn:
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+            row = cur.fetchone()
+            current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+            if current_version == _TARGET_VERSION:
+                log.info("apply_0020: already at v%s; idempotent skip", _TARGET_VERSION)
+                return False
+            if current_version != _TARGET_VERSION - 1:
+                msg = (
+                    f"ERROR: up-migration requires schema v{_TARGET_VERSION - 1}; "
+                    f"got v{current_version}. Refusing to apply."
+                )
+                print(msg, file=sys.stderr)
+                log.error("apply_0020: %s", msg)
+                raise SystemExit(1)
+
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_started",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
             )
-            print(msg, file=sys.stderr)
-            log.error("apply_0020: %s", msg)
-            raise SystemExit(1)
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_started",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
+            sql = migration_sql_path.read_text()
+            conn.executescript(sql)
+            log.info(
+                "apply_0020: migrated from v%s to v%s", current_version, _TARGET_VERSION
+            )
 
-        sql = migration_sql_path.read_text()
-        conn.executescript(sql)
-        log.info(
-            "apply_0020: migrated from v%s to v%s", current_version, _TARGET_VERSION
-        )
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_completed",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
+            )
+            return True
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_completed",
-            {"from_version": current_version, "to_version": _TARGET_VERSION},
-        )
-        return True
-
-    except sqlite3.Error as e:
-        conn.rollback()
-        log.error("apply_0020: error during migration; transaction rolled back")
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_failed",
-            {"from_version": current_version, "error": str(e)},
-        )
-        raise
-
-    finally:
-        conn.close()
+        except sqlite3.Error as e:
+            conn.rollback()
+            log.error("apply_0020: error during migration; transaction rolled back")
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_failed",
+                {"from_version": current_version, "error": str(e)},
+            )
+            raise
 
 
 def apply_down_migration(
@@ -137,58 +140,56 @@ def apply_down_migration(
         vnx_data_dir = Path(db_path).parent.parent
 
     current_version = 0
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cur = conn.cursor()
-        cur.execute("SELECT MAX(version) FROM runtime_schema_version")
-        row = cur.fetchone()
-        current_version = int(row[0]) if (row and row[0] is not None) else 0
 
-        if current_version == _TARGET_VERSION - 1:
-            log.info("apply_0020 down: already at v%s; idempotent skip", _TARGET_VERSION - 1)
-            return False
-        if current_version != _TARGET_VERSION:
-            msg = (
-                f"ERROR: down-migration requires schema v{_TARGET_VERSION}; "
-                f"got v{current_version}. Refusing to apply."
+    with get_connection_for_db(db_path) as conn:
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT MAX(version) FROM runtime_schema_version")
+            row = cur.fetchone()
+            current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+            if current_version == _TARGET_VERSION - 1:
+                log.info("apply_0020 down: already at v%s; idempotent skip", _TARGET_VERSION - 1)
+                return False
+            if current_version != _TARGET_VERSION:
+                msg = (
+                    f"ERROR: down-migration requires schema v{_TARGET_VERSION}; "
+                    f"got v{current_version}. Refusing to apply."
+                )
+                print(msg, file=sys.stderr)
+                log.error("apply_0020 down: %s", msg)
+                raise SystemExit(1)
+
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_started",
+                {"direction": "down", "from_version": current_version, "to_version": _TARGET_VERSION - 1},
             )
-            print(msg, file=sys.stderr)
-            log.error("apply_0020 down: %s", msg)
-            raise SystemExit(1)
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_started",
-            {"direction": "down", "from_version": current_version, "to_version": _TARGET_VERSION - 1},
-        )
+            sql = down_sql_path.read_text()
+            conn.executescript(sql)
+            log.info(
+                "apply_0020 down: rolled back from v%s to v%s",
+                current_version,
+                _TARGET_VERSION - 1,
+            )
 
-        sql = down_sql_path.read_text()
-        conn.executescript(sql)
-        log.info(
-            "apply_0020 down: rolled back from v%s to v%s",
-            current_version,
-            _TARGET_VERSION - 1,
-        )
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_completed",
+                {"direction": "down", "from_version": current_version, "to_version": _TARGET_VERSION - 1},
+            )
+            return True
 
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_completed",
-            {"direction": "down", "from_version": current_version, "to_version": _TARGET_VERSION - 1},
-        )
-        return True
-
-    except sqlite3.Error as e:
-        conn.rollback()
-        log.error("apply_0020 down: error during rollback; transaction rolled back")
-        _emit_migration_event(
-            vnx_data_dir,
-            "migration_failed",
-            {"direction": "down", "from_version": current_version, "error": str(e)},
-        )
-        raise
-
-    finally:
-        conn.close()
+        except sqlite3.Error as e:
+            conn.rollback()
+            log.error("apply_0020 down: error during rollback; transaction rolled back")
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_failed",
+                {"direction": "down", "from_version": current_version, "error": str(e)},
+            )
+            raise
 
 
 if __name__ == "__main__":

--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -11,6 +11,7 @@ import os
 import re
 from pathlib import Path
 from datetime import datetime
+from contextlib import contextmanager
 from typing import List, Optional, Literal, Tuple
 import sys
 
@@ -52,6 +53,19 @@ def _rollback_mode_enabled() -> bool:
     return bool(rollback)
 
 
+@contextmanager
+def _with_items_lock():
+    """Acquire exclusive lock on open_items.lock for read-modify-write safety."""
+    lock_path = STATE_DIR / "open_items.lock"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
 def load_items() -> dict:
     """Load open items database"""
     source = OPEN_ITEMS_FILE
@@ -64,25 +78,33 @@ def load_items() -> dict:
         return json.load(f)
 
 def save_items(data: dict):
-    """Save open items database"""
+    """Save open items database with atomic write (tmp + os.replace)."""
     data["last_updated"] = datetime.now().isoformat()
 
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    with open(OPEN_ITEMS_FILE, 'w') as f:
+    tmp_path = OPEN_ITEMS_FILE.with_suffix(".json.tmp")
+    with open(tmp_path, 'w') as f:
         json.dump(data, f, indent=2)
+    os.replace(tmp_path, OPEN_ITEMS_FILE)
 
 def audit_log_entry(action: str, **kwargs):
-    """Write audit log entry"""
+    """Write audit log entry with flock for concurrent safety."""
     entry = {
         "timestamp": datetime.now().isoformat(),
-        "actor": "T0",  # In practice, could be from env var
+        "actor": "T0",
         "action": action,
         **kwargs
     }
 
     STATE_DIR.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(entry) + '\n'
     with open(AUDIT_LOG, 'a') as f:
-        f.write(json.dumps(entry) + '\n')
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.write(line)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 def generate_item_id(data: dict) -> str:
     """Generate next item ID"""
@@ -127,91 +149,82 @@ def add_item_programmatic(
     Returns:
         (item_id, created): item_id is existing or new, created is False if deduplicated.
     """
-    lock_path = STATE_DIR / "open_items.lock"
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with _with_items_lock():
+        data = load_items()
 
-    with lock_path.open("a+", encoding="utf-8") as lock_handle:
-        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
-        try:
-            data = load_items()
+        if dedup_key:
+            existing = _find_by_dedup_key(data, dedup_key)
+            if existing is not None:
+                return (existing["id"], False)
 
-            # Dedup check: if key matches an existing item (any status), skip.
-            # Closed items are included so duplicate/replayed receipts cannot
-            # recreate findings that were already closed.
-            if dedup_key:
-                existing = _find_by_dedup_key(data, dedup_key)
-                if existing is not None:
-                    return (existing["id"], False)
+        item_id = generate_item_id(data)
 
-            item_id = generate_item_id(data)
+        new_item = {
+            "id": item_id,
+            "status": "open",
+            "severity": severity,
+            "title": title,
+            "details": details,
+            "origin_dispatch_id": dispatch_id,
+            "origin_report_path": report_path,
+            "pr_id": pr_id,
+            "created_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            "closed_reason": None,
+            "source": source,
+        }
+        if dedup_key:
+            new_item["dedup_key"] = dedup_key
 
-            new_item = {
-                "id": item_id,
-                "status": "open",
-                "severity": severity,
-                "title": title,
-                "details": details,
-                "origin_dispatch_id": dispatch_id,
-                "origin_report_path": report_path,
-                "pr_id": pr_id,
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
-                "closed_reason": None,
-                "source": source,
-            }
-            if dedup_key:
-                new_item["dedup_key"] = dedup_key
+        data["items"].append(new_item)
+        save_items(data)
 
-            data["items"].append(new_item)
-            save_items(data)
+        audit_log_entry(
+            "add",
+            item_id=item_id,
+            severity=severity,
+            dispatch_id=dispatch_id,
+            pr_id=pr_id,
+            source=source,
+            dedup_key=dedup_key,
+        )
 
-            audit_log_entry(
-                "add",
-                item_id=item_id,
-                severity=severity,
-                dispatch_id=dispatch_id,
-                pr_id=pr_id,
-                source=source,
-                dedup_key=dedup_key,
-            )
+        generate_digest()
 
-            generate_digest()
-
-            return (item_id, True)
-        finally:
-            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        return (item_id, True)
 
 
 def add_item(args):
     """Add new open item"""
-    data = load_items()
+    with _with_items_lock():
+        data = load_items()
 
-    item_id = generate_item_id(data)
+        item_id = generate_item_id(data)
 
-    new_item = {
-        "id": item_id,
-        "status": "open",
-        "severity": args.severity,
-        "title": args.title,
-        "details": args.details or "",
-        "origin_dispatch_id": args.dispatch,
-        "origin_report_path": args.report,
-        "pr_id": args.pr,
-        "created_at": datetime.now().isoformat(),
-        "updated_at": datetime.now().isoformat(),
-        "closed_reason": None
-    }
+        new_item = {
+            "id": item_id,
+            "status": "open",
+            "severity": args.severity,
+            "title": args.title,
+            "details": args.details or "",
+            "origin_dispatch_id": args.dispatch,
+            "origin_report_path": args.report,
+            "pr_id": args.pr,
+            "created_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            "closed_reason": None
+        }
 
-    data["items"].append(new_item)
-    save_items(data)
+        data["items"].append(new_item)
+        save_items(data)
 
-    audit_log_entry(
-        "add",
-        item_id=item_id,
-        severity=args.severity,
-        dispatch_id=args.dispatch,
-        pr_id=args.pr
-    )
+        audit_log_entry(
+            "add",
+            item_id=item_id,
+            severity=args.severity,
+            dispatch_id=args.dispatch,
+            pr_id=args.pr
+        )
 
     print(f"✅ Added {item_id}: {args.title}")
     print(f"   Severity: {args.severity}, PR: {args.pr or 'none'}")
@@ -220,41 +233,41 @@ def add_item(args):
 
 def close_item(args):
     """Close an open item with specified status"""
-    data = load_items()
+    with _with_items_lock():
+        data = load_items()
 
-    item = None
-    for i in data["items"]:
-        if i["id"] == args.item_id:
-            item = i
-            break
+        item = None
+        for i in data["items"]:
+            if i["id"] == args.item_id:
+                item = i
+                break
 
-    if not item:
-        print(f"❌ Item {args.item_id} not found")
-        return 1
+        if not item:
+            print(f"❌ Item {args.item_id} not found")
+            return 1
 
-    if item["status"] != "open":
-        print(f"⚠️  Item {args.item_id} already {item['status']}")
-        return 1
+        if item["status"] != "open":
+            print(f"⚠️  Item {args.item_id} already {item['status']}")
+            return 1
 
-    # Update item
-    old_status = item["status"]
-    item["status"] = args.status
-    item["closed_reason"] = args.reason
-    item["closed_by_dispatch_id"] = getattr(args, 'dispatch_id', None)
-    item["closed_at"] = datetime.now().isoformat()
-    item["updated_at"] = datetime.now().isoformat()
+        old_status = item["status"]
+        item["status"] = args.status
+        item["closed_reason"] = args.reason
+        item["closed_by_dispatch_id"] = getattr(args, 'dispatch_id', None)
+        item["closed_at"] = datetime.now().isoformat()
+        item["updated_at"] = datetime.now().isoformat()
 
-    save_items(data)
+        save_items(data)
 
-    audit_log_entry(
-        "close",
-        item_id=args.item_id,
-        from_status=old_status,
-        to_status=args.status,
-        reason=args.reason,
-        dispatch_id=item.get("origin_dispatch_id"),
-        pr_id=item.get("pr_id")
-    )
+        audit_log_entry(
+            "close",
+            item_id=args.item_id,
+            from_status=old_status,
+            to_status=args.status,
+            reason=args.reason,
+            dispatch_id=item.get("origin_dispatch_id"),
+            pr_id=item.get("pr_id")
+        )
 
     _log_oi_close_decision(
         oi_id=args.item_id,
@@ -338,43 +351,43 @@ def list_items(args):
 
 def attach_evidence(args):
     """Attach evidence from a report to all open items for a PR (does NOT close them)."""
-    data = load_items()
+    with _with_items_lock():
+        data = load_items()
 
-    pr_id = args.pr
-    report_path = args.report or ""
-    dispatch_id = args.dispatch or ""
+        pr_id = args.pr
+        report_path = args.report or ""
+        dispatch_id = args.dispatch or ""
 
-    matched = 0
-    for item in data["items"]:
-        if item["status"] != "open":
-            continue
-        if item.get("pr_id") != pr_id:
-            continue
+        matched = 0
+        for item in data["items"]:
+            if item["status"] != "open":
+                continue
+            if item.get("pr_id") != pr_id:
+                continue
 
-        # Append evidence entry
-        if "evidence" not in item:
-            item["evidence"] = []
-        item["evidence"].append({
-            "report_path": report_path,
-            "dispatch_id": dispatch_id,
-            "attached_at": datetime.now().isoformat()
-        })
-        item["updated_at"] = datetime.now().isoformat()
-        matched += 1
+            if "evidence" not in item:
+                item["evidence"] = []
+            item["evidence"].append({
+                "report_path": report_path,
+                "dispatch_id": dispatch_id,
+                "attached_at": datetime.now().isoformat()
+            })
+            item["updated_at"] = datetime.now().isoformat()
+            matched += 1
 
-    if matched == 0:
-        print(f"ℹ️  No open items found for {pr_id}")
-        return 0
+        if matched == 0:
+            print(f"ℹ️  No open items found for {pr_id}")
+            return 0
 
-    save_items(data)
+        save_items(data)
 
-    audit_log_entry(
-        "attach_evidence",
-        pr_id=pr_id,
-        report_path=report_path,
-        dispatch_id=dispatch_id,
-        items_matched=matched
-    )
+        audit_log_entry(
+            "attach_evidence",
+            pr_id=pr_id,
+            report_path=report_path,
+            dispatch_id=dispatch_id,
+            items_matched=matched
+        )
 
     print(f"📎 Attached evidence to {matched} open items for {pr_id}")
     print(f"   Report: {report_path}")
@@ -465,8 +478,10 @@ def generate_digest():
         "digest_generated": datetime.now().isoformat()
     }
 
-    with open(DIGEST_FILE, 'w') as f:
+    tmp_digest = DIGEST_FILE.with_suffix(".json.tmp")
+    with open(tmp_digest, 'w') as f:
         json.dump(digest, f, indent=2)
+    os.replace(tmp_digest, DIGEST_FILE)
 
     # Generate markdown
     generate_markdown(data, digest)
@@ -528,8 +543,10 @@ def generate_markdown(data: dict, digest: dict):
     lines.append("---")
     lines.append("Generated automatically by `open_items_manager.py`")
 
-    with open(MARKDOWN_FILE, 'w') as f:
+    tmp_md = MARKDOWN_FILE.with_suffix(".md.tmp")
+    with open(tmp_md, 'w') as f:
         f.write('\n'.join(lines))
+    os.replace(tmp_md, MARKDOWN_FILE)
 
 # ---------------------------------------------------------------------------
 # OI Auto-Close: rescan patterns
@@ -633,39 +650,41 @@ def _check_function_size(func_name: str, file_path: str, threshold: int) -> dict
 
 def rescan_items(args):
     """Rescan open items and auto-close resolved violations."""
-    data = load_items()
     dry_run = getattr(args, 'dry_run', False)
     closed = []
 
-    for item in data["items"]:
-        if item["status"] != "open":
-            continue
+    with _with_items_lock():
+        data = load_items()
 
-        result = check_violation(item)
-        if result is None:
-            continue
-        if result["resolved"]:
-            if not dry_run:
-                item["status"] = "done"
-                item["closed_reason"] = result["reason"]
-                item["closed_at"] = datetime.now().isoformat()
-                item["updated_at"] = datetime.now().isoformat()
-                item["closed_by"] = "auto-rescan"
-            closed.append({
-                "id": item["id"],
-                "title": item["title"],
-                "reason": result["reason"],
-            })
+        for item in data["items"]:
+            if item["status"] != "open":
+                continue
 
-    if not dry_run and closed:
-        save_items(data)
-        for c in closed:
-            audit_log_entry(
-                "auto_close",
-                item_id=c["id"],
-                reason=c["reason"],
-                source="rescan",
-            )
+            result = check_violation(item)
+            if result is None:
+                continue
+            if result["resolved"]:
+                if not dry_run:
+                    item["status"] = "done"
+                    item["closed_reason"] = result["reason"]
+                    item["closed_at"] = datetime.now().isoformat()
+                    item["updated_at"] = datetime.now().isoformat()
+                    item["closed_by"] = "auto-rescan"
+                closed.append({
+                    "id": item["id"],
+                    "title": item["title"],
+                    "reason": result["reason"],
+                })
+
+        if not dry_run and closed:
+            save_items(data)
+            for c in closed:
+                audit_log_entry(
+                    "auto_close",
+                    item_id=c["id"],
+                    reason=c["reason"],
+                    source="rescan",
+                )
 
     prefix = "[DRY RUN] " if dry_run else ""
     verb = "would be " if dry_run else ""

--- a/tests/test_governance_blockers_fix.py
+++ b/tests/test_governance_blockers_fix.py
@@ -1,0 +1,345 @@
+"""Tests for the 3 blockers + 4 high findings in the governance cluster fix.
+
+B-1: open_items_manager.py save_items() atomic write + lock in CLI paths
+B-2: migrations use coordination_db.get_connection() for WAL mode
+B-3: closure_verifier _count_report_blocking_indicators self-reference loop
+H-1: governance_emit duplicate datetime.now()
+H-2: audit_log_entry flock for concurrent safety
+H-3: init_schema single-connection race fix
+H-4: build_t0_state silent swallow -> log.warning
+
+Dispatch-ID: 20260517-fix-governance-cluster
+"""
+
+from __future__ import annotations
+
+import fcntl
+import inspect
+import json
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import textwrap
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_LIB_DIR = _SCRIPT_DIR / "lib"
+
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+
+# ---------------------------------------------------------------------------
+# B-1: open_items_manager atomic save + lock
+# ---------------------------------------------------------------------------
+
+class TestOpenItemsManagerAtomicSave:
+    """B-1: save_items uses tmp + os.replace, CLI paths hold shared lock."""
+
+    def test_save_items_uses_atomic_write(self):
+        """save_items must use os.replace, not direct open(path, 'w')."""
+        source = inspect.getsource(__import__("open_items_manager").save_items)
+        assert "os.replace" in source, "save_items must use os.replace for atomic write"
+        assert ".json.tmp" in source or "with_suffix" in source, (
+            "save_items must write to a .tmp file first"
+        )
+
+    def test_save_items_no_direct_overwrite(self):
+        """save_items must NOT open the canonical file for writing directly."""
+        source = inspect.getsource(__import__("open_items_manager").save_items)
+        assert "open(OPEN_ITEMS_FILE, 'w')" not in source, (
+            "save_items must not open OPEN_ITEMS_FILE directly for writing"
+        )
+
+    def test_add_item_cli_holds_lock(self):
+        """add_item (CLI path) must acquire _with_items_lock."""
+        source = inspect.getsource(__import__("open_items_manager").add_item)
+        assert "_with_items_lock" in source, "add_item must use _with_items_lock"
+
+    def test_close_item_cli_holds_lock(self):
+        """close_item (CLI path) must acquire _with_items_lock."""
+        source = inspect.getsource(__import__("open_items_manager").close_item)
+        assert "_with_items_lock" in source, "close_item must use _with_items_lock"
+
+    def test_attach_evidence_cli_holds_lock(self):
+        """attach_evidence (CLI path) must acquire _with_items_lock."""
+        source = inspect.getsource(__import__("open_items_manager").attach_evidence)
+        assert "_with_items_lock" in source, "attach_evidence must use _with_items_lock"
+
+    def test_rescan_items_cli_holds_lock(self):
+        """rescan_items (CLI path) must acquire _with_items_lock."""
+        source = inspect.getsource(__import__("open_items_manager").rescan_items)
+        assert "_with_items_lock" in source, "rescan_items must use _with_items_lock"
+
+    def test_add_item_programmatic_uses_shared_lock(self):
+        """add_item_programmatic must use _with_items_lock (not inline lock)."""
+        source = inspect.getsource(
+            __import__("open_items_manager").add_item_programmatic
+        )
+        assert "_with_items_lock" in source, (
+            "add_item_programmatic must use _with_items_lock context manager"
+        )
+
+    def test_save_items_roundtrip(self, tmp_path):
+        """save_items writes valid JSON that load_items can read back."""
+        mod = __import__("open_items_manager")
+        orig_file = mod.OPEN_ITEMS_FILE
+        orig_state = mod.STATE_DIR
+        try:
+            mod.STATE_DIR = tmp_path
+            mod.OPEN_ITEMS_FILE = tmp_path / "open_items.json"
+            data = {"schema_version": "1.0", "items": [], "next_id": 1}
+            mod.save_items(data)
+            assert mod.OPEN_ITEMS_FILE.exists()
+            loaded = json.loads(mod.OPEN_ITEMS_FILE.read_text())
+            assert loaded["schema_version"] == "1.0"
+            assert "last_updated" in loaded
+        finally:
+            mod.OPEN_ITEMS_FILE = orig_file
+            mod.STATE_DIR = orig_state
+
+    def test_generate_digest_atomic_writes(self):
+        """generate_digest + generate_markdown must use os.replace."""
+        mod = __import__("open_items_manager")
+        digest_src = inspect.getsource(mod.generate_digest)
+        markdown_src = inspect.getsource(mod.generate_markdown)
+        assert "os.replace" in digest_src, "generate_digest must use os.replace"
+        assert "os.replace" in markdown_src, "generate_markdown must use os.replace"
+
+
+# ---------------------------------------------------------------------------
+# B-2: migrations use get_connection (WAL mode)
+# ---------------------------------------------------------------------------
+
+class TestMigrationsWalMode:
+    """B-2: migration scripts use coordination_db.get_connection for WAL."""
+
+    @pytest.mark.parametrize("module_name", [
+        "migrations.apply_0017",
+        "migrations.apply_0019",
+        "migrations.apply_0020",
+    ])
+    def test_migration_imports_get_connection(self, module_name):
+        """Migration module must import get_connection from coordination_db."""
+        mod = __import__(module_name, fromlist=["apply_migration"])
+        source = inspect.getsource(mod)
+        assert "from coordination_db import get_connection_for_db" in source, (
+            f"{module_name} must import get_connection from coordination_db"
+        )
+
+    @pytest.mark.parametrize("module_name", [
+        "migrations.apply_0017",
+        "migrations.apply_0019",
+        "migrations.apply_0020",
+    ])
+    def test_migration_no_direct_sqlite_connect(self, module_name):
+        """apply_migration must not use sqlite3.connect directly."""
+        mod = __import__(module_name, fromlist=["apply_migration"])
+        source = inspect.getsource(mod.apply_migration)
+        assert "sqlite3.connect" not in source, (
+            f"{module_name}.apply_migration must use get_connection, not sqlite3.connect"
+        )
+
+    def test_apply_0020_down_no_direct_sqlite_connect(self):
+        """apply_down_migration must not use sqlite3.connect directly."""
+        mod = __import__("migrations.apply_0020", fromlist=["apply_down_migration"])
+        source = inspect.getsource(mod.apply_down_migration)
+        assert "sqlite3.connect" not in source, (
+            "apply_0020.apply_down_migration must use get_connection"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B-3: closure_verifier self-reference loop
+# ---------------------------------------------------------------------------
+
+class TestClosureVerifierSelfReference:
+    """B-3: _count_report_blocking_indicators must not match its own output."""
+
+    def _count(self, content: str) -> int:
+        mod = __import__("closure_verifier")
+        return mod._count_report_blocking_indicators(content)
+
+    def test_self_reference_lines_excluded(self):
+        """Lines matching closure verifier output format must be filtered out."""
+        report = textwrap.dedent("""\
+            Closure verifier: FAIL
+            - [FAIL] feature_plan_status: FEATURE_PLAN status is missing
+            - [FAIL] pr_queue_complete: PR queue totals are not fully complete
+            - [PASS] branch_pushed: remote branch found: feat/x
+        """)
+        count = self._count(report)
+        assert count == 0, (
+            f"Self-referential [FAIL]/[PASS] lines must not count as blocking, got {count}"
+        )
+
+    def test_genuine_blocking_still_counted(self):
+        """Real blocking indicators must still be detected."""
+        report = textwrap.dedent("""\
+            ## Review Results
+            [BLOCKING] SQL injection in user input handling
+            **Severity**: blocking
+            severity: blocking
+            BLOCKER: missing auth check
+        """)
+        count = self._count(report)
+        assert count >= 4, f"Expected at least 4 blocking indicators, got {count}"
+
+    def test_status_fail_in_gate_context_counted(self):
+        """Status: FAIL in gate output (not closure verifier format) must count."""
+        report = textwrap.dedent("""\
+            ## Gate Results
+            Gate: codex_gate
+            Status: FAIL
+            Finding: unused import detected
+        """)
+        count = self._count(report)
+        assert count >= 1, f"Status: FAIL in gate context must count, got {count}"
+
+    def test_mixed_content(self):
+        """Mix of self-referential and genuine blocking lines."""
+        report = textwrap.dedent("""\
+            - [FAIL] some_check: something failed
+            [BLOCKING] real finding
+            - [PASS] other_check: passed
+            Status: FAIL
+        """)
+        count = self._count(report)
+        assert count == 2, (
+            f"Expected 2 (BLOCKING + Status: FAIL), got {count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# H-1: governance_emit duplicate datetime.now()
+# ---------------------------------------------------------------------------
+
+class TestGovernanceEmitTimestamp:
+    """H-1: emit_dispatch_receipt must use a single datetime.now() call."""
+
+    def test_single_timestamp_call(self):
+        """now_ts and recorded_ts must derive from the same datetime.now() call."""
+        mod = __import__("governance_emit")
+        source = inspect.getsource(mod.emit_dispatch_receipt)
+        now_calls = re.findall(r"datetime\.now\(", source)
+        assert len(now_calls) == 1, (
+            f"emit_dispatch_receipt must call datetime.now() exactly once, found {len(now_calls)}"
+        )
+
+    def test_recorded_ts_equals_now_ts(self):
+        """recorded_ts must be assigned from now_ts, not a separate call."""
+        mod = __import__("governance_emit")
+        source = inspect.getsource(mod.emit_dispatch_receipt)
+        assert "recorded_ts = now_ts" in source, (
+            "recorded_ts must be assigned from now_ts"
+        )
+
+
+# ---------------------------------------------------------------------------
+# H-2: audit_log_entry flock
+# ---------------------------------------------------------------------------
+
+class TestAuditLogEntryFlock:
+    """H-2: audit_log_entry must use fcntl.flock for concurrent safety."""
+
+    def test_audit_log_uses_flock(self):
+        """audit_log_entry must call fcntl.flock."""
+        mod = __import__("open_items_manager")
+        source = inspect.getsource(mod.audit_log_entry)
+        assert "fcntl.flock" in source, "audit_log_entry must use fcntl.flock"
+
+    def test_audit_log_uses_lock_ex(self):
+        """audit_log_entry must use LOCK_EX for exclusive access."""
+        mod = __import__("open_items_manager")
+        source = inspect.getsource(mod.audit_log_entry)
+        assert "LOCK_EX" in source, "audit_log_entry must use LOCK_EX"
+
+    def test_audit_log_flushes(self):
+        """audit_log_entry must flush before releasing lock."""
+        mod = __import__("open_items_manager")
+        source = inspect.getsource(mod.audit_log_entry)
+        assert "f.flush()" in source, "audit_log_entry must flush before unlock"
+
+    def test_audit_log_writes_valid_ndjson(self, tmp_path):
+        """audit_log_entry produces valid NDJSON."""
+        mod = __import__("open_items_manager")
+        orig_log = mod.AUDIT_LOG
+        orig_state = mod.STATE_DIR
+        try:
+            mod.STATE_DIR = tmp_path
+            mod.AUDIT_LOG = tmp_path / "test_audit.jsonl"
+            mod.audit_log_entry("test_action", item_id="OI-001", severity="warn")
+            content = mod.AUDIT_LOG.read_text()
+            entry = json.loads(content.strip())
+            assert entry["action"] == "test_action"
+            assert entry["item_id"] == "OI-001"
+            assert "timestamp" in entry
+        finally:
+            mod.AUDIT_LOG = orig_log
+            mod.STATE_DIR = orig_state
+
+
+# ---------------------------------------------------------------------------
+# H-3: init_schema single-connection race fix
+# ---------------------------------------------------------------------------
+
+class TestInitSchemaRace:
+    """H-3: init_schema must use a single connection for the full sequence."""
+
+    def test_single_get_connection_call(self):
+        """init_schema must open only one get_connection context."""
+        from coordination_db import init_schema
+        source = inspect.getsource(init_schema)
+        context_opens = source.count("with get_connection(")
+        assert context_opens == 1, (
+            f"init_schema must use exactly 1 get_connection context, found {context_opens}"
+        )
+
+    def test_version_check_inside_connection(self):
+        """Version check + migration loop must be inside the same connection."""
+        from coordination_db import init_schema
+        source = inspect.getsource(init_schema)
+        lines = source.splitlines()
+        with_line = None
+        version_line = None
+        for i, line in enumerate(lines):
+            if "with get_connection(" in line:
+                with_line = i
+            if "SELECT MAX(version)" in line:
+                version_line = i
+        assert with_line is not None, "get_connection context not found"
+        assert version_line is not None, "version check not found"
+        assert version_line > with_line, "version check must be inside connection context"
+
+
+# ---------------------------------------------------------------------------
+# H-4: build_t0_state silent swallow -> log.warning
+# ---------------------------------------------------------------------------
+
+class TestBuildT0StateSilentSwallow:
+    """H-4: main() exception handler must log, not silently pass."""
+
+    def test_no_bare_except_pass_for_build(self):
+        """The top-level build_t0_state exception handler must not silently pass."""
+        mod = __import__("build_t0_state")
+        source = inspect.getsource(mod.main)
+        assert "pass  # SessionStart hook must never block session" not in source, (
+            "The build_t0_state exception handler must log, not 'pass'"
+        )
+
+    def test_exception_logged(self):
+        """The main try/except for build_t0_state must log the exception."""
+        mod = __import__("build_t0_state")
+        source = inspect.getsource(mod.main)
+        assert "log.warning" in source or "log.error" in source, (
+            "main() must log build_t0_state failures, not silently pass"
+        )


### PR DESCRIPTION
## Summary
- **B-1**: `save_items()` uses atomic write (tmp+os.replace); all CLI paths hold shared `open_items.lock` via `_with_items_lock` context manager
- **B-2**: Migrations 0017/0019/0020 use `coordination_db.get_connection_for_db()` for WAL mode instead of direct `sqlite3.connect`
- **B-3**: `_count_report_blocking_indicators` excludes closure verifier's own `[FAIL]/[PASS]` output lines, preventing self-reference loop that blocked passing gates
- **H-1**: Single `datetime.now()` call in `emit_dispatch_receipt` (was duplicate)
- **H-2**: `audit_log_entry` uses `fcntl.flock(LOCK_EX)` for concurrent NDJSON safety
- **H-3**: `init_schema` uses single connection for full init+migration sequence (race fix)
- **H-4**: `build_t0_state` main() logs exceptions instead of silent `pass`

## Test plan
- [x] `pytest tests/test_governance_blockers_fix.py` — 30 tests covering all 7 fixes
- [x] `pytest tests/test_schema_0017_migration.py tests/test_schema_0020_migration.py` — 46 existing migration tests pass
- [x] `pytest tests/test_closure_verifier.py tests/test_governance_emit.py tests/test_build_t0_state.py` — 80 existing module tests pass
- [x] Total: 156 passed, 0 failed, 0 regressions

Dispatch-ID: 20260517-fix-governance-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)