### PR TITLE
refactor(providers): rename deepseek-path-d-blocked -> deepseek-harness-subscription-blocked; allow own-key+hardening, block subscription-redirect

### DIFF
--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -110,18 +110,24 @@ constraints:
     audit_severity: blocking
     override_allowed: false
 
-  - id: deepseek-path-d-blocked
+  - id: deepseek-harness-subscription-blocked
     rule: forbid_route
     forbidden_route:
       provider: deepseek
-      via: claude_harness
+      via: claude_harness_subscription
     reason: >-
-      Path D (Claude binary with ANTHROPIC_BASE_URL redirect) blocked on
-      2026-05-10 — telemetry-leak verified, `claude` v2.1.136 still hits
-      api.anthropic.com 8x per session despite redirect
-      (project_deepseek_v4_pro_paths.md). Tier C network-namespace sandbox
-      is mandatory before Path D can be unblocked. Use Path B (LiteLLM
-      bridge) until that work lands.
+      DeepSeek via Claude-harness (ANTHROPIC_BASE_URL redirect) is ALLOWED
+      with own DeepSeek API-key + hardening: ANTHROPIC_BASE_URL pointing to
+      DeepSeek endpoint, ANTHROPIC_API_KEY set to own DeepSeek key,
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 (+ DISABLE_TELEMETRY +
+      DISABLE_AUTOUPDATER + DISABLE_ERROR_REPORTING), and MCP disabled
+      (--strict-mcp-config --mcp-config '{"mcpServers":{}}'). Measured on
+      claude v2.1.150 (2026-05-26): 0 calls to api.anthropic.com, all
+      inference routes to the DeepSeek endpoint. BLOCKED only when routing
+      through the production OAuth subscription without an own API key —
+      that redirects the protected account identity to DeepSeek, which is
+      the same ban-as as no-anthropic-sdk. Use via=claude_harness_keyed
+      when operating with own key + hardening.
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -8,7 +8,7 @@ Covers every constraint in provider_constraints.yaml:
   - no-anthropic-sdk        (forbid_import — skipped at runtime)
   - zai-via-openrouter-only (forbid_route, blocking)
   - deprecated-glm-models   (forbid_route, blocking)
-  - deepseek-path-d-blocked (forbid_route, blocking)
+  - deepseek-harness-subscription-blocked (forbid_route, blocking)
 
 Plus: file-not-found, bad version, override env var, non-matching routes.
 """
@@ -170,14 +170,19 @@ class TestDeprecatedGlmModels:
 
 
 # ---------------------------------------------------------------------------
-# deepseek-path-d-blocked — forbid_route provider=deepseek via=claude_harness
+# deepseek-harness-subscription-blocked — forbid_route provider=deepseek via=claude_harness_subscription
 # ---------------------------------------------------------------------------
 
-class TestDeepseekPathDBlocked:
+class TestDeepseekHarnessSubscriptionBlocked:
 
-    def test_deepseek_claude_harness_blocked(self, real_enforcer: ConstraintEnforcer):
-        with pytest.raises(HardConstraintViolation, match="deepseek-path-d-blocked"):
-            real_enforcer.enforce(provider="deepseek", via="claude_harness")
+    def test_deepseek_subscription_redirect_blocked(self, real_enforcer: ConstraintEnforcer):
+        """Subscription-redirect path (no own API key) must be blocked."""
+        with pytest.raises(HardConstraintViolation, match="deepseek-harness-subscription-blocked"):
+            real_enforcer.enforce(provider="deepseek", via="claude_harness_subscription")
+
+    def test_deepseek_claude_harness_keyed_allowed(self, real_enforcer: ConstraintEnforcer):
+        """Own-key + hardening path must be allowed (no exception raised)."""
+        real_enforcer.enforce(provider="deepseek", via="claude_harness_keyed")
 
     def test_deepseek_via_litellm_allowed(self, real_enforcer: ConstraintEnforcer):
         real_enforcer.enforce(provider="litellm", sub_provider="deepseek", via="litellm")

--- a/tests/test_constraint_enforcer_kimi_valid.py
+++ b/tests/test_constraint_enforcer_kimi_valid.py
@@ -91,9 +91,14 @@ class TestExistingConstraintsNotRegressed:
         with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
             enforcer.enforce(provider="zai", model="glm-4.5")
 
-    def test_deepseek_claude_harness_still_blocked(self, enforcer: ConstraintEnforcer):
-        with pytest.raises(HardConstraintViolation, match="deepseek-path-d-blocked"):
-            enforcer.enforce(provider="deepseek", via="claude_harness")
+    def test_deepseek_harness_subscription_still_blocked(self, enforcer: ConstraintEnforcer):
+        """Subscription-redirect path remains blocked after kimi enforcer fix."""
+        with pytest.raises(HardConstraintViolation, match="deepseek-harness-subscription-blocked"):
+            enforcer.enforce(provider="deepseek", via="claude_harness_subscription")
+
+    def test_deepseek_harness_keyed_allowed(self, enforcer: ConstraintEnforcer):
+        """Own-key + hardening path is allowed — kimi fix must not regress this."""
+        enforcer.enforce(provider="deepseek", via="claude_harness_keyed")
 
     def test_litellm_deepseek_via_litellm_allowed(self, enforcer: ConstraintEnforcer):
         enforcer.enforce(provider="litellm", sub_provider="deepseek", via="litellm")


### PR DESCRIPTION
## Summary

Rescopes the DeepSeek harness constraint from blocking ALL Claude-harness
Path D traffic to blocking only the subscription-auth-redirect path.

## Why

Measured 2026-05-26 on `claude` v2.1.150 with CONNECT-tunnel-proxy:
with `ANTHROPIC_API_KEY` (own DeepSeek key) + `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+ MCP disabled → 0 calls to `api.anthropic.com`. Anthropic enables this
via `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY`; DeepSeek provides an
Anthropic-compatible endpoint. The ban-risk is the auth identity
(OAuth subscription riding the protected account), not the mechanism.

The human-readable rule in `~/.claude/rules/provider-constraints.md`
was already revised. This PR syncs the machine-readable SSOT.

## Changes

### `scripts/lib/providers/provider_constraints.yaml`
- `id`: `deepseek-path-d-blocked` → `deepseek-harness-subscription-blocked`
- `forbidden_route.via`: `claude_harness` → `claude_harness_subscription`
- `reason`: updated with measured hardened recipe and correct block target

### `tests/test_constraint_enforcer.py`
- Class renamed: `TestDeepseekPathDBlocked` → `TestDeepseekHarnessSubscriptionBlocked`
- Blocked test updated: `via=claude_harness_subscription`, match on new id
- New test: `test_deepseek_claude_harness_keyed_allowed` — own key path must not raise

### `tests/test_constraint_enforcer_kimi_valid.py`
- `test_deepseek_claude_harness_still_blocked` → `test_deepseek_harness_subscription_still_blocked`
- New test: `test_deepseek_harness_keyed_allowed`

## Test results

`pytest tests/test_constraint_enforcer.py tests/test_constraint_enforcer_kimi_valid.py -v`
→ **59 passed, 0 failed**

Dispatch-ID: 20260526-cl3-deepseek-constraint-rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)