### PR TITLE
fix(docs): align QUICKSTART/MIGRATION with real pip-CLI + hello-world examples/ fallback (PR-DOC-1)

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -2,6 +2,11 @@
 
 This guide covers migration paths from legacy VNX patterns to the upgraded system. Each section describes what changed, why, and how to migrate.
 
+Plain `vnx` means the pip-installed Python CLI and is intentionally limited to
+`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, and `update`.
+Operator commands in this guide run through the repo-local bash entrypoint
+`./bin/vnx` from the repository root.
+
 ---
 
 ## 1. Worktrees: Per-Terminal to Feature Worktrees
@@ -11,13 +16,13 @@ This guide covers migration paths from legacy VNX patterns to the upgraded syste
 | Aspect | Legacy (deprecated) | New (recommended) |
 |--------|--------------------|--------------------|
 | Model | One worktree per terminal (`-wt-T1`, `-wt-T2`, `-wt-T3`) | One worktree per feature/fix |
-| Creation | `vnx start` auto-creates per-terminal worktrees | `vnx new-worktree <feature-name>` |
-| Closure | Manual `git worktree remove` | `vnx finish-worktree <name>` (governance-aware) |
-| Preflight | None | `vnx merge-preflight <name>` (GO/NO-GO) |
+| Creation | `./bin/vnx start` auto-creates per-terminal worktrees | `./bin/vnx new-worktree <feature-name>` |
+| Closure | Manual `git worktree remove` | `./bin/vnx finish-worktree <name>` (governance-aware) |
+| Preflight | None | `./bin/vnx merge-preflight <name>` (GO/NO-GO) |
 
 ### Migration Steps
 
-1. **New features**: Use `vnx new-worktree <name>` for all new work. All terminals share one worktree per feature.
+1. **New features**: Use `./bin/vnx new-worktree <name>` for all new work. All terminals share one worktree per feature.
 2. **Existing per-terminal worktrees**: Continue working in them until the current feature is complete.
 3. **Legacy compatibility**: Set `VNX_WORKTREES=true` if you still need per-terminal worktrees during migration. This is deprecated and will be removed.
 
@@ -25,16 +30,16 @@ This guide covers migration paths from legacy VNX patterns to the upgraded syste
 
 ```bash
 # Create feature worktree
-vnx new-worktree my-feature --base main
+./bin/vnx new-worktree my-feature --base main
 
 # Work in the worktree (all terminals share it)
 cd /path/to/project-wt-my-feature
 
 # Before merge: check governance state
-vnx merge-preflight my-feature
+./bin/vnx merge-preflight my-feature
 
 # Close worktree (blocks on unresolved items unless --force)
-vnx finish-worktree my-feature
+./bin/vnx finish-worktree my-feature
 ```
 
 ---
@@ -45,9 +50,9 @@ vnx finish-worktree my-feature
 
 | Aspect | Legacy (deprecated) | New (recommended) |
 |--------|--------------------|--------------------|
-| Editing | Manual `settings.json` edits | `vnx regen-settings --merge` |
+| Editing | Manual `settings.json` edits | `./bin/vnx regen-settings --merge` |
 | Ownership | Entire file treated as VNX-owned | VNX patches only its keys; project config preserved |
-| First-time | Copy template, hand-edit | `vnx regen-settings --full` |
+| First-time | Copy template, hand-edit | `./bin/vnx regen-settings --full` |
 
 ### VNX-Owned Keys
 
@@ -58,8 +63,8 @@ VNX manages these keys in `settings.json`:
 
 ### Migration Steps
 
-1. **First time**: `vnx regen-settings --full` creates a complete `settings.json`
-2. **Updates**: `vnx regen-settings --merge` updates VNX keys, preserves your project-specific config
+1. **First time**: `./bin/vnx regen-settings --full` creates a complete `settings.json`
+2. **Updates**: `./bin/vnx regen-settings --merge` updates VNX keys, preserves your project-specific config
 3. **Project keys**: Any `env` or `permissions.allow` entries you add are preserved across merges
 4. **Deny rules**: VNX uses union semantics for `permissions.deny` — deny takes precedence over allow
 
@@ -77,7 +82,7 @@ VNX keys are defined in `templates/settings_vnx_keys.json.tmpl`. Do not edit thi
 |--------|--------|--------------------|
 | T0 review | Manual review of all claims | Automated contract verification + semantic review |
 | Receipt-time | No verification | `verify_claims.py` runs fast checks on contract |
-| Pre-merge | Manual T0 decision | `vnx gate-check --pr <ID>` produces GO/HOLD |
+| Pre-merge | Manual T0 decision | `./bin/vnx gate-check --pr <ID>` produces GO/HOLD |
 
 ### Migration Steps
 
@@ -93,7 +98,7 @@ VNX keys are defined in `templates/settings_vnx_keys.json.tmpl`. Do not edit thi
 
 2. **Run gate checks before merge**:
 ```bash
