### PR TITLE
feat(skills): add STEP 0 ADR-check to 5 skill files (PR-SKILL-1)

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -15,6 +15,24 @@ Design robust, scalable solutions following a three-phase architectural approach
 - Create implementation blueprints
 - Document decisions and trade-offs
 
+## STEP 0 — Foundational Check (Mandatory)
+
+BEFORE proposing any design, fix, or implementation:
+
+1. **Consult relevant ADRs** in `docs/governance/decisions/`. Special attention to:
+   - ADR-005 (NDJSON audit ledger as primary observability)
+   - ADR-007 (multi-tenant project_id stamping; composite keys for central state DBs)
+   - ADR-010 (subprocess adapter as canonical Claude routing)
+   List any ADR that applies to the task and how it constrains your solution.
+
+2. **Consult relevant memory** in `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md` — particularly entries about past architectural incidents.
+
+3. **Check P4-style incident docs** in `claudedocs/` for analogous failures (e.g., `2026-05-09-p4-migration-architecture-lessons.md` for multi-tenant migration patterns).
+
+4. **State your foundational read aloud** at the start of your response. Example: "ADR-007 applies: new tabel X needs composite PK over project_id. Per P4 §4.2, single-column UNIQUE is a smell. Memory [[adr-007-multitenant-composite-keys]] confirms."
+
+Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 was not consulted at design time.
+
 ## Three-Phase Architecture Process
 
 ### Phase 1: Pattern Analysis

