### PR TITLE
fix(a14-pr2): harden dream review_gate — path-traversal, atomic writes, fail-loud archive

### DIFF
--- a/scripts/dream/install_scheduler.py
+++ b/scripts/dream/install_scheduler.py
@@ -16,6 +16,7 @@ import argparse
 import os
 import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
@@ -73,7 +74,18 @@ def main() -> None:
     out_dir = Path.home() / "Library" / "LaunchAgents"
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "com.vnx.auto-dream.plist"
-    out_path.write_text(rendered, encoding="utf-8")
+    # Atomic write: interrupted installs must not leave a partial plist.
+    fd, tmp_name = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(rendered)
+        os.replace(tmp_name, out_path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
     print(f"Wrote: {out_path}")
     print()

--- a/scripts/dream/review_gate.py
+++ b/scripts/dream/review_gate.py
@@ -7,8 +7,11 @@ ADR-007: all DB ops keyed on (cycle_id, project_id).
 from __future__ import annotations
 
 import json
+import os
+import re
 import sqlite3
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -20,6 +23,30 @@ _ARCHIVE_REASON_MAP: dict[str, str] = {
     "dropped": "stale_30d",
     "archived": "merged_into_other",
 }
+
+# Only alphanumerics, hyphens, underscores, and dots — no slashes or dot-dot segments.
+_SAFE_CYCLE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _validate_cycle_id(cycle_id: str) -> None:
+    """Reject cycle_ids that could escape the dream state directory."""
+    if not _SAFE_CYCLE_ID_RE.match(cycle_id) or ".." in cycle_id or "/" in cycle_id:
+        raise ValueError(f"Invalid cycle_id: {cycle_id!r}")
+
+
+def _atomic_write_json(path: Path, obj: dict) -> None:
+    """Write obj as JSON to path atomically via a temp file + os.replace."""
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(obj, indent=2))
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _emit_review_event(event: dict[str, Any], data_root: Path) -> None:
@@ -36,6 +63,7 @@ def _resolve_data_root(data_root: Path | None) -> Path:
 
 
 def _load_review(state_dir: Path, cycle_id: str, project_id: str) -> dict:
+    _validate_cycle_id(cycle_id)
     review_path = state_dir / f"{cycle_id}-pending-review.json"
     if not review_path.exists():
         raise FileNotFoundError(f"Pending review not found: {review_path}")
@@ -67,12 +95,20 @@ def list_pending_reviews(project_id: str, data_root: Path | None = None) -> list
 def approve_cycle(
     cycle_id: str, project_id: str, db_path: Path, data_root: Path | None = None
 ) -> None:
-    """Apply consolidation to DB; emit NDJSON event first (ADR-005)."""
+    """Apply consolidation to DB; emit NDJSON event first (ADR-005).
+
+    Archive inserts and the status UPDATE are one atomic unit: if any insert
+    fails the exception propagates, conn.commit() is never called, and the
+    pending-review.json is not modified — cycle stays awaiting review.
+    """
+    _validate_cycle_id(cycle_id)
     dr = _resolve_data_root(data_root)
     state_dir = dr / "state" / "dream"
     review = _load_review(state_dir, cycle_id, project_id)
     consolidation = review.get("consolidation", {})
 
