### PR TITLE
feat(a14-auto-dream-pr2): vnx dream CLI + LaunchAgent scheduler + T0 review-gate

### DIFF
--- a/scripts/dream/install_scheduler.py
+++ b/scripts/dream/install_scheduler.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate and install the macOS LaunchAgent plist for auto-dream (ADR-019).
+
+Usage:
+    python3 scripts/dream/install_scheduler.py \\
+        --project-id <id> \\
+        --vnx-bin /path/to/vnx \\
+        [--project-root /path/to/project]
+
+Writes ~/Library/LaunchAgents/com.vnx.auto-dream.plist and prints the
+launchctl load command — does NOT auto-load (operator must run it).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+from project_root import resolve_project_root  # noqa: E402
+
+
+def _render_plist(template_path: Path, ctx: dict[str, str]) -> str:
+    """Render Jinja2 template with context dict."""
+    try:
+        from jinja2 import Environment, FileSystemLoader  # type: ignore[import]
+
+        env = Environment(
+            loader=FileSystemLoader(str(template_path.parent)),
+            autoescape=False,
+        )
+        tmpl = env.get_template(template_path.name)
+        return tmpl.render(**ctx)
+    except ImportError:
+        text = template_path.read_text(encoding="utf-8")
+        for key, value in ctx.items():
+            text = text.replace("{{ " + key + " }}", value)
+        return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Install auto-dream LaunchAgent")
+    parser.add_argument("--project-id", required=True, help="VNX project_id (ADR-007)")
+    parser.add_argument(
+        "--vnx-bin",
+        default=None,
+        help="Path to vnx binary (default: shutil.which('vnx'))",
+    )
+    parser.add_argument(
+        "--project-root",
+        default=None,
+        help="Project root (default: git-resolved)",
+    )
+    args = parser.parse_args()
+
+    vnx_bin = args.vnx_bin or shutil.which("vnx") or "vnx"
+    project_root = (
+        Path(args.project_root).resolve()
+        if args.project_root
+        else resolve_project_root(__file__)
+    )
+
+    template_path = Path(__file__).resolve().parent / "templates" / "com.vnx.auto-dream.plist.j2"
+    ctx = {
+        "vnx_bin_path": vnx_bin,
+        "project_id": args.project_id,
+        "project_root": str(project_root),
+    }
+    rendered = _render_plist(template_path, ctx)
+
+    out_dir = Path.home() / "Library" / "LaunchAgents"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "com.vnx.auto-dream.plist"
+    out_path.write_text(rendered, encoding="utf-8")
+
+    print(f"Wrote: {out_path}")
+    print()
+    print("To enable nightly auto-dream at 03:00 local time, run:")
+    print(f"  launchctl load -w {out_path}")
+    print()
+    print("To disable:")
+    print(f"  launchctl unload -w {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dream/review_gate.py
+++ b/scripts/dream/review_gate.py
@@ -1,0 +1,150 @@
+"""T0 review-gate for auto-dream consolidation cycles (ADR-019).
+
+Approve/reject pending-review.json files written by consolidator.py.
+ADR-005: NDJSON emitted before every DB write.
+ADR-007: all DB ops keyed on (cycle_id, project_id).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+from project_root import resolve_project_root  # noqa: E402
+
+_ARCHIVE_REASON_MAP: dict[str, str] = {
+    "dropped": "stale_30d",
+    "archived": "merged_into_other",
+}
+
+
+def _emit_review_event(event: dict[str, Any], data_root: Path) -> None:
+    """Emit NDJSON event (ADR-005 emit-first)."""
+    events_dir = data_root / "events" / "dream"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    with (events_dir / f"{today}.ndjson").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event) + "\n")
+
+
+def _resolve_data_root(data_root: Path | None) -> Path:
+    return data_root if data_root is not None else (resolve_project_root(__file__) / ".vnx-data")
+
+
+def _load_review(state_dir: Path, cycle_id: str, project_id: str) -> dict:
+    review_path = state_dir / f"{cycle_id}-pending-review.json"
+    if not review_path.exists():
+        raise FileNotFoundError(f"Pending review not found: {review_path}")
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    if review.get("project_id") != project_id:
+        raise ValueError(
+            f"project_id mismatch: expected {project_id!r}, got {review.get('project_id')!r}"
+        )
+    return review
+
+
+def list_pending_reviews(project_id: str, data_root: Path | None = None) -> list[dict]:
+    """Return pending dream cycles awaiting operator review."""
+    dr = _resolve_data_root(data_root)
+    state_dir = dr / "state" / "dream"
+    if not state_dir.is_dir():
+        return []
+    results = []
+    for path in sorted(state_dir.glob("*-pending-review.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("project_id") == project_id and data.get("requires_operator_review"):
+            results.append(data)
+    return results
+
+
+def approve_cycle(
+    cycle_id: str, project_id: str, db_path: Path, data_root: Path | None = None
+) -> None:
+    """Apply consolidation to DB; emit NDJSON event first (ADR-005)."""
+    dr = _resolve_data_root(data_root)
+    state_dir = dr / "state" / "dream"
+    review = _load_review(state_dir, cycle_id, project_id)
+    consolidation = review.get("consolidation", {})
+
+    _emit_review_event(
+        {
+            "event_type": "dream_cycle_approved",
+            "cycle_id": cycle_id,
+            "project_id": project_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+        dr,
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        for action_key, archive_reason in _ARCHIVE_REASON_MAP.items():
+            for entry in consolidation.get(action_key, []):
+                pattern_id = entry.get("id")
+                table = entry.get("table", "")
+                if pattern_id is None:
+                    continue
+                try:
+                    conn.execute(
+                        "INSERT INTO dream_pattern_archives"
+                        " (cycle_id, project_id, original_pattern_id, original_table, archived_reason)"
+                        " VALUES (?, ?, ?, ?, ?)",
+                        (cycle_id, project_id, pattern_id, table, archive_reason),
+                    )
+                except sqlite3.OperationalError:
+                    pass
+        conn.execute(
+            "UPDATE dream_cycles SET status='reviewed', operator_reviewed=1, completed_at=?"
+            " WHERE cycle_id=? AND project_id=?",
+            (datetime.now(timezone.utc).isoformat(), cycle_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    review["requires_operator_review"] = False
+    review_path = state_dir / f"{cycle_id}-pending-review.json"
+    review_path.write_text(json.dumps(review, indent=2), encoding="utf-8")
+
+
+def reject_cycle(
+    cycle_id: str, project_id: str, reason: str, db_path: Path, data_root: Path | None = None
+) -> None:
+    """Reject cycle — no consolidation applied; emit NDJSON event first (ADR-005)."""
+    dr = _resolve_data_root(data_root)
+    state_dir = dr / "state" / "dream"
+    review = _load_review(state_dir, cycle_id, project_id)
+
+    _emit_review_event(
+        {
+            "event_type": "dream_cycle_rejected",
+            "cycle_id": cycle_id,
+            "project_id": project_id,
+            "reason": reason,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+        dr,
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE dream_cycles SET status='rejected', operator_reviewed=1, completed_at=?"
+            " WHERE cycle_id=? AND project_id=?",
+            (datetime.now(timezone.utc).isoformat(), cycle_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    review["requires_operator_review"] = False
+    review["rejected_reason"] = reason
+    review_path = state_dir / f"{cycle_id}-pending-review.json"
+    review_path.write_text(json.dumps(review, indent=2), encoding="utf-8")

--- a/scripts/dream/templates/com.vnx.auto-dream.plist.j2
+++ b/scripts/dream/templates/com.vnx.auto-dream.plist.j2
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.vnx.auto-dream</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ vnx_bin_path }}</string>
+        <string>dream</string>
+        <string>run</string>
+        <string>--project-id</string>
+        <string>{{ project_id }}</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{ project_root }}/.vnx-data/events/dream/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ project_root }}/.vnx-data/events/dream/launchd.err.log</string>
+</dict>
+</plist>

--- a/tests/test_dream_cli.py
+++ b/tests/test_dream_cli.py
@@ -1,0 +1,269 @@
+"""Tests for vnx dream CLI + review_gate (ADR-019 auto-dream PR-2).
+
+Coverage:
+- test_dream_status_with_no_cycles: returns empty gracefully
+- test_dream_review_approve_applies_consolidation: verify DB state writes on approve
+- test_dream_review_reject_archives_only: verify no archive rows on reject
+- test_dream_history_shows_recent_cycles: verify ordering DESC by completed_at
+- test_review_gate_lists_only_pending: verify pending-only filtering
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dream"))
+
+import review_gate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+_DREAM_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dream_cycles (
+    cycle_id          TEXT    NOT NULL,
+    project_id        TEXT    NOT NULL DEFAULT 'vnx-dev',
+    started_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    completed_at      TEXT,
+    status            TEXT    NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','running','completed','failed','reviewed','rejected')),
+    provider          TEXT    NOT NULL DEFAULT 'kimi',
+    insights_input    INTEGER NOT NULL DEFAULT 0,
+    merged_count      INTEGER NOT NULL DEFAULT 0,
+    dropped_count     INTEGER NOT NULL DEFAULT 0,
+    archived_count    INTEGER NOT NULL DEFAULT 0,
+    flagged_count     INTEGER NOT NULL DEFAULT 0,
+    operator_reviewed INTEGER NOT NULL DEFAULT 0,
+    report_path       TEXT,
+    PRIMARY KEY (cycle_id, project_id)
+);
+CREATE TABLE IF NOT EXISTS dream_pattern_archives (
+    archive_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_id                TEXT    NOT NULL,
+    project_id              TEXT    NOT NULL DEFAULT 'vnx-dev',
+    original_pattern_id     INTEGER NOT NULL,
+    original_table          TEXT    NOT NULL,
+    archived_reason         TEXT    NOT NULL,
+    archived_at             TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+"""
+
+_CONSOLIDATION = {
+    "merged": [],
+    "dropped": [{"id": 1, "table": "antipatterns", "reason": "stale_30d"}],
+    "archived": [{"id": 2, "table": "success_patterns", "reason": "merged_into_other"}],
+    "flagged": [],
+    "summary": "test",
+}
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_DREAM_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _write_pending_review(tmp_path: Path, cycle_id: str, project_id: str) -> Path:
+    state_dir = tmp_path / ".vnx-data" / "state" / "dream"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    review_path = state_dir / f"{cycle_id}-pending-review.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "input_count": 10,
+                "consolidation": _CONSOLIDATION,
+                "requires_operator_review": True,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return review_path
+
+
+def _insert_cycle(db_path: Path, cycle_id: str, project_id: str, completed_at: str,
+                  status: str = "completed") -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO dream_cycles (cycle_id, project_id, completed_at, status) VALUES (?,?,?,?)",
+        (cycle_id, project_id, completed_at, status),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDreamStatusNoCycles:
+    def test_dream_status_with_no_cycles(self, tmp_path):
+        """list_pending_reviews returns empty list when state dir absent."""
+        result = review_gate.list_pending_reviews("vnx-dev", tmp_path / ".vnx-data")
+        assert result == []
+
+    def test_dream_status_empty_state_dir(self, tmp_path):
+        """list_pending_reviews returns empty when state dir exists but has no files."""
+        state_dir = tmp_path / ".vnx-data" / "state" / "dream"
+        state_dir.mkdir(parents=True)
+        result = review_gate.list_pending_reviews("vnx-dev", tmp_path / ".vnx-data")
+        assert result == []
+
+
+class TestDreamReviewApprove:
+    def test_approve_applies_consolidation(self, tmp_path):
+        """approve_cycle inserts archive rows + sets status=reviewed in dream_cycles."""
+        db_path = _make_db(tmp_path)
+        cycle_id = "dream-20260529-120000-abcd1234"
+        _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T12:00:00+00:00")
+        _write_pending_review(tmp_path, cycle_id, "vnx-dev")
+
+        with patch("review_gate.resolve_project_root", return_value=tmp_path):
+            review_gate.approve_cycle(
+                cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        archive_rows = conn.execute(
+            "SELECT archived_reason FROM dream_pattern_archives WHERE cycle_id=?",
+            (cycle_id,),
+        ).fetchall()
+        cycle_row = conn.execute(
+            "SELECT status, operator_reviewed FROM dream_cycles WHERE cycle_id=?",
+            (cycle_id,),
+        ).fetchone()
+        conn.close()
+
+        assert len(archive_rows) == 2
+        reasons = {r[0] for r in archive_rows}
+        assert "stale_30d" in reasons
+        assert "merged_into_other" in reasons
+        assert cycle_row[0] == "reviewed"
+        assert cycle_row[1] == 1
+
+    def test_approve_emits_ndjson_event(self, tmp_path):
+        """approve_cycle emits dream_cycle_approved event (ADR-005)."""
+        db_path = _make_db(tmp_path)
+        cycle_id = "dream-20260529-130000-ef012345"
+        _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T13:00:00+00:00")
+        _write_pending_review(tmp_path, cycle_id, "vnx-dev")
+
+        with patch("review_gate.resolve_project_root", return_value=tmp_path):
+            review_gate.approve_cycle(
+                cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+            )
+
+        events = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        assert len(events) == 1
+        lines = [json.loads(l) for l in events[0].read_text().strip().splitlines()]
+        assert any(e["event_type"] == "dream_cycle_approved" for e in lines)
+
+
+class TestDreamReviewReject:
+    def test_reject_archives_only_no_db_rows(self, tmp_path):
+        """reject_cycle sets status=rejected without writing archive rows."""
+        db_path = _make_db(tmp_path)
+        cycle_id = "dream-20260529-140000-gh678901"
+        _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T14:00:00+00:00")
+        _write_pending_review(tmp_path, cycle_id, "vnx-dev")
+
+        with patch("review_gate.resolve_project_root", return_value=tmp_path):
+            review_gate.reject_cycle(
+                cycle_id, "vnx-dev", "test rejection", db_path,
+                data_root=tmp_path / ".vnx-data",
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        archive_count = conn.execute(
+            "SELECT COUNT(*) FROM dream_pattern_archives WHERE cycle_id=?", (cycle_id,)
+        ).fetchone()[0]
+        cycle_row = conn.execute(
+            "SELECT status, operator_reviewed FROM dream_cycles WHERE cycle_id=?", (cycle_id,)
+        ).fetchone()
+        conn.close()
+
+        assert archive_count == 0
+        assert cycle_row[0] == "rejected"
+        assert cycle_row[1] == 1
+
+    def test_reject_stores_reason_in_review_file(self, tmp_path):
+        """reject_cycle writes rejected_reason into the review JSON."""
+        db_path = _make_db(tmp_path)
+        cycle_id = "dream-20260529-150000-ij234567"
+        _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T15:00:00+00:00")
+        review_path = _write_pending_review(tmp_path, cycle_id, "vnx-dev")
+
+        with patch("review_gate.resolve_project_root", return_value=tmp_path):
+            review_gate.reject_cycle(
+                cycle_id, "vnx-dev", "low confidence", db_path,
+                data_root=tmp_path / ".vnx-data",
+            )
+
+        review = json.loads(review_path.read_text())
+        assert review["rejected_reason"] == "low confidence"
+        assert review["requires_operator_review"] is False
+
+
+class TestDreamHistory:
+    def test_history_shows_recent_cycles(self, tmp_path):
+        """Dream cycles are ordered DESC by completed_at."""
+        db_path = _make_db(tmp_path)
+        dates = ["2026-05-27T10:00:00+00:00", "2026-05-28T10:00:00+00:00",
+                 "2026-05-29T10:00:00+00:00"]
+        for i, dt in enumerate(dates):
+            _insert_cycle(db_path, f"dream-cycle-{i:03d}", "vnx-dev", dt)
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT cycle_id FROM dream_cycles WHERE project_id='vnx-dev'"
+            " ORDER BY completed_at DESC LIMIT 10"
+        ).fetchall()
+        conn.close()
+
+        ids = [r[0] for r in rows]
+        assert ids[0] == "dream-cycle-002"
+        assert ids[-1] == "dream-cycle-000"
+
+
+class TestReviewGateListsOnlyPending:
+    def test_lists_only_pending(self, tmp_path):
+        """list_pending_reviews filters out non-pending and wrong project_id files."""
+        # pending for correct project
+        _write_pending_review(tmp_path, "cycle-001", "vnx-dev")
+
+        # non-pending (requires_operator_review=False) for correct project
+        state_dir = tmp_path / ".vnx-data" / "state" / "dream"
+        non_pending = state_dir / "cycle-002-pending-review.json"
+        non_pending.write_text(
+            json.dumps({"cycle_id": "cycle-002", "project_id": "vnx-dev",
+                        "requires_operator_review": False}),
+            encoding="utf-8",
+        )
+
+        # pending for different project
+        other_project = state_dir / "cycle-003-pending-review.json"
+        other_project.write_text(
+            json.dumps({"cycle_id": "cycle-003", "project_id": "other-project",
+                        "requires_operator_review": True}),
+            encoding="utf-8",
+        )
+
+        result = review_gate.list_pending_reviews("vnx-dev", tmp_path / ".vnx-data")
+
+        assert len(result) == 1
+        assert result[0]["cycle_id"] == "cycle-001"

--- a/vnx_cli/commands/dream.py
+++ b/vnx_cli/commands/dream.py
@@ -1,0 +1,170 @@
+"""vnx dream — auto-dream consolidation CLI (ADR-019)."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "dream"))
+
+
+def _get_project_id(args) -> str | None:
+    pid = getattr(args, "project_id", None)
+    if pid:
+        return pid
+    from project_root import resolve_project_id  # type: ignore[import]
+    try:
+        return resolve_project_id()
+    except RuntimeError:
+        return None
+
+
+def _resolve_paths() -> tuple[Path, Path]:
+    """Returns (project_root, db_path)."""
+    from project_root import resolve_project_root  # type: ignore[import]
+    root = resolve_project_root()
+    return root, root / ".vnx-data" / "state" / "quality_intelligence.db"
+
+
+def _cmd_run(args) -> int:
+    project_id = _get_project_id(args)
+    if not project_id:
+        print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
+        return 1
+    dry_run = getattr(args, "dry_run", False)
+    root, db_path = _resolve_paths()
+    import consolidator  # type: ignore[import]
+    result = consolidator.run_dream_cycle(project_id, db_path, dry_run=dry_run)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def _cmd_status(args) -> int:
+    project_id = _get_project_id(args)
+    if not project_id:
+        print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
+        return 1
+    root, db_path = _resolve_paths()
+    if not db_path.exists():
+        print(f"No dream cycles found for project '{project_id}'.")
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT cycle_id, status, completed_at, insights_input,"
+            " merged_count, dropped_count, flagged_count, operator_reviewed"
+            " FROM dream_cycles WHERE project_id=? ORDER BY completed_at DESC LIMIT 1",
+            (project_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        rows = []
+    finally:
+        conn.close()
+    if not rows:
+        print(f"No dream cycles found for project '{project_id}'.")
+        return 0
+    r = rows[0]
+    print(f"Latest dream cycle — '{project_id}'")
+    print(f"  cycle_id    : {r['cycle_id']}")
+    print(f"  status      : {r['status']}")
+    print(f"  completed   : {r['completed_at']}")
+    print(f"  input/merged/dropped/flagged: "
+          f"{r['insights_input']}/{r['merged_count']}/{r['dropped_count']}/{r['flagged_count']}")
+    print(f"  reviewed    : {bool(r['operator_reviewed'])}")
+    import review_gate  # type: ignore[import]
+    pending = review_gate.list_pending_reviews(project_id, root / ".vnx-data")
+    if pending:
+        print(f"\n  Pending reviews ({len(pending)}):")
+        for p in pending:
+            print(f"    - {p['cycle_id']}")
+    return 0
+
+
+def _cmd_review(args) -> int:
+    cycle_id: str = args.cycle_id
+    project_id = _get_project_id(args)
+    if not project_id:
+        print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
+        return 1
+    root, db_path = _resolve_paths()
+    data_root = root / ".vnx-data"
+    import review_gate  # type: ignore[import]
+    approve = getattr(args, "approve", False)
+    reject = getattr(args, "reject", False)
+    reason = getattr(args, "reason", "operator rejected")
+    if not approve and not reject:
+        answer = input(f"Cycle {cycle_id}: [a]pprove / [r]eject? ").strip().lower()
+        approve = answer.startswith("a")
+        reject = answer.startswith("r")
+        if reject and not reason:
+            reason = input("Rejection reason: ").strip() or "operator rejected"
+    try:
+        if reject:
+            review_gate.reject_cycle(cycle_id, project_id, reason, db_path, data_root)
+            print(f"Cycle {cycle_id} rejected.")
+        else:
+            review_gate.approve_cycle(cycle_id, project_id, db_path, data_root)
+            print(f"Cycle {cycle_id} approved; consolidation applied.")
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}")
+        return 1
+    return 0
+
+
+def _cmd_history(args) -> int:
+    project_id = _get_project_id(args)
+    if not project_id:
+        print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
+        return 1
+    limit = getattr(args, "limit", 10)
+    _, db_path = _resolve_paths()
+    if not db_path.exists():
+        print(f"No dream cycles found for project '{project_id}'.")
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT cycle_id, status, completed_at, insights_input,"
+            " merged_count, dropped_count, archived_count, flagged_count, operator_reviewed"
+            " FROM dream_cycles WHERE project_id=? ORDER BY completed_at DESC LIMIT ?",
+            (project_id, limit),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        rows = []
+    finally:
+        conn.close()
+    if not rows:
+        print(f"No dream cycles found for project '{project_id}'.")
+        return 0
+    hdr = f"{'CYCLE_ID':<45} {'STATUS':<10} {'COMPLETED':<20} {'IN':>4} {'M':>3} {'D':>3} {'A':>3} {'F':>3} REV"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        rev = "Y" if r["operator_reviewed"] else "N"
+        ts = str(r["completed_at"] or "")[:20]
+        print(
+            f"{r['cycle_id']:<45} {r['status']:<10} {ts:<20}"
+            f" {r['insights_input']:>4} {r['merged_count']:>3} {r['dropped_count']:>3}"
+            f" {r['archived_count']:>3} {r['flagged_count']:>3} {rev:>3}"
+        )
+    return 0
+
+
+def vnx_dream(args) -> int:
+    sub = getattr(args, "dream_subcommand", None)
+    dispatch = {
+        "run": _cmd_run,
+        "status": _cmd_status,
+        "review": _cmd_review,
+        "history": _cmd_history,
+    }
+    if sub in dispatch:
+        return dispatch[sub](args)
+    print("Usage: vnx dream {run|status|review|history}")
+    return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -246,6 +246,32 @@ def _register_track_subparser(subparsers: argparse.Action) -> None:
     ts_parser.add_argument("--project-dir", default=".", metavar="DIR")
 
 
+def _register_dream_subparser(subparsers: argparse.Action) -> None:
+    dream_parser = subparsers.add_parser(
+        "dream",
+        help="auto-dream memory consolidation (ADR-019)",
+    )
+    dream_subs = dream_parser.add_subparsers(dest="dream_subcommand", metavar="SUBCOMMAND")
+
+    dream_run_p = dream_subs.add_parser("run", help="run a consolidation cycle")
+    dream_run_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_run_p.add_argument("--dry-run", action="store_true", help="emit events but skip DB writes")
+
+    dream_status_p = dream_subs.add_parser("status", help="show latest cycle results")
+    dream_status_p.add_argument("--project-id", default=None, metavar="ID")
+
+    dream_review_p = dream_subs.add_parser("review", help="approve or reject a pending cycle")
+    dream_review_p.add_argument("cycle_id", metavar="CYCLE_ID")
+    dream_review_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_review_p.add_argument("--approve", action="store_true", help="approve without prompting")
+    dream_review_p.add_argument("--reject", action="store_true", help="reject without prompting")
+    dream_review_p.add_argument("--reason", default="operator rejected", metavar="REASON")
+
+    dream_history_p = dream_subs.add_parser("history", help="show recent cycles")
+    dream_history_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_history_p.add_argument("--limit", type=int, default=10, metavar="N")
+
+
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":
         from vnx_cli.commands.init_cmd import vnx_init
@@ -279,6 +305,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.track import vnx_track
         sys.exit(vnx_track(args))
 
+    elif args.command == "dream":
+        from vnx_cli.commands.dream import vnx_dream
+        sys.exit(vnx_dream(args))
+
     else:
         parser.print_help()
         sys.exit(0)
@@ -303,6 +333,7 @@ def main() -> None:
     _register_update_subparser(subparsers)
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)
+    _register_dream_subparser(subparsers)
 
     args = parser.parse_args()
     _dispatch_command(args, parser)


### PR DESCRIPTION
## Summary

- Adds `vnx dream` CLI with `run / status / review / history` subcommands wired to the consolidator and review-gate
- Adds `scripts/dream/review_gate.py`: `approve_cycle` / `reject_cycle` / `list_pending_reviews` with ADR-005 NDJSON-first and ADR-007 composite key compliance
- Adds macOS LaunchAgent plist template (`com.vnx.auto-dream.plist.j2`) + `install_scheduler.py` generator for nightly 03:00 cron
- 8 new tests covering approve/reject state transitions, event emission, ordering, and pending-only filtering

## ADR compliance

- ADR-005: NDJSON emitted before every DB write in `review_gate.py`
- ADR-007: `(cycle_id, project_id)` composite key respected throughout; `list_pending_reviews` scopes by `project_id`
- ADR-003: no Anthropic SDK imports; `consolidator.run_dream_cycle()` is called via plain Python import from CLI

## Test plan

- [x] `python3 -m pytest tests/test_dream_cli.py -v` → 8/8 passed
- [x] `python3 scripts/check_adr_003_no_sdk_imports.py` → PASS
- [x] `python3 -m py_compile` on all new files → no syntax errors

## Parent PR

Depends on PR #690 (A-14 PR-1, auto-dream consolidator core) — already merged.

Dispatch-ID: 20260529-a14-auto-dream-pr2-cli-scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)