### PR TITLE
feat(schema): migration 0021 central install metadata + pin tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 
 ### Added
 - feat(pyproject): `vnx` console_script entry-point + requires-python `>=3.11,<3.14`. Pipx-installable. (Pre-centralization must-have #6)
+- feat(schema): migration 0021 `central_install_pins` + `central_install_events` tables met `scripts/lib/central_install_db.py` helper. Bookkeeping voor project pin tracking + install/update/rollback event history. Pre-centralization must-have #10.
 
 ### Changed
 - chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (was 1.0.0-rc1 / 0.9.0 mismatch); single-source version for pipx wheel + central install pin

--- a/schemas/migrations/0021_central_install_metadata.sql
+++ b/schemas/migrations/0021_central_install_metadata.sql
@@ -1,0 +1,43 @@
+-- VNX Migration 0021 — central install metadata + project pin tracking
+-- Purpose: Bookkeeping for central install pinning and event history.
+--
+-- Design: claudedocs/roadmap/centralization.md
+--
+-- Pre-migration state (v20/v14): elastic worker pool tables.
+-- Post-migration state (v21): adds central_install_pins, central_install_events.
+--
+-- Atomicity: single implicit transaction per statement (SQLite default).
+-- Idempotency: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+--
+-- Applied by: scripts/lib/central_install_db.py (implicit on first use)
+-- Tested by: tests/test_central_install_db.py
+
+CREATE TABLE IF NOT EXISTS central_install_pins (
+    project_id  TEXT    NOT NULL,
+    project_root TEXT   NOT NULL,
+    pin_version TEXT    NOT NULL,
+    pinned_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    pinned_by   TEXT,
+    pin_source  TEXT    CHECK (pin_source IN ('vnx-version-file', 'env-VNX_PIN', 'auto')),
+    notes       TEXT,
+    PRIMARY KEY (project_id, project_root)
+);
+
+CREATE TABLE IF NOT EXISTS central_install_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id    TEXT    NOT NULL,
+    event_type    TEXT    NOT NULL CHECK (event_type IN ('install', 'update', 'rollback', 'verify', 'remove')),
+    from_version  TEXT,
+    to_version    TEXT,
+    occurred_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    success       INTEGER NOT NULL DEFAULT 1,
+    error_message TEXT,
+    actor         TEXT,
+    details_json  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_install_events_project ON central_install_events(project_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_install_events_type ON central_install_events(event_type);
+
+-- Bump schema version
+PRAGMA user_version = 21;

--- a/scripts/lib/central_install_db.py
+++ b/scripts/lib/central_install_db.py
@@ -1,0 +1,198 @@
+"""central_install_db.py — read/write helpers for central-install bookkeeping.
+
+Tables:
+- central_install_pins       (project_id, project_root) → pin_version
+- central_install_events     append-only event log
+
+Connection pattern mirrors coordination_db.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional
+
+from coordination_db import get_connection_for_db
+
+
+# ---------------------------------------------------------------------------
+# Row dataclasses (lightweight)
+# ---------------------------------------------------------------------------
+
+class PinRecord:
+    """Represents a row from central_install_pins."""
+
+    def __init__(self, row: sqlite3.Row) -> None:
+        self.project_id: str = row["project_id"]
+        self.project_root: str = row["project_root"]
+        self.pin_version: str = row["pin_version"]
+        self.pinned_at: str = row["pinned_at"]
+        self.pinned_by: Optional[str] = row["pinned_by"]
+        self.pin_source: Optional[str] = row["pin_source"]
+        self.notes: Optional[str] = row["notes"]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "project_root": self.project_root,
+            "pin_version": self.pin_version,
+            "pinned_at": self.pinned_at,
+            "pinned_by": self.pinned_by,
+            "pin_source": self.pin_source,
+            "notes": self.notes,
+        }
+
+
+class InstallEvent:
+    """Represents a row from central_install_events."""
+
+    def __init__(self, row: sqlite3.Row) -> None:
+        self.id: int = row["id"]
+        self.project_id: str = row["project_id"]
+        self.event_type: str = row["event_type"]
+        self.from_version: Optional[str] = row["from_version"]
+        self.to_version: Optional[str] = row["to_version"]
+        self.occurred_at: str = row["occurred_at"]
+        self.success: bool = bool(row["success"])
+        self.error_message: Optional[str] = row["error_message"]
+        self.actor: Optional[str] = row["actor"]
+        self.details_json: Optional[str] = row["details_json"]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "event_type": self.event_type,
+            "from_version": self.from_version,
+            "to_version": self.to_version,
+            "occurred_at": self.occurred_at,
+            "success": self.success,
+            "error_message": self.error_message,
+            "actor": self.actor,
+            "details": json.loads(self.details_json) if self.details_json else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Schema init (idempotent)
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "schemas"
+    / "migrations"
+    / "0021_central_install_metadata.sql"
+)
+
+
+def init_central_install_schema(db_path: str | Path) -> None:
+    """Create central-install tables if missing. Idempotent."""
+    if not _SCHEMA_SQL_PATH.exists():
+        raise FileNotFoundError(f"Schema migration not found: {_SCHEMA_SQL_PATH}")
+    sql = _SCHEMA_SQL_PATH.read_text(encoding="utf-8")
+    with get_connection_for_db(db_path) as conn:
+        conn.executescript(sql)
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pins
+# ---------------------------------------------------------------------------
+
+def get_project_pin(
+    conn: sqlite3.Connection,
+    project_id: str,
+    project_root: str,
+) -> Optional[PinRecord]:
+    """Return the active pin for a project+root pair, or None."""
+    row = conn.execute(
+        "SELECT * FROM central_install_pins WHERE project_id = ? AND project_root = ?",
+        (project_id, project_root),
+    ).fetchone()
+    return PinRecord(row) if row else None
+
+
+def set_project_pin(
+    conn: sqlite3.Connection,
+    project_id: str,
+    project_root: str,
+    version: str,
+    pinned_by: Optional[str] = None,
+    pin_source: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> None:
+    """Upsert a pin row. Composite PK (project_id, project_root) overwrites on conflict."""
+    conn.execute(
+        """
+        INSERT INTO central_install_pins
+            (project_id, project_root, pin_version, pinned_by, pin_source, notes)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(project_id, project_root) DO UPDATE SET
+            pin_version = excluded.pin_version,
+            pinned_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+            pinned_by = excluded.pinned_by,
+            pin_source = excluded.pin_source,
+            notes = excluded.notes
+        """,
+        (project_id, project_root, version, pinned_by, pin_source, notes),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+def record_install_event(
+    conn: sqlite3.Connection,
+    project_id: str,
+    event_type: str,
+    from_version: Optional[str] = None,
+    to_version: Optional[str] = None,
+    success: bool = True,
+    error_message: Optional[str] = None,
+    actor: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Append an install event. Returns the auto-generated row id."""
+    cur = conn.execute(
+        """
+        INSERT INTO central_install_events
+            (project_id, event_type, from_version, to_version,
+             success, error_message, actor, details_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            project_id,
+            event_type,
+            from_version,
+            to_version,
+            1 if success else 0,
+            error_message,
+            actor,
+            json.dumps(details) if details else None,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def list_install_history(
+    conn: sqlite3.Connection,
+    project_id: str,
+    limit: int = 10,
+) -> List[InstallEvent]:
+    """Return recent install events for a project, newest first."""
+    rows = conn.execute(
+        """
+        SELECT * FROM central_install_events
+        WHERE project_id = ?
+        ORDER BY occurred_at DESC, id DESC
+        LIMIT ?
+        """,
+        (project_id, limit),
+    ).fetchall()
+    return [InstallEvent(r) for r in rows]

--- a/tests/test_central_install_db.py
+++ b/tests/test_central_install_db.py
@@ -1,0 +1,98 @@
+"""tests/test_central_install_db.py — migration 0021 + helper coverage.
+
+Five test cases covering pin roundtrip, event roundtrip, upsert semantics,
+history ordering/limit, and rollback event chains.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_MIGRATION_SQL = (
+    Path(__file__).parent.parent / "schemas" / "migrations" / "0021_central_install_metadata.sql"
+)
+
+
+@pytest.fixture()
+def conn() -> sqlite3.Connection:
+    """Fresh in-memory DB with the 0021 schema applied."""
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(_MIGRATION_SQL.read_text())
+    return db
+
+
+def test_pin_insert_and_read_roundtrip(conn: sqlite3.Connection) -> None:
+    from central_install_db import set_project_pin, get_project_pin
+
+    set_project_pin(conn, "proj-a", "/opt/a", "1.2.3", pinned_by="ci", pin_source="auto")
+    pin = get_project_pin(conn, "proj-a", "/opt/a")
+    assert pin is not None
+    assert pin.pin_version == "1.2.3"
+    assert pin.pinned_by == "ci"
+    assert pin.pin_source == "auto"
+
+
+def test_install_event_roundtrip_with_json_details(conn: sqlite3.Connection) -> None:
+    from central_install_db import record_install_event, list_install_history
+
+    eid = record_install_event(
+        conn,
+        project_id="proj-b",
+        event_type="install",
+        from_version="1.0.0",
+        to_version="1.1.0",
+        actor="deploy-bot",
+        details={"host": "srv-01", "duration_sec": 42},
+    )
+    assert eid > 0
+    history = list_install_history(conn, "proj-b", limit=5)
+    assert len(history) == 1
+    assert history[0].event_type == "install"
+    assert history[0].to_version == "1.1.0"
+    assert history[0].details_json is not None
+
+
+def test_pin_update_overwrites_previous(conn: sqlite3.Connection) -> None:
+    from central_install_db import set_project_pin, get_project_pin
+
+    set_project_pin(conn, "proj-c", "/opt/c", "1.0.0")
+    set_project_pin(conn, "proj-c", "/opt/c", "2.0.0", pinned_by="human")
+    pin = get_project_pin(conn, "proj-c", "/opt/c")
+    assert pin is not None
+    assert pin.pin_version == "2.0.0"
+    assert pin.pinned_by == "human"
+
+
+def test_history_query_limit_and_ordering(conn: sqlite3.Connection) -> None:
+    from central_install_db import record_install_event, list_install_history
+
+    for i in range(5):
+        record_install_event(conn, "proj-d", event_type="verify", actor=f"bot-{i}")
+    history = list_install_history(conn, "proj-d", limit=3)
+    assert len(history) == 3
+    # Newest first because of ORDER BY occurred_at DESC
+    assert history[0].actor == "bot-4"
+    assert history[1].actor == "bot-3"
+    assert history[2].actor == "bot-2"
+
+
+def test_rollback_event_chain(conn: sqlite3.Connection) -> None:
+    from central_install_db import record_install_event, list_install_history
+
+    record_install_event(conn, "proj-e", "install", to_version="2.0.0")
+    record_install_event(conn, "proj-e", "update", from_version="2.0.0", to_version="2.1.0")
+    record_install_event(
+        conn, "proj-e", "rollback", from_version="2.1.0", to_version="2.0.0", success=True
+    )
+    history = list_install_history(conn, "proj-e", limit=10)
+    assert len(history) == 3
+    types = [h.event_type for h in reversed(history)]  # oldest → newest
+    assert types == ["install", "update", "rollback"]
+    rollback = history[0]
+    assert rollback.from_version == "2.1.0"
+    assert rollback.to_version == "2.0.0"
+    assert rollback.success is True


### PR DESCRIPTION
## Summary
Pre-migration must-have #10. Adds metadata tables for central install bookkeeping: which project has which pin, install events, and rollback history.

## Changes
- `schemas/migrations/0021_central_install_metadata.sql` — new tables + indexes + version bump
- `scripts/lib/central_install_db.py` — read/write helper module (pin + event APIs)
- `tests/test_central_install_db.py` — 5 tests covering roundtrip, upsert, ordering, rollback chains
- `CHANGELOG.md` — entry under [Unreleased]

## Verification
```bash
python3 -m pytest tests/test_central_install_db.py -v  # 5 passed
sqlite3 :memory: < schemas/migrations/0021_central_install_metadata.sql  # clean
```

## Dispatch paths
schemas/migrations/0021_central_install_metadata.sql,scripts/lib/central_install_db.py,tests/test_central_install_db.py,CHANGELOG.md

---
- [x] No TODO/FIXME
- [x] Only touched dispatch-paths