### PR TITLE
refactor(quality-db): bootstrap_qi_db migration registry (OI-1542/1544/1541)

### DIFF
--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -9,6 +9,7 @@ import sqlite3
 import sys
 from pathlib import Path
 from datetime import datetime
+from typing import Callable
 import json
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -99,6 +100,484 @@ def initialize_database() -> bool:
     return bootstrap_qi_db(DB_PATH, SCHEMA_FILE)
 
 
+# ---------------------------------------------------------------------------
+# Module-level migration functions (V2–V18)
+# Each function receives the live sqlite3.Connection and runs inside the
+# SAVEPOINT already established by schema_migration.apply_if_below.
+# Use conn.execute() only — never conn.executescript() (breaks SAVEPOINT).
+# ---------------------------------------------------------------------------
+
+def _migrate_v2(conn: sqlite3.Connection) -> None:
+    """V2: pattern_hash on snippet_metadata."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(snippet_metadata)").fetchall()}
+    if "pattern_hash" not in cols:
+        conn.execute("ALTER TABLE snippet_metadata ADD COLUMN pattern_hash TEXT")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_snippet_pattern_hash "
+            "ON snippet_metadata (pattern_hash)"
+        )
+        log('INFO', 'Migrated snippet_metadata: added pattern_hash column + index')
+
+
+def _migrate_v3(conn: sqlite3.Connection) -> None:
+    """V3: session_analytics, improvement_suggestions, nightly_digests tables."""
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_analytics'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS session_analytics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL UNIQUE,
+                project_path TEXT NOT NULL,
+                terminal TEXT,
+                session_date DATE NOT NULL,
+                total_input_tokens INTEGER DEFAULT 0,
+                total_output_tokens INTEGER DEFAULT 0,
+                cache_creation_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                tool_calls_total INTEGER DEFAULT 0,
+                tool_read_count INTEGER DEFAULT 0,
+                tool_edit_count INTEGER DEFAULT 0,
+                tool_bash_count INTEGER DEFAULT 0,
+                tool_grep_count INTEGER DEFAULT 0,
+                tool_write_count INTEGER DEFAULT 0,
+                tool_task_count INTEGER DEFAULT 0,
+                tool_other_count INTEGER DEFAULT 0,
+                message_count INTEGER DEFAULT 0,
+                user_message_count INTEGER DEFAULT 0,
+                assistant_message_count INTEGER DEFAULT 0,
+                duration_minutes REAL,
+                has_error_recovery BOOLEAN DEFAULT FALSE,
+                has_context_reset BOOLEAN DEFAULT FALSE,
+                context_reset_count INTEGER DEFAULT 0,
+                has_large_refactor BOOLEAN DEFAULT FALSE,
+                has_test_cycle BOOLEAN DEFAULT FALSE,
+                primary_activity TEXT,
+                deep_analysis_json TEXT,
+                deep_analysis_model TEXT,
+                deep_analysis_at DATETIME,
+                file_size_bytes INTEGER,
+                analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                analyzer_version TEXT DEFAULT '1.0.0'
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_terminal "
+            "ON session_analytics (terminal, session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_project "
+            "ON session_analytics (project_path, session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_date "
+            "ON session_analytics (session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_activity "
+            "ON session_analytics (primary_activity)"
+        )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS improvement_suggestions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                category TEXT NOT NULL,
+                component TEXT,
+                current_behavior TEXT NOT NULL,
+                suggested_improvement TEXT NOT NULL,
+                evidence TEXT,
+                priority TEXT DEFAULT 'medium',
+                status TEXT DEFAULT 'new',
+                digest_id TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                acted_on_at DATETIME
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_improvement_category "
+            "ON improvement_suggestions (category, status)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_improvement_priority "
+            "ON improvement_suggestions (priority, status)"
+        )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS nightly_digests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                digest_date DATE NOT NULL UNIQUE,
+                sessions_analyzed INTEGER DEFAULT 0,
+                deep_analyzed INTEGER DEFAULT 0,
+                new_suggestions INTEGER DEFAULT 0,
+                total_tokens_used INTEGER DEFAULT 0,
+                digest_markdown TEXT NOT NULL,
+                digest_path TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        log('INFO', 'Migrated: added session_analytics, improvement_suggestions, nightly_digests tables')
+
+
+def _migrate_v4(conn: sqlite3.Connection) -> None:
+    """V4: session_model on session_analytics."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
+    if "session_model" not in cols:
+        conn.execute(
+            "ALTER TABLE session_analytics ADD COLUMN session_model TEXT DEFAULT 'unknown'"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_model "
+            "ON session_analytics (session_model, session_date DESC)"
+        )
+        log('INFO', 'Migrated session_analytics: added session_model column + index')
+
+
+def _migrate_v5(conn: sqlite3.Connection) -> None:
+    """V5: dispatch_id on session_analytics."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
+    if "dispatch_id" not in cols:
+        conn.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_dispatch_id "
+            "ON session_analytics (dispatch_id)"
+        )
+        log('INFO', 'Migrated session_analytics: added dispatch_id column + index')
+
+
+def _migrate_v6(conn: sqlite3.Connection) -> None:
+    """V6: context_reset_count on session_analytics."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
+    if "context_reset_count" not in cols:
+        conn.execute(
+            "ALTER TABLE session_analytics ADD COLUMN context_reset_count INTEGER DEFAULT 0"
+        )
+        log('INFO', 'Migrated session_analytics: added context_reset_count column')
+
+
+def _migrate_v7(conn: sqlite3.Connection) -> None:
+    """V7: report_findings table."""
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS report_findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                report_path TEXT NOT NULL,
+                report_date TIMESTAMP,
+                terminal TEXT,
+                task_type TEXT,
+                patterns_found INTEGER,
+                antipatterns_found INTEGER,
+                prevention_rules_found INTEGER,
+                tags_found TEXT,
+                summary TEXT,
+                age_category TEXT,
+                extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                dispatch_id TEXT
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_report_findings_extracted "
+            "ON report_findings (extracted_at DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_report_findings_dispatch "
+            "ON report_findings (dispatch_id)"
+        )
+        log('INFO', 'Migrated: created report_findings table')
+
+
+def _migrate_v8(conn: sqlite3.Connection) -> None:
+    """V8: dispatch_id on report_findings (for DBs with pre-v7 report_findings)."""
+    if conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
+    ).fetchone():
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(report_findings)").fetchall()}
+        if "dispatch_id" not in cols:
+            conn.execute("ALTER TABLE report_findings ADD COLUMN dispatch_id TEXT")
+            log('INFO', 'Migrated report_findings: added dispatch_id column')
+
+
+def _migrate_v9(conn: sqlite3.Connection) -> None:
+    """V9: CQS columns on dispatch_metadata."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+    if "cqs" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
+        log('INFO', 'Migrated dispatch_metadata: added cqs, normalized_status, cqs_components columns')
+
+
+def _migrate_v10(conn: sqlite3.Connection) -> None:
+    """V10: governance_metrics, spc_control_limits, spc_alerts."""
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='governance_metrics'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS governance_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                period_start DATE NOT NULL,
+                period_end DATE NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_value TEXT NOT NULL,
+                metric_name TEXT NOT NULL,
+                metric_value REAL NOT NULL,
+                sample_size INTEGER NOT NULL,
+                computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup "
+            "ON governance_metrics (period_start, scope_type, metric_name)"
+        )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS spc_control_limits (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                metric_name TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_value TEXT NOT NULL,
+                center_line REAL NOT NULL,
+                ucl REAL NOT NULL,
+                lcl REAL NOT NULL,
+                sigma REAL NOT NULL,
+                sample_count INTEGER NOT NULL,
+                baseline_start DATE,
+                baseline_end DATE,
+                computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(metric_name, scope_type, scope_value)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS spc_alerts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                alert_type TEXT NOT NULL,
+                metric_name TEXT NOT NULL,
+                scope_type TEXT NOT NULL,
+                scope_value TEXT NOT NULL,
+                observed_value REAL NOT NULL,
+                control_limit REAL,
+                description TEXT,
+                severity TEXT DEFAULT 'warning',
+                detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                acknowledged_at DATETIME
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup "
+            "ON spc_alerts (detected_at DESC, severity)"
+        )
+        log('INFO', 'Migrated: created governance_metrics, spc_control_limits, spc_alerts tables')
+
+
+def _migrate_v11(conn: sqlite3.Connection) -> None:
+    """V11: confidence_events (F50-PR3 feedback loop)."""
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_events'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS confidence_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                terminal TEXT,
+                outcome TEXT NOT NULL,
+                patterns_boosted INTEGER DEFAULT 0,
+                patterns_decayed INTEGER DEFAULT 0,
+                confidence_change REAL NOT NULL,
+                occurred_at TEXT NOT NULL
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_conf_events_dispatch "
+            "ON confidence_events (dispatch_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_conf_events_occurred "
+            "ON confidence_events (occurred_at DESC)"
+        )
+        log('INFO', 'Migrated: added confidence_events table')
+
+
+def _migrate_v12(conn: sqlite3.Connection) -> None:
+    """V12: T0 advisory + OI delta columns on dispatch_metadata."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+    if "target_open_items" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
+        conn.execute(
+            "ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0"
+        )
+        conn.execute(
+            "ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0"
+        )
+        log('INFO', 'Migrated dispatch_metadata: added target_open_items, open_items_created, open_items_resolved columns')
+
+
+def _migrate_v13(conn: sqlite3.Connection) -> None:
+    """V13: quality_advisory_json for CQS round-trip preservation (OI-1175)."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+    if "quality_advisory_json" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN quality_advisory_json TEXT")
+        log('INFO', 'Migrated dispatch_metadata: added quality_advisory_json column')
+
+
+def _migrate_v14(conn: sqlite3.Connection) -> None:
+    """V14: dispatch_id on pattern_usage for dispatch-scoped traceability."""
+    if conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='pattern_usage'"
+    ).fetchone():
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(pattern_usage)").fetchall()}
+        if "dispatch_id" not in cols:
+            conn.execute(
+                "ALTER TABLE pattern_usage ADD COLUMN dispatch_id TEXT DEFAULT NULL"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pattern_usage_dispatch_id "
+                "ON pattern_usage (dispatch_id)"
+            )
+            log('INFO', 'Migrated pattern_usage: added dispatch_id column + index')
+
+
+def _migrate_v15(conn: sqlite3.Connection) -> None:
+    """V15: source_dispatch_id on prevention_rules for audit linkage."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(prevention_rules)").fetchall()}
+    if "source_dispatch_id" not in cols:
+        conn.execute(
+            "ALTER TABLE prevention_rules ADD COLUMN source_dispatch_id TEXT DEFAULT NULL"
+        )
+        log('INFO', 'Migrated prevention_rules: added source_dispatch_id column')
+
+
+def _migrate_v16(conn: sqlite3.Connection) -> None:
+    """V16: temporal validity columns (F54 bi-temporal pattern lifecycle).
+
+    SQLite ALTER TABLE does not support non-constant defaults (e.g. CURRENT_TIMESTAMP).
+    Add with DEFAULT NULL, then backfill valid_from for existing rows.
+    """
+    for tbl in ("success_patterns", "antipatterns", "prevention_rules"):
+        cols = {r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()}
+        if "valid_from" not in cols:
+            conn.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_from DATETIME DEFAULT NULL")
+            conn.execute(
+                f"UPDATE {tbl} SET valid_from = datetime('now') WHERE valid_from IS NULL"
+            )
+            log('INFO', f'Migrated {tbl}: added valid_from column + backfilled existing rows')
+        if "valid_until" not in cols:
+            conn.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_until DATETIME DEFAULT NULL")
+            log('INFO', f'Migrated {tbl}: added valid_until column')
+
+
+def _migrate_v17(conn: sqlite3.Connection) -> None:
+    """V17: dispatch_pattern_offered junction + invalidation_reason columns.
+
+    Merges two v17 migrations that landed independently:
+    - dispatch_pattern_offered (this branch — atomic via apply_if_below)
+    - invalidation_reason on success_patterns + antipatterns (from #593 AUDIT-IH-1 main)
+    Both wrapped in single _v17 → atomic via apply_if_below SAVEPOINT.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='dispatch_pattern_offered'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+                dispatch_id   TEXT NOT NULL,
+                pattern_id    TEXT NOT NULL,
+                pattern_title TEXT NOT NULL,
+                offered_at    TEXT NOT NULL,
+                PRIMARY KEY (dispatch_id, pattern_id)
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dpo_dispatch_id "
+            "ON dispatch_pattern_offered (dispatch_id)"
+        )
+        log('INFO', 'Migrated: created dispatch_pattern_offered table + index')
+    # Catalog hygiene: invalidation_reason on success_patterns + antipatterns
+    # (from #593 AUDIT-IH-1 fix — codex blocker about IF NOT EXISTS invalid on SQLite < 3.37)
+    for _htbl in ("success_patterns", "antipatterns"):
+        cols = {r[1] for r in conn.execute(f"PRAGMA table_info({_htbl})").fetchall()}
+        if "invalidation_reason" not in cols:
+            conn.execute(f"ALTER TABLE {_htbl} ADD COLUMN invalidation_reason TEXT")
+            log('INFO', f'Migrated {_htbl}: added invalidation_reason column')
+
+
+def _migrate_v18(conn: sqlite3.Connection) -> None:
+    """V18: dispatch_experiments (unified from dispatch_tracker.db).
+
+    dispatch_experiments was historically written to dispatch_tracker.db by
+    dispatch_parameter_tracker.py. retroactive_backfill.py unified it into
+    quality_intelligence.db. The canonical bootstrap did not include a
+    CREATE TABLE for it, causing BootstrapFailure when _assert_central_tables_exist
+    checked for its presence in source DBs and found it missing in central.
+    Schema mirrors scripts/lib/dispatch_parameter_tracker.py::init_schema() plus the
+    project_id column that migration 0015 would later ADD COLUMN on existing DBs
+    (here we create it upfront so fresh installs get the full schema immediately).
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dispatch_experiments'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dispatch_experiments (
+                id                  INTEGER PRIMARY KEY,
+                dispatch_id         TEXT UNIQUE,
+                timestamp           DATETIME DEFAULT CURRENT_TIMESTAMP,
+                instruction_chars   INTEGER,
+                context_items       INTEGER,
+                repo_map_symbols    INTEGER,
+                role                TEXT,
+                cognition           TEXT,
+                model               TEXT,
+                terminal            TEXT,
+                file_count          INTEGER,
+                success             BOOLEAN,
+                cqs                 REAL,
+                completion_minutes  REAL,
+                test_count          INTEGER,
+                committed           BOOLEAN,
+                lines_changed       INTEGER,
+                project_id          TEXT
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_de_dispatch_id "
+            "ON dispatch_experiments (dispatch_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_de_role "
+            "ON dispatch_experiments (role)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_de_timestamp "
+            "ON dispatch_experiments (timestamp DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_de_project_id "
+            "ON dispatch_experiments (project_id)"
+        )
+        log('INFO', 'Migrated: created dispatch_experiments table + indexes')
+
+
+# Registry mapping version → migration function.
+# bootstrap_qi_db iterates this in sorted key order after V1.
+MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
+    2: _migrate_v2,
+    3: _migrate_v3,
+    4: _migrate_v4,
+    5: _migrate_v5,
+    6: _migrate_v6,
+    7: _migrate_v7,
+    8: _migrate_v8,
+    9: _migrate_v9,
+    10: _migrate_v10,
+    11: _migrate_v11,
+    12: _migrate_v12,
+    13: _migrate_v13,
+    14: _migrate_v14,
+    15: _migrate_v15,
+    16: _migrate_v16,
+    17: _migrate_v17,
+    18: _migrate_v18,
+}
+
+
 def bootstrap_qi_db(db_path: Path, schema_file: Path | None = None) -> bool:
     """Initialize a quality_intelligence DB at ``db_path`` using the canonical schema.
 
@@ -131,447 +610,9 @@ def bootstrap_qi_db(db_path: Path, schema_file: Path | None = None) -> bool:
         if schema_migration.apply_script_if_below(conn, 1, schema_sql):
             log('INFO', 'Base schema applied atomically (v1)')
 
-        # ---- V2: pattern_hash on snippet_metadata ----
-        def _v2(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(snippet_metadata)").fetchall()}
-            if "pattern_hash" not in cols:
-                c.execute("ALTER TABLE snippet_metadata ADD COLUMN pattern_hash TEXT")
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_snippet_pattern_hash "
-                    "ON snippet_metadata (pattern_hash)"
-                )
-                log('INFO', 'Migrated snippet_metadata: added pattern_hash column + index')
-        schema_migration.apply_if_below(conn, 2, _v2)
-
-        # ---- V3: session_analytics, improvement_suggestions, nightly_digests tables ----
-        def _v3(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='session_analytics'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS session_analytics (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        session_id TEXT NOT NULL UNIQUE,
-                        project_path TEXT NOT NULL,
-                        terminal TEXT,
-                        session_date DATE NOT NULL,
-                        total_input_tokens INTEGER DEFAULT 0,
-                        total_output_tokens INTEGER DEFAULT 0,
-                        cache_creation_tokens INTEGER DEFAULT 0,
-                        cache_read_tokens INTEGER DEFAULT 0,
-                        tool_calls_total INTEGER DEFAULT 0,
-                        tool_read_count INTEGER DEFAULT 0,
-                        tool_edit_count INTEGER DEFAULT 0,
-                        tool_bash_count INTEGER DEFAULT 0,
-                        tool_grep_count INTEGER DEFAULT 0,
-                        tool_write_count INTEGER DEFAULT 0,
-                        tool_task_count INTEGER DEFAULT 0,
-                        tool_other_count INTEGER DEFAULT 0,
-                        message_count INTEGER DEFAULT 0,
-                        user_message_count INTEGER DEFAULT 0,
-                        assistant_message_count INTEGER DEFAULT 0,
-                        duration_minutes REAL,
-                        has_error_recovery BOOLEAN DEFAULT FALSE,
-                        has_context_reset BOOLEAN DEFAULT FALSE,
-                        context_reset_count INTEGER DEFAULT 0,
-                        has_large_refactor BOOLEAN DEFAULT FALSE,
-                        has_test_cycle BOOLEAN DEFAULT FALSE,
-                        primary_activity TEXT,
-                        deep_analysis_json TEXT,
-                        deep_analysis_model TEXT,
-                        deep_analysis_at DATETIME,
-                        file_size_bytes INTEGER,
-                        analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        analyzer_version TEXT DEFAULT '1.0.0'
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_terminal "
-                    "ON session_analytics (terminal, session_date DESC)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_project "
-                    "ON session_analytics (project_path, session_date DESC)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_date "
-                    "ON session_analytics (session_date DESC)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_activity "
-                    "ON session_analytics (primary_activity)"
-                )
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS improvement_suggestions (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        session_id TEXT NOT NULL,
-                        category TEXT NOT NULL,
-                        component TEXT,
-                        current_behavior TEXT NOT NULL,
-                        suggested_improvement TEXT NOT NULL,
-                        evidence TEXT,
-                        priority TEXT DEFAULT 'medium',
-                        status TEXT DEFAULT 'new',
-                        digest_id TEXT,
-                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        acted_on_at DATETIME
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_improvement_category "
-                    "ON improvement_suggestions (category, status)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_improvement_priority "
-                    "ON improvement_suggestions (priority, status)"
-                )
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS nightly_digests (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        digest_date DATE NOT NULL UNIQUE,
-                        sessions_analyzed INTEGER DEFAULT 0,
-                        deep_analyzed INTEGER DEFAULT 0,
-                        new_suggestions INTEGER DEFAULT 0,
-                        total_tokens_used INTEGER DEFAULT 0,
-                        digest_markdown TEXT NOT NULL,
-                        digest_path TEXT,
-                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-                    )
-                """)
-                log('INFO', 'Migrated: added session_analytics, improvement_suggestions, nightly_digests tables')
-        schema_migration.apply_if_below(conn, 3, _v3)
-
-        # ---- V4: session_model on session_analytics ----
-        def _v4(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
-            if "session_model" not in cols:
-                c.execute(
-                    "ALTER TABLE session_analytics ADD COLUMN session_model TEXT DEFAULT 'unknown'"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_model "
-                    "ON session_analytics (session_model, session_date DESC)"
-                )
-                log('INFO', 'Migrated session_analytics: added session_model column + index')
-        schema_migration.apply_if_below(conn, 4, _v4)
-
-        # ---- V5: dispatch_id on session_analytics ----
-        def _v5(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
-            if "dispatch_id" not in cols:
-                c.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_session_dispatch_id "
-                    "ON session_analytics (dispatch_id)"
-                )
-                log('INFO', 'Migrated session_analytics: added dispatch_id column + index')
-        schema_migration.apply_if_below(conn, 5, _v5)
-
-        # ---- V6: context_reset_count on session_analytics ----
-        def _v6(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(session_analytics)").fetchall()}
-            if "context_reset_count" not in cols:
-                c.execute(
-                    "ALTER TABLE session_analytics ADD COLUMN context_reset_count INTEGER DEFAULT 0"
-                )
-                log('INFO', 'Migrated session_analytics: added context_reset_count column')
-        schema_migration.apply_if_below(conn, 6, _v6)
-
-        # ---- V7: report_findings table ----
-        def _v7(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS report_findings (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        report_path TEXT NOT NULL,
-                        report_date TIMESTAMP,
-                        terminal TEXT,
-                        task_type TEXT,
-                        patterns_found INTEGER,
-                        antipatterns_found INTEGER,
-                        prevention_rules_found INTEGER,
-                        tags_found TEXT,
-                        summary TEXT,
-                        age_category TEXT,
-                        extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        dispatch_id TEXT
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_report_findings_extracted "
-                    "ON report_findings (extracted_at DESC)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_report_findings_dispatch "
-                    "ON report_findings (dispatch_id)"
-                )
-                log('INFO', 'Migrated: created report_findings table')
-        schema_migration.apply_if_below(conn, 7, _v7)
-
-        # ---- V8: dispatch_id on report_findings (for DBs with pre-v7 report_findings) ----
-        def _v8(c):
-            if c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
-            ).fetchone():
-                cols = {r[1] for r in c.execute("PRAGMA table_info(report_findings)").fetchall()}
-                if "dispatch_id" not in cols:
-                    c.execute("ALTER TABLE report_findings ADD COLUMN dispatch_id TEXT")
-                    log('INFO', 'Migrated report_findings: added dispatch_id column')
-        schema_migration.apply_if_below(conn, 8, _v8)
-
-        # ---- V9: CQS columns on dispatch_metadata ----
-        def _v9(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
-            if "cqs" not in cols:
-                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs REAL")
-                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN normalized_status TEXT")
-                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN cqs_components TEXT")
-                log('INFO', 'Migrated dispatch_metadata: added cqs, normalized_status, cqs_components columns')
-        schema_migration.apply_if_below(conn, 9, _v9)
-
-        # ---- V10: governance_metrics, spc_control_limits, spc_alerts ----
-        def _v10(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='governance_metrics'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS governance_metrics (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        period_start DATE NOT NULL,
-                        period_end DATE NOT NULL,
-                        scope_type TEXT NOT NULL,
-                        scope_value TEXT NOT NULL,
-                        metric_name TEXT NOT NULL,
-                        metric_value REAL NOT NULL,
-                        sample_size INTEGER NOT NULL,
-                        computed_at DATETIME DEFAULT CURRENT_TIMESTAMP
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_gov_metrics_lookup "
-                    "ON governance_metrics (period_start, scope_type, metric_name)"
-                )
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS spc_control_limits (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        metric_name TEXT NOT NULL,
-                        scope_type TEXT NOT NULL,
-                        scope_value TEXT NOT NULL,
-                        center_line REAL NOT NULL,
-                        ucl REAL NOT NULL,
-                        lcl REAL NOT NULL,
-                        sigma REAL NOT NULL,
-                        sample_count INTEGER NOT NULL,
-                        baseline_start DATE,
-                        baseline_end DATE,
-                        computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        UNIQUE(metric_name, scope_type, scope_value)
-                    )
-                """)
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS spc_alerts (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        alert_type TEXT NOT NULL,
-                        metric_name TEXT NOT NULL,
-                        scope_type TEXT NOT NULL,
-                        scope_value TEXT NOT NULL,
-                        observed_value REAL NOT NULL,
-                        control_limit REAL,
-                        description TEXT,
-                        severity TEXT DEFAULT 'warning',
-                        detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        acknowledged_at DATETIME
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_spc_alerts_lookup "
-                    "ON spc_alerts (detected_at DESC, severity)"
-                )
-                log('INFO', 'Migrated: created governance_metrics, spc_control_limits, spc_alerts tables')
-        schema_migration.apply_if_below(conn, 10, _v10)
-
-        # ---- V11: confidence_events (F50-PR3 feedback loop) ----
-        def _v11(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_events'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS confidence_events (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        dispatch_id TEXT NOT NULL,
-                        terminal TEXT,
-                        outcome TEXT NOT NULL,
-                        patterns_boosted INTEGER DEFAULT 0,
-                        patterns_decayed INTEGER DEFAULT 0,
-                        confidence_change REAL NOT NULL,
-                        occurred_at TEXT NOT NULL
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_conf_events_dispatch "
-                    "ON confidence_events (dispatch_id)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_conf_events_occurred "
-                    "ON confidence_events (occurred_at DESC)"
-                )
-                log('INFO', 'Migrated: added confidence_events table')
-        schema_migration.apply_if_below(conn, 11, _v11)
-
-        # ---- V12: T0 advisory + OI delta columns on dispatch_metadata ----
-        def _v12(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
-            if "target_open_items" not in cols:
-                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN target_open_items TEXT")
-                c.execute(
-                    "ALTER TABLE dispatch_metadata ADD COLUMN open_items_created INTEGER DEFAULT 0"
-                )
-                c.execute(
-                    "ALTER TABLE dispatch_metadata ADD COLUMN open_items_resolved INTEGER DEFAULT 0"
-                )
-                log('INFO', 'Migrated dispatch_metadata: added target_open_items, open_items_created, open_items_resolved columns')
-        schema_migration.apply_if_below(conn, 12, _v12)
-
-        # ---- V13: quality_advisory_json for CQS round-trip preservation (OI-1175) ----
-        def _v13(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
-            if "quality_advisory_json" not in cols:
-                c.execute("ALTER TABLE dispatch_metadata ADD COLUMN quality_advisory_json TEXT")
-                log('INFO', 'Migrated dispatch_metadata: added quality_advisory_json column')
-        schema_migration.apply_if_below(conn, 13, _v13)
-
-        # ---- V14: dispatch_id on pattern_usage for dispatch-scoped traceability ----
-        def _v14(c):
-            if c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='pattern_usage'"
-            ).fetchone():
-                cols = {r[1] for r in c.execute("PRAGMA table_info(pattern_usage)").fetchall()}
-                if "dispatch_id" not in cols:
-                    c.execute(
-                        "ALTER TABLE pattern_usage ADD COLUMN dispatch_id TEXT DEFAULT NULL"
-                    )
-                    c.execute(
-                        "CREATE INDEX IF NOT EXISTS idx_pattern_usage_dispatch_id "
-                        "ON pattern_usage (dispatch_id)"
-                    )
-                    log('INFO', 'Migrated pattern_usage: added dispatch_id column + index')
-        schema_migration.apply_if_below(conn, 14, _v14)
-
-        # ---- V15: source_dispatch_id on prevention_rules for audit linkage ----
-        def _v15(c):
-            cols = {r[1] for r in c.execute("PRAGMA table_info(prevention_rules)").fetchall()}
-            if "source_dispatch_id" not in cols:
-                c.execute(
-                    "ALTER TABLE prevention_rules ADD COLUMN source_dispatch_id TEXT DEFAULT NULL"
-                )
-                log('INFO', 'Migrated prevention_rules: added source_dispatch_id column')
-        schema_migration.apply_if_below(conn, 15, _v15)
-
-        # ---- V16: temporal validity columns (F54 bi-temporal pattern lifecycle) ----
-        # SQLite ALTER TABLE does not support non-constant defaults (e.g. CURRENT_TIMESTAMP).
-        # Add with DEFAULT NULL, then backfill valid_from for existing rows.
-        def _v16(c):
-            for tbl in ("success_patterns", "antipatterns", "prevention_rules"):
-                cols = {r[1] for r in c.execute(f"PRAGMA table_info({tbl})").fetchall()}
-                if "valid_from" not in cols:
-                    c.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_from DATETIME DEFAULT NULL")
-                    c.execute(
-                        f"UPDATE {tbl} SET valid_from = datetime('now') WHERE valid_from IS NULL"
-                    )
-                    log('INFO', f'Migrated {tbl}: added valid_from column + backfilled existing rows')
-                if "valid_until" not in cols:
-                    c.execute(f"ALTER TABLE {tbl} ADD COLUMN valid_until DATETIME DEFAULT NULL")
-                    log('INFO', f'Migrated {tbl}: added valid_until column')
-        schema_migration.apply_if_below(conn, 16, _v16)
-
-        # ---- V17: dispatch_pattern_offered junction + invalidation_reason columns ----
-        # Merges two v17 migrations that landed independently:
-        # - dispatch_pattern_offered (this branch — atomic via apply_if_below)
-        # - invalidation_reason on success_patterns + antipatterns (from #593 AUDIT-IH-1 main)
-        # Both wrapped in single _v17 → atomic via apply_if_below SAVEPOINT
-        def _v17(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' "
-                "AND name='dispatch_pattern_offered'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
-                        dispatch_id   TEXT NOT NULL,
-                        pattern_id    TEXT NOT NULL,
-                        pattern_title TEXT NOT NULL,
-                        offered_at    TEXT NOT NULL,
-                        PRIMARY KEY (dispatch_id, pattern_id)
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_dpo_dispatch_id "
-                    "ON dispatch_pattern_offered (dispatch_id)"
-                )
-                log('INFO', 'Migrated: created dispatch_pattern_offered table + index')
-            # Catalog hygiene: invalidation_reason on success_patterns + antipatterns
-            # (from #593 AUDIT-IH-1 fix — codex blocker about IF NOT EXISTS invalid on SQLite < 3.37)
-            for _htbl in ("success_patterns", "antipatterns"):
-                cols = {r[1] for r in c.execute(f"PRAGMA table_info({_htbl})").fetchall()}
-                if "invalidation_reason" not in cols:
-                    c.execute(f"ALTER TABLE {_htbl} ADD COLUMN invalidation_reason TEXT")
-                    log('INFO', f'Migrated {_htbl}: added invalidation_reason column')
-        schema_migration.apply_if_below(conn, 17, _v17)
-
-        # ---- V18: dispatch_experiments (unified from dispatch_tracker.db) ----
-        # dispatch_experiments was historically written to dispatch_tracker.db by
-        # dispatch_parameter_tracker.py. retroactive_backfill.py unified it into
-        # quality_intelligence.db. The canonical bootstrap did not include a
-        # CREATE TABLE for it, causing BootstrapFailure when _assert_central_tables_exist
-        # checked for its presence in source DBs and found it missing in central.
-        # Schema mirrors scripts/lib/dispatch_parameter_tracker.py::init_schema() plus the
-        # project_id column that migration 0015 would later ADD COLUMN on existing DBs
-        # (here we create it upfront so fresh installs get the full schema immediately).
-        def _v18(c):
-            if not c.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='dispatch_experiments'"
-            ).fetchone():
-                c.execute("""
-                    CREATE TABLE IF NOT EXISTS dispatch_experiments (
-                        id                  INTEGER PRIMARY KEY,
-                        dispatch_id         TEXT UNIQUE,
-                        timestamp           DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        instruction_chars   INTEGER,
-                        context_items       INTEGER,
-                        repo_map_symbols    INTEGER,
-                        role                TEXT,
-                        cognition           TEXT,
-                        model               TEXT,
-                        terminal            TEXT,
-                        file_count          INTEGER,
-                        success             BOOLEAN,
-                        cqs                 REAL,
-                        completion_minutes  REAL,
-                        test_count          INTEGER,
-                        committed           BOOLEAN,
-                        lines_changed       INTEGER,
-                        project_id          TEXT
-                    )
-                """)
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_de_dispatch_id "
-                    "ON dispatch_experiments (dispatch_id)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_de_role "
-                    "ON dispatch_experiments (role)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_de_timestamp "
-                    "ON dispatch_experiments (timestamp DESC)"
-                )
-                c.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_de_project_id "
-                    "ON dispatch_experiments (project_id)"
-                )
-                log('INFO', 'Migrated: created dispatch_experiments table + indexes')
-        schema_migration.apply_if_below(conn, 18, _v18)
+        # ---- V2–V18: incremental migrations from registry ----
+        for version in sorted(MIGRATIONS):
+            schema_migration.apply_if_below(conn, version, MIGRATIONS[version])
 
         log('SUCCESS', 'Database schema initialized successfully')
         conn.close()


### PR DESCRIPTION
## What

Converts the inline nested `_vN()` migration closures inside `bootstrap_qi_db` to module-level `def _migrate_vN(conn: sqlite3.Connection) -> None` functions plus a `MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]]` registry.

`bootstrap_qi_db` is now ~60 lines:
1. Load schema file
2. Open connection with `isolation_level = None`
3. V1: `apply_script_if_below(conn, 1, schema_sql)`
4. Loop: `for version in sorted(MIGRATIONS): apply_if_below(conn, version, MIGRATIONS[version])`

## Why

Resolves size OIs: OI-1542, OI-1544, OI-1541. The function was 473 lines with 17 nested closures — a shell size OI trigger. Extracting to module level cuts it to ~60 lines.

## Guarantees preserved

- **SAVEPOINT semantics**: unchanged — `apply_if_below` still wraps each migration in a named SAVEPOINT and rolls back on failure
- **Idempotency**: unchanged — skips via `PRAGMA user_version >= target`
- **Call order**: registry iterated via `sorted(MIGRATIONS)` → deterministic V2–V18 in sequence
- **No algorithmic changes**: pure structural extraction

## Tests

============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.12/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /Users/vincentvandeth/Development/vnx-oi-wt/b2
configfile: pyproject.toml
plugins: hypothesis-6.152.7, cov-7.1.0, asyncio-1.1.0, anyio-4.10.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 16 items

tests/test_schema_idempotency.py::test_bootstrap_fresh_db_applies_all_migrations PASSED [  6%]
tests/test_schema_idempotency.py::test_bootstrap_already_complete_skips_all_migrations PASSED [ 12%]
tests/test_schema_idempotency.py::test_bootstrap_partial_db_applies_remaining_migrations PASSED [ 18%]
tests/test_schema_idempotency.py::test_apply_if_below_rolls_back_on_failure PASSED [ 25%]
tests/test_schema_idempotency.py::test_bootstrap_idempotent_repeated_runs PASSED [ 31%]
tests/test_schema_idempotency.py::test_needs_initial_migration_fresh_db PASSED [ 37%]
tests/test_schema_idempotency.py::test_needs_initial_migration_pragma_high PASSED [ 43%]
tests/test_schema_idempotency.py::test_needs_initial_migration_legacy_table_syncs_pragma PASSED [ 50%]
tests/test_schema_idempotency.py::test_apply_script_if_below_atomic_failure_rolls_back PASSED [ 56%]
tests/test_schema_idempotency.py::test_apply_script_if_below_success PASSED [ 62%]
tests/test_schema_idempotency.py::test_split_sql_statements_quote_and_comment_safe PASSED [ 68%]
tests/test_report_findings_schema.py::TestReportFindingsSchemaCreation::test_report_findings_table_created_by_migration PASSED [ 75%]
tests/test_report_findings_schema.py::TestReportFindingsSchemaCreation::test_report_findings_columns_match_schema PASSED [ 81%]
tests/test_report_findings_schema.py::TestReportFindingsSchemaCreation::test_migration_is_idempotent PASSED [ 87%]
tests/test_report_findings_schema.py::TestPhase3RunsWithoutSchemaError::test_link_sessions_dispatches_no_operational_error PASSED [ 93%]
tests/test_report_findings_schema.py::TestPhase3RunsWithoutSchemaError::test_link_sessions_dispatches_full_main FAILED [100%]

=================================== FAILURES ===================================
___ TestPhase3RunsWithoutSchemaError.test_link_sessions_dispatches_full_main ___

self = <test_report_findings_schema.TestPhase3RunsWithoutSchemaError object at 0x109dbe000>
tmp_path = PosixPath('/private/var/folders/q5/n9hzhbvx3zv05t09g426yblh0000gn/T/pytest-of-vincentvandeth/pytest-74/test_link_sessions_dispatches_1')

    def test_link_sessions_dispatches_full_main(self, tmp_path):
        """Phase 3 main() must return 0 when report_findings table exists."""
        import link_sessions_dispatches as lsd
    
        db_path = tmp_path / "quality_intelligence.db"
        conn = sqlite3.connect(str(db_path))
        conn.executescript("""
            CREATE TABLE dispatch_metadata (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
                dispatch_id TEXT NOT NULL UNIQUE,
                session_id TEXT,
                outcome_status TEXT,
                outcome_report_path TEXT,
                completed_at TEXT
            );
            CREATE TABLE session_analytics (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
                session_id TEXT NOT NULL UNIQUE,
                dispatch_id TEXT
            );
            CREATE TABLE report_findings (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
                report_path TEXT NOT NULL,
                dispatch_id TEXT
            );
        """)
        conn.commit()
        conn.close()
    
        with (
            patch.object(lsd, "DB_PATH", db_path),
            patch.object(lsd, "RECEIPTS_FILE", tmp_path / "t0_receipts.ndjson"),
        ):
>           result = lsd.main()
                     ^^^^^^^^^^

tests/test_report_findings_schema.py:300: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
scripts/link_sessions_dispatches.py:141: in main
    created = ensure_report_findings_table(conn)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

conn = <sqlite3.Connection object at 0x109c0b010>

    def ensure_report_findings_table(conn: sqlite3.Connection) -> bool:
        """Create report_findings table + indexes if they do not exist. Idempotent.
    
        Returns True if the table was freshly created, False if it already existed.
        """
        existed = (
            conn.execute(
                "SELECT name FROM sqlite_master WHERE type='table' AND name='report_findings'"
            ).fetchone()
            is not None
        )
>       conn.executescript(_MIGRATION_SQL)
E       sqlite3.OperationalError: no such column: extracted_at

scripts/lib/report_findings_migration.py:54: OperationalError
=============================== warnings summary ===============================
scripts/lib/vnx_paths.py:256
tests/test_report_findings_schema.py::TestPhase3RunsWithoutSchemaError::test_link_sessions_dispatches_no_operational_error
  /Users/vincentvandeth/Development/vnx-oi-wt/b2/scripts/lib/vnx_paths.py:256: DeprecationWarning: VNX_DATA_DIR env-var set (/Users/vincentvandeth/Development/vnx-roadmap-autopilot-wt/.vnx-data) but VNX_DATA_DIR_EXPLICIT=1 is required for it to be honored. Ignoring and using VNX_HOME-resolved project root. See https://github.com/Vinix24/vnx-orchestration/issues/225
    paths = resolve_paths()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_report_findings_schema.py::TestPhase3RunsWithoutSchemaError::test_link_sessions_dispatches_full_main
=================== 1 failed, 15 passed, 2 warnings in 0.28s ===================

🤖 Generated with [Claude Code](https://claude.com/claude-code)