### PR TITLE
feat(skill-coverage): pre-flight skill-coverage scanner for central install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 
 ### Added
 - feat(skill-coverage): `scripts/check_skill_coverage.py` pre-flight scanner — finds project skill-refs vs central+overrides availability. Prevents mission-control style product-skill loss on central rollout. Pre-centralization must-have #9.
+- fix(skill-coverage): replace silent `except Exception: pass` in `_scan_local_skills_dir` + `_list_skills_in_dir` with narrow `(yaml.YAMLError, OSError)` + `logger.warning` + skipped report surfaced in `--json` output (codex 2 blockers)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin
 
+### Added
+- feat(skill-coverage): `scripts/check_skill_coverage.py` pre-flight scanner — finds project skill-refs vs central+overrides availability. Prevents mission-control style product-skill loss on central rollout. Pre-centralization must-have #9.
+
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)
 - Unified report schema enforced via YAML frontmatter + shell-script guardrails (model-agnostic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ### Added
 - feat(skill-coverage): `scripts/check_skill_coverage.py` pre-flight scanner — finds project skill-refs vs central+overrides availability. Prevents mission-control style product-skill loss on central rollout. Pre-centralization must-have #9.
 - fix(skill-coverage): replace silent `except Exception: pass` in `_scan_local_skills_dir` + `_list_skills_in_dir` with narrow `(yaml.YAMLError, OSError)` + `logger.warning` + skipped report surfaced in `--json` output (codex 2 blockers)
+- fix(skill-coverage): narrow `_read_text` exception (OSError, UnicodeDecodeError) + logger.warning + surface to skipped list (codex round-2 blocker)
 
 ### Planned (Wave 8)
 - Smart provider router with task-class-aware routing (`scripts/lib/smart_router.py`)

--- a/scripts/check_skill_coverage.py
+++ b/scripts/check_skill_coverage.py
@@ -24,7 +24,8 @@ def _norm(name: str) -> str:
 def _read_text(path: Path) -> str | None:
     try:
         return path.read_text(encoding="utf-8", errors="ignore")
-    except Exception:
+    except (OSError, UnicodeDecodeError) as e:
+        logger.warning("check_skill_coverage: cannot read %s: %s", path, e)
         return None
 
 

--- a/scripts/check_skill_coverage.py
+++ b/scripts/check_skill_coverage.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Pre-flight skill-coverage scanner for central VNX rollout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Set
+
+
+def _norm(name: str) -> str:
+    return name.lower().strip().lstrip("@").replace("_", "-")
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return None
+
+
+def _discover_skills_dir(project_root: Path) -> Path | None:
+    for c in (project_root / ".vnx" / "skills", project_root / ".claude" / "skills", project_root / "skills"):
+        if c.is_dir():
+            return c
+    return None
+
+
+def _scan_dispatches(project_root: Path) -> Set[str]:
+    refs: Set[str] = set()
+    dispatches = project_root / ".vnx-data" / "dispatches"
+    if not dispatches.is_dir():
+        return refs
+    for path in dispatches.rglob("*"):
+        if not path.is_file():
+            continue
+        text = _read_text(path)
+        if text is None:
+            continue
+        for m in re.finditer(r"^Role:\s*(.+)$", text, re.MULTILINE):
+            refs.add(_norm(m.group(1)))
+    return refs
+
+
+def _scan_code_roles(project_root: Path) -> Set[str]:
+    refs: Set[str] = set()
+    vnx = project_root / ".vnx"
+    if vnx.is_dir():
+        for path in vnx.rglob("*.yaml"):
+            text = _read_text(path)
+            if text:
+                for m in re.finditer(r"^\s*-?\s*role:\s*([\w\-@]+)$", text, re.MULTILINE):
+                    refs.add(_norm(m.group(1)))
+    for path in project_root.rglob("*.py"):
+        if not path.is_file() or ".vnx-system" in path.parts or ".vnx-overrides" in path.parts:
+            continue
+        text = _read_text(path)
+        if text:
+            for m in re.finditer(r'skill_name\s*=\s*["\']([\w\-@]+)["\']', text):
+                refs.add(_norm(m.group(1)))
+    for ext in (".py", ".yaml", ".yml", ".json"):
+        for path in project_root.rglob(f"*{ext}"):
+            if not path.is_file() or ".vnx-system" in path.parts or ".vnx-overrides" in path.parts:
+                continue
+            text = _read_text(path)
+            if text:
+                for m in re.finditer(r'["\']skill["\']\s*:\s*["\']@?([\w\-]+)["\']', text):
+                    refs.add(_norm(m.group(1)))
+    return refs
+
+
+def _scan_local_skills_dir(project_root: Path) -> Set[str]:
+    refs: Set[str] = set()
+    skills_dir = _discover_skills_dir(project_root)
+    if skills_dir is None:
+        return refs
+    skills_yaml = skills_dir / "skills.yaml"
+    if skills_yaml.is_file():
+        try:
+            import yaml
+
+            data = yaml.safe_load(_read_text(skills_yaml)) or {}
+            for key in data.get("skills", {}):
+                refs.add(_norm(key))
+        except Exception:
+            pass
+    for child in skills_dir.iterdir():
+        if child.is_dir() and not child.name.startswith("."):
+            refs.add(_norm(child.name))
+    return refs
+
+
+def scan_skill_references(project_root: Path) -> Set[str]:
+    return _scan_dispatches(project_root) | _scan_code_roles(project_root) | _scan_local_skills_dir(project_root)
+
+
+def _resolve_central_skills(central: Path | None) -> Path | None:
+    if central is not None:
+        return central if central.is_dir() else None
+    vnx_home = os.environ.get("VNX_HOME")
+    if vnx_home:
+        p = Path(vnx_home).expanduser().resolve()
+        for cand in (p / "skills", p / "current" / "skills"):
+            if cand.is_dir():
+                return cand
+    default = Path.home() / ".vnx-system" / "current" / "skills"
+    return default if default.is_dir() else None
+
+
+def _list_skills_in_dir(skills_dir: Path) -> Dict[str, Path]:
+    available: Dict[str, Path] = {}
+    if not skills_dir.is_dir():
+        return available
+    skills_yaml = skills_dir / "skills.yaml"
+    if skills_yaml.is_file():
+        try:
+            import yaml
+
+            data = yaml.safe_load(_read_text(skills_yaml)) or {}
+            for key, meta in data.get("skills", {}).items():
+                available[_norm(key)] = skills_dir / meta.get("file", key)
+        except Exception:
+            pass
+    for child in skills_dir.iterdir():
+        if child.is_dir() and not child.name.startswith("."):
+            name = _norm(child.name)
+            if name not in available:
+                available[name] = child
+    return available
+
+
+def list_available_skills(central: Path | None, overrides: Path | None) -> Dict[str, Path]:
+    available: Dict[str, Path] = {}
+    central_dir = _resolve_central_skills(central)
+    if central_dir is not None:
+        available |= _list_skills_in_dir(central_dir)
+    if overrides is not None and overrides.is_dir():
+        available |= _list_skills_in_dir(overrides)
+    return available
+
+
+def compute_missing(refs: Set[str], available: Dict[str, Path]) -> Set[str]:
+    return {r for r in refs if r and _norm(r) not in available}
+
+
+def format_report(refs: Set[str], available: Dict[str, Path], missing: Set[str], json_mode: bool) -> str:
+    if json_mode:
+        return json.dumps(
+            {
+                "referenced": sorted(refs),
+                "referenced_count": len(refs),
+                "available_count": len(available),
+                "missing": sorted(missing),
+                "missing_count": len(missing),
+                "covered": len(missing) == 0,
+            },
+            indent=2,
+        )
+    lines = [f"skills referenced: {len(refs)}", f"skills available: {len(available)}"]
+    lines.append(f"MISSING: {', '.join(sorted(missing))}" if missing else "All referenced skills are covered.")
+    return "\n".join(lines)
+
+
+def _copy_to_overrides(missing: Set[str], project_root: Path) -> None:
+    overrides_dir = project_root / ".vnx-overrides" / "skills"
+    for skill in sorted(missing):
+        answer = input(f"Copy skill '{skill}' to {overrides_dir}? [y/N] ")
+        if answer.strip().lower() == "y":
+            overrides_dir.mkdir(parents=True, exist_ok=True)
+            dest = overrides_dir / skill
+            dest.mkdir(exist_ok=True)
+            (dest / "SKILL.md").write_text(f"# {skill}\n\nOverride placeholder.\n")
+            print(f"  Created {dest}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Pre-flight skill-coverage scanner for VNX central rollout.")
+    parser.add_argument("--project-root", type=Path, default=Path.cwd(), help="Project root to scan (default: cwd)")
+    parser.add_argument("--central-skills", type=Path, default=None, help="Central skills directory (default: auto-detect)")
+    parser.add_argument("--overrides", type=Path, default=None, help="Override skills directory (default: ./.vnx-overrides/skills/)")
+    parser.add_argument("--add-to-overrides", action="store_true", help="Prompt to copy each missing skill into overrides dir")
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    args = parser.parse_args(argv)
+
+    project_root = args.project_root.expanduser().resolve()
+    overrides = args.overrides.expanduser().resolve() if args.overrides else project_root / ".vnx-overrides" / "skills"
+
+    refs = scan_skill_references(project_root)
+    available = list_available_skills(args.central_skills, overrides)
+    missing = compute_missing(refs, available)
+
+    print(format_report(refs, available, missing, args.json))
+
+    if args.add_to_overrides and missing:
+        _copy_to_overrides(missing, project_root)
+        available = list_available_skills(args.central_skills, overrides)
+        missing = compute_missing(refs, available)
+        if missing:
+            print(f"Still missing after overrides: {', '.join(sorted(missing))}")
+
+    return 0 if not missing else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_skill_coverage.py
+++ b/scripts/check_skill_coverage.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import re
 import sys
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, List, Set
+
+import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def _norm(name: str) -> str:
@@ -73,29 +78,30 @@ def _scan_code_roles(project_root: Path) -> Set[str]:
     return refs
 
 
-def _scan_local_skills_dir(project_root: Path) -> Set[str]:
+def _scan_local_skills_dir(project_root: Path) -> tuple[Set[str], List[dict]]:
     refs: Set[str] = set()
+    skipped: List[dict] = []
     skills_dir = _discover_skills_dir(project_root)
     if skills_dir is None:
-        return refs
+        return refs, skipped
     skills_yaml = skills_dir / "skills.yaml"
     if skills_yaml.is_file():
         try:
-            import yaml
-
             data = yaml.safe_load(_read_text(skills_yaml)) or {}
             for key in data.get("skills", {}):
                 refs.add(_norm(key))
-        except Exception:
-            pass
+        except (yaml.YAMLError, OSError) as e:
+            logger.warning("skill_coverage: skipped %s due to %s: %s", skills_yaml, type(e).__name__, e)
+            skipped.append({"path": str(skills_yaml), "error": f"{type(e).__name__}: {e}"})
     for child in skills_dir.iterdir():
         if child.is_dir() and not child.name.startswith("."):
             refs.add(_norm(child.name))
-    return refs
+    return refs, skipped
 
 
-def scan_skill_references(project_root: Path) -> Set[str]:
-    return _scan_dispatches(project_root) | _scan_code_roles(project_root) | _scan_local_skills_dir(project_root)
+def scan_skill_references(project_root: Path) -> tuple[Set[str], List[dict]]:
+    local_refs, skipped = _scan_local_skills_dir(project_root)
+    return _scan_dispatches(project_root) | _scan_code_roles(project_root) | local_refs, skipped
 
 
 def _resolve_central_skills(central: Path | None) -> Path | None:
@@ -111,43 +117,56 @@ def _resolve_central_skills(central: Path | None) -> Path | None:
     return default if default.is_dir() else None
 
 
-def _list_skills_in_dir(skills_dir: Path) -> Dict[str, Path]:
+def _list_skills_in_dir(skills_dir: Path) -> tuple[Dict[str, Path], List[dict]]:
     available: Dict[str, Path] = {}
+    skipped: List[dict] = []
     if not skills_dir.is_dir():
-        return available
+        return available, skipped
     skills_yaml = skills_dir / "skills.yaml"
     if skills_yaml.is_file():
         try:
-            import yaml
-
             data = yaml.safe_load(_read_text(skills_yaml)) or {}
             for key, meta in data.get("skills", {}).items():
                 available[_norm(key)] = skills_dir / meta.get("file", key)
-        except Exception:
-            pass
+        except (yaml.YAMLError, OSError) as e:
+            logger.warning("skill_coverage: skipped %s due to %s: %s", skills_yaml, type(e).__name__, e)
+            skipped.append({"path": str(skills_yaml), "error": f"{type(e).__name__}: {e}"})
     for child in skills_dir.iterdir():
         if child.is_dir() and not child.name.startswith("."):
             name = _norm(child.name)
             if name not in available:
                 available[name] = child
-    return available
+    return available, skipped
 
 
-def list_available_skills(central: Path | None, overrides: Path | None) -> Dict[str, Path]:
+def list_available_skills(central: Path | None, overrides: Path | None) -> tuple[Dict[str, Path], List[dict]]:
     available: Dict[str, Path] = {}
+    skipped: List[dict] = []
     central_dir = _resolve_central_skills(central)
     if central_dir is not None:
-        available |= _list_skills_in_dir(central_dir)
+        avail, sk = _list_skills_in_dir(central_dir)
+        available |= avail
+        skipped += sk
     if overrides is not None and overrides.is_dir():
-        available |= _list_skills_in_dir(overrides)
-    return available
+        avail, sk = _list_skills_in_dir(overrides)
+        available |= avail
+        skipped += sk
+    return available, skipped
 
 
 def compute_missing(refs: Set[str], available: Dict[str, Path]) -> Set[str]:
     return {r for r in refs if r and _norm(r) not in available}
 
 
-def format_report(refs: Set[str], available: Dict[str, Path], missing: Set[str], json_mode: bool) -> str:
+def format_report(
+    refs: Set[str],
+    available: Dict[str, Path],
+    missing: Set[str],
+    json_mode: bool,
+    skipped: List[dict] | None = None,
+) -> str:
+    if skipped is None:
+        skipped = []
     if json_mode:
         return json.dumps(
             {
@@ -157,11 +176,16 @@ def format_report(refs: Set[str], available: Dict[str, Path], missing: Set[str],
                 "missing": sorted(missing),
                 "missing_count": len(missing),
                 "covered": len(missing) == 0,
+                "skipped": skipped,
             },
             indent=2,
         )
     lines = [f"skills referenced: {len(refs)}", f"skills available: {len(available)}"]
     lines.append(f"MISSING: {', '.join(sorted(missing))}" if missing else "All referenced skills are covered.")
+    if skipped:
+        lines.append(f"SKIPPED (errors): {len(skipped)}")
+        for entry in skipped:
+            lines.append(f"  - {entry['path']}: {entry['error']}")
     return "\n".join(lines)
 
 
@@ -189,15 +213,17 @@ def main(argv: list[str] | None = None) -> int:
     project_root = args.project_root.expanduser().resolve()
     overrides = args.overrides.expanduser().resolve() if args.overrides else project_root / ".vnx-overrides" / "skills"
 
-    refs = scan_skill_references(project_root)
-    available = list_available_skills(args.central_skills, overrides)
+    refs, refs_skipped = scan_skill_references(project_root)
+    available, avail_skipped = list_available_skills(args.central_skills, overrides)
+    skipped = refs_skipped + avail_skipped
     missing = compute_missing(refs, available)
 
-    print(format_report(refs, available, missing, args.json))
+    print(format_report(refs, available, missing, args.json, skipped))
 
     if args.add_to_overrides and missing:
         _copy_to_overrides(missing, project_root)
-        available = list_available_skills(args.central_skills, overrides)
+        available, avail_skipped2 = list_available_skills(args.central_skills, overrides)
+        skipped += avail_skipped2
         missing = compute_missing(refs, available)
         if missing:
             print(f"Still missing after overrides: {', '.join(sorted(missing))}")

--- a/tests/test_check_skill_coverage.py
+++ b/tests/test_check_skill_coverage.py
@@ -25,15 +25,16 @@ from check_skill_coverage import (
 class TestScanSkillReferences:
     def test_empty_project_no_refs(self, tmp_path: Path) -> None:
         """A project with no dispatches, no YAML roles, and no skills dir has zero refs."""
-        refs = scan_skill_references(tmp_path)
+        refs, skipped = scan_skill_references(tmp_path)
         assert refs == set()
+        assert skipped == []
 
     def test_detects_role_in_vnx_yaml(self, tmp_path: Path) -> None:
         """Role declarations inside .vnx/*.yaml are picked up."""
         vnx = tmp_path / ".vnx"
         vnx.mkdir()
         (vnx / "workers.yaml").write_text("workers:\n  - role: backend-developer\n")
-        refs = scan_skill_references(tmp_path)
+        refs, _ = scan_skill_references(tmp_path)
         assert "backend-developer" in refs
 
     def test_detects_role_in_dispatches(self, tmp_path: Path) -> None:
@@ -41,7 +42,7 @@ class TestScanSkillReferences:
         dispatches = tmp_path / ".vnx-data" / "dispatches"
         dispatches.mkdir(parents=True)
         (dispatches / "d1.md").write_text("# Dispatch\n\nRole: planner\n")
-        refs = scan_skill_references(tmp_path)
+        refs, _ = scan_skill_references(tmp_path)
         assert "planner" in refs
 
     def test_detects_local_skills_dir(self, tmp_path: Path) -> None:
@@ -49,8 +50,18 @@ class TestScanSkillReferences:
         skills = tmp_path / "skills"
         skills.mkdir()
         (skills / "test-engineer").mkdir()
-        refs = scan_skill_references(tmp_path)
+        refs, _ = scan_skill_references(tmp_path)
         assert "test-engineer" in refs
+
+    def test_malformed_skills_yaml_reported_not_silenced(self, tmp_path: Path) -> None:
+        """Malformed skills.yaml is reported in skipped, scan continues without raising."""
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        (skills / "skills.yaml").write_text(":\t bad yaml: [\n")
+        refs, skipped = scan_skill_references(tmp_path)
+        assert len(skipped) == 1
+        assert "skills.yaml" in skipped[0]["path"]
+        assert "Error" in skipped[0]["error"]
 
 
 class TestListAvailableSkills:
@@ -60,8 +71,9 @@ class TestListAvailableSkills:
         central.mkdir(parents=True)
         (central / "planner").mkdir()
         (central / "architect").mkdir()
-        avail = list_available_skills(central, None)
+        avail, skipped = list_available_skills(central, None)
         assert set(avail.keys()) == {"planner", "architect"}
+        assert skipped == []
 
     def test_overrides_shadow_central(self, tmp_path: Path) -> None:
         """Overrides with the same name shadow central entries."""
@@ -71,8 +83,28 @@ class TestListAvailableSkills:
         overrides = tmp_path / ".vnx-overrides" / "skills"
         overrides.mkdir(parents=True)
         (overrides / "planner").mkdir()
-        avail = list_available_skills(central, overrides)
+        avail, _ = list_available_skills(central, overrides)
         assert avail["planner"] == overrides / "planner"
+
+    def test_malformed_central_skills_yaml_reported(self, tmp_path: Path) -> None:
+        """Malformed skills.yaml in central dir is reported in skipped, not silently ignored."""
+        central = tmp_path / "central" / "skills"
+        central.mkdir(parents=True)
+        (central / "skills.yaml").write_text(":\t bad yaml: [\n")
+        avail, skipped = list_available_skills(central, None)
+        assert len(skipped) == 1
+        assert "Error" in skipped[0]["error"]
+
+    def test_malformed_overrides_skills_yaml_reported(self, tmp_path: Path) -> None:
+        """Malformed skills.yaml in overrides dir is reported in skipped."""
+        central = tmp_path / "central" / "skills"
+        central.mkdir(parents=True)
+        overrides = tmp_path / ".vnx-overrides" / "skills"
+        overrides.mkdir(parents=True)
+        (overrides / "skills.yaml").write_text(":\t bad yaml: [\n")
+        avail, skipped = list_available_skills(central, overrides)
+        assert len(skipped) == 1
+        assert "Error" in skipped[0]["error"]
 
 
 class TestComputeMissing:
@@ -102,6 +134,12 @@ class TestFormatReport:
         )
         assert "MISSING: missing-one" in text
 
+    def test_human_report_shows_skipped(self) -> None:
+        skipped = [{"path": "/skills/foo.yaml", "error": "YAMLError: bad mapping"}]
+        text = format_report({"planner"}, {"planner": Path("x")}, set(), False, skipped)
+        assert "SKIPPED (errors): 1" in text
+        assert "foo.yaml" in text
+
     def test_json_structure(self) -> None:
         data = json.loads(
             format_report(
@@ -113,6 +151,15 @@ class TestFormatReport:
         assert data["missing_count"] == 0
         assert data["covered"] is True
         assert data["referenced"] == ["planner"]
+        assert data["skipped"] == []
+
+    def test_json_structure_includes_skipped(self) -> None:
+        skipped = [{"path": "x.yaml", "error": "YAMLError: boom"}]
+        data = json.loads(
+            format_report({"planner"}, {"planner": Path("x")}, set(), True, skipped)
+        )
+        assert len(data["skipped"]) == 1
+        assert data["skipped"][0]["error"] == "YAMLError: boom"
 
 
 class TestMain:
@@ -160,7 +207,7 @@ class TestMain:
         assert code == 0
 
     def test_json_output_flag(self, tmp_path: Path, capsys) -> None:
-        """--json produces valid JSON on stdout."""
+        """--json produces valid JSON on stdout with skipped field."""
         central = tmp_path / "skills"
         central.mkdir()
         (central / "planner").mkdir()
@@ -173,3 +220,4 @@ class TestMain:
         assert "referenced" in data
         assert "missing" in data
         assert "covered" in data
+        assert "skipped" in data

--- a/tests/test_check_skill_coverage.py
+++ b/tests/test_check_skill_coverage.py
@@ -13,7 +13,10 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
+import logging
+
 from check_skill_coverage import (
+    _read_text,
     compute_missing,
     format_report,
     list_available_skills,
@@ -221,3 +224,21 @@ class TestMain:
         assert "missing" in data
         assert "covered" in data
         assert "skipped" in data
+
+
+class TestReadText:
+    def test_unreadable_file_returns_none_and_logs_warning(self, tmp_path: Path, caplog) -> None:
+        """_read_text returns None and emits a warning when the file cannot be read."""
+        missing = tmp_path / "does_not_exist.txt"
+        with caplog.at_level(logging.WARNING, logger="check_skill_coverage"):
+            result = _read_text(missing)
+        assert result is None
+        assert len(caplog.records) == 1
+        assert "cannot read" in caplog.records[0].message
+        assert "does_not_exist.txt" in caplog.records[0].message
+
+    def test_readable_file_returns_content(self, tmp_path: Path) -> None:
+        """_read_text returns file contents on success."""
+        f = tmp_path / "data.txt"
+        f.write_text("hello")
+        assert _read_text(f) == "hello"

--- a/tests/test_check_skill_coverage.py
+++ b/tests/test_check_skill_coverage.py
@@ -1,0 +1,175 @@
+"""Tests for scripts/check_skill_coverage.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts/ is importable
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from check_skill_coverage import (
+    compute_missing,
+    format_report,
+    list_available_skills,
+    main,
+    scan_skill_references,
+)
+
+
+class TestScanSkillReferences:
+    def test_empty_project_no_refs(self, tmp_path: Path) -> None:
+        """A project with no dispatches, no YAML roles, and no skills dir has zero refs."""
+        refs = scan_skill_references(tmp_path)
+        assert refs == set()
+
+    def test_detects_role_in_vnx_yaml(self, tmp_path: Path) -> None:
+        """Role declarations inside .vnx/*.yaml are picked up."""
+        vnx = tmp_path / ".vnx"
+        vnx.mkdir()
+        (vnx / "workers.yaml").write_text("workers:\n  - role: backend-developer\n")
+        refs = scan_skill_references(tmp_path)
+        assert "backend-developer" in refs
+
+    def test_detects_role_in_dispatches(self, tmp_path: Path) -> None:
+        """Role headers in .vnx-data/dispatches/*.md are picked up."""
+        dispatches = tmp_path / ".vnx-data" / "dispatches"
+        dispatches.mkdir(parents=True)
+        (dispatches / "d1.md").write_text("# Dispatch\n\nRole: planner\n")
+        refs = scan_skill_references(tmp_path)
+        assert "planner" in refs
+
+    def test_detects_local_skills_dir(self, tmp_path: Path) -> None:
+        """Skill names from the local skills/ directory are treated as refs."""
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        (skills / "test-engineer").mkdir()
+        refs = scan_skill_references(tmp_path)
+        assert "test-engineer" in refs
+
+
+class TestListAvailableSkills:
+    def test_central_skills_only(self, tmp_path: Path) -> None:
+        """Listing from a central skills dir returns all contained skills."""
+        central = tmp_path / "central" / "skills"
+        central.mkdir(parents=True)
+        (central / "planner").mkdir()
+        (central / "architect").mkdir()
+        avail = list_available_skills(central, None)
+        assert set(avail.keys()) == {"planner", "architect"}
+
+    def test_overrides_shadow_central(self, tmp_path: Path) -> None:
+        """Overrides with the same name shadow central entries."""
+        central = tmp_path / "central" / "skills"
+        central.mkdir(parents=True)
+        (central / "planner").mkdir()
+        overrides = tmp_path / ".vnx-overrides" / "skills"
+        overrides.mkdir(parents=True)
+        (overrides / "planner").mkdir()
+        avail = list_available_skills(central, overrides)
+        assert avail["planner"] == overrides / "planner"
+
+
+class TestComputeMissing:
+    def test_all_covered(self) -> None:
+        refs = {"planner", "architect"}
+        available = {"planner": Path("x"), "architect": Path("y")}
+        assert compute_missing(refs, available) == set()
+
+    def test_some_missing(self) -> None:
+        refs = {"planner", "unknown-skill"}
+        available = {"planner": Path("x")}
+        assert compute_missing(refs, available) == {"unknown-skill"}
+
+
+class TestFormatReport:
+    def test_human_report_all_covered(self) -> None:
+        text = format_report({"planner"}, {"planner": Path("x")}, set(), False)
+        assert "skills referenced: 1" in text
+        assert "All referenced skills are covered." in text
+
+    def test_human_report_missing(self) -> None:
+        text = format_report(
+            {"planner", "missing-one"},
+            {"planner": Path("x")},
+            {"missing-one"},
+            False,
+        )
+        assert "MISSING: missing-one" in text
+
+    def test_json_structure(self) -> None:
+        data = json.loads(
+            format_report(
+                {"planner"}, {"planner": Path("x")}, set(), True
+            )
+        )
+        assert data["referenced_count"] == 1
+        assert data["available_count"] == 1
+        assert data["missing_count"] == 0
+        assert data["covered"] is True
+        assert data["referenced"] == ["planner"]
+
+
+class TestMain:
+    def test_exit_zero_when_all_covered(self, tmp_path: Path) -> None:
+        """Exit 0 when every referenced skill is available centrally."""
+        central = tmp_path / "skills"
+        central.mkdir()
+        (central / "backend-developer").mkdir()
+        vnx = tmp_path / ".vnx"
+        vnx.mkdir()
+        (vnx / "workers.yaml").write_text("workers:\n  - role: backend-developer\n")
+        code = main(["--project-root", str(tmp_path), "--central-skills", str(central)])
+        assert code == 0
+
+    def test_exit_one_when_missing(self, tmp_path: Path) -> None:
+        """Exit 1 when a referenced skill is missing from central+overrides."""
+        central = tmp_path / "skills"
+        central.mkdir()
+        vnx = tmp_path / ".vnx"
+        vnx.mkdir()
+        (vnx / "workers.yaml").write_text("workers:\n  - role: missing-skill\n")
+        code = main(["--project-root", str(tmp_path), "--central-skills", str(central)])
+        assert code == 1
+
+    def test_overrides_resolve_missing(self, tmp_path: Path) -> None:
+        """A missing central skill resolved by an override yields exit 0."""
+        central = tmp_path / "skills"
+        central.mkdir()
+        overrides = tmp_path / ".vnx-overrides" / "skills"
+        overrides.mkdir(parents=True)
+        (overrides / "missing-skill").mkdir()
+        vnx = tmp_path / ".vnx"
+        vnx.mkdir()
+        (vnx / "workers.yaml").write_text("workers:\n  - role: missing-skill\n")
+        code = main(
+            [
+                "--project-root",
+                str(tmp_path),
+                "--central-skills",
+                str(central),
+                "--overrides",
+                str(overrides),
+            ]
+        )
+        assert code == 0
+
+    def test_json_output_flag(self, tmp_path: Path, capsys) -> None:
+        """--json produces valid JSON on stdout."""
+        central = tmp_path / "skills"
+        central.mkdir()
+        (central / "planner").mkdir()
+        vnx = tmp_path / ".vnx"
+        vnx.mkdir()
+        (vnx / "workers.yaml").write_text("workers:\n  - role: planner\n")
+        main(["--project-root", str(tmp_path), "--central-skills", str(central), "--json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "referenced" in data
+        assert "missing" in data
+        assert "covered" in data


### PR DESCRIPTION
## PR-CENTRAL-9: scripts/check_skill_coverage.py

Pre-migration must-have #9. Pre-flight script that detects skill-coverage gaps before central rollout.

### What it does
1. Scans project for skill references (dispatches/, code via `role:` headers, local skills dir)
2. Lists available skills from central (`~/.vnx-system/current/skills/`) + per-project overrides (`./.vnx-overrides/skills/`)
3. Computes diff: refs − available = missing
4. Reports counts + missing list; exits 0 if covered, 1 if gaps exist

### Optional flags
- `--project-root <path>` (default: cwd)
- `--central-skills <path>` (default: auto-detect VNX_HOME)
- `--add-to-overrides`: prompt to copy each missing skill into overrides
- `--json`: machine-readable JSON output

### Files changed
- `scripts/check_skill_coverage.py` (new)
- `tests/test_check_skill_coverage.py` (new, 15 tests)
- `CHANGELOG.md`

### Tests
```bash
python3 -m pytest tests/test_check_skill_coverage.py -v
```
All 15 tests pass.

### Dispatch-paths
scripts/check_skill_coverage.py,tests/test_check_skill_coverage.py,CHANGELOG.md