### PR TITLE
feat(schema): idempotent bootstrap with PRAGMA user_version + transaction wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin
 - feat(schema): idempotent bootstrap — quality_db_init + coordination_db check PRAGMA user_version before each migration block, skip already-applied. Mid-run failures rollback cleanly via SAVEPOINT transactions. New `scripts/lib/schema_migration.py` helper centralises `apply_if_below` + `apply_script_if_below` patterns. (Pre-centralization must-have #4)
+- fix(schema-migration): replace silent `except: pass` in rollback with logger.warning (codex blocker, error-handling gate)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin
+- feat(schema): idempotent bootstrap — quality_db_init + coordination_db check PRAGMA user_version before each migration block, skip already-applied. Mid-run failures rollback cleanly via SAVEPOINT transactions. New `scripts/lib/schema_migration.py` helper centralises `apply_if_below` + `apply_script_if_below` patterns. (Pre-centralization must-have #4)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - fix(coordination_db): migration gate falls back to runtime_schema_version table when PRAGMA user_version=0 (codex round-2 blocker — legacy install compatibility)
 - fix(schema-migration): replace `executescript` with quote/comment-aware SQL splitter inside SAVEPOINT in `apply_script_if_below` — schema script + `PRAGMA user_version` stamp now atomic, mid-script failure rolls back ALL statements (codex round-3 atomicity blocker)
 - fix(coordination_db): use `schema_migration.apply_script_if_below` for both V1 base schema + versioned migrations — eliminates direct `executescript` calls that broke SAVEPOINT atomicity
+- fix(quality_db_init): use `schema_migration.apply_script_if_below` for V1 base schema (codex round-3 follow-up — same atomicity pattern in third file)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin
 - feat(schema): idempotent bootstrap — quality_db_init + coordination_db check PRAGMA user_version before each migration block, skip already-applied. Mid-run failures rollback cleanly via SAVEPOINT transactions. New `scripts/lib/schema_migration.py` helper centralises `apply_if_below` + `apply_script_if_below` patterns. (Pre-centralization must-have #4)
 - fix(schema-migration): replace silent `except: pass` in rollback with logger.warning (codex blocker, error-handling gate)
+- fix(coordination_db): migration gate falls back to runtime_schema_version table when PRAGMA user_version=0 (codex round-2 blocker — legacy install compatibility)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 - feat(schema): idempotent bootstrap — quality_db_init + coordination_db check PRAGMA user_version before each migration block, skip already-applied. Mid-run failures rollback cleanly via SAVEPOINT transactions. New `scripts/lib/schema_migration.py` helper centralises `apply_if_below` + `apply_script_if_below` patterns. (Pre-centralization must-have #4)
 - fix(schema-migration): replace silent `except: pass` in rollback with logger.warning (codex blocker, error-handling gate)
 - fix(coordination_db): migration gate falls back to runtime_schema_version table when PRAGMA user_version=0 (codex round-2 blocker — legacy install compatibility)
+- fix(schema-migration): replace `executescript` with quote/comment-aware SQL splitter inside SAVEPOINT in `apply_script_if_below` — schema script + `PRAGMA user_version` stamp now atomic, mid-script failure rolls back ALL statements (codex round-3 atomicity blocker)
+- fix(coordination_db): use `schema_migration.apply_script_if_below` for both V1 base schema + versioned migrations — eliminates direct `executescript` calls that broke SAVEPOINT atomicity
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -217,13 +217,9 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
     schema_sql = schema_sql_path.read_text(encoding="utf-8")
 
     with get_connection(state_dir) as conn:
-        # V1: base schema (executescript commits automatically)
+        # V1: base schema applied atomically (codex round-2 fix — script + version stamp in one SAVEPOINT)
         if _needs_initial_migration(conn):
-            conn.executescript(schema_sql)
-            # Stamp the version in a new transaction after executescript committed
-            conn.execute('SAVEPOINT "vnx_coord_v1"')
-            conn.execute("PRAGMA user_version = 1")
-            conn.execute('RELEASE SAVEPOINT "vnx_coord_v1"')
+            schema_migration.apply_script_if_below(conn, 1, schema_sql)
 
         # Versioned migration files: runtime_coordination_v2.sql, v3.sql, ...
         schemas_dir = schema_sql_path.parent
@@ -232,14 +228,8 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
             migration_path = schemas_dir / f"runtime_coordination_v{v}.sql"
             if not migration_path.exists():
                 break
-            if schema_migration.get_user_version(conn) < v:
-                migration_sql = migration_path.read_text(encoding="utf-8")
-                conn.executescript(migration_sql)
-                # Stamp version after executescript committed
-                sp = f'"vnx_coord_v{v}"'
-                conn.execute(f"SAVEPOINT {sp}")
-                conn.execute(f"PRAGMA user_version = {v}")
-                conn.execute(f"RELEASE SAVEPOINT {sp}")
+            migration_sql = migration_path.read_text(encoding="utf-8")
+            schema_migration.apply_script_if_below(conn, v, migration_sql)
             v += 1
 
 

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import uuid
 from contextlib import contextmanager
@@ -12,6 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional
 
 import schema_migration
+
+logger = logging.getLogger(__name__)
 
 DB_FILENAME = "runtime_coordination.db"
 
@@ -166,6 +169,30 @@ def _append_event(
     return event_id
 
 
+def _needs_initial_migration(conn: sqlite3.Connection) -> bool:
+    """Check if initial migration is needed.
+
+    Modern path: PRAGMA user_version.
+    Legacy fallback: runtime_schema_version table (pre-CENTRAL-4 schema).
+    """
+    pragma_version = schema_migration.get_user_version(conn)
+    if pragma_version >= 1:
+        return False
+    # Legacy fallback: check runtime_schema_version table
+    try:
+        row = conn.execute(
+            "SELECT version FROM runtime_schema_version ORDER BY applied_at DESC LIMIT 1"
+        ).fetchone()
+        if row and row[0] >= 1:
+            # Legacy install — sync PRAGMA user_version forward
+            conn.execute(f"PRAGMA user_version = {row[0]}")
+            return False
+    except sqlite3.OperationalError as e:
+        # Table doesn't exist → fresh install, needs migration
+        logger.info("coordination_db: no runtime_schema_version table (%s) — assuming fresh install", e)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Schema initialization
 # ---------------------------------------------------------------------------
@@ -191,7 +218,7 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
 
     with get_connection(state_dir) as conn:
         # V1: base schema (executescript commits automatically)
-        if schema_migration.get_user_version(conn) < 1:
+        if _needs_initial_migration(conn):
             conn.executescript(schema_sql)
             # Stamp the version in a new transaction after executescript committed
             conn.execute('SAVEPOINT "vnx_coord_v1"')

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional
 
+import schema_migration
+
 DB_FILENAME = "runtime_coordination.db"
 
 # ---------------------------------------------------------------------------
@@ -171,6 +173,10 @@ def _append_event(
 def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -> None:
     """Initialize (or migrate) the runtime coordination database. Idempotent.
 
+    Tracks applied migrations via PRAGMA user_version (primary) and
+    runtime_schema_version table (secondary, preserved for backward compat).
+    Base schema = user_version 1; each versioned SQL file increments by 1.
+
     Uses a single connection for the entire init+migration sequence to
     prevent TOCTOU races between version check and migration apply.
     """
@@ -184,32 +190,30 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
     schema_sql = schema_sql_path.read_text(encoding="utf-8")
 
     with get_connection(state_dir) as conn:
-        conn.executescript(schema_sql)
-        conn.commit()
+        # V1: base schema (executescript commits automatically)
+        if schema_migration.get_user_version(conn) < 1:
+            conn.executescript(schema_sql)
+            # Stamp the version in a new transaction after executescript committed
+            conn.execute('SAVEPOINT "vnx_coord_v1"')
+            conn.execute("PRAGMA user_version = 1")
+            conn.execute('RELEASE SAVEPOINT "vnx_coord_v1"')
 
-        current_version = 1
-        try:
-            row = conn.execute(
-                "SELECT MAX(version) FROM runtime_schema_version"
-            ).fetchone()
-            if row and row[0] is not None:
-                current_version = row[0]
-        except sqlite3.OperationalError:
-            pass
-
+        # Versioned migration files: runtime_coordination_v2.sql, v3.sql, ...
         schemas_dir = schema_sql_path.parent
-        version = 2
+        v = 2
         while True:
-            migration = schemas_dir / f"runtime_coordination_v{version}.sql"
-            if not migration.exists():
+            migration_path = schemas_dir / f"runtime_coordination_v{v}.sql"
+            if not migration_path.exists():
                 break
-            if version <= current_version:
-                version += 1
-                continue
-            migration_sql = migration.read_text(encoding="utf-8")
-            conn.executescript(migration_sql)
-            conn.commit()
-            version += 1
+            if schema_migration.get_user_version(conn) < v:
+                migration_sql = migration_path.read_text(encoding="utf-8")
+                conn.executescript(migration_sql)
+                # Stamp version after executescript committed
+                sp = f'"vnx_coord_v{v}"'
+                conn.execute(f"SAVEPOINT {sp}")
+                conn.execute(f"PRAGMA user_version = {v}")
+                conn.execute(f"RELEASE SAVEPOINT {sp}")
+            v += 1
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/schema_migration.py
+++ b/scripts/lib/schema_migration.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Shared helper for idempotent SQLite schema migrations via PRAGMA user_version.
+
+Usage
+-----
+    from schema_migration import apply_if_below
+
+    # conn.isolation_level = None is recommended for explicit control
+    apply_if_below(conn, 2, _mig_v2_add_column)
+    apply_if_below(conn, 3, _mig_v3_add_table)
+
+Migration functions passed to apply_if_below MUST use conn.execute() for
+individual statements. Never call conn.executescript() inside migration_fn —
+executescript() commits any active transaction and breaks SAVEPOINT atomicity.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+def get_user_version(conn: sqlite3.Connection) -> int:
+    """Return PRAGMA user_version for the connection's database."""
+    return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def apply_if_below(
+    conn: sqlite3.Connection,
+    target_version: int,
+    migration_fn: Callable[[sqlite3.Connection], None],
+) -> bool:
+    """Apply *migration_fn* only when PRAGMA user_version < *target_version*.
+
+    Uses a SAVEPOINT so mid-migration failures roll back cleanly without
+    corrupting the database. Sets PRAGMA user_version = target_version on
+    success. Returns True if the migration was applied, False if skipped.
+
+    migration_fn must use conn.execute() only — no conn.executescript().
+    """
+    if get_user_version(conn) >= target_version:
+        return False
+
+    sp = f'"vnx_mig_{target_version}"'
+    conn.execute(f"SAVEPOINT {sp}")
+    try:
+        migration_fn(conn)
+        conn.execute(f"PRAGMA user_version = {target_version}")
+        conn.execute(f"RELEASE SAVEPOINT {sp}")
+        logger.debug("schema migration applied: user_version → %d", target_version)
+    except Exception:
+        try:
+            conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+            conn.execute(f"RELEASE SAVEPOINT {sp}")
+        except Exception:
+            pass
+        raise
+    return True
+
+
+def apply_script_if_below(
+    conn: sqlite3.Connection,
+    target_version: int,
+    sql: str,
+) -> bool:
+    """Apply a SQL script via executescript() if user_version < target_version.
+
+    Because executescript() commits automatically, the schema changes and the
+    user_version stamp occur in separate transactions. This is safe when all
+    SQL uses CREATE TABLE IF NOT EXISTS and ALTER TABLE is preceded by
+    column-existence checks — a crash between the two commits causes a harmless
+    re-run of idempotent SQL on next start.
+
+    Returns True if the script was applied, False if skipped.
+    """
+    if get_user_version(conn) >= target_version:
+        return False
+
+    conn.executescript(sql)
+    # executescript() committed above; stamp the version in a new transaction
+    sp = f'"vnx_ver_{target_version}"'
+    conn.execute(f"SAVEPOINT {sp}")
+    conn.execute(f"PRAGMA user_version = {target_version}")
+    conn.execute(f"RELEASE SAVEPOINT {sp}")
+    logger.debug("schema script applied: user_version → %d", target_version)
+    return True

--- a/scripts/lib/schema_migration.py
+++ b/scripts/lib/schema_migration.py
@@ -3,15 +3,22 @@
 
 Usage
 -----
-    from schema_migration import apply_if_below
+    from schema_migration import apply_if_below, apply_script_if_below
 
     # conn.isolation_level = None is recommended for explicit control
-    apply_if_below(conn, 2, _mig_v2_add_column)
-    apply_if_below(conn, 3, _mig_v3_add_table)
+    apply_if_below(conn, 2, _mig_v2_add_column)        # Python migration fn
+    apply_script_if_below(conn, 3, sql_text)            # SQL-file string
 
-Migration functions passed to apply_if_below MUST use conn.execute() for
-individual statements. Never call conn.executescript() inside migration_fn —
+Both helpers run under a SAVEPOINT — mid-migration failure rolls back ALL
+statements + the version stamp atomically.
+
+For ``apply_if_below``: migration_fn MUST use ``conn.execute()`` for individual
+statements. Never call ``conn.executescript()`` inside migration_fn —
 executescript() commits any active transaction and breaks SAVEPOINT atomicity.
+
+For ``apply_script_if_below``: pass the raw SQL text; the helper splits it
+into individual statements (quote- and comment-aware) and executes them
+inside the SAVEPOINT.
 """
 from __future__ import annotations
 
@@ -65,29 +72,113 @@ def apply_if_below(
     return True
 
 
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a SQL script into individual statements by `;` boundaries.
+
+    Handles single/double-quoted strings (no semicolon-split inside literals).
+    Ignores SQL line comments (`-- …`) and block comments (`/* … */`).
+    Returns non-empty, stripped statements ready for ``conn.execute()``.
+    """
+    statements: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(sql)
+    in_string = False
+    quote_char: str | None = None
+    in_block_comment = False
+    in_line_comment = False
+    while i < n:
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            current.append(ch)
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            current.append(ch)
+            if ch == "*" and nxt == "/":
+                current.append(nxt)
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_string:
+            current.append(ch)
+            if ch == quote_char:
+                in_string = False
+                quote_char = None
+            i += 1
+            continue
+        # not in string/comment
+        if ch == "-" and nxt == "-":
+            in_line_comment = True
+            current.append(ch)
+            i += 1
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            current.append(ch)
+            current.append(nxt)
+            i += 2
+            continue
+        if ch in ('"', "'"):
+            in_string = True
+            quote_char = ch
+            current.append(ch)
+            i += 1
+            continue
+        if ch == ";":
+            stmt = "".join(current).strip()
+            if stmt:
+                statements.append(stmt)
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
 def apply_script_if_below(
     conn: sqlite3.Connection,
     target_version: int,
     sql: str,
 ) -> bool:
-    """Apply a SQL script via executescript() if user_version < target_version.
+    """Apply a SQL script atomically if user_version < target_version.
 
-    Because executescript() commits automatically, the schema changes and the
-    user_version stamp occur in separate transactions. This is safe when all
-    SQL uses CREATE TABLE IF NOT EXISTS and ALTER TABLE is preceded by
-    column-existence checks — a crash between the two commits causes a harmless
-    re-run of idempotent SQL on next start.
+    Splits the script into individual statements and executes them inside a
+    SAVEPOINT together with the ``PRAGMA user_version`` stamp. Mid-script
+    failure rolls back ALL statements + the version stamp atomically — no
+    partial schema state is left behind (codex round-2 atomicity fix).
 
     Returns True if the script was applied, False if skipped.
     """
     if get_user_version(conn) >= target_version:
         return False
 
-    conn.executescript(sql)
-    # executescript() committed above; stamp the version in a new transaction
+    statements = _split_sql_statements(sql)
     sp = f'"vnx_ver_{target_version}"'
     conn.execute(f"SAVEPOINT {sp}")
-    conn.execute(f"PRAGMA user_version = {target_version}")
-    conn.execute(f"RELEASE SAVEPOINT {sp}")
-    logger.debug("schema script applied: user_version → %d", target_version)
+    try:
+        for stmt in statements:
+            conn.execute(stmt)
+        conn.execute(f"PRAGMA user_version = {target_version}")
+        conn.execute(f"RELEASE SAVEPOINT {sp}")
+        logger.debug("schema script applied atomically: user_version → %d", target_version)
+    except Exception:
+        try:
+            conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+            conn.execute(f"RELEASE SAVEPOINT {sp}")
+        except Exception as rollback_err:
+            logger.warning(
+                "rollback/release failed (continuing): %s: %s",
+                type(rollback_err).__name__, rollback_err,
+            )
+        raise
     return True

--- a/scripts/lib/schema_migration.py
+++ b/scripts/lib/schema_migration.py
@@ -54,8 +54,13 @@ def apply_if_below(
         try:
             conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
             conn.execute(f"RELEASE SAVEPOINT {sp}")
-        except Exception:
-            pass
+        except Exception as rollback_err:
+            logger.warning(
+                "rollback/release failed (continuing): %s: %s",
+                type(rollback_err).__name__, rollback_err,
+            )
+            # not re-raising: already in error-recovery path; logging ensures
+            # observability without masking the primary failure
         raise
     return True
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -18,6 +18,12 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+import schema_migration
+
+# Highest PRAGMA user_version stamped by bootstrap_qi_db.
+# Increment this constant whenever a new migration block is added.
+HIGHEST_QI_VERSION = 17
+
 # VNX Base Configuration
 PATHS = ensure_env()
 VNX_BASE = Path(PATHS["VNX_HOME"])
@@ -101,355 +107,411 @@ def bootstrap_qi_db(db_path: Path, schema_file: Path | None = None) -> bool:
     relying on module-level constants. ``schema_file`` defaults to the
     canonical ``schemas/quality_intelligence.sql`` resolved from
     ``VNX_HOME``.
+
+    Idempotent via PRAGMA user_version: each migration block is skipped if
+    user_version >= its target. Mid-run failures roll back cleanly via
+    SAVEPOINT. Version stamps range from 1 (base schema) to HIGHEST_QI_VERSION.
     """
     schema_file = Path(schema_file) if schema_file is not None else SCHEMA_FILE
     log('INFO', f'Initializing quality intelligence database at {db_path}...')
 
     try:
-        # Read schema file
         with open(schema_file, 'r') as f:
             schema_sql = f.read()
 
         log('INFO', f'Schema loaded: {len(schema_sql)} characters')
 
-        # Connect to database
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(db_path))
-        cursor = conn.cursor()
+        conn.isolation_level = None  # manual transaction management for SAVEPOINT correctness
 
-        # Execute schema
-        cursor.executescript(schema_sql)
-        conn.commit()
+        # ---- V1: base schema (executescript commits automatically) ----
+        if schema_migration.get_user_version(conn) < 1:
+            conn.executescript(schema_sql)
+            conn.execute('SAVEPOINT "vnx_mig_1"')
+            conn.execute("PRAGMA user_version = 1")
+            conn.execute('RELEASE SAVEPOINT "vnx_mig_1"')
+            log('INFO', 'Base schema applied (v1)')
 
-        # Migration: add pattern_hash column if missing (for existing databases)
-        cursor.execute("PRAGMA table_info(snippet_metadata)")
-        columns = {row[1] for row in cursor.fetchall()}
-        if "pattern_hash" not in columns:
-            cursor.execute("ALTER TABLE snippet_metadata ADD COLUMN pattern_hash TEXT")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_snippet_pattern_hash ON snippet_metadata (pattern_hash)")
-            conn.commit()
-            log('INFO', 'Migrated snippet_metadata: added pattern_hash column + index')
-
-        # Migration: add session_analytics tables if missing (for existing databases)
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='session_analytics'")
-        if not cursor.fetchone():
-            cursor.executescript("""
-                CREATE TABLE IF NOT EXISTS session_analytics (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    session_id TEXT NOT NULL UNIQUE,
-                    project_path TEXT NOT NULL,
-                    terminal TEXT,
-                    session_date DATE NOT NULL,
-                    total_input_tokens INTEGER DEFAULT 0,
-                    total_output_tokens INTEGER DEFAULT 0,
-                    cache_creation_tokens INTEGER DEFAULT 0,
-                    cache_read_tokens INTEGER DEFAULT 0,
-                    tool_calls_total INTEGER DEFAULT 0,
-                    tool_read_count INTEGER DEFAULT 0,
-                    tool_edit_count INTEGER DEFAULT 0,
-                    tool_bash_count INTEGER DEFAULT 0,
-                    tool_grep_count INTEGER DEFAULT 0,
-                    tool_write_count INTEGER DEFAULT 0,
-                    tool_task_count INTEGER DEFAULT 0,
-                    tool_other_count INTEGER DEFAULT 0,
-                    message_count INTEGER DEFAULT 0,
-                    user_message_count INTEGER DEFAULT 0,
-                    assistant_message_count INTEGER DEFAULT 0,
-                    duration_minutes REAL,
-                    has_error_recovery BOOLEAN DEFAULT FALSE,
-                    has_context_reset BOOLEAN DEFAULT FALSE,
-                    context_reset_count INTEGER DEFAULT 0,
-                    has_large_refactor BOOLEAN DEFAULT FALSE,
-                    has_test_cycle BOOLEAN DEFAULT FALSE,
-                    primary_activity TEXT,
-                    deep_analysis_json TEXT,
-                    deep_analysis_model TEXT,
-                    deep_analysis_at DATETIME,
-                    file_size_bytes INTEGER,
-                    analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    analyzer_version TEXT DEFAULT '1.0.0'
-                );
-                CREATE INDEX IF NOT EXISTS idx_session_terminal ON session_analytics (terminal, session_date DESC);
-                CREATE INDEX IF NOT EXISTS idx_session_project ON session_analytics (project_path, session_date DESC);
-                CREATE INDEX IF NOT EXISTS idx_session_date ON session_analytics (session_date DESC);
-                CREATE INDEX IF NOT EXISTS idx_session_activity ON session_analytics (primary_activity);
-
-                CREATE TABLE IF NOT EXISTS improvement_suggestions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    session_id TEXT NOT NULL,
-                    category TEXT NOT NULL,
-                    component TEXT,
-                    current_behavior TEXT NOT NULL,
-                    suggested_improvement TEXT NOT NULL,
-                    evidence TEXT,
-                    priority TEXT DEFAULT 'medium',
-                    status TEXT DEFAULT 'new',
-                    digest_id TEXT,
-                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    acted_on_at DATETIME
-                );
-                CREATE INDEX IF NOT EXISTS idx_improvement_category ON improvement_suggestions (category, status);
-                CREATE INDEX IF NOT EXISTS idx_improvement_priority ON improvement_suggestions (priority, status);
-
-                CREATE TABLE IF NOT EXISTS nightly_digests (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    digest_date DATE NOT NULL UNIQUE,
-                    sessions_analyzed INTEGER DEFAULT 0,
-                    deep_analyzed INTEGER DEFAULT 0,
-                    new_suggestions INTEGER DEFAULT 0,
-                    total_tokens_used INTEGER DEFAULT 0,
-                    digest_markdown TEXT NOT NULL,
-                    digest_path TEXT,
-                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-                );
-            """)
-            conn.commit()
-            log('INFO', 'Migrated: added session_analytics, improvement_suggestions, nightly_digests tables')
-
-        # Migration: add session_model column if missing (for existing databases)
-        cursor.execute("PRAGMA table_info(session_analytics)")
-        sa_columns = {row[1] for row in cursor.fetchall()}
-        if "session_model" not in sa_columns:
-            cursor.execute("ALTER TABLE session_analytics ADD COLUMN session_model TEXT DEFAULT 'unknown'")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_session_model ON session_analytics (session_model, session_date DESC)")
-            conn.commit()
-            log('INFO', 'Migrated session_analytics: added session_model column + index')
-
-        # Migration: add dispatch_id column to session_analytics if missing
-        cursor.execute("PRAGMA table_info(session_analytics)")
-        sa_cols = {row[1] for row in cursor.fetchall()}
-        if "dispatch_id" not in sa_cols:
-            cursor.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_session_dispatch_id ON session_analytics (dispatch_id)")
-            conn.commit()
-            log('INFO', 'Migrated session_analytics: added dispatch_id column + index')
-
-        # Migration: add context_reset_count to session_analytics if missing
-        cursor.execute("PRAGMA table_info(session_analytics)")
-        sa_cols2 = {row[1] for row in cursor.fetchall()}
-        if "context_reset_count" not in sa_cols2:
-            cursor.execute("ALTER TABLE session_analytics ADD COLUMN context_reset_count INTEGER DEFAULT 0")
-            conn.commit()
-            log('INFO', 'Migrated session_analytics: added context_reset_count column')
-
-        # Migration: create report_findings table if missing
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'")
-        if not cursor.fetchone():
-            cursor.executescript("""
-                CREATE TABLE IF NOT EXISTS report_findings (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    report_path TEXT NOT NULL,
-                    report_date TIMESTAMP,
-                    terminal TEXT,
-                    task_type TEXT,
-                    patterns_found INTEGER,
-                    antipatterns_found INTEGER,
-                    prevention_rules_found INTEGER,
-                    tags_found TEXT,
-                    summary TEXT,
-                    age_category TEXT,
-                    extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    dispatch_id TEXT
-                );
-                CREATE INDEX IF NOT EXISTS idx_report_findings_extracted
-                    ON report_findings (extracted_at DESC);
-                CREATE INDEX IF NOT EXISTS idx_report_findings_dispatch
-                    ON report_findings (dispatch_id);
-            """)
-            conn.commit()
-            log('INFO', 'Migrated: created report_findings table')
-
-        # Migration: add dispatch_id column to report_findings if missing (for existing DBs)
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'")
-        if cursor.fetchone():
-            cursor.execute("PRAGMA table_info(report_findings)")
-            rf_cols = {row[1] for row in cursor.fetchall()}
-            if "dispatch_id" not in rf_cols:
-                cursor.execute("ALTER TABLE report_findings ADD COLUMN dispatch_id TEXT")
-                conn.commit()
-                log('INFO', 'Migrated report_findings: added dispatch_id column')
-
-        # Migration: add CQS columns to dispatch_metadata if missing
-        cursor.execute("PRAGMA table_info(dispatch_metadata)")
-        dm_cols = {row[1] for row in cursor.fetchall()}
-        if "cqs" not in dm_cols:
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
-            conn.commit()
-            log('INFO', 'Migrated dispatch_metadata: added cqs, normalized_status, cqs_components columns')
-
-        # Migration: create governance tables if missing
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='governance_metrics'")
-        if not cursor.fetchone():
-            cursor.executescript("""
-                CREATE TABLE IF NOT EXISTS governance_metrics (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    period_start DATE NOT NULL,
-                    period_end DATE NOT NULL,
-                    scope_type TEXT NOT NULL,
-                    scope_value TEXT NOT NULL,
-                    metric_name TEXT NOT NULL,
-                    metric_value REAL NOT NULL,
-                    sample_size INTEGER NOT NULL,
-                    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
-                );
-                CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup
-                    ON governance_metrics (period_start, scope_type, metric_name);
-
-                CREATE TABLE IF NOT EXISTS spc_control_limits (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    metric_name TEXT NOT NULL,
-                    scope_type TEXT NOT NULL,
-                    scope_value TEXT NOT NULL,
-                    center_line REAL NOT NULL,
-                    ucl REAL NOT NULL,
-                    lcl REAL NOT NULL,
-                    sigma REAL NOT NULL,
-                    sample_count INTEGER NOT NULL,
-                    baseline_start DATE,
-                    baseline_end DATE,
-                    computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    UNIQUE(metric_name, scope_type, scope_value)
-                );
-
-                CREATE TABLE IF NOT EXISTS spc_alerts (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    alert_type TEXT NOT NULL,
-                    metric_name TEXT NOT NULL,
-                    scope_type TEXT NOT NULL,
-                    scope_value TEXT NOT NULL,
-                    observed_value REAL NOT NULL,
-                    control_limit REAL,
-                    description TEXT,
-                    severity TEXT DEFAULT 'warning',
-                    detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    acknowledged_at DATETIME
-                );
-                CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup
-                    ON spc_alerts (detected_at DESC, severity);
-            """)
-            conn.commit()
-            log('INFO', 'Migrated: created governance_metrics, spc_control_limits, spc_alerts tables')
-
-        # Migration: add confidence_events table if missing (F50-PR3 feedback loop)
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_events'")
-        if not cursor.fetchone():
-            cursor.executescript("""
-                CREATE TABLE IF NOT EXISTS confidence_events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    dispatch_id TEXT NOT NULL,
-                    terminal TEXT,
-                    outcome TEXT NOT NULL,
-                    patterns_boosted INTEGER DEFAULT 0,
-                    patterns_decayed INTEGER DEFAULT 0,
-                    confidence_change REAL NOT NULL,
-                    occurred_at TEXT NOT NULL
-                );
-                CREATE INDEX IF NOT EXISTS idx_conf_events_dispatch
-                    ON confidence_events (dispatch_id);
-                CREATE INDEX IF NOT EXISTS idx_conf_events_occurred
-                    ON confidence_events (occurred_at DESC);
-            """)
-            conn.commit()
-            log('INFO', 'Migrated: added confidence_events table')
-
-        # Migration: add CQS enhancement columns (T0 advisory + OI delta) if missing
-        cursor.execute("PRAGMA table_info(dispatch_metadata)")
-        dm_cols_v2 = {row[1] for row in cursor.fetchall()}
-        if "target_open_items" not in dm_cols_v2:
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0")
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0")
-            conn.commit()
-            log('INFO', 'Migrated dispatch_metadata: added target_open_items, open_items_created, open_items_resolved columns')
-
-        # Migration: add quality_advisory_json for CQS round-trip preservation (OI-1175)
-        if "quality_advisory_json" not in dm_cols_v2:
-            cursor.execute("ALTER TABLE dispatch_metadata ADD COLUMN quality_advisory_json TEXT")
-            conn.commit()
-            log('INFO', 'Migrated dispatch_metadata: added quality_advisory_json column')
-
-        # Migration: add dispatch_id to pattern_usage for dispatch-scoped traceability
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='pattern_usage'")
-        if cursor.fetchone():
-            cursor.execute("PRAGMA table_info(pattern_usage)")
-            pu_cols = {row[1] for row in cursor.fetchall()}
-            if "dispatch_id" not in pu_cols:
-                cursor.execute(
-                    "ALTER TABLE pattern_usage ADD COLUMN dispatch_id TEXT DEFAULT NULL"
+        # ---- V2: pattern_hash on snippet_metadata ----
+        def _v2(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(snippet_metadata)").fetchall()}
+            if "pattern_hash" not in cols:
+                c.execute("ALTER TABLE snippet_metadata ADD COLUMN pattern_hash TEXT")
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_snippet_pattern_hash "
+                    "ON snippet_metadata (pattern_hash)"
                 )
-                cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_pattern_usage_dispatch_id "
-                    "ON pattern_usage (dispatch_id)"
+                log('INFO', 'Migrated snippet_metadata: added pattern_hash column + index')
+        schema_migration.apply_if_below(conn, 2, _v2)
+
+        # ---- V3: session_analytics, improvement_suggestions, nightly_digests tables ----
+        def _v3(c):
+            if not c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='session_analytics'"
+            ).fetchone():
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS session_analytics (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        session_id TEXT NOT NULL UNIQUE,
+                        project_path TEXT NOT NULL,
+                        terminal TEXT,
+                        session_date DATE NOT NULL,
+                        total_input_tokens INTEGER DEFAULT 0,
+                        total_output_tokens INTEGER DEFAULT 0,
+                        cache_creation_tokens INTEGER DEFAULT 0,
+                        cache_read_tokens INTEGER DEFAULT 0,
+                        tool_calls_total INTEGER DEFAULT 0,
+                        tool_read_count INTEGER DEFAULT 0,
+                        tool_edit_count INTEGER DEFAULT 0,
+                        tool_bash_count INTEGER DEFAULT 0,
+                        tool_grep_count INTEGER DEFAULT 0,
+                        tool_write_count INTEGER DEFAULT 0,
+                        tool_task_count INTEGER DEFAULT 0,
+                        tool_other_count INTEGER DEFAULT 0,
+                        message_count INTEGER DEFAULT 0,
+                        user_message_count INTEGER DEFAULT 0,
+                        assistant_message_count INTEGER DEFAULT 0,
+                        duration_minutes REAL,
+                        has_error_recovery BOOLEAN DEFAULT FALSE,
+                        has_context_reset BOOLEAN DEFAULT FALSE,
+                        context_reset_count INTEGER DEFAULT 0,
+                        has_large_refactor BOOLEAN DEFAULT FALSE,
+                        has_test_cycle BOOLEAN DEFAULT FALSE,
+                        primary_activity TEXT,
+                        deep_analysis_json TEXT,
+                        deep_analysis_model TEXT,
+                        deep_analysis_at DATETIME,
+                        file_size_bytes INTEGER,
+                        analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        analyzer_version TEXT DEFAULT '1.0.0'
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_terminal "
+                    "ON session_analytics (terminal, session_date DESC)"
                 )
-                conn.commit()
-                log('INFO', 'Migrated pattern_usage: added dispatch_id column + index')
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_project "
+                    "ON session_analytics (project_path, session_date DESC)"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_date "
+                    "ON session_analytics (session_date DESC)"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_activity "
+                    "ON session_analytics (primary_activity)"
+                )
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS improvement_suggestions (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        session_id TEXT NOT NULL,
+                        category TEXT NOT NULL,
+                        component TEXT,
+                        current_behavior TEXT NOT NULL,
+                        suggested_improvement TEXT NOT NULL,
+                        evidence TEXT,
+                        priority TEXT DEFAULT 'medium',
+                        status TEXT DEFAULT 'new',
+                        digest_id TEXT,
+                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        acted_on_at DATETIME
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_improvement_category "
+                    "ON improvement_suggestions (category, status)"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_improvement_priority "
+                    "ON improvement_suggestions (priority, status)"
+                )
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS nightly_digests (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        digest_date DATE NOT NULL UNIQUE,
+                        sessions_analyzed INTEGER DEFAULT 0,
+                        deep_analyzed INTEGER DEFAULT 0,
+                        new_suggestions INTEGER DEFAULT 0,
+                        total_tokens_used INTEGER DEFAULT 0,
+                        digest_markdown TEXT NOT NULL,
+                        digest_path TEXT,
+                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                    )
+                """)
+                log('INFO', 'Migrated: added session_analytics, improvement_suggestions, nightly_digests tables')
+        schema_migration.apply_if_below(conn, 3, _v3)
 
-        # Migration: add source_dispatch_id to prevention_rules for audit linkage
-        cursor.execute("PRAGMA table_info(prevention_rules)")
-        pr_cols = {row[1] for row in cursor.fetchall()}
-        if "source_dispatch_id" not in pr_cols:
-            cursor.execute(
-                "ALTER TABLE prevention_rules ADD COLUMN source_dispatch_id TEXT DEFAULT NULL"
-            )
-            conn.commit()
-            log('INFO', 'Migrated prevention_rules: added source_dispatch_id column')
+        # ---- V4: session_model on session_analytics ----
+        def _v4(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
+            if "session_model" not in cols:
+                c.execute(
+                    "ALTER TABLE session_analytics ADD COLUMN session_model TEXT DEFAULT 'unknown'"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_model "
+                    "ON session_analytics (session_model, session_date DESC)"
+                )
+                log('INFO', 'Migrated session_analytics: added session_model column + index')
+        schema_migration.apply_if_below(conn, 4, _v4)
 
-        # Migration: add temporal validity columns (F54 bi-temporal pattern lifecycle)
-        # Note: SQLite ALTER TABLE does not support non-constant defaults (e.g. CURRENT_TIMESTAMP).
+        # ---- V5: dispatch_id on session_analytics ----
+        def _v5(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
+            if "dispatch_id" not in cols:
+                c.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_dispatch_id "
+                    "ON session_analytics (dispatch_id)"
+                )
+                log('INFO', 'Migrated session_analytics: added dispatch_id column + index')
+        schema_migration.apply_if_below(conn, 5, _v5)
+
+        # ---- V6: context_reset_count on session_analytics ----
+        def _v6(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
+            if "context_reset_count" not in cols:
+                c.execute(
+                    "ALTER TABLE session_analytics ADD COLUMN context_reset_count INTEGER DEFAULT 0"
+                )
+                log('INFO', 'Migrated session_analytics: added context_reset_count column')
+        schema_migration.apply_if_below(conn, 6, _v6)
+
+        # ---- V7: report_findings table ----
+        def _v7(c):
+            if not c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
+            ).fetchone():
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS report_findings (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        report_path TEXT NOT NULL,
+                        report_date TIMESTAMP,
+                        terminal TEXT,
+                        task_type TEXT,
+                        patterns_found INTEGER,
+                        antipatterns_found INTEGER,
+                        prevention_rules_found INTEGER,
+                        tags_found TEXT,
+                        summary TEXT,
+                        age_category TEXT,
+                        extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        dispatch_id TEXT
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_report_findings_extracted "
+                    "ON report_findings (extracted_at DESC)"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_report_findings_dispatch "
+                    "ON report_findings (dispatch_id)"
+                )
+                log('INFO', 'Migrated: created report_findings table')
+        schema_migration.apply_if_below(conn, 7, _v7)
+
+        # ---- V8: dispatch_id on report_findings (for DBs with pre-v7 report_findings) ----
+        def _v8(c):
+            if c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
+            ).fetchone():
+                cols = {r[1] for r in c.execute("PRAGMA table_info(report_findings)").fetchall()}
+                if "dispatch_id" not in cols:
+                    c.execute("ALTER TABLE report_findings ADD COLUMN dispatch_id TEXT")
+                    log('INFO', 'Migrated report_findings: added dispatch_id column')
+        schema_migration.apply_if_below(conn, 8, _v8)
+
+        # ---- V9: CQS columns on dispatch_metadata ----
+        def _v9(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+            if "cqs" not in cols:
+                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
+                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
+                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
+                log('INFO', 'Migrated dispatch_metadata: added cqs, normalized_status, cqs_components columns')
+        schema_migration.apply_if_below(conn, 9, _v9)
+
+        # ---- V10: governance_metrics, spc_control_limits, spc_alerts ----
+        def _v10(c):
+            if not c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='governance_metrics'"
+            ).fetchone():
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS governance_metrics (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        period_start DATE NOT NULL,
+                        period_end DATE NOT NULL,
+                        scope_type TEXT NOT NULL,
+                        scope_value TEXT NOT NULL,
+                        metric_name TEXT NOT NULL,
+                        metric_value REAL NOT NULL,
+                        sample_size INTEGER NOT NULL,
+                        computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup "
+                    "ON governance_metrics (period_start, scope_type, metric_name)"
+                )
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS spc_control_limits (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        metric_name TEXT NOT NULL,
+                        scope_type TEXT NOT NULL,
+                        scope_value TEXT NOT NULL,
+                        center_line REAL NOT NULL,
+                        ucl REAL NOT NULL,
+                        lcl REAL NOT NULL,
+                        sigma REAL NOT NULL,
+                        sample_count INTEGER NOT NULL,
+                        baseline_start DATE,
+                        baseline_end DATE,
+                        computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        UNIQUE(metric_name, scope_type, scope_value)
+                    )
+                """)
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS spc_alerts (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        alert_type TEXT NOT NULL,
+                        metric_name TEXT NOT NULL,
+                        scope_type TEXT NOT NULL,
+                        scope_value TEXT NOT NULL,
+                        observed_value REAL NOT NULL,
+                        control_limit REAL,
+                        description TEXT,
+                        severity TEXT DEFAULT 'warning',
+                        detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        acknowledged_at DATETIME
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup "
+                    "ON spc_alerts (detected_at DESC, severity)"
+                )
+                log('INFO', 'Migrated: created governance_metrics, spc_control_limits, spc_alerts tables')
+        schema_migration.apply_if_below(conn, 10, _v10)
+
+        # ---- V11: confidence_events (F50-PR3 feedback loop) ----
+        def _v11(c):
+            if not c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_events'"
+            ).fetchone():
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS confidence_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        dispatch_id TEXT NOT NULL,
+                        terminal TEXT,
+                        outcome TEXT NOT NULL,
+                        patterns_boosted INTEGER DEFAULT 0,
+                        patterns_decayed INTEGER DEFAULT 0,
+                        confidence_change REAL NOT NULL,
+                        occurred_at TEXT NOT NULL
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_conf_events_dispatch "
+                    "ON confidence_events (dispatch_id)"
+                )
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_conf_events_occurred "
+                    "ON confidence_events (occurred_at DESC)"
+                )
+                log('INFO', 'Migrated: added confidence_events table')
+        schema_migration.apply_if_below(conn, 11, _v11)
+
+        # ---- V12: T0 advisory + OI delta columns on dispatch_metadata ----
+        def _v12(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+            if "target_open_items" not in cols:
+                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
+                c.execute(
+                    "ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0"
+                )
+                c.execute(
+                    "ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0"
+                )
+                log('INFO', 'Migrated dispatch_metadata: added target_open_items, open_items_created, open_items_resolved columns')
+        schema_migration.apply_if_below(conn, 12, _v12)
+
+        # ---- V13: quality_advisory_json for CQS round-trip preservation (OI-1175) ----
+        def _v13(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+            if "quality_advisory_json" not in cols:
+                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN quality_advisory_json TEXT")
+                log('INFO', 'Migrated dispatch_metadata: added quality_advisory_json column')
+        schema_migration.apply_if_below(conn, 13, _v13)
+
+        # ---- V14: dispatch_id on pattern_usage for dispatch-scoped traceability ----
+        def _v14(c):
+            if c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='pattern_usage'"
+            ).fetchone():
+                cols = {r[1] for r in c.execute("PRAGMA table_info(pattern_usage)").fetchall()}
+                if "dispatch_id" not in cols:
+                    c.execute(
+                        "ALTER TABLE pattern_usage ADD COLUMN dispatch_id TEXT DEFAULT NULL"
+                    )
+                    c.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_pattern_usage_dispatch_id "
+                        "ON pattern_usage (dispatch_id)"
+                    )
+                    log('INFO', 'Migrated pattern_usage: added dispatch_id column + index')
+        schema_migration.apply_if_below(conn, 14, _v14)
+
+        # ---- V15: source_dispatch_id on prevention_rules for audit linkage ----
+        def _v15(c):
+            cols = {r[1] for r in c.execute("PRAGMA table_info(prevention_rules)").fetchall()}
+            if "source_dispatch_id" not in cols:
+                c.execute(
+                    "ALTER TABLE prevention_rules ADD COLUMN source_dispatch_id TEXT DEFAULT NULL"
+                )
+                log('INFO', 'Migrated prevention_rules: added source_dispatch_id column')
+        schema_migration.apply_if_below(conn, 15, _v15)
+
+        # ---- V16: temporal validity columns (F54 bi-temporal pattern lifecycle) ----
+        # SQLite ALTER TABLE does not support non-constant defaults (e.g. CURRENT_TIMESTAMP).
         # Add with DEFAULT NULL, then backfill valid_from for existing rows.
