### PR TITLE
feat(a11-vnx-init-pr1): vnx init scaffold generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "opentelemetry-api>=1.20",
     "opentelemetry-sdk>=1.20",
     "opentelemetry-exporter-otlp>=1.20",
+    "jinja2>=3.0",
 ]
 
 # Full quality advisory/local-CI audit tools.

--- a/templates/init/default/claude_md.j2
+++ b/templates/init/default/claude_md.j2
@@ -1,0 +1,24 @@
+## VNX Governance System
+
+Project: {{ project_name }} ({{ project_id }})
+VNX version: {{ vnx_version }}
+
+This project uses **VNX Glass Box Governance** for multi-agent orchestration.
+
+### Terminals
+- **T0** (Orchestrator): Plans work, reviews results. Does NOT write code.
+- **T1** (Track A): Primary implementation.
+- **T2** (Track B): Testing and validation.
+- **T3** (Track C): Code review and security.
+
+### Key Paths
+- `.vnx/` — Config (governance_profiles.yaml, config.yml). Commit this.
+- `.vnx-data/` — Runtime state (dispatches, receipts, logs). Do not commit.
+- `.claude/terminals/T0/CLAUDE.md` — T0-specific instructions.
+- `.claude/skills/` — Shared agent skills.
+
+### Quick Start
+1. `vnx doctor` — validate setup
+2. Edit `.claude/terminals/T0/CLAUDE.md` for your project context
+3. `vnx track new <id> --project-id {{ project_id }} --title "..." --goal "..."`
+4. Start T0 terminal: load `@t0-orchestrator`

--- a/templates/init/default/gitignore.j2
+++ b/templates/init/default/gitignore.j2
@@ -1,0 +1,3 @@
+
+# VNX runtime state — do not commit
+.vnx-data/

--- a/templates/init/default/settings.json.j2
+++ b/templates/init/default/settings.json.j2
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(python3 *)",
+      "Bash(pytest *)",
+      "Bash(vnx *)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)"
+    ]
+  }
+}

--- a/templates/init/default/terminals/T0_claude_md.j2
+++ b/templates/init/default/terminals/T0_claude_md.j2
@@ -1,0 +1,18 @@
+# T0 — {{ project_name }}
+
+You are T0 for project `{{ project_id }}`. You orchestrate work. You do not write code.
+
+## Startup
+Load `@t0-orchestrator` before any orchestration action.
+
+## Quick Commands
+```bash
+vnx doctor --project-dir .
+vnx track list --project-id {{ project_id }}
+vnx status --project-dir .
+```
+
+## Feature Plan
+Use `FEATURE_PLAN.md` in the repo root.
+
+Remember: Receipt -> Review -> Decide -> Dispatch (or WAIT).

--- a/templates/init/minimal/claude_md.j2
+++ b/templates/init/minimal/claude_md.j2
@@ -1,0 +1,10 @@
+## VNX — Minimal Setup
+
+Project: {{ project_name }} ({{ project_id }})
+VNX version: {{ vnx_version }}
+
+Single-terminal setup (T0 only). Start Claude Code in this directory.
+
+### Next Steps
+1. `vnx doctor` — validate setup
+2. `vnx track new <id> --project-id {{ project_id }} --title "..." --goal "..."`

--- a/templates/init/minimal/gitignore.j2
+++ b/templates/init/minimal/gitignore.j2
@@ -1,0 +1,3 @@
+
+# VNX runtime state — do not commit
+.vnx-data/

--- a/templates/init/minimal/settings.json.j2
+++ b/templates/init/minimal/settings.json.j2
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(python3 *)",
+      "Bash(vnx *)"
+    ]
+  }
+}

