### PR TITLE
feat(int-2): Wave-5 ADR injection in dispatch context

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -665,3 +665,42 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 );
 
 INSERT OR IGNORE INTO schema_meta(key, value) VALUES ('schema_version', '0');
+
+-- ============================================================================
+-- ADR REGISTRY (PR-INT-1: queryable ADR table + FTS5 for Wave-5 injection)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS adrs (
+    adr_id              TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    status              TEXT    NOT NULL,
+    title               TEXT    NOT NULL,
+    decision_summary    TEXT    NOT NULL,
+    binding_rules       TEXT    NOT NULL DEFAULT '[]',
+    applies_to_tables   TEXT    NOT NULL DEFAULT '[]',
+    applies_to_skills   TEXT    NOT NULL DEFAULT '[]',
+    triggers            TEXT    NOT NULL DEFAULT '[]',
+    file_path           TEXT    NOT NULL,
+    indexed_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    source_hash         TEXT    NOT NULL,
+    PRIMARY KEY (adr_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adrs_status ON adrs(status);
+
+-- FTS5 virtual table for semantic search over ADR content
+CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+    adr_id UNINDEXED,
+    title,
+    decision_summary,
+    binding_rules,
+    content='adrs',
+    content_rowid='rowid'
+);
+
+-- Triggers (adrs_ai, adrs_ad, adrs_au) are created by _migrate_v19 in quality_db_init.py.
+-- SQLite trigger bodies contain semicolons that confuse the schema SQL splitter,
+-- so they are managed via conn.execute() in Python, not via apply_script_if_below.
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.3.0-adr-registry', 'Add adrs table + FTS5 virtual table + sync triggers (PR-INT-1)');

--- a/scripts/index_adrs.py
+++ b/scripts/index_adrs.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Index all ADR markdown files into the adrs table + FTS5.
+
+ADR-005: NDJSON event written BEFORE SQLite commit; raises on event-write failure.
+ADR-007: composite PK (adr_id, project_id); project_id stamped explicitly.
+Idempotent: skips ADRs whose source_hash matches the stored value.
+
+Usage:
+    python3 scripts/index_adrs.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPT_DIR / "lib"))
+
+try:
+    from vnx_paths import ensure_env
+except Exception as exc:
+    raise SystemExit(f"Failed to load vnx_paths: {exc}")
+
+_DEFAULT_PROJECT_ID = "vnx-dev"
+
+
+def _parse_adr(file_path: Path, project_id: str = _DEFAULT_PROJECT_ID) -> dict:
+    stem = file_path.stem  # e.g. ADR-007-multitenant-project-id-stamping
+    parts = stem.split("-")
+    adr_id = f"{parts[0]}-{parts[1]}"  # ADR-007
+
+    content = file_path.read_text(encoding="utf-8")
+    source_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+
+    lines = content.splitlines()
+
+    # Title: first # heading
+    title = ""
+    for line in lines:
+        if line.startswith("# "):
+            title = line[2:].strip()
+            break
+
+    # Status: from **Status:** line or front-matter 'Status: X'
+    status = "Proposed"
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("**Status:**"):
+            status = stripped.split("**Status:**", 1)[1].strip().strip("*")
+            break
+        m = re.match(r"^Status:\s*(.+)$", stripped, re.IGNORECASE)
+        if m:
+            status = m.group(1).strip()
+            break
+
+    # Parse markdown sections by '## ' headers
+    sections: dict[str, str] = {}
+    current_section: Optional[str] = None
+    current_lines: list[str] = []
+    for line in lines:
+        if line.startswith("## "):
+            if current_section is not None:
+                sections[current_section] = "\n".join(current_lines).strip()
+            current_section = line[3:].strip()
+            current_lines = []
+        elif current_section is not None:
+            current_lines.append(line)
+    if current_section is not None:
+        sections[current_section] = "\n".join(current_lines).strip()
+
+    decision_text = sections.get("Decision") or sections.get("decision") or ""
+    decision_summary = decision_text
+
+    # Extract binding_rules: bullet lines from Decision section
+    binding_rules = _extract_bullets(decision_text)
+
+    # applies_to_tables / applies_to_skills: parse if present
+    applies_to_tables = _extract_bullets(sections.get("Applies to tables", ""))
+    applies_to_skills = _extract_bullets(sections.get("Applies to skills", ""))
+
+    # triggers: regex patterns from 'When to apply' section if present
+    triggers = _extract_bullets(sections.get("When to apply", ""))
+
+    return {
+        "adr_id": adr_id,
+        "project_id": project_id,
+        "status": status,
+        "title": title,
+        "decision_summary": decision_summary,
+        "binding_rules": json.dumps(binding_rules),
+        "applies_to_tables": json.dumps(applies_to_tables),
+        "applies_to_skills": json.dumps(applies_to_skills),
+        "triggers": json.dumps(triggers),
+        "file_path": str(file_path),
+        "source_hash": source_hash,
+    }
+
+
+def _extract_bullets(text: str) -> list[str]:
+    bullets = []
+    for line in text.splitlines():
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
+        if m:
+            bullets.append(m.group(1).strip())
+    return bullets
+
+
+def _write_ndjson_event(events_file: Path, adr: dict) -> None:
+    record_id = hashlib.sha256(
+        f"{adr['adr_id']}:{adr['source_hash']}".encode()
+    ).hexdigest()
+    event = {
+        "record_id": record_id,
+        "event_type": "adr_indexed",
+        "adr_id": adr["adr_id"],
+        "project_id": adr["project_id"],
+        "source_hash": adr["source_hash"],
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+    }
+    events_file.parent.mkdir(parents=True, exist_ok=True)
+    # ADR-005: raise on failure, never swallow
+    with open(events_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def _upsert_adr(conn: sqlite3.Connection, adr: dict) -> bool:
+    existing = conn.execute(
+        "SELECT source_hash FROM adrs WHERE adr_id = ? AND project_id = ?",
+        (adr["adr_id"], adr["project_id"]),
+    ).fetchone()
+
+    if existing and existing[0] == adr["source_hash"]:
+        return False  # idempotent skip
+
+    conn.execute(
+        """
+        INSERT INTO adrs
+            (adr_id, project_id, status, title, decision_summary,
+             binding_rules, applies_to_tables, applies_to_skills,
+             triggers, file_path, source_hash)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(adr_id, project_id) DO UPDATE SET
+            status           = excluded.status,
+            title            = excluded.title,
+            decision_summary = excluded.decision_summary,
+            binding_rules    = excluded.binding_rules,
+            applies_to_tables = excluded.applies_to_tables,
+            applies_to_skills = excluded.applies_to_skills,
+            triggers         = excluded.triggers,
+            file_path        = excluded.file_path,
+            indexed_at       = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+            source_hash      = excluded.source_hash
+        """,
+        (
+            adr["adr_id"],
+            adr["project_id"],
+            adr["status"],
+            adr["title"],
+            adr["decision_summary"],
+            adr["binding_rules"],
+            adr["applies_to_tables"],
+            adr["applies_to_skills"],
+            adr["triggers"],
+            adr["file_path"],
+            adr["source_hash"],
+        ),
+    )
+    return True
+
+
+def index_adrs(
+    db_path: Path,
+    adr_dir: Path,
+    events_file: Path,
+    project_id: str = _DEFAULT_PROJECT_ID,
+) -> dict:
+    """Index all ADR-*.md files from adr_dir into db_path.
+
+    Returns a summary dict with 'indexed', 'skipped', 'total' counts.
+    Raises on NDJSON event-write failure (ADR-005).
+    """
+    adr_files = sorted(adr_dir.glob("ADR-*.md"))
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None  # manual transaction control
+
+    indexed = 0
+    skipped = 0
+
+    for md_file in adr_files:
+        adr = _parse_adr(md_file, project_id=project_id)
+
+        # ADR-005: NDJSON event BEFORE SQLite commit; raise on failure
+        _write_ndjson_event(events_file, adr)
+
+        conn.execute("BEGIN")
+        try:
+            changed = _upsert_adr(conn, adr)
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        if changed:
+            indexed += 1
+        else:
+            skipped += 1
+
+    conn.close()
+    return {"indexed": indexed, "skipped": skipped, "total": len(adr_files)}
+
+
+def main() -> None:
+    paths = ensure_env()
+    vnx_home = Path(paths["VNX_HOME"])
+    state_dir = Path(paths["VNX_STATE_DIR"])
+
+    db_path = state_dir / "quality_intelligence.db"
+    adr_dir = vnx_home / "docs" / "governance" / "decisions"
+    events_file = Path(paths["VNX_DATA_DIR"]) / "events" / "adr_index.ndjson"
+
+    if not db_path.exists():
+        raise SystemExit(f"DB not found: {db_path} — run quality_db_init.py first")
+    if not adr_dir.exists():
+        raise SystemExit(f"ADR directory not found: {adr_dir}")
+
+    result = index_adrs(db_path, adr_dir, events_file)
+    print(
+        f"ADR indexing complete: {result['indexed']} indexed, "
+        f"{result['skipped']} skipped, {result['total']} total"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -223,7 +223,8 @@ def fetch_adr_context_section(
         try:
             from project_scope import current_project_id  # noqa: PLC0415
             _pid = current_project_id()
-        except Exception:
+        except (KeyError, AttributeError) as e:
+            logger.debug('project_id not in dispatch context, using vnx-dev default: %s', e)
             _pid = "vnx-dev"
 
     quality_db_path = state_dir / "quality_intelligence.db"

--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -5,15 +5,249 @@ subprocess_dispatch_internals/skill_injection.py and makes it provider-agnostic.
 
 Used by provider_dispatch.py for codex/gemini/litellm dispatches.
 subprocess_dispatch.py delegates here via skill_injection._build_intelligence_section.
+
+INT-2 (Wave-5 ADR injection): fetch_adr_context_section() queries the adrs table
+and injects binding ADR context before the instruction.  Runs on all provider paths.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import re
+import sqlite3
 from pathlib import Path
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Wave-5 ADR injection — constants and helpers (INT-2)
+# ---------------------------------------------------------------------------
+
+ADR_TRIGGER_ROLES = frozenset({
+    "database-engineer",
+    "architect",
+    "intelligence-engineer",
+    "security-engineer",
+})
+
+# Path prefixes that trigger ADR injection regardless of role
+ADR_TRIGGER_PATH_PREFIXES = (
+    "schemas/migrations/",
+    "schemas/",
+    "scripts/lib/coordination_db.py",
+    "scripts/lib/quality_db.py",
+)
+
+ADR_MAX_RESULTS = 3
+ADR_SUMMARY_MAX_CHARS = 200
+
+# Env var checked by fetch_adr_context_section (set by --no-adr-inject in subprocess_dispatch)
+_ENV_NO_ADR_INJECT = "VNX_NO_ADR_INJECT"
+
+
+def _adr_injection_triggered(
+    role: Optional[str],
+    dispatch_paths: Optional[List[str]],
+) -> bool:
+    """Return True when the dispatch meets ADR injection trigger criteria."""
+    if role in ADR_TRIGGER_ROLES:
+        return True
+    if not dispatch_paths:
+        return False
+    for path in dispatch_paths:
+        for prefix in ADR_TRIGGER_PATH_PREFIXES:
+            if path == prefix.rstrip("/") or path.startswith(prefix):
+                return True
+    return False
+
+
+def _build_fts_terms(dispatch_paths: Optional[List[str]]) -> str:
+    """Extract meaningful terms from dispatch paths for FTS5 MATCH query."""
+    if not dispatch_paths:
+        return ""
+    terms: set = set()
+    for path in dispatch_paths:
+        parts = re.split(r"[/._\-]", path)
+        for part in parts:
+            if len(part) > 3 and part.isalpha():
+                terms.add(part)
+    if not terms:
+        return ""
+    return " OR ".join(sorted(terms))
+
+
+def _query_adrs_from_db(
+    db_path: Path,
+    role: Optional[str],
+    dispatch_paths: Optional[List[str]],
+    project_id: str,
+) -> List[dict]:
+    """Query adrs table for relevant accepted ADRs.  Returns list of row dicts."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        params: list = [project_id]
+        where_clauses = ["a.status = 'Accepted'", "a.project_id = ?"]
+        sub_conditions: list = []
+
+        if role:
+            sub_conditions.append("a.applies_to_skills LIKE '%' || ? || '%'")
+            params.append(role)
+
+        fts_terms = _build_fts_terms(dispatch_paths)
+        if fts_terms:
+            sub_conditions.append(
+                "a.rowid IN (SELECT rowid FROM adrs_fts WHERE adrs_fts MATCH ?)"
+            )
+            params.append(fts_terms)
+
+        if sub_conditions:
+            where_clauses.append(f"({' OR '.join(sub_conditions)})")
+
+        sql = (
+            "SELECT a.adr_id, a.title, a.decision_summary, a.binding_rules"
+            " FROM adrs a"
+            f" WHERE {' AND '.join(where_clauses)}"
+            " ORDER BY a.adr_id"
+            f" LIMIT {ADR_MAX_RESULTS}"
+        )
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError as exc:
+        # adrs or adrs_fts table absent — old schema; retry without FTS subquery
+        if "adrs_fts" in str(exc) and fts_terms:  # type: ignore[possibly-undefined]
+            try:
+                no_fts_sub = [c for c in sub_conditions if "adrs_fts" not in c]  # type: ignore[possibly-undefined]
+                no_fts_params = [p for p in params if p != fts_terms]
+                where_no_fts = ["a.status = 'Accepted'", "a.project_id = ?"]
+                if no_fts_sub:
+                    where_no_fts.append(f"({' OR '.join(no_fts_sub)})")
+                sql_no_fts = (
+                    "SELECT a.adr_id, a.title, a.decision_summary, a.binding_rules"
+                    " FROM adrs a"
+                    f" WHERE {' AND '.join(where_no_fts)}"
+                    " ORDER BY a.adr_id"
+                    f" LIMIT {ADR_MAX_RESULTS}"
+                )
+                rows = conn.execute(sql_no_fts, no_fts_params).fetchall()
+                return [dict(r) for r in rows]
+            except Exception:
+                return []
+        logger.debug("_query_adrs_from_db: OperationalError: %s", exc)
+        return []
+    finally:
+        conn.close()
+
+
+def _format_adr_context_block(adrs: List[dict]) -> str:
+    """Format ADR rows as the Wave-5 binding context block."""
+    lines = [
+        "## ADR Context (auto-injected per Wave-5)",
+        "",
+        "The following Architectural Decision Records apply to your dispatch scope:",
+        "",
+    ]
+    for row in adrs:
+        adr_id = row.get("adr_id", "")
+        title = row.get("title", "")
+        summary = (row.get("decision_summary") or "")[:ADR_SUMMARY_MAX_CHARS]
+        lines.append(f"### {adr_id} — {title}")
+        lines.append(f"**Decision summary:** {summary}")
+        try:
+            rules: list = json.loads(row.get("binding_rules") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            rules = []
+        if rules:
+            lines.append("**Binding rules:**")
+            for rule in rules:
+                lines.append(f"- {rule}")
+        lines.append("")
+    lines.append("These are BINDING — your implementation MUST comply.")
+    return "\n".join(lines)
+
+
+def _emit_adr_injection_event(
+    dispatch_id: str,
+    adr_ids: List[str],
+    state_dir: Path,
+) -> None:
+    """Write ADR injection audit event to NDJSON ledger.
+
+    Per ADR-005: ledger-first, raises OSError on write failure.
+    """
+    import datetime  # noqa: PLC0415
+
+    event = {
+        "event": "adr_context_injected",
+        "dispatch_id": dispatch_id,
+        "adr_ids": adr_ids,
+        "injected_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "source": "intelligence_injection.fetch_adr_context_section",
+    }
+    register_path = state_dir / "dispatch_register.ndjson"
+    register_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(register_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event) + "\n")
+
+
+def fetch_adr_context_section(
+    dispatch_id: str,
+    role: Optional[str],
+    dispatch_paths: Optional[List[str]],
+    state_dir: Path,
+    *,
+    project_id: Optional[str] = None,
+    no_inject: bool = False,
+) -> str:
+    """Fetch ADR context block for Wave-5 dispatch injection.
+
+    Returns empty string when no ADRs match or injection is disabled.
+
+    ADR-007: queries are always filtered by project_id.
+    ADR-005: writes NDJSON audit event on injection; raises OSError on event-write failure.
+    DO NOT wrap this function in a bare except — OSError from event-write must propagate.
+    """
+    if no_inject or os.environ.get(_ENV_NO_ADR_INJECT, "0") == "1":
+        return ""
+    if not _adr_injection_triggered(role, dispatch_paths):
+        return ""
+
+    _pid: str
+    if project_id:
+        _pid = project_id
+    else:
+        try:
+            from project_scope import current_project_id  # noqa: PLC0415
+            _pid = current_project_id()
+        except Exception:
+            _pid = "vnx-dev"
+
+    quality_db_path = state_dir / "quality_intelligence.db"
+    if not quality_db_path.exists():
+        return ""
+
+    try:
+        adrs = _query_adrs_from_db(quality_db_path, role, dispatch_paths, _pid)
+    except Exception as exc:
+        logger.warning("ADR context query failed (%s); proceeding without", exc)
+        return ""
+
+    if not adrs:
+        return ""
+
+    adr_ids = [r["adr_id"] for r in adrs]
+    # Per ADR-005: write NDJSON event FIRST, raise on failure (OSError propagates to caller)
+    _emit_adr_injection_event(dispatch_id, adr_ids, state_dir)
+
+    return _format_adr_context_block(adrs)
+
+
+# ---------------------------------------------------------------------------
+# Main injection API
+# ---------------------------------------------------------------------------
 
 
 def build_intelligence_section(
@@ -33,6 +267,7 @@ def build_intelligence_section(
 
     Returns the original instruction unchanged when the database is absent,
     the selector returns no items, or any exception occurs (best-effort).
+    OSError from ADR event-write is re-raised per ADR-005.
     """
     section = fetch_intelligence_section(
         dispatch_id=dispatch_id,
@@ -70,9 +305,25 @@ def fetch_intelligence_section(
     intelligence_persist.update_confidence_from_outcome can match injected
     patterns back to their source dispatch on receipt arrival.
 
-    Any import or DB failure is caught and logged; callers receive an empty
-    string and proceed without intelligence.
+    INT-2: Also prepends ADR context block from the adrs table when triggers match.
+    OSError from ADR event-write propagates (ADR-005: raise on event-write failure).
+    Other exceptions are caught and logged; callers receive empty string.
     """
+    # ADR context injection (INT-2) — runs before existing intelligence
+    # OSError propagates; other exceptions are handled below
+    adr_section: str = ""
+    try:
+        adr_section = fetch_adr_context_section(
+            dispatch_id=dispatch_id,
+            role=role,
+            dispatch_paths=dispatch_paths,
+            state_dir=state_dir,
+        )
+    except OSError:
+        raise  # per ADR-005: event-write failure must propagate
+    except Exception as exc:
+        logger.warning("ADR context fetch failed (%s); proceeding without", exc)
+
     try:
         from intelligence_selector import IntelligenceSelector  # noqa: PLC0415
         quality_db_path = state_dir / "quality_intelligence.db"
@@ -105,12 +356,15 @@ def fetch_intelligence_section(
                 )
         finally:
             selector.close()
-        if not result.items:
-            return ""
-        return format_intelligence_items(result.items)
+        intel_section = format_intelligence_items(result.items) if result.items else ""
     except Exception as exc:
         logger.warning("intelligence injection failed (%s); proceeding without", exc)
-        return ""
+        intel_section = ""
+
+    # Combine: ADR context first (most binding), then intelligence items
+    if adr_section and intel_section:
+        return f"{adr_section}\n\n---\n\n{intel_section}"
+    return adr_section or intel_section
 
 
 def format_intelligence_items(items: list) -> str:

--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -134,8 +134,9 @@ def _query_adrs_from_db(
                 )
                 rows = conn.execute(sql_no_fts, no_fts_params).fetchall()
                 return [dict(r) for r in rows]
-            except Exception:
-                return []
+            except sqlite3.OperationalError as e:
+                logger.warning('ADR DB query failed (table missing or corrupt): %s', e)
+                return []  # ADR injection is best-effort; missing/corrupt DB shouldn't block dispatch
         logger.debug("_query_adrs_from_db: OperationalError: %s", exc)
         return []
     finally:

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -343,7 +343,15 @@ if __name__ == "__main__":
         "--auto-route", action="store_true",
         help="Use smart_router to auto-select model (opt-in, default off).",
     )
+    parser.add_argument(
+        "--no-adr-inject", action="store_true",
+        help="Disable Wave-5 ADR context injection (debug/testing only).",
+    )
     args = parser.parse_args()
+
+    # Wave-5 ADR injection opt-out: set env var before instruction assembly (INT-2)
+    if getattr(args, "no_adr_inject", False):
+        os.environ["VNX_NO_ADR_INJECT"] = "1"
 
     # OI-1107: fall back to Role: header in instruction, then to a documented default.
     if args.role is None:

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -23,7 +23,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 18
+HIGHEST_QI_VERSION = 19
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -499,6 +499,85 @@ def _migrate_v17(conn: sqlite3.Connection) -> None:
             log('INFO', f'Migrated {_htbl}: added invalidation_reason column')
 
 
+def _migrate_v19(conn: sqlite3.Connection) -> None:
+    """V19: adrs table + FTS5 virtual table + sync triggers (PR-INT-1).
+
+    Table/FTS5 may already exist on fresh installs (created by V1 base schema).
+    Triggers are always checked separately because trigger bodies contain
+    semicolons that the schema SQL splitter cannot handle.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS adrs (
+                adr_id              TEXT    NOT NULL,
+                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                status              TEXT    NOT NULL,
+                title               TEXT    NOT NULL,
+                decision_summary    TEXT    NOT NULL,
+                binding_rules       TEXT    NOT NULL DEFAULT '[]',
+                applies_to_tables   TEXT    NOT NULL DEFAULT '[]',
+                applies_to_skills   TEXT    NOT NULL DEFAULT '[]',
+                triggers            TEXT    NOT NULL DEFAULT '[]',
+                file_path           TEXT    NOT NULL,
+                indexed_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                source_hash         TEXT    NOT NULL,
+                PRIMARY KEY (adr_id, project_id)
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_adrs_status ON adrs(status)")
+        log('INFO', 'Migrated: created adrs table (PR-INT-1)')
+
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs_fts'"
+    ).fetchone():
+        conn.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+                adr_id UNINDEXED,
+                title,
+                decision_summary,
+                binding_rules,
+                content='adrs',
+                content_rowid='rowid'
+            )
+        """)
+        log('INFO', 'Migrated: created adrs_fts FTS5 virtual table (PR-INT-1)')
+
+    # Triggers checked separately — trigger bodies contain semicolons that the
+    # schema SQL splitter cannot handle, so they live here, not in quality_intelligence.sql.
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_ai'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_ai AFTER INSERT ON adrs BEGIN
+                INSERT INTO adrs_fts(rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES (new.rowid, new.adr_id, new.title, new.decision_summary, new.binding_rules);
+            END
+        """)
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_ad'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_ad AFTER DELETE ON adrs BEGIN
+                INSERT INTO adrs_fts(adrs_fts, rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES ('delete', old.rowid, old.adr_id, old.title, old.decision_summary, old.binding_rules);
+            END
+        """)
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='adrs_au'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS adrs_au AFTER UPDATE ON adrs BEGIN
+                INSERT INTO adrs_fts(adrs_fts, rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES ('delete', old.rowid, old.adr_id, old.title, old.decision_summary, old.binding_rules);
+                INSERT INTO adrs_fts(rowid, adr_id, title, decision_summary, binding_rules)
+                VALUES (new.rowid, new.adr_id, new.title, new.decision_summary, new.binding_rules);
+            END
+        """)
+        log('INFO', 'Migrated: created adrs FTS5 sync triggers (PR-INT-1)')
+
+
 def _migrate_v18(conn: sqlite3.Connection) -> None:
     """V18: dispatch_experiments (unified from dispatch_tracker.db).
 
@@ -575,6 +654,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     16: _migrate_v16,
     17: _migrate_v17,
     18: _migrate_v18,
+    19: _migrate_v19,
 }
 
 
@@ -654,7 +734,8 @@ def verify_database_structure() -> bool:
             'spc_control_limits',
             'spc_alerts',
             'confidence_events',
-            'report_findings'
+            'report_findings',
+            'adrs',
         ]
 
         # Expected views

--- a/tests/test_adr_injection.py
+++ b/tests/test_adr_injection.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Tests for Wave-5 ADR context injection (PR-INT-2).
+
+Covers: trigger detection, DB query, format, opt-out flag, Superseded guard, top-3 cap.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import intelligence_injection as ii
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _create_adrs_db(path: Path) -> None:
+    """Create a minimal adrs + adrs_fts schema and seed 3 ADRs + 1 Superseded."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS adrs (
+            adr_id              TEXT NOT NULL,
+            project_id          TEXT NOT NULL DEFAULT 'vnx-dev',
+            status              TEXT NOT NULL,
+            title               TEXT NOT NULL,
+            decision_summary    TEXT NOT NULL,
+            binding_rules       TEXT NOT NULL DEFAULT '[]',
+            applies_to_tables   TEXT NOT NULL DEFAULT '[]',
+            applies_to_skills   TEXT NOT NULL DEFAULT '[]',
+            triggers            TEXT NOT NULL DEFAULT '[]',
+            file_path           TEXT NOT NULL,
+            indexed_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            source_hash         TEXT NOT NULL,
+            PRIMARY KEY (adr_id, project_id)
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS adrs_fts USING fts5(
+            adr_id UNINDEXED,
+            title,
+            decision_summary,
+            binding_rules,
+            content='adrs',
+            content_rowid='rowid'
+        );
+    """)
+
+    adrs = [
+        (
+            "ADR-005", "vnx-dev", "Accepted",
+            "Append-Only NDJSON Audit Ledger",
+            "All dispatch lifecycle events MUST write to NDJSON before any SQLite write.",
+            json.dumps(["Write NDJSON first", "SQLite is downstream"]),
+            json.dumps(["dispatch_metadata"]),
+            json.dumps(["database-engineer", "intelligence-engineer"]),
+            json.dumps(["scripts/lib/coordination_db.py", "scripts/lib/quality_db.py"]),
+            "docs/governance/decisions/ADR-005.md",
+            "2026-05-09T00:00:00.000Z",
+            "abc123",
+        ),
+        (
+            "ADR-007", "vnx-dev", "Accepted",
+            "Multi-tenant project_id Stamping Pattern",
+            "All multi-tenant tables carry project_id TEXT NOT NULL, composite UNIQUE.",
+            json.dumps(["Every table needs project_id", "UNIQUE constraints must be composite"]),
+            json.dumps(["adrs", "dispatch_metadata"]),
+            json.dumps(["database-engineer", "architect"]),
+            json.dumps(["schemas/migrations/"]),
+            "docs/governance/decisions/ADR-007.md",
+            "2026-05-09T00:00:00.000Z",
+            "def456",
+        ),
+        (
+            "ADR-010", "vnx-dev", "Accepted",
+            "Frontend Component Isolation",
+            "React components must be isolated with no shared mutable state.",
+            json.dumps(["Use context API", "No global state"]),
+            json.dumps([]),
+            json.dumps(["frontend-developer"]),
+            json.dumps(["src/components/"]),
+            "docs/governance/decisions/ADR-010.md",
+            "2026-05-09T00:00:00.000Z",
+            "ghi789",
+        ),
+        (
+            "ADR-999", "vnx-dev", "Superseded",
+            "Old approach that was superseded",
+            "This decision was superseded and must not be injected.",
+            json.dumps([]),
+            json.dumps([]),
+            json.dumps(["database-engineer"]),
+            json.dumps([]),
+            "docs/governance/decisions/ADR-999.md",
+            "2026-05-01T00:00:00.000Z",
+            "zzz000",
+        ),
+    ]
+
+    conn.executemany(
+        "INSERT OR IGNORE INTO adrs "
+        "(adr_id, project_id, status, title, decision_summary, binding_rules, "
+        " applies_to_tables, applies_to_skills, triggers, file_path, indexed_at, source_hash) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        adrs,
+    )
+
+    # Populate FTS5 content table
+    for row in adrs:
+        conn.execute(
+            "INSERT INTO adrs_fts (adr_id, title, decision_summary, binding_rules) "
+            "VALUES (?,?,?,?)",
+            (row[0], row[3], row[4], row[5]),
+        )
+
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def adr_db_dir(tmp_path):
+    """Return a tmp state dir containing a seeded quality_intelligence.db."""
+    _create_adrs_db(tmp_path / "quality_intelligence.db")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: role=database-engineer + schemas/ path → injects ADR-005 + ADR-007
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionTriggerMatch:
+
+    def test_database_engineer_with_schemas_path_injects_adr005_and_adr007(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-001",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0025_new_table.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        assert "ADR-005" in result
+        assert "ADR-007" in result
+        # ADR-010 (frontend-developer only) must NOT appear
+        assert "ADR-010" not in result
+        # The block must carry the binding header
+        assert "ADR Context (auto-injected per Wave-5)" in result
+        assert "BINDING" in result
+
+    def test_result_contains_decision_summary_and_binding_rules(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-002",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0026_fix.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        # decision_summary present (truncated at 200 chars)
+        assert "All dispatch lifecycle events MUST write to NDJSON" in result
+        # binding rules as bullet list
+        assert "- Write NDJSON first" in result
+
+    def test_ndjson_audit_event_written_on_injection(self, adr_db_dir):
+        ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-003",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0027_col.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        register = adr_db_dir / "dispatch_register.ndjson"
+        assert register.exists()
+        lines = register.read_text().splitlines()
+        events = [json.loads(line) for line in lines if line.strip()]
+        matched = [e for e in events if e.get("event") == "adr_context_injected"
+                   and e.get("dispatch_id") == "test-dispatch-003"]
+        assert matched, "No adr_context_injected event found in NDJSON ledger"
+        assert set(matched[0]["adr_ids"]) >= {"ADR-005", "ADR-007"}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: role=frontend-developer + tests/ path → no injection
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionNoTrigger:
+
+    def test_frontend_developer_with_tests_path_returns_empty(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-010",
+            role="frontend-developer",
+            dispatch_paths=["tests/test_crawler.py"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        assert result == ""
+
+    def test_no_dispatch_paths_no_trigger_role_returns_empty(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-011",
+            role="backend-developer",
+            dispatch_paths=None,
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        assert result == ""
+
+    def test_no_ndjson_written_when_no_injection(self, adr_db_dir):
+        ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-012",
+            role="frontend-developer",
+            dispatch_paths=["src/components/Button.tsx"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        register = adr_db_dir / "dispatch_register.ndjson"
+        if register.exists():
+            lines = register.read_text().splitlines()
+            events = [json.loads(l) for l in lines if l.strip()]
+            matched = [e for e in events if e.get("dispatch_id") == "test-dispatch-012"]
+            assert not matched
+
+
+# ---------------------------------------------------------------------------
+# Test 3: --no-adr-inject flag → no injection regardless of triggers
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionOptOut:
+
+    def test_no_inject_kwarg_disables_injection(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-020",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0028_tbl.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+            no_inject=True,
+        )
+        assert result == ""
+
+    def test_env_var_disables_injection(self, adr_db_dir):
+        with patch.dict(os.environ, {"VNX_NO_ADR_INJECT": "1"}):
+            result = ii.fetch_adr_context_section(
+                dispatch_id="test-dispatch-021",
+                role="database-engineer",
+                dispatch_paths=["schemas/migrations/0029_idx.sql"],
+                state_dir=adr_db_dir,
+                project_id="vnx-dev",
+            )
+        assert result == ""
+
+    def test_env_var_zero_does_not_disable_injection(self, adr_db_dir):
+        with patch.dict(os.environ, {"VNX_NO_ADR_INJECT": "0"}):
+            result = ii.fetch_adr_context_section(
+                dispatch_id="test-dispatch-022",
+                role="database-engineer",
+                dispatch_paths=["schemas/migrations/0030_fix.sql"],
+                state_dir=adr_db_dir,
+                project_id="vnx-dev",
+            )
+        assert result != ""
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Superseded ADRs never injected
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionSupersededGuard:
+
+    def test_superseded_adr_not_in_result(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-030",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0031_tbl.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        assert "ADR-999" not in result
+        assert "superseded" not in result.lower()
+
+    def test_superseded_title_not_in_result(self, adr_db_dir):
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-031",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0032_col.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        assert "Old approach that was superseded" not in result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: top-3 limit honored (mock 5 matches, assert only 3 in output)
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionTopThreeLimit:
+
+    def _seed_five_adrs(self, db_path: Path) -> None:
+        """Add ADR-001 through ADR-004 (on top of existing 005/007 in the fixture)."""
+        conn = sqlite3.connect(str(db_path))
+        extras = [
+            ("ADR-001", "vnx-dev", "Accepted", "Extra ADR One",
+             "Summary one.", "[]", "[]", '["database-engineer"]', "[]",
+             "docs/ADR-001.md", "2026-01-01T00:00:00.000Z", "h1"),
+            ("ADR-002", "vnx-dev", "Accepted", "Extra ADR Two",
+             "Summary two.", "[]", "[]", '["database-engineer"]', "[]",
+             "docs/ADR-002.md", "2026-01-02T00:00:00.000Z", "h2"),
+            ("ADR-003", "vnx-dev", "Accepted", "Extra ADR Three",
+             "Summary three.", "[]", "[]", '["database-engineer"]', "[]",
+             "docs/ADR-003.md", "2026-01-03T00:00:00.000Z", "h3"),
+            ("ADR-004", "vnx-dev", "Accepted", "Extra ADR Four",
+             "Summary four.", "[]", "[]", '["database-engineer"]', "[]",
+             "docs/ADR-004.md", "2026-01-04T00:00:00.000Z", "h4"),
+        ]
+        conn.executemany(
+            "INSERT OR IGNORE INTO adrs "
+            "(adr_id, project_id, status, title, decision_summary, binding_rules, "
+            " applies_to_tables, applies_to_skills, triggers, file_path, indexed_at, source_hash) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            extras,
+        )
+        for row in extras:
+            conn.execute(
+                "INSERT INTO adrs_fts (adr_id, title, decision_summary, binding_rules) "
+                "VALUES (?,?,?,?)",
+                (row[0], row[3], row[4], row[5]),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_at_most_three_adrs_injected(self, adr_db_dir):
+        self._seed_five_adrs(adr_db_dir / "quality_intelligence.db")
+        result = ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-040",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0033_x.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        # Count how many ### ADR-... headers appear
+        import re
+        adr_headers = re.findall(r"### ADR-\w+", result)
+        assert len(adr_headers) <= 3, (
+            f"Expected at most 3 ADR headers, got {len(adr_headers)}: {adr_headers}"
+        )
+
+    def test_ndjson_event_lists_at_most_three_ids(self, adr_db_dir):
+        self._seed_five_adrs(adr_db_dir / "quality_intelligence.db")
+        ii.fetch_adr_context_section(
+            dispatch_id="test-dispatch-041",
+            role="database-engineer",
+            dispatch_paths=["schemas/migrations/0034_y.sql"],
+            state_dir=adr_db_dir,
+            project_id="vnx-dev",
+        )
+        register = adr_db_dir / "dispatch_register.ndjson"
+        lines = register.read_text().splitlines()
+        events = [json.loads(l) for l in lines if l.strip()]
+        matched = [e for e in events if e.get("dispatch_id") == "test-dispatch-041"]
+        assert matched
+        assert len(matched[0]["adr_ids"]) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Trigger helper unit tests
+# ---------------------------------------------------------------------------
+
+class TestAdrTriggerLogic:
+
+    def test_database_engineer_role_triggers(self):
+        assert ii._adr_injection_triggered("database-engineer", None)
+
+    def test_architect_role_triggers(self):
+        assert ii._adr_injection_triggered("architect", [])
+
+    def test_intelligence_engineer_role_triggers(self):
+        assert ii._adr_injection_triggered("intelligence-engineer", [])
+
+    def test_security_engineer_role_triggers(self):
+        assert ii._adr_injection_triggered("security-engineer", [])
+
+    def test_schemas_migrations_path_triggers(self):
+        assert ii._adr_injection_triggered(None, ["schemas/migrations/0001_init.sql"])
+
+    def test_schemas_path_triggers(self):
+        assert ii._adr_injection_triggered(None, ["schemas/quality_intelligence.sql"])
+
+    def test_coordination_db_path_triggers(self):
+        assert ii._adr_injection_triggered(None, ["scripts/lib/coordination_db.py"])
+
+    def test_quality_db_path_triggers(self):
+        assert ii._adr_injection_triggered(None, ["scripts/lib/quality_db.py"])
+
+    def test_unrelated_role_and_path_does_not_trigger(self):
+        assert not ii._adr_injection_triggered(
+            "frontend-developer", ["src/components/Button.tsx"]
+        )
+
+    def test_empty_paths_no_trigger_role_does_not_trigger(self):
+        assert not ii._adr_injection_triggered("backend-developer", [])
+
+
+# ---------------------------------------------------------------------------
+# NDJSON event raise-on-failure
+# ---------------------------------------------------------------------------
+
+class TestAdrInjectionEventWriteRaisesOnFailure:
+
+    def test_osierror_raised_when_state_dir_is_file(self, tmp_path):
+        """_emit_adr_injection_event raises OSError when state_dir is a file."""
+        # Create state_dir as a FILE so mkdir/open fails
+        fake_dir = tmp_path / "not_a_dir"
+        fake_dir.write_text("I am a file")
+        with pytest.raises(OSError):
+            ii._emit_adr_injection_event(
+                dispatch_id="test-err-001",
+                adr_ids=["ADR-005"],
+                state_dir=fake_dir,
+            )

--- a/tests/test_adrs_fts.py
+++ b/tests/test_adrs_fts.py
@@ -1,0 +1,119 @@
+"""tests/test_adrs_fts.py — FTS5 search over adrs table (PR-INT-1).
+
+Verifies:
+- FTS5 query 'multi-tenant' returns ADR-007
+- FTS5 query on title finds correct ADR
+- FTS5 sync triggers work: insert-then-query returns results
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+from quality_db_init import _migrate_v19
+
+
+_ADR_007_SUMMARY = (
+    "All multi-tenant tables in central VNX state DBs carry a project_id TEXT NOT NULL "
+    "DEFAULT 'vnx-dev' column. Every UNIQUE constraint on a natural key is composite "
+    "over project_id. The importer prefix-rewrites with <project_id>:<source_id> for "
+    "shared identifier columns."
+)
+
+_ADR_001_SUMMARY = (
+    "VNX must not use external Redis or any external key-value store for runtime state. "
+    "All coordination state must be stored in local SQLite databases under .vnx-data/."
+)
+
+
+def _make_db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "qi.db"))
+    conn.isolation_level = None
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+    return conn
+
+
+def _insert_adr(conn: sqlite3.Connection, adr_id: str, title: str, summary: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO adrs
+            (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+        VALUES (?, 'vnx-dev', 'Accepted', ?, ?, ?, ?)
+        """,
+        (adr_id, title, summary, f"docs/{adr_id}.md", adr_id[:8]),
+    )
+
+
+class TestAdrsFts:
+    def test_fts5_query_multitenant_returns_adr007(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        # FTS5 requires quoting for hyphenated terms to avoid subtraction parse
+        rows = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-007" in adr_ids, f"ADR-007 not in FTS results: {adr_ids}"
+
+    def test_fts5_query_redis_returns_adr001(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'Redis'"
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-001" in adr_ids
+
+    def test_fts5_query_project_id_returns_adr007(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+        _insert_adr(conn, "ADR-001", "No external Redis", _ADR_001_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'project_id'"
+        ).fetchall()
+        adr_ids = {r[0] for r in rows}
+        assert "ADR-007" in adr_ids
+
+    def test_fts5_empty_on_nonexistent_term(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+
+        rows = conn.execute(
+            "SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH 'xyznonexistenttermxyz'"
+        ).fetchall()
+        assert rows == []
+
+    def test_fts5_updated_after_delete(self, tmp_path):
+        conn = _make_db(tmp_path)
+        _insert_adr(conn, "ADR-007", "Multi-tenant project_id Stamping Pattern", _ADR_007_SUMMARY)
+
+        # Verify it's in FTS before delete
+        rows = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        assert len(rows) >= 1
+
+        # Delete from base table — trigger should remove from FTS
+        conn.execute("DELETE FROM adrs WHERE adr_id='ADR-007' AND project_id='vnx-dev'")
+
+        rows_after = conn.execute(
+            'SELECT adr_id FROM adrs_fts WHERE adrs_fts MATCH \'"multi-tenant"\''
+        ).fetchall()
+        assert rows_after == []

--- a/tests/test_adrs_schema.py
+++ b/tests/test_adrs_schema.py
@@ -1,0 +1,117 @@
+"""tests/test_adrs_schema.py — adrs table + FTS5 + index schema validation (PR-INT-1).
+
+Verifies:
+- V19 migration creates adrs table, FTS5 virtual table, and status index
+- Composite PK (adr_id, project_id) is enforced
+- FTS5 sync triggers exist
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+
+
+def _make_conn(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "test_qi.db"))
+    conn.isolation_level = None
+    return conn
+
+
+def _apply_v19(conn: sqlite3.Connection) -> None:
+    from quality_db_init import _migrate_v19
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+
+
+class TestAdrsTable:
+    def test_adrs_table_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+        ).fetchone()
+        assert row is not None, "adrs table not created"
+
+    def test_adrs_fts5_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs_fts'"
+        ).fetchone()
+        assert row is not None, "adrs_fts virtual table not created"
+
+    def test_status_index_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_adrs_status'"
+        ).fetchone()
+        assert row is not None, "idx_adrs_status index not created"
+
+    def test_triggers_created(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        triggers = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='adrs'"
+            ).fetchall()
+        }
+        assert "adrs_ai" in triggers, "INSERT trigger missing"
+        assert "adrs_ad" in triggers, "DELETE trigger missing"
+        assert "adrs_au" in triggers, "UPDATE trigger missing"
+
+    def test_composite_pk_enforced(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        # Same adr_id + project_id → IntegrityError
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("""
+                INSERT INTO adrs
+                    (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+                VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A dup', 'Decision dup', 'docs/a.md', 'xyz')
+            """)
+
+    def test_different_project_id_allowed(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'vnx-dev', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        # Same adr_id but different project_id → allowed
+        conn.execute("""
+            INSERT INTO adrs
+                (adr_id, project_id, status, title, decision_summary, file_path, source_hash)
+            VALUES ('ADR-001', 'other-project', 'Accepted', 'Title A', 'Decision A', 'docs/a.md', 'abc')
+        """)
+        count = conn.execute("SELECT COUNT(*) FROM adrs WHERE adr_id='ADR-001'").fetchone()[0]
+        assert count == 2
+
+    def test_migration_idempotent(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _apply_v19(conn)
+        # Running again must not raise
+        _apply_v19(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='adrs'"
+        ).fetchone()
+        assert row is not None

--- a/tests/test_index_adrs.py
+++ b/tests/test_index_adrs.py
@@ -1,0 +1,189 @@
+"""tests/test_index_adrs.py — ADR indexer parsing + idempotency + NDJSON events (PR-INT-1).
+
+Verifies:
+- Correct parsing of adr_id, status, title, decision_summary, binding_rules
+- Idempotency: rerun with same source_hash skips row (0 changes)
+- NDJSON event emitted per ADR indexed
+- Raises on event-write failure (ADR-005)
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+from quality_db_init import _migrate_v19
+from index_adrs import _parse_adr, index_adrs
+
+
+_FIXTURE_ADR = """\
+# ADR-007 — Multi-tenant `project_id` Stamping Pattern
+
+**Status:** Accepted
+**Date:** 2026-05-09
+
+## Context
+
+VNX began as a single-tenant system.
+
+## Decision
+
+**All multi-tenant tables carry a project_id column with composite UNIQUE/PK.**
+
+Concrete rules:
+
+- Every table declares project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+- UNIQUE constraints must be composite over project_id
+- Importers must stamp project_id explicitly
+
+## Consequences
+
+### Accepted
+
+- New tables must be project_id-stamped at design time
+"""
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None
+    schema_migration.apply_if_below(conn, 19, _migrate_v19)
+    conn.close()
+    return db_path
+
+
+def _write_adr(tmp_path: Path, filename: str, content: str) -> Path:
+    adr_dir = tmp_path / "decisions"
+    adr_dir.mkdir(exist_ok=True)
+    p = adr_dir / filename
+    p.write_text(content, encoding="utf-8")
+    return adr_dir
+
+
+class TestAdrParser:
+    def test_adr_id_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert adr["adr_id"] == "ADR-007"
+
+    def test_status_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert adr["status"] == "Accepted"
+
+    def test_title_extracted(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert "Multi-tenant" in adr["title"]
+
+    def test_decision_summary_populated(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert "project_id" in adr["decision_summary"]
+
+    def test_binding_rules_json_list(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        rules = json.loads(adr["binding_rules"])
+        assert isinstance(rules, list)
+        assert len(rules) >= 1
+        assert any("project_id" in r for r in rules)
+
+    def test_source_hash_16_chars(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        assert len(adr["source_hash"]) == 16
+
+    def test_project_id_stamped(self, tmp_path):
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
+        assert adr["project_id"] == "test-proj"
+
+
+class TestIndexAdrs:
+    def test_indexes_adr_row(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        result = index_adrs(db_path, adr_dir, events_file)
+        assert result["indexed"] == 1
+        assert result["total"] == 1
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT adr_id FROM adrs WHERE adr_id='ADR-007'").fetchone()
+        conn.close()
+        assert row is not None
+
+    def test_idempotent_rerun_skips(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        result2 = index_adrs(db_path, adr_dir, events_file)
+        assert result2["indexed"] == 0
+        assert result2["skipped"] == 1
+
+    def test_ndjson_event_emitted(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        assert events_file.exists()
+        lines = [l for l in events_file.read_text().splitlines() if l.strip()]
+        assert len(lines) >= 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "adr_indexed"
+        assert event["adr_id"] == "ADR-007"
+        assert "record_id" in event
+
+    def test_ndjson_event_has_record_id(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+        lines = [l for l in events_file.read_text().splitlines() if l.strip()]
+        event = json.loads(lines[0])
+        # record_id must be a 64-char hex sha256
+        assert len(event["record_id"]) == 64
+
+    def test_raises_on_event_write_failure(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        with mock.patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                index_adrs(db_path, adr_dir, events_file)
+
+    def test_changed_content_reindexed(self, tmp_path):
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file)
+
+        # Modify the ADR
+        (adr_dir / "ADR-007-multitenant.md").write_text(
+            _FIXTURE_ADR + "\n\n## Additional notes\n\nUpdated content.\n",
+            encoding="utf-8",
+        )
+        result2 = index_adrs(db_path, adr_dir, events_file)
+        assert result2["indexed"] == 1


### PR DESCRIPTION
## Summary

- Extends `intelligence_injection.py` with `fetch_adr_context_section()` — queries the `adrs` table (INT-1) for relevant accepted ADRs and injects a binding context block before the dispatch instruction
- Trigger criteria: role in `{database-engineer, architect, intelligence-engineer, security-engineer}` OR dispatch paths under `schemas/`, `scripts/lib/coordination_db.py`, `scripts/lib/quality_db.py`
- ADR-007 compliant: all queries filter by `project_id`
- ADR-005 compliant: NDJSON audit event written to `dispatch_register.ndjson` on injection; raises `OSError` on event-write failure
- `--no-adr-inject` flag added to `subprocess_dispatch.py` (sets `VNX_NO_ADR_INJECT=1` env var)
- Integrated into `fetch_intelligence_section` so both Claude subprocess and non-Claude provider paths pick up ADR context automatically

## Test plan

- [ ] `pytest tests/test_adr_injection.py` — 24 tests covering all 5 spec scenarios (trigger match, no-trigger, opt-out, Superseded guard, top-3 cap) + trigger helpers + raise-on-failure
- [ ] `pytest tests/test_intelligence_injection.py` — 23 existing tests still pass (no regression)
- [ ] `SKIP_WHEEL=1 bash scripts/local-ci.sh` — adr-003-no-sdk gate green

All 47 tests pass, local-ci green.

Dispatch-ID: 20260529-int-2-wave5-adr-inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)