### PR TITLE
feat(dream-scheduler-live): auto-dream scheduler + GAP-7 receipt preflight (ADR-019)

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,16 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-29T05:11:24.774710+00:00
+**Last updated**: 2026-05-29T11:54:17.887606+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #699 — fix(a14-wire-0025): wire 0025_dream_consolidation.sql into quality-DB bootstrap (#699) (2026-05-29)
+- #697 — fix(a14-pr2-fix): address all 5 codex blocking findings on PR #696 (#697) (2026-05-29)
+- #691 — fix(issue-687): dispatches sqlite_sequence preservation in 0022 (#691) (2026-05-29)
+- #684 — feat(h-cost-tracking): universal cost tracking for all providers (#684) (2026-05-29)
 - #683 — refactor(hyg-4): extract subparser registrations and dispatch chain from main() (#683) (2026-05-29)
 - #682 — feat(d-role-prompts): add database-engineer, intelligence-engineer, security-engineer roles + update architect (#682) (2026-05-29)
 - #679 — feat(int-1): adrs table + FTS5 + indexer (PR-INT-1) (#679) (2026-05-29)
@@ -122,11 +126,13 @@ _Last 14 days — sourced from git merge commits._
 - #504 — refactor(conversation_analyzer): modularize into package — close OI-1438/1439/1440/1441/1442 (#504) (2026-05-15)
 - #503 — fix(rp): bootstrap audit ordering + test infra hardening (close OI-1450/1451/1452) (#503) (2026-05-15)
 - #502 — fix(dispatcher): log stderr, script_dir leak, receipt processor bootstrap-mode (#502) (2026-05-15)
-- #500 — chore(hardening): narrow silent-except across replay_harness/cleanup_worker_exit/conversation_analyzer (9 findings, OI-1437) (#500) (2026-05-15)
 
 **WAVE 5**
 - #601 — docs: refresh README + ROADMAP for 1.0.0-rc2 (Wave 5/6/7/8 shipped + central install) (#601) (2026-05-18)
 - #569 — docs: Wave 5/6/7/8 documentation overhaul (#569) (2026-05-17)
+
+**WAVE 6**
+- #692 — chore(h2-v2): T0 skill + CLAUDE.md hardening (Wave 6 pool discovery) (#692) (2026-05-29)
 
 **WAVE 8**
 - #570 — fix(wiring): activate 4 dead-code modules from Wave 8 fast-path (auto_apply, validator class, schema-emit, smart_router.route) (#570) (2026-05-17)
@@ -159,6 +165,7 @@ _Last 14 days — sourced from git merge commits._
 - #521 — docs(wave5): PR-5.0 — ADR-017 Control Centre product-shape architecture (#521) (2026-05-16)
 
 **WAVE6**
+- #698 — fix(wave6-pool-lease-spawn): insert terminal_leases row before add_member in pool scale_up (#698) (2026-05-29)
 - #575 — fix(wave6): real spawn impl + config field reads + single heartbeat threshold (3 blockers) (#575) (2026-05-17)
 - #546 — fix(wave6): OI cleanup group 1 (idempotency + regex + ledger + audit) (#546) (2026-05-16)
 - #544 — feat(wave6): PR-6.8 — Control Centre pool-integration (cross-project pool view + supervisor) (#544) (2026-05-16)

--- a/bin/vnx
+++ b/bin/vnx
@@ -315,6 +315,11 @@ Pool commands (elastic worker pool management):
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
+  dream <sub>         Auto-dream memory consolidation (ADR-019)
+                       run --project-id <id>   Run consolidation cycle
+                       install-scheduler       Install nightly scheduler (macOS/Linux)
+                       uninstall-scheduler     Remove nightly scheduler
+                       status                  Show scheduler status
 
 Process commands (visibility and control):
   status             Show terminal health, dispatch queue, and gate results
@@ -2107,6 +2112,9 @@ main() {
       ;;
     pool)
       PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.commands.pool "$@"
+      ;;
+    dream)
+      cmd_dream "$@"
       ;;
     help|-h|--help)
       usage

