### PR TITLE
fix(install-central): shim exec bin/vnx not vnx-cli (typo)

### DIFF
--- a/install-central.sh
+++ b/install-central.sh
@@ -264,7 +264,7 @@ else
   export VNX_HOME="${VNX_SYSTEM_DIR}/current"
 fi
 
-exec "${VNX_HOME}/bin/vnx-cli" "$@"
+exec "${VNX_HOME}/bin/vnx" "$@"
 SHIM
 )
 

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -462,6 +462,74 @@ fi
 rm -rf "$TMP_14" "$test_14_script"
 
 # ---------------------------------------------------------------------------
+# Test 15: shim_no_vnx_cli_reference — installed shim must not contain 'vnx-cli'
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 15: shim_no_vnx_cli_reference — installed shim must not reference 'vnx-cli'"
+
+TMP_15="$(mktemp -d)"
+mkdir -p "${TMP_15}/versions/v1.0.0-rc3"
+
+test_15_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_15_script"
+chmod +x "$test_15_script"
+
+bash "$test_15_script" --target "$TMP_15" --version v1.0.0-rc3 >/dev/null 2>&1
+
+if [ -f "${TMP_15}/bin/vnx" ]; then
+  if grep -q 'vnx-cli' "${TMP_15}/bin/vnx" 2>/dev/null; then
+    fail "shim still contains references to 'vnx-cli'"
+  else
+    pass "shim contains no 'vnx-cli' references"
+  fi
+else
+  fail "shim not found at ${TMP_15}/bin/vnx"
+fi
+
+rm -rf "$TMP_15" "$test_15_script"
+
+# ---------------------------------------------------------------------------
+# Test 16: shim_execs_correct_binary — installed shim exec target is bin/vnx
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 16: shim_execs_correct_binary — shim exec line points to bin/vnx not bin/vnx-cli"
+
+TMP_16="$(mktemp -d)"
+mkdir -p "${TMP_16}/versions/v1.0.0-rc3"
+
+test_16_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_16_script"
+chmod +x "$test_16_script"
+
+bash "$test_16_script" --target "$TMP_16" --version v1.0.0-rc3 >/dev/null 2>&1
+
+if [ -f "${TMP_16}/bin/vnx" ]; then
+  # Shim must contain 'exec "${VNX_HOME}/bin/vnx"' (correct) and not 'bin/vnx-cli'
+  if grep -q 'exec.*bin/vnx"' "${TMP_16}/bin/vnx" && ! grep -q 'bin/vnx-cli' "${TMP_16}/bin/vnx"; then
+    pass "shim exec line correctly references bin/vnx"
+  else
+    exec_line="$(grep 'exec.*bin/vnx' "${TMP_16}/bin/vnx" || echo '(not found)')"
+    fail "shim exec line incorrect: ${exec_line}"
+  fi
+else
+  fail "shim not found at ${TMP_16}/bin/vnx"
+fi
+
+rm -rf "$TMP_16" "$test_16_script"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Problem

Shim heredoc in `install-central.sh` (line 267) referenced `${VNX_HOME}/bin/vnx-cli` which does not exist — the repo only has `bin/vnx`. After any `install-central.sh` run, `vnx --help` failed with:

```
/Users/<user>/.vnx-system/bin/vnx: line N: /path/to/.vnx-system/current/bin/vnx-cli: No such file or directory
```

## Fix

Single-line change in the shim heredoc:

```diff
-exec "${VNX_HOME}/bin/vnx-cli" "$@"
+exec "${VNX_HOME}/bin/vnx" "$@"
```

## Tests

Added regression tests 15 and 16 to `tests/test_install_central.sh`:
- **Test 15** (`shim_no_vnx_cli_reference`): grep installed shim for `vnx-cli` → assert 0 matches
- **Test 16** (`shim_execs_correct_binary`): assert shim exec line references `bin/vnx` not `bin/vnx-cli`

All **40 tests pass** (was 38 before this PR).

Smoke-tested via stubbed real install in `/tmp`: shim installed, `vnx --help` exits 0 and shows usage.

## No regressions

All existing Wave 2a tests green. No .vnx-data/ changes. No changes to `bin/vnx`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)