--- a/templates/init/minimal/terminals/T0_claude_md.j2
+++ b/templates/init/minimal/terminals/T0_claude_md.j2
@@ -1,0 +1,9 @@
+# T0 — {{ project_name }}
+
+You are T0 for project `{{ project_id }}`. Minimal VNX setup.
+
+## Quick Commands
+```bash
+vnx doctor --project-dir .
+vnx track list --project-id {{ project_id }}
+```

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for `vnx init` CLI command (A-11 PR-1 scaffold).
+
+Validates the .claude/ skeleton, local .vnx-data/ layout, .vnx-version pin,
+root CLAUDE.md, FEATURE_PLAN.md, and safety/idempotency semantics.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.init_cmd import vnx_init
+from vnx_cli import __version__
+
+
+def _args(tmp_path, **overrides):
+    ns = argparse.Namespace(
+        project_path=None,
+        project_dir=str(tmp_path),
+        project_id=None,
+        template="default",
+        force=False,
+        non_interactive=False,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+class TestVnxInitCli:
+    def test_init_creates_claude_dir(self, tmp_path):
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        assert (tmp_path / ".claude" / "terminals" / "T0" / "CLAUDE.md").is_file()
+        assert (tmp_path / ".claude" / "skills").is_dir()
+        assert (tmp_path / ".claude" / "settings.json").is_file()
+
+    def test_init_creates_vnx_data_dir(self, tmp_path):
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        vnx_data = tmp_path / ".vnx-data"
+        assert vnx_data.is_dir()
+        assert (vnx_data / "dispatches" / "pending").is_dir()
+        assert (vnx_data / "dispatches" / "active").is_dir()
+        assert (vnx_data / "dispatches" / "completed").is_dir()
+        assert (vnx_data / "events").is_dir()
+        assert (vnx_data / "unified_reports").is_dir()
+
+    def test_init_writes_vnx_version(self, tmp_path):
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        version_file = tmp_path / ".vnx-version"
+        assert version_file.is_file()
+        assert version_file.read_text().strip() == __version__
+
+    def test_init_idempotent_with_force(self, tmp_path):
+        vnx_init(_args(tmp_path))
+        original = (tmp_path / "CLAUDE.md").read_text()
+        (tmp_path / "CLAUDE.md").write_text("modified")
+
+        rc = vnx_init(_args(tmp_path, force=True))
+        assert rc == 0
+        assert (tmp_path / "CLAUDE.md").read_text() == original
+
+    def test_init_aborts_on_existing_without_force(self, tmp_path):
+        vnx_init(_args(tmp_path))
+        rc = vnx_init(_args(tmp_path))
+        assert rc != 0
+
+    def test_init_minimal_template(self, tmp_path):
+        rc = vnx_init(_args(tmp_path, template="minimal"))
+        assert rc == 0
+        assert (tmp_path / ".claude" / "terminals" / "T0" / "CLAUDE.md").is_file()
+        assert (tmp_path / ".vnx-version").is_file()
+
+    def test_init_project_path_positional(self, tmp_path):
+        ns = argparse.Namespace(
+            project_path=str(tmp_path),
+            project_dir=".",
+            project_id=None,
+            template="default",
+            force=False,
+            non_interactive=False,
+        )
+        rc = vnx_init(ns)
+        assert rc == 0
+        assert (tmp_path / ".vnx-version").is_file()

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -8,13 +8,16 @@ marker, and an optional ``agents/`` scaffold. The runtime state tree
 (a user-data-dir for pip installs), never inside the project map. This keeps
 the committed footprint tiny (< 10 KB) and stops a pip-installed VNX from
 writing runtime state into the package or the repo.
+
+A-11 extension: adds .claude/ skeleton, local .vnx-data/ layout, .vnx-version
+pin, root CLAUDE.md and FEATURE_PLAN.md via Jinja2 templates (default/minimal).
 """
 
 import os
 import sys
 from pathlib import Path
 
-from vnx_cli import _engine
+from vnx_cli import _engine, __version__
 
 GOVERNANCE_PROFILES_YAML = """\
 # VNX Governance Profiles
@@ -99,6 +102,18 @@ VNX_DATA_SUBDIRS = [
     "locks",
 ]
 
+# Local .vnx-data/ subdirs written by the init scaffold (always project-local).
+VNX_DATA_INIT_SUBDIRS = [
+    "state",
+    "dispatches/pending",
+    "dispatches/active",
+    "dispatches/completed",
+    "events",
+    "unified_reports",
+]
+
+_VALID_TEMPLATES = {"default", "minimal"}
+
 
 def _atomic_write(path: Path, content: str) -> None:
     """Write ``content`` to ``path`` via a tmp file + os.replace (atomic)."""
@@ -136,10 +151,127 @@ def _is_within(child: Path, parent: Path) -> bool:
         return False
 
 
+def _templates_root(template: str) -> Path:
+    """Return the path to the init template set (default or minimal)."""
+    return _engine.engine_root() / "templates" / "init" / template
+
+
+def _render_template(tmpl_path: Path, ctx: dict) -> str:
+    """Render a Jinja2 .j2 template file with ``ctx`` as the template context."""
+    from jinja2 import Environment, FileSystemLoader, StrictUndefined
+    env = Environment(
+        loader=FileSystemLoader(str(tmpl_path.parent)),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    return env.get_template(tmpl_path.name).render(**ctx)
+
+
+def _scaffold_claude_dir(project_dir: Path, tmpl_root: Path, ctx: dict, force: bool) -> None:
+    """Create the .claude/ skeleton from templates."""
+    claude_dir = project_dir / ".claude"
+
+    t0_md = claude_dir / "terminals" / "T0" / "CLAUDE.md"
+    t0_md.parent.mkdir(parents=True, exist_ok=True)
+    if not t0_md.exists() or force:
+        _atomic_write(t0_md, _render_template(tmpl_root / "terminals" / "T0_claude_md.j2", ctx))
+        print(f"  created {t0_md.relative_to(project_dir)}")
+    else:
+        print(f"  exists  {t0_md.relative_to(project_dir)}")
+
+    skills_dir = claude_dir / "skills"
+    if not skills_dir.exists():
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        print(f"  created {skills_dir.relative_to(project_dir)}/")
+    else:
+        print(f"  exists  {skills_dir.relative_to(project_dir)}/")
+
+    settings_path = claude_dir / "settings.json"
+    if not settings_path.exists() or force:
+        _atomic_write(settings_path, _render_template(tmpl_root / "settings.json.j2", ctx))
+        print(f"  created {settings_path.relative_to(project_dir)}")
+    else:
+        print(f"  exists  {settings_path.relative_to(project_dir)}")
+
+
+def _scaffold_vnx_data_local(project_dir: Path) -> None:
+    """Create the project-local .vnx-data/ skeleton."""
+    vnx_data = project_dir / ".vnx-data"
+    for subdir in VNX_DATA_INIT_SUBDIRS:
+        (vnx_data / subdir).mkdir(parents=True, exist_ok=True)
+    print(f"  created .vnx-data/ (local scaffold)")
+
+
+def _write_vnx_version(project_dir: Path, version: str, force: bool) -> bool:
+    """Write .vnx-version to ``project_dir``. Returns True if written."""
+    path = project_dir / ".vnx-version"
+    if path.exists() and not force:
+        return False
+    _atomic_write(path, version + "\n")
+    return True
+
+
+def _write_root_claude_md(project_dir: Path, tmpl_root: Path, ctx: dict, force: bool) -> None:
+    path = project_dir / "CLAUDE.md"
+    if path.exists() and not force:
+        print("  exists  CLAUDE.md")
+        return
+    _atomic_write(path, _render_template(tmpl_root / "claude_md.j2", ctx))
+    print("  created CLAUDE.md")
+
+
+def _write_feature_plan(project_dir: Path, force: bool) -> None:
+    path = project_dir / "FEATURE_PLAN.md"
+    if path.exists() and not force:
+        print("  exists  FEATURE_PLAN.md")
+        return
+    _atomic_write(
+        path,
+        "# Feature Plan\n\n"
+        "<!-- Start a new track: vnx track new <id>"
+        " --project-id <proj-id> --title '...' --goal '...' -->\n",
+    )
+    print("  created FEATURE_PLAN.md")
+
+
+def _update_gitignore(project_dir: Path) -> None:
+    """Append .vnx-data/ to .gitignore if not already present."""
+    gi_path = project_dir / ".gitignore"
+    marker = ".vnx-data/"
+    if gi_path.exists():
+        content = gi_path.read_text(encoding="utf-8")
+        if marker in content:
+            print(f"  exists  .gitignore (already has {marker})")
+            return
+        new_content = content.rstrip() + "\n\n# VNX runtime state\n" + marker + "\n"
+    else:
+        new_content = "# VNX runtime state\n" + marker + "\n"
+    _atomic_write(gi_path, new_content)
+    print(f"  updated .gitignore (added {marker})")
+
+
 def vnx_init(args) -> int:
-    project_dir = Path(args.project_dir).resolve()
+    raw_dir = getattr(args, "project_path", None) or args.project_dir
+    project_dir = Path(raw_dir).resolve()
+    template = getattr(args, "template", "default") or "default"
+    force = getattr(args, "force", False)
+
+    if template not in _VALID_TEMPLATES:
+        print(f"  error: unknown template {template!r}. Choose: {', '.join(sorted(_VALID_TEMPLATES))}", file=sys.stderr)
+        return 1
 
     print(f"Initialising VNX project at: {project_dir}")
+    print(f"  template: {template}")
+
+    # Safety gate: abort if already initialised and --force not set.
+    version_pin = project_dir / ".vnx-version"
+    if version_pin.exists() and not force:
+        print(
+            f"\n  error: .vnx-version already exists ({version_pin.read_text().strip()}).\n"
+            "  Use --force to reinitialise.",
+            file=sys.stderr,
+        )
+        return 1
 
     try:
         project_id = _engine.derive_project_id(
@@ -203,6 +335,25 @@ def vnx_init(args) -> int:
         (data_root / subdir).mkdir(parents=True, exist_ok=True)
 
     inside_project = _is_within(data_root, project_dir)
+
+    # --- A-11: .claude/ skeleton, local .vnx-data/, version pin, CLAUDE.md -
+    print()
+    tmpl_root = _templates_root(template)
+    ctx = {
+        "project_name": project_dir.name,
+        "project_id": project_id,
+        "vnx_version": __version__,
+    }
+    _scaffold_claude_dir(project_dir, tmpl_root, ctx, force)
+    _scaffold_vnx_data_local(project_dir)
+
+    written = _write_vnx_version(project_dir, __version__, force)
+    print(f"  {'created' if written else 'exists '} .vnx-version ({__version__})")
+
+    _write_root_claude_md(project_dir, tmpl_root, ctx, force)
+    _write_feature_plan(project_dir, force)
+    _update_gitignore(project_dir)
+
     print()
     print(f"Runtime state: {data_root}")
     if inside_project:
@@ -215,9 +366,8 @@ def vnx_init(args) -> int:
     print()
     print("Next steps:")
     print("  1. Review .vnx/governance_profiles.yaml and adjust gates")
-    print("  2. Add agent instructions in agents/<terminal>/CLAUDE.md")
+    print("  2. Edit .claude/terminals/T0/CLAUDE.md for project-specific T0 instructions")
     print("  3. Run `vnx doctor` to validate your setup")
-    if inside_project:
-        print("  4. Add .vnx-data/ to .gitignore (runtime state — do not commit)")
+    print(f"  4. `vnx track new <id> --project-id {project_id} --title '...' --goal '...'`")
 
     return 0

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -67,6 +67,13 @@ def _register_init_subparser(subparsers: argparse.Action) -> None:
         help="scaffold a new VNX project in the current directory",
     )
     init_parser.add_argument(
+        "project_path",
+        nargs="?",
+        default=None,
+        metavar="PROJECT_PATH",
+        help="target directory (default: current directory; overrides --project-dir)",
+    )
+    init_parser.add_argument(
         "--project-dir",
         default=".",
         metavar="DIR",
@@ -78,6 +85,24 @@ def _register_init_subparser(subparsers: argparse.Action) -> None:
         metavar="ID",
         help="explicit project_id (default: derived from the directory name); "
              "must match ^[a-z][a-z0-9-]{1,31}$",
+    )
+    init_parser.add_argument(
+        "--template",
+        default="default",
+        choices=["default", "minimal"],
+        metavar="TEMPLATE",
+        help="scaffold template: 'default' (full T0-T3) or 'minimal' (T0 only). Default: default",
+    )
+    init_parser.add_argument(
+        "--non-interactive",
+        dest="non_interactive",
+        action="store_true",
+        help="skip all interactive prompts (for CI / scripted use)",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing scaffold files (allows reinitialisation)",
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `vnx init [PROJECT_PATH] [--template default|minimal] [--force] [--non-interactive]` command
- Scaffolds `.claude/` skeleton (T0 `CLAUDE.md`, `skills/`, `settings.json`), local `.vnx-data/` layout, `.vnx-version` pin, root `CLAUDE.md`, `FEATURE_PLAN.md`, and `.gitignore` update
- Two templates: `default` (full T0-T3 intent) and `minimal` (T0 only, for trial/learning)
- Safety gate: aborts on existing `.vnx-version` without `--force`
- Jinja2 templates live in `templates/init/{default,minimal}/` (already in `vnx_orchestration` package-data)
- Adds `jinja2>=3.0` as a project dependency

## Test plan

- [x] 7 new tests in `tests/test_cli_init.py` (creates .claude/, creates .vnx-data/, writes .vnx-version, force idempotent, aborts without force, minimal template, project_path positional)
- [x] 24 existing tests in `tests/test_vnx_init.py` still green
- [x] Smoke-tested both templates via CLI: `vnx init <tmp> --template default` and `--template minimal`

Dispatch-ID: 20260529-a11-vnx-init-pr1-core
PR-ID: PR-A11-PR1

🤖 Generated with [Claude Code](https://claude.com/claude-code)