### PR TITLE
fix(install-central): separate PROJECT_ROOT from VNX_HOME in central-install mode (PR-WAVE4-1)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -20,16 +20,59 @@ if [ -f "$SCRIPT_DIR/../scripts/lib/vnx_paths.sh" ]; then
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/../scripts/lib/vnx_paths.sh"
 else
+  # Inline fallback resolver — fires only when scripts/lib/vnx_paths.sh is
+  # absent. Mirrors the layout detection in vnx_paths.sh so a central install
+  # (VNX_HOME = ~/.vnx-system/versions/<v>) does not conflate PROJECT_ROOT with
+  # VNX_HOME. Keep this in sync with scripts/lib/vnx_paths.sh.
   VNX_HOME_DEFAULT="$(cd "$SCRIPT_DIR/.." && pwd)"
+  _vnx_home_git_root="$(git -C "$VNX_HOME_DEFAULT" rev-parse --show-toplevel 2>/dev/null)" || _vnx_home_git_root=""
   if [ "$(basename "$VNX_HOME_DEFAULT")" = "vnx-system" ] && [ "$(basename "$(dirname "$VNX_HOME_DEFAULT")")" = ".claude" ]; then
+    # Embedded layout: project state lives in the parent project.
     PROJECT_ROOT_DEFAULT="$(cd "$VNX_HOME_DEFAULT/../.." && pwd)"
-  elif git -C "$VNX_HOME_DEFAULT" rev-parse --show-toplevel >/dev/null 2>&1 && [ "$(git -C "$VNX_HOME_DEFAULT" rev-parse --show-toplevel 2>/dev/null)" = "$VNX_HOME_DEFAULT" ]; then
-    PROJECT_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+    VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+  elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ]; then
+    # Explicit override exported by the central-install shim.
+    PROJECT_ROOT_DEFAULT="$(cd "$VNX_PROJECT_ROOT" && pwd)"
+    VNX_CANONICAL_ROOT_DEFAULT="$(git -C "$PROJECT_ROOT_DEFAULT" rev-parse --show-toplevel 2>/dev/null)" || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+    [ -n "$VNX_CANONICAL_ROOT_DEFAULT" ] || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+  elif [ -n "$_vnx_home_git_root" ] && [ "$_vnx_home_git_root" = "$VNX_HOME_DEFAULT" ]; then
+    # VNX_HOME is its own git repo: central install OR standalone dev checkout.
+    _vnx_is_central=false
+    if [ -f "${VNX_HOME_DEFAULT}/.vnx-install-mode" ] && [ "$(cat "${VNX_HOME_DEFAULT}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
+      _vnx_is_central=true
+    fi
+    _cwd_git_root=""
+    if [ "$_vnx_is_central" = "false" ]; then
+      _cwd_git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || _cwd_git_root=""
+      if [ -n "$_cwd_git_root" ] && [ "$_cwd_git_root" != "$VNX_HOME_DEFAULT" ]; then
+        _vnx_is_central=true
+      fi
+    fi
+    if [ "$_vnx_is_central" = "true" ]; then
+      if [ -z "$_cwd_git_root" ]; then
+        _cwd_git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || _cwd_git_root=""
+      fi
+      if [ -z "$_cwd_git_root" ]; then
+        _cwd_git_root="$(pwd)"
+      fi
+      if [ "$_cwd_git_root" = "/" ] || [ -z "$_cwd_git_root" ]; then
+        _cwd_git_root="$VNX_HOME_DEFAULT"
+      fi
+      PROJECT_ROOT_DEFAULT="$(cd "$_cwd_git_root" && pwd)"
+      VNX_CANONICAL_ROOT_DEFAULT="$(git -C "$PROJECT_ROOT_DEFAULT" rev-parse --show-toplevel 2>/dev/null)" || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+      [ -n "$VNX_CANONICAL_ROOT_DEFAULT" ] || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+    else
+      # Standalone dev checkout: keep runtime local to the checkout.
+      PROJECT_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+      VNX_CANONICAL_ROOT_DEFAULT="$(git -C "$VNX_HOME_DEFAULT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')" || VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+      [ -n "$VNX_CANONICAL_ROOT_DEFAULT" ] || VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+    fi
+    unset _vnx_is_central _cwd_git_root
   else
     PROJECT_ROOT_DEFAULT="$(cd "$VNX_HOME_DEFAULT/.." && pwd)"
+    VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
   fi
-  VNX_CANONICAL_ROOT_DEFAULT="$(git -C "$VNX_HOME_DEFAULT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')" || VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
-  [ -n "$VNX_CANONICAL_ROOT_DEFAULT" ] || VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+  unset _vnx_home_git_root
 
   export VNX_HOME="${VNX_HOME:-$VNX_HOME_DEFAULT}"
   export PROJECT_ROOT="${PROJECT_ROOT:-$PROJECT_ROOT_DEFAULT}"

--- a/bin/vnx
+++ b/bin/vnx
@@ -30,28 +30,24 @@ else
     # Embedded layout: project state lives in the parent project.
     PROJECT_ROOT_DEFAULT="$(cd "$VNX_HOME_DEFAULT/../.." && pwd)"
     VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
-  elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ]; then
-    # Explicit override exported by the central-install shim.
+  elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ] && [ "$(cd "$VNX_PROJECT_ROOT" && pwd)" != "$VNX_HOME_DEFAULT" ]; then
+    # Explicit override exported by the central-install shim. Ignored when it
+    # points at VNX_HOME itself (shim mis-detection) — parity with the Python
+    # resolver guard; falls through to the git-root branch below.
     PROJECT_ROOT_DEFAULT="$(cd "$VNX_PROJECT_ROOT" && pwd)"
     VNX_CANONICAL_ROOT_DEFAULT="$(git -C "$PROJECT_ROOT_DEFAULT" rev-parse --show-toplevel 2>/dev/null)" || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
     [ -n "$VNX_CANONICAL_ROOT_DEFAULT" ] || VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
   elif [ -n "$_vnx_home_git_root" ] && [ "$_vnx_home_git_root" = "$VNX_HOME_DEFAULT" ]; then
     # VNX_HOME is its own git repo: central install OR standalone dev checkout.
