### PR TITLE
feat(int-1): adrs table + FTS5 + indexer (PR-INT-1)

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -665,3 +665,42 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 );
 
 INSERT OR IGNORE INTO schema_meta(key, value) VALUES ('schema_version', '0');
+
+-- ============================================================================
+-- ADR REGISTRY (PR-INT-1: queryable ADR table + FTS5 for Wave-5 injection)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS adrs (
+    adr_id              TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    status              TEXT    NOT NULL,
+    title               TEXT    NOT NULL,
+    decision_summary    TEXT    NOT NULL,
+    binding_rules       TEXT    NOT NULL DEFAULT '[]',
+    applies_to_tables   TEXT    NOT NULL DEFAULT '[]',
+    applies_to_skills   TEXT    NOT NULL DEFAULT '[]',
+    triggers            TEXT    NOT NULL DEFAULT '[]',
+    file_path           TEXT    NOT NULL,
+    indexed_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    source_hash         TEXT    NOT NULL,
+    PRIMARY KEY (adr_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adrs_status ON adrs(status);
+
+-- FTS5 virtual table for semantic search over ADR content
+CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+    adr_id UNINDEXED,
+    title,
+    decision_summary,
+    binding_rules,
+    content='adrs',
+    content_rowid='rowid'
+);
+
+-- Triggers (adrs_ai, adrs_ad, adrs_au) are created by _migrate_v19 in quality_db_init.py.
+-- SQLite trigger bodies contain semicolons that confuse the schema SQL splitter,
+-- so they are managed via conn.execute() in Python, not via apply_script_if_below.
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.3.0-adr-registry', 'Add adrs table + FTS5 virtual table + sync triggers (PR-INT-1)');

--- a/scripts/index_adrs.py
+++ b/scripts/index_adrs.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Index all ADR markdown files into the adrs table + FTS5.
+
+ADR-005: NDJSON event written BEFORE SQLite commit; raises on event-write failure.
+ADR-007: composite PK (adr_id, project_id); project_id stamped explicitly.
+Idempotent: skips ADRs whose source_hash matches the stored value.
+
+Usage:
+    python3 scripts/index_adrs.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPT_DIR / "lib"))
+
+try:
+    from vnx_paths import ensure_env
+except Exception as exc:
+    raise SystemExit(f"Failed to load vnx_paths: {exc}")
+
+_DEFAULT_PROJECT_ID = "vnx-dev"
+
+
+def _parse_adr(file_path: Path, project_id: str = _DEFAULT_PROJECT_ID) -> dict:
+    stem = file_path.stem  # e.g. ADR-007-multitenant-project-id-stamping
+    parts = stem.split("-")
+    adr_id = f"{parts[0]}-{parts[1]}"  # ADR-007
+
+    content = file_path.read_text(encoding="utf-8")
+    source_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+
+    lines = content.splitlines()
+
+    # Title: first # heading
+    title = ""
+    for line in lines:
+        if line.startswith("# "):
+            title = line[2:].strip()
+            break
+
+    # Status: from **Status:** line or front-matter 'Status: X'
+    status = "Proposed"
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("**Status:**"):
+            status = stripped.split("**Status:**", 1)[1].strip().strip("*")
+            break
+        m = re.match(r"^Status:\s*(.+)$", stripped, re.IGNORECASE)
+        if m:
+            status = m.group(1).strip()
+            break
+
+    # Parse markdown sections by '## ' headers
+    sections: dict[str, str] = {}
+    current_section: Optional[str] = None
+    current_lines: list[str] = []
+    for line in lines:
+        if line.startswith("## "):
+            if current_section is not None:
+                sections[current_section] = "\n".join(current_lines).strip()
+            current_section = line[3:].strip()
+            current_lines = []
+        elif current_section is not None:
+            current_lines.append(line)
+    if current_section is not None:
+        sections[current_section] = "\n".join(current_lines).strip()
+
+    decision_text = sections.get("Decision") or sections.get("decision") or ""
+    decision_summary = decision_text
+
+    # Extract binding_rules: bullet lines from Decision section
+    binding_rules = _extract_bullets(decision_text)
+
+    # applies_to_tables / applies_to_skills: parse if present
+    applies_to_tables = _extract_bullets(sections.get("Applies to tables", ""))
+    applies_to_skills = _extract_bullets(sections.get("Applies to skills", ""))
+
+    # triggers: regex patterns from 'When to apply' section if present
+    triggers = _extract_bullets(sections.get("When to apply", ""))
+
+    return {
+        "adr_id": adr_id,
+        "project_id": project_id,
+        "status": status,
+        "title": title,
+        "decision_summary": decision_summary,
+        "binding_rules": json.dumps(binding_rules),
+        "applies_to_tables": json.dumps(applies_to_tables),
+        "applies_to_skills": json.dumps(applies_to_skills),
+        "triggers": json.dumps(triggers),
+        "file_path": str(file_path),
+        "source_hash": source_hash,
+    }
+
+
+def _extract_bullets(text: str) -> list[str]:
+    bullets = []
+    for line in text.splitlines():
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
+        if m:
+            bullets.append(m.group(1).strip())
+    return bullets
+
+
+def _write_ndjson_event(events_file: Path, adr: dict) -> None:
+    record_id = hashlib.sha256(
+        f"{adr['adr_id']}:{adr['source_hash']}".encode()
+    ).hexdigest()
+    event = {
+        "record_id": record_id,
+        "event_type": "adr_indexed",
+        "adr_id": adr["adr_id"],
+        "project_id": adr["project_id"],
+        "source_hash": adr["source_hash"],
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+    }
+    events_file.parent.mkdir(parents=True, exist_ok=True)
+    # ADR-005: raise on failure, never swallow
+    with open(events_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def _upsert_adr(conn: sqlite3.Connection, adr: dict) -> bool:
+    existing = conn.execute(
+        "SELECT source_hash FROM adrs WHERE adr_id = ? AND project_id = ?",
+        (adr["adr_id"], adr["project_id"]),
+    ).fetchone()
+
+    if existing and existing[0] == adr["source_hash"]:
+        return False  # idempotent skip
+
+    conn.execute(
+        """
+        INSERT INTO adrs
+            (adr_id, project_id, status, title, decision_summary,
+             binding_rules, applies_to_tables, applies_to_skills,
+             triggers, file_path, source_hash)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(adr_id, project_id) DO UPDATE SET
+            status           = excluded.status,
+            title            = excluded.title,
+            decision_summary = excluded.decision_summary,
+            binding_rules    = excluded.binding_rules,
+            applies_to_tables = excluded.applies_to_tables,
+            applies_to_skills = excluded.applies_to_skills,
+            triggers         = excluded.triggers,
+            file_path        = excluded.file_path,
+            indexed_at       = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+            source_hash      = excluded.source_hash
+        """,
+        (
+            adr["adr_id"],
+            adr["project_id"],
+            adr["status"],
+            adr["title"],
+            adr["decision_summary"],
+            adr["binding_rules"],
+            adr["applies_to_tables"],
+            adr["applies_to_skills"],
+            adr["triggers"],
+            adr["file_path"],
+            adr["source_hash"],
+        ),
+    )
+    return True
+
+
+def index_adrs(
+    db_path: Path,
+    adr_dir: Path,
+    events_file: Path,
+    project_id: str = _DEFAULT_PROJECT_ID,
+) -> dict:
+    """Index all ADR-*.md files from adr_dir into db_path.
+
+    Returns a summary dict with 'indexed', 'skipped', 'total' counts.
+    Raises on NDJSON event-write failure (ADR-005).
+    """
+    adr_files = sorted(adr_dir.glob("ADR-*.md"))
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None  # manual transaction control
+
+    indexed = 0
+    skipped = 0
+
+    for md_file in adr_files:
+        adr = _parse_adr(md_file, project_id=project_id)
+
+        # ADR-005: NDJSON event BEFORE SQLite commit; raise on failure
+        _write_ndjson_event(events_file, adr)
+
+        conn.execute("BEGIN")
+        try:
+            changed = _upsert_adr(conn, adr)
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        if changed:
+            indexed += 1
+        else:
+            skipped += 1
+
+    conn.close()
+    return {"indexed": indexed, "skipped": skipped, "total": len(adr_files)}
+
+
+def main() -> None:
+    paths = ensure_env()
+    vnx_home = Path(paths["VNX_HOME"])
+    state_dir = Path(paths["VNX_STATE_DIR"])
+
+    db_path = state_dir / "quality_intelligence.db"
+    adr_dir = vnx_home / "docs" / "governance" / "decisions"
+    events_file = Path(paths["VNX_DATA_DIR"]) / "events" / "adr_index.ndjson"
+
+    if not db_path.exists():
+        raise SystemExit(f"DB not found: {db_path} — run quality_db_init.py first")
+    if not adr_dir.exists():
+        raise SystemExit(f"ADR directory not found: {adr_dir}")
+
+    result = index_adrs(db_path, adr_dir, events_file)
+    print(
+        f"ADR indexing complete: {result['indexed']} indexed, "
+        f"{result['skipped']} skipped, {result['total']} total"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -23,7 +23,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 18
+HIGHEST_QI_VERSION = 19
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -499,6 +499,85 @@ def _migrate_v17(conn: sqlite3.Connection) -> None:
             log('INFO', f'Migrated {_htbl}: added invalidation_reason column')
 
 
+def _migrate_v19(conn: sqlite3.Connection) -> None:
+    """V19: adrs table + FTS5 virtual table + sync triggers (PR-INT-1).
+
+    Table/FTS5 may already exist on fresh installs (created by V1 base schema).
+    Triggers are always checked separately because trigger bodies contain
+    semicolons that the schema SQL splitter cannot handle.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS adrs (
+                adr_id              TEXT    NOT NULL,
+                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                status              TEXT    NOT NULL,
+                title               TEXT    NOT NULL,
+                decision_summary    TEXT    NOT NULL,
+                binding_rules       TEXT    NOT NULL DEFAULT '[]',
+                applies_to_tables   TEXT    NOT NULL DEFAULT '[]',
+                applies_to_skills   TEXT    NOT NULL DEFAULT '[]',
+                triggers            TEXT    NOT NULL DEFAULT '[]',
+                file_path           TEXT    NOT NULL,
+                indexed_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                source_hash         TEXT    NOT NULL,
+                PRIMARY KEY (adr_id, project_id)
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_adrs_status ON adrs(status)")
+        log('INFO', 'Migrated: created adrs table (PR-INT-1)')
+
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs_fts'"
+    ).fetchone():
+        conn.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+                adr_id UNINDEXED,
+                title,
+                decision_summary,
+                binding_rules,
+                content='adrs',
+                content_rowid='rowid'
+            )
+        """)
+        log('INFO', 'Migrated: created adrs_fts FTS5 virtual table (PR-INT-1)')
+
+    # Triggers checked separately — trigger bodies contain semicolons that the
+    # schema SQL splitter cannot handle, so they live here, not in quality_intelligence.sql.
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_ai'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_ai AFTER INSERT ON adrs BEGIN
+                INSERT INTO adrs_fts(rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES (new.rowid, new.adr_id, new.title, new.decision_summary, new.binding_rules);
+            END
+        """)
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_ad'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_ad AFTER DELETE ON adrs BEGIN
+                INSERT INTO adrs_fts(adrs_fts, rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES ('delete', old.rowid, old.adr_id, old.title, old.decision_summary, old.binding_rules);
+            END
+        """)
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_au'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_au AFTER UPDATE ON adrs BEGIN
+                INSERT INTO adrs_fts(adrs_fts, rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES ('delete', old.rowid, old.adr_id, old.title, old.decision_summary, old.binding_rules);
+                INSERT INTO adrs_fts(rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES (new.rowid, new.adr_id, new.title, new.decision_summary, new.binding_rules);
+            END
+        """)
+        log('INFO', 'Migrated: created adrs FTS5 sync triggers (PR-INT-1)')
+
+
 def _migrate_v18(conn: sqlite3.Connection) -> None:
     """V18: dispatch_experiments (unified from dispatch_tracker.db).
 
@@ -575,6 +654,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     16: _migrate_v16,
     17: _migrate_v17,
     18: _migrate_v18,
+    19: _migrate_v19,
 }
 
 
@@ -654,7 +734,8 @@ def verify_database_structure() -> bool:
             'spc_control_limits',
             'spc_alerts',
             'confidence_events',
-            'report_findings'
+            'report_findings',
+            'adrs',
         ]
 
         # Expected views

--- a/tests/test_adrs_fts.py
+++ b/tests/test_adrs_fts.py
@@ -1,0 +1,119 @@
+"""tests/test_adrs_fts.py — FTS5 search over adrs table (PR-INT-1).
+
+Verifies:
+- FTS5 query 'multi-tenant' returns ADR-007
+- FTS5 query on title finds correct ADR
+- FTS5 sync triggers work: insert-then-query returns results
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+from quality_db_init import _migrate_v19
+
+
+_ADR_007_SUMMARY = (
+    "All multi-tenant tables in central VNX state DBs carry a project_id TEXT NOT NULL "
+    "DEFAULT 'vnx-dev' column. Every UNIQUE constraint on a natural key is composite "
+    "over project_id. The importer prefix-rewrites with <project_id>:<source_id> for "
+    "shared identifier columns."
+)
+
+_ADR_001_SUMMARY = (
+    "VNX must not use external Redis or any external key-value store for runtime state. "
+    "All coordination state must be stored in local SQLite databases under .vnx-data/."
+)
+
+
+def _make_db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "qi.db"))
+    conn.isolation_level = None
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+    return conn
+
+
+def _insert_adr(conn: sqlite3.Connection, adr_id: str, title: str, summary: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO adrs
+            (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+        VALUES (?, 'vnx-dev', 'Accepted', ?, ?, ?, ?)
+        """,
+        (adr_id, title, summary, f"docs/{adr_id}.md", adr_id[:8]),
+    )
+
+
+class TestAdrsFts:
+    def test_fts5_query_multitenant_returns_adr007(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        # FTS5 requires quoting for hyphenated terms to avoid subtraction parse
+        rows = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-007" in adr_ids, f"ADR-007 not in FTS results: {adr_ids}"
+
+    def test_fts5_query_redis_returns_adr001(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'Redis'"
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-001" in adr_ids
+
+    def test_fts5_query_project_id_returns_adr007(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'project_id'"
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-007" in adr_ids
+
+    def test_fts5_empty_on_nonexistent_term(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'xyznonexistenttermxyz'"
+        ).fetchall()
+        assert rows == []
+
+    def test_fts5_updated_after_delete(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+
+        # Verify it's in FTS before delete
+        rows = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        assert len(rows) >= 1
+
+        # Delete from base table — trigger should remove from FTS
+        conn.execute("DELETE FROM adrs WHERE adr_id='ADR-007' AND project_id='vnx-dev'")
+
+        rows_after = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        assert rows_after == []

--- a/tests/test_adrs_schema.py
+++ b/tests/test_adrs_schema.py
@@ -1,0 +1,117 @@
+"""tests/test_adrs_schema.py — adrs table + FTS5 + index schema validation (PR-INT-1).
+
+Verifies:
+- V19 migration creates adrs table, FTS5 virtual table, and status index
+- Composite PK (adr_id, project_id) is enforced
+- FTS5 sync triggers exist
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+
+
+def _make_conn(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "test_qi.db"))
+    conn.isolation_level = None
+    return conn
+
+
+def _apply_v19(conn: sqlite3.Connection) -> None:
+    from quality_db_init import _migrate_v19
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+
+
+class TestAdrsTable:
+    def test_adrs_table_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+        ).fetchone()
+        assert row is not None, "adrs table not created"
+
+    def test_adrs_fts5_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs_fts'"
+        ).fetchone()
+        assert row is not None, "adrs_fts virtual table not created"
+
+    def test_status_index_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_adrs_status'"
+        ).fetchone()
+        assert row is not None, "idx_adrs_status index not created"
+
+    def test_triggers_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        triggers = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='adrs'"
+            ).fetchall()
+        }
+        assert "adrs_ai" in triggers, "INSERT trigger missing"
+        assert "adrs_ad" in triggers, "DELETE trigger missing"
+        assert "adrs_au" in triggers, "UPDATE trigger missing"
+
+    def test_composite_pk_enforced(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        # Same adr_id + project_id → IntegrityError
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("""
+                INSERT INTO adrs
+                    (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+                VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A dup', 'Decision dup', 'docs/a.md', 'xyz')
+            """)
+
+    def test_different_project_id_allowed(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        # Same adr_id but different project_id → allowed
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'other-project', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        count = conn.execute("SELECT COUNT(*) FROM adrs WHERE adr_id='ADR-001'").fetchone()[0]
+        assert count == 2
+
+    def test_migration_idempotent(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        # Running again must not raise
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+        ).fetchone()
+        assert row is not None

--- a/tests/test_index_adrs.py
+++ b/tests/test_index_adrs.py
@@ -1,0 +1,189 @@
+"""tests/test_index_adrs.py — ADR indexer parsing + idempotency + NDJSON events (PR-INT-1).
+
+Verifies:
+- Correct parsing of adr_id, status, title, decision_summary, binding_rules
+- Idempotency: rerun with same source_hash skips row (0 changes)
+- NDJSON event emitted per ADR indexed
+- Raises on event-write failure (ADR-005)
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+from quality_db_init import _migrate_v19
+from index_adrs import _parse_adr, index_adrs
+
+
+_FIXTURE_ADR = """\
+# ADR-007 — Multi-tenant `project_id` Stamping Pattern
+
+**Status:** Accepted
+**Date:** 2026-05-09
+
+## Context
+
+VNX began as a single-tenant system.
+
+## Decision
+
+**All multi-tenant tables carry a project_id column with composite UNIQUE/PK.**
+
+Concrete rules:
+
+- Every table declares project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+- UNIQUE constraints must be composite over project_id
+- Importers must stamp project_id explicitly
+
+## Consequences
+
+### Accepted
+
+- New tables must be project_id-stamped at design time
+"""
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+    conn.close()
+    return db_path
+
+
+def _write_adr(tmp_path: Path, filename: str, content: str) -> Path:
+    adr_dir = tmp_path / "decisions"
+    adr_dir.mkdir(exist_ok=True)
+    p = adr_dir / filename
+    p.write_text(content, encoding="utf-8")
+    return adr_dir
+
+
+class TestAdrParser:
+    def test_adr_id_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert adr["adr_id"] == "ADR-007"
+
+    def test_status_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert adr["status"] == "Accepted"
+
+    def test_title_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert "Multi-tenant" in adr["title"]
+
+    def test_decision_summary_populated(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert "project_id" in adr["decision_summary"]
+
+    def test_binding_rules_json_list(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        rules = json.loads(adr["binding_rules"])
+        assert isinstance(rules, list)
+        assert len(rules) >= 1
+        assert any("project_id" in r for r in rules)
+
+    def test_source_hash_16_chars(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert len(adr["source_hash"]) == 16
+
+    def test_project_id_stamped(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
+        assert adr["project_id"] == "test-proj"
+
+
+class TestIndexAdrs:
+    def test_indexes_adr_row(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        result = index_adrs(db_path, adr_dir, events_file)
+        assert result["indexed"] == 1
+        assert result["total"] == 1
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT adr_id FROM adrs WHERE adr_id='ADR-007'").fetchone()
+        conn.close()
+        assert row is not None
+
+    def test_idempotent_rerun_skips(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        result2 = index_adrs(db_path, adr_dir, events_file)
+        assert result2["indexed"] == 0
+        assert result2["skipped"] == 1
+
+    def test_ndjson_event_emitted(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        assert events_file.exists()
+        lines = [l for l in events_file.read_text().splitlines() if l.strip()]
+        assert len(lines) >= 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "adr_indexed"
+        assert event["adr_id"] == "ADR-007"
+        assert "record_id" in event
+
+    def test_ndjson_event_has_record_id(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        lines = [l for l in events_file.read_text().splitlines() if l.strip()]
+        event = json.loads(lines[0])
+        # record_id must be a 64-char hex sha256
+        assert len(event["record_id"]) == 64
+
+    def test_raises_on_event_write_failure(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        with mock.patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                index_adrs(db_path, adr_dir, events_file)
+
+    def test_changed_content_reindexed(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+
+        # Modify the ADR
+        (adr_dir / "ADR-007-multitenant.md").write_text(
+            _FIXTURE_ADR + "\n\n## Additional notes\n\nUpdated content.\n",
+            encoding="utf-8",
+        )
+        result2 = index_adrs(db_path, adr_dir, events_file)
+        assert result2["indexed"] == 1


### PR DESCRIPTION
## Summary

- Adds `adrs` table with composite PK `(adr_id, project_id)` per ADR-007 binding rule
- Adds `adrs_fts` FTS5 virtual table with content sync triggers (`adrs_ai`, `adrs_ad`, `adrs_au`)
- `scripts/index_adrs.py`: idempotent indexer with NDJSON event written before SQLite commit (ADR-005), raises on event-write failure
- V19 migration in `quality_db_init.py` covers existing installs; fresh installs get DDL via V1 schema
- 25 tests: `test_adrs_schema.py` (7), `test_index_adrs.py` (13), `test_adrs_fts.py` (5)
- All 18 existing ADRs indexed; rerun produces 0 changes; FTS5 `"multi-tenant"` returns ADR-007

## Known limitations

- FTS5 trigger bodies contain semicolons that the `apply_script_if_below` SQL splitter cannot handle; triggers are created via `conn.execute()` in `_migrate_v19`, not in `quality_intelligence.sql`. A comment in the schema file documents this.
- Hyphenated search terms (e.g., `multi-tenant`) require FTS5 phrase quoting: `MATCH '"multi-tenant"'` instead of `MATCH 'multi-tenant'`. This is standard SQLite FTS5 behavior.

## Test plan

- [ ] `python -m pytest tests/test_adrs_schema.py tests/test_index_adrs.py tests/test_adrs_fts.py -v` → 25/25 passed
- [ ] `python scripts/quality_db_init.py` → SUCCESS, 24 tables, V19 triggers created
- [ ] `python scripts/index_adrs.py` → 18 indexed, 0 skipped; rerun → 0 indexed, 18 skipped
- [ ] `sqlite3 .vnx-data/state/quality_intelligence.db "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH '\"multi-tenant\"'"` → ADR-007 returned
- [ ] `bash scripts/local-ci.sh` → all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)