### PR TITLE
feat(centralisatie): vnx pause/resume + partial-failure cleanup runbook (Dag 2 PR C)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -207,6 +207,9 @@ Snapshot commands (W0):
   quiesce-check [<path>]    Verify project is safe to migrate (read-only)
 
 Runtime commands:
+  pause [reason]     Gracefully stop dispatcher + receipt_processor + queue_watcher
+                     Writes ${VNX_STATE_DIR}/PAUSED marker for migration cutover
+  resume             Restart daemons after 'vnx pause'; fails if not paused
   recover            Recover from unclean shutdown or stale state
                      Options: --aggressive, --dry-run
 
@@ -1855,6 +1858,12 @@ main() {
       ;;
     quiesce-check)
       cmd_quiesce_check "$@"
+      ;;
+    pause)
+      cmd_pause "$@"
+      ;;
+    resume)
+      cmd_resume "$@"
       ;;
     recover)
       cmd_recover "$@"

--- a/docs/operations/migration-rollback-runbook.md
+++ b/docs/operations/migration-rollback-runbook.md
@@ -260,6 +260,166 @@ and `schema_version` (text PK audit log in QI).
 
 ---
 
+---
+
+## Pre-apply snapshot (mandatory before every --apply)
+
+Before running `migrate_to_central_vnx.py --apply` for any project, snapshot the
+central DB to an archive directory. This snapshot is the fast-restore point for
+Scenario X below.
+
+```bash
+# Set once per apply session
+CENTRAL_DB=~/.vnx-data/state/quality_intelligence.db
+FAILED_PROJECT_ID="mission-control"   # fill in target project
+ARCHIVE_DIR=~/Archive/pre-apply-${FAILED_PROJECT_ID}-$(date +%Y%m%dT%H%M%S)
+
+mkdir -p "$ARCHIVE_DIR"
+cp "$CENTRAL_DB" "$ARCHIVE_DIR/quality_intelligence.db"
+sqlite3 "$CENTRAL_DB" ".dump" > "$ARCHIVE_DIR/quality_intelligence.sql"
+echo "Snapshot written to: $ARCHIVE_DIR"
+```
+
+Verify the snapshot is readable before proceeding:
+
+```bash
+sqlite3 "$ARCHIVE_DIR/quality_intelligence.db" "PRAGMA integrity_check;" | head -3
+```
+
+Expected: `ok`
+
+---
+
+## Scenario X — Partial migration failure (central store cleanup)
+
+Use when project X (e.g. mission-control) fails halfway through `--apply` to the
+central store, leaving partial rows that must be removed before retrying or
+rolling back the source project.
+
+### Step 1 — Identify the partially migrated project
+
+Check which project has an inconsistent row count in the central DB:
+
+```bash
+CENTRAL_DB=~/.vnx-data/state/quality_intelligence.db
+
+sqlite3 "$CENTRAL_DB" "
+SELECT project_id, COUNT(*) as rows
+FROM success_patterns
+GROUP BY project_id
+ORDER BY rows DESC;"
+
+sqlite3 "$CENTRAL_DB" "
+SELECT project_id, COUNT(*) as rows
+FROM antipatterns
+GROUP BY project_id
+ORDER BY rows DESC;"
+```
+
+Compare against the source project DB to confirm the mismatch.
+
+### Step 2 — Pause VNX to prevent concurrent writes
+
+```bash
+vnx pause partial_migration_cleanup
+```
+
+Verify the PAUSED marker exists:
+
+```bash
+cat ~/.vnx-data/state/PAUSED
+```
+
+Do NOT skip this step. Concurrent dispatcher writes during cleanup corrupt the
+central store.
+
+### Step 3 — Central store cleanup
+
+Replace `$FAILED_PROJECT_ID` with the actual project_id from Step 1.
+
+```bash
+CENTRAL_DB=~/.vnx-data/state/quality_intelligence.db
+FAILED_PROJECT_ID="mission-control"
+
+sqlite3 "$CENTRAL_DB" "
+BEGIN IMMEDIATE;
+DELETE FROM success_patterns    WHERE project_id = '${FAILED_PROJECT_ID}';
+DELETE FROM antipatterns        WHERE project_id = '${FAILED_PROJECT_ID}';
+DELETE FROM code_snippets       WHERE project_id = '${FAILED_PROJECT_ID}';
+DELETE FROM snippet_metadata    WHERE project_id = '${FAILED_PROJECT_ID}';
+DELETE FROM intelligence_injections WHERE project_id = '${FAILED_PROJECT_ID}';
+DELETE FROM session_analytics   WHERE project_id = '${FAILED_PROJECT_ID}';
+COMMIT;"
+echo "Exit code: $?"
+```
+
+If any DELETE fails, restore from the pre-apply snapshot (Step 4b) and
+investigate before retrying.
+
+### Step 4a — Validate post-cleanup
+
+Confirm no rows remain for the failed project:
+
+```bash
+sqlite3 "$CENTRAL_DB" "
+SELECT
+  (SELECT COUNT(*) FROM success_patterns    WHERE project_id='${FAILED_PROJECT_ID}') as patterns,
+  (SELECT COUNT(*) FROM antipatterns        WHERE project_id='${FAILED_PROJECT_ID}') as antipatterns,
+  (SELECT COUNT(*) FROM code_snippets       WHERE project_id='${FAILED_PROJECT_ID}') as snippets,
+  (SELECT COUNT(*) FROM snippet_metadata    WHERE project_id='${FAILED_PROJECT_ID}') as snippet_meta,
+  (SELECT COUNT(*) FROM intelligence_injections WHERE project_id='${FAILED_PROJECT_ID}') as injections;"
+```
+
+Expected: all zeros.
+
+Run integrity check to confirm the DB is consistent:
+
+```bash
+sqlite3 "$CENTRAL_DB" "PRAGMA integrity_check;" | head -3
+```
+
+Expected: `ok`
+
+### Step 4b — Restore from pre-apply snapshot (if cleanup fails)
+
+If Step 3 produced errors or the integrity check fails:
+
+```bash
+ARCHIVE_DIR=~/Archive/pre-apply-${FAILED_PROJECT_ID}-<timestamp>
+CENTRAL_DB_TMP=~/.vnx-data/state/quality_intelligence.db.restore-tmp
+
+cp "$ARCHIVE_DIR/quality_intelligence.db" "$CENTRAL_DB_TMP"
+sqlite3 "$CENTRAL_DB_TMP" "PRAGMA integrity_check;" | head -3
+# Expected: ok
+mv "$CENTRAL_DB_TMP" "$CENTRAL_DB"
+echo "Central DB restored from snapshot."
+```
+
+### Step 5 — Re-run dry-run to confirm no traces
+
+```bash
+python3 scripts/migrate_to_central_vnx.py --project "$FAILED_PROJECT_ID" --dry-run
+```
+
+The dry-run should show no conflicts and report the correct row counts for the
+project as if it were unmigrated.
+
+### Step 6 — Resume VNX
+
+```bash
+vnx resume
+```
+
+Confirm lifecycle events were written:
+
+```bash
+tail -2 ~/.vnx-data/events/lifecycle.ndjson | python3 -m json.tool
+```
+
+Expected: one `service_paused` event and one `service_resumed` event.
+
+---
+
 ## Open Items
 
 - OI-ROLLBACK-1: Wire `--rollback-fts5` flag into `migrate_to_central_vnx.py` for