-        for _tbl in ("success_patterns", "antipatterns", "prevention_rules"):
-            cursor.execute(f"PRAGMA table_info({_tbl})")
-            _tbl_cols = {row[1] for row in cursor.fetchall()}
-            if "valid_from" not in _tbl_cols:
-                cursor.execute(
-                    f"ALTER TABLE {_tbl} ADD COLUMN valid_from DATETIME DEFAULT NULL"
-                )
-                # Backfill existing rows so valid_from is not null
-                cursor.execute(
-                    f"UPDATE {_tbl} SET valid_from = datetime('now') WHERE valid_from IS NULL"
-                )
-                conn.commit()
-                log('INFO', f'Migrated {_tbl}: added valid_from column + backfilled existing rows')
-            if "valid_until" not in _tbl_cols:
-                cursor.execute(
-                    f"ALTER TABLE {_tbl} ADD COLUMN valid_until DATETIME DEFAULT NULL"
-                )
-                conn.commit()
-                log('INFO', f'Migrated {_tbl}: added valid_until column')
+        def _v16(c):
+            for tbl in ("success_patterns", "antipatterns", "prevention_rules"):
+                cols = {r[1] for r in c.execute(f"PRAGMA table_info({tbl})").fetchall()}
+                if "valid_from" not in cols:
+                    c.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_from DATETIME DEFAULT NULL")
+                    c.execute(
+                        f"UPDATE {tbl} SET valid_from = datetime('now') WHERE valid_from IS NULL"
+                    )
+                    log('INFO', f'Migrated {tbl}: added valid_from column + backfilled existing rows')
+                if "valid_until" not in cols:
+                    c.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_until DATETIME DEFAULT NULL")
+                    log('INFO', f'Migrated {tbl}: added valid_until column')
+        schema_migration.apply_if_below(conn, 16, _v16)
 
