### PR TITLE
refactor(install-central): move shim content to template file (OI-1562)

### DIFF
--- a/install-central.sh
+++ b/install-central.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eEuo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # install-central.sh — Centralized VNX install to ~/.vnx-system/versions/<version>/
 # Separate from install.sh (embedded/open-source per-project installer).
 #
@@ -235,120 +237,21 @@ swap_symlink() {
 install_shim() {
   local shim_dir="${TARGET_DIR}/bin"
   local shim_path="${shim_dir}/vnx"
+  local tpl_path="${SCRIPT_DIR}/scripts/templates/vnx_shim.sh.tpl"
 
   info "Installing shim at ${shim_path}..."
   run mkdir -p "$shim_dir"
 
-  local shim_content
-  shim_content=$(cat <<'SHIM'
-#!/usr/bin/env bash
-# VNX project-pin shim — reads .vnx-version from project root (cwd traversal)
-set -euo pipefail
-
-VNX_SYSTEM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-# Traverse up from cwd to find .vnx-version
-find_version_pin() {
-  local dir="$PWD"
-  while [ "$dir" != "/" ]; do
-    if [ -f "${dir}/.vnx-version" ]; then
-      cat "${dir}/.vnx-version"
-      return 0
-    fi
-    dir="$(dirname "$dir")"
-  done
-  echo ""
-}
-
-pin="$(find_version_pin | head -1 | tr -d '\n[:space:]')"
-
-if [ -n "$pin" ]; then
-  if ! [[ "$pin" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    echo "[vnx-shim] ERROR: invalid pin '${pin}' in .vnx-version (must match [A-Za-z0-9._-]+)" >&2
-    exit 78  # EX_CONFIG
-  fi
-  version_dir="${VNX_SYSTEM_DIR}/versions/${pin}"
-  if [ ! -d "$version_dir" ]; then
-    echo "[vnx-shim] [x] Pinned version ${pin} not installed at ${version_dir}" >&2
-    echo "[vnx-shim] Run: bash ${VNX_SYSTEM_DIR}/../install-central.sh --version ${pin}" >&2
-    exit 1
-  fi
-  if command -v realpath >/dev/null 2>&1; then
-    resolved=$(realpath "$version_dir" 2>/dev/null) || { echo "[vnx-shim] ERROR: cannot resolve version_dir: ${version_dir}" >&2; exit 78; }
-    versions_root=$(realpath "${VNX_SYSTEM_DIR}/versions")
-    if [[ "$resolved" != "$versions_root"/* ]]; then
-      echo "[vnx-shim] ERROR: pin '${pin}' escapes versions root" >&2; exit 78
-    fi
-  fi
-  export VNX_HOME="$version_dir"
-else
-  if [ ! -e "${VNX_SYSTEM_DIR}/current" ]; then
-    echo "[vnx-shim] [x] No .vnx-version pin found and no current install at ${VNX_SYSTEM_DIR}/current" >&2
-    exit 1
-  fi
-  export VNX_HOME="${VNX_SYSTEM_DIR}/current"
-fi
-
-# ── Project root detection (central install) ────────────────────────────────
-# The inner resolver (scripts/lib/vnx_paths.*) prefers VNX_PROJECT_ROOT when it
-# is set. Clear any inherited value first, so a stale export left in the
-# operator's shell (set for a different project) cannot survive a `cd` and leak
-# the wrong project root.
-unset VNX_PROJECT_ROOT
-
-# Walk up from $PWD looking for a .vnx-version (or .vnx/config.yml) pin, but
-# never cross the git boundary of the directory we started in: a nested project
-# without its own pin must not leak onto a parent project's pin/root above the
-# repository root.
-find_project_root() {
-  local start="$PWD"
-  local git_root=""
-  git_root="$(git -C "$start" rev-parse --show-toplevel 2>/dev/null)" || git_root=""
-
-  local dir="$start"
-  while [ "$dir" != "/" ]; do
-    if [ -f "${dir}/.vnx-version" ] || [ -f "${dir}/.vnx/config.yml" ]; then
-      echo "$dir"
-      return 0
-    fi
-    # Stop at the git boundary — do not traverse above the repository root.
-    if [ -n "$git_root" ] && [ "$dir" = "$git_root" ]; then
-      break
-    fi
-    dir="$(dirname "$dir")"
-  done
-
-  if [ -n "$git_root" ]; then
-    echo "$git_root"   # no pin inside the repo: the repo root is the project root
-    return 0
-  fi
-  echo "$start"        # not in a git repo: fall back to the invocation dir
-}
-
-_vnx_project_root="$(find_project_root)"
-if [ "$_vnx_project_root" = "$VNX_HOME" ]; then
-  # Mis-detection (invoked from inside VNX_HOME itself): stay non-fatal and let
-  # the inner resolver fall back to its own layout heuristics. Aborting here
-  # would break legitimate admin invocations from the install dir.
-  echo "[vnx-shim] WARNING: project root detection returned VNX_HOME; deferring to resolver" >&2
-  echo "[vnx-shim] Run vnx from your project directory (where .vnx-version lives)" >&2
-else
-  export VNX_PROJECT_ROOT="$_vnx_project_root"
-fi
-unset _vnx_project_root
-
-exec "${VNX_HOME}/bin/vnx" "$@"
-SHIM
-)
+  [ -f "$tpl_path" ] || die "Shim template not found: ${tpl_path}"
 
   if [ "$DRY_RUN" = "false" ]; then
     local shim_tmp
     shim_tmp=$(mktemp "${shim_path}.tmp.XXXXXX")
-    printf '%s\n' "$shim_content" > "$shim_tmp"
+    cat "$tpl_path" > "$shim_tmp"
     chmod +x "$shim_tmp"
     mv -f "$shim_tmp" "$shim_path"
   else
-    echo "  [dry-run] write shim to ${shim_path} (chmod +x)"
+    echo "  [dry-run] write shim to ${shim_path} (chmod +x) from $(basename "${tpl_path}")"
   fi
 
   success "Shim installed: ${shim_path}"

--- a/scripts/templates/vnx_shim.sh.tpl
+++ b/scripts/templates/vnx_shim.sh.tpl
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# VNX project-pin shim — reads .vnx-version from project root (cwd traversal)
+set -euo pipefail
+
+VNX_SYSTEM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Traverse up from cwd to find .vnx-version
+find_version_pin() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.vnx-version" ]; then
+      cat "${dir}/.vnx-version"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo ""
+}
+
+pin="$(find_version_pin | head -1 | tr -d '\n[:space:]')"
+
+if [ -n "$pin" ]; then
+  if ! [[ "$pin" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "[vnx-shim] ERROR: invalid pin '${pin}' in .vnx-version (must match [A-Za-z0-9._-]+)" >&2
+    exit 78  # EX_CONFIG
+  fi
+  version_dir="${VNX_SYSTEM_DIR}/versions/${pin}"
+  if [ ! -d "$version_dir" ]; then
+    echo "[vnx-shim] [x] Pinned version ${pin} not installed at ${version_dir}" >&2
+    echo "[vnx-shim] Run: bash ${VNX_SYSTEM_DIR}/../install-central.sh --version ${pin}" >&2
+    exit 1
+  fi
+  if command -v realpath >/dev/null 2>&1; then
+    resolved=$(realpath "$version_dir" 2>/dev/null) || { echo "[vnx-shim] ERROR: cannot resolve version_dir: ${version_dir}" >&2; exit 78; }
+    versions_root=$(realpath "${VNX_SYSTEM_DIR}/versions")
+    if [[ "$resolved" != "$versions_root"/* ]]; then
+      echo "[vnx-shim] ERROR: pin '${pin}' escapes versions root" >&2; exit 78
+    fi
+  fi
+  export VNX_HOME="$version_dir"
+else
+  if [ ! -e "${VNX_SYSTEM_DIR}/current" ]; then
+    echo "[vnx-shim] [x] No .vnx-version pin found and no current install at ${VNX_SYSTEM_DIR}/current" >&2
+    exit 1
+  fi
+  export VNX_HOME="${VNX_SYSTEM_DIR}/current"
+fi
+
+# ── Project root detection (central install) ────────────────────────────────
+# The inner resolver (scripts/lib/vnx_paths.*) prefers VNX_PROJECT_ROOT when it
+# is set. Clear any inherited value first, so a stale export left in the
+# operator's shell (set for a different project) cannot survive a `cd` and leak
+# the wrong project root.
+unset VNX_PROJECT_ROOT
+
+# Walk up from $PWD looking for a .vnx-version (or .vnx/config.yml) pin, but
+# never cross the git boundary of the directory we started in: a nested project
+# without its own pin must not leak onto a parent project's pin/root above the
+# repository root.
+find_project_root() {
+  local start="$PWD"
+  local git_root=""
+  git_root="$(git -C "$start" rev-parse --show-toplevel 2>/dev/null)" || git_root=""
+
+  local dir="$start"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.vnx-version" ] || [ -f "${dir}/.vnx/config.yml" ]; then
+      echo "$dir"
+      return 0
+    fi
+    # Stop at the git boundary — do not traverse above the repository root.
+    if [ -n "$git_root" ] && [ "$dir" = "$git_root" ]; then
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  if [ -n "$git_root" ]; then
+    echo "$git_root"   # no pin inside the repo: the repo root is the project root
+    return 0
+  fi
+  echo "$start"        # not in a git repo: fall back to the invocation dir
+}
+
+_vnx_project_root="$(find_project_root)"
+if [ "$_vnx_project_root" = "$VNX_HOME" ]; then
+  # Mis-detection (invoked from inside VNX_HOME itself): stay non-fatal and let
+  # the inner resolver fall back to its own layout heuristics. Aborting here
+  # would break legitimate admin invocations from the install dir.
+  echo "[vnx-shim] WARNING: project root detection returned VNX_HOME; deferring to resolver" >&2
+  echo "[vnx-shim] Run vnx from your project directory (where .vnx-version lives)" >&2
+else
+  export VNX_PROJECT_ROOT="$_vnx_project_root"
+fi
+unset _vnx_project_root
+
+exec "${VNX_HOME}/bin/vnx" "$@"

--- a/tests/test_install_central.sh
+++ b/tests/test_install_central.sh
@@ -172,6 +172,7 @@ mkdir -p "${TMP_SHIM}/versions/v1.0.0-rc2"
 test_shim_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { : ; }\n'
@@ -217,6 +218,7 @@ ln -sfn "${TMP_ROLLBACK}/versions/${OLD_VER}" "${TMP_ROLLBACK}/current"
 test_rollback_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { return 1; }\n'  # force failure after symlink swap
@@ -247,6 +249,7 @@ mkdir -p "${TMP_ATOMIC}/versions/v1.0.0-rc2"
 test_atomic_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { : ; }\n'
@@ -300,6 +303,7 @@ chmod +x "${FAKE_MV_DIR}/mv"
 test_macos_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { : ; }\n'
@@ -473,6 +477,7 @@ mkdir -p "${TMP_15}/versions/v1.0.0-rc3"
 test_15_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { : ; }\n'
@@ -506,6 +511,7 @@ mkdir -p "${TMP_16}/versions/v1.0.0-rc3"
 test_16_script="$(mktemp)"
 {
   sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
   printf 'check_prereqs() { : ; }\n'
   printf 'clone_version() { : ; }\n'
   printf 'verify_install() { : ; }\n'
@@ -528,6 +534,55 @@ else
 fi
 
 rm -rf "$TMP_16" "$test_16_script"
+
+# ---------------------------------------------------------------------------
+# Test 17: shim template — file exists, passes bash -n, matches installed shim
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 17: shim template exists, is valid bash, installed shim matches template"
+
+TPL_PATH="${REPO_ROOT}/scripts/templates/vnx_shim.sh.tpl"
+
+if [ -f "$TPL_PATH" ]; then
+  pass "template file exists: scripts/templates/vnx_shim.sh.tpl"
+else
+  fail "template file missing: ${TPL_PATH}"
+fi
+
+if bash -n "$TPL_PATH" 2>/dev/null; then
+  pass "template passes bash -n"
+else
+  fail "template fails bash -n: ${TPL_PATH}"
+fi
+
+# Install shim via template, then compare installed file content against template
+TMP_17="$(mktemp -d)"
+mkdir -p "${TMP_17}/versions/v1.0.0-rc3"
+
+test_17_script="$(mktemp)"
+{
+  sed '$ d' "$SCRIPT"  # strip last line: 'main "$@"'
+  printf 'SCRIPT_DIR="%s"\n' "$REPO_ROOT"
+  printf 'check_prereqs() { : ; }\n'
+  printf 'clone_version() { : ; }\n'
+  printf 'verify_install() { : ; }\n'
+  printf 'main "$@"\n'
+} > "$test_17_script"
+chmod +x "$test_17_script"
+
+bash "$test_17_script" --target "$TMP_17" --version v1.0.0-rc3 >/dev/null 2>&1
+
+if [ -f "${TMP_17}/bin/vnx" ]; then
+  if diff -q "$TPL_PATH" "${TMP_17}/bin/vnx" >/dev/null 2>&1; then
+    pass "installed shim content matches template verbatim"
+  else
+    fail "installed shim content differs from template"
+  fi
+else
+  fail "shim not found at ${TMP_17}/bin/vnx"
+fi
+
+rm -rf "$TMP_17" "$test_17_script"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

Extracts the embedded ~97-line shim heredoc from `install_shim()` in `install-central.sh` into a dedicated template file `scripts/templates/vnx_shim.sh.tpl`. Pure structural refactor — no algorithmic changes.

## Changes

- **`install-central.sh`**: Add `SCRIPT_DIR` capture after `set -eEuo pipefail` so the template resolves correctly relative to the script's own directory in all invocation contexts. Replace the 120-line heredoc block in `install_shim` with a 21-line function that reads the template via `cat` and uses the same atomic tmp → chmod → mv write path.
- **`scripts/templates/vnx_shim.sh.tpl`** (new): The extracted shim bash script, verbatim.
- **`tests/test_install_central.sh`**: Inject `SCRIPT_DIR=$REPO_ROOT` override in tests 8, 9, 10, 11, 15, 16 (these build temp scripts via `sed` and run them from mktemp dirs — without the override `SCRIPT_DIR` would resolve to `/tmp`). Add Test 17: verifies template file exists, passes `bash -n`, and installed shim content matches template verbatim.

## Test results

43/43 pass (baseline 40/40; +3 assertions in new Test 17).

## Dispatch

Dispatch-ID: `20260526-oi-b6-install-shim-tpl`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)