### PR TITLE
fix(migrator): canonical bootstrap schema-order for --fresh-central (PR-MIGRATOR-FIX)

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,40 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-17T18:40:18.751052+00:00
+**Last updated**: 2026-05-21T07:04:56.577840+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #614 — fix(resume): VNX_RESUME_IN_PROGRESS bypass for PAUSED-guards (#614) (2026-05-21)
+- #612 — feat(safety): PAUSED marker guards in daemon scripts (#612) (2026-05-21)
+- #613 — fix(singleton): atomic flock(2) replaces mkdir-race (closes OI-1518) (#613) (2026-05-21)
+- #611 — feat(centralisatie): vnx pause/resume + partial-failure cleanup runbook (Dag 2 PR C) (#611) (2026-05-20)
+- #610 — feat(benchmark): FTS5 rebuild benchmark for SEOcrawler maintenance window (Dag 2 PR B) (#610) (2026-05-20)
+- #609 — feat(centralisatie): dispatch_id collision resolver + schema-prep migrations (Dag 2 PR A) (#609) (2026-05-20)
+- #608 — feat(wave2a): bump 1.0.0-rc3 + dry-run tests against 3 projects (#608) (2026-05-20)
+- #607 — feat(migration): schema versioning + rollback playbook (Wave 2a prep) (#607) (2026-05-20)
+- #606 — fix(dashboard): bundle OI-1494 fixes (5 items) + agent-stream archive replay (#606) (2026-05-20)
+- #605 — fix(receipts): project_id scoping audit + fixes (Wave 2a prep) (#605) (2026-05-20)
+- #604 — fix(centralisatie): project_id scoping audit + critical write-leak fixes (#604) (2026-05-20)
+- #603 — docs: refresh HANDOFF + README status banner (master roadmap link) (#603) (2026-05-20)
+- #588 — feat(schema): idempotent bootstrap with PRAGMA user_version + transaction wrapping (#588) (2026-05-18)
+- #591 — feat(doctor): vnx doctor --strict for central-install pre-flight validation (#591) (2026-05-18)
+- #587 — feat(install): install-central.sh for centralized VNX install with project-pin (#587) (2026-05-18)
+- #600 — feat(intelligence): A/B random-skip framework with weekly lift report (#600) (2026-05-18)
+- #596 — fix(governance): _emit_governance retry-with-backoff instead of SystemExit (Kimi audit) (#596) (2026-05-18)
+- #589 — feat(skill-coverage): pre-flight skill-coverage scanner for central install (#589) (2026-05-18)
+- #593 — fix(intelligence): catalogus-hygiene + recency-decay (audit BLOCKER #2) (#593) (2026-05-18)
+- #595 — refactor(dispatch): shared runtime_overrides module (eliminate delivery/recovery duplicate) (#595) (2026-05-18)
+- #594 — feat(intelligence): fine-grained task_class subclass + scope_tags activation (#594) (2026-05-18)
+- #592 — fix(pool): real-subprocess integration tests for pool spawn (Sonnet audit BLOCKER #1) (#592) (2026-05-18)
+- #586 — feat(vnx_paths): .vnx-overrides resolver for per-project central-install customization (#586) (2026-05-17)
+- #590 — feat(schema): migration 0021 central install metadata + pin tracking (#590) (2026-05-17)
+- #584 — feat(cli): vnx version + vnx update subcommands for central install rollback (#584) (2026-05-17)
+- #585 — feat(pyproject): pipx-installable wheel with vnx console_script (#585) (2026-05-17)
+- #583 — chore: sync VERSION + pyproject.toml to 1.0.0-rc2 (#583) (2026-05-17)
+- #582 — fix(provider_dispatch): rotate per-terminal NDJSON ring buffer post-dispatch (#582) (2026-05-17)
 - #580 — fix(smart-router): end-to-end auto-route wiring + enforcer false-positive on Kimi CLI provider (2 blockers) (#580) (2026-05-17)
 - #578 — fix(governance): atomic OI saves + WAL migrations + closure_verifier self-reference loop (3 blockers + 4 high) (#578) (2026-05-17)
 - #576 — fix(security): PRAGMA allowlist + project_id_fn multi-tenant + missing contracts + dup ImportError (2 blockers + 4 medium) (#576) (2026-05-17)
