### PR TITLE
feat(dispatch): complete smart-router for non-Claude providers + constraint-aware routing

### DIFF
--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -185,6 +185,47 @@ def _cost_aware_sort_key(c: "RouteCandidate") -> tuple:
     return (1, float("inf"), -c.composite_score)
 
 
+def _filter_by_constraints(
+    candidates: List[RouteCandidate],
+    env: Optional[Dict] = None,
+) -> "tuple[List[RouteCandidate], List[str]]":
+    """Filter candidates that would violate provider_constraints.yaml.
+
+    Consults providers.constraint_enforcer.check_constraints for each candidate
+    so smart_router never recommends a constraint-violating lane (G8).
+
+    Fail-open: on import error or any per-candidate exception, the candidate is
+    kept (safe over silent drop). Returns (allowed_candidates, applied_ids) where
+    applied_ids lists blocking constraint codes that filtered at least one model.
+    """
+    import os as _os  # noqa: PLC0415
+
+    try:
+        from providers.constraint_enforcer import check_constraints as _check  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return candidates, []
+
+    _env = env if env is not None else dict(_os.environ)
+    allowed: List[RouteCandidate] = []
+    applied: List[str] = []
+
+    for candidate in candidates:
+        try:
+            provider, model = parse_route_model_id(candidate.model_id)
+            violations = _check(provider=provider, model=model, env=_env)
+            blocking = [v for v in violations if v.severity == "blocking"]
+            if blocking:
+                for v in blocking:
+                    if v.code not in applied:
+                        applied.append(v.code)
+            else:
+                allowed.append(candidate)
+        except Exception:  # noqa: BLE001
+            allowed.append(candidate)
+
+    return allowed, applied
+
+
 def _load_recommendations(
     path: Optional[Path] = None,
 ) -> Dict[str, List[RouteCandidate]]:
@@ -259,6 +300,9 @@ def decide(
     task_class = classify_task(instruction, role=role, dispatch_paths=dispatch_paths)
     candidates = recommend(task_class, recommendations_path=recommendations_path)
 
+    # G8: filter constraint-violating candidates before picking primary/fallback.
+    candidates, _constraints_applied = _filter_by_constraints(candidates)
+
     primary = candidates[0] if candidates else None
     fallback = candidates[1] if len(candidates) > 1 else None
 
@@ -277,6 +321,7 @@ def decide(
         primary=primary,
         fallback=fallback,
         reason="; ".join(parts),
+        constraints_applied=_constraints_applied,
         cost_estimate=cost_estimate,
     )
 

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -371,6 +371,7 @@ if __name__ == "__main__":
 
     # PR-SR-4: smart_router auto-route (opt-in, takes precedence over routing_policy).
     _auto_route_applied = False
+    _auto_cheap_lane: "str | None" = None  # G6: non-Claude provider from smart_router
     if getattr(args, "auto_route", False):
         try:
             from smart_router import decide as _smart_route, parse_route_model_id, write_route_decision  # noqa: PLC0415
@@ -386,7 +387,10 @@ if __name__ == "__main__":
                 )
                 if _r_provider == "claude":
                     _effective_model = _r_model
-                    _auto_route_applied = True
+                else:
+                    _auto_cheap_lane = _r_provider  # G6: route to non-Claude provider
+                    args.model = _r_model            # pass recommended model to provider_dispatch
+                _auto_route_applied = True  # G7: always skip routing_policy when smart_router ran
 
             _state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
             write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
@@ -408,6 +412,9 @@ if __name__ == "__main__":
         current_model=_effective_model,
         auto_route_applied=_auto_route_applied,
     )
