### PR TITLE
fix(runtime-coord): add terminal_leases.worker_pid + schema-drift regression guard

### DIFF
--- a/schemas/runtime_coordination.sql
+++ b/schemas/runtime_coordination.sql
@@ -119,6 +119,7 @@ CREATE TABLE IF NOT EXISTS terminal_leases (
     expires_at          TEXT,
     last_heartbeat_at   TEXT,
     released_at         TEXT,
+    worker_pid          INTEGER,
     metadata_json       TEXT    DEFAULT '{}'
 );
 

--- a/schemas/runtime_coordination_v10.sql
+++ b/schemas/runtime_coordination_v10.sql
@@ -49,10 +49,18 @@ CREATE TABLE IF NOT EXISTS terminal_leases (
     expires_at          TEXT,
     last_heartbeat_at   TEXT,
     released_at         TEXT,
+    worker_pid          INTEGER,
     metadata_json       TEXT    DEFAULT '{}',
     FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id),
     UNIQUE(terminal_id, project_id)
 );
+
+-- worker_pid (INTEGER, nullable): OS PID of the worker process currently
+-- attached to this terminal, or NULL when none. Written by
+-- pool_state_repo.store_worker_pid() (called from subprocess_dispatch) and read
+-- by the lease-reaper / runtime_supervise path. On a DB that predates this
+-- column it is self-healed idempotently by the init path
+-- (project_id_migration.ensure_worker_pid_column), independent of user_version.
 
 -- Non-project_id indexes are safe here because these columns exist in v1.
 -- project_id indexes (idx_lease_project, idx_lease_terminal_project) are

