### PR TITLE
docs(rc9): changelog + readme sync (cheap-lanes, constraint-rename, OI-refactors, governance fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to VNX Orchestration are documented here.
 
 Format: [keep-a-changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [semver](https://semver.org/).
 
+## [1.0.0-rc9] — 2026-05-26
+
+### Added
+
+- **feat(governance) GOV-3 (#655)** `scripts/traceability_audit.py` — re-runnable observability tool that cross-references PRs/commits/dispatches/receipts and reports traceability gaps. Four gap categories (A–D): dispatches without completion receipt, receipts with unresolvable dispatch_id, merged PRs without receipt cross-reference, completion receipts missing both pr_id and dispatch_id link. Supports `--since`/`--until` date range, `--repo PATH` override, atomic markdown output. 44 unit tests. First run against vnx-dev (2026-01-01 → 2026-05-26): Category C gaps at 6.0% (most PRs linked via branch-slug heuristic); Categories A/B/D reflect tmux-era receipt schema predating current linkage fields.
+- **feat(governance) GOV-2 (#654)** `scripts/pr_merge.py` canonical T0 merge path: instead of raw `gh pr merge`, T0 calls this script which merges the PR and atomically emits a `pr_merged` receipt (pr_number, dispatch_id, conclusion, merge_method) to `t0_receipts.ndjson` + `dispatch_register.ndjson`. `scripts/backfill_pr_merged_receipts.py` reconciles already-merged PRs against existing receipts; idempotent, supports `--dry-run` / `--limit` / `--since`. Fixes FPY/history gap: previously merged PRs left no governance trail.
+
+### Fixed
+
+- **fix(provider-dispatch) CL1 (#644)** Non-claude provider dispatch (kimi/codex) now captures correct `status`, `output`, and `tokens` in completion receipts. Receipt fields were being dropped for non-claude cheap lanes.
+
+### Changed
+
+- **feat(subprocess-dispatch) CL2 (#652)** Cheap-lane execution routes through `provider_dispatch` instead of Claude fallback. Subprocess dispatch now uses the provider-agnostic entry-point for cheap-lane tasks — removes the hardcoded Claude-only path and enables kimi/codex/gemini as cheap-lane workers.
+- **refactor(providers) CL3 (#643)** Constraint renamed: `deepseek-path-d-blocked` → `deepseek-harness-subscription-blocked`. Semantics expanded: own-key + hardening path (`ANTHROPIC_API_KEY` + `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` + MCP off) is now explicitly **allowed**; subscription-redirect (no own key, rides OAuth subscription) remains blocked. Measured on claude v2.1.150: 0 calls to `api.anthropic.com` with own-key + hardening.
+
+### Refactored
+
+- **refactor(quality-db) OI #645** `bootstrap_qi_db` extracts migration registry (OI-1542/1544/1541) — migration blocks now indexed, removes inline migration sprawl.
+- **refactor(benchmark) OI #646** Extract source-info + report-writers from benchmark main (OI-1510) — cuts benchmark script below size threshold.
+- **refactor(dispatcher) OI #647** Extract stuck-cleanup python + supervisor-ticks from dispatcher (OI-1521/1523).
+- **refactor(receipt-proc) OI #648** Extract mtime-calc python from bootstrap-protection (OI-1525/1524).
+- **refactor(doctor) OI #649** Extract worktree + settings checks from `cmd_doctor` (OI-1573).
+- **refactor(install-central) OI #650** Move shim content to template file (OI-1562) — shim generator no longer embeds multi-line heredoc inline.
+- **refactor(migrate-central) OI #653** Extract `migrate_import` module from `migrate_to_central_vnx.py` (OI-1537/1539, part 1/3).
+- **refactor(migrate-central) OI #657** Extract `migrate_schema` module from `migrate_to_central_vnx.py` (OI-1536/1533, part 2/3).
+
 ## [1.0.0-rc3] — 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@ VNX is an open-source governance-first orchestration runtime for AI CLI workflow
 
 **No framework to import. No cloud dependency. Governance, provenance, and operator control built in.**
 
-## Status (2026-05-20)
+## Status (2026-05-26)
 
-Wave 5/6/7 zijn gemerged. Wave 8 (Smart Router) in flight via PR-split.
-Komende stappen: pre-cutover hardening -> Wave 2a centralisatie (Hybrid C,
-MC -> sales-copilot -> SEOcrawler over 5 dagen) -> Wave 3 DB retirement.
+Wave 5/6/7/8 gemerged. rc9 hardening: cheap-lane routing via provider_dispatch, governance receipt gaps gesloten (GOV-2/3), deepseek-harness constraint herbenoemd.
+Komende stappen: Wave 2a centralisatie (Hybrid C, MC -> sales-copilot -> SEOcrawler over 5 dagen) -> Wave 3 DB retirement.
 
 Volledige roadmap: [claudedocs/roadmap-2026-05-20-master.md][roadmap].
 
 [roadmap]: claudedocs/roadmap-2026-05-20-master.md
 
-Current release: `v1.0.0-rc3` — multi-provider milestone (2026-05-17). Five providers in production with provider-agnostic governance: Claude (Opus/Sonnet/Haiku), Codex (GPT-5.2-codex), Gemini (2.5 Pro/Flash), Kimi CLI (K2.6), LiteLLM bridge (DeepSeek V4 Pro/Flash, GLM-5.1 via OpenRouter).
-See [CHANGELOG.md](CHANGELOG.md) for the release summary.
+Current release: `v1.0.0-rc9` — governance hardening + cheap-lane routing (2026-05-26). Cheap-lane dispatches now route through provider_dispatch (kimi/codex/gemini as cheap-lane workers). `traceability_audit` tool cross-references the full dispatch→receipt→PR→commit chain and reports gaps. `pr_merge.py` canonical merge path emits `pr_merged` receipts for full FPY tracking.
+See [CHANGELOG.md](CHANGELOG.md) for the full release summary.
 
 **API contract is stable from this release forward.** Dispatch envelope, receipt schema, NDJSON ledger format, and 14 ADRs (`docs/governance/decisions/ADR-001` through `ADR-014`) are now backwards-compatibility-honoring. v1.0.0 final ships after Phase 5 reader cutover validation.
 
@@ -195,6 +194,25 @@ Agent hits 65% context → blocked from further tool calls
 
 Zero human intervention. Zero lost work. The receipt ledger maintains a complete chain across rotations.
 
+## What's new in v1.0.0-rc9 (2026-05-26)
+
+### Cheap-lane routing via provider_dispatch (CL1-CL3)
+
+Cheap-lane dispatches now execute through the provider-agnostic `provider_dispatch` entry-point instead of the hardcoded Claude fallback. Non-claude lanes (kimi/codex/gemini) work as cheap-lane workers with correct receipt capture (status, output, tokens).
+
+- **CL1 (#644)** Non-claude receipt fix — kimi/codex completion receipts now capture correct status + tokens
+- **CL2 (#652)** Cheap-lane execution via `provider_dispatch` — removes Claude-only path from subprocess dispatch
+- **CL3 (#643)** Constraint renamed: `deepseek-path-d-blocked` → `deepseek-harness-subscription-blocked`. Own-key + hardening path now explicitly allowed (measured 0 calls to `api.anthropic.com`); subscription-redirect remains blocked.
+
+### Governance receipt gaps closed (GOV-2/3)
+
+- **GOV-2 (#654)** `scripts/pr_merge.py` canonical merge path emits `pr_merged` receipt atomically on every merge/closure, fixing the FPY/history gap where merged PRs left no governance trail. `backfill_pr_merged_receipts.py` reconciles historical PRs.
+- **GOV-3 (#655)** `scripts/traceability_audit.py` — re-runnable tool that cross-references the full dispatch→receipt→PR→commit chain and reports gaps in four categories (A–D). Supports date-range filters, atomic markdown output. 44 unit tests included.
+
+### OI refactors (#645-#650, #653, #657)
+
+Eight size-threshold refactors that modularize oversized scripts: quality-db bootstrap migration registry, benchmark report writers, dispatcher stuck-cleanup, receipt-proc mtime-calc, doctor worktree/settings checks, install-central shim template, and the two-part `migrate_to_central_vnx.py` split into `migrate_import` + `migrate_schema` modules.
+
 ## What's new since v1.0.0-rc1 (May 2026)
 
 > Strategic replan v1.2 organizes work into 6 waves. v1.0.0-rc1 itself shipped Wave 0 + 0.5 (architectural stabilization + Phase 6 P4 migration). Wave 1 (shadow read cutover) and Wave 5 P0/P1 (smart-context injection) shipped on top of the rc1 baseline and are still pending burn-in before the v1.0.0 final tag. 12 additional PRs (#462–#480) shipped post-rc1 — see [CHANGELOG.md](CHANGELOG.md) "Unreleased" for the full PR list.
@@ -366,13 +384,13 @@ vnx doctor --strict              # full pre-flight validation
 ```bash
 git clone https://github.com/Vinix24/vnx-orchestration.git
 cd vnx-orchestration
-bash install-central.sh --version v1.0.0-rc3
+bash install-central.sh --version v1.0.0-rc9
 ```
 
-Central install places VNX at `~/.vnx-system/versions/v1.0.0-rc3/` with atomic symlink swap. Each project pins its version via `.vnx-version`. Per-project customizations go in `.vnx-overrides/skills/`, `.vnx-overrides/schemas/`, and `.vnx-overrides/configs/` — central install reads these before falling back to the shared installation.
+Central install places VNX at `~/.vnx-system/versions/v1.0.0-rc9/` with atomic symlink swap. Each project pins its version via `.vnx-version`. Per-project customizations go in `.vnx-overrides/skills/`, `.vnx-overrides/schemas/`, and `.vnx-overrides/configs/` — central install reads these before falling back to the shared installation.
 
 ```bash
-vnx update --to v1.0.0-rc3       # Flip to a specific version (central install)
+vnx update --to v1.0.0-rc9       # Flip to a specific version (central install)
 vnx doctor --strict              # Full pre-flight: schema check, skill coverage, worktree orphans, active dispatch drain
 ```
 
@@ -540,20 +558,21 @@ Detailed comparisons: [VNX vs Claude Code](docs/comparisons/vnx_vs_claude_code.m
 
 Active development. Priorities shift based on real usage patterns. Full detail in [ROADMAP.md](./ROADMAP.md); recent shipping history in [CHANGELOG.md](./CHANGELOG.md).
 
-### Recently landed (Wave 5, 6, 7, 8 — May 2026)
+### Recently landed (Wave 5, 6, 7, 8 + rc9 hardening — May 2026)
 
 - **Wave 5** (SHIPPED 2026-05-16) — Control Centre + multi-project supervision (single supervisor session managing N per-project T0 orchestrators, schema v12 multi-tenant lease isolation, cross-project intelligence aggregator)
 - **Wave 6** (SHIPPED 2026-05-16) — Workers=N elastic pool with `vnx pool` CLI, queue-aware + cost-aware scaling policies, dead-worker reap, schema v14
 - **Wave 7** (SHIPPED 2026-05-17) — Multi-provider via LiteLLM (DeepSeek/Kimi/GLM), provider governance unification (uniform receipt + report shape), Kimi CLI as 5th provider with OAuth, intelligence injection + token/cost tracking equal first-class across all 5 providers
 - **Wave 8** (SHIPPED 2026-05-17) — Smart router with task-class-aware model selection, hard provider constraint enforcement (`HardConstraintViolation` on policy breach), YAML frontmatter guardrails for uniform report schema, weekly drift + monthly benchmark cadence, self-learning `route_decisions_watcher.py`
 - **Benchmark infrastructure** — reproducible 9-model × 7-task suite + routing recommendations published
+- **rc9 hardening** (SHIPPED 2026-05-26) — cheap-lane routing via `provider_dispatch` (CL1-CL3), `traceability_audit` tool (GOV-3), `pr_merge.py` canonical merge path with `pr_merged` receipt (GOV-2), 8 OI size-threshold refactors (#645-#650, #653, #657)
 
 ### Known gaps / deferred
 
 - **Headless context rotation** (OI-1073) — subprocess workers use single-shot dispatch; active token-stream tracking, auto-rotation, handover writing, and continuation prompt injection are deferred. Interactive terminals retain native Claude Code rotation.
 - **MCP server** — expose VNX state to external Claude sessions; not yet built.
 - **v1.0.0 final tag** — operator decision after Wave 5-8 centralization burn-in validates on mission-control + sales-copilot + SEOcrawler.
-- **Path D (Claude-harness for non-Claude models)** — blocked pending telemetry-leak resolution (`claude` v2.1.136 hits `api.anthropic.com` 8× even with `BASE_URL` redirect, verified 2026-05-10).
+- **Path D (Claude-harness with own DeepSeek key)** — resolved in rc9 (CL3). Own-key + hardening (`ANTHROPIC_API_KEY` + `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` + MCP off) measured at 0 calls to `api.anthropic.com` on claude v2.1.150. Constraint renamed to `deepseek-harness-subscription-blocked` — subscription-redirect (riding OAuth without own key) remains blocked.
 
 ### Future horizons (post-1.0, non-binding)
 


### PR DESCRIPTION
## Summary

Doc-only sync for rc9 (2026-05-26). No code changes.

### CHANGELOG.md

New `## [1.0.0-rc9] — 2026-05-26` entry inserted before rc3 (newest-first order):

- **GOV-3 (#655)** `traceability_audit.py` — dispatch→receipt→PR→commit chain audit tool, 44 tests
- **GOV-2 (#654)** `pr_merge.py` canonical merge path + `pr_merged` receipt, backfill script
- **CL1 (#644)** non-claude (kimi/codex) receipt fix — correct status/output/tokens capture
- **CL2 (#652)** cheap-lane execution via `provider_dispatch` (removes Claude-only fallback)
- **CL3 (#643)** constraint rename: `deepseek-path-d-blocked` → `deepseek-harness-subscription-blocked`; own-key+hardening allowed
- **OI refactors #645-#650, #653, #657** — 8 size-threshold modularizations

### README.md

- Status date 2026-05-20 → 2026-05-26, status text updated
- Current release: `v1.0.0-rc3` → `v1.0.0-rc9` with updated description
- New `## What's new in v1.0.0-rc9` section (CL1-CL3, GOV-2/3, OI refactors)
- Central install version refs updated to rc9
- Roadmap "Recently landed" updated with rc9 bullet
- Known gaps: Path D "blocked" → resolved/renamed

---
Dispatch-ID: 20260526-docs-rc9-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)