+    # Only the .vnx-install-mode marker marks a central install; the old
+    # CWD-git-mismatch heuristic was removed (mis-fired on worktrees, #225).
     _vnx_is_central=false
     if [ -f "${VNX_HOME_DEFAULT}/.vnx-install-mode" ] && [ "$(cat "${VNX_HOME_DEFAULT}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
       _vnx_is_central=true
     fi
     _cwd_git_root=""
-    if [ "$_vnx_is_central" = "false" ]; then
-      _cwd_git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || _cwd_git_root=""
-      if [ -n "$_cwd_git_root" ] && [ "$_cwd_git_root" != "$VNX_HOME_DEFAULT" ]; then
-        _vnx_is_central=true
-      fi
-    fi
     if [ "$_vnx_is_central" = "true" ]; then
-      if [ -z "$_cwd_git_root" ]; then
-        _cwd_git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || _cwd_git_root=""
-      fi
+      _cwd_git_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || _cwd_git_root=""
       if [ -z "$_cwd_git_root" ]; then
         _cwd_git_root="$(pwd)"
       fi

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -84,27 +84,95 @@ def _git_common_root(path: Path) -> Path | None:
     return common_dir.parent if common_dir.name == ".git" else common_dir
 
 
+def _vnx_project_root_override(vnx_home: Path) -> Path | None:
+    """Return the resolved VNX_PROJECT_ROOT override if it is a usable directory.
+
+    VNX_PROJECT_ROOT is the explicit override exported by the central-install
+    shim. It wins over any heuristic but is ignored when it points at VNX_HOME
+    (mis-detection) or at a non-directory.
+    """
+    raw = os.environ.get("VNX_PROJECT_ROOT")
+    if not raw:
+        return None
+    candidate = Path(raw).expanduser().resolve()
+    if candidate.is_dir() and candidate != vnx_home:
+        return candidate
+    return None
+
+
+def _is_central_install(vnx_home: Path) -> bool:
+    """True when VNX_HOME is a standalone git repo serving as a central install.
+
+    Central install = the VNX code tree is shared (e.g. ~/.vnx-system/versions/<v>)
+    and the operator runs from their own project. Detected via the
+    ``.vnx-install-mode`` marker (primary, written by install-central.sh) or a
+    CWD-git-root mismatch (secondary heuristic). Returns False for a standalone
+    dev checkout of vnx-orchestration itself.
+    """
+    if _git_toplevel(vnx_home) != vnx_home:
+        return False
+    marker = vnx_home / ".vnx-install-mode"
+    if marker.is_file():
+        try:
+            if marker.read_text(encoding="utf-8").strip() == "central":
+                return True
+        except OSError:
+            pass
+    cwd_git_root = _git_toplevel(Path.cwd())
+    return bool(cwd_git_root and cwd_git_root != vnx_home)
+
+
 def _default_project_root(vnx_home: Path) -> Path:
     if _is_embedded_layout(vnx_home):
         return vnx_home.parent.parent.resolve()
 
+    # Explicit override exported by the central-install shim (belt-and-suspenders).
+    override = _vnx_project_root_override(vnx_home)
+    if override is not None:
+        return override
+
     git_root = _git_toplevel(vnx_home)
     if git_root == vnx_home:
-        # Standalone repo/worktree layout: runtime/bootstrap stay local to the repo checkout.
+        if _is_central_install(vnx_home):
+            cwd_git_root = _git_toplevel(Path.cwd())
+            resolved = cwd_git_root if cwd_git_root else Path.cwd().resolve()
+            # Safety: never collapse PROJECT_ROOT to filesystem root.
+            if resolved == Path(resolved.anchor):
+                return vnx_home.resolve()
+            return resolved
+        # Standalone dev checkout: runtime/bootstrap stay local to the repo checkout.
         return vnx_home.resolve()
 
     return vnx_home.parent.resolve()
 
 
 def _default_canonical_root(vnx_home: Path) -> Path:
+    if _is_embedded_layout(vnx_home):
+        return vnx_home.resolve()
+
+    # Explicit override: intelligence follows the project's git root.
+    override = _vnx_project_root_override(vnx_home)
+    if override is not None:
+        return _git_toplevel(override) or override
+
     git_root = _git_toplevel(vnx_home)
     if git_root == vnx_home:
+        if _is_central_install(vnx_home):
+            project_root = _default_project_root(vnx_home)
+            return _git_toplevel(project_root) or project_root
         return _git_common_root(vnx_home) or vnx_home.resolve()
     return vnx_home.resolve()
 
 
 def _resolve_project_root(vnx_home: Path) -> Path:
     default_root = _default_project_root(vnx_home)
+
+    # Explicit shim override takes precedence over inherited PROJECT_ROOT, so
+    # direct Python callers honor it even when PROJECT_ROOT was not exported (EC-2).
+    override = _vnx_project_root_override(vnx_home)
+    if override is not None:
+        return override
+
     project_root_env = os.environ.get("PROJECT_ROOT")
     if project_root_env:
         candidate = Path(project_root_env).expanduser().resolve()

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -104,22 +104,25 @@ def _is_central_install(vnx_home: Path) -> bool:
     """True when VNX_HOME is a standalone git repo serving as a central install.
 
     Central install = the VNX code tree is shared (e.g. ~/.vnx-system/versions/<v>)
-    and the operator runs from their own project. Detected via the
-    ``.vnx-install-mode`` marker (primary, written by install-central.sh) or a
-    CWD-git-root mismatch (secondary heuristic). Returns False for a standalone
-    dev checkout of vnx-orchestration itself.
+    and the operator runs from their own project. Detected *only* via the
+    ``.vnx-install-mode`` marker file (content ``central``) written by
+    install-central.sh.
+
+    The earlier CWD-git-root-mismatch heuristic was removed: a git worktree of
+    vnx-orchestration itself produces a CWD git root that differs from VNX_HOME,
+    which mis-fired the heuristic and collapsed PROJECT_ROOT onto the parent repo
+    (issue #225 / PR-WAVE4-1 CI regression). The marker is unambiguous, so a
+    standalone dev checkout or worktree is correctly treated as non-central.
     """
     if _git_toplevel(vnx_home) != vnx_home:
         return False
     marker = vnx_home / ".vnx-install-mode"
     if marker.is_file():
         try:
-            if marker.read_text(encoding="utf-8").strip() == "central":
-                return True
+            return marker.read_text(encoding="utf-8").strip() == "central"
         except OSError:
-            pass
-    cwd_git_root = _git_toplevel(Path.cwd())
-    return bool(cwd_git_root and cwd_git_root != vnx_home)
+            return False
+    return False
 
 
 def _default_project_root(vnx_home: Path) -> Path:

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -84,9 +84,11 @@ VNX_HOME_DEFAULT="$(_vnx_canon_dir "$VNX_HOME_DEFAULT")"
 #   3. Standalone   — VNX_HOME = a vnx-orchestration checkout   → PROJECT_ROOT = VNX_HOME
 #
 # Layouts 2 and 3 both have "VNX_HOME is its own git repo root"; the central
-# install is distinguished by a .vnx-install-mode marker (written by the
-# installer) or, as a fallback, by the CWD git root differing from VNX_HOME.
-# See issue #225 and the Wave 4 install-central synthesis.
+# install is distinguished *only* by a .vnx-install-mode marker written by the
+# installer. The earlier CWD-git-root-mismatch fallback was removed: a worktree
+# of vnx-orchestration itself yields a differing CWD git root and mis-fired the
+# heuristic, collapsing PROJECT_ROOT onto the parent repo (issue #225 /
+# PR-WAVE4-1 CI regression). See the Wave 4 install-central synthesis.
 _VNX_HOME_GIT_ROOT="$(_vnx_git_toplevel "$VNX_HOME_DEFAULT")"
 
 # Canonical repo root owns git-tracked intelligence/provenance. Default to
@@ -96,8 +98,12 @@ VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
 
 if _vnx_is_embedded_layout "$VNX_HOME_DEFAULT"; then
   PROJECT_ROOT_DEFAULT="$(cd -P "$VNX_HOME_DEFAULT/../.." && pwd -P)"
-elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ]; then
+elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ] \
+  && [ "$(_vnx_canon_dir "$VNX_PROJECT_ROOT")" != "$VNX_HOME_DEFAULT" ]; then
   # Explicit override exported by the central-install shim (belt-and-suspenders).