@@ -83,41 +111,6 @@ _Last 14 days — sourced from git merge commits._
 - #434 — fix(dashboard): clean up agent stream lifecycle (#434) (2026-05-07)
 - #433 — chore(gemini): switch default reviewer model to gemini-2.5-pro for deeper reviews (#433) (2026-05-07)
 - #431 — feat(envelopes): per-project paths + four-tuple envelope (Phase 6 P3 v2) (#431) (2026-05-07)
-- #430 — fix(intelligence): wire stamp_source_dispatch_ids into all injection callers (closes OI-1341) (#430) (2026-05-07)
-- #429 — docs(skill): add Codex Defense Checklist to backend-developer skill (#429) (2026-05-07)
-- #428 — fix(intelligence): re-evaluate scope match after canonical remap (closes OI-1340) (#428) (2026-05-07)
-- #427 — fix(closure_verifier): require pr_id on claude_github_optional payloads (closes OI-1339) (#427) (2026-05-07)
-- #426 — fix(project-id): unify _get_project_id fallback via project_scope.current_project_id (closes OI-1342) (#426) (2026-05-07)
-- #425 — fix(closure_verifier): extend report_path enforcement to codex_gate handler (closes OI-1338) (#425) (2026-05-07)
-- #422 — feat(t0-state): strategic_state surface from strategy/ (Phase 2 W-state-5) (#422) (2026-05-06)
-- #417 — feat(strategy): typed current_state.md projector v2 (Phase 2 W-state-3) (#417) (2026-05-06)
-- #416 — feat(identity): four-tuple identity layer + per-project registry (Phase 6 P2) (#416) (2026-05-06)
-- #415 — feat(strategy): prd_index + adr_index builders (Phase 2 W-state-4) (#415) (2026-05-06)
-- #413 — feat(strategy): decisions.ndjson append-only log + writer (Phase 2 W-state-2) (#413) (2026-05-06)
-- #412 — feat(aggregator): read-only federation aggregator (Phase 6 P1) (#412) (2026-05-06)
-- #410 — feat(strategy): roadmap.yaml schema + reader/writer Python module (Phase 2 W-state-1) (#410) (2026-05-06)
-- #408 — fix(dispatcher): drain + dead_letter receipt classification (Phase 1.5 PR-4) (#408) (2026-05-06)
-- #409 — fix(dispatcher): propagate role-alias mapping to gather_intelligence (Phase 1.5 PR-5) (#409) (2026-05-06)
-- #407 — fix(dashboard): guard null in /operator/reports toLowerCase call (#407) (2026-05-06)
-- #406 — fix(dispatch_project_guard): canonicalize non-existent paths + Project-ID stamping (Phase 1.5 PR-3) (#406) (2026-05-06)
-- #405 — fix(intelligence): success_patterns multi-tenant correctness (Phase 1.5 PR-2) (#405) (2026-05-06)
-- #404 — fix(closure_verifier): evidence-contract restoration (Phase 1.5 PR-1) (#404) (2026-05-06)
-- #396 — fix(append_receipt): remove dead duplicate _maybe_reroute_ghost_receipt (UR-001) (#396) (2026-05-06)
-- #403 — feat(cli): vnx status dashboard subcommand (W-UX-3) (#403) (2026-05-06)
-- #402 — chore: ADRs (No-Redis + F43 packaging) + threshold-OI cleanup script (cherry-pick of #395) (#402) (2026-05-06)
-- #400 — fix(t0-state): GC retention sweep for t0_detail JSON snapshots (W-UX-4) (#400) (2026-05-06)
-- #401 — feat(strategy): current_state.md auto-projector + retire vestigial state (W-UX-2) (#401) (2026-05-06)
-- #399 — docs(kickoff): reflect PR #398 MERGED + add Phase 1 PR #395+#396 retry guidance (#399) (2026-05-06)
-- #398 — docs(strategy): persist strategic state + 17 phase FEATURE_PLAN.md files (#398) (2026-05-06)
-
-**W7**
-- #424 — feat(observability): tier labeling + governance gating (Phase 3 W7-G feature-end) (#424) (2026-05-06)
-- #421 — feat(gemini): adapter streaming refactor gated by VNX_GEMINI_STREAM (Phase 3 W7-D) (#421) (2026-05-06)
-- #420 — feat(litellm): adapter proof-of-concept via W7-B mixin (Phase 3 W7-E) (#420) (2026-05-06)
-- #419 — feat(codex): adapter migration to streaming via W7-B mixin (Phase 3 W7-C) (#419) (2026-05-06)
-- #418 — feat(ollama): adapter streaming refactor via W7-B mixin (Phase 3 W7-F) (#418) (2026-05-06)
-- #414 — feat(streaming): _streaming_drainer mixin + event_store dispatch_id fix (Phase 3 W7-B) (#414) (2026-05-06)
-- #411 — feat(events): CanonicalEvent schema + EventStore observability_tier (Phase 3 W7-A) (#411) (2026-05-06)
 
 **WAVE 0**
 - #443 — chore(repo-hygiene): Wave 0 — OI-1373 Tier 3 + 9 stale docs archive (combined) (#443) (2026-05-09)