+    # G6: smart_router non-Claude selection takes precedence over routing_policy result.
+    if _auto_cheap_lane is not None:
+        _cheap_lane_provider = _auto_cheap_lane
     if _cheap_lane_provider is not None or _effective_model != args.model:
         import logging as _log_mod
         _log_mod.getLogger(__name__).info(

--- a/tests/test_smart_router_e2e.py
+++ b/tests/test_smart_router_e2e.py
@@ -115,7 +115,8 @@ class TestAutoRouteNdjsonPersistence:
         record = json.loads(ndjson_path.read_text(encoding="utf-8").strip())
         assert record["chosen_route"]["model_id"] == "claude-opus-4-6"
 
-    def test_debug_task_routes_to_deepseek(self, recommendations_yaml, state_dir):
+    def test_debug_task_routes_to_deepseek(self, recommendations_yaml, state_dir, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
         decision = decide(
             instruction="debug the failing test in subprocess_dispatch",
             role="debugger",

--- a/tests/test_smart_router_multiprovider.py
+++ b/tests/test_smart_router_multiprovider.py
@@ -1,0 +1,312 @@
+"""Tests for G6/G7/G8: smart-router multiprovider complete.
+
+G6: auto-route selecting a non-Claude model dispatches to the right provider
+    via provider_dispatch, not a Claude fallback.
+G7: smart_router and routing_policy are not double-applied — _select_dispatch_path
+    is suppressed when smart_router already ran.
+G8: constraint-violating candidates are filtered during routing (never recommended).
+
+Dispatch-ID: 20260529-161912-smartrouter-complete
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from smart_router import decide, parse_route_model_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def recs_deepseek_wins(tmp_path):
+    """deepseek ranked first (capable tier, explicit low cost)."""
+    data = {
+        "routing_by_task": {
+            "01_code_generation": [
+                {"model_id": "deepseek-v4-pro", "composite_score": 9.0,
+                 "avg_duration_seconds": 212.0, "cost_usd_per_call": 0.001},
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
+                 "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
+            ],
+        },
+    }
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+@pytest.fixture
+def recs_kimi_wins(tmp_path):
+    """kimi CLI ranked first (capable tier, explicit low cost)."""
+    data = {
+        "routing_by_task": {
+            "01_code_generation": [
+                {"model_id": "kimi-k2-0905", "composite_score": 9.0,
+                 "avg_duration_seconds": 200.0, "cost_usd_per_call": 0.001},
+                {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
+                 "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
+            ],
+        },
+    }
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+@pytest.fixture
+def recs_deepseek_only(tmp_path):
+    """Only deepseek — filtering it leaves no candidates."""
+    data = {
+        "routing_by_task": {
+            "01_code_generation": [
+                {"model_id": "deepseek-v4-pro", "composite_score": 9.0,
+                 "avg_duration_seconds": 212.0, "cost_usd_per_call": 0.001},
+            ],
+        },
+    }
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# G8: constraint filtering in smart_router.decide()
+# ---------------------------------------------------------------------------
+
+class TestG8ConstraintFiltering:
+    """Constraint-violating candidates must be filtered before recommendation."""
+
+    def test_deepseek_filtered_when_no_api_key(self, recs_deepseek_wins, monkeypatch):
+        """deepseek ranked first but blocked when DEEPSEEK_API_KEY absent → claude wins."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+        decision = decide(
+            instruction="implement feature",
+            role="backend-developer",
+            recommendations_path=recs_deepseek_wins,
+        )
+
+        assert decision.primary is not None
+        assert decision.primary.model_id == "claude-sonnet-4-6"
+        assert "deepseek-harness-subscription-blocked" in decision.constraints_applied
+
+    def test_deepseek_allowed_when_api_key_set(self, recs_deepseek_wins, monkeypatch):
+        """deepseek passes constraint check when DEEPSEEK_API_KEY is set."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+
+        decision = decide(
+            instruction="implement feature",
+            role="backend-developer",
+            recommendations_path=recs_deepseek_wins,
+        )
+
+        assert decision.primary is not None
+        assert decision.primary.model_id == "deepseek-v4-pro"
+        assert not decision.constraints_applied
+
+    def test_kimi_cli_not_filtered(self, recs_kimi_wins):
+        """kimi CLI lane (provider=kimi, not moonshot) must never be filtered."""
+        decision = decide(
+            instruction="implement feature",
+            role="backend-developer",
+            recommendations_path=recs_kimi_wins,
+        )
+
+        assert decision.primary is not None
+        assert decision.primary.model_id == "kimi-k2-0905"
+        assert not decision.constraints_applied
+
+    def test_all_filtered_primary_is_none(self, recs_deepseek_only, monkeypatch):
+        """All candidates blocked → primary is None; no crash, no silent fallback."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+        decision = decide(
+            instruction="implement feature",
+            recommendations_path=recs_deepseek_only,
+        )
+
+        assert decision.primary is None
+        assert "deepseek-harness-subscription-blocked" in decision.constraints_applied
+
+    def test_constraints_applied_recorded_in_decision(self, recs_deepseek_wins, monkeypatch):
+        """Filtered constraint IDs appear in RouteDecision.constraints_applied."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+        decision = decide(
+            instruction="implement feature",
+            recommendations_path=recs_deepseek_wins,
+        )
+
+        assert isinstance(decision.constraints_applied, list)
+        assert len(decision.constraints_applied) >= 1
+        assert "deepseek-harness-subscription-blocked" in decision.constraints_applied
+
+
+# ---------------------------------------------------------------------------
+# G7: single coherent decision path
+# ---------------------------------------------------------------------------
+
+class TestG7SingleDecisionPath:
+    """_select_dispatch_path short-circuits when auto_route_applied=True (G7)."""
+
+    def test_routing_policy_skipped_when_auto_route_applied(self):
+        """With VNX_ROUTING_POLICY_ENABLED=1 AND auto_route_applied=True → policy skipped."""
+        from subprocess_dispatch import _select_dispatch_path
+
+        provider, model = _select_dispatch_path(
+            task_class="01_code_generation",
+            complexity="medium",
+            current_model="sonnet",
+            env={"VNX_ROUTING_POLICY_ENABLED": "1"},
+            auto_route_applied=True,
+        )
+        assert provider is None
+        assert model == "sonnet"
+
+    def test_routing_policy_no_op_without_flag(self):
+        """Without VNX_ROUTING_POLICY_ENABLED the function is always a no-op."""
+        from subprocess_dispatch import _select_dispatch_path
+
+        provider, model = _select_dispatch_path(
+            task_class="01_code_generation",
+            complexity="medium",
+            current_model="sonnet",
+            env={},
+            auto_route_applied=False,
+        )
+        assert provider is None
+        assert model == "sonnet"
+
+    def test_auto_route_applied_blocks_even_with_policy_enabled(self):
+        """auto_route_applied=True takes precedence over VNX_ROUTING_POLICY_ENABLED."""
+        from subprocess_dispatch import _select_dispatch_path
+
+        # Both flags set: smart_router decision must win.
+        provider, model = _select_dispatch_path(
+            task_class="03_refactoring",
+            complexity="high",
+            current_model="haiku",
+            env={"VNX_ROUTING_POLICY_ENABLED": "1", "VNX_USE_CHEAP_LANE": "1"},
+            auto_route_applied=True,
+        )
+        assert provider is None
+        assert model == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# G6: non-Claude auto-route dispatches to provider_dispatch, not Claude
+# ---------------------------------------------------------------------------
+
+class TestG6NonClaudeDispatch:
+    """auto-route → non-Claude model → dispatches via provider_dispatch, not deliver_with_recovery."""
+
+    def test_kimi_auto_route_calls_dispatch_kimi(self, recs_kimi_wins, state_dir, monkeypatch):
+        """When smart_router selects kimi, provider_dispatch._dispatch_kimi is called."""
+        import provider_dispatch
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setattr("smart_router._RECOMMENDATIONS_PATH", recs_kimi_wins)
+
+        deliver_calls: list = []
+
+        with patch("subprocess_dispatch.deliver_with_recovery",
+                   side_effect=lambda **kw: deliver_calls.append(kw) or True):
+            with patch("provider_dispatch._dispatch_kimi", return_value=0) as mock_kimi:
+                result = provider_dispatch.main([
+                    "--provider", "claude",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "g6-kimi-test",
+                    "--instruction", "implement new feature",
+                    "--model", "sonnet",
+                    "--auto-route",
+                ])
+
+        assert mock_kimi.called, "_dispatch_kimi must be called for kimi route"
+        assert not deliver_calls, "deliver_with_recovery must NOT be called for non-Claude route"
+        assert result == 0
+
+    def test_non_claude_auto_route_no_claude_fallback(self, recs_kimi_wins, state_dir, monkeypatch):
+        """G6 regression guard: deliver_with_recovery never invoked on non-Claude path."""
+        import provider_dispatch
+
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        monkeypatch.setattr("smart_router._RECOMMENDATIONS_PATH", recs_kimi_wins)
+
+        deliver_was_called: list = []
+
+        with patch("subprocess_dispatch.deliver_with_recovery",
+                   side_effect=lambda **kw: deliver_was_called.append(True) or True):
+            with patch("provider_dispatch._dispatch_kimi", return_value=0):
+                provider_dispatch.main([
+                    "--provider", "claude",
+                    "--terminal-id", "T1",
+                    "--dispatch-id", "g6-regression",
+                    "--instruction", "implement feature",
+                    "--model", "sonnet",
+                    "--auto-route",
+                ])
+
+        assert not deliver_was_called
+
+
+class TestG6CheapLaneArgv:
+    """_build_cheap_lane_argv produces correct argv for non-Claude providers."""
+
+    def test_kimi_provider_in_argv(self):
+        import argparse
+        from subprocess_dispatch import _build_cheap_lane_argv
+
+        args = argparse.Namespace(
+            terminal_id="T1",
+            dispatch_id="d-001",
+            instruction="implement feature",
+            model="kimi-k2-0905",
+            role="backend-developer",
+            max_retries=3,
+            gate="",
+            no_auto_commit=False,
+            dispatch_paths="",
+            pr_id=None,
+        )
+        argv = _build_cheap_lane_argv(args, "kimi")
+        assert "--provider" in argv
+        assert argv[argv.index("--provider") + 1] == "kimi"
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == "kimi-k2-0905"
+
+    def test_litellm_deepseek_provider_in_argv(self):
+        import argparse
+        from subprocess_dispatch import _build_cheap_lane_argv
+
+        args = argparse.Namespace(
+            terminal_id="T1",
+            dispatch_id="d-002",
+            instruction="debug failing test",
+            model="deepseek-v4-pro",
+            role="debugger",
+            max_retries=3,
+            gate="",
+            no_auto_commit=False,
+            dispatch_paths="",
+            pr_id=None,
+        )
+        argv = _build_cheap_lane_argv(args, "litellm:deepseek:deepseek-v4-pro")
+        assert "--provider" in argv
+        assert argv[argv.index("--provider") + 1] == "litellm:deepseek:deepseek-v4-pro"


### PR DESCRIPTION
## Summary

- **G6**: `subprocess_dispatch.__main__` now extracts `_auto_cheap_lane` for non-Claude smart_router decisions and routes to `provider_dispatch` via `_execute_cheap_lane_dispatch`. Previously, non-Claude routes were silently dropped and the dispatch fell through to Claude.
- **G7**: `_auto_route_applied = True` is set for both Claude and non-Claude smart_router results, preventing `_select_dispatch_path` (routing_policy) from overriding an already-resolved smart_router decision.
- **G8**: `smart_router.decide()` calls new `_filter_by_constraints()` before selecting primary/fallback. Candidates with blocking constraint violations are dropped; `RouteDecision.constraints_applied` records which constraints fired.

## Verify

- Test: auto-route → non-Claude (kimi) → `_dispatch_kimi` called, `deliver_with_recovery` NOT called → `TestG6NonClaudeDispatch`
- Test: `_select_dispatch_path(auto_route_applied=True)` always returns `(None, model)` → `TestG7SingleDecisionPath`
- Test: deepseek candidate filtered when `DEEPSEEK_API_KEY` absent; kimi CLI never filtered → `TestG8ConstraintFiltering`
- `python3 -m pytest tests/test_smart_router_multiprovider.py tests/test_smart_router*.py tests/test_routing_policy.py tests/test_constraint_enforcer*.py -q` → **233 passed**

## Test plan
- [ ] Run `python3 -m pytest tests/ -k "smart_router or routing or constraint" -q`
- [ ] Verify `VNX_AUTO_ROUTE` default off (no change to dispatch behavior without flag)
- [ ] Check `route_decisions.ndjson` written for non-Claude auto-routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)