### PR TITLE
feat(safety): PAUSED marker guards in daemon scripts (follow-up to PR #611)

### DIFF
--- a/scripts/dispatcher_supervisor.sh
+++ b/scripts/dispatcher_supervisor.sh
@@ -20,6 +20,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
 source "$SCRIPT_DIR/lib/process_lifecycle.sh"
 
+# Respect PAUSED marker: refuse to start while VNX is paused.
+if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+  echo "[dispatcher_supervisor] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
+  exit 0
+fi
+
 VNX_DIR="$VNX_HOME"
 DISPATCHER_SCRIPT="${VNX_DISPATCHER_SCRIPT:-$SCRIPT_DIR/dispatcher_v8_minimal.sh}"
 SUPERVISOR_NAME="dispatcher_supervisor"

--- a/scripts/dispatcher_v8_minimal.sh
+++ b/scripts/dispatcher_v8_minimal.sh
@@ -10,6 +10,13 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PAT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
+
+# Respect PAUSED marker: refuse to start while VNX is paused.
+if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+  echo "[dispatcher_v8_minimal] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
+  exit 0
+fi
+
 source "$SCRIPT_DIR/lib/dispatch_metadata.sh"
 source "$SCRIPT_DIR/lib/dispatch_project_guard.sh"
 source "$SCRIPT_DIR/lib/provider_routing.sh"

--- a/scripts/receipt_processor_supervisor.sh
+++ b/scripts/receipt_processor_supervisor.sh
@@ -20,6 +20,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
 source "$SCRIPT_DIR/lib/process_lifecycle.sh"
 
+# Respect PAUSED marker: refuse to start while VNX is paused.
+if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+  echo "[receipt_processor_supervisor] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
+  exit 0
+fi
+
 VNX_DIR="$VNX_HOME"
 RECEIPT_PROCESSOR_SCRIPT="$SCRIPT_DIR/receipt_processor_v4.sh"
 SUPERVISOR_NAME="receipt_processor_supervisor"

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -4,6 +4,13 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
+
+# Respect PAUSED marker: refuse to start while VNX is paused.
+if [ "${_RP_LIB_MODE:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+  echo "[receipt_processor_v4] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
+  exit 0
+fi
+
 source "$SCRIPT_DIR/lib/receipt_terminal_detection.sh"
 
 # Base directories


### PR DESCRIPTION
## Summary

Belt-and-suspenders defense layer on top of `bin/vnx pause` (PR #611). Each daemon script checks `\${VNX_STATE_DIR}/PAUSED` early and refuses to start when the marker is present.

- `scripts/dispatcher_supervisor.sh`
- `scripts/dispatcher_v8_minimal.sh`
- `scripts/receipt_processor_supervisor.sh`
- `scripts/receipt_processor_v4.sh`

Guards against three real footguns observed during the 2026-05-20 receipt-flood incident:
1. Supervisor restart loop relaunching daemons while paused
2. Ad-hoc `bash scripts/X.sh` from worker dispatches bypassing pause
3. Stale cron/launchd tick resurrecting daemons mid-pause

`receipt_processor_v4` honors `_RP_LIB_MODE=1` so library sourcing (rp_time.sh, internal helpers) is not affected.

## Test plan

- [x] `bash scripts/dispatcher_supervisor.sh` while PAUSED active → exit 0, no process spawned (verified locally during receipt-flood recovery)
- [x] Smoke check: all 4 scripts source cleanly without PAUSED
- [ ] CI green (VNX CI + ADR-003 + Public CI)
- [ ] Codex final-gate (advisory at risk_class=low — pure defensive guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)