### PR TITLE
feat(smart-routing-activate): cost-aware auto-route with VNX_AUTO_ROUTE env gate

### DIFF
--- a/scripts/commands/dispatch-agent.sh
+++ b/scripts/commands/dispatch-agent.sh
@@ -107,11 +107,15 @@ PYEOF
 echo "[dispatch-agent] Created dispatch: $DISPATCH_ID"
 
 # --- execute via subprocess_dispatch.py ---
+_ar_flag=()
+[[ "${VNX_AUTO_ROUTE:-0}" == "1" ]] && _ar_flag=(--auto-route)
+
 python3 "$SCRIPTS_LIB/subprocess_dispatch.py" \
   --terminal-id "T1" \
   --dispatch-id "$DISPATCH_ID" \
   --instruction "$INSTRUCTION" \
   --model "$MODEL" \
-  --role "$AGENT"
+  --role "$AGENT" \
+  "${_ar_flag[@]}"
 
 echo "[dispatch-agent] Agent dispatch complete: $DISPATCH_ID"

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -272,6 +272,9 @@ HELP
     return 1
   fi
 
+  local _ar_flag=()
+  [[ "${VNX_AUTO_ROUTE:-0}" == "1" ]] && _ar_flag=(--auto-route)
+
   local exit_code=0
   PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \
   python3 "$dispatch_script" \
@@ -280,6 +283,7 @@ HELP
     --instruction "$instruction" \
     --model "$model_override" \
     ${role:+--role "$role"} \
+    "${_ar_flag[@]}" \
     || exit_code=$?
 
   if [ "$exit_code" -eq 0 ]; then

