### PR TITLE
feat(install): install-central.sh for centralized VNX install with project-pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - fix(intelligence): catalogus-hygiene — filter governance-event success_patterns (81.6% noise) + memory_consolidation antipatterns (26% noise) at source; recency-decay (0.95^weeks) op confidence; migration invalidates existing noise. Addresses Sonnet audit BLOCKER #2 (intelligence +30pp claim artefact). PR-IH-1 per intelligence-injection-quality-research.
 - fix(intelligence-hygiene): replace ALTER TABLE IF NOT EXISTS (invalid SQLite < 3.37) with Python idempotent column-add via PRAGMA table_info check in quality_db_init.py (codex_gate blocker audit-ih-1-fixforward)
 - fix(intelligence-hygiene): parse ISO timestamps with timezone via fromisoformat + astimezone(UTC) — raw[:26] truncation was dropping tz offsets, skipping recency decay for those rows
+- fix(install-central): pin validation + resolved-path confinement in shim (path-traversal blocker)
+- fix(install-central): atomic rollback restore of previous symlink target (data-integrity blocker)
+- fix(install-central): atomic shim install via mktemp + mv (data-integrity blocker)
+- fix(install-central): macOS-safe atomic symlink swap via tempfile + rename (advisory)
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - fix(install-central): atomic rollback restore of previous symlink target (data-integrity blocker)
 - fix(install-central): atomic shim install via mktemp + mv (data-integrity blocker)
 - fix(install-central): macOS-safe atomic symlink swap via tempfile + rename (advisory)
+- fix(install-central): unlink+ln fallback voor macOS atomic symlink swap (codex edge-case blocker: mv -f kan dest-symlink-naar-dir verkeerd interpreteren)
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - fix(install-central): atomic shim install via mktemp + mv (data-integrity blocker)
 - fix(install-central): macOS-safe atomic symlink swap via tempfile + rename (advisory)
 - fix(install-central): unlink+ln fallback voor macOS atomic symlink swap (codex edge-case blocker: mv -f kan dest-symlink-naar-dir verkeerd interpreteren)
+- fix(install-central): atomic symlink swap via tempfile + mv (no rm-before-replace); cleanup_on_failure raises EX_SOFTWARE on rollback failure (codex round-2 atomicity blocker)
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - refactor(dispatch): extract `_apply_runtime_overrides` from delivery.py + recovery.py to shared `runtime_overrides.py` module (Kimi audit duplication finding). Eliminates copy-paste drift.
 
 ### Added
