### PR TITLE
fix(wave2a): env isolation check + runbook v3 (PR-WAVE2A-5)

### DIFF
--- a/scripts/check_env_isolation.sh
+++ b/scripts/check_env_isolation.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# check_env_isolation.sh — Detect cross-repo VNX env contamination.
+#
+# Checks whether VNX_* env vars in the current shell belong to a different
+# project than the current working directory. Prints a WARNING table per
+# leaked var and outputs actionable unset commands.
+#
+# Exit codes:
+#   0 — no env leakage detected (clean)
+#   1 — one or more VNX_* vars appear to come from a different project
+#
+# Usage:
+#   bash scripts/check_env_isolation.sh
+#
+# No external dependencies — bash only (no Python, no jq, no awk).
+# Compatible with bash 3.2+ (macOS default).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Detect terminal color support; disable if not a TTY or $NO_COLOR set.
+if [[ ! -t 1 ]] || [[ -n "${NO_COLOR:-}" ]]; then
+    RED='' YELLOW='' GREEN='' BOLD='' RESET=''
+fi
+
+# ---------------------------------------------------------------------------
+# Determine current project root (git-based, with fallback to $PWD)
+# ---------------------------------------------------------------------------
+
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    CURRENT_ROOT="$(git rev-parse --show-toplevel)"
+else
+    CURRENT_ROOT="$PWD"
+fi
+
+CURRENT_PROJECT="$(basename "$CURRENT_ROOT")"
+
+# ---------------------------------------------------------------------------
+# VNX_* vars to inspect
+# ---------------------------------------------------------------------------
+
+VNX_VARS=(
+    VNX_DATA_DIR
+    VNX_HOME
+    VNX_STATE_DIR
+    VNX_SKILLS_DIR
+    VNX_PROJECT_ID
+    VNX_PROJECT_ROOT
+)
+
+# ---------------------------------------------------------------------------
+# Scan for leakage
+# ---------------------------------------------------------------------------
+
+LEAKED_VARS=()
+HEADER_PRINTED=0
+
+print_header() {
+    if [[ "$HEADER_PRINTED" -eq 0 ]]; then
+        echo ""
+        echo -e "${BOLD}VNX Environment Isolation Check${RESET}"
+        echo "  Current project : ${CURRENT_PROJECT}"
+        echo "  Project root    : ${CURRENT_ROOT}"
+        echo ""
+        printf "  %-25s %-50s %s\n" "Variable" "Current value" "Status"
+        printf "  %-25s %-50s %s\n" "-------------------------" "--------------------------------------------------" "--------"
+        HEADER_PRINTED=1
+    fi
+}
+
+for var in "${VNX_VARS[@]}"; do
+    val="${!var:-}"
+
+    if [[ -z "$val" ]]; then
+        # Not set — no leakage possible.
+        continue
+    fi
+
+    # Determine whether the value looks like it belongs to the current project.
+    # Strategy: value must contain the current project name or current root as
+    # a path component. Both absolute-path vars and plain string vars (like
+    # VNX_PROJECT_ID) are handled.
+    LOOKS_FOREIGN=0
+
+    # Only flag absolute paths (starting with '/') that point to a different
+    # project root. Relative paths, IDs, and short names are always considered
+    # project-local — the real cross-repo contamination risk comes exclusively
+    # from absolute paths inherited from a different tmux pane.
+    if [[ "$val" == /* ]]; then
+        # Normalise to remove trailing slashes before comparing.
+        val_norm="${val%/}"
+        root_norm="${CURRENT_ROOT%/}"
+        if [[ "$val_norm" != "$root_norm"* ]]; then
+            LOOKS_FOREIGN=1
+        fi
+    fi
+    # Non-absolute values (.vnx-data, .vnx-data/state, project-ids, etc.)
+    # are left with LOOKS_FOREIGN=0.
+
+    print_header
+
+    if [[ "$LOOKS_FOREIGN" -eq 1 ]]; then
+        # Truncate long values for display.
+        display_val="$val"
+        if [[ "${#display_val}" -gt 50 ]]; then
+            display_val="${display_val:0:47}..."
+        fi
+        printf "  ${YELLOW}%-25s${RESET} %-50s ${RED}LEAKED${RESET}\n" "$var" "$display_val"
+        LEAKED_VARS+=("$var")
+    else
+        display_val="$val"
+        if [[ "${#display_val}" -gt 50 ]]; then
+            display_val="${display_val:0:47}..."
+        fi
+        printf "  ${GREEN}%-25s${RESET} %-50s ${GREEN}ok${RESET}\n" "$var" "$display_val"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+if [[ "${#LEAKED_VARS[@]}" -eq 0 ]]; then
+    echo -e "${GREEN}[ok] No VNX env leakage detected — shell is clean for project: ${CURRENT_PROJECT}${RESET}"
+    exit 0
+fi
+
+echo ""
+echo -e "${RED}${BOLD}[WARN] Env leakage detected: ${#LEAKED_VARS[@]} VNX_* var(s) appear to come from a different project.${RESET}"
+echo ""
+echo "  Risk: migrator may read the wrong state directory, producing incorrect"
+echo "  behaviour or silently skipping the intended central DB."
+echo ""
+echo -e "${BOLD}  Run the following before every migrator apply:${RESET}"
+echo ""
+
+# Build a single unset line for easy copy-paste.
+UNSET_CMD="unset"
+for var in "${LEAKED_VARS[@]}"; do
+    UNSET_CMD="$UNSET_CMD $var"
+done
+
+echo "    $UNSET_CMD"
+echo ""
+echo "  Then verify with:"
+echo "    bash scripts/check_env_isolation.sh"
+echo ""
+
+exit 1

--- a/scripts/migrate_to_central_vnx.py
+++ b/scripts/migrate_to_central_vnx.py
@@ -2566,6 +2566,23 @@ def main(argv: Iterable[str] | None = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
 
+    # Env isolation pre-flight: warn if VNX_DATA_DIR is set and does not
+    # match the --central-state argument.  This detects cross-repo env
+    # contamination (e.g. VNX_DATA_DIR inherited from a different tmux pane).
+    # WARN only — not abort — because the flag value always takes precedence
+    # over env vars in the migrator's own code paths.
+    _env_vnx_data_dir = os.environ.get("VNX_DATA_DIR", "")
+    if _env_vnx_data_dir:
+        _central_arg = str(args.central_state.expanduser().resolve())
+        _env_resolved = str(Path(_env_vnx_data_dir).expanduser().resolve()) if _env_vnx_data_dir else ""
+        if _env_resolved and _env_resolved != _central_arg:
+            LOG.warning(
+                "env leak detected: VNX_DATA_DIR=%s vs --central-state=%s. "
+                "Run scripts/check_env_isolation.sh for details.",
+                _env_vnx_data_dir,
+                args.central_state,
+            )
+
     registry_path = args.registry or _default_registry_path()
     try:
         projects = load_registry(registry_path)

--- a/tests/test_migrate_env_isolation.py
+++ b/tests/test_migrate_env_isolation.py
@@ -1,0 +1,326 @@
+"""Regression tests for env isolation pre-flight (PR-WAVE2A-5).
+
+Covers migrator WARN behaviour when VNX_DATA_DIR env var is set:
+
+  - No warning logged when VNX_DATA_DIR is unset
+  - No warning logged when VNX_DATA_DIR matches --central-state (same resolved path)
+  - WARNING logged when VNX_DATA_DIR points to a different project path
+  - WARNING message contains VNX_DATA_DIR value and --central-state value
+  - WARNING message references check_env_isolation.sh
+  - main() does NOT abort (still returns 0 or non-3) when env leak detected
+
+Also covers check_env_isolation.sh exit codes:
+
+  - Exit 0 when all VNX_* vars are unset
+  - Exit 1 when VNX_DATA_DIR is an absolute path from a different project
+  - Exit 0 when VNX_DATA_DIR matches the current project root
+  - Unset command printed on leak detection
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+from scripts import migrate_to_central_vnx as M  # noqa: E402
+from scripts.aggregator.build_central_view import ProjectEntry  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CHECK_SCRIPT = ROOT / "scripts" / "check_env_isolation.sh"
+
+
+def _make_qi_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(
+            """
+            CREATE TABLE success_patterns (
+                id INTEGER PRIMARY KEY,
+                pattern_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                pattern_data TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            CREATE TABLE pattern_usage (
+                pattern_id TEXT PRIMARY KEY,
+                pattern_title TEXT NOT NULL,
+                pattern_hash TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _make_rc_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(
+            """
+            CREATE TABLE runtime_schema_version (
+                version INTEGER PRIMARY KEY,
+                description TEXT
+            );
+            CREATE TABLE dispatches (
+                dispatch_id TEXT PRIMARY KEY,
+                state TEXT,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            INSERT INTO runtime_schema_version (version, description) VALUES (10, 'phase-0');
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def env_isolation_fixture(tmp_path, monkeypatch):
+    """Minimal env for testing env pre-flight in main()."""
+    backup_base = tmp_path / "backups"
+    backup_base.mkdir()
+
+    abort_dir = tmp_path / ".vnx-aggregator"
+    abort_dir.mkdir()
+    monkeypatch.setattr(M, "ABORT_FLAG", abort_dir / "ABORT")
+
+    central_state = tmp_path / "central" / "state"
+    central_state.mkdir(parents=True)
+
+    # Single project
+    proj = tmp_path / "proj-alpha"
+    state = proj / ".vnx-data" / "state"
+    _make_qi_db(state / "quality_intelligence.db")
+    _make_rc_db(state / "runtime_coordination.db")
+    specs = [{"name": "proj-alpha", "path": str(proj), "project_id": "proj-alpha"}]
+
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({"schema_version": 1, "projects": specs}))
+
+    return {
+        "tmp_path": tmp_path,
+        "backup_base": backup_base,
+        "central_state": central_state,
+        "registry": registry,
+    }
+
+
+def _run_main_dry(env: dict, extra_env: dict | None = None) -> tuple[int, list[logging.LogRecord]]:
+    """Run main() in dry-run mode; return (exit_code, log_records).
+
+    Passes --central-state so the env-leak comparison is made against the
+    fixture's central state dir, not the real default ~/.vnx-data/state.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _CapturingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # type: ignore[override]
+            records.append(record)
+
+    handler = _CapturingHandler(level=logging.DEBUG)
+    logger = logging.getLogger("vnx.migrate.apply")
+    logger.addHandler(handler)
+
+    # Patch env for this call
+    orig_env = {k: os.environ.get(k) for k in (extra_env or {})}
+    try:
+        if extra_env:
+            for k, v in extra_env.items():
+                os.environ[k] = v
+
+        # Dry-run just calls migrate_dry_run — intercept at subprocess.call level
+        import unittest.mock as mock
+        with mock.patch("subprocess.call", return_value=0):
+            rc = M.main([
+                "--registry", str(env["registry"]),
+                "--central-state", str(env["central_state"]),
+                # No --apply → dry-run mode; env check runs before subprocess.call
+            ])
+    finally:
+        logger.removeHandler(handler)
+        for k, orig in orig_env.items():
+            if orig is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = orig
+
+    return rc, records
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: env pre-flight WARN logic in main()
+# ---------------------------------------------------------------------------
+
+
+class TestMigratorEnvPreFlight:
+    def test_no_warn_when_env_var_unset(self, env_isolation_fixture, monkeypatch):
+        """No WARNING logged when VNX_DATA_DIR is not set."""
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+        env = env_isolation_fixture
+
+        _, records = _run_main_dry(env)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING and "env leak" in r.getMessage().lower()]
+        assert warn_records == [], f"Expected no env-leak warning. Got: {[r.getMessage() for r in warn_records]}"
+
+    def test_no_warn_when_env_matches_central_state(self, env_isolation_fixture, monkeypatch):
+        """No WARNING when VNX_DATA_DIR resolves to the same path as --central-state."""
+        env = env_isolation_fixture
+        # Set VNX_DATA_DIR to the same central_state path the migrator will use.
+        monkeypatch.setenv("VNX_DATA_DIR", str(env["central_state"]))
+
+        _, records = _run_main_dry(env)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING and "env leak" in r.getMessage().lower()]
+        assert warn_records == [], f"Expected no env-leak warning when paths match. Got: {[r.getMessage() for r in warn_records]}"
+
+    def test_warn_logged_on_mismatch(self, env_isolation_fixture, monkeypatch, tmp_path):
+        """WARNING logged when VNX_DATA_DIR points to a different path than --central-state."""
+        env = env_isolation_fixture
+        foreign_path = tmp_path / "other-project" / ".vnx-data"
+        foreign_path.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(foreign_path))
+
+        _, records = _run_main_dry(env)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING and "env leak" in r.getMessage().lower()]
+        assert warn_records, "Expected at least one env-leak WARNING log record."
+
+    def test_warn_message_contains_env_value(self, env_isolation_fixture, monkeypatch, tmp_path):
+        """WARNING message includes the value of VNX_DATA_DIR."""
+        env = env_isolation_fixture
+        foreign_path = tmp_path / "seocrawler-v2" / ".vnx-data"
+        foreign_path.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(foreign_path))
+
+        _, records = _run_main_dry(env)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING and "env leak" in r.getMessage().lower()]
+        assert warn_records, "Expected env-leak WARNING."
+        msg = warn_records[0].getMessage()
+        assert str(foreign_path) in msg, f"Expected VNX_DATA_DIR value in message. Got: {msg!r}"
+
+    def test_warn_message_references_check_script(self, env_isolation_fixture, monkeypatch, tmp_path):
+        """WARNING message references check_env_isolation.sh."""
+        env = env_isolation_fixture
+        foreign_path = tmp_path / "other-project" / ".vnx-data"
+        foreign_path.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(foreign_path))
+
+        _, records = _run_main_dry(env)
+        warn_records = [r for r in records if r.levelno >= logging.WARNING and "env leak" in r.getMessage().lower()]
+        assert warn_records, "Expected env-leak WARNING."
+        msg = warn_records[0].getMessage()
+        assert "check_env_isolation.sh" in msg, f"Expected check_env_isolation.sh reference. Got: {msg!r}"
+
+    def test_no_abort_on_env_mismatch(self, env_isolation_fixture, monkeypatch, tmp_path):
+        """main() must NOT return exit code 3 (abort) due to env mismatch — WARN only."""
+        env = env_isolation_fixture
+        foreign_path = tmp_path / "other-project" / ".vnx-data"
+        foreign_path.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(foreign_path))
+
+        import unittest.mock as mock
+        with mock.patch("subprocess.call", return_value=0):
+            rc = M.main(["--registry", str(env["registry"])])
+
+        # Env mismatch is WARN only — must not exit 3
+        assert rc != 3, f"main() returned 3 on env mismatch; env leak should only WARN, not abort."
+
+
+# ---------------------------------------------------------------------------
+# check_env_isolation.sh — exit code tests
+# ---------------------------------------------------------------------------
+
+
+def _run_check_script(env_override: dict | None = None) -> tuple[int, str]:
+    """Run check_env_isolation.sh with a clean environment + optional overrides.
+
+    Strips all VNX_* vars from the base env, then applies env_override on top.
+    Returns (exit_code, stdout).
+    """
+    # Start with a clean base: strip all VNX_* vars to avoid cross-test contamination.
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith("VNX_")}
+    if env_override:
+        clean_env.update(env_override)
+
+    result = subprocess.run(
+        ["bash", str(CHECK_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=clean_env,
+        cwd=str(ROOT),
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+class TestCheckEnvIsolationScript:
+    def test_exit_0_when_all_vars_unset(self):
+        """Exit 0 when no VNX_* vars are set — clean env."""
+        rc, output = _run_check_script()
+        assert rc == 0, f"Expected exit 0 for clean env. Got {rc}. Output: {output!r}"
+
+    def test_exit_1_when_foreign_vnx_data_dir(self, tmp_path):
+        """Exit 1 when VNX_DATA_DIR is an absolute path from a different project."""
+        foreign_dir = tmp_path / "seocrawler-v2" / ".vnx-data"
+        foreign_dir.mkdir(parents=True)
+        rc, output = _run_check_script({"VNX_DATA_DIR": str(foreign_dir)})
+        assert rc == 1, f"Expected exit 1 for foreign VNX_DATA_DIR. Got {rc}. Output: {output!r}"
+
+    def test_exit_1_when_foreign_vnx_home(self, tmp_path):
+        """Exit 1 when VNX_HOME is an absolute path from a different project."""
+        foreign_home = tmp_path / "other-project" / ".vnx"
+        foreign_home.mkdir(parents=True)
+        rc, output = _run_check_script({"VNX_HOME": str(foreign_home)})
+        assert rc == 1, f"Expected exit 1 for foreign VNX_HOME. Got {rc}. Output: {output!r}"
+
+    def test_exit_0_when_matching_project_path(self):
+        """Exit 0 when VNX_DATA_DIR points to the current project root's .vnx-data."""
+        matching_dir = str(ROOT / ".vnx-data")
+        rc, output = _run_check_script({"VNX_DATA_DIR": matching_dir})
+        assert rc == 0, f"Expected exit 0 when VNX_DATA_DIR matches project root. Got {rc}. Output: {output!r}"
+
+    def test_exit_0_for_relative_path_vars(self):
+        """Relative path values (e.g. .vnx-data/state) are treated as project-local — no leak."""
+        rc, output = _run_check_script({
+            "VNX_DATA_DIR": ".vnx-data",
+            "VNX_STATE_DIR": ".vnx-data/state",
+        })
+        assert rc == 0, f"Expected exit 0 for relative path vars. Got {rc}. Output: {output!r}"
+
+    def test_unset_command_in_output_on_leak(self, tmp_path):
+        """Output contains 'unset' command when leakage is detected."""
+        foreign_dir = tmp_path / "other-project" / ".vnx-data"
+        foreign_dir.mkdir(parents=True)
+        rc, output = _run_check_script({"VNX_DATA_DIR": str(foreign_dir)})
+        assert rc == 1
+        assert "unset" in output.lower(), f"Expected 'unset' command in output. Got: {output!r}"
+
+    def test_leaked_var_named_in_unset_output(self, tmp_path):
+        """The specific leaked var name appears in the unset command."""
+        foreign_dir = tmp_path / "different-project" / ".vnx-data"
+        foreign_dir.mkdir(parents=True)
+        rc, output = _run_check_script({"VNX_DATA_DIR": str(foreign_dir)})
+        assert rc == 1
+        assert "VNX_DATA_DIR" in output, f"Expected VNX_DATA_DIR in unset output. Got: {output!r}"
+
+    def test_script_is_executable(self):
+        """check_env_isolation.sh must have the executable bit set."""
+        mode = CHECK_SCRIPT.stat().st_mode
+        assert mode & 0o111, f"Expected executable bit on {CHECK_SCRIPT}. Mode: {oct(mode)}"


### PR DESCRIPTION
## Summary

PR-WAVE2A-5 from the Wave 2a Robust Pipeline blueprint.

Addresses issues B2 + D2: cross-repo env contamination (VNX_DATA_DIR/VNX_HOME inherited from a different tmux pane makes the migrator silently target the wrong state directory).

## Changes

### scripts/check_env_isolation.sh (new)
- Detects VNX_DATA_DIR, VNX_HOME, VNX_STATE_DIR, VNX_SKILLS_DIR, VNX_PROJECT_ID, VNX_PROJECT_ROOT set to absolute paths from a different project
- Prints WARNING table per leaked var with current value + status
- Outputs actionable `unset VNX_DATA_DIR VNX_HOME ...` command for copy-paste
- Exit 0 if clean, exit 1 if leakage detected
- Bash-only, no external dependencies (no Python, no jq)

### scripts/migrate_to_central_vnx.py
- Pre-flight env check in `main()`: if VNX_DATA_DIR is set and its resolved path != --central-state → log WARNING (not abort)
- Message: `env leak detected: VNX_DATA_DIR=<val> vs --central-state=<arg>. Run scripts/check_env_isolation.sh for details.`
- No abort — WARN only per spec

### tests/test_migrate_env_isolation.py (new, 14 tests)
- TestMigratorEnvPreFlight: 6 tests for migrator WARN logic
- TestCheckEnvIsolationScript: 8 tests for shell script exit codes and output

### claudedocs/runbook-fresh-central-migration-v3-2026-05-25.md (gitignored)
- V3 runbook superseding v1+v2
- Explicit `unset env vars` step (PF-2) as MANDATORY before every apply
- References `bash scripts/check_env_isolation.sh`
- Integrates --test-apply (PR #622), --project (PR #620), --cleanup-backups (PR #621), --fresh-central (PR #617)

## Test results

```
149 passed (135 existing + 14 new)
```

## Acceptance criteria

- [x] check_env_isolation.sh detects leak + actionable unset output
- [x] Migrator WARN when VNX_DATA_DIR mismatch (no abort)
- [x] Script executable + bash-only (no Python/jq dependencies)
- [x] 135 existing tests green, 14 new tests added

## Dependencies

No deps. Parallel with PR-WAVE2A-2 and PR-WAVE2A-3 (already merged as #620, #621).

Includes: PR #619, #620, #621, #622 already merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)