--- a/scripts/commands/dream.sh
+++ b/scripts/commands/dream.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# VNX command: dream — auto-dream memory consolidation (ADR-019)
+# Sourced by bin/vnx. All VNX_HOME, VNX_STATE_DIR, log, err globals available.
+#
+# Subcommands:
+#   run --project-id <id>               Run a consolidation cycle
+#   install-scheduler --project-id <id> Install + activate nightly schedule
+#   uninstall-scheduler                 Remove nightly schedule
+#   status                              Show scheduler status
+
+cmd_dream() {
+  local subcmd="${1:-help}"
+  shift || true
+
+  local _dream_py="${VNX_HOME}/scripts/dream"
+  local _pypath="${VNX_HOME}/scripts/lib:${VNX_HOME}/scripts/dream:${PYTHONPATH:-}"
+
+  case "$subcmd" in
+    run)
+      PYTHONPATH="$_pypath" python3 "${_dream_py}/consolidator.py" "$@"
+      ;;
+    install-scheduler)
+      PYTHONPATH="$_pypath" python3 "${_dream_py}/scheduler.py" install "$@"
+      ;;
+    uninstall-scheduler)
+      PYTHONPATH="$_pypath" python3 "${_dream_py}/scheduler.py" uninstall "$@"
+      ;;
+    status)
+      PYTHONPATH="$_pypath" python3 "${_dream_py}/scheduler.py" status "$@"
+      ;;
+    help|-h|--help)
+      cat <<'USAGE'
+Usage: vnx dream <subcommand> [options]
+
+Subcommands:
+  run --project-id <id>                Run memory consolidation cycle (ADR-019)
+  install-scheduler --project-id <id>  Install nightly scheduler
+                                       macOS: LaunchAgent (loads at 03:00)
+                                       Linux: crontab entry (runs at 03:00)
+  uninstall-scheduler                  Remove nightly scheduler
+  status                               Show scheduler install status
+
+Options for install-scheduler:
+  --project-id <id>   Project to consolidate (required, ADR-007)
+  --vnx-bin <path>    Path to vnx binary (default: which vnx)
+  --project-root <p>  Project root override (default: git-resolved)
+  --no-load           Write config but do not activate (CI / dry-run)
+USAGE
+      ;;
+    *)
+      err "[dream] Unknown subcommand: $subcmd"
+      err "[dream] Run 'vnx dream help' for usage."
+      return 1
+      ;;
+  esac
+}

--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -19,6 +19,11 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+# If the most recent receipt is older than this, preflight fails (GAP-7).
+_PREFLIGHT_MAX_STALE_HOURS: int = 48
+# Timestamp fields tried in order when checking receipt recency.
+_RECEIPT_TS_FIELDS: tuple[str, ...] = ("timestamp", "completed_at", "created_at")
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 from project_root import resolve_project_root
 
@@ -39,6 +44,53 @@ def _emit_dream_event(event: dict[str, Any]) -> None:
     event_path = events_dir / f"{today}.ndjson"
     with event_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(event) + "\n")
+
+
+def _preflight_receipts(
+    receipts_path: Path,
+    max_stale_hours: int = _PREFLIGHT_MAX_STALE_HOURS,
+) -> tuple[bool, str]:
+    """Verify receipt data is present and not stale before consolidation (GAP-7).
+
+    Returns (ok, reason). When ok=False the cycle must skip with incomplete_data=True.
+    Designed to fail-safe: parse errors on the timestamp field are tolerated
+    (don't block consolidation on ambiguous data; only block on clearly bad states).
+    """
+    if not receipts_path.exists():
+        return False, f"receipts file missing: {receipts_path}"
+    if receipts_path.stat().st_size == 0:
+        return False, "receipts file is empty (receipt processor may not be running)"
+
+    # Check recency of the last receipt line.
+    try:
+        last_line = ""
+        with receipts_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped:
+                    last_line = stripped
+        if last_line:
+            receipt = json.loads(last_line)
+            for field in _RECEIPT_TS_FIELDS:
+                ts_str = receipt.get(field)
+                if not ts_str:
+                    continue
+                try:
+                    ts = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+                    age_hours = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
+                    if age_hours > max_stale_hours:
+                        return (
+                            False,
+                            f"most recent receipt is {age_hours:.1f}h old "
+                            f"(threshold {max_stale_hours}h) — receipt processor may be behind",
+                        )
+                    break  # Found a parseable timestamp; staleness check passed
+                except (ValueError, TypeError):
+                    continue
+    except (OSError, json.JSONDecodeError):
+        pass  # Tolerate read/parse errors; don't block on ambiguous state
+
+    return True, ""
 
 
 def _fetch_patterns(conn: sqlite3.Connection, project_id: str) -> dict[str, list[dict]]:
@@ -131,16 +183,40 @@ def run_dream_cycle(
     project_id: str,
     db_path: Path,
     dry_run: bool = False,
+    max_stale_hours: int = _PREFLIGHT_MAX_STALE_HOURS,
 ) -> dict[str, Any]:
     """Run a single dream consolidation cycle for a project.
 
     ADR-005: NDJSON emit before DB write.
     ADR-007: project_id required throughout.
+    GAP-7: preflight check aborts cycle on missing/stale receipt data.
     Returns a dict with cycle_id, counts, and review_path.
     """
     cycle_id = (
         f"dream-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid4().hex[:8]}"
     )
+
+    # GAP-7: preflight — check receipt data before touching DB.
+    root = resolve_project_root(__file__)
+    receipts_path = root / ".vnx-data" / "state" / "t0_receipts.ndjson"
+    ok, reason = _preflight_receipts(receipts_path, max_stale_hours)
+    if not ok:
+        _emit_dream_event(
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "reason": reason,
+                "incomplete_data": True,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        return {
+            "cycle_id": cycle_id,
+            "skipped": True,
+            "incomplete_data": True,
+            "reason": reason,
+        }
 
     _emit_dream_event(
         {
@@ -156,6 +232,26 @@ def run_dream_cycle(
     patterns = _fetch_patterns(conn, project_id)
     total_input = sum(len(v) for v in patterns.values())
 
+    # Secondary guard: skip if no patterns to consolidate.
+    if total_input == 0:
+        conn.close()
+        _emit_dream_event(
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "reason": "no patterns to consolidate (all tables empty for this project_id)",
+                "incomplete_data": True,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        return {
+            "cycle_id": cycle_id,
+            "skipped": True,
+            "incomplete_data": True,
+            "reason": "no patterns to consolidate",
+        }
+
     try:
         consolidation = _dispatch_kimi_consolidation(patterns, project_id)
     except Exception as exc:
@@ -169,7 +265,6 @@ def run_dream_cycle(
         )
         raise
 
-    root = resolve_project_root(__file__)
     review_dir = root / ".vnx-data" / "state" / "dream"
     review_dir.mkdir(parents=True, exist_ok=True)
     review_path = review_dir / f"{cycle_id}-pending-review.json"

--- a/scripts/dream/scheduler.py
+++ b/scripts/dream/scheduler.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Auto-dream scheduler: install/uninstall nightly schedule (ADR-019).
+
+macOS: LaunchAgent plist installed and loaded via launchctl.
+Linux: crontab entry written via crontab(1).
+
+Usage:
+    python3 scripts/dream/scheduler.py install --project-id <id> [--vnx-bin <path>] [--no-load]
+    python3 scripts/dream/scheduler.py uninstall
+    python3 scripts/dream/scheduler.py status
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+from project_root import resolve_project_root  # noqa: E402
+
+_PLIST_LABEL = "com.vnx.auto-dream"
+_PLIST_NAME = f"{_PLIST_LABEL}.plist"
+_CRON_MARKER = "# vnx-auto-dream"
+
+
+def _launchagents_dir() -> Path:
+    return Path.home() / "Library" / "LaunchAgents"
+
+
+def plist_path() -> Path:
+    return _launchagents_dir() / _PLIST_NAME
+
+
+def _render_plist(vnx_bin: str, project_id: str, project_root: str) -> str:
+    template = Path(__file__).resolve().parent / "templates" / "com.vnx.auto-dream.plist.j2"
+    try:
+        from jinja2 import Environment, FileSystemLoader  # type: ignore[import]
+
+        env = Environment(loader=FileSystemLoader(str(template.parent)), autoescape=False)
+        return env.get_template(template.name).render(
+            vnx_bin_path=vnx_bin, project_id=project_id, project_root=project_root
+        )
+    except ImportError:
+        text = template.read_text(encoding="utf-8")
+        for key, val in [
+            ("vnx_bin_path", vnx_bin),
+            ("project_id", project_id),
+            ("project_root", project_root),
+        ]:
+            text = text.replace("{{ " + key + " }}", val)
+        return text
+
+
+def install_macos(
+    project_id: str, vnx_bin: str, project_root: str, load: bool = True
+) -> None:
+    """Install LaunchAgent plist and optionally load it."""
+    out_dir = _launchagents_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = plist_path()
+    rendered = _render_plist(vnx_bin, project_id, project_root)
+
+    fd, tmp = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(rendered)
+        os.replace(tmp, out_path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+    print(f"[scheduler] Wrote: {out_path}")
+
+    if not load:
+        print(f"[scheduler] Dry-run: to activate, run: launchctl load -w {out_path}")
+        return
+
+    # Idempotent: unload before re-load
+    subprocess.run(["launchctl", "unload", "-w", str(out_path)], capture_output=True)
+    result = subprocess.run(
+        ["launchctl", "load", "-w", str(out_path)], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        sys.stderr.write(f"[scheduler] launchctl load warning: {result.stderr.strip()}\n")
+    else:
+        print(f"[scheduler] Loaded: {_PLIST_LABEL}")
+
+    list_result = subprocess.run(
+        ["launchctl", "list", _PLIST_LABEL], capture_output=True, text=True
+    )
+    if list_result.returncode == 0:
+        print(f"[scheduler] Active: {_PLIST_LABEL}")
+    else:
+        print(f"[scheduler] Registered (verify with: launchctl list | grep vnx)")
+
+
+def uninstall_macos() -> None:
+    """Unload and remove LaunchAgent plist."""
+    path = plist_path()
+    if path.exists():
+        subprocess.run(["launchctl", "unload", "-w", str(path)], capture_output=True)
+        path.unlink()
+        print(f"[scheduler] Removed: {path}")
+    else:
+        print(f"[scheduler] Not installed (plist not found: {path})")
+
+
+def _cron_line(vnx_bin: str, project_id: str) -> str:
+    return f"0 3 * * * {vnx_bin} dream run --project-id {project_id}  {_CRON_MARKER}"
+
+
+def install_linux(project_id: str, vnx_bin: str) -> None:
+    """Write crontab entry for nightly dream run at 03:00."""
+    new_line = _cron_line(vnx_bin, project_id)
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    existing = result.stdout if result.returncode == 0 else ""
+    lines = [ln for ln in existing.splitlines() if _CRON_MARKER not in ln]
+    lines.append(new_line)
+    new_crontab = "\n".join(lines) + "\n"
+
+    proc = subprocess.run(["crontab", "-"], input=new_crontab, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(f"[scheduler] crontab error: {proc.stderr.strip()}\n")
+        sys.exit(1)
+    print(f"[scheduler] Cron entry installed: {new_line}")
+
+
+def uninstall_linux() -> None:
+    """Remove vnx-auto-dream crontab entry."""
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    if result.returncode != 0:
+        print("[scheduler] No crontab found.")
+        return
+    lines = result.stdout.splitlines()
+    filtered = [ln for ln in lines if _CRON_MARKER not in ln]
+    if len(filtered) == len(lines):
+        print("[scheduler] No vnx-auto-dream cron entry found.")
+        return
+    new_crontab = "\n".join(filtered) + "\n"
+    proc = subprocess.run(["crontab", "-"], input=new_crontab, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(f"[scheduler] crontab error: {proc.stderr.strip()}\n")
+        sys.exit(1)
+    print("[scheduler] Cron entry removed.")
+
+
+def status_macos() -> None:
+    path = plist_path()
+    if not path.exists():
+        print("[scheduler] macOS LaunchAgent: not installed")
+        return
+    result = subprocess.run(
+        ["launchctl", "list", _PLIST_LABEL], capture_output=True, text=True
+    )
+    state = "active" if result.returncode == 0 else "installed-not-loaded"
+    print(f"[scheduler] macOS LaunchAgent: {state}")
+    print(f"[scheduler] Plist: {path}")
+
+
+def status_linux() -> None:
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    if result.returncode == 0 and _CRON_MARKER in result.stdout:
+        for line in result.stdout.splitlines():
+            if _CRON_MARKER in line:
+                print(f"[scheduler] Cron: {line}")
+    else:
+        print("[scheduler] Cron: not installed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="VNX auto-dream scheduler (ADR-019)")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_install = sub.add_parser("install", help="Install and activate nightly scheduler")
+    p_install.add_argument("--project-id", required=True, help="Project ID (ADR-007)")
+    p_install.add_argument("--vnx-bin", default=None, help="Path to vnx binary")
+    p_install.add_argument("--project-root", default=None, help="Project root")
+    p_install.add_argument(
+        "--no-load", action="store_true", help="Write config but do not activate (CI/dry-run)"
+    )
+
+    sub.add_parser("uninstall", help="Remove nightly scheduler")
+    sub.add_parser("status", help="Show scheduler status")
+
+    args = parser.parse_args()
+
+    if args.action == "install":
+        vnx_bin = args.vnx_bin or shutil.which("vnx") or "vnx"
+        project_root = (
+            str(Path(args.project_root).resolve())
+            if args.project_root
+            else str(resolve_project_root(__file__))
+        )
+        if sys.platform == "darwin":
+            install_macos(args.project_id, vnx_bin, project_root, load=not args.no_load)
+        else:
+            install_linux(args.project_id, vnx_bin)
+
+    elif args.action == "uninstall":
+        if sys.platform == "darwin":
+            uninstall_macos()
+        else:
+            uninstall_linux()
+
+    elif args.action == "status":
+        if sys.platform == "darwin":
+            status_macos()
+        else:
+            status_linux()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -13,6 +13,7 @@ import json
 import sqlite3
 import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -86,6 +87,24 @@ _KIMI_STREAM_JSON = (
     '\\"archived\\":[],\\"flagged\\":[],\\"summary\\":\\"ok\\"}"}\n'
     '{"event_type":"complete"}\n'
 )
+
+
+def _setup_receipts_and_pattern(tmp_path: Path, db_path: Path) -> None:
+    """Satisfy GAP-7 preflight: fresh receipts file + one pattern row."""
+    receipts = tmp_path / ".vnx-data" / "state" / "t0_receipts.ndjson"
+    receipts.parent.mkdir(parents=True, exist_ok=True)
+    fresh_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    receipts.write_text(
+        json.dumps({"event_type": "receipt", "timestamp": fresh_ts}) + "\n",
+        encoding="utf-8",
+    )
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO success_patterns (project_id, title) VALUES (?,?)",
+        ("vnx-dev", "test-pattern"),
+    )
+    conn.commit()
+    conn.close()
 
 
 def _make_in_memory_db() -> sqlite3.Connection:
@@ -226,6 +245,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _setup_receipts_and_pattern(tmp_path, db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -255,6 +275,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _setup_receipts_and_pattern(tmp_path, db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -285,6 +306,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _setup_receipts_and_pattern(tmp_path, db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),

--- a/tests/test_dream_scheduler.py
+++ b/tests/test_dream_scheduler.py
@@ -1,0 +1,339 @@
+"""Tests for dream scheduler install/uninstall and consolidator preflight (GAP-7).
+
+Coverage:
+- test_preflight_missing_receipts: skip when receipts file absent
+- test_preflight_empty_receipts: skip when receipts file is 0 bytes
+- test_preflight_stale_receipts: skip when last receipt is too old
+- test_preflight_fresh_receipts: pass when receipts are recent
+- test_preflight_no_timestamp_field: pass (don't block on ambiguous data)
+- test_consolidator_skips_on_preflight_failure: run_dream_cycle returns skipped=True
+- test_consolidator_skips_on_empty_patterns: skips when all pattern tables empty
+- test_scheduler_install_macos_writes_plist: plist is written atomically
+- test_scheduler_install_linux_writes_cron: cron line inserted into crontab
+- test_scheduler_uninstall_linux_removes_entry: cron line removed
+- test_scheduler_install_linux_idempotent: second install replaces, not duplicates
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dream"))
+
+import consolidator
+import scheduler
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DREAM_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dream_cycles (
+    cycle_id          TEXT    NOT NULL,
+    project_id        TEXT    NOT NULL DEFAULT 'vnx-dev',
+    started_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    completed_at      TEXT,
+    status            TEXT    NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','running','completed','failed','reviewed','rejected')),
+    provider          TEXT    NOT NULL DEFAULT 'kimi',
+    insights_input    INTEGER NOT NULL DEFAULT 0,
+    merged_count      INTEGER NOT NULL DEFAULT 0,
+    dropped_count     INTEGER NOT NULL DEFAULT 0,
+    archived_count    INTEGER NOT NULL DEFAULT 0,
+    flagged_count     INTEGER NOT NULL DEFAULT 0,
+    operator_reviewed INTEGER NOT NULL DEFAULT 0,
+    report_path       TEXT,
+    PRIMARY KEY (cycle_id, project_id)
+);
+CREATE TABLE IF NOT EXISTS success_patterns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+    title TEXT NOT NULL DEFAULT 'title',
+    description TEXT NOT NULL DEFAULT 'desc',
+    pattern_data TEXT NOT NULL DEFAULT '{}',
+    first_seen DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS antipatterns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+    title TEXT NOT NULL DEFAULT 'title',
+    description TEXT NOT NULL DEFAULT 'desc',
+    pattern_data TEXT NOT NULL DEFAULT '{}',
+    why_problematic TEXT NOT NULL DEFAULT 'bad',
+    first_seen DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_DREAM_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _receipts_path(tmp_path: Path) -> Path:
+    p = tmp_path / ".vnx-data" / "state" / "t0_receipts.ndjson"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _write_receipt(path: Path, ts: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"event_type": "receipt", "timestamp": ts.isoformat()}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Preflight tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightReceipts:
+    def test_preflight_missing_receipts(self, tmp_path):
+        """Missing receipts file → preflight fails."""
+        path = tmp_path / "t0_receipts.ndjson"
+        ok, reason = consolidator._preflight_receipts(path)
+        assert not ok
+        assert "missing" in reason
+
+    def test_preflight_empty_receipts(self, tmp_path):
+        """Zero-byte receipts file → preflight fails."""
+        path = tmp_path / "t0_receipts.ndjson"
+        path.write_text("", encoding="utf-8")
+        ok, reason = consolidator._preflight_receipts(path)
+        assert not ok
+        assert "empty" in reason
+
+    def test_preflight_stale_receipts(self, tmp_path):
+        """Last receipt older than threshold → preflight fails."""
+        path = tmp_path / "t0_receipts.ndjson"
+        old_ts = datetime.now(timezone.utc) - timedelta(hours=73)
+        _write_receipt(path, old_ts)
+        ok, reason = consolidator._preflight_receipts(path, max_stale_hours=48)
+        assert not ok
+        assert "old" in reason
+
+    def test_preflight_fresh_receipts(self, tmp_path):
+        """Recent receipt → preflight passes."""
+        path = tmp_path / "t0_receipts.ndjson"
+        fresh_ts = datetime.now(timezone.utc) - timedelta(hours=2)
+        _write_receipt(path, fresh_ts)
+        ok, reason = consolidator._preflight_receipts(path, max_stale_hours=48)
+        assert ok
+        assert reason == ""
+
+    def test_preflight_no_timestamp_field(self, tmp_path):
+        """Receipt without any known timestamp field → pass (don't block on ambiguous data)."""
+        path = tmp_path / "t0_receipts.ndjson"
+        path.write_text(
+            json.dumps({"event_type": "receipt", "data": "no-ts"}) + "\n", encoding="utf-8"
+        )
+        ok, reason = consolidator._preflight_receipts(path)
+        assert ok
+
+    def test_preflight_multiple_receipts_uses_last(self, tmp_path):
+        """Only the last receipt line's timestamp is checked for staleness."""
+        path = tmp_path / "t0_receipts.ndjson"
+        old_ts = datetime.now(timezone.utc) - timedelta(hours=100)
+        fresh_ts = datetime.now(timezone.utc) - timedelta(hours=1)
+        _write_receipt(path, old_ts)
+        _write_receipt(path, fresh_ts)
+        ok, _ = consolidator._preflight_receipts(path, max_stale_hours=48)
+        assert ok
+
+
+class TestConsolidatorPreflight:
+    def test_skips_on_missing_receipts(self, tmp_path):
+        """run_dream_cycle skips and returns skipped=True when receipts file absent."""
+        db_path = _make_db(tmp_path)
+        receipts = _receipts_path(tmp_path)
+        # receipts file does NOT exist
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._emit_dream_event") as mock_emit,
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        assert result["skipped"] is True
+        assert result["incomplete_data"] is True
+        assert "missing" in result["reason"]
+
+        emitted_types = [c.args[0]["event_type"] for c in mock_emit.call_args_list]
+        assert "dream_cycle_skipped" in emitted_types
+        assert "dream_cycle_started" not in emitted_types
+
+    def test_skips_on_empty_patterns(self, tmp_path):
+        """run_dream_cycle skips when receipts OK but all pattern tables are empty."""
+        db_path = _make_db(tmp_path)
+        receipts = _receipts_path(tmp_path)
+        _write_receipt(receipts, datetime.now(timezone.utc) - timedelta(hours=1))
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._emit_dream_event") as mock_emit,
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        assert result["skipped"] is True
+        assert result["incomplete_data"] is True
+        assert "no patterns" in result["reason"]
+
+    def test_proceeds_when_receipts_ok_and_patterns_exist(self, tmp_path):
+        """run_dream_cycle proceeds past preflight when data is present."""
+        db_path = _make_db(tmp_path)
+        receipts = _receipts_path(tmp_path)
+        _write_receipt(receipts, datetime.now(timezone.utc) - timedelta(hours=1))
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO success_patterns (project_id, title) VALUES (?,?)", ("vnx-dev", "p1")
+        )
+        conn.commit()
+        conn.close()
+
+        fake_consolidation = {
+            "merged": [], "dropped": [], "archived": [], "flagged": [], "summary": "ok"
+        }
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation", return_value=fake_consolidation),
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+
+        assert not result.get("skipped")
+        assert result["input_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Scheduler tests (Linux cron path — platform-safe)
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerLinux:
+    def test_install_linux_writes_cron(self):
+        """install_linux injects a cron line with the project-id and marker."""
+        with (
+            patch("scheduler.subprocess.run") as mock_run,
+        ):
+            # Simulate empty crontab
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            scheduler.install_linux("vnx-dev", "/usr/local/bin/vnx")
+
+        install_call = mock_run.call_args_list[-1]
+        new_crontab = install_call.kwargs.get("input") or install_call.args[1] if len(install_call.args) > 1 else install_call.kwargs.get("input", "")
+        # Find the actual crontab write call
+        write_call = [c for c in mock_run.call_args_list if c.args and c.args[0] == ["crontab", "-"]]
+        assert write_call, "Expected crontab - call"
+        written = write_call[-1].kwargs.get("input", "")
+        assert "vnx-dev" in written
+        assert scheduler._CRON_MARKER in written
+        assert "0 3 * * *" in written
+
+    def test_install_linux_idempotent(self):
+        """Second install replaces existing entry, does not duplicate."""
+        existing = f"0 3 * * * /usr/local/bin/vnx dream run --project-id old  {scheduler._CRON_MARKER}\n"
+        with patch("scheduler.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=existing, stderr="")
+            scheduler.install_linux("vnx-dev", "/usr/local/bin/vnx")
+
+        write_call = [c for c in mock_run.call_args_list if c.args and c.args[0] == ["crontab", "-"]]
+        written = write_call[-1].kwargs.get("input", "")
+        marker_count = written.count(scheduler._CRON_MARKER)
+        assert marker_count == 1, f"Expected exactly 1 cron marker, found {marker_count}"
+        assert "vnx-dev" in written
+
+    def test_uninstall_linux_removes_entry(self):
+        """uninstall_linux removes the vnx-auto-dream cron line."""
+        existing = (
+            "0 5 * * * /usr/bin/something-else\n"
+            f"0 3 * * * /usr/local/bin/vnx dream run --project-id vnx-dev  {scheduler._CRON_MARKER}\n"
+        )
+        with patch("scheduler.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=existing, stderr="")
+            scheduler.uninstall_linux()
+
+        write_call = [c for c in mock_run.call_args_list if c.args and c.args[0] == ["crontab", "-"]]
+        written = write_call[-1].kwargs.get("input", "")
+        assert scheduler._CRON_MARKER not in written
+        assert "/usr/bin/something-else" in written
+
+    def test_uninstall_linux_no_entry(self, capsys):
+        """uninstall_linux does nothing when no entry is present."""
+        existing = "0 5 * * * /usr/bin/something-else\n"
+        with patch("scheduler.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=existing, stderr="")
+            scheduler.uninstall_linux()
+
+        write_call = [c for c in mock_run.call_args_list if c.args and c.args[0] == ["crontab", "-"]]
+        assert not write_call, "Should not write crontab when no marker present"
+
+
+class TestSchedulerMacOS:
+    def test_install_macos_writes_plist(self, tmp_path):
+        """install_macos writes the plist file atomically (via temp+replace)."""
+        with (
+            patch("scheduler._launchagents_dir", return_value=tmp_path),
+            patch("scheduler.subprocess.run") as mock_run,
+            patch("scheduler.resolve_project_root", return_value=tmp_path),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            scheduler.install_macos("vnx-dev", "/usr/local/bin/vnx", str(tmp_path), load=False)
+
+        plist = tmp_path / scheduler._PLIST_NAME
+        assert plist.exists(), "Plist should be written"
+        content = plist.read_text(encoding="utf-8")
+        assert "com.vnx.auto-dream" in content
+        assert "vnx-dev" in content
+
+    def test_install_macos_calls_launchctl_load(self, tmp_path):
+        """install_macos calls launchctl load -w when load=True."""
+        with (
+            patch("scheduler._launchagents_dir", return_value=tmp_path),
+            patch("scheduler.subprocess.run") as mock_run,
+            patch("scheduler.resolve_project_root", return_value=tmp_path),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            scheduler.install_macos("vnx-dev", "/usr/local/bin/vnx", str(tmp_path), load=True)
+
+        commands = [tuple(c.args[0]) for c in mock_run.call_args_list if c.args]
+        load_calls = [c for c in commands if "load" in c and "launchctl" in c]
+        assert load_calls, f"Expected launchctl load call, got: {commands}"
+
+    def test_uninstall_macos_removes_plist(self, tmp_path):
+        """uninstall_macos unloads and deletes the plist."""
+        plist = tmp_path / scheduler._PLIST_NAME
+        plist.write_text("<plist/>", encoding="utf-8")
+
+        with (
+            patch("scheduler._launchagents_dir", return_value=tmp_path),
+            patch("scheduler.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            scheduler.uninstall_macos()
+
+        assert not plist.exists(), "Plist should be removed after uninstall"
+        commands = [tuple(c.args[0]) for c in mock_run.call_args_list if c.args]
+        unload_calls = [c for c in commands if "unload" in c]
+        assert unload_calls, "Expected launchctl unload call"
+
+    def test_uninstall_macos_no_plist(self, tmp_path, capsys):
+        """uninstall_macos prints informative message when plist not present."""
+        with patch("scheduler._launchagents_dir", return_value=tmp_path):
+            scheduler.uninstall_macos()
+
+        out = capsys.readouterr().out
+        assert "not installed" in out.lower() or "not found" in out.lower()


### PR DESCRIPTION
## Summary

- **Scheduler automation** (macOS + Linux): `vnx dream install-scheduler --project-id <id>` installs AND loads the LaunchAgent on macOS (`launchctl load -w`); on Linux writes a crontab entry at `0 3 * * *`. Both are idempotent and platform-auto-detected. `vnx dream uninstall-scheduler` removes cleanly. `--no-load` flag supports CI/dry-run.
- **Receipt-completeness preflight (GAP-7)**: `consolidator.run_dream_cycle()` now checks that the receipts file exists, is non-empty, and that the most recent receipt is fresh (<48h) before touching the DB. On failure it emits `dream_cycle_skipped` with `incomplete_data=True` and returns early — no silent consolidation on empty/stale data.
- **ADR-007 binding**: `dream_cycles` write stamps `project_id` (composite PK). All queries scoped to `project_id`.

## Files changed

| File | Change |
|---|---|
| `scripts/dream/scheduler.py` | New — macOS LaunchAgent + Linux crontab install/uninstall/status |
| `scripts/commands/dream.sh` | New — `vnx dream` CLI: wires install-scheduler / uninstall-scheduler / status / run |
| `scripts/dream/consolidator.py` | Added `_preflight_receipts()` and GAP-7 guard in `run_dream_cycle()` |
| `tests/test_dream_scheduler.py` | New — 17 tests: preflight all cases + scheduler macOS/Linux |
| `tests/test_dream_consolidator.py` | Extended — 14 tests: consolidator happy path + NDJSON emit-first |
| `bin/vnx` | Dream subcommand wired into help text and command loader |

## Verification

```
python3 -m pytest tests/test_dream_scheduler.py tests/test_dream_consolidator.py -v
# 31 passed in 0.20s
```

macOS scheduler install (dry-run/CI mode):
```
vnx dream install-scheduler --project-id vnx-dev --no-load
# [scheduler] Wrote: ~/Library/LaunchAgents/com.vnx.auto-dream.plist
# [scheduler] Dry-run: to activate, run: launchctl load -w <path>
```

Live load: `vnx dream install-scheduler --project-id vnx-dev` calls `launchctl load -w` and confirms with `launchctl list com.vnx.auto-dream`.

Linux: `install_linux()` writes `0 3 * * * <vnx-bin> dream run --project-id <id>  # vnx-auto-dream` to crontab idempotently (replaces on second run).

Receipt preflight: test `test_skips_on_missing_receipts` — receipts file absent → `result["skipped"] == True`, `result["incomplete_data"] == True`, no `dream_cycle_started` event emitted.

## ADR-007

`dream_cycles` INSERT stamps `project_id` as part of the composite `PRIMARY KEY (cycle_id, project_id)`. All `_fetch_patterns()` queries filter by `project_id`. ADR-007 binding cited per T0 requirement.

## Out of scope (deferred per dispatch)

- GAP-4: T0 dispatch-trigger on pending-review.json
- GAP-5: Operator HTML/markdown summary
- GAP-6: 30-day burn-in metrics

## Codex unavailable note

Codex gate deferred per dispatch instruction; gemini-only review if needed; codex re-audit OI will be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)