### PR TITLE
fix(singleton): atomic flock(2) replaces mkdir-race (closes OI-1518)

### DIFF
--- a/scripts/singleton_enforcer.sh
+++ b/scripts/singleton_enforcer.sh
@@ -1,29 +1,81 @@
 #!/bin/bash
-# Singleton Enforcer - PID-safe lifecycle management with atomic lock + fingerprint validation
-# Usage: source this script at the beginning of any script that needs singleton enforcement
+# Singleton Enforcer - atomic flock(2)-based lifecycle management
+#
+# Usage: source this script at the start of any script that needs singleton
+# enforcement, then call `enforce_singleton "<name>" [log_file] [script_path]`.
+#
+# Race-freedom:
+#   flock(2) is a kernel-level POSIX advisory mutex. The file descriptor opened
+#   on the lock file is held for the lifetime of the calling script; when bash
+#   exits, the kernel atomically releases the lock. There is no read-then-claim
+#   window for contenders to slip into. A non-blocking exclusive flock either
+#   succeeds (we are the singleton) or fails (another live instance owns it).
+#
+#   This replaces the prior mkdir+rm_rf+retry design (OI-1518) that had a race
+#   window during stale-lock cleanup: two contenders could both rm_rf each
+#   other's freshly-acquired lock dir under stop_existing semantics, allowing
+#   parallel survivors. The 2026-05-20 receipt-flood incident was triggered
+#   by this race compounded by test daemons that leaked into operator state.
+#
+# Stale-lock handling:
+#   No explicit stale-lock check is needed. If the previous holder died
+#   without cleaning up (kill -9 / power loss), the kernel released the flock
+#   on process exit. The lock file may remain on disk but holds no lock; the
+#   next caller's flock() succeeds immediately.
+#
+# Dependency: flock(1) from util-linux. Default on Linux; on macOS install via
+# `brew install util-linux`.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/vnx_paths.sh
+source "$SCRIPT_DIR/lib/vnx_paths.sh"
 # shellcheck source=lib/process_lifecycle.sh
 source "$SCRIPT_DIR/lib/process_lifecycle.sh"
+
+# Fixed FD for the singleton lock. 200 is conventional for userland and avoids
+# collision with stdin/stdout/stderr (0-2) and tools that use 3-9 ad-hoc.
+# A fixed FD is required because bash 3.2 (default on macOS) does not support
+# the `{varname}>` auto-assign redirect syntax.
+_VNX_SINGLETON_LOCK_FD=200
 
 enforce_singleton() {
     local script_name="${1:-$(basename "$0")}"
     local log_file="${2:-}"
     local script_path="${3:-$0}"
+
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "[SINGLETON] flock(1) not found. Install util-linux (macOS: brew install util-linux)." >&2
+        exit 1
+    fi
+
+    mkdir -p "$VNX_LOCKS_DIR" "$VNX_PIDS_DIR"
+    local lock_file="$VNX_LOCKS_DIR/${script_name}.lock"
+    local pid_file="$VNX_PIDS_DIR/${script_name}.pid"
+
+    # Open the lock file on a fixed FD. The FD inherits the bash process'
+    # lifetime; closing it (or bash exiting) releases the kernel flock.
+    eval "exec ${_VNX_SINGLETON_LOCK_FD}>\"\$lock_file\""
+
+    if ! flock -n -x "$_VNX_SINGLETON_LOCK_FD"; then
+        local existing_pid
+        existing_pid="$(cat "$pid_file" 2>/dev/null || echo unknown)"
+        echo "[SINGLETON] Another instance of $script_name is already running (PID: $existing_pid)"
+        eval "exec ${_VNX_SINGLETON_LOCK_FD}>&-"
+        exit 0
+    fi
+
     local fingerprint
-    # Canonicalize fingerprint to realpath first so relative invocation forms
-    # (e.g. "bash receipt_processor_v4.sh") and absolute forms dedupe correctly.
     fingerprint="$(vnx_proc_realpath "$script_path")"
     if [ -z "$fingerprint" ]; then
         fingerprint="$(vnx_proc_cmdline "$$")"
     fi
+    echo "$$" > "$pid_file"
+    echo "$fingerprint" > "${pid_file}.fingerprint"
 
-    if ! vnx_proc_acquire_lock "$script_name" "$fingerprint" "$log_file" "stop_existing" "singleton_start"; then
-        echo "[SINGLETON] Another instance of $script_name is already running"
-        exit 0
-    fi
-
-    trap "rm -rf '$VNX_LOCKS_DIR/${script_name}.lock'; rm -f '$VNX_PIDS_DIR/${script_name}.pid' '${VNX_PIDS_DIR}/${script_name}.pid.fingerprint'" EXIT INT TERM
+    # PID files are observability/telemetry only — the lock itself is released
+    # by the kernel when fd 200 closes. EXIT/INT/TERM trap cleans the PID
+    # artifacts. The lock file on disk is harmless if left behind.
+    trap "rm -f '$pid_file' '${pid_file}.fingerprint'" EXIT INT TERM
 
     echo "[SINGLETON] Lock acquired for $script_name (PID: $$)"
 }