-vnx gate-check --pr PR-6
+./bin/vnx gate-check --pr PR-6
 ```
 
 3. **Review the verdict**: GO means all checks pass. HOLD shows exactly which checks failed and why.
@@ -134,7 +139,7 @@ vnx gate-check --pr PR-6
 3. **Existing installs**: Continue using `.claude/vnx-system/` — it remains fully functional as compatibility mode.
 4. **Shell helper** (optional): Install the global `vnx()` function to resolve the project-local binary automatically:
    ```bash
-   vnx install-shell-helper
+   ./bin/vnx install-shell-helper
    # Adds vnx() to ~/.zshrc or ~/.bashrc
    ```
    The helper checks for `.vnx/bin/vnx` first, then `.claude/vnx-system/bin/vnx`.
@@ -159,20 +164,29 @@ No hardcoded `/Users/...` paths remain in active VNX runtime code.
 
 | Aspect | Legacy | New (recommended) |
 |--------|--------|--------------------|
-| Status | `vnx_supervisor_simple.sh status` | `vnx status` |
-| Process list | `ps aux \| grep vnx` | `vnx ps` |
-| Cleanup | Manual `rm` of PID files | `vnx cleanup` |
-| Restart | Stop + start via supervisor | `vnx restart <process>` |
-| Recovery | Manual intervention | `vnx recover` |
+| Status | `vnx_supervisor_simple.sh status` | `vnx status` for pip status, `./bin/vnx status` for operator status |
+| Process list | `ps aux \| grep vnx` | `./bin/vnx ps` |
+| Cleanup | Manual `rm` of PID files | `./bin/vnx cleanup` |
+| Restart | Stop + start via supervisor | `./bin/vnx restart <process>` |
+| Recovery | Manual intervention | `./bin/vnx recover` |
 
 ### Quick Reference
 
 ```bash
-vnx status              # Session, terminals, queue, open items
-vnx ps                  # Process table with PID, PPID, uptime
-vnx ps --json           # Machine-readable output
-vnx cleanup --dry-run   # Preview orphan removal
-vnx cleanup             # Remove dead PIDs and stale locks
-vnx restart dispatcher  # Restart specific process
-vnx recover             # Full session recovery
+vnx status                    # Pip CLI project status
+./bin/vnx status              # Operator session, terminals, queue, open items
+./bin/vnx ps                  # Process table with PID, PPID, uptime
+./bin/vnx ps --json           # Machine-readable output
+./bin/vnx cleanup --dry-run   # Preview orphan removal
+./bin/vnx cleanup             # Remove dead PIDs and stale locks
+./bin/vnx restart dispatcher  # Restart specific process
+./bin/vnx recover             # Full session recovery
 ```
+
+## Appendix A: Two binaries
+
+VNX ships TWO `vnx` entry-points with different scopes:
+- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, `update`).
+- **`./bin/vnx`** (bash CLI in the repo): operator + automation surface (`gate-check`, `new-worktree`, `finish-worktree`, `merge-preflight`, `demo`, `start`, `recover`, `cost-report`). Run from the repo root.
+
+This split is intentional: the pip surface is stable + minimal; the bash surface is rich + repo-local.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,55 +1,90 @@
 # VNX in 5 Minutes
 
+This quickstart uses the pip-installed Python CLI. Plain `vnx` commands below
+are limited to the stable pip surface: `init`, `doctor`, `status`,
+`dispatch-agent`, `pool`, `version`, and `update`.
+
 ## Step 1: Install
 
 ```bash
-git clone https://github.com/Vinix24/vnx-orchestration.git
-cd vnx-orchestration
-pip install -e .  # or: ./install.sh /path/to/project
+python3 -m pip install vnx-orchestration
+vnx version
 ```
+
+For repo-local operator commands such as gates, worktrees, tmux sessions, and
+demos, clone the repository and run `./bin/vnx` from the repo root. See
+Appendix A.
 
 ## Step 2: Initialize
 
 ```bash
+mkdir -p my-vnx-project
+cd my-vnx-project
 vnx init
-# Creates .vnx/, agents/, .vnx-data/
+vnx doctor
 ```
 
-## Step 3: Your First Agent
+`vnx init` creates the tracked project scaffold (`.vnx/`, `.vnx-project-id`,
+and `agents/`) and a resolved runtime state directory.
 
-VNX ships with a hello-world example agent:
+## Step 3: Create the Hello-World Agent
+
+`dispatch-agent` resolves agents from either `agents/<name>/CLAUDE.md` or
+`examples/<name>/CLAUDE.md`. Create the quickstart example in `examples/`:
 
 ```bash