--- a/docs/operations/migration-rollback-runbook.md
+++ b/docs/operations/migration-rollback-runbook.md
@@ -391,7 +391,10 @@ CENTRAL_DB_TMP=~/.vnx-data/state/quality_intelligence.db.restore-tmp
 cp "$ARCHIVE_DIR/quality_intelligence.db" "$CENTRAL_DB_TMP"
 sqlite3 "$CENTRAL_DB_TMP" "PRAGMA integrity_check;" | head -3
 # Expected: ok
-mv "$CENTRAL_DB_TMP" "$CENTRAL_DB"
+# Use python3 os.replace for guaranteed atomic swap on the same filesystem.
+# Plain `mv` is non-atomic across filesystem boundaries and can cause partial reads
+# if the tmp and target are on different mounts.
+python3 -c "import os, sys; os.replace(sys.argv[1], sys.argv[2])" "$CENTRAL_DB_TMP" "$CENTRAL_DB"
 echo "Central DB restored from snapshot."
 ```
 

--- a/scripts/commands/pause.sh
+++ b/scripts/commands/pause.sh
@@ -103,6 +103,46 @@ _vnx_pause_stop_daemon() {
   fi
 }
 
+# Helper: create required directories for pause operation.
+_vnx_pause_validate_args() {
+  local state_dir="$1"
+  local events_dir="$2"
+  local pids_dir="$3"
+  mkdir -p "$state_dir" "$events_dir" "$pids_dir" \
+    "${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
+}
+
+# Helper: stop all three targeted daemons; sets _pause_any_failed on error.
+_vnx_pause_stop_daemons() {
+  local pids_dir="$1"
+  _pause_any_failed=0
+  _vnx_pause_stop_daemon "dispatcher" "$pids_dir"
+  _vnx_pause_stop_daemon "receipt_processor" "$pids_dir"
+  _vnx_pause_stop_daemon "queue_watcher" "$pids_dir"
+}
+
+# Helper: atomic write of PAUSED marker (tmp → mv to prevent partial reads).
+_vnx_pause_write_marker() {
+  local paused_file="$1"
+  local ts="$2"
+  local by_dispatch_id="$3"
+  local reason="$4"
+  local tmp_paused="${paused_file}.tmp.$$"
+  python3 -c "import json,sys; print(json.dumps({'paused_at':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
+    "$ts" "$by_dispatch_id" "$reason" > "$tmp_paused"
+  mv "$tmp_paused" "$paused_file"
+}
+
+# Helper: append service_paused NDJSON event using python3 for safe encoding.
+_vnx_pause_log_lifecycle() {
+  local lifecycle_log="$1"
+  local ts="$2"
+  local by_dispatch_id="$3"
+  local reason="$4"
+  python3 -c "import json,sys; print(json.dumps({'event_type':'service_paused','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
+    "$ts" "$by_dispatch_id" "$reason" >> "$lifecycle_log"
+}
+
 cmd_pause() {
   local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
   local pids_dir="${VNX_PIDS_DIR:-${VNX_DATA_DIR}/pids}"
@@ -112,19 +152,14 @@ cmd_pause() {
   local by_dispatch_id="${VNX_DISPATCH_ID:-manual}"
   local reason="${1:-migration_cutover}"
 
-  mkdir -p "$state_dir" "$events_dir" "$pids_dir" \
-    "${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
+  _vnx_pause_validate_args "$state_dir" "$events_dir" "$pids_dir"
 
   if [ -f "$paused_file" ]; then
     log "[pause] Already paused — PAUSED marker exists: $paused_file"
     return 0
   fi
 
-  _pause_any_failed=0
-
-  _vnx_pause_stop_daemon "dispatcher" "$pids_dir"
-  _vnx_pause_stop_daemon "receipt_processor" "$pids_dir"
-  _vnx_pause_stop_daemon "queue_watcher" "$pids_dir"
+  _vnx_pause_stop_daemons "$pids_dir"
 
   if [ "${_pause_any_failed:-0}" -eq 1 ]; then
     err "[pause] Some daemons could not be stopped. PAUSED marker NOT written."
@@ -133,18 +168,10 @@ cmd_pause() {
   fi
   unset _pause_any_failed
 
-  # Atomic write: tmp file → mv (prevents partial reads)
-  # Use python3 for safe JSON encoding — prevents injection via $reason/$by_dispatch_id
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  local tmp_paused="${paused_file}.tmp.$$"
-  python3 -c "import json,sys; print(json.dumps({'paused_at':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
-    "$ts" "$by_dispatch_id" "$reason" > "$tmp_paused"
-  mv "$tmp_paused" "$paused_file"
-
-  # NDJSON lifecycle event (python3 for safe JSON encoding)
-  python3 -c "import json,sys; print(json.dumps({'event_type':'service_paused','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
-    "$ts" "$by_dispatch_id" "$reason" >> "$lifecycle_log"
+  _vnx_pause_write_marker "$paused_file" "$ts" "$by_dispatch_id" "$reason"
+  _vnx_pause_log_lifecycle "$lifecycle_log" "$ts" "$by_dispatch_id" "$reason"
 
   log "[pause] VNX daemons paused. Marker: $paused_file"
   return 0

--- a/scripts/commands/pause.sh
+++ b/scripts/commands/pause.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# VNX Command: pause
+# Gracefully stops per-project daemons for migration cutover.
+#
+# This file is sourced by bin/vnx's command loader. All functions and variables
+# from the main script (log, err, VNX_HOME, VNX_DATA_DIR, etc.) are available
+# when this runs.
+#
+# Creates ${VNX_STATE_DIR}/PAUSED marker and appends service_paused event to
+# ${VNX_DATA_DIR}/events/lifecycle.ndjson.
+#
+# Daemons targeted: dispatcher, receipt_processor, queue_watcher.
+# Idempotent: skips already-stopped daemons without error.
+# Exit 0: all targeted daemons stopped + marker written.
+# Exit 1: one or more daemons could not be stopped (marker NOT written).
+
+# Helper: returns 0 if PID refers to a live (non-zombie) process, 1 otherwise.
+# Zombies have exited but wait() hasn't been called on them; kill -0 succeeds for
+# them but they cannot perform I/O. Treat them as stopped.
+_vnx_proc_is_live() {
+  local pid="$1"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+  # On macOS/Linux, zombie state is 'Z' in ps -o state
+  local state
+  state="$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" || true
+  if [ "$state" = "Z" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# Helper: stop one daemon by PID file. Sets _pause_any_failed=1 on hard failure.
+_vnx_pause_stop_daemon() {
+  local name="$1"
+  local pids_dir="$2"
+  local pid_file="$pids_dir/${name}.pid"
+
+  if [ ! -f "$pid_file" ]; then
+    log "[pause] $name: no PID file — not running (skipped)."
+    return 0
+  fi
+
+  local pid
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  # PID file may have a fingerprint on the same line separated by |
+  pid="${pid%%|*}"
+  pid="$(printf '%s' "$pid" | tr -d '[:space:]')"
+
+  if [ -z "$pid" ] || ! echo "$pid" | grep -qE '^[0-9]+$'; then
+    log "[pause] $name: invalid/empty PID in $pid_file — cleaning up."
+    rm -f "$pid_file" "${pid_file}.fingerprint"
+    return 0
+  fi
+
+  if ! _vnx_proc_is_live "$pid"; then
+    log "[pause] $name (PID: $pid): already stopped — cleaning stale PID file."
+    rm -f "$pid_file" "${pid_file}.fingerprint"
+    return 0
+  fi
+
+  log "[pause] Stopping $name (PID: $pid) with SIGTERM..."
+  kill -TERM "$pid" 2>/dev/null || true
+
+  local elapsed=0
+  while _vnx_proc_is_live "$pid" && [ "$elapsed" -lt 10 ]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  if _vnx_proc_is_live "$pid"; then
+    log "[pause] $name (PID: $pid): still alive after 10s — sending SIGKILL..."
+    kill -KILL "$pid" 2>/dev/null || true
+    sleep 1
+  fi
+
+  if _vnx_proc_is_live "$pid"; then
+    log "[pause] ERROR: $name (PID: $pid) still running after SIGKILL."
+    _pause_any_failed=1
+  else
+    rm -f "$pid_file" "${pid_file}.fingerprint"
+    log "[pause] $name stopped."
+  fi
+}
+
+cmd_pause() {
+  local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
+  local pids_dir="${VNX_PIDS_DIR:-${VNX_DATA_DIR}/pids}"
+  local events_dir="${VNX_DATA_DIR}/events"
+  local paused_file="$state_dir/PAUSED"
+  local lifecycle_log="$events_dir/lifecycle.ndjson"
+  local by_dispatch_id="${VNX_DISPATCH_ID:-manual}"
+  local reason="${1:-migration_cutover}"
+
+  mkdir -p "$state_dir" "$events_dir" "$pids_dir" \
+    "${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
+
+  if [ -f "$paused_file" ]; then
+    log "[pause] Already paused — PAUSED marker exists: $paused_file"
+    return 0
+  fi
+
+  _pause_any_failed=0
+
+  _vnx_pause_stop_daemon "dispatcher" "$pids_dir"
+  _vnx_pause_stop_daemon "receipt_processor" "$pids_dir"
+  _vnx_pause_stop_daemon "queue_watcher" "$pids_dir"
+
+  if [ "${_pause_any_failed:-0}" -eq 1 ]; then
+    err "[pause] Some daemons could not be stopped. PAUSED marker NOT written."
+    unset _pause_any_failed
+    return 1
+  fi
+  unset _pause_any_failed
+
+  # Atomic write: tmp file → mv (prevents partial reads)
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local tmp_paused="${paused_file}.tmp.$$"
+  printf '{"paused_at":"%s","by_dispatch_id":"%s","reason":"%s"}\n' \
+    "$ts" "$by_dispatch_id" "$reason" > "$tmp_paused"
+  mv "$tmp_paused" "$paused_file"
+
+  # NDJSON lifecycle event
+  printf '{"event_type":"service_paused","timestamp":"%s","by_dispatch_id":"%s","reason":"%s"}\n' \
+    "$ts" "$by_dispatch_id" "$reason" >> "$lifecycle_log"
+
+  log "[pause] VNX daemons paused. Marker: $paused_file"
+  return 0
+}

--- a/scripts/commands/pause.sh
+++ b/scripts/commands/pause.sh
@@ -42,11 +42,18 @@ _vnx_pause_stop_daemon() {
     return 0
   fi
 
-  local pid
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  local pid_line pid fingerprint
+  pid_line="$(cat "$pid_file" 2>/dev/null || true)"
   # PID file may have a fingerprint on the same line separated by |
-  pid="${pid%%|*}"
+  pid="${pid_line%%|*}"
   pid="$(printf '%s' "$pid" | tr -d '[:space:]')"
+  # Extract fingerprint (process comm= stored at write time)
+  if printf '%s' "$pid_line" | grep -q '|'; then
+    fingerprint="${pid_line#*|}"
+    fingerprint="$(printf '%s' "$fingerprint" | tr -d '[:space:]')"
+  else
+    fingerprint=""
+  fi
 
   if [ -z "$pid" ] || ! echo "$pid" | grep -qE '^[0-9]+$'; then
     log "[pause] $name: invalid/empty PID in $pid_file — cleaning up."
@@ -58,6 +65,18 @@ _vnx_pause_stop_daemon() {
     log "[pause] $name (PID: $pid): already stopped — cleaning stale PID file."
     rm -f "$pid_file" "${pid_file}.fingerprint"
     return 0
+  fi
+
+  # Validate fingerprint before signaling — prevents killing an unrelated process
+  # that reused the same PID after a stale restart.
+  if [ -n "$fingerprint" ]; then
+    local current_comm
+    current_comm="$(ps -p "$pid" -o comm= 2>/dev/null | tr -d '[:space:]')" || true
+    if [ -z "$current_comm" ] || [ "$current_comm" != "$fingerprint" ]; then
+      log "[pause] WARNING: $name (PID: $pid) fingerprint mismatch — expected '$fingerprint', got '$current_comm'. Skipping kill to avoid harming unrelated process."
+      rm -f "$pid_file" "${pid_file}.fingerprint"
+      return 0
+    fi
   fi
 
   log "[pause] Stopping $name (PID: $pid) with SIGTERM..."
@@ -115,15 +134,16 @@ cmd_pause() {
   unset _pause_any_failed
 
   # Atomic write: tmp file → mv (prevents partial reads)
+  # Use python3 for safe JSON encoding — prevents injection via $reason/$by_dispatch_id
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   local tmp_paused="${paused_file}.tmp.$$"
-  printf '{"paused_at":"%s","by_dispatch_id":"%s","reason":"%s"}\n' \
+  python3 -c "import json,sys; print(json.dumps({'paused_at':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
     "$ts" "$by_dispatch_id" "$reason" > "$tmp_paused"
   mv "$tmp_paused" "$paused_file"
 
-  # NDJSON lifecycle event
-  printf '{"event_type":"service_paused","timestamp":"%s","by_dispatch_id":"%s","reason":"%s"}\n' \
+  # NDJSON lifecycle event (python3 for safe JSON encoding)
+  python3 -c "import json,sys; print(json.dumps({'event_type':'service_paused','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':sys.argv[3]}))" \
     "$ts" "$by_dispatch_id" "$reason" >> "$lifecycle_log"
 
   log "[pause] VNX daemons paused. Marker: $paused_file"

--- a/scripts/commands/resume.sh
+++ b/scripts/commands/resume.sh
@@ -10,37 +10,34 @@
 # Appends service_resumed event to ${VNX_DATA_DIR}/events/lifecycle.ndjson.
 # Removes PAUSED marker on success.
 
-cmd_resume() {
-  local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
-  local scripts_dir="${VNX_HOME}/scripts"
-  local logs_dir="${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
-  local events_dir="${VNX_DATA_DIR}/events"
-  local paused_file="$state_dir/PAUSED"
-  local lifecycle_log="$events_dir/lifecycle.ndjson"
-  local by_dispatch_id="${VNX_DISPATCH_ID:-manual}"
-
+# Helper: verify PAUSED marker exists before attempting resume.
+_vnx_resume_validate_marker() {
+  local paused_file="$1"
   if [ ! -f "$paused_file" ]; then
     err "[resume] Not paused — ${paused_file} does not exist."
     return 1
   fi
+}
 
-  mkdir -p "$events_dir" "$logs_dir"
-
-  local dispatcher_pid receipt_pid
+# Helper: start all three daemons. Sets _resume_dispatcher_pid and
+# _resume_receipt_pid for use by _vnx_resume_verify_readiness.
+_vnx_resume_start_daemons() {
+  local scripts_dir="$1"
+  local logs_dir="$2"
 
   # Restart dispatcher via supervisor (preferred) or directly
   if [ -f "$scripts_dir/dispatcher_supervisor.sh" ]; then
     log "[resume] Starting dispatcher via dispatcher_supervisor.sh..."
     nohup bash "$scripts_dir/dispatcher_supervisor.sh" \
       > "$logs_dir/dispatcher_supervisor.log" 2>&1 &
-    dispatcher_pid=$!
-    log "[resume] dispatcher_supervisor started (PID: $dispatcher_pid)."
+    _resume_dispatcher_pid=$!
+    log "[resume] dispatcher_supervisor started (PID: $_resume_dispatcher_pid)."
   elif [ -f "$scripts_dir/dispatcher_v8_minimal.sh" ]; then
     log "[resume] Starting dispatcher_v8_minimal.sh directly..."
     nohup bash "$scripts_dir/dispatcher_v8_minimal.sh" \
       > "$logs_dir/dispatcher.log" 2>&1 &
-    dispatcher_pid=$!
-    log "[resume] dispatcher started (PID: $dispatcher_pid)."
+    _resume_dispatcher_pid=$!
+    log "[resume] dispatcher started (PID: $_resume_dispatcher_pid)."
   else
     err "[resume] Neither dispatcher_supervisor.sh nor dispatcher_v8_minimal.sh found."
     return 1
@@ -51,14 +48,14 @@ cmd_resume() {
     log "[resume] Starting receipt_processor_supervisor.sh..."
     nohup bash "$scripts_dir/receipt_processor_supervisor.sh" \
       > "$logs_dir/receipt_processor_supervisor.log" 2>&1 &
-    receipt_pid=$!
-    log "[resume] receipt_processor_supervisor started (PID: $receipt_pid)."
+    _resume_receipt_pid=$!
+    log "[resume] receipt_processor_supervisor started (PID: $_resume_receipt_pid)."
   elif [ -f "$scripts_dir/receipt_processor_v4.sh" ]; then
     log "[resume] Starting receipt_processor_v4.sh directly..."
     VNX_MODE=monitor nohup bash "$scripts_dir/receipt_processor_v4.sh" \
       > "$logs_dir/receipt_processor.log" 2>&1 &
-    receipt_pid=$!
-    log "[resume] receipt_processor started (PID: $receipt_pid)."
+    _resume_receipt_pid=$!
+    log "[resume] receipt_processor started (PID: $_resume_receipt_pid)."
   else
     err "[resume] Neither receipt_processor_supervisor.sh nor receipt_processor_v4.sh found."
     return 1
@@ -85,34 +82,57 @@ cmd_resume() {
       log "[resume] WARN: queue_auto_accept.sh not found — skipped."
     fi
   fi
+}
 
-  # Verify mandatory daemons are alive before marking resumed.
-  # Only remove PAUSED marker once daemons are confirmed running.
+# Helper: verify mandatory daemons (dispatcher + receipt_processor) are alive.
+# Uses _resume_dispatcher_pid and _resume_receipt_pid set by _vnx_resume_start_daemons.
+_vnx_resume_verify_readiness() {
   sleep 1
   local resume_failed=0
-  if ! kill -0 "$dispatcher_pid" 2>/dev/null; then
-    log "[resume] WARNING: dispatcher did not stay alive (PID: $dispatcher_pid)."
+  if ! kill -0 "$_resume_dispatcher_pid" 2>/dev/null; then
+    log "[resume] WARNING: dispatcher did not stay alive (PID: $_resume_dispatcher_pid)."
     resume_failed=1
   fi
-  if ! kill -0 "$receipt_pid" 2>/dev/null; then
-    log "[resume] WARNING: receipt_processor did not stay alive (PID: $receipt_pid)."
+  if ! kill -0 "$_resume_receipt_pid" 2>/dev/null; then
+    log "[resume] WARNING: receipt_processor did not stay alive (PID: $_resume_receipt_pid)."
     resume_failed=1
   fi
+  return $resume_failed
+}
 
-  if [ "$resume_failed" -eq 1 ]; then
+# Helper: remove PAUSED marker and append service_resumed NDJSON event.
+# Uses python3 json.dumps for safe encoding — prevents injection via $by_dispatch_id.
+_vnx_resume_log_lifecycle() {
+  local paused_file="$1"
+  local lifecycle_log="$2"
+  local ts="$3"
+  local by_dispatch_id="$4"
+  rm -f "$paused_file"
+  python3 -c "import json,sys; print(json.dumps({'event_type':'service_resumed','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':'resume'}))" \
+    "$ts" "$by_dispatch_id" >> "$lifecycle_log"
+}
+
+cmd_resume() {
+  local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
+  local scripts_dir="${VNX_HOME}/scripts"
+  local logs_dir="${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
+  local events_dir="${VNX_DATA_DIR}/events"
+  local paused_file="$state_dir/PAUSED"
+  local lifecycle_log="$events_dir/lifecycle.ndjson"
+  local by_dispatch_id="${VNX_DISPATCH_ID:-manual}"
+
+  _vnx_resume_validate_marker "$paused_file" || return 1
+  mkdir -p "$events_dir" "$logs_dir"
+  _vnx_resume_start_daemons "$scripts_dir" "$logs_dir" || return 1
+
+  if ! _vnx_resume_verify_readiness; then
     err "[resume] One or more mandatory daemons failed to start. PAUSED marker retained."
     return 1
   fi
 
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-  # Remove PAUSED marker only after daemons confirmed alive
-  rm -f "$paused_file"
-
-  # NDJSON lifecycle event
-  printf '{"event_type":"service_resumed","timestamp":"%s","by_dispatch_id":"%s","reason":"resume"}\n' \
-    "$ts" "$by_dispatch_id" >> "$lifecycle_log"
+  _vnx_resume_log_lifecycle "$paused_file" "$lifecycle_log" "$ts" "$by_dispatch_id"
 
   log "[resume] VNX daemons resumed. Dispatcher and receipt_processor restarted."
   return 0

--- a/scripts/commands/resume.sh
+++ b/scripts/commands/resume.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# VNX Command: resume
+# Restarts per-project daemons after a vnx pause.
+#
+# This file is sourced by bin/vnx's command loader. All functions and variables
+# from the main script (log, err, VNX_HOME, VNX_DATA_DIR, etc.) are available
+# when this runs.
+#
+# Requires ${VNX_STATE_DIR}/PAUSED marker to exist — errors if not paused.
+# Appends service_resumed event to ${VNX_DATA_DIR}/events/lifecycle.ndjson.
+# Removes PAUSED marker on success.
+
+cmd_resume() {
+  local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
+  local scripts_dir="${VNX_HOME}/scripts"
+  local logs_dir="${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
+  local events_dir="${VNX_DATA_DIR}/events"
+  local paused_file="$state_dir/PAUSED"
+  local lifecycle_log="$events_dir/lifecycle.ndjson"
+  local by_dispatch_id="${VNX_DISPATCH_ID:-manual}"
+
+  if [ ! -f "$paused_file" ]; then
+    err "[resume] Not paused — ${paused_file} does not exist."
+    return 1
+  fi
+
+  mkdir -p "$events_dir" "$logs_dir"
+
+  # Restart dispatcher via supervisor (preferred) or directly
+  if [ -f "$scripts_dir/dispatcher_supervisor.sh" ]; then
+    log "[resume] Starting dispatcher via dispatcher_supervisor.sh..."
+    nohup bash "$scripts_dir/dispatcher_supervisor.sh" \
+      > "$logs_dir/dispatcher_supervisor.log" 2>&1 &
+    log "[resume] dispatcher_supervisor started (PID: $!)."
+  elif [ -f "$scripts_dir/dispatcher_v8_minimal.sh" ]; then
+    log "[resume] Starting dispatcher_v8_minimal.sh directly..."
+    nohup bash "$scripts_dir/dispatcher_v8_minimal.sh" \
+      > "$logs_dir/dispatcher.log" 2>&1 &
+    log "[resume] dispatcher started (PID: $!)."
+  else
+    err "[resume] Neither dispatcher_supervisor.sh nor dispatcher_v8_minimal.sh found."
+    return 1
+  fi
+
+  # Restart receipt_processor via supervisor (preferred) or directly
+  if [ -f "$scripts_dir/receipt_processor_supervisor.sh" ]; then
+    log "[resume] Starting receipt_processor_supervisor.sh..."
+    nohup bash "$scripts_dir/receipt_processor_supervisor.sh" \
+      > "$logs_dir/receipt_processor_supervisor.log" 2>&1 &
+    log "[resume] receipt_processor_supervisor started (PID: $!)."
+  elif [ -f "$scripts_dir/receipt_processor_v4.sh" ]; then
+    log "[resume] Starting receipt_processor_v4.sh directly..."
+    VNX_MODE=monitor nohup bash "$scripts_dir/receipt_processor_v4.sh" \
+      > "$logs_dir/receipt_processor.log" 2>&1 &
+    log "[resume] receipt_processor started (PID: $!)."
+  else
+    err "[resume] Neither receipt_processor_supervisor.sh nor receipt_processor_v4.sh found."
+    return 1
+  fi
+
+  # Restart queue_auto_accept when queue popup is disabled
+  if [ "${VNX_QUEUE_POPUP_ENABLED:-1}" = "0" ]; then
+    if [ -f "$scripts_dir/queue_auto_accept.sh" ]; then
+      log "[resume] Starting queue_auto_accept.sh..."
+      nohup bash "$scripts_dir/queue_auto_accept.sh" \
+        > "$logs_dir/queue_auto_accept.log" 2>&1 &
+      log "[resume] queue_auto_accept started (PID: $!)."
+    else
+      log "[resume] WARN: queue_auto_accept.sh not found — skipped."
+    fi
+  fi
+
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # Remove PAUSED marker before writing event (event is the positive confirmation)
+  rm -f "$paused_file"
+
+  # NDJSON lifecycle event
+  printf '{"event_type":"service_resumed","timestamp":"%s","by_dispatch_id":"%s","reason":"resume"}\n' \
+    "$ts" "$by_dispatch_id" >> "$lifecycle_log"
+
+  log "[resume] VNX daemons resumed. Dispatcher and receipt_processor restarted."
+  return 0
+}

--- a/scripts/commands/resume.sh
+++ b/scripts/commands/resume.sh
@@ -26,17 +26,21 @@ cmd_resume() {
 
   mkdir -p "$events_dir" "$logs_dir"
 
+  local dispatcher_pid receipt_pid
+
   # Restart dispatcher via supervisor (preferred) or directly
   if [ -f "$scripts_dir/dispatcher_supervisor.sh" ]; then
     log "[resume] Starting dispatcher via dispatcher_supervisor.sh..."
     nohup bash "$scripts_dir/dispatcher_supervisor.sh" \
       > "$logs_dir/dispatcher_supervisor.log" 2>&1 &
-    log "[resume] dispatcher_supervisor started (PID: $!)."
+    dispatcher_pid=$!
+    log "[resume] dispatcher_supervisor started (PID: $dispatcher_pid)."
   elif [ -f "$scripts_dir/dispatcher_v8_minimal.sh" ]; then
     log "[resume] Starting dispatcher_v8_minimal.sh directly..."
     nohup bash "$scripts_dir/dispatcher_v8_minimal.sh" \
       > "$logs_dir/dispatcher.log" 2>&1 &
-    log "[resume] dispatcher started (PID: $!)."
+    dispatcher_pid=$!
+    log "[resume] dispatcher started (PID: $dispatcher_pid)."
   else
     err "[resume] Neither dispatcher_supervisor.sh nor dispatcher_v8_minimal.sh found."
     return 1
@@ -47,21 +51,33 @@ cmd_resume() {
     log "[resume] Starting receipt_processor_supervisor.sh..."
     nohup bash "$scripts_dir/receipt_processor_supervisor.sh" \
       > "$logs_dir/receipt_processor_supervisor.log" 2>&1 &
-    log "[resume] receipt_processor_supervisor started (PID: $!)."
+    receipt_pid=$!
+    log "[resume] receipt_processor_supervisor started (PID: $receipt_pid)."
   elif [ -f "$scripts_dir/receipt_processor_v4.sh" ]; then
     log "[resume] Starting receipt_processor_v4.sh directly..."
     VNX_MODE=monitor nohup bash "$scripts_dir/receipt_processor_v4.sh" \
       > "$logs_dir/receipt_processor.log" 2>&1 &
-    log "[resume] receipt_processor started (PID: $!)."
+    receipt_pid=$!
+    log "[resume] receipt_processor started (PID: $receipt_pid)."
   else
     err "[resume] Neither receipt_processor_supervisor.sh nor receipt_processor_v4.sh found."
     return 1
   fi
 
-  # Restart queue_auto_accept when queue popup is disabled
-  if [ "${VNX_QUEUE_POPUP_ENABLED:-1}" = "0" ]; then
+  # Restart queue_watcher — mirrors pause.sh which stops it unconditionally.
+  # Use popup watcher when popup is enabled (default), auto-accept otherwise.
+  if [ "${VNX_QUEUE_POPUP_ENABLED:-1}" != "0" ]; then
+    if [ -f "$scripts_dir/queue_popup_watcher.sh" ]; then
+      log "[resume] Starting queue_popup_watcher.sh..."
+      nohup bash "$scripts_dir/queue_popup_watcher.sh" \
+        > "$logs_dir/queue_watcher.log" 2>&1 &
+      log "[resume] queue_watcher started (PID: $!)."
+    else
+      log "[resume] WARN: queue_popup_watcher.sh not found — queue_watcher skipped."
+    fi
+  else
     if [ -f "$scripts_dir/queue_auto_accept.sh" ]; then
-      log "[resume] Starting queue_auto_accept.sh..."
+      log "[resume] Starting queue_auto_accept.sh (queue popup disabled)..."
       nohup bash "$scripts_dir/queue_auto_accept.sh" \
         > "$logs_dir/queue_auto_accept.log" 2>&1 &
       log "[resume] queue_auto_accept started (PID: $!)."
@@ -70,10 +86,28 @@ cmd_resume() {
     fi
   fi
 
+  # Verify mandatory daemons are alive before marking resumed.
+  # Only remove PAUSED marker once daemons are confirmed running.
+  sleep 1
+  local resume_failed=0
+  if ! kill -0 "$dispatcher_pid" 2>/dev/null; then
+    log "[resume] WARNING: dispatcher did not stay alive (PID: $dispatcher_pid)."
+    resume_failed=1
+  fi
+  if ! kill -0 "$receipt_pid" 2>/dev/null; then
+    log "[resume] WARNING: receipt_processor did not stay alive (PID: $receipt_pid)."
+    resume_failed=1
+  fi
+
+  if [ "$resume_failed" -eq 1 ]; then
+    err "[resume] One or more mandatory daemons failed to start. PAUSED marker retained."
+    return 1
+  fi
+
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-  # Remove PAUSED marker before writing event (event is the positive confirmation)
+  # Remove PAUSED marker only after daemons confirmed alive
   rm -f "$paused_file"
 
   # NDJSON lifecycle event

--- a/scripts/commands/resume.sh
+++ b/scripts/commands/resume.sh
@@ -100,21 +100,27 @@ _vnx_resume_verify_readiness() {
   return $resume_failed
 }
 
-# Helper: remove PAUSED marker and append service_resumed NDJSON event.
+# Helper: append service_resumed NDJSON event, then remove PAUSED marker.
+# Order matters: if the audit append fails, the PAUSED marker is retained so
+# VNX cannot be silently resumed without an audit trail.
 # Uses python3 json.dumps for safe encoding — prevents injection via $by_dispatch_id.
 _vnx_resume_log_lifecycle() {
   local paused_file="$1"
   local lifecycle_log="$2"
   local ts="$3"
   local by_dispatch_id="$4"
+  if ! python3 -c "import json,sys; print(json.dumps({'event_type':'service_resumed','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':'resume'}))" \
+    "$ts" "$by_dispatch_id" >> "$lifecycle_log"; then
+    err "[resume] Failed to append service_resumed audit event to ${lifecycle_log}. PAUSED marker retained."
+    return 1
+  fi
   rm -f "$paused_file"
-  python3 -c "import json,sys; print(json.dumps({'event_type':'service_resumed','timestamp':sys.argv[1],'by_dispatch_id':sys.argv[2],'reason':'resume'}))" \
-    "$ts" "$by_dispatch_id" >> "$lifecycle_log"
+  return 0
 }
 
 cmd_resume() {
   local state_dir="${VNX_STATE_DIR:-${VNX_DATA_DIR}/state}"
-  local scripts_dir="${VNX_HOME}/scripts"
+  local scripts_dir="${VNX_HOME:-}/scripts"
   local logs_dir="${VNX_LOGS_DIR:-${VNX_DATA_DIR}/logs}"
   local events_dir="${VNX_DATA_DIR}/events"
   local paused_file="$state_dir/PAUSED"
@@ -123,16 +129,23 @@ cmd_resume() {
 
   _vnx_resume_validate_marker "$paused_file" || return 1
   mkdir -p "$events_dir" "$logs_dir"
-  _vnx_resume_start_daemons "$scripts_dir" "$logs_dir" || return 1
 
-  if ! _vnx_resume_verify_readiness; then
-    err "[resume] One or more mandatory daemons failed to start. PAUSED marker retained."
-    return 1
+  # Test-mode guard: tests source resume.sh and call cmd_resume directly.
+  # Without this guard the helper would spawn real nohup daemons that survive
+  # the test, write to operator-grade state, and proliferate via tmux send-keys.
+  if [ "${VNX_SKIP_DAEMON_SPAWN:-0}" = "1" ]; then
+    log "[resume] VNX_SKIP_DAEMON_SPAWN=1 — skipping daemon spawn + readiness check."
+  else
+    _vnx_resume_start_daemons "$scripts_dir" "$logs_dir" || return 1
+    if ! _vnx_resume_verify_readiness; then
+      err "[resume] One or more mandatory daemons failed to start. PAUSED marker retained."
+      return 1
+    fi
   fi
 
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  _vnx_resume_log_lifecycle "$paused_file" "$lifecycle_log" "$ts" "$by_dispatch_id"
+  _vnx_resume_log_lifecycle "$paused_file" "$lifecycle_log" "$ts" "$by_dispatch_id" || return 1
 
   log "[resume] VNX daemons resumed. Dispatcher and receipt_processor restarted."
   return 0

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -62,7 +62,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "worktree-refresh", "worktree-status", "merge-preflight",
     "smoke", "package-check",
     "dispatch", "gate",
-    "snapshot", "restore", "quiesce-check",
+    "snapshot", "restore", "quiesce-check", "pause", "resume",
     "pool",
 })
 

--- a/tests/test_vnx_pause_resume.py
+++ b/tests/test_vnx_pause_resume.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Tests for vnx pause / resume commands.
+
+Tests invoke the cmd_pause / cmd_resume functions directly (source + call) to
+avoid bin/vnx path-override machinery (.vnx-data/.env_override etc.).
+
+Test matrix:
+  1. pause with no daemons running — idempotent, PAUSED file created
+  2. pause with daemons running   — stops them, PAUSED file created
+  3. pause when already paused    — exit 0, PAUSED file unchanged
+  4. resume without PAUSED file   — exit 1 (error)
+  5. resume with PAUSED file      — removes file, daemons started, event appended
+  6. pause then immediate resume  — round-trip clean, events in correct format
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+PAUSE_SH = VNX_ROOT / "scripts" / "commands" / "pause.sh"
+RESUME_SH = VNX_ROOT / "scripts" / "commands" / "resume.sh"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dirs(tmp_path: Path) -> dict:
+    """Create minimal .vnx-data layout and return env var mapping."""
+    data = tmp_path / ".vnx-data"
+    dirs = {
+        "VNX_DATA_DIR": data,
+        "VNX_STATE_DIR": data / "state",
+        "VNX_PIDS_DIR": data / "pids",
+        "VNX_LOGS_DIR": data / "logs",
+        "VNX_LOCKS_DIR": data / "locks",
+    }
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    (data / "events").mkdir(parents=True, exist_ok=True)
+    return {k: str(v) for k, v in dirs.items()}
+
+
+def _run_cmd(cmd_name: str, env_vars: dict, args: list[str] | None = None) -> subprocess.CompletedProcess:
+    """Source the command file and call cmd_<cmd_name> directly (no bin/vnx)."""
+    cmd_file = VNX_ROOT / "scripts" / "commands" / f"{cmd_name}.sh"
+    exports = "\n".join(f'export {k}="{v}"' for k, v in env_vars.items())
+    bash_script = f"""#!/bin/bash
+set -euo pipefail
+{exports}
+mkdir -p "$VNX_STATE_DIR" "$VNX_PIDS_DIR" "$VNX_LOGS_DIR" "${{VNX_DATA_DIR}}/events"
+log() {{ echo "[log] $*"; }}
+err() {{ echo "[err] $*" >&2; }}
+source "{cmd_file}"
+cmd_{cmd_name} {" ".join(args or [])}
+"""
+    return subprocess.run(
+        ["bash", "-c", bash_script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _write_pid_file(pids_dir: str | Path, name: str, pid: int) -> None:
+    Path(pids_dir).mkdir(parents=True, exist_ok=True)
+    (Path(pids_dir) / f"{name}.pid").write_text(str(pid))
+
+
+def _spawn_dummy_process() -> subprocess.Popen:
+    return subprocess.Popen(
+        ["sleep", "600"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1: pause with no daemons running
+# ---------------------------------------------------------------------------
+
+def test_pause_no_daemons_creates_paused_file(tmp_path: Path):
+    """pause exits 0 and writes PAUSED file when no daemons are running."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-001"
+    result = _run_cmd("pause", env)
+
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}\n{result.stderr}"
+
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    assert paused_file.exists(), "PAUSED marker file not created"
+
+    content = json.loads(paused_file.read_text())
+    assert "paused_at" in content
+    assert content["by_dispatch_id"] == "test-dispatch-001"
+    assert content["reason"] == "migration_cutover"
+
+
+def test_pause_no_daemons_appends_lifecycle_event(tmp_path: Path):
+    """pause appends a service_paused event to lifecycle.ndjson."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-001"
+    _run_cmd("pause", env)
+
+    lifecycle = Path(env["VNX_DATA_DIR"]) / "events" / "lifecycle.ndjson"
+    assert lifecycle.exists(), "lifecycle.ndjson not created"
+
+    lines = [l for l in lifecycle.read_text().splitlines() if l.strip()]
+    assert len(lines) >= 1
+
+    event = json.loads(lines[-1])
+    assert event["event_type"] == "service_paused"
+    assert "timestamp" in event
+    assert event["by_dispatch_id"] == "test-dispatch-001"
+
+
+def test_pause_writes_atomic_paused_file(tmp_path: Path):
+    """PAUSED marker is valid JSON with all required fields."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "dispatch-x"
+    _run_cmd("pause", env, args=["my_reason"])
+
+    content = json.loads((Path(env["VNX_STATE_DIR"]) / "PAUSED").read_text())
+    assert content["reason"] == "my_reason"
+    assert content["by_dispatch_id"] == "dispatch-x"
+    assert "paused_at" in content
+    # No tmp file left behind
+    assert not list(Path(env["VNX_STATE_DIR"]).glob("PAUSED.tmp.*"))
+
+
+# ---------------------------------------------------------------------------
+# Test 2: pause with daemons running
+# ---------------------------------------------------------------------------
+
+def test_pause_stops_running_daemons(tmp_path: Path):
+    """pause sends SIGTERM to running daemons and creates PAUSED file."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-002"
+    pids_dir = env["VNX_PIDS_DIR"]
+
+    procs = {}
+    for name in ["dispatcher", "receipt_processor", "queue_watcher"]:
+        p = _spawn_dummy_process()
+        procs[name] = p
+        _write_pid_file(pids_dir, name, p.pid)
+
+    try:
+        result = _run_cmd("pause", env)
+        assert result.returncode == 0, f"Expected exit 0\n{result.stderr}"
+
+        for name, proc in procs.items():
+            proc.wait(timeout=15)
+            assert not _is_running(proc.pid), f"{name} (PID {proc.pid}) still running"
+
+        paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+        assert paused_file.exists(), "PAUSED marker not written after stopping daemons"
+
+    finally:
+        for proc in procs.values():
+            try:
+                proc.kill()
+                proc.wait(timeout=3)
+            except Exception:
+                pass
+
+
+def test_pause_cleans_stale_pid_files(tmp_path: Path):
+    """pause removes stale PID files pointing to dead processes."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-003"
+
+    _write_pid_file(env["VNX_PIDS_DIR"], "dispatcher", 99999999)
+
+    result = _run_cmd("pause", env)
+    assert result.returncode == 0, f"Expected exit 0\n{result.stderr}"
+
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    assert paused_file.exists(), "PAUSED file not created after stale-PID cleanup"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: pause when already paused
+# ---------------------------------------------------------------------------
+
+def test_pause_idempotent_when_already_paused(tmp_path: Path):
+    """Calling pause twice returns exit 0 the second time without modifying the file."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-004"
+
+    r1 = _run_cmd("pause", env)
+    assert r1.returncode == 0
+
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    assert paused_file.exists()
+    first_content = paused_file.read_text()
+
+    r2 = _run_cmd("pause", env)
+    assert r2.returncode == 0, f"Second pause should exit 0\n{r2.stderr}"
+
+    # PAUSED file must be unchanged (not rewritten)
+    assert paused_file.read_text() == first_content, "PAUSED marker was modified on second pause"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: resume without PAUSED file
+# ---------------------------------------------------------------------------
+
+def test_resume_fails_when_not_paused(tmp_path: Path):
+    """resume exits 1 when PAUSED marker is absent."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-005"
+
+    result = _run_cmd("resume", env)
+    assert result.returncode == 1, f"Expected exit 1, got {result.returncode}\n{result.stdout}"
+
+    stderr_lower = result.stderr.lower()
+    assert "not paused" in stderr_lower or "does not exist" in stderr_lower, \
+        f"Expected error about not being paused\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: resume with PAUSED file
+# ---------------------------------------------------------------------------
+
+def test_resume_removes_paused_marker(tmp_path: Path):
+    """resume removes the PAUSED marker file on success."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-006"
+    # VNX_HOME not needed when no actual scripts to start — skip missing-file errors
+    env["VNX_HOME"] = str(VNX_ROOT)
+
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    paused_file.write_text('{"paused_at":"2026-01-01T00:00:00Z","by_dispatch_id":"test","reason":"test"}\n')
+
+    # Resume will try to start daemons; they may fail (scripts not in VNX_ROOT/scripts)
+    # but the marker removal must still happen before the daemon start attempts.
+    # We only check the marker is removed if exit code is 0.
+    result = _run_cmd("resume", env)
+
+    if result.returncode == 0:
+        assert not paused_file.exists(), "PAUSED marker not removed after resume"
+    else:
+        # If it failed because scripts aren't present, verify the marker was
+        # removed (it is removed before starting daemons in cmd_resume).
+        # Actually in the implementation, marker is removed AFTER daemons start.
+        # If dispatcher_supervisor.sh or dispatcher_v8_minimal.sh is missing, resume fails.
+        # With VNX_HOME pointing to VNX_ROOT, the scripts DO exist, so expect exit 0.
+        pytest.fail(f"resume failed unexpectedly\n{result.stderr}")
+
+
+def test_resume_appends_lifecycle_event(tmp_path: Path):
+    """resume appends a service_resumed event to lifecycle.ndjson."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-007"
+    env["VNX_HOME"] = str(VNX_ROOT)
+
+    lifecycle = Path(env["VNX_DATA_DIR"]) / "events" / "lifecycle.ndjson"
+    pause_event = '{"event_type":"service_paused","timestamp":"2026-01-01T00:00:00Z","by_dispatch_id":"test","reason":"test"}'
+    lifecycle.write_text(pause_event + "\n")
+
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    paused_file.write_text('{"paused_at":"2026-01-01T00:00:00Z","by_dispatch_id":"test","reason":"test"}\n')
+
+    result = _run_cmd("resume", env)
+    assert result.returncode == 0, f"Expected exit 0\n{result.stderr}"
+
+    lines = [l for l in lifecycle.read_text().splitlines() if l.strip()]
+    assert len(lines) >= 2
+
+    last_event = json.loads(lines[-1])
+    assert last_event["event_type"] == "service_resumed"
+    assert "timestamp" in last_event
+    assert last_event["by_dispatch_id"] == "test-dispatch-007"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: pause then resume round-trip
+# ---------------------------------------------------------------------------
+
+def test_pause_then_resume_round_trip(tmp_path: Path):
+    """Full round-trip: pause → verify stopped → resume → verify events."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-008"
+    env["VNX_HOME"] = str(VNX_ROOT)
+
+    lifecycle = Path(env["VNX_DATA_DIR"]) / "events" / "lifecycle.ndjson"
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+    pids_dir = env["VNX_PIDS_DIR"]
+
+    proc = _spawn_dummy_process()
+    _write_pid_file(pids_dir, "dispatcher", proc.pid)
+
+    try:
+        r_pause = _run_cmd("pause", env)
+        assert r_pause.returncode == 0, f"pause failed\n{r_pause.stderr}"
+        assert paused_file.exists(), "PAUSED file missing after pause"
+
+        proc.wait(timeout=15)
+        assert not _is_running(proc.pid), "dispatcher not stopped after pause"
+
+        r_resume = _run_cmd("resume", env)
+        assert r_resume.returncode == 0, f"resume failed\n{r_resume.stderr}"
+        assert not paused_file.exists(), "PAUSED file still present after resume"
+
+        lines = [l for l in lifecycle.read_text().splitlines() if l.strip()]
+        assert len(lines) >= 2, f"Expected at least 2 lifecycle events, got: {lines}"
+
+        events = [json.loads(l) for l in lines]
+        event_types = [e["event_type"] for e in events]
+        assert "service_paused" in event_types, f"Missing service_paused: {event_types}"
+        assert "service_resumed" in event_types, f"Missing service_resumed: {event_types}"
+
+        paused_idx = next(i for i, e in enumerate(events) if e["event_type"] == "service_paused")
+        resumed_idx = next(i for i, e in enumerate(events) if e["event_type"] == "service_resumed")
+        assert paused_idx < resumed_idx, "service_paused must precede service_resumed"
+
+    finally:
+        try:
+            proc.kill()
+            proc.wait(timeout=3)
+        except Exception:
+            pass
+
+
+def test_lifecycle_events_are_valid_ndjson(tmp_path: Path):
+    """Every line in lifecycle.ndjson is valid JSON with required fields."""
+    env = _make_dirs(tmp_path)
+    env["VNX_DISPATCH_ID"] = "test-dispatch-009"
+    env["VNX_HOME"] = str(VNX_ROOT)
+
+    lifecycle = Path(env["VNX_DATA_DIR"]) / "events" / "lifecycle.ndjson"
+    paused_file = Path(env["VNX_STATE_DIR"]) / "PAUSED"
+
+    r_pause = _run_cmd("pause", env)
+    assert r_pause.returncode == 0
+    assert paused_file.exists()
+
+    r_resume = _run_cmd("resume", env)
+    assert r_resume.returncode == 0
+
+    assert lifecycle.exists(), "lifecycle.ndjson not created"
+    lines = [l for l in lifecycle.read_text().splitlines() if l.strip()]
+    assert len(lines) >= 2, f"Expected at least 2 events, got {len(lines)}"
+
+    required_fields = {"event_type", "timestamp", "by_dispatch_id"}
+    for i, line in enumerate(lines):
+        event = json.loads(line)
+        missing = required_fields - set(event.keys())
+        assert not missing, f"Event {i} missing fields {missing}: {event}"
+        assert event["event_type"] in {"service_paused", "service_resumed"}, \
+            f"Unknown event_type in event {i}: {event['event_type']}"

--- a/tests/test_vnx_pause_resume.py
+++ b/tests/test_vnx_pause_resume.py
@@ -16,11 +16,14 @@ Test matrix:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 from pathlib import Path
 
 import pytest
+
+logger = logging.getLogger(__name__)
 
 VNX_ROOT = Path(__file__).resolve().parent.parent
 PAUSE_SH = VNX_ROOT / "scripts" / "commands" / "pause.sh"
@@ -174,8 +177,8 @@ def test_pause_stops_running_daemons(tmp_path: Path):
             try:
                 proc.kill()
                 proc.wait(timeout=3)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning('cleanup failed: %s', e)
 
 
 def test_pause_cleans_stale_pid_files(tmp_path: Path):
@@ -332,8 +335,8 @@ def test_pause_then_resume_round_trip(tmp_path: Path):
         try:
             proc.kill()
             proc.wait(timeout=3)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning('cleanup failed: %s', e)
 
 
 def test_lifecycle_events_are_valid_ndjson(tmp_path: Path):

--- a/tests/test_vnx_pause_resume.py
+++ b/tests/test_vnx_pause_resume.py
@@ -35,7 +35,13 @@ RESUME_SH = VNX_ROOT / "scripts" / "commands" / "resume.sh"
 # ---------------------------------------------------------------------------
 
 def _make_dirs(tmp_path: Path) -> dict:
-    """Create minimal .vnx-data layout and return env var mapping."""
+    """Create minimal .vnx-data layout and return env var mapping.
+
+    Sets VNX_SKIP_DAEMON_SPAWN=1 so cmd_resume does not spawn real nohup
+    daemons. Without this, sourced resume.sh would launch operator-grade
+    dispatcher_supervisor.sh + receipt_processor_supervisor.sh that survive
+    the test and proliferate against real .vnx-data state.
+    """
     data = tmp_path / ".vnx-data"
     dirs = {
         "VNX_DATA_DIR": data,
@@ -47,7 +53,9 @@ def _make_dirs(tmp_path: Path) -> dict:
     for d in dirs.values():
         d.mkdir(parents=True, exist_ok=True)
     (data / "events").mkdir(parents=True, exist_ok=True)
-    return {k: str(v) for k, v in dirs.items()}
+    env = {k: str(v) for k, v in dirs.items()}
+    env["VNX_SKIP_DAEMON_SPAWN"] = "1"
+    return env
 
 
 def _run_cmd(cmd_name: str, env_vars: dict, args: list[str] | None = None) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

- **C.1/C.2**: `scripts/commands/pause.sh` + `scripts/commands/resume.sh` — graceful service-freeze for migration cutover. `vnx pause` stops dispatcher, receipt_processor, queue_watcher with SIGTERM→SIGKILL, writes an atomic `PAUSED` marker file, and appends a `service_paused` lifecycle event. `vnx resume` checks the marker, restarts daemons via supervisor scripts, removes the marker, and appends `service_resumed`. Both commands are idempotent and zombie-aware (macOS zombie processes are treated as stopped).
- **C.3**: `bin/vnx` — pause/resume registered in main case dispatch and usage text.
- **C.4**: `docs/operations/migration-rollback-runbook.md` — new **Pre-apply snapshot** section (mandatory central DB snapshot before every `--apply`) and **Scenario X** (partial migration failure: identify partial rows, pause VNX, DELETE by project_id, validate, restore from snapshot if needed, re-run dry-run, resume).
- **C.5**: `tests/test_vnx_pause_resume.py` — 11 tests: no-daemon idempotency, atomic PAUSED file content, daemon stopping, stale-PID cleanup, double-pause safety, resume-without-pause error, PAUSED marker removal, lifecycle event format, full round-trip, NDJSON schema validation.

## Test plan

- [ ] `pytest tests/test_vnx_pause_resume.py -v` → 11 passed
- [ ] `bash -n scripts/commands/pause.sh && bash -n scripts/commands/resume.sh` → syntax OK
- [ ] `bash -n bin/vnx` → syntax OK
- [ ] Review `docs/operations/migration-rollback-runbook.md` Scenario X procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)