### PR TITLE
feat(future): track layer schema + CLI + migration (PR-FUT-1)

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-28T12:06:29.753025+00:00
+**Last updated**: 2026-05-28T20:58:00.607636+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
@@ -117,16 +117,6 @@ _Last 14 days — sourced from git merge commits._
 - #503 — fix(rp): bootstrap audit ordering + test infra hardening (close OI-1450/1451/1452) (#503) (2026-05-15)
 - #502 — fix(dispatcher): log stderr, script_dir leak, receipt processor bootstrap-mode (#502) (2026-05-15)
 - #500 — chore(hardening): narrow silent-except across replay_harness/cleanup_worker_exit/conversation_analyzer (9 findings, OI-1437) (#500) (2026-05-15)
-- #499 — chore(hardening): narrow silent-except in session_resolver.py (4 findings, OI-1437) (#499) (2026-05-14)
-- #498 — chore(hardening): narrow silent-except in api_operator.py (5 findings, OI-1437) (#498) (2026-05-14)
-- #497 — chore(hardening): narrow silent-except in append_receipt payload.py (5 findings, OI-1437) (#497) (2026-05-14)
-- #496 — chore(hardening): narrow silent-except in dispatch_register.py (5 findings, OI-1437) (#496) (2026-05-14)
-- #495 — chore(hardening): narrow silent-except in api_intelligence.py (6 findings, OI-1437) (#495) (2026-05-14)
-- #494 — chore(hardening): narrow silent-except in learning_loop.py (5 findings, OI-1437) (#494) (2026-05-14)
-- #493 — chore(hardening): narrow silent-except in gather_intelligence.py (6 findings, OI-1437) (#493) (2026-05-14)
-- #492 — chore(hardening): narrow silent-except in intelligence_selector.py (10 findings, OI-1437) (#492) (2026-05-14)
-- #491 — chore(hardening): narrow silent-except in build_t0_state.py (13 findings, OI-1437) (#491) (2026-05-14)
-- #489 — chore(contrib): add CONTRIBUTING.md + ci lint gate (atomic-write + silent-except) (#489) (2026-05-14)
 
 **WAVE 5**
 - #601 — docs: refresh README + ROADMAP for 1.0.0-rc2 (Wave 5/6/7/8 shipped + central install) (#601) (2026-05-18)
@@ -148,8 +138,6 @@ _Last 14 days — sourced from git merge commits._
 - #512 — feat(wave4.6): PR-4.6.5 — litellm_spawn handler extracted from litellm_adapter (#512) (2026-05-15)
 - #511 — feat(wave4.6): PR-4.6.3 — codex_spawn handler extracted from codex_adapter (#511) (2026-05-15)
 - #510 — feat(wave4.6): PR-4.6.4 — gemini_spawn handler extracted from gemini_adapter (#510) (2026-05-15)
-- #490 — feat(wave4.6): PR-4.6.2 — extract claude_spawn from subprocess_dispatch (byte-identical) (#490) (2026-05-14)
-- #488 — feat(wave4.6): PR-4.6.1 — provider_dispatch.py entry-point (additive shim) (#488) (2026-05-14)
 
 **WAVE5**
 - #532 — feat(wave5): PR-5.7 — operator demo runbook + Control Centre docs + completion report (#532) (2026-05-16)
@@ -199,5 +187,11 @@ _No completed features found in register or PR history._
 ## Planned (from ROADMAP.yaml)
 
 ### roadmap-autopilot — Roadmap Autopilot, Auto-Next Feature Loading, and Multi-Reviewer Gates
+Status: planned
+
+### fut-1 — Track-layer schema + DAL + CLI + audit-ordering (PR-FUT-1); seeding + composite-FK deferred to PR-FUT-2
+Status: active
+
+### fut-2 — Track tenant-scoping per ADR-007 — composite PK over project_id, seeding from roadmap, composite-FK dispatches.track → tracks(track_id, project_id), project-aware CLI
 Status: planned
 

--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,57 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-21T07:04:56.577840+00:00
+**Last updated**: 2026-05-28T12:06:29.753025+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #675 — feat(route): enforce provider_constraints.yaml in dispatch pre-flight (PR-ROUTE-1) (#675) (2026-05-28)
+- #674 — docs(readme): rewrite for pip-1.0 + tmux-leaseless-lane + multi-provider architecture (PR-DOC-README) (#674) (2026-05-28)
+- #673 — fix(docs): align QUICKSTART/MIGRATION with real pip-CLI surface + hello-world examples/ fallback (PR-DOC-1) (#673) (2026-05-28)
+- #672 — fix(lane): compute success from receipt status + shell-quote completion-protocol values (PR-HYG-3) (#672) (2026-05-28)
+- #671 — refactor(start): drop upfront T1-T3 pane grid — T0 only at startup, workers spawn on-demand (PR-START-1) (#671) (2026-05-28)
+- #670 — fix(quality): emit tool_unavailable warnings + declare quality-extras in pyproject (PR-QUAL-1) (#670) (2026-05-28)
+- #669 — fix(obs): codex_spawn model-default to gpt-5.5 + token-usage extraction (PR-OBS-1) (#669) (2026-05-28)
+- #668 — chore(hygiene): remove schraplijst-Phase-1 dead modules (~4.1k LOC, fresh-verified) (PR-HYG-2B) (#668) (2026-05-28)
+- #667 — chore(hygiene): remove audit-identified dead code (unused imports, unreachable bin/vnx cases, ongebruikte helpers) (PR-HYG-2A) (#667) (2026-05-28)
+- #659 — refactor(migrate-central): split main into _parse_args + _run_apply (OI-1540/1532, part 3/3) (#659) (2026-05-26)
+- #658 — docs(rc9): changelog + readme sync (cheap-lanes, constraint-rename, OI-refactors, governance fixes) (#658) (2026-05-26)
+- #657 — refactor(migrate-central): extract migrate_schema module (OI-1536/1533, part 2/3) (#657) (2026-05-26)
+- #655 — feat(governance): traceability_audit tool — cross-ref PRs/commits/dispatches/receipts, report gaps (#655) (2026-05-26)
+- #654 — feat(governance): emit pr_merged receipt linking pr_number on merge/closure (fixes FPY/history gap) (#654) (2026-05-26)
+- #653 — refactor(migrate-central): extract migrate_import module (OI-1537/1539, part 1/3) (#653) (2026-05-26)
+- #652 — feat(subprocess-dispatch): execute cheap-lane via provider_dispatch instead of Claude fallback (CL2) (#652) (2026-05-26)
+- #650 — refactor(install-central): move shim content to template file (OI-1562) (#650) (2026-05-26)
+- #649 — refactor(doctor): extract worktree + settings checks from cmd_doctor (OI-1573) (#649) (2026-05-26)
+- #648 — refactor(receipt-proc): extract mtime-calc python from bootstrap-protection (OI-1525/1524) (#648) (2026-05-26)
+- #643 — refactor(providers): rename deepseek-path-d-blocked -> deepseek-harness-subscription-blocked; allow own-key+hardening, block subscription-redirect (#643) (2026-05-26)
+- #644 — fix(provider-dispatch): non-claude (kimi/codex) receipt captures correct status + output + tokens (#644) (2026-05-26)
+- #647 — refactor(dispatcher): extract stuck-cleanup python + supervisor-ticks (OI-1521/1523) (#647) (2026-05-26)
+- #646 — refactor(benchmark): extract source-info + report-writers from main (OI-1510) (#646) (2026-05-26)
+- #645 — refactor(quality-db): bootstrap_qi_db migration registry (OI-1542/1544/1541) (#645) (2026-05-26)
+- #642 — fix(quality-advisory): relax shell size thresholds (func 50->60, file 500->600) to cut false-positive OIs (#642) (2026-05-26)
+- #640 — fix(install): preserve project worker_permissions overrides across cutover (#640) (2026-05-26)
+- #638 — docs(strategy): three-tier public/private layering model (#638) (2026-05-26)
+- #639 — feat(supervisor): flood-safe crash-recovery sweep for orphaned active dispatches (#639) (2026-05-26)
+- #641 — fix(migration): 0017 dispatches/terminal_leases rebuild preserves all columns dynamically (unblocks build_t0_state) (#641) (2026-05-26)
+- #637 — fix(dispatch): complexity-scaled chunk_timeout / total_deadline defaults (#637) (2026-05-26)
+- #636 — fix(runtime-coord): add terminal_leases.worker_pid + schema-drift regression guard (#636) (2026-05-26)
+- #635 — fix(runtime-coord): self-heal worker_states.project_id in init (OI-095) (#635) (2026-05-26)
+- #627 — fix(install-central): shim exec bin/vnx not vnx-cli (was typo) (#627) (2026-05-25)
+- #626 — feat(wave2a-8): housekeeping — stale session cleanup + runbook D3/D4 (#626) (2026-05-25)
+- #625 — fix(wave2a-7): T0 template legacy path + doctor cross-platform glob (#625) (2026-05-25)
+- #624 — fix(wave2a-6): installer template-leak — no developer paths in install output (#624) (2026-05-25)
+- #623 — fix(wave2a): env isolation check + runbook v3 (PR-WAVE2A-5) (#623) (2026-05-25)
+- #622 — fix(wave2a): test-mode apply --test-apply flag (PR-WAVE2A-4) (#622) (2026-05-25)
+- #621 — fix(wave2a): backup retention policy --cleanup-backups (PR-WAVE2A-3) (#621) (2026-05-25)
+- #620 — fix(wave2a): per-project migrator mode --project flag (PR-WAVE2A-2) (#620) (2026-05-25)
+- #619 — fix(wave2a): TCC pre-flight check + per-project backup access probe (PR-WAVE2A-1) (#619) (2026-05-25)
+- #618 — docs(wave2a): robust pipeline architecture blueprint (PR-WAVE2A-BLUEPRINT) (#618) (2026-05-25)
+- #617 — fix(migrator): canonical bootstrap dispatch_experiments + rollback exception masking (PR-MIGRATOR-FIX-V2) (#617) (2026-05-24)
+- #616 — fix(migrator): canonical bootstrap schema-order for --fresh-central (PR-MIGRATOR-FIX) (#616) (2026-05-24)
+- #615 — feat(dashboard): VNX-branded light theme (PR-DASH-V2) (#615) (2026-05-21)
 - #614 — fix(resume): VNX_RESUME_IN_PROGRESS bypass for PAUSED-guards (#614) (2026-05-21)
 - #612 — feat(safety): PAUSED marker guards in daemon scripts (#612) (2026-05-21)
 - #613 — fix(singleton): atomic flock(2) replaces mkdir-race (closes OI-1518) (#613) (2026-05-21)
@@ -82,41 +127,6 @@ _Last 14 days — sourced from git merge commits._
 - #492 — chore(hardening): narrow silent-except in intelligence_selector.py (10 findings, OI-1437) (#492) (2026-05-14)
 - #491 — chore(hardening): narrow silent-except in build_t0_state.py (13 findings, OI-1437) (#491) (2026-05-14)
 - #489 — chore(contrib): add CONTRIBUTING.md + ci lint gate (atomic-write + silent-except) (#489) (2026-05-14)
-- #487 — chore(docs): CHANGELOG — OI-1370 systemic locking refactor series (#482-#486) (#487) (2026-05-13)
-- #486 — fix(oi-1370): PR N4 — final migration; close OI-1370 race comprehensively (#486) (2026-05-13)
-- #485 — feat(oi-1370): PR N3 — migrate compact_state.compact_receipts + backfill_headless_receipts to state_writer (#485) (2026-05-13)
-- #484 — feat(oi-1370): PR N2 — migrate gate_register_emit + cleanup_worker_exit to state_writer (#484) (2026-05-13)
-- #483 — feat(oi-1370): PR N1 — state_writer.append_locked helper (no behavior change) (#483) (2026-05-13)
-- #482 — docs(architect): OI-1370 systemic locking refactor plan (#482) (2026-05-13)
-- #481 — chore(docs): post-rc1 sprint refresh — CHANGELOG + README + FEATURE_PLAN regenerator (12 PRs) (#481) (2026-05-13)
-- #480 — feat(gates): validate + document Vertex routing path for gemini quota workaround (#480) (2026-05-13)
-- #467 — refactor(oi-1294): split compact_open_items_digest below 70-line threshold (#467) (2026-05-13)
-- #464 — chore(t0): canonical subprocess_dispatch.py routing in T0 template + skill (#464) (2026-05-13)
-- #463 — chore(start): default VNX_QUEUE_POPUP_ENABLED=0 in init-time preset templates (#463) (2026-05-13)
-- #465 — fix(security): OI-1369 — reject path traversal in project_id (^[a-z][a-z0-9-]{1,31}$) (#465) (2026-05-13)
-- #449 — docs(governance): ADR-011 amendment v2 — split subagent pilot into 2 sequential gates (#449) (2026-05-09)
-- #448 — docs(release): cut v1.0.0-rc1 — architectural stabilization milestone (#448) (2026-05-09)
-- #447 — docs(governance): ADR-011 amendment — resolve Tentative section to Conditional/Pilot (#447) (2026-05-09)
-- #446 — fix(migration): rewrite 0016 schema-first per ADR-009 (resolves OI-1375/1376/1377) (#446) (2026-05-09)
-- #445 — docs(governance): add ADR-013 (workers=N) + ADR-014 (autonomous chain dispatch) (#445) (2026-05-09)
-- #442 — chore(repo-hygiene): OI-1373 Tier 4 — move 18 FEATURE_PLAN files to private claudedocs/ (#442) (2026-05-09)
-- #441 — chore(repo-hygiene): OI-1373 Tier 2 — move strategy files to private claudedocs/ (#441) (2026-05-09)
-- #440 — chore(repo-hygiene): OI-1373 Tier 1 — move business agent drafts to private claudedocs/ (#440) (2026-05-09)
-- #439 — ci(governance): enforce ADR-003 — block Anthropic SDK imports (#439) (2026-05-09)
-- #432 — feat(migration): one-shot data import script (Phase 6 P4 — DRAFT, operator-review-required) (#432) (2026-05-09)
-- #438 — feat(skills): add database-engineer + intelligence-engineer specialists (#438) (2026-05-09)
-- #437 — ci(profile-a): exclude migration scripts from legacy path gate (#437) (2026-05-07)
-- #436 — docs(skill): add VNX CI workflow conclusion check before merge (t0-orchestrator) (#436) (2026-05-07)
-- #435 — fix(build_current_state): remove legacy path literal from line 263 hint (#435) (2026-05-07)
-- #434 — fix(dashboard): clean up agent stream lifecycle (#434) (2026-05-07)
-- #433 — chore(gemini): switch default reviewer model to gemini-2.5-pro for deeper reviews (#433) (2026-05-07)
-- #431 — feat(envelopes): per-project paths + four-tuple envelope (Phase 6 P3 v2) (#431) (2026-05-07)
-
-**WAVE 0**
-- #443 — chore(repo-hygiene): Wave 0 — OI-1373 Tier 3 + 9 stale docs archive (combined) (#443) (2026-05-09)
-
-**WAVE 1**
-- #457 — docs: refresh README + CHANGELOG for post-rc1 work (Wave 1 + Wave 5 P0/P1) (#457) (2026-05-10)
 
 **WAVE 5**
 - #601 — docs: refresh README + ROADMAP for 1.0.0-rc2 (Wave 5/6/7/8 shipped + central install) (#601) (2026-05-18)
@@ -125,25 +135,13 @@ _Last 14 days — sourced from git merge commits._
 **WAVE 8**
 - #570 — fix(wiring): activate 4 dead-code modules from Wave 8 fast-path (auto_apply, validator class, schema-emit, smart_router.route) (#570) (2026-05-17)
 
-**WAVE1**
-- #454 — feat(wave1): PR-W1.5 — Dashboard shadow wiring + canary divergence test pack + rollback docs (#454) (2026-05-10)
-- #453 — feat(wave1): PR-W1.4 — IntelligenceSelector + DispatchRegister shadow wiring (5 read sites) (#453) (2026-05-09)
-- #452 — feat(wave1): PR-W1.3 — T0 state-builder shadow wiring (4 read sites) (#452) (2026-05-09)
-- #451 — feat(wave1): PR-W1.2 — shadow_logger NDJSON writer + report CLI + rotation (#451) (2026-05-09)
-- #450 — feat(wave1): PR-W1.1 — shadow_verifier independent comparator with 6 hard metrics (#450) (2026-05-09)
-
-**WAVE2**
-- #478 — feat(wave2): Phase 1a redo — migrate function_size_gate to vnx_core + shim layer (#478) (2026-05-13)
-- #469 — feat(wave2): Phase 0a — vnx-orchestration package skeleton + build validation (#469) (2026-05-13)
-
 **WAVE4**
-- #468 — feat(wave4): OTel export foundation — dispatch completion metrics + span emission (opt-in via OTEL_EXPORTER_OTLP_ENDPOINT) (#468) (2026-05-13)
-
-**WAVE4.5**
-- #479 — feat(wave4.5): PR-2b redo — gate reviewer prompts use gh pr diff + fail-loud on errors (#479) (2026-05-13)
-- #477 — feat(wave4.5): PR-3 redo — guard build_intelligence_context against empty dispatch_id (audit-safe) (#477) (2026-05-13)
-- #472 — feat(wave4.5): PR-2 — codex/gemini adapters use PromptAssembler + tri-file activation (#472) (2026-05-13)
-- #471 — feat(wave4.5): PromptAssembler provider-agnostic methods (codex, gemini, litellm) (#471) (2026-05-13)
+- #633 — docs(wave4): central-install runbook + cutover procedure (PR-WAVE4-6) (#633) (2026-05-25)
+- #632 — test(wave4): central-install e2e integration tests (PR-WAVE4-5) (#632) (2026-05-25)
+- #631 — fix(regen-settings): guard against central-install write; detect pre-fix contamination (PR-WAVE4-4) (#631) (2026-05-25)
+- #630 — fix(bin): preserve VNX_PROJECT_ROOT across env reset; add write guard; redirect cmd_update (PR-WAVE4-3) (#630) (2026-05-25)
+- #629 — fix(install-central): write install-mode marker, export VNX_PROJECT_ROOT from shim, fix verify_install (PR-WAVE4-2) (#629) (2026-05-25)
+- #628 — fix(install-central): separate PROJECT_ROOT from VNX_HOME in central-install mode (PR-WAVE4-1) (#628) (2026-05-25)
 
 **WAVE4.6**
 - #513 — feat(wave4.6): PR-4.6.6 — unified event shape via CanonicalEvent + EventStore enforcement (#513) (2026-05-15)
@@ -162,13 +160,6 @@ _Last 14 days — sourced from git merge commits._
 - #523 — feat(wave5): PR-5.3 — multi-tenant lease isolation (schema v12) (#523) (2026-05-16)
 - #522 — feat(wave5): PR-5.1 — multi-project state aggregator write-pad (#522) (2026-05-16)
 - #521 — docs(wave5): PR-5.0 — ADR-017 Control Centre product-shape architecture (#521) (2026-05-16)
-- #462 — feat(wave5): CFX-W5-2 — plumbing gaps (pr_id key + headless daemon entry points) (#462) (2026-05-13)
-- #461 — feat(wave5): PR-W5.5 — production plumbing for P0-P4 context-bundle classes (#461) (2026-05-10)
-- #460 — feat(wave5): PR-W5.4 — schema introspection injection (DDL grounding for DB workers) (#460) (2026-05-10)
-- #459 — feat(wave5): PR-W5.3 — operator memory injection (curated wisdom into worker context) (#459) (2026-05-10)
-- #458 — feat(wave5): PR-W5.2 — code anchor injection (file:line current-state grounding) (#458) (2026-05-10)
-- #456 — feat(wave5): PR-W5.1 — ADR injection by file-touch (governance context to dispatches) (#456) (2026-05-10)
-- #455 — feat(wave5): PR-W5.0 — prior-round findings injection (highest signal-to-effort smart-context) (#455) (2026-05-10)
 
 **WAVE6**
 - #575 — fix(wave6): real spawn impl + config field reads + single heartbeat threshold (3 blockers) (#575) (2026-05-17)

--- a/ROADMAP.yaml
+++ b/ROADMAP.yaml
@@ -14,3 +14,24 @@ features:
       - claude_github_optional
     depends_on: []
     status: planned
+
+  - feature_id: fut-1
+    title: "Track-layer schema + DAL + CLI + audit-ordering (PR-FUT-1); seeding + composite-FK deferred to PR-FUT-2"
+    branch_name: feat/fut-1-track-schema
+    risk_class: medium
+    merge_policy: human
+    review_stack:
+      - codex_gate
+    depends_on: []
+    status: active
+
+  - feature_id: fut-2
+    title: "Track tenant-scoping per ADR-007 — composite PK over project_id, seeding from roadmap, composite-FK dispatches.track → tracks(track_id, project_id), project-aware CLI"
+    branch_name: feat/fut-2-track-tenant-scope
+    risk_class: high
+    merge_policy: human
+    review_stack:
+      - codex_gate
+    depends_on:
+      - fut-1
+    status: planned

