### PR TITLE
fix(dashboard): bundle OI-1494 fixes (5 items) + agent-stream archive replay

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -39,7 +39,9 @@ npm run build
 # -> .next/ (Next.js output)
 ```
 
-**Backend API server** (separate process): `python dashboard/serve_dashboard.py` — runs on port 4173.
+**Backend API server** (separate process): `python dashboard/serve_dashboard.py` — runs on port 4174.
+
+**Registry freshness**: if the project-overview panel shows degraded state, run `vnx registry refresh` to update `~/.vnx/projects.json` timestamps without changing registration data.
 
 **Prerequisites**: Node.js 18+, running VNX dashboard server (`launch-dashboard.sh`), populated `quality_intelligence.db`.
 

--- a/dashboard/api_agent_stream.py
+++ b/dashboard/api_agent_stream.py
@@ -44,10 +44,6 @@ def handle_agent_stream(handler: BaseHTTPRequestHandler, terminal: str, since: s
         _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
         return
 
-    if _store.event_count(terminal) == 0:
-        _send_json(handler, HTTPStatus.NOT_FOUND, {"error": f"No events for terminal {terminal}"})
-        return
-
     # Send SSE headers
     handler.send_response(HTTPStatus.OK)
     handler.send_header("Content-Type", "text/event-stream")

--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -805,6 +805,25 @@ def _operator_post_gate_toggle(body: dict, config_path: Path | None = None) -> t
 import sqlite3
 from typing import Any
 
+
+def _effective_db_mtime(db_path: "Path | str") -> float:
+    """Return the effective mtime of a SQLite db, accounting for WAL mode.
+
+    In WAL mode, .db-wal accumulates writes until checkpoint; the base .db
+    file mtime alone can make a live db appear stale. Returns
+    max(mtime(.db), mtime(.db-wal), mtime(.db-shm)) so freshness checks
+    remain correct regardless of checkpoint timing.
+    """
+    p = Path(db_path)
+    mtimes = []
+    for candidate in (p, p.parent / (p.name + "-wal"), p.parent / (p.name + "-shm")):
+        try:
+            mtimes.append(candidate.stat().st_mtime)
+        except OSError:
+            pass
+    return max(mtimes) if mtimes else 0.0
+
+
 _SYSTEM_HEALTH_DB_TABLES = ("success_patterns", "antipatterns", "prevention_rules", "dispatch_metadata")
 
 
@@ -852,6 +871,8 @@ def _operator_get_system_health() -> dict:
                 status = "dead"
                 intel_details["error"] = "central quality_intelligence.db not available"
         elif DB_PATH.exists():
+            # WAL-aware mtime: .db-wal may be more recent than .db
+            intel_details["db_mtime"] = _effective_db_mtime(DB_PATH)
             conn = sqlite3.connect(str(DB_PATH))
             conn.row_factory = sqlite3.Row
             total_rows = 0

--- a/dashboard/launch-dashboard.sh
+++ b/dashboard/launch-dashboard.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 SERVICE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PORT="${PORT:-4173}"
+# Port 4174 matches the Next.js rewrite target in token-dashboard/next.config.ts
+PORT="${PORT:-4174}"
 
 if command -v python3 >/dev/null 2>&1; then
   echo "Serving dashboard from $SERVICE_DIR on http://localhost:$PORT (dashboard asset at /dashboard/index.html)"

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -122,6 +122,7 @@ from api_health import (  # noqa: E402
 
 from api_operator import (  # noqa: E402
     _api_health,
+    _effective_db_mtime,
     _jump_terminal,
     _operator_get_agents,
     _operator_get_gate_config,

--- a/dashboard/token-dashboard/app/agent-stream/page.tsx
+++ b/dashboard/token-dashboard/app/agent-stream/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Activity, Circle, Pause, Play } from 'lucide-react';
+import { Activity, Archive, Circle, Pause, Play, Radio } from 'lucide-react';
+import { fetchAgentStreamArchiveList, fetchAgentStreamArchive, type ArchiveEntry } from '@/lib/api';
 
 const TERMINALS = ['T1', 'T2', 'T3'] as const;
 type Terminal = (typeof TERMINALS)[number];
+type StreamMode = 'live' | 'archive';
 
 interface StreamEvent {
   type: string;
@@ -72,6 +74,16 @@ function formatTime(iso: string): string {
   }
 }
 
+function formatRelTime(epochSeconds: number): string {
+  const diffMs = Date.now() - epochSeconds * 1000;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  return `${Math.floor(diffH / 24)}d ago`;
+}
+
 function renderEventContent(event: StreamEvent): string {
   const d = event.data;
   if (event.type === 'text' || event.type === 'result') {
@@ -133,11 +145,17 @@ function EventRow({ event }: { event: StreamEvent }) {
 
 export default function AgentStreamPage() {
   const [terminal, setTerminal] = useState<Terminal>('T1');
+  const [mode, setMode] = useState<StreamMode>('live');
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [status, setStatus] = useState<Record<string, TerminalStatus>>({});
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [paused, setPaused] = useState(false);
+
+  // Archive state
+  const [archives, setArchives] = useState<ArchiveEntry[]>([]);
+  const [selectedArchive, setSelectedArchive] = useState<string>('');
+  const [archiveLoading, setArchiveLoading] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -148,14 +166,8 @@ export default function AgentStreamPage() {
   const activeTerminalRef = useRef<Terminal | null>(null);
   const isNavigatingAwayRef = useRef(false);
 
-  // Keep ref in sync with state for use in EventSource callbacks
-  useEffect(() => {
-    pausedRef.current = paused;
-  }, [paused]);
-
-  useEffect(() => {
-    terminalRef.current = terminal;
-  }, [terminal]);
+  useEffect(() => { pausedRef.current = paused; }, [paused]);
+  useEffect(() => { terminalRef.current = terminal; }, [terminal]);
 
   const clearStatusPolling = useCallback(() => {
     if (statusIntervalRef.current) {
@@ -193,12 +205,9 @@ export default function AgentStreamPage() {
 
   const startStatusPolling = useCallback(() => {
     if (statusIntervalRef.current || isNavigatingAwayRef.current) return;
-    statusIntervalRef.current = setInterval(() => {
-      void pollStatus();
-    }, 5000);
+    statusIntervalRef.current = setInterval(() => { void pollStatus(); }, 5000);
   }, [pollStatus]);
 
-  // Connect to SSE
   const connect = useCallback((term: Terminal, since: string | null) => {
     disconnectStream();
     if (isNavigatingAwayRef.current) return;
@@ -220,12 +229,8 @@ export default function AgentStreamPage() {
       if (eventSourceRef.current !== es || isNavigatingAwayRef.current) return;
       try {
         const event: StreamEvent = JSON.parse(msg.data);
-        if (event.timestamp) {
-          lastTimestampRef.current = event.timestamp;
-        }
-        if (!pausedRef.current) {
-          setEvents((prev) => [...prev, event]);
-        }
+        if (event.timestamp) lastTimestampRef.current = event.timestamp;
+        if (!pausedRef.current) setEvents((prev) => [...prev, event]);
       } catch {
         // skip malformed
       }
@@ -238,28 +243,63 @@ export default function AgentStreamPage() {
     };
   }, [disconnectStream]);
 
+  // Load archive list when switching to archive mode or changing terminal
+  useEffect(() => {
+    if (mode !== 'archive') return;
+    let cancelled = false;
+    fetchAgentStreamArchiveList(terminal)
+      .then((list) => {
+        if (!cancelled) {
+          const sorted = [...list].sort((a, b) => b.modified_at - a.modified_at).slice(0, 20);
+          setArchives(sorted);
+          setSelectedArchive(sorted[0]?.dispatch_id ?? '');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setArchives([]);
+          setSelectedArchive('');
+        }
+      });
+    return () => { cancelled = true; };
+  }, [mode, terminal]);
+
+  // Load archive events when selection changes
+  useEffect(() => {
+    if (mode !== 'archive' || !selectedArchive) {
+      if (mode === 'archive') setEvents([]);
+      return;
+    }
+    setArchiveLoading(true);
+    setError(null);
+    fetchAgentStreamArchive(terminal, selectedArchive)
+      .then((raw) => {
+        setEvents(raw as unknown as StreamEvent[]);
+        setArchiveLoading(false);
+      })
+      .catch((err: unknown) => {
+        setError(String(err));
+        setArchiveLoading(false);
+      });
+  }, [mode, terminal, selectedArchive]);
+
   useEffect(() => {
     function handleDocumentClick(event: MouseEvent) {
       if (event.defaultPrevented || event.button !== 0) return;
       if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
       if (!(event.target instanceof Element)) return;
-
       const anchor = event.target.closest('a[href]');
       const href = anchor?.getAttribute('href');
       if (!href || href.startsWith('#')) return;
-
       const nextUrl = new URL(href, window.location.href);
       if (nextUrl.origin !== window.location.origin) return;
-
       if (nextUrl.pathname !== '/agent-stream') {
         isNavigatingAwayRef.current = true;
         clearStatusPolling();
         disconnectStream();
         return;
       }
-
       if (!isNavigatingAwayRef.current) return;
-
       isNavigatingAwayRef.current = false;
       setEvents([]);
       setError(null);
@@ -267,11 +307,8 @@ export default function AgentStreamPage() {
       startStatusPolling();
       connect(terminalRef.current, null);
     }
-
     document.addEventListener('click', handleDocumentClick, true);
-    return () => {
-      document.removeEventListener('click', handleDocumentClick, true);
-    };
+    return () => { document.removeEventListener('click', handleDocumentClick, true); };
   }, [clearStatusPolling, connect, disconnectStream, startStatusPolling]);
 
   useEffect(() => {
@@ -280,23 +317,26 @@ export default function AgentStreamPage() {
     return clearStatusPolling;
   }, [clearStatusPolling, startStatusPolling]);
 
-  // Connect when terminal changes
+  // Connect live stream when terminal changes (live mode only)
   useEffect(() => {
+    if (mode !== 'live') return;
     isNavigatingAwayRef.current = false;
     setEvents([]);
     setError(null);
     lastTimestampRef.current = null;
-
-    if (eventSourceRef.current && activeTerminalRef.current === terminal) {
-      return;
-    }
-
+    if (eventSourceRef.current && activeTerminalRef.current === terminal) return;
     connect(terminal, null);
+    return () => { disconnectStream(); };
+  }, [terminal, mode, connect, disconnectStream]);
 
-    return () => {
+  // Disconnect SSE when switching to archive mode
+  useEffect(() => {
+    if (mode === 'archive') {
       disconnectStream();
-    };
-  }, [terminal, connect, disconnectStream]);
+      setEvents([]);
+      setError(null);
+    }
+  }, [mode, disconnectStream]);
 
   // Auto-scroll
   useEffect(() => {
@@ -325,44 +365,77 @@ export default function AgentStreamPage() {
               Agent Stream
             </h2>
             <p style={{ fontSize: 12, color: 'var(--color-muted)', marginTop: 2 }}>
-              Real-time event stream from worker terminals
+              {mode === 'live' ? 'Real-time event stream from worker terminals' : 'Archived dispatch replay'}
             </p>
           </div>
         </div>
 
         <div className="flex items-center gap-3">
-          {/* Connection status */}
-          <div className="flex items-center gap-2" style={{ fontSize: 12, color: connected ? '#50fa7b' : 'var(--color-muted)' }}>
-            <Circle size={8} fill={connected ? '#50fa7b' : 'var(--color-muted)'} />
-            {connected ? 'Connected' : 'Disconnected'}
+          {/* Mode toggle */}
+          <div style={{ display: 'flex', gap: 4, background: 'rgba(255,255,255,0.04)', borderRadius: 10, padding: 3 }}>
+            {(['live', 'archive'] as StreamMode[]).map((m) => {
+              const active = m === mode;
+              return (
+                <button
+                  key={m}
+                  onClick={() => setMode(m)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: '6px 14px',
+                    borderRadius: 8,
+                    background: active ? 'rgba(249, 115, 22, 0.15)' : 'transparent',
+                    border: `1px solid ${active ? 'rgba(249, 115, 22, 0.3)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    fontWeight: active ? 600 : 400,
+                    color: active ? 'var(--color-accent)' : 'var(--color-muted)',
+                  }}
+                >
+                  {m === 'live' ? <Radio size={12} /> : <Archive size={12} />}
+                  {m === 'live' ? 'Live' : 'Archive'}
+                </button>
+              );
+            })}
           </div>
 
