### PR TITLE
fix(smart-router): end-to-end auto-route wiring + enforcer Kimi CLI false-positive

### DIFF
--- a/scripts/lib/constraint_enforcer.py
+++ b/scripts/lib/constraint_enforcer.py
@@ -112,6 +112,8 @@ class ConstraintEnforcer:
                         raise HardConstraintViolation(cid, msg)
                     logger.warning("[%s] %s", cid, msg)
 
+    _NATIVE_CLI_PROVIDERS = frozenset({"claude", "codex", "gemini", "kimi"})
+
     def _check_forbid_route(
         self,
         constraint: Dict[str, Any],
@@ -127,9 +129,13 @@ class ConstraintEnforcer:
 
         spec_provider = fr.get("provider")
         if spec_provider:
-            effective_provider = sub_provider or provider
-            if not self._match_value(effective_provider, spec_provider):
-                return False
+            if provider and provider.lower() in self._NATIVE_CLI_PROVIDERS:
+                if not self._match_value(provider, spec_provider):
+                    return False
+            else:
+                effective_provider = sub_provider or provider
+                if not self._match_value(effective_provider, spec_provider):
+                    return False
 
         spec_model = fr.get("model")
         if spec_model:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -778,19 +778,37 @@ def main(argv: list[str] | None = None) -> int:
     provider = args.provider
 
     # PR-SR-3/4: smart_router end-to-end pipeline (opt-in via --auto-route).
-    # Uses explicit decide() + parse + write_route_decision() to ensure NDJSON
-    # persistence is never silently swallowed by a bundled route() failure.
+    # Split into import → decide → write stages so that:
+    #   - ImportError (missing yaml dep): graceful fallback
+    #   - FileNotFoundError/ValueError (missing/malformed recommendations): graceful fallback
+    #   - write_route_decision failure: logged at ERROR, visible in audit, not swallowed
     if getattr(args, "auto_route", False):
+        _route_decision = None
+        _sr_imported = False
         try:
             from smart_router import decide as _smart_decide, parse_route_model_id, write_route_decision  # noqa: PLC0415
-
-            _dp = _resolve_dispatch_paths(args.dispatch_paths)
-            _route_decision = _smart_decide(
-                instruction=args.instruction,
-                role=args.role,
-                dispatch_paths=_dp,
+            _sr_imported = True
+        except ImportError as _imp_exc:
+            logger.warning(
+                "smart_router: import failed (%s); falling back to --provider=%s --model=%s",
+                _imp_exc, args.provider, args.model,
             )
 
+        if _sr_imported:
+            try:
+                _dp = _resolve_dispatch_paths(args.dispatch_paths)
+                _route_decision = _smart_decide(
+                    instruction=args.instruction,
+                    role=args.role,
+                    dispatch_paths=_dp,
+                )
+            except (FileNotFoundError, ValueError) as _decide_exc:
+                logger.warning(
+                    "smart_router: decide failed (%s); falling back to --provider=%s --model=%s",
+                    _decide_exc, args.provider, args.model,
+                )
+
+        if _route_decision is not None:
             if _route_decision.primary:
                 _r_provider, _r_model = parse_route_model_id(
                     _route_decision.primary.model_id,
@@ -802,16 +820,16 @@ def main(argv: list[str] | None = None) -> int:
                 os.environ["VNX_TASK_CLASS"] = _route_decision.task_class
 
             _state_dir = _resolve_state_dir()
-            write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
+            try:
+                write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
+            except OSError as _write_exc:
+                logger.error(
+                    "smart_router: route_decisions.ndjson write failed: %s", _write_exc,
+                )
 
             logger.info(
                 "smart_router: auto-route provider=%s model=%s (task_class=%s)",
                 provider, args.model, _route_decision.task_class,
-            )
-        except Exception as _route_exc:
-            logger.warning(
-                "smart_router: auto-route failed (%s); falling back to --provider=%s --model=%s",
-                _route_exc, args.provider, args.model,
             )
 
     # PR-SR-2: enforce provider constraints before any handler runs.

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -777,33 +777,36 @@ def main(argv: list[str] | None = None) -> int:
 
     provider = args.provider
 
-    # PR-SR-3/4: smart_router.route() end-to-end pipeline (opt-in via --auto-route).
+    # PR-SR-3/4: smart_router end-to-end pipeline (opt-in via --auto-route).
+    # Uses explicit decide() + parse + write_route_decision() to ensure NDJSON
+    # persistence is never silently swallowed by a bundled route() failure.
     if getattr(args, "auto_route", False):
         try:
-            from smart_router import route as _smart_route  # noqa: PLC0415
+            from smart_router import decide as _smart_decide, parse_route_model_id, write_route_decision  # noqa: PLC0415
 
-            _dp = None
-            if args.dispatch_paths.strip():
-                _dp = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
-
-            _state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
-            _routing_result = _smart_route(
+            _dp = _resolve_dispatch_paths(args.dispatch_paths)
+            _route_decision = _smart_decide(
                 instruction=args.instruction,
-                dispatch_id=args.dispatch_id,
-                state_dir=_state_dir,
                 role=args.role,
                 dispatch_paths=_dp,
             )
-            if _routing_result.routed:
-                provider = _routing_result.provider
-                args.provider = _routing_result.provider
-                args.model = _routing_result.model
+
+            if _route_decision.primary:
+                _r_provider, _r_model = parse_route_model_id(
+                    _route_decision.primary.model_id,
+                )
+                provider = _r_provider
+                args.provider = _r_provider
+                args.model = _r_model
                 os.environ["VNX_ROUTE_STRATEGY"] = "smart_router"
-                os.environ["VNX_TASK_CLASS"] = _routing_result.decision.task_class
+                os.environ["VNX_TASK_CLASS"] = _route_decision.task_class
+
+            _state_dir = _resolve_state_dir()
+            write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
 
             logger.info(
                 "smart_router: auto-route provider=%s model=%s (task_class=%s)",
-                provider, args.model, _routing_result.decision.task_class,
+                provider, args.model, _route_decision.task_class,
             )
         except Exception as _route_exc:
             logger.warning(

--- a/tests/test_constraint_enforcer_kimi_valid.py
+++ b/tests/test_constraint_enforcer_kimi_valid.py
@@ -1,0 +1,102 @@
+"""Tests for kimi-via-cli-only constraint: native CLI provider NEVER blocked.
+
+The kimi-via-cli-only constraint targets litellm:moonshot API routes.
+provider='kimi' (native CLI via `kimi login` OAuth) is ALWAYS valid and must
+never trigger a violation, regardless of sub_provider or model values passed.
+
+Dispatch-ID: 20260517-fix-smart-router-enforcer
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from constraint_enforcer import ConstraintEnforcer, HardConstraintViolation
+
+
+@pytest.fixture
+def enforcer() -> ConstraintEnforcer:
+    return ConstraintEnforcer()
+
+
+class TestKimiCliAlwaysValid:
+    """provider='kimi' is the native CLI route and must NEVER be blocked."""
+
+    def test_kimi_provider_via_cli_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="kimi", sub_provider=None, via="cli")
+
+    def test_kimi_provider_no_via_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="kimi", sub_provider=None, via=None)
+
+    def test_kimi_provider_with_model_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="kimi", sub_provider=None, model="kimi-k2-0905", via="cli")
+
+    def test_kimi_provider_with_kimi_k2_6_model(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="kimi", sub_provider=None, model="kimi-k2-6", via="cli")
+
+    def test_kimi_provider_case_insensitive(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="Kimi", sub_provider=None, via="cli")
+
+    def test_kimi_provider_with_erroneous_sub_provider(self, enforcer: ConstraintEnforcer):
+        """Even if sub_provider is erroneously set, native CLI provider wins."""
+        enforcer.enforce(provider="kimi", sub_provider="moonshot", via="cli")
+
+    def test_kimi_provider_with_moonshot_via(self, enforcer: ConstraintEnforcer):
+        """provider='kimi' is native CLI — 'moonshot' via is irrelevant."""
+        enforcer.enforce(provider="kimi", sub_provider=None, via="moonshot")
+
+
+class TestLitellmMoonshotStillBlocked:
+    """litellm:moonshot API route must remain blocked (not a regression)."""
+
+    def test_litellm_moonshot_via_api_blocked(self, enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="kimi-via-cli-only"):
+            enforcer.enforce(provider="litellm", sub_provider="moonshot", via="api")
+
+    def test_litellm_moonshot_via_moonshot_blocked(self, enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="kimi-via-cli-only"):
+            enforcer.enforce(provider="litellm", sub_provider="moonshot", via="moonshot")
+
+    def test_litellm_moonshot_via_cli_not_blocked(self, enforcer: ConstraintEnforcer):
+        """litellm via cli is not in the forbidden via list — allowed."""
+        enforcer.enforce(provider="litellm", sub_provider="moonshot", via="cli")
+
+
+class TestOtherNativeCliProvidersUnaffected:
+    """Other native CLI providers must not be blocked by kimi-via-cli-only."""
+
+    def test_claude_provider_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="claude", model="claude-opus-4-7", via="cli")
+
+    def test_gemini_provider_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="gemini", model="gemini-2.5-pro", via="cli")
+
+    def test_codex_provider_not_blocked(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="codex", via="cli")
+
+
+class TestExistingConstraintsNotRegressed:
+    """Ensure the enforcer fix doesn't break other constraints."""
+
+    def test_zai_direct_still_blocked(self, enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="zai-via-openrouter-only"):
+            enforcer.enforce(provider="zai", via="direct")
+
+    def test_deprecated_glm_still_blocked(self, enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            enforcer.enforce(provider="zai", model="glm-4.5")
+
+    def test_deepseek_claude_harness_still_blocked(self, enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="deepseek-path-d-blocked"):
+            enforcer.enforce(provider="deepseek", via="claude_harness")
+
+    def test_litellm_deepseek_via_litellm_allowed(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="litellm", sub_provider="deepseek", via="litellm")
+
+    def test_zai_via_openrouter_allowed(self, enforcer: ConstraintEnforcer):
+        enforcer.enforce(provider="litellm", sub_provider="zai", via="openrouter")

--- a/tests/test_constraint_enforcer_kimi_valid.py
+++ b/tests/test_constraint_enforcer_kimi_valid.py
@@ -50,6 +50,14 @@ class TestKimiCliAlwaysValid:
         """provider='kimi' is native CLI — 'moonshot' via is irrelevant."""
         enforcer.enforce(provider="kimi", sub_provider=None, via="moonshot")
 
+    def test_kimi_provider_double_match_not_blocked(self, enforcer: ConstraintEnforcer):
+        """Even with sub_provider=moonshot AND via=moonshot, native kimi CLI wins."""
+        enforcer.enforce(provider="kimi", sub_provider="moonshot", via="moonshot")
+
+    def test_kimi_provider_sub_moonshot_via_api_not_blocked(self, enforcer: ConstraintEnforcer):
+        """Bench dispatches: provider=kimi with erroneous sub+via still native CLI."""
+        enforcer.enforce(provider="kimi", sub_provider="moonshot", via="api")
+
 
 class TestLitellmMoonshotStillBlocked:
     """litellm:moonshot API route must remain blocked (not a regression)."""

--- a/tests/test_smart_router_e2e.py
+++ b/tests/test_smart_router_e2e.py
@@ -1,0 +1,262 @@
+"""End-to-end tests for smart_router wiring in provider_dispatch.
+
+Verifies that --auto-route produces a route_decisions.ndjson entry for all
+provider paths (claude, kimi, gemini, codex, litellm). Covers the explicit
+decide() + parse_route_model_id() + write_route_decision() pipeline that
+replaced the bundled route() call.
+
+Dispatch-ID: 20260517-fix-smart-router-enforcer
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from smart_router import (
+    RouteCandidate,
+    RouteDecision,
+    decide,
+    parse_route_model_id,
+    write_route_decision,
+)
+
+
+@pytest.fixture
+def recommendations_yaml(tmp_path):
+    data = {
+        "routing_by_task": {
+            "01_code_generation": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
+                 "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
+                {"model_id": "kimi-k2-0905", "composite_score": 7.0,
+                 "avg_duration_seconds": 200.0, "cost_usd_per_call": 0.02},
+            ],
+            "02_code_review": [
+                {"model_id": "claude-opus-4-6", "composite_score": 10.0,
+                 "avg_duration_seconds": 90.9, "cost_usd_per_call": None},
+            ],
+            "05_debugging": [
+                {"model_id": "deepseek-v4-pro", "composite_score": 9.0,
+                 "avg_duration_seconds": 180.0, "cost_usd_per_call": 0.01},
+            ],
+        },
+    }
+    yaml_path = tmp_path / "routing_recommendations.yaml"
+    yaml_path.write_text(yaml.dump(data), encoding="utf-8")
+    return yaml_path
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+class TestAutoRouteNdjsonPersistence:
+    """Core blocker: --auto-route MUST produce a route_decisions.ndjson entry."""
+
+    def test_claude_dispatch_writes_ndjson(self, recommendations_yaml, state_dir):
+        decision = decide(
+            instruction="implement the SubprocessAdapter",
+            role="backend-developer",
+            recommendations_path=recommendations_yaml,
+        )
+        assert decision.primary is not None
+
+        write_route_decision("dispatch-claude-001", decision, state_dir=state_dir)
+
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        assert ndjson_path.exists(), "route_decisions.ndjson must be created"
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+        assert record["dispatch_id"] == "dispatch-claude-001"
+        assert record["task_class"] == "01_code_generation"
+        assert record["chosen_route"]["model_id"] == "claude-sonnet-4-6"
+
+    def test_kimi_route_writes_ndjson(self, recommendations_yaml, state_dir):
+        decision = decide(
+            instruction="implement the CLI adapter",
+            role="backend-developer",
+            recommendations_path=recommendations_yaml,
+        )
+        write_route_decision("dispatch-kimi-001", decision, state_dir=state_dir)
+
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        assert ndjson_path.exists()
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+        assert record["dispatch_id"] == "dispatch-kimi-001"
+        assert "timestamp" in record
+
+    def test_review_task_routes_to_opus(self, recommendations_yaml, state_dir):
+        decision = decide(
+            instruction="review the security changes in auth module",
+            role="reviewer",
+            recommendations_path=recommendations_yaml,
+        )
+        assert decision.task_class == "02_code_review"
+        assert decision.primary.model_id == "claude-opus-4-6"
+
+        provider, model = parse_route_model_id(decision.primary.model_id)
+        assert provider == "claude"
+        assert model == "opus"
+
+        write_route_decision("dispatch-review-001", decision, state_dir=state_dir)
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+        assert record["chosen_route"]["model_id"] == "claude-opus-4-6"
+
+    def test_debug_task_routes_to_deepseek(self, recommendations_yaml, state_dir):
+        decision = decide(
+            instruction="debug the failing test in subprocess_dispatch",
+            role="debugger",
+            recommendations_path=recommendations_yaml,
+        )
+        assert decision.task_class == "05_debugging"
+        assert decision.primary.model_id == "deepseek-v4-pro"
+
+        provider, model = parse_route_model_id(decision.primary.model_id)
+        assert provider == "litellm:deepseek:deepseek-v4-pro"
+        assert model == "deepseek-v4-pro"
+
+        write_route_decision("dispatch-debug-001", decision, state_dir=state_dir)
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+        assert record["chosen_route"]["model_id"] == "deepseek-v4-pro"
+
+
+class TestProviderDispatchAutoRouteIntegration:
+    """Integration test: provider_dispatch.main() with --auto-route writes NDJSON."""
+
+    def test_main_auto_route_writes_ndjson_for_claude(self, recommendations_yaml, state_dir, monkeypatch):
+        import provider_dispatch
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setattr(
+            "smart_router._RECOMMENDATIONS_PATH", recommendations_yaml
+        )
+
+        with patch("subprocess_dispatch.deliver_with_recovery", return_value=True), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            result = provider_dispatch.main([
+                "--provider", "claude",
+                "--terminal-id", "T1",
+                "--dispatch-id", "e2e-claude-auto-route",
+                "--instruction", "implement feature X",
+                "--model", "sonnet",
+                "--auto-route",
+            ])
+
+        assert result == 0
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        assert ndjson_path.exists(), "auto-route MUST produce route_decisions.ndjson entry"
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+        assert record["dispatch_id"] == "e2e-claude-auto-route"
+        assert record["task_class"] == "01_code_generation"
+
+    def test_main_auto_route_overrides_model_for_review(self, recommendations_yaml, state_dir, monkeypatch):
+        import provider_dispatch
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setattr(
+            "smart_router._RECOMMENDATIONS_PATH", recommendations_yaml
+        )
+
+        captured_model = {}
+
+        def _mock_deliver(**kwargs):
+            captured_model["model"] = kwargs.get("model")
+            return True
+
+        with patch("subprocess_dispatch.deliver_with_recovery", side_effect=_mock_deliver), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            result = provider_dispatch.main([
+                "--provider", "claude",
+                "--terminal-id", "T1",
+                "--dispatch-id", "e2e-review-route",
+                "--instruction", "review the code changes for security",
+                "--model", "sonnet",
+                "--role", "reviewer",
+                "--auto-route",
+            ])
+
+        assert result == 0
+        assert captured_model["model"] == "opus"
+
+    def test_main_without_auto_route_no_ndjson(self, state_dir, monkeypatch):
+        import provider_dispatch
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+
+        with patch("subprocess_dispatch.deliver_with_recovery", return_value=True), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            provider_dispatch.main([
+                "--provider", "claude",
+                "--terminal-id", "T1",
+                "--dispatch-id", "e2e-no-auto-route",
+                "--instruction", "implement feature",
+                "--model", "sonnet",
+            ])
+
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        assert not ndjson_path.exists()
+
+    def test_main_auto_route_fallback_on_missing_recommendations(self, tmp_path, monkeypatch):
+        import provider_dispatch
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setattr(
+            "smart_router._RECOMMENDATIONS_PATH",
+            tmp_path / "nonexistent.yaml",
+        )
+
+        with patch("subprocess_dispatch.deliver_with_recovery", return_value=True), \
+             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+            result = provider_dispatch.main([
+                "--provider", "claude",
+                "--terminal-id", "T1",
+                "--dispatch-id", "e2e-fallback",
+                "--instruction", "implement feature",
+                "--model", "sonnet",
+                "--auto-route",
+            ])
+
+        assert result == 0
+
+
+class TestParseRouteModelIdAllProviders:
+    """Verify parse_route_model_id returns correct (provider, model) for all routes."""
+
+    def test_kimi_k2_returns_native_cli(self):
+        provider, model = parse_route_model_id("kimi-k2-0905")
+        assert provider == "kimi"
+        assert model == "kimi-k2-0905"
+
+    def test_kimi_k2_6_returns_native_cli(self):
+        provider, model = parse_route_model_id("kimi-k2-6")
+        assert provider == "kimi"
+        assert model == "kimi-k2-6"
+
+    def test_deepseek_returns_litellm_bridge(self):
+        provider, model = parse_route_model_id("deepseek-v4-pro")
+        assert provider.startswith("litellm:")
+        assert "deepseek" in provider
+
+    def test_glm_returns_litellm_openrouter(self):
+        provider, model = parse_route_model_id("glm-5-1")
+        assert "openrouter" in provider
+
+    def test_claude_sonnet_returns_claude_provider(self):
+        provider, model = parse_route_model_id("claude-sonnet-4-6")
+        assert provider == "claude"
+        assert model == "sonnet"


### PR DESCRIPTION
## Summary
- **BLOCKER 1**: `provider_dispatch.py` auto-route `except Exception` silently swallowed `write_route_decision()` failures — smoke tests produced no `route_decisions.ndjson` entry. Split into 3 targeted exception stages (ImportError, FileNotFoundError/ValueError, OSError) so write failures are logged at ERROR, never swallowed.
- **BLOCKER 2**: `constraint_enforcer.py` `effective_provider = sub_provider or provider` caused `kimi-via-cli-only` to false-positive when `provider='kimi'` had erroneous `sub_provider='moonshot'`. Fixed via `_NATIVE_CLI_PROVIDERS` frozenset check (prior commit) + regression tests for double-match scenario.

## Test plan
- [x] `test_constraint_enforcer_kimi_valid.py` — 20 pass (incl. new double-match tests)
- [x] `test_smart_router_e2e.py` — 13 pass (NDJSON persistence, model override, fallback)
- [x] `test_constraint_enforcer.py` — 56 pass (no regressions)
- [x] `test_smart_router_wiring.py` — 41 pass (no regressions)
- [x] `test_smart_router.py` — 37 pass (no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)