-        # Migration: create dispatch_pattern_offered junction table for isolated per-dispatch
-        # pattern tracking.  Replaces pattern_usage.dispatch_id as the lookup key for
-        # _update_pattern_confidence so concurrent dispatches cannot overwrite each other.
-        cursor.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND name='dispatch_pattern_offered'"
-        )
-        if not cursor.fetchone():
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
-                    dispatch_id   TEXT NOT NULL,
-                    pattern_id    TEXT NOT NULL,
-                    pattern_title TEXT NOT NULL,
-                    offered_at    TEXT NOT NULL,
-                    PRIMARY KEY (dispatch_id, pattern_id)
+        # ---- V17: dispatch_pattern_offered junction table ----
+        def _v17(c):
+            if not c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='dispatch_pattern_offered'"
+            ).fetchone():
+                c.execute("""
+                    CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+                        dispatch_id   TEXT NOT NULL,
+                        pattern_id    TEXT NOT NULL,
+                        pattern_title TEXT NOT NULL,
+                        offered_at    TEXT NOT NULL,
+                        PRIMARY KEY (dispatch_id, pattern_id)
+                    )
+                """)
+                c.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_dpo_dispatch_id "
+                    "ON dispatch_pattern_offered (dispatch_id)"
                 )
-                """
-            )
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_dpo_dispatch_id "
-                "ON dispatch_pattern_offered (dispatch_id)"
-            )
-            conn.commit()
-            log('INFO', 'Migrated: created dispatch_pattern_offered table + index')
+                log('INFO', 'Migrated: created dispatch_pattern_offered table + index')
+        schema_migration.apply_if_below(conn, 17, _v17)
 
         log('SUCCESS', 'Database schema initialized successfully')
-
-        # Close connection
         conn.close()
-
         return True
 
     except Exception as e:

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -125,13 +125,11 @@ def bootstrap_qi_db(db_path: Path, schema_file: Path | None = None) -> bool:
         conn = sqlite3.connect(str(db_path))
         conn.isolation_level = None  # manual transaction management for SAVEPOINT correctness
 
-        # ---- V1: base schema (executescript commits automatically) ----
-        if schema_migration.get_user_version(conn) < 1:
-            conn.executescript(schema_sql)
-            conn.execute('SAVEPOINT "vnx_mig_1"')
-            conn.execute("PRAGMA user_version = 1")
-            conn.execute('RELEASE SAVEPOINT "vnx_mig_1"')
-            log('INFO', 'Base schema applied (v1)')
+        # ---- V1: base schema applied atomically (codex round-3 fix) ----
+        # schema_migration.apply_script_if_below splits SQL and runs all statements
+        # + user_version stamp inside ONE SAVEPOINT — mid-script failure rolls back ALL
+        if schema_migration.apply_script_if_below(conn, 1, schema_sql):
+            log('INFO', 'Base schema applied atomically (v1)')
 
         # ---- V2: pattern_hash on snippet_metadata ----
         def _v2(c):

--- a/tests/test_schema_idempotency.py
+++ b/tests/test_schema_idempotency.py
@@ -23,6 +23,7 @@ for _p in (_SCRIPTS, _LIB):
 
 from quality_db_init import bootstrap_qi_db, HIGHEST_QI_VERSION
 from schema_migration import apply_if_below, get_user_version
+import coordination_db
 
 _SCHEMA_FILE = Path(__file__).resolve().parent.parent / "schemas" / "quality_intelligence.sql"
 
@@ -172,3 +173,42 @@ def test_bootstrap_idempotent_repeated_runs(tmp_path):
         assert _uv(db) == HIGHEST_QI_VERSION, (
             f"user_version drifted on run {run + 1}: expected {HIGHEST_QI_VERSION}, got {_uv(db)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for coordination_db._needs_initial_migration legacy fallback
+# ---------------------------------------------------------------------------
+
+def test_needs_initial_migration_fresh_db():
+    """Fresh DB (PRAGMA=0, no runtime_schema_version table) → needs migration."""
+    conn = sqlite3.connect(":memory:")
+    assert coordination_db._needs_initial_migration(conn) is True
+    conn.close()
+
+
+def test_needs_initial_migration_pragma_high():
+    """PRAGMA user_version=10 → no migration needed."""
+    conn = sqlite3.connect(":memory:")
+    conn.isolation_level = None
+    conn.execute("PRAGMA user_version = 10")
+    assert coordination_db._needs_initial_migration(conn) is False
+    conn.close()
+
+
+def test_needs_initial_migration_legacy_table_syncs_pragma():
+    """PRAGMA=0 but runtime_schema_version table has v9 → no migration + PRAGMA synced to 9."""
+    conn = sqlite3.connect(":memory:")
+    conn.isolation_level = None
+    conn.execute("""
+        CREATE TABLE runtime_schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT
+        )
+    """)
+    conn.execute(
+        "INSERT INTO runtime_schema_version (version, applied_at) VALUES (9, '2026-01-01')"
+    )
+    assert get_user_version(conn) == 0
+    assert coordination_db._needs_initial_migration(conn) is False
+    assert get_user_version(conn) == 9
+    conn.close()

--- a/tests/test_schema_idempotency.py
+++ b/tests/test_schema_idempotency.py
@@ -1,0 +1,174 @@
+"""Tests for idempotent schema bootstrap via PRAGMA user_version.
+
+Covers:
+1. Fresh DB bootstrap → all migrations applied, user_version = HIGHEST_QI_VERSION
+2. Already-bootstrapped DB → 0 new migrations, user_version unchanged
+3. DB at user_version=9 → remaining migrations applied, user_version = HIGHEST_QI_VERSION
+4. Mid-migration failure → transaction rollback, user_version unchanged
+5. Repeated bootstrap (5×) → user_version stays at HIGHEST_QI_VERSION after first run
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+_LIB = _SCRIPTS / "lib"
+for _p in (_SCRIPTS, _LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from quality_db_init import bootstrap_qi_db, HIGHEST_QI_VERSION
+from schema_migration import apply_if_below, get_user_version
+
+_SCHEMA_FILE = Path(__file__).resolve().parent.parent / "schemas" / "quality_intelligence.sql"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _uv(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    v = conn.execute("PRAGMA user_version").fetchone()[0]
+    conn.close()
+    return v
+
+
+def _set_uv(db_path: Path, version: int) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None
+    conn.execute(f"PRAGMA user_version = {version}")
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: fresh DB → all migrations applied
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_fresh_db_applies_all_migrations(tmp_path):
+    """Bootstrap on an empty DB must apply every migration and reach HIGHEST_QI_VERSION."""
+    db = tmp_path / "qi_fresh.db"
+    assert not db.exists()
+
+    result = bootstrap_qi_db(db, schema_file=_SCHEMA_FILE)
+
+    assert result is True, "bootstrap_qi_db must return True on success"
+    assert db.exists(), "DB file must be created"
+    assert _uv(db) == HIGHEST_QI_VERSION, (
+        f"Expected user_version={HIGHEST_QI_VERSION}, got {_uv(db)}"
+    )
+
+    # Spot-check key tables created by inline migrations
+    conn = sqlite3.connect(str(db))
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    conn.close()
+    for tbl in (
+        "session_analytics",
+        "report_findings",
+        "governance_metrics",
+        "confidence_events",
+        "dispatch_pattern_offered",
+    ):
+        assert tbl in tables, f"Table '{tbl}' missing after bootstrap"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: already-bootstrapped DB → 0 new migrations
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_already_complete_skips_all_migrations(tmp_path):
+    """Second bootstrap on a fully-migrated DB must be a no-op."""
+    db = tmp_path / "qi_complete.db"
+
+    # Initial bootstrap
+    assert bootstrap_qi_db(db, schema_file=_SCHEMA_FILE) is True
+    assert _uv(db) == HIGHEST_QI_VERSION
+
+    # Second bootstrap — user_version must not change
+    result = bootstrap_qi_db(db, schema_file=_SCHEMA_FILE)
+
+    assert result is True
+    assert _uv(db) == HIGHEST_QI_VERSION, "user_version must remain unchanged on re-bootstrap"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: DB at user_version=9 → only remaining migrations applied
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_partial_db_applies_remaining_migrations(tmp_path):
+    """DB at user_version=9 must have migrations 10-HIGHEST applied; 1-9 skipped."""
+    db = tmp_path / "qi_v9.db"
+
+    # Build a fully-bootstrapped DB so all tables/columns exist
+    assert bootstrap_qi_db(db, schema_file=_SCHEMA_FILE) is True
+    assert _uv(db) == HIGHEST_QI_VERSION
+
+    # Simulate a v9 state (roll back user_version stamp, schema unchanged)
+    _set_uv(db, 9)
+    assert _uv(db) == 9
+
+    # Re-bootstrap should advance from 9 to HIGHEST_QI_VERSION
+    result = bootstrap_qi_db(db, schema_file=_SCHEMA_FILE)
+
+    assert result is True
+    assert _uv(db) == HIGHEST_QI_VERSION, (
+        f"Expected user_version={HIGHEST_QI_VERSION} after re-bootstrap from 9, got {_uv(db)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: mid-migration failure → rollback, user_version unchanged
+# ---------------------------------------------------------------------------
+
+def test_apply_if_below_rolls_back_on_failure():
+    """apply_if_below must roll back and leave user_version unchanged on migration failure."""
+    conn = sqlite3.connect(":memory:")
+    conn.isolation_level = None
+    conn.executescript("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+
+    # Run a successful migration first to get to version 1
+    def _ok(c):
+        c.execute("ALTER TABLE t ADD COLUMN a TEXT")
+    assert apply_if_below(conn, 1, _ok) is True
+    assert get_user_version(conn) == 1
+
+    # Now attempt a failing migration
+    def _fail(c):
+        c.execute("ALTER TABLE t ADD COLUMN b TEXT")
+        raise RuntimeError("simulated failure")
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        apply_if_below(conn, 2, _fail)
+
+    # user_version must still be 1 (rolled back)
+    assert get_user_version(conn) == 1, (
+        "user_version must not advance when migration_fn raises"
+    )
+
+    # Column 'b' must not exist (transaction rolled back)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(t)").fetchall()}
+    assert "b" not in cols, "Rolled-back column 'b' must not appear in schema"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: repeated bootstrap is idempotent (5 runs)
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_idempotent_repeated_runs(tmp_path):
+    """Calling bootstrap_qi_db 5 times on the same DB must produce identical final state."""
+    db = tmp_path / "qi_repeat.db"
+
+    for run in range(5):
+        result = bootstrap_qi_db(db, schema_file=_SCHEMA_FILE)
+        assert result is True, f"bootstrap_qi_db failed on run {run + 1}"
+        assert _uv(db) == HIGHEST_QI_VERSION, (
+            f"user_version drifted on run {run + 1}: expected {HIGHEST_QI_VERSION}, got {_uv(db)}"
+        )

--- a/tests/test_schema_idempotency.py
+++ b/tests/test_schema_idempotency.py
@@ -212,3 +212,98 @@ def test_needs_initial_migration_legacy_table_syncs_pragma():
     assert coordination_db._needs_initial_migration(conn) is False
     assert get_user_version(conn) == 9
     conn.close()
+
+
+# ----------------------------------------------------------------------
+# Codex round-2 atomicity fix: apply_script_if_below splits SQL and runs
+# the entire script + version stamp inside a single SAVEPOINT.
+# ----------------------------------------------------------------------
+
+def test_apply_script_if_below_atomic_failure_rolls_back(tmp_path):
+    """Mid-script failure must roll back ALL statements + version stamp."""
+    import sqlite3
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+    import schema_migration
+
+    db_path = tmp_path / "test_atomic.db"
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        # Script with a syntax error on the 3rd statement
+        bad_sql = """
+        CREATE TABLE good_a (id INTEGER PRIMARY KEY);
+        CREATE TABLE good_b (id INTEGER PRIMARY KEY);
+        CREATE NONSENSE_STATEMENT_INVALID_SQL;
+        CREATE TABLE never_created (id INTEGER PRIMARY KEY);
+        """
+        try:
+            schema_migration.apply_script_if_below(conn, 5, bad_sql)
+            assert False, "expected exception on bad SQL"
+        except sqlite3.OperationalError:
+            pass
+
+        # Atomicity: good_a + good_b should NOT exist (rolled back)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('good_a', 'good_b', 'never_created')"
+        ).fetchall()
+        assert rows == [], f"expected no tables created, got {rows}"
+
+        # Version stamp also rolled back
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_apply_script_if_below_success(tmp_path):
+    """Successful script: all statements + version stamp applied."""
+    import sqlite3
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+    import schema_migration
+
+    db_path = tmp_path / "test_atomic_ok.db"
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        good_sql = """
+        -- comment with ; in it
+        CREATE TABLE t1 (id INTEGER PRIMARY KEY, label TEXT DEFAULT 'a;b;c');
+        CREATE TABLE t2 (id INTEGER PRIMARY KEY);
+        """
+        applied = schema_migration.apply_script_if_below(conn, 7, good_sql)
+        assert applied is True
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["t1", "t2"]
+
+        # Second call: skip
+        applied2 = schema_migration.apply_script_if_below(conn, 7, good_sql)
+        assert applied2 is False
+    finally:
+        conn.close()
+
+
+def test_split_sql_statements_quote_and_comment_safe():
+    """Splitter must not break on semicolons inside strings or comments."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+    from schema_migration import _split_sql_statements
+
+    sql = """
+    -- leading comment; ignored
+    CREATE TABLE x (
+        id INTEGER PRIMARY KEY,
+        note TEXT DEFAULT 'has;semicolon'
+    );
+    /* block; comment; with; semicolons */
+    INSERT INTO x (note) VALUES ('a;b;c');
+    """
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2, f"expected 2 statements, got {len(stmts)}: {stmts}"
+    assert "CREATE TABLE" in stmts[0]
+    assert "INSERT INTO" in stmts[1]


### PR DESCRIPTION
## Summary

- New `scripts/lib/schema_migration.py` helper with `apply_if_below()` (SAVEPOINT-based atomicity) and `apply_script_if_below()` (executescript caller support)
- `bootstrap_qi_db` refactored into 17 explicit migration versions (v1–v17), each skipped if `PRAGMA user_version >= target`; `isolation_level=None` for explicit transaction control
- `init_schema` in `coordination_db.py` checks `user_version` before base schema and each versioned migration file (v2–v10); version stamped via SAVEPOINT post-executescript
- 5 new tests in `tests/test_schema_idempotency.py`: fresh bootstrap, already-complete skip, partial (v9→17) advancement, rollback on failure, 5× idempotent repeat — all pass

## Test plan

- [x] `pytest tests/test_schema_idempotency.py -v` → 5/5 passed
- [x] `pytest tests/test_runtime_coordination.py` → identical count to baseline (37 pre-existing failures, no regression)
- [x] `bootstrap_qi_db` on fresh DB → `PRAGMA user_version = 17`
- [x] Mid-migration failure rolls back via SAVEPOINT (user_version unchanged)
- [x] DB at user_version=9 advances to 17 on re-bootstrap

🤖 Generated with [Claude Code](https://claude.ai/claude-code)