@@ -126,6 +119,7 @@ _Last 14 days — sourced from git merge commits._
 - #457 — docs: refresh README + CHANGELOG for post-rc1 work (Wave 1 + Wave 5 P0/P1) (#457) (2026-05-10)
 
 **WAVE 5**
+- #601 — docs: refresh README + ROADMAP for 1.0.0-rc2 (Wave 5/6/7/8 shipped + central install) (#601) (2026-05-18)
 - #569 — docs: Wave 5/6/7/8 documentation overhaul (#569) (2026-05-17)
 
 **WAVE 8**

--- a/schemas/runtime_coordination_v10.sql
+++ b/schemas/runtime_coordination_v10.sql
@@ -13,6 +13,20 @@
 --
 -- This file documents the target schema structure. For fresh DB creation,
 -- apply runtime_coordination.sql then all migrations 0010 through 0017.
+--
+-- SCHEMA-ORDER NOTE (fix: PR-MIGRATOR-FIX 2026-05-24):
+-- The CREATE TABLE IF NOT EXISTS statements below are no-ops on a fresh install
+-- because the base tables (dispatches, terminal_leases, worker_states) are
+-- created by runtime_coordination.sql (v1) and runtime_coordination_v9.sql
+-- WITHOUT a project_id column. The project_id column is added by migration
+-- 0010 (dispatches, terminal_leases, etc.) and migration 0017 (worker_states).
+-- Those migrations always run AFTER coordination_db.init_schema completes.
+--
+-- Therefore: CREATE INDEX statements that reference project_id are intentionally
+-- ABSENT from this file. They are created by migrations 0010 and 0017 which
+-- run after init_schema via the migrator or apply_0017.py. Adding them here
+-- caused "no such column: project_id" on fresh --fresh-central installs because
+-- project_id does not exist yet when init_schema runs v10 on a fresh DB.
 
 PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;
@@ -40,10 +54,11 @@ CREATE TABLE IF NOT EXISTS terminal_leases (
     UNIQUE(terminal_id, project_id)
 );
 
+-- Non-project_id indexes are safe here because these columns exist in v1.
+-- project_id indexes (idx_lease_project, idx_lease_terminal_project) are
+-- created by migrations 0010 and 0017 after project_id is added.
 CREATE INDEX IF NOT EXISTS idx_lease_state            ON terminal_leases(state);
 CREATE INDEX IF NOT EXISTS idx_lease_dispatch         ON terminal_leases(dispatch_id);
