### PR TITLE
refactor(tmux1b): leaseless single-shot tmux dispatch lane (subscription escape, airtight no-headless guard)

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1,47 +1,15 @@
 #!/usr/bin/env python3
-"""tmux_interactive_dispatch.py — interactive-tmux Claude dispatch lane (PR-TMUX-1).
+"""tmux_interactive_dispatch.py — single-shot ephemeral leaseless tmux dispatch lane.
 
-The 15-June escape.  Headless ``claude -p`` moves to API credits on 15 June;
-an *interactive* ``claude`` running inside a tmux window stays on the Claude
-subscription.  This module turns that validated mechanism into a real dispatch
-lane with full governance parity (lease + NDJSON audit + clean receipt).
+Each dispatch() call spawns a fresh unique tmux session, drives it with an
+interactive claude worker, waits for the completion receipt, and tears it down.
+No reuse, no warm-open, no leases, no fixed terminal identities.
 
-Two-phase lifecycle (NOT a single blocking close):
-
-  Phase A — :meth:`TmuxInteractiveDispatch.dispatch`
-    1. Spawn a FRESH interactive ``claude`` in a DETACHED tmux window
-       (interactive, never ``claude -p`` — that is the subscription-safe mode).
-    2. Inject the role / CLAUDE.md context the same way subprocess_dispatch
-       does (base + role layers + permission preamble).
-    3. Acquire the terminal lease (parity with subprocess lease-management).
-    4. ``send-keys`` the dispatch instruction.  **Enter is ALWAYS a separate
-       keystroke** — without it the message never reaches the worker.
-    5. Wait until the worker emits a receipt for this dispatch_id (the worker
-       calls ``append_receipt`` directly; the lane appends a completion
-       protocol footer instructing it to).  No 300s chunk-timeout — interactive
-       sessions do not have the event-stream-silence problem; a wide,
-       configurable deadline is used instead.
-    6. Leave the window WARM-OPEN and persist the window/pane handle so Phase B
-       can find it.  Emit NDJSON audit events at parity with subprocess.
-    7. Return the receipt plus the window handle.
-
-  Phase B — :meth:`TmuxInteractiveDispatch.close` (called AFTER T0 review)
-    8. Optionally ``send-keys`` one more follow-up instruction into the still
-       warm session (context + cwd intact = fix-forward without re-spawn), wait
-       for that follow-up receipt, THEN kill the window and release the lease.
-    9. Default (no follow-up): just close the window and free the lease.
-
-Modes:
-  * ``attach=False`` (default): detached window — autonomous dev worker.
-  * ``attach=True``: window surfaced to the operator's terminal (watch + talk).
-
-Wave5 smart-context injection is intentionally NOT wired here — it lands in
-PR-TMUX-2.  The ``smart_context`` parameter of :meth:`dispatch` is the single
-insertion point: pass the assembled intelligence block and it is layered into
-the context exactly like subprocess_dispatch does.  Default ``None`` => no Wave5.
+This lane runs Claude workers on the SUBSCRIPTION (the 15-June billing escape).
+Interactive ``claude`` (never ``claude -p``) stays on the subscription.
 
 BILLING SAFETY: only ``tmux`` subprocess calls spawn an interactive ``claude``
-binary.  No Anthropic SDK is imported anywhere in this module.
+binary. No Anthropic SDK is imported anywhere in this module.
 """
 
 from __future__ import annotations
@@ -54,9 +22,9 @@ import subprocess
 import sqlite3
 import tempfile
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Callable
 
 sys_path_dir = str(Path(__file__).resolve().parent)
 import sys
@@ -66,9 +34,6 @@ if sys_path_dir not in sys.path:
 
 logger = logging.getLogger(__name__)
 
-# Receipt statuses that mark a dispatch as complete for the purpose of the
-# Phase-A / follow-up wait.  A worker emitting any of these (or an event_type
-# ending in ``_completion``) is treated as "done driving".
 DEFAULT_COMPLETION_STATUSES = frozenset({"done", "completed", "failed", "blocked"})
 
 
@@ -85,12 +50,7 @@ class TmuxResult:
 
 
 class TmuxCommandRunner:
-    """Thin wrapper around real ``tmux`` subprocess calls.
-
-    Tests inject a fake with the same surface (``run`` / ``available``) so the
-    spawn->drive->receipt->close round-trip exercises this module's real logic
-    without a live Claude call.
-    """
+    """Thin wrapper around real ``tmux`` subprocess calls."""
 
     def run(
         self,
@@ -117,30 +77,17 @@ class TmuxCommandRunner:
 # ---------------------------------------------------------------------------
 @dataclass
 class InteractiveDispatchResult:
-    """Outcome of Phase A (spawn -> drive -> collect, window stays warm)."""
+    """Outcome of a single-shot ephemeral dispatch (spawn -> drive -> receipt -> teardown)."""
 
     success: bool
     dispatch_id: str
-    terminal_id: str
     session: "str | None" = None
+    label: "str | None" = None
     window_id: "str | None" = None
     pane_id: "str | None" = None
-    lease_generation: "int | None" = None
     receipt: "dict | None" = None
-    attached: bool = False
     failure_reason: "str | None" = None
-
-
-@dataclass
-class InteractiveCloseResult:
-    """Outcome of Phase B (optional follow-up, then close + lease release)."""
-
-    success: bool
-    dispatch_id: str
-    window_killed: bool = False
-    lease_released: bool = False
-    follow_up_receipt: "dict | None" = None
-    failure_reason: "str | None" = None
+    duration_seconds: float = 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -154,11 +101,6 @@ def _default_launch_command(
 ) -> str:
     """Build the interactive ``claude`` launch line (NOT ``claude -p``).
 
-    Mirrors the worker-pane launch in ``scripts/commands/start.sh``: source the
-    profile for PATH/MCP, then start an interactive ``claude`` pinned to *model*.
-    ``--dangerously-skip-permissions`` is added only when *skip_permissions* is
-    set (autonomous detached workers cannot answer permission prompts).
-
     Raises ValueError if *extra_flags* contains ``-p``, ``--print``, or
     ``--print=…``: those flags convert an interactive session to headless,
     defeating the subscription-safe guarantee of this lane.
@@ -167,7 +109,7 @@ def _default_launch_command(
         for token in extra_flags.split():
             if token in ("-p", "--print") or token.startswith("--print="):
                 raise ValueError(
-                    f"extra_flags must not contain -p/--print: "
+                    "extra_flags must not contain -p/--print: "
                     "the interactive lane must stay on the subscription"
                 )
     flags = ""
@@ -187,21 +129,19 @@ def _sanitize_session_name(raw: str) -> str:
 # Core lane
 # ---------------------------------------------------------------------------
 class TmuxInteractiveDispatch:
-    """Drive a dispatch through an interactive tmux Claude session."""
+    """Drive a dispatch through a single-shot ephemeral interactive tmux Claude session."""
 
     def __init__(
         self,
         state_dir: "str | Path",
         *,
         runner: "TmuxCommandRunner | None" = None,
-        session_prefix: str = "vnx-int",
         launch_builder: "Callable[..., str] | None" = None,
         project_root: "str | Path | None" = None,
         receipts_file: "str | Path | None" = None,
     ) -> None:
         self._state_dir = Path(state_dir)
         self._runner = runner or TmuxCommandRunner()
-        self._session_prefix = session_prefix
         self._launch_builder = launch_builder or _default_launch_command
         self._project_root = (
             Path(project_root) if project_root else self._resolve_project_root()
@@ -213,22 +153,10 @@ class TmuxInteractiveDispatch:
             else self._state_dir / "t0_receipts.ndjson"
         )
 
-    # -- path helpers ------------------------------------------------------
     @staticmethod
     def _resolve_project_root() -> Path:
         """scripts/lib/tmux_interactive_dispatch.py -> repo root (parents[2])."""
         return Path(__file__).resolve().parents[2]
-
-    def _resolve_cwd(self, terminal_id: str) -> Path:
-        """Spawn cwd: the terminal dir (skill discovery) if present, else root.
-
-        Matches start.sh, which launches each worker pane in
-        ``.claude/terminals/T{n}`` so Claude Code discovers the symlinked
-        ``.claude/skills/``.  The dispatch instruction itself tells the worker
-        which worktree to ``cd`` into for the actual edits.
-        """
-        term_dir = self._project_root / ".claude" / "terminals" / terminal_id
-        return term_dir if term_dir.is_dir() else self._project_root
 
     def _handle_path(self, dispatch_id: str) -> Path:
         return self._handle_dir / f"{dispatch_id}.json"
@@ -239,12 +167,12 @@ class TmuxInteractiveDispatch:
         event_type: str,
         *,
         dispatch_id: str,
-        terminal_id: str,
+        label: str,
         reason: "str | None" = None,
         metadata: "dict | None" = None,
     ) -> None:
         """Append a coordination event (NDJSON audit parity). Never raises."""
-        meta = {"terminal_id": terminal_id, "lane": "tmux_interactive"}
+        meta = {"label": label, "lane": "tmux_interactive"}
         if metadata:
             meta.update(metadata)
         try:
@@ -269,140 +197,33 @@ class TmuxInteractiveDispatch:
                 exc,
             )
         except Exception as exc:  # noqa: BLE001 — DB unavailable in shadow mode
