### PR TITLE
feat(wave2a-8): housekeeping — stale session cleanup + runbook D3/D4

### DIFF
--- a/scripts/cleanup_stale_vnx_sessions.sh
+++ b/scripts/cleanup_stale_vnx_sessions.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# cleanup_stale_vnx_sessions.sh — detect and optionally kill stale VNX tmux sessions
+#
+# Usage: bash scripts/cleanup_stale_vnx_sessions.sh
+#
+# Finds tmux sessions starting with 'vnx-' that have been idle >7 days.
+# Prints a table, prompts for confirmation, then kills if confirmed.
+# Exit 0 on clean run (including no stale sessions found); 1 on error.
+
+set -euo pipefail
+
+STALE_DAYS=7
+SECONDS_PER_DAY=86400
+STALE_THRESHOLD=$(( STALE_DAYS * SECONDS_PER_DAY ))
+
+NOW=$(date +%s)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+die() { echo "[error] $*" >&2; exit 1; }
+
+check_tmux() {
+    if ! command -v tmux &>/dev/null; then
+        echo "[info] tmux not found — nothing to check."
+        exit 0
+    fi
+}
+
+list_vnx_sessions() {
+    # tmux list-sessions returns non-zero when no sessions exist
+    tmux list-sessions -F '#{session_name} #{session_activity}' 2>/dev/null \
+        | grep '^vnx-' \
+        || true   # empty output is fine; don't propagate non-zero from grep
+}
+
+days_idle() {
+    local activity_ts="$1"
+    local idle_s=$(( NOW - activity_ts ))
+    echo $(( idle_s / SECONDS_PER_DAY ))
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+check_tmux
+
+RAW=$(list_vnx_sessions)
+
+if [[ -z "$RAW" ]]; then
+    echo "[ok] No vnx-* tmux sessions found."
+    exit 0
+fi
+
+# Collect stale sessions into parallel arrays
+STALE_NAMES=()
+STALE_DAYS_IDLE=()
+
+while IFS= read -r line; do
+    session_name=$(echo "$line" | awk '{print $1}')
+    activity_ts=$(echo "$line"  | awk '{print $2}')
+
+    # Guard against non-numeric activity timestamp
+    if ! [[ "$activity_ts" =~ ^[0-9]+$ ]]; then
+        echo "[warn] Could not parse activity timestamp for session '$session_name' — skipping."
+        continue
+    fi
+
+    idle=$(days_idle "$activity_ts")
+
+    if (( idle >= STALE_DAYS )); then
+        STALE_NAMES+=("$session_name")
+        STALE_DAYS_IDLE+=("$idle")
+    fi
+done <<< "$RAW"
+
+if [[ ${#STALE_NAMES[@]} -eq 0 ]]; then
+    echo "[ok] No vnx-* sessions idle >${STALE_DAYS} days."
+    exit 0
+fi
+
+# Print table
+printf "\n%-40s %10s  %s\n" "SESSION" "IDLE (DAYS)" "SUGGESTED KILL"
+printf "%s\n" "$(printf '─%.0s' {1..75})"
+for i in "${!STALE_NAMES[@]}"; do
+    printf "%-40s %10s  tmux kill-session -t %s\n" \
+        "${STALE_NAMES[$i]}" \
+        "${STALE_DAYS_IDLE[$i]}" \
+        "${STALE_NAMES[$i]}"
+done
+printf "\n"
+
+N=${#STALE_NAMES[@]}
+
+# Prompt (default N — safe)
+read -r -p "Kill these $N session(s)? [y/N] " ANSWER </dev/tty || ANSWER="N"
+
+case "$ANSWER" in
+    [yY]|[yY][eE][sS])
+        echo ""
+        for name in "${STALE_NAMES[@]}"; do
+            if tmux kill-session -t "$name" 2>/dev/null; then
+                echo "[ok] Killed: $name"
+            else
+                echo "[warn] Could not kill '$name' (already gone?)."
+            fi
+        done
+        echo ""
+        echo "[done] ${N} session(s) processed."
+        ;;
+    *)
+        echo "[skip] No sessions killed."
+        ;;
+esac
+
+exit 0

--- a/tests/test_cleanup_stale_vnx_sessions.py
+++ b/tests/test_cleanup_stale_vnx_sessions.py
@@ -1,0 +1,260 @@
+"""
+tests/test_cleanup_stale_vnx_sessions.py
+
+Tests for scripts/cleanup_stale_vnx_sessions.sh
+
+Coverage:
+  - Script exists and is executable
+  - No kills without interactive prompt (dry-safe)
+  - Correct parsing of tmux list-sessions output
+  - Graceful handling when tmux is absent
+  - Graceful handling when no vnx-* sessions exist
+"""
+
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "cleanup_stale_vnx_sessions.sh"
+
+
+# ── existence + executable ───────────────────────────────────────────────────
+
+def test_script_exists():
+    assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+
+
+def test_script_is_executable():
+    mode = SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, "Script must be user-executable (chmod +x)"
+
+
+def test_script_syntax():
+    """bash -n must pass with exit code 0."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"Syntax error:\n{result.stderr}"
+
+
+# ── no-kill safety ───────────────────────────────────────────────────────────
+
+def test_no_kill_without_explicit_confirm(tmp_path):
+    """
+    When running non-interactively (stdin is /dev/null) the default answer
+    is 'N', so no tmux kill-session calls should happen.
+
+    We inject a fake `tmux` that reports one stale VNX session (activity
+    timestamp 0 = epoch 1970, so ~20 000 days idle). Then pipe empty stdin
+    to confirm default-N behaviour.
+    """
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent("""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "vnx-mission-control 0"
+        fi
+        # kill-session must NOT be called if user answered N
+        if [[ "$1" == "kill-session" ]]; then
+            echo "UNEXPECTED_KILL" >&2
+            exit 99
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,  # simulate no TTY / default N
+        capture_output=True,
+        text=True,
+    )
+
+    # Script must not have called kill-session
+    assert "UNEXPECTED_KILL" not in result.stderr, (
+        "kill-session was called without explicit y confirmation"
+    )
+    # Must exit cleanly (0)
+    assert result.returncode == 0, (
+        f"Unexpected non-zero exit:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    # Table must appear in stdout
+    assert "vnx-mission-control" in result.stdout
+
+
+def test_skip_message_on_default_no(tmp_path):
+    """Script prints '[skip] No sessions killed.' when user answers N."""
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent("""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "vnx-old-session 0"
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "[skip]" in result.stdout or result.returncode == 0
+
+
+# ── parser correctness ───────────────────────────────────────────────────────
+
+def test_fresh_session_not_listed_as_stale(tmp_path):
+    """
+    A session with activity timestamp = NOW should NOT appear in the stale list.
+    We use a timestamp far in the future (year 2100) to be safe.
+    """
+    import time
+    future_ts = int(time.time()) + 86400 * 365 * 75  # ~75 years from now
+
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent(f"""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "vnx-fresh-session {future_ts}"
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "vnx-fresh-session" not in result.stdout
+    # Should hit "no stale sessions" path
+    assert "No vnx-* sessions idle" in result.stdout or "[ok]" in result.stdout
+
+
+def test_non_vnx_session_not_listed(tmp_path):
+    """Sessions not starting with 'vnx-' must be ignored."""
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent("""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "main 0"
+            echo "work-session 0"
+            echo "vnx-stale-one 0"
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "main" not in result.stdout or "vnx-" not in "main"  # just that it is not in stale table
+    assert "work-session" not in result.stdout
+    assert "vnx-stale-one" in result.stdout
+
+
+# ── graceful edge cases ──────────────────────────────────────────────────────
+
+def test_no_vnx_sessions_exits_clean(tmp_path):
+    """When tmux returns no vnx-* sessions, script exits 0 with '[ok]' message."""
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent("""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "non-vnx-session 0"
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "[ok]" in result.stdout
+
+
+def test_tmux_not_found_exits_clean(tmp_path):
+    """If tmux is not on PATH, script exits 0 with an info message."""
+    import shutil
+
+    # Keep bash and core POSIX tools on PATH; remove tmux by not including its directory.
+    # We build a whitelist PATH that contains bash and standard POSIX dirs but NO tmux.
+    bash_dir = str(Path(shutil.which("bash")).parent)
+    # Standard POSIX dirs that contain date, awk, etc. but typically NOT tmux
+    safe_dirs = [bash_dir, "/bin", "/usr/bin"]
+    # Exclude any dir that contains tmux
+    tmux_path = shutil.which("tmux")
+    if tmux_path:
+        tmux_dir = str(Path(tmux_path).parent)
+        safe_dirs = [d for d in safe_dirs if d != tmux_dir]
+    restricted_path = ":".join(safe_dirs)
+
+    env = {**os.environ, "PATH": restricted_path}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "tmux not found" in result.stdout
+
+
+def test_invalid_timestamp_skipped(tmp_path):
+    """Sessions with non-numeric activity timestamps are skipped with a warning."""
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(textwrap.dedent("""\
+        #!/bin/bash
+        if [[ "$1 $2" == "list-sessions -F" ]]; then
+            echo "vnx-weird-session NOTANUMBER"
+        fi
+    """))
+    fake_tmux.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+    )
+
+    # Must not crash (exit 1 due to parse error is acceptable, but should not kill)
+    assert "UNEXPECTED_KILL" not in result.stderr
+    # Warning should be emitted
+    assert "[warn]" in result.stdout or result.returncode == 0


### PR DESCRIPTION
## Summary

PR-WAVE2A-8 operational housekeeping: D1 (stale tmux session cleanup script) + D3 (worktree-start PF step in runbook) + D4 (backup cleanup instructions in runbook).

## Changes

### [ok] No vnx-* sessions idle >7 days. (new)
- Detects  tmux sessions idle >7 days via 
- Prints table: session name + days idle + suggested kill command
- Prompts  — default N (no kill without explicit confirm)
- Kills only on explicit  answer
- Exits 0 clean / 1 on error; bash-only; executable

###  (updated, gitignored)
- **PF-0** (new): [worktree-start] Initializing isolated .vnx-data for worktree: /Users/vincentvandeth/Development/SEOcrawler_v2
[worktree-start] Found .vnx-intelligence/ in worktree — importing into SQLite...
[intelligence-import] Imported 147196 rows into 17 tables from /Users/vincentvandeth/Development/SEOcrawler_v2/.claude/vnx-system/.vnx-intelligence
[worktree-start] Isolated .vnx-data created: /Users/vincentvandeth/Development/SEOcrawler_v2/.vnx-data
[worktree-start] .env_override written for VNX_DATA_DIR isolation
[worktree-start] Done. Run 'vnx doctor' to verify. verification step — confirms  present and initialized before any migration work
- **PF-1b** (new): stale session hygiene step referencing 
- **PF-4** (expanded): backup sprawl check with 6.7G	/Users/vincentvandeth/Documents/vnx-pre-p4-auto-backup-20260524T172720969781Z
6.7G	/Users/vincentvandeth/Documents/vnx-pre-p4-auto-backup-20260524T181621853122Z
6.7G	/Users/vincentvandeth/Documents/vnx-pre-p4-auto-backup-20260524T182906536627Z
6.6G	/Users/vincentvandeth/Documents/vnx-pre-p4-auto-backup-20260524T192157566319Z
6.4G	/Users/vincentvandeth/Documents/vnx-pre-p4-auto-backup-20260525T035053506070Z +  reference (PR-WAVE2A-3)
- Post-apply section: backup cleanup step + stale session cleanup step added

###  (new)
10 tests; all pass:
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## Acceptance criteria

- [x]  shows stale sessions + asks y/N before kill
- [x] Runbook v3 contains [worktree-start] Initializing isolated .vnx-data for worktree: /Users/vincentvandeth/Development/SEOcrawler_v2
[worktree-start] Found .vnx-intelligence/ in worktree — importing into SQLite...
[intelligence-import] Imported 147196 rows into 17 tables from /Users/vincentvandeth/Development/SEOcrawler_v2/.claude/vnx-system/.vnx-intelligence
[worktree-start] Isolated .vnx-data created: /Users/vincentvandeth/Development/SEOcrawler_v2/.vnx-data
[worktree-start] .env_override written for VNX_DATA_DIR isolation
[worktree-start] Done. Run 'vnx doctor' to verify. as step PF-0
- [x] Runbook v3 contains backup sprawl check +  reference
- [x] No actual kills during scripted dispatch (stdin=DEVNULL → default N)
- [x] 10/10 tests pass

## Test run

============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.12/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt
configfile: pyproject.toml
plugins: hypothesis-6.152.7, cov-7.1.0, asyncio-1.1.0, anyio-4.10.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 10 items

tests/test_cleanup_stale_vnx_sessions.py::test_script_exists PASSED      [ 10%]
tests/test_cleanup_stale_vnx_sessions.py::test_script_is_executable PASSED [ 20%]
tests/test_cleanup_stale_vnx_sessions.py::test_script_syntax PASSED      [ 30%]
tests/test_cleanup_stale_vnx_sessions.py::test_no_kill_without_explicit_confirm PASSED [ 40%]
tests/test_cleanup_stale_vnx_sessions.py::test_skip_message_on_default_no PASSED [ 50%]
tests/test_cleanup_stale_vnx_sessions.py::test_fresh_session_not_listed_as_stale PASSED [ 60%]
tests/test_cleanup_stale_vnx_sessions.py::test_non_vnx_session_not_listed PASSED [ 70%]
tests/test_cleanup_stale_vnx_sessions.py::test_no_vnx_sessions_exits_clean PASSED [ 80%]
tests/test_cleanup_stale_vnx_sessions.py::test_tmux_not_found_exits_clean PASSED [ 90%]
tests/test_cleanup_stale_vnx_sessions.py::test_invalid_timestamp_skipped PASSED [100%]

============================== 10 passed in 1.51s ==============================

Dispatch-ID: 20260525-100501-wave2a-8-housekeeping

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)