### PR TITLE
feat(intelligence): fine-grained task_class subclass + scope_tags activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [s
 ## [Unreleased]
 
 ### Added
+- feat(intelligence): fine-grained task_class subclassing (coding_sql/runtime/intelligence/test/ui) + active scope_tags matching via VNX_INTEL_STRICT_SCOPE env-flag. Selector kan SQL-werk SQL-kennis geven ipv generieke pool. (Audit BLOCKER #2 follow-up PR-IH-2)
 - feat(cli): `vnx version` subcommand prints VERSION, commit, VNX_HOME, pin, Python+platform (pre-central-install support)
 - feat(cli): `vnx update --to <ver> --keep-last N --dry-run --rollback` subcommand for future central install version-flip (pre-central-install scaffolding)
 

--- a/schemas/migrations/2026_05_task_subclass.sql
+++ b/schemas/migrations/2026_05_task_subclass.sql
@@ -1,0 +1,9 @@
+-- 2026_05_task_subclass.sql
+-- Performance indexes for scope-based query filtering introduced by fine-grained
+-- task_class sub-classification (coding_sql / coding_runtime / coding_intelligence /
+-- coding_test / coding_ui). No schema changes -- category column already exists
+-- in success_patterns and antipatterns; populate retroactively via:
+--   python3 scripts/lib/intelligence_backfill.py [--dry-run]
+
+CREATE INDEX IF NOT EXISTS idx_success_patterns_category ON success_patterns(category);
+CREATE INDEX IF NOT EXISTS idx_antipatterns_category ON antipatterns(category);

--- a/scripts/lib/intelligence_backfill.py
+++ b/scripts/lib/intelligence_backfill.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+intelligence_backfill.py — retroactive scope_tags population for quality_intelligence.db.
+
+Updates success_patterns and antipatterns where category is NULL or empty,
+based on keyword matching in title+description. Safe to re-run (idempotent
+because it only touches rows with empty category).
+
+Usage:
+    python3 scripts/lib/intelligence_backfill.py [--db PATH] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+_SCRIPTS_LIB = Path(__file__).resolve().parent
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+try:
+    from project_root import resolve_project_root
+    _PROJECT_ROOT = resolve_project_root(__file__)
+except (ImportError, RuntimeError):
+    _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+logger = logging.getLogger(__name__)
+
+# Keyword patterns → primary tag assigned to matching rows.
+# Priority: first matching rule wins (top = highest priority).
+_KEYWORD_RULES: List[Tuple[List[str], str]] = [
+    (["sql", "schema", "migration", "table"], "sql"),
+    (["async", "await", "asyncio"], "async"),
+    (["security", "secret", "auth"], "security"),
+    (["ui", "html", "css", "dashboard", "tsx"], "ui"),
+    (["runtime", "dispatch", "receipt"], "runtime"),
+    (["intelligence", "pattern"], "intelligence"),
+]
+
+
+def _infer_tag(title: str, description: str) -> Optional[str]:
+    """Return the primary tag for a pattern row, or None if no keyword matches."""
+    haystack = f"{title} {description}".lower()
+    for keywords, primary_tag in _KEYWORD_RULES:
+        if any(re.search(rf"\b{re.escape(kw)}\b", haystack) for kw in keywords):
+            return primary_tag
+    return None
+
+
+def backfill_table(
+    conn: sqlite3.Connection,
+    table: str,
+    *,
+    dry_run: bool = False,
+) -> Tuple[int, int]:
+    """Backfill category for rows with empty category.
+
+    Returns (checked, updated) counts.
+    Only updates rows where category IS NULL or category = ''.
+    """
+    try:
+        rows = conn.execute(
+            f"SELECT id, title, description FROM {table} "
+            "WHERE category IS NULL OR category = ''",
+        ).fetchall()
+    except sqlite3.Error as exc:
+        logger.warning("backfill_table: query failed on %s: %s", table, exc)
+        return 0, 0
+
+    checked = len(rows)
+    updated = 0
+
+    for row in rows:
+        row_id = row[0]
+        title = row[1] or ""
+        description = row[2] or ""
+        tag = _infer_tag(title, description)
+        if tag is None:
+            continue
+        if not dry_run:
+            try:
+                conn.execute(
+                    f"UPDATE {table} SET category = ? WHERE id = ?",
+                    (tag, row_id),
+                )
+            except sqlite3.Error as exc:
+                logger.warning("backfill_table: update failed for %s id=%s: %s", table, row_id, exc)
+                continue
+        updated += 1
+
+    if not dry_run and updated > 0:
+        try:
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.warning("backfill_table: commit failed on %s: %s", table, exc)
+
+    return checked, updated
+
+
+def run_backfill(db_path: Path, *, dry_run: bool = False) -> Dict[str, Dict[str, int]]:
+    """Run the full backfill and return a per-table summary dict."""
+    if not db_path.exists():
+        raise FileNotFoundError(f"DB not found: {db_path}")
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"Failed to open DB {db_path}: {exc}") from exc
+
+    results: Dict[str, Dict[str, int]] = {}
+    try:
+        for table in ("success_patterns", "antipatterns"):
+            checked, updated = backfill_table(conn, table, dry_run=dry_run)
+            results[table] = {"checked": checked, "updated": updated}
+            logger.info(
+                "backfill %s: checked=%d updated=%d dry_run=%s",
+                table, checked, updated, dry_run,
+            )
+    finally:
+        conn.close()
+
+    return results
+
+
+def _default_db_path() -> Optional[Path]:
+    """Resolve default quality_intelligence.db via VNX_STATE_DIR or project root."""
+    state_dir_env = os.environ.get("VNX_STATE_DIR")
+    if state_dir_env:
+        candidate = Path(state_dir_env) / "quality_intelligence.db"
+        if candidate.exists():
+            return candidate
+    candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Backfill scope_tags (category) for intelligence patterns with empty category."
+    )
+    parser.add_argument("--db", type=Path, help="Path to quality_intelligence.db")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    db_path = args.db or _default_db_path()
+    if db_path is None:
+        logger.error("No quality_intelligence.db found. Pass --db <path>.")
+        sys.exit(1)
+
+    try:
+        results = run_backfill(db_path, dry_run=args.dry_run)
+    except (FileNotFoundError, RuntimeError) as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+
+    total_checked = sum(v["checked"] for v in results.values())
+    total_updated = sum(v["updated"] for v in results.values())
+    prefix = "[DRY RUN] " if args.dry_run else ""
+    print(f"{prefix}Backfill complete: {total_checked} rows checked, {total_updated} rows updated")
+    for table, counts in results.items():
+        print(f"  {table}: checked={counts['checked']} updated={counts['updated']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -137,7 +137,7 @@ class IntelligenceSelector:
         """Run the bounded selection algorithm and return an InjectionResult."""
         if injection_point not in VALID_INJECTION_POINTS:
             raise ValueError(f"Invalid injection_point: {injection_point!r}. Must be one of {sorted(VALID_INJECTION_POINTS)}")
-        resolved_class = resolve_task_class(task_class, skill_name)
+        resolved_class = resolve_task_class(task_class, skill_name, dispatch_paths, instruction_text)
         effective_scope: List[str] = list(scope_tags or [])
         for tag in [skill_name, (f"Track-{track}" if track and not track.startswith("Track-") else track), gate, resolved_class]:
             if tag and tag not in effective_scope:
@@ -264,11 +264,34 @@ class IntelligenceSelector:
 
 
 
-def select_intelligence(dispatch_id, injection_point, *, quality_db_path=None, coord_state_dir=None, task_class=None, skill_name=None, scope_tags=None, track=None, gate=None) -> InjectionResult:
+def select_intelligence(
+    dispatch_id,
+    injection_point,
+    *,
+    quality_db_path=None,
+    coord_state_dir=None,
+    task_class=None,
+    skill_name=None,
+    scope_tags=None,
+    track=None,
+    gate=None,
+    dispatch_paths=None,
+    instruction_text=None,
+) -> InjectionResult:
     """Convenience function: select, emit event, record injection, return result."""
     selector = IntelligenceSelector(quality_db_path=quality_db_path, coord_db_state_dir=coord_state_dir)
     try:
-        result = selector.select(dispatch_id=dispatch_id, injection_point=injection_point, task_class=task_class, skill_name=skill_name, scope_tags=scope_tags, track=track, gate=gate)
+        result = selector.select(
+            dispatch_id=dispatch_id,
+            injection_point=injection_point,
+            task_class=task_class,
+            skill_name=skill_name,
+            scope_tags=scope_tags,
+            track=track,
+            gate=gate,
+            dispatch_paths=dispatch_paths,
+            instruction_text=instruction_text,
+        )
         selector.emit_event(result)
         selector.record_injection(result)
         return result

--- a/scripts/lib/intelligence_sources/_common.py
+++ b/scripts/lib/intelligence_sources/_common.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import re
 import sqlite3
 import uuid
 from dataclasses import dataclass, field
@@ -67,11 +69,26 @@ VALID_INJECTION_POINTS = frozenset({"dispatch_create", "dispatch_resume"})
 
 VALID_TASK_CLASSES = frozenset({
     "coding_interactive",
+    "coding_sql",
+    "coding_runtime",
+    "coding_intelligence",
+    "coding_test",
+    "coding_ui",
     "research_structured",
     "docs_synthesis",
     "ops_watchdog",
     "channel_response",
 })
+
+# Maps subclass names to their component keywords for scope expansion in _scope_matches.
+# When a query contains "coding_sql", items tagged "sql", "schema", or "migration" also match.
+_SUBCLASS_TO_KEYWORDS: Dict[str, frozenset] = {
+    "coding_sql": frozenset(["sql", "schema", "migration"]),
+    "coding_runtime": frozenset(["runtime", "dispatch", "receipt"]),
+    "coding_intelligence": frozenset(["intelligence", "pattern"]),
+    "coding_test": frozenset(["test"]),
+    "coding_ui": frozenset(["ui", "html", "css", "dashboard"]),
+}
 
 SKILL_TO_TASK_CLASS = {
     "backend-developer": "coding_interactive",
@@ -203,23 +220,80 @@ def classify_pattern_category(title: str, description: str) -> str:
     return PATTERN_CATEGORY_CODE
 
 
-def resolve_task_class(
-    task_class: Optional[str] = None,
-    skill_name: Optional[str] = None,
+def infer_task_subclass(
+    skill_name: Optional[str],
+    dispatch_paths: Optional[List[str]],
+    instruction_text: Optional[str],
 ) -> str:
-    """Resolve task class from explicit value or skill name. Defaults to coding_interactive."""
-    if task_class and task_class in VALID_TASK_CLASSES:
-        return task_class
-    if skill_name:
-        return SKILL_TO_TASK_CLASS.get(skill_name, "coding_interactive")
+    """Infer a fine-grained task subclass from dispatch paths and instruction text.
+
+    Priority order: sql > runtime > intelligence > test > ui > coding_interactive.
+    Returns one of the VALID_TASK_CLASSES subclass names.
+    """
+    paths_lower = [p.lower() for p in (dispatch_paths or [])]
+    instruction = (instruction_text or "").lower()
+
+    if (
+        any(p.endswith(".sql") or "migrat" in p or "/schemas/" in p or p.startswith("schemas/") for p in paths_lower)
+        or re.search(r"\b(migration|schema|table)\b", instruction)
+    ):
+        return "coding_sql"
+
+    if any(re.search(r"(?:^|/)(?:runtime_|dispatch_|receipt_)", p) for p in paths_lower):
+        return "coding_runtime"
+
+    if any(re.search(r"(?:^|/)intelligence_", p) for p in paths_lower):
+        return "coding_intelligence"
+
+    if any("/tests/" in p or p.startswith("tests/") for p in paths_lower):
+        return "coding_test"
+
+    if any(
+        "/dashboard/" in p or p.startswith("dashboard/") or p.endswith(".html") or p.endswith(".tsx")
+        for p in paths_lower
+    ):
+        return "coding_ui"
+
     return "coding_interactive"
 
 
+def resolve_task_class(
+    task_class: Optional[str] = None,
+    skill_name: Optional[str] = None,
+    dispatch_paths: Optional[List[str]] = None,
+    instruction_text: Optional[str] = None,
+) -> str:
+    """Resolve task class from explicit value, skill name, or inferred from paths/instruction."""
+    if task_class and task_class in VALID_TASK_CLASSES:
+        return task_class
+    base_class = SKILL_TO_TASK_CLASS.get(skill_name or "", "coding_interactive") if skill_name else "coding_interactive"
+    if base_class == "coding_interactive" and (dispatch_paths or instruction_text):
+        return infer_task_subclass(skill_name, dispatch_paths, instruction_text)
+    return base_class
+
+
+def _expand_scope_tags(tags: List[str]) -> frozenset:
+    """Expand subclass scope names to include component keywords for matching."""
+    expanded: set = set(tags)
+    for tag in tags:
+        expanded.update(_SUBCLASS_TO_KEYWORDS.get(tag, frozenset()))
+    return frozenset(expanded)
+
+
 def _scope_matches(item_scope_tags: List[str], query_scope_tags: List[str]) -> bool:
-    """Empty item scope = matches everything. Empty query scope = matches everything."""
-    if not item_scope_tags or not query_scope_tags:
+    """Match item scope against query scope.
+
+    Empty query scope always matches. In strict mode (VNX_INTEL_STRICT_SCOPE=1),
+    an item with no scope tags does NOT match a non-empty query scope.
+    Subclass names in the query are expanded to include component keywords.
+    """
+    if not query_scope_tags:
         return True
-    return bool(set(item_scope_tags) & set(query_scope_tags))
+    strict = os.environ.get("VNX_INTEL_STRICT_SCOPE", "0") == "1"
+    if not item_scope_tags:
+        return not strict
+    expanded_query = _expand_scope_tags(query_scope_tags)
+    return bool(set(item_scope_tags) & expanded_query)
 
 
 def _task_class_matches(item_filter: List[str], task_class: str) -> bool:

--- a/tests/test_task_subclass.py
+++ b/tests/test_task_subclass.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Tests for fine-grained task_class sub-classification and scope_tags activation.
+
+Covers:
+  - infer_task_subclass path/instruction routing
+  - resolve_task_class with dispatch_paths
+  - _scope_matches strict mode (VNX_INTEL_STRICT_SCOPE)
+  - _expand_scope_tags subclass keyword expansion
+  - intelligence_backfill.py keyword-to-tag mapping
+  - IntelligenceSelector scope filtering (sql scope excludes ui-tagged items)
+  - Backwards-compat: VNX_INTEL_STRICT_SCOPE=0 preserves old behaviour
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_sources._common import (
+    VALID_TASK_CLASSES,
+    _expand_scope_tags,
+    _scope_matches,
+    infer_task_subclass,
+    resolve_task_class,
+)
+from intelligence_backfill import _infer_tag, backfill_table, run_backfill
+
+
+# ---------------------------------------------------------------------------
+# infer_task_subclass
+# ---------------------------------------------------------------------------
+
+class TestInferTaskSubclass(unittest.TestCase):
+
+    def test_sql_extension_path(self):
+        result = infer_task_subclass(None, ["schemas/migrations/0025_add_col.sql"], None)
+        self.assertEqual(result, "coding_sql")
+
+    def test_migrate_in_path(self):
+        result = infer_task_subclass(None, ["scripts/lib/migration_helper.py"], None)
+        self.assertEqual(result, "coding_sql")
+
+    def test_schemas_directory(self):
+        result = infer_task_subclass(None, ["schemas/quality_intelligence.sql"], None)
+        self.assertEqual(result, "coding_sql")
+
+    def test_sql_keyword_in_instruction(self):
+        result = infer_task_subclass(None, [], "Add a new table for user sessions")
+        self.assertEqual(result, "coding_sql")
+
+    def test_schema_keyword_in_instruction(self):
+        result = infer_task_subclass(None, [], "Update the schema to add tenant_id")
+        self.assertEqual(result, "coding_sql")
+
+    def test_ui_html_path(self):
+        result = infer_task_subclass(None, ["dashboard/index.html"], None)
+        self.assertEqual(result, "coding_ui")
+
+    def test_ui_tsx_path(self):
+        result = infer_task_subclass(None, ["dashboard/components/Table.tsx"], None)
+        self.assertEqual(result, "coding_ui")
+
+    def test_ui_dashboard_directory(self):
+        result = infer_task_subclass(None, ["dashboard/static/app.js"], None)
+        self.assertEqual(result, "coding_ui")
+
+    def test_runtime_path(self):
+        result = infer_task_subclass(None, ["scripts/lib/runtime_coordination.py"], None)
+        self.assertEqual(result, "coding_runtime")
+
+    def test_dispatch_path(self):
+        result = infer_task_subclass(None, ["scripts/lib/dispatch_tracker.py"], None)
+        self.assertEqual(result, "coding_runtime")
+
+    def test_receipt_path(self):
+        result = infer_task_subclass(None, ["scripts/lib/receipt_processor.py"], None)
+        self.assertEqual(result, "coding_runtime")
+
+    def test_intelligence_path(self):
+        result = infer_task_subclass(None, ["scripts/lib/intelligence_selector.py"], None)
+        self.assertEqual(result, "coding_intelligence")
+
+    def test_tests_directory(self):
+        result = infer_task_subclass(None, ["tests/test_foo.py"], None)
+        self.assertEqual(result, "coding_test")
+
+    def test_tests_subdir(self):
+        result = infer_task_subclass(None, ["scripts/tests/integration.py"], None)
+        self.assertEqual(result, "coding_test")
+
+    def test_default_fallback(self):
+        result = infer_task_subclass(None, ["scripts/lib/some_helper.py"], None)
+        self.assertEqual(result, "coding_interactive")
+
+    def test_empty_inputs_fallback(self):
+        result = infer_task_subclass(None, [], None)
+        self.assertEqual(result, "coding_interactive")
+
+    def test_sql_takes_priority_over_tests(self):
+        # SQL path alongside test path: SQL wins (higher priority)
+        result = infer_task_subclass(None, ["tests/test_migration.sql"], None)
+        self.assertEqual(result, "coding_sql")
+
+    def test_all_subclasses_in_valid_task_classes(self):
+        for subclass in ("coding_sql", "coding_runtime", "coding_intelligence", "coding_test", "coding_ui"):
+            self.assertIn(subclass, VALID_TASK_CLASSES)
+
+
+# ---------------------------------------------------------------------------
+# resolve_task_class with dispatch_paths
+# ---------------------------------------------------------------------------
+
+class TestResolveTaskClassWithPaths(unittest.TestCase):
+
+    def test_explicit_class_wins(self):
+        result = resolve_task_class("research_structured", None, ["schema.sql"], None)
+        self.assertEqual(result, "research_structured")
+
+    def test_infers_sql_from_paths(self):
+        result = resolve_task_class(None, "backend-developer", ["schemas/0025.sql"], None)
+        self.assertEqual(result, "coding_sql")
+
+    def test_infers_ui_from_paths(self):
+        result = resolve_task_class(None, "backend-developer", ["dashboard/index.html"], None)
+        self.assertEqual(result, "coding_ui")
+
+    def test_no_paths_returns_base_class(self):
+        result = resolve_task_class(None, "backend-developer", None, None)
+        self.assertEqual(result, "coding_interactive")
+
+    def test_research_skill_not_subclassed(self):
+        # architect skill → research_structured (not coding_interactive), so subclassing skips
+        result = resolve_task_class(None, "architect", ["schemas/0025.sql"], None)
+        self.assertEqual(result, "research_structured")
+
+
+# ---------------------------------------------------------------------------
+# _expand_scope_tags
+# ---------------------------------------------------------------------------
+
+class TestExpandScopeTags(unittest.TestCase):
+
+    def test_coding_sql_expands(self):
+        expanded = _expand_scope_tags(["coding_sql"])
+        self.assertIn("sql", expanded)
+        self.assertIn("schema", expanded)
+        self.assertIn("migration", expanded)
+        self.assertIn("coding_sql", expanded)
+
+    def test_coding_ui_expands(self):
+        expanded = _expand_scope_tags(["coding_ui"])
+        self.assertIn("ui", expanded)
+        self.assertIn("dashboard", expanded)
+        self.assertIn("coding_ui", expanded)
+
+    def test_non_subclass_passthrough(self):
+        expanded = _expand_scope_tags(["backend-developer", "Track-T1"])
+        self.assertIn("backend-developer", expanded)
+        self.assertIn("Track-T1", expanded)
+        self.assertNotIn("sql", expanded)
+
+    def test_empty_input(self):
+        self.assertEqual(_expand_scope_tags([]), frozenset())
+
+
+# ---------------------------------------------------------------------------
+# _scope_matches strict mode
+# ---------------------------------------------------------------------------
+
+class TestScopeMatchesStrictMode(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.pop("VNX_INTEL_STRICT_SCOPE", None)
+
+    def tearDown(self):
+        os.environ.pop("VNX_INTEL_STRICT_SCOPE", None)
+
+    def test_empty_query_always_matches(self):
+        self.assertTrue(_scope_matches([], []))
+        self.assertTrue(_scope_matches(["sql"], []))
+
+    def test_default_empty_item_matches_nonempty_query(self):
+        # VNX_INTEL_STRICT_SCOPE not set → old behaviour, empty item = matches all
+        self.assertTrue(_scope_matches([], ["sql"]))
+
+    def test_strict_off_empty_item_matches_nonempty_query(self):
+        os.environ["VNX_INTEL_STRICT_SCOPE"] = "0"
+        self.assertTrue(_scope_matches([], ["sql"]))
+
+    def test_strict_on_empty_item_does_not_match_nonempty_query(self):
+        os.environ["VNX_INTEL_STRICT_SCOPE"] = "1"
+        self.assertFalse(_scope_matches([], ["sql"]))
+
+    def test_strict_on_empty_query_still_matches(self):
+        os.environ["VNX_INTEL_STRICT_SCOPE"] = "1"
+        self.assertTrue(_scope_matches([], []))
+
+    def test_sql_item_matches_sql_query(self):
+        self.assertTrue(_scope_matches(["sql"], ["sql"]))
+
+    def test_sql_item_does_not_match_ui_query(self):
+        self.assertFalse(_scope_matches(["sql"], ["ui"]))
+
+    def test_ui_item_does_not_match_sql_scope(self):
+        self.assertFalse(_scope_matches(["ui"], ["sql"]))
+
+    def test_coding_sql_scope_matches_sql_item(self):
+        # coding_sql expands to include 'sql', so items tagged 'sql' match
+        self.assertTrue(_scope_matches(["sql"], ["coding_sql"]))
+
+    def test_coding_sql_scope_does_not_match_ui_item(self):
+        self.assertFalse(_scope_matches(["ui"], ["coding_sql"]))
+
+
+# ---------------------------------------------------------------------------
+# intelligence_backfill keyword inference
+# ---------------------------------------------------------------------------
+
+class TestBackfillInferTag(unittest.TestCase):
+
+    def test_sql_keyword(self):
+        self.assertEqual(_infer_tag("Add table for sessions", ""), "sql")
+
+    def test_schema_keyword(self):
+        self.assertEqual(_infer_tag("Schema update", "Adds new column"), "sql")
+
+    def test_migration_keyword(self):
+        self.assertEqual(_infer_tag("DB migration", ""), "sql")
+
+    def test_async_keyword(self):
+        self.assertEqual(_infer_tag("Async task runner", "Uses asyncio"), "async")
+
+    def test_security_keyword(self):
+        self.assertEqual(_infer_tag("Auth token", "security check"), "security")
+
+    def test_ui_keyword(self):
+        self.assertEqual(_infer_tag("Dashboard component", "html rendering"), "ui")
+
+    def test_runtime_keyword(self):
+        self.assertEqual(_infer_tag("Runtime coordination", "dispatch handling"), "runtime")
+
+    def test_intelligence_keyword(self):
+        self.assertEqual(_infer_tag("Intelligence injection", "pattern extraction"), "intelligence")
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(_infer_tag("Generic cleanup", "some util refactor"))
+
+    def test_sql_takes_priority_over_async(self):
+        # 'table' matches sql rule before 'async' rule
+        self.assertEqual(_infer_tag("Async table migration", ""), "sql")
+
+
+class TestBackfillTable(unittest.TestCase):
+
+    def _make_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.executescript("""
+            CREATE TABLE success_patterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                description TEXT,
+                category TEXT
+            );
+            CREATE TABLE antipatterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                description TEXT,
+                category TEXT
+            );
+            INSERT INTO success_patterns (title, description, category)
+                VALUES ('SQL table migration', 'Adds new table', '');
+            INSERT INTO success_patterns (title, description, category)
+                VALUES ('UI dashboard fix', 'html rendering fix', NULL);
+            INSERT INTO success_patterns (title, description, category)
+                VALUES ('Already tagged', 'code pattern', 'code');
+            INSERT INTO antipatterns (title, description, category)
+                VALUES ('Runtime dispatch error', 'receipt processing bug', '');
+        """)
+        return conn
+
+    def test_backfill_updates_empty_category(self):
+        conn = self._make_db()
+        checked, updated = backfill_table(conn, "success_patterns")
+        self.assertEqual(checked, 2)  # two rows with empty category
+        self.assertEqual(updated, 2)
+        row = conn.execute("SELECT category FROM success_patterns WHERE title = 'SQL table migration'").fetchone()
+        self.assertEqual(row[0], "sql")
+        row = conn.execute("SELECT category FROM success_patterns WHERE title = 'UI dashboard fix'").fetchone()
+        self.assertEqual(row[0], "ui")
+        conn.close()
+
+    def test_backfill_does_not_touch_existing_category(self):
+        conn = self._make_db()
+        backfill_table(conn, "success_patterns")
+        row = conn.execute("SELECT category FROM success_patterns WHERE title = 'Already tagged'").fetchone()
+        self.assertEqual(row[0], "code")
+        conn.close()
+
+    def test_dry_run_makes_no_changes(self):
+        conn = self._make_db()
+        checked, updated = backfill_table(conn, "success_patterns", dry_run=True)
+        self.assertEqual(updated, 2)  # would-be updates
+        row = conn.execute("SELECT category FROM success_patterns WHERE title = 'SQL table migration'").fetchone()
+        self.assertEqual(row[0] or "", "")  # unchanged
+        conn.close()
+
+    def test_backfill_antipatterns(self):
+        conn = self._make_db()
+        checked, updated = backfill_table(conn, "antipatterns")
+        self.assertEqual(checked, 1)
+        self.assertEqual(updated, 1)
+        row = conn.execute("SELECT category FROM antipatterns WHERE id = 1").fetchone()
+        self.assertEqual(row[0], "runtime")
+        conn.close()
+
+
+class TestRunBackfill(unittest.TestCase):
+
+    def test_run_backfill_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            run_backfill(Path("/nonexistent/path/quality_intelligence.db"))
+
+    def test_run_backfill_with_real_db(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = Path(f.name)
+        try:
+            conn = sqlite3.connect(str(db_path))
+            conn.executescript("""
+                CREATE TABLE success_patterns (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT, description TEXT, category TEXT
+                );
+                CREATE TABLE antipatterns (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT, description TEXT, category TEXT
+                );
+                INSERT INTO success_patterns (title, description, category)
+                    VALUES ('SQL schema migration', 'table changes', '');
+            """)
+            conn.close()
+            results = run_backfill(db_path)
+            self.assertEqual(results["success_patterns"]["checked"], 1)
+            self.assertEqual(results["success_patterns"]["updated"], 1)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds 5 coding sub-classes (`coding_sql`, `coding_runtime`, `coding_intelligence`, `coding_test`, `coding_ui`) to `VALID_TASK_CLASSES`
- `infer_task_subclass()` routes dispatch paths + instruction text to the right sub-class (SQL files → `coding_sql`, dashboard/ → `coding_ui`, etc.)
- `resolve_task_class()` accepts `dispatch_paths` + `instruction_text` and calls `infer_task_subclass` for coding skills
- `_scope_matches()` now expands subclass names to component keywords (`coding_sql` → includes `sql`, `schema`, `migration`) and supports `VNX_INTEL_STRICT_SCOPE=1` strict mode
- `intelligence_backfill.py` (new): retroactively populates empty `category` fields in success_patterns + antipatterns via keyword matching
- Migration `2026_05_task_subclass.sql`: adds `idx_success_patterns_category` + `idx_antipatterns_category` indexes
- `select()` and `select_intelligence()` forward `dispatch_paths`/`instruction_text` to `resolve_task_class`

## Test plan

- [x] `pytest tests/test_task_subclass.py -v` — 53 passed, 0 failed
- [x] Pre-existing `test_intelligence_selector.py` failures verified as pre-existing on main (coordination_db migration issue unrelated to this PR)
- [x] `infer_task_subclass` path routing: SQL, UI, runtime, intelligence, test, default
- [x] `resolve_task_class` with dispatch_paths: explicit class wins, research skills not subclassed
- [x] `_scope_matches` strict mode: `VNX_INTEL_STRICT_SCOPE=0` = old behaviour, `=1` = empty item scope rejects non-empty query
- [x] Scope expansion: `coding_sql` in query matches items with `category=sql`
- [x] Backfill: keyword inference, idempotent (skips existing categories), dry-run

Dispatch-ID: audit-ih-2-task-subclass-20260517-234432

🤖 Generated with [Claude Code](https://claude.com/claude-code)