### PR TITLE
fix(dispatch): scale chunk_timeout/total_deadline by complexity

### DIFF
--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -315,6 +315,14 @@ if __name__ == "__main__":
     )
     _hb_thread.start()
 
+    # Scale chunk/total timeouts by --complexity so compute-heavy ("high")
+    # dispatches get more headroom and aren't killed by the per-chunk timeout
+    # during a long quiet-but-working step (e.g. static analysis). These are the
+    # *base* values fed into deliver_with_recovery; apply_runtime_overrides runs
+    # downstream so VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE still take precedence.
+    from subprocess_dispatch_internals.runtime_overrides import complexity_timeout_defaults
+    _chunk_timeout, _total_deadline = complexity_timeout_defaults(args.complexity)
+
     try:
         ok = deliver_with_recovery(
             terminal_id=args.terminal_id,
@@ -323,6 +331,8 @@ if __name__ == "__main__":
             dispatch_id=args.dispatch_id,
             role=args.role,
             max_retries=args.max_retries,
+            chunk_timeout=_chunk_timeout,
+            total_deadline=_total_deadline,
             auto_commit=not args.no_auto_commit,
             gate=args.gate,
             dispatch_paths=_dispatch_paths,

--- a/scripts/lib/subprocess_dispatch_internals/runtime_overrides.py
+++ b/scripts/lib/subprocess_dispatch_internals/runtime_overrides.py
@@ -6,6 +6,39 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Complexity-scaled timeout defaults.
+#
+# A subprocess dispatch was killed by the per-chunk timeout (300s) while a
+# worker was doing legitimate compute-heavy work (static analysis for a
+# schema-drift test) without emitting a tool-event for >300s. The per-chunk
+# timeout fires when no event arrives within the window, so it mis-fires on
+# quiet-but-working compute. Scaling the base defaults by --complexity gives
+# heavy dispatches more headroom while leaving low/medium unchanged.
+#
+# Precedence is preserved by apply_runtime_overrides running AFTER these values
+# are seeded as the base: VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE env overrides
+# still win over the complexity-scaled default, which in turn wins over the
+# function-signature base default.
+_COMPLEXITY_TIMEOUTS: dict[str, tuple[float, float]] = {
+    "low": (300.0, 900.0),
+    "medium": (300.0, 900.0),
+    "high": (600.0, 1800.0),
+}
+_BASE_COMPLEXITY_TIMEOUTS: tuple[float, float] = (300.0, 900.0)
+
+
+def complexity_timeout_defaults(complexity: str) -> tuple[float, float]:
+    """Return (chunk_timeout, total_deadline) scaled by dispatch complexity.
+
+    low/medium keep the historical base defaults (300s / 900s); high gets more
+    headroom (600s / 1800s) so compute-heavy workers that go quiet during a long
+    analysis step are not killed prematurely by the per-chunk timeout.
+
+    Unknown or None values fall back to the base defaults so an unexpected
+    --complexity value never shrinks the headroom below the historical baseline.
+    """
+    return _COMPLEXITY_TIMEOUTS.get((complexity or "").lower(), _BASE_COMPLEXITY_TIMEOUTS)
+
 
 def apply_runtime_overrides(chunk_timeout: float, total_deadline: float) -> tuple[float, float]:
     """Honor VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE env overrides.

--- a/tests/test_chunk_timeout_complexity.py
+++ b/tests/test_chunk_timeout_complexity.py
@@ -1,0 +1,116 @@
+"""Tests for complexity-scaled chunk_timeout / total_deadline defaults.
+
+Background: a subprocess dispatch was killed by the per-chunk timeout (300s)
+while a worker was doing legitimate compute-heavy work without emitting a
+tool-event for >300s. The fix scales the base timeouts by --complexity so
+"high" dispatches get more headroom, while env overrides
+(VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE) retain top precedence.
+
+Precedence (highest to lowest):
+    env override  >  complexity-scaled default  >  function-signature base
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure scripts/lib is on the path
+_LIB = Path(__file__).resolve().parents[1] / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from subprocess_dispatch_internals.runtime_overrides import (  # noqa: E402
+    apply_runtime_overrides,
+    complexity_timeout_defaults,
+)
+
+
+# --- complexity-scaled defaults -------------------------------------------
+
+
+def test_high_complexity_gets_more_headroom():
+    """complexity=high yields chunk_timeout=600 / total_deadline=1800."""
+    ct, td = complexity_timeout_defaults("high")
+    assert ct == 600.0
+    assert td == 1800.0
+
+
+def test_medium_complexity_unchanged():
+    """complexity=medium keeps the historical base defaults (300 / 900)."""
+    ct, td = complexity_timeout_defaults("medium")
+    assert ct == 300.0
+    assert td == 900.0
+
+
+def test_low_complexity_unchanged():
+    """complexity=low keeps the historical base defaults (300 / 900)."""
+    ct, td = complexity_timeout_defaults("low")
+    assert ct == 300.0
+    assert td == 900.0
+
+
+def test_unknown_complexity_falls_back_to_base():
+    """An unexpected --complexity value falls back to base, never below baseline."""
+    ct, td = complexity_timeout_defaults("ludicrous")
+    assert ct == 300.0
+    assert td == 900.0
+
+
+def test_none_complexity_falls_back_to_base():
+    """None (no value) falls back to base defaults instead of crashing."""
+    ct, td = complexity_timeout_defaults(None)  # type: ignore[arg-type]
+    assert ct == 300.0
+    assert td == 900.0
+
+
+def test_complexity_is_case_insensitive():
+    """Mixed-case complexity values resolve like their lowercase form."""
+    ct, td = complexity_timeout_defaults("HIGH")
+    assert ct == 600.0
+    assert td == 1800.0
+
+
+# --- precedence: env override wins over complexity-scaled default ----------
+
+
+def test_env_chunk_timeout_wins_over_high_complexity(monkeypatch):
+    """VNX_CHUNK_TIMEOUT overrides the complexity-scaled chunk_timeout.
+
+    Mirrors the production call path: complexity_timeout_defaults seeds the
+    base values, then apply_runtime_overrides runs downstream and env wins.
+    """
+    monkeypatch.setenv("VNX_CHUNK_TIMEOUT", "1200.0")
+    monkeypatch.delenv("VNX_TOTAL_DEADLINE", raising=False)
+    base_ct, base_td = complexity_timeout_defaults("high")
+    ct, td = apply_runtime_overrides(base_ct, base_td)
+    assert ct == 1200.0  # env wins
+    assert td == 1800.0  # complexity-scaled default retained
+
+
+def test_env_total_deadline_wins_over_high_complexity(monkeypatch):
+    """VNX_TOTAL_DEADLINE overrides the complexity-scaled total_deadline."""
+    monkeypatch.delenv("VNX_CHUNK_TIMEOUT", raising=False)
+    monkeypatch.setenv("VNX_TOTAL_DEADLINE", "3600.0")
+    base_ct, base_td = complexity_timeout_defaults("high")
+    ct, td = apply_runtime_overrides(base_ct, base_td)
+    assert ct == 600.0  # complexity-scaled default retained
+    assert td == 3600.0  # env wins
+
+
+def test_env_wins_regardless_of_complexity(monkeypatch):
+    """With both env vars set, the env values are used for every complexity."""
+    monkeypatch.setenv("VNX_CHUNK_TIMEOUT", "42.0")
+    monkeypatch.setenv("VNX_TOTAL_DEADLINE", "84.0")
+    for complexity in ("low", "medium", "high"):
+        ct, td = apply_runtime_overrides(*complexity_timeout_defaults(complexity))
+        assert ct == 42.0
+        assert td == 84.0
+
+
+def test_no_env_lets_complexity_scaled_value_pass_through(monkeypatch):
+    """Without env overrides, the complexity-scaled defaults flow through unchanged."""
+    monkeypatch.delenv("VNX_CHUNK_TIMEOUT", raising=False)
+    monkeypatch.delenv("VNX_TOTAL_DEADLINE", raising=False)
+    ct, td = apply_runtime_overrides(*complexity_timeout_defaults("high"))
+    assert ct == 600.0
+    assert td == 1800.0


### PR DESCRIPTION
Premature `chunk timeout (300s)` kills compute-heavy workers that legitimately go quiet during long compute (e.g. static analysis for the schema-drift test) -> wasteful retry. This scales chunk_timeout/total_deadline by --complexity (high: 600/1800; low/medium: 300/900 unchanged), with VNX_CHUNK_TIMEOUT/VNX_TOTAL_DEADLINE env overrides retaining highest precedence.

Scope: subprocess_dispatch.py + runtime_overrides.py + test only. (A prior worker run also added an unrelated reviewer-gate change; that was split off to branch backup/chunk-gate-20260526 and is NOT part of this PR.)