--- a/schemas/migrations/0022_track_layer.sql
+++ b/schemas/migrations/0022_track_layer.sql
@@ -1,0 +1,174 @@
+-- VNX Migration 0022 — track layer (tracks, phase history, dependencies, open-item links)
+--
+-- Purpose: Promote dispatches.track to first-class by adding the parent tracks table
+--          and related link tables. Extends dispatches with state CHECK + operator gate.
+--
+-- Design: claudedocs/FUTURE-SYSTEM-DESIGN-2026-05-28.md
+--
+-- Pre-migration state (v21): central install metadata.
+-- Post-migration state (v22): track layer tables + dispatches extensions.
+--
+-- SQLite caveats:
+--   ALTER TABLE cannot add CHECK constraints to existing columns directly.
+--   The dispatches table is rebuilt to add the state CHECK and operator_approved_at.
+--   Existing data is preserved via INSERT ... SELECT.
+--   The new state CHECK includes all legacy states for backward compatibility.
+--
+-- Idempotency: apply_script_if_below skips the entire script when user_version >= 22.
+--   Partial-run safety: SAVEPOINT wraps all statements in apply_script_if_below.
+--
+-- Applied by: scripts/migrate_future_system.py
+-- Tested by: tests/test_tracks_schema.py
+
+-- ============================================================================
+-- TRACKS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tracks (
+    track_id                TEXT    NOT NULL PRIMARY KEY,
+    title                   TEXT    NOT NULL,
+    goal_state              TEXT    NOT NULL,
+    phase                   TEXT    NOT NULL DEFAULT 'queued'
+                                    CHECK (phase IN ('queued', 'active', 'parked', 'done')),
+    next_up                 INTEGER NOT NULL DEFAULT 0,
+    sort_order              INTEGER NOT NULL DEFAULT 0,
+    priority                TEXT,
+    requires_operator_promotion INTEGER NOT NULL DEFAULT 1,
+    instruction_template    TEXT,
+    context_composer_rules  TEXT,
+    pr_ref                  TEXT,
+    trigger_condition       TEXT,
+    project_id              TEXT    NOT NULL DEFAULT 'vnx-dev',
+    created_at              TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    phase_changed_at        TEXT,
+    completed_at            TEXT,
+    metadata_json           TEXT    DEFAULT '{}'
+);
+
+-- ============================================================================
+-- TRACK PHASE HISTORY
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS track_phase_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id    TEXT    NOT NULL REFERENCES tracks(track_id),
+    from_phase  TEXT,
+    to_phase    TEXT    NOT NULL,
+    actor       TEXT    NOT NULL CHECK (actor IN ('operator', 'T0', 'system')),
+    reason      TEXT,
+    approval_id TEXT,
+    occurred_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- ============================================================================
+-- TRACK DEPENDENCIES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS track_dependencies (
+    from_track_id       TEXT    NOT NULL REFERENCES tracks(track_id),
+    to_track_id         TEXT    NOT NULL REFERENCES tracks(track_id),
+    kind                TEXT    NOT NULL CHECK (kind IN ('hard', 'soft', 'overlap')),
+    derivation_source   TEXT    NOT NULL
+                                CHECK (derivation_source IN (
+                                    'manual', 'git_ancestry', 'path_overlap', 'oi_ref', 'pr_ref'
+                                )),
+    confidence          REAL    NOT NULL DEFAULT 1.0,
+    evidence_json       TEXT,
+    derived_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (from_track_id, to_track_id)
+);
+
+-- ============================================================================
+-- TRACK OPEN ITEMS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS track_open_items (
+    track_id    TEXT    NOT NULL REFERENCES tracks(track_id),
+    oi_id       TEXT    NOT NULL,
+    link_type   TEXT    NOT NULL CHECK (link_type IN ('blocks', 'warns', 'related')),
+    link_source TEXT    NOT NULL CHECK (link_source IN ('file_path', 'mention', 'manual')),
+    linked_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- ============================================================================
+-- EXTEND DISPATCHES — rebuild to add CHECK on state + operator_approved_at
+-- ============================================================================
+--
+-- SQLite does not support ALTER TABLE ADD CONSTRAINT or ADD COLUMN with CHECK.
+-- Rebuild pattern: rename → create new → copy data → drop old.
+--
+-- The new state CHECK includes all legacy dispatch states so existing rows
+-- remain valid after migration.
+
+ALTER TABLE dispatches RENAME TO dispatches_pre_v22;
+
+CREATE TABLE dispatches (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id     TEXT    NOT NULL UNIQUE,
+    state           TEXT    NOT NULL DEFAULT 'proposed'
+                            CHECK (state IN (
+                                'proposed', 'ready', 'active', 'completed', 'failed',
+                                'queued', 'claimed', 'delivering', 'accepted', 'running',
+                                'timed_out', 'failed_delivery', 'expired', 'recovered',
+                                'dead_letter'
+                            )),
+    terminal_id     TEXT,
+    track           TEXT    REFERENCES tracks(track_id),
+    priority        TEXT    DEFAULT 'P2',
+    pr_ref          TEXT,
+    gate            TEXT,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    bundle_path     TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_after   TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    operator_approved_at TEXT
+);
+
+INSERT INTO dispatches (
+    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json
+)
+SELECT
+    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json
+FROM dispatches_pre_v22;
+
+DROP TABLE dispatches_pre_v22;
+
+-- ============================================================================
+-- INDEXES — dispatches (rebuilt above)
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_state
+    ON dispatches (state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_terminal
+    ON dispatches (terminal_id, state);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_created
+    ON dispatches (created_at DESC);
+
+-- ============================================================================
+-- INDEXES — track layer
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_tracks_phase_nextup
+    ON tracks(project_id, phase, next_up DESC, sort_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tracks_next_up
+    ON tracks(project_id) WHERE next_up = 1 AND phase = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_dispatches_ready
+    ON dispatches(state, operator_approved_at)
+    WHERE state = 'proposed' OR state = 'ready';
+
+CREATE INDEX IF NOT EXISTS idx_track_deps_from
+    ON track_dependencies(from_track_id);
+
+CREATE INDEX IF NOT EXISTS idx_track_phase_history
+    ON track_phase_history(track_id, occurred_at DESC);
+
+-- Bump schema version
+PRAGMA user_version = 22;

--- a/schemas/migrations/0022_track_layer.sql
+++ b/schemas/migrations/0022_track_layer.sql
@@ -146,6 +146,9 @@ FROM dispatches_pre_v22;
 
 DROP TABLE dispatches_pre_v22;
 
+INSERT OR REPLACE INTO sqlite_sequence(name, seq)
+    SELECT 'dispatches', COALESCE(MAX(id), 0) FROM dispatches;
+
 -- ============================================================================
 -- INDEXES — dispatches (rebuilt above)
 -- ============================================================================

--- a/schemas/migrations/0022_track_layer.sql
+++ b/schemas/migrations/0022_track_layer.sql
@@ -111,7 +111,8 @@ ALTER TABLE dispatches RENAME TO dispatches_pre_v22;
 
 CREATE TABLE dispatches (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    dispatch_id     TEXT    NOT NULL UNIQUE,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
     state           TEXT    NOT NULL DEFAULT 'proposed'
                             CHECK (state IN (
                                 'proposed', 'ready', 'active', 'completed', 'failed',
@@ -130,15 +131,16 @@ CREATE TABLE dispatches (
     updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     expires_after   TEXT,
     metadata_json   TEXT    DEFAULT '{}',
-    operator_approved_at TEXT
+    operator_approved_at TEXT,
+    UNIQUE(dispatch_id, project_id)
 );
 
 INSERT INTO dispatches (
-    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate,
     attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json
 )
 SELECT
-    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate,
     attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json
 FROM dispatches_pre_v22;
 

--- a/schemas/migrations/0022_track_layer.sql
+++ b/schemas/migrations/0022_track_layer.sql
@@ -6,7 +6,13 @@
 -- Design: claudedocs/FUTURE-SYSTEM-DESIGN-2026-05-28.md
 --
 -- Pre-migration state (v21): central install metadata.
--- Post-migration state (v22): track layer tables + dispatches extensions.
+-- Post-migration state (v22): track layer tables + dispatches rebuilt WITHOUT track FK.
+--
+-- FK deferral: dispatches.track is rebuilt here WITHOUT REFERENCES tracks(track_id).
+--   The FK is added in migration 0023, which runs after tracks are seeded and existing
+--   dispatch rows are tagged. This prevents FK violations on real v21 installs where
+--   dispatch rows with pre-existing track values exist before the tracks table is
+--   populated. Option A from dispatch 20260528-fut-1-fix1-codex-r1.
 --
 -- SQLite caveats:
 --   ALTER TABLE cannot add CHECK constraints to existing columns directly.
@@ -87,7 +93,8 @@ CREATE TABLE IF NOT EXISTS track_open_items (
     oi_id       TEXT    NOT NULL,
     link_type   TEXT    NOT NULL CHECK (link_type IN ('blocks', 'warns', 'related')),
     link_source TEXT    NOT NULL CHECK (link_source IN ('file_path', 'mention', 'manual')),
-    linked_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    linked_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (track_id, oi_id, link_type)
 );
 
 -- ============================================================================
@@ -113,7 +120,7 @@ CREATE TABLE dispatches (
                                 'dead_letter'
                             )),
     terminal_id     TEXT,
-    track           TEXT    REFERENCES tracks(track_id),
+    track           TEXT,
     priority        TEXT    DEFAULT 'P2',
     pr_ref          TEXT,
     gate            TEXT,

--- a/schemas/migrations/0023_dispatches_fk.sql
+++ b/schemas/migrations/0023_dispatches_fk.sql
@@ -20,7 +20,8 @@ ALTER TABLE dispatches RENAME TO dispatches_pre_v23;
 
 CREATE TABLE dispatches (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    dispatch_id     TEXT    NOT NULL UNIQUE,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
     state           TEXT    NOT NULL DEFAULT 'proposed'
                             CHECK (state IN (
                                 'proposed', 'ready', 'active', 'completed', 'failed',
@@ -39,16 +40,17 @@ CREATE TABLE dispatches (
     updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     expires_after   TEXT,
     metadata_json   TEXT    DEFAULT '{}',
-    operator_approved_at TEXT
+    operator_approved_at TEXT,
+    UNIQUE(dispatch_id, project_id)
 );
 
 INSERT INTO dispatches (
-    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate,
     attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json,
     operator_approved_at
 )
 SELECT
-    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate,
     attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json,
     operator_approved_at
 FROM dispatches_pre_v23;

--- a/schemas/migrations/0023_dispatches_fk.sql
+++ b/schemas/migrations/0023_dispatches_fk.sql
@@ -57,6 +57,9 @@ FROM dispatches_pre_v23;
 
 DROP TABLE dispatches_pre_v23;
 
+INSERT OR REPLACE INTO sqlite_sequence(name, seq)
+    SELECT 'dispatches', COALESCE(MAX(id), 0) FROM dispatches;
+
 -- Recreate dispatch indexes (dropped with the renamed table)
 CREATE INDEX IF NOT EXISTS idx_dispatch_state
     ON dispatches (state, updated_at DESC);

--- a/schemas/migrations/0023_dispatches_fk.sql
+++ b/schemas/migrations/0023_dispatches_fk.sql
@@ -1,0 +1,72 @@
+-- VNX Migration 0023 — dispatches FK rebuild (adds track → tracks(track_id) constraint)
+--
+-- Purpose: Add the foreign key from dispatches.track to tracks(track_id).
+--   0022 intentionally omitted this FK so that tracks could be seeded and
+--   existing dispatch rows tagged before FK enforcement. This migration runs
+--   after seed + tag, making the FK safe to add.
+--   Option A from dispatch 20260528-fut-1-fix1-codex-r1.
+--
+-- Pre-condition: tracks table populated (migration 0022 + seed step complete).
+--   Orphaned track refs must be nullified before this runs — see
+--   _nullify_orphaned_track_refs() in scripts/migrate_future_system.py.
+--
+-- Idempotency: apply_script_if_below skips the entire script when user_version >= 23.
+--   Partial-run safety: SAVEPOINT wraps all statements in apply_script_if_below.
+--
+-- Applied by: scripts/migrate_future_system.py (step after seed + tag)
+-- Tested by: tests/test_migrate_fk_order_real_data.py, tests/test_tracks_schema.py
+
+ALTER TABLE dispatches RENAME TO dispatches_pre_v23;
+
+CREATE TABLE dispatches (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id     TEXT    NOT NULL UNIQUE,
+    state           TEXT    NOT NULL DEFAULT 'proposed'
+                            CHECK (state IN (
+                                'proposed', 'ready', 'active', 'completed', 'failed',
+                                'queued', 'claimed', 'delivering', 'accepted', 'running',
+                                'timed_out', 'failed_delivery', 'expired', 'recovered',
+                                'dead_letter'
+                            )),
+    terminal_id     TEXT,
+    track           TEXT    REFERENCES tracks(track_id),
+    priority        TEXT    DEFAULT 'P2',
+    pr_ref          TEXT,
+    gate            TEXT,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    bundle_path     TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_after   TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    operator_approved_at TEXT
+);
+
+INSERT INTO dispatches (
+    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json,
+    operator_approved_at
+)
+SELECT
+    id, dispatch_id, state, terminal_id, track, priority, pr_ref, gate,
+    attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json,
+    operator_approved_at
+FROM dispatches_pre_v23;
+
+DROP TABLE dispatches_pre_v23;
+
+-- Recreate dispatch indexes (dropped with the renamed table)
+CREATE INDEX IF NOT EXISTS idx_dispatch_state
+    ON dispatches (state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_terminal
+    ON dispatches (terminal_id, state);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_created
+    ON dispatches (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dispatches_ready
+    ON dispatches(state, operator_approved_at)
+    WHERE state = 'proposed' OR state = 'ready';
+
+PRAGMA user_version = 23;

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -31,6 +31,25 @@ except ImportError:
     _shadow_verifier = None  # type: ignore[assignment]
     _shadow_logger = None  # type: ignore[assignment]
 
+# ---------------------------------------------------------------------------
+# NDJSON write path documentation
+#
+# Two separate NDJSON paths exist in this module — intentional, not a bug:
+#
+# Path 1 (legacy, fire-and-forget): append_event()
+#   Writes to: <state_dir>/dispatch_register.ndjson
+#   Semantics: best-effort, never raises, suitable for fire-and-forget hooks
+#   Used by: all legacy callers (schema_migration hooks, CLI bash callers, etc.)
+#
+# Path 2 (transactional, ADR-005): register_proposed_track_dispatch()
+#   Writes to: <state_dir.parent>/events/dispatch_register.ndjson
+#   Semantics: raises on failure; NDJSON written before SQLite commit
+#   Used by: new track-layer operations requiring ledger-first guarantee
+#
+# DO NOT merge the two paths — legacy callers rely on best-effort semantics;
+# new callers must use the transactional path and handle OSError propagation.
+# ---------------------------------------------------------------------------
+
 # SQL template identifier used in shadow comparisons (no actual SQL — NDJSON source)
 _REGISTER_NDJSON_TEMPLATE = "dispatch_register.ndjson"
 
@@ -149,6 +168,11 @@ def _build_event_record(
         record["agent_id"] = agent_id
     if extra and isinstance(extra, dict):
         record["extra"] = extra
+    import hashlib as _hashlib
+    _primary = dispatch_id or feature_id or str(pr_number)
+    record["record_id"] = _hashlib.sha256(
+        f'{event}:{_primary}:{record["timestamp"]}'.encode()
+    ).hexdigest()[:16]
     return record
 
 
@@ -616,11 +640,16 @@ def register_proposed_track_dispatch(
     terminal_id: str,
     track_id: str,
     pr_ref: str,
+    *,
+    project_id: str = "vnx-dev",
 ) -> None:
     """Insert a proposed dispatch row + emit NDJSON audit event (ADR-005 compliant).
 
     NDJSON write precedes the SQLite commit. If the audit write fails it raises
     and no DB row is created. Raises sqlite3.Error on DB failure.
+
+    ``project_id`` is written into the dispatches row (defaults to ``vnx-dev``
+    for backwards compatibility with callers that do not supply it).
     """
     import sqlite3 as _sqlite3
 
@@ -630,8 +659,8 @@ def register_proposed_track_dispatch(
         pr_ref or "", terminal_id or "", "", None,
     )
 
-    # Write NDJSON first — ADR-005 requires ledger before DB
-    _write_event_locked(Path(state_dir) / "dispatch_register.ndjson", record)
+    # Write NDJSON first — ADR-005 requires ledger before DB; events/ not state/
+    _write_event_locked(Path(state_dir).parent / "events" / "dispatch_register.ndjson", record)
 
     db_path = Path(state_dir) / "runtime_coordination.db"
     conn = _sqlite3.connect(str(db_path), timeout=10.0)
@@ -640,10 +669,10 @@ def register_proposed_track_dispatch(
     try:
         conn.execute(
             """
-            INSERT INTO dispatches (dispatch_id, state, terminal_id, track, pr_ref)
-            VALUES (?, 'proposed', ?, ?, ?)
+            INSERT INTO dispatches (dispatch_id, project_id, state, terminal_id, track, pr_ref)
+            VALUES (?, ?, 'proposed', ?, ?, ?)
             """,
-            (dispatch_id, terminal_id, track_id, pr_ref),
+            (dispatch_id, project_id, terminal_id, track_id, pr_ref),
         )
         conn.commit()
     finally:

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -610,6 +610,47 @@ def _query_recent_dispatches(
     return legacy
 
 
+def register_proposed_track_dispatch(
+    state_dir: "str | Path",
+    dispatch_id: str,
+    terminal_id: str,
+    track_id: str,
+    pr_ref: str,
+) -> None:
+    """Insert a proposed dispatch row + emit NDJSON audit event.
+
+    Routes dispatch creation through the register so the NDJSON audit trail
+    is always written alongside the DB row. Raises sqlite3.Error on DB failure;
+    NDJSON write is best-effort (never raises).
+    """
+    import sqlite3 as _sqlite3
+
+    db_path = Path(state_dir) / "runtime_coordination.db"
+    conn = _sqlite3.connect(str(db_path), timeout=10.0)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute(
+            """
+            INSERT INTO dispatches (dispatch_id, state, terminal_id, track, pr_ref)
+            VALUES (?, 'proposed', ?, ?, ?)
+            """,
+            (dispatch_id, terminal_id, track_id, pr_ref),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        record = _build_event_record(
+            "dispatch_created", dispatch_id, None,
+            pr_ref or "", terminal_id or "", "", None,
+        )
+        _write_event_locked(Path(state_dir) / "dispatch_register.ndjson", record)
+    except Exception:
+        pass
+
+
 # CLI for bash callers
 def _cli(argv: list[str]) -> int:
     if len(argv) < 3 or argv[1] != "append":

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -617,13 +617,21 @@ def register_proposed_track_dispatch(
     track_id: str,
     pr_ref: str,
 ) -> None:
-    """Insert a proposed dispatch row + emit NDJSON audit event.
+    """Insert a proposed dispatch row + emit NDJSON audit event (ADR-005 compliant).
 
-    Routes dispatch creation through the register so the NDJSON audit trail
-    is always written alongside the DB row. Raises sqlite3.Error on DB failure;
-    NDJSON write is best-effort (never raises).
+    NDJSON write precedes the SQLite commit. If the audit write fails it raises
+    and no DB row is created. Raises sqlite3.Error on DB failure.
     """
     import sqlite3 as _sqlite3
+
+    # Build audit record before any I/O
+    record = _build_event_record(
+        "dispatch_created", dispatch_id, None,
+        pr_ref or "", terminal_id or "", "", None,
+    )
+
+    # Write NDJSON first — ADR-005 requires ledger before DB
+    _write_event_locked(Path(state_dir) / "dispatch_register.ndjson", record)
 
     db_path = Path(state_dir) / "runtime_coordination.db"
     conn = _sqlite3.connect(str(db_path), timeout=10.0)
@@ -640,15 +648,6 @@ def register_proposed_track_dispatch(
         conn.commit()
     finally:
         conn.close()
-
-    try:
-        record = _build_event_record(
-            "dispatch_created", dispatch_id, None,
-            pr_ref or "", terminal_id or "", "", None,
-        )
-        _write_event_locked(Path(state_dir) / "dispatch_register.ndjson", record)
-    except Exception:
-        pass
 
 
 # CLI for bash callers

--- a/scripts/lib/schema_migration.py
+++ b/scripts/lib/schema_migration.py
@@ -28,6 +28,20 @@ from typing import Callable
 
 logger = logging.getLogger(__name__)
 
+# Pre-flight hook registry: migration version → list of fn(conn) callables.
+# Hooks run inside apply_script_if_below before any SQL executes.
+# Each fn must raise (e.g. RuntimeError) to abort; returning None means pass.
+_PREFLIGHT_HOOKS: dict[int, list] = {}
+
+
+def register_preflight(version: int, fn) -> None:
+    """Register fn(conn) as a pre-flight guard for migration *version*.
+
+    Called inside apply_script_if_below before SQL execution, so direct callers
+    cannot bypass the check by skipping the wrapper function.
+    """
+    _PREFLIGHT_HOOKS.setdefault(version, []).append(fn)
+
 
 def get_user_version(conn: sqlite3.Connection) -> int:
     """Return PRAGMA user_version for the connection's database."""
@@ -161,6 +175,9 @@ def apply_script_if_below(
     """
     if get_user_version(conn) >= target_version:
         return False
+
+    for hook in _PREFLIGHT_HOOKS.get(target_version, []):
+        hook(conn)  # raises on failure; prevents any SQL from executing
 
     statements = _split_sql_statements(sql)
     sp = f'"vnx_ver_{target_version}"'

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""tracks.py — pure data-access layer for the VNX track system.
+
+CRUD + phase transitions + dependency helpers.
+Uses coordination_db.get_connection_for_db for WAL-mode, FK-enforced connections.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+DB_FILENAME = "runtime_coordination.db"
+
+VALID_PHASES = frozenset({"queued", "active", "parked", "done"})
+
+ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    "queued":  frozenset({"active", "parked"}),
+    "active":  frozenset({"done", "parked"}),
+    "parked":  frozenset({"queued"}),
+    "done":    frozenset(),
+}
+
+
+class TrackNotFoundError(ValueError):
+    pass
+
+
+class InvalidPhaseError(ValueError):
+    pass
+
+
+class InvalidTransitionError(ValueError):
+    pass
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _db_path(state_dir: str | Path) -> Path:
+    return Path(state_dir) / DB_FILENAME
+
+
+def _get_conn(state_dir: str | Path) -> sqlite3.Connection:
+    path = _db_path(state_dir)
+    conn = sqlite3.connect(str(path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _row_to_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+def create_track(
+    state_dir: str | Path,
+    track_id: str,
+    title: str,
+    goal_state: str,
+    *,
+    phase: str = "queued",
+    sort_order: int = 0,
+    priority: Optional[str] = None,
+    project_id: str = "vnx-dev",
+    requires_operator_promotion: int = 1,
+    instruction_template: Optional[str] = None,
+    context_composer_rules: Optional[str] = None,
+    pr_ref: Optional[str] = None,
+    trigger_condition: Optional[str] = None,
+    metadata_json: Optional[str] = None,
+) -> dict[str, Any]:
+    if phase not in VALID_PHASES:
+        raise InvalidPhaseError(f"Invalid phase: {phase!r}. Must be one of {sorted(VALID_PHASES)}")
+
+    now = _now_utc()
+    conn = _get_conn(state_dir)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tracks (
+                track_id, title, goal_state, phase, next_up, sort_order, priority,
+                requires_operator_promotion, instruction_template, context_composer_rules,
+                pr_ref, trigger_condition, project_id, created_at, phase_changed_at,
+                metadata_json
+            ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                track_id, title, goal_state, phase, sort_order, priority,
+                requires_operator_promotion, instruction_template, context_composer_rules,
+                pr_ref, trigger_condition, project_id, now, now,
+                metadata_json or "{}",
+            ),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def get_track(state_dir: str | Path, track_id: str) -> dict[str, Any] | None:
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
+        return _row_to_dict(row)
+    finally:
+        conn.close()
+
+
+def list_tracks(
+    state_dir: str | Path,
+    *,
+    phase: Optional[str] = None,
+    project_id: str = "vnx-dev",
+) -> list[dict[str, Any]]:
+    conn = _get_conn(state_dir)
+    try:
+        if phase is not None:
+            if phase not in VALID_PHASES:
+                raise InvalidPhaseError(f"Invalid phase: {phase!r}")
+            rows = conn.execute(
+                """
+                SELECT * FROM tracks
+                WHERE project_id = ? AND phase = ?
+                ORDER BY next_up DESC, sort_order ASC, track_id ASC
+                """,
+                (project_id, phase),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT * FROM tracks
+                WHERE project_id = ?
+                ORDER BY next_up DESC, sort_order ASC, track_id ASC
+                """,
+                (project_id,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase transitions
+# ---------------------------------------------------------------------------
+
+def transition_phase(
+    state_dir: str | Path,
+    track_id: str,
+    to_phase: str,
+    *,
+    actor: str,
+    reason: Optional[str] = None,
+    approval_id: Optional[str] = None,
+) -> dict[str, Any]:
+    if actor not in ("operator", "T0", "system"):
+        raise ValueError(f"Invalid actor: {actor!r}. Must be 'operator', 'T0', or 'system'")
+    if to_phase not in VALID_PHASES:
+        raise InvalidPhaseError(f"Invalid to_phase: {to_phase!r}")
+
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
+        if not row:
+            raise TrackNotFoundError(f"Track not found: {track_id!r}")
+
+        track = dict(row)
+        from_phase = track["phase"]
+
+        if from_phase == to_phase:
+            return track
+
+        allowed = ALLOWED_TRANSITIONS.get(from_phase, frozenset())
+        if to_phase not in allowed:
+            raise InvalidTransitionError(
+                f"Transition {from_phase!r} → {to_phase!r} not allowed. "
+                f"Allowed from {from_phase!r}: {sorted(allowed) or 'none'}"
+            )
+
+        now = _now_utc()
+        completed_at = now if to_phase == "done" else None
+
+        conn.execute(
+            """
+            UPDATE tracks
+            SET phase = ?, phase_changed_at = ?, completed_at = COALESCE(?, completed_at),
+                updated_at = ?
+            WHERE track_id = ?
+            """,
+            (to_phase, now, completed_at, now, track_id),
+        ) if _has_updated_at(conn) else conn.execute(
+            """
+            UPDATE tracks
+            SET phase = ?, phase_changed_at = ?, completed_at = COALESCE(?, completed_at)
+            WHERE track_id = ?
+            """,
+            (to_phase, now, completed_at, track_id),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO track_phase_history
+                (track_id, from_phase, to_phase, actor, reason, approval_id, occurred_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (track_id, from_phase, to_phase, actor, reason, approval_id, now),
+        )
+
+        conn.commit()
+
+        updated = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
+        return dict(updated)
+    finally:
+        conn.close()
+
+
+def _has_updated_at(conn: sqlite3.Connection) -> bool:
+    info = conn.execute("PRAGMA table_info(tracks)").fetchall()
+    return any(row[1] == "updated_at" for row in info)
+
+
+# ---------------------------------------------------------------------------
+# Next-up management
+# ---------------------------------------------------------------------------
+
+def set_next_up(state_dir: str | Path, track_id: str) -> None:
+    """Mark track_id as next_up=1, clearing any previous next_up in the same project."""
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
+        if not row:
+            raise TrackNotFoundError(f"Track not found: {track_id!r}")
+
+        track = dict(row)
+        project_id = track["project_id"]
+
+        # Clear existing next_up for this project
+        conn.execute(
+            "UPDATE tracks SET next_up = 0 WHERE project_id = ? AND next_up = 1",
+            (project_id,),
+        )
+        conn.execute(
+            "UPDATE tracks SET next_up = 1 WHERE track_id = ?",
+            (track_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Open item linking
+# ---------------------------------------------------------------------------
+
+def link_open_item(
+    state_dir: str | Path,
+    track_id: str,
+    oi_id: str,
+    link_type: str,
+    link_source: str,
+) -> None:
+    valid_link_types = frozenset({"blocks", "warns", "related"})
+    valid_link_sources = frozenset({"file_path", "mention", "manual"})
+
+    if link_type not in valid_link_types:
+        raise ValueError(f"Invalid link_type: {link_type!r}. Must be one of {sorted(valid_link_types)}")
+    if link_source not in valid_link_sources:
+        raise ValueError(f"Invalid link_source: {link_source!r}. Must be one of {sorted(valid_link_sources)}")
+
+    conn = _get_conn(state_dir)
+    try:
+        if not conn.execute("SELECT 1 FROM tracks WHERE track_id = ?", (track_id,)).fetchone():
+            raise TrackNotFoundError(f"Track not found: {track_id!r}")
+
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO track_open_items
+                (track_id, oi_id, link_type, link_source, linked_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (track_id, oi_id, link_type, link_source, _now_utc()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+def add_dependency(
+    state_dir: str | Path,
+    from_track_id: str,
+    to_track_id: str,
+    kind: str,
+    derivation_source: str,
+    *,
+    confidence: float = 1.0,
+    evidence_json: Optional[str] = None,
+) -> None:
+    valid_kinds = frozenset({"hard", "soft", "overlap"})
+    valid_sources = frozenset({"manual", "git_ancestry", "path_overlap", "oi_ref", "pr_ref"})
+
+    if kind not in valid_kinds:
+        raise ValueError(f"Invalid kind: {kind!r}. Must be one of {sorted(valid_kinds)}")
+    if derivation_source not in valid_sources:
+        raise ValueError(f"Invalid derivation_source: {derivation_source!r}. Must be one of {sorted(valid_sources)}")
+
+    conn = _get_conn(state_dir)
+    try:
+        for tid in (from_track_id, to_track_id):
+            if not conn.execute("SELECT 1 FROM tracks WHERE track_id = ?", (tid,)).fetchone():
+                raise TrackNotFoundError(f"Track not found: {tid!r}")
+
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO track_dependencies
+                (from_track_id, to_track_id, kind, derivation_source, confidence,
+                 evidence_json, derived_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                from_track_id, to_track_id, kind, derivation_source, confidence,
+                evidence_json, _now_utc(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch link queries (used by `vnx track show`)
+# ---------------------------------------------------------------------------
+
+def get_linked_dispatches(
+    state_dir: str | Path,
+    track_id: str,
+) -> list[dict[str, Any]]:
+    conn = _get_conn(state_dir)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM dispatches WHERE track = ? ORDER BY created_at DESC",
+            (track_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_linked_open_items(
+    state_dir: str | Path,
+    track_id: str,
+) -> list[dict[str, Any]]:
+    conn = _get_conn(state_dir)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM track_open_items WHERE track_id = ? ORDER BY linked_at DESC",
+            (track_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_recent_receipts(
+    state_dir: str | Path,
+    track_id: str,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Return recent coordination events for dispatches linked to track_id."""
+    conn = _get_conn(state_dir)
+    try:
+        dispatch_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT dispatch_id FROM dispatches WHERE track = ?", (track_id,)
+            ).fetchall()
+        ]
+        if not dispatch_ids:
+            return []
+
+        placeholders = ", ".join("?" * len(dispatch_ids))
+        rows = conn.execute(
+            f"""
+            SELECT * FROM coordination_events
+            WHERE entity_id IN ({placeholders})
+            ORDER BY occurred_at DESC
+            LIMIT ?
+            """,
+            (*dispatch_ids, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -55,23 +55,20 @@ def _emit_track_event(
     actor: str,
     details: Optional[dict] = None,
 ) -> None:
-    """Best-effort: write one NDJSON audit line to track_events.ndjson."""
-    try:
-        _lib = Path(__file__).resolve().parent
-        if str(_lib) not in sys.path:
-            sys.path.insert(0, str(_lib))
-        import state_writer  # noqa: PLC0415
-        record: dict[str, Any] = {
-            "event_type": event_type,
-            "track_id": track_id,
-            "actor": actor,
-            "timestamp": _now_utc(),
-        }
-        if details:
-            record["details"] = details
-        state_writer.append_locked(Path(state_dir) / _TRACK_EVENTS_FILE, record)
-    except Exception:
-        pass
+    """Write one NDJSON audit line to track_events.ndjson. Raises on write failure (ADR-005)."""
+    _lib = Path(__file__).resolve().parent
+    if str(_lib) not in sys.path:
+        sys.path.insert(0, str(_lib))
+    import state_writer  # noqa: PLC0415
+    record: dict[str, Any] = {
+        "event_type": event_type,
+        "track_id": track_id,
+        "actor": actor,
+        "timestamp": _now_utc(),
+    }
+    if details:
+        record["details"] = details
+    state_writer.append_locked(Path(state_dir) / _TRACK_EVENTS_FILE, record)
 
 
 def _get_conn(state_dir: str | Path) -> sqlite3.Connection:
@@ -130,12 +127,12 @@ def create_track(
                 metadata_json or "{}",
             ),
         )
+        _emit_track_event(state_dir, "track_created", track_id, "system", {"title": title})
         conn.commit()
         row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
         result = dict(row)
     finally:
         conn.close()
-    _emit_track_event(state_dir, "track_created", track_id, "system", {"title": title})
     return result
 
 
@@ -247,16 +244,16 @@ def transition_phase(
             (track_id, from_phase, to_phase, actor, reason, approval_id, now),
         )
 
+        _emit_track_event(
+            state_dir, "track_phase_transition", track_id, actor,
+            {"from": from_phase, "to": to_phase},
+        )
         conn.commit()
 
         updated = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
         result = dict(updated)
     finally:
         conn.close()
-    _emit_track_event(
-        state_dir, "track_phase_transition", track_id, actor,
-        {"from": from_phase, "to": to_phase},
-    )
     return result
 
 
@@ -289,10 +286,10 @@ def set_next_up(state_dir: str | Path, track_id: str) -> None:
             "UPDATE tracks SET next_up = 1 WHERE track_id = ?",
             (track_id,),
         )
+        _emit_track_event(state_dir, "track_next_up_set", track_id, "system")
         conn.commit()
     finally:
         conn.close()
-    _emit_track_event(state_dir, "track_next_up_set", track_id, "system")
 
 
 # ---------------------------------------------------------------------------
@@ -327,13 +324,13 @@ def link_open_item(
             """,
             (track_id, oi_id, link_type, link_source, _now_utc()),
         )
+        _emit_track_event(
+            state_dir, "track_oi_linked", track_id, "system",
+            {"oi_id": oi_id, "link_type": link_type},
+        )
         conn.commit()
     finally:
         conn.close()
-    _emit_track_event(
-        state_dir, "track_oi_linked", track_id, "system",
-        {"oi_id": oi_id, "link_type": link_type},
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -376,13 +373,13 @@ def add_dependency(
                 evidence_json, _now_utc(),
             ),
         )
+        _emit_track_event(
+            state_dir, "track_dep_added", from_track_id, "system",
+            {"to": to_track_id, "kind": kind},
+        )
         conn.commit()
     finally:
         conn.close()
-    _emit_track_event(
-        state_dir, "track_dep_added", from_track_id, "system",
-        {"to": to_track_id, "kind": kind},
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -60,15 +60,19 @@ def _emit_track_event(
     if str(_lib) not in sys.path:
         sys.path.insert(0, str(_lib))
     import state_writer  # noqa: PLC0415
+    import hashlib as _hashlib
+    _ts = _now_utc()
+    _rid = _hashlib.sha256(f'{event_type}:{track_id}:{_ts}'.encode()).hexdigest()[:16]
     record: dict[str, Any] = {
         "event_type": event_type,
         "track_id": track_id,
         "actor": actor,
-        "timestamp": _now_utc(),
+        "timestamp": _ts,
+        "record_id": _rid,
     }
     if details:
         record["details"] = details
-    state_writer.append_locked(Path(state_dir) / _TRACK_EVENTS_FILE, record)
+    state_writer.append_locked(Path(state_dir).parent / "events" / _TRACK_EVENTS_FILE, record)
 
 
 def _get_conn(state_dir: str | Path) -> sqlite3.Connection:

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 DB_FILENAME = "runtime_coordination.db"
+_TRACK_EVENTS_FILE = "track_events.ndjson"
 
 VALID_PHASES = frozenset({"queued", "active", "parked", "done"})
 
@@ -44,6 +46,32 @@ def _now_utc() -> str:
 
 def _db_path(state_dir: str | Path) -> Path:
     return Path(state_dir) / DB_FILENAME
+
+
+def _emit_track_event(
+    state_dir: str | Path,
+    event_type: str,
+    track_id: str,
+    actor: str,
+    details: Optional[dict] = None,
+) -> None:
+    """Best-effort: write one NDJSON audit line to track_events.ndjson."""
+    try:
+        _lib = Path(__file__).resolve().parent
+        if str(_lib) not in sys.path:
+            sys.path.insert(0, str(_lib))
+        import state_writer  # noqa: PLC0415
+        record: dict[str, Any] = {
+            "event_type": event_type,
+            "track_id": track_id,
+            "actor": actor,
+            "timestamp": _now_utc(),
+        }
+        if details:
+            record["details"] = details
+        state_writer.append_locked(Path(state_dir) / _TRACK_EVENTS_FILE, record)
+    except Exception:
+        pass
 
 
 def _get_conn(state_dir: str | Path) -> sqlite3.Connection:
@@ -104,9 +132,11 @@ def create_track(
         )
         conn.commit()
         row = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
-        return dict(row)
+        result = dict(row)
     finally:
         conn.close()
+    _emit_track_event(state_dir, "track_created", track_id, "system", {"title": title})
+    return result
 
 
 def get_track(state_dir: str | Path, track_id: str) -> dict[str, Any] | None:
@@ -220,9 +250,14 @@ def transition_phase(
         conn.commit()
 
         updated = conn.execute("SELECT * FROM tracks WHERE track_id = ?", (track_id,)).fetchone()
-        return dict(updated)
+        result = dict(updated)
     finally:
         conn.close()
+    _emit_track_event(
+        state_dir, "track_phase_transition", track_id, actor,
+        {"from": from_phase, "to": to_phase},
+    )
+    return result
 
 
 def _has_updated_at(conn: sqlite3.Connection) -> bool:
@@ -257,6 +292,7 @@ def set_next_up(state_dir: str | Path, track_id: str) -> None:
         conn.commit()
     finally:
         conn.close()
+    _emit_track_event(state_dir, "track_next_up_set", track_id, "system")
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +330,10 @@ def link_open_item(
         conn.commit()
     finally:
         conn.close()
+    _emit_track_event(
+        state_dir, "track_oi_linked", track_id, "system",
+        {"oi_id": oi_id, "link_type": link_type},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -339,6 +379,10 @@ def add_dependency(
         conn.commit()
     finally:
         conn.close()
+    _emit_track_event(
+        state_dir, "track_dep_added", from_track_id, "system",
+        {"to": to_track_id, "kind": kind},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -448,7 +448,5 @@ def get_recent_receipts(
             (*dispatch_ids, limit),
         ).fetchall()
         return [dict(r) for r in rows]
-    except sqlite3.OperationalError:
-        return []
     finally:
         conn.close()

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -83,6 +83,11 @@ def _assert_dispatches_schema_intact(conn: sqlite3.Connection) -> None:
         )
 
 
+# Register PRAGMA pre-flight for 0022: any call to apply_script_if_below(22, ...)
+# triggers the column assertion, even when invoked outside of run().
+schema_migration.register_preflight(22, _assert_dispatches_schema_intact)
+
+
 # ---------------------------------------------------------------------------
 # Step 1: apply migration SQL
 # ---------------------------------------------------------------------------
@@ -99,6 +104,7 @@ def apply_migration(conn: sqlite3.Connection, project_root: Path) -> None:
         print(f"  [skip] migration 0022 already applied (user_version={current_version})")
         return
 
+    _assert_dispatches_schema_intact(conn)
     print("  [apply] migration 0022_track_layer.sql ...")
     schema_migration.apply_script_if_below(conn, 22, sql)
     print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
@@ -480,6 +486,9 @@ def run(project_root: Path | None = None) -> None:
 
         # Step 3b: nullify orphaned track refs that weren't mapped (FK safety for 0023)
         _nullify_orphaned_track_refs(conn)
+
+        # emit_events BEFORE commit — if emit fails, seed rolls back (ADR-005)
+        emit_events(conn, inserted_ids)
         conn.commit()
 
         # Step 4: apply 0023 — adds dispatches.track FK now that tracks are seeded
@@ -488,10 +497,6 @@ def run(project_root: Path | None = None) -> None:
 
         # Step 5
         set_initial_next_up(conn)
-
-        # Step 6
-        emit_events(conn, inserted_ids)
-
         conn.commit()
         print(f"\n  Migration complete. {len(tracks)} track(s) in DB.\n")
 

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -88,6 +88,27 @@ def apply_migration(conn: sqlite3.Connection, project_root: Path) -> None:
     print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
 
 
+def apply_migration_0023(conn: sqlite3.Connection, project_root: Path) -> None:
+    """Apply 0023_dispatches_fk.sql — adds tracks FK after seed+tag (Option A).
+
+    Pre-condition: tracks seeded + orphaned track refs nullified.
+    """
+    migration_path = _MIGRATIONS / "0023_dispatches_fk.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    sql = migration_path.read_text(encoding="utf-8")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 23:
+        print(f"  [skip] migration 0023 already applied (user_version={current_version})")
+        return
+
+    print("  [apply] migration 0023_dispatches_fk.sql ...")
+    schema_migration.apply_script_if_below(conn, 23, sql)
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
 # ---------------------------------------------------------------------------
 # Step 2: parse master-roadmap tracks table
 # ---------------------------------------------------------------------------
@@ -273,6 +294,22 @@ def seed_tracks(conn: sqlite3.Connection, tracks: list[dict]) -> list[str]:
 # Step 3: tag existing dispatches with track FK
 # ---------------------------------------------------------------------------
 
+def _nullify_orphaned_track_refs(conn: sqlite3.Connection) -> int:
+    """NULL out dispatches.track values that don't match any seeded track.
+
+    Must run after seed_tracks and before apply_migration_0023. Prevents FK
+    violations from pre-existing dispatch rows with unknown track values.
+    """
+    result = conn.execute(
+        "UPDATE dispatches SET track = NULL "
+        "WHERE track IS NOT NULL AND track NOT IN (SELECT track_id FROM tracks)"
+    )
+    count = result.rowcount
+    if count:
+        print(f"  [warn]  nullified {count} orphaned track ref(s) before FK enforcement")
+    return count
+
+
 def tag_dispatches(conn: sqlite3.Connection) -> int:
     """Update dispatches.track based on PR-cluster prefix matching."""
     try:
@@ -409,7 +446,7 @@ def run(project_root: Path | None = None) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:
-        # Step 1
+        # Step 1: apply 0022 — creates track tables; dispatches rebuilt WITHOUT track FK
         apply_migration(conn, project_root)
         conn.commit()
 
@@ -419,13 +456,21 @@ def run(project_root: Path | None = None) -> None:
 
         inserted_ids = seed_tracks(conn, tracks)
 
-        # Step 3
+        # Step 3: tag existing dispatches by PR-cluster prefix
         tagged = tag_dispatches(conn)
 
-        # Step 4
-        set_initial_next_up(conn)
+        # Step 3b: nullify orphaned track refs that weren't mapped (FK safety for 0023)
+        _nullify_orphaned_track_refs(conn)
+        conn.commit()
+
+        # Step 4: apply 0023 — adds dispatches.track FK now that tracks are seeded
+        apply_migration_0023(conn, project_root)
+        conn.commit()
 
         # Step 5
+        set_initial_next_up(conn)
+
+        # Step 6
         emit_events(conn, inserted_ids)
 
         conn.commit()

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -1,28 +1,20 @@
 #!/usr/bin/env python3
-"""migrate_future_system.py — one-shot idempotent migration to seed the track layer.
+"""migrate_future_system.py — apply 0022_track_layer migration (schema only).
 
 Steps:
-  1. Apply schemas/migrations/0022_track_layer.sql
-  2. Seed 6 tracks from claudedocs/VNX-MASTER-ROADMAP-2026-05-28.md §1 table
-  3. Tag existing dispatches by PR-cluster prefix → track FK
-  4. Set next_up=1 on first queued track with all dependencies done/active
-  5. Emit migration receipt + track_created events into coordination_events
+  1. PRAGMA pre-flight: assert dispatches schema and UNIQUE constraint are intact
+  2. Apply schemas/migrations/0022_track_layer.sql (idempotent via user_version)
 
-Idempotency: tracks already present by ID are skipped (source_hash in metadata_json).
-Re-running is safe and produces no duplicate rows.
+Seeding tracks and applying 0023_dispatches_fk.sql are deferred to PR-FUT-2
+where they will be designed with proper ADR-007 tenant-scoping (composite PK
+over project_id for tracks and a composite-FK from dispatches.track).
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
-import re
 import sqlite3
 import sys
-import uuid
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Bootstrap sys.path so lib modules resolve regardless of cwd
@@ -36,52 +28,8 @@ _MIGRATIONS = _SCHEMAS / "migrations"
 if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
 
-from project_root import resolve_project_root, resolve_state_dir
+from project_root import resolve_project_root
 import schema_migration
-
-
-# ---------------------------------------------------------------------------
-# PR-cluster → track-ID mapping (dispatch.tag logic)
-# ---------------------------------------------------------------------------
-
-PR_CLUSTER_TO_TRACK: list[tuple[str, str]] = [
-    ("PR-HYG-", "track-02"),
-    ("PR-DOC-", "track-05"),
-    ("PR-OBS-", "track-03"),
-    ("PR-ROUTE-", "track-04"),
-    ("PR-TMUX-", "track-01"),
-    ("PR-LANE-", "track-01"),
-    ("PR-START-", "track-02"),
-    ("PR-QUAL-", "track-02"),
-    ("PR-MON-", "track-05"),
-    ("PR-FUT-", "track-06"),
-    ("PR-PIP-", "track-02"),
-]
-
-
-def _now_utc() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
-
-
-def _source_hash(track_id: str, title: str, goal_state: str) -> str:
-    content = f"{track_id}|{title}|{goal_state}"
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
-
-
-# ---------------------------------------------------------------------------
-# Audit NDJSON emission helper (ADR-005)
-# ---------------------------------------------------------------------------
-
-def _emit_migration_audit(events_dir: Path, event_type: str, details: dict) -> None:
-    """Write one NDJSON audit line to events/migration_audit.ndjson. Raises on failure (ADR-005)."""
-    import state_writer as _sw
-    ts = _now_utc()
-    rid = hashlib.sha256(
-        f'{event_type}:{json.dumps(details, sort_keys=True)}:{ts}'.encode()
-    ).hexdigest()[:16]
-    record: dict = {"event_type": event_type, "timestamp": ts, "record_id": rid, **details}
-    events_dir.mkdir(parents=True, exist_ok=True)
-    _sw.append_locked(events_dir / "migration_audit.ndjson", record)
 
 
 # ---------------------------------------------------------------------------
@@ -120,37 +68,6 @@ def _assert_dispatches_schema_intact(conn: sqlite3.Connection) -> None:
 schema_migration.register_preflight(22, _assert_dispatches_schema_intact)
 
 
-def _assert_dispatches_schema_post_0022(conn: sqlite3.Connection) -> None:
-    """Assert post-0022 schema is intact before 0023 rebuild."""
-    cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
-    expected = {'id', 'dispatch_id', 'project_id', 'state', 'terminal_id', 'track', 'priority',
-                'pr_ref', 'gate', 'attempt_count', 'bundle_path', 'created_at', 'updated_at',
-                'expires_after', 'metadata_json', 'operator_approved_at'}
-    missing = expected - cols
-    extra = cols - expected
-    if missing or extra:
-        raise RuntimeError(
-            f'dispatches schema drift after 0022: missing={missing} extra={extra}. '
-            'Refusing 0023 rebuild — schema state does not match expected post-0022 shape.'
-        )
-    indexes = list(conn.execute("PRAGMA index_list('dispatches')"))
-    composite_unique_exists = False
-    for idx in indexes:
-        if idx[2]:  # unique flag
-            idx_cols = [c[2] for c in conn.execute(f"PRAGMA index_info('{idx[1]}')")]
-            if set(idx_cols) == {'dispatch_id', 'project_id'}:
-                composite_unique_exists = True
-                break
-    if not composite_unique_exists:
-        raise RuntimeError(
-            'dispatches missing UNIQUE(dispatch_id, project_id) after 0022 — '
-            'migration 0022 must preserve this constraint'
-        )
-
-
-schema_migration.register_preflight(23, _assert_dispatches_schema_post_0022)
-
-
 # ---------------------------------------------------------------------------
 # Step 1: apply migration SQL
 # ---------------------------------------------------------------------------
@@ -173,353 +90,16 @@ def apply_migration(conn: sqlite3.Connection, project_root: Path) -> None:
     print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
 
 
-def apply_migration_0023(conn: sqlite3.Connection, project_root: Path) -> None:
-    """Apply 0023_dispatches_fk.sql — adds tracks FK after seed+tag (Option A).
-
-    Pre-condition: tracks seeded + orphaned track refs nullified.
-    """
-    migration_path = _MIGRATIONS / "0023_dispatches_fk.sql"
-    if not migration_path.exists():
-        raise FileNotFoundError(f"Migration not found: {migration_path}")
-
-    sql = migration_path.read_text(encoding="utf-8")
-
-    current_version = schema_migration.get_user_version(conn)
-    if current_version >= 23:
-        print(f"  [skip] migration 0023 already applied (user_version={current_version})")
-        return
-
-    _assert_dispatches_schema_post_0022(conn)
-    print("  [apply] migration 0023_dispatches_fk.sql ...")
-    schema_migration.apply_script_if_below(conn, 23, sql)
-    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
-
-
-# ---------------------------------------------------------------------------
-# Step 2: parse master-roadmap tracks table
-# ---------------------------------------------------------------------------
-
-ROADMAP_FILE = "claudedocs/VNX-MASTER-ROADMAP-2026-05-28.md"
-
-# Track phases derived from roadmap narrative (section "2. Phase — ACTIVE")
-_TRACK_PHASES: dict[str, str] = {
-    "track-01": "active",
-    "track-02": "active",
-    "track-03": "queued",
-    "track-04": "queued",
-    "track-05": "queued",
-    "track-06": "parked",
-}
-
-_TRACK_SORT_ORDER: dict[str, int] = {
-    "track-01": 1,
-    "track-02": 2,
-    "track-03": 3,
-    "track-04": 4,
-    "track-05": 5,
-    "track-06": 6,
-}
-
-_TRACK_PRIORITY: dict[str, str] = {
-    "track-01": "high",
-    "track-02": "high",
-    "track-03": "medium",
-    "track-04": "medium",
-    "track-05": "medium",
-    "track-06": "low",
-}
-
-_TRACK_PR_REF: dict[str, str] = {
-    "track-01": "PR-TMUX-2,PR-LANE-WIRE-1,PR-LANE-DEFAULT-FLIP",
-    "track-02": "PR-HYG-1,PR-HYG-2,PR-HYG-3,PR-HYG-4,PR-DOC-1,PR-DOC-README",
-    "track-03": "PR-OBS-1,PR-OBS-3,PR-OBS-4,PR-OBS-5",
-    "track-04": "PR-ROUTE-1,PR-ROUTE-2,PR-ROUTE-3",
-    "track-05": "PR-MON-1,PR-MON-2,PR-QUAL-1",
-    "track-06": "PR-FUT-1,PR-FUT-2,PR-FUT-3",
-}
-
-
-def _strip_md_bold(text: str) -> str:
-    return re.sub(r"\*\*(.+?)\*\*", r"\1", text).strip()
-
-
-def _parse_tracks_from_roadmap(project_root: Path) -> list[dict]:
-    roadmap_path = project_root / ROADMAP_FILE
-    if not roadmap_path.exists():
-        raise FileNotFoundError(
-            f"Master-roadmap not found: {roadmap_path}\n"
-            "Cannot seed tracks without source of truth. Halting."
-        )
-
-    text = roadmap_path.read_text(encoding="utf-8")
-
-    # Find the "Feature-tracks" table in section "1."
-    section_match = re.search(
-        r"##\s+1\.\s+Feature-tracks.*?(?=\n##\s+\d+\.)",
-        text,
-        re.DOTALL,
-    )
-    if not section_match:
-        raise ValueError(
-            f"Could not find '## 1. Feature-tracks' section in {roadmap_path}. "
-            "Roadmap format may have changed. Halting."
-        )
-
-    section = section_match.group(0)
-
-    # Extract table rows: | **track-NN** | **Title** | Goal-state |
-    row_re = re.compile(
-        r"\|\s*\*\*?(track-\d+)\*\*?\s*\|\s*\*\*?(.+?)\*\*?\s*\|\s*(.+?)\s*\|",
-        re.MULTILINE,
-    )
-
-    tracks = []
-    for m in row_re.finditer(section):
-        track_id = m.group(1).strip()
-        title = _strip_md_bold(m.group(2)).strip()
-        goal_state = _strip_md_bold(m.group(3)).strip()
-
-        if not track_id.startswith("track-"):
-            continue
-
-        tracks.append({
-            "track_id": track_id,
-            "title": title,
-            "goal_state": goal_state,
-            "phase": _TRACK_PHASES.get(track_id, "queued"),
-            "sort_order": _TRACK_SORT_ORDER.get(track_id, 99),
-            "priority": _TRACK_PRIORITY.get(track_id),
-            "pr_ref": _TRACK_PR_REF.get(track_id),
-            "project_id": "vnx-dev",
-            "source_hash": _source_hash(track_id, title, goal_state),
-        })
-
-    if len(tracks) == 0:
-        raise ValueError(
-            f"Parsed 0 tracks from {roadmap_path}. "
-            "Table format may have changed. Halting."
-        )
-
-    if len(tracks) < 6:
-        raise ValueError(
-            f"Expected 6 tracks, parsed {len(tracks)}. "
-            "Table may be incomplete. Halting."
-        )
-
-    return tracks
-
-
-def seed_tracks(conn: sqlite3.Connection, tracks: list[dict]) -> list[str]:
-    """Insert tracks; skip rows that already exist with same source_hash."""
-    inserted: list[str] = []
-    skipped: list[str] = []
-    now = _now_utc()
-
-    for t in tracks:
-        row = conn.execute(
-            "SELECT metadata_json FROM tracks WHERE track_id = ?", (t["track_id"],)
-        ).fetchone()
-
-        if row:
-            try:
-                meta = json.loads(row[0] or "{}")
-                if meta.get("source_hash") == t["source_hash"]:
-                    skipped.append(t["track_id"])
-                    continue
-                # source_hash differs → update title/goal/pr_ref but preserve phase
-                conn.execute(
-                    """
-                    UPDATE tracks SET title = ?, goal_state = ?, pr_ref = ?,
-                        metadata_json = ?
-                    WHERE track_id = ?
-                    """,
-                    (
-                        t["title"], t["goal_state"], t.get("pr_ref"),
-                        json.dumps({"source_hash": t["source_hash"]}),
-                        t["track_id"],
-                    ),
-                )
-                inserted.append(t["track_id"])
-                continue
-            except (json.JSONDecodeError, TypeError):
-                skipped.append(t["track_id"])
-                continue
-
-        conn.execute(
-            """
-            INSERT INTO tracks (
-                track_id, title, goal_state, phase, next_up, sort_order, priority,
-                pr_ref, project_id, created_at, phase_changed_at, metadata_json
-            ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                t["track_id"],
-                t["title"],
-                t["goal_state"],
-                t["phase"],
-                t["sort_order"],
-                t.get("priority"),
-                t.get("pr_ref"),
-                t["project_id"],
-                now,
-                now,
-                json.dumps({"source_hash": t["source_hash"]}),
-            ),
-        )
-        inserted.append(t["track_id"])
-
-    if skipped:
-        print(f"  [skip] already seeded: {', '.join(skipped)}")
-    if inserted:
-        print(f"  [ok]   seeded tracks: {', '.join(inserted)}")
-
-    return inserted
-
-
-# ---------------------------------------------------------------------------
-# Step 3: tag existing dispatches with track FK
-# ---------------------------------------------------------------------------
-
-def _nullify_orphaned_track_refs(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> int:
-    """NULL out dispatches.track values that don't match any seeded track.
-
-    Must run after seed_tracks and before apply_migration_0023. Prevents FK
-    violations from pre-existing dispatch rows with unknown track values.
-    """
-    result = conn.execute(
-        "UPDATE dispatches SET track = NULL "
-        "WHERE track IS NOT NULL AND track NOT IN (SELECT track_id FROM tracks)"
-    )
-    count = result.rowcount
-    if count:
-        print(f"  [warn]  nullified {count} orphaned track ref(s) before FK enforcement")
-        if events_dir is not None:
-            _emit_migration_audit(events_dir, "dispatch_track_refs_nullified", {"count": count})
-    return count
-
-
-def tag_dispatches(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> int:
-    """Update dispatches.track based on PR-cluster prefix matching."""
-    try:
-        rows = conn.execute(
-            "SELECT dispatch_id, pr_ref, metadata_json FROM dispatches "
-            "WHERE track IS NULL OR track = ''"
-        ).fetchall()
-    except sqlite3.OperationalError:
-        return 0
-
-    tagged = 0
-    for row in rows:
-        dispatch_id = row[0]
-        pr_ref = row[1] or ""
-
-        # Also check metadata_json for feature or pr keys
-        try:
-            meta = json.loads(row[2] or "{}")
-            meta_pr = meta.get("pr_ref") or meta.get("pr") or meta.get("feature") or ""
-        except (json.JSONDecodeError, TypeError):
-            meta_pr = ""
-
-        candidate = pr_ref or meta_pr
-
-        for prefix, track_id in PR_CLUSTER_TO_TRACK:
-            if candidate.upper().startswith(prefix.upper()):
-                conn.execute(
-                    "UPDATE dispatches SET track = ? WHERE dispatch_id = ?",
-                    (track_id, dispatch_id),
-                )
-                tagged += 1
-                break
-
-    if tagged:
-        print(f"  [ok]   tagged {tagged} dispatch(es) with track FK")
-        if events_dir is not None:
-            _emit_migration_audit(events_dir, "dispatches_track_tagged", {"tagged_count": tagged})
-    return tagged
-
-
-# ---------------------------------------------------------------------------
-# Step 4: set next_up=1
-# ---------------------------------------------------------------------------
-
-def set_initial_next_up(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> None:
-    """Set next_up=1 on the first queued track whose dependencies are all done/active."""
-    # Clear stale next_up flags
-    conn.execute("UPDATE tracks SET next_up = 0 WHERE next_up = 1")
-    if events_dir is not None:
-        _emit_migration_audit(events_dir, "tracks_next_up_cleared", {})
-
-    # Get all queued tracks ordered by sort_order
-    queued = conn.execute(
-        "SELECT track_id FROM tracks WHERE phase = 'queued' AND project_id = 'vnx-dev' "
-        "ORDER BY sort_order ASC, track_id ASC"
-    ).fetchall()
-
-    for (track_id,) in queued:
-        deps = conn.execute(
-            "SELECT to_track_id FROM track_dependencies WHERE from_track_id = ? AND kind = 'hard'",
-            (track_id,),
-        ).fetchall()
-
-        all_satisfied = True
-        for (dep_id,) in deps:
-            dep_row = conn.execute("SELECT phase FROM tracks WHERE track_id = ?", (dep_id,)).fetchone()
-            if not dep_row or dep_row[0] not in ("done", "active"):
-                all_satisfied = False
-                break
-
-        if all_satisfied:
-            conn.execute("UPDATE tracks SET next_up = 1 WHERE track_id = ?", (track_id,))
-            print(f"  [ok]   next_up=1 on {track_id}")
-            if events_dir is not None:
-                _emit_migration_audit(events_dir, "track_next_up_set", {"track_id": track_id})
-            break
-
-
-# ---------------------------------------------------------------------------
-# Step 5: emit coordination events
-# ---------------------------------------------------------------------------
-
-def emit_events(conn: sqlite3.Connection, inserted_track_ids: list[str]) -> None:
-    """Emit track_created events for each newly seeded track."""
-    has_project_id = any(
-        row[1] == "project_id"
-        for row in conn.execute("PRAGMA table_info(coordination_events)").fetchall()
-    )
-
-    now = _now_utc()
-    for track_id in inserted_track_ids:
-        event_id = str(uuid.uuid4())
-        if has_project_id:
-            conn.execute(
-                """
-                INSERT INTO coordination_events
-                    (event_id, event_type, entity_type, entity_id,
-                     actor, metadata_json, occurred_at, project_id)
-                VALUES (?, 'track_created', 'track', ?, 'system', '{}', ?, 'vnx-dev')
-                """,
-                (event_id, track_id, now),
-            )
-        else:
-            conn.execute(
-                """
-                INSERT INTO coordination_events
-                    (event_id, event_type, entity_type, entity_id,
-                     actor, metadata_json, occurred_at)
-                VALUES (?, 'track_created', 'track', ?, 'system', '{}', ?)
-                """,
-                (event_id, track_id, now),
-            )
-
-    if inserted_track_ids:
-        print(f"  [ok]   emitted {len(inserted_track_ids)} track_created event(s)")
-
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def run(project_root: Path | None = None) -> None:
+    """Validate dispatches schema integrity and apply 0022_track_layer migration.
+
+    Seeding tracks, tagging dispatches, and applying 0023_dispatches_fk are
+    deferred to PR-FUT-2 (ADR-007 compliance: composite PK over project_id).
+    """
     if project_root is None:
         project_root = resolve_project_root(__file__)
 
@@ -540,47 +120,16 @@ def run(project_root: Path | None = None) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:
-        # Step 0: assert schema is intact before any rebuild (version-aware guard)
-        _current_ver = schema_migration.get_user_version(conn)
-        if _current_ver < 22:
+        # PRAGMA pre-flight: assert dispatches schema intact before any rebuild
+        current_ver = schema_migration.get_user_version(conn)
+        if current_ver < 22:
             _assert_dispatches_schema_intact(conn)
-        elif _current_ver < 23:
-            _assert_dispatches_schema_post_0022(conn)
-        # version >= 23: both migrations already applied; no rebuild will run
 
-        # Step 1: apply 0022 — creates track tables; dispatches rebuilt WITHOUT track FK
+        # Apply 0022 — creates track tables; dispatches rebuilt WITHOUT track FK
         apply_migration(conn, project_root)
         conn.commit()
 
-        # Step 2: parse roadmap and seed tracks
-        tracks = _parse_tracks_from_roadmap(project_root)
-        print(f"\n  Parsed {len(tracks)} track(s) from roadmap")
-
-        inserted_ids = seed_tracks(conn, tracks)
-
-        events_dir = project_root / ".vnx-data" / "events"
-
-        # Step 3: tag existing dispatches by PR-cluster prefix
-        tagged = tag_dispatches(conn, events_dir)
-
-        # Step 3b: nullify orphaned track refs that weren't mapped (FK safety for 0023)
-        _nullify_orphaned_track_refs(conn, events_dir)
-
-        # emit_events BEFORE commit — if emit fails, seed rolls back (ADR-005)
-        emit_events(conn, inserted_ids)
-        conn.commit()
-
-        # Step 4: apply 0023 — adds dispatches.track FK now that tracks are seeded
-        # Pre-condition: assert post-0022 schema intact before 0023 rebuild
-        if schema_migration.get_user_version(conn) < 23:
-            _assert_dispatches_schema_post_0022(conn)
-        apply_migration_0023(conn, project_root)
-        conn.commit()
-
-        # Step 5
-        set_initial_next_up(conn, events_dir)
-        conn.commit()
-        print(f"\n  Migration complete. {len(tracks)} track(s) in DB.\n")
+        print(f"\n  Migration complete. Schema at user_version={schema_migration.get_user_version(conn)}.\n")
 
     except Exception:
         conn.rollback()

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -68,6 +68,22 @@ def _source_hash(track_id: str, title: str, goal_state: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Step 0: PRAGMA pre-flight — guard against schema drift before rebuild
+# ---------------------------------------------------------------------------
+
+def _assert_dispatches_schema_intact(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+    expected = {'id', 'dispatch_id', 'project_id', 'state', 'terminal_id', 'track', 'priority',
+                'pr_ref', 'gate', 'attempt_count', 'bundle_path', 'created_at', 'updated_at',
+                'expires_after', 'metadata_json'}
+    missing = expected - cols
+    if missing:
+        raise RuntimeError(
+            f'dispatches schema missing expected columns: {missing}. Refusing rebuild.'
+        )
+
+
+# ---------------------------------------------------------------------------
 # Step 1: apply migration SQL
 # ---------------------------------------------------------------------------
 
@@ -446,6 +462,9 @@ def run(project_root: Path | None = None) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:
+        # Step 0: assert schema is intact before any rebuild
+        _assert_dispatches_schema_intact(conn)
+
         # Step 1: apply 0022 — creates track tables; dispatches rebuilt WITHOUT track FK
         apply_migration(conn, project_root)
         conn.commit()

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -22,6 +22,7 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Bootstrap sys.path so lib modules resolve regardless of cwd
@@ -68,6 +69,22 @@ def _source_hash(track_id: str, title: str, goal_state: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Audit NDJSON emission helper (ADR-005)
+# ---------------------------------------------------------------------------
+
+def _emit_migration_audit(events_dir: Path, event_type: str, details: dict) -> None:
+    """Write one NDJSON audit line to events/migration_audit.ndjson. Raises on failure (ADR-005)."""
+    import state_writer as _sw
+    ts = _now_utc()
+    rid = hashlib.sha256(
+        f'{event_type}:{json.dumps(details, sort_keys=True)}:{ts}'.encode()
+    ).hexdigest()[:16]
+    record: dict = {"event_type": event_type, "timestamp": ts, "record_id": rid, **details}
+    events_dir.mkdir(parents=True, exist_ok=True)
+    _sw.append_locked(events_dir / "migration_audit.ndjson", record)
+
+
+# ---------------------------------------------------------------------------
 # Step 0: PRAGMA pre-flight — guard against schema drift before rebuild
 # ---------------------------------------------------------------------------
 
@@ -77,15 +94,61 @@ def _assert_dispatches_schema_intact(conn: sqlite3.Connection) -> None:
                 'pr_ref', 'gate', 'attempt_count', 'bundle_path', 'created_at', 'updated_at',
                 'expires_after', 'metadata_json'}
     missing = expected - cols
-    if missing:
+    extra = cols - expected
+    if missing or extra:
         raise RuntimeError(
-            f'dispatches schema missing expected columns: {missing}. Refusing rebuild.'
+            f'dispatches schema drift: missing={missing} extra={extra}. '
+            'Refusing rebuild — please add migration logic for the new columns first.'
+        )
+    indexes = list(conn.execute("PRAGMA index_list('dispatches')"))
+    composite_unique_exists = False
+    for idx in indexes:
+        if idx[2]:  # unique flag
+            idx_cols = [c[2] for c in conn.execute(f"PRAGMA index_info('{idx[1]}')")]
+            if set(idx_cols) == {'dispatch_id', 'project_id'}:
+                composite_unique_exists = True
+                break
+    if not composite_unique_exists:
+        raise RuntimeError(
+            'dispatches missing UNIQUE(dispatch_id, project_id) — '
+            'was added in migration 0017, must be preserved'
         )
 
 
 # Register PRAGMA pre-flight for 0022: any call to apply_script_if_below(22, ...)
 # triggers the column assertion, even when invoked outside of run().
 schema_migration.register_preflight(22, _assert_dispatches_schema_intact)
+
+
+def _assert_dispatches_schema_post_0022(conn: sqlite3.Connection) -> None:
+    """Assert post-0022 schema is intact before 0023 rebuild."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+    expected = {'id', 'dispatch_id', 'project_id', 'state', 'terminal_id', 'track', 'priority',
+                'pr_ref', 'gate', 'attempt_count', 'bundle_path', 'created_at', 'updated_at',
+                'expires_after', 'metadata_json', 'operator_approved_at'}
+    missing = expected - cols
+    extra = cols - expected
+    if missing or extra:
+        raise RuntimeError(
+            f'dispatches schema drift after 0022: missing={missing} extra={extra}. '
+            'Refusing 0023 rebuild — schema state does not match expected post-0022 shape.'
+        )
+    indexes = list(conn.execute("PRAGMA index_list('dispatches')"))
+    composite_unique_exists = False
+    for idx in indexes:
+        if idx[2]:  # unique flag
+            idx_cols = [c[2] for c in conn.execute(f"PRAGMA index_info('{idx[1]}')")]
+            if set(idx_cols) == {'dispatch_id', 'project_id'}:
+                composite_unique_exists = True
+                break
+    if not composite_unique_exists:
+        raise RuntimeError(
+            'dispatches missing UNIQUE(dispatch_id, project_id) after 0022 — '
+            'migration 0022 must preserve this constraint'
+        )
+
+
+schema_migration.register_preflight(23, _assert_dispatches_schema_post_0022)
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +189,7 @@ def apply_migration_0023(conn: sqlite3.Connection, project_root: Path) -> None:
         print(f"  [skip] migration 0023 already applied (user_version={current_version})")
         return
 
+    _assert_dispatches_schema_post_0022(conn)
     print("  [apply] migration 0023_dispatches_fk.sql ...")
     schema_migration.apply_script_if_below(conn, 23, sql)
     print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
@@ -316,7 +380,7 @@ def seed_tracks(conn: sqlite3.Connection, tracks: list[dict]) -> list[str]:
 # Step 3: tag existing dispatches with track FK
 # ---------------------------------------------------------------------------
 
-def _nullify_orphaned_track_refs(conn: sqlite3.Connection) -> int:
+def _nullify_orphaned_track_refs(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> int:
     """NULL out dispatches.track values that don't match any seeded track.
 
     Must run after seed_tracks and before apply_migration_0023. Prevents FK
@@ -329,10 +393,12 @@ def _nullify_orphaned_track_refs(conn: sqlite3.Connection) -> int:
     count = result.rowcount
     if count:
         print(f"  [warn]  nullified {count} orphaned track ref(s) before FK enforcement")
+        if events_dir is not None:
+            _emit_migration_audit(events_dir, "dispatch_track_refs_nullified", {"count": count})
     return count
 
 
-def tag_dispatches(conn: sqlite3.Connection) -> int:
+def tag_dispatches(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> int:
     """Update dispatches.track based on PR-cluster prefix matching."""
     try:
         rows = conn.execute(
@@ -367,6 +433,8 @@ def tag_dispatches(conn: sqlite3.Connection) -> int:
 
     if tagged:
         print(f"  [ok]   tagged {tagged} dispatch(es) with track FK")
+        if events_dir is not None:
+            _emit_migration_audit(events_dir, "dispatches_track_tagged", {"tagged_count": tagged})
     return tagged
 
 
@@ -374,10 +442,12 @@ def tag_dispatches(conn: sqlite3.Connection) -> int:
 # Step 4: set next_up=1
 # ---------------------------------------------------------------------------
 
-def set_initial_next_up(conn: sqlite3.Connection) -> None:
+def set_initial_next_up(conn: sqlite3.Connection, events_dir: Optional[Path] = None) -> None:
     """Set next_up=1 on the first queued track whose dependencies are all done/active."""
     # Clear stale next_up flags
     conn.execute("UPDATE tracks SET next_up = 0 WHERE next_up = 1")
+    if events_dir is not None:
+        _emit_migration_audit(events_dir, "tracks_next_up_cleared", {})
 
     # Get all queued tracks ordered by sort_order
     queued = conn.execute(
@@ -401,6 +471,8 @@ def set_initial_next_up(conn: sqlite3.Connection) -> None:
         if all_satisfied:
             conn.execute("UPDATE tracks SET next_up = 1 WHERE track_id = ?", (track_id,))
             print(f"  [ok]   next_up=1 on {track_id}")
+            if events_dir is not None:
+                _emit_migration_audit(events_dir, "track_next_up_set", {"track_id": track_id})
             break
 
 
@@ -468,8 +540,13 @@ def run(project_root: Path | None = None) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:
-        # Step 0: assert schema is intact before any rebuild
-        _assert_dispatches_schema_intact(conn)
+        # Step 0: assert schema is intact before any rebuild (version-aware guard)
+        _current_ver = schema_migration.get_user_version(conn)
+        if _current_ver < 22:
+            _assert_dispatches_schema_intact(conn)
+        elif _current_ver < 23:
+            _assert_dispatches_schema_post_0022(conn)
+        # version >= 23: both migrations already applied; no rebuild will run
 
         # Step 1: apply 0022 — creates track tables; dispatches rebuilt WITHOUT track FK
         apply_migration(conn, project_root)
@@ -481,22 +558,27 @@ def run(project_root: Path | None = None) -> None:
 
         inserted_ids = seed_tracks(conn, tracks)
 
+        events_dir = project_root / ".vnx-data" / "events"
+
         # Step 3: tag existing dispatches by PR-cluster prefix
-        tagged = tag_dispatches(conn)
+        tagged = tag_dispatches(conn, events_dir)
 
         # Step 3b: nullify orphaned track refs that weren't mapped (FK safety for 0023)
-        _nullify_orphaned_track_refs(conn)
+        _nullify_orphaned_track_refs(conn, events_dir)
 
         # emit_events BEFORE commit — if emit fails, seed rolls back (ADR-005)
         emit_events(conn, inserted_ids)
         conn.commit()
 
         # Step 4: apply 0023 — adds dispatches.track FK now that tracks are seeded
+        # Pre-condition: assert post-0022 schema intact before 0023 rebuild
+        if schema_migration.get_user_version(conn) < 23:
+            _assert_dispatches_schema_post_0022(conn)
         apply_migration_0023(conn, project_root)
         conn.commit()
 
         # Step 5
-        set_initial_next_up(conn)
+        set_initial_next_up(conn, events_dir)
         conn.commit()
         print(f"\n  Migration complete. {len(tracks)} track(s) in DB.\n")
 

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""migrate_future_system.py — one-shot idempotent migration to seed the track layer.
+
+Steps:
+  1. Apply schemas/migrations/0022_track_layer.sql
+  2. Seed 6 tracks from claudedocs/VNX-MASTER-ROADMAP-2026-05-28.md §1 table
+  3. Tag existing dispatches by PR-cluster prefix → track FK
+  4. Set next_up=1 on first queued track with all dependencies done/active
+  5. Emit migration receipt + track_created events into coordination_events
+
+Idempotency: tracks already present by ID are skipped (source_hash in metadata_json).
+Re-running is safe and produces no duplicate rows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Bootstrap sys.path so lib modules resolve regardless of cwd
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).resolve().parent
+_LIB = _HERE / "lib"
+_SCHEMAS = _HERE.parent / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from project_root import resolve_project_root, resolve_state_dir
+import schema_migration
+
+
+# ---------------------------------------------------------------------------
+# PR-cluster → track-ID mapping (dispatch.tag logic)
+# ---------------------------------------------------------------------------
+
+PR_CLUSTER_TO_TRACK: list[tuple[str, str]] = [
+    ("PR-HYG-", "track-02"),
+    ("PR-DOC-", "track-05"),
+    ("PR-OBS-", "track-03"),
+    ("PR-ROUTE-", "track-04"),
+    ("PR-TMUX-", "track-01"),
+    ("PR-LANE-", "track-01"),
+    ("PR-START-", "track-02"),
+    ("PR-QUAL-", "track-02"),
+    ("PR-MON-", "track-05"),
+    ("PR-FUT-", "track-06"),
+    ("PR-PIP-", "track-02"),
+]
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _source_hash(track_id: str, title: str, goal_state: str) -> str:
+    content = f"{track_id}|{title}|{goal_state}"
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Step 1: apply migration SQL
+# ---------------------------------------------------------------------------
+
+def apply_migration(conn: sqlite3.Connection, project_root: Path) -> None:
+    migration_path = _MIGRATIONS / "0022_track_layer.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    sql = migration_path.read_text(encoding="utf-8")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 22:
+        print(f"  [skip] migration 0022 already applied (user_version={current_version})")
+        return
+
+    print("  [apply] migration 0022_track_layer.sql ...")
+    schema_migration.apply_script_if_below(conn, 22, sql)
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
+# ---------------------------------------------------------------------------
+# Step 2: parse master-roadmap tracks table
+# ---------------------------------------------------------------------------
+
+ROADMAP_FILE = "claudedocs/VNX-MASTER-ROADMAP-2026-05-28.md"
+
+# Track phases derived from roadmap narrative (section "2. Phase — ACTIVE")
+_TRACK_PHASES: dict[str, str] = {
+    "track-01": "active",
+    "track-02": "active",
+    "track-03": "queued",
+    "track-04": "queued",
+    "track-05": "queued",
+    "track-06": "parked",
+}
+
+_TRACK_SORT_ORDER: dict[str, int] = {
+    "track-01": 1,
+    "track-02": 2,
+    "track-03": 3,
+    "track-04": 4,
+    "track-05": 5,
+    "track-06": 6,
+}
+
+_TRACK_PRIORITY: dict[str, str] = {
+    "track-01": "high",
+    "track-02": "high",
+    "track-03": "medium",
+    "track-04": "medium",
+    "track-05": "medium",
+    "track-06": "low",
+}
+
+_TRACK_PR_REF: dict[str, str] = {
+    "track-01": "PR-TMUX-2,PR-LANE-WIRE-1,PR-LANE-DEFAULT-FLIP",
+    "track-02": "PR-HYG-1,PR-HYG-2,PR-HYG-3,PR-HYG-4,PR-DOC-1,PR-DOC-README",
+    "track-03": "PR-OBS-1,PR-OBS-3,PR-OBS-4,PR-OBS-5",
+    "track-04": "PR-ROUTE-1,PR-ROUTE-2,PR-ROUTE-3",
+    "track-05": "PR-MON-1,PR-MON-2,PR-QUAL-1",
+    "track-06": "PR-FUT-1,PR-FUT-2,PR-FUT-3",
+}
+
+
+def _strip_md_bold(text: str) -> str:
+    return re.sub(r"\*\*(.+?)\*\*", r"\1", text).strip()
+
+
+def _parse_tracks_from_roadmap(project_root: Path) -> list[dict]:
+    roadmap_path = project_root / ROADMAP_FILE
+    if not roadmap_path.exists():
+        raise FileNotFoundError(
+            f"Master-roadmap not found: {roadmap_path}\n"
+            "Cannot seed tracks without source of truth. Halting."
+        )
+
+    text = roadmap_path.read_text(encoding="utf-8")
+
+    # Find the "Feature-tracks" table in section "1."
+    section_match = re.search(
+        r"##\s+1\.\s+Feature-tracks.*?(?=\n##\s+\d+\.)",
+        text,
+        re.DOTALL,
+    )
+    if not section_match:
+        raise ValueError(
+            f"Could not find '## 1. Feature-tracks' section in {roadmap_path}. "
+            "Roadmap format may have changed. Halting."
+        )
+
+    section = section_match.group(0)
+
+    # Extract table rows: | **track-NN** | **Title** | Goal-state |
+    row_re = re.compile(
+        r"\|\s*\*\*?(track-\d+)\*\*?\s*\|\s*\*\*?(.+?)\*\*?\s*\|\s*(.+?)\s*\|",
+        re.MULTILINE,
+    )
+
+    tracks = []
+    for m in row_re.finditer(section):
+        track_id = m.group(1).strip()
+        title = _strip_md_bold(m.group(2)).strip()
+        goal_state = _strip_md_bold(m.group(3)).strip()
+
+        if not track_id.startswith("track-"):
+            continue
+
+        tracks.append({
+            "track_id": track_id,
+            "title": title,
+            "goal_state": goal_state,
+            "phase": _TRACK_PHASES.get(track_id, "queued"),
+            "sort_order": _TRACK_SORT_ORDER.get(track_id, 99),
+            "priority": _TRACK_PRIORITY.get(track_id),
+            "pr_ref": _TRACK_PR_REF.get(track_id),
+            "project_id": "vnx-dev",
+            "source_hash": _source_hash(track_id, title, goal_state),
+        })
+
+    if len(tracks) == 0:
+        raise ValueError(
+            f"Parsed 0 tracks from {roadmap_path}. "
+            "Table format may have changed. Halting."
+        )
+
+    if len(tracks) < 6:
+        raise ValueError(
+            f"Expected 6 tracks, parsed {len(tracks)}. "
+            "Table may be incomplete. Halting."
+        )
+
+    return tracks
+
+
+def seed_tracks(conn: sqlite3.Connection, tracks: list[dict]) -> list[str]:
+    """Insert tracks; skip rows that already exist with same source_hash."""
+    inserted: list[str] = []
+    skipped: list[str] = []
+    now = _now_utc()
+
+    for t in tracks:
+        row = conn.execute(
+            "SELECT metadata_json FROM tracks WHERE track_id = ?", (t["track_id"],)
+        ).fetchone()
+
+        if row:
+            try:
+                meta = json.loads(row[0] or "{}")
+                if meta.get("source_hash") == t["source_hash"]:
+                    skipped.append(t["track_id"])
+                    continue
+                # source_hash differs → update title/goal/pr_ref but preserve phase
+                conn.execute(
+                    """
+                    UPDATE tracks SET title = ?, goal_state = ?, pr_ref = ?,
+                        metadata_json = ?
+                    WHERE track_id = ?
+                    """,
+                    (
+                        t["title"], t["goal_state"], t.get("pr_ref"),
+                        json.dumps({"source_hash": t["source_hash"]}),
+                        t["track_id"],
+                    ),
+                )
+                inserted.append(t["track_id"])
+                continue
+            except (json.JSONDecodeError, TypeError):
+                skipped.append(t["track_id"])
+                continue
+
+        conn.execute(
+            """
+            INSERT INTO tracks (
+                track_id, title, goal_state, phase, next_up, sort_order, priority,
+                pr_ref, project_id, created_at, phase_changed_at, metadata_json
+            ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                t["track_id"],
+                t["title"],
+                t["goal_state"],
+                t["phase"],
+                t["sort_order"],
+                t.get("priority"),
+                t.get("pr_ref"),
+                t["project_id"],
+                now,
+                now,
+                json.dumps({"source_hash": t["source_hash"]}),
+            ),
+        )
+        inserted.append(t["track_id"])
+
+    if skipped:
+        print(f"  [skip] already seeded: {', '.join(skipped)}")
+    if inserted:
+        print(f"  [ok]   seeded tracks: {', '.join(inserted)}")
+
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Step 3: tag existing dispatches with track FK
+# ---------------------------------------------------------------------------
+
+def tag_dispatches(conn: sqlite3.Connection) -> int:
+    """Update dispatches.track based on PR-cluster prefix matching."""
+    try:
+        rows = conn.execute(
+            "SELECT dispatch_id, pr_ref, metadata_json FROM dispatches "
+            "WHERE track IS NULL OR track = ''"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return 0
+
+    tagged = 0
+    for row in rows:
+        dispatch_id = row[0]
+        pr_ref = row[1] or ""
+
+        # Also check metadata_json for feature or pr keys
+        try:
+            meta = json.loads(row[2] or "{}")
+            meta_pr = meta.get("pr_ref") or meta.get("pr") or meta.get("feature") or ""
+        except (json.JSONDecodeError, TypeError):
+            meta_pr = ""
+
+        candidate = pr_ref or meta_pr
+
+        for prefix, track_id in PR_CLUSTER_TO_TRACK:
+            if candidate.upper().startswith(prefix.upper()):
+                conn.execute(
+                    "UPDATE dispatches SET track = ? WHERE dispatch_id = ?",
+                    (track_id, dispatch_id),
+                )
+                tagged += 1
+                break
+
+    if tagged:
+        print(f"  [ok]   tagged {tagged} dispatch(es) with track FK")
+    return tagged
+
+
+# ---------------------------------------------------------------------------
+# Step 4: set next_up=1
+# ---------------------------------------------------------------------------
+
+def set_initial_next_up(conn: sqlite3.Connection) -> None:
+    """Set next_up=1 on the first queued track whose dependencies are all done/active."""
+    # Clear stale next_up flags
+    conn.execute("UPDATE tracks SET next_up = 0 WHERE next_up = 1")
+
+    # Get all queued tracks ordered by sort_order
+    queued = conn.execute(
+        "SELECT track_id FROM tracks WHERE phase = 'queued' AND project_id = 'vnx-dev' "
+        "ORDER BY sort_order ASC, track_id ASC"
+    ).fetchall()
+
+    for (track_id,) in queued:
+        deps = conn.execute(
+            "SELECT to_track_id FROM track_dependencies WHERE from_track_id = ? AND kind = 'hard'",
+            (track_id,),
+        ).fetchall()
+
+        all_satisfied = True
+        for (dep_id,) in deps:
+            dep_row = conn.execute("SELECT phase FROM tracks WHERE track_id = ?", (dep_id,)).fetchone()
+            if not dep_row or dep_row[0] not in ("done", "active"):
+                all_satisfied = False
+                break
+
+        if all_satisfied:
+            conn.execute("UPDATE tracks SET next_up = 1 WHERE track_id = ?", (track_id,))
+            print(f"  [ok]   next_up=1 on {track_id}")
+            break
+
+
+# ---------------------------------------------------------------------------
+# Step 5: emit coordination events
+# ---------------------------------------------------------------------------
+
+def emit_events(conn: sqlite3.Connection, inserted_track_ids: list[str]) -> None:
+    """Emit track_created events for each newly seeded track."""
+    has_project_id = any(
+        row[1] == "project_id"
+        for row in conn.execute("PRAGMA table_info(coordination_events)").fetchall()
+    )
+
+    now = _now_utc()
+    for track_id in inserted_track_ids:
+        event_id = str(uuid.uuid4())
+        if has_project_id:
+            conn.execute(
+                """
+                INSERT INTO coordination_events
+                    (event_id, event_type, entity_type, entity_id,
+                     actor, metadata_json, occurred_at, project_id)
+                VALUES (?, 'track_created', 'track', ?, 'system', '{}', ?, 'vnx-dev')
+                """,
+                (event_id, track_id, now),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO coordination_events
+                    (event_id, event_type, entity_type, entity_id,
+                     actor, metadata_json, occurred_at)
+                VALUES (?, 'track_created', 'track', ?, 'system', '{}', ?)
+                """,
+                (event_id, track_id, now),
+            )
+
+    if inserted_track_ids:
+        print(f"  [ok]   emitted {len(inserted_track_ids)} track_created event(s)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run(project_root: Path | None = None) -> None:
+    if project_root is None:
+        project_root = resolve_project_root(__file__)
+
+    state_dir = project_root / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "runtime_coordination.db"
+
+    if not db_path.exists():
+        raise FileNotFoundError(
+            f"runtime_coordination.db not found at {db_path}\n"
+            "Run `vnx init` or initialize the schema first."
+        )
+
+    print(f"\nVNX migrate_future_system — db: {db_path}")
+
+    conn = sqlite3.connect(str(db_path), timeout=30.0)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    try:
+        # Step 1
+        apply_migration(conn, project_root)
+        conn.commit()
+
+        # Step 2: parse roadmap and seed tracks
+        tracks = _parse_tracks_from_roadmap(project_root)
+        print(f"\n  Parsed {len(tracks)} track(s) from roadmap")
+
+        inserted_ids = seed_tracks(conn, tracks)
+
+        # Step 3
+        tagged = tag_dispatches(conn)
+
+        # Step 4
+        set_initial_next_up(conn)
+
+        # Step 5
+        emit_events(conn, inserted_ids)
+
+        conn.commit()
+        print(f"\n  Migration complete. {len(tracks)} track(s) in DB.\n")
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    try:
+        run()
+    except Exception as exc:
+        print(f"\n  [ERROR] {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -708,7 +708,114 @@ class TestRegisterProposedTrackDispatch:
         assert row is not None
         assert row[1] == "proposed"
 
-        ndjson_path = state_dir / "dispatch_register.ndjson"
+        ndjson_path = state_dir.parent / "events" / "dispatch_register.ndjson"
         assert ndjson_path.exists()
         lines = [l for l in ndjson_path.read_text().splitlines() if l.strip()]
         assert any("disp-ok-001" in l for l in lines)
+
+
+# ---------------------------------------------------------------------------
+# record_id in _build_event_record
+# ---------------------------------------------------------------------------
+
+class TestBuildEventRecordId:
+    def test_build_event_record_contains_record_id(self, isolated_data_dir):
+        """_build_event_record must include a deterministic record_id field."""
+        append_event("dispatch_created", dispatch_id="dr-001")
+        reg = _reg_path(isolated_data_dir)
+        rec = json.loads(reg.read_text().strip())
+        assert "record_id" in rec, "record_id must be present in every emitted event record"
+        assert len(rec["record_id"]) == 16, "record_id must be a 16-hex-char sha256 prefix"
+
+    def test_record_id_is_deterministic(self, isolated_data_dir):
+        """Two records with the same event/dispatch_id/timestamp get the same record_id.
+        
+        We cannot control the timestamp from outside, so instead we verify that two
+        different events get DIFFERENT record_ids (confirming the hash input varies).
+        """
+        append_event("dispatch_created", dispatch_id="det-001")
+        append_event("dispatch_promoted", dispatch_id="det-002")
+        lines = _reg_path(isolated_data_dir).read_text().strip().splitlines()
+        records = [json.loads(l) for l in lines]
+        rid_a = records[0]["record_id"]
+        rid_b = records[1]["record_id"]
+        assert rid_a != rid_b, "Different events must produce different record_ids"
+
+
+# ---------------------------------------------------------------------------
+# register_proposed_track_dispatch audit failure rollback
+# ---------------------------------------------------------------------------
+
+class TestRegisterProposedTrackDispatchRollback:
+    """register_proposed_track_dispatch must NOT commit a dispatches row when the
+    NDJSON write fails (ADR-005 ledger-first guarantee)."""
+
+    def _make_db(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Returns (state_dir, db_path) with a post-0022 DB."""
+        import sqlite3 as _sqlite3
+        import sys as _sys
+        schemas = Path(__file__).resolve().parent.parent / "schemas" / "migrations"
+        _sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+        import schema_migration as _sm
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "runtime_coordination.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'proposed',
+                terminal_id TEXT, track TEXT,
+                priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT,
+                attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+                operator_approved_at TEXT,
+                UNIQUE(dispatch_id, project_id)
+            )
+        """)
+        conn.commit()
+        conn.close()
+        return state_dir, db_path
+
+    def test_no_dispatch_row_when_ndjson_write_fails(self, tmp_path):
+        """When _write_event_locked raises, no dispatches row is committed."""
+        state_dir, db_path = self._make_db(tmp_path)
+
+        with patch.object(dispatch_register, "_write_event_locked", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                dispatch_register.register_proposed_track_dispatch(
+                    state_dir, "dr-fail-001", "T1", "track-01", "PR-TEST-1"
+                )
+
+        import sqlite3 as _sqlite3
+        conn = _sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM dispatches WHERE dispatch_id = 'dr-fail-001'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 0, "No dispatches row must be committed when NDJSON write fails"
+
+    def test_dispatch_row_created_on_success(self, tmp_path):
+        """On successful NDJSON write + DB insert, the row exists."""
+        state_dir, db_path = self._make_db(tmp_path)
+        events_dir = tmp_path / "events"
+        events_dir.mkdir(parents=True)
+
+        dispatch_register.register_proposed_track_dispatch(
+            state_dir, "dr-ok-001", "T1", "track-01", "PR-TEST-2"
+        )
+
+        import sqlite3 as _sqlite3
+        conn = _sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM dispatches WHERE dispatch_id = 'dr-ok-001'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -624,3 +624,91 @@ class TestWritePathsUnchangedByShadowMode:
         assert "write-test-flag-unset" in ids
         assert "write-test-flag-shadow" in ids
         assert "write-test-flag-1" in ids
+
+
+# ---------------------------------------------------------------------------
+# register_proposed_track_dispatch — ADR-005 audit ordering
+# ---------------------------------------------------------------------------
+
+import sqlite3 as _sqlite3
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    """Create a state dir with a minimal dispatches DB for register tests."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "runtime_coordination.db"
+    conn = _sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT,
+            track TEXT,
+            priority TEXT DEFAULT 'P2',
+            pr_ref TEXT,
+            gate TEXT,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+class TestRegisterProposedTrackDispatch:
+    """ADR-005: NDJSON must precede SQLite; failure in audit write must abort creation."""
+
+    def test_raises_when_ndjson_write_fails(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch.object(dispatch_register, "_write_event_locked", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                dispatch_register.register_proposed_track_dispatch(
+                    state_dir, "disp-fail-001", "T1", "track-01", "PR-FUT-1"
+                )
+
+    def test_no_db_row_created_when_ndjson_write_fails(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch.object(dispatch_register, "_write_event_locked", side_effect=OSError("disk full")):
+            try:
+                dispatch_register.register_proposed_track_dispatch(
+                    state_dir, "disp-fail-002", "T1", "track-01", "PR-FUT-1"
+                )
+            except OSError:
+                pass
+
+        db_path = state_dir / "runtime_coordination.db"
+        conn = _sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT dispatch_id FROM dispatches WHERE dispatch_id = 'disp-fail-002'"
+        ).fetchone()
+        conn.close()
+        assert row is None, "No DB row must exist when NDJSON write failed"
+
+    def test_success_path_creates_db_row_and_ndjson(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_register.register_proposed_track_dispatch(
+            state_dir, "disp-ok-001", "T1", "track-01", "PR-FUT-1"
+        )
+        db_path = state_dir / "runtime_coordination.db"
+        conn = _sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT dispatch_id, state FROM dispatches WHERE dispatch_id = 'disp-ok-001'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[1] == "proposed"
+
+        ndjson_path = state_dir / "dispatch_register.ndjson"
+        assert ndjson_path.exists()
+        lines = [l for l in ndjson_path.read_text().splitlines() if l.strip()]
+        assert any("disp-ok-001" in l for l in lines)

--- a/tests/test_migrate_0022_preflight.py
+++ b/tests/test_migrate_0022_preflight.py
@@ -1,0 +1,249 @@
+"""tests/test_migrate_0022_preflight.py — PRAGMA pre-flight for migration 0022.
+
+Verifies:
+1. _assert_dispatches_schema_intact raises RuntimeError on v9-style DB (no project_id)
+2. apply_migration() directly (without run()) also triggers the preflight
+3. apply_script_if_below is never called when the preflight fails
+4. No SQL schema changes happen when the preflight raises
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _PROJECT_ROOT / "scripts" / "lib"
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+
+
+FIXTURE_ROADMAP = """\
+# VNX Master Roadmap — fixture
+
+## 1. Feature-tracks
+
+| Track | Goal | Doel-state |
+|---|---|---|
+| **track-01** | **15-juni Subscription Escape** | Alle Claude-workers default via tmux-leaseless lane. |
+| **track-02** | **Public 1.0 Launch** | `pip install vnx-orchestration` werkend. |
+| **track-03** | **Observability Activation** | Command-centre live, per-provider token-capture. |
+| **track-04** | **Routing Hardening** | `provider_constraints.yaml` enforced. |
+| **track-05** | **Governance Self-Monitoring** | Health-heartbeat-laag actief. |
+| **track-06** | **Dimitri Adoption** | Track-layer + Context-composer-assembly. |
+
+## 2. Phase — ACTIVE
+
+(content elided for test)
+"""
+
+
+def _make_v9_project(tmp_path: Path) -> Path:
+    """Create a project with a v9-style dispatches table (no project_id column)."""
+    project_dir = tmp_path / "v9project"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    claudedocs = project_dir / "claudedocs"
+    claudedocs.mkdir()
+    (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
+        FIXTURE_ROADMAP, encoding="utf-8"
+    )
+
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT,
+            pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+            metadata_json TEXT DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+            event_type TEXT, entity_type TEXT, entity_id TEXT,
+            from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+            metadata_json TEXT, occurred_at TEXT, project_id TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return project_dir
+
+
+def _get_migrate_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "migrate_future_system",
+        _SCRIPTS / "migrate_future_system.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestPreflight0022Blocking:
+    """PRAGMA pre-flight raises before 0022 SQL executes when project_id is missing."""
+
+    def test_run_raises_on_v9_schema(self, tmp_path):
+        """Full run() raises RuntimeError when dispatches lacks project_id."""
+        project_dir = _make_v9_project(tmp_path)
+        mod = _get_migrate_module()
+        with pytest.raises(RuntimeError, match="project_id"):
+            mod.run(project_dir)
+
+    def test_apply_migration_direct_raises_on_v9_schema(self, tmp_path):
+        """apply_migration() directly (bypassing run()) still triggers the preflight."""
+        project_dir = _make_v9_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        mod = _get_migrate_module()
+        try:
+            with pytest.raises(RuntimeError, match="project_id"):
+                mod.apply_migration(conn, project_dir)
+        finally:
+            conn.close()
+
+    def test_preflight_fires_before_apply_script_if_below(self, tmp_path):
+        """apply_script_if_below is never called when the preflight fails."""
+        project_dir = _make_v9_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        mod = _get_migrate_module()
+        try:
+            with patch.object(schema_migration, "apply_script_if_below") as mock_apply:
+                with pytest.raises(RuntimeError, match="project_id"):
+                    mod.apply_migration(conn, project_dir)
+                mock_apply.assert_not_called()
+        finally:
+            conn.close()
+
+    def test_no_schema_change_after_preflight_failure(self, tmp_path):
+        """After the preflight raises, dispatches table is unchanged (no SQL ran)."""
+        project_dir = _make_v9_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        mod = _get_migrate_module()
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        try:
+            with pytest.raises(RuntimeError):
+                mod.apply_migration(conn, project_dir)
+        finally:
+            conn.close()
+
+        conn2 = sqlite3.connect(str(db_path))
+        cols = {row[1] for row in conn2.execute("PRAGMA table_info('dispatches')")}
+        version = conn2.execute("PRAGMA user_version").fetchone()[0]
+        conn2.close()
+        assert "project_id" not in cols
+        assert version == 0
+
+
+class TestDirectApplyScriptPreflight:
+    """apply_script_if_below(22, ...) triggers the preflight — no bypass possible.
+
+    Importing migrate_future_system registers a pre-hook for migration 22 in
+    schema_migration._PREFLIGHT_HOOKS. Once registered, any caller of
+    apply_script_if_below(22, ...) runs the PRAGMA check, even without going
+    through apply_migration() or run().
+    """
+
+    _MIGRATIONS = _PROJECT_ROOT / "schemas" / "migrations"
+
+    def test_direct_apply_script_raises_on_v9_db(self, tmp_path):
+        """Direct apply_script_if_below(22, sql) raises when project_id is missing."""
+        # Importing the module registers the hook — this is the proof that there is no bypass.
+        _get_migrate_module()
+
+        project_dir = _make_v9_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        sql = (self._MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            with pytest.raises(RuntimeError, match="project_id"):
+                schema_migration.apply_script_if_below(conn, 22, sql)
+        finally:
+            conn.close()
+
+    def test_direct_apply_script_passes_on_v21_db(self, tmp_path):
+        """Direct apply_script_if_below(22, sql) succeeds when all expected columns exist."""
+        _get_migrate_module()
+
+        state_dir = tmp_path / ".vnx-data" / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'queued',
+                terminal_id TEXT, track TEXT,
+                priority TEXT DEFAULT 'P2',
+                pr_ref TEXT, gate TEXT,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                bundle_path TEXT,
+                created_at TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '',
+                expires_after TEXT,
+                metadata_json TEXT DEFAULT '{}',
+                UNIQUE(dispatch_id, project_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE coordination_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+                event_type TEXT, entity_type TEXT, entity_id TEXT,
+                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+                metadata_json TEXT, occurred_at TEXT, project_id TEXT
+            )
+        """)
+        conn.commit()
+        sql = (self._MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+        # Should not raise — project_id is present, preflight passes.
+        schema_migration.apply_script_if_below(conn, 22, sql)
+        conn.close()
+
+    def test_no_sql_executed_when_preflight_raises(self, tmp_path):
+        """No schema changes after a pre-hook raises — SAVEPOINT never opened."""
+        _get_migrate_module()
+
+        project_dir = _make_v9_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        sql = (self._MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            try:
+                schema_migration.apply_script_if_below(conn, 22, sql)
+            except RuntimeError:
+                pass
+        finally:
+            conn.close()
+
+        conn2 = sqlite3.connect(str(db_path))
+        version = conn2.execute("PRAGMA user_version").fetchone()[0]
+        tables = {r[0] for r in conn2.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        conn2.close()
+        assert version == 0
+        assert "tracks" not in tables

--- a/tests/test_migrate_fk_order_real_data.py
+++ b/tests/test_migrate_fk_order_real_data.py
@@ -67,7 +67,8 @@ def _init_project(tmp_path: Path) -> Path:
     conn.execute("""
         CREATE TABLE dispatches (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id     TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
             state           TEXT    NOT NULL DEFAULT 'queued',
             terminal_id     TEXT,
             track           TEXT,
@@ -79,7 +80,8 @@ def _init_project(tmp_path: Path) -> Path:
             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             expires_after   TEXT,
-            metadata_json   TEXT    DEFAULT '{}'
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""

--- a/tests/test_migrate_fk_order_real_data.py
+++ b/tests/test_migrate_fk_order_real_data.py
@@ -1,0 +1,211 @@
+"""tests/test_migrate_fk_order_real_data.py — FK ordering regression for PR-FUT-1 fix1.
+
+Verifies that migrate_future_system.run() does not abort when the DB already
+contains dispatches with non-null track values that were set before the tracks
+table was populated (real v21 data scenario).
+
+Option A (dispatch 20260528-fut-1-fix1-codex-r1):
+- 0022 creates track tables + rebuilds dispatches WITHOUT FK
+- tracks are seeded
+- orphaned refs are nullified
+- 0023 rebuilds dispatches WITH FK (safe — all track values now valid or NULL)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _PROJECT_ROOT / "scripts" / "lib"
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+_SCHEMAS = _PROJECT_ROOT / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+FIXTURE_ROADMAP = """\
+# VNX Master Roadmap — FK order fixture
+
+## 1. Feature-tracks
+
+| Track | Goal | Doel-state |
+|---|---|---|
+| **track-01** | **15-juni Subscription Escape** | Alle Claude-workers default via tmux-leaseless lane. |
+| **track-02** | **Public 1.0 Launch** | `pip install vnx-orchestration` werkend. |
+| **track-03** | **Observability Activation** | Command-centre live, per-provider token-capture. |
+| **track-04** | **Routing Hardening** | `provider_constraints.yaml` enforced. |
+| **track-05** | **Governance Self-Monitoring** | Health-heartbeat-laag actief. |
+| **track-06** | **Dimitri Adoption** | Track-layer + Context-composer-assembly. |
+
+## 2. Phase — ACTIVE
+
+(content elided)
+"""
+
+
+def _init_project(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "project"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    claudedocs = project_dir / "claudedocs"
+    claudedocs.mkdir()
+
+    (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(FIXTURE_ROADMAP, encoding="utf-8")
+
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return project_dir
+
+
+def _get_migrate_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "migrate_future_system",
+        _SCRIPTS / "migrate_future_system.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestFKOrderRealData:
+    def test_orphan_track_does_not_crash_migration(self, tmp_path):
+        """Migration must complete without error when orphaned track ref exists."""
+        project_dir = _init_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state, track) "
+            "VALUES ('disp-orphan', 'queued', 'track-99-orphan')"
+        )
+        conn.commit()
+        conn.close()
+
+        mod = _get_migrate_module()
+        mod.run(project_dir)  # must not raise
+
+    def test_orphan_track_nullified(self, tmp_path):
+        """Option A behavior: orphaned track ref is nullified before FK enforcement."""
+        project_dir = _init_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state, track) "
+            "VALUES ('disp-orphan', 'queued', 'track-99-orphan')"
+        )
+        conn.commit()
+        conn.close()
+
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT track FROM dispatches WHERE dispatch_id = 'disp-orphan'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] is None, f"Expected track=NULL after nullification, got {row[0]!r}"
+
+    def test_valid_track_preserved(self, tmp_path):
+        """Dispatches with a valid PR prefix are tagged and FK is preserved."""
+        project_dir = _init_project(tmp_path)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state, pr_ref) "
+            "VALUES ('disp-hyg-valid', 'queued', 'PR-HYG-1')"
+        )
+        conn.commit()
+        conn.close()
+
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT track FROM dispatches WHERE dispatch_id = 'disp-hyg-valid'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == "track-02", f"Expected track-02 from PR-HYG- mapping, got {row[0]!r}"
+
+    def test_schema_version_reaches_23(self, tmp_path):
+        """Full migration run ends at user_version=23."""
+        project_dir = _init_project(tmp_path)
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        conn.close()
+        assert version == 23
+
+    def test_fk_enforced_after_migration(self, tmp_path):
+        """After migration, inserting an invalid track FK raises IntegrityError."""
+        project_dir = _init_project(tmp_path)
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state, track) "
+                "VALUES ('disp-bad-fk', 'proposed', 'track-nonexistent')"
+            )
+            conn.commit()
+        conn.close()

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -246,7 +246,8 @@ class TestMigrateFutureSystem:
         with pytest.raises((FileNotFoundError, ValueError)):
             mod.run(project_dir)
 
-    def test_schema_version_22_set(self, project_dir):
+    def test_schema_version_23_set(self, project_dir):
+        """Full migration run (0022 + 0023) ends at user_version=23."""
         mod = _get_migrate_module()
         mod.run(project_dir)
 
@@ -254,4 +255,4 @@ class TestMigrateFutureSystem:
         conn = sqlite3.connect(str(db_path))
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 22
+        assert version == 23

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from unittest.mock import patch
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _LIB = _PROJECT_ROOT / "scripts" / "lib"
@@ -318,3 +319,216 @@ class TestPragmaPreflightAssertion:
         cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
         conn.close()
         assert "project_id" in cols
+
+
+class TestEmitEventsOrdering:
+    """emit_events runs BEFORE conn.commit() on the seed step (ADR-005)."""
+
+    def test_emit_failure_rolls_back_seed(self, tmp_path):
+        """If emit_events raises, seed tracks are not committed to DB."""
+        project_dir = _init_project(tmp_path)
+        mod = _get_migrate_module()
+
+        with patch.object(mod, "emit_events", side_effect=RuntimeError("emit failed")):
+            with pytest.raises(RuntimeError, match="emit failed"):
+                mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        conn.close()
+        assert count == 0, "Seed must be rolled back when emit_events fails"
+
+
+class TestBidirectionalPreflight:
+    """_assert_dispatches_schema_intact raises on extra columns AND missing UNIQUE."""
+
+    def _db_with_extra_column(self, tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
+        project_dir = tmp_path / "extra_col"
+        state_dir = project_dir / ".vnx-data" / "state"
+        state_dir.mkdir(parents=True)
+        claudedocs = project_dir / "claudedocs"
+        claudedocs.mkdir()
+        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
+            FIXTURE_ROADMAP, encoding="utf-8"
+        )
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'queued',
+                terminal_id TEXT, track TEXT, priority TEXT,
+                pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+                metadata_json TEXT DEFAULT '{}',
+                extra_column TEXT,
+                UNIQUE(dispatch_id, project_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE coordination_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+                event_type TEXT, entity_type TEXT, entity_id TEXT,
+                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+                metadata_json TEXT, occurred_at TEXT, project_id TEXT
+            )
+        """)
+        conn.commit()
+        return project_dir, conn
+
+    def test_raises_on_extra_column(self, tmp_path):
+        project_dir, conn = self._db_with_extra_column(tmp_path)
+        conn.close()
+        mod = _get_migrate_module()
+        with pytest.raises(RuntimeError, match="extra="):
+            mod.run(project_dir)
+
+    def test_raises_on_missing_unique(self, tmp_path):
+        """A dispatches table without UNIQUE(dispatch_id, project_id) fails preflight."""
+        project_dir = tmp_path / "no_unique"
+        state_dir = project_dir / ".vnx-data" / "state"
+        state_dir.mkdir(parents=True)
+        claudedocs = project_dir / "claudedocs"
+        claudedocs.mkdir()
+        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
+            FIXTURE_ROADMAP, encoding="utf-8"
+        )
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'queued',
+                terminal_id TEXT, track TEXT, priority TEXT,
+                pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+                metadata_json TEXT DEFAULT '{}'
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE coordination_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+                event_type TEXT, entity_type TEXT, entity_id TEXT,
+                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+                metadata_json TEXT, occurred_at TEXT, project_id TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+        mod = _get_migrate_module()
+        with pytest.raises(RuntimeError, match="UNIQUE"):
+            mod.run(project_dir)
+
+
+class TestPreflightBefore0023:
+    """Second preflight (_assert_dispatches_schema_post_0022) triggers before 0023 rebuild."""
+
+    def test_preflight_0023_registered(self):
+        """schema_migration has a preflight hook for version 23 after module import."""
+        mod = _get_migrate_module()
+        import schema_migration as _sm
+        assert 23 in _sm._PREFLIGHT_HOOKS, "preflight for 0023 must be registered"
+
+    def test_preflight_0023_raises_on_missing_operator_approved_at(self, tmp_path):
+        """If post-0022 schema is missing operator_approved_at, 0023 is refused."""
+        project_dir = _init_project(tmp_path)
+        mod = _get_migrate_module()
+
+        original_apply = schema_migration.apply_script_if_below
+
+        def patched_apply(conn, target_version, sql):
+            if target_version == 22:
+                # Apply 0022 but then DROP operator_approved_at to simulate drift
+                result = original_apply(conn, target_version, sql)
+                if result:
+                    conn.execute("ALTER TABLE dispatches RENAME TO dispatches_tmp_test")
+                    conn.execute("""
+                        CREATE TABLE dispatches (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            dispatch_id TEXT NOT NULL,
+                            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                            state TEXT NOT NULL DEFAULT 'queued',
+                            terminal_id TEXT, track TEXT, priority TEXT,
+                            pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                            bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+                            updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+                            metadata_json TEXT DEFAULT '{}',
+                            UNIQUE(dispatch_id, project_id)
+                        )
+                    """)
+                    conn.execute("INSERT INTO dispatches SELECT id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate, attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json FROM dispatches_tmp_test")
+                    conn.execute("DROP TABLE dispatches_tmp_test")
+                return result
+            return original_apply(conn, target_version, sql)
+
+        with patch.object(schema_migration, "apply_script_if_below", patched_apply):
+            with pytest.raises(RuntimeError, match="operator_approved_at"):
+                mod.run(project_dir)
+
+
+class TestMigrationAuditNDJSON:
+    """Migration UPDATE blocks emit structured events to migration_audit.ndjson."""
+
+    def test_full_run_creates_migration_audit_file(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
+        assert audit_path.exists(), "migration_audit.ndjson must be created by run()"
+
+    def test_audit_contains_next_up_set_event(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
+        content = audit_path.read_text(encoding="utf-8")
+        import json as _json
+        events = [_json.loads(line) for line in content.splitlines() if line.strip()]
+        types = {e["event_type"] for e in events}
+        assert "track_next_up_set" in types or "tracks_next_up_cleared" in types, (
+            f"Expected next_up audit event, got event types: {types}"
+        )
+
+    def test_audit_events_have_record_id(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
+        content = audit_path.read_text(encoding="utf-8")
+        import json as _json
+        events = [_json.loads(line) for line in content.splitlines() if line.strip()]
+        for evt in events:
+            assert "record_id" in evt, f"Event missing record_id: {evt}"
+
+
+class TestPreflightThroughApplyScriptIfBelow:
+    """Preflight hook triggers even when apply_script_if_below is called directly (Fix 8)."""
+
+    def test_direct_apply_triggers_preflight_for_22(self, tmp_path):
+        """Directly calling apply_script_if_below(conn, 22, sql) triggers the v22 preflight."""
+        db_path = tmp_path / "direct.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        # Create a dispatches table WITHOUT project_id — should fail preflight
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL UNIQUE,
+                state TEXT NOT NULL DEFAULT 'queued'
+            )
+        """)
+        conn.commit()
+
+        mod = _get_migrate_module()
+        sql_path = _MIGRATIONS / "0022_track_layer.sql"
+        sql = sql_path.read_text(encoding="utf-8")
+        with pytest.raises(RuntimeError, match="project_id|schema drift"):
+            schema_migration.apply_script_if_below(conn, 22, sql)
+        conn.close()

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -71,7 +71,8 @@ def _init_project(tmp_path: Path, roadmap_content: str = FIXTURE_ROADMAP) -> Pat
     conn.execute("""
         CREATE TABLE dispatches (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id     TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
             state           TEXT    NOT NULL DEFAULT 'queued',
             terminal_id     TEXT,
             track           TEXT,
@@ -83,7 +84,8 @@ def _init_project(tmp_path: Path, roadmap_content: str = FIXTURE_ROADMAP) -> Pat
             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             expires_after   TEXT,
-            metadata_json   TEXT    DEFAULT '{}'
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""
@@ -222,13 +224,15 @@ class TestMigrateFutureSystem:
         conn.execute("""
             CREATE TABLE dispatches (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                dispatch_id TEXT NOT NULL UNIQUE,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
                 state TEXT NOT NULL DEFAULT 'queued',
                 terminal_id TEXT, track TEXT, priority TEXT,
                 pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
                 bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
                 updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
-                metadata_json TEXT DEFAULT '{}'
+                metadata_json TEXT DEFAULT '{}',
+                UNIQUE(dispatch_id, project_id)
             )
         """)
         conn.execute("""
@@ -256,3 +260,61 @@ class TestMigrateFutureSystem:
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
         assert version == 23
+
+
+class TestPragmaPreflightAssertion:
+    """_assert_dispatches_schema_intact raises RuntimeError when project_id missing."""
+
+    def _v9_style_project(self, tmp_path: Path) -> Path:
+        """Create a project with a v9-style dispatches table (no project_id)."""
+        project_dir = tmp_path / "v9project"
+        state_dir = project_dir / ".vnx-data" / "state"
+        state_dir.mkdir(parents=True)
+        claudedocs = project_dir / "claudedocs"
+        claudedocs.mkdir()
+        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
+            FIXTURE_ROADMAP, encoding="utf-8"
+        )
+
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL UNIQUE,
+                state TEXT NOT NULL DEFAULT 'queued',
+                terminal_id TEXT, track TEXT, priority TEXT,
+                pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+                metadata_json TEXT DEFAULT '{}'
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE coordination_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+                event_type TEXT, entity_type TEXT, entity_id TEXT,
+                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+                metadata_json TEXT, occurred_at TEXT, project_id TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+        return project_dir
+
+    def test_preflight_raises_on_missing_project_id(self, tmp_path):
+        project_dir = self._v9_style_project(tmp_path)
+        mod = _get_migrate_module()
+        with pytest.raises(RuntimeError, match="project_id"):
+            mod.run(project_dir)
+
+    def test_preflight_passes_on_v21_schema(self, tmp_path):
+        """v21 DB with project_id passes the preflight and migration proceeds."""
+        project_dir = _init_project(tmp_path)
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+        conn.close()
+        assert "project_id" in cols

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -1,0 +1,257 @@
+"""tests/test_migrate_future_system.py — tests for scripts/migrate_future_system.py.
+
+Tests:
+- Seed 6 tracks from fixture master-roadmap
+- Idempotency: re-run produces no duplicate rows
+- Dispatch tagging by PR-cluster prefix
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _PROJECT_ROOT / "scripts" / "lib"
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+_SCHEMAS = _PROJECT_ROOT / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+
+
+# ---------------------------------------------------------------------------
+# Fixture roadmap content (mirrors the real master-roadmap table structure)
+# ---------------------------------------------------------------------------
+
+FIXTURE_ROADMAP = """\
+# VNX Master Roadmap — fixture
+
+## 1. Feature-tracks
+
+| Track | Goal | Doel-state |
+|---|---|---|
+| **track-01** | **15-juni Subscription Escape** | Alle Claude-workers default via tmux-leaseless lane. |
+| **track-02** | **Public 1.0 Launch** | `pip install vnx-orchestration` werkend. |
+| **track-03** | **Observability Activation** | Command-centre live, per-provider token-capture. |
+| **track-04** | **Routing Hardening** | `provider_constraints.yaml` enforced. |
+| **track-05** | **Governance Self-Monitoring** | Health-heartbeat-laag actief. |
+| **track-06** | **Dimitri Adoption** | Track-layer + Context-composer-assembly. |
+
+## 2. Phase — ACTIVE
+
+(content elided for test)
+"""
+
+
+def _init_project(tmp_path: Path, roadmap_content: str = FIXTURE_ROADMAP) -> Path:
+    """Create a minimal project with DB + fixture roadmap."""
+    project_dir = tmp_path / "project"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    claudedocs = project_dir / "claudedocs"
+    claudedocs.mkdir()
+
+    # Write fixture roadmap
+    (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(roadmap_content, encoding="utf-8")
+
+    # Initialize DB with base dispatches + coordination_events tables
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    return project_dir
+
+
+@pytest.fixture()
+def project_dir(tmp_path):
+    return _init_project(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Import the migration module
+# ---------------------------------------------------------------------------
+
+def _get_migrate_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "migrate_future_system",
+        _SCRIPTS / "migrate_future_system.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestMigrateFutureSystem:
+    def test_seeds_six_tracks(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        conn.close()
+        assert count == 6
+
+    def test_all_track_ids_present(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        ids = {r[0] for r in conn.execute("SELECT track_id FROM tracks").fetchall()}
+        conn.close()
+        assert ids == {"track-01", "track-02", "track-03", "track-04", "track-05", "track-06"}
+
+    def test_idempotent_rerun(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        mod.run(project_dir)  # second run must be idempotent
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        conn.close()
+        assert count == 6
+
+    def test_dispatch_tagging_by_pr_prefix(self, project_dir):
+        # Pre-seed a dispatch with pr_ref = PR-HYG-1 (should map to track-02)
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state, pr_ref) "
+            "VALUES ('disp-hyg-001', 'queued', 'PR-HYG-1')"
+        )
+        conn.commit()
+        conn.close()
+
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT track FROM dispatches WHERE dispatch_id = 'disp-hyg-001'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "track-02"
+
+    def test_migration_events_emitted(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM coordination_events WHERE event_type = 'track_created'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 6
+
+    def test_events_not_duplicated_on_rerun(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM coordination_events WHERE event_type = 'track_created'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 6
+
+    def test_missing_roadmap_raises(self, tmp_path):
+        # Project without roadmap file
+        project_dir = tmp_path / "bare"
+        state_dir = project_dir / ".vnx-data" / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "runtime_coordination.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL UNIQUE,
+                state TEXT NOT NULL DEFAULT 'queued',
+                terminal_id TEXT, track TEXT, priority TEXT,
+                pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+                bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
+                metadata_json TEXT DEFAULT '{}'
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE coordination_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+                event_type TEXT, entity_type TEXT, entity_id TEXT,
+                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+                metadata_json TEXT, occurred_at TEXT, project_id TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        mod = _get_migrate_module()
+        with pytest.raises((FileNotFoundError, ValueError)):
+            mod.run(project_dir)
+
+    def test_schema_version_22_set(self, project_dir):
+        mod = _get_migrate_module()
+        mod.run(project_dir)
+
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        conn.close()
+        assert version == 22

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -1,9 +1,10 @@
 """tests/test_migrate_future_system.py — tests for scripts/migrate_future_system.py.
 
 Tests:
-- Seed 6 tracks from fixture master-roadmap
-- Idempotency: re-run produces no duplicate rows
-- Dispatch tagging by PR-cluster prefix
+- PRAGMA preflight raises on missing project_id (v9-style schema)
+- PRAGMA preflight passes on v21 schema with proper UNIQUE constraint
+- Bidirectional preflight: raises on extra columns, raises on missing UNIQUE
+- Preflight hook triggers via direct apply_script_if_below call
 """
 
 from __future__ import annotations
@@ -13,7 +14,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from unittest.mock import patch
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _LIB = _PROJECT_ROOT / "scripts" / "lib"
@@ -29,42 +29,12 @@ if str(_SCRIPTS) not in sys.path:
 import schema_migration
 
 
-# ---------------------------------------------------------------------------
-# Fixture roadmap content (mirrors the real master-roadmap table structure)
-# ---------------------------------------------------------------------------
-
-FIXTURE_ROADMAP = """\
-# VNX Master Roadmap — fixture
-
-## 1. Feature-tracks
-
-| Track | Goal | Doel-state |
-|---|---|---|
-| **track-01** | **15-juni Subscription Escape** | Alle Claude-workers default via tmux-leaseless lane. |
-| **track-02** | **Public 1.0 Launch** | `pip install vnx-orchestration` werkend. |
-| **track-03** | **Observability Activation** | Command-centre live, per-provider token-capture. |
-| **track-04** | **Routing Hardening** | `provider_constraints.yaml` enforced. |
-| **track-05** | **Governance Self-Monitoring** | Health-heartbeat-laag actief. |
-| **track-06** | **Dimitri Adoption** | Track-layer + Context-composer-assembly. |
-
-## 2. Phase — ACTIVE
-
-(content elided for test)
-"""
-
-
-def _init_project(tmp_path: Path, roadmap_content: str = FIXTURE_ROADMAP) -> Path:
-    """Create a minimal project with DB + fixture roadmap."""
+def _init_project(tmp_path: Path) -> Path:
+    """Create a minimal project with DB having a v21-style dispatches table."""
     project_dir = tmp_path / "project"
     state_dir = project_dir / ".vnx-data" / "state"
     state_dir.mkdir(parents=True)
-    claudedocs = project_dir / "claudedocs"
-    claudedocs.mkdir()
 
-    # Write fixture roadmap
-    (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(roadmap_content, encoding="utf-8")
-
-    # Initialize DB with base dispatches + coordination_events tables
     db_path = state_dir / "runtime_coordination.db"
     conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA journal_mode = WAL")
@@ -111,15 +81,6 @@ def _init_project(tmp_path: Path, roadmap_content: str = FIXTURE_ROADMAP) -> Pat
     return project_dir
 
 
-@pytest.fixture()
-def project_dir(tmp_path):
-    return _init_project(tmp_path)
-
-
-# ---------------------------------------------------------------------------
-# Import the migration module
-# ---------------------------------------------------------------------------
-
 def _get_migrate_module():
     import importlib.util
     spec = importlib.util.spec_from_file_location(
@@ -131,138 +92,6 @@ def _get_migrate_module():
     return mod
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-class TestMigrateFutureSystem:
-    def test_seeds_six_tracks(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-        conn.close()
-        assert count == 6
-
-    def test_all_track_ids_present(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        ids = {r[0] for r in conn.execute("SELECT track_id FROM tracks").fetchall()}
-        conn.close()
-        assert ids == {"track-01", "track-02", "track-03", "track-04", "track-05", "track-06"}
-
-    def test_idempotent_rerun(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-        mod.run(project_dir)  # second run must be idempotent
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-        conn.close()
-        assert count == 6
-
-    def test_dispatch_tagging_by_pr_prefix(self, project_dir):
-        # Pre-seed a dispatch with pr_ref = PR-HYG-1 (should map to track-02)
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "INSERT INTO dispatches (dispatch_id, state, pr_ref) "
-            "VALUES ('disp-hyg-001', 'queued', 'PR-HYG-1')"
-        )
-        conn.commit()
-        conn.close()
-
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-
-        conn = sqlite3.connect(str(db_path))
-        row = conn.execute(
-            "SELECT track FROM dispatches WHERE dispatch_id = 'disp-hyg-001'"
-        ).fetchone()
-        conn.close()
-        assert row is not None
-        assert row[0] == "track-02"
-
-    def test_migration_events_emitted(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute(
-            "SELECT COUNT(*) FROM coordination_events WHERE event_type = 'track_created'"
-        ).fetchone()[0]
-        conn.close()
-        assert count == 6
-
-    def test_events_not_duplicated_on_rerun(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-        mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute(
-            "SELECT COUNT(*) FROM coordination_events WHERE event_type = 'track_created'"
-        ).fetchone()[0]
-        conn.close()
-        assert count == 6
-
-    def test_missing_roadmap_raises(self, tmp_path):
-        # Project without roadmap file
-        project_dir = tmp_path / "bare"
-        state_dir = project_dir / ".vnx-data" / "state"
-        state_dir.mkdir(parents=True)
-        db_path = state_dir / "runtime_coordination.db"
-
-        conn = sqlite3.connect(str(db_path))
-        conn.execute("""
-            CREATE TABLE dispatches (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                dispatch_id TEXT NOT NULL,
-                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
-                state TEXT NOT NULL DEFAULT 'queued',
-                terminal_id TEXT, track TEXT, priority TEXT,
-                pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
-                bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
-                updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
-                metadata_json TEXT DEFAULT '{}',
-                UNIQUE(dispatch_id, project_id)
-            )
-        """)
-        conn.execute("""
-            CREATE TABLE coordination_events (
-                id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
-                event_type TEXT, entity_type TEXT, entity_id TEXT,
-                from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
-                metadata_json TEXT, occurred_at TEXT, project_id TEXT
-            )
-        """)
-        conn.commit()
-        conn.close()
-
-        mod = _get_migrate_module()
-        with pytest.raises((FileNotFoundError, ValueError)):
-            mod.run(project_dir)
-
-    def test_schema_version_23_set(self, project_dir):
-        """Full migration run (0022 + 0023) ends at user_version=23."""
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        version = conn.execute("PRAGMA user_version").fetchone()[0]
-        conn.close()
-        assert version == 23
-
-
 class TestPragmaPreflightAssertion:
     """_assert_dispatches_schema_intact raises RuntimeError when project_id missing."""
 
@@ -271,11 +100,6 @@ class TestPragmaPreflightAssertion:
         project_dir = tmp_path / "v9project"
         state_dir = project_dir / ".vnx-data" / "state"
         state_dir.mkdir(parents=True)
-        claudedocs = project_dir / "claudedocs"
-        claudedocs.mkdir()
-        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
-            FIXTURE_ROADMAP, encoding="utf-8"
-        )
 
         db_path = state_dir / "runtime_coordination.db"
         conn = sqlite3.connect(str(db_path))
@@ -321,25 +145,6 @@ class TestPragmaPreflightAssertion:
         assert "project_id" in cols
 
 
-class TestEmitEventsOrdering:
-    """emit_events runs BEFORE conn.commit() on the seed step (ADR-005)."""
-
-    def test_emit_failure_rolls_back_seed(self, tmp_path):
-        """If emit_events raises, seed tracks are not committed to DB."""
-        project_dir = _init_project(tmp_path)
-        mod = _get_migrate_module()
-
-        with patch.object(mod, "emit_events", side_effect=RuntimeError("emit failed")):
-            with pytest.raises(RuntimeError, match="emit failed"):
-                mod.run(project_dir)
-
-        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-        conn.close()
-        assert count == 0, "Seed must be rolled back when emit_events fails"
-
-
 class TestBidirectionalPreflight:
     """_assert_dispatches_schema_intact raises on extra columns AND missing UNIQUE."""
 
@@ -347,11 +152,6 @@ class TestBidirectionalPreflight:
         project_dir = tmp_path / "extra_col"
         state_dir = project_dir / ".vnx-data" / "state"
         state_dir.mkdir(parents=True)
-        claudedocs = project_dir / "claudedocs"
-        claudedocs.mkdir()
-        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
-            FIXTURE_ROADMAP, encoding="utf-8"
-        )
         db_path = state_dir / "runtime_coordination.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("PRAGMA journal_mode = WAL")
@@ -394,11 +194,6 @@ class TestBidirectionalPreflight:
         project_dir = tmp_path / "no_unique"
         state_dir = project_dir / ".vnx-data" / "state"
         state_dir.mkdir(parents=True)
-        claudedocs = project_dir / "claudedocs"
-        claudedocs.mkdir()
-        (claudedocs / "VNX-MASTER-ROADMAP-2026-05-28.md").write_text(
-            FIXTURE_ROADMAP, encoding="utf-8"
-        )
         db_path = state_dir / "runtime_coordination.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("PRAGMA journal_mode = WAL")
@@ -428,84 +223,6 @@ class TestBidirectionalPreflight:
         mod = _get_migrate_module()
         with pytest.raises(RuntimeError, match="UNIQUE"):
             mod.run(project_dir)
-
-
-class TestPreflightBefore0023:
-    """Second preflight (_assert_dispatches_schema_post_0022) triggers before 0023 rebuild."""
-
-    def test_preflight_0023_registered(self):
-        """schema_migration has a preflight hook for version 23 after module import."""
-        mod = _get_migrate_module()
-        import schema_migration as _sm
-        assert 23 in _sm._PREFLIGHT_HOOKS, "preflight for 0023 must be registered"
-
-    def test_preflight_0023_raises_on_missing_operator_approved_at(self, tmp_path):
-        """If post-0022 schema is missing operator_approved_at, 0023 is refused."""
-        project_dir = _init_project(tmp_path)
-        mod = _get_migrate_module()
-
-        original_apply = schema_migration.apply_script_if_below
-
-        def patched_apply(conn, target_version, sql):
-            if target_version == 22:
-                # Apply 0022 but then DROP operator_approved_at to simulate drift
-                result = original_apply(conn, target_version, sql)
-                if result:
-                    conn.execute("ALTER TABLE dispatches RENAME TO dispatches_tmp_test")
-                    conn.execute("""
-                        CREATE TABLE dispatches (
-                            id INTEGER PRIMARY KEY AUTOINCREMENT,
-                            dispatch_id TEXT NOT NULL,
-                            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
-                            state TEXT NOT NULL DEFAULT 'queued',
-                            terminal_id TEXT, track TEXT, priority TEXT,
-                            pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
-                            bundle_path TEXT, created_at TEXT NOT NULL DEFAULT '',
-                            updated_at TEXT NOT NULL DEFAULT '', expires_after TEXT,
-                            metadata_json TEXT DEFAULT '{}',
-                            UNIQUE(dispatch_id, project_id)
-                        )
-                    """)
-                    conn.execute("INSERT INTO dispatches SELECT id, dispatch_id, project_id, state, terminal_id, track, priority, pr_ref, gate, attempt_count, bundle_path, created_at, updated_at, expires_after, metadata_json FROM dispatches_tmp_test")
-                    conn.execute("DROP TABLE dispatches_tmp_test")
-                return result
-            return original_apply(conn, target_version, sql)
-
-        with patch.object(schema_migration, "apply_script_if_below", patched_apply):
-            with pytest.raises(RuntimeError, match="operator_approved_at"):
-                mod.run(project_dir)
-
-
-class TestMigrationAuditNDJSON:
-    """Migration UPDATE blocks emit structured events to migration_audit.ndjson."""
-
-    def test_full_run_creates_migration_audit_file(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
-        assert audit_path.exists(), "migration_audit.ndjson must be created by run()"
-
-    def test_audit_contains_next_up_set_event(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
-        content = audit_path.read_text(encoding="utf-8")
-        import json as _json
-        events = [_json.loads(line) for line in content.splitlines() if line.strip()]
-        types = {e["event_type"] for e in events}
-        assert "track_next_up_set" in types or "tracks_next_up_cleared" in types, (
-            f"Expected next_up audit event, got event types: {types}"
-        )
-
-    def test_audit_events_have_record_id(self, project_dir):
-        mod = _get_migrate_module()
-        mod.run(project_dir)
-        audit_path = project_dir / ".vnx-data" / "events" / "migration_audit.ndjson"
-        content = audit_path.read_text(encoding="utf-8")
-        import json as _json
-        events = [_json.loads(line) for line in content.splitlines() if line.strip()]
-        for evt in events:
-            assert "record_id" in evt, f"Event missing record_id: {evt}"
 
 
 class TestPreflightThroughApplyScriptIfBelow:

--- a/tests/test_track_cli.py
+++ b/tests/test_track_cli.py
@@ -1,5 +1,8 @@
 """tests/test_track_cli.py — CLI tests for `vnx track` subcommands.
 
+Includes tests for NDJSON audit trail written by `vnx track dispatch`
+(ADR-005 compliance, Finding 3 of dispatch 20260528-fut-1-fix1-codex-r1).
+
 Uses subprocess to invoke the installed `vnx` CLI (or falls back to
 running the module directly) against a temp project directory with a
 pre-initialized coordination DB.
@@ -7,6 +10,7 @@ pre-initialized coordination DB.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import subprocess
 import sys
@@ -214,4 +218,81 @@ class TestTrackShow:
 
     def test_show_nonexistent_exit_nonzero(self, project_dir):
         rc, out, err = _run_vnx(["track", "show", "track-nope"], project_dir)
+        assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# vnx track dispatch — NDJSON audit (ADR-005 / Finding 3)
+# ---------------------------------------------------------------------------
+
+class TestTrackDispatchAudit:
+    def _create_track(self, project_dir, track_id="track-01"):
+        _run_vnx(
+            ["track", "new", track_id, "--title", "T", "--goal", "G"],
+            project_dir,
+        )
+
+    def test_dispatch_exit_0(self, project_dir):
+        self._create_track(project_dir)
+        rc, out, err = _run_vnx(
+            ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
+            project_dir,
+        )
+        assert rc == 0, f"stdout: {out}\nstderr: {err}"
+
+    def test_dispatch_row_created_in_db(self, project_dir):
+        self._create_track(project_dir)
+        _run_vnx(
+            ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
+            project_dir,
+        )
+        db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT state, track, pr_ref FROM dispatches WHERE track = 'track-01'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "proposed"
+        assert row[2] == "PR-FUT-1"
+
+    def test_dispatch_ndjson_emitted(self, project_dir):
+        """dispatch_register.ndjson must contain a dispatch_created event after dispatch."""
+        self._create_track(project_dir)
+        _run_vnx(
+            ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
+            project_dir,
+        )
+        register_path = project_dir / ".vnx-data" / "state" / "dispatch_register.ndjson"
+        assert register_path.exists(), "dispatch_register.ndjson not created"
+
+        events = []
+        for line in register_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+
+        dispatch_created = [e for e in events if e.get("event") == "dispatch_created"]
+        assert len(dispatch_created) >= 1, f"No dispatch_created event found; events={events}"
+
+    def test_dispatch_ndjson_contains_dispatch_id(self, project_dir):
+        """NDJSON event must reference the created dispatch_id."""
+        self._create_track(project_dir)
+        _run_vnx(
+            ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
+            project_dir,
+        )
+        register_path = project_dir / ".vnx-data" / "state" / "dispatch_register.ndjson"
+        events = [
+            json.loads(ln) for ln in register_path.read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+        dispatch_ids = [e.get("dispatch_id", "") for e in events if e.get("event") == "dispatch_created"]
+        assert any("track-01" in did for did in dispatch_ids), f"dispatch_id not in events: {dispatch_ids}"
+
+    def test_dispatch_invalid_track_exit_nonzero(self, project_dir):
+        rc, out, err = _run_vnx(
+            ["track", "dispatch", "track-nope", "--pr", "PR-FUT-1", "--terminal", "T1"],
+            project_dir,
+        )
         assert rc != 0

--- a/tests/test_track_cli.py
+++ b/tests/test_track_cli.py
@@ -1,0 +1,217 @@
+"""tests/test_track_cli.py — CLI tests for `vnx track` subcommands.
+
+Uses subprocess to invoke the installed `vnx` CLI (or falls back to
+running the module directly) against a temp project directory with a
+pre-initialized coordination DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS = Path(__file__).resolve().parent.parent / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _init_project(tmp_path: Path) -> Path:
+    """Create a minimal VNX project tree with runtime_coordination.db."""
+    project_dir = tmp_path / "project"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+
+    sql = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 22, sql)
+    conn.commit()
+    conn.close()
+    return project_dir
+
+
+def _run_vnx(args: list[str], project_dir: Path) -> tuple[int, str, str]:
+    """Run `vnx <args>` against project_dir, return (rc, stdout, stderr)."""
+    cmd = [sys.executable, "-m", "vnx_cli.main"] + args + ["--project-dir", str(project_dir)]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(_PROJECT_ROOT),
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+@pytest.fixture()
+def project_dir(tmp_path):
+    return _init_project(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# vnx track new
+# ---------------------------------------------------------------------------
+
+class TestTrackNew:
+    def test_create_track_exit_0(self, project_dir):
+        rc, out, err = _run_vnx(
+            ["track", "new", "track-01", "--title", "Test Track", "--goal", "Goal state"],
+            project_dir,
+        )
+        assert rc == 0, f"stderr: {err}"
+
+    def test_create_track_output_mentions_id(self, project_dir):
+        rc, out, err = _run_vnx(
+            ["track", "new", "track-01", "--title", "T1", "--goal", "G1"],
+            project_dir,
+        )
+        assert "track-01" in out
+
+    def test_create_track_with_priority(self, project_dir):
+        rc, out, err = _run_vnx(
+            ["track", "new", "track-02", "--title", "T2", "--goal", "G2", "--priority", "high"],
+            project_dir,
+        )
+        assert rc == 0, f"stderr: {err}"
+
+
+# ---------------------------------------------------------------------------
+# vnx track list
+# ---------------------------------------------------------------------------
+
+class TestTrackList:
+    def test_list_empty(self, project_dir):
+        rc, out, err = _run_vnx(["track", "list"], project_dir)
+        assert rc == 0
+
+    def test_list_shows_created_track(self, project_dir):
+        _run_vnx(
+            ["track", "new", "track-01", "--title", "Sub Escape", "--goal", "All via tmux"],
+            project_dir,
+        )
+        rc, out, err = _run_vnx(["track", "list"], project_dir)
+        assert rc == 0
+        assert "track-01" in out
+
+    def test_list_phase_filter(self, project_dir):
+        _run_vnx(
+            ["track", "new", "track-01", "--title", "T1", "--goal", "G1"],
+            project_dir,
+        )
+        rc, out, err = _run_vnx(["track", "list", "--phase", "queued"], project_dir)
+        assert rc == 0
+        assert "track-01" in out
+
+    def test_list_phase_filter_excludes(self, project_dir):
+        _run_vnx(
+            ["track", "new", "track-01", "--title", "T1", "--goal", "G1"],
+            project_dir,
+        )
+        rc, out, err = _run_vnx(["track", "list", "--phase", "done"], project_dir)
+        assert rc == 0
+        assert "track-01" not in out
+
+
+# ---------------------------------------------------------------------------
+# vnx track activate / park / unpark
+# ---------------------------------------------------------------------------
+
+class TestTrackPhaseTransitions:
+    def _create_track(self, project_dir, track_id="track-01"):
+        _run_vnx(
+            ["track", "new", track_id, "--title", "T", "--goal", "G"],
+            project_dir,
+        )
+
+    def test_activate_exit_0(self, project_dir):
+        self._create_track(project_dir)
+        rc, out, err = _run_vnx(["track", "activate", "track-01"], project_dir)
+        assert rc == 0, f"stderr: {err}"
+
+    def test_park_requires_reason(self, project_dir):
+        self._create_track(project_dir)
+        _run_vnx(["track", "activate", "track-01"], project_dir)
+        rc, out, err = _run_vnx(["track", "park", "track-01", "--reason", "blocked"], project_dir)
+        assert rc == 0, f"stderr: {err}"
+
+    def test_unpark_after_park(self, project_dir):
+        self._create_track(project_dir)
+        _run_vnx(["track", "activate", "track-01"], project_dir)
+        _run_vnx(["track", "park", "track-01", "--reason", "temp"], project_dir)
+        rc, out, err = _run_vnx(["track", "unpark", "track-01"], project_dir)
+        assert rc == 0, f"stderr: {err}"
+
+    def test_invalid_track_exit_nonzero(self, project_dir):
+        rc, out, err = _run_vnx(["track", "activate", "track-nope"], project_dir)
+        assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# vnx track show
+# ---------------------------------------------------------------------------
+
+class TestTrackShow:
+    def test_show_existing(self, project_dir):
+        _run_vnx(
+            ["track", "new", "track-01", "--title", "Sub Escape", "--goal", "tmux default"],
+            project_dir,
+        )
+        rc, out, err = _run_vnx(["track", "show", "track-01"], project_dir)
+        assert rc == 0
+        assert "track-01" in out
+        assert "Sub Escape" in out
+
+    def test_show_nonexistent_exit_nonzero(self, project_dir):
+        rc, out, err = _run_vnx(["track", "show", "track-nope"], project_dir)
+        assert rc != 0

--- a/tests/test_track_cli.py
+++ b/tests/test_track_cli.py
@@ -46,7 +46,8 @@ def _init_project(tmp_path: Path) -> Path:
     conn.execute("""
         CREATE TABLE dispatches (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id     TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
             state           TEXT    NOT NULL DEFAULT 'queued',
             terminal_id     TEXT,
             track           TEXT,
@@ -58,7 +59,8 @@ def _init_project(tmp_path: Path) -> Path:
             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             expires_after   TEXT,
-            metadata_json   TEXT    DEFAULT '{}'
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""
@@ -263,7 +265,7 @@ class TestTrackDispatchAudit:
             ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
             project_dir,
         )
-        register_path = project_dir / ".vnx-data" / "state" / "dispatch_register.ndjson"
+        register_path = project_dir / ".vnx-data" / "events" / "dispatch_register.ndjson"
         assert register_path.exists(), "dispatch_register.ndjson not created"
 
         events = []
@@ -282,7 +284,7 @@ class TestTrackDispatchAudit:
             ["track", "dispatch", "track-01", "--pr", "PR-FUT-1", "--terminal", "T1"],
             project_dir,
         )
-        register_path = project_dir / ".vnx-data" / "state" / "dispatch_register.ndjson"
+        register_path = project_dir / ".vnx-data" / "events" / "dispatch_register.ndjson"
         events = [
             json.loads(ln) for ln in register_path.read_text(encoding="utf-8").splitlines()
             if ln.strip()

--- a/tests/test_tracks_audit.py
+++ b/tests/test_tracks_audit.py
@@ -1,0 +1,176 @@
+"""tests/test_tracks_audit.py — NDJSON audit emission from tracks DAL.
+
+Verifies that every write operation in scripts/lib/tracks.py appends a
+corresponding NDJSON event to track_events.ndjson (ADR-005 compliance).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS = Path(__file__).resolve().parent.parent / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration
+import tracks
+
+
+def _create_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT,
+            priority TEXT DEFAULT 'P2',
+            pr_ref TEXT, gate TEXT,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT,
+            from_state TEXT, to_state TEXT, actor TEXT, reason TEXT,
+            metadata_json TEXT, occurred_at TEXT, project_id TEXT
+        )
+    """)
+    conn.commit()
+
+    sql = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 22, sql)
+    conn.commit()
+    conn.close()
+    return db_path.parent
+
+
+def _read_events(state_dir: Path) -> list[dict]:
+    path = state_dir / "track_events.ndjson"
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+@pytest.fixture()
+def state_dir(tmp_path):
+    return _create_db(tmp_path)
+
+
+class TestTrackCreatedAudit:
+    def test_create_track_emits_event(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "Title", "Goal")
+        events = _read_events(state_dir)
+        assert any(e["event_type"] == "track_created" for e in events)
+
+    def test_create_track_event_has_track_id(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "Title", "Goal")
+        events = _read_events(state_dir)
+        created = [e for e in events if e["event_type"] == "track_created"]
+        assert len(created) >= 1
+        assert created[0]["track_id"] == "track-01"
+
+    def test_create_track_event_has_actor(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "Title", "Goal")
+        events = _read_events(state_dir)
+        created = [e for e in events if e["event_type"] == "track_created"]
+        assert created[0]["actor"] == "system"
+
+    def test_create_track_event_has_timestamp(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "Title", "Goal")
+        events = _read_events(state_dir)
+        created = [e for e in events if e["event_type"] == "track_created"]
+        assert "timestamp" in created[0]
+
+
+class TestTransitionPhaseAudit:
+    def test_transition_emits_event(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G", phase="queued")
+        tracks.transition_phase(state_dir, "track-01", "active", actor="operator")
+        events = _read_events(state_dir)
+        assert any(e["event_type"] == "track_phase_transition" for e in events)
+
+    def test_transition_event_details(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G", phase="queued")
+        tracks.transition_phase(state_dir, "track-01", "active", actor="T0")
+        events = _read_events(state_dir)
+        transitions = [e for e in events if e["event_type"] == "track_phase_transition"]
+        assert len(transitions) >= 1
+        evt = transitions[0]
+        assert evt["track_id"] == "track-01"
+        assert evt["actor"] == "T0"
+        assert evt["details"]["from"] == "queued"
+        assert evt["details"]["to"] == "active"
+
+
+class TestSetNextUpAudit:
+    def test_set_next_up_emits_event(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G")
+        tracks.set_next_up(state_dir, "track-01")
+        events = _read_events(state_dir)
+        assert any(e["event_type"] == "track_next_up_set" for e in events)
+
+    def test_set_next_up_event_track_id(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G")
+        tracks.set_next_up(state_dir, "track-01")
+        events = _read_events(state_dir)
+        next_up_events = [e for e in events if e["event_type"] == "track_next_up_set"]
+        assert next_up_events[0]["track_id"] == "track-01"
+
+
+class TestLinkOpenItemAudit:
+    def test_link_open_item_emits_event(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G")
+        tracks.link_open_item(state_dir, "track-01", "OI-999", "blocks", "manual")
+        events = _read_events(state_dir)
+        assert any(e["event_type"] == "track_oi_linked" for e in events)
+
+    def test_link_open_item_event_details(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T", "G")
+        tracks.link_open_item(state_dir, "track-01", "OI-999", "warns", "file_path")
+        events = _read_events(state_dir)
+        oi_events = [e for e in events if e["event_type"] == "track_oi_linked"]
+        assert oi_events[0]["details"]["oi_id"] == "OI-999"
+        assert oi_events[0]["details"]["link_type"] == "warns"
+
+
+class TestAddDependencyAudit:
+    def test_add_dependency_emits_event(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        tracks.create_track(state_dir, "track-02", "T2", "G2")
+        tracks.add_dependency(state_dir, "track-02", "track-01", "hard", "manual")
+        events = _read_events(state_dir)
+        assert any(e["event_type"] == "track_dep_added" for e in events)
+
+    def test_add_dependency_event_details(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        tracks.create_track(state_dir, "track-02", "T2", "G2")
+        tracks.add_dependency(state_dir, "track-02", "track-01", "soft", "manual")
+        events = _read_events(state_dir)
+        dep_events = [e for e in events if e["event_type"] == "track_dep_added"]
+        assert dep_events[0]["track_id"] == "track-02"
+        assert dep_events[0]["details"]["to"] == "track-01"
+        assert dep_events[0]["details"]["kind"] == "soft"

--- a/tests/test_tracks_audit.py
+++ b/tests/test_tracks_audit.py
@@ -10,6 +10,7 @@ import json
 import sqlite3
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -34,7 +35,8 @@ def _create_db(tmp_path: Path) -> Path:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS dispatches (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id TEXT NOT NULL UNIQUE,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
             state TEXT NOT NULL DEFAULT 'queued',
             terminal_id TEXT, track TEXT,
             priority TEXT DEFAULT 'P2',
@@ -43,7 +45,8 @@ def _create_db(tmp_path: Path) -> Path:
             bundle_path TEXT,
             created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-            expires_after TEXT, metadata_json TEXT DEFAULT '{}'
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""
@@ -174,3 +177,120 @@ class TestAddDependencyAudit:
         assert dep_events[0]["track_id"] == "track-02"
         assert dep_events[0]["details"]["to"] == "track-01"
         assert dep_events[0]["details"]["kind"] == "soft"
+
+
+# ---------------------------------------------------------------------------
+# ADR-005: mutation functions raise on audit write failure; no DB row committed
+# ---------------------------------------------------------------------------
+
+import state_writer as _sw
+
+
+class TestAuditWriteFailureRaises:
+    """All 5 mutation functions must raise and leave no committed DB row
+    when the NDJSON write fails (ADR-005 ledger-first guarantee)."""
+
+    def _count(self, state_dir: Path, table: str, where: str, val: str) -> int:
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {where} = ?", (val,)
+        ).fetchone()
+        conn.close()
+        return row[0]
+
+    def test_create_track_raises_on_audit_failure(self, state_dir):
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            with pytest.raises(OSError):
+                tracks.create_track(state_dir, "track-fail-01", "T", "G")
+
+    def test_create_track_no_row_after_audit_failure(self, state_dir):
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            try:
+                tracks.create_track(state_dir, "track-fail-02", "T", "G")
+            except OSError:
+                pass
+        assert self._count(state_dir, "tracks", "track_id", "track-fail-02") == 0
+
+    def test_transition_phase_raises_on_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-tp-01", "T", "G", phase="queued")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            with pytest.raises(OSError):
+                tracks.transition_phase(state_dir, "track-tp-01", "active", actor="operator")
+
+    def test_transition_phase_no_phase_change_after_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-tp-02", "T", "G", phase="queued")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            try:
+                tracks.transition_phase(state_dir, "track-tp-02", "active", actor="operator")
+            except OSError:
+                pass
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT phase FROM tracks WHERE track_id = 'track-tp-02'").fetchone()
+        conn.close()
+        assert row[0] == "queued"
+
+    def test_set_next_up_raises_on_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-nu-01", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            with pytest.raises(OSError):
+                tracks.set_next_up(state_dir, "track-nu-01")
+
+    def test_set_next_up_not_committed_after_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-nu-02", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            try:
+                tracks.set_next_up(state_dir, "track-nu-02")
+            except OSError:
+                pass
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT next_up FROM tracks WHERE track_id = 'track-nu-02'").fetchone()
+        conn.close()
+        assert row[0] == 0
+
+    def test_link_open_item_raises_on_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-oi-01", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            with pytest.raises(OSError):
+                tracks.link_open_item(state_dir, "track-oi-01", "OI-x", "blocks", "manual")
+
+    def test_link_open_item_no_row_after_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-oi-02", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            try:
+                tracks.link_open_item(state_dir, "track-oi-02", "OI-y", "blocks", "manual")
+            except OSError:
+                pass
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT COUNT(*) FROM track_open_items WHERE track_id = 'track-oi-02'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == 0
+
+    def test_add_dependency_raises_on_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-dep-a", "T", "G", phase="active")
+        tracks.create_track(state_dir, "track-dep-b", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            with pytest.raises(OSError):
+                tracks.add_dependency(state_dir, "track-dep-b", "track-dep-a", "hard", "manual")
+
+    def test_add_dependency_no_row_after_audit_failure(self, state_dir):
+        tracks.create_track(state_dir, "track-dep-c", "T", "G", phase="active")
+        tracks.create_track(state_dir, "track-dep-d", "T", "G")
+        with patch.object(_sw, "append_locked", side_effect=OSError("full")):
+            try:
+                tracks.add_dependency(state_dir, "track-dep-d", "track-dep-c", "hard", "manual")
+            except OSError:
+                pass
+        db_path = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT COUNT(*) FROM track_dependencies "
+            "WHERE from_track_id = 'track-dep-d'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == 0

--- a/tests/test_tracks_audit.py
+++ b/tests/test_tracks_audit.py
@@ -67,7 +67,7 @@ def _create_db(tmp_path: Path) -> Path:
 
 
 def _read_events(state_dir: Path) -> list[dict]:
-    path = state_dir / "track_events.ndjson"
+    path = state_dir.parent / "events" / "track_events.ndjson"
     if not path.exists():
         return []
     events = []

--- a/tests/test_tracks_lib.py
+++ b/tests/test_tracks_lib.py
@@ -1,0 +1,327 @@
+"""tests/test_tracks_lib.py — unit tests for scripts/lib/tracks.py.
+
+Tests:
+- create/get/list/transition/set_next_up happy paths
+- Validation errors (invalid phase, invalid actor, invalid transition)
+- link_open_item and add_dependency
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS = Path(__file__).resolve().parent.parent / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration
+import tracks
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _create_db(tmp_path: Path) -> Path:
+    """Create a minimal runtime_coordination.db with migration 0022 applied."""
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+
+    sql = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 22, sql)
+    conn.commit()
+    conn.close()
+    return db_path.parent
+
+
+@pytest.fixture()
+def state_dir(tmp_path):
+    return _create_db(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# create_track
+# ---------------------------------------------------------------------------
+
+class TestCreateTrack:
+    def test_create_returns_dict(self, state_dir):
+        t = tracks.create_track(state_dir, "track-01", "Title One", "Goal One")
+        assert t["track_id"] == "track-01"
+        assert t["title"] == "Title One"
+        assert t["goal_state"] == "Goal One"
+        assert t["phase"] == "queued"
+
+    def test_create_with_priority(self, state_dir):
+        t = tracks.create_track(state_dir, "track-02", "T2", "G2", priority="high")
+        assert t["priority"] == "high"
+
+    def test_create_invalid_phase(self, state_dir):
+        with pytest.raises(tracks.InvalidPhaseError):
+            tracks.create_track(state_dir, "track-03", "T3", "G3", phase="invalid")
+
+    def test_create_duplicate_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-04", "T4", "G4")
+        with pytest.raises(Exception):  # UNIQUE constraint violation
+            tracks.create_track(state_dir, "track-04", "T4", "G4")
+
+
+# ---------------------------------------------------------------------------
+# get_track
+# ---------------------------------------------------------------------------
+
+class TestGetTrack:
+    def test_get_existing(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        t = tracks.get_track(state_dir, "track-01")
+        assert t is not None
+        assert t["track_id"] == "track-01"
+
+    def test_get_nonexistent_returns_none(self, state_dir):
+        assert tracks.get_track(state_dir, "track-nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# list_tracks
+# ---------------------------------------------------------------------------
+
+class TestListTracks:
+    def test_list_all(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        tracks.create_track(state_dir, "track-02", "T2", "G2", phase="active")
+        result = tracks.list_tracks(state_dir)
+        assert len(result) == 2
+
+    def test_list_by_phase(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        tracks.create_track(state_dir, "track-02", "T2", "G2", phase="active")
+        queued = tracks.list_tracks(state_dir, phase="queued")
+        assert len(queued) == 1
+        assert queued[0]["track_id"] == "track-01"
+
+    def test_list_invalid_phase_raises(self, state_dir):
+        with pytest.raises(tracks.InvalidPhaseError):
+            tracks.list_tracks(state_dir, phase="invalid")
+
+    def test_list_empty(self, state_dir):
+        assert tracks.list_tracks(state_dir) == []
+
+    def test_list_project_isolation(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", project_id="project-a")
+        tracks.create_track(state_dir, "track-02", "T2", "G2", project_id="project-b")
+        result = tracks.list_tracks(state_dir, project_id="project-a")
+        assert len(result) == 1
+        assert result[0]["track_id"] == "track-01"
+
+
+# ---------------------------------------------------------------------------
+# transition_phase
+# ---------------------------------------------------------------------------
+
+class TestTransitionPhase:
+    def test_queued_to_active(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        t = tracks.transition_phase(state_dir, "track-01", "active", actor="operator")
+        assert t["phase"] == "active"
+
+    def test_active_to_done(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        t = tracks.transition_phase(state_dir, "track-01", "done", actor="T0")
+        assert t["phase"] == "done"
+        assert t.get("completed_at") is not None
+
+    def test_active_to_parked(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        t = tracks.transition_phase(state_dir, "track-01", "parked", actor="operator", reason="blocked")
+        assert t["phase"] == "parked"
+
+    def test_parked_to_queued_unpark(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="parked")
+        t = tracks.transition_phase(state_dir, "track-01", "queued", actor="operator")
+        assert t["phase"] == "queued"
+
+    def test_done_is_terminal(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        tracks.transition_phase(state_dir, "track-01", "done", actor="T0")
+        with pytest.raises(tracks.InvalidTransitionError):
+            tracks.transition_phase(state_dir, "track-01", "active", actor="operator")
+
+    def test_invalid_actor_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        with pytest.raises(ValueError, match="Invalid actor"):
+            tracks.transition_phase(state_dir, "track-01", "active", actor="robot")
+
+    def test_invalid_to_phase_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        with pytest.raises(tracks.InvalidPhaseError):
+            tracks.transition_phase(state_dir, "track-01", "flying", actor="operator")
+
+    def test_nonexistent_track_raises(self, state_dir):
+        with pytest.raises(tracks.TrackNotFoundError):
+            tracks.transition_phase(state_dir, "track-nope", "active", actor="operator")
+
+    def test_phase_history_recorded(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        tracks.transition_phase(state_dir, "track-01", "active", actor="operator", reason="go")
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = conn.execute(
+            "SELECT from_phase, to_phase, actor, reason FROM track_phase_history "
+            "WHERE track_id = 'track-01'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == "queued"
+        assert row[1] == "active"
+        assert row[2] == "operator"
+        assert row[3] == "go"
+
+    def test_noop_transition_returns_track(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        t = tracks.transition_phase(state_dir, "track-01", "queued", actor="operator")
+        assert t["phase"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# set_next_up
+# ---------------------------------------------------------------------------
+
+class TestSetNextUp:
+    def test_set_next_up(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        tracks.set_next_up(state_dir, "track-01")
+        t = tracks.get_track(state_dir, "track-01")
+        assert t["next_up"] == 1
+
+    def test_set_next_up_clears_previous(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="queued")
+        tracks.create_track(state_dir, "track-02", "T2", "G2", phase="queued")
+        tracks.set_next_up(state_dir, "track-01")
+        tracks.set_next_up(state_dir, "track-02")
+
+        t1 = tracks.get_track(state_dir, "track-01")
+        t2 = tracks.get_track(state_dir, "track-02")
+        assert t1["next_up"] == 0
+        assert t2["next_up"] == 1
+
+    def test_set_next_up_nonexistent_raises(self, state_dir):
+        with pytest.raises(tracks.TrackNotFoundError):
+            tracks.set_next_up(state_dir, "track-nope")
+
+
+# ---------------------------------------------------------------------------
+# link_open_item
+# ---------------------------------------------------------------------------
+
+class TestLinkOpenItem:
+    def test_link_open_item(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        tracks.link_open_item(state_dir, "track-01", "OI-1234", "blocks", "manual")
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = conn.execute(
+            "SELECT oi_id, link_type, link_source FROM track_open_items WHERE track_id = 'track-01'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == "OI-1234"
+        assert row[1] == "blocks"
+
+    def test_invalid_link_type_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        with pytest.raises(ValueError, match="link_type"):
+            tracks.link_open_item(state_dir, "track-01", "OI-1", "invalid", "manual")
+
+    def test_invalid_link_source_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        with pytest.raises(ValueError, match="link_source"):
+            tracks.link_open_item(state_dir, "track-01", "OI-1", "warns", "bad_source")
+
+    def test_nonexistent_track_raises(self, state_dir):
+        with pytest.raises(tracks.TrackNotFoundError):
+            tracks.link_open_item(state_dir, "track-nope", "OI-1", "warns", "manual")
+
+
+# ---------------------------------------------------------------------------
+# add_dependency
+# ---------------------------------------------------------------------------
+
+class TestAddDependency:
+    def test_add_dependency(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1", phase="active")
+        tracks.create_track(state_dir, "track-02", "T2", "G2", phase="queued")
+        tracks.add_dependency(state_dir, "track-02", "track-01", "hard", "manual")
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = conn.execute(
+            "SELECT kind, derivation_source FROM track_dependencies "
+            "WHERE from_track_id = 'track-02' AND to_track_id = 'track-01'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "hard"
+        assert row[1] == "manual"
+
+    def test_invalid_kind_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        tracks.create_track(state_dir, "track-02", "T2", "G2")
+        with pytest.raises(ValueError, match="kind"):
+            tracks.add_dependency(state_dir, "track-02", "track-01", "strict", "manual")
+
+    def test_invalid_derivation_source_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        tracks.create_track(state_dir, "track-02", "T2", "G2")
+        with pytest.raises(ValueError, match="derivation_source"):
+            tracks.add_dependency(state_dir, "track-02", "track-01", "hard", "unknown_source")
+
+    def test_nonexistent_track_raises(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        with pytest.raises(tracks.TrackNotFoundError):
+            tracks.add_dependency(state_dir, "track-nope", "track-01", "hard", "manual")

--- a/tests/test_tracks_lib.py
+++ b/tests/test_tracks_lib.py
@@ -258,6 +258,31 @@ class TestSetNextUp:
 
 
 # ---------------------------------------------------------------------------
+# get_recent_receipts
+# ---------------------------------------------------------------------------
+
+class TestGetRecentReceipts:
+    def test_get_recent_receipts_raises_on_corrupt_db(self, monkeypatch, tmp_path):
+        class BrokenConnection:
+            def __init__(self):
+                self.closed = False
+
+            def execute(self, *args, **kwargs):
+                raise sqlite3.OperationalError("database disk image is malformed")
+
+            def close(self):
+                self.closed = True
+
+        conn = BrokenConnection()
+        monkeypatch.setattr(tracks, "_get_conn", lambda state_dir: conn)
+
+        with pytest.raises(sqlite3.OperationalError, match="malformed"):
+            tracks.get_recent_receipts(tmp_path, "track-01")
+
+        assert conn.closed is True
+
+
+# ---------------------------------------------------------------------------
 # link_open_item
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tracks_lib.py
+++ b/tests/test_tracks_lib.py
@@ -288,6 +288,20 @@ class TestLinkOpenItem:
         with pytest.raises(tracks.TrackNotFoundError):
             tracks.link_open_item(state_dir, "track-nope", "OI-1", "warns", "manual")
 
+    def test_link_open_item_idempotent_no_duplicates(self, state_dir):
+        tracks.create_track(state_dir, "track-01", "T1", "G1")
+        tracks.link_open_item(state_dir, "track-01", "OI-1234", "blocks", "manual")
+        tracks.link_open_item(state_dir, "track-01", "OI-1234", "blocks", "manual")
+        tracks.link_open_item(state_dir, "track-01", "OI-1234", "blocks", "manual")
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM track_open_items "
+            "WHERE track_id='track-01' AND oi_id='OI-1234' AND link_type='blocks'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1
+
 
 # ---------------------------------------------------------------------------
 # add_dependency

--- a/tests/test_tracks_lib.py
+++ b/tests/test_tracks_lib.py
@@ -40,7 +40,8 @@ def _create_db(tmp_path: Path) -> Path:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS dispatches (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id     TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
             state           TEXT    NOT NULL DEFAULT 'queued',
             terminal_id     TEXT,
             track           TEXT,
@@ -52,7 +53,8 @@ def _create_db(tmp_path: Path) -> Path:
             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             expires_after   TEXT,
-            metadata_json   TEXT    DEFAULT '{}'
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""

--- a/tests/test_tracks_schema.py
+++ b/tests/test_tracks_schema.py
@@ -1,0 +1,302 @@
+"""tests/test_tracks_schema.py — migration 0022 schema validation.
+
+Verifies:
+- Migration runs cleanly on a fresh DB with existing dispatches
+- Four new tables created with correct structure
+- CHECK constraints reject invalid values
+- UNIQUE next_up index enforced
+- Dispatches table extended with operator_approved_at
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCHEMAS = Path(__file__).resolve().parent.parent / "schemas"
+_MIGRATIONS = _SCHEMAS / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration
+
+
+def _base_db(tmp_path: Path) -> sqlite3.Connection:
+    """Create a minimal coordination DB with the base dispatches table."""
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL UNIQUE,
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def _apply_migration_0022(conn: sqlite3.Connection) -> None:
+    sql = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 22, sql)
+    conn.commit()
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {r[0] for r in rows}
+
+
+def _index_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+    return {r[0] for r in rows}
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [r[1] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Migration correctness
+# ---------------------------------------------------------------------------
+
+class TestMigration0022:
+    def test_migration_applies_on_fresh_db(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        assert schema_migration.get_user_version(conn) == 22
+
+    def test_all_four_tables_created(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        tables = _table_names(conn)
+        assert "tracks" in tables
+        assert "track_phase_history" in tables
+        assert "track_dependencies" in tables
+        assert "track_open_items" in tables
+
+    def test_dispatches_extended_with_operator_approved_at(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        cols = _column_names(conn, "dispatches")
+        assert "operator_approved_at" in cols
+
+    def test_existing_dispatch_data_preserved(self, tmp_path):
+        conn = _base_db(tmp_path)
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, state) VALUES ('disp-001', 'queued')"
+        )
+        conn.commit()
+        _apply_migration_0022(conn)
+        row = conn.execute(
+            "SELECT dispatch_id, state FROM dispatches WHERE dispatch_id = 'disp-001'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "disp-001"
+        assert row[1] == "queued"
+
+    def test_migration_is_idempotent(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        _apply_migration_0022(conn)  # second call must be a no-op
+        assert schema_migration.get_user_version(conn) == 22
+
+    def test_required_indexes_created(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        indexes = _index_names(conn)
+        assert "idx_tracks_phase_nextup" in indexes
+        assert "ux_tracks_next_up" in indexes
+        assert "idx_dispatches_ready" in indexes
+        assert "idx_track_deps_from" in indexes
+        assert "idx_track_phase_history" in indexes
+
+
+# ---------------------------------------------------------------------------
+# Tracks table constraints
+# ---------------------------------------------------------------------------
+
+class TestTracksConstraints:
+    def _migrated_conn(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        return conn
+
+    def test_valid_phase_accepted(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        for phase in ("queued", "active", "parked", "done"):
+            conn.execute(
+                "INSERT INTO tracks (track_id, title, goal_state, phase) VALUES (?, 'T', 'G', ?)",
+                (f"track-{phase}", phase),
+            )
+        conn.commit()
+
+    def test_invalid_phase_rejected(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO tracks (track_id, title, goal_state, phase) "
+                "VALUES ('track-bad', 'T', 'G', 'invalid_phase')"
+            )
+            conn.commit()
+
+    def test_unique_next_up_enforced(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+            "VALUES ('track-01', 'T1', 'G1', 'queued', 1)"
+        )
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+                "VALUES ('track-02', 'T2', 'G2', 'queued', 1)"
+            )
+            conn.commit()
+
+    def test_unique_next_up_allows_non_queued_duplicate(self, tmp_path):
+        """next_up=1 on an active track does not conflict with queued next_up=1."""
+        conn = self._migrated_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+            "VALUES ('track-01', 'T1', 'G1', 'queued', 1)"
+        )
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+            "VALUES ('track-02', 'T2', 'G2', 'active', 1)"
+        )
+        conn.commit()
+
+    def test_unique_next_up_allows_zero(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+            "VALUES ('track-01', 'T1', 'G1', 'queued', 0)"
+        )
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase, next_up) "
+            "VALUES ('track-02', 'T2', 'G2', 'queued', 0)"
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Dispatches state constraint
+# ---------------------------------------------------------------------------
+
+class TestDispatchesStateConstraint:
+    def _migrated_conn(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        return conn
+
+    def test_valid_future_states_accepted(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        for state in ("proposed", "ready", "active", "completed", "failed"):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state) VALUES (?, ?)",
+                (f"disp-{state}", state),
+            )
+        conn.commit()
+
+    def test_legacy_states_accepted(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        for state in ("queued", "claimed", "running", "timed_out", "dead_letter"):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state) VALUES (?, ?)",
+                (f"disp-leg-{state}", state),
+            )
+        conn.commit()
+
+    def test_invalid_dispatch_state_rejected(self, tmp_path):
+        conn = self._migrated_conn(tmp_path)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state) VALUES ('disp-bad', 'bogus_state')"
+            )
+            conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# track_dependencies constraints
+# ---------------------------------------------------------------------------
+
+class TestTrackDependenciesConstraints:
+    def _migrated_conn_with_tracks(self, tmp_path):
+        conn = _base_db(tmp_path)
+        _apply_migration_0022(conn)
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase) "
+            "VALUES ('track-01', 'T1', 'G1', 'active')"
+        )
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase) "
+            "VALUES ('track-02', 'T2', 'G2', 'queued')"
+        )
+        conn.commit()
+        return conn
+
+    def test_valid_dependency_inserted(self, tmp_path):
+        conn = self._migrated_conn_with_tracks(tmp_path)
+        conn.execute(
+            "INSERT INTO track_dependencies "
+            "(from_track_id, to_track_id, kind, derivation_source) "
+            "VALUES ('track-02', 'track-01', 'hard', 'manual')"
+        )
+        conn.commit()
+
+    def test_invalid_kind_rejected(self, tmp_path):
+        conn = self._migrated_conn_with_tracks(tmp_path)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO track_dependencies "
+                "(from_track_id, to_track_id, kind, derivation_source) "
+                "VALUES ('track-02', 'track-01', 'invalid_kind', 'manual')"
+            )
+            conn.commit()
+
+    def test_invalid_derivation_source_rejected(self, tmp_path):
+        conn = self._migrated_conn_with_tracks(tmp_path)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO track_dependencies "
+                "(from_track_id, to_track_id, kind, derivation_source) "
+                "VALUES ('track-02', 'track-01', 'hard', 'invalid_source')"
+            )
+            conn.commit()

--- a/tests/test_tracks_schema.py
+++ b/tests/test_tracks_schema.py
@@ -391,12 +391,12 @@ class TestV21ProjectIdPreservation:
 
 
 # ---------------------------------------------------------------------------
-# sqlite_sequence preservation across 0022 and 0023 rebuilds
+# sqlite_sequence preservation across 0022 rebuild
 # ---------------------------------------------------------------------------
 
 class TestSqliteSequencePreservation:
-    """AUTOINCREMENT sequence must survive the RENAME→CREATE→INSERT→DROP rebuilds
-    in both 0022 and 0023 so IDs stay monotonically increasing."""
+    """AUTOINCREMENT sequence must survive the RENAME→CREATE→INSERT→DROP rebuild
+    in 0022 so IDs stay monotonically increasing."""
 
     def _base_db_with_rows(self, tmp_path: Path, n: int) -> sqlite3.Connection:
         """Build a pre-0022 DB with n dispatch rows."""
@@ -471,38 +471,3 @@ class TestSqliteSequencePreservation:
         )
         conn.close()
 
-    def test_sequence_preserved_after_0023(self, tmp_path):
-        """After both 0022 and 0023 rebuilds, the next auto-insert id still continues from N+1."""
-        n = 7
-
-        # Build pre-0022 DB
-        conn = self._base_db_with_rows(tmp_path, n)
-
-        # Apply 0022
-        sql_22 = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
-        schema_migration.apply_script_if_below(conn, 22, sql_22)
-        conn.commit()
-
-        # Seed a minimal tracks table so 0023 FK is satisfiable
-        conn.execute(
-            "INSERT INTO tracks (track_id, title, goal_state, phase) VALUES ('t-test', 'T', 'G', 'active')"
-        )
-        conn.commit()
-
-        # Apply 0023
-        sql_23 = (_MIGRATIONS / "0023_dispatches_fk.sql").read_text(encoding="utf-8")
-        schema_migration.apply_script_if_below(conn, 23, sql_23)
-        conn.commit()
-
-        # Delete all rows, insert new, verify id continues from N+1
-        conn.execute("DELETE FROM dispatches")
-        conn.commit()
-        conn.execute("INSERT INTO dispatches (dispatch_id, state) VALUES ('new-post-0023', 'queued')")
-        conn.commit()
-        row = conn.execute("SELECT id FROM dispatches WHERE dispatch_id = 'new-post-0023'").fetchone()
-        assert row is not None
-        assert row[0] > n, (
-            f"After 0023 rebuild, expected id > {n} but got {row[0]}. "
-            "sqlite_sequence was not preserved."
-        )
-        conn.close()

--- a/tests/test_tracks_schema.py
+++ b/tests/test_tracks_schema.py
@@ -388,3 +388,121 @@ class TestV21ProjectIdPreservation:
                 "VALUES ('d-x', 'vnx-dev', 'queued')"
             )
             conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# sqlite_sequence preservation across 0022 and 0023 rebuilds
+# ---------------------------------------------------------------------------
+
+class TestSqliteSequencePreservation:
+    """AUTOINCREMENT sequence must survive the RENAME→CREATE→INSERT→DROP rebuilds
+    in both 0022 and 0023 so IDs stay monotonically increasing."""
+
+    def _base_db_with_rows(self, tmp_path: Path, n: int) -> sqlite3.Connection:
+        """Build a pre-0022 DB with n dispatch rows."""
+        db_path = tmp_path / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dispatches (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id     TEXT    NOT NULL,
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state           TEXT    NOT NULL DEFAULT 'queued',
+                terminal_id     TEXT,
+                track           TEXT,
+                priority        TEXT    DEFAULT 'P2',
+                pr_ref          TEXT,
+                gate            TEXT,
+                attempt_count   INTEGER NOT NULL DEFAULT 0,
+                bundle_path     TEXT,
+                created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                expires_after   TEXT,
+                metadata_json   TEXT    DEFAULT '{}',
+                UNIQUE(dispatch_id, project_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS coordination_events (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id    TEXT,
+                event_type  TEXT,
+                entity_type TEXT,
+                entity_id   TEXT,
+                from_state  TEXT,
+                to_state    TEXT,
+                actor       TEXT,
+                reason       TEXT,
+                metadata_json TEXT,
+                occurred_at TEXT,
+                project_id  TEXT
+            )
+        """)
+        for i in range(n):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, state) VALUES (?, 'queued')",
+                (f"disp-{i:03d}",),
+            )
+        conn.commit()
+        return conn
+
+    def test_sequence_preserved_after_0022(self, tmp_path):
+        """After 0022 rebuild, the next auto-insert gets id > N (not reset to 1)."""
+        n = 5
+        conn = self._base_db_with_rows(tmp_path, n)
+        sql = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, 22, sql)
+        conn.commit()
+
+        # Delete all rows to force reliance on sqlite_sequence for next id
+        conn.execute("DELETE FROM dispatches")
+        conn.commit()
+
+        # Insert a new row and check the id is > n
+        conn.execute("INSERT INTO dispatches (dispatch_id, state) VALUES ('new-post-0022', 'queued')")
+        conn.commit()
+        row = conn.execute("SELECT id FROM dispatches WHERE dispatch_id = 'new-post-0022'").fetchone()
+        assert row is not None
+        assert row[0] > n, (
+            f"After 0022 rebuild, expected id > {n} but got {row[0]}. "
+            "sqlite_sequence was not preserved."
+        )
+        conn.close()
+
+    def test_sequence_preserved_after_0023(self, tmp_path):
+        """After both 0022 and 0023 rebuilds, the next auto-insert id still continues from N+1."""
+        n = 7
+
+        # Build pre-0022 DB
+        conn = self._base_db_with_rows(tmp_path, n)
+
+        # Apply 0022
+        sql_22 = (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, 22, sql_22)
+        conn.commit()
+
+        # Seed a minimal tracks table so 0023 FK is satisfiable
+        conn.execute(
+            "INSERT INTO tracks (track_id, title, goal_state, phase) VALUES ('t-test', 'T', 'G', 'active')"
+        )
+        conn.commit()
+
+        # Apply 0023
+        sql_23 = (_MIGRATIONS / "0023_dispatches_fk.sql").read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, 23, sql_23)
+        conn.commit()
+
+        # Delete all rows, insert new, verify id continues from N+1
+        conn.execute("DELETE FROM dispatches")
+        conn.commit()
+        conn.execute("INSERT INTO dispatches (dispatch_id, state) VALUES ('new-post-0023', 'queued')")
+        conn.commit()
+        row = conn.execute("SELECT id FROM dispatches WHERE dispatch_id = 'new-post-0023'").fetchone()
+        assert row is not None
+        assert row[0] > n, (
+            f"After 0023 rebuild, expected id > {n} but got {row[0]}. "
+            "sqlite_sequence was not preserved."
+        )
+        conn.close()

--- a/tests/test_tracks_schema.py
+++ b/tests/test_tracks_schema.py
@@ -35,7 +35,8 @@ def _base_db(tmp_path: Path) -> sqlite3.Connection:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS dispatches (
             id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            dispatch_id     TEXT    NOT NULL UNIQUE,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
             state           TEXT    NOT NULL DEFAULT 'queued',
             terminal_id     TEXT,
             track           TEXT,
@@ -47,7 +48,8 @@ def _base_db(tmp_path: Path) -> sqlite3.Connection:
             created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             expires_after   TEXT,
-            metadata_json   TEXT    DEFAULT '{}'
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
         )
     """)
     conn.execute("""
@@ -298,5 +300,91 @@ class TestTrackDependenciesConstraints:
                 "INSERT INTO track_dependencies "
                 "(from_track_id, to_track_id, kind, derivation_source) "
                 "VALUES ('track-02', 'track-01', 'hard', 'invalid_source')"
+            )
+            conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# v21 project_id + composite UNIQUE survival across migration 0022
+# ---------------------------------------------------------------------------
+
+class TestV21ProjectIdPreservation:
+    """Migration 0022 on a v21 DB (with project_id + composite UNIQUE) must
+    preserve project_id and enforce the composite UNIQUE post-migration."""
+
+    def _v21_db(self, tmp_path: Path) -> sqlite3.Connection:
+        """Build a v21-style DB with project_id and composite UNIQUE."""
+        db_path = tmp_path / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dispatches (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id     TEXT    NOT NULL,
+                project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+                state           TEXT    NOT NULL DEFAULT 'queued',
+                terminal_id     TEXT,
+                track           TEXT,
+                priority        TEXT    DEFAULT 'P2',
+                pr_ref          TEXT,
+                gate            TEXT,
+                attempt_count   INTEGER NOT NULL DEFAULT 0,
+                bundle_path     TEXT,
+                created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                expires_after   TEXT,
+                metadata_json   TEXT    DEFAULT '{}',
+                UNIQUE(dispatch_id, project_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS coordination_events (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id    TEXT,
+                event_type  TEXT,
+                entity_type TEXT,
+                entity_id   TEXT,
+                from_state  TEXT,
+                to_state    TEXT,
+                actor       TEXT,
+                reason      TEXT,
+                metadata_json TEXT,
+                occurred_at TEXT,
+                project_id  TEXT
+            )
+        """)
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES ('d-x', 'vnx-dev', 'queued')"
+        )
+        conn.commit()
+        return conn
+
+    def test_migration_does_not_crash_on_v21(self, tmp_path):
+        conn = self._v21_db(tmp_path)
+        _apply_migration_0022(conn)
+
+    def test_project_id_column_present_after_migration(self, tmp_path):
+        conn = self._v21_db(tmp_path)
+        _apply_migration_0022(conn)
+        cols = _column_names(conn, "dispatches")
+        assert "project_id" in cols
+
+    def test_existing_row_project_id_preserved(self, tmp_path):
+        conn = self._v21_db(tmp_path)
+        _apply_migration_0022(conn)
+        row = conn.execute(
+            "SELECT project_id FROM dispatches WHERE dispatch_id = 'd-x'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "vnx-dev"
+
+    def test_composite_unique_enforced_after_migration(self, tmp_path):
+        conn = self._v21_db(tmp_path)
+        _apply_migration_0022(conn)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, project_id, state) "
+                "VALUES ('d-x', 'vnx-dev', 'queued')"
             )
             conn.commit()

--- a/vnx_cli/commands/track.py
+++ b/vnx_cli/commands/track.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""vnx track — manage feature-tracks in the VNX orchestration system."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_state_dir(project_dir: str | Path) -> Path:
+    return Path(project_dir).resolve() / ".vnx-data" / "state"
+
+
+def _require_tracks_lib(state_dir: Path) -> Any:
+    scripts_lib = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+    if str(scripts_lib) not in sys.path:
+        sys.path.insert(0, str(scripts_lib))
+    import tracks as tracks_lib
+    return tracks_lib
+
+
+def _format_table(rows: list[dict[str, Any]]) -> str:
+    """Format tracks list as aligned table: phase | next | id | title | pr | depends_on."""
+    if not rows:
+        return "  (no tracks)"
+
+    lines = [f"  {'PHASE':<8} {'NEXT':<5} {'ID':<10} {'TITLE':<40} {'PR':<15} DEPENDS_ON"]
+    lines.append("  " + "-" * 90)
+
+    for r in rows:
+        phase = r.get("phase", "")
+        next_flag = "*" if r.get("next_up") else " "
+        tid = r.get("track_id", "")
+        title = (r.get("title") or "")[:38]
+        pr = (r.get("pr_ref") or "")[:14]
+        lines.append(f"  {phase:<8} {next_flag:<5} {tid:<10} {title:<40} {pr:<15}")
+
+    return "\n".join(lines)
+
+
+def _cmd_new(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    try:
+        track = tracks_lib.create_track(
+            state_dir,
+            args.track_id,
+            title=args.title,
+            goal_state=args.goal,
+            priority=getattr(args, "priority", None),
+        )
+        print(f"  Created track {track['track_id']}: {track['title']}")
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_activate(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    reason = getattr(args, "reason", None)
+    try:
+        track = tracks_lib.transition_phase(
+            state_dir, args.track_id,
+            to_phase="active",
+            actor="operator",
+            reason=reason,
+        )
+        print(f"  Activated {track['track_id']} (phase: {track['phase']})")
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_park(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    reason = getattr(args, "reason", None)
+    try:
+        track = tracks_lib.transition_phase(
+            state_dir, args.track_id,
+            to_phase="parked",
+            actor="operator",
+            reason=reason,
+        )
+        print(f"  Parked {track['track_id']} (phase: {track['phase']})")
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_unpark(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    reason = getattr(args, "reason", None)
+    try:
+        track = tracks_lib.transition_phase(
+            state_dir, args.track_id,
+            to_phase="queued",
+            actor="operator",
+            reason=reason,
+        )
+        print(f"  Unparked {track['track_id']} (phase: {track['phase']})")
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_dispatch(args) -> int:
+    """Create a dispatch row for a track (state=proposed)."""
+    import sqlite3
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    track = tracks_lib.get_track(state_dir, args.track_id)
+    if not track:
+        print(f"  Error: track not found: {args.track_id!r}", file=sys.stderr)
+        return 1
+
+    import uuid
+    from datetime import datetime, timezone
+
+    dispatch_id = f"{args.track_id}-{args.pr}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    db_path = state_dir / "runtime_coordination.db"
+
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute(
+            """
+            INSERT INTO dispatches (dispatch_id, state, terminal_id, track, pr_ref)
+            VALUES (?, 'proposed', ?, ?, ?)
+            """,
+            (dispatch_id, args.terminal, args.track_id, args.pr),
+        )
+        conn.commit()
+        print(f"  Created dispatch {dispatch_id}")
+        print(f"  State: proposed (awaiting operator_approved_at)")
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+def _cmd_list(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    phase = getattr(args, "phase", None)
+    project_id = getattr(args, "project_id", "vnx-dev") or "vnx-dev"
+
+    try:
+        rows = tracks_lib.list_tracks(state_dir, phase=phase, project_id=project_id)
+        print(_format_table(rows))
+        return 0
+    except Exception as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_show(args) -> int:
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    track = tracks_lib.get_track(state_dir, args.track_id)
+    if not track:
+        print(f"  Error: track not found: {args.track_id!r}", file=sys.stderr)
+        return 1
+
+    print(f"  Track: {track['track_id']}")
+    print(f"  Title: {track['title']}")
+    print(f"  Goal:  {track['goal_state']}")
+    print(f"  Phase: {track['phase']}")
+    print(f"  Next:  {'yes' if track.get('next_up') else 'no'}")
+    print(f"  PR:    {track.get('pr_ref') or '-'}")
+    print(f"  Priority: {track.get('priority') or '-'}")
+
+    dispatches = tracks_lib.get_linked_dispatches(state_dir, args.track_id)
+    print(f"\n  Dispatches ({len(dispatches)}):")
+    for d in dispatches:
+        print(f"    {d.get('dispatch_id', ''):<40} state={d.get('state', '')}")
+
+    ois = tracks_lib.get_linked_open_items(state_dir, args.track_id)
+    print(f"\n  Open Items ({len(ois)}):")
+    for oi in ois:
+        print(f"    {oi.get('oi_id', ''):<20} [{oi.get('link_type', '')}]")
+
+    receipts = tracks_lib.get_recent_receipts(state_dir, args.track_id, limit=5)
+    print(f"\n  Recent Receipts ({len(receipts)}):")
+    for r in receipts:
+        print(f"    {r.get('event_type', ''):<25} {r.get('occurred_at', '')}")
+
+    return 0
+
+
+def vnx_track(args) -> int:
+    sub = getattr(args, "track_subcommand", None)
+    if sub == "new":
+        return _cmd_new(args)
+    elif sub == "activate":
+        return _cmd_activate(args)
+    elif sub == "park":
+        return _cmd_park(args)
+    elif sub == "unpark":
+        return _cmd_unpark(args)
+    elif sub == "dispatch":
+        return _cmd_dispatch(args)
+    elif sub == "list":
+        return _cmd_list(args)
+    elif sub == "show":
+        return _cmd_show(args)
+    else:
+        print("  vnx track: missing subcommand. See `vnx track --help`")
+        return 1

--- a/vnx_cli/commands/track.py
+++ b/vnx_cli/commands/track.py
@@ -115,9 +115,18 @@ def _cmd_unpark(args) -> int:
         return 1
 
 
+def _require_dispatch_register():
+    scripts_lib = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+    if str(scripts_lib) not in sys.path:
+        sys.path.insert(0, str(scripts_lib))
+    import dispatch_register
+    return dispatch_register
+
+
 def _cmd_dispatch(args) -> int:
     """Create a dispatch row for a track (state=proposed)."""
-    import sqlite3
+    from datetime import datetime, timezone
+
     state_dir = _resolve_state_dir(args.project_dir)
     tracks_lib = _require_tracks_lib(state_dir)
 
@@ -126,32 +135,21 @@ def _cmd_dispatch(args) -> int:
         print(f"  Error: track not found: {args.track_id!r}", file=sys.stderr)
         return 1
 
-    import uuid
-    from datetime import datetime, timezone
-
-    dispatch_id = f"{args.track_id}-{args.pr}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
-    db_path = state_dir / "runtime_coordination.db"
-
-    conn = sqlite3.connect(str(db_path), timeout=10.0)
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA foreign_keys = ON")
+    dispatch_id = (
+        f"{args.track_id}-{args.pr}"
+        f"-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    )
+    register = _require_dispatch_register()
     try:
-        conn.execute(
-            """
-            INSERT INTO dispatches (dispatch_id, state, terminal_id, track, pr_ref)
-            VALUES (?, 'proposed', ?, ?, ?)
-            """,
-            (dispatch_id, args.terminal, args.track_id, args.pr),
+        register.register_proposed_track_dispatch(
+            state_dir, dispatch_id, args.terminal, args.track_id, args.pr
         )
-        conn.commit()
         print(f"  Created dispatch {dispatch_id}")
         print(f"  State: proposed (awaiting operator_approved_at)")
         return 0
     except Exception as exc:
         print(f"  Error: {exc}", file=sys.stderr)
         return 1
-    finally:
-        conn.close()
 
 
 def _cmd_list(args) -> int:

--- a/vnx_cli/commands/track.py
+++ b/vnx_cli/commands/track.py
@@ -142,7 +142,8 @@ def _cmd_dispatch(args) -> int:
     register = _require_dispatch_register()
     try:
         register.register_proposed_track_dispatch(
-            state_dir, dispatch_id, args.terminal, args.track_id, args.pr
+            state_dir, dispatch_id, args.terminal, args.track_id, args.pr,
+            project_id=track.get("project_id") or "vnx-dev",
         )
         print(f"  Created dispatch {dispatch_id}")
         print(f"  State: proposed (awaiting operator_approved_at)")

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -129,6 +129,57 @@ def main() -> None:
         help="project directory to check for .vnx-version pin (default: current directory)",
     )
 
+    # track subcommand
+    track_parser = subparsers.add_parser(
+        "track",
+        help="manage feature-tracks (new/activate/park/unpark/dispatch/list/show)",
+    )
+    track_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory (default: current directory)",
+    )
+    track_subs = track_parser.add_subparsers(dest="track_subcommand", metavar="SUBCOMMAND")
+
+    tn_parser = track_subs.add_parser("new", help="create a new track")
+    tn_parser.add_argument("track_id", metavar="TRACK_ID")
+    tn_parser.add_argument("--title", required=True, metavar="TITLE")
+    tn_parser.add_argument("--goal", required=True, metavar="GOAL")
+    tn_parser.add_argument("--priority", choices=["high", "medium", "low"], metavar="PRIORITY")
+    tn_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    ta_parser = track_subs.add_parser("activate", help="activate a queued track")
+    ta_parser.add_argument("track_id", metavar="TRACK_ID")
+    ta_parser.add_argument("--reason", metavar="REASON")
+    ta_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tp_parser = track_subs.add_parser("park", help="park an active track")
+    tp_parser.add_argument("track_id", metavar="TRACK_ID")
+    tp_parser.add_argument("--reason", required=True, metavar="REASON")
+    tp_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tu_parser = track_subs.add_parser("unpark", help="unpark a parked track to queued")
+    tu_parser.add_argument("track_id", metavar="TRACK_ID")
+    tu_parser.add_argument("--reason", metavar="REASON")
+    tu_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    td_parser = track_subs.add_parser("dispatch", help="create a dispatch for a track")
+    td_parser.add_argument("track_id", metavar="TRACK_ID")
+    td_parser.add_argument("--pr", required=True, metavar="PR-ID")
+    td_parser.add_argument("--terminal", required=True, choices=["T1", "T2", "T3"], metavar="TERMINAL")
+    td_parser.add_argument("--instruction-file", metavar="PATH")
+    td_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tl_parser = track_subs.add_parser("list", help="list tracks")
+    tl_parser.add_argument("--phase", choices=["queued", "active", "parked", "done"], metavar="PHASE")
+    tl_parser.add_argument("--project-id", default="vnx-dev", metavar="PROJECT_ID")
+    tl_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    ts_parser = track_subs.add_parser("show", help="show track detail")
+    ts_parser.add_argument("track_id", metavar="TRACK_ID")
+    ts_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
     # update subcommand
     update_parser = subparsers.add_parser(
         "update",
@@ -187,6 +238,10 @@ def main() -> None:
     elif args.command == "update":
         from vnx_cli.commands.update import vnx_update
         sys.exit(vnx_update(args))
+
+    elif args.command == "track":
+        from vnx_cli.commands.track import vnx_track
+        sys.exit(vnx_track(args))
 
     else:
         parser.print_help()

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -7,6 +7,58 @@ import sys
 from vnx_cli import __version__
 
 
+def _register_track_subparser(subparsers: argparse.Action) -> None:
+    track_parser = subparsers.add_parser(
+        "track",
+        help="manage feature-tracks (new/activate/park/unpark/dispatch/list/show)",
+    )
+    track_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory (default: current directory)",
+    )
+    track_subs = track_parser.add_subparsers(dest="track_subcommand", metavar="SUBCOMMAND")
+
+    tn_parser = track_subs.add_parser("new", help="create a new track")
+    tn_parser.add_argument("track_id", metavar="TRACK_ID")
+    tn_parser.add_argument("--title", required=True, metavar="TITLE")
+    tn_parser.add_argument("--goal", required=True, metavar="GOAL")
+    tn_parser.add_argument("--priority", choices=["high", "medium", "low"], metavar="PRIORITY")
+    tn_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    ta_parser = track_subs.add_parser("activate", help="activate a queued track")
+    ta_parser.add_argument("track_id", metavar="TRACK_ID")
+    ta_parser.add_argument("--reason", metavar="REASON")
+    ta_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tp_parser = track_subs.add_parser("park", help="park an active track")
+    tp_parser.add_argument("track_id", metavar="TRACK_ID")
+    tp_parser.add_argument("--reason", required=True, metavar="REASON")
+    tp_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tu_parser = track_subs.add_parser("unpark", help="unpark a parked track to queued")
+    tu_parser.add_argument("track_id", metavar="TRACK_ID")
+    tu_parser.add_argument("--reason", metavar="REASON")
+    tu_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    td_parser = track_subs.add_parser("dispatch", help="create a dispatch for a track")
+    td_parser.add_argument("track_id", metavar="TRACK_ID")
+    td_parser.add_argument("--pr", required=True, metavar="PR-ID")
+    td_parser.add_argument("--terminal", required=True, choices=["T1", "T2", "T3"], metavar="TERMINAL")
+    td_parser.add_argument("--instruction-file", metavar="PATH")
+    td_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tl_parser = track_subs.add_parser("list", help="list tracks")
+    tl_parser.add_argument("--phase", choices=["queued", "active", "parked", "done"], metavar="PHASE")
+    tl_parser.add_argument("--project-id", default="vnx-dev", metavar="PROJECT_ID")
+    tl_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    ts_parser = track_subs.add_parser("show", help="show track detail")
+    ts_parser.add_argument("track_id", metavar="TRACK_ID")
+    ts_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="vnx",
@@ -130,55 +182,7 @@ def main() -> None:
     )
 
     # track subcommand
-    track_parser = subparsers.add_parser(
-        "track",
-        help="manage feature-tracks (new/activate/park/unpark/dispatch/list/show)",
-    )
-    track_parser.add_argument(
-        "--project-dir",
-        default=".",
-        metavar="DIR",
-        help="project directory (default: current directory)",
-    )
-    track_subs = track_parser.add_subparsers(dest="track_subcommand", metavar="SUBCOMMAND")
-
-    tn_parser = track_subs.add_parser("new", help="create a new track")
-    tn_parser.add_argument("track_id", metavar="TRACK_ID")
-    tn_parser.add_argument("--title", required=True, metavar="TITLE")
-    tn_parser.add_argument("--goal", required=True, metavar="GOAL")
-    tn_parser.add_argument("--priority", choices=["high", "medium", "low"], metavar="PRIORITY")
-    tn_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    ta_parser = track_subs.add_parser("activate", help="activate a queued track")
-    ta_parser.add_argument("track_id", metavar="TRACK_ID")
-    ta_parser.add_argument("--reason", metavar="REASON")
-    ta_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    tp_parser = track_subs.add_parser("park", help="park an active track")
-    tp_parser.add_argument("track_id", metavar="TRACK_ID")
-    tp_parser.add_argument("--reason", required=True, metavar="REASON")
-    tp_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    tu_parser = track_subs.add_parser("unpark", help="unpark a parked track to queued")
-    tu_parser.add_argument("track_id", metavar="TRACK_ID")
-    tu_parser.add_argument("--reason", metavar="REASON")
-    tu_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    td_parser = track_subs.add_parser("dispatch", help="create a dispatch for a track")
-    td_parser.add_argument("track_id", metavar="TRACK_ID")
-    td_parser.add_argument("--pr", required=True, metavar="PR-ID")
-    td_parser.add_argument("--terminal", required=True, choices=["T1", "T2", "T3"], metavar="TERMINAL")
-    td_parser.add_argument("--instruction-file", metavar="PATH")
-    td_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    tl_parser = track_subs.add_parser("list", help="list tracks")
-    tl_parser.add_argument("--phase", choices=["queued", "active", "parked", "done"], metavar="PHASE")
-    tl_parser.add_argument("--project-id", default="vnx-dev", metavar="PROJECT_ID")
-    tl_parser.add_argument("--project-dir", default=".", metavar="DIR")
-
-    ts_parser = track_subs.add_parser("show", help="show track detail")
-    ts_parser.add_argument("track_id", metavar="TRACK_ID")
-    ts_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    _register_track_subparser(subparsers)
 
     # update subcommand
     update_parser = subparsers.add_parser(


### PR DESCRIPTION
## Scope

v22 schema + DAL + CLI + audit-ordering. Seeding and composite-FK moved to FUT-2 per ADR-007.

**Included:**
- `schemas/migrations/0022_track_layer.sql` — 4 new tables (`tracks`, `track_open_items`, `track_dependencies`, `track_events`) with `project_id` + composite UNIQUE constraints; `dispatches` rebuilt with `operator_approved_at` column, NO track FK (deferred)
- `scripts/lib/tracks.py` — DAL with ADR-005 audit ordering (NDJSON before SQLite commit)
- `vnx_cli/commands/track.py` — `vnx track` subcommands (new/list/show/transition/next-up)
- `scripts/migrate_future_system.py` — schema-validate + apply 0022 only; seeding removed
- PRAGMA pre-flight with bidirectional column + UNIQUE(dispatch_id, project_id) check

**Deferred to FUT-2:**
- tracks tenant-scoping per ADR-007 (composite PK over project_id)
- Seeding logic from roadmap (seed_tracks, tag_dispatches, set_initial_next_up)
- Composite-FK from dispatches.track to tracks(track_id, project_id)
- Integration tests for multi-project scenarios
- Project-aware CLI (`vnx track new --project-id`)

## Round history

6 codex_gate rounds, 4 fix-forward dispatches, 1 architect-reflection, 2 peer-reviews (Codex + Kimi), 1 external Codex GPT-5 Pro out-of-band review — all on this branch. Root cause for scope-shrink: seeding code used global `tracks.track_id` as FK, violating ADR-007 (composite UNIQUE/PK over project_id mandatory for central state DBs).

## References

- [ADR-007 Multi-tenant project_id Stamping](docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md)
- [Architect Reflection](claudedocs/FUT-1-ARCHITECT-REFLECTION-2026-05-28.md)
- [Codex Peer Review](claudedocs/FUT-1-ARCHITECT-CODEX-PEER-REVIEW-2026-05-28.md)
- [Kimi Peer Review](claudedocs/FUT-1-ARCHITECT-KIMI-PEER-REVIEW-2026-05-28.md)

**Note:** FUT-2 issue to be opened post-merge.