### PR TITLE
fix(regen-settings): guard against central-install write; detect pre-fix contamination (PR-WAVE4-4)

### DIFF
--- a/scripts/commands/doctor.sh
+++ b/scripts/commands/doctor.sh
@@ -53,6 +53,25 @@ run_package_check() {
   return 0
 }
 
+run_contamination_check() {
+  # Wave 4 PR-4: warn (non-fatal) on pre-fix runtime state inside a central
+  # install. Mirrors check_contamination() in vnx_doctor.py so both doctor
+  # paths share one detector. Only fires for central installs; never fails.
+  if ! type _vnx_is_central_install >/dev/null 2>&1 || ! _vnx_is_central_install; then
+    return 0
+  fi
+  local check_script="$VNX_HOME/scripts/vnx_contamination_check.sh"
+  if [ ! -f "$check_script" ]; then
+    return 0
+  fi
+  if bash "$check_script" --version-dir "$VNX_HOME" --quiet; then
+    log "[doctor] OK: No runtime state inside central install."
+  else
+    log "[doctor] WARN: Pre-fix contamination inside central install — see cleanup instructions above."
+  fi
+  return 0
+}
+
 ensure_write_access() {
   local test_file="$VNX_STATE_DIR/.vnx_doctor_write_test"
   if touch "$test_file" 2>/dev/null; then
@@ -315,6 +334,7 @@ except:
 
   ensure_write_access || failed=1
   run_path_hygiene_check || failed=1
+  run_contamination_check
   if [ "$do_package_check" -eq 1 ]; then
     run_package_check || failed=1
   fi

--- a/scripts/commands/regen_settings.sh
+++ b/scripts/commands/regen_settings.sh
@@ -76,6 +76,19 @@ HELP
     return 1
   fi
 
+  # Wave 4 PR-4: never write settings.json into an immutable central install.
+  # The merge/full target is "$PROJECT_ROOT/.claude/settings.json". If PROJECT_ROOT
+  # mis-resolved onto VNX_HOME (the install-central bug), writing there would
+  # contaminate the shared, versioned code tree. The guard is marker-gated
+  # (only fires when .vnx-install-mode=central), so embedded and standalone-dev
+  # layouts — where PROJECT_ROOT == VNX_HOME is legitimate — are unaffected.
+  # --validate is read-only and intentionally exempt.
+  if [ "$mode" = "--merge" ] || [ "$mode" = "--full" ]; then
+    if type _guard_not_vnx_home >/dev/null 2>&1; then
+      _guard_not_vnx_home "$PROJECT_ROOT" || return 1
+    fi
+  fi
+
   # Require python3
   if ! command -v python3 &>/dev/null; then
     err "[regen-settings] python3 is required"

--- a/scripts/vnx_contamination_check.sh
+++ b/scripts/vnx_contamination_check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# VNX contamination check — detect pre-fix runtime state inside a central install.
+#
+# Wave 4 PR-4. Before the install-central path-resolver fix (PR-WAVE4-1..3), a
+# mis-resolved PROJECT_ROOT could write project runtime state — .vnx-data,
+# .claude/settings.json, .vnx-intelligence — *into* the immutable central code
+# tree (~/.vnx-system/versions/<v>/). After the fix, new invocations write to
+# the correct project dir, but any pre-fix contamination silently persists.
+#
+# This sweeps the central install for such contamination and prints actionable
+# cleanup instructions. It NEVER deletes anything — removal is an explicit
+# operator decision (receipts written into the central tree may need to be
+# copied into the owning project first).
+#
+# Usage:
+#   vnx_contamination_check.sh                       # scan ~/.vnx-system/versions/*
+#   vnx_contamination_check.sh --install-root DIR    # scan DIR/versions/*
+#   vnx_contamination_check.sh --version-dir DIR     # scan exactly DIR
+#   vnx_contamination_check.sh --quiet               # suppress the "clean" message
+#
+# Resolution order for the scan root (when neither flag is given):
+#   1. $VNX_CENTRAL_ROOT
+#   2. $HOME/.vnx-system
+#
+# Exit codes:
+#   0  no contamination found (or nothing to scan)
+#   1  contamination found (warnings printed to stderr)
+#   2  usage error
+
+set -u
+
+# Runtime directories that must never live inside the immutable central tree.
+BLOCKED_ENTRIES=(".vnx-data" ".claude" ".vnx-intelligence")
+
+_cc_out()  { printf '%s\n' "$*"; }
+_cc_warn() { printf '%s\n' "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage: vnx_contamination_check.sh [--install-root DIR | --version-dir DIR] [--quiet]
+
+Detects pre-fix runtime contamination (.vnx-data, .claude, .vnx-intelligence)
+inside a central VNX install. Warns with cleanup instructions; never deletes.
+
+Exit 0 = clean, 1 = contamination found, 2 = usage error.
+USAGE
+}
+
+main() {
+  local install_root=""
+  local version_dir=""
+  local quiet=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --install-root)
+        install_root="${2:-}"
+        [ -n "$install_root" ] || { _cc_warn "[contamination-check] --install-root requires a path"; return 2; }
+        shift 2
+        ;;
+      --version-dir)
+        version_dir="${2:-}"
+        [ -n "$version_dir" ] || { _cc_warn "[contamination-check] --version-dir requires a path"; return 2; }
+        shift 2
+        ;;
+      --quiet)
+        quiet=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *)
+        _cc_warn "[contamination-check] Unknown option: $1"
+        usage >&2
+        return 2
+        ;;
+    esac
+  done
+
+  # Build the list of version dirs to scan.
+  local -a scan_dirs=()
+  if [ -n "$version_dir" ]; then
+    scan_dirs+=("$version_dir")
+  else
+    [ -n "$install_root" ] || install_root="${VNX_CENTRAL_ROOT:-$HOME/.vnx-system}"
+    local versions_dir="$install_root/versions"
+    if [ -d "$versions_dir" ]; then
+      local d
+      for d in "$versions_dir"/*/; do
+        # nullglob-safe: a non-matching glob yields the literal pattern, which
+        # is not a directory and is skipped here.
+        [ -d "$d" ] || continue
+        scan_dirs+=("${d%/}")
+      done
+    fi
+  fi
+
+  if [ "${#scan_dirs[@]}" -eq 0 ]; then
+    [ "$quiet" -eq 1 ] || _cc_out "[contamination-check] No central install version dirs to scan."
+    return 0
+  fi
+
+  local found=0
+  local vdir entry path
+  for vdir in "${scan_dirs[@]}"; do
+    [ -d "$vdir" ] || continue
+    for entry in "${BLOCKED_ENTRIES[@]}"; do
+      path="$vdir/$entry"
+      if [ -e "$path" ]; then
+        found=1
+        _cc_warn "[contamination-check] WARN: runtime state inside central install:"
+        _cc_warn "  $path"
+        _cc_warn "  Cleanup (after copying any needed receipts into your project): rm -rf '$path'"
+      fi
+    done
+  done
+
+  if [ "$found" -eq 1 ]; then
+    _cc_warn "[contamination-check] Pre-fix contamination detected. Review and remove the paths above manually."
+    return 1
+  fi
+
+  [ "$quiet" -eq 1 ] || _cc_out "[contamination-check] Clean: no runtime state inside central install."
+  return 0
+}
+
+main "$@"

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -483,6 +483,49 @@ def check_path_hygiene(paths: Dict[str, str]) -> List[CheckResult]:
         return [CheckResult("hygiene", FAIL, "Path hygiene check failed")]
 
 
+def check_contamination(paths: Dict[str, str]) -> List[CheckResult]:
+    """Warn (non-fatal) on pre-fix runtime state inside a central install.
+
+    Wave 4 PR-4. Only meaningful for central installs (VNX_HOME =
+    ~/.vnx-system/versions/<v>, marked by .vnx-install-mode=central); embedded
+    and standalone-dev layouts carry no marker and are skipped. Delegates to
+    scripts/vnx_contamination_check.sh so the bash doctor path and this
+    Python path share one detector. Always WARN, never FAIL — removing
+    contamination is an explicit operator decision.
+    """
+    vnx_home = Path(paths["VNX_HOME"])
+    marker = vnx_home / ".vnx-install-mode"
+    try:
+        is_central = marker.is_file() and marker.read_text(encoding="utf-8").strip() == "central"
+    except OSError:
+        is_central = False
+    if not is_central:
+        return []
+
+    script = vnx_home / "scripts" / "vnx_contamination_check.sh"
+    if not script.exists():
+        return []
+
+    try:
+        result = subprocess.run(
+            ["bash", str(script), "--version-dir", str(vnx_home), "--quiet"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return [CheckResult("contamination", WARN, "Contamination check timed out")]
+
+    if result.returncode == 0:
+        return [CheckResult("contamination", PASS, "No runtime state in central install")]
+
+    details = [ln for ln in result.stderr.strip().split("\n") if ln][:10]
+    return [CheckResult(
+        "contamination", WARN,
+        "Pre-fix runtime state found inside central install",
+        remediation="Copy any needed receipts into the owning project, then remove the paths listed below",
+        details=details,
+    )]
+
+
 # ---------------------------------------------------------------------------
 # Runtime checks (delegates to vnx_doctor_runtime.py)
 # ---------------------------------------------------------------------------
@@ -542,6 +585,7 @@ def run_doctor(paths: Dict[str, str], *,
     results.extend(check_worktree(paths))
     results.extend(check_version(paths))
     results.extend(check_path_hygiene(paths))
+    results.extend(check_contamination(paths))
 
     if package_check:
         vnx_home = Path(paths["VNX_HOME"])

--- a/tests/test_wave4_contamination_check.py
+++ b/tests/test_wave4_contamination_check.py
@@ -1,0 +1,179 @@
+"""Wave 4 PR-4 — pre-fix contamination detection.
+
+Before the install-central path-resolver fix, a mis-resolved ``PROJECT_ROOT``
+could write project runtime state (``.vnx-data``, ``.claude``,
+``.vnx-intelligence``) *into* the immutable central code tree
+(``~/.vnx-system/versions/<v>/``). After the fix, new invocations write to the
+correct project dir, but pre-fix contamination silently persists.
+
+``scripts/vnx_contamination_check.sh`` sweeps a central install for such state
+and warns with cleanup instructions — it never deletes. ``vnx doctor`` surfaces
+the same detector via ``check_contamination`` (non-fatal WARN).
+
+These tests run the real shell script via subprocess and the real
+``check_contamination`` function — neither is reimplemented in the test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "vnx_contamination_check.sh"
+_BLOCKED = (".vnx-data", ".claude", ".vnx-intelligence")
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_install(tmp_path: Path, *, contaminate: list[str] | None = None) -> Path:
+    """A ~/.vnx-system layout with one version dir, optionally contaminated."""
+    root = tmp_path / "vnx-system"
+    version_dir = root / "versions" / "v1.0.0-rc4"
+    version_dir.mkdir(parents=True)
+    (version_dir / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    for entry in contaminate or []:
+        (version_dir / entry).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+# ── standalone script: --install-root sweep ──────────────────────────────────
+def test_install_root_clean_returns_zero(tmp_path):
+    root = _make_install(tmp_path)
+    result = _run("--install-root", str(root))
+    assert result.returncode == 0, result.stderr
+    assert "Clean" in result.stdout
+
+
+def test_install_root_detects_vnx_data(tmp_path):
+    root = _make_install(tmp_path, contaminate=[".vnx-data"])
+    result = _run("--install-root", str(root))
+    assert result.returncode == 1
+    assert ".vnx-data" in result.stderr
+    assert "rm -rf" in result.stderr  # actionable cleanup instruction
+    assert "manually" in result.stderr  # never auto-deletes
+
+
+def test_install_root_detects_claude_settings(tmp_path):
+    root = _make_install(tmp_path, contaminate=[".claude"])
+    version_dir = root / "versions" / "v1.0.0-rc4"
+    (version_dir / ".claude" / "settings.json").write_text("{}\n", encoding="utf-8")
+    result = _run("--install-root", str(root))
+    assert result.returncode == 1
+    assert ".claude" in result.stderr
+    # Detection is non-destructive: the contaminated file is still present.
+    assert (version_dir / ".claude" / "settings.json").is_file()
+
+
+def test_install_root_scans_every_version(tmp_path):
+    root = _make_install(tmp_path)
+    dirty = root / "versions" / "v0.9.0"
+    (dirty / ".vnx-intelligence").mkdir(parents=True)
+    result = _run("--install-root", str(root))
+    assert result.returncode == 1
+    assert "v0.9.0" in result.stderr
+    assert ".vnx-intelligence" in result.stderr
+
+
+# ── standalone script: --version-dir (single dir, used by vnx doctor) ─────────
+def test_version_dir_clean(tmp_path):
+    root = _make_install(tmp_path)
+    version_dir = root / "versions" / "v1.0.0-rc4"
+    result = _run("--version-dir", str(version_dir), "--quiet")
+    assert result.returncode == 0
+    assert result.stdout == ""  # --quiet suppresses the clean message
+
+
+def test_version_dir_contaminated(tmp_path):
+    root = _make_install(tmp_path, contaminate=[".vnx-data"])
+    version_dir = root / "versions" / "v1.0.0-rc4"
+    result = _run("--version-dir", str(version_dir))
+    assert result.returncode == 1
+    assert str(version_dir / ".vnx-data") in result.stderr
+
+
+# ── standalone script: graceful + error paths ────────────────────────────────
+def test_missing_install_root_is_clean(tmp_path):
+    result = _run("--install-root", str(tmp_path / "nope"))
+    assert result.returncode == 0
+    assert "No central install" in result.stdout
+
+
+def test_install_root_without_value_is_usage_error(tmp_path):
+    result = _run("--install-root")
+    assert result.returncode == 2
+
+
+def test_unknown_option_is_usage_error(tmp_path):
+    result = _run("--bogus")
+    assert result.returncode == 2
+    assert "Unknown option" in result.stderr
+
+
+# ── vnx doctor integration: check_contamination ──────────────────────────────
+def _load_doctor():
+    scripts_dir = _REPO_ROOT / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        "vnx_doctor_under_test", scripts_dir / "vnx_doctor.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec: dataclasses resolve field types via
+    # sys.modules[cls.__module__], which fails for an unregistered module.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_central_vnx_home(tmp_path: Path, *, contaminate: list[str] | None = None) -> Path:
+    """A VNX_HOME standing in for ~/.vnx-system/versions/<v> with the real script."""
+    home = tmp_path / "versions" / "v1.0.0-rc4"
+    (home / "scripts").mkdir(parents=True)
+    (home / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    import shutil
+
+    shutil.copy(_SCRIPT, home / "scripts" / "vnx_contamination_check.sh")
+    for entry in contaminate or []:
+        (home / entry).mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def test_doctor_check_skips_non_central(tmp_path):
+    doctor = _load_doctor()
+    home = tmp_path / "embedded-project"
+    (home / "scripts").mkdir(parents=True)
+    # No .vnx-install-mode marker → not a central install → check is a no-op.
+    results = doctor.check_contamination({"VNX_HOME": str(home)})
+    assert results == []
+
+
+def test_doctor_check_passes_when_clean(tmp_path):
+    doctor = _load_doctor()
+    home = _make_central_vnx_home(tmp_path)
+    results = doctor.check_contamination({"VNX_HOME": str(home)})
+    assert len(results) == 1
+    assert results[0].status == doctor.PASS
+
+
+def test_doctor_check_warns_on_contamination(tmp_path):
+    doctor = _load_doctor()
+    home = _make_central_vnx_home(tmp_path, contaminate=[".vnx-data"])
+    results = doctor.check_contamination({"VNX_HOME": str(home)})
+    assert len(results) == 1
+    # Non-fatal: contamination is a WARN, never FAIL — must not break doctor exit.
+    assert results[0].status == doctor.WARN
+    assert results[0].status != doctor.FAIL
+    assert any(".vnx-data" in d for d in results[0].details)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_wave4_regen_settings_target.py
+++ b/tests/test_wave4_regen_settings_target.py
@@ -1,0 +1,198 @@
+"""Wave 4 PR-4 — regen-settings writes to the project, never the central install.
+
+``vnx regen-settings`` renders ``$PROJECT_ROOT/.claude/settings.json``. In a
+central install (VNX_HOME = ``~/.vnx-system/versions/<v>``, immutable shared
+code), the only way that target could land inside VNX_HOME is if PROJECT_ROOT
+mis-resolved onto VNX_HOME (the Wave 4 install-central bug). PR-WAVE4-4 adds a
+marker-gated guard to ``cmd_regen_settings`` that refuses ``--merge`` / ``--full``
+in that case.
+
+These tests drive the real ``bin/vnx`` end-to-end (no reimplementation):
+
+  * from a real project dir → settings.json lands in the project, not VNX_HOME.
+  * from inside the central install (PROJECT_ROOT collapses onto VNX_HOME) →
+    guard error, exit non-zero, nothing written into the code tree.
+  * ``--validate`` is read-only and exempt from the guard.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GUARD_MSG = "cannot write project state under immutable central install"
+
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_INTELLIGENCE_DIR",
+    "VNX_SKILLS_DIR",
+)
+
+
+def _git_init(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    return path.resolve()
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _make_central_install(tmp_path: Path) -> Path:
+    """A standalone git repo standing in for ~/.vnx-system/versions/<v>.
+
+    Ships exactly the pieces ``vnx regen-settings`` touches: the CLI, the path
+    resolver, the regen command, the merge engine, and the settings template.
+    """
+    install = _git_init(tmp_path / "vnx-install")
+
+    (install / "bin").mkdir()
+    shutil.copy(_REPO_ROOT / "bin" / "vnx", install / "bin" / "vnx")
+    os.chmod(install / "bin" / "vnx", 0o755)
+
+    (install / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "lib" / "vnx_paths.sh",
+        install / "scripts" / "lib" / "vnx_paths.sh",
+    )
+
+    (install / "scripts" / "commands").mkdir(parents=True)
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "commands" / "regen_settings.sh",
+        install / "scripts" / "commands" / "regen_settings.sh",
+    )
+    shutil.copy(
+        _REPO_ROOT / "scripts" / "vnx_settings_merge.py",
+        install / "scripts" / "vnx_settings_merge.py",
+    )
+
+    (install / "templates").mkdir()
+    shutil.copy(
+        _REPO_ROOT / "templates" / "settings_vnx_keys.json.tmpl",
+        install / "templates" / "settings_vnx_keys.json.tmpl",
+    )
+
+    (install / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    return install
+
+
+def _run_vnx(install: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(install / "bin" / "vnx"), *args],
+        cwd=cwd,
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── target lands in the project, not the central install ──────────────────────
+def test_regen_full_writes_into_project_not_central(tmp_path):
+    install = _make_central_install(tmp_path)
+    project = _git_init(tmp_path / "real-project")
+
+    result = _run_vnx(install, project, "regen-settings", "--full", "--no-backup")
+    assert result.returncode == 0, result.stderr + result.stdout
+
+    project_settings = project / ".claude" / "settings.json"
+    assert project_settings.is_file(), "settings.json must be created in the project"
+    # The central code tree must remain untouched.
+    assert not (install / ".claude").exists()
+
+    data = json.loads(project_settings.read_text(encoding="utf-8"))
+    assert "hooks" in data and "permissions" in data
+
+
+def test_regen_merge_writes_into_project_not_central(tmp_path):
+    install = _make_central_install(tmp_path)
+    project = _git_init(tmp_path / "real-project")
+
+    result = _run_vnx(install, project, "regen-settings", "--merge", "--no-backup")
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (project / ".claude" / "settings.json").is_file()
+    assert not (install / ".claude").exists()
+    assert _GUARD_MSG not in result.stderr
+
+
+# ── guarantee: never write into VNX_HOME when PROJECT_ROOT collapses onto it ──
+# Defense in depth — running from inside the central install collapses
+# PROJECT_ROOT onto VNX_HOME. The PR-3 source-time guard in vnx_paths.sh and the
+# PR-4 regen guard both target this; the observable guarantee is identical: the
+# command fails and writes nothing into the immutable code tree.
+def test_regen_merge_blocked_from_inside_central_install(tmp_path):
+    install = _make_central_install(tmp_path)
+    result = _run_vnx(install, install, "regen-settings", "--merge", "--no-backup")
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+    assert not (install / ".claude").exists()
+
+
+def test_regen_full_blocked_from_inside_central_install(tmp_path):
+    install = _make_central_install(tmp_path)
+    result = _run_vnx(install, install, "regen-settings", "--full", "--no-backup")
+    assert result.returncode != 0
+    assert _GUARD_MSG in result.stderr
+    assert not (install / ".claude").exists()
+
+
+# ── unit: the PR-4 regen guard's own control flow ─────────────────────────────
+# Sources the REAL cmd_regen_settings (not reimplemented) with a spy standing in
+# for the PR-3 _guard_not_vnx_home collaborator, to prove that write modes invoke
+# the guard against PROJECT_ROOT and that --validate is exempt. This is the inner
+# defense layer that catches PROJECT_ROOT == VNX_HOME even when the source-time
+# guard does not fire (e.g. VNX_DATA_DIR explicitly relocated to a real project).
+def _run_regen_unit(mode: str, *, guard_returns: int) -> subprocess.CompletedProcess:
+    regen = _REPO_ROOT / "scripts" / "commands" / "regen_settings.sh"
+    program = f"""
+set -u
+source "{regen}"
+err() {{ printf '%s\\n' "$*" >&2; }}
+log() {{ printf '%s\\n' "$*"; }}
+PROJECT_ROOT="/collapsed/vnx-home"
+VNX_HOME="/collapsed/vnx-home"
+_guard_not_vnx_home() {{ printf 'GUARD_CALLED:%s\\n' "$1" >&2; return {guard_returns}; }}
+cmd_regen_settings {mode} --no-backup
+printf 'RC=%s\\n' "$?"
+"""
+    return subprocess.run(
+        ["bash", "-c", program], capture_output=True, text=True, env=_clean_env()
+    )
+
+
+@pytest.mark.parametrize("mode", ["--merge", "--full"])
+def test_regen_guard_invoked_for_write_modes(mode):
+    result = _run_regen_unit(mode, guard_returns=1)
+    assert "GUARD_CALLED:/collapsed/vnx-home" in result.stderr
+    assert "RC=1" in result.stdout  # guard tripping aborts the command
+
+
+def test_regen_guard_skipped_for_validate():
+    result = _run_regen_unit("--validate", guard_returns=1)
+    # --validate is read-only and must not consult the write guard at all.
+    assert "GUARD_CALLED" not in result.stderr
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## PR-WAVE4-4 — Defensive guards

Defense-in-depth for the Wave 4 install-central path-resolver fix (PR-WAVE4-1..3, #628/#629/#630). Spec: `claudedocs/wave4-synthesis-2026-05-25.md` §PR-4.

### Problem
`vnx regen-settings` renders `$PROJECT_ROOT/.claude/settings.json`. In a central install, if `PROJECT_ROOT` mis-resolved onto `VNX_HOME` (the install-central bug), settings.json would be written into the immutable shared code tree. Separately, earlier mis-resolved runs may have left runtime state (`.vnx-data`, `.claude`, `.vnx-intelligence`) inside `~/.vnx-system/versions/*/`.

### Changes
- **`scripts/commands/regen_settings.sh`** — marker-gated guard refuses `--merge`/`--full` when `PROJECT_ROOT` collapses onto `VNX_HOME`. `--validate` (read-only) is exempt. Embedded/standalone-dev layouts (no `.vnx-install-mode` marker) are unaffected.
- **`scripts/vnx_contamination_check.sh`** (new) — operator sweep over `~/.vnx-system/versions/*/` (or `--version-dir`) for pre-fix contamination. Warns with `rm -rf` cleanup instructions; **never auto-deletes**.
- **`scripts/vnx_doctor.py` + `scripts/commands/doctor.sh`** — surface the contamination sweep as a non-fatal `WARN` check, symmetric across both doctor paths, central-install-only.

### Tests
- `tests/test_wave4_regen_settings_target.py` (6) — regen writes into the project not the central install (`--full`/`--merge`); write blocked when `PROJECT_ROOT == VNX_HOME`; guard control flow (write-modes consult the guard, `--validate` exempt).
- `tests/test_wave4_contamination_check.py` (12) — standalone script detect/clean/error paths + `vnx doctor` `check_contamination` PASS/WARN/skip.

All 19 new tests pass. Existing wave4 + doctor-template suites unaffected.

### Known pre-existing failures (NOT introduced by this PR)
7 doctor tests on the branch baseline fail independently of this change (verified by stashing this PR's `vnx_doctor.py`): `test_vnx_doctor.py` `check_path_resolution` raises `KeyError: 'VNX_INTELLIGENCE_DIR'` (fixture drift after PR-1's path model), and `test_vnx_doctor_strict.py` embedded-mode status drift. These predate PR-4 and are out of its scope.

Dispatch-ID: 20260525-195904-wave4-pr4-regen-settings-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)