-            logger.debug(
-                "interactive: emit %s skipped (%s)", event_type, exc
-            )
-
-    # -- lease -------------------------------------------------------------
-    def _acquire_lease(self, terminal_id: str, dispatch_id: str) -> "int | None":
-        """Acquire the terminal lease; return the new generation or None.
-
-        Failure is non-fatal in shadow mode (DB unavailable): we log and return
-        None so the dispatch still spawns, mirroring TmuxAdapter.validate_lease.
-        """
-        try:
-            from runtime_coordination import (
-                acquire_lease,
-                get_connection,
-                register_dispatch,
-            )
-
-            with get_connection(self._state_dir) as conn:
-                # Register the dispatch first (idempotent) so the lease's
-                # dispatch_id FK is satisfied — the real flow registers via the
-                # queue before leasing; the lane registers on its own behalf.
-                register_dispatch(
-                    conn,
-                    dispatch_id=dispatch_id,
-                    terminal_id=terminal_id,
-                    actor="tmux_interactive",
-                )
-                lease = acquire_lease(
-                    conn,
-                    terminal_id=terminal_id,
-                    dispatch_id=dispatch_id,
-                    actor="tmux_interactive",
-                    reason=f"interactive dispatch {dispatch_id}",
-                )
-                conn.commit()
-                return int(lease.get("generation")) if lease else None
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "interactive: lease acquire failed for %s/%s: %s",
-                terminal_id,
-                dispatch_id,
-                exc,
-            )
-            return None
-
-    def _release_lease(
-        self, terminal_id: str, generation: "int | None", dispatch_id: str
-    ) -> bool:
-        """Release the lease. Returns True on release (or already-released)."""
-        if generation is None:
-            return False
-        try:
-            from runtime_coordination import get_connection, release_lease
-
-            with get_connection(self._state_dir) as conn:
-                release_lease(
-                    conn,
-                    terminal_id=terminal_id,
-                    generation=generation,
-                    actor="tmux_interactive",
-                    reason=f"interactive close {dispatch_id}",
-                )
-                conn.commit()
-                return True
-        except Exception as exc:  # noqa: BLE001 — already idle / generation drift
-            logger.warning(
-                "interactive: lease release for %s gen=%s treated as no-op: %s",
-                terminal_id,
-                generation,
-                exc,
-            )
-            return False
+            logger.debug("interactive: emit %s skipped (%s)", event_type, exc)
 
     # -- context assembly --------------------------------------------------
     def _assemble_context(
         self,
-        terminal_id: str,
-        instruction: str,
+        *,
         role: "str | None",
-        dispatch_id: str,
-        model: str,
         smart_context: "str | None" = None,
     ) -> str:
-        """Layer base + role CLAUDE.md context, exactly like subprocess_dispatch.
-
-        Wave5 smart-context is layered ONLY when *smart_context* is provided
-        (the PR-TMUX-2 insertion point).  Default ``None`` => no intelligence
-        section, keeping this PR scoped to the core lane.
-        """
-        intelligence_section = smart_context or ""
-        body: "str | None" = None
-        try:
-            from subprocess_dispatch_internals.skill_injection import (
-                _inject_permission_profile,
-                _legacy_claude_md_resolution,
-                _try_prompt_assembler,
+        """Build role-based context preamble + optional smart_context block."""
+        parts: list[str] = []
+        if role:
+            parts.append(f"## Role\n\nYou are operating as a **{role}** worker.")
+        else:
+            parts.append(
+                "## Worker Preamble\n\n"
+                "You are a VNX headless worker executing a dispatch instruction."
             )
+        if smart_context:
+            parts.append(smart_context)
+        return "\n\n".join(parts)
 
-            meta: dict = {
-                "role": role or "",
-                "terminal": terminal_id,
-                "dispatch_id": dispatch_id,
-                "model": model,
-            }
-            body = _try_prompt_assembler(
-                terminal_id, instruction, role, meta, intelligence_section
-            )
-            if body is None:
-                body = _legacy_claude_md_resolution(
-                    terminal_id, instruction, role, intelligence_section
-                )
-            body = _inject_permission_profile(terminal_id, role, body)
-            return body
-        except Exception as exc:  # noqa: BLE001 — assembly is best-effort
-            logger.warning(
-                "interactive: context assembly fell back to raw instruction (%s)",
-                exc,
-            )
-            return instruction
-
-    def _build_completion_protocol(
-        self, dispatch_id: str, terminal_id: str
-    ) -> str:
+    def _build_completion_protocol(self, dispatch_id: str, label: str) -> str:
         """Footer instructing the worker to emit a clean receipt directly.
 
-        The interactive worker does not go through the markdown -> receipt
-        processor route; it calls ``append_receipt`` directly so a clean
-        ``status`` receipt for this dispatch_id lands in the canonical NDJSON,
-        which is what Phase A polls on.
-
         The path to ``append_receipt.py`` is ABSOLUTE so it resolves correctly
-        regardless of the worker's cwd (which is ``.claude/terminals/T{n}``
-        when skill-discovery dirs are present).
+        regardless of the worker's cwd.
         """
         append_receipt = self._project_root / "scripts" / "append_receipt.py"
         return (
@@ -413,13 +234,28 @@ class TmuxInteractiveDispatch:
             f"python3 {append_receipt} --receipt "
             f"'{{\"event_type\": \"subprocess_completion\", "
             f"\"dispatch_id\": \"{dispatch_id}\", "
-            f"\"terminal\": \"{terminal_id}\", "
+            f"\"terminal\": \"{label}\", "
             "\"status\": \"done\", "
             "\"source\": \"tmux_interactive\"}'\n"
             "```\n\n"
             "Use `\"status\": \"failed\"` instead if you could not complete the "
             "work. Always write your unified report first, then emit the receipt "
             "as the last step.\n"
+        )
+
+    def _scope_note(self, dispatch_paths: "list[str] | str | None") -> str:
+        """Generate a scope-guard block instructing the worker to stay within paths."""
+        if not dispatch_paths:
+            return ""
+        if isinstance(dispatch_paths, str):
+            paths = [dispatch_paths]
+        else:
+            paths = list(dispatch_paths)
+        paths_str = "\n".join(f"  - `{p}`" for p in paths)
+        return (
+            "\n\n---\n\n## Scope Guard\n\n"
+            "**Edit ONLY within these paths.** Do not touch files outside this scope:\n\n"
+            f"{paths_str}\n"
         )
 
     # -- tmux primitives ---------------------------------------------------
@@ -468,12 +304,7 @@ class TmuxInteractiveDispatch:
         warmup_timeout: float,
         poll_interval: float,
     ) -> bool:
-        """Poll capture-pane until a readiness marker appears or timeout.
-
-        Best-effort: interactive prompt detection is fragile, so on timeout we
-        proceed anyway (the send-keys below still queues into the input box).
-        Returns True if a marker was observed.
-        """
+        """Poll capture-pane until a readiness marker appears or timeout."""
         deadline = time.monotonic() + warmup_timeout
         while time.monotonic() < deadline:
             cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
@@ -490,12 +321,7 @@ class TmuxInteractiveDispatch:
         return False
 
     def _deliver_instruction(self, pane_id: str, body: str) -> bool:
-        """Clear the input, paste the instruction body, submit with Enter.
-
-        The body is delivered via tmux paste-buffer (multi-line safe) and the
-        Enter that submits it is sent as a SEPARATE keystroke afterwards.
-        """
-        # Clear any pending input first.
+        """Clear input, paste the instruction body, submit with Enter."""
         self._runner.run(["send-keys", "-t", pane_id, "C-u"])
         if not self._paste(pane_id, body):
             return False
@@ -531,7 +357,6 @@ class TmuxInteractiveDispatch:
         res = self._runner.run(["kill-session", "-t", session])
         if res.returncode == 0:
             return True