--- a/skills/database-engineer/SKILL.md
+++ b/skills/database-engineer/SKILL.md
@@ -24,6 +24,24 @@ The specific recurring failure-modes are catalogued in `references/bug-taxonomy.
 - Operator complains "stuck at 100% CPU for hours" — likely O(N×M) (see `references/sqlite-fts5-gotchas.md`)
 - Any code that calls `INSERT OR IGNORE` or `INSERT OR REPLACE`
 
+## STEP 0 — Foundational Check (Mandatory)
+
+BEFORE proposing any design, fix, or implementation:
+
+1. **Consult relevant ADRs** in `docs/governance/decisions/`. Special attention to:
+   - ADR-005 (NDJSON audit ledger as primary observability)
+   - ADR-007 (multi-tenant project_id stamping; composite keys for central state DBs)
+   - ADR-010 (subprocess adapter as canonical Claude routing)
+   List any ADR that applies to the task and how it constrains your solution.
+
+2. **Consult relevant memory** in `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md` — particularly entries about past architectural incidents.
+
+3. **Check P4-style incident docs** in `claudedocs/` for analogous failures (e.g., `2026-05-09-p4-migration-architecture-lessons.md` for multi-tenant migration patterns).
+
+4. **State your foundational read aloud** at the start of your response. Example: "ADR-007 applies: new tabel X needs composite PK over project_id. Per P4 §4.2, single-column UNIQUE is a smell. Memory [[adr-007-multitenant-composite-keys]] confirms."
+
+Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 was not consulted at design time.
+
 ## Decision Protocol
 
 Before writing migration code, walk through `references/migration-defense-checklist.md` (loaded explicitly when needed; checklist is reproduced inline below for fast access).

--- a/skills/debugger/SKILL.md
+++ b/skills/debugger/SKILL.md
@@ -30,6 +30,24 @@ Follow a structured debugging approach for every issue:
 
 ## Guidelines
 
+## STEP 0 — Foundational Check (Mandatory)
+
+BEFORE proposing any design, fix, or implementation:
+
+1. **Consult relevant ADRs** in `docs/governance/decisions/`. Special attention to:
+   - ADR-005 (NDJSON audit ledger as primary observability)
+   - ADR-007 (multi-tenant project_id stamping; composite keys for central state DBs)
+   - ADR-010 (subprocess adapter as canonical Claude routing)
+   List any ADR that applies to the task and how it constrains your solution.
+
+2. **Consult relevant memory** in `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md` — particularly entries about past architectural incidents.
+
+3. **Check P4-style incident docs** in `claudedocs/` for analogous failures (e.g., `2026-05-09-p4-migration-architecture-lessons.md` for multi-tenant migration patterns).
+
+4. **State your foundational read aloud** at the start of your response. Example: "ADR-007 applies: new tabel X needs composite PK over project_id. Per P4 §4.2, single-column UNIQUE is a smell. Memory [[adr-007-multitenant-composite-keys]] confirms."
+
+Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 was not consulted at design time.
+
 ### Debugging Workflow
 1. Gather error context (stack traces, logs, state)
 2. Check recent changes (git diff, commit history)

--- a/skills/intelligence-engineer/SKILL.md
+++ b/skills/intelligence-engineer/SKILL.md
@@ -24,6 +24,24 @@ This skill exists alongside `database-engineer` (which covers SQLite mechanics g
 - Designing a new intelligence-feeding mechanism (e.g. new event type → injection rule)
 - Modifying any code that touches the project_id flow (registry → import → query → injection)
 
+## STEP 0 — Foundational Check (Mandatory)
+
+BEFORE proposing any design, fix, or implementation:
+
+1. **Consult relevant ADRs** in `docs/governance/decisions/`. Special attention to:
+   - ADR-005 (NDJSON audit ledger as primary observability)
+   - ADR-007 (multi-tenant project_id stamping; composite keys for central state DBs)
+   - ADR-010 (subprocess adapter as canonical Claude routing)
+   List any ADR that applies to the task and how it constrains your solution.
+
+2. **Consult relevant memory** in `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md` — particularly entries about past architectural incidents.
+
+3. **Check P4-style incident docs** in `claudedocs/` for analogous failures (e.g., `2026-05-09-p4-migration-architecture-lessons.md` for multi-tenant migration patterns).
+
+4. **State your foundational read aloud** at the start of your response. Example: "ADR-007 applies: new tabel X needs composite PK over project_id. Per P4 §4.2, single-column UNIQUE is a smell. Memory [[adr-007-multitenant-composite-keys]] confirms."
+
+Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 was not consulted at design time.
+
 ## Decision Protocol
 
 When asked a "where does X live in VNX?" question, FIRST consult `references/quality-intelligence-schema.md` and `references/runtime-coordination-schema.md` for table-by-table content. Don't guess; the schemas have evolved and the canonical answer is in the schema files + their accompanying `quality_db_init.py` imperative additions.

--- a/skills/security-engineer/SKILL.md
+++ b/skills/security-engineer/SKILL.md
@@ -42,6 +42,24 @@ Conduct comprehensive security audits to identify and remediate vulnerabilities 
 
 ## Security Audit Workflow
 
+## STEP 0 — Foundational Check (Mandatory)
+
+BEFORE proposing any design, fix, or implementation:
+
+1. **Consult relevant ADRs** in `docs/governance/decisions/`. Special attention to:
+   - ADR-005 (NDJSON audit ledger as primary observability)
+   - ADR-007 (multi-tenant project_id stamping; composite keys for central state DBs)
+   - ADR-010 (subprocess adapter as canonical Claude routing)
+   List any ADR that applies to the task and how it constrains your solution.
+
+2. **Consult relevant memory** in `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md` — particularly entries about past architectural incidents.
+
+3. **Check P4-style incident docs** in `claudedocs/` for analogous failures (e.g., `2026-05-09-p4-migration-architecture-lessons.md` for multi-tenant migration patterns).
+
+4. **State your foundational read aloud** at the start of your response. Example: "ADR-007 applies: new tabel X needs composite PK over project_id. Per P4 §4.2, single-column UNIQUE is a smell. Memory [[adr-007-multitenant-composite-keys]] confirms."
+
+Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 was not consulted at design time.
+
 1. **Initial Assessment** - Inventory endpoints, review auth, check dependencies
 2. **Static Analysis** - Scan Python code, review JS/TS, check for hardcoded secrets
 3. **Dynamic Testing** - Test for injection, verify rate limiting, check session handling


### PR DESCRIPTION
## Summary

- Adds mandatory `## STEP 0 — Foundational Check (Mandatory)` block to 5 skill SKILL.md files: `debugger`, `architect`, `database-engineer`, `intelligence-engineer`, `security-engineer`
- Inserted before the first workflow step in each file (additive only — no existing content removed)
- 90 LOC added across 5 files; no code, scripts, or tests changed

## Motivation

FUT-1 chain (2026-05-28) burned 6 codex rounds because ADR-007 (composite keys for multi-tenant central DBs) was not consulted at design time. An external reviewer found it in one read; 3 internal reviewers missed it. STEP 0 enforces ADR + memory + incident-doc consultation before any design or fix is proposed, making this a skill-level gate instead of a recall-dependent check.

## Test plan

- [ ] Verify 5 SKILL.md files each contain `## STEP 0 — Foundational Check (Mandatory)` block
- [ ] Confirm no existing skill content was removed (additive-only diff)
- [ ] CI unaffected (markdown-only changes)

Dispatch-ID: 20260529-skill1-adr-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)