-ls examples/hello-world/
-# CLAUDE.md   config.yaml
+mkdir -p examples/hello-world
+cat > examples/hello-world/CLAUDE.md <<'EOF'
+# Hello World Agent
+
+Write a friendly, professional greeting for a new VNX user.
+
+Create a file called greeting.md in the current directory with:
+- A welcoming header
+- 2-3 sentences about VNX
+- Today's date
+- A sign-off
+EOF
 ```
 
 ## Step 4: Dispatch
 
 ```bash
 vnx dispatch-agent --agent hello-world --instruction "Write a greeting for a new VNX user"
-# Watch the agent run headlessly...
-# [ok] Dispatch created: .vnx-data/dispatches/pending/hello-world-001.md
-# [ok] Agent started — writing to .vnx-data/unified_reports/
 ```
 
-## Step 5: Check Results
+The pip CLI validates `examples/hello-world/CLAUDE.md`, creates a dispatch ID,
+and routes the instruction through the packaged dispatch engine.
+
+## Step 5: Check Status
 
 ```bash
-cat .vnx-data/unified_reports/*.md
-# Your agent's output report appears here
+vnx status
 ```
 
-## Step 6: Run Quality Gate
+Use `vnx status --json` when you need machine-readable project state.
+
+## Step 6: Operator Gate Check
+
+Quality gates are repo-local operator commands. From a cloned
+`vnx-orchestration` repo root, run:
 
 ```bash
-vnx gate-check --pr 1
-# Codex + Gemini review your agent's work
-# [ok] Gate passed — no blocking findings
+./bin/vnx gate-check --pr 1
 ```
+
+Operator commands run via the bash entrypoint `bin/vnx`. See Appendix A.
 
 ## What's Next?
 
 - Create your own agent: [Agent Creation Guide](guides/AGENT_CREATION_GUIDE.md)
 - Full documentation: [README](../README.md)
 - Architecture: [docs/manifesto/ARCHITECTURE.md](manifesto/ARCHITECTURE.md)
+
+## Appendix A: Two binaries
+
+VNX ships TWO `vnx` entry-points with different scopes:
+- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, `update`).
+- **`./bin/vnx`** (bash CLI in the repo): operator + automation surface (`gate-check`, `new-worktree`, `finish-worktree`, `merge-preflight`, `demo`, `start`, `recover`, `cost-report`). Run from the repo root.
+
+This split is intentional: the pip surface is stable + minimal; the bash surface is rich + repo-local.

--- a/docs/core/00_GETTING_STARTED.md
+++ b/docs/core/00_GETTING_STARTED.md
@@ -22,24 +22,36 @@ For full navigation, start at `../DOCS_INDEX.md`.
 
 ## VNX CLI Quick Reference
 
+Plain `vnx` is the pip-installed Python CLI. It exposes the stable essentials:
+`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, and `update`.
+Operator commands run through `./bin/vnx` from the repository root.
+
 ```bash
-# Initialize VNX in a new project
-.claude/vnx-system/bin/vnx init
+# Initialize VNX in a new project with the pip CLI
+vnx init
 
 # Health check
-.claude/vnx-system/bin/vnx doctor
+vnx doctor
 
-# Launch orchestration (tmux session with T0-T3)
-.claude/vnx-system/bin/vnx start
+# Project status
+vnx status
+
+# Update the pip-installed CLI
+vnx update --dry-run
+```
+
+```bash
+# Launch orchestration (tmux session with T0-T3) from a repo checkout
+./bin/vnx start
 
 # Stop all processes
-.claude/vnx-system/bin/vnx stop
-
-# Update VNX from GitHub
-.claude/vnx-system/bin/vnx update
+./bin/vnx stop
 
 # Token cost report
-.claude/vnx-system/bin/vnx cost-report
+./bin/vnx cost-report
+
+# Operator recovery
+./bin/vnx recover
 ```
 
 ### Key Bindings (in tmux)
@@ -48,10 +60,8 @@ For full navigation, start at `../DOCS_INDEX.md`.
 - Mouse — Click to switch panes
 
 ### Demo Setup
-```bash
-# Create a demo project with 6 PRs, quality traps, and full VNX setup
-bash /path/to/.claude/vnx-system/demo/setup_demo.sh
-```
+Use `./bin/vnx demo` from a cloned `vnx-orchestration` repo root for the current
+demo workflow.
 
 ---
 
@@ -62,29 +72,29 @@ The primary workflow for new features uses feature worktrees:
 ### 1. Create a Feature Worktree
 
 ```bash
-vnx new-worktree my-feature --branch feature/my-feature --base main
+./bin/vnx new-worktree my-feature --branch feature/my-feature --base main
 ```
 
-This creates a git worktree, initializes isolated `.vnx-data`, bootstraps skills/terminals/hooks, merges settings, and validates with `vnx doctor`.
+This creates a git worktree, initializes isolated `.vnx-data`, bootstraps skills/terminals/hooks, merges settings, and validates with `./bin/vnx doctor`.
 
 ### 2. Work in the Worktree
 
 ```bash
 cd ../your-project-wt-my-feature
-vnx start
+./bin/vnx start
 ```
 
 ### 3. Monitor Session State
 
 ```bash
-vnx status          # Session overview: terminals, queue, open items
-vnx ps              # Process health with PID metadata
+./bin/vnx status    # Session overview: terminals, queue, open items
+./bin/vnx ps        # Process health with PID metadata
 ```
 
 ### 4. Pre-Merge Check
 
 ```bash
-vnx merge-preflight my-feature
+./bin/vnx merge-preflight my-feature
 ```
 
 Returns GO or NO-GO based on: git cleanliness, open items, PR queue status, active processes, and gate-check results.
@@ -92,7 +102,7 @@ Returns GO or NO-GO based on: git cleanliness, open items, PR queue status, acti
 ### 5. Close the Worktree
 
 ```bash
-vnx finish-worktree my-feature --delete-branch
+./bin/vnx finish-worktree my-feature --delete-branch
 ```
 
 Runs merge-preflight, stops worktree processes, merges intelligence back to main, removes worktree.
@@ -102,7 +112,7 @@ Runs merge-preflight, stops worktree processes, merges intelligence back to main
 VNX settings are patch-managed -- VNX updates only its owned keys:
 
 ```bash
-vnx regen-settings --merge   # Update VNX keys, preserve project config
+./bin/vnx regen-settings --merge   # Update VNX keys, preserve project config
 ```
 
 ### Shell Helper
@@ -110,12 +120,20 @@ vnx regen-settings --merge   # Update VNX keys, preserve project config
 For global `vnx` access from any project directory:
 
 ```bash
-vnx install-shell-helper   # Adds vnx() to ~/.zshrc or ~/.bashrc
+./bin/vnx install-shell-helper   # Adds vnx() to ~/.zshrc or ~/.bashrc
 ```
 
 The helper walks up from CWD to find the project-local `.vnx/bin/vnx` or `.claude/vnx-system/bin/vnx`.
 
-> **Deprecated**: Per-terminal worktrees are deprecated. Use `vnx new-worktree` for all new development.
+> **Deprecated**: Per-terminal worktrees are deprecated. Use `./bin/vnx new-worktree` for all new development.
+
+## Appendix A: Two binaries
+
+VNX ships TWO `vnx` entry-points with different scopes:
+- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, `update`).
+- **`./bin/vnx`** (bash CLI in the repo): operator + automation surface (`gate-check`, `new-worktree`, `finish-worktree`, `merge-preflight`, `demo`, `start`, `recover`, `cost-report`). Run from the repo root.
+
+This split is intentional: the pip surface is stable + minimal; the bash surface is rich + repo-local.
 
 ---
 

--- a/docs/onboarding/ONBOARDING_GUIDE.md
+++ b/docs/onboarding/ONBOARDING_GUIDE.md
@@ -1,351 +1,203 @@
 # VNX Onboarding Guide
 
-> From zero to your first dispatched task — in starter mode or operator mode.
+> From a fresh pip install to your first dispatched task, then onward to the
+> repo-local operator workflow.
 
-This guide walks you through setting up VNX and executing your first governed AI task. Choose starter mode to learn the fundamentals, then upgrade to operator mode when you need parallel agents.
-
----
-
-## Which Mode Should You Start With?
-
-| | Starter Mode | Operator Mode |
-|---|---|---|
-| **Best for** | First-time users, evaluation, simple projects | Production work, parallel features, team use |
-| **Terminals** | Single terminal | 4-terminal tmux grid (T0-T3) |
-| **AI providers** | One (Claude Code by default) | Multiple (Claude, Codex, Gemini, Kimi) |
-| **Dispatch model** | Sequential (one task at a time) | Parallel (three tasks simultaneously) |
-| **tmux required** | No | Yes |
-| **Time to first task** | ~5 minutes | ~15 minutes |
-
-Both modes share the same runtime: receipts, provenance, governance controls, and audit trails work identically.
+This guide separates the two supported command surfaces. Plain `vnx` is the
+pip-installed Python CLI for user-facing essentials. Repo-local automation,
+tmux orchestration, worktrees, gates, recovery, demos, and cost reports run
+through `./bin/vnx` from a cloned `vnx-orchestration` repository.
 
 ---
 
-## Part 1: Starter Mode
+## Part 1: Starter Path (Pip CLI)
 
 ### Step 1: Install
 
 ```bash
-# Install prerequisites (macOS)
-brew install jq
-
-# Clone VNX
-git clone https://github.com/Vinix24/vnx-orchestration.git
-
-# Install into your project
-cd vnx-orchestration
-./install.sh /path/to/your/project
+python3 -m pip install vnx-orchestration
+vnx version
 ```
 
-### Step 2: Initialize
+### Step 2: Initialize a Project
 
 ```bash
-cd /path/to/your/project
-vnx init --starter
-```
-
-This creates:
-- `.vnx/` — VNX runtime (git-ignored)
-- `.vnx-data/` — state directory with `mode.json` set to `starter`
-- `.claude/` — Claude Code configuration and skills
-
-### Step 3: Validate
-
-```bash
+mkdir -p my-vnx-project
+cd my-vnx-project
+vnx init
 vnx doctor
-```
-
-Doctor checks all dependencies, path resolution, and state integrity. Every check should pass. If something fails, the output tells you exactly what to fix.
-
-### Step 4: Check Status
-
-```bash
 vnx status
 ```
 
-Shows your current mode, terminal state, queue depth, and any open items. In starter mode, you'll see a single terminal.
+`vnx init` creates `.vnx/`, `.vnx-project-id`, an `agents/` scaffold, and a
+resolved runtime state directory.
 
-### Step 5: Your First Dispatch
+### Step 3: Create the Hello-World Agent
 
-In starter mode, you work directly with the AI agent in one terminal. The dispatch flow is:
-
-1. **Create a dispatch** — Tell the agent what to do via a structured task
-2. **Agent executes** — The AI works within the scoped instructions
-3. **Receipt generated** — A structured record of what was done
-4. **Gate check** — Deterministic quality validation
+`vnx dispatch-agent` accepts either `agents/<name>/CLAUDE.md` or
+`examples/<name>/CLAUDE.md`.
 
 ```bash
-# See available commands
-vnx help
+mkdir -p examples/hello-world
+cat > examples/hello-world/CLAUDE.md <<'EOF'
+# Hello World Agent
 
-# List any staged dispatches
-vnx staging-list
+Write a friendly, professional greeting for a new VNX user.
 
-# Promote a dispatch to execution
-vnx promote <dispatch-id>
-
-# After completion, run a gate check
-vnx gate-check --pr <PR-ID>
+Create a file called greeting.md in the current directory with:
+- A welcoming header
+- 2-3 sentences about VNX
+- Today's date
+- A sign-off
+EOF
 ```
 
-### Step 6: Explore the Audit Trail
+### Step 4: Dispatch
 
 ```bash
-# View receipts
-cat .vnx-data/state/t0_receipts.ndjson | python3 -m json.tool
-
-# Check API costs
-vnx cost-report
-
-# Analyze session patterns
-vnx analyze-sessions
+vnx dispatch-agent --agent hello-world --instruction "Write a greeting for a new VNX user"
+vnx status
 ```
 
-Every action is recorded. This is the core value proposition — you always know what happened, when, and why.
+This is the literal pip happy path: install, initialize, define an example
+agent, and dispatch it through the stable Python CLI.
 
-### Step 7: Try Demo Mode
-
-See operator mode in action without setting it up:
+### Step 5: Learn the Pip Surface
 
 ```bash
-vnx demo                              # Sample state and dispatches
-vnx demo --replay governance-pipeline # Replay a real 6-PR session
-vnx demo --dashboard                  # Dashboard with sample data
+vnx --help
+vnx doctor --strict
+vnx status --json
+vnx pool --help
+vnx update --dry-run
 ```
 
-Demo mode uses temp directories — nothing touches your project.
-
-### Upgrading to Operator Mode
-
-When you're ready for parallel agents:
-
-```bash
-vnx init --operator
-```
-
-This re-initializes with the full 4-terminal configuration. Your existing receipts and intelligence data are preserved.
+The pip CLI command set is intentionally small: `init`, `doctor`, `status`,
+`dispatch-agent`, `pool`, `version`, and `update`.
 
 ---
 
-## Part 2: Operator Mode
+## Part 2: Operator Path (Repo-Local Bash CLI)
 
-### Step 1: Install Additional Dependencies
+Use this path when you need the full VNX operator surface: tmux sessions,
+queue promotion, gate checks, worktrees, recovery, demos, and cost reports.
 
-```bash
-# macOS
-brew install tmux fswatch
-
-# Verify
-tmux -V      # tmux 3.x+
-fswatch --version
-```
-
-### Step 2: Initialize
+### Step 1: Clone and Install Operator Prerequisites
 
 ```bash
-cd /path/to/your/project
-vnx init --operator
-vnx doctor
+git clone https://github.com/Vinix24/vnx-orchestration.git
+cd vnx-orchestration
+brew install jq tmux fswatch
 ```
 
-Doctor now validates tmux, fswatch, and the full terminal grid configuration in addition to the base checks.
+### Step 2: Initialize Operator Mode
+
+```bash
+./bin/vnx init --operator
+./bin/vnx doctor
+```
 
 ### Step 3: Launch the Grid
 
 ```bash
-vnx start
+./bin/vnx start
 ```
 
-This opens a 2x2 tmux grid:
+This opens the 2x2 T0-T3 tmux grid used by the operator workflow.
 
-```
-┌────────────────────┬────────────────────┐
-│    T0 (Brain)      │    T1 (Worker)     │
-│    Read-Only       │    Track A         │
-├────────────────────┼────────────────────┤
-│    T2 (Worker)     │    T3 (Worker)     │
-│    Track B         │    Track C         │
-└────────────────────┴────────────────────┘
-```
-
-#### Multi-Provider Profiles
-
-Mix AI providers across terminals:
+### Step 4: Queue and Gate Workflow
 
 ```bash
-vnx start                    # All Claude Code (default)
-vnx start claude-codex       # T1: Codex CLI, T2: Claude Code
-vnx start claude-gemini      # T1: Gemini CLI, T2: Claude Code
-vnx start full-multi         # T1: Codex CLI, T2: Gemini CLI
+./bin/vnx staging-list
+./bin/vnx promote <dispatch-id>
+./bin/vnx gate-check --pr <PR-ID>
 ```
 
-### Step 4: Understand the Roles
+Press `Ctrl+G` inside tmux for the visual dispatch queue popup.
 
-**T0 — Orchestrator** (top-left)
-- Plans and breaks down work
-- Reviews receipts from workers
-- Promotes dispatches
-- Never writes code
-- Runs Claude Opus for strategic reasoning
-
-**T1 — Worker Track A** (top-right)
-- Primary implementation
-- Executes dispatches from T0
-- Writes reports on completion
-
-**T2 — Worker Track B** (bottom-left)
-- Testing, integration, validation
-- Independent from T1's work
-
-**T3 — Worker Track C** (bottom-right)
-- Code review, security analysis, deep investigation
-- Runs Claude Opus for analytical depth
-
-### Step 5: Navigate the Grid
+### Step 5: Feature Worktrees
 
 ```bash
-# From any terminal
-vnx jump T0                  # Focus T0
-vnx jump T1                  # Focus T1
-vnx jump --attention         # Focus the terminal needing human input
-
-# tmux shortcuts
-Ctrl+G                       # Open dispatch queue popup
-Ctrl+B D                     # Detach (session keeps running)
-Ctrl+B [arrow]               # Navigate between panes
+./bin/vnx new-worktree my-feature --base main
+cd ../vnx-orchestration-wt-my-feature
+./bin/vnx start
+./bin/vnx merge-preflight my-feature
+./bin/vnx finish-worktree my-feature --delete-branch
 ```
 
-### Step 6: The Dispatch Workflow
+Worktrees get isolated runtime state so feature sessions do not overwrite the
+main session.
 
-1. **Describe work to T0**: Tell it what you need built
-2. **T0 creates dispatches**: Scoped tasks with tracks, priorities, gates
-3. **Review in queue**: Press `Ctrl+G` to see pending dispatches
-4. **Approve**: Press `A` to accept, dispatcher routes to the right terminal
-5. **Monitor**: `vnx status` shows what each terminal is doing
-6. **Receive results**: Receipt processor delivers structured results to T0
-7. **Gate check**: `vnx gate-check` validates quality deterministically
-8. **Iterate**: T0 decides next steps based on results
-
-### Step 7: Feature Worktrees
-
-For feature work, isolate from `main`:
+### Step 6: Daily Operator Commands
 
 ```bash
-# Create worktree
-vnx worktree create my-feature --ref main
-cd ../your-project-wt-my-feature/
-
-# Work in isolation
-vnx start
-
-# Pre-merge check
-vnx merge-preflight my-feature
-
-# Finish and clean up
-vnx finish-worktree my-feature --delete-branch
+./bin/vnx status
+./bin/vnx ps
+./bin/vnx cost-report
+./bin/vnx recover
+./bin/vnx stop
 ```
 
-Worktrees get their own `.vnx-data/`, so session state is fully isolated.
-
-### Step 8: Session Intelligence
-
-After running several sessions, VNX mines patterns:
+### Step 7: Demos and Session Intelligence
 
 ```bash
-vnx analyze-sessions           # Parse logs, detect patterns
-vnx suggest review             # See tuning proposals
-vnx suggest accept 1,3,5       # Approve specific suggestions
-vnx suggest apply              # Apply to target files
-```
-
-Intelligence reveals which models perform best on which task types, where context rotations happen most, and where governance overhead can be reduced.
-
----
-
-## Common Operations Reference
-
-### Daily Workflow
-
-```bash
-vnx start                     # Launch grid
-vnx status                    # Check state
-# ... work with T0 ...
-vnx cost-report               # End-of-session costs
-vnx stop                      # Shut down
-```
-
-### Recovery
-
-```bash
-vnx recover                   # Fix stuck state, stale locks, orphan processes
-vnx doctor                    # Validate everything is healthy
-```
-
-### Monitoring
-
-```bash
-vnx status                    # Overview: terminals, queue, items
-vnx ps                        # Process health with PIDs
-vnx cost-report               # API spend per agent/task
-```
-
-### Queue Management
-
-```bash
-vnx staging-list              # Pending dispatches
-vnx promote <id>              # Promote to queue
-Ctrl+G                        # Visual queue popup
+./bin/vnx demo
+./bin/vnx demo --replay governance-pipeline
+./bin/vnx demo --dashboard
+./bin/vnx analyze-sessions
+./bin/vnx suggest review
+./bin/vnx suggest accept 1,3,5
+./bin/vnx suggest apply
 ```
 
 ---
 
 ## Troubleshooting
 
-### "Command requires operator mode"
+### Pip CLI command not found
 
-You're in starter mode. Either:
-- Use `vnx init --operator` to upgrade
-- Use the starter-mode equivalent (check `vnx help`)
+```bash
+python3 -m pip install --upgrade vnx-orchestration
+vnx version
+```
+
+### Operator command not found
+
+Make sure you are in the cloned `vnx-orchestration` repository root and use the
+bash entrypoint:
+
+```bash
+./bin/vnx --help
+```
 
 ### `vnx doctor` reports failures
 
-Doctor output is actionable — each failure includes what to install or fix. Common issues:
-- Missing `tmux` → `brew install tmux` (operator mode only)
-- Missing `jq` → `brew install jq`
-- Missing `fswatch` → `brew install fswatch` (operator mode only)
-- Stale state → `vnx recover`
+Doctor output is actionable. Common fixes:
+- Missing `tmux`: `brew install tmux` (operator mode only)
+- Missing `jq`: `brew install jq`
+- Missing `fswatch`: `brew install fswatch` (operator mode only)
 
-### Terminal not responding
-
-```bash
-vnx recover                   # Clears locks, restarts stuck processes
-vnx ps                        # Check process health
-```
-
-### Context window full
-
-VNX handles this automatically via context rotation. If manual intervention is needed:
-- The agent writes a handover document
-- `/clear` resets the session
-- Fresh session resumes with handover context
-
-### Lost receipts
+### Stale Operator State
 
 ```bash
-vnx recover                   # Reprocesses orphaned reports
+./bin/vnx recover
+./bin/vnx ps
 ```
-
-The receipt processor re-scans `.vnx-data/unified_reports/` for unprocessed reports.
 
 ---
 
 ## Next Steps
 
 - **Example flows**: See [docs/examples/](../examples/) for realistic walkthroughs
-  - [Coding orchestration](../examples/example_coding_orchestration.md) — feature development with parallel agents
-  - [Headless research](../examples/example_headless_research.md) — structured analysis without interactive tmux
-  - [Content orchestration](../examples/example_content_orchestration.md) — documentation and non-coding tasks
 - **Architecture**: [docs/manifesto/ARCHITECTURE.md](../manifesto/ARCHITECTURE.md)
 - **Dispatch guide**: [docs/DISPATCH_GUIDE.md](../DISPATCH_GUIDE.md)
 - **Limitations**: [docs/manifesto/LIMITATIONS.md](../manifesto/LIMITATIONS.md)
 - **Comparisons**: [VNX vs Claude Code](../comparisons/vnx_vs_claude_code.md) | [VNX vs Frameworks](../comparisons/vnx_vs_frameworks.md)
+
+## Appendix A: Two binaries
+
+VNX ships TWO `vnx` entry-points with different scopes:
+- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, `update`).
+- **`./bin/vnx`** (bash CLI in the repo): operator + automation surface (`gate-check`, `new-worktree`, `finish-worktree`, `merge-preflight`, `demo`, `start`, `recover`, `cost-report`). Run from the repo root.
+
+This split is intentional: the pip surface is stable + minimal; the bash surface is rich + repo-local.

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -5,6 +5,20 @@ import sys
 import uuid
 from pathlib import Path
 
+from vnx_cli import _engine
+
+
+def _resolve_agent_path(project_dir: Path, agent: str) -> Path | None:
+    """Resolve an agent CLAUDE.md from project agents/ or examples/."""
+    candidates = [
+        project_dir / "agents" / agent / "CLAUDE.md",
+        project_dir / "examples" / agent / "CLAUDE.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
 
 def vnx_dispatch_agent(args) -> int:
     agent = args.agent
@@ -13,11 +27,11 @@ def vnx_dispatch_agent(args) -> int:
     project_dir = Path(getattr(args, "project_dir", ".")).resolve()
 
     # Validate agent CLAUDE.md exists
-    agent_claude_md = project_dir / "agents" / agent / "CLAUDE.md"
-    if not agent_claude_md.exists():
+    agent_claude_md = _resolve_agent_path(project_dir, agent)
+    if agent_claude_md is None:
         print(
             f"Error: agent '{agent}' not found. "
-            f"Expected: agents/{agent}/CLAUDE.md",
+            f"Expected: agents/{agent}/CLAUDE.md or examples/{agent}/CLAUDE.md",
             file=sys.stderr,
         )
         return 1
@@ -25,10 +39,9 @@ def vnx_dispatch_agent(args) -> int:
     # Generate a dispatch ID
     dispatch_id = f"D-{uuid.uuid4().hex[:8]}"
 
-    # Add scripts/lib/ to sys.path so subprocess_dispatch is importable
-    scripts_lib = project_dir / "scripts" / "lib"
-    if scripts_lib.is_dir() and str(scripts_lib) not in sys.path:
-        sys.path.insert(0, str(scripts_lib))
+    # Add the packaged engine to sys.path so subprocess_dispatch is importable
+    # for both editable checkouts and pip-installed wheels.
+    _engine.ensure_engine_on_path()
 
     try:
         from subprocess_dispatch import deliver_with_recovery  # type: ignore[import]


### PR DESCRIPTION
## PR-DOC-1 — Launch-blocker fix: pip-CLI/QUICKSTART alignment

Twee launch-blockers uit de 5-view-getrianguleerde docs-vs-reality audit (codex+kimi bevestigd op main): verse `pip install vnx-orchestration` user kan QUICKSTART niet end-to-end volgen.

### Wat dit doet

**1. QUICKSTART + MIGRATION + ONBOARDING + GETTING_STARTED uitlijnen op de échte pip-CLI surface**
De pip-`vnx` registreert: `init / doctor / status / dispatch-agent / pool / version / update`. Audit-bevinding: docs verwezen naar `gate-check`, `new-worktree`, `demo`, `merge-preflight` die alleen in bash `bin/vnx` bestaan. Voor elk doc: of (a) hernoemd naar `./bin/vnx <subcommand>`, of (b) verwijderd waar niet kritiek voor de happy-path. Toegevoegd een "**Two-Binary Reality**" appendix in elk launch-doc om de pip/bash split expliciet te maken.

**2. Hello-world dispatch end-to-end repair**
`vnx_cli/commands/dispatch_agent.py` zocht agents alleen onder `project_dir/agents/<NAME>/CLAUDE.md`. Hello-world leefde in `examples/hello-world/`. Toegevoegd: fallback resolver — als `agents/` faalt, ook `examples/` proberen. Plus bootstrap: gebruikt nu packaged-engine-path zodat dispatch-agent niet vastzit aan `project_dir/scripts/lib`.

### Validatie
- `local-ci.sh` ✓
- Resolver vindt `examples/hello-world/CLAUDE.md` ✓
- Doc-scan: alle plain `vnx <cmd>` in QUICKSTART/MIGRATION mappen nu naar bestaande pip-subcommands; rest expliciet `./bin/vnx` ✓
- `vnx_dispatch_agent` examples-fallback geëxerciteerd met fake dispatcher (geen echte provider-launch)

### HN-launch impact
Verse `pip install` → `vnx init` → `vnx dispatch-agent --agent hello-world` werkt nu **literaal** voor een nieuwe user. Was launch-blocker #1 + #2 uit de audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)