### PR TITLE
fix(central-qdb): detect partial-init QI DB and complete bootstrap (OI-011)

### DIFF
--- a/scripts/migrate_to_central_vnx.py
+++ b/scripts/migrate_to_central_vnx.py
@@ -418,10 +418,68 @@ def _central_is_empty(qi_db: Path, rc_db: Path) -> bool:
     must run. Bookkeeping tables (``p4_import_*``) created by a previous
     failed apply do not count as "populated" — only the sentinel
     business tables matter.
+
+    Note: this function returns True for *both* a completely empty DB
+    (no tables) and one with only bookkeeping / partial-init tables (e.g.
+    ``dispatch_experiments`` from ``retroactive_backfill``). The
+    ``_qi_is_partial`` helper distinguishes these two sub-cases so the
+    apply flow can handle each correctly.
     """
     qi_fresh = not _has_table(qi_db, _QI_SENTINEL_TABLE)
     rc_fresh = not _has_table(rc_db, _RC_SENTINEL_TABLE)
     return qi_fresh or rc_fresh
+
+
+def _qi_is_partial(qi_db: Path) -> bool:
+    """True if the QI DB has tables but is missing the canonical sentinel.
+
+    OI-011 fix: ``retroactive_backfill._open_tracker()`` creates
+    ``dispatch_experiments`` in the central QI DB but skips all other
+    tables.  The result is a DB that ``_central_is_empty`` considers
+    "fresh" (missing ``success_patterns``) yet already contains data —
+    a partial-init limbo where ``bootstrap_qi_db`` should complete the
+    schema without requiring the ``--fresh-central`` operator gate
+    (which is reserved for truly empty, first-deploy DBs).
+
+    Returns True when ALL of:
+    - DB file exists and is non-empty.
+    - At least one table is present (not a truly-empty file).
+    - The sentinel table (``success_patterns``) is absent.
+
+    ``user_version`` is intentionally NOT checked here: DBs created
+    outside ``bootstrap_qi_db`` (e.g. test fixtures, legacy snapshots)
+    may have ``user_version=0`` while still containing the sentinel and
+    valid data.  Using ``user_version=0`` alone as an indicator would
+    incorrectly trigger bootstrap on those DBs and corrupt them.
+
+    ``bootstrap_qi_db`` is idempotent — existing tables and rows
+    (including ``dispatch_experiments`` data) are preserved via
+    ``CREATE TABLE IF NOT EXISTS`` and column-presence guards.
+    """
+    if not qi_db.exists() or qi_db.stat().st_size == 0:
+        return False
+    try:
+        con = sqlite3.connect(str(qi_db))
+        try:
+            table_count = con.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type IN ('table','virtual')"
+            ).fetchone()[0]
+            if table_count == 0:
+                return False  # truly empty file — not partial, treat as fresh
+            has_sentinel = (
+                con.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type IN ('table','virtual') AND name = ?",
+                    (_QI_SENTINEL_TABLE,),
+                ).fetchone()
+                is not None
+            )
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return False
+    return not has_sentinel
 
 
 def _init_central_if_missing(qi_db: Path, rc_db: Path) -> None:
@@ -1825,11 +1883,20 @@ def _run_apply(args: argparse.Namespace, projects: list[ProjectEntry]) -> int:
 
     central_state.mkdir(parents=True, exist_ok=True)
 
+    # OI-011 fix: detect partial-init QI DB BEFORE the --fresh-central gate.
+    # A partial DB (e.g. dispatch_experiments only from retroactive_backfill)
+    # has tables but user_version=0 — it is NOT fresh and must NOT require
+    # --fresh-central, since existing data would be incorrectly abandoned.
+    # _init_central_if_missing is safe to call on a partial DB (idempotent).
+    central_qi_partial = _qi_is_partial(central_qi)
+
     # Round-3 fix-forward: detect a fresh central BEFORE creating empty
     # DB files. Without this gate, an operator who has just blown away
     # ~/.vnx-data/state/ would see "import complete" against empty DBs.
+    # OI-011: partial-init QI (data present, not truly empty) bypasses this
+    # gate — _init_central_if_missing handles the bootstrap idempotently.
     central_was_fresh = _central_is_empty(central_qi, central_rc)
-    if central_was_fresh and not args.fresh_central:
+    if central_was_fresh and not args.fresh_central and not central_qi_partial:
         LOG.error(
             "central appears fresh (missing canonical schema at %s); "
             "pass --fresh-central to acknowledge first-deploy bootstrap",
@@ -1847,10 +1914,23 @@ def _run_apply(args: argparse.Namespace, projects: list[ProjectEntry]) -> int:
 
     pre_snapshot = _snapshot_central(central_qi, central_rc)
     try:
-        if central_was_fresh:
+        if central_was_fresh and not central_qi_partial:
             LOG.info(
                 "central is fresh; running canonical bootstrap "
                 "(quality_db_init + coordination_db.init_schema)"
+            )
+            _init_central_if_missing(central_qi, central_rc)
+        elif central_qi_partial:
+            # OI-011 fix: partial-init QI DB (e.g. only dispatch_experiments
+            # created by retroactive_backfill._open_tracker()) — complete the
+            # bootstrap via _init_central_if_missing which handles both QI
+            # (idempotent: dispatch_experiments data preserved) and RC init.
+            # ADR-007: bootstrap_qi_db wires composite PKs over project_id.
+            LOG.info(
+                "partial-init central QI DB detected (tables present but "
+                "user_version=0 or missing sentinel '%s'); running canonical "
+                "bootstrap to complete schema — existing data preserved",
+                _QI_SENTINEL_TABLE,
             )
             _init_central_if_missing(central_qi, central_rc)
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -589,6 +589,10 @@ def _migrate_v18(conn: sqlite3.Connection) -> None:
     Schema mirrors scripts/lib/dispatch_parameter_tracker.py::init_schema() plus the
     project_id column that migration 0015 would later ADD COLUMN on existing DBs
     (here we create it upfront so fresh installs get the full schema immediately).
+
+    OI-011 fix: if the table already exists (e.g. created by
+    retroactive_backfill._open_tracker() without project_id), add the
+    project_id column so apply_composite_unique_constraints can proceed.
     """
     if not conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='dispatch_experiments'"
