### PR TITLE
fix(a14-wire-0025): wire dream migration into quality-DB bootstrap

### DIFF
--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -23,7 +23,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 19
+HIGHEST_QI_VERSION = 20
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -634,6 +634,70 @@ def _migrate_v18(conn: sqlite3.Connection) -> None:
         log('INFO', 'Migrated: created dispatch_experiments table + indexes')
 
 
+def _migrate_v20(conn: sqlite3.Connection) -> None:
+    """V20: dream_cycles + dream_pattern_archives (ADR-019 auto-dream, ADR-007 composite PKs).
+
+    Wires schemas/migrations/0025_dream_consolidation.sql into the bootstrap.
+    File is named 0025 following sequential SQL file numbering; internal
+    version is v20 (next after v19). ADR-007: both tables carry composite PKs
+    over project_id.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dream_cycles'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dream_cycles (
+                cycle_id          TEXT    NOT NULL,
+                project_id        TEXT    NOT NULL DEFAULT 'vnx-dev',
+                started_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                completed_at      TEXT,
+                status            TEXT    NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending','running','completed','failed','reviewed','rejected')),
+                provider          TEXT    NOT NULL DEFAULT 'kimi',
+                insights_input    INTEGER NOT NULL DEFAULT 0,
+                merged_count      INTEGER NOT NULL DEFAULT 0,
+                dropped_count     INTEGER NOT NULL DEFAULT 0,
+                archived_count    INTEGER NOT NULL DEFAULT 0,
+                flagged_count     INTEGER NOT NULL DEFAULT 0,
+                operator_reviewed INTEGER NOT NULL DEFAULT 0,
+                report_path       TEXT,
+                PRIMARY KEY (cycle_id, project_id)
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dream_cycles_project_status "
+            "ON dream_cycles(project_id, status, started_at DESC)"
+        )
+        log('INFO', 'Migrated: created dream_cycles table + index (ADR-019, ADR-007 composite PK)')
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dream_pattern_archives'"
+    ).fetchone():
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS dream_pattern_archives (
+                archive_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                cycle_id            TEXT    NOT NULL,
+                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                original_pattern_id INTEGER NOT NULL,
+                original_table      TEXT    NOT NULL
+                                    CHECK (original_table IN ('success_patterns','antipatterns','intelligence_injections')),
+                archived_reason     TEXT    NOT NULL
+                                    CHECK (archived_reason IN ('stale_30d','exact_duplicate','merged_into_other','operator_rejected')),
+                archived_at         TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                FOREIGN KEY (cycle_id, project_id) REFERENCES dream_cycles(cycle_id, project_id)
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dream_archives_cycle "
+            "ON dream_pattern_archives(cycle_id, project_id)"
+        )
+        # Pre-initialize sqlite_sequence high-water-mark (FUT-2A lesson)
+        conn.execute("DELETE FROM sqlite_sequence WHERE name = 'dream_pattern_archives'")
+        conn.execute(
+            "INSERT INTO sqlite_sequence(name, seq) VALUES ('dream_pattern_archives', 0)"
+        )
+        log('INFO', 'Migrated: created dream_pattern_archives table + index (ADR-019, ADR-007)')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -655,6 +719,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     17: _migrate_v17,
     18: _migrate_v18,
     19: _migrate_v19,
+    20: _migrate_v20,
 }
 
 
@@ -736,6 +801,8 @@ def verify_database_structure() -> bool:
             'confidence_events',
             'report_findings',
             'adrs',
+            'dream_cycles',
+            'dream_pattern_archives',
         ]
 
         # Expected views

--- a/tests/test_quality_db_dream_migration.py
+++ b/tests/test_quality_db_dream_migration.py
@@ -1,0 +1,222 @@
+"""Regression tests for v20 dream migration (ADR-019, ADR-007).
+
+Verifies that bootstrap_qi_db creates dream_cycles and dream_pattern_archives.
+Covers: fresh bootstrap, idempotent re-run, composite PK structure (ADR-007).
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import quality_db_init
+import schema_migration
+
+_SCHEMA_FILE = REPO_ROOT / "schemas" / "quality_intelligence.sql"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bootstrap(db_path: Path) -> bool:
+    return quality_db_init.bootstrap_qi_db(db_path, _SCHEMA_FILE)
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+
+def _index_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDreamMigrationV20:
+    def test_bootstrap_creates_dream_cycles(self, tmp_path):
+        """bootstrap_qi_db creates dream_cycles table on fresh DB."""
+        db_path = tmp_path / "quality_intelligence.db"
+        result = _bootstrap(db_path)
+        assert result is True
+
+        conn = sqlite3.connect(str(db_path))
+        tables = _table_names(conn)
+        conn.close()
+
+        assert "dream_cycles" in tables
+
+    def test_bootstrap_creates_dream_pattern_archives(self, tmp_path):
+        """bootstrap_qi_db creates dream_pattern_archives table on fresh DB."""
+        db_path = tmp_path / "quality_intelligence.db"
+        result = _bootstrap(db_path)
+        assert result is True
+
+        conn = sqlite3.connect(str(db_path))
+        tables = _table_names(conn)
+        conn.close()
+
+        assert "dream_pattern_archives" in tables
+
+    def test_dream_cycles_composite_pk_adr007(self, tmp_path):
+        """dream_cycles has composite PRIMARY KEY (cycle_id, project_id) per ADR-007."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        pk_cols = {
+            r[1]
+            for r in conn.execute("PRAGMA table_info(dream_cycles)").fetchall()
+            if r[5] > 0  # pk column (column 5 = pk index, 0 = not PK)
+        }
+        conn.close()
+
+        assert "cycle_id" in pk_cols
+        assert "project_id" in pk_cols
+
+    def test_dream_cycles_indexes_created(self, tmp_path):
+        """bootstrap creates idx_dream_cycles_project_status index."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        indexes = _index_names(conn)
+        conn.close()
+
+        assert "idx_dream_cycles_project_status" in indexes
+
+    def test_dream_archives_indexes_created(self, tmp_path):
+        """bootstrap creates idx_dream_archives_cycle index."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        indexes = _index_names(conn)
+        conn.close()
+
+        assert "idx_dream_archives_cycle" in indexes
+
+    def test_user_version_is_20_after_bootstrap(self, tmp_path):
+        """PRAGMA user_version is 20 after bootstrap (v20 is HIGHEST_QI_VERSION)."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        version = schema_migration.get_user_version(conn)
+        conn.close()
+
+        assert version == quality_db_init.HIGHEST_QI_VERSION
+        assert version == 20
+
+    def test_bootstrap_idempotent_on_existing_db(self, tmp_path):
+        """Running bootstrap twice does not corrupt dream tables or raise."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        # Insert a row so we can verify data survives the second bootstrap
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dream_cycles(cycle_id, project_id, status, provider) "
+            "VALUES ('test-cycle-01', 'vnx-dev', 'completed', 'kimi')"
+        )
+        conn.commit()
+        conn.close()
+
+        result = _bootstrap(db_path)
+        assert result is True
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT cycle_id FROM dream_cycles").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "test-cycle-01"
+
+    def test_dream_pattern_archives_sqlite_sequence_initialized(self, tmp_path):
+        """sqlite_sequence has an entry for dream_pattern_archives after bootstrap."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'dream_pattern_archives'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == 0
+
+    def test_dream_cycles_insert_and_query(self, tmp_path):
+        """dream_cycles accepts INSERT and enforces project_id scoping."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dream_cycles(cycle_id, project_id, status, provider) "
+            "VALUES (?, ?, ?, ?)",
+            ("cycle-001", "proj-a", "completed", "kimi"),
+        )
+        conn.execute(
+            "INSERT INTO dream_cycles(cycle_id, project_id, status, provider) "
+            "VALUES (?, ?, ?, ?)",
+            ("cycle-001", "proj-b", "completed", "kimi"),
+        )
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT cycle_id, project_id FROM dream_cycles ORDER BY project_id"
+        ).fetchall()
+        conn.close()
+
+        assert len(rows) == 2
+        assert rows[0] == ("cycle-001", "proj-a")
+        assert rows[1] == ("cycle-001", "proj-b")
+
+    def test_dream_migration_does_not_drop_existing_tables(self, tmp_path):
+        """v20 migration does not drop or truncate tables that already exist."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO dream_cycles(cycle_id, project_id, status, provider) "
+            "VALUES ('keep-me', 'vnx-dev', 'completed', 'kimi')"
+        )
+        conn.commit()
+
+        # Manually downgrade user_version to simulate re-running v20
+        conn.execute("PRAGMA user_version = 19")
+        conn.commit()
+        conn.close()
+
+        result = _bootstrap(db_path)
+        assert result is True
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT cycle_id FROM dream_cycles WHERE cycle_id = 'keep-me'"
+        ).fetchone()
+        conn.close()
+
+        assert row is not None, "existing dream_cycles row must survive re-migration"


