### PR TITLE
fix(install-central): preserve VNX_PROJECT_ROOT, write guard, cmd_update redirect (PR-WAVE4-3)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -12,9 +12,16 @@ export VNX_EXECUTABLE="$VNX_BIN"
 # (e.g. SEOcrawler PROJECT_ROOT leaking into marketing-magic-circle).
 # Preserve VNX_DATA_DIR if explicitly set (worktree isolation)
 _VNX_SAVED_DATA_DIR="${VNX_DATA_DIR:-}"
-unset PROJECT_ROOT VNX_HOME VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR
+# Save any incoming VNX_PROJECT_ROOT (exported per-invocation by the
+# central-install shim, or set explicitly by an operator). The env reset below
+# unsets it together with PROJECT_ROOT/VNX_HOME so the resolver re-detects from
+# a clean slate, then we restore the explicit project-root override so
+# vnx_paths.sh re-applies it (detection priority 2: VNX_PROJECT_ROOT).
+_VNX_INCOMING_PROJECT_ROOT="${VNX_PROJECT_ROOT:-}"
+unset PROJECT_ROOT VNX_HOME VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_PROJECT_ROOT
 [ -n "$_VNX_SAVED_DATA_DIR" ] && export VNX_DATA_DIR="$_VNX_SAVED_DATA_DIR"
-unset _VNX_SAVED_DATA_DIR
+[ -n "$_VNX_INCOMING_PROJECT_ROOT" ] && export VNX_PROJECT_ROOT="$_VNX_INCOMING_PROJECT_ROOT"
+unset _VNX_SAVED_DATA_DIR _VNX_INCOMING_PROJECT_ROOT
 
 if [ -f "$SCRIPT_DIR/../scripts/lib/vnx_paths.sh" ]; then
   # shellcheck source=/dev/null
@@ -83,6 +90,30 @@ else
   export VNX_DB_DIR="${VNX_DB_DIR:-$VNX_DATA_DIR/database}"
   export VNX_INTELLIGENCE_DIR="${VNX_INTELLIGENCE_DIR:-$VNX_CANONICAL_ROOT/.vnx-intelligence}"
 
