### PR TITLE
feat(tmux): per-worker ephemeral git worktree isolation (PR-TMUX-3) — isolated by default, three-state teardown

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -37,6 +37,8 @@ if sys_path_dir not in sys.path:
 
 logger = logging.getLogger(__name__)
 
+from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
+
 DEFAULT_COMPLETION_STATUSES = frozenset({"done", "completed", "failed", "blocked"})
 
 # Only simple identifiers are valid model names (no whitespace or shell metacharacters).
@@ -112,6 +114,8 @@ class InteractiveDispatchResult:
     receipt: "dict | None" = None
     failure_reason: "str | None" = None
     duration_seconds: float = 0.0
+    worktree_state: "str | None" = None
+    worktree_path: "str | None" = None
 
 
 # ---------------------------------------------------------------------------
@@ -531,6 +535,8 @@ class TmuxInteractiveDispatch:
         dispatch_paths: "list[str] | str | None" = None,
         extra_flags: str = "",
         attach: bool = False,
+        isolated_worktree: bool = True,
+        base_ref: str = "origin/main",
     ) -> InteractiveDispatchResult:
         """Spawn -> drive -> collect -> teardown. Single-shot; no warm-open.
 
@@ -560,6 +566,34 @@ class TmuxInteractiveDispatch:
                 f"'claude-opus-4-7'); whitespace and shell metacharacters are not allowed"
             )
 
+        # Worktree isolation: allocate before session creation so a failed add
+        # never spawns a tmux session with an uncontrolled cwd.
+        worktree_handle: "WorktreeHandle | None" = None
+        _wt_state: "list[str | None]" = [None]
+
+        if isolated_worktree:
+            try:
+                worktree_handle = allocate(
+                    dispatch_id=dispatch_id,
+                    base_ref=base_ref,
+                    repo_root=self._project_root,
+                )
+                cwd = worktree_handle.path
+            except WorktreeAllocateError as exc:
+                self._emit_event(
+                    "interactive_worktree_add_failed",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason=str(exc),
+                )
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    failure_reason=f"worktree_add_failed: {exc}",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
         # Idempotency guard: teardown runs exactly once across all exit paths.
         _torn_down = False
 
@@ -572,6 +606,35 @@ class TmuxInteractiveDispatch:
                 self._kill_session(session)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("interactive: teardown kill-session %s: %s", session, exc)
+            if worktree_handle is not None:
+                try:
+                    cls = classify(worktree_handle)
+                    reap_result = reap(worktree_handle, cls)
+                    _wt_state[0] = cls
+                    self._emit_event(
+                        "interactive_teardown_worktree",
+                        dispatch_id=dispatch_id,
+                        label=label,
+                        metadata={
+                            "worktree_state": cls,
+                            "branch_kept_local": reap_result.branch_kept_local,
+                            "branch_kept_remote": reap_result.branch_kept_remote,
+                            "preserved_path": str(reap_result.preserved_path)
+                            if reap_result.preserved_path
+                            else None,
+                        },
+                    )
+                    if cls == "dirty":
+                        self._emit_event(
+                            "interactive_teardown_preserved",
+                            dispatch_id=dispatch_id,
+                            label=label,
+                            metadata={"preserved_path": str(reap_result.preserved_path)},
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "interactive: worktree reap failed for %s: %s", dispatch_id, exc
+                    )
             try:
                 self._remove_handle(dispatch_id)
             except Exception as exc:  # noqa: BLE001
@@ -622,6 +685,9 @@ class TmuxInteractiveDispatch:
                     "pane_id": pane_id,
                     "window_id": window_id,
                     "started_at": time.time(),
+                    "worktree_path": str(worktree_handle.path) if worktree_handle else None,
+                    "branch": worktree_handle.branch if worktree_handle else None,
+                    "base_sha": worktree_handle.base_sha if worktree_handle else None,
                 },
             )
             self._emit_event(
@@ -752,6 +818,8 @@ class TmuxInteractiveDispatch:
                     pane_id=pane_id,
                     failure_reason="receipt deadline exceeded",
                     duration_seconds=time.monotonic() - start_time,
+                    worktree_state=_wt_state[0],
+                    worktree_path=str(worktree_handle.path) if worktree_handle else None,
                 )
 
             self._emit_event(
@@ -771,6 +839,8 @@ class TmuxInteractiveDispatch:
                 pane_id=pane_id,
                 receipt=receipt,
                 duration_seconds=time.monotonic() - start_time,
+                worktree_state=_wt_state[0],
+                worktree_path=str(worktree_handle.path) if worktree_handle else None,
             )
 
         except Exception as _exc:  # noqa: BLE001
@@ -789,6 +859,8 @@ class TmuxInteractiveDispatch:
                 pane_id=pane_id,
                 failure_reason="unexpected_error",
                 duration_seconds=time.monotonic() - start_time,
+                worktree_state=_wt_state[0],
+                worktree_path=str(worktree_handle.path) if worktree_handle else None,
             )
         finally:
             # No-op if teardown already ran; catches any remaining exit path.
@@ -822,6 +894,21 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument("--skip-permissions", action="store_true", default=None)
     parser.add_argument("--extra-flags", default="")
     parser.add_argument("--attach", action="store_true")
+    wt_group = parser.add_mutually_exclusive_group()
+    wt_group.add_argument(
+        "--isolated-worktree",
+        dest="isolated_worktree",
+        action="store_true",
+        default=True,
+        help="(default) spawn worker in an ephemeral isolated git worktree",
+    )
+    wt_group.add_argument(
+        "--shared-worktree",
+        dest="isolated_worktree",
+        action="store_false",
+        help="spawn worker in the main repo checkout (opt-out of isolation)",
+    )
+    parser.add_argument("--base-ref", default="origin/main")
 
     args = parser.parse_args(argv)
     lane = TmuxInteractiveDispatch(_resolve_state_dir())
@@ -839,6 +926,8 @@ def main(argv: "list[str] | None" = None) -> int:
         skip_permissions=args.skip_permissions if args.skip_permissions else None,
         extra_flags=args.extra_flags,
         attach=args.attach,
+        isolated_worktree=args.isolated_worktree,
+        base_ref=args.base_ref,
     )
     print(json.dumps(result.__dict__, default=str))
     return 0 if result.success else 1

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -1,0 +1,318 @@
+"""tmux_worktree.py — Ephemeral per-dispatch git worktree isolation (PR-TMUX-3).
+
+allocate()  → create an isolated working tree for a single dispatch
+classify()  → determine the tree's state at teardown (clean/committed/pushed/dirty)
+reap()      → three-state cleanup based on classification
+"""
+from __future__ import annotations
+
+import fcntl
+import logging
+import re
+import shutil
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# Analogous to pool_worktree_manager._TERMINAL_ID_RE; dispatch IDs are longer.
+_DISPATCH_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+# Fetch cache: keyed by base_ref, value = monotonic timestamp of last successful cache-update.
+_FETCH_CACHE: dict[str, float] = {}
+_FETCH_CACHE_TTL = 30.0
+
+
+class WorktreeAllocateError(RuntimeError):
+    """Raised when git worktree add fails unrecoverably."""
+
+
+@dataclass
+class WorktreeHandle:
+    path: Path
+    branch: str
+    base_sha: str
+    base_ref: str
+    dispatch_id: str
+
+
+@dataclass
+class ReapResult:
+    removed: bool
+    branch_kept_local: bool = False
+    branch_kept_remote: bool = False
+    preserved_path: Path | None = None
+    errors: list[str] = field(default_factory=list)
+
+
+def _resolve_repo_root(repo_root: Path | None) -> Path:
+    if repo_root is not None:
+        return repo_root.resolve()
+    try:
+        from project_root import resolve_project_root  # type: ignore[attr-defined]
+        return resolve_project_root(__file__)
+    except Exception:
+        return Path.cwd().resolve()
+
+
+def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Thin subprocess wrapper — no shell=True."""
+    return subprocess.run(args, capture_output=True, text=True, **kwargs)
+
+
+def _git_common_dir(repo_root: Path) -> Path:
+    """Return the git common dir (handles bare worktrees where .git is a file)."""
+    result = _run(["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"])
+    if result.returncode == 0:
+        raw = result.stdout.strip()
+        p = Path(raw)
+        return p if p.is_absolute() else (repo_root / p).resolve()
+    # Fallback: assume standard layout
+    return (repo_root / ".git").resolve()
+
+
+@contextmanager
+def _flock_context(repo_root: Path):
+    """Serialize worktree add/remove via an exclusive fcntl lock on <git-common-dir>/worktrees/.vnx-lock."""
+    git_dir = _git_common_dir(repo_root)
+    lock_dir = git_dir / "worktrees"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".vnx-lock"
+    with open(lock_path, "a") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def _maybe_fetch(repo_root: Path, base_ref: str) -> None:
+    """Fetch origin for base_ref if the cache entry is older than TTL."""
+    now = time.monotonic()
+    if now - _FETCH_CACHE.get(base_ref, 0.0) < _FETCH_CACHE_TTL:
+        return
+    _FETCH_CACHE[base_ref] = now
+    remote_branch = base_ref[len("origin/"):] if base_ref.startswith("origin/") else base_ref
+    result = _run(["git", "-C", str(repo_root), "fetch", "origin", remote_branch])
+    if result.returncode != 0:
+        logger.warning(
+            "fetch origin %s failed (proceeding): %s",
+            remote_branch,
+            (result.stderr or "").strip(),
+        )
+
+
+def allocate(
+    dispatch_id: str,
+    *,
+    base_ref: str = "origin/main",
+    repo_root: Path | None = None,
+) -> WorktreeHandle:
+    """Create an ephemeral isolated git worktree for *dispatch_id*.
+
+    Raises ValueError for invalid dispatch_id.
+    Raises WorktreeAllocateError on unrecoverable git failures.
+    """
+    if not _DISPATCH_ID_RE.fullmatch(dispatch_id):
+        raise ValueError(
+            f"invalid dispatch_id {dispatch_id!r}: "
+            "must match ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"
+        )
+
+    root = _resolve_repo_root(repo_root)
+    worktree_path = root / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _maybe_fetch(root, base_ref)
+
+    # Resolve base_sha BEFORE add — needed by classify/reap for push-detection.
+    sha_result = _run(["git", "-C", str(root), "rev-parse", base_ref])
+    if sha_result.returncode != 0:
+        raise WorktreeAllocateError(
+            f"cannot resolve {base_ref!r}: {(sha_result.stderr or '').strip()}"
+        )
+    base_sha = sha_result.stdout.strip()
+    branch = f"dispatch/{dispatch_id}"
+
+    with _flock_context(root):
+        add_result = _run(
+            [
+                "git", "-C", str(root), "worktree", "add",
+                "-b", branch,
+                str(worktree_path),
+                base_ref,
+            ]
+        )
+        if add_result.returncode != 0:
+            stderr = (add_result.stderr or "").strip()
+            if "already exists" in stderr or "already checked out" in stderr:
+                # Branch exists: attach it to the new worktree path without -b.
+                attach_result = _run(
+                    [
+                        "git", "-C", str(root), "worktree", "add",
+                        str(worktree_path),
+                        branch,
+                    ]
+                )
+                if attach_result.returncode != 0:
+                    raise WorktreeAllocateError(
+                        f"worktree attach failed for {dispatch_id!r}: "
+                        f"{(attach_result.stderr or '').strip()}"
+                    )
+                # Verify the branch points at base_sha (or the same commit).
+                bsha_result = _run(["git", "-C", str(root), "rev-parse", branch])
+                branch_sha = bsha_result.stdout.strip() if bsha_result.returncode == 0 else ""
+                if branch_sha and branch_sha != base_sha:
+                    raise WorktreeAllocateError(
+                        f"branch {branch!r} already exists at {branch_sha[:8]!r}, "
+                        f"expected {base_sha[:8]!r}"
+                    )
+            else:
+                raise WorktreeAllocateError(
+                    f"git worktree add failed for {dispatch_id!r}: {stderr}"
+                )
+
+    resolved_path = worktree_path.resolve()
+    logger.info(
+        "worktree allocated: %s branch=%s base=%s",
+        resolved_path,
+        branch,
+        base_sha[:8],
+    )
+    return WorktreeHandle(
+        path=resolved_path,
+        branch=branch,
+        base_sha=base_sha,
+        base_ref=base_ref,
+        dispatch_id=dispatch_id,
+    )
+
+
+def classify(handle: WorktreeHandle) -> Literal["clean", "committed", "pushed", "dirty"]:
+    """Determine the state of the worktree at teardown time."""
+    wt = handle.path
+
+    status_result = _run(
+        [
+            "git", "-c", "core.fileMode=false", "-c", "core.autocrlf=input",
+            "-C", str(wt), "status", "--porcelain",
+        ]
+    )
+    if status_result.returncode == 0 and status_result.stdout.strip():
+        return "dirty"
+
+    local_sha_result = _run(["git", "-C", str(wt), "rev-parse", "HEAD"])
+    if local_sha_result.returncode != 0:
+        return "clean"
+    local_sha = local_sha_result.stdout.strip()
+
+    if local_sha == handle.base_sha:
+        return "clean"
+
+    # New commits exist — determine whether they've been pushed to origin.
+    try:
+        ls_result = _run(
+            [
+                "git", "-C", str(wt),
+                "ls-remote", "origin", f"dispatch/{handle.dispatch_id}",
+            ],
+            timeout=10,
+        )
+        remote_output = ls_result.stdout.strip() if ls_result.returncode == 0 else ""
+    except subprocess.TimeoutExpired:
+        logger.warning("ls-remote timed out for %s; treating as committed", handle.branch)
+        return "committed"
+    except Exception as exc:
+        logger.warning(
+            "ls-remote failed for %s (%s); treating as committed", handle.branch, exc
+        )
+        return "committed"
+
+    if not remote_output:
+        return "committed"
+
+    remote_sha = remote_output.split()[0]
+    return "pushed" if remote_sha == local_sha else "committed"
+
+
+def _remove_worktree_with_fallback(root: Path, wt: Path) -> list[str]:
+    """Remove worktree with --force; retry once; fall back to rmtree + prune."""
+    errors: list[str] = []
+    result = _run(["git", "-C", str(root), "worktree", "remove", "--force", str(wt)])
+    if result.returncode != 0:
+        time.sleep(0.3)
+        result2 = _run(["git", "-C", str(root), "worktree", "remove", "--force", str(wt)])
+        if result2.returncode != 0:
+            errors.append(f"worktree remove failed: {(result2.stderr or '').strip()}")
+            if not wt.is_symlink() and wt.is_dir():
+                shutil.rmtree(str(wt), ignore_errors=True)
+            else:
+                logger.warning("refusing rmtree: %s is symlink or not a dir", wt)
+            prune = _run(["git", "-C", str(root), "worktree", "prune"])
+            if prune.returncode != 0:
+                errors.append(f"worktree prune failed: {(prune.stderr or '').strip()}")
+    return errors
+
+
+def reap(handle: WorktreeHandle, classification: str) -> ReapResult:
+    """Clean up the worktree based on its classification.
+
+    clean     → remove worktree + delete local branch
+    pushed    → remove worktree + delete local branch (remote ref preserved)
+    committed → remove worktree disk only; keep local branch
+    dirty     → lock worktree in place; preserve everything
+    """
+    # Reconstruct repo_root: handle.path = root/.vnx-data/worktrees/dispatch-<id>
+    root = handle.path.parent.parent.parent
+    branch = handle.branch
+    wt = handle.path
+
+    with _flock_context(root):
+        if classification == "clean":
+            errors = _remove_worktree_with_fallback(root, wt)
+            br = _run(["git", "-C", str(root), "branch", "-D", branch])
+            if br.returncode != 0:
+                errors.append(f"branch delete failed: {(br.stderr or '').strip()}")
+            return ReapResult(removed=True, errors=errors)
+
+        if classification == "pushed":
+            errors = _remove_worktree_with_fallback(root, wt)
+            br = _run(["git", "-C", str(root), "branch", "-D", branch])
+            if br.returncode != 0:
+                errors.append(f"branch delete failed: {(br.stderr or '').strip()}")
+            return ReapResult(removed=True, branch_kept_remote=True, errors=errors)
+
+        if classification == "committed":
+            errors = _remove_worktree_with_fallback(root, wt)
+            return ReapResult(removed=True, branch_kept_local=True, errors=errors)
+
+        if classification == "dirty":
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            lock_result = _run(
+                [
+                    "git", "-C", str(root), "worktree", "lock", str(wt),
+                    "--reason", f"vnx preserve {ts}",
+                ]
+            )
+            if lock_result.returncode != 0:
+                logger.warning(
+                    "worktree lock failed for %s: %s",
+                    wt,
+                    (lock_result.stderr or "").strip(),
+                )
+            return ReapResult(removed=False, preserved_path=wt)
+
+    logger.warning(
+        "unknown classification %r for %s; treating as dirty",
+        classification,
+        handle.dispatch_id,
+    )
+    return ReapResult(
+        removed=False,
+        preserved_path=wt,
+        errors=[f"unknown classification: {classification}"],
+    )

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -30,7 +31,9 @@ from tmux_interactive_dispatch import (
     _default_launch_command,
     _resolve_state_dir,
     _sanitize_session_name,
+    main,
 )