--- a/scripts/singleton_enforcer.sh
+++ b/scripts/singleton_enforcer.sh
@@ -54,23 +54,57 @@ enforce_singleton() {
 
     # Open the lock file on a fixed FD. The FD inherits the bash process'
     # lifetime; closing it (or bash exiting) releases the kernel flock.
-    eval "exec ${_VNX_SINGLETON_LOCK_FD}>\"\$lock_file\""
-
-    if ! flock -n -x "$_VNX_SINGLETON_LOCK_FD"; then
-        local existing_pid
-        existing_pid="$(cat "$pid_file" 2>/dev/null || echo unknown)"
-        echo "[SINGLETON] Another instance of $script_name is already running (PID: $existing_pid)"
-        eval "exec ${_VNX_SINGLETON_LOCK_FD}>&-"
-        exit 0
+    # Failure to open (permission, ENOSPC, etc.) is a real error, not a clean
+    # singleton refusal — surface it loudly so the operator notices.
+    if ! eval "exec ${_VNX_SINGLETON_LOCK_FD}>\"\$lock_file\"" 2>/dev/null; then
+        echo "[SINGLETON] Failed to open lock file $lock_file (permission, ENOSPC, or FS issue)" >&2
+        exit 1
     fi
+
+    # flock -E sets a distinct exit code for "lock held" (contention) so we can
+    # distinguish it from other failure modes (bad FD, syscall error, etc.).
+    # Without -E, every non-zero exit looks the same and a real bug would be
+    # silently masked as "another instance running".
+    flock -n -x -E 75 "$_VNX_SINGLETON_LOCK_FD"
+    local flock_rc=$?
+    case $flock_rc in
+        0)
+            ;;
+        75)
+            local existing_pid
+            existing_pid="$(cat "$pid_file" 2>/dev/null || echo unknown)"
+            echo "[SINGLETON] Another instance of $script_name is already running (PID: $existing_pid)"
+            eval "exec ${_VNX_SINGLETON_LOCK_FD}>&-"
+            exit 0
+            ;;
+        *)
+            echo "[SINGLETON] flock failed with unexpected exit code $flock_rc (not contention)" >&2
+            eval "exec ${_VNX_SINGLETON_LOCK_FD}>&-"
+            exit 1
+            ;;
+    esac
 
     local fingerprint
     fingerprint="$(vnx_proc_realpath "$script_path")"
     if [ -z "$fingerprint" ]; then
         fingerprint="$(vnx_proc_cmdline "$$")"
     fi
-    echo "$$" > "$pid_file"
-    echo "$fingerprint" > "${pid_file}.fingerprint"
+
+    # Atomic write: writer-process-tagged tmp + rename(2). Prevents a
+    # partial or empty PID/fingerprint file being visible if this script
+    # is interrupted between the write and the close.
+    local pid_tmp="${pid_file}.tmp.$$"
+    local fp_tmp="${pid_file}.fingerprint.tmp.$$"
+    if ! printf '%s\n' "$$" > "$pid_tmp" || ! mv "$pid_tmp" "$pid_file"; then
+        echo "[SINGLETON] Failed to write PID file $pid_file" >&2
+        rm -f "$pid_tmp"
+        exit 1
+    fi
+    if ! printf '%s\n' "$fingerprint" > "$fp_tmp" || ! mv "$fp_tmp" "${pid_file}.fingerprint"; then
+        echo "[SINGLETON] Failed to write fingerprint file" >&2
+        rm -f "$fp_tmp" "$pid_file"
+        exit 1
+    fi
 
     # PID files are observability/telemetry only — the lock itself is released
     # by the kernel when fd 200 closes. EXIT/INT/TERM trap cleans the PID