+  # Ignored when it points at VNX_HOME itself (shim mis-detection) — parity with
+  # the Python resolver's _vnx_project_root_override guard; falls through to the
+  # git-root branch below.
   PROJECT_ROOT_DEFAULT="$(_vnx_canon_dir "$VNX_PROJECT_ROOT")"
   _VNX_CANONICAL_FROM_PROJECT="$(_vnx_git_toplevel "$PROJECT_ROOT_DEFAULT")"
   if [ -n "$_VNX_CANONICAL_FROM_PROJECT" ]; then
@@ -109,25 +115,15 @@ elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ]; then
 elif [ -n "$_VNX_HOME_GIT_ROOT" ] && [ "$_VNX_HOME_GIT_ROOT" = "$VNX_HOME_DEFAULT" ]; then
   # VNX_HOME is its own git repo root: central install OR standalone dev checkout.
   _vnx_is_central=false
-  # Primary signal: install-mode marker written by install-central.sh.
+  # Only signal: install-mode marker written by install-central.sh.
   if [ -f "${VNX_HOME_DEFAULT}/.vnx-install-mode" ] \
     && [ "$(cat "${VNX_HOME_DEFAULT}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
     _vnx_is_central=true
   fi
-  # Secondary heuristic: CWD git root differs from VNX_HOME → the operator is
-  # running from their own project, not from inside the VNX source tree.
-  _CWD_GIT_ROOT=""
-  if [ "$_vnx_is_central" = "false" ]; then
-    _CWD_GIT_ROOT="$(_vnx_git_toplevel "$(pwd)")"
-    if [ -n "$_CWD_GIT_ROOT" ] && [ "$_CWD_GIT_ROOT" != "$VNX_HOME_DEFAULT" ]; then
-      _vnx_is_central=true
-    fi
-  fi
 
+  _CWD_GIT_ROOT=""
   if [ "$_vnx_is_central" = "true" ]; then
-    if [ -z "$_CWD_GIT_ROOT" ]; then
-      _CWD_GIT_ROOT="$(_vnx_git_toplevel "$(pwd)")"
-    fi
+    _CWD_GIT_ROOT="$(_vnx_git_toplevel "$(pwd)")"
     if [ -z "$_CWD_GIT_ROOT" ]; then
       _CWD_GIT_ROOT="$(pwd)"
     fi

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -74,26 +74,87 @@ unset _VNX_HOME_FROM_SCRIPT
 VNX_HOME_DEFAULT="$(_vnx_canon_dir "$VNX_HOME_DEFAULT")"
 
 # Default runtime/bootstrap root.
-# Embedded layout keeps runtime in the parent project; standalone repo/worktree
-# layout keeps runtime local to the checkout itself.
+#
+# Three layouts must be distinguished, because VNX_HOME (immutable code) and
+# PROJECT_ROOT (per-project runtime state) only coincide for a self-dev checkout:
+#
+#   1. Embedded     — VNX_HOME nested under the project's .claude tree (see
+#                     _vnx_is_embedded_layout)                  → PROJECT_ROOT = <project>
+#   2. Central      — VNX_HOME = a shared versioned install     → PROJECT_ROOT = CWD git root
+#   3. Standalone   — VNX_HOME = a vnx-orchestration checkout   → PROJECT_ROOT = VNX_HOME
+#
+# Layouts 2 and 3 both have "VNX_HOME is its own git repo root"; the central
+# install is distinguished by a .vnx-install-mode marker (written by the
+# installer) or, as a fallback, by the CWD git root differing from VNX_HOME.
+# See issue #225 and the Wave 4 install-central synthesis.
 _VNX_HOME_GIT_ROOT="$(_vnx_git_toplevel "$VNX_HOME_DEFAULT")"
+
+# Canonical repo root owns git-tracked intelligence/provenance. Default to
+# VNX_HOME; the branches below repoint it to the project in central mode so
+# intelligence exports land in the project, not the immutable code tree.
+VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+
 if _vnx_is_embedded_layout "$VNX_HOME_DEFAULT"; then
   PROJECT_ROOT_DEFAULT="$(cd -P "$VNX_HOME_DEFAULT/../.." && pwd -P)"
+elif [ -n "${VNX_PROJECT_ROOT:-}" ] && [ -d "$VNX_PROJECT_ROOT" ]; then
+  # Explicit override exported by the central-install shim (belt-and-suspenders).
+  PROJECT_ROOT_DEFAULT="$(_vnx_canon_dir "$VNX_PROJECT_ROOT")"
+  _VNX_CANONICAL_FROM_PROJECT="$(_vnx_git_toplevel "$PROJECT_ROOT_DEFAULT")"
+  if [ -n "$_VNX_CANONICAL_FROM_PROJECT" ]; then
+    VNX_CANONICAL_ROOT_DEFAULT="$_VNX_CANONICAL_FROM_PROJECT"
+  else
+    VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+  fi
+  unset _VNX_CANONICAL_FROM_PROJECT
 elif [ -n "$_VNX_HOME_GIT_ROOT" ] && [ "$_VNX_HOME_GIT_ROOT" = "$VNX_HOME_DEFAULT" ]; then
-  PROJECT_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+  # VNX_HOME is its own git repo root: central install OR standalone dev checkout.
+  _vnx_is_central=false
+  # Primary signal: install-mode marker written by install-central.sh.
+  if [ -f "${VNX_HOME_DEFAULT}/.vnx-install-mode" ] \
+    && [ "$(cat "${VNX_HOME_DEFAULT}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
+    _vnx_is_central=true
+  fi
+  # Secondary heuristic: CWD git root differs from VNX_HOME → the operator is
+  # running from their own project, not from inside the VNX source tree.
+  _CWD_GIT_ROOT=""
+  if [ "$_vnx_is_central" = "false" ]; then
+    _CWD_GIT_ROOT="$(_vnx_git_toplevel "$(pwd)")"
+    if [ -n "$_CWD_GIT_ROOT" ] && [ "$_CWD_GIT_ROOT" != "$VNX_HOME_DEFAULT" ]; then
+      _vnx_is_central=true
+    fi
+  fi
+
+  if [ "$_vnx_is_central" = "true" ]; then
+    if [ -z "$_CWD_GIT_ROOT" ]; then
+      _CWD_GIT_ROOT="$(_vnx_git_toplevel "$(pwd)")"
+    fi
+    if [ -z "$_CWD_GIT_ROOT" ]; then
+      _CWD_GIT_ROOT="$(pwd)"
+    fi
+    # Safety: never let PROJECT_ROOT collapse to filesystem root or empty.
+    if [ "$_CWD_GIT_ROOT" = "/" ] || [ -z "$_CWD_GIT_ROOT" ]; then
+      _CWD_GIT_ROOT="$VNX_HOME_DEFAULT"
+    fi
+    PROJECT_ROOT_DEFAULT="$(_vnx_canon_dir "$_CWD_GIT_ROOT")"
+    # Intelligence exports follow the project, not the immutable code tree.
+    VNX_CANONICAL_ROOT_DEFAULT="$(_vnx_git_toplevel "$PROJECT_ROOT_DEFAULT")"
+    if [ -z "${VNX_CANONICAL_ROOT_DEFAULT:-}" ]; then
+      VNX_CANONICAL_ROOT_DEFAULT="$PROJECT_ROOT_DEFAULT"
+    fi
+  else
+    # Standalone dev checkout: runtime/bootstrap stay local to the checkout.
+    PROJECT_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
+    _VNX_HOME_COMMON_ROOT="$(_vnx_git_common_root "$VNX_HOME_DEFAULT")"
+    if [ -n "$_VNX_HOME_COMMON_ROOT" ]; then
+      VNX_CANONICAL_ROOT_DEFAULT="$_VNX_HOME_COMMON_ROOT"
+    fi
+    unset _VNX_HOME_COMMON_ROOT
+  fi
+  unset _vnx_is_central _CWD_GIT_ROOT
 else
   PROJECT_ROOT_DEFAULT="$(cd -P "$VNX_HOME_DEFAULT/.." && pwd -P)"
 fi
-
-# Canonical repo root owns git-tracked intelligence/provenance.
-VNX_CANONICAL_ROOT_DEFAULT="$VNX_HOME_DEFAULT"
-if [ -n "$_VNX_HOME_GIT_ROOT" ] && [ "$_VNX_HOME_GIT_ROOT" = "$VNX_HOME_DEFAULT" ]; then
-  _VNX_HOME_COMMON_ROOT="$(_vnx_git_common_root "$VNX_HOME_DEFAULT")"
-  if [ -n "$_VNX_HOME_COMMON_ROOT" ]; then
-    VNX_CANONICAL_ROOT_DEFAULT="$_VNX_HOME_COMMON_ROOT"
-  fi
-fi
-unset _VNX_HOME_GIT_ROOT _VNX_HOME_COMMON_ROOT
+unset _VNX_HOME_GIT_ROOT
 
 # Guard against cross-project env contamination:
 # If inherited VNX_HOME points to a different project tree than VNX_HOME_DEFAULT

--- a/tests/test_wave4_path_resolver.py
+++ b/tests/test_wave4_path_resolver.py
@@ -11,9 +11,14 @@ These tests pin the corrected detection hierarchy:
 
   1. embedded layout            -> PROJECT_ROOT = vnx_home.parent.parent
   2. VNX_PROJECT_ROOT override  -> PROJECT_ROOT = that dir (shim, belt+braces)
+     (ignored when it equals VNX_HOME — shim mis-detection)
   3. central install (marker)   -> PROJECT_ROOT = CWD git root
-  4. central install (heuristic)-> PROJECT_ROOT = CWD git root
-  5. standalone dev checkout    -> PROJECT_ROOT = VNX_HOME (unchanged)
+  4. standalone dev checkout    -> PROJECT_ROOT = VNX_HOME (unchanged)
+
+The ``.vnx-install-mode`` marker is the *only* central-install signal. The
+earlier CWD-git-root-mismatch heuristic was removed (PR-WAVE4-1 round 2): it
+mis-fired for a git worktree of vnx-orchestration itself, collapsing
+PROJECT_ROOT onto the parent repo. See issue #225.
 
 Both resolver implementations (Python module + the shell scripts run via
 subprocess) are exercised so the three sources cannot drift apart.
@@ -109,15 +114,20 @@ def test_central_install_with_marker_uses_cwd_git_root(tmp_path, monkeypatch):
     assert _default_project_root(install) != install
 
 
-# ── Case 3: central install, no marker, CWD git mismatch ─────────────────────
-def test_central_install_detected_by_git_mismatch(tmp_path, monkeypatch):
+# ── Case 3: marker file is REQUIRED — no heuristic fallback ──────────────────
+def test_marker_file_required_for_central(tmp_path, monkeypatch):
+    # No .vnx-install-mode marker: even though CWD git root differs from VNX_HOME
+    # (the removed heuristic's trigger), this must NOT be treated as central.
     install = _make_central_install(tmp_path, marker=False)
     project = _git_init(tmp_path / "real-project")
 
     monkeypatch.chdir(project)
     assert not (install / ".vnx-install-mode").exists()
-    assert _is_central_install(install) is True
-    assert _default_project_root(install) == project
+    # Heuristic removed: CWD-git-mismatch no longer marks central.
+    assert _is_central_install(install) is False
+    # Standalone dev checkout: PROJECT_ROOT stays at VNX_HOME, never the CWD repo.
+    assert _default_project_root(install) == install
+    assert _default_project_root(install) != project
 
 
 # ── Case 4: standalone dev checkout (unchanged) ──────────────────────────────
@@ -146,13 +156,16 @@ def test_vnx_project_root_env_override_wins(tmp_path, monkeypatch):
 
 def test_vnx_project_root_ignored_when_equal_to_vnx_home(tmp_path, monkeypatch):
     # A mis-detected override pointing at VNX_HOME must be ignored, not honored.
-    install = _make_central_install(tmp_path, marker=False)
+    # Marker present so central detection still fires; the bad override must not
+    # collapse PROJECT_ROOT onto VNX_HOME but resolve to the CWD project instead.
+    install = _make_central_install(tmp_path, marker=True)
     project = _git_init(tmp_path / "real-project")
 
     monkeypatch.chdir(project)
     monkeypatch.setenv("VNX_PROJECT_ROOT", str(install))
 
     assert _default_project_root(install) == project
+    assert _resolve_project_root(install) == project
 
 
 # ── Case 6: central install + CWD outside any git repo ───────────────────────
@@ -188,9 +201,11 @@ def test_central_install_refuses_filesystem_root(tmp_path, monkeypatch):
 
 
 # ── Case 7: bin/vnx inline fallback parity with vnx_paths.sh ──────────────────
-def _run_shell_resolver(script_path: Path, project_cwd: Path) -> dict:
+def _run_shell_resolver(script_path: Path, project_cwd: Path, extra_env: dict | None = None) -> dict:
     """Source vnx_paths.sh and capture the resolved exports."""
     env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    if extra_env:
+        env.update(extra_env)
     out = subprocess.run(
         [
             "bash",
@@ -265,6 +280,71 @@ def test_bin_vnx_inline_fallback_central_mode(tmp_path):
     assert resolved["VNX_HOME"] == str(install)
     assert resolved["PROJECT_ROOT"] == str(project)
     assert resolved["VNX_CANONICAL_ROOT"] == str(project)
+
+
+# ── Case 7b: VNX_PROJECT_ROOT == VNX_HOME is ignored (shell + bin/vnx parity) ─
+def test_vnx_project_root_eq_vnx_home_ignored_shell(tmp_path):
+    """Shell resolver: a VNX_PROJECT_ROOT pointing at VNX_HOME must be ignored.
+
+    Parity with the Python ``_vnx_project_root_override`` guard. Without the
+    guard, PROJECT_ROOT would collapse onto VNX_HOME (the immutable code tree).
+    """
+    install = _make_central_install(tmp_path, marker=True)
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+    project = _git_init(tmp_path / "real-project")
+
+    resolved = _run_shell_resolver(
+        install / "scripts" / "lib" / "vnx_paths.sh",
+        project,
+        extra_env={"VNX_PROJECT_ROOT": str(install)},
+    )
+    assert resolved["VNX_HOME"] == str(install)
+    # Bad override ignored -> central marker resolves PROJECT_ROOT to CWD project.
+    assert resolved["PROJECT_ROOT"] == str(project)
+    assert resolved["PROJECT_ROOT"] != str(install)
+
+
+def test_vnx_project_root_eq_vnx_home_ignored_bin_vnx(tmp_path):
+    """bin/vnx inline fallback: VNX_PROJECT_ROOT == VNX_HOME must be ignored too."""
+    install = _make_central_install(tmp_path, marker=True)
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+
+    cmds = install / "scripts" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "doctor.sh").write_text(
+        "cmd_doctor() {\n"
+        '  printf "PROJECT_ROOT=%s\\n" "$PROJECT_ROOT"\n'
+        '  printf "VNX_HOME=%s\\n" "$VNX_HOME"\n'
+        '  printf "VNX_CANONICAL_ROOT=%s\\n" "$VNX_CANONICAL_ROOT"\n'
+        "  exit 0\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    assert not (install / "scripts" / "lib" / "vnx_paths.sh").exists()
+
+    project = _git_init(tmp_path / "real-project")
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    env["VNX_PROJECT_ROOT"] = str(install)
+    out = subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "doctor"],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    resolved = dict(
+        line.split("=", 1) for line in out.stdout.splitlines() if "=" in line
+    )
+    assert resolved["VNX_HOME"] == str(install)
+    assert resolved["PROJECT_ROOT"] == str(project)
+    assert resolved["PROJECT_ROOT"] != str(install)
 
 
 # ── Case 8: VNX_CANONICAL_ROOT follows the project in central mode ───────────

--- a/tests/test_wave4_path_resolver.py
+++ b/tests/test_wave4_path_resolver.py
@@ -1,0 +1,296 @@
+"""Wave 4 PR-1 — regression tests for the central-install path resolver.
+
+Root cause (issue #225 / Wave 4 synthesis): ``scripts/lib/vnx_paths.sh``,
+``scripts/lib/vnx_paths.py`` and the ``bin/vnx`` inline fallback all set
+``PROJECT_ROOT = VNX_HOME`` whenever VNX_HOME is its own git repo root. For a
+central install (VNX_HOME = ``~/.vnx-system/versions/<v>``) that is wrong: the
+operator runs from their own project, so project state, settings and
+intelligence ended up inside the immutable code tree.
+
+These tests pin the corrected detection hierarchy:
+
+  1. embedded layout            -> PROJECT_ROOT = vnx_home.parent.parent
+  2. VNX_PROJECT_ROOT override  -> PROJECT_ROOT = that dir (shim, belt+braces)
+  3. central install (marker)   -> PROJECT_ROOT = CWD git root
+  4. central install (heuristic)-> PROJECT_ROOT = CWD git root
+  5. standalone dev checkout    -> PROJECT_ROOT = VNX_HOME (unchanged)
+
+Both resolver implementations (Python module + the shell scripts run via
+subprocess) are exercised so the three sources cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+import vnx_paths  # noqa: E402
+from vnx_paths import (  # noqa: E402
+    _default_canonical_root,
+    _default_project_root,
+    _is_central_install,
+    _resolve_project_root,
+)
+
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_LOGS_DIR",
+    "VNX_PIDS_DIR",
+    "VNX_LOCKS_DIR",
+    "VNX_SOCKETS_DIR",
+    "VNX_REPORTS_DIR",
+    "VNX_HEADLESS_REPORTS_DIR",
+    "VNX_DB_DIR",
+    "VNX_INTELLIGENCE_DIR",
+    "VNX_SKILLS_DIR",
+)
+
+
+def _git_init(path: Path) -> Path:
+    """Initialise ``path`` as its own git repository with one empty commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    return path.resolve()
+
+
+@pytest.fixture(autouse=True)
+def _clean_vnx_env(monkeypatch):
+    """Strip every VNX_* path var so detection is driven only by the test."""
+    for key in _VNX_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+def _make_central_install(tmp_path: Path, marker: bool) -> Path:
+    """A standalone git repo standing in for ~/.vnx-system/versions/<v>."""
+    install = _git_init(tmp_path / "vnx-install")
+    if marker:
+        (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    return install
+
+
+# ── Case 1: embedded layout (unchanged) ──────────────────────────────────────
+def test_embedded_layout_resolves_parent_project(tmp_path):
+    project = tmp_path / "my-project"
+    vnx_home = project / ".claude" / "vnx-system"
+    vnx_home.mkdir(parents=True)
+
+    assert _default_project_root(vnx_home.resolve()) == project.resolve()
+
+
+# ── Case 2: central install + marker file ────────────────────────────────────
+def test_central_install_with_marker_uses_cwd_git_root(tmp_path, monkeypatch):
+    install = _make_central_install(tmp_path, marker=True)
+    project = _git_init(tmp_path / "real-project")
+
+    monkeypatch.chdir(project)
+    assert _is_central_install(install) is True
+    assert _default_project_root(install) == project
+    assert _default_project_root(install) != install
+
+
+# ── Case 3: central install, no marker, CWD git mismatch ─────────────────────
+def test_central_install_detected_by_git_mismatch(tmp_path, monkeypatch):
+    install = _make_central_install(tmp_path, marker=False)
+    project = _git_init(tmp_path / "real-project")
+
+    monkeypatch.chdir(project)
+    assert not (install / ".vnx-install-mode").exists()
+    assert _is_central_install(install) is True
+    assert _default_project_root(install) == project
+
+
+# ── Case 4: standalone dev checkout (unchanged) ──────────────────────────────
+def test_standalone_dev_checkout_keeps_vnx_home(tmp_path, monkeypatch):
+    # VNX_HOME is its own git repo, no marker, and CWD is inside VNX_HOME.
+    checkout = _git_init(tmp_path / "vnx-orchestration")
+
+    monkeypatch.chdir(checkout)
+    assert _is_central_install(checkout) is False
+    assert _default_project_root(checkout) == checkout
+
+
+# ── Case 5: explicit VNX_PROJECT_ROOT override ───────────────────────────────
+def test_vnx_project_root_env_override_wins(tmp_path, monkeypatch):
+    install = _make_central_install(tmp_path, marker=True)
+    project = _git_init(tmp_path / "real-project")
+    override = _git_init(tmp_path / "override-project")
+
+    # CWD points at `project`, but the explicit override must win.
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("VNX_PROJECT_ROOT", str(override))
+
+    assert _default_project_root(install) == override
+    assert _resolve_project_root(install) == override
+
+
+def test_vnx_project_root_ignored_when_equal_to_vnx_home(tmp_path, monkeypatch):
+    # A mis-detected override pointing at VNX_HOME must be ignored, not honored.
+    install = _make_central_install(tmp_path, marker=False)
+    project = _git_init(tmp_path / "real-project")
+
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("VNX_PROJECT_ROOT", str(install))
+
+    assert _default_project_root(install) == project
+
+
+# ── Case 6: central install + CWD outside any git repo ───────────────────────
+def test_central_install_cwd_outside_git_falls_back_to_cwd(tmp_path, monkeypatch):
+    install = _make_central_install(tmp_path, marker=True)
+    outside = (tmp_path / "loose-dir")
+    outside.mkdir()
+
+    # Precondition: the loose dir is not inside any git repo.
+    if vnx_paths._git_toplevel(outside) is not None:
+        pytest.skip("temp dir unexpectedly lives inside a git repository")
+
+    monkeypatch.chdir(outside)
+    assert _is_central_install(install) is True
+    # No git root for CWD -> fall back to CWD itself (never to VNX_HOME).
+    assert _default_project_root(install) == outside.resolve()
+
+
+def test_central_install_refuses_filesystem_root(tmp_path, monkeypatch):
+    # Safety guard: if CWD resolves to "/", PROJECT_ROOT must not collapse there.
+    install = _make_central_install(tmp_path, marker=True)
+
+    # VNX_HOME still resolves to its own git root (keeps the central branch
+    # reachable); only CWD is forced to "/" with no git root above it.
+    def _fake_toplevel(p):
+        return install if Path(p).resolve() == install else None
+
+    monkeypatch.setattr(vnx_paths.Path, "cwd", staticmethod(lambda: Path("/")))
+    monkeypatch.setattr(vnx_paths, "_git_toplevel", _fake_toplevel)
+
+    assert _is_central_install(install) is True
+    assert _default_project_root(install) == install.resolve()
+
+
+# ── Case 7: bin/vnx inline fallback parity with vnx_paths.sh ──────────────────
+def _run_shell_resolver(script_path: Path, project_cwd: Path) -> dict:
+    """Source vnx_paths.sh and capture the resolved exports."""
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    out = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{script_path}"; '
+            'printf "PROJECT_ROOT=%s\\n" "$PROJECT_ROOT"; '
+            'printf "VNX_HOME=%s\\n" "$VNX_HOME"; '
+            'printf "VNX_CANONICAL_ROOT=%s\\n" "$VNX_CANONICAL_ROOT"',
+        ],
+        cwd=project_cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return dict(
+        line.split("=", 1) for line in out.stdout.splitlines() if "=" in line
+    )
+
+
+def test_shell_resolver_central_mode(tmp_path):
+    install = _make_central_install(tmp_path, marker=True)
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+    project = _git_init(tmp_path / "real-project")
+
+    resolved = _run_shell_resolver(install / "scripts" / "lib" / "vnx_paths.sh", project)
+    assert resolved["VNX_HOME"] == str(install)
+    assert resolved["PROJECT_ROOT"] == str(project)
+    assert resolved["VNX_CANONICAL_ROOT"] == str(project)
+
+
+def test_bin_vnx_inline_fallback_central_mode(tmp_path):
+    """The bin/vnx inline fallback (no vnx_paths.sh present) must match."""
+    install = _make_central_install(tmp_path, marker=True)
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+
+    # Stub the dispatched command so the REAL path resolver runs unmodified
+    # and we can observe what it computed. No scripts/lib/vnx_paths.sh -> the
+    # inline fallback fires.
+    cmds = install / "scripts" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "doctor.sh").write_text(
+        "cmd_doctor() {\n"
+        '  printf "PROJECT_ROOT=%s\\n" "$PROJECT_ROOT"\n'
+        '  printf "VNX_HOME=%s\\n" "$VNX_HOME"\n'
+        '  printf "VNX_CANONICAL_ROOT=%s\\n" "$VNX_CANONICAL_ROOT"\n'
+        "  exit 0\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    assert not (install / "scripts" / "lib" / "vnx_paths.sh").exists()
+
+    project = _git_init(tmp_path / "real-project")
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    out = subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "doctor"],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    resolved = dict(
+        line.split("=", 1) for line in out.stdout.splitlines() if "=" in line
+    )
+    assert resolved["VNX_HOME"] == str(install)
+    assert resolved["PROJECT_ROOT"] == str(project)
+    assert resolved["VNX_CANONICAL_ROOT"] == str(project)
+
+
+# ── Case 8: VNX_CANONICAL_ROOT follows the project in central mode ───────────
+def test_canonical_root_is_project_not_vnx_home_in_central(tmp_path, monkeypatch):
+    install = _make_central_install(tmp_path, marker=True)
+    project = _git_init(tmp_path / "real-project")
+
+    monkeypatch.chdir(project)
+    canonical = _default_canonical_root(install)
+    assert canonical == project
+    assert canonical != install
+
+
+def test_resolve_paths_end_to_end_central(tmp_path, monkeypatch):
+    """Full resolve_paths(): data + intelligence land in the project, not VNX_HOME."""
+    install = _make_central_install(tmp_path, marker=True)
+    project = _git_init(tmp_path / "real-project")
+
+    monkeypatch.setenv("VNX_HOME", str(install))
+    monkeypatch.chdir(project)
+
+    paths = vnx_paths.resolve_paths()
+    assert paths["VNX_HOME"] == str(install)
+    assert paths["PROJECT_ROOT"] == str(project)
+    assert paths["VNX_DATA_DIR"] == str(project / ".vnx-data")
+    assert paths["VNX_INTELLIGENCE_DIR"] == str(project / ".vnx-intelligence")
+    # Nothing should resolve inside the immutable code tree.
+    assert str(install) not in paths["VNX_DATA_DIR"]
+    assert str(install) not in paths["VNX_INTELLIGENCE_DIR"]


### PR DESCRIPTION
## Root cause (CRITICAL BLOCKER — issue #225, Wave 4 synthesis PR-1)

`scripts/lib/vnx_paths.sh`, `scripts/lib/vnx_paths.py` and the `bin/vnx` inline
fallback all set `PROJECT_ROOT = VNX_HOME` whenever `VNX_HOME` is its own git
repo root. For a **central install** (`VNX_HOME = ~/.vnx-system/versions/<v>/`)
that conflation is wrong: the operator runs from their own project, so all
project state, settings and intelligence landed in
`~/.vnx-system/versions/<v>/` instead of the real project. This is the reason
the three cutover attempts (MC + SEOcrawler) failed.

The same bug existed in the `bin/vnx` inline fallback (red-team finding) — that
path is fixed too.

## Fix

Distinguish three layouts in **all three** resolvers:

| Layout | Condition | PROJECT_ROOT |
|---|---|---|
| Embedded | `VNX_HOME` under `<project>/.claude/vnx-system` | `<project>` |
| Central | `VNX_HOME` is a shared versioned install | CWD git root |
| Standalone | `VNX_HOME` is a vnx-orchestration dev checkout | `VNX_HOME` (unchanged) |

Central detection hierarchy:
1. `VNX_PROJECT_ROOT` explicit override (exported by the central-install shim) — wins, ignored if it equals `VNX_HOME`.
2. `.vnx-install-mode` marker file == `central` (written by `install-central.sh`, lands in PR-2).
3. CWD git root differs from `VNX_HOME` (heuristic fallback).

In central mode `VNX_CANONICAL_ROOT` also repoints to the project git root, so
`VNX_INTELLIGENCE_DIR` exports follow the project rather than the immutable code
tree. Safety guards refuse `/` and empty resolves and fall back to `VNX_HOME`.

**Scope guards** (embedded + standalone unaffected): the new branches only fire
when `VNX_PROJECT_ROOT` is set, a marker file is present, or the CWD git root
differs from `VNX_HOME`. A standalone dev checkout run from inside its own tree
keeps the existing `PROJECT_ROOT = VNX_HOME` behavior.

## Files

- `scripts/lib/vnx_paths.sh` — `PROJECT_ROOT_DEFAULT` resolver + `VNX_PROJECT_ROOT` override + central `VNX_CANONICAL_ROOT` fix.
- `scripts/lib/vnx_paths.py` — `_default_project_root()`, `_default_canonical_root()`, `_is_central_install()`, `_resolve_project_root()` (honors `VNX_PROJECT_ROOT`).
- `bin/vnx` — inline fallback resolver brought to parity (same red-team bug).
- `tests/test_wave4_path_resolver.py` — 12 regression cases.

## Tests

```
pytest tests/test_wave4_path_resolver.py -v   # 12 passed
```

Cases: embedded layout, central+marker, central-by-git-heuristic, standalone dev
checkout, `VNX_PROJECT_ROOT` override + ignore-when-equal-to-VNX_HOME,
CWD-outside-git fallback, refuse-filesystem-root, **shell + inline-fallback
parity via subprocess** (the actual `vnx_paths.sh` and `bin/vnx` are executed,
not reimplemented), canonical-root-follows-project, and full `resolve_paths()`
end-to-end (data + intelligence land in the project).

## Manual test

```bash
# Simulate a central install + separate project, clean env
mkdir -p /tmp/t/proj && (cd /tmp/t/proj && git init -q && git commit -q --allow-empty -m i)
mkdir -p /tmp/t/install/scripts/lib && (cd /tmp/t/install && git init -q && git commit -q --allow-empty -m i)
echo central > /tmp/t/install/.vnx-install-mode
cp scripts/lib/vnx_paths.py scripts/lib/vnx_ids.py /tmp/t/install/scripts/lib/
cd /tmp/t/proj && env -u VNX_CANONICAL_ROOT -u PROJECT_ROOT -u VNX_DATA_DIR \
  VNX_HOME=/tmp/t/install python3 /tmp/t/install/scripts/lib/vnx_paths.py
# -> PROJECT_ROOT=/tmp/t/proj, VNX_CANONICAL_ROOT=/tmp/t/proj,
#    VNX_DATA_DIR=/tmp/t/proj/.vnx-data, VNX_HOME=/tmp/t/install
```

## Notes for reviewer

- Pre-existing, **out-of-scope** test failures on this branch (also fail on `main`, unrelated to these 3 files): 5 in `tests/test_vnx_doctor.py` (the `vnx_env` fixture builds a paths dict without `VNX_INTELLIGENCE_DIR`, crashing `vnx_doctor.py:122`) and 2 in `tests/test_vnx_doctor_strict.py` (`_check_install_mode` reads the real `~/.vnx-system/current` install on the dev machine). Neither touches the resolver.
- `vnx_paths.py:resolve_paths()` still honors an inherited `VNX_CANONICAL_ROOT` env var without the mismatch-rejection the shell has. In the production flow `bin/vnx`→`vnx_paths.sh` sanitizes it first, so this is benign, but the shell/python asymmetry is a candidate for PR-3 hardening.

Dispatch-ID: 20260525-140637-wave4-pr1-path-resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)