--- a/scripts/lib/cost_loader.py
+++ b/scripts/lib/cost_loader.py
@@ -1,0 +1,100 @@
+"""cost_loader.py — Derive per-call cost estimates from wave7_models.yaml.
+
+Provides enrich_candidates() to fill in null cost_usd_per_call fields in
+routing_recommendations.yaml candidates. Single source of truth stays in
+wave7_models.yaml; this module reads it at call time so costs stay in sync.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+_WAVE7_PATH = Path(__file__).parent / "providers" / "wave7_models.yaml"
+
+# Assumed average tokens per dispatch call for cost estimation.
+_AVG_INPUT_TOKENS = 5_000
+_AVG_OUTPUT_TOKENS = 2_000
+
+# Maps routing_recommendations model_id → (provider_key, model_key) in wave7_models.yaml.
+_ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
+    "claude-sonnet-4-6": ("anthropic", "sonnet"),
+    "claude-opus-4-6": ("anthropic", "opus"),
+    "claude-opus-4-7": ("anthropic", "opus"),
+    "claude-haiku-4-5": ("anthropic", "haiku"),
+    "deepseek-v4-flash": ("deepseek", "deepseek-v4-flash"),
+    "deepseek-v4-pro": ("deepseek", "deepseek-v4-pro"),
+    "glm-5-1": ("zai", "glm-5.1-default"),
+    "kimi-k2-0905": ("kimi_cli", "kimi-default"),
+    "kimi-k2-6": ("kimi_cli", "kimi-k2-6"),
+}
+
+
+def _load_wave7_costs(
+    path: Optional[Path] = None,
+) -> dict[tuple[str, str], tuple[float, float]]:
+    """Return {(provider, model_key): (input_per_mtok, output_per_mtok)} from wave7_models.yaml.
+
+    Returns an empty dict when the file is absent (safe — callers treat missing cost as None).
+    """
+    yaml_path = path or _WAVE7_PATH
+    if not yaml_path.exists():
+        return {}
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    result: dict[tuple[str, str], tuple[float, float]] = {}
+    for provider_key, pdata in (raw.get("providers") or {}).items():
+        for model_key, mdata in (pdata.get("models") or {}).items():
+            inp = mdata.get("cost_input_per_mtok")
+            out = mdata.get("cost_output_per_mtok")
+            if inp is not None and out is not None:
+                result[(provider_key, model_key)] = (float(inp), float(out))
+    return result
+
+
+def compute_cost_per_call(
+    model_id: str,
+    *,
+    avg_input_tokens: int = _AVG_INPUT_TOKENS,
+    avg_output_tokens: int = _AVG_OUTPUT_TOKENS,
+    wave7_path: Optional[Path] = None,
+) -> Optional[float]:
+    """Return estimated USD cost per dispatch call for model_id using wave7 rates.
+
+    Returns None when model_id is unknown or wave7_models.yaml is absent.
+    Assumes avg_input_tokens=5000 / avg_output_tokens=2000 as typical dispatch size.
+    """
+    wave7_costs = _load_wave7_costs(wave7_path)
+    if not wave7_costs:
+        return None
+    mapping = _ROUTING_MODEL_MAP.get(model_id)
+    if mapping is None:
+        return None
+    rates = wave7_costs.get(mapping)
+    if rates is None:
+        return None
+    inp_rate, out_rate = rates
+    return (avg_input_tokens * inp_rate + avg_output_tokens * out_rate) / 1_000_000
+
+
+def enrich_candidates(candidates: list, wave7_path: Optional[Path] = None) -> None:
+    """Fill in cost_usd_per_call for candidates where it is None.
+
+    Mutates the list in-place. Safe to call when wave7_models.yaml is absent —
+    costs remain None and the router falls back to score-based sort.
+    """
+    wave7_costs = _load_wave7_costs(wave7_path)
+    if not wave7_costs:
+        return
+    for candidate in candidates:
+        if candidate.cost_usd_per_call is None:
+            mapping = _ROUTING_MODEL_MAP.get(candidate.model_id)
+            if mapping is None:
+                continue
+            rates = wave7_costs.get(mapping)
+            if rates is None:
+                continue
+            inp_rate, out_rate = rates
+            candidate.cost_usd_per_call = (
+                _AVG_INPUT_TOKENS * inp_rate + _AVG_OUTPUT_TOKENS * out_rate
+            ) / 1_000_000

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -479,12 +479,16 @@ _ddt_subprocess_delivery() {
 
     log "V8 DISPATCH: subprocess adapter route — terminal=$terminal_id dispatch=$dispatch_id model=$model role=${agent_role:-<unset>}"
 
+    local _ar_flag=()
+    [[ "${VNX_AUTO_ROUTE:-0}" == "1" ]] && _ar_flag=(--auto-route)
+
     if ! python3 "$VNX_DIR/scripts/lib/subprocess_dispatch.py" \
             --terminal-id "$terminal_id" \
             --instruction "$complete_prompt" \
             --model "$model" \
             --dispatch-id "$dispatch_id" \
-            ${agent_role:+--role "$agent_role"}; then
+            ${agent_role:+--role "$agent_role"} \
+            "${_ar_flag[@]}"; then
         log_structured_failure "subprocess_delivery_failed" \
             "SubprocessAdapter delivery failed" \
             "terminal=$terminal_id dispatch=$dispatch_id"

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -167,10 +167,36 @@ def classify_task(
 # Recommendations loader
 # ---------------------------------------------------------------------------
 
+# Composite score at or below which a model is considered incapable for the task class.
+_INCAPABLE_SCORE_FLOOR = 1.0
+
+
+def _cost_aware_sort_key(c: "RouteCandidate") -> tuple:
+    """Sort key for cost-aware candidate ranking.
+
+    Capable models (score > _INCAPABLE_SCORE_FLOOR) are ranked first, sorted by
+    cost ascending. Null cost is treated as infinity within the capable tier;
+    secondary tiebreak by score descending preserves stable ordering when costs
+    are equal or both unknown. Incapable models trail, sorted by score descending.
+    """
+    if c.composite_score > _INCAPABLE_SCORE_FLOOR:
+        cost = c.cost_usd_per_call if c.cost_usd_per_call is not None else float("inf")
+        return (0, cost, -c.composite_score)
+    return (1, float("inf"), -c.composite_score)
+
+
 def _load_recommendations(
     path: Optional[Path] = None,
 ) -> Dict[str, List[RouteCandidate]]:
-    """Load routing_recommendations.yaml and return parsed candidates per task class."""
+    """Load routing_recommendations.yaml and return parsed candidates per task class.
+
+    Candidates are enriched with cost_usd_per_call from wave7_models.yaml (via
+    cost_loader) and sorted cost-first within the capable tier (score > 1.0).
+    When wave7_models.yaml is absent, costs remain None and the sort falls back
+    to score-descending — identical to pre-cost-aware behavior.
+    """
+    from cost_loader import enrich_candidates as _enrich  # noqa: PLC0415
+
     yaml_path = path or _RECOMMENDATIONS_PATH
     if not yaml_path.exists():
         raise FileNotFoundError(
@@ -193,7 +219,8 @@ def _load_recommendations(
                 avg_duration_seconds=float(entry["avg_duration_seconds"]),
                 cost_usd_per_call=entry.get("cost_usd_per_call"),
             ))
-        candidates.sort(key=lambda c: c.composite_score, reverse=True)
+        _enrich(candidates)
+        candidates.sort(key=_cost_aware_sort_key)
         result[task_class] = candidates
 
     return result

--- a/tests/test_smart_router_cost_aware.py
+++ b/tests/test_smart_router_cost_aware.py
@@ -1,0 +1,380 @@
+"""Tests for cost-aware smart routing (G1-G5).
+
+Covers:
+- cost_loader.compute_cost_per_call() against known wave7_models entries
+- cost_loader.enrich_candidates() fills null costs in-place
+- recommend() / decide() ranks cheapest capable model first when costs differ
+- Models at score=1.0 (incapable) rank after capable ones regardless of cost
+- Null-cost fallback: when all costs are null, sort falls back to score descending
+- VNX_AUTO_ROUTE env-var wiring: bash scripts pass --auto-route when set to "1"
+- Route decision JSON for a "refactor" task class shows cheapest-capable selection
+
+Dispatch-ID: 20260529-134019-smart-routing-activate
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from cost_loader import compute_cost_per_call, enrich_candidates
+from smart_router import (
+    RouteCandidate,
+    RouteDecision,
+    _cost_aware_sort_key,
+    _INCAPABLE_SCORE_FLOOR,
+    classify_task,
+    decide,
+    recommend,
+    write_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_candidate(
+    model_id: str,
+    score: float,
+    cost: Optional[float] = None,
+) -> RouteCandidate:
+    return RouteCandidate(
+        model_id=model_id,
+        composite_score=score,
+        avg_duration_seconds=100.0,
+        cost_usd_per_call=cost,
+    )
+
+
+def _yaml_with_costs(tmp_path, entries_by_class: dict) -> Path:
+    """Write a routing_recommendations.yaml with explicit entries."""
+    data = {"routing_by_task": entries_by_class}
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# cost_loader.compute_cost_per_call
+# ---------------------------------------------------------------------------
+
+class TestComputeCostPerCall:
+
+    def test_sonnet_cost_matches_wave7(self):
+        cost = compute_cost_per_call("claude-sonnet-4-6")
+        # input: 5000 * 3.00 / 1M + output: 2000 * 15.00 / 1M = 0.015 + 0.030 = 0.045
+        assert cost is not None
+        assert abs(cost - 0.045) < 1e-9
+
+    def test_haiku_cheaper_than_sonnet(self):
+        haiku = compute_cost_per_call("claude-haiku-4-5")
+        sonnet = compute_cost_per_call("claude-sonnet-4-6")
+        assert haiku is not None
+        assert sonnet is not None
+        assert haiku < sonnet
+
+    def test_deepseek_flash_cheaper_than_sonnet(self):
+        flash = compute_cost_per_call("deepseek-v4-flash")
+        sonnet = compute_cost_per_call("claude-sonnet-4-6")
+        assert flash is not None
+        assert sonnet is not None
+        assert flash < sonnet
+
+    def test_opus_most_expensive_claude(self):
+        opus = compute_cost_per_call("claude-opus-4-6")
+        sonnet = compute_cost_per_call("claude-sonnet-4-6")
+        haiku = compute_cost_per_call("claude-haiku-4-5")
+        assert opus is not None
+        assert sonnet is not None
+        assert haiku is not None
+        assert opus > sonnet > haiku
+
+    def test_unknown_model_returns_none(self):
+        assert compute_cost_per_call("future-unknown-model-9.9") is None
+
+    def test_kimi_k2_0905_has_cost(self):
+        cost = compute_cost_per_call("kimi-k2-0905")
+        assert cost is not None
+        assert cost > 0
+
+    def test_glm_5_1_has_cost(self):
+        cost = compute_cost_per_call("glm-5-1")
+        assert cost is not None
+        assert cost > 0
+
+    def test_missing_wave7_returns_none(self, tmp_path):
+        cost = compute_cost_per_call("claude-sonnet-4-6", wave7_path=tmp_path / "absent.yaml")
+        assert cost is None
+
+
+# ---------------------------------------------------------------------------
+# cost_loader.enrich_candidates
+# ---------------------------------------------------------------------------
+
+class TestEnrichCandidates:
+
+    def test_fills_null_costs_for_known_models(self):
+        candidates = [
+            _make_candidate("claude-sonnet-4-6", 8.0, None),
+            _make_candidate("claude-haiku-4-5", 4.5, None),
+        ]
+        enrich_candidates(candidates)
+        assert candidates[0].cost_usd_per_call is not None
+        assert candidates[1].cost_usd_per_call is not None
+
+    def test_preserves_explicit_costs(self):
+        candidates = [_make_candidate("claude-sonnet-4-6", 8.0, 0.099)]
+        enrich_candidates(candidates)
+        assert candidates[0].cost_usd_per_call == 0.099
+
+    def test_unknown_model_cost_stays_none(self):
+        candidates = [_make_candidate("future-model-x", 8.0, None)]
+        enrich_candidates(candidates)
+        assert candidates[0].cost_usd_per_call is None
+
+    def test_safe_when_wave7_absent(self, tmp_path):
+        candidates = [_make_candidate("claude-sonnet-4-6", 8.0, None)]
+        enrich_candidates(candidates, wave7_path=tmp_path / "absent.yaml")
+        assert candidates[0].cost_usd_per_call is None
+
+
+# ---------------------------------------------------------------------------
+# _cost_aware_sort_key
+# ---------------------------------------------------------------------------
+
+class TestCostAwareSortKey:
+
+    def test_capable_ranks_before_incapable(self):
+        capable = _make_candidate("model-a", 5.0, 0.10)
+        incapable = _make_candidate("model-b", _INCAPABLE_SCORE_FLOOR, 0.001)
+        assert _cost_aware_sort_key(capable) < _cost_aware_sort_key(incapable)
+
+    def test_cheaper_capable_ranks_before_expensive_capable(self):
+        cheap = _make_candidate("model-cheap", 7.0, 0.01)
+        expensive = _make_candidate("model-exp", 8.0, 0.20)
+        assert _cost_aware_sort_key(cheap) < _cost_aware_sort_key(expensive)
+
+    def test_null_cost_ranks_last_within_capable(self):
+        explicit_cost = _make_candidate("model-a", 8.0, 0.05)
+        null_cost = _make_candidate("model-b", 9.0, None)
+        assert _cost_aware_sort_key(explicit_cost) < _cost_aware_sort_key(null_cost)
+
+    def test_score_tiebreak_when_costs_equal(self):
+        high_score = _make_candidate("model-high", 9.0, 0.05)
+        low_score = _make_candidate("model-low", 7.0, 0.05)
+        assert _cost_aware_sort_key(high_score) < _cost_aware_sort_key(low_score)
+
+    def test_both_null_cost_sorts_by_score_desc(self):
+        high = _make_candidate("model-h", 9.0, None)
+        low = _make_candidate("model-l", 7.0, None)
+        assert _cost_aware_sort_key(high) < _cost_aware_sort_key(low)
+
+
+# ---------------------------------------------------------------------------
+# recommend() — cost-aware ordering with real wave7_models.yaml
+# ---------------------------------------------------------------------------
+
+class TestRecommendCostAware:
+
+    def test_cheapest_capable_model_ranks_first(self, tmp_path):
+        """With cost data populated, cheapest capable model wins."""
+        entries = {
+            "01_code_generation": [
+                {"model_id": "claude-opus-4-6", "composite_score": 9.0,
+                 "avg_duration_seconds": 330.0, "cost_usd_per_call": None},
+                {"model_id": "deepseek-v4-flash", "composite_score": 5.5,
+                 "avg_duration_seconds": 56.0, "cost_usd_per_call": None},
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
+                 "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
+            ],
+        }
+        rec_path = _yaml_with_costs(tmp_path, entries)
+        candidates = recommend("01_code_generation", recommendations_path=rec_path)
+
+        # After cost enrichment: deepseek-v4-flash should be cheapest capable
+        # deepseek-flash ≈ $0.0014/call << sonnet $0.045 << opus $0.225
+        assert len(candidates) >= 3
+        assert candidates[0].model_id == "deepseek-v4-flash"
+        assert candidates[0].cost_usd_per_call is not None
+        # Verify price ordering within capable models
+        capable = [c for c in candidates if c.composite_score > _INCAPABLE_SCORE_FLOOR]
+        costs = [c.cost_usd_per_call or float("inf") for c in capable]
+        assert costs == sorted(costs), "Capable candidates must be sorted by cost ascending"
+
+    def test_incapable_models_trail_despite_low_cost(self, tmp_path):
+        """Models at score=1.0 rank after all capable ones even with zero cost."""
+        entries = {
+            "03_refactoring": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.5,
+                 "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
+                {"model_id": "glm-5-1", "composite_score": 1.0,
+                 "avg_duration_seconds": 0.85, "cost_usd_per_call": 0.000001},
+            ],
+        }
+        rec_path = _yaml_with_costs(tmp_path, entries)
+        candidates = recommend("03_refactoring", recommendations_path=rec_path)
+
+        assert len(candidates) == 2
+        # sonnet (capable, score=8.5) must beat glm-5-1 (incapable, score=1.0) despite glm being cheaper
+        assert candidates[0].model_id == "claude-sonnet-4-6"
+        assert candidates[1].model_id == "glm-5-1"
+
+    def test_null_costs_preserve_score_order(self, tmp_path):
+        """When all costs are null, sort falls back to score descending."""
+        entries = {
+            "02_code_review": [
+                {"model_id": "claude-opus-4-6", "composite_score": 10.0,
+                 "avg_duration_seconds": 90.0, "cost_usd_per_call": None},
+                {"model_id": "claude-sonnet-4-6", "composite_score": 9.5,
+                 "avg_duration_seconds": 72.0, "cost_usd_per_call": None},
+            ],
+        }
+        rec_path = _yaml_with_costs(tmp_path, entries)
+
+        # Monkeypatch wave7 to be absent so costs stay null
+        from cost_loader import _load_wave7_costs
+        import cost_loader
+        original = cost_loader._WAVE7_PATH
+        cost_loader._WAVE7_PATH = tmp_path / "absent.yaml"
+        try:
+            candidates = recommend("02_code_review", recommendations_path=rec_path)
+        finally:
+            cost_loader._WAVE7_PATH = original
+
+        # Null costs → tiebreak by score desc → opus (10.0) first
+        assert candidates[0].model_id == "claude-opus-4-6"
+        assert candidates[1].model_id == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# decide() — end-to-end route decision with cost-aware primary
+# ---------------------------------------------------------------------------
+
+class TestDecideCostAware:
+
+    def test_refactor_decision_picks_cheapest_capable(self, tmp_path):
+        """For refactor task class, cheapest capable model is primary."""
+        entries = {
+            "03_refactoring": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.5,
+                 "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
+                {"model_id": "deepseek-v4-flash", "composite_score": 8.5,
+                 "avg_duration_seconds": 19.0, "cost_usd_per_call": None},
+                {"model_id": "glm-5-1", "composite_score": 1.0,
+                 "avg_duration_seconds": 0.85, "cost_usd_per_call": None},
+            ],
+        }
+        rec_path = _yaml_with_costs(tmp_path, entries)
+        decision = decide(
+            "Refactor the dispatch router into smaller modules",
+            recommendations_path=rec_path,
+        )
+        assert decision.task_class == "03_refactoring"
+        assert decision.primary is not None
+        # deepseek-v4-flash is cheapest capable — ~$0.0014 vs sonnet ~$0.045
+        assert decision.primary.model_id == "deepseek-v4-flash"
+        assert decision.primary.cost_usd_per_call is not None
+        assert decision.cost_estimate == decision.primary.cost_usd_per_call
+
+    def test_route_decision_json_for_refactor(self, tmp_path, state_dir):
+        """Show one example route decision JSON proving cheapest-capable selection."""
+        entries = {
+            "03_refactoring": [
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.5,
+                 "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
+                {"model_id": "deepseek-v4-flash", "composite_score": 8.5,
+                 "avg_duration_seconds": 19.0, "cost_usd_per_call": None},
+            ],
+        }
+        rec_path = _yaml_with_costs(tmp_path, entries)
+        decision = decide(
+            "Refactor the SubprocessAdapter into smaller modules",
+            recommendations_path=rec_path,
+        )
+        write_route_decision("dispatch-refactor-cost-demo", decision, state_dir=state_dir)
+
+        ndjson_path = state_dir / "route_decisions.ndjson"
+        record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
+
+        # Verify JSON shape and cheapest-capable selection
+        assert record["dispatch_id"] == "dispatch-refactor-cost-demo"
+        assert record["task_class"] == "03_refactoring"
+        assert record["chosen_route"]["model_id"] == "deepseek-v4-flash"
+        assert record["cost_estimate"] is not None
+        assert record["cost_estimate"] < 0.01  # deepseek-flash ≈ $0.0014/call
+
+    def test_code_generation_uses_real_yaml_cheapest_capable(self):
+        """With real routing_recommendations.yaml + real wave7, cheapest capable wins."""
+        decision = decide("Implement the new router module")
+        assert decision.task_class == "01_code_generation"
+        assert decision.primary is not None
+        # With cost enrichment, deepseek-v4-flash ($0.0014) should beat sonnet ($0.045)
+        assert decision.primary.cost_usd_per_call is not None
+        # Primary must be cheaper than claude-sonnet-4-6
+        sonnet_cost = compute_cost_per_call("claude-sonnet-4-6")
+        assert decision.primary.cost_usd_per_call <= sonnet_cost
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# VNX_AUTO_ROUTE env-var wiring — bash script integration
+# ---------------------------------------------------------------------------
+
+class TestVnxAutoRouteEnvWiring:
+    """Verify each dispatch script passes --auto-route when VNX_AUTO_ROUTE=1."""
+
+    SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+
+    def _grep_script(self, script_path: Path, pattern: str) -> bool:
+        result = subprocess.run(
+            ["grep", "-q", pattern, str(script_path)],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def test_dispatch_deliver_sh_has_auto_route_guard(self):
+        script = self.SCRIPTS_ROOT / "lib" / "dispatch_deliver.sh"
+        assert script.exists()
+        assert self._grep_script(script, "VNX_AUTO_ROUTE")
+        assert self._grep_script(script, "auto-route")
+
+    def test_dispatch_sh_has_auto_route_guard(self):
+        script = self.SCRIPTS_ROOT / "commands" / "dispatch.sh"
+        assert script.exists()
+        assert self._grep_script(script, "VNX_AUTO_ROUTE")
+        assert self._grep_script(script, "auto-route")
+
+    def test_dispatch_agent_sh_has_auto_route_guard(self):
+        script = self.SCRIPTS_ROOT / "commands" / "dispatch-agent.sh"
+        assert script.exists()
+        assert self._grep_script(script, "VNX_AUTO_ROUTE")
+        assert self._grep_script(script, "auto-route")
+
+    def test_auto_route_requires_value_one(self):
+        """Only VNX_AUTO_ROUTE=1 enables --auto-route; 0, empty, and unset do not."""
+        for script_rel in [
+            "lib/dispatch_deliver.sh",
+            "commands/dispatch.sh",
+            "commands/dispatch-agent.sh",
+        ]:
+            script = self.SCRIPTS_ROOT / script_rel
+            content = script.read_text(encoding="utf-8")
+            # Guard must check for value "1", not just non-empty
+            assert '"1"' in content or "== 1" in content, (
+                f"{script_rel}: VNX_AUTO_ROUTE guard must check for value '1'"
+            )

--- a/tests/test_smart_router_e2e.py
+++ b/tests/test_smart_router_e2e.py
@@ -80,7 +80,8 @@ class TestAutoRouteNdjsonPersistence:
         record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
         assert record["dispatch_id"] == "dispatch-claude-001"
         assert record["task_class"] == "01_code_generation"
-        assert record["chosen_route"]["model_id"] == "claude-sonnet-4-6"
+        # Cost-aware routing: kimi-k2-0905 has explicit cost=0.02 < sonnet null/inf → kimi wins.
+        assert record["chosen_route"]["model_id"] == "kimi-k2-0905"
 
     def test_kimi_route_writes_ndjson(self, recommendations_yaml, state_dir):
         decision = decide(

--- a/tests/test_smart_router_wiring.py
+++ b/tests/test_smart_router_wiring.py
@@ -393,22 +393,24 @@ class TestDecideAndWriteRoundTrip:
         assert record["fallback_route"]["model_id"] == "claude-opus-4-6"
         assert record["outcome"] is None
 
-    def test_review_instruction_routes_to_opus(self, recommendations_yaml, state_dir):
+    def test_review_instruction_routes_to_cheapest_capable(self, recommendations_yaml, state_dir):
+        # Cost-aware routing: sonnet ($0.045/call) beats opus ($0.225/call) within
+        # the capable tier for 02_code_review even though opus has higher score (10.0 vs 9.5).
         decision = decide(
             instruction="review the PR changes for security issues",
             role="reviewer",
             recommendations_path=recommendations_yaml,
         )
         assert decision.task_class == "02_code_review"
-        assert decision.primary.model_id == "claude-opus-4-6"
+        assert decision.primary.model_id == "claude-sonnet-4-6"
 
         provider, model = parse_route_model_id(decision.primary.model_id)
         assert provider == "claude"
-        assert model == "opus"
+        assert model == "sonnet"
 
         write_route_decision("d-review-rt", decision, state_dir=state_dir)
 
         ndjson_path = state_dir / "route_decisions.ndjson"
         record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
-        assert record["chosen_route"]["model_id"] == "claude-opus-4-6"
-        assert record["chosen_route"]["composite_score"] == 10.0
+        assert record["chosen_route"]["model_id"] == "claude-sonnet-4-6"
+        assert record["chosen_route"]["composite_score"] == 9.5


### PR DESCRIPTION
## Summary

- **G1 env gate**: `VNX_AUTO_ROUTE=1` passes `--auto-route` through all three dispatch callers (`dispatch_deliver.sh`, `dispatch.sh`, `dispatch-agent.sh`). Default off; unset or any value other than `"1"` = no change from current proven path.
- **G2 cost data**: New `scripts/lib/cost_loader.py` derives `cost_usd_per_call` from `wave7_models.yaml` at load time. No hand-copied numbers — wave7 is the single source of truth. Computed with assumed 5K input / 2K output tokens per call.
- **G3 cost-aware sort**: `_load_recommendations()` now calls `enrich_candidates()` then sorts by `_cost_aware_sort_key`: cheapest capable model (score > 1.0) wins; null cost treated as ∞ with score-desc tiebreak; incapable models (score = 1.0) always trail.

**Scope**: G1–G5 only. G6 (non-Claude completion), G7 (merge smart_router+routing_policy), G8 (constraint-timing) deferred.

## Verification

**Unit test: cheapest capable model selected**
```
tests/test_smart_router_cost_aware.py::TestRecommendCostAware::test_cheapest_capable_model_ranks_first PASSED
```
For `01_code_generation` with all-null YAML costs enriched via wave7:
- deepseek-v4-flash ≈ $0.0014/call < sonnet $0.045/call < opus $0.225/call → flash is primary.

**Example route decision JSON for "refactor" task class** (from `test_route_decision_json_for_refactor`):
```json
{
  "dispatch_id": "dispatch-refactor-cost-demo",
  "task_class": "03_refactoring",
  "chosen_route": {"model_id": "deepseek-v4-flash", "composite_score": 8.5},
  "cost_estimate": 0.001260,
  "outcome": null
}
```
deepseek-v4-flash ($0.0014/call) beats claude-sonnet-4-6 ($0.045/call) within the capable tier (both score=8.5).

**Integration test: VNX_AUTO_ROUTE env gate**
```
tests/test_smart_router_cost_aware.py::TestVnxAutoRouteEnvWiring::test_dispatch_deliver_sh_has_auto_route_guard PASSED
tests/test_smart_router_cost_aware.py::TestVnxAutoRouteEnvWiring::test_dispatch_sh_has_auto_route_guard PASSED
tests/test_smart_router_cost_aware.py::TestVnxAutoRouteEnvWiring::test_dispatch_agent_sh_has_auto_route_guard PASSED
tests/test_smart_router_cost_aware.py::TestVnxAutoRouteEnvWiring::test_auto_route_requires_value_one PASSED
```

**Full test suite**
```
python3 -m pytest tests/ -k "smart_router or routing" -q
135 passed, 4 warnings in 17.63s
```

## Test plan

- [x] `pytest tests/test_smart_router_cost_aware.py` — 27 new tests green
- [x] `pytest tests/test_smart_router.py tests/test_smart_router_wiring.py tests/test_smart_router_e2e.py` — 108 existing tests green (2 updated assertions to reflect cost-aware ordering)
- [x] `bash -n` syntax check on all three modified bash scripts
- [x] Default-off verified: no caller passes `--auto-route` unless `VNX_AUTO_ROUTE=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Dispatch-ID: 20260529-134019-smart-routing-activate