### PR TITLE
fix(install): preserve project worker_permissions overrides across cutover

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -231,6 +231,8 @@ Commands:
   bootstrap-terminals  Create ./\.claude/terminals (default: T0..T3)
   bootstrap-hooks    Deploy SessionStart hooks to .claude/hooks/ + settings.json
   regen-settings     Patch-manage settings.json (--merge|--full|--validate)
+  regen-worker-permissions  Overlay-merge worker_permissions.yaml preserving project overrides
+                     (--merge|--full|--validate)
   start [--profile X] Launch VNX tmux session (interactive profile selection)
                      Profiles: claude-only, claude-codex, claude-gemini, full-multi
   start --preset <name>  Start with a saved startup preset
@@ -1921,6 +1923,17 @@ main() {
       ;;
     regen-settings)
       cmd_regen_settings "$@"
+      ;;
+    regen-worker-permissions)
+      if ! type cmd_regen_worker_permissions &>/dev/null; then
+        _load_command "regen_worker_permissions" 2>/dev/null || true
+      fi
+      if type cmd_regen_worker_permissions &>/dev/null; then
+        cmd_regen_worker_permissions "$@"
+      else
+        err "[regen-worker-permissions] command not available (scripts/commands/regen_worker_permissions.sh missing)"
+        exit 1
+      fi
       ;;
     start)
       cmd_start "$@"

--- a/scripts/commands/regen_settings.sh
+++ b/scripts/commands/regen_settings.sh
@@ -114,4 +114,18 @@ HELP
   fi
 
   python3 "$merge_script" "${cmd_args[@]}"
+
+  # Co-run worker_permissions merge so both managed files stay in sync.
+  # Only fires for --merge and --full (not --validate which is read-only and already returned).
+  if [ "$mode" = "--merge" ] || [ "$mode" = "--full" ]; then
+    local wp_merge_script="$VNX_HOME/scripts/vnx_worker_permissions_merge.py"
+    if [ -f "$wp_merge_script" ]; then
+      local wp_args=("$mode" "--project-root" "$PROJECT_ROOT" "--vnx-home" "$VNX_HOME")
+      [ "$dry_run" -eq 1 ]    && wp_args+=("--dry-run")
+      [ "$no_backup" -eq 1 ]  && wp_args+=("--no-backup")
+      # --json for settings.json output does not apply to worker_permissions output
+      python3 "$wp_merge_script" "${wp_args[@]}" \
+        || log "[regen-settings] WARN: worker_permissions merge had issues (non-fatal)"
+    fi
+  fi
 }

