### PR TITLE
fix(trace): dual-scheme pr_id+pr_number + backfill — cat-C gap 73% → 0% (PR-B-TRACE)

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-28T20:58:00.607636+00:00
+**Last updated**: 2026-05-28T21:13:49.276597+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._

--- a/scripts/backfill_pr_merged_receipts.py
+++ b/scripts/backfill_pr_merged_receipts.py
@@ -19,7 +19,10 @@ BILLING SAFETY: No Anthropic SDK. No direct API calls.
 from __future__ import annotations
 
 import argparse
+import datetime
+import fcntl
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -36,33 +39,113 @@ from governance_receipts import emit_governance_receipt
 EXIT_OK = 0
 EXIT_ERROR = 1
 
+_PR_LABEL_RE = re.compile(r"\bPR-([A-Z0-9]+(?:-[A-Z0-9]+)*)\b", re.IGNORECASE)
+
+
+def _extract_pr_id_from_subject(subject: str) -> Optional[str]:
+    """Extract internal PR-N label from commit subject or PR title."""
+    m = _PR_LABEL_RE.search(subject)
+    return f"PR-{m.group(1).upper()}" if m else None
+
+
+def _lookup_dispatch_id_for_pr(
+    pr_number: int,
+    branch: str,
+    register_events: List[Dict[str, Any]],
+) -> str:
+    """Find dispatch_id from dispatch_register events by pr_number or branch-slug match.
+
+    Priority: pr_number exact match > branch-slug heuristic > '' (not found).
+    """
+    # 1. Exact pr_number match
+    for ev in reversed(register_events):
+        if ev.get("pr_number") == pr_number and ev.get("dispatch_id"):
+            return str(ev["dispatch_id"])
+
+    # 2. Branch-slug heuristic: tokenise branch and match against dispatch_id strings
+    if branch:
+        branch_raw = branch.lower().replace("/", "-").replace("_", "-")
+        tokens = [t for t in re.split(r"[-]+", branch_raw) if len(t) >= 4]
+        if tokens:
+            for ev in reversed(register_events):
+                did = str(ev.get("dispatch_id") or "")
+                if not did:
+                    continue
+                did_lower = did.lower()
+                matches = sum(1 for tok in tokens if tok in did_lower)
+                if matches >= max(1, len(tokens) // 2):
+                    return did
+
+    return ""
+
 
 def _resolve_receipts_path() -> Path:
     paths = ensure_env()
     return Path(paths["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
 
 
-def _load_receipted_pr_numbers(receipts_path: Path) -> Set[int]:
-    """Return set of pr_number values already in t0_receipts.ndjson with event_type=pr_merged."""
-    if not receipts_path.exists():
-        return set()
-    result: Set[int] = set()
-    for line in receipts_path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
+def _resolve_events_pr_merged_path() -> Path:
+    """Return path for ADR-005 events ledger: .vnx-data/events/pr_merged.ndjson."""
+    paths = ensure_env()
+    events_dir = Path(paths["VNX_STATE_DIR"]).parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    return events_dir / "pr_merged.ndjson"
+
+
+def _append_locked(path: Path, record: Dict[str, Any]) -> None:
+    """Append a JSON record to an NDJSON file under an exclusive lock."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
         try:
-            rec = json.loads(line)
-        except json.JSONDecodeError:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _load_receipted_pr_numbers(
+    receipts_path: Path,
+    events_path: Optional[Path] = None,
+) -> Set[int]:
+    """Return set of pr_number values already receipted as pr_merged.
+
+    Scans both t0_receipts.ndjson and events/pr_merged.ndjson (ADR-005 ledger)
+    so idempotency works regardless of which path prior runs wrote to.
+
+    events_path: explicit override. When None, derived as receipts_path/../events/pr_merged.ndjson
+    (no env-var lookup, so test isolation is preserved).
+    """
+    result: Set[int] = set()
+    paths_to_scan: List[Path] = [receipts_path]
+
+    # Derive events path from receipts_path structure (state/ → events/pr_merged.ndjson)
+    if events_path is None:
+        candidate = receipts_path.parent.parent / "events" / "pr_merged.ndjson"
+        if candidate.resolve() != receipts_path.resolve():
+            events_path = candidate
+
+    if events_path is not None and events_path not in paths_to_scan:
+        paths_to_scan.append(events_path)
+
+    for path in paths_to_scan:
+        if not path.exists():
             continue
-        event = rec.get("event_type") or rec.get("event") or ""
-        if event == "pr_merged":
-            pn = rec.get("pr_number")
-            if pn is not None:
-                try:
-                    result.add(int(pn))
-                except (TypeError, ValueError):
-                    pass
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event = rec.get("event_type") or rec.get("event") or ""
+            if event == "pr_merged":
+                pn = rec.get("pr_number")
+                if pn is not None:
+                    try:
+                        result.add(int(pn))
+                    except (TypeError, ValueError):
+                        pass
     return result
 
 
@@ -72,11 +155,9 @@ def _gh_list_merged_prs(limit: int, since: Optional[str] = None) -> List[Dict[st
         "gh", "pr", "list",
         "--state", "merged",
         "--limit", str(max(limit, 1)),
-        "--json", "number,title,headRefName,mergedAt,baseRefName",
+        "--json", "number,title,headRefName,mergedAt,baseRefName,mergeCommit",
     ]
-    if since:
-        # gh does not support --search date filtering directly, handled post-fetch
-        pass
+    # gh does not support --search date filtering directly, handled post-fetch
     try:
         result = subprocess.run(
             args, capture_output=True, text=True, timeout=60, check=False,
@@ -90,30 +171,59 @@ def _gh_list_merged_prs(limit: int, since: Optional[str] = None) -> List[Dict[st
         return []
 
 
+def _load_dispatch_register_events() -> List[Dict[str, Any]]:
+    """Load dispatch_register.ndjson events. Best-effort — returns [] on failure."""
+    try:
+        from dispatch_register import read_events
+        return read_events()
+    except Exception:
+        return []
+
+
 def _emit_backfill_receipt(
     pr: Dict[str, Any],
     *,
-    receipts_file: Optional[str] = None,
+    pr_id: str = "",
+    dispatch_id: str = "",
+    events_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Emit a pr_merged receipt for a single PR (backfill mode)."""
+    """Emit a pr_merged receipt for a single PR to events/pr_merged.ndjson (ADR-005).
+
+    Dual-scheme: pr_number (GitHub numeric) + pr_id (internal PR-N/PR-LABEL).
+    pr_id_resolution='unmatched' when no internal label could be derived.
+    Uses the merge commit timestamp for accurate historical placement.
+    """
     pr_number = int(pr["number"])
-    kwargs: Dict[str, Any] = {
+    merged_at = pr.get("mergedAt", "")
+
+    # Use merge commit timestamp if available for accurate historical placement
+    merge_commit = pr.get("mergeCommit") or {}
+    commit_ts = str(merge_commit.get("committedDate") or merge_commit.get("authoredDate") or merged_at)
+
+    receipt: Dict[str, Any] = {
+        "timestamp": commit_ts or merged_at or datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "event_type": "pr_merged",
+        "status": "success",
+        "terminal": "T0",
+        "source": "backfill_pr_merged_receipts",
         "pr_number": pr_number,
         "conclusion": "merged",
         "merge_method": "unknown",
         "pr_title": pr.get("title", ""),
         "branch": pr.get("headRefName", ""),
-        "merged_at": pr.get("mergedAt", ""),
+        "merged_at": merged_at,
         "backfilled": True,
     }
-    return emit_governance_receipt(
-        "pr_merged",
-        status="success",
-        terminal="T0",
-        source="backfill_pr_merged_receipts",
-        receipts_file=receipts_file,
-        **kwargs,
-    )
+    if pr_id:
+        receipt["pr_id"] = pr_id
+    else:
+        receipt["pr_id_resolution"] = "unmatched"
+    if dispatch_id:
+        receipt["dispatch_id"] = dispatch_id
+
+    target_path = events_path if events_path is not None else _resolve_events_pr_merged_path()
+    _append_locked(target_path, receipt)
+    return receipt
 
 
 def _emit_register_event(pr_number: int) -> bool:
@@ -136,10 +246,18 @@ def backfill(
     since: Optional[str] = None,
     dry_run: bool = False,
     receipts_file: Optional[str] = None,
+    events_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Run the backfill and return a summary dict."""
+    """Run the backfill and return a summary dict.
+
+    Writes new pr_merged receipts to events/pr_merged.ndjson (ADR-005 ledger).
+    The receipts_file parameter is kept for backwards compatibility but is only
+    used to seed the already-receipted set (idempotency check).
+    events_path overrides the default events/pr_merged.ndjson destination.
+    """
     receipts_path = Path(receipts_file) if receipts_file else _resolve_receipts_path()
-    already_receipted = _load_receipted_pr_numbers(receipts_path)
+    resolved_events_path = events_path if events_path is not None else _resolve_events_pr_merged_path()
+    already_receipted = _load_receipted_pr_numbers(receipts_path, events_path=resolved_events_path)
 
     merged_prs = _gh_list_merged_prs(limit=limit, since=since)
 
@@ -156,6 +274,9 @@ def backfill(
         pr for pr in merged_prs
         if pr.get("number") is not None and int(pr["number"]) not in already_receipted
     ]
+
+    # Load dispatch_register events once for dispatch_id lookup
+    register_events = _load_dispatch_register_events()
 
     summary: Dict[str, Any] = {
         "total_merged_prs": len(merged_prs),
@@ -175,13 +296,24 @@ def backfill(
             "merged_at": pr.get("mergedAt", ""),
         }
 
+        # Derive dual-scheme fields
+        subject = pr.get("title", "") or pr.get("headRefName", "")
+        pr_id = _extract_pr_id_from_subject(subject)
+        dispatch_id = _lookup_dispatch_id_for_pr(pr_number, pr.get("headRefName", ""), register_events)
+        detail["pr_id"] = pr_id or ""
+        detail["dispatch_id"] = dispatch_id
+
         if dry_run:
             detail["action"] = "would_backfill"
         else:
             try:
-                receipt = _emit_backfill_receipt(pr, receipts_file=str(receipts_path))
+                receipt = _emit_backfill_receipt(
+                    pr,
+                    pr_id=pr_id or "",
+                    dispatch_id=dispatch_id,
+                    events_path=events_path,
+                )
                 detail["action"] = "backfilled"
-                detail["receipt_status"] = receipt.get("append_status", "unknown")
                 detail["register_ok"] = _emit_register_event(pr_number)
                 summary["backfilled"] += 1
             except Exception as exc:

--- a/scripts/backfill_pr_merged_receipts.py
+++ b/scripts/backfill_pr_merged_receipts.py
@@ -22,11 +22,14 @@ import argparse
 import datetime
 import fcntl
 import json
+import logging
 import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+
+log = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 LIB_DIR = SCRIPT_DIR / "lib"
@@ -172,11 +175,14 @@ def _gh_list_merged_prs(limit: int, since: Optional[str] = None) -> List[Dict[st
 
 
 def _load_dispatch_register_events() -> List[Dict[str, Any]]:
-    """Load dispatch_register.ndjson events. Best-effort — returns [] on failure."""
+    """Load dispatch_register.ndjson events. Best-effort — returns [] on graceful miss."""
     try:
         from dispatch_register import read_events
         return read_events()
-    except Exception:
+    except (ImportError, FileNotFoundError):
+        return []
+    except Exception as e:
+        log.warning("dispatch_register load failed: %s", e, exc_info=True)
         return []
 
 

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -50,6 +51,34 @@ from governance_receipts import emit_governance_receipt
 
 EXIT_OK = 0
 EXIT_ERROR = 1
+
+# Matches internal PR labels: pure numeric (PR-42) and alphanumeric (PR-HYG-1, PR-TMUX-3, PR-ROUTE-1).
+_PR_LABEL_RE = re.compile(r"\bPR-([A-Z0-9]+(?:-[A-Z0-9]+)*)\b", re.IGNORECASE)
+
+
+def _extract_pr_id(subject: str) -> Optional[str]:
+    """Extract internal PR-N/PR-LABEL from commit subject or PR title.
+
+    Returns the first match as an uppercase string, e.g. "PR-HYG-1" or "PR-42".
+    Returns None if no internal PR label is found.
+    """
+    m = _PR_LABEL_RE.search(subject)
+    if m:
+        return f"PR-{m.group(1).upper()}"
+    return None
+
+
+def _lookup_dispatch_id_by_pr_number(pr_number: int) -> str:
+    """Look up dispatch_id in dispatch_register by pr_number. Best-effort, returns '' on miss."""
+    try:
+        from dispatch_register import read_events
+        events = read_events()
+        for ev in reversed(events):
+            if ev.get("pr_number") == pr_number and ev.get("dispatch_id"):
+                return str(ev["dispatch_id"])
+    except Exception:
+        pass
+    return ""
 
 
 def _gh(args: list[str], *, check: bool = False, timeout: int = 30) -> subprocess.CompletedProcess[str]:
@@ -97,9 +126,15 @@ def _emit_receipt(
     merge_method: str,
     pr_title: str,
     branch: str,
+    pr_id: str = "",
+    pr_id_resolution: str = "",
     receipts_file: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Write pr_merged receipt to t0_receipts.ndjson."""
+    """Write pr_merged receipt to t0_receipts.ndjson with dual-scheme linkage.
+
+    Dual-scheme: pr_number (GitHub numeric) + pr_id (internal PR-N/PR-LABEL).
+    pr_id_resolution='unmatched' when no internal label could be derived.
+    """
     kwargs: Dict[str, Any] = {
         "pr_number": pr_number,
         "conclusion": "merged",
@@ -107,6 +142,10 @@ def _emit_receipt(
         "pr_title": pr_title,
         "branch": branch,
     }
+    if pr_id:
+        kwargs["pr_id"] = pr_id
+    elif pr_id_resolution:
+        kwargs["pr_id_resolution"] = pr_id_resolution
     if dispatch_id:
         kwargs["dispatch_id"] = dispatch_id
     return emit_governance_receipt(
@@ -188,6 +227,12 @@ def merge_pr(
 
     result["success"] = True
 
+    # Derive internal PR-N label from title for dual-scheme receipt
+    pr_id = _extract_pr_id(result["pr_title"] or result["branch"])
+    if not dispatch_id:
+        dispatch_id = _lookup_dispatch_id_by_pr_number(pr_number)
+    result["dispatch_id"] = dispatch_id
+
     # Emit receipt to t0_receipts.ndjson
     try:
         receipt = _emit_receipt(
@@ -196,6 +241,8 @@ def merge_pr(
             merge_method=merge_method,
             pr_title=result["pr_title"],
             branch=result["branch"],
+            pr_id=pr_id or "",
+            pr_id_resolution="" if pr_id else "unmatched",
             receipts_file=receipts_file,
         )
         result["receipt_status"] = receipt.get("append_status", "unknown")

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -35,11 +35,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+log = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 LIB_DIR = SCRIPT_DIR / "lib"
@@ -76,8 +79,8 @@ def _lookup_dispatch_id_by_pr_number(pr_number: int) -> str:
         for ev in reversed(events):
             if ev.get("pr_number") == pr_number and ev.get("dispatch_id"):
                 return str(ev["dispatch_id"])
-    except Exception:
-        pass
+    except Exception as e:
+        log.warning("dispatch lookup failed: %s", e)
     return ""
 
 

--- a/scripts/traceability_audit.py
+++ b/scripts/traceability_audit.py
@@ -162,6 +162,8 @@ def load_all_receipts(
         data_dir / "state" / "t0_receipts.ndjson",
         project_root / ".vnx-intelligence" / "receipts" / "t0_receipts.ndjson",
         project_root / "receipts" / "t0_receipts.ndjson",
+        # ADR-005 backfill ledger: pr_merged receipts written by backfill_pr_merged_receipts.py
+        data_dir / "events" / "pr_merged.ndjson",
     ]
     # Also check central ~/.vnx-data
     home_central = Path.home() / ".vnx-data" / "state" / "t0_receipts.ndjson"
@@ -172,8 +174,11 @@ def load_all_receipts(
     records: List[ReceiptRecord] = []
     for path in candidates:
         for rec in iter_receipts(path, since, until):
-            # Dedup by dispatch_id + event_type + timestamp
-            key = f"{rec.dispatch_id}|{rec.event_type}|{rec.timestamp}"
+            # Dedup by dispatch_id + event_type + timestamp + pr_number.
+            # pr_number disambiguates pr_merged receipts that share the same second
+            # (batch-backfilled receipts often have identical timestamps).
+            pr_number_str = str(rec.raw.get("pr_number") or "")
+            key = f"{rec.dispatch_id}|{rec.event_type}|{rec.timestamp}|{pr_number_str}"
             if key not in seen_keys:
                 seen_keys.add(key)
                 records.append(rec)
@@ -593,6 +598,13 @@ def gap_prs_without_receipt(
             pr_num_str = str(pr.number)
             for r in receipts:
                 if pr_num_str in (r.dispatch_id or "") or gh_ref in (r.pr_id or ""):
+                    linked = True
+                    break
+
+        # Strategy 2b: direct pr_number field match (covers backfilled and forward-emit receipts)
+        if not linked and pr.number:
+            for r in receipts:
+                if r.raw.get("pr_number") == pr.number:
                     linked = True
                     break
 

--- a/scripts/traceability_audit.py
+++ b/scripts/traceability_audit.py
@@ -601,10 +601,10 @@ def gap_prs_without_receipt(
                     linked = True
                     break
 
-        # Strategy 2b: direct pr_number field match (covers backfilled and forward-emit receipts)
+        # Strategy 2b: direct pr_number field match — only pr_merged events close the gap
         if not linked and pr.number:
             for r in receipts:
-                if r.raw.get("pr_number") == pr.number:
+                if r.raw.get("event_type") == "pr_merged" and r.raw.get("pr_number") == pr.number:
                     linked = True
                     break
 

--- a/tests/test_backfill_pr_merged.py
+++ b/tests/test_backfill_pr_merged.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Tests for backfill_pr_merged_receipts.py — dual-scheme + dispatch_id lookup + idempotency.
+
+Covers:
+- Backfill emits receipts to events/pr_merged.ndjson (ADR-005 ledger)
+- Receipt carries pr_id when title has (PR-X) prefix
+- Receipt carries pr_id_resolution='unmatched' when no (PR-X) found
+- dispatch_id is looked up from dispatch_register events by pr_number
+- dispatch_id is looked up by branch-slug when pr_number has no match
+- Backfill is idempotent: re-run emits 0 duplicates
+- _extract_pr_id_from_subject and _lookup_dispatch_id_for_pr unit tests
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def vnx_env(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    events_dir = data_dir / "events"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    events_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "events_dir": events_dir,
+        "receipts_path": state_dir / "t0_receipts.ndjson",
+        "events_pr_merged": events_dir / "pr_merged.ndjson",
+    }
+
+
+def _load_ndjson(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _make_merged_pr(
+    number: int,
+    title: str,
+    branch: str = "feature-branch",
+    merged_at: str = "2026-05-20T10:00:00Z",
+) -> Dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "headRefName": branch,
+        "mergedAt": merged_at,
+        "baseRefName": "main",
+        "mergeCommit": {"oid": "abc123", "committedDate": merged_at},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: _extract_pr_id_from_subject
+# ---------------------------------------------------------------------------
+
+class TestExtractPrIdFromSubject:
+    def test_alphanumeric_label(self):
+        import backfill_pr_merged_receipts as bfr
+        assert bfr._extract_pr_id_from_subject("feat(hyg): remove dead code (PR-HYG-2B)") == "PR-HYG-2B"
+
+    def test_pure_numeric_label(self):
+        import backfill_pr_merged_receipts as bfr
+        assert bfr._extract_pr_id_from_subject("fix: something (PR-42)") == "PR-42"
+
+    def test_no_label_returns_none(self):
+        import backfill_pr_merged_receipts as bfr
+        assert bfr._extract_pr_id_from_subject("docs: update readme") is None
+
+    def test_tmux_label(self):
+        import backfill_pr_merged_receipts as bfr
+        assert bfr._extract_pr_id_from_subject("feat(tmux): worktree isolation (PR-TMUX-3)") == "PR-TMUX-3"
+
+
+# ---------------------------------------------------------------------------
+# Unit: _lookup_dispatch_id_for_pr
+# ---------------------------------------------------------------------------
+
+class TestLookupDispatchIdForPr:
+    def _make_register_event(self, pr_number: int, dispatch_id: str) -> Dict[str, Any]:
+        return {
+            "event": "dispatch_completed",
+            "dispatch_id": dispatch_id,
+            "pr_number": pr_number,
+            "timestamp": "2026-05-20T10:00:00Z",
+        }
+
+    def test_pr_number_exact_match(self):
+        import backfill_pr_merged_receipts as bfr
+        events = [
+            self._make_register_event(675, "20260528-route-1-enforce"),
+            self._make_register_event(668, "20260528-hyg-2b-deadmodules"),
+        ]
+        result = bfr._lookup_dispatch_id_for_pr(675, "feat/route-1-enforce", events)
+        assert result == "20260528-route-1-enforce"
+
+    def test_different_pr_number_no_match(self):
+        import backfill_pr_merged_receipts as bfr
+        events = [self._make_register_event(100, "20260520-some-dispatch")]
+        result = bfr._lookup_dispatch_id_for_pr(999, "feat/unknown-branch", events)
+        assert result == ""
+
+    def test_branch_slug_fallback(self):
+        import backfill_pr_merged_receipts as bfr
+        events = [
+            {
+                "event": "dispatch_created",
+                "dispatch_id": "20260520-trace-gap-fix",
+                "timestamp": "2026-05-20T10:00:00Z",
+            }
+        ]
+        result = bfr._lookup_dispatch_id_for_pr(677, "feat/trace-gap-fix", events)
+        assert result == "20260520-trace-gap-fix"
+
+    def test_empty_events_returns_empty(self):
+        import backfill_pr_merged_receipts as bfr
+        result = bfr._lookup_dispatch_id_for_pr(500, "feat/some-feature", [])
+        assert result == ""
+
+    def test_pr_number_wins_over_branch_slug(self):
+        import backfill_pr_merged_receipts as bfr
+        events = [
+            {
+                "event": "dispatch_created",
+                "dispatch_id": "20260520-branch-match-dispatch",
+                "timestamp": "2026-05-20T09:00:00Z",
+            },
+            self._make_register_event(675, "20260520-exact-pr-dispatch"),
+        ]
+        result = bfr._lookup_dispatch_id_for_pr(675, "feat/branch-match", events)
+        assert result == "20260520-exact-pr-dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Integration: backfill() with fixture data
+# ---------------------------------------------------------------------------
+
+class TestBackfillIntegration:
+    """Backfill emits receipts to events/pr_merged.ndjson with dual-scheme fields."""
+
+    def test_emits_receipts_to_events_file(self, vnx_env, monkeypatch):
+        """Backfill writes receipts to events/pr_merged.ndjson, not t0_receipts.ndjson."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [
+            _make_merged_pr(675, "feat(route): enforce constraints (PR-ROUTE-1)", "feat/route-1-enforce"),
+            _make_merged_pr(674, "docs(readme): update docs", "feat/doc-readme"),
+        ]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(
+            receipts_file=str(vnx_env["receipts_path"]),
+            events_path=events_path,
+        )
+
+        assert summary["missing_receipt_count"] == 2
+        assert summary["backfilled"] == 2
+        assert summary["errors"] == 0
+
+        receipts = _load_ndjson(events_path)
+        assert len(receipts) == 2
+
+    def test_pr_id_extracted_from_title(self, vnx_env, monkeypatch):
+        """Receipt has pr_id='PR-ROUTE-1' when title contains (PR-ROUTE-1)."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [
+            _make_merged_pr(675, "feat(route): enforce constraints (PR-ROUTE-1)", "feat/route-1-enforce"),
+        ]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        bfr.backfill(receipts_file=str(vnx_env["receipts_path"]), events_path=events_path)
+
+        receipts = _load_ndjson(events_path)
+        r675 = next((r for r in receipts if r.get("pr_number") == 675), None)
+        assert r675 is not None
+        assert r675.get("pr_id") == "PR-ROUTE-1"
+        assert "pr_id_resolution" not in r675
+
+    def test_pr_id_resolution_unmatched_when_no_label(self, vnx_env, monkeypatch):
+        """Receipt has pr_id_resolution='unmatched' when title has no PR-X label."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [
+            _make_merged_pr(674, "docs(readme): update docs without label", "feat/doc-readme"),
+        ]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        bfr.backfill(receipts_file=str(vnx_env["receipts_path"]), events_path=events_path)
+
+        receipts = _load_ndjson(events_path)
+        r674 = next((r for r in receipts if r.get("pr_number") == 674), None)
+        assert r674 is not None
+        assert r674.get("pr_id_resolution") == "unmatched"
+        assert not r674.get("pr_id")
+
+    def test_dispatch_id_from_register(self, vnx_env, monkeypatch):
+        """dispatch_id is resolved from dispatch_register when pr_number matches."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [
+            _make_merged_pr(675, "feat(route): enforce constraints (PR-ROUTE-1)", "feat/route-1-enforce"),
+        ]
+        register_events = [
+            {
+                "event": "dispatch_completed",
+                "dispatch_id": "20260528-route-1-enforce",
+                "pr_number": 675,
+                "timestamp": "2026-05-28T12:00:00Z",
+            }
+        ]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: register_events)
+
+        events_path = vnx_env["events_pr_merged"]
+        bfr.backfill(receipts_file=str(vnx_env["receipts_path"]), events_path=events_path)
+
+        receipts = _load_ndjson(events_path)
+        r675 = next((r for r in receipts if r.get("pr_number") == 675), None)
+        assert r675 is not None
+        assert r675.get("dispatch_id") == "20260528-route-1-enforce"
+
+    def test_idempotent_no_duplicates_on_rerun(self, vnx_env, monkeypatch):
+        """Running backfill twice emits each receipt exactly once."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [
+            _make_merged_pr(675, "feat(route): enforce constraints (PR-ROUTE-1)", "feat/route-1-enforce"),
+            _make_merged_pr(674, "docs: update readme", "feat/doc-readme"),
+        ]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        receipts_path = vnx_env["receipts_path"]
+
+        # First run
+        s1 = bfr.backfill(receipts_file=str(receipts_path), events_path=events_path)
+        assert s1["backfilled"] == 2
+
+        # Second run — nothing new should be emitted
+        s2 = bfr.backfill(receipts_file=str(receipts_path), events_path=events_path)
+        assert s2["backfilled"] == 0
+        assert s2["missing_receipt_count"] == 0
+
+        # events/pr_merged.ndjson has exactly 2 receipts (no duplicates)
+        all_receipts = _load_ndjson(events_path)
+        pr_numbers = [r.get("pr_number") for r in all_receipts]
+        assert sorted(pr_numbers) == [674, 675]
+
+    def test_dry_run_writes_nothing(self, vnx_env, monkeypatch):
+        """--dry-run reports would_backfill but writes nothing."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [_make_merged_pr(675, "feat(route): constraints (PR-ROUTE-1)")]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(
+            dry_run=True,
+            receipts_file=str(vnx_env["receipts_path"]),
+            events_path=events_path,
+        )
+
+        assert summary["dry_run"] is True
+        assert summary["missing_receipt_count"] == 1
+        assert summary["backfilled"] == 0
+        assert not events_path.exists() or _load_ndjson(events_path) == []
+
+    def test_receipt_pr_number_field_always_present(self, vnx_env, monkeypatch):
+        """pr_number is always in every backfilled receipt."""
+        import backfill_pr_merged_receipts as bfr
+
+        merged_prs = [_make_merged_pr(700, "chore: no label")]
+        monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
+
+        events_path = vnx_env["events_pr_merged"]
+        bfr.backfill(receipts_file=str(vnx_env["receipts_path"]), events_path=events_path)
+
+        receipts = _load_ndjson(events_path)
+        assert len(receipts) == 1
+        assert receipts[0]["pr_number"] == 700
+        assert receipts[0]["event_type"] == "pr_merged"
+        assert receipts[0]["backfilled"] is True

--- a/tests/test_pr_merge_dual_scheme.py
+++ b/tests/test_pr_merge_dual_scheme.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Tests for dual-scheme pr_id/pr_number storage in pr_merge.py.
+
+Covers:
+- Receipt carries both pr_id and pr_number when commit subject has (PR-X) prefix
+- pr_id_resolution='unmatched' when no PR-X prefix found in title
+- Alphanumeric PR labels (PR-HYG-1, PR-TMUX-3) are extracted correctly
+- Pure numeric PR labels (PR-42) are extracted correctly
+- dispatch_id is included in receipt when known
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def vnx_env(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "receipts_path": state_dir / "t0_receipts.ndjson",
+    }
+
+
+def _load_receipts(path: Path) -> list[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _pr_merged_receipts(path: Path, pr_number: int) -> list[Dict[str, Any]]:
+    return [
+        r for r in _load_receipts(path)
+        if (r.get("event_type") or r.get("event")) == "pr_merged"
+        and r.get("pr_number") == pr_number
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _extract_pr_id unit tests
+# ---------------------------------------------------------------------------
+
+class TestExtractPrId:
+    """Unit tests for _extract_pr_id helper."""
+
+    def test_pure_numeric_label(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("feat: something (PR-42)") == "PR-42"
+
+    def test_alphanumeric_label_hyg(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("chore(hygiene): remove dead code (PR-HYG-1)") == "PR-HYG-1"
+
+    def test_alphanumeric_label_tmux(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("feat(tmux): worktree isolation (PR-TMUX-3)") == "PR-TMUX-3"
+
+    def test_alphanumeric_label_route(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("feat(route): enforce constraints (PR-ROUTE-1)") == "PR-ROUTE-1"
+
+    def test_returns_none_when_no_label(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("feat(misc): cleanup without label") is None
+
+    def test_returns_none_for_empty_string(self):
+        import pr_merge
+        assert pr_merge._extract_pr_id("") is None
+
+    def test_first_match_wins(self):
+        import pr_merge
+        result = pr_merge._extract_pr_id("something PR-HYG-1 then PR-42")
+        assert result == "PR-HYG-1"
+
+    def test_uppercase_normalisation(self):
+        import pr_merge
+        result = pr_merge._extract_pr_id("feat: title (pr-hyg-1)")
+        assert result == "PR-HYG-1"
+
+
+# ---------------------------------------------------------------------------
+# merge_pr dual-scheme receipt tests
+# ---------------------------------------------------------------------------
+
+class TestMergePrDualScheme:
+    """merge_pr() emits receipt with both pr_id and pr_number."""
+
+    def _make_pr_data(self, number: int, title: str, branch: str = "feature-branch") -> Dict[str, Any]:
+        return {"number": number, "title": title, "headRefName": branch, "state": "OPEN"}
+
+    def test_receipt_has_both_pr_id_and_pr_number(self, vnx_env, monkeypatch):
+        """When title contains (PR-HYG-1), receipt carries both pr_id='PR-HYG-1' and pr_number."""
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
+            n, "chore(hygiene): remove dead code (PR-HYG-1)", "feat/hyg-1-dead-code"
+        ))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+
+        receipts_path = vnx_env["receipts_path"]
+        result = pr_merge.merge_pr(pr_number=668, receipts_file=str(receipts_path))
+
+        assert result["success"] is True
+
+        matching = _pr_merged_receipts(receipts_path, 668)
+        assert len(matching) == 1, f"Expected 1 receipt, got {len(matching)}"
+        r = matching[0]
+        assert r["pr_number"] == 668
+        assert r.get("pr_id") == "PR-HYG-1", f"Expected pr_id='PR-HYG-1', got {r.get('pr_id')!r}"
+        assert "pr_id_resolution" not in r, "pr_id_resolution should be absent when pr_id is known"
+
+    def test_receipt_has_pr_id_resolution_unmatched_when_no_label(self, vnx_env, monkeypatch):
+        """When title has no PR-N label, receipt has pr_id_resolution='unmatched'."""
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
+            n, "docs(readme): update installation instructions", "feat/docs-readme"
+        ))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+
+        receipts_path = vnx_env["receipts_path"]
+        result = pr_merge.merge_pr(pr_number=674, receipts_file=str(receipts_path))
+
+        assert result["success"] is True
+
+        matching = _pr_merged_receipts(receipts_path, 674)
+        assert len(matching) == 1
+        r = matching[0]
+        assert r["pr_number"] == 674
+        assert r.get("pr_id_resolution") == "unmatched", (
+            f"Expected pr_id_resolution='unmatched', got {r.get('pr_id_resolution')!r}"
+        )
+        assert not r.get("pr_id"), f"pr_id should be absent/empty, got {r.get('pr_id')!r}"
+
+    def test_receipt_has_pr_number_regardless_of_pr_id(self, vnx_env, monkeypatch):
+        """pr_number is always present whether or not pr_id is found."""
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
+            n, "fix: hotfix with no label", "fix/hotfix"
+        ))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+
+        receipts_path = vnx_env["receipts_path"]
+        pr_merge.merge_pr(pr_number=999, receipts_file=str(receipts_path))
+
+        matching = _pr_merged_receipts(receipts_path, 999)
+        assert len(matching) == 1
+        assert matching[0]["pr_number"] == 999
+
+    def test_numeric_label_extracted(self, vnx_env, monkeypatch):
+        """Pure numeric labels like (PR-42) are also extracted into pr_id."""
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
+            n, "feat: implement schema versioning (PR-42)", "feat/schema-versioning"
+        ))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+
+        receipts_path = vnx_env["receipts_path"]
+        pr_merge.merge_pr(pr_number=642, receipts_file=str(receipts_path))
+
+        matching = _pr_merged_receipts(receipts_path, 642)
+        assert len(matching) == 1
+        assert matching[0].get("pr_id") == "PR-42"
+
+    def test_dispatch_id_included_when_provided(self, vnx_env, monkeypatch):
+        """dispatch_id is stored in receipt when explicitly provided."""
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
+            n, "feat(trace): fix traceability gap (PR-B-TRACE)", "feat/trace-gap-fix"
+        ))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+
+        receipts_path = vnx_env["receipts_path"]
+        pr_merge.merge_pr(
+            pr_number=677,
+            dispatch_id="20260528-b-trace-gap-fix",
+            receipts_file=str(receipts_path),
+        )
+
+        matching = _pr_merged_receipts(receipts_path, 677)
+        assert len(matching) == 1
+        assert matching[0].get("dispatch_id") == "20260528-b-trace-gap-fix"
+        assert matching[0].get("pr_id") == "PR-B-TRACE"

--- a/tests/test_pr_merge_receipt.py
+++ b/tests/test_pr_merge_receipt.py
@@ -36,7 +36,9 @@ def vnx_env(tmp_path, monkeypatch):
     """Set up a minimal VNX environment with writable state directories."""
     data_dir = tmp_path / "data"
     state_dir = data_dir / "state"
+    events_dir = data_dir / "events"
     state_dir.mkdir(parents=True, exist_ok=True)
+    events_dir.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
@@ -49,7 +51,12 @@ def vnx_env(tmp_path, monkeypatch):
     monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
     monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
     (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
-    return {"state_dir": state_dir, "data_dir": data_dir, "receipts_path": state_dir / "t0_receipts.ndjson"}
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "receipts_path": state_dir / "t0_receipts.ndjson",
+        "events_pr_merged": events_dir / "pr_merged.ndjson",
+    }
 
 
 def _load_receipts(path: Path) -> list[Dict[str, Any]]:
@@ -257,22 +264,25 @@ class TestBackfillPrMergedReceipts:
         ]
 
     def test_backfill_emits_receipt_for_missing_pr(self, vnx_env, monkeypatch):
-        """Backfill writes a receipt for every merged PR that lacks one."""
+        """Backfill writes receipts to events/pr_merged.ndjson (ADR-005 ledger)."""
         import backfill_pr_merged_receipts as bfr
 
         merged_prs = self._make_merged_prs([100, 101, 102])
         monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
 
         receipts_path = vnx_env["receipts_path"]
-        summary = bfr.backfill(receipts_file=str(receipts_path))
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(receipts_file=str(receipts_path), events_path=events_path)
 
         assert summary["missing_receipt_count"] == 3
         assert summary["backfilled"] == 3
         assert summary["errors"] == 0
 
+        # Backfilled receipts go to events/pr_merged.ndjson, not t0_receipts.ndjson
         for pr_n in [100, 101, 102]:
-            matching = _receipts_for_pr(receipts_path, pr_n)
-            assert len(matching) >= 1, f"Expected receipt for PR#{pr_n}"
+            matching = _receipts_for_pr(events_path, pr_n)
+            assert len(matching) >= 1, f"Expected receipt for PR#{pr_n} in events/pr_merged.ndjson"
             assert matching[0]["backfilled"] is True
 
     def test_backfill_skips_already_receipted_prs(self, vnx_env, monkeypatch):
@@ -281,7 +291,7 @@ class TestBackfillPrMergedReceipts:
 
         merged_prs = self._make_merged_prs([200, 201])
 
-        # Pre-populate a receipt for PR 200
+        # Pre-populate a receipt for PR 200 in t0_receipts.ndjson
         receipts_path = vnx_env["receipts_path"]
         existing = {
             "timestamp": "2026-05-01T09:00:00Z",
@@ -292,18 +302,20 @@ class TestBackfillPrMergedReceipts:
         receipts_path.write_text(json.dumps(existing) + "\n", encoding="utf-8")
 
         monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
 
-        summary = bfr.backfill(receipts_file=str(receipts_path))
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(receipts_file=str(receipts_path), events_path=events_path)
 
         assert summary["missing_receipt_count"] == 1
         assert summary["backfilled"] == 1
 
-        # PR 200 should not have an additional receipt
-        matching_200 = _receipts_for_pr(receipts_path, 200)
-        assert len(matching_200) == 1, "PR 200 already had a receipt, no duplicate expected"
+        # PR 200 was already in t0_receipts — no new receipt in events/
+        matching_200 = _receipts_for_pr(events_path, 200)
+        assert len(matching_200) == 0, "PR 200 already had a receipt, no backfill expected"
 
-        # PR 201 should now have one
-        matching_201 = _receipts_for_pr(receipts_path, 201)
+        # PR 201 should be in events/
+        matching_201 = _receipts_for_pr(events_path, 201)
         assert len(matching_201) == 1
 
     def test_dry_run_writes_nothing(self, vnx_env, monkeypatch):
@@ -312,16 +324,18 @@ class TestBackfillPrMergedReceipts:
 
         merged_prs = self._make_merged_prs([300, 301])
         monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
 
         receipts_path = vnx_env["receipts_path"]
-        summary = bfr.backfill(dry_run=True, receipts_file=str(receipts_path))
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(dry_run=True, receipts_file=str(receipts_path), events_path=events_path)
 
         assert summary["dry_run"] is True
         assert summary["missing_receipt_count"] == 2
         assert summary["backfilled"] == 0
 
-        # Nothing written
-        assert not receipts_path.exists() or not _load_receipts(receipts_path)
+        # Nothing written to events/
+        assert not events_path.exists() or not _load_receipts(events_path)
 
     def test_since_filter_excludes_old_prs(self, vnx_env, monkeypatch):
         """--since filters out PRs merged before the given date."""
@@ -332,16 +346,18 @@ class TestBackfillPrMergedReceipts:
             {"number": 401, "title": "new", "headRefName": "b-401", "mergedAt": "2026-05-15T00:00:00Z"},
         ]
         monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
 
         receipts_path = vnx_env["receipts_path"]
-        summary = bfr.backfill(since="2026-01-01", receipts_file=str(receipts_path))
+        events_path = vnx_env["events_pr_merged"]
+        summary = bfr.backfill(since="2026-01-01", receipts_file=str(receipts_path), events_path=events_path)
 
         assert summary["missing_receipt_count"] == 1
         assert summary["backfilled"] == 1
 
-        # Only PR 401 should have a receipt
-        assert len(_receipts_for_pr(receipts_path, 401)) == 1
-        assert len(_receipts_for_pr(receipts_path, 400)) == 0
+        # Only PR 401 should have a receipt in events/
+        assert len(_receipts_for_pr(events_path, 401)) == 1
+        assert len(_receipts_for_pr(events_path, 400)) == 0
 
     def test_backfill_receipt_has_pr_number(self, vnx_env, monkeypatch):
         """Backfilled receipt has pr_number field for FPY/history query."""
@@ -349,11 +365,13 @@ class TestBackfillPrMergedReceipts:
 
         merged_prs = self._make_merged_prs([500])
         monkeypatch.setattr(bfr, "_gh_list_merged_prs", lambda limit, since: merged_prs)
+        monkeypatch.setattr(bfr, "_load_dispatch_register_events", lambda: [])
 
         receipts_path = vnx_env["receipts_path"]
-        bfr.backfill(receipts_file=str(receipts_path))
+        events_path = vnx_env["events_pr_merged"]
+        bfr.backfill(receipts_file=str(receipts_path), events_path=events_path)
 
-        matching = _receipts_for_pr(receipts_path, 500)
+        matching = _receipts_for_pr(events_path, 500)
         assert len(matching) == 1
         r = matching[0]
         assert r["pr_number"] == 500

--- a/tests/test_traceability_audit.py
+++ b/tests/test_traceability_audit.py
@@ -569,3 +569,42 @@ class TestRunHelperExceptionPaths:
         captured = capsys.readouterr()
         assert "traceability-audit" in captured.err
         assert "permission denied" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 17. Strategy 2b: event_type=pr_merged strictness
+# ---------------------------------------------------------------------------
+
+class TestCategoryCStrategy2b:
+    """Strategy 2b must only close the gap for receipts with event_type='pr_merged'."""
+
+    def _pr_receipt(self, pr_number: int, event_type: str) -> ReceiptRecord:
+        raw = {"pr_number": pr_number, "event_type": event_type}
+        return ReceiptRecord(
+            dispatch_id="20260101-test",
+            pr_id="",
+            event_type=event_type,
+            status="success",
+            timestamp="2026-01-15T10:00:00Z",
+            commit_hash="",
+            terminal="T1",
+            source_file="test.ndjson",
+            raw=raw,
+        )
+
+    def test_pr_number_with_task_complete_does_not_close_gap(self):
+        """Receipt with pr_number but event_type='task_complete' must NOT trace the PR."""
+        prs = [_pr(number=700, internal_pr_ids=[], branch="feat/orphan")]
+        receipts = [self._pr_receipt(pr_number=700, event_type="task_complete")]
+        dispatches: list[DispatchRecord] = []
+        report = gap_prs_without_receipt(prs, receipts, dispatches)
+        assert report.gap_count == 1, "task_complete receipt with pr_number must not close cat-C gap"
+
+    def test_pr_number_with_pr_merged_closes_gap(self):
+        """Receipt with pr_number AND event_type='pr_merged' SHOULD trace the PR."""
+        prs = [_pr(number=701, internal_pr_ids=[], branch="feat/orphan2")]
+        receipts = [self._pr_receipt(pr_number=701, event_type="pr_merged")]
+        dispatches: list[DispatchRecord] = []
+        report = gap_prs_without_receipt(prs, receipts, dispatches)
+        assert report.gap_count == 0, "pr_merged receipt with matching pr_number must close cat-C gap"
+        assert report.traced == 1


### PR DESCRIPTION
## Summary

- **Root cause:** Scheme-mismatch between receipts (internal `PR-N` labels) and GitHub (numeric `#600+` IDs) made 126/173 merged PRs (73%) untraced in audit cat C. This is a follow-up to #654 which shipped `pr_merged` receipt emit but didn't bridge both schemes.
- **Part 1 — `scripts/pr_merge.py`:** `merge_pr()` now emits dual-scheme receipts: `pr_number` (GitHub numeric, always present) + `pr_id` (internal PR-N label, extracted from commit subject via regex). Falls back to `pr_id_resolution='unmatched'` when no internal label found in title or branch.
- **Part 2 — `scripts/backfill_pr_merged_receipts.py`:** Queries GitHub for all merged PRs, compares against existing receipts, emits backfill records to `events/pr_merged.ndjson` (ADR-005 ledger). Idempotent by `pr_number`. Dual-scheme fields on every record with `backfilled: true` marker.
- **Audit fix — `scripts/traceability_audit.py`:** Loads `events/pr_merged.ndjson` in candidate list; cat-C linkage strategy 2b matches `pr_number` field directly.

## Result

```
### C — Merged PRs without receipt/dispatch linkage
| Traced | 174 (100.0%) |
| Gap    | 0 (0.0%)     |
```

Gap: 73% → 0% on `--since 2026-05-14`.

## Test plan

- [x] `python3 -m pytest tests/test_pr_merge_dual_scheme.py tests/test_backfill_pr_merged.py tests/test_pr_merge_receipt.py -v` — 46 passed
- [x] `bash scripts/local-ci.sh` — all gates passed
- [x] `python3 scripts/traceability_audit.py --since 2026-05-14 --no-write | grep -A2 "### C"` — 0 (0.0%) gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)