@@ -632,6 +636,22 @@ def _migrate_v18(conn: sqlite3.Connection) -> None:
             "ON dispatch_experiments (project_id)"
         )
         log('INFO', 'Migrated: created dispatch_experiments table + indexes')
+    else:
+        # Table already exists (e.g. from retroactive_backfill._open_tracker() which
+        # creates it without project_id). Ensure project_id is present so the
+        # composite UNIQUE rebuild in apply_composite_unique_constraints can proceed.
+        cols = {r[1] for r in conn.execute(
+            "PRAGMA table_info(dispatch_experiments)"
+        ).fetchall()}
+        if "project_id" not in cols:
+            conn.execute(
+                "ALTER TABLE dispatch_experiments ADD COLUMN project_id TEXT"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_de_project_id "
+                "ON dispatch_experiments (project_id)"
+            )
+            log('INFO', 'Migrated dispatch_experiments: added missing project_id column + index')
 
 
 def _migrate_v20(conn: sqlite3.Connection) -> None:

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -365,20 +365,80 @@ def check_database(paths: Dict[str, str]) -> List[CheckResult]:
 
     try:
         conn = sqlite3.connect(str(db_path))
-        cursor = conn.execute(
+        table_count = conn.execute(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"
-        )
-        table_count = cursor.fetchone()[0]
+        ).fetchone()[0]
+        user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+        has_sentinel = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='success_patterns'"
+        ).fetchone() is not None
         conn.close()
-
-        if table_count >= 10:
-            return [CheckResult("database", PASS,
-                                f"Quality DB: {table_count} tables")]
-        return [CheckResult("database", FAIL,
-                            f"Quality DB incomplete: {table_count} tables (expected >= 10)",
-                            "Run: vnx init-db")]
     except sqlite3.Error as e:
         return [CheckResult("database", FAIL, f"Cannot read DB: {e}")]