--- a/scripts/commands/regen_worker_permissions.sh
+++ b/scripts/commands/regen_worker_permissions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# VNX Command: regen-worker-permissions
+# Overlay-merge for worker_permissions.yaml — mirrors regen-settings semantics.
+#
+# This file is sourced by bin/vnx's command loader. All functions and variables
+# from the main script (log, err, VNX_HOME, PROJECT_ROOT, etc.)
+# are available when this runs.
+#
+# Merge semantics:
+#   --merge: Overlay VNX-managed keys from the shipped template into the project
+#            worker_permissions.yaml at PROJECT_ROOT/.vnx/worker_permissions.yaml.
+#            - version, _vnx_meta: replaced (VNX-owned)
+#            - profiles (VNX roles): unioned per-field (allowed_tools, denied_tools,
+#              bash_allow_patterns, bash_deny_patterns); file_write_scope is UNIONED
+#              so project-added paths (e.g. src/**) survive cutover
+#            - profiles (project-only roles): preserved unchanged
+#            - terminal_assignments: VNX baseline; project overrides win
+#   --full:  Generate worker_permissions.yaml from the VNX template (first-time init)
+#   --validate: Read-only structural validation
+
+cmd_regen_worker_permissions() {
+  local mode=""
+  local dry_run=0
+  local no_backup=0
+  local json_output=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --merge)
+        mode="--merge"
+        ;;
+      --full)
+        mode="--full"
+        ;;
+      --validate)
+        mode="--validate"
+        ;;
+      --dry-run)
+        dry_run=1
+        ;;
+      --no-backup)
+        no_backup=1
+        ;;
+      --json)
+        json_output=1
+        ;;
+      -h|--help)
+        cat <<HELP
+Usage: vnx regen-worker-permissions <--merge|--full|--validate> [options]
+
+Modes:
+  --merge      Merge VNX template into existing .vnx/worker_permissions.yaml
+  --full       Generate .vnx/worker_permissions.yaml from VNX template (first-time)
+  --validate   Validate existing .vnx/worker_permissions.yaml structure
+
+Options:
+  --dry-run    Show what would change without writing
+  --no-backup  Skip backup of existing file
+  --json       Output result as JSON (for scripting)
+  -h, --help   Show this help
+
+Merge semantics:
+  version / _vnx_meta          VNX-managed — replaced from template
+  profiles (VNX roles)         Per-field union: VNX baseline + project extras
+  profiles.<role>.file_write_scope  Union — project paths (e.g. src/**) survive
+  profiles (project-only roles)  Preserved unchanged
+  terminal_assignments          VNX baseline; project overrides win on collision
+
+This command is idempotent and safe to run on every rc-cutover.
+HELP
+        return 0
+        ;;
+      *)
+        err "[regen-worker-permissions] Unknown option: $1"
+        return 1
+        ;;
+    esac
+    shift
+  done
+
+  if [ -z "$mode" ]; then
+    err "[regen-worker-permissions] Specify --merge, --full, or --validate"
+    return 1
+  fi
+
+  # Central-install write guard: same as regen-settings.
+  # --validate is read-only and exempt.
+  if [ "$mode" = "--merge" ] || [ "$mode" = "--full" ]; then
+    if type _guard_not_vnx_home >/dev/null 2>&1; then
+      _guard_not_vnx_home "$PROJECT_ROOT" || return 1
+    fi
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    err "[regen-worker-permissions] python3 is required"
+    return 1
+  fi
+
+  local merge_script="$VNX_HOME/scripts/vnx_worker_permissions_merge.py"
+  if [ ! -f "$merge_script" ]; then
+    err "[regen-worker-permissions] Missing merge script: $merge_script"
+    return 1
+  fi
+
+  local cmd_args=("$mode" "--project-root" "$PROJECT_ROOT" "--vnx-home" "$VNX_HOME")
+
+  [ "$dry_run" -eq 1 ]    && cmd_args+=("--dry-run")
+  [ "$no_backup" -eq 1 ]  && cmd_args+=("--no-backup")
+  [ "$json_output" -eq 1 ] && cmd_args+=("--json")
+
+  python3 "$merge_script" "${cmd_args[@]}"
+}

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -51,12 +51,18 @@ def _inject_permission_profile(terminal_id: str, role: str | None, instruction: 
 
 
 def _resolve_effective_role(terminal_id: str, role: str | None) -> str | None:
-    """Resolve effective role from terminal_assignments when role is None."""
+    """Resolve effective role from terminal_assignments when role is None.
+
+    Uses the project-override-first path resolution from worker_permissions so
+    central-install and embedded installs both find the project's customised
+    worker_permissions.yaml rather than the immutable VNX_HOME template.
+    """
     if role:
         return role
     try:
-        import yaml
-        yaml_path = Path(__file__).resolve().parents[3] / ".vnx" / "worker_permissions.yaml"
+        from worker_permissions import _resolve_permissions_yaml  # noqa: PLC0415
+        yaml_path = _resolve_permissions_yaml()
+        import yaml  # noqa: PLC0415
         data = yaml.safe_load(yaml_path.read_text()) or {}
         return data.get("terminal_assignments", {}).get(terminal_id)
     except Exception as exc:

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -49,7 +49,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "staging-list", "promote", "queue-status", "gate-check", "suggest",
     "cost-report", "analyze-sessions", "intelligence-export",
     "intelligence-import", "init-feature", "bootstrap-skills",
-    "bootstrap-terminals", "bootstrap-hooks", "regen-settings",
+    "bootstrap-terminals", "bootstrap-hooks", "regen-settings", "regen-worker-permissions",
     "patch-agent-files", "register", "list-projects", "unregister",
     "roadmap", "insights",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -5,6 +5,17 @@ Loads role-based permission profiles from .vnx/worker_permissions.yaml and
 generates CLAUDE.md permission instructions that are injected into dispatch
 instructions before subprocess launch.
 
+Path resolution priority (prevents template leak during rc-cutover):
+  1. $VNX_PROJECT_ROOT/.vnx/worker_permissions.yaml  — project override file
+  2. $PROJECT_ROOT/.vnx/worker_permissions.yaml       — same, alternate env var
+  3. Sibling resolution: Path(__file__).parents[2]/.vnx/worker_permissions.yaml
+     Works in both dev-mode (repo root/.vnx/) and central install (VNX_HOME/.vnx/).
+  4. $VNX_HOME/.vnx/worker_permissions.yaml           — fallback to shipped template
+
+In central-install mode the shipped template (VNX_HOME) is immutable and may
+not contain project-specific file_write_scope paths.  Priority 1/2 ensures the
+project copy wins; priority 3/4 are fallback-only.
+
 BILLING SAFETY: No Anthropic SDK. No api.anthropic.com calls.
 """
 
@@ -12,13 +23,46 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-_PERMISSIONS_YAML_PATH = Path(__file__).resolve().parents[2] / ".vnx" / "worker_permissions.yaml"
+
+def _resolve_permissions_yaml() -> Path:
+    """Resolve worker_permissions.yaml with project-override-first priority.
+
+    Returns the first existing path from the priority list above.
+    Falls back to the sibling path even if it does not yet exist — callers
+    handle missing files gracefully via _load_yaml's empty-dict return.
+    """
+    # Priority 1: explicit project root override (set by central-install shim)
+    for env_var in ("VNX_PROJECT_ROOT", "PROJECT_ROOT"):
+        proj = os.environ.get(env_var)
+        if proj:
+            candidate = Path(proj) / ".vnx" / "worker_permissions.yaml"
+            if candidate.exists():
+                return candidate
+
+    # Priority 2: sibling resolution (works in dev-mode and embedded installs)
+    sibling = Path(__file__).resolve().parents[2] / ".vnx" / "worker_permissions.yaml"
+    if sibling.exists():
+        return sibling
+
+    # Priority 3: VNX_HOME env var (central install fallback)
+    vnx_home = os.environ.get("VNX_HOME")
+    if vnx_home:
+        candidate = Path(vnx_home) / "worker_permissions.yaml"
+        if candidate.exists():
+            return candidate
+
+    # Return the sibling path as default (may not exist; callers handle gracefully)
+    return sibling
+
+
+_PERMISSIONS_YAML_PATH = _resolve_permissions_yaml()
 
 
 @dataclass
@@ -41,12 +85,18 @@ def _load_yaml(path: Path) -> dict:
         return {}
 
 
-def load_permissions(role: str, yaml_path: Path = _PERMISSIONS_YAML_PATH) -> PermissionProfile:
+def load_permissions(role: str, yaml_path: Path | None = None) -> PermissionProfile:
     """Load PermissionProfile for role from worker_permissions.yaml.
+
+    yaml_path defaults to None which triggers project-override-first resolution
+    on every call (important in central-install mode where PROJECT_ROOT may be
+    set after module import).  Pass an explicit path in tests.
 
     Returns a profile with empty lists (no restrictions) when the role is not
     found or the YAML cannot be loaded — callers remain functional.
     """
+    if yaml_path is None:
+        yaml_path = _resolve_permissions_yaml()
     data = _load_yaml(yaml_path)
     profiles = data.get("profiles", {})
     raw = profiles.get(role)
@@ -118,7 +168,7 @@ def generate_permission_preamble(profile: PermissionProfile) -> str:
 
 def validate_dispatch_permissions(
     dispatch_metadata: dict,
-    yaml_path: Path = _PERMISSIONS_YAML_PATH,
+    yaml_path: Path | None = None,
 ) -> list[str]:
     """Check if dispatch role matches terminal assignment.
 
@@ -135,6 +185,8 @@ def validate_dispatch_permissions(
     if not terminal or not role:
         return warnings
 
+    if yaml_path is None:
+        yaml_path = _resolve_permissions_yaml()
     data = _load_yaml(yaml_path)
     assignments = data.get("terminal_assignments", {})
     expected_role = assignments.get(terminal)

--- a/scripts/vnx_worker_permissions_merge.py
+++ b/scripts/vnx_worker_permissions_merge.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""VNX Worker Permissions Merge Engine
+
+Manages worker_permissions.yaml with overlay semantics that mirror the
+settings.json merge pattern (vnx_settings_merge.py):
+
+  _vnx_meta.managed_keys documents what VNX owns vs what the project owns.
+  On every regen/cutover the merge engine reads the shipped template (VNX_HOME),
+  reads the project file (PROJECT_ROOT/.vnx/worker_permissions.yaml), and produces
+  a merged output that preserves project overrides.
+
+Merge semantics per key:
+  version              VNX-managed — always taken from template
+  _vnx_meta            VNX-managed — always taken from template
+  profiles.<role>      Baseline role entries: VNX-managed (overwritten by template).
+                       Project-added roles that do NOT exist in the template are
+                       preserved unchanged.
+                       Within a role that exists in BOTH template and project:
+                         allowed_tools      union (template baseline + project extras)
+                         denied_tools       union (template baseline + project extras)
+                         bash_allow_patterns union
+                         bash_deny_patterns  union
+                         file_write_scope   union — THIS is where project paths live
+  terminal_assignments VNX-managed baseline; project overrides are preserved
+                       (project value wins for terminals that exist in both)
+
+Usage:
+  python3 vnx_worker_permissions_merge.py --merge  --project-root /path/to/project --vnx-home /path/to/vnx
+  python3 vnx_worker_permissions_merge.py --full   --project-root /path/to/project --vnx-home /path/to/vnx
+  python3 vnx_worker_permissions_merge.py --validate --project-root /path/to/project --vnx-home /path/to/vnx
+  python3 vnx_worker_permissions_merge.py --merge  --project-root /path/to/project --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import shutil
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# VNX-managed keys documentation (mirrored in _vnx_meta.managed_keys)
+# ---------------------------------------------------------------------------
+
+VNX_MANAGED_PROFILE_KEYS = {
+    "allowed_tools",
+    "denied_tools",
+    "bash_allow_patterns",
+    "bash_deny_patterns",
+}
+# file_write_scope is intentionally NOT in this set — it is project-owned.
+# VNX provides defaults; projects extend with their own source paths.
+
+VNX_MANAGED_TOP_KEYS = {"version", "_vnx_meta"}
+# terminal_assignments: VNX baseline, project overrides win for collisions.
+
+
+# ---------------------------------------------------------------------------
+# Template location
+# ---------------------------------------------------------------------------
+
+def find_template(vnx_home: str) -> str:
+    """Locate the shipped worker_permissions.yaml template in VNX_HOME."""
+    # Primary: shipped template under .vnx/templates/
+    tmpl = os.path.join(vnx_home, "templates", "worker_permissions.yaml.tmpl")
+    if os.path.isfile(tmpl):
+        return tmpl
+    # Fallback: the .vnx/ root file itself (dev-mode layout where vnx home IS repo root/.vnx)
+    root_file = os.path.join(vnx_home, "worker_permissions.yaml")
+    if os.path.isfile(root_file):
+        return root_file
+    return tmpl  # let caller raise the missing-file error
+
+
+def load_yaml(path: str) -> dict:
+    """Load a YAML file; return empty dict if missing."""
+    if not os.path.isfile(path):
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_template(vnx_home: str) -> dict:
+    """Load and return the VNX worker_permissions template."""
+    tmpl_path = find_template(vnx_home)
+    if not os.path.isfile(tmpl_path):
+        print(f"ERROR: worker_permissions template not found at: {tmpl_path}", file=sys.stderr)
+        sys.exit(1)
+    return load_yaml(tmpl_path)
+
+
+def project_permissions_path(project_root: str) -> str:
+    return os.path.join(project_root, ".vnx", "worker_permissions.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Merge helpers
+# ---------------------------------------------------------------------------
+
+def union_list(base: list, overlay: list) -> list:
+    """Union two lists, preserving base-first order, deduplicating."""
+    seen: set = set()
+    result: list = []
+    for item in base + overlay:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def merge_role(template_role: dict, project_role: dict) -> dict:
+    """Merge a single role definition.
+
+    VNX baseline keys (allowed_tools, denied_tools, bash_*) are unioned so that
+    VNX additions (e.g. new deny patterns) reach project installs while project
+    extras survive.
+
+    file_write_scope is union-merged: VNX baseline paths + project-specific paths.
+    """
+    result: dict[str, Any] = {}
+
+    for key in ("allowed_tools", "denied_tools", "bash_allow_patterns", "bash_deny_patterns"):
+        base = template_role.get(key) or []
+        proj = project_role.get(key) or []
+        result[key] = union_list(base, proj)
+
+    # file_write_scope: union — project paths survive rc-cutover
+    base_scope = template_role.get("file_write_scope") or []
+    proj_scope = project_role.get("file_write_scope") or []
+    result["file_write_scope"] = union_list(base_scope, proj_scope)
+
+    # Preserve any unknown project-added keys within the role
+    for k, v in project_role.items():
+        if k not in result:
+            result[k] = v
+
+    return result
+
+
+def merge_profiles(template_profiles: dict, project_profiles: dict) -> dict:
+    """Merge profiles section.
+
+    Roles in template: merged (VNX baseline + project overrides).
+    Roles only in project: preserved unchanged (project-added roles).
+    """
+    result: dict = {}
+
+    # Process template roles first (baseline + project overlay)
+    for role, tmpl_role in template_profiles.items():
+        if role in project_profiles:
+            result[role] = merge_role(tmpl_role, project_profiles[role])
+        else:
+            # Template-only role: use template as-is
+            result[role] = copy.deepcopy(tmpl_role)
+
+    # Preserve project-only roles (not in template)
+    for role, proj_role in project_profiles.items():
+        if role not in result:
+            result[role] = copy.deepcopy(proj_role)
+
+    return result
+
+
+def merge_terminal_assignments(template_ta: dict, project_ta: dict) -> dict:
+    """Merge terminal_assignments.
+
+    Template provides baseline (T1=backend-developer etc).
+    Project overrides win for terminals that appear in both — projects may
+    remap terminals to project-specific roles.
+    Project-only terminals are preserved.
+    """
+    result = dict(template_ta)
+    for terminal, role in project_ta.items():
+        result[terminal] = role  # project wins for any collision
+    return result
+
+
+def merge_permissions(existing: dict, template: dict) -> dict:
+    """Merge existing project file with VNX template."""
+    result: dict = {}
+
+    # VNX-managed top-level keys: always from template
+    result["version"] = template.get("version", 1)
+    result["_vnx_meta"] = template.get("_vnx_meta", _default_vnx_meta())
+
+    # profiles: merge logic above
+    result["profiles"] = merge_profiles(
+        template.get("profiles", {}),
+        existing.get("profiles", {}),
+    )
+
+    # terminal_assignments: merge with project-wins-on-collision
+    result["terminal_assignments"] = merge_terminal_assignments(
+        template.get("terminal_assignments", {}),
+        existing.get("terminal_assignments", {}),
+    )
+
+    # Preserve any unknown top-level project keys
+    for k, v in existing.items():
+        if k not in result:
+            result[k] = v
+
+    return result
+
+
+def _default_vnx_meta() -> dict:
+    return {
+        "managed_keys": [
+            "version",
+            "profiles.<role>.allowed_tools (vnx_baseline)",
+            "profiles.<role>.denied_tools (vnx_baseline)",
+            "profiles.<role>.bash_allow_patterns (vnx_baseline)",
+            "profiles.<role>.bash_deny_patterns (vnx_baseline)",
+            "terminal_assignments (vnx_baseline; project overrides win)",
+        ],
+        "project_owned_keys": [
+            "profiles.<role>.file_write_scope",
+            "profiles.<project-role>  (roles not in template)",
+        ],
+        "description": (
+            "VNX worker permission profiles. "
+            "Merge via 'vnx regen-worker-permissions --merge'. "
+            "file_write_scope and project-added roles survive cutover."
+        ),
+    }
+
+
+def generate_full_permissions(template: dict) -> dict:
+    """Generate a project worker_permissions.yaml from the VNX template (first-time)."""
+    result = copy.deepcopy(template)
+    if "_vnx_meta" not in result:
+        result["_vnx_meta"] = _default_vnx_meta()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_permissions(data: dict) -> list[str]:
+    """Validate the structure of worker_permissions.yaml.  Returns list of issues."""
+    issues: list[str] = []
+
+    if not isinstance(data, dict):
+        issues.append("root must be a YAML mapping")
+        return issues
+
+    profiles = data.get("profiles")
+    if profiles is None:
+        issues.append("missing 'profiles' section")
+    elif not isinstance(profiles, dict):
+        issues.append("'profiles' must be a mapping")
+    else:
+        for role, body in profiles.items():
+            if not isinstance(body, dict):
+                issues.append(f"profiles.{role}: must be a mapping")
+                continue
+            for list_key in ("allowed_tools", "denied_tools", "bash_allow_patterns",
+                             "bash_deny_patterns", "file_write_scope"):
+                v = body.get(list_key)
+                if v is not None and not isinstance(v, list):
+                    issues.append(f"profiles.{role}.{list_key}: must be a list")
+
+    ta = data.get("terminal_assignments")
+    if ta is not None and not isinstance(ta, dict):
+        issues.append("'terminal_assignments' must be a mapping")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# IO helpers
+# ---------------------------------------------------------------------------
+
+def backup_file(path: str) -> str | None:
+    if not os.path.isfile(path):
+        return None
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bak = f"{path}.bak.{ts}"
+    shutil.copy2(path, bak)
+    return bak
+
+
+def write_yaml(path: str, data: dict) -> None:
+    """Atomically write a YAML file."""
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    os.replace(tmp, path)
+
+
+def diff_summary(existing: dict | None, merged: dict) -> list[str]:
+    """Generate a human-readable diff summary for the merge."""
+    lines: list[str] = []
+
+    if existing is None:
+        lines.append("[regen-worker-permissions] Creating new worker_permissions.yaml")
+        return lines
+
+    old_profiles = set(existing.get("profiles", {}).keys())
+    new_profiles = set(merged.get("profiles", {}).keys())
+    added = new_profiles - old_profiles
+    removed = old_profiles - new_profiles
+    if added:
+        lines.append(f"  profiles: +{sorted(added)}")
+    if removed:
+        lines.append(f"  profiles: -{sorted(removed)}")
+
+    for role in new_profiles & old_profiles:
+        old_scope = set(existing.get("profiles", {}).get(role, {}).get("file_write_scope") or [])
+        new_scope = set(merged.get("profiles", {}).get(role, {}).get("file_write_scope") or [])
+        gained = new_scope - old_scope
+        lost = old_scope - new_scope
+        if gained:
+            lines.append(f"  profiles.{role}.file_write_scope: +{sorted(gained)}")
+        if lost:
+            lines.append(f"  profiles.{role}.file_write_scope: -{sorted(lost)}")
+
+    old_ta = existing.get("terminal_assignments", {})
+    new_ta = merged.get("terminal_assignments", {})
+    for t, role in new_ta.items():
+        if old_ta.get(t) != role:
+            lines.append(f"  terminal_assignments.{t}: {old_ta.get(t)!r} -> {role!r}")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="VNX Worker Permissions Merge Engine",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--merge", action="store_true",
+                      help="Merge VNX template into existing worker_permissions.yaml")
+    mode.add_argument("--full", action="store_true",
+                      help="Generate worker_permissions.yaml from VNX template (first-time init)")
+    mode.add_argument("--validate", action="store_true",
+                      help="Validate existing worker_permissions.yaml structure")
+
+    parser.add_argument("--project-root", required=True, help="Project root directory")
+    parser.add_argument("--vnx-home", default=None,
+                        help="VNX home directory (auto-detected if omitted)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would change without writing")
+    parser.add_argument("--no-backup", action="store_true",
+                        help="Skip backup of existing file")
+    parser.add_argument("--json", action="store_true",
+                        help="Output result as JSON (for scripting)")
+
+    args = parser.parse_args()
+
+    project_root = os.path.realpath(args.project_root)
+    target_path = project_permissions_path(project_root)
+
+    # Auto-detect vnx_home when not provided
+    if args.vnx_home:
+        vnx_home = args.vnx_home
+    else:
+        vnx_home = _detect_vnx_home(project_root)
+
+    if args.validate:
+        data = load_yaml(target_path)
+        if not data:
+            print(f"ERROR: {target_path} not found or empty", file=sys.stderr)
+            return 1
+        issues = validate_permissions(data)
+        if issues:
+            for i in issues:
+                print(f"  FAIL: {i}", file=sys.stderr)
+            return 1
+        print(f"[regen-worker-permissions] {target_path}: valid")
+        return 0
+
+    template = load_template(vnx_home)
+
+    if args.full:
+        existing = load_yaml(target_path) if os.path.isfile(target_path) else None
+        result = generate_full_permissions(template)
+
+        issues = validate_permissions(result)
+        if issues:
+            print("ERROR: generated permissions failed validation:", file=sys.stderr)
+            for i in issues:
+                print(f"  {i}", file=sys.stderr)
+            return 1
+
+        if args.dry_run:
+            if args.json:
+                import json
+                print(json.dumps(result, indent=2))
+            else:
+                print("[regen-worker-permissions] --full --dry-run: would create worker_permissions.yaml")
+                if existing:
+                    print("[regen-worker-permissions] WARNING: would overwrite existing file")
+            return 0
+
+        if existing and not args.no_backup:
+            bak = backup_file(target_path)
+            print(f"[regen-worker-permissions] Backup: {bak}")
+
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        write_yaml(target_path, result)
+        print(f"[regen-worker-permissions] Created: {target_path} (full)")
+        return 0
+
+    # --merge mode
+    existing = load_yaml(target_path) if os.path.isfile(target_path) else None
+
+    if existing is None:
+        print("[regen-worker-permissions] No existing file; generating full from template")
+        result = generate_full_permissions(template)
+    else:
+        result = merge_permissions(existing, template)
+
+    issues = validate_permissions(result)
+    if issues:
+        print("ERROR: merged permissions failed validation:", file=sys.stderr)
+        for i in issues:
+            print(f"  {i}", file=sys.stderr)
+        return 1
+
+    summary = diff_summary(existing, result)
+
+    if args.dry_run:
+        if args.json:
+            import json
+            print(json.dumps(result, indent=2))
+        else:
+            print("[regen-worker-permissions] --merge --dry-run:")
+            if summary:
+                for line in summary:
+                    print(line)
+            else:
+                print("  (no changes)")
+        return 0
+
+    if existing and not args.no_backup:
+        bak = backup_file(target_path)
+        print(f"[regen-worker-permissions] Backup: {bak}")
+
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    write_yaml(target_path, result)
+
+    if summary:
+        for line in summary:
+            print(line)
+    print(f"[regen-worker-permissions] Updated: {target_path} (merge)")
+    return 0
+
+
+def _detect_vnx_home(project_root: str) -> str:
+    """Auto-detect VNX_HOME from the environment or standard locations."""
+    vnx_home_env = os.environ.get("VNX_HOME")
+    if vnx_home_env and os.path.isdir(vnx_home_env):
+        return vnx_home_env
+
+    # Embedded layout: project/.vnx/
+    embedded = os.path.join(project_root, ".vnx")
+    if os.path.isdir(embedded):
+        return embedded
+
+    return embedded  # best guess
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/worker_permissions.yaml.tmpl
+++ b/templates/worker_permissions.yaml.tmpl
@@ -1,8 +1,9 @@
 version: 1
 
-# VNX worker permission profiles.
-# Project-specific overrides survive rc-cutover via 'vnx regen-worker-permissions --merge'.
-# VNX-managed keys are listed in _vnx_meta.managed_keys below.
+# VNX worker permission profiles — shipped template.
+# Project-specific overrides (file_write_scope, project-added roles) survive
+# rc-cutover via 'vnx regen-worker-permissions --merge'.
+# DO NOT edit this template directly — edit the project copy at .vnx/worker_permissions.yaml.
 
 _vnx_meta:
   managed_keys:
@@ -14,7 +15,7 @@ _vnx_meta:
     - "terminal_assignments (vnx_baseline; project overrides win)"
   project_owned_keys:
     - "profiles.<role>.file_write_scope"
-    - "profiles.<project-role>  (roles not present in the template)"
+    - "profiles.<project-role>  (roles not present in this template)"
   description: >
     VNX worker permission profiles. Merge via 'vnx regen-worker-permissions --merge'.
     file_write_scope entries and project-added roles survive cutover unchanged.

--- a/tests/test_worker_permissions_merge.py
+++ b/tests/test_worker_permissions_merge.py
@@ -1,0 +1,406 @@
+"""Regression tests for worker_permissions overlay merge.
+
+Critical invariant: project-specific file_write_scope entries (e.g. src/**)
+added to the backend-developer profile MUST survive a simulated regen/cutover
+(re-running the merge with the VNX-shipped template).
+
+Covers:
+  - file_write_scope union: project paths survive after merge
+  - VNX-managed fields (allowed_tools, denied_tools, bash_deny_patterns) union
+  - Project-added roles not in template are preserved unchanged
+  - terminal_assignments: project overrides win on collision
+  - Idempotency: merging twice produces same result
+  - First-time (no existing file) falls back to full from template
+  - _vnx_meta is always replaced with template version
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from vnx_worker_permissions_merge import (
+    diff_summary,
+    generate_full_permissions,
+    merge_permissions,
+    merge_role,
+    validate_permissions,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VNX_TEMPLATE: dict[str, Any] = yaml.safe_load(textwrap.dedent("""\
+    version: 1
+
+    _vnx_meta:
+      managed_keys:
+        - version
+        - "profiles.<role>.allowed_tools (vnx_baseline)"
+        - "profiles.<role>.denied_tools (vnx_baseline)"
+        - "profiles.<role>.bash_allow_patterns (vnx_baseline)"
+        - "profiles.<role>.bash_deny_patterns (vnx_baseline)"
+        - "terminal_assignments (vnx_baseline; project overrides win)"
+      project_owned_keys:
+        - "profiles.<role>.file_write_scope"
+        - "profiles.<project-role>  (roles not present in this template)"
+      description: "VNX worker permission profiles."
+
+    profiles:
+      backend-developer:
+        allowed_tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+        denied_tools: [WebSearch, WebFetch]
+        bash_allow_patterns:
+          - "pytest*"
+          - "python3*"
+          - "git add*"
+          - "git commit*"
+          - "git push origin*"
+          - "pip install*"
+          - "bash -n*"
+        bash_deny_patterns:
+          - "rm -rf*"
+          - "git reset --hard*"
+          - "git push --force*"
+          - "git push -f*"
+          - "curl*anthropic*"
+        file_write_scope:
+          - "scripts/**"
+          - "tests/**"
+          - "dashboard/**"
+
+      test-engineer:
+        allowed_tools: [Read, Write, Edit, Bash, Grep, Glob]
+        denied_tools: [WebSearch, WebFetch, MultiEdit]
+        bash_allow_patterns:
+          - "pytest*"
+          - "python3 -m pytest*"
+          - "git add*"
+          - "git commit*"
+        bash_deny_patterns:
+          - "rm -rf*"
+          - "git push*"
+          - "git reset*"
+        file_write_scope:
+          - "tests/**"
+          - "scripts/check_*"
+
+    terminal_assignments:
+      T1: backend-developer
+      T2: test-engineer
+      T3: frontend-developer
+"""))
+
+PROJECT_WITH_SRC_SCOPE: dict[str, Any] = yaml.safe_load(textwrap.dedent("""\
+    version: 1
+
+    profiles:
+      backend-developer:
+        allowed_tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+        denied_tools: [WebSearch, WebFetch]
+        bash_allow_patterns:
+          - "pytest*"
+          - "python3*"
+          - "git add*"
+          - "git commit*"
+          - "git push origin*"
+          - "pip install*"
+          - "bash -n*"
+        bash_deny_patterns:
+          - "rm -rf*"
+          - "git reset --hard*"
+          - "git push --force*"
+          - "git push -f*"
+          - "curl*anthropic*"
+        file_write_scope:
+          - "scripts/**"
+          - "tests/**"
+          - "dashboard/**"
+          - "src/**"
+
+      test-engineer:
+        allowed_tools: [Read, Write, Edit, Bash, Grep, Glob]
+        denied_tools: [WebSearch, WebFetch, MultiEdit]
+        bash_allow_patterns:
+          - "pytest*"
+          - "python3 -m pytest*"
+          - "git add*"
+          - "git commit*"
+        bash_deny_patterns:
+          - "rm -rf*"
+          - "git push*"
+          - "git reset*"
+        file_write_scope:
+          - "tests/**"
+          - "scripts/check_*"
+
+    terminal_assignments:
+      T1: backend-developer
+      T2: test-engineer
+      T3: frontend-developer
+"""))
+
+
+# ---------------------------------------------------------------------------
+# Core regression: project file_write_scope survives cutover
+# ---------------------------------------------------------------------------
+
+class TestFileWriteScopeSurvivesCutover:
+    """The primary regression guard: src/** must survive after merge with template."""
+
+    def test_project_src_scope_preserved_after_merge(self) -> None:
+        """src/** added by project must survive merging with the VNX template."""
+        result = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        scope = result["profiles"]["backend-developer"]["file_write_scope"]
+        assert "src/**" in scope, (
+            "project-added src/** was lost during merge — template-leak regression"
+        )
+
+    def test_vnx_baseline_scope_paths_also_present(self) -> None:
+        """VNX template paths must still be present after merge."""
+        result = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        scope = result["profiles"]["backend-developer"]["file_write_scope"]
+        for expected in ("scripts/**", "tests/**", "dashboard/**"):
+            assert expected in scope, f"VNX baseline path {expected!r} lost after merge"
+
+    def test_idempotent_merge_preserves_src_scope(self) -> None:
+        """Merging twice (simulating two consecutive cutovers) must be idempotent."""
+        first = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        second = merge_permissions(first, VNX_TEMPLATE)
+        scope = second["profiles"]["backend-developer"]["file_write_scope"]
+        assert "src/**" in scope, "src/** lost after second merge (idempotency failure)"
+
+    def test_no_duplicates_in_scope_after_double_merge(self) -> None:
+        """Union must deduplicate: no path appears twice after repeated merges."""
+        first = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        second = merge_permissions(first, VNX_TEMPLATE)
+        scope = second["profiles"]["backend-developer"]["file_write_scope"]
+        assert len(scope) == len(set(scope)), f"Duplicates in file_write_scope: {scope}"
+
+
+# ---------------------------------------------------------------------------
+# VNX-managed fields: union behaviour
+# ---------------------------------------------------------------------------
+
+class TestVnxManagedFieldsUnion:
+    def test_allowed_tools_union(self) -> None:
+        project = {
+            "profiles": {"backend-developer": {"allowed_tools": ["Read", "ExtraCustomTool"]}},
+            "terminal_assignments": {},
+        }
+        result = merge_permissions(project, VNX_TEMPLATE)
+        tools = result["profiles"]["backend-developer"]["allowed_tools"]
+        assert "Read" in tools
+        assert "Bash" in tools          # from template
+        assert "ExtraCustomTool" in tools  # project extra preserved
+
+    def test_denied_tools_union(self) -> None:
+        project = {
+            "profiles": {"backend-developer": {"denied_tools": ["WebSearch", "ProjectDenied"]}},
+            "terminal_assignments": {},
+        }
+        result = merge_permissions(project, VNX_TEMPLATE)
+        denied = result["profiles"]["backend-developer"]["denied_tools"]
+        assert "WebSearch" in denied
+        assert "WebFetch" in denied     # from template
+        assert "ProjectDenied" in denied  # project extra preserved
+
+    def test_bash_deny_patterns_union(self) -> None:
+        project = {
+            "profiles": {"backend-developer": {
+                "bash_deny_patterns": ["rm -rf*", "my-custom-deny*"]
+            }},
+            "terminal_assignments": {},
+        }
+        result = merge_permissions(project, VNX_TEMPLATE)
+        deny = result["profiles"]["backend-developer"]["bash_deny_patterns"]
+        assert "rm -rf*" in deny
+        assert "git push --force*" in deny  # from template
+        assert "my-custom-deny*" in deny    # project extra preserved
+
+
+# ---------------------------------------------------------------------------
+# Project-added roles survive cutover
+# ---------------------------------------------------------------------------
+
+class TestProjectAddedRolesSurvive:
+    def test_project_only_role_preserved(self) -> None:
+        project = yaml.safe_load(textwrap.dedent("""\
+            version: 1
+            profiles:
+              backend-developer:
+                allowed_tools: [Read, Write, Edit, Bash]
+                denied_tools: [WebSearch]
+                file_write_scope:
+                  - "scripts/**"
+                  - "src/**"
+              seocrawler-extractor:
+                allowed_tools: [Read, Write, Edit, Bash]
+                denied_tools: [WebSearch, WebFetch]
+                bash_allow_patterns:
+                  - "python3*"
+                file_write_scope:
+                  - "app/extractors/**"
+                  - "tests/extractors/**"
+            terminal_assignments:
+              T1: seocrawler-extractor
+        """))
+
+        result = merge_permissions(project, VNX_TEMPLATE)
+
+        # Project-only role must survive
+        assert "seocrawler-extractor" in result["profiles"], (
+            "project-added role 'seocrawler-extractor' was dropped during merge"
+        )
+        extractor = result["profiles"]["seocrawler-extractor"]
+        assert "app/extractors/**" in extractor["file_write_scope"]
+        assert "tests/extractors/**" in extractor["file_write_scope"]
+
+    def test_project_only_role_scope_not_mutated(self) -> None:
+        """Project-added roles must not get VNX baseline paths injected into them."""
+        project = yaml.safe_load(textwrap.dedent("""\
+            version: 1
+            profiles:
+              special-agent:
+                allowed_tools: [Read]
+                denied_tools: []
+                file_write_scope:
+                  - "special/**"
+            terminal_assignments: {}
+        """))
+
+        result = merge_permissions(project, VNX_TEMPLATE)
+        scope = result["profiles"]["special-agent"]["file_write_scope"]
+        assert scope == ["special/**"], (
+            f"project-only role got unexpected paths injected: {scope}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# terminal_assignments: project overrides win
+# ---------------------------------------------------------------------------
+
+class TestTerminalAssignments:
+    def test_project_terminal_override_wins(self) -> None:
+        project = {
+            "profiles": {},
+            "terminal_assignments": {"T1": "seocrawler-extractor", "T2": "test-engineer"},
+        }
+        result = merge_permissions(project, VNX_TEMPLATE)
+        ta = result["terminal_assignments"]
+        assert ta["T1"] == "seocrawler-extractor", (
+            "project terminal override for T1 was overwritten by VNX template"
+        )
+        assert ta["T2"] == "test-engineer"   # same value — no conflict
+
+    def test_vnx_baseline_terminals_present_when_project_does_not_override(self) -> None:
+        project = {"profiles": {}, "terminal_assignments": {}}
+        result = merge_permissions(project, VNX_TEMPLATE)
+        ta = result["terminal_assignments"]
+        assert ta.get("T3") == "frontend-developer"  # from VNX template
+
+
+# ---------------------------------------------------------------------------
+# _vnx_meta always comes from template
+# ---------------------------------------------------------------------------
+
+class TestVnxMeta:
+    def test_vnx_meta_replaced_from_template(self) -> None:
+        project = {
+            "profiles": {},
+            "terminal_assignments": {},
+            "_vnx_meta": {"managed_keys": ["stale-key"], "description": "old"},
+        }
+        result = merge_permissions(project, VNX_TEMPLATE)
+        meta = result.get("_vnx_meta", {})
+        # The template _vnx_meta must be present and the stale project meta gone
+        assert "stale-key" not in str(meta.get("managed_keys", []))
+        assert "version" in str(meta.get("managed_keys", []))
+
+    def test_version_always_from_template(self) -> None:
+        project = {"version": 99, "profiles": {}, "terminal_assignments": {}}
+        result = merge_permissions(project, VNX_TEMPLATE)
+        assert result["version"] == VNX_TEMPLATE["version"]
+
+
+# ---------------------------------------------------------------------------
+# First-time (no existing file): full from template
+# ---------------------------------------------------------------------------
+
+class TestFirstTimeInit:
+    def test_full_mode_generates_all_roles(self) -> None:
+        result = generate_full_permissions(VNX_TEMPLATE)
+        assert "backend-developer" in result["profiles"]
+        assert "test-engineer" in result["profiles"]
+
+    def test_full_mode_adds_vnx_meta(self) -> None:
+        result = generate_full_permissions(VNX_TEMPLATE)
+        assert "_vnx_meta" in result
+
+    def test_merge_with_none_existing_equals_full(self) -> None:
+        """merge_permissions with empty existing dict behaves like a full generate."""
+        result = merge_permissions({}, VNX_TEMPLATE)
+        full = generate_full_permissions(VNX_TEMPLATE)
+        # Both must have same roles
+        assert set(result["profiles"].keys()) == set(full["profiles"].keys())
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_valid_permissions_passes(self) -> None:
+        result = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        issues = validate_permissions(result)
+        assert issues == []
+
+    def test_invalid_profiles_not_dict(self) -> None:
+        bad = {"profiles": ["not", "a", "dict"], "terminal_assignments": {}}
+        issues = validate_permissions(bad)
+        assert any("profiles" in i for i in issues)
+
+    def test_invalid_file_write_scope_not_list(self) -> None:
+        bad = {
+            "profiles": {
+                "backend-developer": {
+                    "allowed_tools": [],
+                    "file_write_scope": "should-be-a-list",
+                }
+            },
+            "terminal_assignments": {},
+        }
+        issues = validate_permissions(bad)
+        assert any("file_write_scope" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# diff_summary helper
+# ---------------------------------------------------------------------------
+
+class TestDiffSummary:
+    def test_added_scope_path_appears_in_diff(self) -> None:
+        before = merge_permissions({}, VNX_TEMPLATE)
+        # Simulate a project adding src/**
+        project_with_src = yaml.safe_load(yaml.dump(before))
+        project_with_src["profiles"]["backend-developer"]["file_write_scope"].append("src/**")
+        after = merge_permissions(project_with_src, VNX_TEMPLATE)
+        summary = diff_summary(before, after)
+        assert any("src/**" in line for line in summary), (
+            f"diff_summary did not mention src/**:\n{summary}"
+        )
+
+    def test_no_changes_produces_empty_summary(self) -> None:
+        merged = merge_permissions(PROJECT_WITH_SRC_SCOPE, VNX_TEMPLATE)
+        # Second merge must show no changes
+        second = merge_permissions(merged, VNX_TEMPLATE)
+        summary = diff_summary(merged, second)
+        assert summary == [], f"Expected no diff, got: {summary}"


### PR DESCRIPTION
## Problem

During rc-cutover or `vnx update`, the VNX template re-applies to `.vnx/worker_permissions.yaml`. Projects that added `src/**` (or other paths) to `file_write_scope` for the `backend-developer` role lose those overrides every time. The file was treated as fully VNX-owned with no preserve/overlay path.

## Root cause

`worker_permissions.yaml` had no merge semantics — no `_vnx_meta.managed_keys` equivalent, no merge engine, no distinction between VNX-managed keys and project-owned keys. `worker_permissions.py` also used a hardcoded relative path that always resolved to `VNX_HOME/.vnx/` (the shipped template) regardless of whether a project-specific file existed.

## Fix

### Merge engine (`vnx_worker_permissions_merge.py`)

Mirrors `vnx_settings_merge.py` semantics:

| Key | Owner | Behaviour |
|---|---|---|
| `version`, `_vnx_meta` | VNX | Always replaced from template |
| `profiles.<role>.allowed_tools` etc | VNX baseline | Union: template + project extras |
| `profiles.<role>.file_write_scope` | **Project** | Union: VNX defaults + project paths |
| `profiles.<project-role>` | **Project** | Preserved unchanged |
| `terminal_assignments` | VNX baseline | Project overrides win on collision |

### Path resolution (`worker_permissions.py`)

4-level priority replaces the single hardcoded relative path:
1. `$VNX_PROJECT_ROOT/.vnx/worker_permissions.yaml` (central-install shim export)
2. `$PROJECT_ROOT/.vnx/worker_permissions.yaml`
3. Sibling resolution (works in both dev-mode and embedded installs)
4. `$VNX_HOME/worker_permissions.yaml` (fallback to shipped template)

Resolution happens on every `load_permissions()` call, not at module import time.

### CLI surface (`regen-worker-permissions`)

New `vnx regen-worker-permissions --merge|--full|--validate` command. Invoked automatically at the end of `vnx regen-settings --merge` so every cutover keeps both files in sync.

### Template (`templates/worker_permissions.yaml.tmpl`)

Canonical shipped template with `_vnx_meta.managed_keys` block documenting ownership boundaries.

### skill_injection.py

`_resolve_effective_role` now delegates to `_resolve_permissions_yaml()` instead of a hardcoded `parents[3]` path that gave the wrong result in embedded installs.

## Tests

21 new tests in `tests/test_worker_permissions_merge.py`:

- Core regression: `src/**` added to `file_write_scope` survives merge
- Idempotency: merging twice produces no diff and no duplicates
- VNX-managed fields union correctly
- Project-added roles not in template are preserved unchanged
- Terminal assignment project overrides win
- `_vnx_meta` always comes from template
- First-time (no existing file) falls back to full generate
- Validation surface

All 35 tests (14 existing + 21 new) pass.

## Files changed

- `scripts/vnx_worker_permissions_merge.py` — new merge engine
- `scripts/commands/regen_worker_permissions.sh` — new CLI command
- `scripts/commands/regen_settings.sh` — chains into worker_permissions merge
- `scripts/lib/worker_permissions.py` — project-override-first path resolution
- `scripts/lib/subprocess_dispatch_internals/skill_injection.py` — uses resolver
- `templates/worker_permissions.yaml.tmpl` — canonical template with `_vnx_meta`
- `.vnx/worker_permissions.yaml` — `_vnx_meta` block added
- `bin/vnx` — `regen-worker-permissions` command registered
- `tests/test_worker_permissions_merge.py` — 21 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)