+  # Central-install write guard (mirror of scripts/lib/vnx_paths.sh). In a
+  # central install (.vnx-install-mode=central) project state must never resolve
+  # under VNX_HOME — that tree is immutable shared code. Fail loud instead of
+  # corrupting it. No-op for embedded / standalone-dev layouts (no marker). Uses
+  # raw printf because err() is not defined yet at this point in the script.
+  if [ -f "${VNX_HOME_DEFAULT}/.vnx-install-mode" ] \
+    && [ "$(cat "${VNX_HOME_DEFAULT}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
+    _vnx_guard_home="$(cd "$VNX_HOME_DEFAULT" && pwd -P)"
+    for _vnx_guard_var in VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_INTELLIGENCE_DIR; do
+      _vnx_guard_val="${!_vnx_guard_var:-}"
+      [ -n "$_vnx_guard_val" ] || continue
+      case "$_vnx_guard_val" in
+        "$_vnx_guard_home"|"$_vnx_guard_home"/*)
+          printf 'ERROR: [guard] cannot write project state under immutable central install\n' >&2
+          printf 'ERROR: [guard]   %s=%s\n' "$_vnx_guard_var" "$_vnx_guard_val" >&2
+          printf 'ERROR: [guard]   VNX_HOME=%s (immutable shared code)\n' "$_vnx_guard_home" >&2
+          printf 'ERROR: [guard]   PROJECT_ROOT mis-detected; run vnx from your project directory\n' >&2
+          exit 1
+          ;;
+      esac
+    done
+    unset _vnx_guard_home _vnx_guard_var _vnx_guard_val
+  fi
+
   if [ -d "$PROJECT_ROOT_DEFAULT/.claude/skills" ]; then
     export VNX_SKILLS_DIR="$PROJECT_ROOT_DEFAULT/.claude/skills"
   else
@@ -124,6 +155,38 @@ log() {
 
 err() {
   printf 'ERROR: %s\n' "$*" >&2
+}
+
+# ── Central-install write guard ───────────────────────────────────────────
+# A central install marks its (immutable, shared) versioned code tree with a
+# .vnx-install-mode=central file written by install-central.sh. In that layout
+# no project state may be written under VNX_HOME. These helpers catch
+# PROJECT_ROOT mis-detection where PROJECT_ROOT collapses onto VNX_HOME — the
+# Wave 4 install-central bug. Embedded / standalone-dev layouts carry no marker
+# (PROJECT_ROOT == VNX_HOME is legitimate there), so the guard is a no-op.
+_vnx_is_central_install() {
+  [ -f "${VNX_HOME}/.vnx-install-mode" ] \
+    && [ "$(cat "${VNX_HOME}/.vnx-install-mode" 2>/dev/null)" = "central" ]
+}
+
+# Refuse a write whose target resolves under VNX_HOME in a central install.
+# Usage: _guard_not_vnx_home "<target-path>" || return 1
+_guard_not_vnx_home() {
+  local target="$1"
+  _vnx_is_central_install || return 0
+  local canon_target canon_home
+  canon_target="$(cd "$target" 2>/dev/null && pwd -P)" || canon_target="$target"
+  canon_home="$(cd "$VNX_HOME" 2>/dev/null && pwd -P)" || canon_home="$VNX_HOME"
+  case "$canon_target" in
+    "$canon_home"|"$canon_home"/*)
+      err "[guard] cannot write project state under immutable central install"
+      err "[guard]   target:   $canon_target"
+      err "[guard]   VNX_HOME: $canon_home (immutable shared code)"
+      err "[guard]   PROJECT_ROOT mis-detected — run vnx from your project directory (where .vnx-version lives)"
+      return 1
+      ;;
+  esac
+  return 0
 }
 
 # ── Command loader ──────────────────────────────────────────────────────
@@ -636,6 +699,9 @@ cmd_intelligence_import() {
 }
 
 cmd_init() {
+  # Refuse to bootstrap into the immutable central code tree (mis-detection).
+  _guard_not_vnx_home "$PROJECT_ROOT" || return 1
+
   # Parse --starter / --operator flags before forwarding to Python init.
   local mode_flag=""
   local init_args=()
@@ -920,6 +986,7 @@ select_snippet_for_target() {
 }
 
   cmd_patch_agent_files() {
+    _guard_not_vnx_home "$PROJECT_ROOT" || return 1
     local target
   for target in "$PROJECT_ROOT/CLAUDE.md" "$PROJECT_ROOT/AGENTS.md" "$PROJECT_ROOT/GEMINI.md"; do
     local base
@@ -1109,6 +1176,7 @@ EOF
 }
 
 cmd_bootstrap_skills() {
+  _guard_not_vnx_home "$PROJECT_ROOT" || return 1
   local project_claude_dir="$PROJECT_ROOT/.claude"
   local project_skills_dir="$project_claude_dir/skills"
   local shipped_skills_dir="$VNX_HOME/skills"
@@ -1181,6 +1249,7 @@ cmd_bootstrap_skills() {
 }
 
 cmd_bootstrap_terminals() {
+  _guard_not_vnx_home "$PROJECT_ROOT" || return 1
   local terminals_dir="$PROJECT_ROOT/.claude/terminals"
   local force=0
   local terminal_ids="T0 T1 T2 T3"
@@ -1346,6 +1415,7 @@ PYEOF
 }
 
 cmd_bootstrap_hooks() {
+  _guard_not_vnx_home "$PROJECT_ROOT" || return 1
   local project_claude_dir="$PROJECT_ROOT/.claude"
   local project_hooks_dir="$project_claude_dir/hooks"
   local project_settings="$project_claude_dir/settings.json"
@@ -1780,6 +1850,20 @@ cmd_update() {
       log "[update] Remote: unable to fetch (check network/URL)"
     fi
     return 0
+  fi
+
+  # Central install: the shared, versioned code tree is immutable. A self-update
+  # via clone+install would mutate it (or, worse, the wrong PROJECT_ROOT). Block
+  # the mutating path here — note that --check (read-only, handled above) and
+  # --pin (writes version.lock, not project state) still work. To move a central
+  # install forward, install a new version and repoint the per-project
+  # .vnx-version pin so the shim resolves it on the next invocation.
+  if _vnx_is_central_install; then
+    log "[update] Central install detected — 'vnx update' cannot mutate the shared code tree."
+    log "[update] Install a new version: bash <vnx-system>/install-central.sh --version <new-version>"
+    log "[update] Then repin this project: echo <new-version> > .vnx-version"
+    log "[update] (Use 'vnx update --check' for a read-only dry run.)"
+    return 1
   fi
 
   log "[update] Pulling latest VNX from: $origin_url (branch: $branch)"

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -249,6 +249,37 @@ if [ -z "${VNX_SKILLS_DIR:-}" ]; then
   fi
 fi
 
+# ── Central-install write guard ────────────────────────────────────────────
+# In a central install (.vnx-install-mode=central marker in VNX_HOME), project
+# state must never resolve under VNX_HOME — that tree is immutable shared code.
+# If detection mis-fired and collapsed PROJECT_ROOT onto VNX_HOME (the Wave 4
+# install-central bug), fail loud rather than silently writing receipts,
+# dispatches and intelligence into the code tree. Standalone-dev / embedded
+# layouts carry no marker, so this is a no-op there (state under the checkout is
+# legitimate). The check runs after the worktree override so it sees final paths.
+if [ -f "${VNX_HOME}/.vnx-install-mode" ] \
+  && [ "$(cat "${VNX_HOME}/.vnx-install-mode" 2>/dev/null)" = "central" ]; then
+  _vnx_guard_home="$(_vnx_canon_dir "$VNX_HOME")"
+  for _vnx_guard_var in VNX_DATA_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_INTELLIGENCE_DIR; do
+    _vnx_guard_val="${!_vnx_guard_var:-}"
+    [ -n "$_vnx_guard_val" ] || continue
+    case "$_vnx_guard_val" in
+      "$_vnx_guard_home"|"$_vnx_guard_home"/*)
+        printf 'ERROR: [vnx_paths] cannot write project state under immutable central install\n' >&2
+        printf 'ERROR: [vnx_paths]   %s=%s\n' "$_vnx_guard_var" "$_vnx_guard_val" >&2
+        printf 'ERROR: [vnx_paths]   VNX_HOME=%s (immutable shared code)\n' "$_vnx_guard_home" >&2
+        printf 'ERROR: [vnx_paths]   PROJECT_ROOT mis-detected; run from your project directory\n' >&2
+        # Data-integrity guard: halt unconditionally so the misconfiguration
+        # cannot proceed to write into the code tree, regardless of whether the
+        # caller enabled `set -e`. Restore the caller's shell options first.
+        eval "$__VNX_PATHS_SHELLOPTS"
+        exit 1
+        ;;
+    esac
+  done
+  unset _vnx_guard_home _vnx_guard_var _vnx_guard_val
+fi
+
 # ── Resolver functions ────────────────────────────────────────
 # These are callable from any script that sources vnx_paths.sh.
 # They resolve runtime dependencies dynamically instead of

--- a/tests/test_wave4_cmd_update.py
+++ b/tests/test_wave4_cmd_update.py
@@ -1,0 +1,178 @@
+"""Wave 4 PR-3 — ``vnx update`` behaviour under a central install.
+
+A central install's shared, versioned code tree is immutable. The mutating
+``vnx update`` (clone + install) path must be blocked there with an actionable
+redirect to ``install-central.sh`` plus a per-project ``.vnx-version`` repin.
+The read-only ``vnx update --check`` dry run must keep working everywhere and
+must not mutate anything — in particular it must never touch the project's
+``.vnx-version`` pin.
+
+All cases use a local git repo as the update origin so the tests stay offline
+and deterministic (no network ``git ls-remote`` / ``git clone``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_LOGS_DIR",
+    "VNX_PIDS_DIR",
+    "VNX_LOCKS_DIR",
+    "VNX_SOCKETS_DIR",
+    "VNX_REPORTS_DIR",
+    "VNX_HEADLESS_REPORTS_DIR",
+    "VNX_DB_DIR",
+    "VNX_INTELLIGENCE_DIR",
+    "VNX_SKILLS_DIR",
+)
+
+_PIN = "v1.0.0-rc4\n"
+
+
+def _git_init(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    return path.resolve()
+
+
+def _make_install(tmp_path: Path, *, marker: bool) -> Path:
+    install = _git_init(tmp_path / "vnx-install")
+    if marker:
+        (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+    return install
+
+
+def _make_origin(tmp_path: Path) -> Path:
+    """A local git repo standing in for the update origin, with a stub install.sh."""
+    origin = _git_init(tmp_path / "origin-repo")
+    (origin / "install.sh").write_text(
+        "#!/usr/bin/env bash\necho \"[stub-install] target=$1\"\nexit 0\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "install.sh"], cwd=origin, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add install"], cwd=origin, check=True)
+    # Normalise to 'main' so `git clone --branch main` works regardless of the
+    # local git's init.defaultBranch setting.
+    subprocess.run(["git", "branch", "-M", "main"], cwd=origin, check=True)
+    return origin
+
+
+def _make_project(tmp_path: Path, name: str = "real-project") -> Path:
+    project = _git_init(tmp_path / name)
+    (project / ".vnx-version").write_text(_PIN, encoding="utf-8")
+    return project
+
+
+def _run_update(install: Path, project: Path, *args: str) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    return subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "update", *args],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── central: --check is a read-only dry run ──────────────────────────────────
+def test_central_update_check_succeeds_no_mutation(tmp_path):
+    install = _make_install(tmp_path, marker=True)
+    origin = _make_origin(tmp_path)
+    project = _make_project(tmp_path)
+
+    result = _run_update(install, project, "--check", str(origin))
+    assert result.returncode == 0, result.stderr
+    assert "Check mode" in result.stdout
+    # Dry run: no project runtime dir created, pin untouched.
+    assert not (project / ".vnx-data").exists()
+    assert (project / ".vnx-version").read_text() == _PIN
+
+
+def test_central_update_check_preserves_pin(tmp_path):
+    install = _make_install(tmp_path, marker=True)
+    origin = _make_origin(tmp_path)
+    project = _make_project(tmp_path)
+
+    _run_update(install, project, "--check", str(origin))
+    assert (project / ".vnx-version").read_text() == _PIN
+
+
+# ── central: mutating update is blocked + redirected ─────────────────────────
+def test_central_update_blocks_self_update(tmp_path):
+    install = _make_install(tmp_path, marker=True)
+    origin = _make_origin(tmp_path)
+    project = _make_project(tmp_path)
+
+    result = _run_update(install, project, str(origin))
+    assert result.returncode == 1
+    assert "Central install detected" in result.stdout
+    assert "install-central.sh" in result.stdout
+    # Redirect fires before any clone/install.
+    assert "Pulling latest VNX" not in result.stdout
+
+
+def test_central_update_block_preserves_pin(tmp_path):
+    install = _make_install(tmp_path, marker=True)
+    origin = _make_origin(tmp_path)
+    project = _make_project(tmp_path)
+
+    _run_update(install, project, str(origin))
+    assert (project / ".vnx-version").read_text() == _PIN
+    # The immutable code tree was not written to.
+    assert not (install / ".vnx-origin").exists()
+
+
+# ── non-central: update proceeds (no redirect) ───────────────────────────────
+def test_non_central_update_check_no_redirect(tmp_path):
+    install = _make_install(tmp_path, marker=False)
+    origin = _make_origin(tmp_path)
+    project = _make_project(tmp_path)
+
+    result = _run_update(install, project, "--check", str(origin))
+    assert result.returncode == 0, result.stderr
+    assert "Central install detected" not in result.stdout
+    assert "Check mode" in result.stdout
+
+
+def test_non_central_full_update_runs_install(tmp_path):
+    """Without the central marker, the mutating path proceeds (stub install)."""
+    install = _make_install(tmp_path, marker=False)
+    origin = _make_origin(tmp_path)
+    # Run from inside the checkout: standalone-dev resolves PROJECT_ROOT=VNX_HOME.
+    result = _run_update(install, install, str(origin))
+    assert "Central install detected" not in result.stdout
+    assert result.returncode == 0, result.stderr
+    assert "[stub-install]" in result.stdout
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_wave4_save_restore.py
+++ b/tests/test_wave4_save_restore.py
@@ -1,0 +1,168 @@
+"""Wave 4 PR-3 — bin/vnx save/restore of VNX_PROJECT_ROOT.
+
+The central-install shim exports ``VNX_PROJECT_ROOT`` per invocation. ``bin/vnx``
+resets the project-context env vars (``PROJECT_ROOT``/``VNX_HOME``/…) so the
+resolver re-detects from a clean slate, but it must preserve the explicit
+``VNX_PROJECT_ROOT`` override across that reset and re-export it, so
+``vnx_paths.sh`` re-applies it (detection priority 2).
+
+The discriminating test: point CWD at one git project but ``VNX_PROJECT_ROOT``
+at a *different* one. If save/restore works, the explicit override wins; if it
+were dropped during the unset phase, the resolver would fall back to the CWD
+project instead.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_LOGS_DIR",
+    "VNX_PIDS_DIR",
+    "VNX_LOCKS_DIR",
+    "VNX_SOCKETS_DIR",
+    "VNX_REPORTS_DIR",
+    "VNX_HEADLESS_REPORTS_DIR",
+    "VNX_DB_DIR",
+    "VNX_INTELLIGENCE_DIR",
+    "VNX_SKILLS_DIR",
+)
+
+_DOCTOR_STUB = (
+    "cmd_doctor() {\n"
+    '  printf "PROJECT_ROOT=%s\\n" "$PROJECT_ROOT"\n'
+    '  printf "VNX_HOME=%s\\n" "$VNX_HOME"\n'
+    '  printf "VNX_DATA_DIR=%s\\n" "$VNX_DATA_DIR"\n'
+    "  exit 0\n"
+    "}\n"
+)
+
+
+def _git_init(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    return path.resolve()
+
+
+def _make_install(tmp_path: Path) -> Path:
+    install = _git_init(tmp_path / "vnx-install")
+    (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+    cmds = install / "scripts" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "doctor.sh").write_text(_DOCTOR_STUB, encoding="utf-8")
+    return install
+
+
+def _run_doctor(install: Path, cwd: Path, extra_env: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    if extra_env:
+        env.update(extra_env)
+    out = subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "doctor"],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return dict(line.split("=", 1) for line in out.stdout.splitlines() if "=" in line)
+
+
+def test_explicit_override_survives_env_reset(tmp_path):
+    """VNX_PROJECT_ROOT (project A) must win over CWD (project B)."""
+    install = _make_install(tmp_path)
+    override = _git_init(tmp_path / "override-project")
+    cwd_project = _git_init(tmp_path / "cwd-project")
+
+    resolved = _run_doctor(
+        install, cwd_project, extra_env={"VNX_PROJECT_ROOT": str(override)}
+    )
+    assert resolved["VNX_HOME"] == str(install)
+    # Override survived the unset/restore phase and beat the CWD project.
+    assert resolved["PROJECT_ROOT"] == str(override)
+    assert resolved["PROJECT_ROOT"] != str(cwd_project)
+
+
+def test_override_drives_data_dir(tmp_path):
+    """Data dir follows the restored override, not the CWD."""
+    install = _make_install(tmp_path)
+    override = _git_init(tmp_path / "override-project")
+    cwd_project = _git_init(tmp_path / "cwd-project")
+
+    resolved = _run_doctor(
+        install, cwd_project, extra_env={"VNX_PROJECT_ROOT": str(override)}
+    )
+    assert resolved["VNX_DATA_DIR"] == str(override / ".vnx-data")
+
+
+def test_no_override_falls_back_to_cwd(tmp_path):
+    """Without VNX_PROJECT_ROOT, central detection uses the CWD git root."""
+    install = _make_install(tmp_path)
+    cwd_project = _git_init(tmp_path / "cwd-project")
+
+    resolved = _run_doctor(install, cwd_project)
+    assert resolved["PROJECT_ROOT"] == str(cwd_project)
+
+
+def test_override_equal_to_vnx_home_ignored(tmp_path):
+    """A bad override pointing at VNX_HOME must be ignored, not honored."""
+    install = _make_install(tmp_path)
+    cwd_project = _git_init(tmp_path / "cwd-project")
+
+    resolved = _run_doctor(
+        install, cwd_project, extra_env={"VNX_PROJECT_ROOT": str(install)}
+    )
+    # Falls through to central detection → CWD project, never VNX_HOME.
+    assert resolved["PROJECT_ROOT"] == str(cwd_project)
+    assert resolved["PROJECT_ROOT"] != str(install)
+
+
+def test_override_preserved_alongside_data_dir_override(tmp_path):
+    """VNX_DATA_DIR and VNX_PROJECT_ROOT are both preserved across the reset."""
+    install = _make_install(tmp_path)
+    override = _git_init(tmp_path / "override-project")
+    cwd_project = _git_init(tmp_path / "cwd-project")
+    explicit_data = tmp_path / "explicit-data"
+
+    resolved = _run_doctor(
+        install,
+        cwd_project,
+        extra_env={
+            "VNX_PROJECT_ROOT": str(override),
+            "VNX_DATA_DIR": str(explicit_data),
+        },
+    )
+    assert resolved["PROJECT_ROOT"] == str(override)
+    assert resolved["VNX_DATA_DIR"] == str(explicit_data)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_wave4_write_guard.py
+++ b/tests/test_wave4_write_guard.py
@@ -1,0 +1,207 @@
+"""Wave 4 PR-3 — central-install write guard.
+
+In a central install, ``VNX_HOME`` is an immutable, shared, versioned code tree
+marked by a ``.vnx-install-mode=central`` file. No project state may ever be
+written under it. If path detection mis-fired and collapsed ``PROJECT_ROOT``
+onto ``VNX_HOME`` (the Wave 4 install-central bug), the resolver must fail loud
+instead of silently writing receipts/dispatches/intelligence into the code tree.
+
+The guard lives in two mirrored places, both exercised here:
+
+  * ``scripts/lib/vnx_paths.sh`` — fires at source time over the final
+    ``VNX_DATA_DIR`` / ``VNX_STATE_DIR`` / ``VNX_DISPATCH_DIR`` /
+    ``VNX_INTELLIGENCE_DIR`` values.
+  * the ``bin/vnx`` inline fallback — same check when ``vnx_paths.sh`` is absent.
+
+The guard is gated on the ``.vnx-install-mode`` marker, so standalone-dev and
+embedded layouts (where ``PROJECT_ROOT == VNX_HOME`` is legitimate) are
+unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_GUARD_MSG = "cannot write project state under immutable central install"
+
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_LOGS_DIR",
+    "VNX_PIDS_DIR",
+    "VNX_LOCKS_DIR",
+    "VNX_SOCKETS_DIR",
+    "VNX_REPORTS_DIR",
+    "VNX_HEADLESS_REPORTS_DIR",
+    "VNX_DB_DIR",
+    "VNX_INTELLIGENCE_DIR",
+    "VNX_SKILLS_DIR",
+)
+
+
+def _git_init(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    return path.resolve()
+
+
+def _make_central_install(tmp_path: Path, marker: bool = True) -> Path:
+    """A standalone git repo standing in for ~/.vnx-system/versions/<v>."""
+    install = _git_init(tmp_path / "vnx-install")
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+    if marker:
+        (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    return install
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _source_paths(install: Path, cwd: Path, extra_env: dict | None = None):
+    """Source vnx_paths.sh in a subprocess; return CompletedProcess."""
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{install}/scripts/lib/vnx_paths.sh"; '
+            'printf "PROJECT_ROOT=%s\\n" "$PROJECT_ROOT"; '
+            'printf "VNX_DATA_DIR=%s\\n" "$VNX_DATA_DIR"',
+        ],
+        cwd=cwd,
+        env=_clean_env(extra_env),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── vnx_paths.sh guard ───────────────────────────────────────────────────────
+def test_paths_sh_blocks_data_dir_under_vnx_home(tmp_path):
+    """VNX_DATA_DIR explicitly pointed inside VNX_HOME → fail loud."""
+    install = _make_central_install(tmp_path)
+    project = _git_init(tmp_path / "real-project")
+
+    result = _source_paths(
+        install, project, extra_env={"VNX_DATA_DIR": str(install / ".vnx-data")}
+    )
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+    assert "VNX_DATA_DIR" in result.stderr
+
+
+def test_paths_sh_blocks_state_dir_under_vnx_home(tmp_path):
+    install = _make_central_install(tmp_path)
+    project = _git_init(tmp_path / "real-project")
+
+    result = _source_paths(
+        install, project, extra_env={"VNX_STATE_DIR": str(install / "state")}
+    )
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+
+
+def test_paths_sh_allows_data_dir_in_project(tmp_path):
+    """Correct central detection: data lands in the project → no guard."""
+    install = _make_central_install(tmp_path)
+    project = _git_init(tmp_path / "real-project")
+
+    result = _source_paths(install, project)
+    assert result.returncode == 0, result.stderr
+    assert _GUARD_MSG not in result.stderr
+    resolved = dict(
+        line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+    )
+    assert resolved["PROJECT_ROOT"] == str(project)
+    assert resolved["VNX_DATA_DIR"] == str(project / ".vnx-data")
+
+
+def test_paths_sh_no_marker_allows_state_under_home(tmp_path):
+    """Standalone dev checkout (no marker): state under VNX_HOME is legitimate."""
+    install = _make_central_install(tmp_path, marker=False)
+    # Run from inside the checkout — standalone dev resolves PROJECT_ROOT=VNX_HOME,
+    # so VNX_DATA_DIR lands under VNX_HOME and must NOT trip the guard.
+    result = _source_paths(install, install)
+    assert result.returncode == 0, result.stderr
+    assert _GUARD_MSG not in result.stderr
+
+
+# ── bin/vnx end-to-end guard ─────────────────────────────────────────────────
+def _make_bin_install(tmp_path: Path, with_paths_lib: bool) -> Path:
+    install = _git_init(tmp_path / "vnx-install")
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+    (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    if with_paths_lib:
+        (install / "scripts" / "lib").mkdir(parents=True)
+        shutil.copy(
+            _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+            install / "scripts" / "lib" / "vnx_paths.sh",
+        )
+    # A skills dir so bootstrap-skills would otherwise have something to copy.
+    (install / "skills").mkdir(exist_ok=True)
+    (install / "skills" / "skills.yaml").write_text("skills: []\n", encoding="utf-8")
+    return install
+
+
+def test_bin_vnx_bootstrap_skills_blocked_when_cwd_is_install(tmp_path):
+    """`cd <central install> && vnx bootstrap-skills` → guard error, exit 1, no write."""
+    install = _make_bin_install(tmp_path, with_paths_lib=True)
+
+    result = subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "bootstrap-skills"],
+        cwd=install,
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+    # No project state should have been written into the code tree.
+    assert not (install / ".claude").exists()
+
+
+def test_bin_vnx_inline_fallback_blocks_under_home(tmp_path):
+    """Inline fallback (no vnx_paths.sh) enforces the same guard."""
+    install = _make_bin_install(tmp_path, with_paths_lib=False)
+    assert not (install / "scripts" / "lib" / "vnx_paths.sh").exists()
+
+    result = subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), "bootstrap-skills"],
+        cwd=install,
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+    assert not (install / ".claude").exists()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## PR-WAVE4-3 — bin/vnx hardening

Third PR in the Wave 4 install-central chain (after #628 PR-1, #629 PR-2). Adds the belt-and-suspenders hardening so a central install can never write project state into the immutable shared code tree.

### What changed
- **Save/restore `VNX_PROJECT_ROOT`** (`bin/vnx`): the incoming override (exported per-invocation by the central-install shim) is saved before the `PROJECT_ROOT`/`VNX_HOME` env reset and re-exported afterwards, so `vnx_paths.sh` re-applies it as detection priority 2 instead of dropping it during the clean-slate unset.
- **Write guard** (`scripts/lib/vnx_paths.sh` + `bin/vnx` inline fallback): when a `.vnx-install-mode=central` marker is present, any of `VNX_DATA_DIR` / `VNX_STATE_DIR` / `VNX_DISPATCH_DIR` / `VNX_INTELLIGENCE_DIR` resolving under `VNX_HOME` fails loud with `cannot write project state under immutable central install`. `_guard_not_vnx_home()` also guards `cmd_init`, `cmd_patch_agent_files`, `cmd_bootstrap_skills/terminals/hooks`. No-op for embedded / standalone-dev layouts (no marker).
- **`cmd_update` redirect**: central installs block the mutating clone+install path and redirect to `install-central.sh --version <new>` + a per-project `.vnx-version` repin. Read-only `--check` and `--pin` keep working everywhere and never touch project state.

### Tests (all exercise the real `bin/vnx` + `vnx_paths.sh` via subprocess)
| File | Cases |
|---|---|
| `tests/test_wave4_write_guard.py` | 6 |
| `tests/test_wave4_save_restore.py` | 5 |
| `tests/test_wave4_cmd_update.py` | 6 |

`17 passed` for the new suites. Regression: `test_wave4_path_resolver` + `test_wave4_install_central_marker` + `test_wave4_shim_traversal` + `test_path_resolution_regression` = `50 passed`.

### Acceptance
- [x] Write guard blocks writing under `VNX_HOME`
- [x] Save/restore `VNX_PROJECT_ROOT` works (explicit override beats CWD)
- [x] `cmd_update` validation green (`--check` dry-run, no mutation; mutating path blocked in central)
- [x] New tests green
- [x] Existing tests green (no regression)

Dispatch-ID: 20260525-154246-wave4-pr3-write-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)