### PR TITLE
fix(quality): emit tool_unavailable warnings + declare [quality] extras in pyproject (PR-QUAL-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ vnx doctor              # Validate everything
 ```
 
 Starter mode needs only bash, python3, git, and jq. Operator mode additionally requires tmux and fswatch.
+For full local-CI/audit functionality, install the quality extras with `pip install 'vnx-orchestration[quality]'`; install `shellcheck` separately as a system binary.
 
 ### Pipx (recommended for central deploy)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.20",
 ]
 
+# Full quality advisory/local-CI audit tools.
+# Install via `pip install vnx-orchestration[quality]`.
+[project.optional-dependencies]
+quality = ["vulture>=2.10", "ruff>=0.6"]
+
 [project.scripts]
 vnx = "vnx_cli.main:main"
 

--- a/scripts/lib/quality_advisory.py
+++ b/scripts/lib/quality_advisory.py
@@ -42,6 +42,9 @@ class QualityCheck:
     message: str = ""
     evidence: str = ""
     action_required: bool = False
+    tool: Optional[str] = None
+    level: Optional[str] = None
+    code: Optional[str] = None
 
 
 @dataclass
@@ -62,6 +65,13 @@ class QualityAdvisory:
             "summary": self.summary,
             "t0_recommendation": self.t0_recommendation,
         }
+
+
+class CheckRecord(dict):
+    """Dict check record with attribute access for object-style callers."""
+
+    def __getattr__(self, name: str) -> Any:
+        return self.get(name)
 
 
 def get_changed_files(repo_root: Optional[Path] = None) -> List[Path]:
@@ -327,8 +337,12 @@ def _run_ruff_check(file_path: Path) -> List[QualityCheck]:
                     evidence=f"line={finding.get('location', {}).get('row')},code={ruff_code}",
                     action_required=False,
                 ))
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-        pass  # Linter not available or failed
+            if result.returncode != 0 and not findings:
+                checks.append(_tool_unavailable_check("ruff", file_path, "lint check", result=result))
+        elif result.returncode != 0:
+            checks.append(_tool_unavailable_check("ruff", file_path, "lint check", result=result))
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as exc:
+        checks.append(_tool_unavailable_check("ruff", file_path, "lint check", exc=exc))
 
     return checks
 
@@ -362,8 +376,12 @@ def _run_shellcheck(file_path: Path) -> List[QualityCheck]:
                     evidence=f"line={finding.get('line')},code=SC{finding.get('code')}",
                     action_required=False,
                 ))
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-        pass  # Shellcheck not available or failed
+            if result.returncode != 0 and not findings:
+                checks.append(_tool_unavailable_check("shellcheck", file_path, "shell lint check", result=result))
+        elif result.returncode != 0:
+            checks.append(_tool_unavailable_check("shellcheck", file_path, "shell lint check", result=result))
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as exc:
+        checks.append(_tool_unavailable_check("shellcheck", file_path, "shell lint check", exc=exc))
 
     return checks
 
@@ -398,10 +416,44 @@ def check_dead_code(file_path: Path) -> List[QualityCheck]:
                     evidence=f"line={match.group(2)},confidence={match.group(4)}%",
                     action_required=False,
                 ))
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        pass  # Vulture not available or failed
+        if result.returncode != 0 and not result.stdout.strip():
+            checks.append(_tool_unavailable_check("vulture", file_path, "dead-code check", result=result))
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        checks.append(_tool_unavailable_check("vulture", file_path, "dead-code check", exc=exc))
 
     return checks
+
+
+def _tool_unavailable_check(
+    tool: str,
+    file_path: Path,
+    skipped_check: str,
+    exc: Optional[BaseException] = None,
+    result: Optional[subprocess.CompletedProcess[str]] = None,
+) -> QualityCheck:
+    error_class = "FileNotFoundError"
+    if exc is not None:
+        error_class = type(exc).__name__
+    if result is not None:
+        error_class = f"exit_{result.returncode}"
+
+    if error_class == "FileNotFoundError":
+        message = f"tool_unavailable: {tool} not installed; {skipped_check} skipped"
+    else:
+        message = f"tool_unavailable: {tool} failed ({error_class}); {skipped_check} skipped"
+
+    return QualityCheck(
+        check_id="tool_unavailable",
+        severity="warning",
+        file=str(file_path),
+        symbol=tool,
+        message=message,
+        evidence=f"tool={tool},error_class={error_class}",
+        action_required=False,
+        tool=tool,
+        level="warn",
+        code="tool_unavailable",
+    )
 
 
 def check_test_coverage_hygiene(changed_files: List[Path], repo_root: Path) -> List[QualityCheck]:
@@ -536,7 +588,7 @@ def _generate_open_items(checks: List[QualityCheck], blocking_only: bool) -> Lis
 
 
 def generate_quality_advisory(
-    changed_files: List[Path],
+    changed_files: List[Path | str],
     repo_root: Optional[Path] = None,
 ) -> QualityAdvisory:
     """Generate complete quality advisory for changed files.
@@ -552,23 +604,25 @@ def generate_quality_advisory(
         repo_root = Path.cwd()
 
     advisory = QualityAdvisory()
-    advisory.scope = [str(f) for f in changed_files]
+    changed_paths = [Path(f) for f in changed_files]
+    advisory.scope = [str(f) for f in changed_paths]
 
     all_checks: List[QualityCheck] = []
 
     # Run checks on each changed file
-    for file_path in changed_files:
+    for file_path in changed_paths:
         all_checks.extend(check_file_size(file_path))
         all_checks.extend(check_function_sizes(file_path))
         all_checks.extend(run_linting(file_path))
         all_checks.extend(check_dead_code(file_path))
 
     # Test coverage hygiene check (across all files)
-    all_checks.extend(check_test_coverage_hygiene(changed_files, repo_root))
+    all_checks.extend(check_test_coverage_hygiene(changed_paths, repo_root))
 
     # Convert checks to dict format
-    advisory.checks = [
-        {
+    advisory.checks = []
+    for c in all_checks:
+        record = CheckRecord({
             "check_id": c.check_id,
             "severity": c.severity,
             "file": c.file,
@@ -576,9 +630,14 @@ def generate_quality_advisory(
             "message": c.message,
             "evidence": c.evidence,
             "action_required": c.action_required,
-        }
-        for c in all_checks
-    ]
+        })
+        if c.tool is not None:
+            record["tool"] = c.tool
+        if c.level is not None:
+            record["level"] = c.level
+        if c.code is not None:
+            record["code"] = c.code
+        advisory.checks.append(record)
 
     # Calculate summary
     warning_count = sum(1 for c in all_checks if c.severity == "warning")

--- a/tests/test_quality_advisory_pipeline.py
+++ b/tests/test_quality_advisory_pipeline.py
@@ -11,6 +11,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
+import quality_advisory as quality_advisory_module
 from quality_advisory import (
     QualityCheck,
     check_file_size,
@@ -323,6 +324,26 @@ class TestQualityAdvisoryGeneration:
         assert "reason" in rec
         assert "suggested_dispatches" in rec
         assert "open_items" in rec
+
+    def test_missing_quality_tools_emit_tool_unavailable_warnings(self, tmp_path, monkeypatch):
+        """Missing ruff, shellcheck, and vulture should be visible warnings."""
+        py_file = tmp_path / "test.py"
+        py_file.write_text("x = 1\n")
+        sh_file = tmp_path / "test.sh"
+        sh_file.write_text("#!/usr/bin/env bash\necho ok\n")
+
+        def missing_tool(*args, **kwargs):
+            raise FileNotFoundError(args[0][0])
+
+        monkeypatch.setattr(quality_advisory_module.subprocess, "run", missing_tool)
+
+        advisory = generate_quality_advisory([py_file, sh_file], repo_root=tmp_path)
+        warnings = [c for c in advisory.checks if c.code == "tool_unavailable"]
+
+        assert {w.tool for w in warnings} == {"ruff", "shellcheck", "vulture"}
+        assert all(w.severity == "warning" for w in warnings)
+        assert all(w.level == "warn" for w in warnings)
+        assert all(w["code"] == "tool_unavailable" for w in warnings)
 
 
 class TestTerminalSnapshot:

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -38,6 +38,12 @@ def _check_tools() -> list[Check]:
             status=PASS if found else FAIL,
             detail=found or f"{tool} not found in PATH",
         ))
+    shellcheck = shutil.which("shellcheck")
+    results.append(Check(
+        name="tool:shellcheck",
+        status=PASS if shellcheck else WARN,
+        detail=shellcheck or "shellcheck not found in PATH; shell lint checks will emit tool_unavailable warnings",
+    ))
     return results
 
 


### PR DESCRIPTION
## PR-QUAL-1 — quality_advisory fail-loud + declare optional extras

Closes audit-finding #14 (codex): `quality_advisory` silently passed when `vulture`/`shellcheck`/`ruff` were missing — a broken checker looked identical to a clean file. For a repo positioning around governance, silent-disabled checks zijn HN-embarrassement.

### Wat dit doet
- **`scripts/lib/quality_advisory.py`**: tool-invocations emit nu `QualityCheck(code='tool_unavailable', tool=<name>, level='warn', message='tool_unavailable: <X> not installed; <check> skipped')` i.p.v. `try/except pass`. De advisory neemt deze warnings mee in de receipt's quality_advisory blok — operator ziet expliciet welke checks niet draaiden i.p.v. lege blokken.
- **`pyproject.toml`**: nieuwe `[project.optional-dependencies]` group:
  ```
  quality = ["vulture>=2.10", "ruff>=0.6"]
  ```
  Installeer via `pip install vnx-orchestration[quality]` voor volle local-CI/audit-functionaliteit. `shellcheck` is system-binary, niet pip-pakket → `vnx doctor` checkt 'm op PATH.
- **`vnx_cli/commands/doctor.py`**: nieuwe shellcheck-availability-check in doctor-output.
- **`README.md`**: kort mentioned the `[quality]` extras.

### Validatie
- `local-ci.sh` ✓
- Focused regression test: `tools_unavailable` warnings emit correct
- PATH-smoke (vulture/ruff weg uit PATH): beide melden zich correct als `tool_unavailable` warnings in de advisory

### Audit-trail
Lost OI-1078-onderdeel op (silently-disabled checks). Past in track-03 (Observability Activation) + track-02 (1.0 launch hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)