-          {/* Pause/Resume */}
-          <button
-            onClick={() => setPaused(!paused)}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '7px 14px',
-              borderRadius: 8,
-              background: paused ? 'rgba(249, 115, 22, 0.15)' : 'rgba(255,255,255,0.05)',
-              border: `1px solid ${paused ? 'rgba(249, 115, 22, 0.3)' : 'rgba(255,255,255,0.1)'}`,
-              cursor: 'pointer',
-              fontSize: 12,
-              color: paused ? 'var(--color-accent)' : 'var(--color-muted)',
-            }}
-          >
-            {paused ? <Play size={13} /> : <Pause size={13} />}
-            {paused ? 'Resume' : 'Pause'}
-          </button>
+          {/* Connection status (live mode only) */}
+          {mode === 'live' && (
+            <div className="flex items-center gap-2" style={{ fontSize: 12, color: connected ? '#50fa7b' : 'var(--color-muted)' }}>
+              <Circle size={8} fill={connected ? '#50fa7b' : 'var(--color-muted)'} />
+              {connected ? 'Connected' : 'Disconnected'}
+            </div>
+          )}
 
-          {/* Agent / Terminal selector */}
+          {/* Pause/Resume (live mode only) */}
+          {mode === 'live' && (
+            <button
+              onClick={() => setPaused(!paused)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '7px 14px',
+                borderRadius: 8,
+                background: paused ? 'rgba(249, 115, 22, 0.15)' : 'rgba(255,255,255,0.05)',
+                border: `1px solid ${paused ? 'rgba(249, 115, 22, 0.3)' : 'rgba(255,255,255,0.1)'}`,
+                cursor: 'pointer',
+                fontSize: 12,
+                color: paused ? 'var(--color-accent)' : 'var(--color-muted)',
+              }}
+            >
+              {paused ? <Play size={13} /> : <Pause size={13} />}
+              {paused ? 'Resume' : 'Pause'}
+            </button>
+          )}
+
+          {/* Terminal selector */}
           <div data-testid="agent-selector" style={{ display: 'flex', gap: 4 }}>
             {TERMINALS.map((t) => {
               const active = t === terminal;
-              const hasEvents = !!status[t];
               const ts = status[t];
+              const hasEvents = !!ts;
               const label = ts?.agent_name || t;
               return (
                 <button
@@ -411,8 +484,56 @@ export default function AgentStreamPage() {
         </div>
       </div>
 
-      {/* Status bar */}
-      {terminalStatus && (
+      {/* Archive selector (archive mode) */}
+      {mode === 'archive' && (
+        <div
+          style={{
+            marginBottom: 16,
+            padding: '12px 16px',
+            background: 'rgba(255,255,255,0.02)',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.07)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Archive size={14} style={{ color: 'var(--color-muted)', flexShrink: 0 }} />
+          <span style={{ fontSize: 12, color: 'var(--color-muted)', flexShrink: 0 }}>Dispatch:</span>
+          {archives.length === 0 ? (
+            <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>No archives for {terminal}</span>
+          ) : (
+            <select
+              value={selectedArchive}
+              onChange={(e) => setSelectedArchive(e.target.value)}
+              style={{
+                background: 'rgba(255,255,255,0.06)',
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 6,
+                color: 'var(--color-foreground)',
+                fontSize: 12,
+                padding: '4px 8px',
+                cursor: 'pointer',
+                maxWidth: 480,
+                flex: 1,
+              }}
+            >
+              {archives.map((a) => (
+                <option key={a.dispatch_id} value={a.dispatch_id}>
+                  {a.dispatch_id} — {formatRelTime(a.modified_at)}, {a.file_size} bytes
+                </option>
+              ))}
+            </select>
+          )}
+          {archiveLoading && (
+            <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>Loading…</span>
+          )}
+        </div>
+      )}
+
+      {/* Status bar (live mode) */}
+      {mode === 'live' && terminalStatus && (
         <div
           style={{
             display: 'flex',
@@ -430,6 +551,31 @@ export default function AgentStreamPage() {
           <span>Displayed: <strong style={{ color: 'var(--color-foreground)' }}>{events.length}</strong></span>
           {terminalStatus.last_timestamp && (
             <span>Last: <strong style={{ color: 'var(--color-foreground)' }}>{formatTime(terminalStatus.last_timestamp)}</strong></span>
+          )}
+        </div>
+      )}
+
+      {/* Archive status bar */}
+      {mode === 'archive' && events.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 24,
+            padding: '10px 16px',
+            marginBottom: 16,
+            background: 'rgba(255,255,255,0.02)',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.06)',
+            fontSize: 12,
+            color: 'var(--color-muted)',
+          }}
+        >
+          <span>Events: <strong style={{ color: 'var(--color-foreground)' }}>{events.length}</strong></span>
+          {events[0]?.timestamp && (
+            <span>From: <strong style={{ color: 'var(--color-foreground)' }}>{formatTime(events[0].timestamp)}</strong></span>
+          )}
+          {events[events.length - 1]?.timestamp && (
+            <span>To: <strong style={{ color: 'var(--color-foreground)' }}>{formatTime(events[events.length - 1].timestamp)}</strong></span>
           )}
         </div>
       )}
@@ -479,11 +625,13 @@ export default function AgentStreamPage() {
           >
             <Activity size={32} strokeWidth={1.5} />
             <span style={{ fontSize: 13 }}>
-              {connected ? 'Waiting for events...' : `No events for ${terminal}`}
+              {mode === 'live'
+                ? (connected ? 'Waiting for events...' : `No events for ${terminal}`)
+                : (archiveLoading ? 'Loading archive...' : (selectedArchive ? 'No events in this archive' : `No archives for ${terminal}`))}
             </span>
           </div>
         ) : (
-          events.map((ev, i) => <EventRow key={`${ev.terminal}-${ev.sequence}-${i}`} event={ev} />)
+          events.map((ev, i) => <EventRow key={`${ev.terminal}-${ev.sequence ?? i}-${i}`} event={ev} />)
         )}
       </div>
     </div>

--- a/dashboard/token-dashboard/app/operator/reports/page.tsx
+++ b/dashboard/token-dashboard/app/operator/reports/page.tsx
@@ -21,7 +21,7 @@ const STATUS_COLORS: Record<string, { color: string; bg: string; border: string 
 };
 
 function TrackBadge({ track }: { track: string | null | undefined }) {
-  const safeTrack = (track ?? 'UNKNOWN').toUpperCase();
+  const safeTrack = (track || 'UNKNOWN').toUpperCase();
   const cfg = TRACK_COLORS[safeTrack] ?? { color: '#6B6B6B', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
   return (
     <span

--- a/dashboard/token-dashboard/app/operator/reports/page.tsx
+++ b/dashboard/token-dashboard/app/operator/reports/page.tsx
@@ -20,8 +20,9 @@ const STATUS_COLORS: Record<string, { color: string; bg: string; border: string 
   failed:  { color: '#ff6b6b', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
 };
 
-function TrackBadge({ track }: { track: string }) {
-  const cfg = TRACK_COLORS[track.toUpperCase()] ?? { color: '#6B6B6B', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
+function TrackBadge({ track }: { track: string | null | undefined }) {
+  const safeTrack = (track ?? 'UNKNOWN').toUpperCase();
+  const cfg = TRACK_COLORS[safeTrack] ?? { color: '#6B6B6B', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
   return (
     <span
       style={{
@@ -35,7 +36,7 @@ function TrackBadge({ track }: { track: string }) {
         letterSpacing: '0.04em',
       }}
     >
-      {track.toUpperCase()}
+      {safeTrack}
     </span>
   );
 }

--- a/dashboard/token-dashboard/lib/api.ts
+++ b/dashboard/token-dashboard/lib/api.ts
@@ -62,3 +62,32 @@ export async function fetchTranscript(sessionId: string): Promise<TranscriptResp
   }
   return res.json();
 }
+
+export interface ArchiveEntry {
+  dispatch_id: string;
+  file_size: number;
+  modified_at: number;
+}
+
+export async function fetchAgentStreamArchiveList(terminal: string): Promise<ArchiveEntry[]> {
+  const res = await fetch(`/api/agent-stream/${encodeURIComponent(terminal)}/archives`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch archive list for ${terminal}: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
+}
+
+export async function fetchAgentStreamArchive(
+  terminal: string,
+  dispatchId: string,
+): Promise<Record<string, unknown>[]> {
+  const res = await fetch(
+    `/api/agent-stream/${encodeURIComponent(terminal)}/archive/${encodeURIComponent(dispatchId)}`,
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch archive ${dispatchId}: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
+}

--- a/scripts/commands/registry.sh
+++ b/scripts/commands/registry.sh
@@ -162,3 +162,40 @@ else:
     print(f'Not found in registry: {project_path}')
 " || return 1
 }
+
+# ── refresh ──────────────────────────────────────────────────────────────
+cmd_refresh() {
+  # Touch updated_at for all registered projects without changing other data.
+  # Dashboard reads this timestamp to determine if the registry is fresh.
+  if [ ! -f "$VNX_REGISTRY_FILE" ]; then
+    log "No projects registered. Use 'vnx register' first."
+    return 0
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    err "[refresh] python3 is required"
+    return 1
+  fi
+
+  python3 -c "
+import json, os, sys
+from datetime import datetime, timezone
+
+registry_file = '$VNX_REGISTRY_FILE'
+with open(registry_file) as f:
+    data = json.load(f)
+
+now = datetime.now(timezone.utc).isoformat()
+count = 0
+for p in data.get('projects', []):
+    p['updated_at'] = now
+    count += 1
+
+with open(registry_file, 'w') as f:
+    json.dump(data, f, indent=2)
+
+print(f'Refreshed updated_at for {count} project(s) in {registry_file}')
+" || return 1
+
+  log "[refresh] Registry timestamps updated in $VNX_REGISTRY_FILE"
+}

--- a/scripts/commands/registry.sh
+++ b/scripts/commands/registry.sh
@@ -178,7 +178,7 @@ cmd_refresh() {
   fi
 
   python3 -c "
-import json, os, sys
+import json, os, sys, tempfile
 from datetime import datetime, timezone
 
 registry_file = '$VNX_REGISTRY_FILE'
@@ -191,8 +191,29 @@ for p in data.get('projects', []):
     p['updated_at'] = now
     count += 1
 
-with open(registry_file, 'w') as f:
-    json.dump(data, f, indent=2)
+reg_dir = os.path.dirname(registry_file)
+fd, tmp_path = tempfile.mkstemp(dir=reg_dir, prefix='.projects-', suffix='.tmp')
+try:
+    with os.fdopen(fd, 'w') as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp_path, registry_file)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
+
+event = {
+    'event_type': 'registry_refresh',
+    'timestamp': now,
+    'operator': 'vnx',
+    'project_count': count,
+}
+events_path = os.path.join(os.path.expanduser('~'), '.vnx-data', 'events', 'registry_refresh.ndjson')
+os.makedirs(os.path.dirname(events_path), exist_ok=True)
+with open(events_path, 'a') as f:
+    f.write(json.dumps(event) + '\n')
 
 print(f'Refreshed updated_at for {count} project(s) in {registry_file}')
 " || return 1

--- a/tests/test_dashboard_sse_empty_file.py
+++ b/tests/test_dashboard_sse_empty_file.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Test: SSE handler does not 404 when the live NDJSON file is empty (0 bytes).
+
+Dispatch-ID: 20260520-1450-dashboard-phase-a
+"""
+
+import sys
+import time
+import unittest
+from http import HTTPStatus
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_DIR = PROJECT_ROOT / "dashboard"
+SCRIPTS_LIB = PROJECT_ROOT / "scripts" / "lib"
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+if str(DASHBOARD_DIR) not in sys.path:
+    sys.path.insert(0, str(DASHBOARD_DIR))
+
+
+class FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler."""
+
+    def __init__(self, break_on_flush: bool = True):
+        self.wfile = MagicMock()
+        # Raise BrokenPipeError on flush so the polling loop exits immediately
+        if break_on_flush:
+            self.wfile.flush.side_effect = BrokenPipeError
+        self.response_code: int | None = None
+        self.headers_sent: list[tuple[str, str]] = []
+        self._headers_ended = False
+
+    def send_response(self, code) -> None:
+        self.response_code = int(code)
+
+    def send_header(self, key: str, value: str) -> None:
+        self.headers_sent.append((key, value))
+
+    def end_headers(self) -> None:
+        self._headers_ended = True
+
+
+def _make_mock_store(event_count: int = 0):
+    store = MagicMock()
+    store.event_count.return_value = event_count
+    store.tail.return_value = iter([])
+    return store
+
+
+class TestSSEHandlerEmptyFile(unittest.TestCase):
+    """SSE endpoint stays open (200 OK) even when event store is empty."""
+
+    def _fresh_module(self, mock_store):
+        """Import api_agent_stream with a patched _store."""
+        if "api_agent_stream" in sys.modules:
+            del sys.modules["api_agent_stream"]
+        with patch("event_store.EventStore", return_value=mock_store):
+            import api_agent_stream  # noqa: PLC0415
+            # Replace module-level _store so the handler uses our mock
+            api_agent_stream._store = mock_store
+        return api_agent_stream
+
+    def test_no_404_on_empty_store(self):
+        """When event_count==0, handle_agent_stream must NOT return 404."""
+        mock_store = _make_mock_store(event_count=0)
+        mod = self._fresh_module(mock_store)
+        handler = FakeHandler(break_on_flush=True)
+
+        mod.handle_agent_stream(handler, "T1", None)
+
+        self.assertNotEqual(
+            handler.response_code,
+            int(HTTPStatus.NOT_FOUND),
+            "SSE handler must not return 404 for empty event store",
+        )
+
+    def test_sse_headers_sent_on_empty_store(self):
+        """With empty store, SSE response headers are still emitted before poll loop."""
+        mock_store = _make_mock_store(event_count=0)
+        mod = self._fresh_module(mock_store)
+        handler = FakeHandler(break_on_flush=True)
+
+        mod.handle_agent_stream(handler, "T1", None)
+
+        self.assertEqual(
+            handler.response_code,
+            int(HTTPStatus.OK),
+            "SSE handler must send 200 OK before entering poll loop",
+        )
+        content_types = [v for k, v in handler.headers_sent if k == "Content-Type"]
+        self.assertIn(
+            "text/event-stream",
+            content_types,
+            "SSE Content-Type header must be sent even for empty event store",
+        )
+
+    def test_invalid_terminal_still_bad_request(self):
+        """Unknown terminal names still get 400 (bad request)."""
+        mock_store = _make_mock_store(event_count=0)
+        mod = self._fresh_module(mock_store)
+        handler = FakeHandler(break_on_flush=False)
+
+        mod.handle_agent_stream(handler, "TX_INVALID", None)
+
+        self.assertEqual(
+            handler.response_code,
+            int(HTTPStatus.BAD_REQUEST),
+            "Unknown terminal must return 400 BAD_REQUEST",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_track_badge_null.py
+++ b/tests/test_dashboard_track_badge_null.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Test: TrackBadge null-guard — resolves null/undefined track without crashing.
+
+Since this component is TypeScript/React, we validate the logic in Python by
+replicating the safeTrack resolution rule and asserting expected outputs.
+
+Dispatch-ID: 20260520-1450-dashboard-phase-a
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PAGE_PATH = (
+    PROJECT_ROOT
+    / "dashboard"
+    / "token-dashboard"
+    / "app"
+    / "operator"
+    / "reports"
+    / "page.tsx"
+)
+
+
+def _extract_track_badge_source(path: Path) -> str:
+    """Return the TrackBadge function source from the TSX file."""
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"function TrackBadge\(.*?\{(.*?)^function ",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError("TrackBadge function not found in page.tsx")
+    return match.group(0)
+
+
+def _safetrack(track) -> str:
+    """Python equivalent of the TypeScript safeTrack resolution in TrackBadge."""
+    return (track if track is not None and track != "" else "UNKNOWN").upper()
+
+
+class TestTrackBadgeNullGuard(unittest.TestCase):
+    """Validate null-guard logic for TrackBadge."""
+
+    def test_null_resolves_to_unknown(self):
+        self.assertEqual(_safetrack(None), "UNKNOWN")
+
+    def test_empty_string_resolves_to_unknown(self):
+        self.assertEqual(_safetrack(""), "UNKNOWN")
+
+    def test_valid_track_uppercased(self):
+        for track, expected in [("A", "A"), ("b", "B"), ("C", "C")]:
+            with self.subTest(track=track):
+                self.assertEqual(_safetrack(track), expected)
+
+    def test_arbitrary_track_uppercased(self):
+        self.assertEqual(_safetrack("x"), "X")
+
+    def test_tsx_signature_uses_nullable_type(self):
+        """TrackBadge prop type must accept null/undefined."""
+        if not PAGE_PATH.exists():
+            self.skipTest("page.tsx not found — skipping file-level check")
+        source = _extract_track_badge_source(PAGE_PATH)
+        self.assertRegex(
+            source,
+            r"track\s*\}\s*:\s*\{.*?track\s*:\s*string\s*\|.*?null",
+            "TrackBadge must declare track as string | null | undefined",
+        )
+
+    def test_tsx_uses_safetrack_variable(self):
+        """TrackBadge must use safeTrack variable, not raw track.toUpperCase()."""
+        if not PAGE_PATH.exists():
+            self.skipTest("page.tsx not found — skipping file-level check")
+        source = _extract_track_badge_source(PAGE_PATH)
+        # Old broken pattern must not appear
+        self.assertNotIn("track.toUpperCase()", source,
+                         "TrackBadge must not call track.toUpperCase() directly")
+        # New safe pattern must be present
+        self.assertIn("safeTrack", source, "TrackBadge must use safeTrack variable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_wal_aware_staleness.py
+++ b/tests/test_dashboard_wal_aware_staleness.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Test: _effective_db_mtime returns WAL-file mtime when it is more recent.
+
+Dispatch-ID: 20260520-1450-dashboard-phase-a
+"""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_DIR = PROJECT_ROOT / "dashboard"
+SCRIPTS_LIB = PROJECT_ROOT / "scripts" / "lib"
+
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+if str(DASHBOARD_DIR) not in sys.path:
+    sys.path.insert(0, str(DASHBOARD_DIR))
+
+
+def _import_helper():
+    """Import _effective_db_mtime from api_operator (or serve_dashboard as re-export)."""
+    try:
+        from api_operator import _effective_db_mtime  # noqa: PLC0415
+        return _effective_db_mtime
+    except ImportError:
+        from serve_dashboard import _effective_db_mtime  # noqa: PLC0415
+        return _effective_db_mtime
+
+
+class TestEffectiveDbMtime(unittest.TestCase):
+    """_effective_db_mtime picks the most recent sidecar file mtime."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _touch(self, path: Path, offset_seconds: float = 0) -> float:
+        """Write an empty file and set its mtime. Returns the set mtime."""
+        path.write_bytes(b"")
+        target = time.time() + offset_seconds
+        os.utime(str(path), (target, target))
+        return target
+
+    def test_returns_db_mtime_when_no_wal(self):
+        fn = _import_helper()
+        db = self.tmpdir / "test.db"
+        self._touch(db, offset_seconds=0)
+        result = fn(db)
+        self.assertAlmostEqual(result, db.stat().st_mtime, places=1)
+
+    def test_returns_wal_mtime_when_wal_is_newer(self):
+        fn = _import_helper()
+        db = self.tmpdir / "coord.db"
+        wal = self.tmpdir / "coord.db-wal"
+        self._touch(db, offset_seconds=-10)  # 10 s older
+        newer_ts = self._touch(wal, offset_seconds=0)
+
+        result = fn(db)
+        self.assertAlmostEqual(result, newer_ts, delta=1.0,
+                               msg="Should return WAL mtime when it is more recent than .db")
+
+    def test_returns_shm_mtime_when_shm_is_newest(self):
+        fn = _import_helper()
+        db = self.tmpdir / "qi.db"
+        wal = self.tmpdir / "qi.db-wal"
+        shm = self.tmpdir / "qi.db-shm"
+        self._touch(db, offset_seconds=-20)
+        self._touch(wal, offset_seconds=-10)
+        newest_ts = self._touch(shm, offset_seconds=0)
+
+        result = fn(db)
+        self.assertAlmostEqual(result, newest_ts, delta=1.0,
+                               msg="Should return shm mtime when it is newest")
+
+    def test_returns_zero_for_nonexistent_db(self):
+        fn = _import_helper()
+        result = fn(self.tmpdir / "nonexistent.db")
+        self.assertEqual(result, 0.0)
+
+    def test_db_mtime_wins_when_wal_is_older(self):
+        fn = _import_helper()
+        db = self.tmpdir / "recent.db"
+        wal = self.tmpdir / "recent.db-wal"
+        newest_ts = self._touch(db, offset_seconds=0)
+        self._touch(wal, offset_seconds=-30)
+
+        result = fn(db)
+        self.assertAlmostEqual(result, newest_ts, delta=1.0,
+                               msg="Should return .db mtime when it is newer than WAL")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bundled fix voor OI-1494 + feature-gap agent-stream archive replay.

- **Fix 1 (SSE 404)**: `api_agent_stream.py` — verwijder `event_count==0` check + 404-return; post-dispatch truncated live file geeft nu keep-alive SSE ipv 404
- **Fix 2 (TrackBadge)**: `reports/page.tsx` — null-guard op `track` prop; `null`/`undefined` resolvet naar `UNKNOWN` zonder crash
- **Fix 3 (port)**: `launch-dashboard.sh` — default port `4173` → `4174` (matcht Next.js rewrite target)
- **Fix 4 (registry)**: `registry.sh` — voeg `vnx registry refresh` subcommand toe; `dashboard/README.md` docs-vermelding
- **Fix 5 (WAL mtime)**: `api_operator.py` — `_effective_db_mtime` helper (`max(.db, .db-wal, .db-shm) mtime`) + toegepast in system-health intelligence_db check
- **Feature (archive replay)**: `agent-stream/page.tsx` — Live/Archive mode-toggle + dispatch dropdown + array-fetch via bestaande backend endpoints

Cross-references: OI-1494, `claudedocs/dashboard-agent-stream-archive-replay-gap.md`

## Test plan

- [ ] `python -m pytest tests/test_dashboard_sse_empty_file.py` — 3 tests, SSE geen 404 op lege file
- [ ] `python -m pytest tests/test_dashboard_track_badge_null.py` — 5 tests, null-guard TrackBadge
- [ ] `python -m pytest tests/test_dashboard_wal_aware_staleness.py` — 5 tests, WAL-aware mtime helper
- [ ] Bestaande dashboard tests: `python -m pytest tests/test_dashboard_*.py`
- [ ] TypeScript: `npx tsc --noEmit` in `dashboard/token-dashboard/` — geen fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)