-        # tmux returns non-zero when the session is already gone; treat as done.
         logger.debug(
             "interactive: kill-session %s rc=%s (likely already gone): %s",
             session,
@@ -541,18 +366,11 @@ class TmuxInteractiveDispatch:
         return False
 
     def _attach(self, session: str) -> bool:
-        """Surface the session to the operator (best-effort).
-
-        When this process runs inside tmux (``$TMUX`` set) ``switch-client``
-        moves the operator's client to the session.  Outside tmux we cannot
-        block on ``attach-session`` here, so we record the session and rely on
-        the operator running ``tmux attach -t <session>``.
-        """
+        """Surface the session to the operator (best-effort)."""
         if os.environ.get("TMUX"):
             return self._runner.run(["switch-client", "-t", session]).returncode == 0
         logger.info(
-            "interactive: not inside tmux — attach with: tmux attach -t %s",
-            session,
+            "interactive: not inside tmux — attach with: tmux attach -t %s", session
         )
         return False
 
@@ -593,18 +411,16 @@ class TmuxInteractiveDispatch:
     def _wait_for_receipt(
         self,
         dispatch_id: str,
-        *,
         deadline_seconds: float,
         poll_interval: float,
         completion_statuses: frozenset,
+        *,
         baseline_count: int = 0,
     ) -> "dict | None":
         """Poll the canonical receipts NDJSON until a NEW completion appears.
 
-        No 300s chunk-timeout: interactive sessions never go event-silent the
-        way ``claude -p`` does, so we use a single wide *deadline_seconds*.
-        Returns the newest matching receipt beyond *baseline_count*, or None on
-        deadline.
+        Only counts receipts beyond *baseline_count* (F3: stale-receipt guard).
+        Returns the newest matching receipt beyond baseline, or None on deadline.
         """
         deadline = time.monotonic() + deadline_seconds
         while True:
@@ -617,12 +433,14 @@ class TmuxInteractiveDispatch:
 
     # -- handle persistence ------------------------------------------------
     def _persist_handle(self, dispatch_id: str, handle: dict) -> None:
-        """Atomically persist the warm-window handle for Phase B."""
+        """Atomically persist the crash-recovery handle."""
         self._handle_dir.mkdir(parents=True, exist_ok=True)
         path = self._handle_path(dispatch_id)
         tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
         try:
-            tmp.write_text(json.dumps(handle, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.write_text(
+                json.dumps(handle, indent=2, sort_keys=True), encoding="utf-8"
+            )
             os.replace(tmp, path)
         finally:
             if tmp.exists():
@@ -650,31 +468,38 @@ class TmuxInteractiveDispatch:
             if path.exists():
                 path.unlink()
         except OSError as exc:
-            logger.debug("interactive: handle unlink failed for %s: %s", dispatch_id, exc)
+            logger.debug(
+                "interactive: handle unlink failed for %s: %s", dispatch_id, exc
+            )
 
     # ------------------------------------------------------------------
-    # Phase A
+    # Single-shot ephemeral dispatch
     # ------------------------------------------------------------------
     def dispatch(
         self,
-        terminal_id: str,
         instruction: str,
         dispatch_id: str,
         *,
         role: "str | None" = None,
         model: str = "sonnet",
-        attach: bool = False,
+        worker_label: "str | None" = None,
         skip_permissions: "bool | None" = None,
         smart_context: "str | None" = None,
         deadline_seconds: float = 3600.0,
         poll_interval: float = 5.0,
         warmup_timeout: float = 30.0,
         warmup_poll_interval: float = 1.0,
-        ready_markers: "tuple[str, ...]" = ("for shortcuts", "? for shortcuts", "Welcome to Claude"),
+        ready_markers: "tuple[str, ...]" = (
+            "for shortcuts",
+            "? for shortcuts",
+            "Welcome to Claude",
+        ),
         completion_statuses: frozenset = DEFAULT_COMPLETION_STATUSES,
+        dispatch_paths: "list[str] | str | None" = None,
         extra_flags: str = "",
+        attach: bool = False,
     ) -> InteractiveDispatchResult:
-        """Spawn -> drive -> collect.  Leaves the window WARM-OPEN on success.
+        """Spawn -> drive -> collect -> teardown. Single-shot; no warm-open.
 
         ``skip_permissions`` defaults to ``not attach``: an autonomous detached
         worker cannot answer permission prompts, while an attached (human in the
@@ -684,339 +509,199 @@ class TmuxInteractiveDispatch:
             return InteractiveDispatchResult(
                 success=False,
                 dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
                 failure_reason="tmux binary not found in PATH",
             )
 
         if skip_permissions is None:
             skip_permissions = not attach
 
-        session = _sanitize_session_name(f"{self._session_prefix}-{dispatch_id}")
-        cwd = self._resolve_cwd(terminal_id)
+        label = worker_label or dispatch_id
+        session = _sanitize_session_name(f"vnx-{dispatch_id}")
+        cwd = self._project_root
+        start_time = time.monotonic()
 
-        # 1. spawn fresh interactive claude in a detached window
+        # Idempotency guard: teardown runs exactly once across all exit paths.
+        _torn_down = False
+
+        def _teardown(status: str) -> None:
+            nonlocal _torn_down
+            if _torn_down:
+                return
+            _torn_down = True
+            self._kill_session(session)
+            self._remove_handle(dispatch_id)
+            self._emit_event(
+                "interactive_exit",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason=f"status={status}",
+                metadata={"session": session},
+            )
+
+        # 1. Spawn detached session
         spawned = self._spawn_session(session, cwd)
         if spawned is None:
+            self._emit_event(
+                "interactive_spawn_failed",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason="tmux new-session failed",
+            )
             return InteractiveDispatchResult(
                 success=False,
                 dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
                 session=session,
+                label=label,
                 failure_reason="tmux new-session failed",
+                duration_seconds=time.monotonic() - start_time,
             )
+
         pane_id, window_id = spawned
+
+        # 2. Persist handle for crash-recovery / operator tmux attach
+        self._persist_handle(
+            dispatch_id,
+            {
+                "dispatch_id": dispatch_id,
+                "label": label,
+                "session": session,
+                "pane_id": pane_id,
+                "window_id": window_id,
+                "started_at": time.time(),
+            },
+        )
         self._emit_event(
             "interactive_spawn",
             dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
+            label=label,
             reason=f"spawned interactive claude in {session}",
             metadata={"session": session, "pane_id": pane_id, "window_id": window_id},
         )
 
-        launch_cmd = self._launch_builder(
-            model, skip_permissions=skip_permissions, extra_flags=extra_flags
-        )
-        if not self._launch_claude(pane_id, launch_cmd):
-            self._kill_session(session)
-            return InteractiveDispatchResult(
-                success=False,
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                session=session,
-                window_id=window_id,
-                pane_id=pane_id,
-                failure_reason="failed to launch interactive claude",
+        try:
+            # 3. Launch claude
+            launch_cmd = self._launch_builder(
+                model, skip_permissions=skip_permissions, extra_flags=extra_flags
+            )
+            if not self._launch_claude(pane_id, launch_cmd):
+                self._emit_event(
+                    "interactive_launch_failed",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="send-keys for claude launch failed",
+                    metadata={"session": session},
+                )
+                _teardown("launch_failed")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="failed to launch interactive claude",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
+            # 4. Wait for readiness (best-effort)
+            self._wait_ready(
+                pane_id,
+                ready_markers=ready_markers,
+                warmup_timeout=warmup_timeout,
+                poll_interval=warmup_poll_interval,
             )
 
-        # 2. acquire lease (parity with subprocess)
-        lease_generation = self._acquire_lease(terminal_id, dispatch_id)
+            if attach:
+                self._attach(session)
 
-        # 3. wait for the session to be ready to accept input (best-effort)
-        self._wait_ready(
-            pane_id,
-            ready_markers=ready_markers,
-            warmup_timeout=warmup_timeout,
-            poll_interval=warmup_poll_interval,
-        )
+            # 5. Baseline snapshot BEFORE delivery (F3: stale-receipt guard)
+            baseline = len(self._matching_receipts(dispatch_id, completion_statuses))
 
-        attached = self._attach(session) if attach else False
+            # 6. Assemble body
+            body = (
+                self._assemble_context(role=role, smart_context=smart_context)
+                + "\n\n"
+                + instruction
+                + self._scope_note(dispatch_paths)
+                + self._build_completion_protocol(dispatch_id, label)
+            )
 
-        # Snapshot baseline BEFORE delivering the instruction.  Any matching
-        # receipt that already exists in the NDJSON (stale / reused dispatch_id)
-        # is counted in the baseline so _wait_for_receipt only returns on a
-        # FRESH receipt beyond that count — avoids false Phase-A completion.
-        baseline = len(self._matching_receipts(dispatch_id, completion_statuses))
-
-        # 4. assemble context (base + role; Wave5 only if smart_context given)
-        body = self._assemble_context(
-            terminal_id, instruction, role, dispatch_id, model, smart_context
-        )
-        body = body + self._build_completion_protocol(dispatch_id, terminal_id)
-
-        # 5. send-keys the dispatch instruction (Enter as a separate keystroke)
-        self._emit_event(
-            "interactive_deliver_start",
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            reason="send-keys dispatch instruction",
-            metadata={"session": session, "pane_id": pane_id, "attached": attached},
-        )
-        if not self._deliver_instruction(pane_id, body):
+            # 7. Deliver instruction
             self._emit_event(
-                "interactive_deliver_failure",
+                "interactive_deliver_start",
                 dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                reason="send-keys/paste of instruction failed",
+                label=label,
+                reason="send-keys dispatch instruction",
                 metadata={"session": session, "pane_id": pane_id},
             )
-            # Window stays open for inspection; persist handle so Phase B can close.
-            self._persist_handle(
+            if not self._deliver_instruction(pane_id, body):
+                self._emit_event(
+                    "interactive_deliver_failed",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="send-keys/paste of instruction failed",
+                    metadata={"session": session},
+                )
+                _teardown("deliver_failed")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="failed to deliver instruction via send-keys",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
+            # 8. Wait for receipt
+            receipt = self._wait_for_receipt(
                 dispatch_id,
-                self._build_handle(
-                    dispatch_id, terminal_id, session, window_id, pane_id,
-                    lease_generation, attached, model, role, "deliver_failed",
-                ),
+                deadline_seconds,
+                poll_interval,
+                completion_statuses,
+                baseline_count=baseline,
             )
-            return InteractiveDispatchResult(
-                success=False,
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                session=session,
-                window_id=window_id,
-                pane_id=pane_id,
-                lease_generation=lease_generation,
-                attached=attached,
-                failure_reason="failed to deliver instruction via send-keys",
-            )
-        self._emit_event(
-            "interactive_deliver_success",
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            reason="dispatch instruction delivered",
-            metadata={"session": session, "pane_id": pane_id},
-        )
 
-        # 6. persist handle BEFORE waiting so Phase B can always find the warm
-        #    window even if the receipt wait times out.
-        self._persist_handle(
-            dispatch_id,
-            self._build_handle(
-                dispatch_id, terminal_id, session, window_id, pane_id,
-                lease_generation, attached, model, role, "awaiting_receipt",
-            ),
-        )
+            if receipt is None:
+                _teardown("timeout")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="receipt deadline exceeded",
+                    duration_seconds=time.monotonic() - start_time,
+                )
 
-        # 7. wait for the worker's completion receipt
-        receipt = self._wait_for_receipt(
-            dispatch_id,
-            deadline_seconds=deadline_seconds,
-            poll_interval=poll_interval,
-            completion_statuses=completion_statuses,
-            baseline_count=baseline,
-        )
-
-        if receipt is None:
             self._emit_event(
-                "interactive_receipt_timeout",
+                "interactive_receipt_observed",
                 dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                reason=f"no completion receipt within {deadline_seconds:.0f}s",
-                metadata={"session": session, "pane_id": pane_id},
+                label=label,
+                reason=f"receipt status={receipt.get('status')}",
+                metadata={"session": session, "status": receipt.get("status")},
             )
-            # Window intentionally left WARM-OPEN for operator inspection.
+            _teardown("success")
             return InteractiveDispatchResult(
-                success=False,
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                session=session,
-                window_id=window_id,
-                pane_id=pane_id,
-                lease_generation=lease_generation,
-                attached=attached,
-                failure_reason="receipt deadline exceeded (window left warm-open)",
-            )
-
-        self._emit_event(
-            "interactive_receipt_observed",
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            reason=f"receipt status={receipt.get('status')}",
-            metadata={"session": session, "status": receipt.get("status")},
-        )
-        # Refresh the handle with the observed receipt status; window stays warm.
-        self._persist_handle(
-            dispatch_id,
-            self._build_handle(
-                dispatch_id, terminal_id, session, window_id, pane_id,
-                lease_generation, attached, model, role, "warm_open",
-                receipt_status=receipt.get("status"),
-            ),
-        )
-        self._emit_event(
-            "interactive_warm_open",
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            reason="window left warm-open pending T0 review",
-            metadata={"session": session, "window_id": window_id},
-        )
-
-        return InteractiveDispatchResult(
-            success=True,
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            session=session,
-            window_id=window_id,
-            pane_id=pane_id,
-            lease_generation=lease_generation,
-            receipt=receipt,
-            attached=attached,
-        )
-
-    @staticmethod
-    def _build_handle(
-        dispatch_id: str,
-        terminal_id: str,
-        session: str,
-        window_id: str,
-        pane_id: str,
-        lease_generation: "int | None",
-        attached: bool,
-        model: str,
-        role: "str | None",
-        phase: str,
-        receipt_status: "str | None" = None,
-    ) -> dict:
-        handle = {
-            "dispatch_id": dispatch_id,
-            "terminal_id": terminal_id,
-            "session": session,
-            "window_id": window_id,
-            "pane_id": pane_id,
-            "lease_generation": lease_generation,
-            "attached": attached,
-            "model": model,
-            "role": role,
-            "phase": phase,
-            "updated_at": time.time(),
-        }
-        if receipt_status is not None:
-            handle["receipt_status"] = receipt_status
-        return handle
-
-    # ------------------------------------------------------------------
-    # Phase B
-    # ------------------------------------------------------------------
-    def close(
-        self,
-        dispatch_id: str,
-        follow_up_instruction: "str | None" = None,
-        *,
-        deadline_seconds: float = 3600.0,
-        poll_interval: float = 5.0,
-        completion_statuses: frozenset = DEFAULT_COMPLETION_STATUSES,
-    ) -> InteractiveCloseResult:
-        """Close the warm window (Phase B), optionally driving one follow-up.
-
-        Called AFTER T0 review.  With *follow_up_instruction*, one more command
-        is sent into the still-warm session (context + cwd intact = fix-forward
-        without re-spawn) and its receipt awaited before teardown.  Without it,
-        the window is killed and the lease released immediately.
-
-        Idempotent: a missing handle (already closed) returns success.
-        """
-        handle = self._load_handle(dispatch_id)
-        if handle is None:
-            logger.info(
-                "interactive: no handle for %s — already closed (no-op)", dispatch_id
-            )
-            return InteractiveCloseResult(
                 success=True,
                 dispatch_id=dispatch_id,
-                window_killed=False,
-                lease_released=False,
-                failure_reason="no handle (already closed)",
+                session=session,
+                label=label,
+                window_id=window_id,
+                pane_id=pane_id,
+                receipt=receipt,
+                duration_seconds=time.monotonic() - start_time,
             )
 
-        session = handle.get("session") or ""
-        pane_id = handle.get("pane_id") or ""
-        terminal_id = handle.get("terminal_id") or ""
-        lease_generation = handle.get("lease_generation")
-
-        follow_up_receipt: "dict | None" = None
-        follow_up_ok = True
-
-        if follow_up_instruction:
-            baseline = len(
-                self._matching_receipts(dispatch_id, completion_statuses)
-            )
-            self._emit_event(
-                "interactive_follow_up_deliver",
-                dispatch_id=dispatch_id,
-                terminal_id=terminal_id,
-                reason="send-keys follow-up into warm session",
-                metadata={"session": session, "pane_id": pane_id},
-            )
-            delivered = self._deliver_instruction(
-                pane_id,
-                follow_up_instruction
-                + self._build_completion_protocol(dispatch_id, terminal_id),
-            )
-            if not delivered:
-                follow_up_ok = False
-                logger.warning(
-                    "interactive: follow-up send-keys failed for %s", dispatch_id
-                )
-            else:
-                follow_up_receipt = self._wait_for_receipt(
-                    dispatch_id,
-                    deadline_seconds=deadline_seconds,
-                    poll_interval=poll_interval,
-                    completion_statuses=completion_statuses,
-                    baseline_count=baseline,
-                )
-                if follow_up_receipt is None:
-                    follow_up_ok = False
-                    self._emit_event(
-                        "interactive_follow_up_timeout",
-                        dispatch_id=dispatch_id,
-                        terminal_id=terminal_id,
-                        reason=f"no follow-up receipt within {deadline_seconds:.0f}s",
-                        metadata={"session": session},
-                    )
-
-        # Teardown always runs (cleanup must happen even on follow-up timeout).
-        window_killed = self._kill_session(session) if session else False
-        lease_released = self._release_lease(
-            terminal_id, lease_generation, dispatch_id
-        )
-        self._emit_event(
-            "interactive_window_closed",
-            dispatch_id=dispatch_id,
-            terminal_id=terminal_id,
-            reason="warm window closed + lease released",
-            metadata={
-                "session": session,
-                "window_killed": window_killed,
-                "lease_released": lease_released,
-                "had_follow_up": bool(follow_up_instruction),
-            },
-        )
-        self._remove_handle(dispatch_id)
-
-        return InteractiveCloseResult(
-            success=follow_up_ok,
-            dispatch_id=dispatch_id,
-            window_killed=window_killed,
-            lease_released=lease_released,
-            follow_up_receipt=follow_up_receipt,
-            failure_reason=(
-                None if follow_up_ok else "follow-up did not complete (window still closed)"
-            ),
-        )
+        finally:
+            # Catches unexpected exceptions; no-op if teardown already ran.
+            _teardown("exception")
 
 
 # ---------------------------------------------------------------------------
-# CLI — operator / T0 entry point (dispatch + close subcommands)
+# CLI — single-shot dispatch entry point
 # ---------------------------------------------------------------------------
 def _resolve_state_dir() -> Path:
     """VNX_STATE_DIR, else VNX_DATA_DIR/state, else <root>/.vnx-data/state."""
@@ -1033,50 +718,37 @@ def main(argv: "list[str] | None" = None) -> int:
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Interactive-tmux Claude dispatch lane (PR-TMUX-1)"
+        description="Interactive-tmux Claude dispatch lane — single-shot ephemeral"
     )
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    pa = sub.add_parser("dispatch", help="Phase A: spawn -> drive -> collect (warm-open)")
-    pa.add_argument("--terminal-id", required=True)
-    pa.add_argument("--dispatch-id", required=True)
-    pa.add_argument("--instruction", required=True)
-    pa.add_argument("--role", default=None)
-    pa.add_argument("--model", default="sonnet")
-    pa.add_argument("--attach", action="store_true")
-    pa.add_argument("--deadline-seconds", type=float, default=3600.0)
-    pa.add_argument("--poll-interval", type=float, default=5.0)
-    pa.add_argument("--warmup-timeout", type=float, default=30.0)
-
-    pb = sub.add_parser("close", help="Phase B: optional follow-up, then close + release")
-    pb.add_argument("--dispatch-id", required=True)
-    pb.add_argument("--follow-up", default=None, help="Optional follow-up instruction")
-    pb.add_argument("--deadline-seconds", type=float, default=3600.0)
-    pb.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument("--dispatch-id", required=True)
+    parser.add_argument("--instruction", required=True)
+    parser.add_argument("--role", default=None)
+    parser.add_argument("--model", default="sonnet")
+    parser.add_argument("--worker-label", default=None)
+    parser.add_argument("--deadline-seconds", type=float, default=3600.0)
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument("--warmup-timeout", type=float, default=30.0)
+    parser.add_argument("--dispatch-paths", nargs="*", default=None)
+    parser.add_argument("--skip-permissions", action="store_true", default=None)
+    parser.add_argument("--extra-flags", default="")
+    parser.add_argument("--attach", action="store_true")
 
     args = parser.parse_args(argv)
     lane = TmuxInteractiveDispatch(_resolve_state_dir())
 
-    if args.command == "dispatch":
-        result = lane.dispatch(
-            args.terminal_id,
-            args.instruction,
-            args.dispatch_id,
-            role=args.role,
-            model=args.model,
-            attach=args.attach,
-            deadline_seconds=args.deadline_seconds,
-            poll_interval=args.poll_interval,
-            warmup_timeout=args.warmup_timeout,
-        )
-        print(json.dumps(result.__dict__, default=str))
-        return 0 if result.success else 1
-
-    result = lane.close(
+    result = lane.dispatch(
+        args.instruction,
         args.dispatch_id,
-        follow_up_instruction=args.follow_up,
+        role=args.role,
+        model=args.model,
+        worker_label=args.worker_label,
         deadline_seconds=args.deadline_seconds,
         poll_interval=args.poll_interval,
+        warmup_timeout=args.warmup_timeout,
+        dispatch_paths=args.dispatch_paths,
+        skip_permissions=args.skip_permissions if args.skip_permissions else None,
+        extra_flags=args.extra_flags,
+        attach=args.attach,
     )
     print(json.dumps(result.__dict__, default=str))
     return 0 if result.success else 1

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import shlex
 import shutil
 import subprocess
 import sqlite3
@@ -35,6 +37,27 @@ if sys_path_dir not in sys.path:
 logger = logging.getLogger(__name__)
 
 DEFAULT_COMPLETION_STATUSES = frozenset({"done", "completed", "failed", "blocked"})
+
+# Only simple identifiers are valid model names (no whitespace or shell metacharacters).
+_SAFE_MODEL_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+def _assert_no_headless_flags(launch_cmd: str) -> None:
+    """Raise ValueError if the assembled launch command contains -p/--print/--print=…
+
+    Applied to the FINAL command regardless of how it was built (default builder,
+    custom launch_builder, or model interpolation) before _launch_claude is called.
+    """
+    try:
+        tokens = shlex.split(launch_cmd)
+    except ValueError:
+        tokens = launch_cmd.split()
+    for token in tokens:
+        if token in ("-p", "--print") or token.startswith("--print="):
+            raise ValueError(
+                f"headless flag {token!r} detected in assembled launch command; "
+                "this lane must use interactive claude (subscription), not headless"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -101,10 +124,16 @@ def _default_launch_command(
 ) -> str:
     """Build the interactive ``claude`` launch line (NOT ``claude -p``).
 
-    Raises ValueError if *extra_flags* contains ``-p``, ``--print``, or
-    ``--print=…``: those flags convert an interactive session to headless,
-    defeating the subscription-safe guarantee of this lane.
+    Raises ValueError if *model* contains whitespace or shell metacharacters, or
+    if *extra_flags* contains ``-p``, ``--print``, or ``--print=…``: those flags
+    convert an interactive session to headless, defeating the subscription-safe
+    guarantee of this lane.
     """
+    if not _SAFE_MODEL_RE.match(model):
+        raise ValueError(
+            f"model {model!r} must be a simple identifier (e.g. 'sonnet', "
+            f"'claude-opus-4-7'); whitespace and shell metacharacters are not allowed"
+        )
     if extra_flags:
         for token in extra_flags.split():
             if token in ("-p", "--print") or token.startswith("--print="):
@@ -520,6 +549,13 @@ class TmuxInteractiveDispatch:
         cwd = self._project_root
         start_time = time.monotonic()
 
+        # Belt-and-suspenders: validate model before any session creation.
+        if not _SAFE_MODEL_RE.match(model):
+            raise ValueError(
+                f"model {model!r} must be a simple identifier (e.g. 'sonnet', "
+                f"'claude-opus-4-7'); whitespace and shell metacharacters are not allowed"
+            )
+
         # Idempotency guard: teardown runs exactly once across all exit paths.
         _torn_down = False
 
@@ -528,61 +564,99 @@ class TmuxInteractiveDispatch:
             if _torn_down:
                 return
             _torn_down = True
-            self._kill_session(session)
-            self._remove_handle(dispatch_id)
-            self._emit_event(
-                "interactive_exit",
-                dispatch_id=dispatch_id,
-                label=label,
-                reason=f"status={status}",
-                metadata={"session": session},
-            )
+            try:
+                self._kill_session(session)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("interactive: teardown kill-session %s: %s", session, exc)
+            try:
+                self._remove_handle(dispatch_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("interactive: teardown remove-handle %s: %s", dispatch_id, exc)
+            try:
+                self._emit_event(
+                    "interactive_exit",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason=f"status={status}",
+                    metadata={"session": session},
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("interactive: teardown emit %s: %s", dispatch_id, exc)
 
-        # 1. Spawn detached session
-        spawned = self._spawn_session(session, cwd)
-        if spawned is None:
-            self._emit_event(
-                "interactive_spawn_failed",
-                dispatch_id=dispatch_id,
-                label=label,
-                reason="tmux new-session failed",
-            )
-            return InteractiveDispatchResult(
-                success=False,
-                dispatch_id=dispatch_id,
-                session=session,
-                label=label,
-                failure_reason="tmux new-session failed",
-                duration_seconds=time.monotonic() - start_time,
-            )
-
-        pane_id, window_id = spawned
-
-        # 2. Persist handle for crash-recovery / operator tmux attach
-        self._persist_handle(
-            dispatch_id,
-            {
-                "dispatch_id": dispatch_id,
-                "label": label,
-                "session": session,
-                "pane_id": pane_id,
-                "window_id": window_id,
-                "started_at": time.time(),
-            },
-        )
-        self._emit_event(
-            "interactive_spawn",
-            dispatch_id=dispatch_id,
-            label=label,
-            reason=f"spawned interactive claude in {session}",
-            metadata={"session": session, "pane_id": pane_id, "window_id": window_id},
-        )
-
+        # FIX 2: Global teardown envelope starts before _spawn_session so any
+        # exception after a session may exist still triggers teardown.
+        pane_id: "str | None" = None
+        window_id: "str | None" = None
         try:
-            # 3. Launch claude
+            # 1. Spawn detached session
+            spawned = self._spawn_session(session, cwd)
+            if spawned is None:
+                self._emit_event(
+                    "interactive_spawn_failed",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="tmux new-session failed",
+                )
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    failure_reason="tmux new-session failed",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
+            pane_id, window_id = spawned
+
+            # 2. Persist handle for crash-recovery / operator tmux attach
+            self._persist_handle(
+                dispatch_id,
+                {
+                    "dispatch_id": dispatch_id,
+                    "label": label,
+                    "session": session,
+                    "pane_id": pane_id,
+                    "window_id": window_id,
+                    "started_at": time.time(),
+                },
+            )
+            self._emit_event(
+                "interactive_spawn",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason=f"spawned interactive claude in {session}",
+                metadata={"session": session, "pane_id": pane_id, "window_id": window_id},
+            )
+
+            # 3. Build launch command
             launch_cmd = self._launch_builder(
                 model, skip_permissions=skip_permissions, extra_flags=extra_flags
             )
+
+            # FIX 1: Final-command guard — bites regardless of how the command
+            # was built (default builder, custom launch_builder, model injection).
+            try:
+                _assert_no_headless_flags(launch_cmd)
+            except ValueError:
+                self._emit_event(
+                    "interactive_launch_failed",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="headless flag detected in launch command",
+                    metadata={"session": session},
+                )
+                _teardown("headless_flag_blocked")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="headless_flag_blocked",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
             if not self._launch_claude(pane_id, launch_cmd):
                 self._emit_event(
                     "interactive_launch_failed",
@@ -695,8 +769,25 @@ class TmuxInteractiveDispatch:
                 duration_seconds=time.monotonic() - start_time,
             )
 
+        except Exception as _exc:  # noqa: BLE001
+            # Unexpected error (e.g. _persist_handle raises): convert to failure
+            # result so the caller always gets a structured outcome.
+            logger.warning(
+                "interactive: unexpected error in dispatch %s: %s", dispatch_id, _exc
+            )
+            _teardown("unexpected_error")
+            return InteractiveDispatchResult(
+                success=False,
+                dispatch_id=dispatch_id,
+                session=session,
+                label=label,
+                window_id=window_id,
+                pane_id=pane_id,
+                failure_reason="unexpected_error",
+                duration_seconds=time.monotonic() - start_time,
+            )
         finally:
-            # Catches unexpected exceptions; no-op if teardown already ran.
+            # No-op if teardown already ran; catches any remaining exit path.
             _teardown("exception")
 
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1,20 +1,9 @@
 #!/usr/bin/env python3
-"""Tests for tmux_interactive_dispatch.py (PR-TMUX-1).
+"""Tests for tmux_interactive_dispatch.py — single-shot ephemeral leaseless model.
 
-Exercises the real two-phase lane logic through a stub tmux runner — no live
-Claude call, mirroring the burn-in / subprocess stub convention. The stub
-simulates the worker by appending a completion receipt to the canonical NDJSON
-when the dispatch (or follow-up) instruction is submitted (paste-buffer + Enter).
-
-Coverage:
-  * Phase A round-trip: spawn -> drive -> receipt; lease acquired; handle persisted.
-  * Enter is ALWAYS a separate keystroke after a paste-buffer.
-  * Completion-protocol footer instructs the worker to call append_receipt.
-  * Window stays WARM-OPEN after Phase A (no kill-session).
-  * Phase B close: kills session, releases lease, removes handle.
-  * Phase B follow-up: drives the warm session and awaits the follow-up receipt.
-  * NDJSON audit parity: coordination_events emitted for spawn/deliver/close.
-  * Negative paths: tmux missing, spawn failure, receipt timeout, double-close.
+PR-TMUX-1b: all lease/close/warm-open tests replaced by single-shot ephemeral coverage.
+Each dispatch spawns, drives, collects a receipt, and tears down in a single call.
+No fixed terminal identities, no warm-open, no leases.
 """
 
 from __future__ import annotations
@@ -29,10 +18,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from runtime_coordination import get_connection, get_events, get_lease, init_schema
+from runtime_coordination import get_connection, get_events, init_schema
 from tmux_interactive_dispatch import (
     DEFAULT_COMPLETION_STATUSES,
-    InteractiveCloseResult,
     InteractiveDispatchResult,
     TmuxInteractiveDispatch,
     TmuxResult,
@@ -42,11 +30,11 @@ from tmux_interactive_dispatch import (
 
 
 class FakeTmux:
-    """In-memory tmux that records commands and simulates a worker receipt.
+    """Stub tmux runner that simulates worker completion.
 
-    On the first ``send-keys ... Enter`` that follows a ``paste-buffer`` it
-    appends a completion receipt for ``dispatch_id`` to ``receipts_file`` — the
-    stand-in for the interactive worker calling ``append_receipt`` directly.
+    On the first ``send-keys ... Enter`` following a ``paste-buffer``, writes a
+    completion receipt to ``receipts_file`` — simulating the worker calling
+    ``append_receipt`` directly after finishing work.
     """
 
     def __init__(
@@ -54,23 +42,26 @@ class FakeTmux:
         *,
         receipts_file: Path,
         dispatch_id: str,
-        terminal_id: str,
         available: bool = True,
         spawn_ok: bool = True,
+        launch_ok: bool = True,
+        deliver_ok: bool = True,
         emit_receipt: bool = True,
         ready_content: str = "Welcome to Claude\n? for shortcuts",
     ) -> None:
         self.receipts_file = receipts_file
         self.dispatch_id = dispatch_id
-        self.terminal_id = terminal_id
         self._available = available
         self._spawn_ok = spawn_ok
+        self._launch_ok = launch_ok
+        self._deliver_ok = deliver_ok
         self._emit_receipt = emit_receipt
         self._ready_content = ready_content
         self.commands: list[list[str]] = []
         self.pasted: list[str] = []
         self.killed_sessions: list[str] = []
         self._pending_paste = False
+        self._literal_send_attempted = False
         self.receipts_written = 0
 
     def available(self) -> bool:
@@ -84,34 +75,49 @@ class FakeTmux:
             if not self._spawn_ok:
                 return TmuxResult(1, "", "session create failed")
             return TmuxResult(0, "%1\n")
+
         if cmd == "display-message":
             return TmuxResult(0, "@1\n")
+
         if cmd == "capture-pane":
             return TmuxResult(0, self._ready_content)
+
         if cmd == "load-buffer":
+            if not self._deliver_ok:
+                return TmuxResult(1, "", "load-buffer failed")
             if input_text is not None:
                 self.pasted.append(input_text)
             else:
-                # last arg is a temp file path
                 try:
                     self.pasted.append(Path(args[-1]).read_text(encoding="utf-8"))
                 except OSError:
                     self.pasted.append("")
             return TmuxResult(0)
+
         if cmd == "paste-buffer":
             self._pending_paste = True
             return TmuxResult(0)
+
         if cmd == "send-keys":
+            # First literal-mode send (launch command); fail if launch_ok=False.
+            if "-l" in args and not self._literal_send_attempted:
+                self._literal_send_attempted = True
+                if not self._launch_ok:
+                    return TmuxResult(1, "", "send-keys literal failed")
+            # paste-buffer + Enter → simulate worker completing.
             if args[-1] == "Enter" and self._pending_paste:
                 self._pending_paste = False
                 if self._emit_receipt:
                     self._write_receipt()
             return TmuxResult(0)
+
         if cmd == "kill-session":
             self.killed_sessions.append(args[-1])
             return TmuxResult(0)
+
         if cmd == "switch-client":
             return TmuxResult(0)
+
         return TmuxResult(0)
 
     def _write_receipt(self) -> None:
@@ -119,7 +125,7 @@ class FakeTmux:
         receipt = {
             "event_type": "subprocess_completion",
             "dispatch_id": self.dispatch_id,
-            "terminal": self.terminal_id,
+            "terminal": "ephemeral",
             "status": "done",
             "source": "tmux_interactive",
             "seq": self.receipts_written,
@@ -131,7 +137,6 @@ class FakeTmux:
 
 class _LaneTestCase(unittest.TestCase):
     DISPATCH_ID = "20260527-tmuxint-test"
-    TERMINAL = "T1"
 
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -145,10 +150,10 @@ class _LaneTestCase(unittest.TestCase):
             self.state_dir,
             runner=fake,
             receipts_file=self.receipts_file,
-            project_root=self.state_dir,  # no terminal dir -> spawn cwd = root
+            project_root=self.state_dir,
         )
 
-    def _fast_dispatch(self, lane, fake, **overrides):
+    def _fast_dispatch(self, lane: TmuxInteractiveDispatch, **overrides):
         kwargs = dict(
             role="backend-developer",
             model="sonnet",
@@ -158,172 +163,208 @@ class _LaneTestCase(unittest.TestCase):
             warmup_poll_interval=0.01,
         )
         kwargs.update(overrides)
-        return lane.dispatch(self.TERMINAL, "Do the thing.", self.DISPATCH_ID, **kwargs)
+        return lane.dispatch("Do the thing.", self.DISPATCH_ID, **kwargs)
 
 
-class TestPhaseADispatch(_LaneTestCase):
-    def test_round_trip_success(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
+class TestSingleShotSuccess(_LaneTestCase):
+    def test_single_shot_success(self):
+        """Happy path: spawn -> receipt appears -> success; session killed, handle removed."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
         lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake)
+        result = self._fast_dispatch(lane)
 
         self.assertIsInstance(result, InteractiveDispatchResult)
         self.assertTrue(result.success, result.failure_reason)
         self.assertIsNotNone(result.receipt)
         self.assertEqual(result.receipt["status"], "done")
-        self.assertEqual(result.pane_id, "%1")
-        self.assertEqual(result.window_id, "@1")
-        self.assertIsNotNone(result.lease_generation)
-
-    def test_window_stays_warm_open_after_phase_a(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
-        lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
-        # Phase A must NOT close the window.
-        self.assertEqual(fake.killed_sessions, [])
-        # Handle persisted so Phase B can find the warm window.
+        self.assertEqual(result.dispatch_id, self.DISPATCH_ID)
+        # Teardown must have run: session killed.
+        self.assertTrue(fake.killed_sessions, "kill-session was not called on success teardown")
+        # Teardown must have run: handle removed.
         handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
-        self.assertTrue(handle_path.exists())
-        handle = json.loads(handle_path.read_text())
-        self.assertEqual(handle["phase"], "warm_open")
-        self.assertEqual(handle["pane_id"], "%1")
+        self.assertFalse(handle_path.exists(), "handle file must be removed after teardown")
 
-    def test_enter_is_separate_keystroke_after_paste(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
+    def test_completion_protocol_absolute_path(self):
+        """F1: body injected into the session contains the absolute path to append_receipt.py."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
         lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
+        self._fast_dispatch(lane)
 
-        # Find the paste-buffer for the dispatch instruction, then assert the
-        # very next send-keys is a standalone "Enter" (not combined).
-        idx = next(
-            i for i, c in enumerate(fake.commands) if c and c[0] == "paste-buffer"
-        )
-        following = [c for c in fake.commands[idx + 1 :] if c and c[0] == "send-keys"]
-        self.assertTrue(following, "no send-keys after paste-buffer")
-        self.assertEqual(following[0][-1], "Enter")
-        self.assertEqual(len(following[0]), 4)  # send-keys -t <pane> Enter
-
-    def test_completion_protocol_footer_present(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
-        lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
-        # The pasted instruction body must instruct the worker to emit a receipt.
+        expected_abs = str(self.state_dir / "scripts" / "append_receipt.py")
         delivered = "\n".join(fake.pasted)
-        self.assertIn("append_receipt.py", delivered)
-        self.assertIn(self.DISPATCH_ID, delivered)
+        self.assertIn(
+            "python3 " + expected_abs,
+            delivered,
+            "absolute path to append_receipt.py must appear in the delivered body",
+        )
 
-    def test_lease_acquired_in_db(self):
+    def test_enter_is_separate_keystroke(self):
+        """Launch cmd and body paste each submit Enter as a standalone send-keys call."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        self._fast_dispatch(lane)
+
+        cmds = fake.commands
+
+        # After the literal-mode send-keys (launch command), the very next send-keys = Enter.
+        literal_idx = next(
+            (i for i, c in enumerate(cmds) if c and c[0] == "send-keys" and "-l" in c),
+            None,
+        )
+        self.assertIsNotNone(literal_idx, "no send-keys -l (literal) found for launch command")
+        post_literal_sk = [c for c in cmds[literal_idx + 1:] if c and c[0] == "send-keys"]
+        self.assertTrue(post_literal_sk, "no send-keys after launch literal")
+        self.assertEqual(post_literal_sk[0][-1], "Enter")
+        # Must be: send-keys -t <pane> Enter  (4 tokens, no combined payload)
+        self.assertEqual(len(post_literal_sk[0]), 4)
+
+        # After paste-buffer, the very next send-keys = Enter.
+        paste_idx = next(
+            (i for i, c in enumerate(cmds) if c and c[0] == "paste-buffer"),
+            None,
+        )
+        self.assertIsNotNone(paste_idx, "no paste-buffer found for body delivery")
+        post_paste_sk = [c for c in cmds[paste_idx + 1:] if c and c[0] == "send-keys"]
+        self.assertTrue(post_paste_sk, "no send-keys after paste-buffer")
+        self.assertEqual(post_paste_sk[0][-1], "Enter")
+        self.assertEqual(len(post_paste_sk[0]), 4)
+
+    def test_unique_session_per_dispatch(self):
+        """Different dispatch_ids yield different session names with no T1/T2/T3 literals."""
+        id1, id2 = "20260527-worker-alpha", "20260527-worker-beta"
+        sessions = []
+        for did in (id1, id2):
+            fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=did)
+            lane = TmuxInteractiveDispatch(
+                self.state_dir,
+                runner=fake,
+                receipts_file=self.receipts_file,
+                project_root=self.state_dir,
+            )
+            r = lane.dispatch(
+                "Do the thing.", did,
+                model="sonnet", deadline_seconds=5.0,
+                poll_interval=0.01, warmup_timeout=0.5, warmup_poll_interval=0.01,
+            )
+            sessions.append(r.session)
+
+        self.assertNotEqual(sessions[0], sessions[1], "different dispatch_ids must yield different sessions")
+        for s in sessions:
+            self.assertIsNotNone(s)
+            for fixed_terminal in ("T1", "T2", "T3"):
+                self.assertNotIn(fixed_terminal, s, f"session name must not contain {fixed_terminal!r}")
+
+    def test_scope_note_injected(self):
+        """dispatch_paths injects a scope block into the body; absent paths injects nothing."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        self._fast_dispatch(lane, dispatch_paths=["scripts/", "tests/"])
+        delivered = "\n".join(fake.pasted)
+        self.assertIn("Edit ONLY within these paths", delivered)
+        self.assertIn("`scripts/`", delivered)
+
+        # Without paths — use a separate receipts file to isolate from prior dispatch.
+        did2 = "20260527-no-scope"
+        rf2 = self.state_dir / "receipts2.ndjson"
+        fake2 = FakeTmux(receipts_file=rf2, dispatch_id=did2)
+        lane2 = TmuxInteractiveDispatch(
+            self.state_dir, runner=fake2, receipts_file=rf2, project_root=self.state_dir,
+        )
+        lane2.dispatch(
+            "Do the thing.", did2,
+            model="sonnet", deadline_seconds=5.0,
+            poll_interval=0.01, warmup_timeout=0.5, warmup_poll_interval=0.01,
+        )
+        delivered2 = "\n".join(fake2.pasted)
+        self.assertNotIn("Edit ONLY within these paths", delivered2)
+
+
+class TestTimeoutTeardown(_LaneTestCase):
+    def test_timeout_tears_down(self):
+        """Deadline exceeded: failure result, session killed, handle removed, exit event emitted."""
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
+            emit_receipt=False,
         )
         lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
-        with get_connection(self.state_dir) as conn:
-            lease = get_lease(conn, self.TERMINAL)
-        self.assertEqual(lease["state"], "leased")
-        self.assertEqual(lease["dispatch_id"], self.DISPATCH_ID)
+        result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
 
-    def test_audit_events_emitted(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
-        lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
-        with get_connection(self.state_dir) as conn:
-            events = get_events(conn, entity_id=self.DISPATCH_ID)
-        types = {e["event_type"] for e in events}
-        for expected in (
-            "interactive_spawn",
-            "interactive_deliver_start",
-            "interactive_deliver_success",
-            "interactive_receipt_observed",
-            "interactive_warm_open",
-        ):
-            self.assertIn(expected, types)
-
-    def test_attach_false_by_default_no_switch_client(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-        )
-        lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake)
-        self.assertFalse(result.attached)
-        self.assertFalse(any(c[0] == "switch-client" for c in fake.commands))
-
-
-class TestPhaseANegative(_LaneTestCase):
-    def test_tmux_unavailable(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-            available=False,
-        )
-        lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake)
-        self.assertFalse(result.success)
-        self.assertIn("tmux", result.failure_reason)
-
-    def test_spawn_failure(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-            spawn_ok=False,
-        )
-        lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake)
-        self.assertFalse(result.success)
-        self.assertIn("new-session", result.failure_reason)
-
-    def test_receipt_timeout_leaves_window_open(self):
-        fake = FakeTmux(
-            receipts_file=self.receipts_file,
-            dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
-            emit_receipt=False,  # worker never emits a receipt
-        )
-        lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake, deadline_seconds=0.2, poll_interval=0.02)
         self.assertFalse(result.success)
         self.assertIn("deadline", result.failure_reason)
-        # Warm-open contract: window NOT killed on timeout, handle persisted.
-        self.assertEqual(fake.killed_sessions, [])
+        self.assertTrue(fake.killed_sessions, "kill-session must be called on timeout")
         handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
-        self.assertTrue(handle_path.exists())
+        self.assertFalse(handle_path.exists(), "handle must be removed on timeout teardown")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn("interactive_exit", {e["event_type"] for e in events})
 
-    def test_stale_receipt_does_not_complete_phase_a(self):
-        """A pre-existing completion receipt for the same dispatch_id must NOT
-        trigger a false Phase-A success.  The baseline snapshot taken before
-        delivery ensures the stale receipt is counted in the baseline so only
-        a fresh receipt (len > baseline) would satisfy the wait."""
-        # Pre-write a stale matching completion receipt for the dispatch_id.
+
+class TestLaunchFailureTeardown(_LaneTestCase):
+    def test_launch_failure_tears_down(self):
+        """Failed send-keys for launch: teardown runs, no instruction delivered, failure result."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            launch_ok=False,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success)
+        self.assertIn("launch", result.failure_reason)
+        self.assertTrue(fake.killed_sessions, "kill-session must be called on launch failure")
+        handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
+        self.assertFalse(handle_path.exists())
+        self.assertEqual(fake.pasted, [], "instruction must not be delivered when launch fails")
+
+
+class TestDeliverFailureTeardown(_LaneTestCase):
+    def test_deliver_failure_tears_down(self):
+        """load-buffer failure during delivery: teardown runs, failure result."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            deliver_ok=False,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success)
+        self.assertIn("deliver", result.failure_reason)
+        self.assertTrue(fake.killed_sessions, "kill-session must be called on deliver failure")
+        handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
+        self.assertFalse(handle_path.exists())
+
+
+class TestNoDashP(_LaneTestCase):
+    def test_no_dash_p_in_launch(self):
+        """F2: default launch command has no -p; extra_flags with -p/--print raises ValueError."""
+        cmd = _default_launch_command("sonnet")
+        self.assertIn("claude --model sonnet", cmd)
+        self.assertNotIn("-p", cmd.split())
+        self.assertNotIn("--print", cmd.split())
+
+        with self.assertRaises(ValueError):
+            _default_launch_command("sonnet", extra_flags="-p")
+        with self.assertRaises(ValueError):
+            _default_launch_command("sonnet", extra_flags="--print")
+        with self.assertRaises(ValueError):
+            _default_launch_command("sonnet", extra_flags="--print=stream")
+
+        # Benign flag must still build without error.
+        safe = _default_launch_command("sonnet", extra_flags="--verbose")
+        self.assertIn("--verbose", safe)
+        self.assertNotIn("-p", safe.split())
+
+
+class TestStaleReceiptGuard(_LaneTestCase):
+    def test_stale_receipt_does_not_complete(self):
+        """F3: pre-existing receipt for dispatch_id must not satisfy the baseline-guarded wait."""
         stale = {
             "event_type": "subprocess_completion",
             "dispatch_id": self.DISPATCH_ID,
-            "terminal": self.TERMINAL,
+            "terminal": "ephemeral",
             "status": "done",
             "source": "stale_from_prior_run",
         }
@@ -331,131 +372,34 @@ class TestPhaseANegative(_LaneTestCase):
         with self.receipts_file.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(stale) + "\n")
 
-        # emit_receipt=False: the stub worker never emits a fresh receipt.
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
             emit_receipt=False,
         )
         lane = self._make_lane(fake)
-        result = self._fast_dispatch(lane, fake, deadline_seconds=0.2, poll_interval=0.02)
+        result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
 
-        # The stale receipt must NOT count as completion — must time out.
         self.assertFalse(result.success)
         self.assertIn("deadline", result.failure_reason)
 
 
-class TestPhaseBClose(_LaneTestCase):
-    def _dispatched_lane(self):
+class TestTeardownIdempotent(_LaneTestCase):
+    def test_teardown_idempotent(self):
+        """Early teardown (launch fail) + finally teardown must not double-kill the session."""
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
-            terminal_id=self.TERMINAL,
+            launch_ok=False,
         )
         lane = self._make_lane(fake)
-        self._fast_dispatch(lane, fake)
-        return lane, fake
+        self._fast_dispatch(lane)
 
-    def test_close_kills_session_and_releases_lease(self):
-        lane, fake = self._dispatched_lane()
-        result = lane.close(self.DISPATCH_ID)
-        self.assertIsInstance(result, InteractiveCloseResult)
-        self.assertTrue(result.success)
-        self.assertTrue(result.window_killed)
-        self.assertTrue(result.lease_released)
-        self.assertIn(_sanitize_session_name(f"vnx-int-{self.DISPATCH_ID}"), fake.killed_sessions)
-
-        # Lease back to idle.
-        with get_connection(self.state_dir) as conn:
-            lease = get_lease(conn, self.TERMINAL)
-        self.assertEqual(lease["state"], "idle")
-        # Handle removed.
-        handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
-        self.assertFalse(handle_path.exists())
-
-    def test_close_emits_window_closed_event(self):
-        lane, fake = self._dispatched_lane()
-        lane.close(self.DISPATCH_ID)
-        with get_connection(self.state_dir) as conn:
-            events = get_events(conn, entity_id=self.DISPATCH_ID)
-        types = {e["event_type"] for e in events}
-        self.assertIn("interactive_window_closed", types)
-
-    def test_close_with_follow_up(self):
-        lane, fake = self._dispatched_lane()
-        baseline_receipts = fake.receipts_written
-        result = lane.close(
-            self.DISPATCH_ID,
-            follow_up_instruction="Now fix the lint error.",
-            deadline_seconds=5.0,
-            poll_interval=0.01,
+        kill_cmds = [c for c in fake.commands if c and c[0] == "kill-session"]
+        self.assertEqual(
+            len(kill_cmds), 1,
+            f"kill-session called {len(kill_cmds)} times; _torn_down guard must prevent double-kill",
         )
-        self.assertTrue(result.success, result.failure_reason)
-        self.assertIsNotNone(result.follow_up_receipt)
-        # A new receipt was driven by the follow-up.
-        self.assertEqual(fake.receipts_written, baseline_receipts + 1)
-        self.assertTrue(result.window_killed)
-        self.assertTrue(result.lease_released)
-
-    def test_double_close_is_idempotent(self):
-        lane, fake = self._dispatched_lane()
-        first = lane.close(self.DISPATCH_ID)
-        self.assertTrue(first.success)
-        second = lane.close(self.DISPATCH_ID)
-        self.assertTrue(second.success)
-        self.assertFalse(second.window_killed)
-        self.assertFalse(second.lease_released)
-
-    def test_follow_up_timeout_still_closes(self):
-        lane, fake = self._dispatched_lane()
-        # Stop emitting receipts so the follow-up wait times out.
-        fake._emit_receipt = False
-        result = lane.close(
-            self.DISPATCH_ID,
-            follow_up_instruction="Try again.",
-            deadline_seconds=0.2,
-            poll_interval=0.02,
-        )
-        self.assertFalse(result.success)
-        self.assertIsNone(result.follow_up_receipt)
-        # Cleanup still happened.
-        self.assertTrue(result.window_killed)
-        self.assertTrue(result.lease_released)
-
-
-class TestHelpers(_LaneTestCase):
-    def test_default_launch_command_interactive_not_headless(self):
-        cmd = _default_launch_command("sonnet")
-        self.assertIn("claude --model sonnet", cmd)
-        self.assertNotIn(" -p", cmd)  # interactive, never headless
-        self.assertNotIn("--dangerously-skip-permissions", cmd)
-
-    def test_default_launch_command_skip_permissions(self):
-        cmd = _default_launch_command("opus", skip_permissions=True)
-        self.assertIn("--dangerously-skip-permissions", cmd)
-
-    def test_sanitize_session_name(self):
-        self.assertEqual(_sanitize_session_name("vnx-int-2026.05:27"), "vnx-int-2026-05-27")
-
-    def test_default_completion_statuses(self):
-        self.assertIn("done", DEFAULT_COMPLETION_STATUSES)
-        self.assertIn("failed", DEFAULT_COMPLETION_STATUSES)
-
-    def test_extra_flags_rejects_print_mode(self):
-        """extra_flags containing -p or --print must raise ValueError (billing
-        invariant: the interactive lane must never become headless)."""
-        with self.assertRaises(ValueError):
-            _default_launch_command("sonnet", extra_flags="-p")
-        with self.assertRaises(ValueError):
-            _default_launch_command("sonnet", extra_flags="--print")
-        with self.assertRaises(ValueError):
-            _default_launch_command("sonnet", extra_flags="--print=stream")
-        # A benign extra flag must still build the command without error.
-        cmd = _default_launch_command("sonnet", extra_flags="--verbose")
-        self.assertIn("--verbose", cmd)
-        self.assertNotIn("-p", cmd.split())
-        self.assertNotIn("--print", cmd.split())
 
 
 if __name__ == "__main__":

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -24,6 +24,7 @@ from tmux_interactive_dispatch import (
     InteractiveDispatchResult,
     TmuxInteractiveDispatch,
     TmuxResult,
+    _assert_no_headless_flags,
     _default_launch_command,
     _sanitize_session_name,
 )
@@ -382,6 +383,76 @@ class TestStaleReceiptGuard(_LaneTestCase):
 
         self.assertFalse(result.success)
         self.assertIn("deadline", result.failure_reason)
+
+
+class TestHeadlessGuard(_LaneTestCase):
+    def test_model_with_dash_p_rejected(self):
+        """model='sonnet -p' raises ValueError before any tmux session is spawned."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        with self.assertRaises(ValueError):
+            self._fast_dispatch(lane, model="sonnet -p")
+        spawn_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertEqual(spawn_cmds, [], "no session must be spawned for an invalid model")
+
+    def test_model_with_print_rejected(self):
+        """model='sonnet --print' raises ValueError before any tmux session is spawned."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        with self.assertRaises(ValueError):
+            self._fast_dispatch(lane, model="sonnet --print")
+        spawn_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertEqual(spawn_cmds, [], "no session must be spawned for an invalid model")
+
+    def test_custom_launch_builder_with_dash_p_rejected(self):
+        """Custom launch_builder returning a command with '-p' is blocked by final-command guard."""
+        def bad_builder(model, *, skip_permissions=False, extra_flags=""):
+            return "claude -p something"
+
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = TmuxInteractiveDispatch(
+            self.state_dir,
+            runner=fake,
+            launch_builder=bad_builder,
+            receipts_file=self.receipts_file,
+            project_root=self.state_dir,
+        )
+        result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_reason, "headless_flag_blocked")
+        # Guard fires before _launch_claude, so no literal-mode send-keys should occur.
+        literal_sends = [c for c in fake.commands if c and c[0] == "send-keys" and "-l" in c]
+        self.assertEqual(literal_sends, [], "launch send-keys must not happen when headless flag blocked")
+        self.assertTrue(fake.killed_sessions, "session must be killed on headless_flag_blocked teardown")
+
+    def test_assert_no_headless_flags_raises_on_dash_p(self):
+        """_assert_no_headless_flags raises ValueError for command containing -p."""
+        with self.assertRaises(ValueError):
+            _assert_no_headless_flags("source ~/.zshrc; claude --model sonnet -p")
+
+    def test_assert_no_headless_flags_passes_clean_command(self):
+        """_assert_no_headless_flags is silent for a clean interactive launch command."""
+        _assert_no_headless_flags("source ~/.zshrc 2>/dev/null; claude --model sonnet")
+
+
+class TestTeardownGlobal(_LaneTestCase):
+    def test_persist_handle_exception_still_tears_down(self):
+        """Exception in _persist_handle triggers teardown and returns a failure result."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        def raise_on_persist(dispatch_id, handle):
+            raise RuntimeError("simulated persist failure")
+
+        lane._persist_handle = raise_on_persist
+        result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success, "dispatch must return failure result when _persist_handle raises")
+        self.assertTrue(
+            fake.killed_sessions,
+            "session must be killed (teardown ran) even when _persist_handle raises",
+        )
 
 
 class TestTeardownIdempotent(_LaneTestCase):


### PR DESCRIPTION
## PR-TMUX-1b — Leaseless single-shot tmux dispatch lane

Rewrites `scripts/lib/tmux_interactive_dispatch.py` from the lease + warm-open model to **single-shot ephemeral, leaseless**. Operator decision (2026-05-27): the fixed T1/T2/T3 + terminal-lease machinery only earned its keep for persistent/reusable sessions; the leaseless model is simpler, fan-out-native, and the right fit for Claude **subscription** workers (the 15-June billing escape). The legacy subprocess `claude -p` lane stays as the paid-API/burst lane + non-Claude providers.

### Model
Each dispatch spawns a fresh unique session (`vnx-{dispatch_id}`), drives it, waits for the receipt (baseline-aware), and tears it down. No fixed terminals, no lease, no heartbeat, no warm-open, no `close()`. Audit is dispatch_id-keyed via the existing event/receipt trail. Module 1086 → 758 lines.

### Kept / hardened
- **Billing invariant (airtight):** interactive `claude --model` only, never `claude -p`. A `_assert_no_headless_flags` guard tokenizes the FINAL assembled launch command (covering `model` interpolation AND custom `launch_builder`) and rejects `-p`/`--print`; `model` is sanitized for shell metacharacters.
- F1 absolute receipt path, F3 receipt baseline, send-keys correctness (separate Enter).
- Teardown wrapped in a global try/finally (covers spawn + handle-persist exceptions), idempotent, runs on every exit path — no window/session leak.
- F7 scope-guard: `dispatch_paths` injected into the worker prompt.

### Independent validation (codex + kimi)
- **Codex: BLOCKING** → found `model="sonnet -p"` could smuggle headless mode past the extra_flags-only guard, defeating the subscription-escape. **Fixed** (final-command guard + model sanitization) and directly verified (guard rejects `-p`/`--print`).
- **Kimi: SOUND** → confirmed single-shot lifecycle, teardown idempotency, completion baseline, leaseless cleanliness, send-keys.

### Gates
- `local-ci.sh`: adr-003-no-sdk ✓, wheel-install ✓
- Tests: **46 passed** (interactive lane + coupling guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