+
+    results: List[CheckResult] = []
+
+    if table_count < 10:
+        results.append(CheckResult(
+            "database", FAIL,
+            f"Quality DB incomplete: {table_count} tables (expected >= 10)",
+            "Run: python3 scripts/quality_db_init.py or vnx doctor --repair-quality-db",
+        ))
+        return results
+
+    results.append(CheckResult("database", PASS, f"Quality DB: {table_count} tables"))
+
+    # OI-011 repair detection: partial-init (dispatch_experiments only from
+    # retroactive_backfill) or never-bootstrapped (user_version=0).
+    if user_version == 0 or not has_sentinel:
+        results.append(CheckResult(
+            "database", WARN,
+            f"Quality DB under-versioned: user_version={user_version}, "
+            f"sentinel={'present' if has_sentinel else 'MISSING'}. "
+            "Self-learning loop and intelligence layer will not function.",
+            "Run: python3 scripts/quality_db_init.py  "
+            "or: vnx doctor --repair-quality-db",
+        ))
+    else:
+        results.append(CheckResult(
+            "database", PASS,
+            f"Quality DB bootstrapped (user_version={user_version})",
+        ))
+
+    return results
+
+
+def repair_quality_db(paths: Dict[str, str]) -> int:
+    """Run bootstrap_qi_db against the central QI DB to complete partial init.
+
+    Idempotent: safe to run on fully-bootstrapped DBs (all migrations skip).
+    Returns 0 on success, 1 on failure.
+    """
+    db_path = Path(paths["VNX_STATE_DIR"]) / "quality_intelligence.db"
+    vnx_home = Path(paths["VNX_HOME"])
+    schema_file = vnx_home / "schemas" / "quality_intelligence.sql"
+
+    print(f"Repairing quality DB at {db_path}...")
+
+    if not schema_file.exists():
+        print(f"ERROR: schema file not found: {schema_file}", file=sys.stderr)
+        return 1
+
+    try:
+        import importlib
+        qdb = importlib.import_module("scripts.quality_db_init")
+        success = qdb.bootstrap_qi_db(db_path, schema_file)
+        if success:
+            conn = sqlite3.connect(str(db_path))
+            user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+            conn.close()
+            print(f"Quality DB repair complete. user_version={user_version}")
+            return 0
+        print("ERROR: bootstrap_qi_db returned False", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"ERROR: repair failed: {exc}", file=sys.stderr)
+        return 1
 
 
 # ---------------------------------------------------------------------------
@@ -693,9 +753,22 @@ def main() -> int:
                         help="Runtime preflight only")
     parser.add_argument("--json", action="store_true",
                         help="Output all results as JSON")
+    parser.add_argument(
+        "--repair-quality-db",
+        action="store_true",
+        help=(
+            "OI-011 repair: run bootstrap_qi_db against the central quality DB "
+            "to complete a partial-init (e.g. dispatch_experiments-only from "
+            "retroactive_backfill). Idempotent — safe to run on a fully-bootstrapped "
+            "DB. Exits 0 on success, 1 on failure."
+        ),
+    )
     args = parser.parse_args()
 
     paths = ensure_env()
