### PR TITLE
fix(wave2a-6): installer template-leak — no developer paths in install output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -167,6 +167,43 @@ log() {
   printf '%s\n' "$*"
 }
 
+# ── Template substitution ────────────────────────────────────────────────
+# Replace install-time placeholders in all installed text files.
+# Only substitutes the three install-time variables:
+#   {{USER_HOME}}        → $HOME (current user's home directory)
+#   {{VNX_PROJECT_ROOT}} → $TARGET_PROJECT_DIR (project being installed into)
+#   {{VNX_HOME}}         → $TARGET_VNX_DIR (.vnx/ directory in target project)
+#
+# Other {{...}} patterns (receipt templates, skill templates, etc.) are
+# left untouched. Uses atomic writes (tmp → rename) for safety.
+_substitute_install_templates() {
+  local target_dir="$1"
+  local user_home="$HOME"
+  local vnx_project_root="$TARGET_PROJECT_DIR"
+  local vnx_home="$TARGET_VNX_DIR"
+
+  while IFS= read -r -d '' file; do
+    # Skip files without any of our install-time placeholders.
+    # Use separate grep calls for portability (BSD grep on macOS lacks \| ERE alternation).
+    if ! grep -qF '{{USER_HOME}}' "$file" 2>/dev/null && \
+       ! grep -qF '{{VNX_PROJECT_ROOT}}' "$file" 2>/dev/null && \
+       ! grep -qF '{{VNX_HOME}}' "$file" 2>/dev/null; then
+      continue
+    fi
+    local tmp_file="${file}.vnx_install_tmp"
+    # Use | as sed delimiter to avoid conflicts with path separators in values
+    sed \
+      -e "s|{{USER_HOME}}|${user_home}|g" \
+      -e "s|{{VNX_PROJECT_ROOT}}|${vnx_project_root}|g" \
+      -e "s|{{VNX_HOME}}|${vnx_home}|g" \
+      "$file" > "$tmp_file" && mv "$tmp_file" "$file"
+  done < <(find "$target_dir" -type f \
+    \( -name '*.yml'     -o -name '*.yaml' -o -name '*.json' \
+       -o -name '*.sh'   -o -name '*.py'   -o -name '*.md'  \
+       -o -name '*.conf' -o -name '*.toml' -o -name '*.example' \) \
+    -print0 2>/dev/null)
+}
+
 copy_item() {
   local src="$1"
   local dst="$2"
@@ -325,6 +362,10 @@ install_docs
 
 chmod +x "$TARGET_VNX_DIR/bin/vnx"
 bootstrap_provider_skills
+
+# Substitute install-time template placeholders in all installed files.
+_substitute_install_templates "$TARGET_VNX_DIR"
+log "[install] Substituted install-time placeholders ({{USER_HOME}}, {{VNX_PROJECT_ROOT}}, {{VNX_HOME}})"
 
 # Persist origin URL for vnx update
 if git -C "$SRC_ROOT" remote get-url origin >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -176,11 +176,35 @@ log() {
 #
 # Other {{...}} patterns (receipt templates, skill templates, etc.) are
 # left untouched. Uses atomic writes (tmp → rename) for safety.
+
+# Escape a value for safe use as a sed s|...|REPLACEMENT|g string.
+# The characters &, |, and backslash have special meaning in the replacement
+# field and must be backslash-escaped before interpolation.
+_sed_escape() {
+  printf '%s' "$1" | sed 's/[&|\\]/\\&/g'
+}
+
 _substitute_install_templates() {
   local target_dir="$1"
   local user_home="$HOME"
   local vnx_project_root="$TARGET_PROJECT_DIR"
   local vnx_home="$TARGET_VNX_DIR"
+
+  # Escape replacement values so that special sed characters (&, |, \) in
+  # paths (e.g. /home/foo&bar or a path with a backslash) cannot corrupt the
+  # substituted output.
+  local user_home_esc vnx_project_root_esc vnx_home_esc
+  user_home_esc="$(_sed_escape "$user_home")"
+  vnx_project_root_esc="$(_sed_escape "$vnx_project_root")"
+  vnx_home_esc="$(_sed_escape "$vnx_home")"
+
+  # Build the extension filter as a bash array so no eval is needed and
+  # special characters in $target_dir cannot be interpreted as shell code.
+  local -a _scan_ext_args=(
+    -name '*.yml'  -o -name '*.yaml' -o -name '*.json'
+    -o -name '*.sh'   -o -name '*.py'   -o -name '*.md'
+    -o -name '*.conf' -o -name '*.toml' -o -name '*.example'
+  )
 
   while IFS= read -r -d '' file; do
     # Skip files without any of our install-time placeholders.
@@ -191,17 +215,14 @@ _substitute_install_templates() {
       continue
     fi
     local tmp_file="${file}.vnx_install_tmp"
-    # Use | as sed delimiter to avoid conflicts with path separators in values
+    # Use | as sed delimiter to avoid conflicts with / in path values.
+    # Replacement values are pre-escaped via _sed_escape.
     sed \
-      -e "s|{{USER_HOME}}|${user_home}|g" \
-      -e "s|{{VNX_PROJECT_ROOT}}|${vnx_project_root}|g" \
-      -e "s|{{VNX_HOME}}|${vnx_home}|g" \
+      -e "s|{{USER_HOME}}|${user_home_esc}|g" \
+      -e "s|{{VNX_PROJECT_ROOT}}|${vnx_project_root_esc}|g" \
+      -e "s|{{VNX_HOME}}|${vnx_home_esc}|g" \
       "$file" > "$tmp_file" && mv "$tmp_file" "$file"
-  done < <(find "$target_dir" -type f \
-    \( -name '*.yml'     -o -name '*.yaml' -o -name '*.json' \
-       -o -name '*.sh'   -o -name '*.py'   -o -name '*.md'  \
-       -o -name '*.conf' -o -name '*.toml' -o -name '*.example' \) \
-    -print0 2>/dev/null)
+  done < <(find "$target_dir" -type f \( "${_scan_ext_args[@]}" \) -print0 2>/dev/null)
 }
 
 copy_item() {

--- a/scripts/aggregator/projects.json.example
+++ b/scripts/aggregator/projects.json.example
@@ -1,48 +1,26 @@
 {
   "schema_version": 2,
-  "operator_id": "vincent-vd",
+  "operator_id": "your-operator-id",
   "projects": [
     {
-      "name": "vnx-roadmap-autopilot",
-      "project_id": "vnx-dev",
-      "path": "/Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt",
+      "name": "my-vnx-project",
+      "project_id": "my-project",
+      "path": "{{USER_HOME}}/Development/my-vnx-project",
       "layout": "vnx-data-state",
-      "registered_at": "2026-04-03T12:53:57.796283+00:00",
+      "registered_at": "2026-01-01T00:00:00+00:00",
       "agents": {
-        "orchestrator_id": "dev-T0",
+        "orchestrator_id": "my-project-T0",
         "agent_id": null
       }
     },
     {
-      "name": "mission-control",
-      "project_id": "mc",
-      "path": "/Users/vincentvandeth/Desktop/BUSINESS/development/mission-control",
+      "name": "project-two",
+      "project_id": "project-two",
+      "path": "{{USER_HOME}}/Development/project-two",
       "layout": "vnx-data-state",
-      "registered_at": "2026-05-06T00:00:00+00:00",
+      "registered_at": "2026-01-01T00:00:00+00:00",
       "agents": {
-        "orchestrator_id": "mc-T0",
-        "agent_id": null
-      }
-    },
-    {
-      "name": "sales-copilot",
-      "project_id": "sales-copilot",
-      "path": "/Users/vincentvandeth/Desktop/BUSINESS/development/sales-copilot",
-      "layout": "vnx-data-state",
-      "registered_at": "2026-05-06T00:00:00+00:00",
-      "agents": {
-        "orchestrator_id": "sales-T0",
-        "agent_id": null
-      }
-    },
-    {
-      "name": "SEOcrawler_v2",
-      "project_id": "seocrawler-v2",
-      "path": "/Users/vincentvandeth/Development/SEOcrawler_v2",
-      "layout": "vnx-data-state",
-      "registered_at": "2026-05-06T00:00:00+00:00",
-      "agents": {
-        "orchestrator_id": "seo-T0",
+        "orchestrator_id": "project-two-T0",
         "agent_id": null
       }
     }

--- a/scripts/check_installer_no_template_leak.sh
+++ b/scripts/check_installer_no_template_leak.sh
@@ -34,8 +34,13 @@ PLACEHOLDER_PATTERNS=(
     "{{VNX_HOME}}"
 )
 
-# File extensions to scan
-SCAN_EXTENSIONS="-name '*.yml' -o -name '*.yaml' -o -name '*.json' -o -name '*.sh' -o -name '*.py' -o -name '*.md' -o -name '*.conf' -o -name '*.toml' -o -name '*.example'"
+# File extensions to scan — stored as an array so no eval is needed and
+# special characters in directory paths cannot be interpreted as shell code.
+SCAN_EXT_ARGS=(
+    -name '*.yml'   -o -name '*.yaml' -o -name '*.json'
+    -o -name '*.sh'    -o -name '*.py'   -o -name '*.md'
+    -o -name '*.conf'  -o -name '*.toml' -o -name '*.example'
+)
 
 # ── Prepare install dir ──────────────────────────────────────────────────────
 
@@ -74,7 +79,7 @@ scan_for_pattern() {
             echo "  VIOLATION [$label]: .vnx/$rel contains '$pattern'"
             VIOLATIONS=$((VIOLATIONS + 1))
         fi
-    done < <(eval "find '$dir' -type f \( $SCAN_EXTENSIONS \) -print0 2>/dev/null")
+    done < <(find "$dir" -type f \( "${SCAN_EXT_ARGS[@]}" \) -print0 2>/dev/null)
 }
 
 echo ""

--- a/scripts/check_installer_no_template_leak.sh
+++ b/scripts/check_installer_no_template_leak.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check_installer_no_template_leak.sh
+#
+# CI/CD gate: verifies that install.sh produces no developer-machine-specific
+# paths in the installed .vnx directory.
+#
+# Usage:
+#   bash scripts/check_installer_no_template_leak.sh [INSTALLED_VNX_DIR]
+#
+# If INSTALLED_VNX_DIR is not given, the script runs install.sh itself to a
+# temp directory and checks the output.
+#
+# Exit code 0: clean (no leaks). Exit code 1: violations found.
+#
+# Dispatch-ID: 20260525-083038-wave2a-6-installer-template-leak
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Patterns that must NEVER appear in installed output ──────────────────────
+
+# Hardcoded developer machine paths
+FORBIDDEN_PATTERNS=(
+    "/Users/vincentvandeth"
+    "vincent-vd"
+)
+
+# Install-time placeholders that must be substituted
+PLACEHOLDER_PATTERNS=(
+    "{{USER_HOME}}"
+    "{{VNX_PROJECT_ROOT}}"
+    "{{VNX_HOME}}"
+)
+
+# File extensions to scan
+SCAN_EXTENSIONS="-name '*.yml' -o -name '*.yaml' -o -name '*.json' -o -name '*.sh' -o -name '*.py' -o -name '*.md' -o -name '*.conf' -o -name '*.toml' -o -name '*.example'"
+
+# ── Prepare install dir ──────────────────────────────────────────────────────
+
+CLEANUP_TMPDIR=false
+if [ $# -ge 1 ] && [ -d "$1" ]; then
+    INSTALLED_VNX_DIR="$1"
+else
+    # Run install.sh to a fresh temp dir
+    TMP_PROJ="$(mktemp -d /tmp/vnx-leak-check-XXXXXX)"
+    CLEANUP_TMPDIR=true
+    FAKE_HOME="$(mktemp -d /tmp/vnx-leak-check-home-XXXXXX)"
+
+    echo "[check] Installing to $TMP_PROJ (HOME=$FAKE_HOME)..."
+    HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" "$TMP_PROJ" 2>/dev/null \
+        || { echo "[check] ERROR: install.sh failed"; exit 1; }
+
+    INSTALLED_VNX_DIR="$TMP_PROJ/.vnx"
+fi
+
+# ── Scan for violations ──────────────────────────────────────────────────────
+
+VIOLATIONS=0
+
+scan_for_pattern() {
+    local dir="$1"
+    local pattern="$2"
+    local label="$3"
+
+    while IFS= read -r -d '' file; do
+        # Skip this script itself — it legitimately contains the pattern strings
+        # as string constants for comparison purposes.
+        [ "$(basename "$file")" = "check_installer_no_template_leak.sh" ] && continue
+
+        if grep -qF "$pattern" "$file" 2>/dev/null; then
+            rel="${file#$dir/}"
+            echo "  VIOLATION [$label]: .vnx/$rel contains '$pattern'"
+            VIOLATIONS=$((VIOLATIONS + 1))
+        fi
+    done < <(eval "find '$dir' -type f \( $SCAN_EXTENSIONS \) -print0 2>/dev/null")
+}
+
+echo ""
+echo "VNX Installer Template-Leak Check"
+echo "────────────────────────────────────"
+echo "[check] Scanning: $INSTALLED_VNX_DIR"
+echo ""
+
+# Check forbidden developer paths
+echo "── Checking forbidden developer paths ──"
+for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+    scan_for_pattern "$INSTALLED_VNX_DIR" "$pattern" "developer-path"
+done
+
+# Check unsubstituted placeholders
+echo "── Checking unsubstituted placeholders ──"
+for ph in "${PLACEHOLDER_PATTERNS[@]}"; do
+    scan_for_pattern "$INSTALLED_VNX_DIR" "$ph" "unsubstituted-placeholder"
+done
+
+# ── Linux-only: /Users/ prefix check (macOS is legitimate) ──────────────────
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "── Checking /Users/ prefix (Linux CI only) ──"
+    scan_for_pattern "$INSTALLED_VNX_DIR" "/Users/" "macos-hardcoded-path"
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+if [ "$CLEANUP_TMPDIR" = true ]; then
+    rm -rf "${TMP_PROJ:-}" "${FAKE_HOME:-}" 2>/dev/null || true
+fi
+
+# ── Result ───────────────────────────────────────────────────────────────────
+echo ""
+if [ "$VIOLATIONS" -gt 0 ]; then
+    echo "FAILED — $VIOLATIONS violation(s) found in installed output."
+    echo "Fix: replace hardcoded paths with {{USER_HOME}}, {{VNX_PROJECT_ROOT}}, or {{VNX_HOME}} placeholders."
+    exit 1
+fi
+
+echo "PASSED — installer output is clean (no developer paths, no unsubstituted placeholders)."
+exit 0

--- a/scripts/vnx_doctor.sh
+++ b/scripts/vnx_doctor.sh
@@ -30,7 +30,8 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/vnx_install.py' \
     --glob '!**/commands/merge_preflight.sh' \
     --glob '!**/*.deprecated' \
-    --glob '!**/*.log' || true)
+    --glob '!**/*.log' \
+    --glob '!**/check_installer_no_template_leak.sh' || true)
   # Also check bin/vnx (no extension, so glob won't match it)
   if [ -f "$BIN_DIR/vnx" ]; then
     local_matches=$(rg -n "$PATTERN" "$BIN_DIR/vnx" || true)
@@ -56,7 +57,8 @@ else
     --exclude='vnx_install.py' \
     --exclude='merge_preflight.sh' \
     --exclude='*.deprecated' \
-    --exclude='*.log' || true)
+    --exclude='*.log' \
+    --exclude='check_installer_no_template_leak.sh' || true)
   # Also check bin/vnx
   if [ -f "$BIN_DIR/vnx" ]; then
     local_matches=$(grep -n -E "$PATTERN" "$BIN_DIR/vnx" || true)

--- a/tests/test_installer_no_template_leak.py
+++ b/tests/test_installer_no_template_leak.py
@@ -259,3 +259,110 @@ class TestInstallerOutputIsClean:
             "Hardcoded /Users/ paths found in installed output on non-macOS host:\n"
             + "\n".join(violations)
         )
+
+
+# ---------------------------------------------------------------------------
+# R2 regression tests — shell injection + sed escaping (PR-WAVE2A-6 R2)
+# ---------------------------------------------------------------------------
+
+class TestInstallerR2Security:
+    """Regression tests for the R2 codex findings:
+    - No eval in scan logic (array-based find)
+    - sed replacement values escape &, |, and backslash
+    """
+
+    def test_install_no_eval_in_scan_logic(self):
+        """install.sh must not use eval in the file-scan / find loop.
+
+        The codex blocking finding flagged shell injection via:
+          done < <(eval "find '$dir' -type f \\( $SCAN_EXTENSIONS \\) -print0")
+        The fix builds find args as a bash array and calls find directly.
+        This test greps the install.sh source for any eval usage inside the
+        _substitute_install_templates or surrounding scan context and asserts
+        none are present.
+        """
+        content = INSTALL_SH.read_text()
+
+        # Collect all lines that contain eval (case-sensitive).
+        eval_lines = [
+            (i + 1, line.rstrip())
+            for i, line in enumerate(content.splitlines())
+            if "eval" in line
+        ]
+
+        # Filter: allow eval that appears only in comments (lines whose first
+        # non-whitespace token is '#') or in test/documentation strings.
+        blocking = []
+        for lineno, line in eval_lines:
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue  # comment — allowed
+            blocking.append(f"install.sh:{lineno}: {line}")
+
+        assert not blocking, (
+            "eval found in non-comment install.sh lines — "
+            "scan logic must use array-based find, not eval:\n"
+            + "\n".join(blocking)
+        )
+
+    def test_install_path_with_special_chars(self, tmp_path):
+        """install.sh must handle project paths that contain &, backslash, and |.
+
+        These characters have special meaning in sed replacement strings.
+        Without _sed_escape(), a HOME like /tmp/foo&bar would corrupt the
+        substituted output.  This test verifies that substitution produces the
+        literal path value in the installed file, not a garbled replacement.
+        """
+        # Build a target directory at a clean tmp path (no special chars in
+        # the FS path itself — OS constraints prevent | in dir names on macOS/Linux).
+        # We test escaping by injecting the special chars into a fake HOME value
+        # via the environment, which maps to {{USER_HOME}} in templates.
+        #
+        # Use a fake HOME whose string representation contains &.
+        # NOTE: the OS path itself cannot literally contain |, but we can still
+        # exercise the _sed_escape path by crafting the env HOME value.
+        # We verify via a simple template file placed in the install target.
+
+        # Create a minimal stub target that has a file with the placeholder.
+        fake_home_str = str(tmp_path / "home&special")
+        target = tmp_path / "target_project"
+        target.mkdir()
+        vnx_dir = target / ".vnx"
+        vnx_dir.mkdir()
+        # Place a stub template file that contains the placeholder.
+        stub_dir = vnx_dir / "scripts"
+        stub_dir.mkdir()
+        stub_file = stub_dir / "stub.conf"
+        stub_file.write_text("home_dir={{USER_HOME}}\n")
+
+        # Run install.sh into the target (install.sh also writes its own files,
+        # but we only care that our stub is not corrupted).
+        env = dict(os.environ)
+        env["HOME"] = fake_home_str
+        result = subprocess.run(
+            ["bash", str(INSTALL_SH), str(target)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        # install.sh may exit non-zero for unrelated reasons (e.g. git remote),
+        # but the substitution must have run.  Check the stub file directly.
+        # Locate the stub in the installed .vnx/scripts/.
+        installed_stub = target / ".vnx" / "scripts" / "stub.conf"
+        if not installed_stub.exists():
+            # install.sh overwrites the .vnx dir — look for stub at alternate path.
+            installed_stub = stub_file
+
+        if not installed_stub.exists():
+            pytest.skip("Stub file not present after install — install layout may differ")
+
+        content = installed_stub.read_text()
+        # The substitution must produce the literal fake_home_str (with &).
+        # If _sed_escape is missing, & would expand to the matched text (/tmp/.../home)
+        # and the result would NOT equal fake_home_str.
+        assert f"home_dir={fake_home_str}" in content, (
+            f"Expected literal home path '{fake_home_str}' after {{{{USER_HOME}}}} substitution.\n"
+            f"Got file content:\n{content}\n"
+            "& in path was likely not escaped — _sed_escape may not be applied."
+        )

--- a/tests/test_installer_no_template_leak.py
+++ b/tests/test_installer_no_template_leak.py
@@ -24,6 +24,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 INSTALL_SH = REPO_ROOT / "install.sh"
+CHECKER_SH = REPO_ROOT / "scripts" / "check_installer_no_template_leak.sh"
 
 # Paths that must never appear hardcoded in shipped template files.
 # These are developer-machine-specific strings.
@@ -302,6 +303,36 @@ class TestInstallerR2Security:
         assert not blocking, (
             "eval found in non-comment install.sh lines — "
             "scan logic must use array-based find, not eval:\n"
+            + "\n".join(blocking)
+        )
+
+    def test_checker_no_eval_in_scan_logic(self):
+        """check_installer_no_template_leak.sh must not use eval in scan logic.
+
+        R3 codex finding: the CI gate script introduced the same shell-injection
+        anti-pattern as install.sh R1:
+          done < <(eval "find '$dir' -type f \\( $SCAN_EXTENSIONS \\) -print0")
+        The fix replaces the string variable with a bash array (SCAN_EXT_ARGS)
+        and calls find directly — no eval anywhere in scan logic.
+        """
+        content = CHECKER_SH.read_text()
+
+        eval_lines = [
+            (i + 1, line.rstrip())
+            for i, line in enumerate(content.splitlines())
+            if "eval" in line
+        ]
+
+        blocking = []
+        for lineno, line in eval_lines:
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue  # comment — allowed
+            blocking.append(f"check_installer_no_template_leak.sh:{lineno}: {line}")
+
+        assert not blocking, (
+            "eval found in non-comment lines of check_installer_no_template_leak.sh — "
+            "scan logic must use array-based find (SCAN_EXT_ARGS), not eval:\n"
             + "\n".join(blocking)
         )
 

--- a/tests/test_installer_no_template_leak.py
+++ b/tests/test_installer_no_template_leak.py
@@ -1,0 +1,261 @@
+"""Installer template-leak tests — PR-WAVE2A-6.
+
+Verifies that install.sh ships no developer-machine-specific paths into target
+projects, and that all install-time {{PLACEHOLDER}} variables are substituted.
+
+Design:
+- Source check: shipped source files must not contain hardcoded developer paths.
+- Install check: run install.sh with a controlled HOME to verify clean output.
+  Using HOME=/tmp/vnx-test-home-<pid> makes the test deterministic on any OS.
+  On CI (Ubuntu), real HOME=/home/runner also works — no /Users/ will appear.
+
+Dispatch-ID: 20260525-083038-wave2a-6-installer-template-leak
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+# Paths that must never appear hardcoded in shipped template files.
+# These are developer-machine-specific strings.
+HARDCODED_DEVELOPER_PATHS = [
+    "/Users/vincentvandeth",
+    "vincent-vd",          # personal operator_id used as default in example files
+]
+
+# File extensions to check in source/install dirs.
+TEXT_EXTENSIONS = {
+    ".yml", ".yaml", ".json", ".sh", ".py", ".md",
+    ".conf", ".toml", ".example",
+}
+
+# Source-repo directories whose contents are shipped to target projects.
+# Mirrors the SHIP_PATHS and DOCS_SHIP_DIRS lists in install.sh.
+SHIPPED_SOURCE_DIRS = [
+    "scripts",
+    "configs",
+    "templates",
+    "hooks",
+    "schemas",
+    "docs/core",
+    "docs/intelligence",
+    "docs/operations",
+    "docs/orchestration",
+    "docs/testing",
+]
+
+# Install-time placeholder variables that MUST be substituted before delivery.
+INSTALL_TIME_PLACEHOLDERS = [
+    "{{USER_HOME}}",
+    "{{VNX_PROJECT_ROOT}}",
+    "{{VNX_HOME}}",
+]
+
+# Files that legitimately contain the forbidden pattern strings as constants
+# for comparison/checking purposes — excluded from source and install scans.
+SCAN_SKIP_FILENAMES = {
+    "check_installer_no_template_leak.sh",  # checker script defines patterns
+    "test_installer_no_template_leak.py",   # test file defines patterns
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _text_files_in(directory: Path, *, skip_filenames: set[str] | None = None) -> list[Path]:
+    """Return all text files under *directory* with known text extensions.
+
+    Files whose ``name`` is in *skip_filenames* are excluded. Defaults to
+    ``SCAN_SKIP_FILENAMES`` which excludes checker/test files that
+    legitimately contain the forbidden pattern strings as string constants.
+    """
+    if skip_filenames is None:
+        skip_filenames = SCAN_SKIP_FILENAMES
+    result = []
+    if not directory.is_dir():
+        return result
+    for f in directory.rglob("*"):
+        if f.is_file() and f.suffix in TEXT_EXTENSIONS and f.name not in skip_filenames:
+            result.append(f)
+    return result
+
+
+def _read_safe(path: Path) -> str:
+    """Read file, ignoring decode errors (binary content is irrelevant)."""
+    try:
+        return path.read_text(errors="ignore")
+    except OSError:
+        return ""
+
+
+def _run_install(target_dir: Path, fake_home: Path) -> subprocess.CompletedProcess:
+    """Run install.sh with a controlled HOME for deterministic testing."""
+    env = dict(os.environ)
+    env["HOME"] = str(fake_home)
+    return subprocess.run(
+        ["bash", str(INSTALL_SH), str(target_dir)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-level checks (don't need install)
+# ---------------------------------------------------------------------------
+
+class TestSourceFilesHaveNoHardcodedPaths:
+    """Shipped source files must not contain developer-machine-specific paths."""
+
+    def test_no_developer_paths_in_shipped_sources(self):
+        """No hardcoded /Users/vincentvandeth or developer-specific IDs in source."""
+        violations: list[str] = []
+
+        for rel_dir in SHIPPED_SOURCE_DIRS:
+            directory = REPO_ROOT / rel_dir
+            for f in _text_files_in(directory):
+                content = _read_safe(f)
+                for pattern in HARDCODED_DEVELOPER_PATHS:
+                    if pattern in content:
+                        rel = f.relative_to(REPO_ROOT)
+                        violations.append(f"{rel}: contains '{pattern}'")
+
+        assert not violations, (
+            "Developer machine paths found in shipped source files — "
+            "replace with {{USER_HOME}} or a generic placeholder:\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_nvm_version_paths_hardcoded_in_scripts(self):
+        """Scripts must not contain hardcoded .nvm/versions/node/v<version> paths."""
+        # Dynamic $HOME/.nvm lookups are fine; hardcoded /Users/x/.nvm/versions/node/v20.x is not.
+        pattern = "/.nvm/versions/node/v"
+        violations: list[str] = []
+
+        for rel_dir in ["scripts", "templates", "hooks"]:
+            directory = REPO_ROOT / rel_dir
+            for f in _text_files_in(directory):
+                if f.suffix not in {".sh", ".py"}:
+                    continue
+                content = _read_safe(f)
+                # Allow occurrences inside grep PATTERN strings (vnx_doctor.sh defines the pattern itself)
+                for line in content.splitlines():
+                    if pattern in line:
+                        # Exclude lines that are defining/checking the forbidden pattern
+                        if "PATTERN=" in line or "grep" in line:
+                            continue
+                        rel = f.relative_to(REPO_ROOT)
+                        violations.append(f"{rel}: hardcoded nvm version path on line: {line.strip()}")
+
+        assert not violations, (
+            "Hardcoded .nvm/versions/node/v<version> paths found — "
+            "use $NVM_DIR or $HOME/.nvm instead:\n"
+            + "\n".join(violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Install-output checks
+# ---------------------------------------------------------------------------
+
+class TestInstallerOutputIsClean:
+    """install.sh output must be free of developer paths and unsubstituted placeholders."""
+
+    @pytest.fixture(scope="class")
+    def installed_dir(self, tmp_path_factory):
+        """Run install.sh once for the whole class; yield the .vnx install dir."""
+        target = tmp_path_factory.mktemp("install_target")
+        fake_home = tmp_path_factory.mktemp("fake_home")
+
+        result = _run_install(target, fake_home)
+        assert result.returncode == 0, (
+            f"install.sh failed (exit {result.returncode}).\n"
+            f"stdout: {result.stdout[-2000:]}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+        return target / ".vnx"
+
+    def test_no_developer_username_in_installed_files(self, installed_dir):
+        """No /Users/vincentvandeth or developer-specific IDs in installed output."""
+        violations: list[str] = []
+        for f in _text_files_in(installed_dir):
+            content = _read_safe(f)
+            for pattern in HARDCODED_DEVELOPER_PATHS:
+                if pattern in content:
+                    rel = f.relative_to(installed_dir)
+                    violations.append(f".vnx/{rel}: contains '{pattern}'")
+
+        assert not violations, (
+            "Developer machine paths leaked into installed output:\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_install_time_placeholders_remaining(self, installed_dir):
+        """{{USER_HOME}}, {{VNX_PROJECT_ROOT}}, {{VNX_HOME}} must all be substituted."""
+        violations: list[str] = []
+        for f in _text_files_in(installed_dir):
+            content = _read_safe(f)
+            for ph in INSTALL_TIME_PLACEHOLDERS:
+                if ph in content:
+                    rel = f.relative_to(installed_dir)
+                    violations.append(f".vnx/{rel}: unsubstituted {ph}")
+
+        assert not violations, (
+            "Unsubstituted install-time placeholders found — "
+            "install.sh substitution did not run or missed these files:\n"
+            + "\n".join(violations)
+        )
+
+    def test_projects_example_paths_use_fake_home(self, installed_dir, tmp_path_factory):
+        """projects.json.example paths must use the current HOME after install."""
+        # Run a fresh install with a known fake home to verify path derivation.
+        target = tmp_path_factory.mktemp("path_check_target")
+        fake_home = Path("/tmp/vnx-wave2a-test-home")
+
+        result = _run_install(target, fake_home)
+        assert result.returncode == 0, f"install.sh failed: {result.stderr[-1000:]}"
+
+        example = target / ".vnx" / "scripts" / "aggregator" / "projects.json.example"
+        assert example.exists(), "projects.json.example not found after install"
+
+        content = example.read_text()
+        data = json.loads(content)
+
+        for proj in data.get("projects", []):
+            path = proj.get("path", "")
+            assert str(fake_home) in path, (
+                f"Project path '{path}' does not contain fake HOME '{fake_home}'. "
+                "{{USER_HOME}} substitution may not have reached this file."
+            )
+
+    def test_no_users_prefix_on_linux_ci(self, installed_dir):
+        """On Linux CI (non-macOS), no /Users/ prefix should appear in installed files.
+
+        This test is skipped on macOS where /Users/ is the legitimate HOME prefix.
+        On GitHub Actions (ubuntu-latest), HOME=/home/runner — no /Users/ can appear
+        unless a path was hardcoded (not derived from $HOME).
+        """
+        if sys.platform == "darwin":
+            pytest.skip("On macOS, /Users/ is a legitimate HOME prefix — skip CI-only check")
+
+        violations: list[str] = []
+        for f in _text_files_in(installed_dir):
+            content = _read_safe(f)
+            if "/Users/" in content:
+                rel = f.relative_to(installed_dir)
+                violations.append(f".vnx/{rel}: contains '/Users/' (hardcoded macOS path?)")
+
+        assert not violations, (
+            "Hardcoded /Users/ paths found in installed output on non-macOS host:\n"
+            + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

PR-WAVE2A-6 — Installer Template-Leak Fix.

Fixes `install.sh` shipping developer-machine-specific paths into target projects.

## Root Cause

The `scripts/aggregator/projects.json.example` contained 4 hardcoded developer projects with literal `/Users/vincentvandeth` paths and `vincent-vd` operator_id. When install.sh copied these files, they landed verbatim in target projects, causing `vnx_doctor` path-hygiene failures on re-install.

## Changes

### `install.sh`
Added `_substitute_install_templates()` that runs post-copy on all installed text files:
- Replaces `{{USER_HOME}}` → `$HOME`
- Replaces `{{VNX_PROJECT_ROOT}}` → target project dir
- Replaces `{{VNX_HOME}}` → target `.vnx/` dir
- Uses atomic writes (`.vnx_install_tmp` → `mv`) for safety
- BSD grep-compatible (separate `-qF` calls, not ERE alternation)
- Skips binary and non-text files via extension filter

### `scripts/aggregator/projects.json.example`
Replaced 4 hardcoded developer entries with 2 generic template entries using `{{USER_HOME}}` placeholders and neutral project names (`my-vnx-project`, `project-two`).

### `scripts/check_installer_no_template_leak.sh` (new)
Standalone CI/CD gate script:
- Runs `install.sh` to a temp dir with `HOME=/tmp/vnx-...`
- Asserts no `/Users/vincentvandeth`, `vincent-vd`, or unsubstituted `{{...}}` in installed files
- Linux-only check for any `/Users/` prefix (CI gate)
- Excludes itself from scan (it defines the patterns as string constants)
- Callable from CI: `bash "$VNX_HOME/scripts/check_installer_no_template_leak.sh"`

### `tests/test_installer_no_template_leak.py` (new)
6-test suite (5 active + 1 CI-only skip on macOS):
- `test_no_developer_paths_in_shipped_sources` — source audit
- `test_no_nvm_version_paths_hardcoded_in_scripts` — nvm version path check
- `test_no_developer_username_in_installed_files` — install output audit
- `test_no_install_time_placeholders_remaining` — substitution completeness
- `test_projects_example_paths_use_fake_home` — `{{USER_HOME}}` roundtrip
- `test_no_users_prefix_on_linux_ci` — skipped on macOS, runs on Ubuntu CI

## Test Results

```
pytest tests/test_installer_no_template_leak.py tests/test_migrate*.py -q
154 passed, 1 skipped, 1 warning
```

## CI Note

`.github/workflows/public-ci.yml` already runs `install.sh` to a temp dir in the `smoke` job. To wire in the new gate, add after the existing install step:

```yaml
- name: Installer template-leak gate
  run: |
    bash ./scripts/check_installer_no_template_leak.sh
```

Or add `tests/test_installer_no_template_leak.py` to the profile-a pytest run in `vnx-ci.yml`. (Outside T1 write scope — documented for T0 follow-up.)

## Dispatch-ID

20260525-083038-wave2a-6-installer-template-leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)