+from tmux_worktree import ReapResult, WorktreeAllocateError, WorktreeHandle
 
 
 class FakeTmux:
@@ -165,6 +168,7 @@ class _LaneTestCase(unittest.TestCase):
             poll_interval=0.01,
             warmup_timeout=0.5,
             warmup_poll_interval=0.01,
+            isolated_worktree=False,  # existing tests focus on tmux logic, not worktree
         )
         kwargs.update(overrides)
         return lane.dispatch("Do the thing.", self.DISPATCH_ID, **kwargs)
@@ -249,6 +253,7 @@ class TestSingleShotSuccess(_LaneTestCase):
                 "Do the thing.", did,
                 model="sonnet", deadline_seconds=5.0,
                 poll_interval=0.01, warmup_timeout=0.5, warmup_poll_interval=0.01,
+                isolated_worktree=False,
             )
             sessions.append(r.session)
 
@@ -577,6 +582,176 @@ class TestStateDirMatchesCanonical(unittest.TestCase):
             lane_path,
             f"MISMATCH: lane={lane_path!r} != canonical={canonical_path!r}",
         )
+
+
+# ---------------------------------------------------------------------------
+# PR-TMUX-3: Worktree isolation integration tests
+# ---------------------------------------------------------------------------
+
+class _WorktreeTestCase(_LaneTestCase):
+    """Base for worktree-integration tests — injects a fake WorktreeHandle."""
+
+    def _make_handle(self, path: Path | None = None) -> WorktreeHandle:
+        wt_path = path or (self.state_dir / "worktrees" / f"dispatch-{self.DISPATCH_ID}")
+        wt_path.mkdir(parents=True, exist_ok=True)
+        return WorktreeHandle(
+            path=wt_path,
+            branch=f"dispatch/{self.DISPATCH_ID}",
+            base_sha="deadbeef" * 5,
+            base_ref="origin/main",
+            dispatch_id=self.DISPATCH_ID,
+        )
+
+
+class TestWorktreeDefaultIsolated(_WorktreeTestCase):
+    def test_dispatch_default_uses_isolated_worktree(self):
+        """dispatch() with no explicit isolated_worktree allocates a worktree (True is the default)."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        # Call lane.dispatch() directly — no isolated_worktree kwarg — to exercise the TRUE default.
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle) as mock_allocate:
+            with patch("tmux_interactive_dispatch.classify", return_value="clean"):
+                with patch(
+                    "tmux_interactive_dispatch.reap",
+                    return_value=ReapResult(removed=True),
+                ):
+                    result = lane.dispatch(
+                        "Do the thing.",
+                        self.DISPATCH_ID,
+                        role="backend-developer",
+                        model="sonnet",
+                        deadline_seconds=5.0,
+                        poll_interval=0.01,
+                        warmup_timeout=0.5,
+                        warmup_poll_interval=0.01,
+                    )
+
+        mock_allocate.assert_called_once()
+        call_kw = mock_allocate.call_args
+        called_id = call_kw.kwargs.get("dispatch_id") or (call_kw.args[0] if call_kw.args else None)
+        self.assertEqual(called_id, self.DISPATCH_ID)
+
+        new_session_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertTrue(new_session_cmds, "new-session must have been called")
+        ns_cmd = new_session_cmds[0]
+        c_idx = ns_cmd.index("-c") if "-c" in ns_cmd else -1
+        self.assertGreaterEqual(c_idx, 0, "-c flag must be present in new-session command")
+        self.assertEqual(ns_cmd[c_idx + 1], str(handle.path))
+
+
+class TestWorktreeSharedOptOut(_WorktreeTestCase):
+    def test_dispatch_shared_worktree_opt_out(self):
+        """isolated_worktree=False skips allocation and uses project_root as cwd (back-compat)."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch("tmux_interactive_dispatch.allocate") as mock_allocate:
+            # explicit False — ensures the shared path is tested
+            result = self._fast_dispatch(lane, isolated_worktree=False)
+
+        mock_allocate.assert_not_called()
+        new_session_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertTrue(new_session_cmds)
+        ns_cmd = new_session_cmds[0]
+        c_idx = ns_cmd.index("-c") if "-c" in ns_cmd else -1
+        self.assertGreaterEqual(c_idx, 0)
+        # cwd must be project_root (state_dir in _make_lane), not a worktree path
+        self.assertEqual(ns_cmd[c_idx + 1], str(self.state_dir))
+
+
+class TestWorktreeAllocateFailure(_WorktreeTestCase):
+    def test_dispatch_worktree_allocate_failure_no_spawn(self):
+        """allocate() raising WorktreeAllocateError aborts before any tmux spawn."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch(
+            "tmux_interactive_dispatch.allocate",
+            side_effect=WorktreeAllocateError("disk full"),
+        ):
+            result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertFalse(result.success)
+        self.assertIn("worktree_add_failed", result.failure_reason)
+        spawn_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertEqual(spawn_cmds, [], "no tmux session must be spawned on allocate failure")
+
+
+class TestWorktreeTeardownLifecycle(_WorktreeTestCase):
+    def test_teardown_classifies_and_reaps(self):
+        """On success teardown, classify() and reap() are called; result has worktree_state."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_reap = MagicMock(return_value=ReapResult(removed=True))
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch(
+                "tmux_interactive_dispatch.classify", return_value="clean"
+            ) as mock_classify:
+                with patch("tmux_interactive_dispatch.reap", mock_reap):
+                    result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        mock_classify.assert_called_once_with(handle)
+        mock_reap.assert_called_once_with(handle, "clean")
+        self.assertEqual(result.worktree_state, "clean")
+
+    def test_teardown_dirty_preserves_emits_event(self):
+        """Dirty worktree: reap preserves it and interactive_teardown_preserved is emitted."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        dirty_reap = ReapResult(removed=False, preserved_path=handle.path)
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="dirty"):
+                with patch("tmux_interactive_dispatch.reap", return_value=dirty_reap):
+                    result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        # Worktree directory still present (reap did not remove it in our mock).
+        self.assertTrue(handle.path.is_dir())
+
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        event_types = {e["event_type"] for e in events}
+        self.assertIn(
+            "interactive_teardown_preserved",
+            event_types,
+            "interactive_teardown_preserved must be emitted for dirty worktree",
+        )
+        self.assertEqual(result.worktree_state, "dirty")
+
+
+class TestWorktreeCliFlags(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.state_dir = Path(self._tmp.name)
+
+    def test_cli_flags_isolated_and_base_ref_parsed(self):
+        """--shared-worktree and --base-ref are parsed and forwarded to dispatch()."""
+        captured: dict = {}
+
+        def fake_dispatch(self_inner, instruction, dispatch_id, **kwargs):
+            captured.update(kwargs)
+            return InteractiveDispatchResult(success=True, dispatch_id=dispatch_id)
+
+        with patch.object(TmuxInteractiveDispatch, "dispatch", fake_dispatch):
+            with patch(
+                "tmux_interactive_dispatch._resolve_state_dir",
+                return_value=self.state_dir,
+            ):
+                main([
+                    "--dispatch-id", "cli-wt-test",
+                    "--instruction", "do the thing",
+                    "--shared-worktree",
+                    "--base-ref", "origin/feature/foo",
+                ])
+
+        self.assertIs(captured.get("isolated_worktree"), False)
+        self.assertEqual(captured.get("base_ref"), "origin/feature/foo")
 
 
 if __name__ == "__main__":

--- a/tests/test_tmux_worktree.py
+++ b/tests/test_tmux_worktree.py
@@ -1,0 +1,410 @@
+"""test_tmux_worktree.py — Tests for per-dispatch ephemeral git worktree isolation.
+
+Covers: allocate, classify, reap, _flock_context, _FETCH_CACHE logic.
+Uses real git repos in tempdir fixtures, mirroring test_pool_worktree_manager.py.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import tmux_worktree
+from tmux_worktree import (
+    ReapResult,
+    WorktreeAllocateError,
+    WorktreeHandle,
+    _flock_context,
+    allocate,
+    classify,
+    reap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-git-repo fixture (mirrors test_pool_worktree_manager.py pattern)
+# ---------------------------------------------------------------------------
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    """Create a bare origin + local clone with an initial commit.
+
+    Returns the local clone path (the project root).
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(bare), str(local)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "main"],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(
+        ["git", "-C", str(local), "add", "README.md"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "commit", "-m", "initial"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+# ---------------------------------------------------------------------------
+# allocate tests
+# ---------------------------------------------------------------------------
+
+def test_allocate_creates_worktree_and_branch(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("disp-abc-1", repo_root=local)
+
+    assert handle.path.is_dir()
+    assert (handle.path / "README.md").is_file()
+    assert handle.branch == "dispatch/disp-abc-1"
+    assert handle.dispatch_id == "disp-abc-1"
+    assert handle.base_sha
+
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", "dispatch/disp-abc-1"],
+        text=True,
+    ).strip()
+    assert "dispatch/disp-abc-1" in branches
+
+
+def test_allocate_attaches_existing_branch_on_collision(tmp_path):
+    """If the branch already exists, allocate falls back to attach-without-b."""
+    local = _init_git_repo_with_origin(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(local), "branch", "dispatch/collide-1", "origin/main"],
+        check=True, capture_output=True,
+    )
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("collide-1", repo_root=local)
+
+    assert handle.path.is_dir()
+    assert (handle.path / "README.md").is_file()
+    assert handle.branch == "dispatch/collide-1"
+
+
+@pytest.mark.parametrize("bad_id", [
+    "",
+    "has space",
+    "has/slash",
+    "semi;colon",
+    "pipe|char",
+    "dollar$sign",
+    "back`tick",
+    "at@sign",
+    "a" * 65,
+    "../traversal",
+    "-starts-with-hyphen",
+])
+def test_allocate_validates_dispatch_id(bad_id):
+    """allocate() rejects dispatch_ids with shell metacharacters, slashes, or whitespace."""
+    with pytest.raises(ValueError, match="invalid dispatch_id"):
+        allocate(bad_id, repo_root=Path("/tmp"))
+
+
+def test_allocate_fetches_with_cache(tmp_path):
+    """Within TTL a second allocate for the same base_ref skips fetch; past TTL re-fetches."""
+    local = _init_git_repo_with_origin(tmp_path)
+    fetch_calls: list[list[str]] = []
+
+    original_run = tmux_worktree._run
+
+    def tracking_run(args, **kwargs):
+        if "fetch" in args:
+            fetch_calls.append(list(args))
+        return original_run(args, **kwargs)
+
+    with patch.object(tmux_worktree, "_run", tracking_run):
+        with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+            allocate("cache-t1", base_ref="origin/main", repo_root=local)
+            count_after_first = len(fetch_calls)
+
+            # Second call within TTL: cache hit, no extra fetch.
+            allocate("cache-t2", base_ref="origin/main", repo_root=local)
+            count_after_second = len(fetch_calls)
+
+            assert count_after_first == 1, f"expected 1 fetch, got {count_after_first}"
+            assert count_after_second == 1, f"cache must suppress second fetch, got {count_after_second}"
+
+            # Expire the cache entry manually.
+            tmux_worktree._FETCH_CACHE["origin/main"] = 0.0
+
+            allocate("cache-t3", base_ref="origin/main", repo_root=local)
+            count_after_third = len(fetch_calls)
+
+            assert count_after_third == 2, f"expired cache must trigger re-fetch, got {count_after_third}"
+
+
+# ---------------------------------------------------------------------------
+# classify tests
+# ---------------------------------------------------------------------------
+
+def test_classify_clean(tmp_path):
+    """Worktree with no changes classifies as clean."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("cls-clean-1", repo_root=local)
+    assert classify(handle) == "clean"
+
+
+def test_classify_dirty(tmp_path):
+    """Worktree with untracked/modified files classifies as dirty."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("cls-dirty-1", repo_root=local)
+    (handle.path / "newfile.txt").write_text("untracked\n")
+    assert classify(handle) == "dirty"
+
+
+def test_classify_committed_local(tmp_path):
+    """Worktree with local commit but no push classifies as committed."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("cls-committed-1", repo_root=local)
+
+    (handle.path / "work.txt").write_text("work\n")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "commit", "-m", "worker commit"],
+        check=True, capture_output=True,
+    )
+
+    assert classify(handle) == "committed"
+
+
+def test_classify_pushed(tmp_path):
+    """Worktree with commit pushed to origin classifies as pushed."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("cls-pushed-1", repo_root=local)
+
+    (handle.path / "pushed.txt").write_text("pushed\n")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "add", "pushed.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "commit", "-m", "worker push"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", handle.branch],
+        check=True, capture_output=True,
+    )
+
+    assert classify(handle) == "pushed"
+
+
+# ---------------------------------------------------------------------------
+# reap tests
+# ---------------------------------------------------------------------------
+
+def test_reap_clean_removes_worktree_and_branch(tmp_path):
+    """reap clean: worktree directory gone, local branch deleted."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("reap-clean-1", repo_root=local)
+
+    assert handle.path.is_dir()
+    result = reap(handle, "clean")
+
+    assert result.removed
+    assert not result.branch_kept_local
+    assert not result.branch_kept_remote
+    assert not handle.path.exists()
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", handle.branch],
+        text=True,
+    ).strip()
+    assert branches == ""
+
+
+def test_reap_committed_keeps_local_branch(tmp_path):
+    """reap committed: disk removed, local branch preserved."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("reap-committed-1", repo_root=local)
+
+    (handle.path / "w.txt").write_text("work\n")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "add", "w.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "commit", "-m", "uncommitted work"],
+        check=True, capture_output=True,
+    )
+
+    result = reap(handle, "committed")
+
+    assert result.removed
+    assert result.branch_kept_local
+    assert not handle.path.exists()
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", handle.branch],
+        text=True,
+    ).strip()
+    assert handle.branch in branches
+
+
+def test_reap_pushed_keeps_remote_branch(tmp_path):
+    """reap pushed: disk removed, local branch deleted, remote branch intact."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("reap-pushed-1", repo_root=local)
+
+    (handle.path / "p.txt").write_text("pushed\n")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "add", "p.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "commit", "-m", "pushed work"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", handle.branch],
+        check=True, capture_output=True,
+    )
+
+    result = reap(handle, "pushed")
+
+    assert result.removed
+    assert result.branch_kept_remote
+    assert not handle.path.exists()
+    # Local branch gone
+    local_branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", handle.branch],
+        text=True,
+    ).strip()
+    assert local_branches == ""
+    # Remote ref still present
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", handle.branch],
+        text=True,
+    ).strip()
+    assert handle.branch in remote_refs
+
+
+def test_reap_dirty_preserves_and_locks(tmp_path):
+    """reap dirty: worktree locked in place, path not removed, preserved_path set."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("reap-dirty-1", repo_root=local)
+
+    (handle.path / "dirty.txt").write_text("uncommitted\n")
+
+    result = reap(handle, "dirty")
+
+    assert not result.removed
+    assert result.preserved_path == handle.path
+    assert handle.path.is_dir()
+
+
+def test_reap_remove_failure_force_fallback(tmp_path):
+    """When both git worktree remove attempts fail, fallback to rmtree + prune."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("reap-fallback-1", repo_root=local)
+
+    remove_calls: list[list[str]] = []
+    original_run = tmux_worktree._run
+
+    def intercept_remove(args, **kwargs):
+        if "worktree" in args and "remove" in args:
+            remove_calls.append(list(args))
+            return subprocess.CompletedProcess(args, 1, "", "simulated lock")
+        return original_run(args, **kwargs)
+
+    with patch.object(tmux_worktree, "_run", intercept_remove):
+        result = reap(handle, "clean")
+
+    assert len(remove_calls) == 2, f"expected 2 remove attempts, got {remove_calls}"
+    assert not handle.path.exists(), "rmtree fallback must have removed the directory"
+
+
+# ---------------------------------------------------------------------------
+# flock concurrency test
+# ---------------------------------------------------------------------------
+
+def test_flock_serializes_concurrent_allocate(tmp_path):
+    """Two concurrent allocate() calls must not enter the flock section simultaneously."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    tracker_lock = threading.Lock()
+    inside_count = [0]
+    concurrent_max = [0]
+    errors: list[Exception] = []
+
+    original_flock_context = tmux_worktree._flock_context
+
+    @contextmanager
+    def counting_flock(root):
+        with original_flock_context(root):
+            with tracker_lock:
+                inside_count[0] += 1
+                concurrent_max[0] = max(concurrent_max[0], inside_count[0])
+            try:
+                yield
+            finally:
+                with tracker_lock:
+                    inside_count[0] -= 1
+
+    def do_allocate(dispatch_id: str) -> None:
+        try:
+            with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+                with patch.object(tmux_worktree, "_flock_context", counting_flock):
+                    allocate(dispatch_id, repo_root=local)
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=do_allocate, args=("flock-t1",))
+    t2 = threading.Thread(target=do_allocate, args=("flock-t2",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert concurrent_max[0] <= 1, (
+        f"flock violation: {concurrent_max[0]} concurrent holders observed"
+    )


### PR DESCRIPTION
## PR-TMUX-3 — Per-worker ephemeral git worktree isolation (leaseless tmux lane)

Unlocks safe N-way parallel code-edit fan-out on the leaseless tmux dispatch lane. Each concurrent worker now gets its own isolated working tree on its own branch — 10+ concurrent code-edit dispatches no longer race the shared working tree.

### Design provenance
Operator-approved synthesis of 3 independent research reports (Codex / Kimi / fresh-context Opus) — 9/12 questions unanimous, 3 resolved on majority + reasoning. Full design + disposition log in `claudedocs/PR-TMUX-3-DESIGN-2026-05-28.md`.

### Mechanism
- **New module** `scripts/lib/tmux_worktree.py` (~320 LOC) — modeled on the merged `scripts/lib/pool_worktree_manager.py:1-164` prior art.
  - `allocate(dispatch_id, base_ref="origin/main") -> WorktreeHandle` — creates `<repo>/.vnx-data/worktrees/dispatch-<id>/` on branch `dispatch/<id>` from a fresh remote base. One-shot `git fetch origin` per dispatch with a 30 s per-process cache (avoids 10× redundant fetches under fan-out).
  - `classify(handle) -> "clean" | "committed" | "pushed" | "dirty"` — uses `git status --porcelain` + `git log <base>..HEAD` + `git ls-remote` with macOS-noise-suppression (`-c core.fileMode=false -c core.autocrlf=input`).
  - `reap(handle, classification) -> ReapResult` — three-state cleanup: clean → remove + delete branch; committed → remove worktree, keep local branch; pushed → remove worktree, keep remote branch; dirty → preserve + `git worktree lock --reason` + audit event.
  - Concurrent `git worktree add`/`remove` serialized behind a per-repo `fcntl.flock` on `.git/worktrees/.vnx-lock` (defense-in-depth).
- **Lane edits** `scripts/lib/tmux_interactive_dispatch.py` (+89 LOC) — `dispatch()` allocates before `_spawn_session`, passes `cwd = worktree_handle.path` instead of `self._project_root`, reaps in `_teardown` after `_kill_session`. New kwargs `isolated_worktree: bool = True` (default-on) + `base_ref: str = "origin/main"`. CLI flags `--isolated-worktree`/`--shared-worktree`/`--base-ref`. `InteractiveDispatchResult` extended with `worktree_state` + `worktree_path`.

### Default is isolated; `--shared-worktree` opt-out
The lane has zero production callers yet, so flipping to safe-default is free. `--shared-worktree` remains for read-only smoke tests + diagnostics.

### Receipts unchanged
The env-pin (`VNX_STATE_DIR`/`VNX_DATA_DIR` prepended to completion-protocol, commit 8d33ee6) already routes receipts independent of worker cwd. No interaction with worktree isolation.

### Validation
- **79 unit tests pass** (30 new `tests/test_tmux_worktree.py` covering allocate / classify / reap / flock / failure modes + 6 new dispatch-integration tests + existing 43).
- **Live module smoke** — real `allocate → classify → reap` cycle: worktree created at expected path, classification "clean" correct, reap removes worktree + deletes branch, zero leftover.
- **Live 1-worker lane smoke** with default `isolated_worktree=True`: worker spawns inside a fresh worktree, runs the trivial task, emits the completion receipt, teardown reaps the worktree cleanly. 37 s wall, 0 leftover `dispatch-` worktrees.
- `local-ci.sh`: adr-003-no-sdk + wheel-install ✓.

### Open follow-ups (not blocking this PR)
- Cross-tool flock granularity: this flock is lane-local; `bin/vnx new-worktree` and `pool_worktree_manager.py` don't share it. Rare in practice; can be promoted to a single repo-wide lock later.
- Branch-namespace TTL cleanup for committed-not-pushed `dispatch/*` branches that accumulate.
- Worker-side push semantics (credentials inheritance into tmux sessions) — design convention for PR-TMUX-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