-CREATE INDEX IF NOT EXISTS idx_lease_project          ON terminal_leases(project_id);
-CREATE INDEX IF NOT EXISTS idx_lease_terminal_project ON terminal_leases(terminal_id, project_id);
 
 -- ============================================================================
 -- DISPATCHES (v10 — composite UNIQUE)
@@ -70,10 +85,11 @@ CREATE TABLE IF NOT EXISTS dispatches (
     UNIQUE(dispatch_id, project_id)
 );
 
+-- Non-project_id indexes are safe here (columns exist from v1 schema).
+-- idx_dispatches_project is created by migration 0010 after project_id is added.
 CREATE INDEX IF NOT EXISTS idx_dispatch_state    ON dispatches(state, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_dispatch_terminal ON dispatches(terminal_id, state);
 CREATE INDEX IF NOT EXISTS idx_dispatch_created  ON dispatches(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
 
 -- ============================================================================
 -- WORKER STATES (v10 — project_id added)
@@ -97,9 +113,10 @@ CREATE TABLE IF NOT EXISTS worker_states (
     PRIMARY KEY (terminal_id)
 );
 
+-- Non-project_id indexes are safe here (columns exist from v9 schema).
+-- idx_worker_states_project is created by migration 0017 after project_id is added.
 CREATE INDEX IF NOT EXISTS idx_worker_state   ON worker_states(state);
 CREATE INDEX IF NOT EXISTS idx_worker_dispatch ON worker_states(dispatch_id);
-CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
 
 -- ============================================================================
 -- SCHEMA VERSION

--- a/tests/test_migrate_to_central_vnx_fresh_central.py
+++ b/tests/test_migrate_to_central_vnx_fresh_central.py
@@ -1,0 +1,464 @@
+"""Regression tests for the --fresh-central migrator path.
+
+Covers the schema-order bug where runtime_coordination_v10.sql created
+CREATE INDEX statements referencing project_id before migration 0010 had
+added that column, causing OperationalError "no such column: project_id"
+on every fresh --fresh-central run.
+
+Root cause: runtime_coordination_v10.sql contained:
+    CREATE INDEX idx_lease_project ON terminal_leases(project_id);
+    CREATE INDEX idx_lease_terminal_project ON terminal_leases(terminal_id, project_id);
+    CREATE INDEX idx_dispatches_project ON dispatches(project_id);
+    CREATE INDEX idx_worker_states_project ON worker_states(project_id);
+
+On a fresh install, init_schema applies v1..v10 sequentially. By the time v10
+runs, the base tables (dispatches, terminal_leases, worker_states) already
+exist from v1/v9 WITHOUT a project_id column. The v10 CREATE TABLE IF NOT
+EXISTS statements are no-ops (tables already present), but the CREATE INDEX
+statements still execute — and fail because project_id does not exist yet.
+Migration 0010 (which would ADD COLUMN project_id) only runs AFTER
+coordination_db.init_schema completes, so the column is never present during
+v10 index creation.
+
+Fix: remove the four project_id-referencing CREATE INDEX statements from
+runtime_coordination_v10.sql. Those indexes are created by migrations 0010
+and 0017 which always run post-bootstrap.
+
+Dispatch-ID: 20260524-204635-migrator-fresh-central-fix
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+from scripts import migrate_to_central_vnx as M  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Source DB fixture builders (minimal valid schema per project)
+# ---------------------------------------------------------------------------
+
+
+def _make_source_qi_db(path: Path, project_id: str) -> None:
+    """Create a minimal quality_intelligence source DB with dispatch_metadata rows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    try:
+        con.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS success_patterns (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                pattern_type TEXT NOT NULL,
+                category     TEXT NOT NULL,
+                title        TEXT NOT NULL,
+                description  TEXT NOT NULL,
+                pattern_data TEXT NOT NULL,
+                project_id   TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            CREATE TABLE IF NOT EXISTS dispatch_metadata (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL UNIQUE,
+                terminal    TEXT NOT NULL,
+                track       TEXT NOT NULL,
+                role        TEXT,
+                project_id  TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            """
+        )
+        for i in range(3):
+            con.execute(
+                "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, role, project_id)"
+                " VALUES (?, 'T1', 'A', 'developer', ?)",
+                (f"{project_id}-dispatch-{i}", project_id),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _make_source_rc_db(path: Path, project_id: str) -> None:
+    """Create a minimal runtime_coordination source DB."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    try:
+        con.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS runtime_schema_version (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE IF NOT EXISTS dispatches (
+                dispatch_id TEXT PRIMARY KEY,
+                state       TEXT NOT NULL DEFAULT 'queued',
+                project_id  TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            INSERT OR IGNORE INTO runtime_schema_version (version, description)
+            VALUES (10, 'test-fixture');
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _build_four_project_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    """Build 4 minimal source projects and write a registry JSON.
+
+    Returns (registry_path, backup_base).
+    """
+    specs = []
+    project_ids = ["proj-a", "proj-b", "proj-c", "proj-d"]
+
+    for pid in project_ids:
+        proj_dir = tmp_path / pid
+        state_dir = proj_dir / ".vnx-data" / "state"
+
+        _make_source_qi_db(state_dir / "quality_intelligence.db", pid)
+        _make_source_rc_db(state_dir / "runtime_coordination.db", pid)
+        specs.append({"name": pid, "path": str(proj_dir), "project_id": pid})
+
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({"schema_version": 1, "projects": specs}))
+
+    backup_base = tmp_path / "backups"
+    backup_base.mkdir()
+
+    return registry, backup_base
+
+
+def _run_fresh_central(
+    tmp_path: Path,
+    registry: Path,
+    backup_base: Path,
+    *,
+    extra_args: list[str] | None = None,
+) -> tuple[int, Path, Path]:
+    """Invoke M.main with --fresh-central against an empty central state dir.
+
+    Returns (exit_code, central_qi_path, central_rc_path).
+    """
+    central_state = tmp_path / "central" / "state"
+    # Do NOT pre-create central_state — the migrator must handle a missing dir.
+
+    cmd = [
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        "--fresh-central",
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    rc = M.main(cmd)
+    return rc, central_state / "quality_intelligence.db", central_state / "runtime_coordination.db"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: full fresh-central run
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_central_exits_zero(tmp_path, monkeypatch):
+    """--fresh-central apply against a missing central dir must exit 0."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, _, _ = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0, "Expected exit 0 from fresh-central apply"
+
+
+def test_fresh_central_dispatch_metadata_has_all_project_ids(tmp_path, monkeypatch):
+    """Central dispatch_metadata must contain rows for all 4 project_ids after fresh-central."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, qi_db, _ = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0, f"Migration failed with exit code {rc}"
+    assert qi_db.exists(), "Central quality_intelligence.db missing after migration"
+
+    con = sqlite3.connect(str(qi_db))
+    try:
+        project_ids = sorted(
+            r[0]
+            for r in con.execute(
+                "SELECT DISTINCT project_id FROM dispatch_metadata ORDER BY project_id"
+            )
+        )
+    finally:
+        con.close()
+
+    assert project_ids == ["proj-a", "proj-b", "proj-c", "proj-d"], (
+        f"Expected 4 project_ids in dispatch_metadata, got: {project_ids}"
+    )
+
+
+def test_fresh_central_dispatch_metadata_row_count(tmp_path, monkeypatch):
+    """Each of the 4 projects inserts 3 rows; central must have 12 total."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, qi_db, _ = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0
+    con = sqlite3.connect(str(qi_db))
+    try:
+        total = con.execute("SELECT COUNT(*) FROM dispatch_metadata").fetchone()[0]
+    finally:
+        con.close()
+
+    assert total == 12, f"Expected 12 rows in central dispatch_metadata (4 projects × 3), got {total}"
+
+
+def test_fresh_central_dispatch_metadata_table_exists_post_bootstrap(tmp_path, monkeypatch):
+    """dispatch_metadata must exist in the central QI DB after the bootstrap phase.
+
+    This directly tests the regression: before the fix, the bootstrap would
+    fail with 'no such column: project_id' during coordination_db.init_schema
+    (v10 CREATE INDEX on project_id that did not exist yet). After the fix,
+    bootstrap completes and dispatch_metadata is present.
+    """
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, qi_db, _ = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0, "Fresh-central migration must not fail with schema-order error"
+
+    con = sqlite3.connect(str(qi_db))
+    try:
+        row = con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dispatch_metadata'"
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert row is not None, "dispatch_metadata table absent from central QI DB post-bootstrap"
+
+
+def test_fresh_central_project_id_column_in_dispatch_metadata(tmp_path, monkeypatch):
+    """dispatch_metadata must have a project_id column after migration 0010 runs."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, qi_db, _ = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0
+    con = sqlite3.connect(str(qi_db))
+    try:
+        columns = [r[1] for r in con.execute("PRAGMA table_info(dispatch_metadata)")]
+    finally:
+        con.close()
+
+    assert "project_id" in columns, (
+        f"project_id column missing from dispatch_metadata after migration 0010; "
+        f"columns present: {columns}"
+    )
+
+
+def test_fresh_central_central_rc_has_dispatches_table(tmp_path, monkeypatch):
+    """Central runtime_coordination.db must have dispatches table after bootstrap."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, _, rc_db = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0
+    assert rc_db.exists(), "Central runtime_coordination.db missing after migration"
+
+    con = sqlite3.connect(str(rc_db))
+    try:
+        row = con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dispatches'"
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert row is not None, "dispatches table absent from central RC DB post-bootstrap"
+
+
+def test_fresh_central_rc_project_id_column_in_dispatches(tmp_path, monkeypatch):
+    """dispatches must have project_id column in central RC DB after migration 0010."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc, _, rc_db = _run_fresh_central(tmp_path, registry, backup_base)
+
+    assert rc == 0
+    con = sqlite3.connect(str(rc_db))
+    try:
+        columns = [r[1] for r in con.execute("PRAGMA table_info(dispatches)")]
+    finally:
+        con.close()
+
+    assert "project_id" in columns, (
+        f"project_id column missing from dispatches in central RC DB; "
+        f"columns present: {columns}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard: without --fresh-central on an empty central, migrator must refuse
+# ---------------------------------------------------------------------------
+
+
+def test_missing_fresh_central_flag_refuses_empty_dir(tmp_path, monkeypatch):
+    """Omitting --fresh-central on a missing central state dir must return exit 1.
+
+    The operator-acknowledgement gate prevents accidental first-deploy wipes.
+    """
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+    central_state = tmp_path / "no-central-yet" / "state"
+    # Deliberately NOT pre-creating central_state so it is genuinely empty/missing.
+
+    rc = M.main([
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        # --fresh-central intentionally OMITTED
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ])
+
+    assert rc == 1, (
+        "Expected exit 1 when --fresh-central is omitted on an empty central dir"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: fresh-central run followed by a second apply is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_central_idempotent_second_apply(tmp_path, monkeypatch):
+    """A second --apply on an already-bootstrapped central must be a clean no-op.
+
+    After the first fresh-central run, the sentinel tables exist and the
+    central is no longer fresh. The second run goes through the normal
+    (non-fresh) path; it must still exit 0 and not duplicate rows.
+    """
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+    registry, backup_base = _build_four_project_fixture(tmp_path)
+
+    rc1, qi_db, _ = _run_fresh_central(tmp_path, registry, backup_base)
+    assert rc1 == 0, "First fresh-central apply must succeed"
+
+    con = sqlite3.connect(str(qi_db))
+    try:
+        count_after_run1 = con.execute("SELECT COUNT(*) FROM dispatch_metadata").fetchone()[0]
+    finally:
+        con.close()
+
+    # Second run: central is no longer fresh, so --fresh-central is not needed.
+    central_state = tmp_path / "central" / "state"
+    rc2 = M.main([
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ])
+    assert rc2 == 0, "Second apply on already-bootstrapped central must exit 0"
+
+    con = sqlite3.connect(str(qi_db))
+    try:
+        count_after_run2 = con.execute("SELECT COUNT(*) FROM dispatch_metadata").fetchone()[0]
+    finally:
+        con.close()
+
+    assert count_after_run1 == count_after_run2, (
+        f"Row count changed between run 1 ({count_after_run1}) "
+        f"and run 2 ({count_after_run2}); second run is not idempotent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema-order regression: v10 indexes must not reference project_id directly
+# ---------------------------------------------------------------------------
+
+
+def test_v10_schema_no_project_id_indexes_before_migration_0010(tmp_path):
+    """runtime_coordination_v10.sql must not CREATE INDEX on project_id columns.
+
+    This is the direct regression guard. Verifies that the schema file does
+    not contain active (non-comment) CREATE INDEX statements referencing
+    project_id columns that don't exist during init_schema phase.
+
+    Before the fix, the file contained four such statements:
+        CREATE INDEX IF NOT EXISTS idx_lease_project ON terminal_leases(project_id);
+        CREATE INDEX IF NOT EXISTS idx_lease_terminal_project ON terminal_leases(terminal_id, project_id);
+        CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
+        CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
+
+    These caused 'no such column: project_id' on fresh installs. After the fix,
+    the index names only appear in comments; the SQL statements are absent.
+    """
+    import re
+
+    v10_path = ROOT / "schemas" / "runtime_coordination_v10.sql"
+    assert v10_path.exists(), f"v10 schema file not found at {v10_path}"
+
+    # Strip comments before scanning for CREATE INDEX on project_id.
+    # Comments in the file use -- (single-line only; no block comments in these files).
+    non_comment_lines = [
+        line for line in v10_path.read_text().splitlines()
+        if not line.lstrip().startswith("--")
+    ]
+    non_comment_sql = "\n".join(non_comment_lines)
+
+    # Any CREATE INDEX whose column list contains 'project_id' is forbidden.
+    # Pattern: CREATE [UNIQUE] INDEX [IF NOT EXISTS] name ON table(...project_id...)
+    bad_indexes = re.findall(
+        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+[^\n]+\(\s*[^)]*\bproject_id\b[^)]*\)",
+        non_comment_sql,
+        re.IGNORECASE,
+    )
+    assert not bad_indexes, (
+        f"runtime_coordination_v10.sql contains active CREATE INDEX statements "
+        f"referencing project_id. These cause 'no such column: project_id' on "
+        f"fresh installs because project_id is added by migration 0010 AFTER "
+        f"coordination_db.init_schema completes. Offending statements: {bad_indexes}"
+    )
+
+
+def test_v10_schema_is_valid_sqlite_on_fresh_db(tmp_path):
+    """Apply v1 + v10 sequentially on a fresh DB; must not raise OperationalError.
+
+    Before the fix: applying v10 after v1 would fail with
+    'no such column: project_id' during CREATE INDEX execution.
+    After the fix: both files apply cleanly.
+    """
+    rc_db = tmp_path / "runtime_coordination.db"
+    v1_sql = (ROOT / "schemas" / "runtime_coordination.sql").read_text()
+    v10_sql = (ROOT / "schemas" / "runtime_coordination_v10.sql").read_text()
+
+    con = sqlite3.connect(str(rc_db))
+    try:
+        con.executescript(v1_sql)
+        # This was the failing line before the fix.
+        con.executescript(v10_sql)
+    except sqlite3.OperationalError as exc:
+        pytest.fail(
+            f"runtime_coordination_v10.sql failed on a fresh DB after v1: {exc}. "
+            f"This is the schema-order bug. Check for CREATE INDEX on project_id "
+            f"columns that do not yet exist."
+        )
+    finally:
+        con.close()

--- a/tests/test_project_id_migration.py
+++ b/tests/test_project_id_migration.py
@@ -337,7 +337,24 @@ def test_runtime_schema_version_bumped(tmp_path: Path) -> None:
         latest = conn.execute(
             "SELECT MAX(version) FROM runtime_schema_version"
         ).fetchone()[0]
-        assert latest == RUNTIME_SCHEMA_VERSION == 10
+        # Migration 0010 stamps RUNTIME_SCHEMA_VERSION (10) into
+        # runtime_schema_version. The schema bootstrap (init_schema via
+        # runtime_coordination_v10.sql) also inserts version 12 for the
+        # Wave 5 PR-5.3 multi-tenant composite UNIQUE changes.
+        # Assert that the migration-0010 target version is present AND
+        # that the latest version is at least that — accommodating the
+        # bootstrap's higher version stamp.
+        row = conn.execute(
+            "SELECT 1 FROM runtime_schema_version WHERE version = ?",
+            (RUNTIME_SCHEMA_VERSION,),
+        ).fetchone()
+        assert row is not None, (
+            f"runtime_schema_version row for migration-0010 target "
+            f"(version={RUNTIME_SCHEMA_VERSION}) missing after migration"
+        )
+        assert latest >= RUNTIME_SCHEMA_VERSION, (
+            f"MAX(version) {latest} < RUNTIME_SCHEMA_VERSION {RUNTIME_SCHEMA_VERSION}"
+        )
     finally:
         conn.close()
 


### PR DESCRIPTION
## Root Cause

`runtime_coordination_v10.sql` contained four `CREATE INDEX` statements that reference `project_id` columns before migration 0010 has added them:

```sql
CREATE INDEX IF NOT EXISTS idx_lease_project ON terminal_leases(project_id);
CREATE INDEX IF NOT EXISTS idx_lease_terminal_project ON terminal_leases(terminal_id, project_id);
CREATE INDEX IF NOT EXISTS idx_dispatches_project ON dispatches(project_id);
CREATE INDEX IF NOT EXISTS idx_worker_states_project ON worker_states(project_id);
```

### Schema-order chain on a fresh `--fresh-central` install

1. `coordination_db.init_schema()` applies v1 through v10 sequentially
2. v1 creates `dispatches`, `terminal_leases` **without** `project_id`
3. v10's `CREATE TABLE IF NOT EXISTS` statements are **no-ops** (tables already exist from v1)
4. v10's `CREATE INDEX idx_lease_project ON terminal_leases(project_id)` → **OperationalError: no such column: project_id**

Migration 0010 adds `project_id` via `ALTER TABLE`, but it only runs **after** `init_schema` completes. The central DB stays at 4096 bytes (header only); no tables imported.

## Fix

Remove the four `project_id`-referencing `CREATE INDEX` statements from `runtime_coordination_v10.sql`. These indexes are already created by migrations 0010 and 0017 which always run post-bootstrap via the migrator.

## Files Changed

- **`schemas/runtime_coordination_v10.sql`** — remove 4 premature `project_id` indexes; add explanatory comments
- **`tests/test_migrate_to_central_vnx_fresh_central.py`** — 11 new tests covering the full `--fresh-central` happy path and regression guards
- **`tests/test_project_id_migration.py`** — fix stale `MAX(version) == 10` assertion (v10.sql bootstrap inserts version 12; test now checks version 10 is present AND latest >= 10)

## Test Evidence

```
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_exits_zero PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_dispatch_metadata_has_all_project_ids PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_dispatch_metadata_row_count PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_dispatch_metadata_table_exists_post_bootstrap PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_project_id_column_in_dispatch_metadata PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_central_rc_has_dispatches_table PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_rc_project_id_column_in_dispatches PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_missing_fresh_central_flag_refuses_empty_dir PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_fresh_central_idempotent_second_apply PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_v10_schema_no_project_id_indexes_before_migration_0010 PASSED
tests/test_migrate_to_central_vnx_fresh_central.py::test_v10_schema_is_valid_sqlite_on_fresh_db PASSED
11 passed in 1.20s
```

Migration-related suite: **156 passed, 0 failed**.

## Operator Runbook (re-run after merge)

See `claudedocs/runbook-fresh-central-migration-2026-05-24.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)