### PR TITLE
fix(obs): codex_spawn default model + token-usage extraction (PR-OBS-1)

### DIFF
--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -35,6 +35,8 @@ from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CODEX_MODEL = "gpt-5.5"
+
 
 @dataclass
 class CodexSpawnResult:
@@ -78,7 +80,7 @@ class CodexSpawnResult:
 # ---------------------------------------------------------------------------
 
 _TOKEN_TEXT_RE = re.compile(
-    r"tokens?:\s*(\d+)\s+input\s*/\s*(\d+)\s+output",
+    r"tokens?(?:\s+used)?:\s*([\d,]+)\s+input(?:\s*/|,)(?:\s*[\d,]+\s+cached(?:\s*/|,))?\s*([\d,]+)\s+output",
     re.IGNORECASE,
 )
 
@@ -94,14 +96,33 @@ def _extract_token_count_payload(event: dict) -> Optional[dict]:
             return payload
         if em.get("type") == "token_count":
             return em
+        usage = payload.get("usage") if isinstance(payload, dict) else None
+        if isinstance(usage, dict):
+            return usage
+    usage = event.get("usage")
+    if isinstance(usage, dict):
+        return usage
     msg = event.get("msg")
     if isinstance(msg, dict) and msg.get("type") == "token_count":
         return msg
     item = event.get("item")
     if isinstance(item, dict) and item.get("type") == "token_count":
         return item
-    if event.get("type") == "token_count":
+    if event.get("type") in ("token_count", "token_usage"):
         return event
