### PR TITLE
refactor(benchmark): extract source-info + report-writers from main (OI-1510)

### DIFF
--- a/scripts/benchmark/fts5_rebuild_benchmark.py
+++ b/scripts/benchmark/fts5_rebuild_benchmark.py
@@ -231,6 +231,47 @@ def _write_json_report(report: dict, path: Path) -> None:
     os.replace(tmp, path)
 
 
+def _collect_source_info(source_db: Path, work_dir: Path) -> "tuple[dict, Path]":
+    """Collect source DB PRAGMA metadata and create a working copy for benchmarking.
+
+    Returns (source_info dict, path to work copy).
+    """
+    src_conn = sqlite3.connect(str(source_db), timeout=30)
+    journal_mode = src_conn.execute("PRAGMA journal_mode").fetchone()[0]
+    page_size = src_conn.execute("PRAGMA page_size").fetchone()[0]
+    page_count = src_conn.execute("PRAGMA page_count").fetchone()[0]
+    src_conn.close()
+
+    source_info: dict = {
+        "path": str(source_db),
+        "size_bytes": source_db.stat().st_size,
+        "journal_mode": journal_mode,
+        "page_size": page_size,
+        "page_count": page_count,
+        "work_copy": "",
+    }
+
+    print("[benchmark] Copying DB to work dir...")
+    t_copy_start = time.monotonic()
+    work_db = _copy_db(source_db, work_dir)
+    t_copy_end = time.monotonic()
+    print(f"[benchmark] Copy done in {t_copy_end - t_copy_start:.1f}s -> {work_db}")
+    source_info["work_copy"] = str(work_db)
+    source_info["copy_wall_seconds"] = round(t_copy_end - t_copy_start, 3)
+
+    return source_info, work_db
+
+
+def _write_reports(report: dict, report_dir: Path, stem: str) -> None:
+    """Write JSON and Markdown reports and print their file locations."""
+    json_path = report_dir / f"{stem}.json"
+    md_path = report_dir / f"{stem}.md"
+    _write_json_report(report, json_path)
+    _write_md_report(report, md_path)
+    print(f"[benchmark] JSON report: {json_path}")
+    print(f"[benchmark] MD report:   {md_path}")
+
+
 def _write_md_report(report: dict, path: Path) -> None:
     lines = []
     meta = report["meta"]
@@ -385,30 +426,7 @@ def main() -> None:
     print(f"[benchmark] Work dir:  {work_dir}")
     print(f"[benchmark] Tables:    {tables}")
 
-    # --- Source DB metadata ---
-    src_conn = sqlite3.connect(str(source_db), timeout=30)
-    journal_mode = src_conn.execute("PRAGMA journal_mode").fetchone()[0]
-    page_size = src_conn.execute("PRAGMA page_size").fetchone()[0]
-    page_count = src_conn.execute("PRAGMA page_count").fetchone()[0]
-    src_conn.close()
-
-    source_info = {
-        "path": str(source_db),
-        "size_bytes": source_db.stat().st_size,
-        "journal_mode": journal_mode,
-        "page_size": page_size,
-        "page_count": page_count,
-        "work_copy": "",
-    }
-
-    # --- Copy DB ---
-    print(f"[benchmark] Copying DB to work dir...")
-    t_copy_start = time.monotonic()
-    work_db = _copy_db(source_db, work_dir)
-    t_copy_end = time.monotonic()
-    print(f"[benchmark] Copy done in {t_copy_end - t_copy_start:.1f}s -> {work_db}")
-    source_info["work_copy"] = str(work_db)
-    source_info["copy_wall_seconds"] = round(t_copy_end - t_copy_start, 3)
+    source_info, work_db = _collect_source_info(source_db, work_dir)
 
     # --- Benchmark each table ---
     pre_rss = _baseline_memory_rss()
@@ -452,15 +470,7 @@ def main() -> None:
         },
     }
 