+    # ADR-005: emit before DB write. If DB fails afterward the operator sees the
+    # error and can retry; the pending-review.json is not touched on failure.
     _emit_review_event(
         {
             "event_type": "dream_cycle_approved",
@@ -91,15 +127,14 @@ def approve_cycle(
                 table = entry.get("table", "")
                 if pattern_id is None:
                     continue
-                try:
-                    conn.execute(
-                        "INSERT INTO dream_pattern_archives"
-                        " (cycle_id, project_id, original_pattern_id, original_table, archived_reason)"
-                        " VALUES (?, ?, ?, ?, ?)",
-                        (cycle_id, project_id, pattern_id, table, archive_reason),
-                    )
-                except sqlite3.OperationalError:
-                    pass
+                # Let any OperationalError propagate — do NOT swallow it.
+                # An insert failure aborts the whole transaction (no commit).
+                conn.execute(
+                    "INSERT INTO dream_pattern_archives"
+                    " (cycle_id, project_id, original_pattern_id, original_table, archived_reason)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (cycle_id, project_id, pattern_id, table, archive_reason),
+                )
         conn.execute(
             "UPDATE dream_cycles SET status='reviewed', operator_reviewed=1, completed_at=?"
             " WHERE cycle_id=? AND project_id=?",
@@ -111,13 +146,14 @@ def approve_cycle(
 
     review["requires_operator_review"] = False
     review_path = state_dir / f"{cycle_id}-pending-review.json"
-    review_path.write_text(json.dumps(review, indent=2), encoding="utf-8")
+    _atomic_write_json(review_path, review)
 
 
 def reject_cycle(
     cycle_id: str, project_id: str, reason: str, db_path: Path, data_root: Path | None = None
 ) -> None:
     """Reject cycle — no consolidation applied; emit NDJSON event first (ADR-005)."""
+    _validate_cycle_id(cycle_id)
     dr = _resolve_data_root(data_root)
     state_dir = dr / "state" / "dream"
     review = _load_review(state_dir, cycle_id, project_id)
@@ -147,4 +183,4 @@ def reject_cycle(
     review["requires_operator_review"] = False
     review["rejected_reason"] = reason
     review_path = state_dir / f"{cycle_id}-pending-review.json"
-    review_path.write_text(json.dumps(review, indent=2), encoding="utf-8")
+    _atomic_write_json(review_path, review)

--- a/tests/test_dream_cli.py
+++ b/tests/test_dream_cli.py
@@ -240,6 +240,101 @@ class TestDreamHistory:
         assert ids[-1] == "dream-cycle-000"
 
 
+class TestCycleIdValidation:
+    """Finding 1 — cycle_id path-traversal guard."""
+
+    def test_dotdot_segment_is_rejected(self):
+        """`../escape` must raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid cycle_id"):
+            review_gate._validate_cycle_id("../escape")
+
+    def test_slash_in_id_is_rejected(self):
+        """`a/b` must raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid cycle_id"):
+            review_gate._validate_cycle_id("a/b")
+
+    def test_normal_cycle_id_passes(self):
+        """Typical cycle_id format must not raise."""
+        review_gate._validate_cycle_id("dream-20260529-120000-abcd1234")
+
+    def test_load_review_rejects_path_traversal(self, tmp_path):
+        """`_load_review` raises ValueError before constructing any path."""
+        state_dir = tmp_path / "state" / "dream"
+        state_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="Invalid cycle_id"):
+            review_gate._load_review(state_dir, "../escape", "vnx-dev")
+
+    def test_approve_cycle_rejects_path_traversal(self, tmp_path):
+        """`approve_cycle` raises ValueError on unsafe cycle_id."""
+        db_path = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="Invalid cycle_id"):
+            review_gate.approve_cycle(
+                "../escape", "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+            )
+
+    def test_reject_cycle_rejects_path_traversal(self, tmp_path):
+        """`reject_cycle` raises ValueError on unsafe cycle_id."""
+        db_path = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="Invalid cycle_id"):
+            review_gate.reject_cycle(
+                "../escape", "vnx-dev", "reason", db_path, data_root=tmp_path / ".vnx-data"
+            )
+
+
+def _make_db_no_archives(tmp_path: Path) -> Path:
+    """DB with dream_cycles only — archive INSERT will raise OperationalError."""
+    db_path = tmp_path / "quality_intelligence_no_arch.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+    CREATE TABLE IF NOT EXISTS dream_cycles (
+        cycle_id          TEXT    NOT NULL,
+        project_id        TEXT    NOT NULL DEFAULT 'vnx-dev',
+        started_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        completed_at      TEXT,
+        status            TEXT    NOT NULL DEFAULT 'pending',
+        operator_reviewed INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (cycle_id, project_id)
+    );
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestApproveArchiveFailure:
+    """Finding 2 — archive insert failure must not silently mark cycle reviewed."""
+
+    def test_approve_archive_failure_does_not_mark_reviewed(self, tmp_path):
+        """If archive INSERT fails, cycle must NOT be left as 'reviewed'."""
+        db_path = _make_db_no_archives(tmp_path)
+        cycle_id = "dream-20260529-160000-ab123456"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dream_cycles (cycle_id, project_id, completed_at, status)"
+            " VALUES (?,?,?,?)",
+            (cycle_id, "vnx-dev", "2026-05-29T16:00:00+00:00", "completed"),
+        )
+        conn.commit()
+        conn.close()
+        _write_pending_review(tmp_path, cycle_id, "vnx-dev")
+
+        with patch("review_gate.resolve_project_root", return_value=tmp_path):
+            with pytest.raises(sqlite3.OperationalError):
+                review_gate.approve_cycle(
+                    cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+                )
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT status, operator_reviewed FROM dream_cycles WHERE cycle_id=?",
+            (cycle_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row[0] != "reviewed", "cycle must not be marked reviewed when archive insert fails"
+        assert row[1] == 0, "operator_reviewed must remain 0 on archive failure"
+
+
 class TestReviewGateListsOnlyPending:
     def test_lists_only_pending(self, tmp_path):
         """list_pending_reviews filters out non-pending and wrong project_id files."""


### PR DESCRIPTION
## Summary

PR #696 (squash commit 9e1cfee) was merged to main at the **pre-fix state**, carrying 4 codex blocking findings and 1 warning identified during the review gate. The fix commit 9d21564 was pushed to the source branch after the merge and never landed on main. This PR cherry-picks that fix via `git cherry-pick 9d21564`.

### Findings from PR #696 that this remediates

**Blocking (4)**

1. **Path-traversal on cycle_id** — `_load_review`, `approve_cycle`, `reject_cycle` accepted arbitrary strings including `..` and `/` segments, enabling directory traversal on the pending-review file path. Fixed by `_validate_cycle_id()` enforcing `^[A-Za-z0-9_.-]+$` and rejecting `..` and `/` at all three call sites.

2. **Swallowed archive-insert failure (approve path)** — `except sqlite3.OperationalError: pass` silently discarded DB write failures; the cycle was then marked reviewed even if the archive row was never written. Fixed by removing the blanket suppress; failures now propagate and leave `pending-review.json` untouched so the cycle stays awaiting review.

3. **Non-atomic write in `approve_cycle`** — direct `open(path, 'w')` on `pending-review.json` left a partial file on process kill mid-write. Fixed via `_atomic_write_json()` (mkstemp + `os.replace`).

4. **Non-atomic write in `reject_cycle`** — same pattern. Fixed with the same `_atomic_write_json()` helper.

**Warning (1)**

5. **Non-atomic plist write in `install_scheduler.py`** — `plistlib.dump()` wrote directly to the target path. Fixed with the same atomic-write pattern (mkstemp + `os.replace`).

### What changed

- `scripts/review_gate.py`: `_validate_cycle_id()` + `_atomic_write_json()` helpers; validation applied at `_load_review`, `approve_cycle`, `reject_cycle`; removed `except sqlite3.OperationalError: pass`.
- `scripts/install_scheduler.py`: atomic plist write.
- `tests/test_dream_cli.py`: 6 new cycle_id-validation tests + 1 archive-failure propagation test (15 total, all passing).

### Governance constraints preserved

- ADR-007: DB ops remain keyed on composite `(cycle_id, project_id)` — unchanged.
- ADR-005: NDJSON emit-first order preserved.
- ADR-003: no `import anthropic` — verified via `scripts/check_adr_003_no_sdk_imports.py`.

## Test plan

- [x] `python3 -m pytest tests/test_dream_cli.py -v` → 15 passed
- [x] `python3 scripts/check_adr_003_no_sdk_imports.py` → PASS
- [ ] T0 codex + gemini gates on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)