### PR TITLE
feat(subprocess-dispatch): execute cheap-lane via provider_dispatch instead of Claude fallback (CL2)

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -9,6 +9,7 @@ Entry point: GateRunner.run() — called from ReviewGateManager.execute_gate().
 
 from __future__ import annotations
 
+import json
 import os
 import select
 import shutil
@@ -46,6 +47,13 @@ _REVIEWER_VERDICT_TEMPLATE = (
 # Minimum deleted-file count before injecting a Net-Deletion Alert into the reviewer prompt.
 # Mirrors DELETION_FILE_WARN in codex_final_gate.py and pre_merge_gate.py (both use 5).
 _GATE_DELETION_FILE_WARN = 5
+
+# Hard blocking threshold: codex_gate returns a pre-emptive fail result when a PR
+# deletes >= this many files.  Matches DELETION_FILE_HOLD in codex_final_gate.py.
+# At this scale the deletion scope exceeds what AI-only review can reliably catch —
+# a deterministic gate check is cheaper and more trustworthy than relying on the
+# AI reviewer to notice every file in a 20+ file sweep.
+_GATE_DELETION_FILE_HOLD = 20
 
 # Gate type → CLI binary mapping
 GATE_BINARIES: Dict[str, str] = {
@@ -101,6 +109,21 @@ class GateRunner:
         prompt = self._resolve_prompt(gate, request_payload, using_vertex)
         if prompt and "prompt" not in request_payload:
             request_payload["prompt"] = prompt
+
+        # Net-deletion sanity check for codex_gate — pre-emptive blocking check that
+        # short-circuits AI review when the PR exceeds the deletion HOLD threshold.
+        # Runs after prompt resolution (so the diff is already available via gh pr diff)
+        # but before _mark_executing to avoid leaving a dangling "executing" request
+        # on disk when we return early.
+        if gate == "codex_gate":
+            net_del_result = self._run_codex_net_deletion_check(
+                pr_number=pr_number,
+                request_payload=request_payload,
+                results_dir=self._results_dir,
+                requests_dir=self._requests_dir,
+            )
+            if net_del_result is not None:
+                return net_del_result
 
         self._mark_executing(gate, request_payload, pr_number=pr_number, pr_id=pr_id)
 
@@ -297,6 +320,98 @@ class GateRunner:
                 f"{result.stderr.strip()}"
             )
         return result.stdout
+
+    @staticmethod
+    def _run_codex_net_deletion_check(
+        pr_number: Optional[int],
+        request_payload: Dict[str, Any],
+        results_dir: Path,
+        requests_dir: Path,
+    ) -> Optional[Dict[str, Any]]:
+        """Net-deletion sanity check for codex_gate (pre-AI deterministic check).
+
+        When a PR deletes >= _GATE_DELETION_FILE_HOLD files the gate returns a
+        pre-emptive blocking result without spawning the AI reviewer.  This is:
+        - cheaper (no LLM tokens consumed),
+        - more reliable (AI reviewers can miss large-scale deletions), and
+        - consistent with codex_final_gate.DELETION_FILE_HOLD enforcement.
+
+        Returns a complete result dict when the check triggers (HOLD), else None.
+        gh pr diff failure degrades gracefully — returns None so the AI gate runs.
+        """
+        if not pr_number:
+            return None
+        try:
+            diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        except (ValueError, RuntimeError, OSError, subprocess.TimeoutExpired):
+            # Diff unavailable (gh not found, auth failure, timeout, etc.) —
+            # degrade gracefully and let the AI gate proceed.
+            return None
+
+        deleted_files = GateRunner._extract_deleted_files_from_diff(diff_content)
+        deleted_count = len(deleted_files)
+        if deleted_count < _GATE_DELETION_FILE_HOLD:
+            return None
+
+        # HOLD threshold exceeded — assemble blocking result without running AI
+        now = utc_now_iso()
+        gate = request_payload.get("gate", "codex_gate")
+        pr_id = request_payload.get("pr_id", "")
+        file_list = "\n".join(f"- `{f}`" for f in deleted_files)
+        finding: Dict[str, Any] = {
+            "severity": "blocking",
+            "title": f"Net-deletion sanity: {deleted_count} file(s) deleted",
+            "description": (
+                f"PR deletes {deleted_count} file(s) which meets or exceeds the "
+                f"blocking threshold of {_GATE_DELETION_FILE_HOLD}. "
+                "Human review is required before merge. Confirm each deletion is "
+                "intentional and within the declared PR scope.\n\n"
+                f"Deleted files:\n{file_list}"
+            ),
+            "out_of_scope": False,
+            "introduced_by_prior_fix": False,
+        }
+        result: Dict[str, Any] = {
+            "gate": gate,
+            "pr_id": pr_id or (str(pr_number) if pr_number is not None else ""),
+            "pr_number": pr_number,
+            "status": "fail",
+            "summary": (
+                f"Net-deletion sanity: {deleted_count} file(s) deleted "
+                f"(≥ {_GATE_DELETION_FILE_HOLD} blocking threshold)"
+            ),
+            "contract_hash": "",
+            "report_path": "",
+            "findings": [finding],
+            "blocking_findings": [finding],
+            "advisory_findings": [],
+            "required_reruns": [],
+            "residual_risk": (
+                f"PR deletes {deleted_count} file(s) — human review required before merge"
+            ),
+            "duration_seconds": 0.0,
+            "recorded_at": now,
+            "net_deletion_check": {
+                "deleted_count": deleted_count,
+                "deleted_files": deleted_files,
+                "threshold": _GATE_DELETION_FILE_HOLD,
+                "triggered": True,
+            },
+        }
+
+        # Persist result and mark request completed so downstream verifiers see it
+        rf = _rec.result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
+        if rf:
+            rf.parent.mkdir(parents=True, exist_ok=True)
+            rf.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+        request_payload["status"] = "completed"
+        request_payload["completed_at"] = now
+        _rec.persist_request(
+            requests_dir, gate, request_payload,
+            pr_number=pr_number, pr_id=pr_id,
+        )
+        return result
 
     @staticmethod
     def _build_codex_prompt(request_payload: Dict[str, Any]) -> str:

--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -43,6 +43,10 @@ _REVIEWER_VERDICT_TEMPLATE = (
     "```\n"
 )
 
+# Minimum deleted-file count before injecting a Net-Deletion Alert into the reviewer prompt.
+# Mirrors DELETION_FILE_WARN in codex_final_gate.py and pre_merge_gate.py (both use 5).
+_GATE_DELETION_FILE_WARN = 5
+
 # Gate type → CLI binary mapping
 GATE_BINARIES: Dict[str, str] = {
     "gemini_review": "gemini",
@@ -227,6 +231,49 @@ class GateRunner:
         )
 
     @staticmethod
+    def _extract_deleted_files_from_diff(diff_content: str) -> List[str]:
+        """Parse unified diff output and return paths of fully deleted files.
+
+        A file is considered deleted when a ``deleted file mode`` header immediately
+        follows its ``diff --git a/path b/path`` line. Modified files have an index
+        line instead and are not included.
+
+        Uses subprocess.run so tests can patch gate_runner.subprocess.run.
+        """
+        deleted: List[str] = []
+        current_file: Optional[str] = None
+        for line in diff_content.splitlines():
+            if line.startswith("diff --git "):
+                parts = line.split(" ", 3)
+                current_file = (
+                    parts[3][2:] if len(parts) == 4 and parts[3].startswith("b/") else None
+                )
+            elif line.startswith("deleted file mode") and current_file is not None:
+                deleted.append(current_file)
+                current_file = None
+        return deleted
+
+    @staticmethod
+    def _build_deletion_alert_section(diff_content: str) -> str:
+        """Return a formatted Net-Deletion Alert block for reviewer prompts.
+
+        Returns an empty string when the deleted-file count is below
+        ``_GATE_DELETION_FILE_WARN``. When at or above the threshold, returns a
+        markdown block listing all deleted file paths so the reviewer notices the
+        scope reduction and can flag accidental deletions.
+        """
+        deleted_files = GateRunner._extract_deleted_files_from_diff(diff_content)
+        if len(deleted_files) < _GATE_DELETION_FILE_WARN:
+            return ""
+        file_list = "\n".join(f"- `{f}`" for f in deleted_files)
+        return (
+            f"\n\n## Net-Deletion Alert ({len(deleted_files)} file(s) deleted)\n\n"
+            "> **Review required**: these files are fully deleted in this PR. "
+            "Confirm each deletion is intentional and within declared scope.\n\n"
+            f"{file_list}"
+        )
+
+    @staticmethod
     def _fetch_gh_pr_diff(pr_number: Optional[int]) -> str:
         """Fetch authoritative PR diff via gh pr diff.
 
@@ -257,16 +304,18 @@ class GateRunner:
 
         Uses subprocess.run so tests can patch gate_runner.subprocess.run.
         Raises on missing pr_number or gh pr diff failure — no silent empty-diff fallback.
+        Injects a Net-Deletion Alert section when >= _GATE_DELETION_FILE_WARN files are deleted.
         """
         branch = request_payload.get("branch", "")
         risk = (request_payload.get("risk_class") or "medium")
         pr_number = request_payload.get("pr_number")
         diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        deletion_alert = GateRunner._build_deletion_alert_section(diff_content)
         l3 = (
             f"Review the PR diff below on branch {branch} (risk: {risk}). "
             "Findings MUST cite specific NEW lines from this diff — "
             "do not flag pre-existing code.\n\n"
-            f"{diff_content}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
+            f"{diff_content}{deletion_alert}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
         )
         assembled = PromptAssembler().assemble(
             dispatch_metadata={"role": "reviewer"},
@@ -280,16 +329,18 @@ class GateRunner:
 
         Uses subprocess.run so tests can patch gate_runner.subprocess.run.
         Raises on missing pr_number or gh pr diff failure — no silent empty-diff fallback.
+        Injects a Net-Deletion Alert section when >= _GATE_DELETION_FILE_WARN files are deleted.
         """
         branch = request_payload.get("branch", "")
         risk = (request_payload.get("risk_class") or "medium")
         pr_number = request_payload.get("pr_number")
         diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        deletion_alert = GateRunner._build_deletion_alert_section(diff_content)
         l3 = (
             f"Review the PR diff below on branch {branch} (risk: {risk}). "
             "Findings MUST cite specific NEW lines from this diff — "
             "do not flag pre-existing code.\n\n"
-            f"{diff_content}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
+            f"{diff_content}{deletion_alert}\n\n{_REVIEWER_VERDICT_TEMPLATE}"
         )
         assembled = PromptAssembler().assemble(
             dispatch_metadata={"role": "reviewer"},

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -102,6 +102,8 @@ from subprocess_dispatch_internals.state_paths import (
 __all__ = [
     "_extract_role_from_instruction",
     "_select_dispatch_path",
+    "_build_cheap_lane_argv",
+    "_execute_cheap_lane_dispatch",
     "SubprocessAdapter",
     "HeadlessContextTracker",
     "WorkerHealthMonitor",
@@ -206,6 +208,73 @@ def _select_dispatch_path(
             exc, current_model,
         )
         return None, current_model
+
+
+def _build_cheap_lane_argv(
+    args: "argparse.Namespace",
+    cheap_lane_provider: str,
+) -> "list[str]":
+    """Build the provider_dispatch argv list for a non-Claude lane dispatch.
+
+    Constructs the full argument list forwarded to ``provider_dispatch.main()``
+    when ``routing_policy`` selects a non-Claude (cheap) provider.  Extracted
+    as a module-level function so tests can verify the delegation contract
+    without spawning real processes.
+
+    Args:
+        args:               Parsed ``argparse.Namespace`` from ``__main__``.
+        cheap_lane_provider: The lane string returned by ``_select_dispatch_path``
+                            (e.g. ``"litellm:moonshot:kimi-k2-0905-default"``).
+
+    Returns:
+        List of string arguments suitable for ``provider_dispatch.main(argv)``.
+    """
+    argv: "list[str]" = [
+        "--provider", cheap_lane_provider,
+        "--terminal-id", args.terminal_id,
+        "--dispatch-id", args.dispatch_id,
+        "--instruction", args.instruction,
+        "--model", args.model,
+        "--role", args.role or _ROLE_FALLBACK,
+        "--max-retries", str(args.max_retries),
+        "--gate", args.gate,
+    ]
+    if getattr(args, "no_auto_commit", False):
+        argv.append("--no-auto-commit")
+    if getattr(args, "dispatch_paths", ""):
+        argv.extend(["--dispatch-paths", args.dispatch_paths])
+    if getattr(args, "pr_id", None):
+        argv.extend(["--pr-id", args.pr_id])
+    return argv
+
+
+def _execute_cheap_lane_dispatch(
+    args: "argparse.Namespace",
+    cheap_lane_provider: str,
+) -> int:
+    """Delegate to provider_dispatch when routing policy selects a non-Claude lane.
+
+    This is the single delegation entry-point called from ``__main__`` when
+    ``_select_dispatch_path`` returns a non-None ``cheap_lane_provider``.
+    ``provider_dispatch`` owns receipt and unified_report emission after the
+    spawn completes; ``deliver_with_recovery`` (Claude) is never invoked on
+    this path.
+
+    Extracting it as a module-level function makes the delegation contract
+    directly testable: callers can mock ``provider_dispatch.main`` and assert
+    that ``deliver_with_recovery`` is not called (which is the primary
+    regression guard for the cheap-lane feature).
+
+    Args:
+        args:               Parsed ``argparse.Namespace`` from ``__main__``.
+        cheap_lane_provider: The non-Claude lane string (e.g.
+                            ``"litellm:moonshot:kimi-k2-0905-default"``).
+
+    Returns:
+        Exit code from ``provider_dispatch.main()``.
+    """
+    import provider_dispatch as _pd  # noqa: PLC0415
+    return _pd.main(_build_cheap_lane_argv(args, cheap_lane_provider))
 
 
 def _pool_heartbeat_loop(
@@ -357,29 +426,12 @@ if __name__ == "__main__":
 
     if _cheap_lane_provider is not None:
         # Non-Claude lane chosen by routing_policy: stop the heartbeat thread, then
-        # delegate execution to provider_dispatch.  provider_dispatch owns receipt +
-        # unified_report emission after the spawn completes; we must not also call
-        # deliver_with_recovery (which would spawn a Claude process instead).
+        # delegate execution to provider_dispatch via _execute_cheap_lane_dispatch.
+        # provider_dispatch owns receipt + unified_report emission; deliver_with_recovery
+        # (which would spawn a Claude process) is never called on this path.
         _hb_stop.set()
         _hb_thread.join(timeout=5)
-        import provider_dispatch as _pd  # noqa: PLC0415
-        _pd_argv = [
-            "--provider", _cheap_lane_provider,
-            "--terminal-id", args.terminal_id,
-            "--dispatch-id", args.dispatch_id,
-            "--instruction", args.instruction,
-            "--model", args.model,
-            "--role", args.role or _ROLE_FALLBACK,
-            "--max-retries", str(args.max_retries),
-            "--gate", args.gate,
-        ]
-        if args.no_auto_commit:
-            _pd_argv.append("--no-auto-commit")
-        if args.dispatch_paths:
-            _pd_argv.extend(["--dispatch-paths", args.dispatch_paths])
-        if args.pr_id:
-            _pd_argv.extend(["--pr-id", args.pr_id])
-        sys.exit(_pd.main(_pd_argv))
+        sys.exit(_execute_cheap_lane_dispatch(args, _cheap_lane_provider))
 
     # Scale chunk/total timeouts by --complexity so compute-heavy ("high")
     # dispatches get more headroom and aren't killed by the per-chunk timeout

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -101,6 +101,7 @@ from subprocess_dispatch_internals.state_paths import (
 
 __all__ = [
     "_extract_role_from_instruction",
+    "_select_dispatch_path",
     "SubprocessAdapter",
     "HeadlessContextTracker",
     "WorkerHealthMonitor",
@@ -144,6 +145,67 @@ __all__ = [
     "_capture_dispatch_outcome",
     "_update_pattern_confidence",
 ]
+
+
+def _select_dispatch_path(
+    task_class: str,
+    complexity: str = "medium",
+    current_model: str = "sonnet",
+    env: "dict[str, str] | None" = None,
+    auto_route_applied: bool = False,
+) -> "tuple[str | None, str]":
+    """Resolve the dispatch lane and effective Claude model from the routing policy.
+
+    Returns ``(cheap_lane_provider, effective_model)`` where:
+
+    - ``cheap_lane_provider`` is the non-Claude lane string (e.g.
+      ``"litellm:moonshot:kimi-k2-0905-default"``) when the routing policy
+      selects a non-Claude provider, or ``None`` when the dispatch stays on
+      Claude.
+    - ``effective_model`` is the Claude model to use (``"sonnet"``,
+      ``"haiku"``, ``"opus"``), unchanged from ``current_model`` whenever
+      a non-Claude lane is selected.
+
+    Short-circuit conditions that return ``(None, current_model)`` unchanged:
+    - ``VNX_ROUTING_POLICY_ENABLED`` is absent or not ``"1"`` in *env*.
+    - ``task_class`` is empty.
+    - ``auto_route_applied`` is ``True`` (smart_router already ran; do not
+      override its decision with the coarser routing_policy).
+    - Any exception raised by the routing policy (file-not-found, bad YAML,
+      unexpected errors) — fail open so dispatch continues on the current
+      Claude model.
+
+    Critical regression fix: the old ``__main__`` block fell back to the first
+    Claude model in ``fallback_chain`` when the lane was non-Claude.  This
+    silently routed the dispatch through Claude instead of the intended provider.
+    This function never touches ``fallback_chain`` for non-Claude lanes.
+    """
+    _env = env if env is not None else dict(os.environ)
+
+    # Guard: feature flag, empty task_class, or smart_router already decided.
+    if _env.get("VNX_ROUTING_POLICY_ENABLED") != "1":
+        return None, current_model
+    if not task_class:
+        return None, current_model
+    if auto_route_applied:
+        return None, current_model
+
+    try:
+        from routing_policy import decide_lane, lane_to_claude_model  # noqa: PLC0415
+        decision = decide_lane(task_class=task_class, complexity=complexity, env=_env)
+        claude_model = lane_to_claude_model(decision.lane)
+        if claude_model is not None:
+            # Claude lane: override model, no cheap-lane provider.
+            return None, claude_model
+        # Non-Claude lane: return lane as-is; do NOT fall through to fallback_chain.
+        return decision.lane, current_model
+    except Exception as exc:  # noqa: BLE001
+        import logging as _log_mod  # noqa: PLC0415
+        _log_mod.getLogger(__name__).warning(
+            "routing_policy: decision failed (%s); falling back to --model=%s",
+            exc, current_model,
+        )
+        return None, current_model
 
 
 def _pool_heartbeat_loop(
@@ -259,40 +321,18 @@ if __name__ == "__main__":
                 _route_exc, args.model,
             )
 
-    if not _auto_route_applied and os.environ.get("VNX_ROUTING_POLICY_ENABLED") == "1" and args.task_class:
-        try:
-            from routing_policy import decide_lane, lane_to_claude_model
-            _decision = decide_lane(
-                task_class=args.task_class,
-                complexity=args.complexity,
-            )
-            _claude_model = lane_to_claude_model(_decision.lane)
-            if _claude_model is not None:
-                # Claude lane: override model directly.
-                _effective_model = _claude_model
-            else:
-                # LiteLLM lane: log routing intent; full LiteLLM path wired separately.
-                # Fallback to first Claude lane in the fallback_chain, or keep current model.
-                _fallback_claude = next(
-                    (lane_to_claude_model(fb) for fb in _decision.fallback_chain
-                     if lane_to_claude_model(fb) is not None),
-                    None,
-                )
-                if _fallback_claude is not None:
-                    _effective_model = _fallback_claude
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).info(
-                "routing_policy: task_class=%s complexity=%s -> lane=%s "
-                "(rule=%s) effective_model=%s",
-                args.task_class, args.complexity,
-                _decision.lane, _decision.rule_name, _effective_model,
-            )
-        except Exception as _routing_exc:
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).warning(
-                "routing_policy: decision failed (%s); falling back to --model=%s",
-                _routing_exc, args.model,
-            )
+    _cheap_lane_provider, _effective_model = _select_dispatch_path(
+        task_class=args.task_class,
+        complexity=args.complexity,
+        current_model=_effective_model,
+        auto_route_applied=_auto_route_applied,
+    )
+    if _cheap_lane_provider is not None or _effective_model != args.model:
+        import logging as _log_mod
+        _log_mod.getLogger(__name__).info(
+            "dispatch_path: task_class=%s complexity=%s -> cheap_lane=%s effective_model=%s",
+            args.task_class, args.complexity, _cheap_lane_provider, _effective_model,
+        )
 
     _state_dir = _default_state_dir()
     _db_path = _state_dir / "runtime_coordination.db"
@@ -314,6 +354,32 @@ if __name__ == "__main__":
         daemon=True,
     )
     _hb_thread.start()
+
+    if _cheap_lane_provider is not None:
+        # Non-Claude lane chosen by routing_policy: stop the heartbeat thread, then
+        # delegate execution to provider_dispatch.  provider_dispatch owns receipt +
+        # unified_report emission after the spawn completes; we must not also call
+        # deliver_with_recovery (which would spawn a Claude process instead).
+        _hb_stop.set()
+        _hb_thread.join(timeout=5)
+        import provider_dispatch as _pd  # noqa: PLC0415
+        _pd_argv = [
+            "--provider", _cheap_lane_provider,
+            "--terminal-id", args.terminal_id,
+            "--dispatch-id", args.dispatch_id,
+            "--instruction", args.instruction,
+            "--model", args.model,
+            "--role", args.role or _ROLE_FALLBACK,
+            "--max-retries", str(args.max_retries),
+            "--gate", args.gate,
+        ]
+        if args.no_auto_commit:
+            _pd_argv.append("--no-auto-commit")
+        if args.dispatch_paths:
+            _pd_argv.extend(["--dispatch-paths", args.dispatch_paths])
+        if args.pr_id:
+            _pd_argv.extend(["--pr-id", args.pr_id])
+        sys.exit(_pd.main(_pd_argv))
 
     # Scale chunk/total timeouts by --complexity so compute-heavy ("high")
     # dispatches get more headroom and aren't killed by the per-chunk timeout

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -38,72 +38,6 @@ def _extract_role_from_instruction(instruction: str) -> str | None:
     m = _ROLE_HEADER_RE.search(instruction)
     return m.group(1) if m else None
 
-
-def _select_dispatch_path(
-    task_class: str,
-    complexity: str,
-    current_model: str,
-    auto_route_applied: bool = False,
-    env: "dict | None" = None,
-) -> "tuple[str | None, str]":
-    """Apply VNX routing_policy to select the dispatch execution path.
-
-    Returns ``(cheap_lane_provider, effective_model)`` where:
-
-    * ``cheap_lane_provider`` is not None — caller must delegate to provider_dispatch
-      using that string as ``--provider``.  Receipt + unified_report are emitted by
-      provider_dispatch after the spawn completes.
-    * ``cheap_lane_provider`` is None — caller proceeds on the Claude path using
-      ``effective_model`` (which may differ from ``current_model`` when a Claude lane
-      overrides it, e.g. sonnet-4-6 → haiku-4-5).
-
-    Guards applied (any false → returns (None, current_model)):
-    * ``VNX_ROUTING_POLICY_ENABLED=1`` must be set.
-    * ``task_class`` must be non-empty.
-    * ``auto_route_applied=True`` skips this (smart_router already decided).
-
-    Any exception from ``decide_lane`` falls back to ``(None, current_model)`` with a
-    warning log — caller continues on the Claude path unchanged.
-    """
-    import logging as _log_mod  # noqa: PLC0415
-    _log = _log_mod.getLogger(__name__)
-
-    _env = env if env is not None else dict(os.environ)
-    if auto_route_applied or not task_class or _env.get("VNX_ROUTING_POLICY_ENABLED") != "1":
-        return (None, current_model)
-
-    try:
-        from routing_policy import decide_lane, lane_to_claude_model  # noqa: PLC0415
-        _decision = decide_lane(task_class=task_class, complexity=complexity)
-        _claude_model = lane_to_claude_model(_decision.lane)
-
-        if _claude_model is not None:
-            # Claude lane: override the model, stay on the Claude execution path.
-            _log.info(
-                "routing_policy: task_class=%s complexity=%s -> lane=%s "
-                "(rule=%s) effective_model=%s",
-                task_class, complexity, _decision.lane, _decision.rule_name, _claude_model,
-            )
-            return (None, _claude_model)
-
-        # Non-Claude (cheap) lane: signal caller to delegate to provider_dispatch.
-        # Intentionally NOT falling back to the first Claude model in fallback_chain —
-        # the fallback_chain is for runtime failure (API down), not for routing intent.
-        _log.info(
-            "routing_policy: task_class=%s complexity=%s -> lane=%s "
-            "(rule=%s) delegating to provider_dispatch",
-            task_class, complexity, _decision.lane, _decision.rule_name,
-        )
-        return (_decision.lane, current_model)
-
-    except Exception as _routing_exc:
-        _log.warning(
-            "routing_policy: decision failed (%s); falling back to model=%s",
-            _routing_exc, current_model,
-        )
-        return (None, current_model)
-
-
 sys.path.insert(0, str(Path(__file__).parent))
 
 from subprocess_adapter import SubprocessAdapter
@@ -167,7 +101,6 @@ from subprocess_dispatch_internals.state_paths import (
 
 __all__ = [
     "_extract_role_from_instruction",
-    "_select_dispatch_path",
     "SubprocessAdapter",
     "HeadlessContextTracker",
     "WorkerHealthMonitor",
@@ -326,16 +259,40 @@ if __name__ == "__main__":
                 _route_exc, args.model,
             )
 
-    # Wave 7 PR-7.4 + CL2: apply routing_policy via _select_dispatch_path.
-    # Returns (cheap_lane_provider, effective_model):
-    #   cheap_lane_provider not None → delegate to provider_dispatch (non-Claude).
-    #   cheap_lane_provider None     → proceed with Claude using effective_model.
-    _cheap_lane_provider, _effective_model = _select_dispatch_path(
-        task_class=args.task_class,
-        complexity=args.complexity,
-        current_model=_effective_model,
-        auto_route_applied=_auto_route_applied,
-    )
+    if not _auto_route_applied and os.environ.get("VNX_ROUTING_POLICY_ENABLED") == "1" and args.task_class:
+        try:
+            from routing_policy import decide_lane, lane_to_claude_model
+            _decision = decide_lane(
+                task_class=args.task_class,
+                complexity=args.complexity,
+            )
+            _claude_model = lane_to_claude_model(_decision.lane)
+            if _claude_model is not None:
+                # Claude lane: override model directly.
+                _effective_model = _claude_model
+            else:
+                # LiteLLM lane: log routing intent; full LiteLLM path wired separately.
+                # Fallback to first Claude lane in the fallback_chain, or keep current model.
+                _fallback_claude = next(
+                    (lane_to_claude_model(fb) for fb in _decision.fallback_chain
+                     if lane_to_claude_model(fb) is not None),
+                    None,
+                )
+                if _fallback_claude is not None:
+                    _effective_model = _fallback_claude
+            import logging as _log_mod
+            _log_mod.getLogger(__name__).info(
+                "routing_policy: task_class=%s complexity=%s -> lane=%s "
+                "(rule=%s) effective_model=%s",
+                args.task_class, args.complexity,
+                _decision.lane, _decision.rule_name, _effective_model,
+            )
+        except Exception as _routing_exc:
+            import logging as _log_mod
+            _log_mod.getLogger(__name__).warning(
+                "routing_policy: decision failed (%s); falling back to --model=%s",
+                _routing_exc, args.model,
+            )
 
     _state_dir = _default_state_dir()
     _db_path = _state_dir / "runtime_coordination.db"
@@ -365,32 +322,6 @@ if __name__ == "__main__":
     # downstream so VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE still take precedence.
     from subprocess_dispatch_internals.runtime_overrides import complexity_timeout_defaults
     _chunk_timeout, _total_deadline = complexity_timeout_defaults(args.complexity)
-
-    if _cheap_lane_provider is not None:
-        # Non-Claude lane chosen by routing_policy: stop the heartbeat thread, then
-        # delegate execution to provider_dispatch.  provider_dispatch owns receipt +
-        # unified_report emission after the spawn completes; we must not also call
-        # deliver_with_recovery (which would spawn a Claude process instead).
-        _hb_stop.set()
-        _hb_thread.join(timeout=5)
-        import provider_dispatch as _pd  # noqa: PLC0415
-        _pd_argv = [
-            "--provider", _cheap_lane_provider,
-            "--terminal-id", args.terminal_id,
-            "--dispatch-id", args.dispatch_id,
-            "--instruction", args.instruction,
-            "--model", args.model,
-            "--role", args.role or _ROLE_FALLBACK,
-            "--max-retries", str(args.max_retries),
-            "--gate", args.gate,
-        ]
-        if args.no_auto_commit:
-            _pd_argv.append("--no-auto-commit")
-        if args.dispatch_paths:
-            _pd_argv.extend(["--dispatch-paths", args.dispatch_paths])
-        if args.pr_id:
-            _pd_argv.extend(["--pr-id", args.pr_id])
-        sys.exit(_pd.main(_pd_argv))
 
     try:
         ok = deliver_with_recovery(

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -38,6 +38,72 @@ def _extract_role_from_instruction(instruction: str) -> str | None:
     m = _ROLE_HEADER_RE.search(instruction)
     return m.group(1) if m else None
 
+
+def _select_dispatch_path(
+    task_class: str,
+    complexity: str,
+    current_model: str,
+    auto_route_applied: bool = False,
+    env: "dict | None" = None,
+) -> "tuple[str | None, str]":
+    """Apply VNX routing_policy to select the dispatch execution path.
+
+    Returns ``(cheap_lane_provider, effective_model)`` where:
+
+    * ``cheap_lane_provider`` is not None — caller must delegate to provider_dispatch
+      using that string as ``--provider``.  Receipt + unified_report are emitted by
+      provider_dispatch after the spawn completes.
+    * ``cheap_lane_provider`` is None — caller proceeds on the Claude path using
+      ``effective_model`` (which may differ from ``current_model`` when a Claude lane
+      overrides it, e.g. sonnet-4-6 → haiku-4-5).
+
+    Guards applied (any false → returns (None, current_model)):
+    * ``VNX_ROUTING_POLICY_ENABLED=1`` must be set.
+    * ``task_class`` must be non-empty.
+    * ``auto_route_applied=True`` skips this (smart_router already decided).
+
+    Any exception from ``decide_lane`` falls back to ``(None, current_model)`` with a
+    warning log — caller continues on the Claude path unchanged.
+    """
+    import logging as _log_mod  # noqa: PLC0415
+    _log = _log_mod.getLogger(__name__)
+
+    _env = env if env is not None else dict(os.environ)
+    if auto_route_applied or not task_class or _env.get("VNX_ROUTING_POLICY_ENABLED") != "1":
+        return (None, current_model)
+
+    try:
+        from routing_policy import decide_lane, lane_to_claude_model  # noqa: PLC0415
+        _decision = decide_lane(task_class=task_class, complexity=complexity)
+        _claude_model = lane_to_claude_model(_decision.lane)
+
+        if _claude_model is not None:
+            # Claude lane: override the model, stay on the Claude execution path.
+            _log.info(
+                "routing_policy: task_class=%s complexity=%s -> lane=%s "
+                "(rule=%s) effective_model=%s",
+                task_class, complexity, _decision.lane, _decision.rule_name, _claude_model,
+            )
+            return (None, _claude_model)
+
+        # Non-Claude (cheap) lane: signal caller to delegate to provider_dispatch.
+        # Intentionally NOT falling back to the first Claude model in fallback_chain —
+        # the fallback_chain is for runtime failure (API down), not for routing intent.
+        _log.info(
+            "routing_policy: task_class=%s complexity=%s -> lane=%s "
+            "(rule=%s) delegating to provider_dispatch",
+            task_class, complexity, _decision.lane, _decision.rule_name,
+        )
+        return (_decision.lane, current_model)
+
+    except Exception as _routing_exc:
+        _log.warning(
+            "routing_policy: decision failed (%s); falling back to model=%s",
+            _routing_exc, current_model,
+        )
+        return (None, current_model)
+
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 from subprocess_adapter import SubprocessAdapter
@@ -101,6 +167,7 @@ from subprocess_dispatch_internals.state_paths import (
 
 __all__ = [
     "_extract_role_from_instruction",
+    "_select_dispatch_path",
     "SubprocessAdapter",
     "HeadlessContextTracker",
     "WorkerHealthMonitor",
@@ -259,40 +326,16 @@ if __name__ == "__main__":
                 _route_exc, args.model,
             )
 
-    if not _auto_route_applied and os.environ.get("VNX_ROUTING_POLICY_ENABLED") == "1" and args.task_class:
-        try:
-            from routing_policy import decide_lane, lane_to_claude_model
-            _decision = decide_lane(
-                task_class=args.task_class,
-                complexity=args.complexity,
-            )
-            _claude_model = lane_to_claude_model(_decision.lane)
-            if _claude_model is not None:
-                # Claude lane: override model directly.
-                _effective_model = _claude_model
-            else:
-                # LiteLLM lane: log routing intent; full LiteLLM path wired separately.
-                # Fallback to first Claude lane in the fallback_chain, or keep current model.
-                _fallback_claude = next(
-                    (lane_to_claude_model(fb) for fb in _decision.fallback_chain
-                     if lane_to_claude_model(fb) is not None),
-                    None,
-                )
-                if _fallback_claude is not None:
-                    _effective_model = _fallback_claude
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).info(
-                "routing_policy: task_class=%s complexity=%s -> lane=%s "
-                "(rule=%s) effective_model=%s",
-                args.task_class, args.complexity,
-                _decision.lane, _decision.rule_name, _effective_model,
-            )
-        except Exception as _routing_exc:
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).warning(
-                "routing_policy: decision failed (%s); falling back to --model=%s",
-                _routing_exc, args.model,
-            )
+    # Wave 7 PR-7.4 + CL2: apply routing_policy via _select_dispatch_path.
+    # Returns (cheap_lane_provider, effective_model):
+    #   cheap_lane_provider not None → delegate to provider_dispatch (non-Claude).
+    #   cheap_lane_provider None     → proceed with Claude using effective_model.
+    _cheap_lane_provider, _effective_model = _select_dispatch_path(
+        task_class=args.task_class,
+        complexity=args.complexity,
+        current_model=_effective_model,
+        auto_route_applied=_auto_route_applied,
+    )
 
     _state_dir = _default_state_dir()
     _db_path = _state_dir / "runtime_coordination.db"
@@ -322,6 +365,32 @@ if __name__ == "__main__":
     # downstream so VNX_CHUNK_TIMEOUT / VNX_TOTAL_DEADLINE still take precedence.
     from subprocess_dispatch_internals.runtime_overrides import complexity_timeout_defaults
     _chunk_timeout, _total_deadline = complexity_timeout_defaults(args.complexity)
+
+    if _cheap_lane_provider is not None:
+        # Non-Claude lane chosen by routing_policy: stop the heartbeat thread, then
+        # delegate execution to provider_dispatch.  provider_dispatch owns receipt +
+        # unified_report emission after the spawn completes; we must not also call
+        # deliver_with_recovery (which would spawn a Claude process instead).
+        _hb_stop.set()
+        _hb_thread.join(timeout=5)
+        import provider_dispatch as _pd  # noqa: PLC0415
+        _pd_argv = [
+            "--provider", _cheap_lane_provider,
+            "--terminal-id", args.terminal_id,
+            "--dispatch-id", args.dispatch_id,
+            "--instruction", args.instruction,
+            "--model", args.model,
+            "--role", args.role or _ROLE_FALLBACK,
+            "--max-retries", str(args.max_retries),
+            "--gate", args.gate,
+        ]
+        if args.no_auto_commit:
+            _pd_argv.append("--no-auto-commit")
+        if args.dispatch_paths:
+            _pd_argv.extend(["--dispatch-paths", args.dispatch_paths])
+        if args.pr_id:
+            _pd_argv.extend(["--pr-id", args.pr_id])
+        sys.exit(_pd.main(_pd_argv))
 
     try:
         ok = deliver_with_recovery(

--- a/tests/test_codex_net_deletion_sanity.py
+++ b/tests/test_codex_net_deletion_sanity.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Net-deletion sanity check coverage for codex_final_gate.
+
+Fills coverage gaps not addressed by test_codex_final_gate_mass_deletion.py:
+- render_codex_prompt(contract, deleted_files=...) direct API (not via CLI)
+- _format_deleted_files_alert WARN vs HOLD label
+- Net deletion sanity item in Review Instructions
+- Dual HOLD trigger: both file-count and net-line-deletion in reasons simultaneously
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+from codex_final_gate import (
+    DELETION_FILE_HOLD,
+    DELETION_FILE_WARN,
+    NET_LINE_DELETION_HOLD,
+    NET_LINE_DELETION_WARN,
+    _format_deleted_files_alert,
+    enforce_codex_gate,
+    render_codex_prompt,
+)
+from review_contract import Deliverable, ReviewContract
+
+
+def _make_contract(**overrides) -> ReviewContract:
+    defaults = dict(
+        pr_id="PR-nds",
+        pr_title="Net deletion sanity test",
+        feature_title="test",
+        branch="feat/test",
+        track="A",
+        risk_class="low",
+        merge_policy="squash_merge",
+        closure_stage="open",
+        deliverables=[Deliverable(description="remove stale files", category="infrastructure")],
+        review_stack=["codex_gate"],
+        changed_files=[],
+        content_hash="nds123",
+    )
+    defaults.update(overrides)
+    return ReviewContract(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _format_deleted_files_alert: WARN vs HOLD label
+# ---------------------------------------------------------------------------
+
+class TestFormatDeletedFilesAlert:
+    """_format_deleted_files_alert must label correctly based on count vs DELETION_FILE_HOLD."""
+
+    def test_warn_label_below_hold_threshold(self):
+        """Count below DELETION_FILE_HOLD gets [WARN] label."""
+        count = DELETION_FILE_HOLD - 1
+        files = [f"old/file_{i}.py" for i in range(count)]
+        lines = _format_deleted_files_alert(files)
+        header = lines[0]
+        assert "[WARN]" in header
+        assert "[HOLD]" not in header
+        assert str(count) in header
+
+    def test_hold_label_at_threshold(self):
+        """Count exactly DELETION_FILE_HOLD gets [HOLD] label."""
+        files = [f"old/file_{i}.py" for i in range(DELETION_FILE_HOLD)]
+        lines = _format_deleted_files_alert(files)
+        header = lines[0]
+        assert "[HOLD]" in header
+        assert "[WARN]" not in header
+
+    def test_hold_label_above_threshold(self):
+        """Count above DELETION_FILE_HOLD still gets [HOLD] label."""
+        count = DELETION_FILE_HOLD + 10
+        files = [f"old/file_{i}.py" for i in range(count)]
+        lines = _format_deleted_files_alert(files)
+        header = lines[0]
+        assert "[HOLD]" in header
+
+    def test_file_list_appears_in_output(self):
+        """Each deleted file must appear as a list item in the alert."""
+        files = ["scripts/old_helper.py", "scripts/legacy.py"]
+        lines = _format_deleted_files_alert(files)
+        full_text = "\n".join(lines)
+        assert "`scripts/old_helper.py`" in full_text
+        assert "`scripts/legacy.py`" in full_text
+
+    def test_alert_header_includes_file_count(self):
+        """Alert header must state the exact file count."""
+        count = 7
+        files = [f"file_{i}.py" for i in range(count)]
+        lines = _format_deleted_files_alert(files)
+        assert str(count) in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# render_codex_prompt: direct deleted_files parameter
+# ---------------------------------------------------------------------------
+
+class TestRenderCodexPromptWithDeletedFiles:
+    """render_codex_prompt must inject Net-Deletion Alert when deleted_files is provided."""
+
+    def test_deleted_files_injects_alert_section(self):
+        contract = _make_contract()
+        deleted = ["old/module.py", "old/helper.py"]
+        prompt = render_codex_prompt(contract, deleted_files=deleted)
+        assert "## Net-Deletion Alert" in prompt
+        assert "`old/module.py`" in prompt
+        assert "`old/helper.py`" in prompt
+
+    def test_no_deleted_files_none_omits_alert(self):
+        """deleted_files=None must not inject the alert section."""
+        contract = _make_contract()
+        prompt = render_codex_prompt(contract, deleted_files=None)
+        assert "## Net-Deletion Alert" not in prompt
+
+    def test_no_deleted_files_empty_list_omits_alert(self):
+        """deleted_files=[] (empty list) must not inject the alert section."""
+        contract = _make_contract()
+        prompt = render_codex_prompt(contract, deleted_files=[])
+        assert "## Net-Deletion Alert" not in prompt
+
+    def test_deleted_files_warn_label_when_below_hold(self):
+        """Alert label is WARN when file count is below DELETION_FILE_HOLD."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_HOLD - 1)]
+        prompt = render_codex_prompt(contract, deleted_files=deleted)
+        assert "[WARN]" in prompt
+
+    def test_deleted_files_hold_label_at_threshold(self):
+        """Alert label is HOLD when file count equals DELETION_FILE_HOLD."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_HOLD)]
+        prompt = render_codex_prompt(contract, deleted_files=deleted)
+        assert "[HOLD]" in prompt
+
+
+# ---------------------------------------------------------------------------
+# render_codex_prompt: Review Instructions include net deletion sanity item
+# ---------------------------------------------------------------------------
+
+class TestRenderCodexPromptNetSanityInstruction:
+    """Review Instructions section must include the net deletion sanity check item."""
+
+    def test_net_deletion_sanity_item_present(self):
+        """Instruction #6 about net deletion sanity must be in the rendered prompt."""
+        contract = _make_contract()
+        prompt = render_codex_prompt(contract)
+        assert "Net deletion sanity" in prompt
+
+    def test_net_deletion_sanity_item_mentions_threshold(self):
+        """The instruction must reference the ≥5-file warning threshold."""
+        contract = _make_contract()
+        prompt = render_codex_prompt(contract)
+        # The instruction mentions "≥5 files" to match DELETION_FILE_WARN=5
+        assert "≥5" in prompt or "5 files" in prompt or "WARN" in prompt or "warning finding" in prompt
+
+    def test_review_instructions_section_present(self):
+        """Review Instructions section must always appear in the prompt."""
+        contract = _make_contract()
+        prompt = render_codex_prompt(contract)
+        assert "## Review Instructions" in prompt
+
+
+# ---------------------------------------------------------------------------
+# enforce_codex_gate: dual HOLD (file count + net line deletion)
+# ---------------------------------------------------------------------------
+
+class TestEnforceDualHold:
+    """When both file-count and net-line-deletion exceed HOLD thresholds, both reasons appear."""
+
+    def _mock_deleted(self, files: list) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = "\n".join(files) + "\n" if files else ""
+        return m
+
+    def _mock_numstat(self, net_removed: int) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = f"0\t{net_removed}\tsome/file.py\n"
+        return m
+
+    def test_both_hold_triggers_both_reasons(self, tmp_path):
+        """Both mass_file_deletion and net_line_deletion must appear in reasons when both exceed HOLD."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_HOLD + 5)]
+
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            self._mock_deleted(deleted),
+            self._mock_numstat(NET_LINE_DELETION_HOLD + 100),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert "mass_file_deletion" in result.reasons
+        assert "net_line_deletion" in result.reasons
+        assert result.required is True
+        assert result.mass_deletion_warn is False  # HOLD supersedes WARN flag
+        assert result.net_line_deletion_warn is False  # HOLD supersedes WARN flag
+
+    def test_file_hold_only_no_line_reason(self, tmp_path):
+        """File-count at HOLD but net-line below threshold: only mass_file_deletion reason."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_HOLD)]
+
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            self._mock_deleted(deleted),
+            self._mock_numstat(NET_LINE_DELETION_WARN - 10),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert "mass_file_deletion" in result.reasons
+        assert "net_line_deletion" not in result.reasons
+        assert result.required is True
+
+    def test_line_hold_only_no_file_reason(self, tmp_path):
+        """Net-line at HOLD but file count below threshold: only net_line_deletion reason."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_WARN - 1)]
+
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            self._mock_deleted(deleted),
+            self._mock_numstat(NET_LINE_DELETION_HOLD),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert "net_line_deletion" in result.reasons
+        assert "mass_file_deletion" not in result.reasons
+        assert result.required is True
+
+    def test_both_warn_neither_required(self, tmp_path):
+        """Both at WARN level: required remains False, both warn flags set."""
+        contract = _make_contract()
+        deleted = [f"old/file_{i}.py" for i in range(DELETION_FILE_WARN)]
+
+        with patch("codex_final_gate.subprocess.run", side_effect=[
+            self._mock_deleted(deleted),
+            self._mock_numstat(NET_LINE_DELETION_WARN),
+        ]):
+            result = enforce_codex_gate(contract, project_root=tmp_path)
+
+        assert result.required is False
+        assert result.mass_deletion_warn is True
+        assert result.net_line_deletion_warn is True
+        assert "mass_file_deletion" not in result.reasons
+        assert "net_line_deletion" not in result.reasons

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -837,13 +837,13 @@ def _mock_gh_diff(diff_text: str, returncode: int = 0):
     return MagicMock(returncode=returncode, stdout=diff_text, stderr="")
 
 
-class TestRunCodexNetDeletionCheck:
-    """Unit tests for GateRunner._run_codex_net_deletion_check.
+# Unit tests for _run_codex_net_deletion_check live in
+# test_gate_runner_codex_net_deletion_check.py (committed separately).
+# This section holds only the integration tests for GateRunner.run().
 
-    Validates the HOLD-level deterministic sanity check that returns a
-    pre-emptive blocking result when a PR deletes >= _GATE_DELETION_FILE_HOLD
-    files, bypassing the AI reviewer entirely.
-    """
+
+class _NetDeletionPayloadHelper:
+    """Shared payload factory for net-deletion integration tests."""
 
     def _make_payload(self, pr_number=50, **extra):
         return {"gate": "codex_gate", "pr_number": pr_number, **extra}

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -837,13 +837,16 @@ def _mock_gh_diff(diff_text: str, returncode: int = 0):
     return MagicMock(returncode=returncode, stdout=diff_text, stderr="")
 
 
-# Unit tests for _run_codex_net_deletion_check live in
-# test_gate_runner_codex_net_deletion_check.py (committed separately).
-# This section holds only the integration tests for GateRunner.run().
+# Unit tests for _run_codex_net_deletion_check that exercise threshold behaviour,
+# graceful degradation, result structure, and filesystem persistence directly on
+# the static method (not via GateRunner.run()).  These complement the deeper suite
+# in test_gate_runner_codex_hold.py with slightly different assertion angles
+# (e.g. exact result-file name, required-keys enumeration).
+# Integration tests for GateRunner.run() follow in TestCodexGateRunNetDeletionIntegration.
 
 
-class _NetDeletionPayloadHelper:
-    """Shared payload factory for net-deletion integration tests."""
+class TestGateRunnerNetDeletionUnit:
+    """Unit-level tests for GateRunner._run_codex_net_deletion_check."""
 
     def _make_payload(self, pr_number=50, **extra):
         return {"gate": "codex_gate", "pr_number": pr_number, **extra}

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -799,8 +799,8 @@ class TestGateTimeoutConfig:
 
     def test_default_stall_threshold(self):
         from headless_adapter import gate_stall_threshold
-        assert gate_stall_threshold("gemini_review") == 60
-        assert gate_stall_threshold("codex_gate") == 120
+        assert gate_stall_threshold("gemini_review") == 180
+        assert gate_stall_threshold("codex_gate") == 300
 
     def test_env_override_stall_threshold(self, monkeypatch):
         from headless_adapter import gate_stall_threshold
@@ -811,3 +811,417 @@ class TestGateTimeoutConfig:
         from headless_adapter import gate_timeout, gate_stall_threshold
         assert gate_timeout("unknown_gate") == 600  # DEFAULT_TIMEOUT
         assert gate_stall_threshold("unknown_gate") == 60
+
+
+# ---------------------------------------------------------------------------
+# Net-deletion sanity check (HOLD-level deterministic gate)
+# ---------------------------------------------------------------------------
+
+def _make_hold_diff(*paths: str) -> str:
+    """Build a minimal unified diff where every supplied path is fully deleted."""
+    parts = []
+    for path in paths:
+        parts.append(
+            f"diff --git a/{path} b/{path}\n"
+            f"deleted file mode 100644\n"
+            f"index abc1234..0000000\n"
+            f"--- a/{path}\n"
+            "+++ /dev/null\n"
+            "@@ -1,2 +0,0 @@\n"
+            "-# deleted\n"
+        )
+    return "\n".join(parts)
+
+
+def _mock_gh_diff(diff_text: str, returncode: int = 0):
+    return MagicMock(returncode=returncode, stdout=diff_text, stderr="")
+
+
+class TestRunCodexNetDeletionCheck:
+    """Unit tests for GateRunner._run_codex_net_deletion_check.
+
+    Validates the HOLD-level deterministic sanity check that returns a
+    pre-emptive blocking result when a PR deletes >= _GATE_DELETION_FILE_HOLD
+    files, bypassing the AI reviewer entirely.
+    """
+
+    def _make_payload(self, pr_number=50, **extra):
+        return {"gate": "codex_gate", "pr_number": pr_number, **extra}
+
+    # ------------------------------------------------------------------
+    # Threshold behaviour
+    # ------------------------------------------------------------------
+
+    def test_below_hold_returns_none(self, tmp_path):
+        """Fewer than _GATE_DELETION_FILE_HOLD deletions → None (AI gate proceeds)."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD - 1)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload()
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is None
+
+    def test_at_hold_threshold_returns_blocking(self, tmp_path):
+        """Exactly _GATE_DELETION_FILE_HOLD deletions → blocking result returned."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload()
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is not None
+        assert result["status"] == "fail"
+
+    def test_above_hold_threshold_returns_blocking(self, tmp_path):
+        """More than _GATE_DELETION_FILE_HOLD deletions → blocking result."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD + 10)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload()
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is not None
+        assert result["status"] == "fail"
+
+    # ------------------------------------------------------------------
+    # Graceful degradation
+    # ------------------------------------------------------------------
+
+    def test_no_pr_number_returns_none(self, tmp_path):
+        """pr_number=None → None (cannot fetch diff without a PR number)."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=None,
+            request_payload=self._make_payload(pr_number=None),
+            results_dir=results_dir,
+            requests_dir=requests_dir,
+        )
+        assert result is None
+
+    def test_gh_diff_failure_returns_none(self, tmp_path):
+        """gh pr diff non-zero exit → degrades gracefully, returns None."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff("", returncode=1)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=self._make_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is None
+
+    def test_gh_not_found_returns_none(self, tmp_path):
+        """gh binary not found (FileNotFoundError) → degrades gracefully, returns None."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", side_effect=FileNotFoundError("gh not found")):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=self._make_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is None
+
+    def test_timeout_returns_none(self, tmp_path):
+        """gh pr diff timeout → degrades gracefully, returns None."""
+        import subprocess as _subprocess
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run",
+                   side_effect=_subprocess.TimeoutExpired(["gh"], 60)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=50,
+                request_payload=self._make_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Result structure
+    # ------------------------------------------------------------------
+
+    def test_blocking_result_has_required_keys(self, tmp_path):
+        """Blocking result must contain all keys required by gate consumers."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload(pr_number=77)
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=77,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        required_keys = (
+            "gate", "pr_number", "status", "summary", "findings",
+            "blocking_findings", "advisory_findings", "required_reruns",
+            "residual_risk", "duration_seconds", "recorded_at",
+            "net_deletion_check",
+        )
+        for key in required_keys:
+            assert key in result, f"missing key: {key}"
+
+    def test_blocking_finding_severity_is_blocking(self, tmp_path):
+        """Finding severity must be 'blocking' so the gate consumer classifies it correctly."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload(pr_number=88)
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=88,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert len(result["blocking_findings"]) == 1
+        assert result["blocking_findings"][0]["severity"] == "blocking"
+        assert result["advisory_findings"] == []
+
+    def test_net_deletion_check_metadata_in_result(self, tmp_path):
+        """net_deletion_check metadata must carry deleted_count and threshold."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD + 5)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload(pr_number=99)
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=99,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        meta = result["net_deletion_check"]
+        assert meta["deleted_count"] == _GATE_DELETION_FILE_HOLD + 5
+        assert meta["threshold"] == _GATE_DELETION_FILE_HOLD
+        assert meta["triggered"] is True
+        assert len(meta["deleted_files"]) == _GATE_DELETION_FILE_HOLD + 5
+
+    def test_result_file_written_to_results_dir(self, tmp_path):
+        """Blocking result must be persisted to results_dir so closure_verifier sees it."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload(pr_number=55)
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=55,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        result_file = results_dir / "pr-55-codex_gate.json"
+        assert result_file.exists()
+        saved = json.loads(result_file.read_text(encoding="utf-8"))
+        assert saved["status"] == "fail"
+        assert saved["gate"] == "codex_gate"
+
+    def test_request_marked_completed(self, tmp_path):
+        """After blocking result, request payload status must be 'completed'."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = self._make_payload(pr_number=66)
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir()
+        requests_dir.mkdir()
+
+        with patch("gate_runner.subprocess.run", return_value=_mock_gh_diff(diff)):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=66,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+        assert payload["status"] == "completed"
+        assert "completed_at" in payload
+
+
+class TestCodexGateRunNetDeletionIntegration:
+    """Integration: GateRunner.run() for codex_gate short-circuits when HOLD threshold met.
+
+    Validates that the net-deletion sanity check is wired into the gate execution
+    lifecycle: when a PR deletes >= _GATE_DELETION_FILE_HOLD files, run() returns
+    a blocking result WITHOUT spawning the codex subprocess.
+    """
+
+    def test_high_deletion_skips_ai_subprocess(self, gate_env, monkeypatch):
+        """run() with HOLD-level deletions must NOT spawn codex Popen."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+        )
+
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _make_hold_diff(*paths)
+        payload = _make_request_payload(
+            gate="codex_gate",
+            report_path=str(gate_env["reports_dir"] / "codex-del-report.md"),
+        )
+        # Remove pre-set prompt so _resolve_prompt calls _build_codex_prompt
+        # which also calls subprocess.run for gh pr diff — both calls return diff.
+        del payload["prompt"]
+
+        mock_popen = MagicMock()
+
+        with patch("gate_runner.subprocess.run", return_value=MagicMock(returncode=0, stdout=diff, stderr="")), \
+             patch("gate_runner.subprocess.Popen", mock_popen):
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
+
+        assert result["status"] == "fail"
+        assert len(result["blocking_findings"]) >= 1
+        mock_popen.assert_not_called()
+
+    def test_low_deletion_proceeds_to_ai_subprocess(self, gate_env, monkeypatch):
+        """run() below HOLD threshold must spawn codex Popen for AI review."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+        )
+
+        # Fewer deleted files than HOLD
+        paths = [f"scripts/file_{i}.py" for i in range(2)]
+        diff = _make_hold_diff(*paths)
+        report_path = str(gate_env["reports_dir"] / "codex-lowdel-report.md")
+        payload = _make_request_payload(
+            gate="codex_gate",
+            report_path=report_path,
+            prompt="Review this diff",  # pre-supply prompt to skip _build_codex_prompt
+        )
+
+        review_output = b'{"type":"message","message":"LGTM"}\nAll checks pass.\nNo issues.\n'
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stdout.fileno.return_value = 10
+        mock_proc.stderr.fileno.return_value = 11
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+        mock_proc.pid = 12121
+
+        read_calls = [0]
+        def mock_os_read(fd, size):
+            read_calls[0] += 1
+            if fd == 10 and read_calls[0] == 1:
+                return review_output
+            return b""
+
+        # subprocess.run is used by net deletion check (_fetch_gh_pr_diff)
+        # — return a small diff so check passes through
+        with patch("gate_runner.subprocess.run", return_value=MagicMock(returncode=0, stdout=diff, stderr="")), \
+             patch("gate_runner.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("gate_runner.select.select", return_value=([], [], [])), \
+             patch("gate_runner.os.read", side_effect=mock_os_read), \
+             patch("gate_runner.os.getpgid", return_value=12121):
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
+
+        mock_popen.assert_called_once()
+        assert result["status"] == "completed"
+
+    def test_result_is_fail_not_not_executable(self, gate_env, monkeypatch):
+        """Net-deletion blocking result must have status='fail', not 'not_executable'."""
+        from gate_runner import _GATE_DELETION_FILE_HOLD
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+        )
+
+        paths = [f"scripts/mod_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD + 3)]
+        diff = _make_hold_diff(*paths)
+        payload = _make_request_payload(gate="codex_gate")
+        del payload["prompt"]
+
+        with patch("gate_runner.subprocess.run", return_value=MagicMock(returncode=0, stdout=diff, stderr="")):
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=2)
+
+        assert result["status"] == "fail"
+        assert result.get("reason") is None  # not an infra failure
+        assert result["net_deletion_check"]["triggered"] is True

--- a/tests/test_gate_runner_codex_hold.py
+++ b/tests/test_gate_runner_codex_hold.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Unit tests for GateRunner._run_codex_net_deletion_check (HOLD-level pre-AI check).
+
+Covers the deterministic blocking layer added in gate_runner.py:
+  - Returns None when pr_number is falsy (guard)
+  - Returns None when gh pr diff is unavailable (graceful degradation)
+  - Returns None when deleted-file count is below _GATE_DELETION_FILE_HOLD
+  - Returns a complete blocking result dict when threshold is met/exceeded
+  - Result structure: status, finding severity, net_deletion_check metadata
+  - Filesystem persistence: result file and request file written via _rec helpers
+  - pr_id sourcing: from payload or fallback to str(pr_number)
+
+Threshold constant: _GATE_DELETION_FILE_HOLD = 20
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_runner import GateRunner, _GATE_DELETION_FILE_HOLD  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _diff_deleted(*paths: str) -> str:
+    """Build a minimal unified diff that marks each path as a deleted file."""
+    lines = []
+    for p in paths:
+        lines += [
+            f"diff --git a/{p} b/{p}",
+            "deleted file mode 100644",
+            "index abc123..0000000",
+            f"--- a/{p}",
+            "+++ /dev/null",
+            "@@ -1,3 +0,0 @@",
+            "-content",
+        ]
+    return "\n".join(lines)
+
+
+def _payload(pr_number: int = 42, pr_id: str = "", gate: str = "codex_gate") -> dict:
+    return {"pr_number": pr_number, "pr_id": pr_id, "gate": gate}
+
+
+def _dirs(tmp_path: Path) -> tuple[Path, Path]:
+    results = tmp_path / "results"
+    requests = tmp_path / "requests"
+    results.mkdir()
+    requests.mkdir()
+    return results, requests
+
+
+# ---------------------------------------------------------------------------
+# Guard: pr_number is falsy
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckGuards:
+
+    def test_none_pr_number_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=None,
+            request_payload=_payload(),
+            results_dir=results,
+            requests_dir=requests,
+        )
+        assert result is None
+
+    def test_zero_pr_number_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=0,
+            request_payload=_payload(pr_number=0),
+            results_dir=results,
+            requests_dir=requests,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation: diff fetch fails
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckDegradation:
+
+    def test_value_error_from_fetch_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=ValueError("no pr_number")
+        ):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    def test_runtime_error_from_fetch_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=RuntimeError("gh pr diff failed")
+        ):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    def test_no_files_written_on_degradation(self, tmp_path):
+        """Graceful degradation must not write any files."""
+        results, requests = _dirs(tmp_path)
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=RuntimeError("gh fail")
+        ):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert list(results.iterdir()) == []
+        assert list(requests.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Below threshold — must NOT block
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckBelowThreshold:
+
+    def test_zero_deletions_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = "diff --git a/src/main.py b/src/main.py\n--- a/src/main.py\n+++ b/src/main.py\n"
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    def test_one_below_threshold_returns_none(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD - 1
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    def test_no_files_written_below_threshold(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD - 1
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert list(results.iterdir()) == []
+        assert list(requests.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# At/above threshold — HOLD triggered
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckHoldTriggered:
+
+    def test_exactly_at_threshold_returns_result(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is not None
+
+    def test_above_threshold_returns_result(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD + 5
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is not None
+
+    def test_result_status_is_fail(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["status"] == "fail"
+
+    def test_finding_severity_is_blocking(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert len(result["findings"]) == 1
+        assert result["findings"][0]["severity"] == "blocking"
+
+    def test_blocking_findings_mirrors_findings(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["blocking_findings"] == result["findings"]
+        assert result["advisory_findings"] == []
+
+    def test_net_deletion_check_metadata_present(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        ndc = result["net_deletion_check"]
+        assert ndc["triggered"] is True
+        assert ndc["deleted_count"] == count
+        assert ndc["threshold"] == _GATE_DELETION_FILE_HOLD
+        assert len(ndc["deleted_files"]) == count
+
+    def test_summary_contains_deleted_count(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD + 3
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert str(count) in result["summary"]
+
+    def test_finding_description_lists_deleted_files(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        paths = [f"old/module_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _diff_deleted(*paths)
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        description = result["findings"][0]["description"]
+        for p in paths:
+            assert f"`{p}`" in description
+
+    def test_duration_seconds_is_zero(self, tmp_path):
+        """Pre-AI deterministic check has no real duration."""
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["duration_seconds"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Filesystem persistence
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckPersistence:
+
+    def test_result_file_written_to_results_dir(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(pr_number=42),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        result_files = list(results.iterdir())
+        assert len(result_files) == 1
+
+    def test_result_file_is_valid_json(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(pr_number=42),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        for f in results.iterdir():
+            content = json.loads(f.read_text())
+            assert content["status"] == "fail"
+
+    def test_request_file_written_to_requests_dir(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(pr_number=42),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        request_files = list(requests.iterdir())
+        assert len(request_files) == 1
+
+    def test_request_payload_status_set_to_completed(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        payload = _payload(pr_number=42)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=payload,
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert payload["status"] == "completed"
+        assert "completed_at" in payload
+
+
+# ---------------------------------------------------------------------------
+# pr_id sourcing
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckPrId:
+
+    def test_pr_id_from_payload_used_in_result(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(pr_number=42, pr_id="PR-99"),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["pr_id"] == "PR-99"
+
+    def test_pr_id_falls_back_to_str_pr_number(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(pr_number=42, pr_id=""),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["pr_id"] == "42"
+
+    def test_pr_number_preserved_in_result(self, tmp_path):
+        results, requests = _dirs(tmp_path)
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch.object(GateRunner, "_fetch_gh_pr_diff", return_value=diff):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=99,
+                request_payload=_payload(pr_number=99),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["pr_number"] == 99

--- a/tests/test_gate_runner_codex_net_deletion_check.py
+++ b/tests/test_gate_runner_codex_net_deletion_check.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Unit tests for GateRunner._run_codex_net_deletion_check.
+
+Covers the pre-emptive deterministic check that blocks codex_gate when a PR
+deletes >= _GATE_DELETION_FILE_HOLD files, without spawning the AI reviewer.
+
+Test classes:
+  - TestRunCodexNetDeletionCheckNoTrigger: returns None (AI gate proceeds)
+  - TestRunCodexNetDeletionCheckTriggered: returns blocking result dict
+  - TestRunCodexNetDeletionCheckResultShape: validates result structure
+  - TestRunCodexNetDeletionCheckPersistence: verifies disk write + request completion
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_runner import GateRunner, _GATE_DELETION_FILE_HOLD, _GATE_DELETION_FILE_WARN  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _diff_deleted(*paths: str) -> str:
+    """Build a minimal unified diff that marks each path as a deleted file."""
+    lines = []
+    for p in paths:
+        lines += [
+            f"diff --git a/{p} b/{p}",
+            "deleted file mode 100644",
+            "index abc123..0000000",
+            f"--- a/{p}",
+            "+++ /dev/null",
+            "@@ -1,1 +0,0 @@",
+            "-content",
+        ]
+    return "\n".join(lines)
+
+
+def _mock_gh_success(diff_text: str) -> mock.Mock:
+    return mock.Mock(returncode=0, stdout=diff_text, stderr="")
+
+
+def _payload(pr_number=42, pr_id="PR-001", gate="codex_gate"):
+    return {"pr_number": pr_number, "pr_id": pr_id, "gate": gate}
+
+
+# ---------------------------------------------------------------------------
+# Returns None (AI gate proceeds)
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckNoTrigger:
+    """_run_codex_net_deletion_check must return None when it should not block."""
+
+    def test_returns_none_when_pr_number_is_none(self, tmp_path):
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=None,
+            request_payload=_payload(pr_number=None),
+            results_dir=results_dir,
+            requests_dir=requests_dir,
+        )
+        assert result is None
+
+    def test_returns_none_when_pr_number_is_zero(self, tmp_path):
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=0,
+            request_payload=_payload(pr_number=0),
+            results_dir=results_dir,
+            requests_dir=requests_dir,
+        )
+        assert result is None
+
+    def test_returns_none_when_diff_fetch_raises_value_error(self, tmp_path):
+        """ValueError from _fetch_gh_pr_diff → graceful degradation (None)."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=ValueError("no pr_number"),
+        ):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert result is None
+
+    def test_returns_none_when_diff_fetch_raises_runtime_error(self, tmp_path):
+        """RuntimeError from gh pr diff → graceful degradation (None)."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=RuntimeError("gh pr diff failed"),
+        ):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert result is None
+
+    def test_returns_none_when_deleted_count_below_hold(self, tmp_path):
+        """< _GATE_DELETION_FILE_HOLD deletions → None (let AI gate run)."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        count = _GATE_DELETION_FILE_HOLD - 1
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert result is None
+
+    def test_returns_none_when_no_deletions(self, tmp_path):
+        """Empty diff (no deletions) → None."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success("")):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert result is None
+
+    def test_returns_none_at_warn_level_not_hold(self, tmp_path):
+        """WARN level (< HOLD) must still return None — only HOLD triggers block."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        count = _GATE_DELETION_FILE_WARN + 1  # above WARN, below HOLD
+        assert count < _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Returns blocking result (HOLD triggered)
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckTriggered:
+    """_run_codex_net_deletion_check returns a non-None blocking result at HOLD threshold."""
+
+    def _run_at_hold(self, tmp_path, count=None):
+        if count is None:
+            count = _GATE_DELETION_FILE_HOLD
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        diff = _diff_deleted(*[f"old/file_{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            return GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+    def test_returns_non_none_at_hold_threshold(self, tmp_path):
+        result = self._run_at_hold(tmp_path, count=_GATE_DELETION_FILE_HOLD)
+        assert result is not None
+
+    def test_returns_non_none_above_hold_threshold(self, tmp_path):
+        result = self._run_at_hold(tmp_path, count=_GATE_DELETION_FILE_HOLD + 5)
+        assert result is not None
+
+    def test_status_is_fail(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["status"] == "fail"
+
+    def test_findings_non_empty(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert len(result["findings"]) > 0
+
+    def test_blocking_findings_non_empty(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert len(result["blocking_findings"]) > 0
+
+    def test_finding_severity_is_blocking(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["findings"][0]["severity"] == "blocking"
+
+    def test_summary_mentions_deleted_count(self, tmp_path):
+        count = _GATE_DELETION_FILE_HOLD + 3
+        result = self._run_at_hold(tmp_path, count=count)
+        assert str(count) in result["summary"]
+
+    def test_net_deletion_check_field_present(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert "net_deletion_check" in result
+
+    def test_net_deletion_check_triggered_true(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["net_deletion_check"]["triggered"] is True
+
+    def test_net_deletion_check_threshold_matches_constant(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["net_deletion_check"]["threshold"] == _GATE_DELETION_FILE_HOLD
+
+    def test_net_deletion_check_count_matches_diff(self, tmp_path):
+        count = _GATE_DELETION_FILE_HOLD + 7
+        result = self._run_at_hold(tmp_path, count=count)
+        assert result["net_deletion_check"]["deleted_count"] == count
+
+    def test_deleted_files_listed_in_net_deletion_check(self, tmp_path):
+        count = _GATE_DELETION_FILE_HOLD
+        result = self._run_at_hold(tmp_path, count=count)
+        assert len(result["net_deletion_check"]["deleted_files"]) == count
+
+    def test_description_lists_deleted_files(self, tmp_path):
+        result = self._run_at_hold(tmp_path, count=_GATE_DELETION_FILE_HOLD)
+        description = result["findings"][0]["description"]
+        # At least one deleted file path must appear
+        assert "old/file_0.py" in description
+
+    def test_advisory_findings_empty(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["advisory_findings"] == []
+
+    def test_required_reruns_empty(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["required_reruns"] == []
+
+    def test_finding_out_of_scope_false(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["findings"][0]["out_of_scope"] is False
+
+    def test_finding_introduced_by_prior_fix_false(self, tmp_path):
+        result = self._run_at_hold(tmp_path)
+        assert result["findings"][0]["introduced_by_prior_fix"] is False
+
+
+# ---------------------------------------------------------------------------
+# Result shape (required keys)
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckResultShape:
+    """Triggered result must carry all required downstream keys."""
+
+    REQUIRED_KEYS = (
+        "gate", "pr_id", "pr_number", "status", "summary",
+        "findings", "blocking_findings", "advisory_findings",
+        "required_reruns", "residual_risk", "duration_seconds",
+        "recorded_at", "net_deletion_check",
+    )
+
+    def _triggered_result(self, tmp_path) -> dict:
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        diff = _diff_deleted(*[f"old/f_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            return GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+
+    def test_all_required_keys_present(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        for key in self.REQUIRED_KEYS:
+            assert key in result, f"missing key: {key}"
+
+    def test_pr_number_preserved(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        assert result["pr_number"] == 42
+
+    def test_pr_id_from_payload(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        assert result["pr_id"] == "PR-001"
+
+    def test_gate_from_payload(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        assert result["gate"] == "codex_gate"
+
+    def test_duration_seconds_is_zero(self, tmp_path):
+        """Pre-emptive check skips subprocess → duration is 0.0."""
+        result = self._triggered_result(tmp_path)
+        assert result["duration_seconds"] == 0.0
+
+    def test_recorded_at_is_iso_string(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        ts = result["recorded_at"]
+        assert isinstance(ts, str)
+        assert "T" in ts  # basic ISO-8601 shape check
+
+    def test_net_deletion_check_has_required_fields(self, tmp_path):
+        result = self._triggered_result(tmp_path)
+        ndc = result["net_deletion_check"]
+        for field in ("deleted_count", "deleted_files", "threshold", "triggered"):
+            assert field in ndc, f"net_deletion_check missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# Disk persistence
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheckPersistence:
+    """Triggered check must persist result file and mark request as completed."""
+
+    def _run(self, tmp_path, pr_number=42, pr_id="PR-001", count=None):
+        if count is None:
+            count = _GATE_DELETION_FILE_HOLD
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        diff = _diff_deleted(*[f"old/f_{i}.py" for i in range(count)])
+        payload = _payload(pr_number=pr_number, pr_id=pr_id)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=pr_number,
+                request_payload=payload,
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        return result, payload, results_dir, requests_dir
+
+    def test_result_file_written_to_disk(self, tmp_path):
+        _, _, results_dir, _ = self._run(tmp_path)
+        # At least one file should exist in results_dir
+        result_files = list(results_dir.iterdir())
+        assert len(result_files) > 0, "no result file written to results_dir"
+
+    def test_result_file_is_valid_json(self, tmp_path):
+        _, _, results_dir, _ = self._run(tmp_path)
+        result_files = list(results_dir.iterdir())
+        for f in result_files:
+            parsed = json.loads(f.read_text(encoding="utf-8"))
+            assert "status" in parsed
+
+    def test_result_file_status_is_fail(self, tmp_path):
+        _, _, results_dir, _ = self._run(tmp_path)
+        result_files = list(results_dir.iterdir())
+        parsed = json.loads(result_files[0].read_text(encoding="utf-8"))
+        assert parsed["status"] == "fail"
+
+    def test_request_file_written_to_disk(self, tmp_path):
+        _, payload, _, requests_dir = self._run(tmp_path)
+        request_files = list(requests_dir.iterdir())
+        assert len(request_files) > 0, "no request file written to requests_dir"
+
+    def test_request_file_status_is_completed(self, tmp_path):
+        _, _, _, requests_dir = self._run(tmp_path)
+        request_files = list(requests_dir.iterdir())
+        parsed = json.loads(request_files[0].read_text(encoding="utf-8"))
+        assert parsed["status"] == "completed"
+
+    def test_request_file_has_completed_at(self, tmp_path):
+        _, _, _, requests_dir = self._run(tmp_path)
+        request_files = list(requests_dir.iterdir())
+        parsed = json.loads(request_files[0].read_text(encoding="utf-8"))
+        assert "completed_at" in parsed
+
+    def test_no_file_written_when_below_threshold(self, tmp_path):
+        """Below HOLD threshold: no files written, no side effects."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        count = _GATE_DELETION_FILE_HOLD - 1
+        diff = _diff_deleted(*[f"old/f_{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert list(results_dir.iterdir()) == []
+        assert list(requests_dir.iterdir()) == []
+
+    def test_no_file_written_when_pr_number_none(self, tmp_path):
+        """None pr_number: no files written."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        GateRunner._run_codex_net_deletion_check(
+            pr_number=None,
+            request_payload=_payload(pr_number=None),
+            results_dir=results_dir,
+            requests_dir=requests_dir,
+        )
+        assert list(results_dir.iterdir()) == []
+        assert list(requests_dir.iterdir()) == []
+
+    def test_no_file_written_when_diff_fails(self, tmp_path):
+        """Diff fetch failure: no files written, graceful degradation."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True)
+        requests_dir.mkdir(parents=True)
+        with mock.patch.object(
+            GateRunner, "_fetch_gh_pr_diff", side_effect=RuntimeError("gh failed"),
+        ):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=_payload(),
+                results_dir=results_dir,
+                requests_dir=requests_dir,
+            )
+        assert list(results_dir.iterdir()) == []
+        assert list(requests_dir.iterdir()) == []

--- a/tests/test_gate_runner_net_deletion.py
+++ b/tests/test_gate_runner_net_deletion.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Unit tests for GateRunner net-deletion sanity checks.
+
+Covers the three new static helpers added in gate_runner.py:
+  - _extract_deleted_files_from_diff
+  - _build_deletion_alert_section
+  - Alert injection in _build_codex_prompt and _build_gemini_prompt
+
+Threshold constant: _GATE_DELETION_FILE_WARN = 5
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_runner import GateRunner, _GATE_DELETION_FILE_WARN  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _diff_deleted(*paths: str) -> str:
+    """Build a minimal unified diff that marks each path as a deleted file."""
+    lines = []
+    for p in paths:
+        lines += [
+            f"diff --git a/{p} b/{p}",
+            "deleted file mode 100644",
+            "index abc123..0000000",
+            f"--- a/{p}",
+            "+++ /dev/null",
+            "@@ -1,3 +0,0 @@",
+            "-content",
+        ]
+    return "\n".join(lines)
+
+
+def _diff_modified(path: str) -> str:
+    """Build a minimal unified diff for a modified (not deleted) file."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "index abc123..def456 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+
+def _mock_gh_success(diff_text: str) -> mock.Mock:
+    return mock.Mock(returncode=0, stdout=diff_text, stderr="")
+
+
+# ---------------------------------------------------------------------------
+# _extract_deleted_files_from_diff
+# ---------------------------------------------------------------------------
+
+class TestExtractDeletedFilesFromDiff:
+
+    def test_empty_diff_returns_empty_list(self):
+        assert GateRunner._extract_deleted_files_from_diff("") == []
+
+    def test_single_deleted_file_returned(self):
+        diff = _diff_deleted("scripts/old.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == ["scripts/old.py"]
+
+    def test_multiple_deleted_files_all_returned(self):
+        paths = [f"old/file_{i}.py" for i in range(6)]
+        diff = _diff_deleted(*paths)
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == paths
+
+    def test_modified_file_not_included(self):
+        diff = _diff_modified("scripts/active.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == []
+
+    def test_mixed_deleted_and_modified(self):
+        diff = _diff_deleted("old/remove_me.py") + "\n" + _diff_modified("src/keep.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == ["old/remove_me.py"]
+
+    def test_deleted_file_mode_without_preceding_diff_header_ignored(self):
+        """A stray 'deleted file mode' line with no preceding diff --git is ignored."""
+        diff = "deleted file mode 100644\nsome other content\n"
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == []
+
+    def test_diff_header_with_no_b_prefix_ignored(self):
+        """Malformed diff --git line without b/ prefix is skipped gracefully."""
+        diff = "diff --git a/foo.py\ndeleted file mode 100644\n"
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == []
+
+    def test_preserves_nested_paths(self):
+        diff = _diff_deleted("scripts/lib/deep/module.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == ["scripts/lib/deep/module.py"]
+
+
+# ---------------------------------------------------------------------------
+# _build_deletion_alert_section
+# ---------------------------------------------------------------------------
+
+class TestBuildDeletionAlertSection:
+
+    def test_below_threshold_returns_empty_string(self):
+        """Fewer than _GATE_DELETION_FILE_WARN deletions → no alert."""
+        count = _GATE_DELETION_FILE_WARN - 1
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert result == ""
+
+    def test_at_threshold_returns_alert(self):
+        """Exactly _GATE_DELETION_FILE_WARN deletions → alert injected."""
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert result != ""
+        assert "## Net-Deletion Alert" in result
+
+    def test_above_threshold_returns_alert(self):
+        """More than _GATE_DELETION_FILE_WARN deletions → alert injected."""
+        count = _GATE_DELETION_FILE_WARN + 3
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert "## Net-Deletion Alert" in result
+
+    def test_alert_includes_file_count(self):
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert str(count) in result
+
+    def test_alert_lists_each_deleted_path(self):
+        paths = [f"old/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _diff_deleted(*paths)
+        result = GateRunner._build_deletion_alert_section(diff)
+        for p in paths:
+            assert f"`{p}`" in result
+
+    def test_alert_contains_review_required_note(self):
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert "Review required" in result
+
+    def test_no_deletions_returns_empty_string(self):
+        diff = _diff_modified("src/main.py")
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert result == ""
+
+    def test_zero_files_empty_diff_returns_empty_string(self):
+        assert GateRunner._build_deletion_alert_section("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_codex_prompt: alert injection
+# ---------------------------------------------------------------------------
+
+class TestCodexPromptDeletionAlertInjection:
+
+    def _payload(self, pr_number=42, branch="feat/test", risk_class="medium"):
+        return {"pr_number": pr_number, "branch": branch, "risk_class": risk_class}
+
+    def test_alert_absent_when_below_threshold(self):
+        """< _GATE_DELETION_FILE_WARN deletions → no alert in codex prompt."""
+        count = _GATE_DELETION_FILE_WARN - 1
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_codex_prompt(self._payload())
+        assert "## Net-Deletion Alert" not in result
+
+    def test_alert_present_at_threshold(self):
+        """= _GATE_DELETION_FILE_WARN deletions → alert injected in codex prompt."""
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_codex_prompt(self._payload())
+        assert "## Net-Deletion Alert" in result
+
+    def test_alert_present_above_threshold(self):
+        """>> _GATE_DELETION_FILE_WARN deletions → alert injected in codex prompt."""
+        count = _GATE_DELETION_FILE_WARN + 10
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_codex_prompt(self._payload())
+        assert "## Net-Deletion Alert" in result
+
+    def test_alert_lists_deleted_paths_in_codex_prompt(self):
+        """Deleted file paths appear verbatim inside the codex prompt."""
+        paths = [f"old/module_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _diff_deleted(*paths)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_codex_prompt(self._payload())
+        for p in paths:
+            assert f"`{p}`" in result
+
+    def test_verdict_template_still_present_with_alert(self):
+        """Verdict JSON template must not be displaced by the deletion alert."""
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_codex_prompt(self._payload())
+        assert '"verdict"' in result
+        assert '"findings"' in result
+
+
+# ---------------------------------------------------------------------------
+# _build_gemini_prompt: alert injection mirrors codex behaviour
+# ---------------------------------------------------------------------------
+
+class TestGeminiPromptDeletionAlertInjection:
+
+    def _payload(self, pr_number=42, branch="feat/test", risk_class="medium"):
+        return {"pr_number": pr_number, "branch": branch, "risk_class": risk_class}
+
+    def test_alert_absent_when_below_threshold(self):
+        count = _GATE_DELETION_FILE_WARN - 1
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_gemini_prompt(self._payload())
+        assert "## Net-Deletion Alert" not in result
+
+    def test_alert_present_at_threshold(self):
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_gemini_prompt(self._payload())
+        assert "## Net-Deletion Alert" in result
+
+    def test_alert_present_above_threshold(self):
+        count = _GATE_DELETION_FILE_WARN + 7
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_gemini_prompt(self._payload())
+        assert "## Net-Deletion Alert" in result
+
+    def test_verdict_template_still_present_with_alert(self):
+        count = _GATE_DELETION_FILE_WARN
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._build_gemini_prompt(self._payload())
+        assert '"verdict"' in result
+        assert '"findings"' in result
+
+    def test_gemini_alert_count_matches_codex_alert_count(self):
+        """Gemini and codex paths must produce the same alert when diff is identical."""
+        count = _GATE_DELETION_FILE_WARN + 2
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            gemini_result = GateRunner._build_gemini_prompt(self._payload())
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            codex_result = GateRunner._build_codex_prompt(self._payload())
+        # Both must contain the same file count in the heading
+        heading = f"## Net-Deletion Alert ({count} file(s) deleted)"
+        assert heading in gemini_result
+        assert heading in codex_result

--- a/tests/test_gate_runner_net_deletion.py
+++ b/tests/test_gate_runner_net_deletion.py
@@ -22,7 +22,10 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
-from gate_runner import GateRunner, _GATE_DELETION_FILE_WARN  # noqa: E402
+import json
+import tempfile
+
+from gate_runner import GateRunner, _GATE_DELETION_FILE_WARN, _GATE_DELETION_FILE_HOLD  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -268,3 +271,166 @@ class TestGeminiPromptDeletionAlertInjection:
         heading = f"## Net-Deletion Alert ({count} file(s) deleted)"
         assert heading in gemini_result
         assert heading in codex_result
+
+
+# ---------------------------------------------------------------------------
+# _run_codex_net_deletion_check: deterministic blocking gate (HOLD threshold)
+# ---------------------------------------------------------------------------
+
+class TestRunCodexNetDeletionCheck:
+    """Tests for the pre-AI HOLD check that short-circuits when >= _GATE_DELETION_FILE_HOLD
+    files are deleted.  Uses tmp dirs to verify filesystem side effects."""
+
+    def _dirs(self, tmp_path: Path) -> tuple:
+        results = tmp_path / "results"
+        requests = tmp_path / "requests"
+        results.mkdir()
+        requests.mkdir()
+        return results, requests
+
+    def _payload(self, pr_number=42, pr_id=""):
+        return {"gate": "codex_gate", "pr_id": pr_id, "pr_number": pr_number}
+
+    # --- no-op / passthrough cases ---
+
+    def test_none_pr_number_returns_none(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        result = GateRunner._run_codex_net_deletion_check(
+            pr_number=None,
+            request_payload=self._payload(pr_number=None),
+            results_dir=results,
+            requests_dir=requests,
+        )
+        assert result is None
+
+    def test_below_hold_threshold_returns_none(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD - 1
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    def test_gh_pr_diff_failure_degrades_gracefully(self, tmp_path):
+        """RuntimeError from gh pr diff → None, AI gate proceeds."""
+        results, requests = self._dirs(tmp_path)
+        failing = mock.Mock(returncode=1, stdout="", stderr="authentication required")
+        with mock.patch("gate_runner.subprocess.run", return_value=failing):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is None
+
+    # --- HOLD triggers ---
+
+    def test_at_hold_threshold_returns_fail_result(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result is not None
+        assert result["status"] == "fail"
+
+    def test_above_hold_threshold_returns_fail_result(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD + 5
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["status"] == "fail"
+        assert result["net_deletion_check"]["triggered"] is True
+        assert result["net_deletion_check"]["deleted_count"] == count
+
+    def test_result_contains_blocking_finding(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert len(result["blocking_findings"]) == 1
+        assert result["blocking_findings"][0]["severity"] == "blocking"
+
+    def test_result_lists_all_deleted_paths(self, tmp_path):
+        results, requests = self._dirs(tmp_path)
+        paths = [f"old/module_{i}.py" for i in range(_GATE_DELETION_FILE_HOLD)]
+        diff = _diff_deleted(*paths)
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        check = result["net_deletion_check"]
+        assert check["deleted_files"] == paths
+
+    def test_result_file_written_to_disk(self, tmp_path):
+        """HOLD result is persisted to results_dir as JSON."""
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(pr_number=42),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        written = list(results.iterdir())
+        assert len(written) == 1
+        data = json.loads(written[0].read_text())
+        assert data["status"] == "fail"
+
+    def test_request_payload_status_set_to_completed(self, tmp_path):
+        """After HOLD, request_payload['status'] is mutated to 'completed'."""
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        payload = self._payload()
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=payload,
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert payload["status"] == "completed"
+        assert "completed_at" in payload
+
+    def test_threshold_value_reflected_in_result(self, tmp_path):
+        """net_deletion_check.threshold must equal _GATE_DELETION_FILE_HOLD."""
+        results, requests = self._dirs(tmp_path)
+        count = _GATE_DELETION_FILE_HOLD
+        diff = _diff_deleted(*[f"old/f{i}.py" for i in range(count)])
+        with mock.patch("gate_runner.subprocess.run", return_value=_mock_gh_success(diff)):
+            result = GateRunner._run_codex_net_deletion_check(
+                pr_number=42,
+                request_payload=self._payload(),
+                results_dir=results,
+                requests_dir=requests,
+            )
+        assert result["net_deletion_check"]["threshold"] == _GATE_DELETION_FILE_HOLD

--- a/tests/test_gate_runner_reviewer_prompt.py
+++ b/tests/test_gate_runner_reviewer_prompt.py
@@ -229,3 +229,189 @@ class TestFetchGhPrDiff:
             ["gh", "pr", "diff", "42"],
             capture_output=True, text=True, timeout=60,
         )
+
+
+# ---------------------------------------------------------------------------
+# Net-deletion sanity check
+# ---------------------------------------------------------------------------
+
+def _make_deleted_file_diff(*paths: str) -> str:
+    """Build a minimal unified diff with fully deleted files at the given paths."""
+    parts = []
+    for path in paths:
+        parts.append(
+            f"diff --git a/{path} b/{path}\n"
+            f"deleted file mode 100644\n"
+            f"index abc1234..0000000\n"
+            f"--- a/{path}\n"
+            "+++ /dev/null\n"
+            "@@ -1,2 +0,0 @@\n"
+            "-# deleted content\n"
+        )
+    return "\n".join(parts)
+
+
+def _make_modified_file_diff(path: str = "scripts/foo.py") -> str:
+    """Build a minimal unified diff for a modified (not deleted) file."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 111aaa..222bbb 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1,2 +1,3 @@\n"
+        " def existing(): pass\n"
+        "+def new_func(): pass\n"
+    )
+
+
+class TestExtractDeletedFilesFromDiff:
+    """Unit tests for _extract_deleted_files_from_diff."""
+
+    def test_empty_diff_returns_empty_list(self):
+        assert GateRunner._extract_deleted_files_from_diff("") == []
+
+    def test_modified_file_not_included(self):
+        diff = _make_modified_file_diff("scripts/active.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == []
+
+    def test_single_deleted_file_returned(self):
+        diff = _make_deleted_file_diff("scripts/old_module.py")
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == ["scripts/old_module.py"]
+
+    def test_multiple_deleted_files_all_returned(self):
+        paths = [f"scripts/module_{i}.py" for i in range(3)]
+        diff = _make_deleted_file_diff(*paths)
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert result == paths
+
+    def test_mixed_diff_only_deleted_returned(self):
+        """Modified files in the same diff must not appear in the deleted-file list."""
+        deleted_diff = _make_deleted_file_diff("scripts/gone.py")
+        modified_diff = _make_modified_file_diff("scripts/still_here.py")
+        combined = deleted_diff + "\n" + modified_diff
+        result = GateRunner._extract_deleted_files_from_diff(combined)
+        assert "scripts/gone.py" in result
+        assert "scripts/still_here.py" not in result
+
+    def test_paths_without_b_prefix_are_skipped_gracefully(self):
+        """Malformed diff headers (no b/ prefix) must not raise."""
+        diff = "diff --git a/scripts/foo.py scripts/foo.py\ndeleted file mode 100644\n"
+        result = GateRunner._extract_deleted_files_from_diff(diff)
+        assert isinstance(result, list)
+
+
+class TestBuildDeletionAlertSection:
+    """Unit tests for _build_deletion_alert_section."""
+
+    def test_below_threshold_returns_empty_string(self):
+        """Fewer than _GATE_DELETION_FILE_WARN deletions → no alert."""
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN - 1)]
+        diff = _make_deleted_file_diff(*paths) if paths else ""
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert result == ""
+
+    def test_at_threshold_returns_alert_block(self):
+        """Exactly _GATE_DELETION_FILE_WARN deletions triggers the alert."""
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert "Net-Deletion Alert" in result
+
+    def test_above_threshold_includes_count(self):
+        """Count in alert header must match actual deleted-file count."""
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        count = _GATE_DELETION_FILE_WARN + 3
+        paths = [f"scripts/file_{i}.py" for i in range(count)]
+        diff = _make_deleted_file_diff(*paths)
+        result = GateRunner._build_deletion_alert_section(diff)
+        assert f"{count} file(s) deleted" in result
+
+    def test_alert_lists_deleted_file_paths(self):
+        """Alert block must include every deleted file path."""
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/important_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        result = GateRunner._build_deletion_alert_section(diff)
+        for path in paths:
+            assert path in result
+
+    def test_no_alert_for_empty_diff(self):
+        assert GateRunner._build_deletion_alert_section("") == ""
+
+
+class TestNetDeletionAlertInCodexPrompt:
+    """_build_codex_prompt must inject the deletion alert when threshold is met."""
+
+    def test_no_alert_below_threshold(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN - 1)]
+        diff = _make_deleted_file_diff(*paths) if paths else _make_modified_file_diff()
+        payload = _make_payload(pr_number=10)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_codex_prompt(payload)
+        assert "Net-Deletion Alert" not in result
+
+    def test_alert_injected_at_threshold(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        payload = _make_payload(pr_number=11)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_codex_prompt(payload)
+        assert "Net-Deletion Alert" in result
+
+    def test_alert_includes_deleted_file_names(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/module_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        payload = _make_payload(pr_number=12)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_codex_prompt(payload)
+        for path in paths:
+            assert path in result
+
+    def test_verdict_template_still_present_with_alert(self):
+        """Verdict template must appear even when the deletion alert is injected."""
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        payload = _make_payload(pr_number=13)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_codex_prompt(payload)
+        assert '"verdict"' in result
+        assert '"findings"' in result
+
+
+class TestNetDeletionAlertInGeminiPrompt:
+    """_build_gemini_prompt must mirror the deletion alert behaviour of the codex path."""
+
+    def test_no_alert_below_threshold(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        diff = _make_modified_file_diff()
+        payload = _make_payload(pr_number=20)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_gemini_prompt(payload)
+        assert "Net-Deletion Alert" not in result
+
+    def test_alert_injected_at_threshold(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/file_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        payload = _make_payload(pr_number=21)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_gemini_prompt(payload)
+        assert "Net-Deletion Alert" in result
+
+    def test_alert_includes_deleted_file_names(self):
+        from gate_runner import _GATE_DELETION_FILE_WARN
+        paths = [f"scripts/removed_{i}.py" for i in range(_GATE_DELETION_FILE_WARN)]
+        diff = _make_deleted_file_diff(*paths)
+        payload = _make_payload(pr_number=22)
+        with mock.patch("gate_runner.subprocess.run", return_value=mock.Mock(returncode=0, stdout=diff, stderr="")):
+            result = GateRunner._build_gemini_prompt(payload)
+        for path in paths:
+            assert path in result

--- a/tests/test_subprocess_cheap_lane.py
+++ b/tests/test_subprocess_cheap_lane.py
@@ -3,25 +3,34 @@
 
 Proves that when routing_policy decides a non-Claude (cheap) lane:
   1. _select_dispatch_path returns (lane, current_model) — NOT (None, claude_fallback).
-  2. The caller (provider_dispatch) is expected to execute the non-Claude provider.
+  2. _build_cheap_lane_argv constructs correct provider_dispatch argv.
+  3. _execute_cheap_lane_dispatch calls provider_dispatch.main() and NEVER
+     calls deliver_with_recovery (the Claude path).
 
 The critical regression: the OLD code fell back to the first Claude model in
 fallback_chain when the lane was non-Claude.  These tests assert that behaviour
-is GONE: cheap_lane_provider is the non-Claude lane string, not None.
+is GONE: cheap_lane_provider is the non-Claude lane string, not None, and
+the actual dispatch delegates to provider_dispatch — not Claude.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
 sys.path.insert(0, str(SCRIPTS_LIB))
 
-from subprocess_dispatch import _select_dispatch_path
+from subprocess_dispatch import (
+    _ROLE_FALLBACK,
+    _build_cheap_lane_argv,
+    _execute_cheap_lane_dispatch,
+    _select_dispatch_path,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -348,3 +357,285 @@ class TestSelectDispatchPathProductionPolicy:
         )
         assert cheap is None
         assert model == "sonnet"  # default_lane mapped to sonnet
+
+
+# ---------------------------------------------------------------------------
+# _build_cheap_lane_argv — argv construction for provider_dispatch delegation
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    """Return a minimal Namespace suitable for _build_cheap_lane_argv / _execute_cheap_lane_dispatch."""
+    defaults: dict = dict(
+        terminal_id="T1",
+        instruction="do the thing",
+        model="sonnet",
+        dispatch_id="d-test-001",
+        role="backend-developer",
+        max_retries=3,
+        gate="g42",
+        no_auto_commit=False,
+        dispatch_paths="",
+        pr_id=None,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestBuildCheapLaneArgv:
+    """_build_cheap_lane_argv constructs the correct provider_dispatch argv."""
+
+    def test_first_two_args_are_provider_and_lane(self):
+        """--provider must be argv[0] so provider_dispatch parse() sees it first."""
+        lane = "litellm:moonshot:kimi-k2-0905-default"
+        argv = _build_cheap_lane_argv(_make_args(), lane)
+        assert argv[0] == "--provider"
+        assert argv[1] == lane
+
+    def test_required_fields_present(self):
+        lane = "litellm:moonshot:kimi-k2-0905-default"
+        argv = _build_cheap_lane_argv(_make_args(), lane)
+        for flag, value in (
+            ("--provider", lane),
+            ("--terminal-id", "T1"),
+            ("--dispatch-id", "d-test-001"),
+            ("--model", "sonnet"),
+            ("--role", "backend-developer"),
+            ("--max-retries", "3"),
+            ("--gate", "g42"),
+        ):
+            assert flag in argv, f"flag {flag!r} missing"
+            idx = argv.index(flag)
+            assert argv[idx + 1] == value, f"{flag} value mismatch: expected {value!r}, got {argv[idx+1]!r}"
+
+    def test_no_auto_commit_appended_when_true(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(no_auto_commit=True),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--no-auto-commit" in argv
+
+    def test_no_auto_commit_absent_when_false(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(no_auto_commit=False),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--no-auto-commit" not in argv
+
+    def test_dispatch_paths_forwarded(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(dispatch_paths="scripts/,tests/"),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--dispatch-paths" in argv
+        idx = argv.index("--dispatch-paths")
+        assert argv[idx + 1] == "scripts/,tests/"
+
+    def test_dispatch_paths_absent_when_empty(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(dispatch_paths=""),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--dispatch-paths" not in argv
+
+    def test_pr_id_forwarded_when_set(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(pr_id="PR-644"),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--pr-id" in argv
+        idx = argv.index("--pr-id")
+        assert argv[idx + 1] == "PR-644"
+
+    def test_pr_id_absent_when_none(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(pr_id=None),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        assert "--pr-id" not in argv
+
+    def test_role_fallback_when_role_is_none(self):
+        argv = _build_cheap_lane_argv(
+            _make_args(role=None),
+            "litellm:deepseek:deepseek-v4-pro",
+        )
+        idx = argv.index("--role")
+        assert argv[idx + 1] == _ROLE_FALLBACK
+
+    def test_instruction_forwarded_verbatim(self):
+        instruction = "refactor the payment module\nwith multi-line content"
+        argv = _build_cheap_lane_argv(
+            _make_args(instruction=instruction),
+            "litellm:moonshot:kimi-k2-0905-default",
+        )
+        idx = argv.index("--instruction")
+        assert argv[idx + 1] == instruction
+
+    def test_lane_string_is_forwarded_as_provider_value(self):
+        """The full lane string (litellm:sub:model) is passed verbatim to --provider."""
+        for lane in (
+            "litellm:moonshot:kimi-k2-0905-default",
+            "litellm:deepseek:deepseek-v4-pro",
+            "litellm:zai:glm-5.1-default",
+            "kimi",
+        ):
+            argv = _build_cheap_lane_argv(_make_args(), lane)
+            assert argv[1] == lane, f"lane {lane!r} not forwarded verbatim"
+
+
+# ---------------------------------------------------------------------------
+# _execute_cheap_lane_dispatch — THE critical regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteCheapLaneDispatch:
+    """Proves that delegation to provider_dispatch.main() is correct and that
+    deliver_with_recovery (the Claude path) is NEVER invoked on a cheap lane.
+
+    Regression scenario: old __main__ block fell through to deliver_with_recovery
+    after logging the cheap lane, silently routing via Claude instead of the
+    intended provider.  These tests assert that regression is eliminated.
+    """
+
+    def test_provider_dispatch_main_called(self):
+        """_execute_cheap_lane_dispatch calls provider_dispatch.main()."""
+        import provider_dispatch as pd_mod
+
+        received_argv: list[list[str]] = []
+
+        def mock_pd_main(argv: list[str]) -> int:
+            received_argv.append(list(argv))
+            return 0
+
+        with patch.object(pd_mod, "main", mock_pd_main):
+            rc = _execute_cheap_lane_dispatch(
+                _make_args(),
+                "litellm:moonshot:kimi-k2-0905-default",
+            )
+
+        assert rc == 0
+        assert len(received_argv) == 1
+        assert "--provider" in received_argv[0]
+        assert "litellm:moonshot:kimi-k2-0905-default" in received_argv[0]
+
+    def test_exit_code_propagated_from_provider_dispatch(self):
+        """Return value from provider_dispatch.main() is passed back as-is."""
+        import provider_dispatch as pd_mod
+
+        for expected in (0, 1, 2):
+            with patch.object(pd_mod, "main", return_value=expected):
+                rc = _execute_cheap_lane_dispatch(
+                    _make_args(),
+                    "litellm:moonshot:kimi-k2-0905-default",
+                )
+            assert rc == expected, f"Expected exit code {expected}, got {rc}"
+
+    def test_deliver_with_recovery_not_called_for_cheap_lane(self):
+        """deliver_with_recovery (Claude) must NOT be called on a cheap lane.
+
+        This is the primary regression guard.  Any code path that invokes
+        deliver_with_recovery on a non-Claude lane silently routes through
+        Claude instead of the chosen provider.
+        """
+        import provider_dispatch as pd_mod
+        from subprocess_dispatch_internals import recovery as recovery_mod
+
+        dwr_calls: list = []
+
+        def mock_dwr(*args: object, **kwargs: object) -> bool:
+            dwr_calls.append((args, kwargs))
+            return True
+
+        with (
+            patch.object(pd_mod, "main", return_value=0),
+            patch.object(recovery_mod, "deliver_with_recovery", mock_dwr),
+        ):
+            _execute_cheap_lane_dispatch(
+                _make_args(),
+                "litellm:moonshot:kimi-k2-0905-default",
+            )
+
+        assert dwr_calls == [], (
+            f"deliver_with_recovery (Claude) was called {len(dwr_calls)} time(s) for a "
+            "cheap lane dispatch — this is the Claude fallback regression."
+        )
+
+    def test_provider_argv_contains_correct_terminal_and_dispatch_ids(self):
+        """Forwarded argv must carry the original terminal_id and dispatch_id."""
+        import provider_dispatch as pd_mod
+
+        received: list[list[str]] = []
+
+        with patch.object(pd_mod, "main", lambda argv: received.append(list(argv)) or 0):
+            _execute_cheap_lane_dispatch(
+                _make_args(terminal_id="T2", dispatch_id="d-cl2-9999"),
+                "litellm:deepseek:deepseek-v4-pro",
+            )
+
+        argv = received[0]
+        tid_idx = argv.index("--terminal-id")
+        did_idx = argv.index("--dispatch-id")
+        assert argv[tid_idx + 1] == "T2"
+        assert argv[did_idx + 1] == "d-cl2-9999"
+
+    def test_cheap_lane_never_falls_back_to_claude_end_to_end(self):
+        """End-to-end: routing decision + delegation — Claude is never invoked.
+
+        Simulates the full flow as __main__ executes it:
+          1. _select_dispatch_path returns a non-Claude lane
+             (with Claude in fallback_chain — the old code used that chain).
+          2. _execute_cheap_lane_dispatch delegates to provider_dispatch.main().
+          3. deliver_with_recovery is never reached.
+
+        This is the definitive proof that the cheap-lane regression is fixed.
+        """
+        from routing_policy import RoutingDecision
+        import provider_dispatch as pd_mod
+        from subprocess_dispatch_internals import recovery as recovery_mod
+
+        # Lane with Claude in fallback_chain — old code would have resolved this
+        cheap_decision = RoutingDecision(
+            lane="litellm:moonshot:kimi-k2-0905-default",
+            rule_name="code-review-cheap",
+            rationale="test: route to moonshot",
+            fallback_chain=["litellm:deepseek:deepseek-v4-pro", "claude/sonnet-4-6"],
+        )
+
+        dwr_calls: list = []
+        pd_calls: list[list[str]] = []
+
+        with patch("routing_policy.decide_lane", return_value=cheap_decision):
+            cheap_provider, effective_model = _select_dispatch_path(
+                task_class="code-review",
+                complexity="medium",
+                current_model="sonnet",
+                env={"VNX_ROUTING_POLICY_ENABLED": "1"},
+            )
+
+        # Routing phase: non-Claude provider selected, current_model unchanged
+        assert cheap_provider == "litellm:moonshot:kimi-k2-0905-default"
+        assert effective_model == "sonnet"
+
+        # Dispatch phase: delegate to provider_dispatch — Claude must not run
+        with (
+            patch.object(pd_mod, "main", lambda argv: pd_calls.append(list(argv)) or 0),
+            patch.object(recovery_mod, "deliver_with_recovery", lambda *a, **kw: dwr_calls.append(1) or True),
+        ):
+            rc = _execute_cheap_lane_dispatch(
+                _make_args(instruction="review the code", dispatch_id="d-e2e-cl2"),
+                cheap_provider,
+            )
+
+        # provider_dispatch.main() was called with the correct --provider
+        assert len(pd_calls) == 1, f"provider_dispatch.main called {len(pd_calls)} times, expected 1"
+        pd_argv = pd_calls[0]
+        assert "--provider" in pd_argv
+        assert "litellm:moonshot:kimi-k2-0905-default" in pd_argv
+
+        # deliver_with_recovery (Claude) was never invoked
+        assert dwr_calls == [], (
+            "deliver_with_recovery (Claude) was invoked for a non-Claude lane — "
+            "this is the cheap-lane regression that must not exist."
+        )
+
+        assert rc == 0

--- a/tests/test_subprocess_cheap_lane.py
+++ b/tests/test_subprocess_cheap_lane.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""tests/test_subprocess_cheap_lane.py — Cheap-lane delegation in subprocess_dispatch.
+
+Proves that when routing_policy decides a non-Claude (cheap) lane:
+  1. _select_dispatch_path returns (lane, current_model) — NOT (None, claude_fallback).
+  2. The caller (provider_dispatch) is expected to execute the non-Claude provider.
+
+The critical regression: the OLD code fell back to the first Claude model in
+fallback_chain when the lane was non-Claude.  These tests assert that behaviour
+is GONE: cheap_lane_provider is the non-Claude lane string, not None.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from subprocess_dispatch import _select_dispatch_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _env(**kwargs: str) -> dict:
+    return dict(kwargs)
+
+
+def _enabled(**extra: str) -> dict:
+    return {"VNX_ROUTING_POLICY_ENABLED": "1", **extra}
+
+
+# ---------------------------------------------------------------------------
+# Routing disabled — guards short-circuit before decide_lane is called
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDispatchPathDisabled:
+    def test_no_env_var_returns_defaults(self):
+        cheap, model = _select_dispatch_path(
+            task_class="code-review",
+            complexity="medium",
+            current_model="sonnet",
+            env=_env(),  # VNX_ROUTING_POLICY_ENABLED absent
+        )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_env_var_zero_returns_defaults(self):
+        cheap, model = _select_dispatch_path(
+            task_class="code-review",
+            complexity="medium",
+            current_model="sonnet",
+            env=_env(VNX_ROUTING_POLICY_ENABLED="0"),
+        )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_empty_task_class_returns_defaults(self):
+        cheap, model = _select_dispatch_path(
+            task_class="",
+            complexity="medium",
+            current_model="sonnet",
+            env=_enabled(),
+        )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_auto_route_applied_skips_routing(self):
+        """When smart_router already ran, routing_policy must not override it."""
+        cheap, model = _select_dispatch_path(
+            task_class="code-review",
+            complexity="medium",
+            current_model="haiku",
+            auto_route_applied=True,
+            env=_enabled(),
+        )
+        assert cheap is None
+        assert model == "haiku"  # unchanged — smart_router decision preserved
+
+
+# ---------------------------------------------------------------------------
+# Claude lanes — cheap_lane_provider is None; effective_model is updated
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDispatchPathClaudeLane:
+    def test_claude_sonnet_lane_updates_model(self):
+        from routing_policy import RoutingDecision
+
+        decision = RoutingDecision(
+            lane="claude/sonnet-4-6",
+            rule_name="refactor-code-default",
+            rationale="test",
+            fallback_chain=[],
+        )
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, model = _select_dispatch_path(
+                task_class="refactor",
+                complexity="medium",
+                current_model="opus",  # should be overridden
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_claude_haiku_lane_updates_model(self):
+        from routing_policy import RoutingDecision
+
+        decision = RoutingDecision(
+            lane="claude/haiku-4-5",
+            rule_name="simple-cleanup",
+            rationale="test",
+            fallback_chain=["claude/sonnet-4-6"],
+        )
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, model = _select_dispatch_path(
+                task_class="lint-narrow",
+                complexity="low",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "haiku"
+
+    def test_claude_opus_lane_updates_model(self):
+        from routing_policy import RoutingDecision
+
+        decision = RoutingDecision(
+            lane="claude/opus",
+            rule_name="research-deep",
+            rationale="test",
+            fallback_chain=[],
+        )
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, model = _select_dispatch_path(
+                task_class="research",
+                complexity="high",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "opus"
+
+
+# ---------------------------------------------------------------------------
+# Non-Claude (cheap) lanes — THE critical regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDispatchPathCheapLane:
+    """Non-Claude lanes must return (lane, current_model), never (None, claude_fallback).
+
+    The OLD code found the first Claude model in fallback_chain and set _effective_model
+    to it, silently routing the dispatch through Claude instead of the chosen provider.
+    These tests prove that behaviour is eliminated.
+    """
+
+    def test_litellm_moonshot_lane_not_claude_fallback(self):
+        """code-review → kimi/moonshot: cheap_lane_provider set, Claude NOT used."""
+        from routing_policy import RoutingDecision
+
+        decision = RoutingDecision(
+            lane="litellm:moonshot:kimi-k2-0905-default",
+            rule_name="review-analysis",
+            rationale="test",
+            # fallback_chain contains Claude — old code would have used this as _effective_model!
+            fallback_chain=["litellm:deepseek:deepseek-v4-pro", "claude/sonnet-4-6"],
+        )
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, model = _select_dispatch_path(
+                task_class="code-review",
+                complexity="medium",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+
+        # cheap_lane_provider MUST be the lane — not None (old fallback was None + Claude model)
+        assert cheap == "litellm:moonshot:kimi-k2-0905-default"
+        # effective_model is unchanged — provider_dispatch resolves its own model
+        assert model == "sonnet"
+
+    def test_litellm_deepseek_lane_not_claude_fallback(self):
+        """DeepSeek lane: cheap_lane_provider set, Claude model NOT used."""
+        from routing_policy import RoutingDecision
+
+        decision = RoutingDecision(
+            lane="litellm:deepseek:deepseek-v4-pro",
+            rule_name="cost-optimized-code",
+            rationale="test",
+            fallback_chain=["litellm:moonshot:kimi-k2-0905-default", "claude/sonnet-4-6"],
+        )
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, model = _select_dispatch_path(
+                task_class="refactor",
+                complexity="medium",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+
+        assert cheap == "litellm:deepseek:deepseek-v4-pro"
+        assert model == "sonnet"  # NOT overridden to a Claude model
+
+    def test_current_model_preserved_unchanged_for_various_inputs(self):
+        """Whatever current_model is, it passes through unmodified when lane is cheap."""
+        from routing_policy import RoutingDecision
+
+        for original_model in ("sonnet", "opus", "haiku", "claude-sonnet-4-6"):
+            decision = RoutingDecision(
+                lane="litellm:moonshot:kimi-k2-0905-default",
+                rule_name="review-analysis",
+                rationale="test",
+                fallback_chain=["claude/sonnet-4-6"],
+            )
+            with patch("routing_policy.decide_lane", return_value=decision):
+                cheap, model = _select_dispatch_path(
+                    task_class="code-review",
+                    complexity="medium",
+                    current_model=original_model,
+                    env=_enabled(),
+                )
+            assert cheap is not None, f"cheap_lane_provider unset for current_model={original_model!r}"
+            assert model == original_model, (
+                f"current_model={original_model!r} was unexpectedly changed to {model!r}"
+            )
+
+    def test_cheap_lane_provider_is_full_lane_string(self):
+        """cheap_lane_provider equals the full lane string, ready for --provider arg."""
+        from routing_policy import RoutingDecision
+
+        lane = "litellm:moonshot:kimi-k2-0905-default"
+        decision = RoutingDecision(lane=lane, rule_name="r", rationale="t", fallback_chain=[])
+        with patch("routing_policy.decide_lane", return_value=decision):
+            cheap, _ = _select_dispatch_path(
+                task_class="analysis",
+                complexity="low",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+        assert cheap == lane  # passed verbatim to provider_dispatch --provider
+
+
+# ---------------------------------------------------------------------------
+# Error handling — any failure falls back to (None, current_model)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDispatchPathErrors:
+    def test_decide_lane_file_not_found_falls_back(self):
+        with patch("routing_policy.decide_lane", side_effect=FileNotFoundError("no policy")):
+            cheap, model = _select_dispatch_path(
+                task_class="code-review",
+                complexity="medium",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_decide_lane_value_error_falls_back(self):
+        with patch("routing_policy.decide_lane", side_effect=ValueError("bad yaml")):
+            cheap, model = _select_dispatch_path(
+                task_class="refactor",
+                complexity="high",
+                current_model="opus",
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "opus"
+
+    def test_decide_lane_runtime_error_falls_back(self):
+        with patch("routing_policy.decide_lane", side_effect=RuntimeError("unexpected")):
+            cheap, model = _select_dispatch_path(
+                task_class="research",
+                complexity="high",
+                current_model="sonnet",
+                env=_enabled(),
+            )
+        assert cheap is None
+        assert model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Production policy smoke tests — against the real routing_policy.yaml
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDispatchPathProductionPolicy:
+    """Exercises the real routing_policy.yaml to catch yaml drift."""
+
+    def test_code_review_routes_to_cheap_moonshot_lane(self):
+        """code-review → litellm:moonshot (cheap); must NOT produce Claude."""
+        cheap, model = _select_dispatch_path(
+            task_class="code-review",
+            complexity="medium",
+            current_model="sonnet",
+            env=_enabled(),
+        )
+        assert cheap == "litellm:moonshot:kimi-k2-0905-default"
+        assert model == "sonnet"  # unchanged
+
+    def test_refactor_medium_routes_to_claude_sonnet(self):
+        """refactor + medium → claude/sonnet-4-6 (cheap is None, model overridden)."""
+        cheap, model = _select_dispatch_path(
+            task_class="refactor",
+            complexity="medium",
+            current_model="opus",  # should be overridden
+            env=_enabled(),
+        )
+        assert cheap is None
+        assert model == "sonnet"
+
+    def test_lint_narrow_low_routes_to_claude_haiku(self):
+        """lint-narrow + low → claude/haiku-4-5 (cheap is None)."""
+        cheap, model = _select_dispatch_path(
+            task_class="lint-narrow",
+            complexity="low",
+            current_model="sonnet",
+            env=_enabled(),
+        )
+        assert cheap is None
+        assert model == "haiku"
+
+    def test_analysis_routes_to_cheap_moonshot_lane(self):
+        """analysis → litellm:moonshot (cheap); must NOT produce Claude."""
+        cheap, model = _select_dispatch_path(
+            task_class="analysis",
+            complexity="medium",
+            current_model="sonnet",
+            env=_enabled(),
+        )
+        assert cheap == "litellm:moonshot:kimi-k2-0905-default"
+        assert model == "sonnet"
+
+    def test_unknown_task_class_returns_claude_default(self):
+        """Unknown task_class hits default lane (claude/sonnet-4-6)."""
+        cheap, model = _select_dispatch_path(
+            task_class="unknown-task-xyz",
+            complexity="medium",
+            current_model="haiku",
+            env=_enabled(),
+        )
+        assert cheap is None
+        assert model == "sonnet"  # default_lane mapped to sonnet


### PR DESCRIPTION
## Summary

When `VNX_ROUTING_POLICY_ENABLED=1` and `routing_policy` selects a non-Claude (cheap) lane, `subprocess_dispatch` now correctly delegates to `provider_dispatch.main()` and never calls `deliver_with_recovery` (the Claude path).

## Root cause

The old `__main__` block had the delegation logic present (from `e7bbf0b`) but the delegation was buried inline with no testable surface. The regression risk: any future inline-logic reversion would silently route cheap lanes through Claude again.

## Changes

### `scripts/lib/subprocess_dispatch.py`
- **`_build_cheap_lane_argv(args, cheap_lane_provider)`** — builds the `provider_dispatch` argv list from the parsed `argparse.Namespace`; extracted from `__main__` so tests can verify the delegation contract without spawning processes
- **`_execute_cheap_lane_dispatch(args, cheap_lane_provider)`** — single delegation entry-point: imports `provider_dispatch` and calls `main(argv)`; the `__main__` block now calls this function
- Both added to `__all__`
- `__main__` delegation block simplified to `sys.exit(_execute_cheap_lane_dispatch(args, _cheap_lane_provider))` — no logic change, Claude lane path untouched

### `tests/test_subprocess_cheap_lane.py`
- **`TestBuildCheapLaneArgv`** (11 tests) — verifies all argv fields, optional flags (`--no-auto-commit`, `--dispatch-paths`, `--pr-id`), role fallback, lane string passthrough
- **`TestExecuteCheapLaneDispatch`** (5 tests) — the critical regression guard:
  - `test_provider_dispatch_main_called` — asserts `provider_dispatch.main()` is called
  - `test_exit_code_propagated_from_provider_dispatch` — exit code 0/1/2 passthrough
  - **`test_deliver_with_recovery_not_called_for_cheap_lane`** — patches `deliver_with_recovery` and asserts 0 calls (primary regression guard)
  - `test_provider_argv_contains_correct_terminal_and_dispatch_ids` — forwarded IDs
  - **`test_cheap_lane_never_falls_back_to_claude_end_to_end`** — full routing + delegation simulation; Claude in `fallback_chain` is ignored

## Test results

```
35 passed in 0.15s (was 19, +16 new)
```

## Dispatch-ID

`20260526-cl2-subprocess-cheaplane`

🤖 Generated with [Claude Code](https://claude.com/claude-code)