-    # --- Write reports ---
-    json_path = report_dir / f"{stem}.json"
-    md_path = report_dir / f"{stem}.md"
-
-    _write_json_report(report, json_path)
-    _write_md_report(report, md_path)
-
-    print(f"[benchmark] JSON report: {json_path}")
-    print(f"[benchmark] MD report:   {md_path}")
+    _write_reports(report, report_dir, stem)
 
     risk = report["summary"]["risk_classification"]
     print(

--- a/tests/benchmark/test_fts5_rebuild_benchmark.py
+++ b/tests/benchmark/test_fts5_rebuild_benchmark.py
@@ -227,6 +227,148 @@ class TestMetricKeys:
             assert key in v, f"Missing validation key: {key}"
 
 
+class TestCollectSourceInfo:
+    def test_returns_correct_keys(self, synthetic_db: Path, tmp_path: Path):
+        """_collect_source_info returns a dict with all expected PRAGMA keys."""
+        work_dir = tmp_path / "work"
+        source_info, work_db = bm._collect_source_info(synthetic_db, work_dir)
+
+        for key in ("path", "size_bytes", "journal_mode", "page_size", "page_count", "work_copy", "copy_wall_seconds"):
+            assert key in source_info, f"Missing key: {key}"
+
+    def test_work_copy_matches_returned_path(self, synthetic_db: Path, tmp_path: Path):
+        """source_info['work_copy'] matches the returned work_db path."""
+        work_dir = tmp_path / "work"
+        source_info, work_db = bm._collect_source_info(synthetic_db, work_dir)
+
+        assert source_info["work_copy"] == str(work_db)
+        assert work_db.exists()
+
+    def test_copy_wall_seconds_non_negative(self, synthetic_db: Path, tmp_path: Path):
+        """copy_wall_seconds is a non-negative float."""
+        work_dir = tmp_path / "work"
+        source_info, _ = bm._collect_source_info(synthetic_db, work_dir)
+
+        assert isinstance(source_info["copy_wall_seconds"], float)
+        assert source_info["copy_wall_seconds"] >= 0
+
+    def test_source_db_not_mutated(self, synthetic_db: Path, tmp_path: Path):
+        """Source DB file is not modified during source info collection."""
+        work_dir = tmp_path / "work"
+        size_before = synthetic_db.stat().st_size
+
+        bm._collect_source_info(synthetic_db, work_dir)
+
+        assert synthetic_db.stat().st_size == size_before
+
+    def test_path_and_size_bytes_match_source(self, synthetic_db: Path, tmp_path: Path):
+        """path and size_bytes fields reflect the original source DB."""
+        work_dir = tmp_path / "work"
+        source_info, _ = bm._collect_source_info(synthetic_db, work_dir)
+
+        assert source_info["path"] == str(synthetic_db)
+        assert source_info["size_bytes"] == synthetic_db.stat().st_size
+
+
+class TestWriteReports:
+    def _build_report(self, synthetic_db: Path, work_db: Path, table_results: list) -> dict:
+        from datetime import datetime, timezone
+
+        fts5_results = [t for t in table_results if t.get("is_fts5") and not t.get("error")]
+        total_wall = sum(t["wall_seconds"] for t in fts5_results if t.get("wall_seconds") is not None)
+        return {
+            "meta": {
+                "run_date": datetime.now(timezone.utc).isoformat(),
+                "script": "test",
+                "psutil_available": bm._HAVE_PSUTIL,
+            },
+            "source_db": {
+                "path": str(synthetic_db),
+                "size_bytes": synthetic_db.stat().st_size,
+                "journal_mode": "wal",
+                "page_size": 4096,
+                "page_count": 1,
+                "work_copy": str(work_db),
+            },
+            "tables": table_results,
+            "summary": {
+                "fts5_tables_benchmarked": [t["table"] for t in fts5_results],
+                "total_wall_seconds": round(total_wall, 3),
+                "recommended_maintenance_window_seconds": round(total_wall * 1.5, 3),
+                "risk_classification": bm._risk_classification(total_wall),
+            },
+        }
+
+    def test_both_files_created(self, synthetic_db: Path, tmp_path: Path):
+        """_write_reports creates both JSON and MD files."""
+        work_dir = tmp_path / "work"
+        report_dir = tmp_path / "reports"
+        work_db = bm._copy_db(synthetic_db, work_dir)
+
+        pre_rss = bm._baseline_memory_rss()
+        pre_io = bm._disk_io_snapshot()
+        table_results = [bm._benchmark_table(work_db, "code_snippets", pre_rss, pre_io)]
+        report = self._build_report(synthetic_db, work_db, table_results)
+
+        bm._write_reports(report, report_dir, "test-stem")
+
+        assert (report_dir / "test-stem.json").exists()
+        assert (report_dir / "test-stem.md").exists()
+
+    def test_no_tmp_files_linger(self, synthetic_db: Path, tmp_path: Path):
+        """No .tmp sidecar files remain after _write_reports completes."""
+        work_dir = tmp_path / "work"
+        report_dir = tmp_path / "reports"
+        work_db = bm._copy_db(synthetic_db, work_dir)
+
+        pre_rss = bm._baseline_memory_rss()
+        pre_io = bm._disk_io_snapshot()
+        table_results = [bm._benchmark_table(work_db, "code_snippets", pre_rss, pre_io)]
+        report = self._build_report(synthetic_db, work_db, table_results)
+
+        bm._write_reports(report, report_dir, "test-stem")
+
+        assert not (report_dir / "test-stem.json.tmp").exists()
+        assert not (report_dir / "test-stem.md.tmp").exists()
+
+    def test_json_parses_with_expected_keys(self, synthetic_db: Path, tmp_path: Path):
+        """Written JSON parses cleanly and contains expected top-level keys."""
+        import json
+
+        work_dir = tmp_path / "work"
+        report_dir = tmp_path / "reports"
+        work_db = bm._copy_db(synthetic_db, work_dir)
+
+        pre_rss = bm._baseline_memory_rss()
+        pre_io = bm._disk_io_snapshot()
+        table_results = [bm._benchmark_table(work_db, "code_snippets", pre_rss, pre_io)]
+        report = self._build_report(synthetic_db, work_db, table_results)
+
+        bm._write_reports(report, report_dir, "test-stem")
+
+        parsed = json.loads((report_dir / "test-stem.json").read_text())
+        for key in ("meta", "source_db", "tables", "summary"):
+            assert key in parsed, f"Missing top-level key in JSON: {key}"
+
+    def test_md_contains_expected_headings(self, synthetic_db: Path, tmp_path: Path):
+        """Written Markdown contains all required section headings."""
+        work_dir = tmp_path / "work"
+        report_dir = tmp_path / "reports"
+        work_db = bm._copy_db(synthetic_db, work_dir)
+
+        pre_rss = bm._baseline_memory_rss()
+        pre_io = bm._disk_io_snapshot()
+        table_results = [bm._benchmark_table(work_db, "code_snippets", pre_rss, pre_io)]
+        report = self._build_report(synthetic_db, work_db, table_results)
+
+        bm._write_reports(report, report_dir, "test-stem")
+
+        content = (report_dir / "test-stem.md").read_text()
+        assert "FTS5 Rebuild Benchmark" in content
+        assert "## Summary" in content
+        assert "## Maintenance Window Recommendation" in content
+
+
 class TestReportOutput:
     def test_json_report_written_atomically(self, synthetic_db: Path, tmp_path: Path):
         """JSON report exists and parses cleanly after benchmark run."""


### PR DESCRIPTION
## Summary

Resolves OI-1510. `main()` in `scripts/benchmark/fts5_rebuild_benchmark.py` was 128 lines. This PR extracts two helper functions to bring it to ~90 lines with no behavioral change.

## Changes

### `_collect_source_info(source_db, work_dir) -> (dict, Path)`
Encapsulates the source DB PRAGMA metadata collection (journal_mode, page_size, page_count) and the DB copy operation with timing. Previously this was inline in `main()`.

### `_write_reports(report, report_dir, stem) -> None`
Encapsulates JSON/MD path construction, atomic writes, and the path-print output. Previously inline in `main()`.

### Tests added
- `TestCollectSourceInfo` — 5 tests: correct keys, work_copy matches returned path, copy_wall_seconds non-negative, source not mutated, path/size_bytes accuracy.
- `TestWriteReports` — 4 tests: both files created, no .tmp lingering, JSON keys, MD headings.

## Verification

```
pytest tests/benchmark/test_fts5_rebuild_benchmark.py -v
# 23 passed in 0.21s
```

Behavior is identical — pure structural extraction, no algorithmic change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)