### PR TITLE
fix(wave6): pool scale_up now inserts terminal_leases row before add_member (FK fix)

### DIFF
--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -271,6 +271,15 @@ class PoolManager:
                 )
 
             try:
+                self.repo.release_pool_lease(target.terminal_id, target.reason, now)
+            except Exception as exc:
+                log.warning(
+                    "reap: lease release failed for %s: %s",
+                    target.terminal_id,
+                    exc,
+                )
+
+            try:
                 from pool_worktree_manager import reap_worker_worktree  # noqa: E402
                 reap_worker_worktree(target.terminal_id)
             except Exception as exc:
@@ -384,16 +393,35 @@ class PoolManager:
                     role,
                 )
                 if spawn_result.success:
-                    self.repo.add_member(
-                        self.pool_id, terminal_id, provider, role, now,
-                        pid=spawn_result.pid,
-                    )
-                    result.spawned.append(terminal_id)
-                    log.info(
-                        "scale_up: spawned terminal=%s provider=%s",
-                        terminal_id,
-                        provider,
-                    )
+                    try:
+                        self.repo.add_or_refresh_pool_lease(
+                            terminal_id, spawn_result.pid, now
+                        )
+                        self.repo.add_member(
+                            self.pool_id, terminal_id, provider, role, now,
+                            pid=spawn_result.pid,
+                        )
+                        result.spawned.append(terminal_id)
+                        log.info(
+                            "scale_up: spawned terminal=%s provider=%s",
+                            terminal_id,
+                            provider,
+                        )
+                    except Exception as reg_exc:
+                        err = f"post-spawn registration failed for terminal={terminal_id}: {reg_exc}"
+                        result.errors.append(err)
+                        log.exception(
+                            "scale_up: registration error terminal=%s; cleaning up", terminal_id
+                        )
+                        self._kill_subprocess(terminal_id, spawn_result.pid)
+                        try:
+                            from pool_worktree_manager import reap_worker_worktree  # noqa: E402
+                            reap_worker_worktree(terminal_id)
+                        except Exception as wt_exc:
+                            log.warning(
+                                "scale_up: worktree cleanup failed for %s: %s",
+                                terminal_id, wt_exc,
+                            )
                 else:
                     err = f"spawn failed for terminal={terminal_id}: {spawn_result.error}"
                     result.errors.append(err)
@@ -408,13 +436,16 @@ class PoolManager:
     def _execute_scale_down(self, decision: PoolDecision, now: float) -> ExecResult:
         result = ExecResult(decision=decision)
 
+        _config, _, members = self.load_state()
+        # Build membership_id -> terminal_id map for lease release
+        mid_to_terminal = {m.membership_id: m.terminal_id for m in members}
+
         if decision.targets:  # OI-1483: use pre-computed targets from decide()
             membership_ids = list(decision.targets)
         else:
-            config, _, members = self.load_state()
             membership_ids = select_for_scale_down(
                 members=members,
-                provider_mix=config.provider_mix,
+                provider_mix=_config.provider_mix,
                 delta=decision.delta,
             )
 
@@ -429,6 +460,17 @@ class PoolManager:
                 err = f"reap error for membership={membership_id}: {exc}"
                 result.errors.append(err)
                 log.exception("scale_down: reap error membership=%s", membership_id)
+                continue
+
+            terminal_id = mid_to_terminal.get(membership_id)
+            if terminal_id:
+                try:
+                    self.repo.release_pool_lease(terminal_id, "scale_down", now)
+                except Exception as exc:
+                    log.warning(
+                        "scale_down: lease release failed for terminal=%s: %s",
+                        terminal_id, exc,
+                    )
 
         return result
 

--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -533,6 +533,98 @@ class PoolStateRepository:
         finally:
             conn.close()
 