### PR DESCRIPTION
## Summary

- Wires `schemas/migrations/0025_dream_consolidation.sql` into the quality-DB bootstrap by adding `_migrate_v20` to `scripts/quality_db_init.py`
- Bumps `HIGHEST_QI_VERSION` from 19 to 20; registers `20: _migrate_v20` in `MIGRATIONS`
- Adds `dream_cycles` and `dream_pattern_archives` to `verify_database_structure` expected-tables list
- Adds 10-test regression suite (`tests/test_quality_db_dream_migration.py`) covering fresh bootstrap, idempotency, composite PK structure, index creation, and sqlite_sequence initialization

## ADR-007 compliance (MANDATORY)

Both tables carry composite PKs over `project_id`:
- `dream_cycles`: `PRIMARY KEY (cycle_id, project_id)`
- `dream_pattern_archives`: `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` with `FOREIGN KEY (cycle_id, project_id) REFERENCES dream_cycles`

## Root cause fix

`HIGHEST_QI_VERSION = 19` + no v20 entry in `MIGRATIONS` meant `0025_dream_consolidation.sql` was never applied. `bootstrap_qi_db` iterates `MIGRATIONS` in sorted order after V1; adding v20 makes it apply on next bootstrap.

## Version gap resolution

SQL file named `0025` follows sequential file numbering. Internal Python version is `v20` (next after `v19`) — no parallel scheme introduced.

## Verification

```
Tables found: ['dream_cycles', 'dream_pattern_archives']
PASS: both dream tables created by bootstrap
```

```
tests/test_quality_db_dream_migration.py  10/10 PASSED
tests/test_dream_consolidator.py          30/30 PASSED
tests/test_dream_cli.py                   30/30 PASSED
```

## Codex unavailable note

Codex review not triggered per dispatch instruction. Gemini-only review or codex re-audit OI to be filed per codex-unavailable template.

## Open Items

None.

🤖 Dispatch-ID: 20260529-134016-a14-wire-0025