### PR TITLE
fix(dream-mode-tier): register dream in TIER_OPERATOR_ONLY + bin/vnx dispatch

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -2108,6 +2108,9 @@ main() {
     pool)
       PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.commands.pool "$@"
       ;;
+    dream)
+      PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.main dream "$@"
+      ;;
     help|-h|--help)
       usage
       ;;

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -61,7 +61,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "new-worktree", "finish-worktree", "worktree-start", "worktree-stop",
     "worktree-refresh", "worktree-status", "merge-preflight",
     "smoke", "package-check",
-    "dispatch", "gate",
+    "dispatch", "gate", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",
     "pool",
 })


### PR DESCRIPTION
## Summary

- Adds `"dream"` to `TIER_OPERATOR_ONLY` in `scripts/lib/vnx_mode.py` so the dream command is allowed in operator mode
- Adds `dream)` case in `bin/vnx` routing to `python3 -m vnx_cli.main dream "$@"` so the command is actually dispatched

## Why both changes

Adding only the mode-tier entry without the bin/vnx case causes `test_mode_commands_implemented_in_bin` to fail (mode tier has dream, bin/vnx doesn't). The test suite requires symmetry.

## Test plan

- [x] `python3 -m pytest tests/test_docs_command_validation.py -q` — 12 passed
- [x] `bash -n bin/vnx` — syntax check passes
- [x] `bin/vnx dream --help` — shows usage without mode-gate error

Dispatch-ID: 20260529-160651-dream-modetier

🤖 Generated with [Claude Code](https://claude.com/claude-code)