--- a/tests/test_singleton_enforcer_flock.py
+++ b/tests/test_singleton_enforcer_flock.py
@@ -1,0 +1,198 @@
+"""Regression tests for OI-1518: atomic flock-based bash singleton enforcer.
+
+The bug: scripts/singleton_enforcer.sh previously delegated to
+vnx_proc_acquire_lock with mode=stop_existing. That path used
+mkdir+rm_rf+retry for stale-lock takeover, with a race window where two
+parallel contenders could both rm_rf each other's freshly-claimed lock dir
+and both proceed as singletons.
+
+The 2026-05-20 receipt-flood incident saw 10x receipt_processor_v4,
+8x dispatcher_supervisor, and 8x receipt_processor_supervisor running in
+parallel after a burst of pause/resume cycles raced into the cleanup window.
+
+The fix replaces mkdir-based mutex with flock(1) on a fixed FD. flock(2) is
+a kernel-level atomic syscall — there is no read-then-claim race.
+
+This module tests:
+  1. Single-process: enforce_singleton acquires and reports correctly.
+  2. Parallel 10x: exactly one acquires, nine see "Another instance running".
+  3. After holder exits, next acquirer succeeds (lock auto-released by kernel).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SINGLETON_SH = VNX_ROOT / "scripts" / "singleton_enforcer.sh"
+
+
+@pytest.fixture
+def singleton_env(tmp_path: Path) -> dict:
+    """Tmp dirs for locks/pids; no VNX_HOME leakage to real state."""
+    data = tmp_path / ".vnx-data"
+    dirs = {
+        "VNX_DATA_DIR": data,
+        "VNX_STATE_DIR": data / "state",
+        "VNX_LOCKS_DIR": data / "locks",
+        "VNX_PIDS_DIR": data / "pids",
+        "VNX_LOGS_DIR": data / "logs",
+    }
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    env = {k: str(v) for k, v in dirs.items()}
+    env["PATH"] = os.environ.get("PATH", "")
+    return env
+
+
+def _spawn_acquirer(env: dict, name: str, hold_seconds: float) -> subprocess.CompletedProcess:
+    """Spawn one bash that sources singleton_enforcer.sh and tries to acquire.
+
+    Returns the completed process; stdout contains "Lock acquired" for the
+    winner or "Another instance" for losers.
+    """
+    script = f"""#!/bin/bash
+set -euo pipefail
+source "{SINGLETON_SH}"
+enforce_singleton "{name}"
+sleep {hold_seconds}
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _require_flock():
+    if shutil.which("flock") is None:
+        pytest.skip("flock(1) not available; install util-linux")
+
+
+class TestSingleProcess:
+    def test_acquire_and_release(self, singleton_env):
+        """Single acquirer succeeds; PID file contains its PID."""
+        result = _spawn_acquirer(singleton_env, "single_test", hold_seconds=0.1)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "Lock acquired" in result.stdout, f"stdout: {result.stdout}"
+
+        # Lock file may remain (kernel only releases the lock state, not the
+        # inode), but the PID file should be cleaned by the EXIT trap.
+        pid_file = Path(singleton_env["VNX_PIDS_DIR"]) / "single_test.pid"
+        assert not pid_file.exists(), "PID file not cleaned on exit"
+
+    def test_sequential_acquires_both_succeed(self, singleton_env):
+        """After first releases, second acquires cleanly."""
+        r1 = _spawn_acquirer(singleton_env, "seq_test", hold_seconds=0.1)
+        assert r1.returncode == 0
+        assert "Lock acquired" in r1.stdout
+
+        r2 = _spawn_acquirer(singleton_env, "seq_test", hold_seconds=0.1)
+        assert r2.returncode == 0
+        assert "Lock acquired" in r2.stdout, f"second acquire failed: {r2.stdout}"
+
+
+class TestParallelRace:
+    def test_ten_parallel_acquires_exactly_one_wins(self, singleton_env):
+        """The receipt-flood scenario: 10 contenders, expect exactly 1 winner.
+
+        Each contender holds the lock for 2s. They all start within a tight
+        window. Without flock atomicity (prior mkdir-race design), multiple
+        contenders could all see the lock as free and proceed in parallel.
+        """
+        name = "parallel_test"
+        hold = 2.0
+        n = 10
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            futures = [pool.submit(_spawn_acquirer, singleton_env, name, hold) for _ in range(n)]
+            results = [f.result() for f in as_completed(futures)]
+
+        winners = [r for r in results if "Lock acquired" in r.stdout]
+        losers = [r for r in results if "Another instance" in r.stdout]
+
+        assert len(winners) == 1, (
+            f"Expected exactly 1 winner, got {len(winners)}. "
+            f"Winners stdout: {[w.stdout for w in winners]}\n"
+            f"Losers stdout: {[l.stdout[:200] for l in losers]}"
+        )
+        assert len(losers) == n - 1, (
+            f"Expected {n-1} losers, got {len(losers)}. "
+            f"Unclassified: {[r.stdout for r in results if r not in winners and r not in losers]}"
+        )
+
+    def test_loser_exits_cleanly_with_zero(self, singleton_env):
+        """Losers exit 0 (clean refusal), not 1 (error)."""
+        name = "loser_exit_test"
+        hold = 1.5
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(_spawn_acquirer, singleton_env, name, hold) for _ in range(3)]
+            results = [f.result() for f in as_completed(futures)]
+
+        for r in results:
+            assert r.returncode == 0, (
+                f"Singleton contender exited non-zero. "
+                f"Should be 0 (clean refusal). stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+
+
+class TestLockRelease:
+    def test_lock_released_on_normal_exit(self, singleton_env):
+        """After holder exits normally, next acquirer succeeds immediately."""
+        name = "release_test"
+
+        # Hold briefly, release.
+        r1 = _spawn_acquirer(singleton_env, name, hold_seconds=0.05)
+        assert r1.returncode == 0
+
+        # Immediately acquire again — must succeed without delay.
+        start = time.time()
+        r2 = _spawn_acquirer(singleton_env, name, hold_seconds=0.05)
+        elapsed = time.time() - start
+
+        assert r2.returncode == 0
+        assert "Lock acquired" in r2.stdout
+        assert elapsed < 2.0, f"Re-acquire took {elapsed:.2f}s — kernel did not release lock cleanly"
+
+    def test_lock_released_on_sigkill(self, singleton_env):
+        """When holder is SIGKILLed mid-hold, kernel auto-releases lock.
+
+        Models the daemon-crash recovery path: a previous instance died
+        without running its trap handler. The flock is released by the
+        kernel on process exit (no userland cleanup needed), so the next
+        acquirer must succeed even though no trap ran.
+        """
+        name = "sigkill_test"
+        script = f"""#!/bin/bash
+set -euo pipefail
+source "{SINGLETON_SH}"
+enforce_singleton "{name}"
+exec sleep 30
+"""
+        proc = subprocess.Popen(
+            ["bash", "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=singleton_env,
+        )
+
+        time.sleep(0.5)
+        proc.kill()
+        proc.wait(timeout=5)
+
+        r = _spawn_acquirer(singleton_env, name, hold_seconds=0.05)
+        assert r.returncode == 0
+        assert "Lock acquired" in r.stdout, f"After SIGKILL, next acquire failed: {r.stdout}"


### PR DESCRIPTION
## Summary

Root-cause fix for the 2026-05-20 receipt-flood incident. Closes **OI-1518**.

The prior `scripts/singleton_enforcer.sh` delegated to `vnx_proc_acquire_lock` with `mode=stop_existing`. That path used `mkdir + rm_rf + retry` for stale-lock takeover, with a race window where two parallel contenders could both `rm_rf` each other's freshly-claimed lock dir under stop_existing semantics. The receipt-flood saw 10× receipt_processor_v4, 8× dispatcher_supervisor, and 8× receipt_processor_supervisor coexist after pause/resume cycles raced into this window.

## What changed

`scripts/singleton_enforcer.sh` — rewrite using POSIX `flock(2)` via `flock(1)` on a fixed FD (200; bash 3.2 on macOS does not support `{var}>` auto-assign).

`flock(2)` is a **kernel atomic syscall** — there is no read-then-claim window. The FD is held for the lifetime of the calling bash; when bash exits (normal, SIGTERM, or SIGKILL) the kernel releases the lock atomically. No userland cleanup is required for lock release.

`scripts/lib/process_lifecycle.sh::vnx_proc_acquire_lock` left intact but no longer called — should be considered deprecated.

## Why this is robust

- 10 contenders all blocking on `flock -n -x` → exactly 1 wins, 9 see EAGAIN and exit 0
- SIGKILLed previous holder → kernel releases lock on process exit; next start succeeds without stale-lock heuristic
- Daemon scripts that override the EXIT trap no longer leave a stuck lock — kernel owns lock release

## Dependency

`flock(1)` from util-linux. Default on Linux (CI uses `ubuntu-latest`). macOS: `brew install util-linux`. Verified available in this worktree at `/opt/homebrew/bin/flock`.

## Test plan

`tests/test_singleton_enforcer_flock.py` — 6 cases:

- [x] Single acquire/release + PID file cleanup via trap
- [x] Sequential acquires both succeed
- [x] **10 parallel acquires → exactly 1 winner** (OI-1518 regression)
- [x] Losers exit 0 (clean refusal, not error)
- [x] Lock released on normal exit (next acquire fast)
- [x] Lock released on SIGKILL (kernel auto-release, no trap)

`6 passed in 5.50s` on macOS + bash 3.2 with Homebrew flock.

## Order of operations

1. This PR + PR #612 (PAUSED-guards) review/merge
2. Then `vnx resume` is safe to run (race vector eliminated + defense-in-depth marker guards in place)
3. Then Wave 2a centralisatie cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)