### PR TITLE
feat(dream-scheduler-v2): install-scheduler subcommands + GAP-7 receipt preflight

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import sqlite3
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -28,6 +28,40 @@ _TABLE_SORT_COL: dict[str, str] = {
     "antipatterns": "first_seen",
     "intelligence_injections": "injected_at",
 }
+
+
+def _check_receipt_completeness(
+    data_root: Path, max_age_hours: int = 48
+) -> tuple[bool, str]:
+    """GAP-7 preflight: verify recent processed receipts exist and are not stale.
+
+    Checks {data_root}/receipts/processed/ for any file modified within max_age_hours.
+    Returns (True, "ok") when fresh receipts are found, (False, reason) otherwise.
+    """
+    processed_dir = data_root / "receipts" / "processed"
+    if not processed_dir.exists():
+        return False, f"receipts/processed directory absent: {processed_dir}"
+
+    files = list(processed_dir.iterdir())
+    if not files:
+        return False, "receipts/processed is empty — no dispatch receipts found"
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+    fresh = [
+        f for f in files
+        if datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc) >= cutoff
+    ]
+    if not fresh:
+        most_recent_ts = max(
+            datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc) for f in files
+        )
+        age_h = (datetime.now(timezone.utc) - most_recent_ts).total_seconds() / 3600
+        return (
+            False,
+            f"all receipts stale (newest {age_h:.1f}h ago, threshold {max_age_hours}h)",
+        )
+
+    return True, "ok"
 
 
 def _emit_dream_event(event: dict[str, Any]) -> None:
@@ -141,6 +175,27 @@ def run_dream_cycle(
     cycle_id = (
         f"dream-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid4().hex[:8]}"
     )
+
+    # GAP-7: receipt-completeness preflight — skip cycle on empty/stale data
+    data_root = resolve_project_root(__file__) / ".vnx-data"
+    complete, detail = _check_receipt_completeness(data_root)
+    if not complete:
+        _emit_dream_event(
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "reason": "incomplete_data",
+                "detail": detail,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        return {
+            "status": "skipped",
+            "cycle_id": cycle_id,
+            "reason": "incomplete_data",
+            "detail": detail,
+        }
 
     _emit_dream_event(
         {

--- a/scripts/dream/scheduler.py
+++ b/scripts/dream/scheduler.py
@@ -1,0 +1,156 @@
+"""Dream scheduler — platform-aware install/uninstall of nightly auto-dream job.
+
+macOS: LaunchAgent plist in ~/Library/LaunchAgents/ + `launchctl load -w`.
+Linux: crontab entry (nightly 03:00).
+
+ADR-007: project_id stamped for multi-project isolation.
+ADR-019: auto-dream nightly consolidation.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+from project_root import resolve_project_root  # noqa: E402
+
+_PLIST_LABEL = "com.vnx.auto-dream"
+_PLIST_NAME = f"{_PLIST_LABEL}.plist"
+_CRON_MARKER = f"# vnx-auto-dream:{_PLIST_LABEL}"
+
+
+def _render_plist(template_path: Path, ctx: dict) -> str:
+    try:
+        from jinja2 import Environment, FileSystemLoader  # type: ignore[import]
+        env = Environment(loader=FileSystemLoader(str(template_path.parent)), autoescape=False)
+        return env.get_template(template_path.name).render(**ctx)
+    except ImportError:
+        text = template_path.read_text(encoding="utf-8")
+        for key, value in ctx.items():
+            text = text.replace("{{ " + key + " }}", value)
+        return text
+
+
+def _install_macos(project_id: str, project_root: Path, vnx_bin: str) -> str:
+    template_path = (
+        Path(__file__).resolve().parent / "templates" / "com.vnx.auto-dream.plist.j2"
+    )
+    ctx = {
+        "vnx_bin_path": vnx_bin,
+        "project_id": project_id,
+        "project_root": str(project_root),
+    }
+    rendered = _render_plist(template_path, ctx)
+
+    out_dir = Path.home() / "Library" / "LaunchAgents"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / _PLIST_NAME
+
+    fd, tmp_name = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(rendered)
+        os.replace(tmp_name, out_path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    # Idempotent: unload before re-loading (suppressed if not loaded yet)
+    subprocess.run(["launchctl", "unload", "-w", str(out_path)], capture_output=True)
+    result = subprocess.run(
+        ["launchctl", "load", "-w", str(out_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"launchctl load failed: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return f"Installed and loaded: {out_path}"
+
+
+def _uninstall_macos() -> str:
+    out_path = Path.home() / "Library" / "LaunchAgents" / _PLIST_NAME
+    if not out_path.exists():
+        return f"Not installed: {out_path}"
+    subprocess.run(["launchctl", "unload", "-w", str(out_path)], capture_output=True)
+    out_path.unlink()
+    return f"Unloaded and removed: {out_path}"
+
+
+def _cron_line(vnx_bin: str, project_id: str) -> str:
+    return f"0 3 * * * {vnx_bin} dream run --project-id {project_id}  {_CRON_MARKER}"
+
+
+def _install_linux(project_id: str, vnx_bin: str) -> str:
+    new_line = _cron_line(vnx_bin, project_id)
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    existing = result.stdout if result.returncode == 0 else ""
+    lines = [ln for ln in existing.splitlines() if _CRON_MARKER not in ln]
+    lines.append(new_line)
+    new_crontab = "\n".join(lines) + "\n"
+    proc = subprocess.run(["crontab", "-"], input=new_crontab, text=True, capture_output=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"crontab install failed: {proc.stderr.strip()}")
+    return f"Cron entry installed: {new_line}"
+
+
+def _uninstall_linux() -> str:
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    if result.returncode != 0:
+        return "No crontab found; nothing to remove."
+    existing = result.stdout
+    if _CRON_MARKER not in existing:
+        return "Auto-dream cron entry not found; nothing to remove."
+    lines = [ln for ln in existing.splitlines() if _CRON_MARKER not in ln]
+    new_crontab = "\n".join(lines) + "\n" if lines else ""
+    proc = subprocess.run(["crontab", "-"], input=new_crontab, text=True, capture_output=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"crontab removal failed: {proc.stderr.strip()}")
+    return "Auto-dream cron entry removed."
+
+
+def install_scheduler(
+    project_id: str,
+    project_root: Path | None = None,
+    vnx_bin: str | None = None,
+) -> str:
+    """Install nightly auto-dream scheduler. Returns status string.
+
+    macOS: writes ~/Library/LaunchAgents/com.vnx.auto-dream.plist, runs launchctl load -w.
+    Linux: adds crontab entry at 03:00 daily.
+    ADR-007: project_id on plist/cron for isolation.
+    """
+    if project_root is None:
+        project_root = resolve_project_root(__file__)
+    if vnx_bin is None:
+        vnx_bin = shutil.which("vnx") or "vnx"
+
+    sys_platform = platform.system()
+    if sys_platform == "Darwin":
+        return _install_macos(project_id, project_root, vnx_bin)
+    elif sys_platform == "Linux":
+        return _install_linux(project_id, vnx_bin)
+    else:
+        raise RuntimeError(
+            f"Unsupported platform: {sys_platform}. Only macOS and Linux supported."
+        )
+
+
+def uninstall_scheduler() -> str:
+    """Remove nightly auto-dream scheduler. Returns status string."""
+    sys_platform = platform.system()
+    if sys_platform == "Darwin":
+        return _uninstall_macos()
+    elif sys_platform == "Linux":
+        return _uninstall_linux()
+    else:
+        raise RuntimeError(f"Unsupported platform: {sys_platform}.")

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -6,6 +6,7 @@ Coverage:
 - test_parse_kimi_response_strict_json: response JSON extraction
 - test_dry_run_no_db_write: dry-run skips dream_cycles INSERT
 - test_run_dream_cycle_happy_path: full cycle with mocked kimi
+- GAP-7 receipt-completeness preflight: stale/empty → skip with warning event
 """
 from __future__ import annotations
 
@@ -218,6 +219,13 @@ class TestExtractKimiText:
         assert consolidator._extract_kimi_text(stdout) == ""
 
 
+def _make_fresh_receipts(tmp_path: Path) -> None:
+    """Create a fresh processed receipt so the GAP-7 preflight passes."""
+    processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+    processed.mkdir(parents=True, exist_ok=True)
+    (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+
+
 class TestDryRun:
     def test_dry_run_no_db_write(self, tmp_path):
         """Dry-run emits NDJSON and writes pending-review.json but skips dream_cycles INSERT."""
@@ -226,6 +234,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _make_fresh_receipts(tmp_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -255,6 +264,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _make_fresh_receipts(tmp_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -285,6 +295,7 @@ class TestDryRun:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _make_fresh_receipts(tmp_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -309,3 +320,130 @@ class TestDryRun:
         assert event_types.index("dream_cycle_started") < event_types.index(
             "dream_cycle_completed"
         )
+
+
+# ---------------------------------------------------------------------------
+# GAP-7 receipt-completeness preflight tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckReceiptCompleteness:
+    def test_missing_processed_dir_returns_false(self, tmp_path):
+        """No receipts/processed dir → incomplete."""
+        data_root = tmp_path / ".vnx-data"
+        ok, reason = consolidator._check_receipt_completeness(data_root)
+        assert not ok
+        assert "absent" in reason
+
+    def test_empty_processed_dir_returns_false(self, tmp_path):
+        """Empty receipts/processed dir → incomplete."""
+        (tmp_path / ".vnx-data" / "receipts" / "processed").mkdir(parents=True)
+        ok, reason = consolidator._check_receipt_completeness(tmp_path / ".vnx-data")
+        assert not ok
+        assert "empty" in reason
+
+    def test_fresh_receipt_returns_true(self, tmp_path):
+        """A recently modified receipt file → complete."""
+        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+        processed.mkdir(parents=True)
+        (processed / "receipt-001.ndjson").write_text("{}", encoding="utf-8")
+        ok, reason = consolidator._check_receipt_completeness(tmp_path / ".vnx-data")
+        assert ok
+        assert reason == "ok"
+
+    def test_stale_receipts_return_false(self, tmp_path):
+        """All receipts older than max_age_hours → incomplete."""
+        import time
+        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+        processed.mkdir(parents=True)
+        old_file = processed / "receipt-old.ndjson"
+        old_file.write_text("{}", encoding="utf-8")
+        # Set mtime to 200 hours ago
+        old_ts = time.time() - (200 * 3600)
+        import os
+        os.utime(str(old_file), (old_ts, old_ts))
+
+        ok, reason = consolidator._check_receipt_completeness(
+            tmp_path / ".vnx-data", max_age_hours=48
+        )
+        assert not ok
+        assert "stale" in reason
+
+
+class TestRunDreamCycleReceiptPreflight:
+    def test_skips_when_no_receipts(self, tmp_path):
+        """run_dream_cycle returns status=skipped when receipts/processed absent."""
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True)
+        conn = __import__("sqlite3").connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        with patch("consolidator.resolve_project_root", return_value=tmp_path):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "incomplete_data"
+
+    def test_skip_emits_ndjson_warning_event(self, tmp_path):
+        """Skipped cycle emits dream_cycle_skipped NDJSON event (ADR-005)."""
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True)
+        conn = __import__("sqlite3").connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        with patch("consolidator.resolve_project_root", return_value=tmp_path):
+            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+
+        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        assert len(event_files) == 1
+        lines = [json.loads(l) for l in event_files[0].read_text().strip().splitlines()]
+        assert any(e["event_type"] == "dream_cycle_skipped" for e in lines)
+        skipped = next(e for e in lines if e["event_type"] == "dream_cycle_skipped")
+        assert skipped["reason"] == "incomplete_data"
+
+    def test_skip_does_not_call_kimi(self, tmp_path):
+        """Skipped cycle must not invoke kimi consolidation."""
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True)
+        conn = __import__("sqlite3").connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation") as mock_kimi,
+        ):
+            consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        mock_kimi.assert_not_called()
+
+    def test_proceeds_when_fresh_receipts_present(self, tmp_path):
+        """run_dream_cycle proceeds normally when fresh receipts exist."""
+        db_path = tmp_path / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True)
+        conn = __import__("sqlite3").connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        # Create a fresh receipt file
+        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+        processed.mkdir(parents=True)
+        (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch(
+                "consolidator._dispatch_kimi_consolidation",
+                return_value=_FAKE_CONSOLIDATION,
+            ),
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+
+        assert result.get("status") != "skipped"
+        assert "cycle_id" in result

--- a/tests/test_dream_scheduler.py
+++ b/tests/test_dream_scheduler.py
@@ -1,0 +1,256 @@
+"""Tests for scripts/dream/scheduler.py (ADR-019 auto-dream scheduler v2).
+
+Coverage:
+- install_scheduler (macOS): plist written, launchctl called
+- install_scheduler (Linux): crontab line added idempotently
+- uninstall_scheduler (macOS): plist removed, launchctl unload called
+- uninstall_scheduler (Linux): crontab line removed
+- unsupported platform raises RuntimeError
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dream"))
+
+import scheduler
+
+
+# ---------------------------------------------------------------------------
+# macOS tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSchedulerMacOS:
+    def test_plist_written_and_launchctl_called(self, tmp_path):
+        """install_scheduler on Darwin writes plist + calls launchctl load -w."""
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+
+        completed_ok = MagicMock()
+        completed_ok.returncode = 0
+        completed_ok.stderr = ""
+        completed_ok.stdout = ""
+
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", return_value=completed_ok) as mock_run,
+            patch("scheduler.resolve_project_root", return_value=tmp_path),
+        ):
+            result = scheduler.install_scheduler(
+                project_id="vnx-dev",
+                project_root=tmp_path,
+                vnx_bin="/usr/local/bin/vnx",
+            )
+
+        plist_path = launch_agents / "com.vnx.auto-dream.plist"
+        assert plist_path.exists(), "plist not written"
+        content = plist_path.read_text()
+        assert "vnx-dev" in content
+        assert "/usr/local/bin/vnx" in content
+
+        # launchctl unload + load should have been called
+        calls_cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert any("unload" in cmd for cmd in calls_cmds)
+        assert any("load" in cmd for cmd in calls_cmds)
+        assert "Installed and loaded" in result
+
+    def test_install_idempotent(self, tmp_path):
+        """Second install overwrites plist + unloads before re-loading."""
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+
+        ok = MagicMock(returncode=0, stderr="", stdout="")
+
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", return_value=ok),
+            patch("scheduler.resolve_project_root", return_value=tmp_path),
+        ):
+            scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")
+            scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")
+
+        plist_path = launch_agents / "com.vnx.auto-dream.plist"
+        assert plist_path.exists()
+
+    def test_launchctl_failure_raises(self, tmp_path):
+        """RuntimeError raised when launchctl load returns non-zero."""
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock()
+            if "load" in cmd and "unload" not in cmd:
+                m.returncode = 1
+                m.stderr = "service already loaded"
+                m.stdout = ""
+            else:
+                m.returncode = 0
+                m.stderr = ""
+                m.stdout = ""
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+            patch("scheduler.resolve_project_root", return_value=tmp_path),
+        ):
+            with pytest.raises(RuntimeError, match="launchctl load failed"):
+                scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")
+
+
+class TestUninstallSchedulerMacOS:
+    def test_uninstall_removes_plist(self, tmp_path):
+        """uninstall_scheduler on Darwin unloads + removes plist."""
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        plist_path = launch_agents / "com.vnx.auto-dream.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+
+        ok = MagicMock(returncode=0)
+
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", return_value=ok),
+        ):
+            result = scheduler.uninstall_scheduler()
+
+        assert not plist_path.exists()
+        assert "Unloaded and removed" in result
+
+    def test_uninstall_when_not_installed(self, tmp_path):
+        """uninstall_scheduler returns gracefully when plist absent."""
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+        ):
+            result = scheduler.uninstall_scheduler()
+
+        assert "Not installed" in result
+
+
+# ---------------------------------------------------------------------------
+# Linux tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSchedulerLinux:
+    def test_cron_entry_added(self):
+        """install_scheduler on Linux adds crontab entry with project_id."""
+        existing_cron = "30 6 * * * /usr/bin/backup\n"
+
+        captured = {}
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            if cmd == ["crontab", "-l"]:
+                m.stdout = existing_cron
+            elif cmd == ["crontab", "-"]:
+                captured["new"] = kwargs.get("input", "")
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            result = scheduler.install_scheduler("vnx-dev", vnx_bin="/usr/bin/vnx")
+
+        assert "vnx-dev" in captured["new"]
+        assert "vnx-auto-dream" in captured["new"]
+        assert "# vnx-auto-dream" in result or "Cron entry" in result
+
+    def test_cron_idempotent(self):
+        """Re-installing replaces existing auto-dream cron line (no duplicates)."""
+        existing = "0 3 * * * /usr/bin/vnx dream run --project-id vnx-dev  # vnx-auto-dream:com.vnx.auto-dream\n"
+        captured = {}
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            if cmd == ["crontab", "-l"]:
+                m.stdout = existing
+            elif cmd == ["crontab", "-"]:
+                captured["new"] = kwargs.get("input", "")
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            scheduler.install_scheduler("vnx-dev", vnx_bin="/usr/bin/vnx")
+
+        lines = [l for l in captured["new"].splitlines() if "vnx-auto-dream" in l]
+        assert len(lines) == 1, "Expected exactly one auto-dream cron line"
+
+
+class TestUninstallSchedulerLinux:
+    def test_cron_entry_removed(self):
+        """uninstall_scheduler on Linux removes the auto-dream cron line."""
+        existing = (
+            "30 6 * * * /usr/bin/backup\n"
+            "0 3 * * * /usr/bin/vnx dream run --project-id vnx-dev  # vnx-auto-dream:com.vnx.auto-dream\n"
+        )
+        captured = {}
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            if cmd == ["crontab", "-l"]:
+                m.stdout = existing
+            elif cmd == ["crontab", "-"]:
+                captured["new"] = kwargs.get("input", "")
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            result = scheduler.uninstall_scheduler()
+
+        assert "vnx-auto-dream" not in captured.get("new", "")
+        assert "removed" in result.lower()
+
+    def test_uninstall_when_not_present(self):
+        """uninstall_scheduler returns gracefully when no auto-dream line exists."""
+        def mock_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = "30 6 * * * /usr/bin/backup\n"
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            result = scheduler.uninstall_scheduler()
+
+        assert "not found" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unsupported platform
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedPlatform:
+    def test_install_raises_on_windows(self):
+        with patch("scheduler.platform.system", return_value="Windows"):
+            with pytest.raises(RuntimeError, match="Unsupported platform"):
+                scheduler.install_scheduler("vnx-dev")
+
+    def test_uninstall_raises_on_windows(self):
+        with patch("scheduler.platform.system", return_value="Windows"):
+            with pytest.raises(RuntimeError, match="Unsupported platform"):
+                scheduler.uninstall_scheduler()

--- a/vnx_cli/commands/dream.py
+++ b/vnx_cli/commands/dream.py
@@ -156,6 +156,34 @@ def _cmd_history(args) -> int:
     return 0
 
 
+def _cmd_install_scheduler(args) -> int:
+    project_id = _get_project_id(args)
+    if not project_id:
+        print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
+        return 1
+    from pathlib import Path
+    root, _ = _resolve_paths()
+    import scheduler  # type: ignore[import]
+    try:
+        msg = scheduler.install_scheduler(project_id=project_id, project_root=root)
+        print(msg)
+    except RuntimeError as exc:
+        print(f"error: {exc}")
+        return 1
+    return 0
+
+
+def _cmd_uninstall_scheduler(args) -> int:
+    import scheduler  # type: ignore[import]
+    try:
+        msg = scheduler.uninstall_scheduler()
+        print(msg)
+    except RuntimeError as exc:
+        print(f"error: {exc}")
+        return 1
+    return 0
+
+
 def vnx_dream(args) -> int:
     sub = getattr(args, "dream_subcommand", None)
     dispatch = {
@@ -163,8 +191,10 @@ def vnx_dream(args) -> int:
         "status": _cmd_status,
         "review": _cmd_review,
         "history": _cmd_history,
+        "install-scheduler": _cmd_install_scheduler,
+        "uninstall-scheduler": _cmd_uninstall_scheduler,
     }
     if sub in dispatch:
         return dispatch[sub](args)
-    print("Usage: vnx dream {run|status|review|history}")
+    print("Usage: vnx dream {run|status|review|history|install-scheduler|uninstall-scheduler}")
     return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -271,6 +271,15 @@ def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_history_p.add_argument("--project-id", default=None, metavar="ID")
     dream_history_p.add_argument("--limit", type=int, default=10, metavar="N")
 
+    dream_install_p = dream_subs.add_parser(
+        "install-scheduler", help="install nightly auto-dream scheduler (macOS/Linux)"
+    )
+    dream_install_p.add_argument("--project-id", default=None, metavar="ID")
+
+    dream_subs.add_parser(
+        "uninstall-scheduler", help="remove nightly auto-dream scheduler"
+    )
+
 
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":


### PR DESCRIPTION
## Summary

- `vnx dream install-scheduler [--project-id <id>]`: idempotent macOS LaunchAgent install + `launchctl load -w`; Linux cron fallback. Project-id stamped on plist/cron for isolation (ADR-007).
- `vnx dream uninstall-scheduler`: clean removal (plist unload + delete on macOS; cron line removal on Linux).
- GAP-7 receipt-completeness preflight in `scripts/dream/consolidator.py`: before fetching patterns, checks `{data_root}/receipts/processed/` for files modified within 48h. Stale or absent → emits `dream_cycle_skipped` NDJSON event and returns `{status: "skipped", reason: "incomplete_data"}` — no kimi call, no DB write.

## Verify

- `vnx dream install-scheduler --project-id vnx-dev` — on macOS: writes `~/Library/LaunchAgents/com.vnx.auto-dream.plist` and runs `launchctl load -w`. `vnx dream uninstall-scheduler` unloads and removes it.
- Linux path: crontab entry added at 03:00 daily with marker `# vnx-auto-dream:com.vnx.auto-dream`; uninstall removes it.
- Receipt preflight: stale/empty `receipts/processed` → cycle skips with `dream_cycle_skipped` event, kimi not invoked, no DB row.
- `python3 -m pytest tests/test_dream_scheduler.py tests/test_dream_consolidator.py tests/test_dream_cli.py tests/test_docs_command_validation.py -q` → **60 passed**
- Mode-tier intact: `dream` stays in `TIER_OPERATOR_ONLY`; `install-scheduler` / `uninstall-scheduler` are subcommands under `dream`, not new top-level bin/vnx commands. `bin/vnx` untouched.

## ADR compliance

- ADR-007: project_id stamped on LaunchAgent plist and cron entry.
- ADR-005: NDJSON event emitted before any skip return.
- ADR-003 / no-anthropic-sdk: no SDK imports; scheduler uses subprocess only.

## Open Items

_(none)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)