### PR TITLE
fix(resume): VNX_RESUME_IN_PROGRESS bypass for PAUSED-guards (deadlock from #611+#612)

### DIFF
--- a/scripts/commands/resume.sh
+++ b/scripts/commands/resume.sh
@@ -21,9 +21,19 @@ _vnx_resume_validate_marker() {
 
 # Helper: start all three daemons. Sets _resume_dispatcher_pid and
 # _resume_receipt_pid for use by _vnx_resume_verify_readiness.
+#
+# Exports VNX_RESUME_IN_PROGRESS=1 so the spawned daemon scripts bypass their
+# PAUSED-marker startup guards (added in PR #612). Without this bypass the
+# guards reject the daemons before flock acquisition, _vnx_resume_verify_readiness
+# sees the PIDs dead, and cmd_resume fails closed with PAUSED retained — a
+# chicken-and-egg deadlock between the audit-integrity ordering (PR #611:
+# verify daemons before clearing marker) and the defense layer (PR #612:
+# refuse start while marker present).
 _vnx_resume_start_daemons() {
   local scripts_dir="$1"
   local logs_dir="$2"
+
+  export VNX_RESUME_IN_PROGRESS=1
 
   # Restart dispatcher via supervisor (preferred) or directly
   if [ -f "$scripts_dir/dispatcher_supervisor.sh" ]; then

--- a/scripts/dispatcher_supervisor.sh
+++ b/scripts/dispatcher_supervisor.sh
@@ -21,7 +21,10 @@ source "$SCRIPT_DIR/lib/vnx_paths.sh"
 source "$SCRIPT_DIR/lib/process_lifecycle.sh"
 
 # Respect PAUSED marker: refuse to start while VNX is paused.
-if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+# VNX_RESUME_IN_PROGRESS=1 bypass is set by cmd_resume in scripts/commands/resume.sh
+# so that the resume flow can verify daemon readiness BEFORE removing the PAUSED
+# marker (audit-integrity ordering; see PR #611).
+if [ "${VNX_RESUME_IN_PROGRESS:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
   echo "[dispatcher_supervisor] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
   exit 0
 fi

--- a/scripts/dispatcher_v8_minimal.sh
+++ b/scripts/dispatcher_v8_minimal.sh
@@ -12,7 +12,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
 
 # Respect PAUSED marker: refuse to start while VNX is paused.
-if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+# VNX_RESUME_IN_PROGRESS=1 bypass is set by cmd_resume in scripts/commands/resume.sh
+# so that the resume flow can verify daemon readiness BEFORE removing the PAUSED
+# marker (audit-integrity ordering; see PR #611).
+if [ "${VNX_RESUME_IN_PROGRESS:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
   echo "[dispatcher_v8_minimal] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
   exit 0
 fi

--- a/scripts/receipt_processor_supervisor.sh
+++ b/scripts/receipt_processor_supervisor.sh
@@ -21,7 +21,10 @@ source "$SCRIPT_DIR/lib/vnx_paths.sh"
 source "$SCRIPT_DIR/lib/process_lifecycle.sh"
 
 # Respect PAUSED marker: refuse to start while VNX is paused.
-if [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+# VNX_RESUME_IN_PROGRESS=1 bypass is set by cmd_resume in scripts/commands/resume.sh
+# so that the resume flow can verify daemon readiness BEFORE removing the PAUSED
+# marker (audit-integrity ordering; see PR #611).
+if [ "${VNX_RESUME_IN_PROGRESS:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
   echo "[receipt_processor_supervisor] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
   exit 0
 fi

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -6,7 +6,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/vnx_paths.sh"
 
 # Respect PAUSED marker: refuse to start while VNX is paused.
-if [ "${_RP_LIB_MODE:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
+# _RP_LIB_MODE=1 bypasses for library-sourcing helpers (rp_time.sh, etc.).
+# VNX_RESUME_IN_PROGRESS=1 bypass is set by cmd_resume in scripts/commands/resume.sh
+# so that the resume flow can verify daemon readiness BEFORE removing the PAUSED
+# marker (audit-integrity ordering; see PR #611).
+if [ "${_RP_LIB_MODE:-0}" != "1" ] && [ "${VNX_RESUME_IN_PROGRESS:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
   echo "[receipt_processor_v4] PAUSED marker present at ${VNX_STATE_DIR}/PAUSED — refusing to start. Run 'vnx resume' to clear." >&2
   exit 0
 fi


### PR DESCRIPTION
## Summary

Closes a chicken-and-egg deadlock that surfaced when PR #611 (audit-integrity ordering: verify daemons before clearing PAUSED) and PR #612 (PAUSED-guards: refuse to start while marker present) shipped together.

Without this fix, `vnx resume` fails closed every time:
1. cmd_resume spawns dispatcher_supervisor.sh + receipt_processor_supervisor.sh via nohup
2. PAUSED-guards reject them immediately (marker still present)
3. _vnx_resume_verify_readiness sees PIDs dead after 1s sleep
4. cmd_resume errors out, PAUSED retained, no service_resumed event

## Fix

cmd_resume's `_vnx_resume_start_daemons` exports `VNX_RESUME_IN_PROGRESS=1` before any nohup. All four daemon startup guards now check the env var alongside the PAUSED file:

```bash
if [ "${VNX_RESUME_IN_PROGRESS:-0}" != "1" ] && [ -f "${VNX_STATE_DIR}/PAUSED" ]; then
    echo "[...] PAUSED marker present — refusing to start." >&2
    exit 0
fi
```

The bypass is scoped to cmd_resume's shell + nohup children. Ad-hoc `bash scripts/X.sh`, cron, launchd, and stray supervisor retries do not inherit the variable and continue to be blocked.

## Live recovery evidence

Verified 2026-05-21 05:10 UTC on the actual paused state from the 2026-05-20 receipt-flood incident:

```
[resume] Starting dispatcher via dispatcher_supervisor.sh...
[resume] dispatcher_supervisor started (PID: 58125).
[resume] Starting receipt_processor_supervisor.sh...
[resume] receipt_processor_supervisor started (PID: 58126).
[resume] Starting queue_popup_watcher.sh...
[resume] queue_watcher started (PID: 58127).
[resume] VNX daemons resumed. Dispatcher and receipt_processor restarted.
```

- PAUSED marker REMOVED ✓
- service_resumed event written with by_dispatch_id=manual-recovery-2026-05-21-r2 ✓
- ps shows exactly 1 of each daemon (no proliferation) ✓
- A racing second queue_popup_watcher spawn was correctly rejected by the flock(2) singleton (PR #613) — no duplicate

## Test plan

- [x] Live recovery on real paused state succeeded (above)
- [ ] Codex final gate
- [ ] VNX CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)