### PR TITLE
feat(cli): vnx version + vnx update subcommands for central install rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - feat(cli): `vnx update --to <ver> --keep-last N --dry-run --rollback` subcommand for future central install version-flip (pre-central-install scaffolding)
 
 ### Fixed
+- fix(cli-update): path-traversal validation + ADR-005 audit events for symlink-flip + prune + git FileNotFoundError handling (codex blocker + 3 advisories)
 - fix(pyproject): build-backend `setuptools.backends._legacy` → `setuptools.build_meta`. Wheel build now succeeds via `python -m build`.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 
 ## [Unreleased]
 
+### Added
+- feat(cli): `vnx version` subcommand prints VERSION, commit, VNX_HOME, pin, Python+platform (pre-central-install support)
+- feat(cli): `vnx update --to <ver> --keep-last N --dry-run --rollback` subcommand for future central install version-flip (pre-central-install scaffolding)
+
 ### Fixed
 - fix(pyproject): build-backend `setuptools.backends._legacy` → `setuptools.build_meta`. Wheel build now succeeds via `python -m build`.
 

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -2,6 +2,7 @@
 """Tests for vnx update subcommand."""
 
 import io
+import json
 import sys
 from argparse import Namespace
 from contextlib import redirect_stdout
@@ -20,6 +21,8 @@ from vnx_cli.commands.update import (
     _list_version_dirs,
     _current_target,
     _prune_old_versions,
+    _atomic_symlink_flip,
+    _validate_version_name,
     DEFAULT_KEEP_LAST,
 )
 
@@ -33,7 +36,7 @@ def _update_args(*, to_version=None, keep_last=DEFAULT_KEEP_LAST, dry_run=False,
     )
 
 
-def _capture_update(args) -> tuple[str, str, int]:
+def _capture_update(args) -> tuple:
     out_buf = io.StringIO()
     err_buf = io.StringIO()
     with redirect_stdout(out_buf):
@@ -191,3 +194,200 @@ def test_rollback_no_previous_version(tmp_path, monkeypatch, capsys):
     assert rc == 1
     captured = capsys.readouterr()
     assert "previous" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# _validate_version_name — path traversal + injection