+    return None
+
+
+def _parse_token_int(value: Any) -> Optional[int]:
+    """Return a token count from int or comma-formatted string values."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.replace(",", "").strip()
+        if stripped.isdigit():
+            return int(stripped)
     return None
 
 
@@ -109,28 +130,37 @@ def _normalize_token_count(payload: dict) -> Optional[dict]:
     """Normalize a Codex token_count payload to the canonical token_usage dict."""
     if not isinstance(payload, dict):
         return None
-    input_t = payload.get("input_tokens")
+    input_t = _parse_token_int(payload.get("input_tokens"))
     if input_t is None:
-        input_t = payload.get("prompt_tokens", 0)
-    output_t = payload.get("output_tokens")
+        input_t = _parse_token_int(payload.get("prompt_tokens")) or 0
+    output_t = _parse_token_int(payload.get("output_tokens"))
     if output_t is None:
-        output_t = payload.get("completion_tokens", 0)
-    if not isinstance(input_t, int) or not isinstance(output_t, int):
-        return None
+        output_t = _parse_token_int(payload.get("completion_tokens")) or 0
     if input_t == 0 and output_t == 0:
         return None
-    cache_read = payload.get("cached_input_tokens")
+    cache_read = _parse_token_int(payload.get("cached_input_tokens"))
     if cache_read is None:
-        cache_read = payload.get("cache_read_tokens", 0)
-    cache_creation = payload.get("cache_creation_input_tokens")
+        cache_read = _parse_token_int(payload.get("cache_read_tokens")) or 0
+    cache_creation = _parse_token_int(payload.get("cache_creation_input_tokens"))
     if cache_creation is None:
-        cache_creation = payload.get("cache_creation_tokens", 0)
+        cache_creation = _parse_token_int(payload.get("cache_creation_tokens")) or 0
     return {
         "input_tokens": int(input_t),
         "output_tokens": int(output_t),
-        "cache_creation_tokens": int(cache_creation) if isinstance(cache_creation, int) else 0,
-        "cache_read_tokens": int(cache_read) if isinstance(cache_read, int) else 0,
+        "cache_creation_tokens": int(cache_creation),
+        "cache_read_tokens": int(cache_read),
     }
+
+
+def _extract_token_count_from_text(text: str) -> Optional[dict]:
+    """Parse Codex's human-readable token summary line when it appears."""
+    match = _TOKEN_TEXT_RE.search(text or "")
+    if not match:
+        return None
+    return _normalize_token_count({
+        "input_tokens": match.group(1),
+        "output_tokens": match.group(2),
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -178,13 +208,21 @@ def _normalize_text_events(
         return make("init", {"raw_type": etype})
     if etype == "agent_message":
         content = payload.get("text", payload.get("content", payload.get("message", "")))
-        return make("text", {"text": str(content)})
+        data = {"text": str(content)}
+        token_count = _extract_token_count_from_text(str(content))
+        if token_count:
+            data["token_count"] = token_count
+        return make("text", data)
     if etype == "item.completed" and item_type == "agent_message":
-        content = item.get("content", "")
+        content = item.get("text", item.get("content", ""))
         if isinstance(content, list):
             texts = [b.get("text", "") for b in content if isinstance(b, dict)]
             content = "\n".join(t for t in texts if t)
-        return make("text", {"text": str(content)})
+        data = {"text": str(content)}
+        token_count = _extract_token_count_from_text(str(content))
+        if token_count:
+            data["token_count"] = token_count
+        return make("text", data)
     if etype in ("item.started", "item.updated") and item_type == "command_execution":
         cmd_str = item.get("command", item.get("cmd", item.get("args", "")))
         if isinstance(cmd_str, list):
@@ -268,12 +306,17 @@ def normalize_codex_event(raw: dict, terminal_id: str, dispatch_id: str) -> Cano
     })
 
 
-def _build_cmd(model: str) -> list:
+def _resolve_codex_model(model: Optional[str]) -> str:
+    """Resolve explicit model first, then env default, then the current CLI default."""
+    requested = (model or "").strip()
+    if requested:
+        return requested
+    return os.environ.get("VNX_CODEX_DEFAULT_MODEL", "").strip() or DEFAULT_CODEX_MODEL
+
+
+def _build_cmd(model: Optional[str]) -> list:
     """Build the codex exec argv."""
-    cmd = ["codex", "exec", "--json"]
-    if model:
-        cmd += ["-c", f'model="{model}"']
-    return cmd
+    return ["codex", "exec", "--json", "--model", _resolve_codex_model(model)]
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +343,7 @@ class _NormalizerHost(StreamingDrainerMixin):
 
 def _launch_codex_proc(
     prompt: str,
-    model: str,
+    model: Optional[str],
     extra_env: Optional[Dict[str, str]],
     cwd: Optional[Any],
 ) -> Tuple[Optional[subprocess.Popen], Optional[CodexSpawnResult]]:
@@ -490,7 +533,7 @@ def _drain_stream(
 
 def spawn_codex(
     prompt: str,
-    model: str,
+    model: Optional[str],
     dispatch_id: str,
     terminal_id: str,
     *,

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -36,8 +36,8 @@ providers:
     enabled: true
     api_key_env: OPENAI_API_KEY
     models:
-      gpt-5.2-codex:
-        litellm_name: "openai/gpt-5.2-codex"
+      gpt-5.5:
+        litellm_name: "openai/gpt-5.5"
         cost_input_per_mtok: 1.25
         cost_output_per_mtok: 10.00
         max_tokens: 32000

--- a/tests/test_codex_spawn_byte_identity.py
+++ b/tests/test_codex_spawn_byte_identity.py
@@ -47,10 +47,23 @@ _TERMINAL_ID = "T1"
 _RAW_THREAD_STARTED = {"type": "thread.started"}
 _RAW_AGENT_MSG = {"type": "agent_message", "text": "LGTM. No blocking findings."}
 _RAW_TURN_COMPLETED = {"type": "turn.completed"}
+_RAW_TURN_COMPLETED_USAGE_0130 = {
+    "type": "turn.completed",
+    "usage": {
+        "input_tokens": 15545,
+        "cached_input_tokens": 6528,
+        "output_tokens": 23,
+        "reasoning_output_tokens": 14,
+    },
+}
 _RAW_ERROR = {"type": "error", "message": "something went wrong"}
 _RAW_ITEM_COMPLETED_AGENT = {
     "type": "item.completed",
     "item": {"type": "agent_message", "content": "Check passed."},
+}
+_RAW_ITEM_COMPLETED_AGENT_TEXT_0130 = {
+    "type": "item.completed",
+    "item": {"id": "item_0", "type": "agent_message", "text": "SMOKE_OK"},
 }
 _RAW_TOKEN_COUNT = {
     "event_msg": {
@@ -118,6 +131,21 @@ class TestNormalizerIdentity:
 
     def test_normalizer_identity_token_count(self):
         self._assert_identical(_RAW_TOKEN_COUNT)
+
+    def test_turn_completed_usage_shape_from_codex_0130(self):
+        event = _normalize_via_spawn(_RAW_TURN_COMPLETED_USAGE_0130)
+        assert event.event_type == "complete"
+        assert event.data["token_count"] == {
+            "input_tokens": 15545,
+            "output_tokens": 23,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 6528,
+        }
+
+    def test_item_completed_agent_message_text_shape_from_codex_0130(self):
+        event = _normalize_via_spawn(_RAW_ITEM_COMPLETED_AGENT_TEXT_0130)
+        assert event.event_type == "text"
+        assert event.data["text"] == "SMOKE_OK"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -23,8 +23,28 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
-from provider_spawns.codex_spawn import CodexSpawnResult, _kill_proc, spawn_codex
+from provider_spawns.codex_spawn import CodexSpawnResult, _build_cmd, _kill_proc, spawn_codex
 from canonical_event import CanonicalEvent
+
+
+# ---------------------------------------------------------------------------
+# Test 0: model defaults and explicit override
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnModelResolution:
+    """codex_spawn uses the current Codex CLI default unless explicitly overridden."""
+
+    def test_build_cmd_defaults_to_gpt55(self, monkeypatch):
+        monkeypatch.delenv("VNX_CODEX_DEFAULT_MODEL", raising=False)
+        assert _build_cmd("") == ["codex", "exec", "--json", "--model", "gpt-5.5"]
+
+    def test_build_cmd_uses_env_default(self, monkeypatch):
+        monkeypatch.setenv("VNX_CODEX_DEFAULT_MODEL", "gpt-5.5-test")
+        assert _build_cmd("") == ["codex", "exec", "--json", "--model", "gpt-5.5-test"]
+
+    def test_build_cmd_explicit_model_overrides_env_default(self, monkeypatch):
+        monkeypatch.setenv("VNX_CODEX_DEFAULT_MODEL", "gpt-5.5-test")
+        assert _build_cmd("gpt-5.5") == ["codex", "exec", "--json", "--model", "gpt-5.5"]
 
 
 


### PR DESCRIPTION
## PR-OBS-1 — codex_spawn model-default + token-usage extraction fix

Fixes 2 latent VNX-infra-bugs die de hele nacht codex-via-subprocess_dispatch onbruikbaar maakten:

1. **Model-default bug**: `codex_spawn.py` defaultte naar `gpt-5.2-codex` (bestaat niet meer in codex-cli 0.130) → elke `provider_dispatch --provider codex` fast-failde met exit 1, 2.9s, `token_usage=0`. Nu: default resolvet via `VNX_CODEX_DEFAULT_MODEL` env → fallback `gpt-5.5` (matcht codex-cli 0.130 default). Explicit `--model` wint nog steeds.
2. **Token-usage extraction**: Codex 0.130 emit `turn.completed.usage` shape met `cached_input_tokens` — VNX's extractor matchte de oude shape → altijd 0. Nu: nieuwe shape correct geparsed.

### Validatie
- `local-ci.sh` ✓
- `tests/test_codex_spawn_byte_identity.py` + `test_codex_spawn_fail_closed.py`: 29 passed
- Token-extraction regression tests: 6 passed
- **Live smoke** (gedraaid door codex): `20260528-obs1-smoke` receipt → `model=gpt-5.5, status=success, token_usage={input:15545, output:7, cache_hit:6528}` — beide bugs gefixt en bewezen end-to-end live.

### Wat dit ontgrendelt
- Cheap-lane codex via `subprocess_dispatch --provider codex` werkt weer (governance-trail behouden i.p.v. `codex exec`-direct-bypass).
- Token-cost tracking voor codex dispatches accuraat (was altijd 0 → bracht token-stats endpoint in fail-loud territory).
- Sluit OI-1078-onderdeel (advisory/observability gap op codex-pad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)