--- a/scripts/lib/project_id_migration.py
+++ b/scripts/lib/project_id_migration.py
@@ -94,6 +94,49 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(r[1] == column for r in rows)
 
 
+# ---------------------------------------------------------------------------
+# worker_pid self-heal — 2nd schema-code drift (after worker_states.project_id)
+# ---------------------------------------------------------------------------
+#
+# rc6 code WRITES and READS ``terminal_leases.worker_pid``
+# (pool_state_repo.store_worker_pid / list_members), but no schema file or
+# migration ever defined the column. Every dispatch logged
+# "PID persistence failed: no such column: worker_pid" — non-fatal (the write
+# is in a rolled-back try/except) but it blinds the supervisor's worker-PID
+# tracking, degrading the lease-reaper / runtime_supervise path.
+#
+# The column is now declared in schemas/runtime_coordination{,_v10}.sql, but a
+# fresh DB builds terminal_leases from the v1 base (CREATE TABLE IF NOT EXISTS
+# in v10 is a no-op on the existing table) and pre-existing DBs predate the
+# declaration entirely — so, exactly like worker_states.project_id (OI-095), a
+# version-independent idempotent self-heal on every init is required. SQLite
+# has no ``ADD COLUMN IF NOT EXISTS``; guard with PRAGMA table_info first.
+WORKER_PID_TABLE = "terminal_leases"
+WORKER_PID_COLUMN = "worker_pid"
+
+
+def ensure_worker_pid_column(conn: sqlite3.Connection) -> str:
+    """Idempotently ensure ``terminal_leases.worker_pid`` (INTEGER, nullable).
+
+    Returns one of:
+      - ``"added"``           — column was just added
+      - ``"already_present"`` — column already existed
+      - ``"skipped_missing"`` — terminal_leases table not present in this DB
+
+    Reapplying is a clean no-op regardless of ``user_version``. Nullable
+    INTEGER: a worker PID when one is attached, NULL otherwise.
+    """
+    _validate_identifier(WORKER_PID_TABLE)
+    if not _table_exists(conn, WORKER_PID_TABLE):
+        return "skipped_missing"
+    if _column_exists(conn, WORKER_PID_TABLE, WORKER_PID_COLUMN):
+        return "already_present"
+    conn.execute(
+        f"ALTER TABLE {WORKER_PID_TABLE} ADD COLUMN {WORKER_PID_COLUMN} INTEGER"
+    )
+    return "added"
+
+
 def apply_project_id_migration(
     conn: sqlite3.Connection,
     tables: Iterable[str],
@@ -155,6 +198,9 @@ def run_runtime_coordination_migration(db_path: str | Path) -> Dict[str, object]
     try:
         conn.execute("PRAGMA foreign_keys = ON")
         results = apply_project_id_migration(conn, RUNTIME_COORDINATION_TABLES)
+        # Self-heal the 2nd schema-code drift: terminal_leases.worker_pid.
+        # Independent of the project_id columns above; nullable INTEGER.
+        worker_pid_status = ensure_worker_pid_column(conn)
         conn.execute(
             "INSERT OR IGNORE INTO runtime_schema_version (version, description) "
             "VALUES (?, ?)",
@@ -169,6 +215,7 @@ def run_runtime_coordination_migration(db_path: str | Path) -> Dict[str, object]
         "db_path": str(path),
         "schema_version": RUNTIME_SCHEMA_VERSION,
         "results": results,
+        "worker_pid_status": worker_pid_status,
     }
 
 

--- a/scripts/runtime_coordination_init.py
+++ b/scripts/runtime_coordination_init.py
@@ -220,6 +220,12 @@ def main() -> int:
             elif status == "skipped_missing":
                 log("WARNING", f"  runtime_coordination.{table}: not present, skipped")
 
+        worker_pid_status = runtime_result.get("worker_pid_status")
+        if worker_pid_status == "added":
+            log("SUCCESS", "  runtime_coordination.terminal_leases: worker_pid added")
+        elif worker_pid_status == "skipped_missing":
+            log("WARNING", "  runtime_coordination.terminal_leases: not present, worker_pid skipped")
+
         qi_db = Path(state_dir) / "quality_intelligence.db"
         qi_result = run_quality_intelligence_migration(qi_db)
         if qi_result.get("status") == "skipped_no_db":

--- a/tests/test_runtime_coordination_schema_drift.py
+++ b/tests/test_runtime_coordination_schema_drift.py
@@ -1,0 +1,539 @@
+"""Schema-code drift guard for the runtime_coordination database.
+
+Twice now, runtime_coordination code has referenced a column the schema never
+defined:
+  1. worker_states.project_id  (OI-095, PR #635)
+  2. terminal_leases.worker_pid (this PR)
+
+Both shipped silently — the writes sat in try/except blocks that logged
+"no such column: ..." and rolled back, blinding worker-health and PID
+telemetry. This test catches the WHOLE class statically:
+
+  1. Parse the canonical schema (runtime_coordination.sql + every
+     runtime_coordination_v*.sql + every schemas/migrations/*.sql) into a
+     ``{table: set(columns)}`` map. Columns come from CREATE TABLE bodies and
+     ``ALTER TABLE ... ADD COLUMN`` statements; table-rebuild temporaries
+     (``<name>_v10``) are folded back onto their canonical name. The map is a
+     *superset* of every column a table may legitimately carry.
+
+  2. Scan the runtime_coordination DB-access code for column references and
+     assert each one exists in the schema for its table.
+
+False-positive discipline (the dispatch's explicit priority — under-claim
+rather than over-flag):
+  - Only HIGH-CONFIDENCE positions are scanned: ``UPDATE t SET col = ``,
+    ``INSERT INTO t (cols)``, and alias-qualified ``a.col`` reads where the
+    alias resolves to a real table via FROM/JOIN/UPDATE/INSERT.
+  - Bare unqualified ``SELECT col``/``WHERE col`` lists are deliberately NOT
+    scanned. pool_state_repo.get_config() intentionally SELECTs optional
+    columns (cost_ceiling_usd, heartbeat_stale_seconds) that older DBs lack and
+    falls back via ``except sqlite3.OperationalError`` — flagging those would be
+    a false positive. The two real drifts (a SET write and an alias-qualified
+    read) are both covered by the scanned positions.
+  - Dynamically-built clauses (f-string ``{...}`` placeholders, ``%`` format
+    markers) are skipped — their column set cannot be resolved statically.
+  - Only references to tables PRESENT in the runtime_coordination schema map
+    are checked; cross-DB (quality_intelligence) references auto-skip.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCHEMAS_DIR = _REPO_ROOT / "schemas"
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+# SQL clause keywords that must never be mistaken for a table alias.
+_ALIAS_STOPWORDS = frozenset({
+    "WHERE", "SET", "ON", "USING", "VALUES", "GROUP", "ORDER", "LIMIT",
+    "LEFT", "RIGHT", "INNER", "OUTER", "FULL", "CROSS", "JOIN", "AND", "OR",
+    "AS", "SELECT", "INTO", "WHEN", "THEN", "ELSE", "END", "RETURNING",
+    "HAVING", "OFFSET", "UNION", "EXCEPT", "INTERSECT",
+})
+
+_SQL_HINT_RE = re.compile(r"\b(UPDATE|INSERT|SELECT|FROM|JOIN)\b", re.IGNORECASE)
+_IDENT = r"[A-Za-z_]\w*"
+
+
+def _normalize_table(name: str) -> str:
+    """Fold rebuild temporaries (``dispatches_v10``) onto the canonical name."""
+    return re.sub(r"_v\d+$", "", name)
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Remove ``--`` line comments and ``/* */`` block comments, preserving
+    single-quoted string literals.
+
+    Without this, a trailing inline comment (``state TEXT NOT NULL,  -- note``)
+    glues onto the *next* column when the CREATE TABLE body is split on commas:
+    that column's token becomes ``--`` and the real column is dropped from the
+    schema map — surfacing as a phantom drift finding (false positive). It also
+    keeps unbalanced parens inside comments (``-- FK (informational``) from
+    breaking the balanced-paren body extractor.
+    """
+    out: List[str] = []
+    i, n = 0, len(sql)
+    in_str = False
+    while i < n:
+        c = sql[i]
+        if in_str:
+            out.append(c)
+            if c == "'":
+                if i + 1 < n and sql[i + 1] == "'":  # '' escape inside literal
+                    out.append("'")
+                    i += 2
+                    continue
+                in_str = False
+            i += 1
+            continue
+        if c == "'":
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "-" and i + 1 < n and sql[i + 1] == "-":
+            j = sql.find("\n", i)
+            if j == -1:
+                break
+            i = j  # preserve the newline so line structure is kept
+            continue
+        if c == "/" and i + 1 < n and sql[i + 1] == "*":
+            j = sql.find("*/", i + 2)
+            if j == -1:
+                break
+            i = j + 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Schema parsing
+# ---------------------------------------------------------------------------
+
+def _extract_create_table_body(sql: str, start: int) -> Tuple[str, int]:
+    """Return the parenthesised body of a CREATE TABLE starting at the first
+    ``(`` at/after *start*, using balanced-paren matching. Returns (body, end)."""
+    open_idx = sql.find("(", start)
+    if open_idx == -1:
+        return "", start
+    depth = 0
+    for i in range(open_idx, len(sql)):
+        c = sql[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[open_idx + 1:i], i
+    return sql[open_idx + 1:], len(sql)
+
+
+def _split_top_level(body: str) -> List[str]:
+    """Split on commas that sit at paren-depth 0."""
+    items: List[str] = []
+    depth = 0
+    buf: List[str] = []
+    for c in body:
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        if c == "," and depth == 0:
+            items.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+    if buf:
+        items.append("".join(buf))
+    return items
+
+
+# Leaders of a table-level constraint clause in SQLite — never column names.
+# "KEY" is deliberately excluded: SQLite has no bare ``KEY (...)`` constraint
+# (that is MySQL syntax), and ``schema_meta`` has a real column literally named
+# ``key``. Including "KEY" would skip that column and report a phantom drift.
+_CONSTRAINT_LEADERS = frozenset({
+    "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "CONSTRAINT",
+})
+# Require a column body ``(`` so prose like "CREATE TABLE statements below"
+# in comments is not mistaken for a real table definition.
+_CREATE_TABLE_RE = re.compile(
+    rf"CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+({_IDENT})\s*\(", re.IGNORECASE
+)
+_ADD_COLUMN_RE = re.compile(
+    rf"ALTER\s+TABLE\s+({_IDENT})\s+ADD\s+COLUMN\s+({_IDENT})", re.IGNORECASE
+)
+# ``CREATE INDEX ... ON table (`` — SQLite cannot index a column that does not
+# exist, so an index target is definitive proof the column is part of the
+# schema. This captures columns added by Python migration runners (e.g.
+# apply_ab_arm.py adds intelligence_injections.ab_arm, whose only canonical SQL
+# artifact is the index here — the ALTER lives in a comment).
+_CREATE_INDEX_RE = re.compile(
+    rf"CREATE\s+(?:UNIQUE\s+)?INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+{_IDENT}\s+ON\s+({_IDENT})\s*\(",
+    re.IGNORECASE,
+)
+
+
+def _create_table_names(sql_files: List[Path]) -> Set[str]:
+    """All normalized table names defined by CREATE TABLE in *sql_files*."""
+    names: Set[str] = set()
+    for path in sql_files:
+        sql = _strip_sql_comments(path.read_text(encoding="utf-8"))
+        for m in _CREATE_TABLE_RE.finditer(sql):
+            names.add(_normalize_table(m.group(1)))
+    return names
+
+
+def parse_schema_columns(
+    sql_files: List[Path], allowlist: Set[str]
+) -> Dict[str, Set[str]]:
+    """Build ``{table: set(columns)}`` (superset) for tables in *allowlist*.
+
+    Columns accrue from CREATE TABLE bodies and ALTER TABLE ADD COLUMN across
+    every file. Non-allowlisted tables (e.g. quality_intelligence tables that
+    the cross-DB project_id migrations also ALTER) are dropped so they never
+    seed false positives.
+    """
+    table_cols: Dict[str, Set[str]] = {t: set() for t in allowlist}
+
+    for path in sql_files:
+        sql = _strip_sql_comments(path.read_text(encoding="utf-8"))
+
+        for m in _CREATE_TABLE_RE.finditer(sql):
+            table = _normalize_table(m.group(1))
+            if table not in allowlist:
+                continue
+            body, _ = _extract_create_table_body(sql, m.end() - 1)
+            cols = table_cols[table]
+            for item in _split_top_level(body):
+                tokens = item.strip().split()
+                if not tokens:
+                    continue
+                if tokens[0].upper() in _CONSTRAINT_LEADERS:
+                    continue
+                col = tokens[0].strip('`"[]')
+                if re.fullmatch(_IDENT, col):
+                    cols.add(col)
+
+        for m in _ADD_COLUMN_RE.finditer(sql):
+            table = _normalize_table(m.group(1))
+            if table in allowlist:
+                table_cols[table].add(m.group(2))
+
+        for m in _CREATE_INDEX_RE.finditer(sql):
+            table = _normalize_table(m.group(1))
+            if table not in allowlist:
+                continue
+            body, _ = _extract_create_table_body(sql, m.end() - 1)
+            for item in _split_top_level(body):
+                item = item.strip()
+                if not item or "(" in item:  # skip expression indexes
+                    continue
+                col = item.split()[0].strip('`"[]')  # drop ASC/DESC/COLLATE
+                if re.fullmatch(_IDENT, col):
+                    table_cols[table].add(col)
+
+    return table_cols
+
+
+# ---------------------------------------------------------------------------
+# Code scanning
+# ---------------------------------------------------------------------------
+
+def _iter_sql_strings(source: str) -> List[str]:
+    """Extract candidate SQL string literals from Python source via AST.
+
+    f-strings are reconstructed with ``{}`` standing in for interpolations so
+    the dynamic-clause guard downstream can detect and skip them.
+    """
+    out: List[str] = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return out  # unparseable module — skip (documented limitation)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _SQL_HINT_RE.search(node.value):
+                out.append(node.value)
+        elif isinstance(node, ast.JoinedStr):
+            parts: List[str] = []
+            for v in node.values:
+                if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                    parts.append(v.value)
+                else:
+                    parts.append("{}")  # interpolation marker
+            rebuilt = "".join(parts)
+            if _SQL_HINT_RE.search(rebuilt):
+                out.append(rebuilt)
+    return out
+
+
+_FROM_JOIN_RE = re.compile(
+    rf"\b(?:FROM|JOIN)\s+({_IDENT})(?:\s+(?:AS\s+)?({_IDENT}))?", re.IGNORECASE
+)
+_UPDATE_RE = re.compile(rf"\bUPDATE\s+({_IDENT})", re.IGNORECASE)
+_INSERT_RE = re.compile(
+    rf"\bINSERT\s+(?:OR\s+\w+\s+)?INTO\s+({_IDENT})", re.IGNORECASE
+)
+_UPDATE_SET_RE = re.compile(
+    rf"\bUPDATE\s+({_IDENT})\s+SET\s+(.*?)(?:\bWHERE\b|\bRETURNING\b|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+_INSERT_COLS_RE = re.compile(
+    rf"\bINSERT\s+(?:OR\s+\w+\s+)?INTO\s+({_IDENT})\s*\(([^)]*)\)",
+    re.IGNORECASE | re.DOTALL,
+)
+_QUALIFIED_RE = re.compile(rf"\b({_IDENT})\.({_IDENT})\b")
+
+
+def _is_dynamic(fragment: str) -> bool:
+    return "{" in fragment or "%" in fragment
+
+
+def _build_alias_map(sql: str) -> Dict[str, str]:
+    """Map alias/table tokens → normalized table name."""
+    alias_map: Dict[str, str] = {}
+    for m in _FROM_JOIN_RE.finditer(sql):
+        table = _normalize_table(m.group(1))
+        alias_map[m.group(1)] = table
+        alias_map[table] = table
+        alias = m.group(2)
+        if alias and alias.upper() not in _ALIAS_STOPWORDS:
+            alias_map[alias] = table
+    for m in _UPDATE_RE.finditer(sql):
+        alias_map[m.group(1)] = _normalize_table(m.group(1))
+    for m in _INSERT_RE.finditer(sql):
+        alias_map[m.group(1)] = _normalize_table(m.group(1))
+    return alias_map
+
+
+def scan_column_refs(sql: str) -> Set[Tuple[str, str]]:
+    """Return high-confidence ``(table, column)`` references from one SQL string."""
+    sql = _strip_sql_comments(sql)
+    refs: Set[Tuple[str, str]] = set()
+    alias_map = _build_alias_map(sql)
+
+    # UPDATE t SET col = ?, col2 = ?
+    for m in _UPDATE_SET_RE.finditer(sql):
+        table = _normalize_table(m.group(1))
+        set_clause = m.group(2)
+        if _is_dynamic(set_clause):
+            continue
+        for assignment in _split_top_level(set_clause):
+            if "=" not in assignment:
+                continue
+            lhs = assignment.split("=", 1)[0].strip()
+            col = lhs.split(".")[-1].strip('`"[] ')
+            if re.fullmatch(_IDENT, col):
+                refs.add((table, col))
+
+    # INSERT INTO t (col1, col2, ...)
+    for m in _INSERT_COLS_RE.finditer(sql):
+        table = _normalize_table(m.group(1))
+        col_list = m.group(2)
+        if _is_dynamic(col_list) or "SELECT" in col_list.upper():
+            continue
+        for raw in col_list.split(","):
+            col = raw.strip().split(".")[-1].strip('`"[] ')
+            if re.fullmatch(_IDENT, col):
+                refs.add((table, col))
+
+    # alias-qualified reads: a.col / table.col
+    for m in _QUALIFIED_RE.finditer(sql):
+        alias, col = m.group(1), m.group(2)
+        table = alias_map.get(alias)
+        if table is not None:
+            refs.add((table, col))
+
+    return refs
+
+
+def _iter_scan_targets() -> List[Path]:
+    """All Python modules under scripts/ — auto-scoped by schema-map membership."""
+    return sorted(_SCRIPTS_DIR.rglob("*.py"))
+
+
+def _schema_files() -> List[Path]:
+    """All SQL files that may add columns to a runtime_coordination table."""
+    files = [_SCHEMAS_DIR / "runtime_coordination.sql"]
+    files += sorted(_SCHEMAS_DIR.glob("runtime_coordination_v*.sql"))
+    files += [
+        p for p in sorted((_SCHEMAS_DIR / "migrations").glob("*.sql"))
+        if not p.name.endswith("_down.sql")
+    ]
+    return [f for f in files if f.exists()]
+
+
+def _rc_table_seed_files() -> List[Path]:
+    """Files that CREATE runtime_coordination tables.
+
+    The core tables live in the base + versioned schema files. The only tables
+    introduced by migrations to the runtime_coordination DB are the elastic
+    worker-pool tables (0020) and the central-install metadata tables (0021);
+    0019 only ALTERs existing tables. The cross-DB project_id migrations
+    (0010/0015) and the quality_intelligence migrations are deliberately NOT
+    seeds — their CREATE/ALTER targets must not enter the rc allowlist.
+    """
+    files = [_SCHEMAS_DIR / "runtime_coordination.sql"]
+    files += sorted(_SCHEMAS_DIR.glob("runtime_coordination_v*.sql"))
+    for name in ("0019_t0_lifecycle_tokens.sql",
+                 "0020_elastic_worker_pool.sql",
+                 "0021_central_install_metadata.sql"):
+        files.append(_SCHEMAS_DIR / "migrations" / name)
+    return [f for f in files if f.exists()]
+
+
+def runtime_coordination_tables() -> Set[str]:
+    """The runtime_coordination table allowlist, derived from its schema files."""
+    return _create_table_names(_rc_table_seed_files())
+
+
+def build_schema_map() -> Dict[str, Set[str]]:
+    return parse_schema_columns(_schema_files(), runtime_coordination_tables())
+
+
+def collect_drift(schema_map: Dict[str, Set[str]]) -> List[Tuple[Path, str, str]]:
+    """Return ``[(file, table, column)]`` for every code ref absent from schema."""
+    findings: List[Tuple[Path, str, str]] = []
+    for py_path in _iter_scan_targets():
+        source = py_path.read_text(encoding="utf-8")
+        for sql in _iter_sql_strings(source):
+            for table, column in scan_column_refs(sql):
+                if table not in schema_map:
+                    continue  # not a runtime_coordination table — skip
+                if column not in schema_map[table]:
+                    findings.append((py_path, table, column))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Sanity tests for the parser/scanner themselves
+# ---------------------------------------------------------------------------
+
+def test_schema_map_has_core_tables_and_columns() -> None:
+    schema_map = build_schema_map()
+    for table in ("terminal_leases", "dispatches", "worker_states",
+                  "dispatch_attempts", "coordination_events"):
+        assert table in schema_map, f"{table} missing from parsed schema"
+    # The columns this PR adds / depends on.
+    assert "worker_pid" in schema_map["terminal_leases"]
+    assert "project_id" in schema_map["worker_states"]
+    assert "project_id" in schema_map["coordination_events"]
+
+
+def test_scanner_extracts_set_insert_and_qualified() -> None:
+    sql = (
+        "UPDATE terminal_leases SET worker_pid = ? WHERE terminal_id = ?"
+    )
+    assert ("terminal_leases", "worker_pid") in scan_column_refs(sql)
+
+    sql_join = (
+        "SELECT tl.worker_pid FROM worker_pool_membership wpm "
+        "LEFT JOIN terminal_leases tl ON tl.terminal_id = wpm.terminal_id"
+    )
+    refs = scan_column_refs(sql_join)
+    assert ("terminal_leases", "worker_pid") in refs
+
+    sql_insert = "INSERT INTO worker_states (terminal_id, project_id) VALUES (?, ?)"
+    refs_ins = scan_column_refs(sql_insert)
+    assert ("worker_states", "terminal_id") in refs_ins
+    assert ("worker_states", "project_id") in refs_ins
+
+
+def test_parser_keeps_columns_after_inline_comments() -> None:
+    """Columns whose preceding line carries a trailing ``-- comment`` must still
+    be parsed. Regression for the false-positive class on incident_log /
+    retry_budgets (columns dropped because the comment glued onto the next item).
+    """
+    schema_map = build_schema_map()
+    incident_cols = schema_map["incident_log"]
+    for col in ("entity_id", "dispatch_id", "terminal_id", "state",
+                "escalated", "auto_recovery_halted", "failure_detail"):
+        assert col in incident_cols, f"incident_log.{col} lost by the parser"
+    assert "escalated_at" in schema_map["retry_budgets"]
+
+
+def test_parser_keeps_column_named_key() -> None:
+    """A column literally named ``key`` (schema_meta) must not be mistaken for a
+    table-level KEY constraint and dropped."""
+    assert "key" in build_schema_map()["schema_meta"]
+
+
+def test_parser_harvests_index_only_columns() -> None:
+    """A column whose only canonical SQL artifact is a CREATE INDEX (added by a
+    Python migration runner, e.g. intelligence_injections.ab_arm) must land in
+    the schema map."""
+    assert "ab_arm" in build_schema_map()["intelligence_injections"]
+
+
+def test_strip_sql_comments_preserves_string_literals() -> None:
+    # A ``--`` inside a quoted default must survive; the trailing comment must go.
+    stripped = _strip_sql_comments("col TEXT DEFAULT 'a--b',  -- drop me\n")
+    assert "'a--b'" in stripped
+    assert "drop me" not in stripped
+
+
+def test_scanner_skips_dynamic_set_clause() -> None:
+    # pool_state_repo.update_config builds the SET list dynamically.
+    sql = "UPDATE pool_config SET {} WHERE project_id = ? AND pool_id = ?"
+    assert scan_column_refs(sql) == set() or all(
+        col != "{}" for _, col in scan_column_refs(sql)
+    )
+    # No bogus column should be produced from the placeholder.
+    assert not any(c == "" for _, c in scan_column_refs(sql))
+
+
+def test_alias_stopwords_not_treated_as_table() -> None:
+    # "WHERE" must never become an alias for dispatches.
+    alias_map = _build_alias_map("SELECT * FROM dispatches WHERE state = ?")
+    assert "WHERE" not in alias_map
+    assert alias_map.get("dispatches") == "dispatches"
+
+
+# ---------------------------------------------------------------------------
+# Proof the guard catches the drift class (would have FAILED before Part 1)
+# ---------------------------------------------------------------------------
+
+def test_guard_would_have_caught_worker_pid_drift() -> None:
+    """Simulate the pre-fix schema (no worker_pid) → scanner must flag it."""
+    schema_map = build_schema_map()
+    pre_fix = {t: set(cols) for t, cols in schema_map.items()}
+    pre_fix["terminal_leases"].discard("worker_pid")
+
+    findings = collect_drift(pre_fix)
+    drift_cols = {(t, c) for _, t, c in findings}
+    assert ("terminal_leases", "worker_pid") in drift_cols, (
+        "guard failed to detect the worker_pid drift against a pre-fix schema"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The actual guard — the current codebase must be drift-free
+# ---------------------------------------------------------------------------
+
+def test_no_runtime_coordination_schema_drift() -> None:
+    schema_map = build_schema_map()
+    findings = collect_drift(schema_map)
+    if findings:
+        lines = [
+            f"  {path.relative_to(_REPO_ROOT)}: {table}.{column} "
+            f"(column not in schema for {table})"
+            for path, table, column in sorted(set(findings), key=lambda f: (str(f[0]), f[1], f[2]))
+        ]
+        pytest.fail(
+            "Schema-code drift detected — code references columns absent from "
+            "the runtime_coordination schema:\n" + "\n".join(lines)
+        )

--- a/tests/test_worker_pid_selfheal.py
+++ b/tests/test_worker_pid_selfheal.py
@@ -1,0 +1,219 @@
+"""Tests for the terminal_leases.worker_pid self-heal.
+
+Background: rc6's runtime_coordination code WRITES and READS
+``terminal_leases.worker_pid`` (pool_state_repo.store_worker_pid / list_members)
+but no schema file or migration ever defined the column — the 2nd schema-code
+drift after worker_states.project_id (OI-095). Every dispatch logged
+"PID persistence failed: no such column: worker_pid".
+
+Coverage:
+  A. Fresh canonical init → terminal_leases already has worker_pid
+  B. Legacy DB without worker_pid → init self-heals it, independent of
+     ``user_version`` (proves version-independence)
+  C. Re-run is a clean no-op (idempotent)
+  D. terminal_leases absent → ``skipped_missing`` (no crash)
+  E. Real ``PoolStateRepository.store_worker_pid`` UPDATE fails before the heal
+     and succeeds after (regression: runs the actual production code path)
+  F. ``run_runtime_coordination_migration`` reports the worker_pid status
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from project_id_migration import (  # noqa: E402
+    ensure_worker_pid_column,
+    run_runtime_coordination_migration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _init_runtime_db(state_dir: Path) -> Path:
+    """Initialise a fresh runtime_coordination.db via the canonical schema."""
+    from runtime_coordination import init_schema  # local import (sys.path set above)
+
+    init_schema(state_dir, _SCHEMAS_DIR / "runtime_coordination.sql")
+    return state_dir / "runtime_coordination.db"
+
+
+def _make_legacy_leases_db(db_path: Path, *, user_version: int = 0) -> None:
+    """Build a runtime_coordination.db whose terminal_leases predates worker_pid."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE terminal_leases (
+                id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                terminal_id       TEXT NOT NULL,
+                project_id        TEXT NOT NULL DEFAULT 'vnx-dev',
+                state             TEXT NOT NULL DEFAULT 'idle',
+                dispatch_id       TEXT,
+                generation        INTEGER NOT NULL DEFAULT 1,
+                leased_at         TEXT,
+                expires_at        TEXT,
+                last_heartbeat_at TEXT,
+                released_at       TEXT,
+                metadata_json     TEXT DEFAULT '{}',
+                UNIQUE(terminal_id, project_id)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE TABLE runtime_schema_version "
+            "(version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO terminal_leases (terminal_id, state, generation) VALUES (?, 'idle', 1)",
+            [("T1",), ("T2",), ("T3",)],
+        )
+        conn.execute(f"PRAGMA user_version = {int(user_version)}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# A. Fresh canonical init already carries worker_pid
+# ---------------------------------------------------------------------------
+
+def test_fresh_canonical_db_has_worker_pid(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert "worker_pid" in _columns(conn, "terminal_leases")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# B. Legacy DB self-heals, independent of user_version
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("user_version", [0, 12, 99])
+def test_legacy_db_heals_worker_pid_any_version(tmp_path: Path, user_version: int) -> None:
+    db_path = tmp_path / "runtime_coordination.db"
+    _make_legacy_leases_db(db_path, user_version=user_version)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert "worker_pid" not in _columns(conn, "terminal_leases")
+        assert ensure_worker_pid_column(conn) == "added"
+        conn.commit()
+        assert "worker_pid" in _columns(conn, "terminal_leases")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# C. Idempotent — re-run is a clean no-op
+# ---------------------------------------------------------------------------
+
+def test_worker_pid_heal_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime_coordination.db"
+    _make_legacy_leases_db(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert ensure_worker_pid_column(conn) == "added"
+        conn.commit()
+        assert ensure_worker_pid_column(conn) == "already_present"
+        assert ensure_worker_pid_column(conn) == "already_present"
+        # Exactly one worker_pid column — no duplication.
+        assert _columns(conn, "terminal_leases").count("worker_pid") == 1
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# D. terminal_leases absent → skipped_missing
+# ---------------------------------------------------------------------------
+
+def test_worker_pid_skipped_when_table_missing(tmp_path: Path) -> None:
+    db_path = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert ensure_worker_pid_column(conn) == "skipped_missing"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# E. Real production path: PoolStateRepository.store_worker_pid
+# ---------------------------------------------------------------------------
+
+def test_store_worker_pid_fails_before_heal_succeeds_after(tmp_path: Path) -> None:
+    """Runs the actual pool_state_repo code, not a reimplementation."""
+    from pool_state_repo import PoolStateRepository
+
+    db_path = tmp_path / "runtime_coordination.db"
+    _make_legacy_leases_db(db_path)
+    repo = PoolStateRepository(db_path, project_id="vnx-dev")
+
+    # Before the heal: the UPDATE references a column that does not exist.
+    with pytest.raises(sqlite3.OperationalError, match="worker_pid"):
+        repo.store_worker_pid("T1", 4242)
+
+    # Heal, then the same real code path must succeed.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert ensure_worker_pid_column(conn) == "added"
+        conn.commit()
+    finally:
+        conn.close()
+
+    repo.store_worker_pid("T1", 4242)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT worker_pid FROM terminal_leases WHERE terminal_id = ?", ("T1",)
+        ).fetchone()
+        assert row[0] == 4242
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# F. run_runtime_coordination_migration reports worker_pid status
+# ---------------------------------------------------------------------------
+
+def test_runtime_migration_reports_worker_pid_added(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime_coordination.db"
+    _make_legacy_leases_db(db_path)
+
+    result = run_runtime_coordination_migration(db_path)
+    assert result["status"] == "ok"
+    assert result["worker_pid_status"] == "added"
+
+    # Re-run is idempotent and now reports the column already present.
+    result2 = run_runtime_coordination_migration(db_path)
+    assert result2["worker_pid_status"] == "already_present"
+
+
+def test_runtime_migration_fresh_db_worker_pid_present(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = _init_runtime_db(state_dir)
+
+    result = run_runtime_coordination_migration(db_path)
+    # Fresh canonical schema already declares worker_pid → no ALTER needed.
+    assert result["worker_pid_status"] == "already_present"


### PR DESCRIPTION
## The drift

rc6's runtime_coordination code WRITES and READS `terminal_leases.worker_pid`:

- `pool_state_repo.store_worker_pid()` runs `UPDATE terminal_leases SET worker_pid = ? WHERE terminal_id = ? AND project_id = ?` (called from `subprocess_dispatch.py` with `os.getpid()`).
- It is read back: `SELECT ... tl.worker_pid FROM worker_pool_membership wpm LEFT JOIN terminal_leases tl ...` and `row["worker_pid"]`.

But `grep -rn worker_pid schemas/` returned nothing — the column was absent from the base schema and every migration. Effect: every dispatch logged `PID persistence failed: no such column: worker_pid`. Non-fatal (the write sits in a rolled-back try/except) but the supervisor cannot track worker PIDs, degrading the lease-reaper / `runtime_supervise` path.

**This is the 2nd occurrence of this exact class.** The 1st was `worker_states.project_id` (OI-095, #635). Both shipped silently because the failing write was swallowed by a try/except.

## Part 1 — add the column

- `worker_pid INTEGER` (nullable, default NULL) declared on `terminal_leases` in `schemas/runtime_coordination_v10.sql` and `schemas/runtime_coordination.sql` so fresh inits carry it.
- `ensure_worker_pid_column()` in `scripts/lib/project_id_migration.py` self-heals existing DBs idempotently — `PRAGMA table_info` guard then `ALTER TABLE ADD COLUMN`, version-independent (SQLite has no `ADD COLUMN IF NOT EXISTS`). Same pattern as the project_id self-heal from #635. Wired into `run_runtime_coordination_migration()` and logged by `runtime_coordination_init.py`.

## Part 2 — schema-drift regression guard

`tests/test_runtime_coordination_schema_drift.py` parses the canonical schema (`runtime_coordination.sql` + `runtime_coordination_v*.sql` + `migrations/*.sql`) into `{table: set(columns)}`, then statically scans the DB-access code under `scripts/` for column references (UPDATE SET, INSERT column lists, alias-qualified reads) and fails on any column a runtime_coordination table references but the schema does not define.

`test_guard_would_have_caught_worker_pid_drift` proves it: against a pre-fix schema (worker_pid discarded) the guard flags `terminal_leases.worker_pid`. **It would have caught both this drift and #635.**

False-positive discipline (the priority was under-claim over over-flag):
- Strips SQL `--`/`/* */` comments before parsing — a trailing inline comment was gluing onto the next column and dropping it (would have phantom-flagged `incident_log` / `retry_budgets` columns).
- Drops `KEY` from the constraint-leader set — SQLite has no bare `KEY` constraint, and `schema_meta` has a real column named `key`.
- Harvests `CREATE INDEX ... ON t (col)` targets — SQLite cannot index a non-existent column, so this recovers columns added by Python migration runners whose only SQL artifact is the index (e.g. `intelligence_injections.ab_arm` via `apply_ab_arm.py`).
- Skips dynamically-built clauses (`{}` f-string / `%` markers) and unqualified bare column lists (documented in the module docstring).

## Tests

```
python3 -m pytest tests/test_worker_pid_selfheal.py tests/test_runtime_coordination_schema_drift.py
  → 19 passed
python3 -m pytest <new + 7 related migration/schema/pool modules>
  → 199 passed
python3 -m pytest <6 further schema/migration-adjacent modules>
  → 102 passed
```

`test_worker_pid_selfheal.py` covers: fresh canonical DB already has the column; legacy DB heals across `user_version` 0/12/99; idempotent rerun; `skipped_missing` when table absent; and the real `PoolStateRepository.store_worker_pid` UPDATE failing before the heal and succeeding after (runs production code, not a reimplementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)