### PR TITLE
refactor(dispatcher): extract stuck-cleanup python + supervisor-ticks (OI-1521/1523)

### DIFF
--- a/scripts/dispatcher_v8_minimal.sh
+++ b/scripts/dispatcher_v8_minimal.sh
@@ -143,6 +143,7 @@ source "$SCRIPT_DIR/lib/dispatch_logging.sh"
 source "$SCRIPT_DIR/lib/dispatch_lifecycle.sh"
 source "$SCRIPT_DIR/lib/dispatch_deliver.sh"
 source "$SCRIPT_DIR/lib/dispatch_create.sh"
+source "$SCRIPT_DIR/lib/dispatcher_supervisor_ticks.sh"
 
 # Large-payload threshold (referenced by dispatch_deliver.sh tmux_load_buffer_safe)
 VNX_DISPATCH_MAX_INLINE="${VNX_DISPATCH_MAX_INLINE:-51200}"  # 50KB default
@@ -550,20 +551,7 @@ _cleanup_stuck_dispatches() {
             # Releasing a claim that belongs to a different dispatch corrupts the
             # new dispatch's terminal ownership (codex PR-4 finding 1).
             local _current_claimed_by
-            export _VNX_STUCK_TERMINAL="$_stuck_terminal"
-            _current_claimed_by=$(python3 - 2>/dev/null <<'PYEOF'
-import json, os
-state_file = os.path.join(os.environ.get("VNX_STATE_DIR", ""), "terminal_state.json")
-terminal   = os.environ.get("_VNX_STUCK_TERMINAL", "")
-try:
-    with open(state_file, "r", encoding="utf-8") as fh:
-        d = json.load(fh)
-    print(((d.get("terminals") or {}).get(terminal) or {}).get("claimed_by") or "")
-except Exception:
-    print("")
-PYEOF
-            ) || _current_claimed_by=""
-            unset _VNX_STUCK_TERMINAL
+            _current_claimed_by=$(python3 "$SCRIPT_DIR/lib/get_terminal_claimed_by.py" "$_stuck_terminal" 2>/dev/null) || _current_claimed_by=""
 
             if [ "$_current_claimed_by" = "$_stuck_dispatch_id" ]; then
                 if ! release_terminal_claim "$_stuck_terminal" "$_stuck_dispatch_id"; then
@@ -597,51 +585,6 @@ PYEOF
             log "V8 WARN: Failed to quarantine stuck dispatch file: $stuck_file"
         fi
     done < <(find "$ACTIVE_DIR" -name "*.md" -type f -mmin +60 2>/dev/null || :)
-}
-
-# --- Unified supervisor: throttled runtime_supervise tick (SUP-PR3) ---
-# Invokes RuntimeSupervisor.supervise_all() at most once per 60s when
-# VNX_SUPERVISOR_MODE=unified. Default legacy mode is bit-identical.
-_maybe_runtime_supervise() {
-    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
-    local interval="${VNX_RUNTIME_SUPERVISE_INTERVAL:-60}"
-    local state_file="$STATE_DIR/.last_runtime_supervise_ts"
-    local now last
-    now=$(date +%s)
-    last=0
-    if [[ -f "$state_file" ]]; then
-        last=$(cat "$state_file" 2>/dev/null || echo 0)
-        [[ "$last" =~ ^[0-9]+$ ]] || last=0
-    fi
-    if (( now - last < interval )); then
-        return 0
-    fi
-    local log_file="$VNX_LOGS_DIR/runtime_supervise.log"
-    mkdir -p "$(dirname "$log_file")"
-    python3 "$VNX_DIR/scripts/lib/runtime_supervise.py" >> "$log_file" 2>&1 || true
-    echo "$now" > "$state_file"
-}
-
-_unified_supervisor_lease_sweep_tick() {
-    # SUP-PR2: throttled lease_sweep tick. Activates only when
-    # VNX_SUPERVISOR_MODE=unified. Default (unset/legacy) = no behavior change.
-    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
-
-    local state_file="$VNX_DATA_DIR/state/.last_lease_sweep_ts"
-    local interval="${VNX_LEASE_SWEEP_INTERVAL_SEC:-30}"
-    local now last
-    now=$(date +%s)
-    last=0
-    if [[ -f "$state_file" ]]; then
-        last=$(cat "$state_file" 2>/dev/null || echo 0)
-        [[ "$last" =~ ^[0-9]+$ ]] || last=0
-    fi
-    if (( now - last >= interval )); then
-        mkdir -p "$VNX_LOGS_DIR" "$(dirname "$state_file")"
-        python3 "$SCRIPT_DIR/lib/lease_sweep.py" \
-            >> "$VNX_LOGS_DIR/lease_sweep.log" 2>&1 || true
-        echo "$now" > "$state_file"
-    fi
 }
 
 process_dispatches() {

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# dispatcher_supervisor_ticks.sh — Unified supervisor tick helpers for the dispatcher.
+#
+# Source this from dispatcher_v8_minimal.sh after dispatch_logging.sh is loaded.
+#
+# Required bindings (provided by the sourcing dispatcher):
+#   log()            — from scripts/lib/dispatch_logging.sh
+#   STATE_DIR        — dispatcher state directory (VNX_STATE_DIR)
+#   VNX_LOGS_DIR     — log directory
+#   VNX_DIR          — VNX home directory
+#   VNX_DATA_DIR     — VNX data directory
+#   SCRIPT_DIR       — directory containing the dispatcher script
+#
+# Environment variables (optional, with defaults):
+#   VNX_SUPERVISOR_MODE            — "unified" enables ticks; default is "legacy" (no-op)
+#   VNX_RUNTIME_SUPERVISE_INTERVAL — seconds between supervise_all() calls; default 60
+#   VNX_LEASE_SWEEP_INTERVAL_SEC   — seconds between lease_sweep calls; default 30
+
+# _maybe_runtime_supervise — throttled RuntimeSupervisor.supervise_all() tick (SUP-PR3).
+# Invokes scripts/lib/runtime_supervise.py at most once per
+# VNX_RUNTIME_SUPERVISE_INTERVAL seconds when VNX_SUPERVISOR_MODE=unified.
+# Default legacy mode is bit-identical (returns 0 immediately).
+_maybe_runtime_supervise() {
+    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
+    local interval="${VNX_RUNTIME_SUPERVISE_INTERVAL:-60}"
+    local state_file="$STATE_DIR/.last_runtime_supervise_ts"
+    local now last
+    now=$(date +%s)
+    last=0
+    if [[ -f "$state_file" ]]; then
+        last=$(cat "$state_file" 2>/dev/null || echo 0)
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    fi
+    if (( now - last < interval )); then
+        return 0
+    fi
+    local log_file="$VNX_LOGS_DIR/runtime_supervise.log"
+    mkdir -p "$(dirname "$log_file")"
+    python3 "$VNX_DIR/scripts/lib/runtime_supervise.py" >> "$log_file" 2>&1 || true
+    echo "$now" > "$state_file"
+}
+
+# _unified_supervisor_lease_sweep_tick — throttled lease_sweep tick (SUP-PR2).
+# Invokes scripts/lib/lease_sweep.py at most once per
+# VNX_LEASE_SWEEP_INTERVAL_SEC seconds when VNX_SUPERVISOR_MODE=unified.
+# Default (unset/legacy) = no behaviour change.
+_unified_supervisor_lease_sweep_tick() {
+    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
+
+    local state_file="$VNX_DATA_DIR/state/.last_lease_sweep_ts"
+    local interval="${VNX_LEASE_SWEEP_INTERVAL_SEC:-30}"
+    local now last
+    now=$(date +%s)
+    last=0
+    if [[ -f "$state_file" ]]; then
+        last=$(cat "$state_file" 2>/dev/null || echo 0)
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    fi
+    if (( now - last >= interval )); then
+        mkdir -p "$VNX_LOGS_DIR" "$(dirname "$state_file")"
+        python3 "$SCRIPT_DIR/lib/lease_sweep.py" \
+            >> "$VNX_LOGS_DIR/lease_sweep.log" 2>&1 || true
+        echo "$now" > "$state_file"
+    fi
+}

--- a/scripts/lib/get_terminal_claimed_by.py
+++ b/scripts/lib/get_terminal_claimed_by.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Look up the claimed_by field for a terminal in terminal_state.json.
+
+Usage:
+    python3 get_terminal_claimed_by.py <terminal_id>
+
+Reads VNX_STATE_DIR from the environment to locate terminal_state.json.
+Prints the claimed_by value (string) or an empty string when the terminal
+is unclaimed, the state file is absent, or any parse error occurs.
+
+Exit code is always 0 — errors are silent and callers test for empty
+output (matching the heredoc behaviour this script replaces).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _get_terminal_claimed_by(terminal: str, state_dir: str) -> str:
+    """Return claimed_by for *terminal* from terminal_state.json, or ''."""
+    state_file = os.path.join(state_dir, "terminal_state.json")
+    try:
+        with open(state_file, "r", encoding="utf-8") as fh:
+            d = json.load(fh)
+        return ((d.get("terminals") or {}).get(terminal) or {}).get("claimed_by") or ""
+    except Exception:
+        return ""
+
+
+def main() -> None:
+    if len(sys.argv) >= 2:
+        terminal = sys.argv[1]
+    else:
+        # Backward-compatibility fallback used by the old heredoc call site.
+        terminal = os.environ.get("_VNX_STUCK_TERMINAL", "")
+
+    state_dir = os.environ.get("VNX_STATE_DIR", "")
+    print(_get_terminal_claimed_by(terminal, state_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_get_terminal_claimed_by.py
+++ b/tests/test_get_terminal_claimed_by.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/get_terminal_claimed_by.py (OI-1521/1523 extraction).
+
+Verifies:
+  - Returns claimed_by when the terminal is present and claimed
+  - Returns empty string when terminal is unclaimed (null/missing)
+  - Returns empty string when terminal key is absent from terminal_state.json
+  - Returns empty string when the state file does not exist
+  - Returns empty string when state_file is malformed JSON
+  - Accepts terminal_id as CLI argv[1]
+  - Falls back to _VNX_STUCK_TERMINAL env var when argv[1] is absent
+  - bash -n passes (trivially — it is a .py file; verified via python3 -m py_compile)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "lib" / "get_terminal_claimed_by.py"
+SCRIPTS_LIB = str(REPO_ROOT / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+from get_terminal_claimed_by import _get_terminal_claimed_by
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — internal helper
+# ---------------------------------------------------------------------------
+
+class TestGetTerminalClaimedByUnit:
+    """Direct tests for the _get_terminal_claimed_by() helper."""
+
+    def _write_state(self, tmp_dir: str, data: dict) -> None:
+        path = os.path.join(tmp_dir, "terminal_state.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def test_returns_claimed_by_when_present(self, tmp_path):
+        """claimed_by is returned when the terminal is claimed."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T1": {"claimed_by": "dispatch-abc-123", "status": "busy"}}},
+        )
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == "dispatch-abc-123"
+
+    def test_returns_empty_when_claimed_by_is_null(self, tmp_path):
+        """claimed_by=null → returns empty string (not the string 'None')."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T1": {"claimed_by": None, "status": "idle"}}},
+        )
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_claimed_by_is_missing(self, tmp_path):
+        """Terminal entry exists but claimed_by key absent → empty string."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T1": {"status": "idle"}}},
+        )
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_terminal_absent(self, tmp_path):
+        """Terminal not in state file → empty string."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T2": {"claimed_by": "dispatch-xyz"}}},
+        )
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_terminals_key_missing(self, tmp_path):
+        """State JSON has no 'terminals' key → empty string."""
+        self._write_state(str(tmp_path), {"other_key": {}})
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_state_file_absent(self, tmp_path):
+        """No terminal_state.json in state dir → empty string, no exception."""
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_state_file_malformed(self, tmp_path):
+        """Corrupt JSON → empty string, no exception."""
+        path = os.path.join(str(tmp_path), "terminal_state.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("{not valid json")
+        result = _get_terminal_claimed_by("T1", str(tmp_path))
+        assert result == ""
+
+    def test_returns_empty_when_state_dir_empty_string(self):
+        """state_dir='' → empty string (file will not exist)."""
+        result = _get_terminal_claimed_by("T1", "")
+        assert result == ""
+
+    def test_multiple_terminals(self, tmp_path):
+        """Returns correct claimed_by when multiple terminals are present."""
+        self._write_state(
+            str(tmp_path),
+            {
+                "terminals": {
+                    "T1": {"claimed_by": "dispatch-t1"},
+                    "T2": {"claimed_by": "dispatch-t2"},
+                    "T3": {"claimed_by": None},
+                }
+            },
+        )
+        assert _get_terminal_claimed_by("T1", str(tmp_path)) == "dispatch-t1"
+        assert _get_terminal_claimed_by("T2", str(tmp_path)) == "dispatch-t2"
+        assert _get_terminal_claimed_by("T3", str(tmp_path)) == ""
+
+
+# ---------------------------------------------------------------------------
+# CLI / subprocess tests
+# ---------------------------------------------------------------------------
+
+class TestGetTerminalClaimedByCLI:
+    """Run the script as a subprocess to verify CLI arg handling."""
+
+    def _run(self, args: list[str], env: dict | None = None, input_data: str | None = None) -> subprocess.CompletedProcess:
+        cmd = [sys.executable, str(SCRIPT)] + args
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env or os.environ.copy(),
+        )
+
+    def _write_state(self, state_dir: str, data: dict) -> None:
+        path = os.path.join(state_dir, "terminal_state.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def test_cli_arg_takes_terminal_id(self, tmp_path):
+        """Terminal ID passed as argv[1] is resolved correctly."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T2": {"claimed_by": "dispatch-cli-01"}}},
+        )
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(tmp_path)
+        result = self._run(["T2"], env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "dispatch-cli-01"
+
+    def test_cli_env_fallback_no_argv(self, tmp_path):
+        """Falls back to _VNX_STUCK_TERMINAL env var when no argv[1]."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T3": {"claimed_by": "dispatch-env-01"}}},
+        )
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(tmp_path)
+        env["_VNX_STUCK_TERMINAL"] = "T3"
+        result = self._run([], env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "dispatch-env-01"
+
+    def test_cli_empty_output_when_unclaimed(self, tmp_path):
+        """Prints empty line when terminal is unclaimed."""
+        self._write_state(
+            str(tmp_path),
+            {"terminals": {"T1": {"claimed_by": None}}},
+        )
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(tmp_path)
+        result = self._run(["T1"], env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_cli_exit_0_on_missing_state(self, tmp_path):
+        """Exit code is 0 even when state file is absent."""
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(tmp_path)
+        result = self._run(["T1"], env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_cli_exit_0_on_malformed_json(self, tmp_path):
+        """Exit code is 0 on corrupt JSON — caller checks empty output."""
+        path = os.path.join(str(tmp_path), "terminal_state.json")
+        with open(path, "w") as fh:
+            fh.write("NOT JSON")
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(tmp_path)
+        result = self._run(["T1"], env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_py_compile_passes(self):
+        """Script compiles without syntax errors (regression guard for extraction)."""
+        result = subprocess.run(
+            [sys.executable, "-m", "py_compile", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"py_compile failed:\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Bash syntax check for dispatcher_supervisor_ticks.sh
+# ---------------------------------------------------------------------------
+
+class TestDispatcherSupervisorTicksSyntax:
+    """bash -n must pass on the new lib file (OI-1523 extraction guard)."""
+
+    def test_bash_n_passes(self):
+        ticks_sh = REPO_ROOT / "scripts" / "lib" / "dispatcher_supervisor_ticks.sh"
+        result = subprocess.run(
+            ["bash", "-n", str(ticks_sh)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher syntax guard after extraction
+# ---------------------------------------------------------------------------
+
+class TestDispatcherSyntaxAfterExtraction:
+    """bash -n must still pass on the main dispatcher after the refactor."""
+
+    def test_dispatcher_bash_n_passes(self):
+        dispatcher = REPO_ROOT / "scripts" / "dispatcher_v8_minimal.sh"
+        result = subprocess.run(
+            ["bash", "-n", str(dispatcher)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-xvs"]))


### PR DESCRIPTION
## Summary

Resolves OI-1521 and OI-1523 by extracting two pieces of inline logic out of `scripts/dispatcher_v8_minimal.sh` (691 → 633 lines).

## Changes

### 1. `scripts/lib/get_terminal_claimed_by.py` (new, OI-1521)

Extracts the inline Python heredoc that looked up `claimed_by` in `terminal_state.json` from `_cleanup_stuck_dispatches`. The heredoc required an `export _VNX_STUCK_TERMINAL` / `unset` dance; the new script accepts the terminal ID as `argv[1]` and reads `VNX_STATE_DIR` from the environment. Backward-compat env-var fallback preserved.

**Call site before:**
```bash
export _VNX_STUCK_TERMINAL="$_stuck_terminal"
_current_claimed_by=$(python3 - 2>/dev/null <<'PYEOF'
import json, os
...14 lines of heredoc...
PYEOF
) || _current_claimed_by=""
unset _VNX_STUCK_TERMINAL
```

**Call site after (1 line):**
```bash
_current_claimed_by=$(python3 "$SCRIPT_DIR/lib/get_terminal_claimed_by.py" "$_stuck_terminal" 2>/dev/null) || _current_claimed_by=""
```

### 2. `scripts/lib/dispatcher_supervisor_ticks.sh` (new, OI-1523)

Extracts `_maybe_runtime_supervise` and `_unified_supervisor_lease_sweep_tick` into a dedicated lib file. Sourced from the dispatcher after `dispatch_logging.sh` (so `log()` is available). Call sites in `process_dispatches()` unchanged — function names and signatures are identical.

### 3. `scripts/dispatcher_v8_minimal.sh` (modified)

- Adds `source "$SCRIPT_DIR/lib/dispatcher_supervisor_ticks.sh"` to the module load block
- Replaces the 14-line heredoc block with a 1-line python3 call
- Removes the two supervisor tick function definitions (now in lib)

Net: 691 → 633 lines. **Behavior is identical.**

## Tests

`tests/test_get_terminal_claimed_by.py` — 17 tests:
- Unit tests for `_get_terminal_claimed_by()`: claimed/unclaimed/null/absent/malformed/empty-dir
- CLI tests: argv[1], env-var fallback, exit-0 on all error paths
- `bash -n` guards for `dispatcher_supervisor_ticks.sh` and the refactored dispatcher

All 17 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)