+
+    if args.repair_quality_db:
+        return repair_quality_db(paths)
 
     results = run_doctor(
         paths,

--- a/tests/test_central_quality_db_bootstrap.py
+++ b/tests/test_central_quality_db_bootstrap.py
@@ -1,0 +1,464 @@
+"""Tests for OI-011: central QI DB partial-init bootstrap fix.
+
+Root cause: retroactive_backfill._open_tracker() creates dispatch_experiments
+in the central QI DB (user_version=0, no other tables). migrate_to_central_vnx
+previously skipped bootstrap_qi_db in this state, leaving the self-learning
+loop and intelligence layer broken.
+
+Covers:
+- _qi_is_partial detects partial-init DB correctly
+- _qi_is_partial returns False for truly empty and fully bootstrapped DBs
+- migrate apply flow completes a partial-init QI DB (dispatch_experiments only)
+- dispatch_experiments table + rows are preserved through bootstrap
+- Running the bootstrap twice is idempotent (no error, no data loss)
+- vnx_doctor.check_database warns on under-versioned central QI DB
+- repair_quality_db completes a partial DB to current version
+
+ADR-007 binding: all new central tables carry composite UNIQUE/PK over project_id.
+bootstrap_qi_db enforces this via the migration chain.
+
+Dispatch-ID: 20260529-161904-central-qdb
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import scripts.migrate_to_central_vnx as M  # noqa: E402
+import scripts.quality_db_init as QDB  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_partial_qi_db(path: Path, rows: int = 3) -> None:
+    """Create a QI DB with only dispatch_experiments (mimics retroactive_backfill).
+
+    Exactly mirrors retroactive_backfill._open_tracker(): creates
+    dispatch_experiments with PRAGMA user_version = 0 (never bootstrapped).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS dispatch_experiments (
+                id INTEGER PRIMARY KEY,
+                dispatch_id TEXT UNIQUE,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                instruction_chars INTEGER,
+                context_items INTEGER,
+                repo_map_symbols INTEGER,
+                role TEXT,
+                cognition TEXT,
+                model TEXT,
+                terminal TEXT,
+                file_count INTEGER,
+                success BOOLEAN,
+                cqs REAL,
+                completion_minutes REAL,
+                test_count INTEGER,
+                committed BOOLEAN,
+                lines_changed INTEGER
+            );
+            CREATE INDEX IF NOT EXISTS idx_de_dispatch_id ON dispatch_experiments (dispatch_id);
+        """)
+        for i in range(rows):
+            conn.execute(
+                "INSERT INTO dispatch_experiments (dispatch_id, role, model, terminal)"
+                " VALUES (?, 'backend-developer', 'sonnet', 'T1')",
+                (f"partial-dispatch-{i}",),
+            )
+        conn.commit()
+        # user_version stays at 0 — never bootstrapped
+    finally:
+        conn.close()
+
+
+def _make_fully_bootstrapped_qi_db(path: Path) -> None:
+    """Create a fully bootstrapped QI DB."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    QDB.bootstrap_qi_db(path, schema_file)
+
+
+def _get_user_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _table_exists(db_path: Path, table: str) -> bool:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table','virtual') AND name=?",
+            (table,),
+        ).fetchone() is not None
+    finally:
+        conn.close()
+
+
+def _row_count(db_path: Path, table: str) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _qi_is_partial detection
+# ---------------------------------------------------------------------------
+
+def test_qi_is_partial_true_for_dispatch_experiments_only(tmp_path):
+    """Partial DB (dispatch_experiments, user_version=0) must be detected."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=2)
+
+    assert M._qi_is_partial(qi_db) is True, (
+        "_qi_is_partial must return True for a DB with dispatch_experiments "
+        "only (user_version=0, missing success_patterns)"
+    )
+
+
+def test_qi_is_partial_false_for_missing_file(tmp_path):
+    """Non-existent file is not partial."""
+    qi_db = tmp_path / "does_not_exist.db"
+    assert M._qi_is_partial(qi_db) is False
+
+
+def test_qi_is_partial_false_for_empty_file(tmp_path):
+    """Zero-byte file is not partial."""
+    qi_db = tmp_path / "empty.db"
+    qi_db.write_bytes(b"")
+    assert M._qi_is_partial(qi_db) is False
+
+
+def test_qi_is_partial_false_for_no_tables(tmp_path):
+    """SQLite file with no tables is truly empty, not partial."""
+    qi_db = tmp_path / "fresh.db"
+    sqlite3.connect(str(qi_db)).close()
+    assert M._qi_is_partial(qi_db) is False
+
+
+def test_qi_is_partial_false_for_fully_bootstrapped(tmp_path):
+    """Fully bootstrapped DB must not be detected as partial."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_fully_bootstrapped_qi_db(qi_db)
+
+    assert M._qi_is_partial(qi_db) is False, (
+        "_qi_is_partial must return False for a fully bootstrapped DB "
+        f"(user_version={_get_user_version(qi_db)})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_qi_db on partial DB — schema completeness
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_completes_partial_db_to_highest_version(tmp_path):
+    """bootstrap_qi_db must bring a partial DB up to HIGHEST_QI_VERSION."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=3)
+
+    assert _get_user_version(qi_db) == 0, "precondition: partial DB has user_version=0"
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    result = QDB.bootstrap_qi_db(qi_db, schema_file)
+
+    assert result is True, "bootstrap_qi_db must return True"
+    assert _get_user_version(qi_db) == QDB.HIGHEST_QI_VERSION, (
+        f"user_version must be {QDB.HIGHEST_QI_VERSION} after bootstrap, "
+        f"got {_get_user_version(qi_db)}"
+    )
+
+
+def test_bootstrap_creates_success_patterns_on_partial_db(tmp_path):
+    """success_patterns (the sentinel table) must exist after bootstrap."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=1)
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    QDB.bootstrap_qi_db(qi_db, schema_file)
+
+    assert _table_exists(qi_db, "success_patterns"), (
+        "success_patterns must exist in central QI DB after bootstrap"
+    )
+
+
+def test_bootstrap_creates_dream_tables_on_partial_db(tmp_path):
+    """dream_cycles and dream_pattern_archives (ADR-019) must exist after bootstrap."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=1)
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    QDB.bootstrap_qi_db(qi_db, schema_file)
+
+    for table in ("dream_cycles", "dream_pattern_archives"):
+        assert _table_exists(qi_db, table), (
+            f"{table} must exist in central QI DB after bootstrap (ADR-019)"
+        )
+
+
+def test_bootstrap_preserves_dispatch_experiments_table(tmp_path):
+    """dispatch_experiments must still exist after bootstrap (not dropped/recreated)."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=5)
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    QDB.bootstrap_qi_db(qi_db, schema_file)
+
+    assert _table_exists(qi_db, "dispatch_experiments"), (
+        "dispatch_experiments must survive bootstrap on a partial DB"
+    )
+
+
+def test_bootstrap_preserves_dispatch_experiments_rows(tmp_path):
+    """Existing dispatch_experiments rows must survive bootstrap."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=4)
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    QDB.bootstrap_qi_db(qi_db, schema_file)
+
+    count = _row_count(qi_db, "dispatch_experiments")
+    assert count == 4, (
+        f"dispatch_experiments must retain 4 rows after bootstrap, got {count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: bootstrap twice = no error, no data loss
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_twice_is_idempotent(tmp_path):
+    """Running bootstrap_qi_db twice on a partial DB must not error or lose data."""
+    qi_db = tmp_path / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=3)
+
+    schema_file = ROOT / "schemas" / "quality_intelligence.sql"
+    assert QDB.bootstrap_qi_db(qi_db, schema_file) is True, "first bootstrap must succeed"
+    assert QDB.bootstrap_qi_db(qi_db, schema_file) is True, "second bootstrap must succeed"
+
+    assert _get_user_version(qi_db) == QDB.HIGHEST_QI_VERSION
+    assert _row_count(qi_db, "dispatch_experiments") == 3
+
+
+# ---------------------------------------------------------------------------
+# migrate_to_central_vnx apply flow with partial QI DB
+# ---------------------------------------------------------------------------
+
+def _make_source_rc_db(path: Path, project_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    try:
+        con.executescript("""
+            CREATE TABLE IF NOT EXISTS runtime_schema_version (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE IF NOT EXISTS dispatches (
+                dispatch_id TEXT PRIMARY KEY,
+                state TEXT NOT NULL DEFAULT 'queued',
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            INSERT OR IGNORE INTO runtime_schema_version (version, description)
+            VALUES (10, 'test-fixture');
+        """)
+        con.commit()
+    finally:
+        con.close()
+
+
+def _build_registry(tmp_path: Path, project_id: str = "proj-test") -> tuple[Path, Path]:
+    proj_dir = tmp_path / project_id
+    state_dir = proj_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    _make_source_rc_db(state_dir / "runtime_coordination.db", project_id)
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({
+        "schema_version": 1,
+        "projects": [{"name": project_id, "path": str(proj_dir), "project_id": project_id}],
+    }))
+    backup_base = tmp_path / "backups"
+    backup_base.mkdir()
+    return registry, backup_base
+
+
+def test_apply_handles_partial_qi_db(tmp_path, monkeypatch):
+    """migrate apply must bootstrap a partial central QI DB without --fresh-central.
+
+    Scenario: central QI DB has dispatch_experiments (user_version=0) from
+    retroactive_backfill but has never been fully bootstrapped. The migrator
+    must detect this via _qi_is_partial and complete the bootstrap.
+    """
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+
+    registry, backup_base = _build_registry(tmp_path)
+
+    central_state = tmp_path / "central" / "state"
+    central_state.mkdir(parents=True, exist_ok=True)
+    central_qi = central_state / "quality_intelligence.db"
+
+    # Pre-create partial central QI DB (the OI-011 condition)
+    _make_partial_qi_db(central_qi, rows=2)
+    assert _get_user_version(central_qi) == 0, "precondition: partial DB"
+
+    rc = M.main([
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        # --fresh-central intentionally OMITTED: partial DB should not need it
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ])
+
+    assert rc == 0, (
+        "apply must exit 0 when central QI DB is partial-init (OI-011 fix). "
+        f"Got exit {rc}"
+    )
+
+    assert _table_exists(central_qi, "success_patterns"), (
+        "success_patterns must exist in central QI DB after apply on partial DB"
+    )
+    assert _get_user_version(central_qi) == QDB.HIGHEST_QI_VERSION, (
+        f"user_version must be {QDB.HIGHEST_QI_VERSION} after apply, "
+        f"got {_get_user_version(central_qi)}"
+    )
+
+
+def test_apply_partial_qi_db_preserves_existing_rows(tmp_path, monkeypatch):
+    """dispatch_experiments rows must survive the partial-init bootstrap path."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+
+    registry, backup_base = _build_registry(tmp_path)
+
+    central_state = tmp_path / "central" / "state"
+    central_state.mkdir(parents=True, exist_ok=True)
+    central_qi = central_state / "quality_intelligence.db"
+
+    _make_partial_qi_db(central_qi, rows=3)
+
+    M.main([
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ])
+
+    count = _row_count(central_qi, "dispatch_experiments")
+    assert count >= 3, (
+        f"dispatch_experiments must retain at least 3 rows after partial bootstrap; got {count}"
+    )
+
+
+def test_apply_partial_qi_db_idempotent(tmp_path, monkeypatch):
+    """Running apply twice on a partial-init central DB must be a clean no-op."""
+    monkeypatch.setattr(M, "ABORT_FLAG", tmp_path / ".vnx-aggregator" / "ABORT")
+
+    registry, backup_base = _build_registry(tmp_path)
+
+    central_state = tmp_path / "central" / "state"
+    central_state.mkdir(parents=True, exist_ok=True)
+    central_qi = central_state / "quality_intelligence.db"
+
+    _make_partial_qi_db(central_qi, rows=2)
+
+    cmd = [
+        "--apply",
+        "--confirm", M.CONFIRMATION_PHRASE,
+        "--no-prompt",
+        "--registry", str(registry),
+        "--backup-base", str(backup_base),
+        "--central-state", str(central_state),
+    ]
+
+    rc1 = M.main(cmd)
+    assert rc1 == 0, f"First apply must exit 0, got {rc1}"
+
+    count_after_run1 = _row_count(central_qi, "dispatch_experiments")
+
+    rc2 = M.main(cmd)
+    assert rc2 == 0, f"Second apply must exit 0, got {rc2}"
+
+    count_after_run2 = _row_count(central_qi, "dispatch_experiments")
+    assert count_after_run1 == count_after_run2, (
+        f"dispatch_experiments row count changed between run 1 ({count_after_run1}) "
+        f"and run 2 ({count_after_run2}); second apply is not idempotent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# vnx_doctor check_database detects under-versioned central QI DB
+# ---------------------------------------------------------------------------
+
+def test_doctor_check_database_warns_on_partial_db(tmp_path):
+    """check_database must return WARN for a QI DB with user_version=0."""
+    import scripts.vnx_doctor as D
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_db = state_dir / "quality_intelligence.db"
+    _make_partial_qi_db(qi_db, rows=1)
+
+    # Add enough tables to pass the table_count >= 10 gate by creating a few extras
+    conn = sqlite3.connect(str(qi_db))
+    try:
+        for i in range(15):
+            conn.execute(f"CREATE TABLE IF NOT EXISTS fake_table_{i} (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    fake_paths = {"VNX_STATE_DIR": str(state_dir)}
+    results = D.check_database(fake_paths)
+
+    statuses = [r.status for r in results]
+    assert "warn" in statuses, (
+        f"check_database must return at least one WARN for under-versioned QI DB; "
+        f"got statuses: {statuses}"
+    )
+    warn_messages = [r.message for r in results if r.status == "warn"]
+    assert any("under-versioned" in m or "user_version" in m for m in warn_messages), (
+        f"WARN message must mention 'under-versioned' or 'user_version'; "
+        f"got: {warn_messages}"
+    )
+
+
+def test_doctor_check_database_pass_on_bootstrapped_db(tmp_path):
+    """check_database must not WARN for a fully bootstrapped DB."""
+    import scripts.vnx_doctor as D
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    qi_db = state_dir / "quality_intelligence.db"
+    _make_fully_bootstrapped_qi_db(qi_db)
+
+    fake_paths = {"VNX_STATE_DIR": str(state_dir)}
+    results = D.check_database(fake_paths)
+
+    warn_or_fail = [r for r in results if r.status in ("warn", "fail")]
+    under_ver_issues = [
+        r for r in warn_or_fail
+        if "under-versioned" in r.message or "user_version=0" in r.message
+    ]
+    assert not under_ver_issues, (
+        f"check_database must not warn about version for a fully bootstrapped DB; "
+        f"issues: {under_ver_issues}"
+    )


### PR DESCRIPTION
## Summary

- **Root cause (OI-011)**: `retroactive_backfill._open_tracker()` creates `dispatch_experiments` in the central QI DB (user_version=0, no base schema). `_central_is_empty` then sees tables present (not empty) but `success_patterns` absent — a partial-init limbo where `bootstrap_qi_db` was never called.
- **Fix**: `_qi_is_partial()` detects this state (file exists, tables > 0, sentinel absent). `_run_apply` routes partial DBs through `_init_central_if_missing` (idempotent) without requiring `--fresh-central`. `_migrate_v18` adds `project_id` to an already-existing `dispatch_experiments` table so the composite UNIQUE rebuild can proceed.
- **Operator repair path**: `vnx doctor --repair-quality-db` runs `bootstrap_qi_db` against the central QI DB to complete a partial init. `check_database` warns with actionable remediation on under-versioned (user_version=0 or missing sentinel) DBs.
- **ADR-007**: `bootstrap_qi_db` wires composite PKs over `project_id` on all new tables (dream_cycles, dream_pattern_archives, dispatch_experiments).

## Test plan

- [x] `test_qi_is_partial_true_for_dispatch_experiments_only` — partial DB detected
- [x] `test_qi_is_partial_false_for_*` — no false positives (missing, empty, no-tables, bootstrapped)
- [x] `test_bootstrap_completes_partial_db_to_highest_version` — user_version reaches HIGHEST_QI_VERSION
- [x] `test_bootstrap_creates_success_patterns_on_partial_db` — sentinel table present after bootstrap
- [x] `test_bootstrap_creates_dream_tables_on_partial_db` — ADR-019 tables present after bootstrap
- [x] `test_bootstrap_preserves_dispatch_experiments_table` — table not dropped/recreated
- [x] `test_bootstrap_preserves_dispatch_experiments_rows` — existing rows intact after bootstrap
- [x] `test_bootstrap_twice_is_idempotent` — no error or data loss on double run
- [x] `test_apply_handles_partial_qi_db` — apply exits 0 without --fresh-central on partial DB
- [x] `test_apply_partial_qi_db_preserves_existing_rows` — dispatch_experiments rows preserved through apply
- [x] `test_apply_partial_qi_db_idempotent` — second apply is clean no-op
- [x] `test_doctor_check_database_warns_on_partial_db` — WARN with user_version mention
- [x] `test_doctor_check_database_pass_on_bootstrapped_db` — no false WARN on fully bootstrapped DB

**Full run**: `python3 -m pytest tests/test_central_quality_db_bootstrap.py -v` → 16/16 passed
**Broad filter**: `python3 -m pytest tests/ -k "central or quality_db or migrate" -q` → 378/378 passed (11 pre-existing collection errors in unrelated test files)

Dispatch-ID: 20260529-161904-central-qdb

🤖 Generated with [Claude Code](https://claude.com/claude-code)