### PR TITLE
feat(vnx_paths): .vnx-overrides resolver for per-project central-install customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,13 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ### Added
 - feat(cli): `vnx version` subcommand prints VERSION, commit, VNX_HOME, pin, Python+platform (pre-central-install support)
 - feat(cli): `vnx update --to <ver> --keep-last N --dry-run --rollback` subcommand for future central install version-flip (pre-central-install scaffolding)
+- feat(vnx_paths): override-resolver `_resolve_overrides_dir()` + `get_skill_path()` — per-project `.vnx-overrides/skills,schemas,configs/` directory takes precedence over central VNX_HOME. Enables mission-control-style custom assets without central pollution. (Pre-centralization must-have #5)
+- feat(pyproject): `vnx` console_script entry-point + requires-python `>=3.11,<3.14`. Pipx-installable. (Pre-centralization must-have #6)
+- feat(schema): migration 0021 `central_install_pins` + `central_install_events` tables met `scripts/lib/central_install_db.py` helper. Bookkeeping voor project pin tracking + install/update/rollback event history. Pre-centralization must-have #10.
 
 ### Fixed
 - fix(cli-update): path-traversal validation + ADR-005 audit events for symlink-flip + prune + git FileNotFoundError handling (codex blocker + 3 advisories)
 - fix(pyproject): build-backend `setuptools.backends._legacy` → `setuptools.build_meta`. Wheel build now succeeds via `python -m build`.
-
-### Added
-- feat(pyproject): `vnx` console_script entry-point + requires-python `>=3.11,<3.14`. Pipx-installable. (Pre-centralization must-have #6)
-- feat(schema): migration 0021 `central_install_pins` + `central_install_events` tables met `scripts/lib/central_install_db.py` helper. Bookkeeping voor project pin tracking + install/update/rollback event history. Pre-centralization must-have #10.
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ### Fixed
 - fix(cli-update): path-traversal validation + ADR-005 audit events for symlink-flip + prune + git FileNotFoundError handling (codex blocker + 3 advisories)
 - fix(pyproject): build-backend `setuptools.backends._legacy` → `setuptools.build_meta`. Wheel build now succeeds via `python -m build`.
+- fix(vnx_paths): validate skill_name + resolved-path confinement check in get_skill_path (codex path-traversal blocker)
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import warnings
 from pathlib import Path
@@ -283,6 +284,30 @@ def resolve_central_data_dir(project_id: str) -> Path:
     return Path.home() / ".vnx-data" / project_id
 
 
+_SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_skill_name(skill_name: str) -> str:
+    """Validate skill_name is a safe bare name with no path traversal.
+
+    Raises:
+        ValueError: on empty string, path separators, dots, or any char
+                    outside [A-Za-z0-9_-].
+    """
+    if not skill_name:
+        raise ValueError(f"invalid skill name: {skill_name!r}")
+    if not _SKILL_NAME_RE.match(skill_name):
+        raise ValueError(f"invalid skill name: {skill_name!r}")
+    return skill_name
+
+
+def _confine_skill_path(resolved: Path, skill_root: Path) -> None:
+    """Raise ValueError if resolved path escapes skill_root."""
+    root_str = str(skill_root.resolve()) + os.sep
+    if not str(resolved).startswith(root_str):
+        raise ValueError(f"resolved path escapes skill root: {resolved}")
+
+
 def get_skill_path(skill_name: str, project_root: Optional[Path] = None) -> Path:
     """Return the resolved Path for a named skill directory.
 
@@ -291,19 +316,28 @@ def get_skill_path(skill_name: str, project_root: Optional[Path] = None) -> Path
     2. VNX_HOME/skills/<skill_name>/
 
     Raises:
+        ValueError: if skill_name fails validation or resolved path escapes skill root.
         FileNotFoundError: if the skill directory is not found in any location.
     """
+    skill_name = _validate_skill_name(skill_name)
+
     if project_root is not None:
         overrides_dir = _resolve_overrides_dir(Path(project_root))
         if overrides_dir is not None:
-            override_skill = overrides_dir / "skills" / skill_name
+            skill_root = overrides_dir / "skills"
+            override_skill = skill_root / skill_name
+            resolved = override_skill.resolve()
+            _confine_skill_path(resolved, skill_root)
             if override_skill.is_dir():
-                return override_skill.resolve()
+                return resolved
 
     vnx_home = _resolve_vnx_home()
-    central_skill = vnx_home / "skills" / skill_name
+    skill_root = vnx_home / "skills"
+    central_skill = skill_root / skill_name
+    resolved = central_skill.resolve()
+    _confine_skill_path(resolved, skill_root)
     if central_skill.is_dir():
-        return central_skill.resolve()
+        return resolved
 
     raise FileNotFoundError(
         f"Skill {skill_name!r} not found in overrides or central VNX_HOME ({vnx_home})"

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import warnings
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 # Self-bootstrap: ensure scripts/lib is on sys.path so sibling imports work
 # regardless of whether the caller set up the repo root or lib dir.
@@ -24,6 +24,14 @@ if _lib not in _sys.path:
 from vnx_ids import PROJECT_ID_RE as _PROJECT_ID_RE
 
 log = logging.getLogger(__name__)
+
+
+def _resolve_overrides_dir(project_root: Path) -> Optional[Path]:
+    """Return project_root/.vnx-overrides if it exists as a directory, else None."""
+    candidate = project_root / ".vnx-overrides"
+    if candidate.is_dir():
+        return candidate
+    return None
 
 
 def _resolve_vnx_home() -> Path:
@@ -156,11 +164,17 @@ def resolve_paths() -> Dict[str, str]:
     if "VNX_SKILLS_DIR" in os.environ:
         paths["VNX_SKILLS_DIR"] = os.environ["VNX_SKILLS_DIR"]
     else:
-        claude_skills = project_root / ".claude" / "skills"
-        if claude_skills.is_dir():
-            paths["VNX_SKILLS_DIR"] = str(claude_skills)
+        # Resolver order: .vnx-overrides/skills > .claude/skills > VNX_HOME/skills
+        overrides_dir = _resolve_overrides_dir(project_root)
+        overrides_skills = overrides_dir / "skills" if overrides_dir is not None else None
+        if overrides_skills is not None and overrides_skills.is_dir():
+            paths["VNX_SKILLS_DIR"] = str(overrides_skills)
         else:
-            paths["VNX_SKILLS_DIR"] = str(vnx_home / "skills")
+            claude_skills = project_root / ".claude" / "skills"
+            if claude_skills.is_dir():
+                paths["VNX_SKILLS_DIR"] = str(claude_skills)
+            else:
+                paths["VNX_SKILLS_DIR"] = str(vnx_home / "skills")
 
     return paths
 
@@ -267,6 +281,33 @@ def resolve_central_data_dir(project_id: str) -> Path:
             f"(no dots, slashes, leading dashes, or special chars): {project_id!r}"
         )
     return Path.home() / ".vnx-data" / project_id
+
+
+def get_skill_path(skill_name: str, project_root: Optional[Path] = None) -> Path:
+    """Return the resolved Path for a named skill directory.
+
+    Resolution order:
+    1. project_root/.vnx-overrides/skills/<skill_name>/  (if project_root supplied)
+    2. VNX_HOME/skills/<skill_name>/
+
+    Raises:
+        FileNotFoundError: if the skill directory is not found in any location.
+    """
+    if project_root is not None:
+        overrides_dir = _resolve_overrides_dir(Path(project_root))
+        if overrides_dir is not None:
+            override_skill = overrides_dir / "skills" / skill_name
+            if override_skill.is_dir():
+                return override_skill.resolve()
+
+    vnx_home = _resolve_vnx_home()
+    central_skill = vnx_home / "skills" / skill_name
+    if central_skill.is_dir():
+        return central_skill.resolve()
+
+    raise FileNotFoundError(
+        f"Skill {skill_name!r} not found in overrides or central VNX_HOME ({vnx_home})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_vnx_paths_overrides.py
+++ b/tests/test_vnx_paths_overrides.py
@@ -9,7 +9,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
-from vnx_paths import _resolve_overrides_dir, get_skill_path, resolve_paths
+from vnx_paths import _resolve_overrides_dir, _validate_skill_name, get_skill_path, resolve_paths
 
 
 class TestResolveOverridesDir:
@@ -40,6 +40,93 @@ class TestResolveOverridesDir:
         result = _resolve_overrides_dir(tmp_path)
         assert result is not None
         assert (result / "schemas" / "v10.sql").exists()
+
+
+class TestValidateSkillName:
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("")
+
+    def test_dot_dot_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("..")
+
+    def test_path_traversal_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("../etc/passwd")
+
+    def test_slash_in_name_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("foo/../../bar")
+
+    def test_absolute_path_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("/absolute/path")
+
+    def test_dot_in_name_raises(self):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            _validate_skill_name("some.skill")
+
+    def test_valid_alphanum_passes(self):
+        assert _validate_skill_name("mySKILL123") == "mySKILL123"
+
+    def test_valid_underscore_passes(self):
+        assert _validate_skill_name("my_skill") == "my_skill"
+
+    def test_valid_dash_passes(self):
+        assert _validate_skill_name("skill-with-dash") == "skill-with-dash"
+
+
+class TestGetSkillPathTraversal:
+    def test_traversal_in_name_raises_value_error(self, tmp_path, monkeypatch):
+        """get_skill_path('../etc/passwd') → ValueError."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        with pytest.raises(ValueError, match="invalid skill name"):
+            get_skill_path("../etc/passwd")
+
+    def test_foo_dotdot_bar_raises(self, tmp_path, monkeypatch):
+        """get_skill_path('foo/../../bar') → ValueError."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        with pytest.raises(ValueError, match="invalid skill name"):
+            get_skill_path("foo/../../bar")
+
+    def test_absolute_path_raises(self, tmp_path, monkeypatch):
+        """get_skill_path('/absolute/path') → ValueError."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        with pytest.raises(ValueError, match="invalid skill name"):
+            get_skill_path("/absolute/path")
+
+    def test_empty_name_raises(self, tmp_path, monkeypatch):
+        """get_skill_path('') → ValueError."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        with pytest.raises(ValueError, match="invalid skill name"):
+            get_skill_path("")
+
+    def test_valid_name_with_central_skill(self, tmp_path, monkeypatch):
+        """get_skill_path('normal_skill_name') succeeds when skill exists."""
+        vnx_home = tmp_path / "vnx-home"
+        skill_dir = vnx_home / "skills" / "normal_skill_name"
+        skill_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        result = get_skill_path("normal_skill_name")
+        assert result == skill_dir.resolve()
+
+    def test_valid_dash_name_with_central_skill(self, tmp_path, monkeypatch):
+        """get_skill_path('skill-with-dash') succeeds when skill exists."""
+        vnx_home = tmp_path / "vnx-home"
+        skill_dir = vnx_home / "skills" / "skill-with-dash"
+        skill_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        result = get_skill_path("skill-with-dash")
+        assert result == skill_dir.resolve()
 
 
 class TestGetSkillPath:

--- a/tests/test_vnx_paths_overrides.py
+++ b/tests/test_vnx_paths_overrides.py
@@ -1,0 +1,168 @@
+"""Tests for _resolve_overrides_dir() and get_skill_path() added in PR-CENTRAL-5."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from vnx_paths import _resolve_overrides_dir, get_skill_path, resolve_paths
+
+
+class TestResolveOverridesDir:
+    def test_no_overrides_dir_returns_none(self, tmp_path):
+        """No .vnx-overrides directory → returns None."""
+        assert _resolve_overrides_dir(tmp_path) is None
+
+    def test_overrides_dir_exists_returns_path(self, tmp_path):
+        """Present .vnx-overrides directory → returns the Path."""
+        overrides = tmp_path / ".vnx-overrides"
+        overrides.mkdir()
+        result = _resolve_overrides_dir(tmp_path)
+        assert result == overrides
+
+    def test_overrides_dir_is_file_returns_none(self, tmp_path):
+        """File named .vnx-overrides is not a directory → returns None."""
+        (tmp_path / ".vnx-overrides").write_text("not a dir")
+        assert _resolve_overrides_dir(tmp_path) is None
+
+    def test_schemas_accessible_under_overrides_dir(self, tmp_path):
+        """Schemas reachable via the returned overrides dir."""
+        overrides = tmp_path / ".vnx-overrides"
+        schemas = overrides / "schemas"
+        schemas.mkdir(parents=True)
+        schema_file = schemas / "v10.sql"
+        schema_file.write_text("-- v10")
+
+        result = _resolve_overrides_dir(tmp_path)
+        assert result is not None
+        assert (result / "schemas" / "v10.sql").exists()
+
+
+class TestGetSkillPath:
+    def test_no_overrides_fallback_to_central(self, tmp_path, monkeypatch):
+        """No .vnx-overrides → central VNX_HOME/skills/<name> is returned."""
+        vnx_home = tmp_path / "vnx-home"
+        central_skill = vnx_home / "skills" / "my-skill"
+        central_skill.mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        result = get_skill_path("my-skill", project_root)
+        assert result == central_skill.resolve()
+
+    def test_override_skill_resolved_from_overrides(self, tmp_path, monkeypatch):
+        """.vnx-overrides/skills/custom_skill/ → resolved from overrides."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+
+        project_root = tmp_path / "project"
+        override_skill = project_root / ".vnx-overrides" / "skills" / "custom-skill"
+        override_skill.mkdir(parents=True)
+
+        result = get_skill_path("custom-skill", project_root)
+        assert result == override_skill.resolve()
+
+    def test_overrides_wins_over_central(self, tmp_path, monkeypatch):
+        """Skill in both locations → overrides version wins."""
+        vnx_home = tmp_path / "vnx-home"
+        central_skill = vnx_home / "skills" / "shared-skill"
+        central_skill.mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+
+        project_root = tmp_path / "project"
+        override_skill = project_root / ".vnx-overrides" / "skills" / "shared-skill"
+        override_skill.mkdir(parents=True)
+
+        result = get_skill_path("shared-skill", project_root)
+        assert result == override_skill.resolve()
+        assert result != central_skill.resolve()
+
+    def test_unknown_skill_raises_file_not_found(self, tmp_path, monkeypatch):
+        """Skill not found anywhere → FileNotFoundError."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
+            get_skill_path("nonexistent", project_root)
+
+    def test_no_project_root_falls_back_to_central(self, tmp_path, monkeypatch):
+        """project_root=None → only central VNX_HOME is checked."""
+        vnx_home = tmp_path / "vnx-home"
+        central_skill = vnx_home / "skills" / "central-only"
+        central_skill.mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+
+        result = get_skill_path("central-only")
+        assert result == central_skill.resolve()
+
+
+class TestResolvePathsSkillsDir:
+    """Tests for resolve_paths() VNX_SKILLS_DIR resolution.
+
+    resolve_paths() derives project_root as vnx_home.parent (when no git root).
+    So overrides/claude skills must be placed under tmp_path (vnx_home.parent),
+    not a separate project subdir.
+    """
+
+    def test_overrides_skills_takes_priority_over_claude_skills(self, tmp_path, monkeypatch):
+        """VNX_SKILLS_DIR resolution: .vnx-overrides/skills > .claude/skills."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        monkeypatch.delenv("VNX_SKILLS_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+
+        # project_root = vnx_home.parent = tmp_path (how resolve_paths() derives it)
+        overrides_skills = tmp_path / ".vnx-overrides" / "skills"
+        overrides_skills.mkdir(parents=True)
+        claude_skills = tmp_path / ".claude" / "skills"
+        claude_skills.mkdir(parents=True)
+
+        paths = resolve_paths()
+        assert paths["VNX_SKILLS_DIR"] == str(overrides_skills)
+
+    def test_no_overrides_falls_back_to_claude_skills(self, tmp_path, monkeypatch):
+        """Without overrides dir, .claude/skills is used when present."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        monkeypatch.delenv("VNX_SKILLS_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+
+        # project_root = vnx_home.parent = tmp_path
+        claude_skills = tmp_path / ".claude" / "skills"
+        claude_skills.mkdir(parents=True)
+
+        paths = resolve_paths()
+        assert paths["VNX_SKILLS_DIR"] == str(claude_skills)
+
+    def test_env_var_overrides_all(self, tmp_path, monkeypatch):
+        """VNX_SKILLS_DIR env var takes priority over everything."""
+        vnx_home = tmp_path / "vnx-home"
+        (vnx_home / "skills").mkdir(parents=True)
+        monkeypatch.setenv("VNX_HOME", str(vnx_home))
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+
+        explicit_skills = tmp_path / "explicit-skills"
+        explicit_skills.mkdir()
+        monkeypatch.setenv("VNX_SKILLS_DIR", str(explicit_skills))
+
+        # overrides dir exists but env var wins
+        (tmp_path / ".vnx-overrides" / "skills").mkdir(parents=True)
+
+        paths = resolve_paths()
+        assert paths["VNX_SKILLS_DIR"] == str(explicit_skills)


### PR DESCRIPTION
## Summary

- Adds `_resolve_overrides_dir(project_root)` — returns `project_root/.vnx-overrides` if it exists as a directory, else None
- Updates `VNX_SKILLS_DIR` resolution in `resolve_paths()`: overrides/skills > .claude/skills > VNX_HOME/skills
- Adds public `get_skill_path(skill_name, project_root=None)` for per-skill resolution with overrides precedence; raises `FileNotFoundError` when not found anywhere
- 12 new tests in `tests/test_vnx_paths_overrides.py`; 47 existing vnx_paths tests remain green

## Test plan

- [x] `pytest tests/test_vnx_paths_overrides.py -v` → 12 passed
- [x] `pytest tests/test_vnx_paths_central.py tests/test_vnx_paths_traversal.py tests/test_vnx_paths_shell_worktree.py -v` → 47 passed, no regressions

Dispatch-ID: central-5-override-resolver-20260517-222743

🤖 Generated with [Claude Code](https://claude.ai/claude-code)