+# ---------------------------------------------------------------------------
+
+def test_validate_rejects_path_traversal_dotdot(capsys):
+    with pytest.raises(ValueError, match="invalid version name"):
+        _validate_version_name("../../outside")
+
+
+def test_validate_rejects_absolute_path(capsys):
+    with pytest.raises(ValueError, match="invalid version name"):
+        _validate_version_name("/etc/passwd")
+
+
+def test_validate_rejects_shell_injection():
+    with pytest.raises(ValueError, match="invalid version name"):
+        _validate_version_name("foo;rm -rf /")
+
+
+def test_validate_accepts_semver_with_rc():
+    assert _validate_version_name("v1.0.0-rc2") == "v1.0.0-rc2"
+
+
+def test_validate_accepts_edge():
+    assert _validate_version_name("edge") == "edge"
+
+
+def test_validate_accepts_latest():
+    assert _validate_version_name("latest") == "latest"
+
+
+def test_validate_accepts_bare_semver():
+    assert _validate_version_name("1.2.3") == "1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# vnx_update path-traversal: no filesystem mutation on invalid target
+# ---------------------------------------------------------------------------
+
+def test_update_path_traversal_no_mutation(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="../../outside")
+
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "invalid version name" in captured.err
+    # No filesystem mutation
+    assert not (tmp_path / "versions").exists()
+    assert not (tmp_path / "current").exists()
+
+
+def test_update_absolute_path_rejected(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="/etc/passwd")
+
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "invalid version name" in captured.err
+    assert not (tmp_path / "versions").exists()
+
+
+def test_update_shell_injection_rejected(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="foo;rm -rf /")
+
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "invalid version name" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# ADR-005: symlink flip emits NDJSON audit events
+# ---------------------------------------------------------------------------
+
+def test_symlink_flip_emits_audit_events(tmp_path):
+    root = tmp_path / "install"
+    root.mkdir()
+    target_dir = root / "versions" / "v1.0.0"
+    target_dir.mkdir(parents=True)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _atomic_symlink_flip(root, target_dir, dry_run=False, audit_log=audit_log)
+
+    assert audit_log.exists()
+    lines = audit_log.read_text().strip().splitlines()
+    assert len(lines) == 2
+
+    before = json.loads(lines[0])
+    after = json.loads(lines[1])
+
+    assert before["event_type"] == "central_install_update"
+    assert before["to_version"] == "v1.0.0"
+    assert before["success"] is False
+    assert before["phase"] == "before_flip"
+
+    assert after["event_type"] == "central_install_update"
+    assert after["to_version"] == "v1.0.0"
+    assert after["success"] is True
+    assert after["phase"] == "after_flip"
+
+
+def test_symlink_flip_audit_event_has_timestamp(tmp_path):
+    root = tmp_path / "install"
+    root.mkdir()
+    target_dir = root / "versions" / "v2.0.0"
+    target_dir.mkdir(parents=True)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _atomic_symlink_flip(root, target_dir, dry_run=False, audit_log=audit_log)
+
+    lines = audit_log.read_text().strip().splitlines()
+    for line in lines:
+        record = json.loads(line)
+        assert "timestamp" in record
+        assert record["timestamp"]  # non-empty
+
+
+def test_symlink_flip_dry_run_no_audit_event(tmp_path):
+    root = tmp_path / "install"
+    root.mkdir()
+    target_dir = root / "versions" / "v1.0.0"
+    target_dir.mkdir(parents=True)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _atomic_symlink_flip(root, target_dir, dry_run=True, audit_log=audit_log)
+
+    assert not audit_log.exists()
+
+
+# ---------------------------------------------------------------------------
+# ADR-005: prune emits NDJSON audit events
+# ---------------------------------------------------------------------------
+
+def test_prune_emits_audit_event(tmp_path):
+    for v in ("v1", "v2", "v3", "v4", "v5"):
+        (tmp_path / "versions" / v).mkdir(parents=True)
+
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    assert audit_log.exists()
+    lines = audit_log.read_text().strip().splitlines()
+    assert len(lines) == 2  # 5 - 3 = 2 pruned
+
+    for line in lines:
+        record = json.loads(line)
+        assert record["event_type"] == "central_install_prune"
+        assert "pruned_version" in record
+        assert record["keep_last_N"] == 3
+        assert "timestamp" in record
+
+
+def test_prune_dry_run_no_audit_event(tmp_path):
+    for v in ("v1", "v2", "v3", "v4", "v5"):
+        (tmp_path / "versions" / v).mkdir(parents=True)
+
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=True, audit_log=audit_log)
+
+    assert not audit_log.exists()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess FileNotFoundError — controlled error, no crash
+# ---------------------------------------------------------------------------
+
+def test_git_not_found_returns_controlled_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="v1.0.0")
+
+    with patch("subprocess.run", side_effect=FileNotFoundError("git not found")):
+        rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "git executable not found in PATH" in captured.err
+
+
+def test_git_not_found_no_exception_raised(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="v1.0.0")
+
+    with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+        try:
+            rc = vnx_update(args)
+        except FileNotFoundError:
+            pytest.fail("FileNotFoundError leaked out of vnx_update — must be caught internally")
+
+    assert rc == 1

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for vnx update subcommand."""
+
+import io
+import sys
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.update import (
+    vnx_update,
+    _resolve_root,
+    _list_version_dirs,
+    _current_target,
+    _prune_old_versions,
+    DEFAULT_KEEP_LAST,
+)
+
+
+def _update_args(*, to_version=None, keep_last=DEFAULT_KEEP_LAST, dry_run=False, rollback=False):
+    return Namespace(
+        to_version=to_version,
+        keep_last=keep_last,
+        dry_run=dry_run,
+        rollback=rollback,
+    )
+
+
+def _capture_update(args) -> tuple[str, str, int]:
+    out_buf = io.StringIO()
+    err_buf = io.StringIO()
+    with redirect_stdout(out_buf):
+        rc = vnx_update(args)
+    return out_buf.getvalue(), "", rc
+
+
+# ---------------------------------------------------------------------------
+# _resolve_root
+# ---------------------------------------------------------------------------
+
+def test_resolve_root_respects_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    assert _resolve_root() == tmp_path.resolve()
+
+
+def test_resolve_root_returns_path_object(monkeypatch):
+    monkeypatch.delenv("VNX_HOME_ROOT", raising=False)
+    result = _resolve_root()
+    assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# _list_version_dirs / _current_target
+# ---------------------------------------------------------------------------
+
+def test_list_version_dirs_empty_root(tmp_path):
+    assert _list_version_dirs(tmp_path) == []
+
+
+def test_list_version_dirs_finds_dirs(tmp_path):
+    (tmp_path / "versions" / "1.0.0-rc1").mkdir(parents=True)
+    (tmp_path / "versions" / "1.0.0-rc2").mkdir(parents=True)
+    dirs = _list_version_dirs(tmp_path)
+    assert len(dirs) == 2
+    assert all(d.is_dir() for d in dirs)
+
+
+def test_current_target_no_symlink(tmp_path):
+    assert _current_target(tmp_path) is None
+
+
+def test_current_target_resolves_symlink(tmp_path):
+    target = tmp_path / "versions" / "1.0.0-rc1"
+    target.mkdir(parents=True)
+    current = tmp_path / "current"
+    current.symlink_to(target)
+    assert _current_target(tmp_path) == target.resolve()
+
+
+# ---------------------------------------------------------------------------
+# _prune_old_versions
+# ---------------------------------------------------------------------------
+
+def test_prune_dry_run_no_deletions(tmp_path):
+    for v in ("v1", "v2", "v3", "v4", "v5"):
+        (tmp_path / "versions" / v).mkdir(parents=True)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _prune_old_versions(tmp_path, keep_last=3, dry_run=True)
+
+    output = buf.getvalue()
+    assert "[dry-run]" in output
+    # All dirs still present
+    assert len(list((tmp_path / "versions").iterdir())) == 5
+
+
+def test_prune_keeps_correct_count(tmp_path):
+    for v in ("v1", "v2", "v3", "v4", "v5"):
+        d = tmp_path / "versions" / v
+        d.mkdir(parents=True)
+
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False)
+    remaining = list((tmp_path / "versions").iterdir())
+    assert len(remaining) == 3
+
+
+# ---------------------------------------------------------------------------
+# vnx_update --dry-run --to edge
+# ---------------------------------------------------------------------------
+
+def test_dry_run_to_edge_prints_actions(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="edge", dry_run=True)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = vnx_update(args)
+
+    output = buf.getvalue()
+    assert rc == 0
+    assert "[dry-run]" in output
+    assert "edge" in output
+
+
+def test_dry_run_no_filesystem_changes(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="1.0.0-rc3", dry_run=True)
+
+    vnx_update(args)
+
+    # No versions/ directory should be created
+    assert not (tmp_path / "versions").exists()
+    assert not (tmp_path / "current").exists()
+
+
+def test_dry_run_schema_warning_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version="edge", dry_run=True)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        vnx_update(args)
+
+    assert "schema-bootstrap" in buf.getvalue().lower() or "central-4" in buf.getvalue().lower()
+
+
+# ---------------------------------------------------------------------------
+# vnx_update error cases
+# ---------------------------------------------------------------------------
+
+def test_missing_to_without_rollback(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(to_version=None, rollback=False)
+
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "--to" in captured.err or "required" in captured.err.lower()
+
+
+def test_rollback_no_current_symlink(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = _update_args(rollback=True)
+
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "rollback" in captured.err.lower() or "symlink" in captured.err.lower()
+
+
+def test_rollback_no_previous_version(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+
+    only_ver = tmp_path / "versions" / "1.0.0-rc1"
+    only_ver.mkdir(parents=True)
+    (tmp_path / "current").symlink_to(only_ver)
+
+    args = _update_args(rollback=True)
+    rc = vnx_update(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "previous" in captured.err.lower()

--- a/tests/test_vnx_cli_version.py
+++ b/tests/test_vnx_cli_version.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for vnx version subcommand."""
+
+import io
+import sys
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.version import vnx_version, _read_version_file, _read_pin
+
+
+def _version_args(project_dir="."):
+    return Namespace(project_dir=str(project_dir))
+
+
+def _capture_version(args) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = vnx_version(args)
+    return buf.getvalue(), rc
+
+
+# ---------------------------------------------------------------------------
+# _read_version_file
+# ---------------------------------------------------------------------------
+
+def test_read_version_file_returns_string():
+    version = _read_version_file()
+    assert isinstance(version, str)
+    assert len(version) > 0
+
+
+def test_read_version_file_matches_repo_version():
+    version_file = REPO_ROOT / "VERSION"
+    if version_file.is_file():
+        expected = version_file.read_text(encoding="utf-8").strip()
+        assert _read_version_file() == expected
+
+
+# ---------------------------------------------------------------------------
+# _read_pin
+# ---------------------------------------------------------------------------
+
+def test_read_pin_no_file(tmp_path):
+    assert _read_pin(tmp_path) == "current"
+
+
+def test_read_pin_with_file(tmp_path):
+    (tmp_path / ".vnx-version").write_text("1.0.0-rc3\n")
+    assert _read_pin(tmp_path) == "1.0.0-rc3 (project)"
+
+
+def test_read_pin_empty_file(tmp_path):
+    (tmp_path / ".vnx-version").write_text("   \n")
+    assert _read_pin(tmp_path) == "current"
+
+
+# ---------------------------------------------------------------------------
+# vnx_version output structure
+# ---------------------------------------------------------------------------
+
+def test_version_exit_code_zero(tmp_path):
+    _, rc = _capture_version(_version_args(tmp_path))
+    assert rc == 0
+
+
+def test_version_prints_vnx_prefix(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    assert output.startswith("VNX ")
+
+
+def test_version_contains_commit_line(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    assert any(line.startswith("Commit:") for line in output.splitlines())
+
+
+def test_version_contains_vnx_home_line(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    assert any(line.startswith("VNX_HOME:") for line in output.splitlines())
+
+
+def test_version_contains_pin_line(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    assert any(line.startswith("Pin:") for line in output.splitlines())
+
+
+def test_version_contains_python_line(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    python_lines = [l for l in output.splitlines() if l.startswith("Python:")]
+    assert len(python_lines) == 1
+    # Must contain major.minor.patch
+    assert f"{sys.version_info.major}.{sys.version_info.minor}" in python_lines[0]
+
+
+def test_version_five_lines_total(tmp_path):
+    output, _ = _capture_version(_version_args(tmp_path))
+    lines = [l for l in output.splitlines() if l.strip()]
+    assert len(lines) == 5
+
+
+def test_version_pin_reflects_vnx_version_file(tmp_path):
+    (tmp_path / ".vnx-version").write_text("1.0.0-rc99")
+    output, _ = _capture_version(_version_args(tmp_path))
+    assert "1.0.0-rc99 (project)" in output

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -5,15 +5,21 @@ Schema-bootstrap (--schema) is a no-op stub until CENTRAL-4 (idempotent schema b
 merges. Atomic symlink flip via os.replace() ensures no partial-swap window.
 """
 
+import fcntl
+import json
 import os
+import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
 VNX_GIT_REMOTE = "https://github.com/Vinix24/vnx-orchestration"
 DEFAULT_KEEP_LAST = 3
+
+_VERSION_RE = re.compile(r"^(edge|latest|v?\d+\.\d+\.\d+(?:-[\w.]+)?)$")
 
 
 def _resolve_root() -> Path:
@@ -29,7 +35,45 @@ def _resolve_root() -> Path:
     return (Path.home() / ".vnx-system-test").expanduser().resolve()
 
 
-def _list_version_dirs(root: Path) -> list[Path]:
+def _resolve_audit_log() -> Path:
+    """Resolve path for central install audit event log."""
+    vnx_data = os.environ.get("VNX_DATA_DIR")
+    if vnx_data:
+        base = Path(vnx_data).expanduser().resolve()
+    else:
+        base = Path.home() / ".vnx-data"
+    return base / "events" / "central_install.ndjson"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _emit_audit_event(
+    event_type: str, fields: dict, audit_log: "Path | None" = None
+) -> None:
+    """Append an audit event to the central install NDJSON log with exclusive locking."""
+    path = audit_log or _resolve_audit_log()
+    record = {"event_type": event_type, "timestamp": _now_iso(), **fields}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    with open(path, "a", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        f.write(line)
+
+
+def _validate_version_name(target: str) -> str:
+    """Validate and return a safe version name.
+
+    Allowed: edge, latest, vX.Y.Z, X.Y.Z, vX.Y.Z-suffix (alphanumeric/./-)
+    Raises ValueError on path traversal, shell metacharacters, or invalid format.
+    """
+    if not _VERSION_RE.match(target):
+        raise ValueError(f"invalid version name: {target!r}")
+    return target
+
+
+def _list_version_dirs(root: Path) -> list:
     versions_dir = root / "versions"
     if not versions_dir.is_dir():
         return []
@@ -39,7 +83,7 @@ def _list_version_dirs(root: Path) -> list[Path]:
     )
 
 
-def _current_target(root: Path) -> Path | None:
+def _current_target(root: Path):
     current = root / "current"
     if current.is_symlink():
         try:
@@ -50,6 +94,9 @@ def _current_target(root: Path) -> Path | None:
 
 
 def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
+    # Belt-and-suspenders: validate before every path join regardless of call site
+    _validate_version_name(target)
+
     versions_dir = root / "versions"
     target_dir = versions_dir / target
 
@@ -77,12 +124,18 @@ def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
     return target_dir
 
 
-def _atomic_symlink_flip(root: Path, target_dir: Path, dry_run: bool) -> None:
+def _atomic_symlink_flip(
+    root: Path, target_dir: Path, dry_run: bool, audit_log: "Path | None" = None
+) -> None:
     current = root / "current"
 
     if dry_run:
         print(f"[dry-run] Would flip symlink: {current} -> {target_dir}")
         return
+
+    from_version = _current_target(root)
+    from_name = from_version.name if from_version else None
+    to_name = target_dir.name
 
     root.mkdir(parents=True, exist_ok=True)
     tmp_link = root / "current.tmp"
@@ -91,11 +144,27 @@ def _atomic_symlink_flip(root: Path, target_dir: Path, dry_run: bool) -> None:
         tmp_link.unlink(missing_ok=True)
 
     tmp_link.symlink_to(target_dir)
+
+    _emit_audit_event(
+        "central_install_update",
+        {"from_version": from_name, "to_version": to_name, "success": False, "phase": "before_flip"},
+        audit_log=audit_log,
+    )
+
     os.replace(tmp_link, current)
+
+    _emit_audit_event(
+        "central_install_update",
+        {"from_version": from_name, "to_version": to_name, "success": True, "phase": "after_flip"},
+        audit_log=audit_log,
+    )
+
     print(f"Activated: {current} -> {target_dir}")
 
 
-def _prune_old_versions(root: Path, keep_last: int, dry_run: bool) -> None:
+def _prune_old_versions(
+    root: Path, keep_last: int, dry_run: bool, audit_log: "Path | None" = None
+) -> None:
     versions = _list_version_dirs(root)
     current = _current_target(root)
 
@@ -110,6 +179,11 @@ def _prune_old_versions(root: Path, keep_last: int, dry_run: bool) -> None:
         if dry_run:
             print(f"[dry-run] Would prune: {version_dir}")
         else:
+            _emit_audit_event(
+                "central_install_prune",
+                {"pruned_version": version_dir.name, "keep_last_N": keep_last},
+                audit_log=audit_log,
+            )
             print(f"Pruning: {version_dir}")
             shutil.rmtree(version_dir)
 
@@ -138,7 +212,7 @@ def _do_rollback(root: Path, dry_run: bool) -> int:
 
 
 def vnx_update(args) -> int:
-    target: str | None = getattr(args, "to_version", None)
+    target: "str | None" = getattr(args, "to_version", None)
     keep_last: int = getattr(args, "keep_last", DEFAULT_KEEP_LAST)
     dry_run: bool = getattr(args, "dry_run", False)
     rollback: bool = getattr(args, "rollback", False)
@@ -155,6 +229,12 @@ def vnx_update(args) -> int:
         print("Error: --to <version> is required (or use --rollback).", file=sys.stderr)
         return 1
 
+    try:
+        target = _validate_version_name(target)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
     # Schema bootstrap: no-op until CENTRAL-4
     print("Warning: schema-bootstrap skipped (no-op until CENTRAL-4 merges).")
 
@@ -162,8 +242,14 @@ def vnx_update(args) -> int:
         target_dir = _fetch_version(root, target, dry_run=dry_run)
         _atomic_symlink_flip(root, target_dir, dry_run=dry_run)
         _prune_old_versions(root, keep_last=keep_last, dry_run=dry_run)
+    except FileNotFoundError:
+        print("Error: git executable not found in PATH", file=sys.stderr)
+        return 1
     except subprocess.CalledProcessError as exc:
         print(f"Error: git operation failed: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"Error: OS error during update: {exc}", file=sys.stderr)
         return 1
 
     if dry_run:

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""vnx update — version-flip for central VNX install (pre-central-install scaffolding).
+
+Schema-bootstrap (--schema) is a no-op stub until CENTRAL-4 (idempotent schema bootstrap)
+merges. Atomic symlink flip via os.replace() ensures no partial-swap window.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+VNX_GIT_REMOTE = "https://github.com/Vinix24/vnx-orchestration"
+DEFAULT_KEEP_LAST = 3
+
+
+def _resolve_root() -> Path:
+    env_root = os.environ.get("VNX_HOME_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+
+    candidate = Path.home() / ".vnx-system"
+    if candidate.is_dir():
+        return candidate
+
+    # Sandbox: central install doesn't exist yet
+    return (Path.home() / ".vnx-system-test").expanduser().resolve()
+
+
+def _list_version_dirs(root: Path) -> list[Path]:
+    versions_dir = root / "versions"
+    if not versions_dir.is_dir():
+        return []
+    return sorted(
+        [d for d in versions_dir.iterdir() if d.is_dir()],
+        key=lambda d: d.stat().st_mtime,
+    )
+
+
+def _current_target(root: Path) -> Path | None:
+    current = root / "current"
+    if current.is_symlink():
+        try:
+            return current.resolve()
+        except OSError:
+            return None
+    return None
+
+
+def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
+    versions_dir = root / "versions"
+    target_dir = versions_dir / target
+
+    if dry_run:
+        print(f"[dry-run] Would clone/pull {VNX_GIT_REMOTE} -> {target_dir}")
+        return target_dir
+
+    versions_dir.mkdir(parents=True, exist_ok=True)
+
+    if target_dir.is_dir():
+        print(f"Pulling {target} in {target_dir}...")
+        subprocess.run(
+            ["git", "-C", str(target_dir), "pull", "--ff-only"],
+            check=True,
+        )
+    else:
+        ref = "main" if target == "edge" else target
+        print(f"Cloning {VNX_GIT_REMOTE} (ref={ref}) -> {target_dir}...")
+        subprocess.run(
+            ["git", "clone", "--branch", ref, "--depth", "1",
+             VNX_GIT_REMOTE, str(target_dir)],
+            check=True,
+        )
+
+    return target_dir
+
+
+def _atomic_symlink_flip(root: Path, target_dir: Path, dry_run: bool) -> None:
+    current = root / "current"
+
+    if dry_run:
+        print(f"[dry-run] Would flip symlink: {current} -> {target_dir}")
+        return
+
+    root.mkdir(parents=True, exist_ok=True)
+    tmp_link = root / "current.tmp"
+
+    if tmp_link.is_symlink() or tmp_link.exists():
+        tmp_link.unlink(missing_ok=True)
+
+    tmp_link.symlink_to(target_dir)
+    os.replace(tmp_link, current)
+    print(f"Activated: {current} -> {target_dir}")
+
+
+def _prune_old_versions(root: Path, keep_last: int, dry_run: bool) -> None:
+    versions = _list_version_dirs(root)
+    current = _current_target(root)
+
+    # Keep the newest keep_last dirs; prune anything older, skip current
+    if len(versions) <= keep_last:
+        return
+
+    to_prune = versions[: len(versions) - keep_last]
+    for version_dir in to_prune:
+        if current and version_dir.resolve() == current.resolve():
+            continue
+        if dry_run:
+            print(f"[dry-run] Would prune: {version_dir}")
+        else:
+            print(f"Pruning: {version_dir}")
+            shutil.rmtree(version_dir)
+
+
+def _do_rollback(root: Path, dry_run: bool) -> int:
+    versions = _list_version_dirs(root)
+    current = _current_target(root)
+
+    if current is None:
+        print("Error: no current symlink — nothing to roll back.", file=sys.stderr)
+        return 1
+
+    previous = [v for v in reversed(versions) if v.resolve() != current.resolve()]
+    if not previous:
+        print("Error: no previous version available for rollback.", file=sys.stderr)
+        return 1
+
+    prev_dir = previous[0]
+    if dry_run:
+        print(f"[dry-run] Would rollback current -> {prev_dir}")
+        return 0
+
+    _atomic_symlink_flip(root, prev_dir, dry_run=False)
+    print(f"Rolled back to: {prev_dir.name}")
+    return 0
+
+
+def vnx_update(args) -> int:
+    target: str | None = getattr(args, "to_version", None)
+    keep_last: int = getattr(args, "keep_last", DEFAULT_KEEP_LAST)
+    dry_run: bool = getattr(args, "dry_run", False)
+    rollback: bool = getattr(args, "rollback", False)
+
+    root = _resolve_root()
+
+    if dry_run:
+        print(f"[dry-run] VNX_HOME_ROOT: {root}")
+
+    if rollback:
+        return _do_rollback(root, dry_run=dry_run)
+
+    if not target:
+        print("Error: --to <version> is required (or use --rollback).", file=sys.stderr)
+        return 1
+
+    # Schema bootstrap: no-op until CENTRAL-4
+    print("Warning: schema-bootstrap skipped (no-op until CENTRAL-4 merges).")
+
+    try:
+        target_dir = _fetch_version(root, target, dry_run=dry_run)
+        _atomic_symlink_flip(root, target_dir, dry_run=dry_run)
+        _prune_old_versions(root, keep_last=keep_last, dry_run=dry_run)
+    except subprocess.CalledProcessError as exc:
+        print(f"Error: git operation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if dry_run:
+        print(f"[dry-run] Update to '{target}' would succeed.")
+    else:
+        print(f"VNX updated to '{target}'.")
+
+    return 0

--- a/vnx_cli/commands/version.py
+++ b/vnx_cli/commands/version.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""vnx version — print VNX version, build info, and resolved paths."""
+
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _read_version_file() -> str:
+    here = Path(__file__).resolve()
+    # vnx_cli/commands/version.py -> vnx_cli/commands -> vnx_cli -> project root
+    for ancestor in [here.parent, here.parent.parent, here.parent.parent.parent]:
+        version_file = ancestor / "VERSION"
+        if version_file.is_file():
+            content = version_file.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    return "unknown"
+
+
+def _git_commit(repo_dir: Path) -> str:
+    try:
+        output = subprocess.check_output(
+            ["git", "-C", str(repo_dir), "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return output or "unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _resolve_vnx_home() -> str:
+    env_val = os.environ.get("VNX_HOME")
+    if env_val:
+        return env_val
+
+    try:
+        scripts_lib = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "lib")
+        if scripts_lib not in sys.path:
+            sys.path.insert(0, scripts_lib)
+        from vnx_paths import resolve_paths  # type: ignore[import]
+        return resolve_paths().get("VNX_HOME", "unresolved")
+    except Exception:
+        return "unresolved"
+
+
+def _read_pin(project_dir: Path) -> str:
+    pin_file = project_dir / ".vnx-version"
+    if pin_file.is_file():
+        pin = pin_file.read_text(encoding="utf-8").strip()
+        if pin:
+            return f"{pin} (project)"
+    return "current"
+
+
+def vnx_version(args) -> int:
+    version = _read_version_file()
+
+    # Resolve project root from module location for git
+    repo_dir = Path(__file__).resolve().parent.parent.parent
+    commit = _git_commit(repo_dir)
+
+    vnx_home = _resolve_vnx_home()
+
+    project_dir = Path(getattr(args, "project_dir", ".")).resolve()
+    pin = _read_pin(project_dir)
+
+    py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    plat = platform.system().lower()
+
+    print(f"VNX {version}")
+    print(f"Commit: {commit}")
+    print(f"VNX_HOME: {vnx_home}")
+    print(f"Pin: {pin}")
+    print(f"Python: {py_ver} {plat}")
+
+    return 0

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -105,6 +105,47 @@ def main() -> None:
         help="pool subcommand and arguments",
     )
 
+    # version subcommand
+    version_parser = subparsers.add_parser(
+        "version",
+        help="print VNX version, commit, VNX_HOME, pin, and Python info",
+    )
+    version_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory to check for .vnx-version pin (default: current directory)",
+    )
+
+    # update subcommand
+    update_parser = subparsers.add_parser(
+        "update",
+        help="flip active VNX version in central install (pre-central-install scaffolding)",
+    )
+    update_parser.add_argument(
+        "--to",
+        dest="to_version",
+        metavar="VERSION",
+        help="target version (e.g. '1.0.0-rc3' or 'edge')",
+    )
+    update_parser.add_argument(
+        "--keep-last",
+        type=int,
+        default=3,
+        metavar="N",
+        help="number of old versions to retain (default: 3)",
+    )
+    update_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print planned actions without making filesystem changes",
+    )
+    update_parser.add_argument(
+        "--rollback",
+        action="store_true",
+        help="revert current symlink to the previous version",
+    )
+
     args = parser.parse_args()
 
     if args.command == "init":
@@ -126,6 +167,14 @@ def main() -> None:
     elif args.command == "pool":
         from vnx_cli.commands.pool import main as pool_main
         sys.exit(pool_main(argv=getattr(args, "pool_args", None) or None))
+
+    elif args.command == "version":
+        from vnx_cli.commands.version import vnx_version
+        sys.exit(vnx_version(args))
+
+    elif args.command == "update":
+        from vnx_cli.commands.update import vnx_update
+        sys.exit(vnx_update(args))
 
     else:
         parser.print_help()


### PR DESCRIPTION
## Summary

- Implements pre-migration must-have **#3** (CENTRAL-3) from `/Users/vincentvandeth/.claude/plans/cozy-tumbling-leaf.md`
- `vnx version` — prints VERSION, git commit (HEAD short hash), VNX_HOME path, project pin (`.vnx-version`), Python version + platform
- `vnx update` — atomic symlink flip for future central install; supports `--to <version>`, `--keep-last N`, `--dry-run`, `--rollback`; schema-bootstrap call is **no-op stub** until CENTRAL-4 (idempotent schema bootstrap) merges

## Notes

- `vnx update --to` schema-bootstrap step is intentionally skipped with a warning until CENTRAL-4 merges
- Sandbox root (`~/.vnx-system-test/`) used automatically when no central install (`~/.vnx-system/`) exists
- Atomic symlink flip uses `os.replace()` for no-partial-swap guarantee
- 27 new tests, all passing

## Test plan

- [x] `python3 -m vnx_cli.main version` — 5-line output, exit 0
- [x] `python3 -m vnx_cli.main update --dry-run --to edge` — prints actions, no filesystem changes
- [x] `pytest tests/test_vnx_cli_version.py tests/test_vnx_cli_update.py -v` — 27/27 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)