### PR TITLE
refactor(receipt-proc): extract mtime-calc python from bootstrap-protection (OI-1525/1524)

### DIFF
--- a/scripts/lib/rp_find_newest_report_mtime.py
+++ b/scripts/lib/rp_find_newest_report_mtime.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Find the newest mtime (integer seconds) across two report directories.
+
+Usage:
+    python3 rp_find_newest_report_mtime.py <unified_dir> <headless_dir> <fallback_ts>
+
+Outputs a single integer to stdout: the highest mtime found among all *.md files
+in <unified_dir> and <headless_dir>.  If no files are found (or both dirs are
+absent/empty), outputs <fallback_ts> instead.
+
+Stat failures are reported to stderr and skipped; the scan continues so that one
+unreadable entry does not discard all other mtimes.
+
+This module was extracted from the inline Python heredoc inside
+_rp_apply_bootstrap_protection() in scripts/receipt_processor_v4.sh (OI-1525/1524).
+Behaviour is intentionally identical to the original.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def find_newest_report_mtime(unified: str, headless: str, fallback: int) -> int:
+    """Return the highest mtime across *.md files in *unified* and *headless*.
+
+    Args:
+        unified:  Path to the unified reports directory.
+        headless: Path to the headless reports directory.
+        fallback: Value returned when no *.md files are found.
+
+    Returns:
+        Highest integer mtime found, or *fallback* if no files exist.
+    """
+    max_mtime = 0
+    for d in (unified, headless):
+        p = Path(d)
+        if not p.is_dir():
+            continue
+        for f in p.glob("*.md"):
+            try:
+                mtime = int(f.stat().st_mtime)
+                if mtime > max_mtime:
+                    max_mtime = mtime
+            except OSError as e:
+                print(f"warning: stat failed for {f}: {e}", file=sys.stderr)
+    return max_mtime if max_mtime > 0 else fallback
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print(
+            f"Usage: {sys.argv[0]} <unified_dir> <headless_dir> <fallback_ts>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    unified, headless, fallback_raw = sys.argv[1], sys.argv[2], sys.argv[3]
+    try:
+        fallback = int(fallback_raw)
+    except ValueError:
+        print(f"error: fallback_ts must be an integer, got {fallback_raw!r}", file=sys.stderr)
+        sys.exit(1)
+
+    result = find_newest_report_mtime(unified, headless, fallback)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/receipt_processor_v4.sh
+++ b/scripts/receipt_processor_v4.sh
@@ -390,27 +390,9 @@ _rp_apply_bootstrap_protection() {
         log "WARN" "Marking current report state as baseline. Historical reports skipped."
 
         # Find newest report mtime via Python for cross-platform compatibility.
+        # Logic lives in scripts/lib/rp_find_newest_report_mtime.py (OI-1525/1524).
         local new_watermark
-        new_watermark=$(python3 - "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" "$now" <<'PY'
-import sys
-from pathlib import Path
-
-unified, headless, fallback = sys.argv[1], sys.argv[2], int(sys.argv[3])
-max_mtime = 0
-for d in (unified, headless):
-    p = Path(d)
-    if not p.is_dir():
-        continue
-    for f in p.glob("*.md"):
-        try:
-            mtime = int(f.stat().st_mtime)
-            if mtime > max_mtime:
-                max_mtime = mtime
-        except OSError as e:
-            print(f"warning: stat failed for {f}: {e}", file=sys.stderr)
-print(max_mtime if max_mtime > 0 else fallback)
-PY
-)
+        new_watermark=$(python3 "$SCRIPT_DIR/lib/rp_find_newest_report_mtime.py" "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" "$now")
         [ -z "$new_watermark" ] && new_watermark="$now"
 
         local _old_watermark

--- a/tests/test_rp_find_newest_report_mtime.py
+++ b/tests/test_rp_find_newest_report_mtime.py
@@ -1,0 +1,196 @@
+"""Unit tests for scripts/lib/rp_find_newest_report_mtime.py
+
+Tests exercise the Python module directly (find_newest_report_mtime) and as a
+CLI subprocess to verify the interface used by receipt_processor_v4.sh.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow importing the module directly.
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "rp_find_newest_report_mtime.py"
+sys.path.insert(0, str(_LIB.parent))
+
+from rp_find_newest_report_mtime import find_newest_report_mtime  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    """Run the script as a CLI subprocess."""
+    return subprocess.run(
+        [sys.executable, str(_LIB), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_report(directory: Path, name: str, mtime: int) -> Path:
+    f = directory / name
+    f.write_text("# dummy report")
+    os.utime(str(f), (mtime, mtime))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — find_newest_report_mtime()
+# ---------------------------------------------------------------------------
+
+def test_returns_max_mtime_across_both_dirs():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        unified = tmp / "unified"
+        headless = tmp / "headless"
+        unified.mkdir()
+        headless.mkdir()
+
+        t1 = 1_700_000_000
+        t2 = 1_700_001_000  # newer
+
+        _make_report(unified, "a.md", t1)
+        _make_report(headless, "b.md", t2)
+
+        result = find_newest_report_mtime(str(unified), str(headless), fallback=0)
+        assert result == t2, f"Expected {t2}, got {result}"
+
+
+def test_uses_unified_when_headless_absent():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        unified = tmp / "unified"
+        unified.mkdir()
+
+        t1 = 1_700_000_000
+        _make_report(unified, "r.md", t1)
+
+        result = find_newest_report_mtime(str(unified), str(tmp / "nonexistent"), fallback=0)
+        assert result == t1
+
+
+def test_fallback_when_no_reports():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        unified = tmp / "unified"
+        headless = tmp / "headless"
+        unified.mkdir()
+        headless.mkdir()
+
+        fallback = 1_600_000_000
+        result = find_newest_report_mtime(str(unified), str(headless), fallback=fallback)
+        assert result == fallback, f"Expected fallback {fallback}, got {result}"
+
+
+def test_fallback_when_both_dirs_absent():
+    fallback = 1_600_000_000
+    result = find_newest_report_mtime("/nonexistent_a", "/nonexistent_b", fallback=fallback)
+    assert result == fallback
+
+
+def test_ignores_non_md_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        unified = tmp / "unified"
+        unified.mkdir()
+
+        t_md = 1_700_000_000
+        t_other = 1_700_999_999  # would be newer if counted
+
+        _make_report(unified, "report.md", t_md)
+        txt = unified / "notes.txt"
+        txt.write_text("ignored")
+        os.utime(str(txt), (t_other, t_other))
+
+        result = find_newest_report_mtime(str(unified), "/nonexistent", fallback=0)
+        assert result == t_md, f"Non-.md file must be ignored; expected {t_md}, got {result}"
+
+
+def test_stat_failure_skipped_others_still_counted(capsys, tmp_path):
+    """Broken symlink triggers OSError; remaining files are still considered."""
+    unified = tmp_path / "unified"
+    unified.mkdir()
+
+    t_good = 1_700_000_000
+    _make_report(unified, "good.md", t_good)
+
+    broken = unified / "broken.md"
+    broken.symlink_to("/nonexistent_vnx_test_target/report.md")
+
+    result = find_newest_report_mtime(str(unified), "/nonexistent", fallback=0)
+    assert result == t_good, f"Expected {t_good} despite broken symlink, got {result}"
+
+    captured = capsys.readouterr()
+    assert "warning: stat failed" in captured.err
+
+
+def test_single_report_equals_its_mtime():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        unified = Path(tmpdir) / "unified"
+        unified.mkdir()
+        t = 1_710_000_000
+        _make_report(unified, "only.md", t)
+
+        result = find_newest_report_mtime(str(unified), "/nonexistent", fallback=0)
+        assert result == t
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — subprocess interface used by Bash
+# ---------------------------------------------------------------------------
+
+def test_cli_outputs_integer_to_stdout():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        unified = Path(tmpdir) / "u"
+        unified.mkdir()
+        t = 1_720_000_000
+        _make_report(unified, "r.md", t)
+
+        proc = _run_cli(str(unified), "/nonexistent", "0")
+        assert proc.returncode == 0, f"CLI failed: {proc.stderr}"
+        assert proc.stdout.strip().isdigit(), f"Expected integer stdout, got: {proc.stdout!r}"
+        assert int(proc.stdout.strip()) == t
+
+
+def test_cli_fallback_when_no_reports():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        unified = Path(tmpdir) / "u"
+        unified.mkdir()
+        fallback = 1_600_000_000
+
+        proc = _run_cli(str(unified), "/nonexistent", str(fallback))
+        assert proc.returncode == 0, proc.stderr
+        assert int(proc.stdout.strip()) == fallback
+
+
+def test_cli_missing_args_exits_nonzero():
+    proc = _run_cli("only_one_arg")
+    assert proc.returncode != 0
+    assert "Usage" in proc.stderr
+
+
+def test_cli_invalid_fallback_exits_nonzero():
+    proc = _run_cli("/tmp", "/tmp", "not_a_number")
+    assert proc.returncode != 0
+    assert "error" in proc.stderr.lower()
+
+
+def test_cli_warns_on_stat_failure_stderr():
+    """Broken symlink → warning on stderr, still exits 0, mtime from good files used."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        unified = Path(tmpdir) / "u"
+        unified.mkdir()
+        t = 1_700_000_000
+        _make_report(unified, "good.md", t)
+
+        broken = unified / "broken.md"
+        broken.symlink_to("/nonexistent_vnx_test_target/report.md")
+
+        proc = _run_cli(str(unified), "/nonexistent", "0")
+        assert proc.returncode == 0, f"CLI must exit 0 despite stat failure: {proc.stderr}"
+        assert "warning: stat failed" in proc.stderr
+        assert int(proc.stdout.strip()) == t


### PR DESCRIPTION
## Summary

Extracts the inline Python heredoc from `_rp_apply_bootstrap_protection()` in `receipt_processor_v4.sh` into a standalone library module: `scripts/lib/rp_find_newest_report_mtime.py`.

This resolves OI-1525/1524.

## Changes

- **`scripts/receipt_processor_v4.sh`** — heredoc (18 lines) replaced by a single subprocess call: `python3 "$SCRIPT_DIR/lib/rp_find_newest_report_mtime.py" ...`
- **`scripts/lib/rp_find_newest_report_mtime.py`** (new) — standalone Python module with `find_newest_report_mtime()` function + CLI entry point
- **`tests/test_rp_find_newest_report_mtime.py`** (new) — 12 unit tests covering function API and CLI interface

## Behaviour

Purely structural extraction. Algorithm, fallback semantics, and stderr warning on stat failures are identical to the original.

## Tests

- **New tests:** 12/12 passed (`test_rp_find_newest_report_mtime.py`)
- **Existing bootstrap tests:** 6 pre-existing failures (unrelated `tee` log-dir issue, confirmed identical before/after this change on baseline)

## Dispatch

`Dispatch-ID: 20260526-oi-b4-receipt-proc`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)