+- feat(install): `install-central.sh` for centralized VNX install (apart van embedded `install.sh`) — clones to `~/.vnx-system/versions/<v>/`, atomic symlink-swap, project-pin via `.vnx-version`. Pre-centralization must-have #7.
 - feat(intelligence): A/B random-skip framework (V5 per intelligence-injection-quality-research). Adds `ab_arm` column to intelligence_injections + 10% control-arm skip via `VNX_INTEL_AB_TEST=1` env flag + weekly lift report (`scripts/intelligence_ab_report.py`). Enables verifiable +30pp lift measurement. Audit BLOCKER #2 closes-the-loop PR-IH-3.
 - feat(intelligence): fine-grained task_class subclassing (coding_sql/runtime/intelligence/test/ui) + active scope_tags matching via VNX_INTEL_STRICT_SCOPE env-flag. Selector kan SQL-werk SQL-kennis geven ipv generieke pool. (Audit BLOCKER #2 follow-up PR-IH-2)
 - feat(cli): `vnx version` subcommand prints VERSION, commit, VNX_HOME, pin, Python+platform (pre-central-install support)

--- a/docs/operations/install-central-runbook.md
+++ b/docs/operations/install-central-runbook.md
@@ -1,0 +1,140 @@
+# install-central.sh Operator Runbook
+
+Central VNX install for operators running multiple projects from a shared system install.
+Distinct from `install.sh` (per-project embedded install for open-source users).
+
+## When to use which installer
+
+| Scenario | Script |
+|---|---|
+| Open-source user, one project, self-contained | `install.sh` |
+| Operator with multiple projects, shared binary, project pinning | `install-central.sh` |
+| CI/CD environment needing reproducible version pin | `install-central.sh --version <pin>` |
+
+`install.sh` copies VNX into `.vnx/` inside the project. `install-central.sh` installs VNX once to `~/.vnx-system/versions/<version>/` and exposes a shim (`~/.vnx-system/bin/vnx`) that reads `.vnx-version` from the project root.
+
+## Pre-flight checklist
+
+Before running `install-central.sh`:
+
+- [ ] Python >= 3.11 and < 3.14 available: `python3 --version`
+- [ ] git available: `git --version`
+- [ ] sqlite3 available: `sqlite3 --version`
+- [ ] At least 500MB free disk in target parent: `df -h ~`
+- [ ] Network access to `github.com` (for clone) unless `--source` points to a local mirror
+- [ ] Target directory (`~/.vnx-system` by default) is writable
+
+Run `--dry-run` first to validate without side effects:
+
+```bash
+bash install-central.sh --dry-run
+```
+
+## Installation
+
+```bash
+# Default: latest stable to ~/.vnx-system
+bash install-central.sh
+
+# Pin a specific version
+bash install-central.sh --version v1.0.0-rc2
+
+# Custom install root
+bash install-central.sh --target /opt/vnx-system --version v1.0.0-rc2
+
+# Internal mirror
+bash install-central.sh --source https://internal.git/vnx-orchestration --version v1.0.0-rc2
+```
+
+After install, add the shim to PATH:
+
+```bash
+export PATH="${PATH}:${HOME}/.vnx-system/bin"
+```
+
+Add to `~/.zshrc` or `~/.bashrc` to persist.
+
+## Project pinning via .vnx-version
+
+Each project can pin a specific installed version:
+
+```bash
+echo 'v1.0.0-rc2' > /path/to/project/.vnx-version
+```
+
+The shim reads `.vnx-version` by traversing up from `cwd`. When no pin is found, it falls back to `~/.vnx-system/current` (the last installed version).
+
+Installing a new version does NOT break pinned projects. Old versions remain at `~/.vnx-system/versions/`.
+
+## Upgrading
+
+```bash
+# Install new version (keeps old versions)
+bash install-central.sh --version v1.0.1
+
+# Update project pin
+echo 'v1.0.1' > /path/to/project/.vnx-version
+```
+
+The `current` symlink points to the newly installed version after each successful run.
+
+## Rollback procedure
+
+If the new version causes issues, roll back the symlink manually:
+
+```bash
+# List installed versions
+ls ~/.vnx-system/versions/
+
+# Re-point current to a previous version
+ln -sfn ~/.vnx-system/versions/v1.0.0-rc1 ~/.vnx-system/current
+```
+
+Or re-run the installer with the previous version:
+
+```bash
+bash install-central.sh --version v1.0.0-rc1
+```
+
+Project pins in `.vnx-version` are unaffected and continue to work.
+
+## Troubleshooting
+
+**`git clone failed`**
+
+- Verify network access to the source URL
+- Check the version tag exists: `git ls-remote --tags https://github.com/Vinix24/vnx-orchestration`
+- Use `--source` to point to a local clone: `--source /path/to/local/vnx-orchestration`
+
+**`Pinned version X not installed`**
+
+The shim found `.vnx-version` but that version is not in `~/.vnx-system/versions/`. Run:
+
+```bash
+bash install-central.sh --version <pin>
+```
+
+**`Insufficient disk space`**
+
+Free at least 500MB in the target parent directory. Each version install is roughly 50-100MB.
+
+**`Python version check failed`**
+
+Install or activate Python 3.11-3.13. With pyenv:
+
+```bash
+pyenv install 3.11.9
+pyenv global 3.11.9
+```
+
+**Schema bootstrap check non-zero**
+
+The install succeeded but `quality_db_init.py --check-only` returned non-zero. Run it manually to inspect:
+
+```bash
+python3 ~/.vnx-system/current/scripts/quality_db_init.py
+```
+
+**Idempotency: re-running with the same version**
+
+Re-running `install-central.sh` with the same `--version` skips the clone (`already installed` message) and re-runs symlink swap and shim install. Safe to run multiple times.

--- a/install-central.sh
+++ b/install-central.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-central.sh — Centralized VNX install to ~/.vnx-system/versions/<version>/
+# Separate from install.sh (embedded/open-source per-project installer).
+#
+# Layout created:
+#   ~/.vnx-system/
+#     versions/v1.0.0-rc2/     (immutable, content-addressed install)
+#     current -> versions/...   (symlink, atomic switch)
+#     bin/vnx                   (shim that reads .vnx-version from project root)
+
+VERSION="v1.0.0-rc2"
+TARGET_DIR="${HOME}/.vnx-system"
+SOURCE_URL="https://github.com/Vinix24/vnx-orchestration"
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      TARGET_DIR="$2"; shift 2 ;;
+    --target=*)
+      TARGET_DIR="${1#*=}"; shift ;;
+    --version)
+      VERSION="$2"; shift 2 ;;
+    --version=*)
+      VERSION="${1#*=}"; shift ;;
+    --source)
+      SOURCE_URL="$2"; shift 2 ;;
+    --source=*)
+      SOURCE_URL="${1#*=}"; shift ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    -h|--help)
+      cat <<HELP
+Usage: install-central.sh [OPTIONS]
+
+Options:
+  --target <dir>    Install root (default: ~/.vnx-system)
+  --version <ver>   Version to install (default: v1.0.0-rc2)
+  --source <url>    Git source URL (default: github.com/Vinix24/vnx-orchestration)
+  --dry-run         Print steps without touching filesystem
+  -h, --help        Show this help
+
+Examples:
+  bash install-central.sh
+  bash install-central.sh --version v1.0.0-rc2 --dry-run
+  bash install-central.sh --target /opt/vnx-system --version v1.0.0-rc2
+HELP
+      exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()    { echo "[install-central] $*"; }
+success() { echo "[install-central] [ok] $*"; }
+warn()    { echo "[install-central] [!] $*" >&2; }
+die()     { echo "[install-central] [x] $*" >&2; exit 1; }
+
+run() {
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# check_prereqs — fail-fast on missing dependencies
+# ---------------------------------------------------------------------------
+check_prereqs() {
+  info "Checking prerequisites..."
+
+  for cmd in git sqlite3 python3; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      die "Required command not found: $cmd"
+    fi
+  done
+
+  # Python version check: >= 3.11 and < 3.14
+  local py_ver
+  py_ver=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+  local py_major py_minor
+  py_major=$(echo "$py_ver" | cut -d. -f1)
+  py_minor=$(echo "$py_ver" | cut -d. -f2)
+
+  if [ "$py_major" -lt 3 ] || { [ "$py_major" -eq 3 ] && [ "$py_minor" -lt 11 ]; }; then
+    die "Python >= 3.11 required, found ${py_ver}"
+  fi
+  if [ "$py_major" -eq 3 ] && [ "$py_minor" -ge 14 ]; then
+    die "Python < 3.14 required, found ${py_ver}"
+  fi
+
+  # Disk space: require >= 500 MB free in target parent
+  local target_parent
+  target_parent=$(dirname "$TARGET_DIR")
+  if [ -d "$target_parent" ]; then
+    local free_kb
+    free_kb=$(df -k "$target_parent" 2>/dev/null | awk 'NR==2{print $4}')
+    if [ -n "$free_kb" ] && [ "$free_kb" -lt 512000 ]; then
+      die "Insufficient disk space: ${free_kb}KB free in ${target_parent}, need >= 500MB"
+    fi
+  fi
+
+  success "Prerequisites OK (python ${py_ver}, git, sqlite3)"
+}
+
+# ---------------------------------------------------------------------------
+# clone_version — idempotent git clone to versions/<version>/
+# ---------------------------------------------------------------------------
+clone_version() {
+  local version_dir="${TARGET_DIR}/versions/${VERSION}"
+
+  if [ -d "$version_dir" ]; then
+    info "Version ${VERSION} already installed at ${version_dir} — skipping clone"
+    return 0
+  fi
+
+  info "Cloning ${SOURCE_URL} @ ${VERSION} -> ${version_dir}..."
+  run mkdir -p "$(dirname "$version_dir")"
+
+  local clone_url="$SOURCE_URL"
+  # Normalize: add https:// if not present
+  if [[ "$clone_url" != https://* ]] && [[ "$clone_url" != git@* ]] && [[ "$clone_url" != http://* ]]; then
+    clone_url="https://${clone_url}"
+  fi
+
+  if [ "$DRY_RUN" = "false" ]; then
+    local tmp_dir="${version_dir}.tmp"
+    git clone --depth 1 --branch "$VERSION" "$clone_url" "$tmp_dir" \
+      || die "git clone failed for ${clone_url} @ ${VERSION}"
+    mv "$tmp_dir" "$version_dir"
+  else
+    echo "  [dry-run] git clone --depth 1 --branch ${VERSION} ${clone_url} ${version_dir}"
+  fi
+
+  success "Cloned ${VERSION} to ${version_dir}"
+}
+
+# ---------------------------------------------------------------------------
+# swap_symlink — atomic current -> versions/<version> switch
+# ---------------------------------------------------------------------------
+swap_symlink() {
+  local version_dir="${TARGET_DIR}/versions/${VERSION}"
+  local current_link="${TARGET_DIR}/current"
+
+  info "Swapping symlink: ${current_link} -> ${version_dir}..."
+  run mkdir -p "${TARGET_DIR}/versions"
+
+  if [ "$DRY_RUN" = "false" ]; then
+    local tmp_link="${TARGET_DIR}/current.tmp.$$"
+    ln -s "$version_dir" "$tmp_link"
+    # mv -T is Linux-specific; use portable approach for macOS compatibility
+    if mv -T "$tmp_link" "$current_link" 2>/dev/null; then
+      : # Linux mv -T succeeded
+    else
+      # macOS: ln -sfn is atomic enough for our needs
+      rm -f "$tmp_link"
+      ln -sfn "$version_dir" "$current_link"
+    fi
+  else
+    echo "  [dry-run] ln -sfn ${version_dir} ${current_link}"
+  fi
+
+  success "Symlink updated: ${current_link} -> ${version_dir}"
+}
+
+# ---------------------------------------------------------------------------
+# install_shim — ~/.vnx-system/bin/vnx project-pin shim
+# ---------------------------------------------------------------------------
+install_shim() {
+  local shim_dir="${TARGET_DIR}/bin"
+  local shim_path="${shim_dir}/vnx"
+
+  info "Installing shim at ${shim_path}..."
+  run mkdir -p "$shim_dir"
+
+  local shim_content
+  shim_content=$(cat <<'SHIM'
+#!/usr/bin/env bash
+# VNX project-pin shim — reads .vnx-version from project root (cwd traversal)
+set -euo pipefail
+
+VNX_SYSTEM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Traverse up from cwd to find .vnx-version
+find_version_pin() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.vnx-version" ]; then
+      cat "${dir}/.vnx-version"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo ""
+}
+
+pin="$(find_version_pin)"
+
+if [ -n "$pin" ]; then
+  version_dir="${VNX_SYSTEM_DIR}/versions/${pin}"
+  if [ ! -d "$version_dir" ]; then
+    echo "[vnx-shim] [x] Pinned version ${pin} not installed at ${version_dir}" >&2
+    echo "[vnx-shim] Run: bash ${VNX_SYSTEM_DIR}/../install-central.sh --version ${pin}" >&2
+    exit 1
+  fi
+  export VNX_HOME="$version_dir"
+else
+  if [ ! -e "${VNX_SYSTEM_DIR}/current" ]; then
+    echo "[vnx-shim] [x] No .vnx-version pin found and no current install at ${VNX_SYSTEM_DIR}/current" >&2
+    exit 1
+  fi
+  export VNX_HOME="${VNX_SYSTEM_DIR}/current"
+fi
+
+exec "${VNX_HOME}/bin/vnx-cli" "$@"
+SHIM
+)
+
+  if [ "$DRY_RUN" = "false" ]; then
+    printf '%s\n' "$shim_content" > "$shim_path"
+    chmod +x "$shim_path"
+  else
+    echo "  [dry-run] write shim to ${shim_path} (chmod +x)"
+  fi
+
+  success "Shim installed: ${shim_path}"
+}
+
+# ---------------------------------------------------------------------------
+# verify_install — post-install sanity checks
+# ---------------------------------------------------------------------------
+verify_install() {
+  local version_dir="${TARGET_DIR}/versions/${VERSION}"
+  local current_link="${TARGET_DIR}/current"
+  local shim_path="${TARGET_DIR}/bin/vnx"
+
+  info "Verifying install..."
+
+  if [ "$DRY_RUN" = "false" ]; then
+    [ -d "$version_dir" ]  || die "version_dir missing: ${version_dir}"
+    [ -L "$current_link" ] || die "current symlink missing: ${current_link}"
+    [ -x "$shim_path" ]    || die "shim not executable: ${shim_path}"
+
+    # Schema bootstrap check (idempotent)
+    local db_init="${version_dir}/scripts/quality_db_init.py"
+    if [ -f "$db_init" ]; then
+      python3 "$db_init" --check-only 2>/dev/null \
+        && success "Schema bootstrap check passed" \
+        || warn "Schema bootstrap check returned non-zero — may need manual init"
+    else
+      info "quality_db_init.py not found at ${db_init} — skipping schema check"
+    fi
+  else
+    echo "  [dry-run] verify: version_dir, current symlink, shim executable, schema bootstrap"
+  fi
+
+  success "Verification complete"
+}
+
+# ---------------------------------------------------------------------------
+# Rollback helper — called on ERR when mid-flow symlink was swapped
+# ---------------------------------------------------------------------------
+_SYMLINK_SWAPPED=false
+rollback_on_error() {
+  if [ "$_SYMLINK_SWAPPED" = "true" ] && [ "$DRY_RUN" = "false" ]; then
+    warn "Rolling back symlink due to installation error..."
+    rm -f "${TARGET_DIR}/current"
+  fi
+}
+trap rollback_on_error ERR
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  echo ""
+  info "VNX Central Install"
+  info "  version : ${VERSION}"
+  info "  target  : ${TARGET_DIR}"
+  info "  source  : ${SOURCE_URL}"
+  if [ "$DRY_RUN" = "true" ]; then
+    info "  mode    : DRY RUN (no filesystem changes)"
+  fi
+  echo ""
+
+  check_prereqs
+  clone_version
+  swap_symlink
+  _SYMLINK_SWAPPED=true
+  install_shim
+  verify_install
+
+  echo ""
+  success "VNX ${VERSION} installed successfully"
+  echo ""
+  echo "  Install root : ${TARGET_DIR}"
+  echo "  Current      : ${TARGET_DIR}/current -> versions/${VERSION}"
+  echo "  Shim         : ${TARGET_DIR}/bin/vnx"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Add ${TARGET_DIR}/bin to your PATH:"
+  echo "       export PATH=\"\${PATH}:${TARGET_DIR}/bin\""
+  echo "  2. Pin a project to this version:"
+  echo "       echo '${VERSION}' > /path/to/project/.vnx-version"
+  echo "  3. Run: vnx setup"
+  echo ""
+}
+
+main "$@"

--- a/install-central.sh
+++ b/install-central.sh
@@ -159,38 +159,49 @@ clone_version() {
 }
 
 # ---------------------------------------------------------------------------
-# swap_symlink — atomic current -> versions/<version> switch
+# swap_symlink current_link target — atomic symlink replacement
+#   Never removes $current_link before successful replacement.
+#   Both Linux (GNU mv -T) and macOS (BSD mv -f via rename(2)) paths are safe
+#   because $current_link is always a symlink or nonexistent, never a real dir.
+#   Returns 75 (EX_TEMPFAIL) on failure; caller handles rollback.
 # ---------------------------------------------------------------------------
 swap_symlink() {
-  local version_dir="${TARGET_DIR}/versions/${VERSION}"
-  local current_link="${TARGET_DIR}/current"
+  local current_link="$1"
+  local target="$2"
+  local tmp_link="${current_link}.swap.$$"
 
-  info "Swapping symlink: ${current_link} -> ${version_dir}..."
-  run mkdir -p "${TARGET_DIR}/versions"
+  info "Swapping symlink: ${current_link} -> ${target}..."
 
-  if [ "$DRY_RUN" = "false" ]; then
-    local new_link_tmp="${TARGET_DIR}/current.tmp.$$"
-    ln -sn "$version_dir" "$new_link_tmp"
-    if mv -fT "$new_link_tmp" "$current_link" 2>/dev/null; then
-      : # GNU mv -T succeeded
-    else
-      # macOS/BSD fallback: unlink + atomic ln.
-      # Critical: NEVER `mv $tmp $current_link` here — if $current_link is a symlink
-      # to a directory, mv without -T moves the temp link INTO that directory instead
-      # of replacing the symlink itself.
-      rm -f "$current_link" || true
-      if ! ln -sn "$(readlink "$new_link_tmp")" "$current_link"; then
-        rm -f "$new_link_tmp"
-        echo "ERROR: failed to install symlink atomically" >&2
-        exit 75  # EX_TEMPFAIL
-      fi
-      rm -f "$new_link_tmp"
-    fi
-  else
-    echo "  [dry-run] ln -sfn ${version_dir} ${current_link}"
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] ln -sfn ${target} ${current_link}"
+    success "Symlink updated: ${current_link} -> ${target}"
+    return 0
   fi
 
-  success "Symlink updated: ${current_link} -> ${version_dir}"
+  mkdir -p "$(dirname "$current_link")"
+
+  ln -sn "$target" "$tmp_link" || {
+    rm -f "$tmp_link"
+    echo "ERROR: failed to create temp symlink" >&2
+    return 75
+  }
+
+  # Try GNU mv -T first (Linux). macOS BSD mv without -T follows symlinks to
+  # directories, so mv -f is not safe there. Python os.replace() maps directly
+  # to rename(2) on all POSIX platforms — atomic, no directory-following.
+  if mv -fT "$tmp_link" "$current_link" 2>/dev/null; then
+    : # GNU mv -T succeeded (Linux)
+  elif python3 -c "import os,sys; os.replace(sys.argv[1],sys.argv[2])" \
+         "$tmp_link" "$current_link" 2>/dev/null; then
+    : # python os.replace() => rename(2), atomic on macOS
+  else
+    rm -f "$tmp_link"
+    echo "ERROR: failed to rename temp symlink" >&2
+    return 75
+  fi
+
+  success "Symlink updated: ${current_link} -> ${target}"
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -302,21 +313,17 @@ verify_install() {
 }
 
 # ---------------------------------------------------------------------------
-# Rollback helper — called on ERR when mid-flow symlink was swapped
+# Rollback helper — called on ERR; restores previous symlink or exits 70
 # ---------------------------------------------------------------------------
-_SYMLINK_SWAPPED=false
-_previous_target=""
+_PREVIOUS_TARGET=""
 
 cleanup_on_failure() {
-  if [ "$_SYMLINK_SWAPPED" = "true" ] && [ "$DRY_RUN" = "false" ]; then
-    warn "Rolling back symlink due to installation error..."
-    if [ -n "${_previous_target:-}" ] && [ -e "$_previous_target" ]; then
-      ln -sfn "$_previous_target" "${TARGET_DIR}/current" 2>/dev/null || true
-      echo "ROLLBACK: restored previous symlink target ${_previous_target}"
-    else
-      rm -f "${TARGET_DIR}/current"
-      echo "ROLLBACK: removed current symlink (no previous target to restore)"
+  if [ -n "${_PREVIOUS_TARGET:-}" ]; then
+    if ! swap_symlink "${TARGET_DIR}/current" "$_PREVIOUS_TARGET"; then
+      echo "FATAL: rollback failed — manual recovery required: previous=$_PREVIOUS_TARGET" >&2
+      exit 70  # EX_SOFTWARE
     fi
+    echo "ROLLBACK: restored previous symlink target $_PREVIOUS_TARGET"
   fi
 }
 trap cleanup_on_failure ERR
@@ -338,10 +345,9 @@ main() {
   check_prereqs
   clone_version
   if [ -L "${TARGET_DIR}/current" ]; then
-    _previous_target=$(readlink "${TARGET_DIR}/current")
+    _PREVIOUS_TARGET=$(readlink "${TARGET_DIR}/current")
   fi
-  swap_symlink
-  _SYMLINK_SWAPPED=true
+  swap_symlink "${TARGET_DIR}/current" "${TARGET_DIR}/versions/${VERSION}"
   install_shim
   verify_install
 

--- a/install-central.sh
+++ b/install-central.sh
@@ -15,6 +15,18 @@ TARGET_DIR="${HOME}/.vnx-system"
 SOURCE_URL="https://github.com/Vinix24/vnx-orchestration"
 DRY_RUN=false
 
+# Defined early so arg parsing can call it before helpers are defined.
+validate_version() {
+  local v="$1"
+  if [ -z "$v" ]; then
+    echo "[install-central] [x] version must not be empty" >&2; exit 78
+  fi
+  if ! [[ "$v" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "[install-central] [x] invalid version '${v}' (must match [A-Za-z0-9._-]+)" >&2
+    exit 78  # EX_CONFIG
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Arg parsing
 # ---------------------------------------------------------------------------
@@ -55,6 +67,8 @@ HELP
       echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
+
+validate_version "$VERSION"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -155,16 +169,10 @@ swap_symlink() {
   run mkdir -p "${TARGET_DIR}/versions"
 
   if [ "$DRY_RUN" = "false" ]; then
-    local tmp_link="${TARGET_DIR}/current.tmp.$$"
-    ln -s "$version_dir" "$tmp_link"
-    # mv -T is Linux-specific; use portable approach for macOS compatibility
-    if mv -T "$tmp_link" "$current_link" 2>/dev/null; then
-      : # Linux mv -T succeeded
-    else
-      # macOS: ln -sfn is atomic enough for our needs
-      rm -f "$tmp_link"
-      ln -sfn "$version_dir" "$current_link"
-    fi
+    local new_link_tmp="${TARGET_DIR}/current.tmp.$$"
+    ln -sn "$version_dir" "$new_link_tmp"
+    mv -fT "$new_link_tmp" "$current_link" 2>/dev/null || \
+      mv -f "$new_link_tmp" "$current_link"  # macOS fallback (no -T flag)
   else
     echo "  [dry-run] ln -sfn ${version_dir} ${current_link}"
   fi
@@ -203,14 +211,25 @@ find_version_pin() {
   echo ""
 }
 
-pin="$(find_version_pin)"
+pin="$(find_version_pin | head -1 | tr -d '\n[:space:]')"
 
 if [ -n "$pin" ]; then
+  if ! [[ "$pin" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "[vnx-shim] ERROR: invalid pin '${pin}' in .vnx-version (must match [A-Za-z0-9._-]+)" >&2
+    exit 78  # EX_CONFIG
+  fi
   version_dir="${VNX_SYSTEM_DIR}/versions/${pin}"
   if [ ! -d "$version_dir" ]; then
     echo "[vnx-shim] [x] Pinned version ${pin} not installed at ${version_dir}" >&2
     echo "[vnx-shim] Run: bash ${VNX_SYSTEM_DIR}/../install-central.sh --version ${pin}" >&2
     exit 1
+  fi
+  if command -v realpath >/dev/null 2>&1; then
+    resolved=$(realpath "$version_dir" 2>/dev/null) || { echo "[vnx-shim] ERROR: cannot resolve version_dir: ${version_dir}" >&2; exit 78; }
+    versions_root=$(realpath "${VNX_SYSTEM_DIR}/versions")
+    if [[ "$resolved" != "$versions_root"/* ]]; then
+      echo "[vnx-shim] ERROR: pin '${pin}' escapes versions root" >&2; exit 78
+    fi
   fi
   export VNX_HOME="$version_dir"
 else
@@ -226,8 +245,11 @@ SHIM
 )
 
   if [ "$DRY_RUN" = "false" ]; then
-    printf '%s\n' "$shim_content" > "$shim_path"
-    chmod +x "$shim_path"
+    local shim_tmp
+    shim_tmp=$(mktemp "${shim_path}.tmp.XXXXXX")
+    printf '%s\n' "$shim_content" > "$shim_tmp"
+    chmod +x "$shim_tmp"
+    mv -f "$shim_tmp" "$shim_path"
   else
     echo "  [dry-run] write shim to ${shim_path} (chmod +x)"
   fi
@@ -270,13 +292,21 @@ verify_install() {
 # Rollback helper — called on ERR when mid-flow symlink was swapped
 # ---------------------------------------------------------------------------
 _SYMLINK_SWAPPED=false
-rollback_on_error() {
+_previous_target=""
+
+cleanup_on_failure() {
   if [ "$_SYMLINK_SWAPPED" = "true" ] && [ "$DRY_RUN" = "false" ]; then
     warn "Rolling back symlink due to installation error..."
-    rm -f "${TARGET_DIR}/current"
+    if [ -n "${_previous_target:-}" ] && [ -e "$_previous_target" ]; then
+      ln -sfn "$_previous_target" "${TARGET_DIR}/current" 2>/dev/null || true
+      echo "ROLLBACK: restored previous symlink target ${_previous_target}"
+    else
+      rm -f "${TARGET_DIR}/current"
+      echo "ROLLBACK: removed current symlink (no previous target to restore)"
+    fi
   fi
 }
-trap rollback_on_error ERR
+trap cleanup_on_failure ERR
 
 # ---------------------------------------------------------------------------
 # Main
@@ -294,6 +324,9 @@ main() {
 
   check_prereqs
   clone_version
+  if [ -L "${TARGET_DIR}/current" ]; then
+    _previous_target=$(readlink "${TARGET_DIR}/current")
+  fi
   swap_symlink
   _SYMLINK_SWAPPED=true
   install_shim

--- a/install-central.sh
+++ b/install-central.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eEuo pipefail
 
 # install-central.sh — Centralized VNX install to ~/.vnx-system/versions/<version>/
 # Separate from install.sh (embedded/open-source per-project installer).
@@ -171,8 +171,21 @@ swap_symlink() {
   if [ "$DRY_RUN" = "false" ]; then
     local new_link_tmp="${TARGET_DIR}/current.tmp.$$"
     ln -sn "$version_dir" "$new_link_tmp"
-    mv -fT "$new_link_tmp" "$current_link" 2>/dev/null || \
-      mv -f "$new_link_tmp" "$current_link"  # macOS fallback (no -T flag)
+    if mv -fT "$new_link_tmp" "$current_link" 2>/dev/null; then
+      : # GNU mv -T succeeded
+    else
+      # macOS/BSD fallback: unlink + atomic ln.
+      # Critical: NEVER `mv $tmp $current_link` here — if $current_link is a symlink
+      # to a directory, mv without -T moves the temp link INTO that directory instead
+      # of replacing the symlink itself.
+      rm -f "$current_link" || true
+      if ! ln -sn "$(readlink "$new_link_tmp")" "$current_link"; then
+        rm -f "$new_link_tmp"
+        echo "ERROR: failed to install symlink atomically" >&2
+        exit 75  # EX_TEMPFAIL
+      fi
+      rm -f "$new_link_tmp"
+    fi
   else
     echo "  [dry-run] ln -sfn ${version_dir} ${current_link}"
   fi

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -139,6 +139,139 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 7: invalid --version (path-traversal) exits EX_CONFIG (78)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 7: invalid --version exits 78 (EX_CONFIG)"
+
+bad_version_code=0
+bad_version_output="$(bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version "../etc/passwd" 2>&1)" || bad_version_code=$?
+
+if [ "$bad_version_code" -eq 78 ]; then
+  pass "invalid --version exits 78"
+else
+  fail "invalid --version exit code was ${bad_version_code}, expected 78"
+fi
+
+if echo "$bad_version_output" | grep -qi "invalid"; then
+  pass "invalid --version error message contains 'invalid'"
+else
+  fail "invalid --version error message missing 'invalid'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: shim pin validation — bad pin in installed shim exits 78
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 8: shim rejects invalid pin (exits 78)"
+
+TMP_SHIM="$(mktemp -d)"
+mkdir -p "${TMP_SHIM}/versions/v1.0.0-rc2"
+
+# Install shim without clone/verify by overriding those functions
+test_shim_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_shim_script"
+chmod +x "$test_shim_script"
+bash "$test_shim_script" --target "$TMP_SHIM" --version v1.0.0-rc2 >/dev/null 2>&1
+
+if [ -x "${TMP_SHIM}/bin/vnx" ]; then
+  pass "shim written to ${TMP_SHIM}/bin/vnx"
+
+  # Create .vnx-version with bad pin and test from that dir
+  TMP_BAD_PIN_DIR="$(mktemp -d)"
+  printf '../etc/passwd\n' > "${TMP_BAD_PIN_DIR}/.vnx-version"
+
+  shim_exit_code=0
+  (cd "$TMP_BAD_PIN_DIR" && bash "${TMP_SHIM}/bin/vnx" 2>/dev/null) || shim_exit_code=$?
+
+  if [ "$shim_exit_code" -eq 78 ]; then
+    pass "shim rejects '../etc/passwd' pin with exit 78"
+  else
+    fail "shim exit code was ${shim_exit_code}, expected 78 for bad pin"
+  fi
+
+  rm -rf "$TMP_BAD_PIN_DIR"
+else
+  fail "shim not installed at ${TMP_SHIM}/bin/vnx"
+fi
+
+rm -rf "$TMP_SHIM" "$test_shim_script"
+
+# ---------------------------------------------------------------------------
+# Test 9: rollback restores previous 'current' symlink on install failure
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 9: rollback restores previous symlink on failure"
+
+TMP_ROLLBACK="$(mktemp -d)"
+OLD_VER="v0.9.0"
+mkdir -p "${TMP_ROLLBACK}/versions/${OLD_VER}"
+ln -sfn "${TMP_ROLLBACK}/versions/${OLD_VER}" "${TMP_ROLLBACK}/current"
+
+test_rollback_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { return 1; }\n'  # force failure after symlink swap
+  printf 'main "$@"\n'
+} > "$test_rollback_script"
+chmod +x "$test_rollback_script"
+
+bash "$test_rollback_script" --target "$TMP_ROLLBACK" --version v1.0.0-rc2 >/dev/null 2>&1 || true
+
+current_target="$(readlink "${TMP_ROLLBACK}/current" 2>/dev/null || echo "MISSING")"
+if echo "$current_target" | grep -qF "$OLD_VER"; then
+  pass "rollback restored previous symlink (${OLD_VER})"
+else
+  fail "rollback did not restore previous symlink (got: ${current_target})"
+fi
+
+rm -rf "$TMP_ROLLBACK" "$test_rollback_script"
+
+# ---------------------------------------------------------------------------
+# Test 10: shim install uses atomic tempfile (no leftover .tmp. files)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 10: shim install leaves no temp files"
+
+TMP_ATOMIC="$(mktemp -d)"
+mkdir -p "${TMP_ATOMIC}/versions/v1.0.0-rc2"
+
+test_atomic_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_atomic_script"
+chmod +x "$test_atomic_script"
+
+bash "$test_atomic_script" --target "$TMP_ATOMIC" --version v1.0.0-rc2 >/dev/null 2>&1
+
+if [ -x "${TMP_ATOMIC}/bin/vnx" ]; then
+  pass "shim exists and is executable"
+else
+  fail "shim missing or not executable"
+fi
+
+leftover_tmp="$(ls "${TMP_ATOMIC}/bin/"vnx.tmp.* 2>/dev/null || true)"
+if [ -z "$leftover_tmp" ]; then
+  pass "no leftover .tmp. files in shim dir"
+else
+  fail "leftover temp files found: ${leftover_tmp}"
+fi
+
+rm -rf "$TMP_ATOMIC" "$test_atomic_script"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -334,6 +334,134 @@ fi
 rm -rf "$TMP_MACOS" "$FAKE_MV_DIR" "$test_macos_script"
 
 # ---------------------------------------------------------------------------
+# Test 12: swap_symlink happy path — succeeds, symlink updated, no temp files
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 12: swap_symlink atomic swap — existing target replaced, no temp files"
+
+TMP_12="$(mktemp -d)"
+OLD_VER_12="v0.9.0"
+NEW_VER_12="v1.0.0-rc2"
+mkdir -p "${TMP_12}/versions/${OLD_VER_12}" "${TMP_12}/versions/${NEW_VER_12}"
+ln -sn "${TMP_12}/versions/${OLD_VER_12}" "${TMP_12}/current"
+
+test_12_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"
+  printf 'DRY_RUN=false\n'
+  printf 'swap_symlink "%s/current" "%s/versions/%s"\n' "$TMP_12" "$TMP_12" "$NEW_VER_12"
+} > "$test_12_script"
+
+test_12_exit=0
+bash "$test_12_script" >/dev/null 2>&1 || test_12_exit=$?
+
+if [ "$test_12_exit" -eq 0 ]; then
+  pass "swap_symlink exits 0 on happy path"
+else
+  fail "swap_symlink exited ${test_12_exit}, expected 0"
+fi
+
+current_12="$(readlink "${TMP_12}/current" 2>/dev/null || echo "MISSING")"
+if echo "$current_12" | grep -qF "$NEW_VER_12"; then
+  pass "current symlink points to new version after swap"
+else
+  fail "current symlink not updated: ${current_12}"
+fi
+
+leftover_12="$(ls "${TMP_12}/"current.swap.* 2>/dev/null || true)"
+if [ -z "$leftover_12" ]; then
+  pass "no leftover .swap. temp files after successful swap"
+else
+  fail "leftover temp files found: ${leftover_12}"
+fi
+
+rm -rf "$TMP_12" "$test_12_script"
+
+# ---------------------------------------------------------------------------
+# Test 13: swap_symlink — ln fails (read-only parent dir) → temp cleaned, current unchanged
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 13: swap_symlink ln failure — tempfile cleaned up, current symlink unchanged"
+
+TMP_13="$(mktemp -d)"
+OLD_VER_13="v0.9.0"
+NEW_VER_13="v1.0.0-rc2"
+mkdir -p "${TMP_13}/versions/${OLD_VER_13}" "${TMP_13}/versions/${NEW_VER_13}"
+ln -sn "${TMP_13}/versions/${OLD_VER_13}" "${TMP_13}/current"
+chmod 555 "$TMP_13"  # make parent dir read-only so ln -sn fails
+
+test_13_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"
+  printf 'DRY_RUN=false\n'
+  printf 'swap_symlink "%s/current" "%s/versions/%s"\n' "$TMP_13" "$TMP_13" "$NEW_VER_13"
+} > "$test_13_script"
+
+test_13_exit=0
+bash "$test_13_script" >/dev/null 2>&1 || test_13_exit=$?
+
+chmod 755 "$TMP_13"  # restore for cleanup
+
+if [ "$test_13_exit" -eq 75 ]; then
+  pass "swap_symlink returns 75 (EX_TEMPFAIL) when ln fails"
+else
+  fail "expected exit 75, got ${test_13_exit}"
+fi
+
+current_13="$(readlink "${TMP_13}/current" 2>/dev/null || echo "MISSING")"
+if echo "$current_13" | grep -qF "$OLD_VER_13"; then
+  pass "current symlink unchanged after swap_symlink failure"
+else
+  fail "current symlink was modified during failure: ${current_13}"
+fi
+
+leftover_13="$(ls "${TMP_13}/"current.swap.* 2>/dev/null || true)"
+if [ -z "$leftover_13" ]; then
+  pass "no leftover .swap. temp files after ln failure"
+else
+  fail "leftover temp files found after failure: ${leftover_13}"
+fi
+
+rm -rf "$TMP_13" "$test_13_script"
+
+# ---------------------------------------------------------------------------
+# Test 14: cleanup_on_failure — rollback fails → exits 70, FATAL logged
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 14: cleanup_on_failure broken rollback — exits 70, FATAL message logged"
+
+TMP_14="$(mktemp -d)"
+chmod 555 "$TMP_14"  # read-only so swap_symlink's ln fails inside cleanup_on_failure
+
+test_14_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"
+  printf 'DRY_RUN=false\n'
+  printf 'TARGET_DIR="%s"\n' "$TMP_14"
+  printf '_PREVIOUS_TARGET="%s/some-version"\n' "$TMP_14"
+  printf 'cleanup_on_failure\n'
+} > "$test_14_script"
+
+test_14_exit=0
+test_14_output="$(bash "$test_14_script" 2>&1)" || test_14_exit=$?
+
+chmod 755 "$TMP_14"  # restore for cleanup
+
+if [ "$test_14_exit" -eq 70 ]; then
+  pass "cleanup_on_failure exits 70 (EX_SOFTWARE) when rollback fails"
+else
+  fail "expected exit 70, got ${test_14_exit}"
+fi
+
+if echo "$test_14_output" | grep -qi "FATAL"; then
+  pass "cleanup_on_failure logs FATAL message on rollback failure"
+else
+  fail "FATAL message not found in output: ${test_14_output}"
+fi
+
+rm -rf "$TMP_14" "$test_14_script"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for install-central.sh --dry-run mode.
+# Verifies: no filesystem mutations, expected output lines, exit code 0, idempotency.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/install-central.sh"
+TMP_TARGET="/tmp/vnx-central-test-$$"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  [ok] $1"; PASS=$((PASS + 1)); }
+fail() { echo "  [x] $1" >&2; FAIL=$((FAIL + 1)); }
+
+# Clean up tmp target if created during tests
+cleanup() { rm -rf "$TMP_TARGET" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: --dry-run exits 0 and produces expected output
+# ---------------------------------------------------------------------------
+echo "Test 1: --dry-run exits 0 with expected output"
+
+output="$(bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version v1.0.0-rc2 2>&1)"
+exit_code=$?
+
+if [ "$exit_code" -eq 0 ]; then
+  pass "exit code 0"
+else
+  fail "exit code was ${exit_code}, expected 0"
+fi
+
+for expected in \
+  "VNX Central Install" \
+  "version" \
+  "target" \
+  "DRY RUN" \
+  "Prerequisites OK" \
+  "Symlink updated" \
+  "Shim installed" \
+  "Verification complete" \
+  "installed successfully"
+do
+  if echo "$output" | grep -q "$expected"; then
+    pass "output contains: ${expected}"
+  else
+    fail "output missing: ${expected}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 2: --dry-run does NOT create filesystem artifacts
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 2: --dry-run leaves no filesystem artifacts"
+
+bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version v1.0.0-rc2 >/dev/null 2>&1
+
+if [ ! -e "$TMP_TARGET" ]; then
+  pass "target dir not created"
+else
+  fail "target dir was created (should not exist in dry-run): ${TMP_TARGET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: --dry-run output contains git clone step (not actual clone)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 3: --dry-run shows git clone without running it"
+
+output="$(bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version v1.0.0-rc2 2>&1)"
+
+if echo "$output" | grep -q "git clone"; then
+  pass "dry-run output shows git clone step"
+else
+  fail "dry-run output missing git clone step"
+fi
+
+if [ ! -d "${TMP_TARGET}/versions" ]; then
+  pass "versions/ dir not created in dry-run"
+else
+  fail "versions/ dir was created (should not exist in dry-run)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: --help exits 0 and shows usage
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 4: --help exits 0 with usage"
+
+help_output="$(bash "$SCRIPT" --help 2>&1)"
+help_code=$?
+
+if [ "$help_code" -eq 0 ]; then
+  pass "--help exit code 0"
+else
+  fail "--help exit code was ${help_code}"
+fi
+
+for expected in "--target" "--version" "--source" "--dry-run"; do
+  if echo "$help_output" | grep -qF -- "$expected"; then
+    pass "--help shows: ${expected}"
+  else
+    fail "--help missing: ${expected}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 5: bash -n syntax check
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 5: syntax check install-central.sh"
+
+if bash -n "$SCRIPT"; then
+  pass "install-central.sh passes bash -n"
+else
+  fail "install-central.sh fails bash -n"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: Re-run with same args (idempotency) in dry-run = same exit code
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 6: idempotent re-run (dry-run)"
+
+run1="$(bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version v1.0.0-rc2; echo $?)"
+run2="$(bash "$SCRIPT" --dry-run --target "$TMP_TARGET" --version v1.0.0-rc2; echo $?)"
+
+# Both should exit 0 (captured as last line)
+code1=$(echo "$run1" | tail -1)
+code2=$(echo "$run2" | tail -1)
+
+if [ "$code1" -eq 0 ] && [ "$code2" -eq 0 ]; then
+  pass "both runs exit 0 (idempotent)"
+else
+  fail "idempotency broken: run1=${code1} run2=${code2}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -272,6 +272,68 @@ fi
 rm -rf "$TMP_ATOMIC" "$test_atomic_script"
 
 # ---------------------------------------------------------------------------
+# Test 11: macOS-like fallback (mv without -T) uses unlink+ln correctly
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 11: macOS-like fallback: mock mv without -T support"
+
+TMP_MACOS="$(mktemp -d)"
+OLD_VER_MAC="v0.9.0"
+NEW_VER_MAC="v1.0.0-rc2"
+mkdir -p "${TMP_MACOS}/versions/${OLD_VER_MAC}"
+mkdir -p "${TMP_MACOS}/versions/${NEW_VER_MAC}"
+ln -sfn "${TMP_MACOS}/versions/${OLD_VER_MAC}" "${TMP_MACOS}/current"
+
+# Fake mv that rejects -T to simulate macOS/BSD behaviour
+FAKE_MV_DIR="$(mktemp -d)"
+cat > "${FAKE_MV_DIR}/mv" <<'FAKEMV'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    -fT|-T) exit 1 ;;
+  esac
+done
+exec /bin/mv "$@"
+FAKEMV
+chmod +x "${FAKE_MV_DIR}/mv"
+
+test_macos_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_macos_script"
+chmod +x "$test_macos_script"
+
+macos_exit=0
+PATH="${FAKE_MV_DIR}:${PATH}" bash "$test_macos_script" \
+  --target "$TMP_MACOS" --version "$NEW_VER_MAC" >/dev/null 2>&1 || macos_exit=$?
+
+if [ "$macos_exit" -eq 0 ]; then
+  pass "macOS fallback exits 0"
+else
+  fail "macOS fallback exit code was ${macos_exit}, expected 0"
+fi
+
+current_target="$(readlink "${TMP_MACOS}/current" 2>/dev/null || echo "MISSING")"
+if echo "$current_target" | grep -qF "$NEW_VER_MAC"; then
+  pass "symlink correctly points to new version after macOS fallback"
+else
+  fail "symlink target after macOS fallback: ${current_target} (expected: ${NEW_VER_MAC})"
+fi
+
+leftover="$(ls "${TMP_MACOS}/"current.tmp.* 2>/dev/null || true)"
+if [ -z "$leftover" ]; then
+  pass "no leftover temp symlinks after macOS fallback"
+else
+  fail "leftover temp symlinks found: ${leftover}"
+fi
+
+rm -rf "$TMP_MACOS" "$FAKE_MV_DIR" "$test_macos_script"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Adds `install-central.sh` as the primary deployment script for centralized VNX installs (separate from `install.sh` which remains the embedded/open-source per-project installer)
- Clones to `~/.vnx-system/versions/<version>/` with atomic symlink swap, project-pin via `.vnx-version` traversal shim
- Pre-flight checks (Python 3.11–3.13, git, sqlite3, 500MB disk), idempotent re-runs, rollback on ERR

## Test plan

- [x] `bash install-central.sh --dry-run --target /tmp/vnx-system-test --version v1.0.0-rc2` exits 0 with full expected output
- [x] `bash tests/test_install_central.sh` — 20/20 passed
- [x] `bash -n install-central.sh` — syntax OK
- [x] No filesystem mutations in dry-run mode (verified)
- [x] Idempotent re-run in dry-run produces exit 0

## Files changed

- `install-central.sh` (new, ~220 LOC)
- `tests/test_install_central.sh` (new, ~100 LOC)
- `docs/operations/install-central-runbook.md` (new, ~90 LOC)
- `CHANGELOG.md` (updated [Unreleased] section)

Pre-centralization must-have #7 (CENTRAL-7).

Dispatch-ID: central-7-install-central-20260517-223143

🤖 Generated with [Claude Code](https://claude.com/claude-code)