+    def add_or_refresh_pool_lease(
+        self,
+        terminal_id: str,
+        pid: Optional[int],
+        now: float,
+    ) -> None:
+        """INSERT or refresh a terminal_leases row for a pool worker (ADR-007, ADR-005).
+
+        Idempotent via ON CONFLICT DO UPDATE so re-spawn of the same terminal is safe.
+        Generates a unique lease_token (required by partial UNIQUE idx on lease_token != '').
+        dispatch_id stays NULL — pool workers are not bound to a single dispatch.
+        """
+        now_iso = _iso_now(now)
+        token = _uuid7()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO terminal_leases
+                    (terminal_id, project_id, state, worker_pid,
+                     last_heartbeat_at, lease_token)
+                VALUES (?, ?, 'leased', ?, ?, ?)
+                ON CONFLICT(terminal_id, project_id) DO UPDATE SET
+                    state             = 'leased',
+                    worker_pid        = excluded.worker_pid,
+                    last_heartbeat_at = excluded.last_heartbeat_at,
+                    lease_token       = excluded.lease_token
+                """,
+                (terminal_id, self.project_id, pid, now_iso, token),
+            )
+            conn.commit()
+            log.debug(
+                "add_or_refresh_pool_lease: terminal=%s pid=%s project=%s",
+                terminal_id, pid, self.project_id,
+            )
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        self._emit_ledger("pool.lease.acquired", {
+            "terminal_id": terminal_id,
+            "project_id": self.project_id,
+            "pid": pid,
+            "now": now,
+        })
+
+    def release_pool_lease(
+        self,
+        terminal_id: str,
+        reason: str,
+        now: float,
+    ) -> None:
+        """Release a pool worker's terminal_leases row (ADR-005).
+
+        Sets state='released', clears lease_token so the partial unique index
+        slot is freed, and nulls worker_pid so the reaper ignores it.
+        """
+        now_iso = _iso_now(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE terminal_leases
+                SET state             = 'released',
+                    lease_token       = '',
+                    worker_pid        = NULL,
+                    last_heartbeat_at = ?
+                WHERE terminal_id = ? AND project_id = ?
+                  AND state != 'released'
+                """,
+                (now_iso, terminal_id, self.project_id),
+            )
+            conn.commit()
+            log.debug("release_pool_lease: terminal=%s reason=%s", terminal_id, reason)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        try:
+            self._emit_ledger("pool.lease.released", {
+                "terminal_id": terminal_id,
+                "project_id": self.project_id,
+                "reason": reason,
+                "now": now,
+            })
+        except Exception:
+            log.error("release_pool_lease: ledger emit failed for terminal=%s", terminal_id)
+
     def update_config(self, pool_id: str, updates: Dict) -> None:
         """Update pool_config fields. Keys map to PoolConfig field names."""
         _FIELD_MAP = {

--- a/tests/fixtures/pool_state_fixtures.py
+++ b/tests/fixtures/pool_state_fixtures.py
@@ -165,7 +165,9 @@ CREATE TABLE IF NOT EXISTS worker_pool_membership (
     released_at         TEXT,
     release_reason      TEXT,
     spawn_generation    INTEGER NOT NULL DEFAULT 1,
-    metadata_json       TEXT    DEFAULT '{}'
+    metadata_json       TEXT    DEFAULT '{}',
+    FOREIGN KEY (terminal_id, project_id)
+        REFERENCES terminal_leases(terminal_id, project_id)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_membership_active

--- a/tests/pool/test_pool_lease_e2e.py
+++ b/tests/pool/test_pool_lease_e2e.py
@@ -1,0 +1,370 @@
+"""test_pool_lease_e2e.py — E2E tests for pool lease + membership lifecycle.
+
+Covers the FK gap that allowed scale_up to succeed without inserting a
+terminal_leases row (the FK on worker_pool_membership was missing from the
+test fixture schema).
+
+Tests run against a real on-disk SQLite DB with PRAGMA foreign_keys = ON
+and a production-accurate schema (including the FK constraint).
+
+Dispatch-ID: 20260529-131408-pool-lease-fix
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+if str(_FIXTURES) not in sys.path:
+    sys.path.insert(0, str(_FIXTURES))
+
+from pool_manager import ExecResult, PoolManager, SpawnResult  # noqa: E402
+from pool_state_repo import PoolStateRepository  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Production-accurate schema fixture (includes FK on worker_pool_membership)
+# ---------------------------------------------------------------------------
+
+_PROD_SCHEMA = """
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS runtime_schema_version (
+    version     INTEGER PRIMARY KEY,
+    description TEXT,
+    applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+INSERT OR IGNORE INTO runtime_schema_version(version, description)
+VALUES (14, 'e2e-prod-schema');
+
+CREATE TABLE IF NOT EXISTS terminal_leases (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id       TEXT    NOT NULL,
+    project_id        TEXT    NOT NULL,
+    state             TEXT    NOT NULL DEFAULT 'idle',
+    lease_token       TEXT    NOT NULL DEFAULT '',
+    last_heartbeat_at TEXT,
+    worker_pid        INTEGER,
+    released_at       TEXT,
+    generation        INTEGER NOT NULL DEFAULT 1,
+    dispatch_id       TEXT,
+    UNIQUE(terminal_id, project_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_leases_token
+    ON terminal_leases(lease_token) WHERE lease_token != '';
+
+CREATE TABLE IF NOT EXISTS dispatches (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    project_id  TEXT NOT NULL DEFAULT 'vnx-dev',
+    state       TEXT NOT NULL DEFAULT 'queued',
+    UNIQUE(dispatch_id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS pool_config (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id              TEXT    NOT NULL,
+    pool_id                 TEXT    NOT NULL DEFAULT 'default',
+    min_workers             INTEGER NOT NULL DEFAULT 1,
+    max_workers             INTEGER NOT NULL DEFAULT 6,
+    target_workers          INTEGER NOT NULL DEFAULT 3,
+    role_mix_json           TEXT    NOT NULL DEFAULT '["backend-developer"]',
+    provider_mix_json       TEXT    NOT NULL DEFAULT '["claude"]',
+    scale_policy            TEXT    NOT NULL DEFAULT 'queue_depth_v1',
+    cooldown_seconds        INTEGER NOT NULL DEFAULT 120,
+    cost_ceiling_usd        REAL,
+    heartbeat_stale_seconds REAL    NOT NULL DEFAULT 180,
+    created_at              TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at              TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE(project_id, pool_id),
+    CHECK (min_workers >= 0),
+    CHECK (max_workers >= min_workers),
+    CHECK (target_workers >= min_workers AND target_workers <= max_workers)
+);
+
+CREATE TABLE IF NOT EXISTS worker_pools (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id          TEXT    NOT NULL,
+    pool_id             TEXT    NOT NULL DEFAULT 'default',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    current_size        INTEGER NOT NULL DEFAULT 0,
+    target_size         INTEGER NOT NULL DEFAULT 0,
+    healthy_count       INTEGER NOT NULL DEFAULT 0,
+    stuck_count         INTEGER NOT NULL DEFAULT 0,
+    last_scaled_at      TEXT,
+    last_scale_action   TEXT,
+    last_decision_json  TEXT    DEFAULT '{}',
+    metadata_json       TEXT    DEFAULT '{}',
+    UNIQUE(project_id, pool_id),
+    FOREIGN KEY (project_id, pool_id) REFERENCES pool_config(project_id, pool_id)
+);
+
+CREATE TABLE IF NOT EXISTS worker_pool_membership (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id      TEXT    NOT NULL,
+    project_id       TEXT    NOT NULL,
+    pool_id          TEXT    NOT NULL DEFAULT 'default',
+    provider         TEXT    NOT NULL,
+    role             TEXT    NOT NULL,
+    joined_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    released_at      TEXT,
+    release_reason   TEXT,
+    spawn_generation INTEGER NOT NULL DEFAULT 1,
+    metadata_json    TEXT    DEFAULT '{}',
+    FOREIGN KEY (terminal_id, project_id)
+        REFERENCES terminal_leases(terminal_id, project_id),
+    FOREIGN KEY (project_id, pool_id)
+        REFERENCES pool_config(project_id, pool_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_membership_active
+    ON worker_pool_membership(terminal_id, project_id)
+    WHERE released_at IS NULL;
+
+PRAGMA foreign_keys = ON;
+"""
+
+PROJECT_ID = "vnx-dev"
+POOL_ID = "default"
+
+
+def _make_prod_db(tmp_path: Path) -> Path:
+    """Create an on-disk DB with production-accurate schema and FK enabled."""
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "events").mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_PROD_SCHEMA)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO pool_config
+            (project_id, pool_id, min_workers, max_workers, target_workers,
+             scale_policy, cooldown_seconds, provider_mix_json, heartbeat_stale_seconds)
+        VALUES (?, ?, 0, 4, 1, 'queue_depth_v1', 60, '["claude"]', 180)
+        """,
+        (PROJECT_ID, POOL_ID),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO worker_pools (project_id, pool_id, state, current_size, target_size)
+        VALUES (?, ?, 'idle', 0, 1)
+        """,
+        (PROJECT_ID, POOL_ID),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _stub_spawn(pid: int = 42000):
+    """Return a spawn_fn that never actually spawns a subprocess."""
+    def _fn(project_id, pool_id, terminal_id, provider, role):
+        return SpawnResult(terminal_id=terminal_id, success=True, pid=pid)
+    return _fn
+
+
+def _count_rows(db_path: Path, table: str, where: str = "1=1") -> int:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON")
+    row = conn.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}").fetchone()
+    conn.close()
+    return row[0] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# E2E: scale 0→1 creates both lease + membership rows (FK enforced)
+# ---------------------------------------------------------------------------
+
+class TestPoolLeaseE2E:
+    def test_scale_up_creates_lease_and_membership(self, tmp_path):
+        """scale 0→1 must create terminal_leases AND worker_pool_membership.
+
+        If add_or_refresh_pool_lease is missing (the original bug), add_member
+        raises sqlite3.IntegrityError: FOREIGN KEY constraint failed because the
+        FK terminal_leases(terminal_id, project_id) is enforced.
+        """
+        db_path = _make_prod_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES (?, ?, ?)",
+            ("d-e2e-001", PROJECT_ID, "queued"),
+        )
+        conn.commit()
+        conn.close()
+
+        mgr = PoolManager(PROJECT_ID, POOL_ID, db_path, spawn_fn=_stub_spawn(42001))
+
+        with patch("pool_worktree_manager.create_worker_worktree", return_value=tmp_path / "wt"):
+            result = mgr.tick()
+
+        assert len(result.errors) == 0, f"Unexpected errors: {result.errors}"
+        assert len(result.spawned) == 1
+
+        # Both rows must exist
+        lease_count = _count_rows(
+            db_path, "terminal_leases",
+            f"project_id='{PROJECT_ID}' AND state='leased'"
+        )
+        membership_count = _count_rows(
+            db_path, "worker_pool_membership",
+            f"project_id='{PROJECT_ID}' AND released_at IS NULL"
+        )
+        assert lease_count == 1, f"Expected 1 lease row, got {lease_count}"
+        assert membership_count == 1, f"Expected 1 membership row, got {membership_count}"
+
+        # Lease token must be non-empty (partial unique index compliance)
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT lease_token, worker_pid FROM terminal_leases WHERE project_id = ?",
+            (PROJECT_ID,),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] != "", "lease_token must be non-empty"
+        assert row[1] == 42001, "worker_pid must match spawn result"
+
+    def test_scale_up_lease_missing_raises_fk_error_without_fix(self, tmp_path):
+        """Regression guard: inserting membership WITHOUT lease raises FK error when FKs are on."""
+        db_path = _make_prod_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO worker_pool_membership
+                    (terminal_id, project_id, pool_id, provider, role, joined_at, metadata_json)
+                VALUES ('ghost-terminal', ?, ?, 'claude', 'backend-developer',
+                        strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), '{}')
+                """,
+                (PROJECT_ID, POOL_ID),
+            )
+        conn.close()
+
+    def test_reap_releases_lease_row(self, tmp_path):
+        """reap_dead must release the lease row so no dangling lease remains."""
+        db_path = _make_prod_db(tmp_path)
+        repo = PoolStateRepository(db_path, PROJECT_ID)
+        now = time.time() - 400  # far in the past so heartbeat is stale
+
+        repo.add_or_refresh_pool_lease("vnx-dev-T-reap", 99001, now)
+        repo.add_member(POOL_ID, "vnx-dev-T-reap", "claude", "backend-developer", now, pid=99001)
+
+        mgr = PoolManager(PROJECT_ID, POOL_ID, db_path, spawn_fn=_stub_spawn())
+        from pool_reaper import ReapConfig
+        mgr.reap_config = ReapConfig(heartbeat_stale_threshold_s=60.0, warmup_window_s=0.0)
+
+        with patch("pool_manager.PoolManager._kill_subprocess"), \
+             patch("pool_worktree_manager.reap_worker_worktree"):
+            reaped = mgr.reap_dead()
+
+        assert len(reaped) >= 1
+
+        # Lease must be released (not in 'leased' state)
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT state FROM terminal_leases WHERE terminal_id = ? AND project_id = ?",
+            ("vnx-dev-T-reap", PROJECT_ID),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "released", f"Expected released, got {row[0]}"
+
+    def test_scale_down_releases_lease_row(self, tmp_path):
+        """scale_down must release the lease row so no dangling lease remains."""
+        db_path = _make_prod_db(tmp_path)
+        repo = PoolStateRepository(db_path, PROJECT_ID)
+        now = time.time()
+
+        repo.add_or_refresh_pool_lease("vnx-dev-T-sd", 88001, now)
+        mid = repo.add_member(POOL_ID, "vnx-dev-T-sd", "claude", "backend-developer", now, pid=88001)
+
+        from pool_decision_engine import PoolDecision
+        decision = PoolDecision(
+            action="scale_down", delta=-1, reason="test", targets={mid}
+        )
+        mgr = PoolManager(PROJECT_ID, POOL_ID, db_path, spawn_fn=_stub_spawn())
+        mgr.execute(decision)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT state FROM terminal_leases WHERE terminal_id = ? AND project_id = ?",
+            ("vnx-dev-T-sd", PROJECT_ID),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "released", f"Expected released, got {row[0]}"
+
+    def test_no_leaked_worktree_on_registration_failure(self, tmp_path):
+        """If add_member raises (e.g. FK violation), the worktree must be cleaned up."""
+        db_path = _make_prod_db(tmp_path)
+
+        reap_calls = []
+
+        def _spawn(project_id, pool_id, terminal_id, provider, role):
+            return SpawnResult(terminal_id=terminal_id, success=True, pid=77777)
+
+        mgr = PoolManager(PROJECT_ID, POOL_ID, db_path, spawn_fn=_spawn)
+
+        # Patch add_member to simulate FK failure after lease insert
+        original_add_member = mgr.repo.add_member
+
+        def _bad_add_member(*args, **kwargs):
+            raise sqlite3.IntegrityError("simulated FK failure")
+
+        mgr.repo.add_member = _bad_add_member
+
+        with patch("pool_manager.PoolManager._kill_subprocess") as mock_kill, \
+             patch("pool_worktree_manager.reap_worker_worktree") as mock_reap_wt, \
+             patch("pool_worktree_manager.create_worker_worktree", return_value=tmp_path / "wt"):
+            from pool_decision_engine import PoolDecision
+            decision = PoolDecision(action="scale_up", delta=1, reason="test")
+            result = mgr.execute(decision)
+
+        assert len(result.spawned) == 0
+        assert len(result.errors) == 1
+        mock_kill.assert_called_once()
+        mock_reap_wt.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI project_id resolution
+# ---------------------------------------------------------------------------
+
+class TestCliProjectIdResolution:
+    def test_resolve_project_id_returns_explicit_when_given(self):
+        from vnx_cli.commands.pool import _resolve_project_id
+        assert _resolve_project_id("my-project") == "my-project"
+
+    def test_resolve_project_id_derives_from_marker_when_none(self, tmp_path):
+        from vnx_cli.commands.pool import _resolve_project_id
+
+        # Write a .vnx-project-id marker in tmp_path
+        marker = tmp_path / ".vnx-project-id"
+        marker.write_text("test-project\n")
+
+        with patch("vnx_paths.resolve_state_dir", return_value=tmp_path / ".vnx-data" / "state"), \
+             patch("vnx_paths.project_id_from_state_dir") as mock_pid:
+            mock_pid.return_value = "test-project"
+            result = _resolve_project_id(None)
+
+        assert result == "test-project"
+
+    def test_resolve_project_id_falls_back_to_default_on_error(self):
+        from vnx_cli.commands.pool import _resolve_project_id
+
+        with patch("vnx_paths.project_id_from_state_dir", return_value=""):
+            result = _resolve_project_id(None)
+
+        assert result == "default"

--- a/tests/pool/test_spawn_integration.py
+++ b/tests/pool/test_spawn_integration.py
@@ -36,7 +36,7 @@ from pool_manager import (
 )
 from pool_reaper import ReapConfig, ReapTarget
 from pool_state_repo import PoolStateRepository
-from pool_state_fixtures import create_test_db_file
+from pool_state_fixtures import create_test_db_file, insert_lease
 
 
 def _setup_db(tmp_path: Path, min_workers: int = 0, max_workers: int = 4) -> Path:
@@ -132,6 +132,9 @@ class TestSpawnIntegrationFullFlow:
         mock_popen.return_value = mock_proc
 
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
         repo.add_member("default", "T1", "claude", "backend-developer", 100.0, pid=44444)
 

--- a/tests/pool/test_subprocess_spawn.py
+++ b/tests/pool/test_subprocess_spawn.py
@@ -34,7 +34,7 @@ from pool_manager import (
     _spawn_via_provider_dispatch,
 )
 from pool_state_repo import PoolStateRepository
-from pool_state_fixtures import _BASE_SCHEMA, create_test_db_file
+from pool_state_fixtures import _BASE_SCHEMA, create_test_db_file, insert_lease
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +237,9 @@ class TestSpawnViaProviderDispatch:
 class TestPidInMembershipMetadata:
     def test_add_member_stores_pid(self, tmp_path):
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
 
         membership_id = repo.add_member("default", "T1", "claude", "backend-developer", 1000.0, pid=54321)
@@ -247,6 +250,9 @@ class TestPidInMembershipMetadata:
 
     def test_add_member_without_pid_omits_key(self, tmp_path):
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
 
         repo.add_member("default", "T1", "claude", "backend-developer", 1000.0)
@@ -257,6 +263,9 @@ class TestPidInMembershipMetadata:
 
     def test_list_members_reads_pid(self, tmp_path):
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
         repo.add_member("default", "T1", "claude", "backend-developer", 1000.0, pid=12345)
 
@@ -268,6 +277,9 @@ class TestPidInMembershipMetadata:
 
     def test_list_members_pid_none_when_absent(self, tmp_path):
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
         repo.add_member("default", "T1", "claude", "backend-developer", 1000.0)
 
@@ -278,6 +290,9 @@ class TestPidInMembershipMetadata:
 
     def test_list_members_pid_survives_json_roundtrip(self, tmp_path):
         db_path = _setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
         repo.add_member("default", "T1", "claude", "backend-developer", 1000.0, pid=2**31 - 1)
 
@@ -343,6 +358,9 @@ class TestReaperPidValidation:
         from pool_reaper import ReapConfig
 
         db_path = _setup_db(tmp_path, min_workers=0, max_workers=4)
+        conn = sqlite3.connect(str(db_path))
+        insert_lease(conn, "T1")
+        conn.close()
         repo = PoolStateRepository(db_path, "vnx-dev")
         repo.add_member("default", "T1", "claude", "backend-developer", 500.0, pid=11111)
 

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -180,8 +180,22 @@ def cmd_reap(args: argparse.Namespace) -> int:
     return 0
 
 
-def _make_manager(project: str, pool_id: Optional[str]) -> PoolManager:
-    return PoolManager(project_id=project, pool_id=pool_id or "default")
+def _resolve_project_id(explicit: Optional[str]) -> str:
+    """Return the explicit project id or derive it from the .vnx-project-id marker."""
+    if explicit is not None:
+        return explicit
+    try:
+        from vnx_paths import project_id_from_state_dir, resolve_state_dir  # noqa: E402
+        derived = project_id_from_state_dir(resolve_state_dir())
+        if derived:
+            return derived
+    except Exception:
+        pass
+    return "default"
+
+
+def _make_manager(project: Optional[str], pool_id: Optional[str]) -> PoolManager:
+    return PoolManager(project_id=_resolve_project_id(project), pool_id=pool_id or "default")
 
 
 def _fmt_age(timestamp: float) -> str:
@@ -198,19 +212,19 @@ def main(argv: Optional[List[str]] = None) -> int:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_status = sub.add_parser("status", help="show pool state")
-    p_status.add_argument("--project", default="default")
+    p_status.add_argument("--project", default=None)
     p_status.add_argument("--pool-id", dest="pool_id", default=None)
     p_status.add_argument("--json", action="store_true")
     p_status.set_defaults(func=cmd_status)
 
     p_scale = sub.add_parser("scale", help="force scale pool to N workers")
-    p_scale.add_argument("--project", required=True)
+    p_scale.add_argument("--project", default=None)
     p_scale.add_argument("--to", type=int, required=True)
     p_scale.add_argument("--pool-id", dest="pool_id", default=None)
     p_scale.set_defaults(func=cmd_scale)
 
     p_config = sub.add_parser("config", help="update pool config")
-    p_config.add_argument("--project", required=True)
+    p_config.add_argument("--project", default=None)
     p_config.add_argument("--pool-id", dest="pool_id", default=None)
     p_config.add_argument("--min", type=int, dest="min")
     p_config.add_argument("--max", type=int, dest="max")
@@ -219,7 +233,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_config.set_defaults(func=cmd_config)
 
     p_reap = sub.add_parser("reap", help="reap stale workers (dry-run by default)")
-    p_reap.add_argument("--project", required=True)
+    p_reap.add_argument("--project", default=None)
     p_reap.add_argument("--pool-id", dest="pool_id", default=None)
     p_reap.add_argument("--force", action="store_true", help="actually reap (default: dry-run)")
     p_reap.set_defaults(func=cmd_reap)


### PR DESCRIPTION
## Summary

- **Root cause**: `worker_pool_membership` has `FOREIGN KEY (terminal_id, project_id) REFERENCES terminal_leases(terminal_id, project_id)`. Pool `scale_up` spawned a dynamic terminal but never INSERTed the matching `terminal_leases` row. Every `add_member` call raised `sqlite3.IntegrityError: FOREIGN KEY constraint failed`, rolled back, and leaked the spawned worktree.
- **Fix**: `add_or_refresh_pool_lease` (idempotent upsert via `ON CONFLICT DO UPDATE`) is called after a successful spawn and before `add_member`. On registration failure, the subprocess is killed and the worktree is reaped — no more leaks.
- **Release path**: `reap_dead` and `_execute_scale_down` now call `release_pool_lease` (sets `state='released'`, clears `lease_token` and `worker_pid`) so no dangling lease rows remain after a worker exits.
- **CLI project_id**: `--project` now defaults to the `.vnx-project-id` marker (via `project_id_from_state_dir(resolve_state_dir())`). Previously defaulted to the literal `"default"` string, causing `bin/vnx pool status` to fail with no args.
- **Test gap closed**: `_BASE_SCHEMA` fixture now includes the FK constraint on `worker_pool_membership → terminal_leases`. New `tests/pool/test_pool_lease_e2e.py` uses a production-accurate schema with FKs ON and validates the full lease+membership lifecycle.

**ADR-007**: every lease INSERT stamps `project_id` explicitly — composite `UNIQUE(terminal_id, project_id)` respected.  
**ADR-005**: `pool.lease.acquired` and `pool.lease.released` events emitted to `.vnx-data/events/pool_events.ndjson`.

## Changes

| File | Change |
|---|---|
| `scripts/lib/pool_state_repo.py` | `add_or_refresh_pool_lease` + `release_pool_lease` methods |
| `scripts/lib/pool_manager.py` | `_execute_scale_up` lease INSERT + cleanup; `_execute_scale_down` + `reap_dead` lease release |
| `vnx_cli/commands/pool.py` | `_resolve_project_id` helper; all 4 subcommands derive project from marker |
| `tests/fixtures/pool_state_fixtures.py` | FK added to `_BASE_SCHEMA` |
| `tests/pool/test_subprocess_spawn.py` | `insert_lease` before direct `add_member` calls (6 tests) |
| `tests/pool/test_spawn_integration.py` | `insert_lease` before direct `add_member` call (1 test) |
| `tests/pool/test_pool_lease_e2e.py` | New: E2E tests with production schema + FK enforcement |

## Test plan

- [x] `python3 -m pytest tests/pool/ -q` → **36 passed**, 1 warning
- [x] `git worktree list` shows no leaked `pool/*` worktrees
- [x] FK regression guard: `test_scale_up_lease_missing_raises_fk_error_without_fix` confirms `IntegrityError` is raised when lease row absent
- [x] E2E: `test_scale_up_creates_lease_and_membership` confirms both rows created on scale 0→1 with FK enabled
- [x] Reap + scale_down tests confirm lease released after worker exits

**Dispatch-ID**: 20260529-131408-pool-lease-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)