### PR TITLE
fix(dream): guard empty-DB hang + add kimi timeout (GAP-7/ADR-019)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -12,12 +12,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+
+# Minimum number of core patterns (success_patterns + antipatterns) required to
+# proceed with consolidation. Below this threshold the cycle is skipped cleanly.
+_MIN_PATTERN_THRESHOLD: int = 1
+
+# Default kimi subprocess timeout in seconds; override via VNX_DREAM_KIMI_TIMEOUT.
+_DEFAULT_KIMI_TIMEOUT: int = 180
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 from project_root import resolve_project_root
@@ -151,12 +160,22 @@ Patterns to consolidate:
 """
 
 
-def _dispatch_kimi_consolidation(patterns_input: dict, project_id: str) -> dict:
-    """Dispatch kimi K2.6 cheap-lane for pattern consolidation and parse the result."""
+def _dispatch_kimi_consolidation(
+    patterns_input: dict, project_id: str, timeout: float = _DEFAULT_KIMI_TIMEOUT
+) -> dict:
+    """Dispatch kimi K2.6 cheap-lane for pattern consolidation and parse the result.
+
+    Raises subprocess.TimeoutExpired if kimi does not respond within ``timeout`` seconds.
+    """
     from kimi_wrapper import kimi_exec  # noqa: PLC0415
 
     prompt = _build_consolidation_prompt(patterns_input, project_id)
-    stdout = kimi_exec(prompt, dispatch_id=f"dream-{project_id}", project_id=project_id)
+    stdout = kimi_exec(
+        prompt,
+        dispatch_id=f"dream-{project_id}",
+        project_id=project_id,
+        timeout=timeout,
+    )
     text = _extract_kimi_text(stdout) or stdout
     return _parse_kimi_response(text)
 
@@ -206,52 +225,134 @@ def run_dream_cycle(
         }
     )
 
+    kimi_timeout = float(
+        os.environ.get("VNX_DREAM_KIMI_TIMEOUT", str(_DEFAULT_KIMI_TIMEOUT))
+    )
+
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
-    patterns = _fetch_patterns(conn, project_id)
-    total_input = sum(len(v) for v in patterns.values())
-
     try:
-        consolidation = _dispatch_kimi_consolidation(patterns, project_id)
-    except Exception as exc:
+        patterns = _fetch_patterns(conn, project_id)
+        total_input = sum(len(v) for v in patterns.values())
+
+        # Insufficient-data guard: skip cleanly when there are no core patterns to
+        # consolidate (e.g. freshly-bootstrapped DB). Kimi is NOT invoked. (GAP-7)
+        core_count = len(patterns.get("success_patterns", [])) + len(
+            patterns.get("antipatterns", [])
+        )
+        if core_count < _MIN_PATTERN_THRESHOLD:
+            _emit_dream_event(
+                {
+                    "event_type": "dream_cycle_skipped",
+                    "cycle_id": cycle_id,
+                    "project_id": project_id,
+                    "reason": "insufficient_data",
+                    "detail": (
+                        f"core_count={core_count} below threshold={_MIN_PATTERN_THRESHOLD}"
+                    ),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+            return {
+                "status": "skipped",
+                "cycle_id": cycle_id,
+                "reason": "insufficient_data",
+                "detail": f"core_count={core_count}",
+            }
+
+        try:
+            consolidation = _dispatch_kimi_consolidation(
+                patterns, project_id, timeout=kimi_timeout
+            )
+        except subprocess.TimeoutExpired:
+            _emit_dream_event(
+                {
+                    "event_type": "dream_cycle_timeout",
+                    "cycle_id": cycle_id,
+                    "project_id": project_id,
+                    "timeout_seconds": int(kimi_timeout),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+            return {
+                "status": "timeout",
+                "cycle_id": cycle_id,
+                "reason": "kimi_timeout",
+                "timeout_seconds": int(kimi_timeout),
+            }
+        except Exception as exc:
+            _emit_dream_event(
+                {
+                    "event_type": "dream_cycle_failed",
+                    "cycle_id": cycle_id,
+                    "project_id": project_id,
+                    "error": str(exc)[:500],
+                }
+            )
+            raise
+
+        root = resolve_project_root(__file__)
+        review_dir = root / ".vnx-data" / "state" / "dream"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        review_path = review_dir / f"{cycle_id}-pending-review.json"
+        review_path.write_text(
+            json.dumps(
+                {
+                    "cycle_id": cycle_id,
+                    "project_id": project_id,
+                    "input_count": total_input,
+                    "consolidation": consolidation,
+                    "requires_operator_review": True,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        merged_count = len(consolidation.get("merged", []))
+        dropped_count = len(consolidation.get("dropped", []))
+        archived_count = len(consolidation.get("archived", []))
+        flagged_count = len(consolidation.get("flagged", []))
+
         _emit_dream_event(
             {
-                "event_type": "dream_cycle_failed",
-                "cycle_id": cycle_id,
-                "project_id": project_id,
-                "error": str(exc)[:500],
-            }
-        )
-        raise
-
-    root = resolve_project_root(__file__)
-    review_dir = root / ".vnx-data" / "state" / "dream"
-    review_dir.mkdir(parents=True, exist_ok=True)
-    review_path = review_dir / f"{cycle_id}-pending-review.json"
-    review_path.write_text(
-        json.dumps(
-            {
+                "event_type": "dream_cycle_completed",
                 "cycle_id": cycle_id,
                 "project_id": project_id,
                 "input_count": total_input,
-                "consolidation": consolidation,
-                "requires_operator_review": True,
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+                "merged_count": merged_count,
+                "dropped_count": dropped_count,
+                "archived_count": archived_count,
+                "flagged_count": flagged_count,
+                "review_path": str(review_path),
+            }
+        )
 
-    merged_count = len(consolidation.get("merged", []))
-    dropped_count = len(consolidation.get("dropped", []))
-    archived_count = len(consolidation.get("archived", []))
-    flagged_count = len(consolidation.get("flagged", []))
+        if not dry_run:
+            conn.execute(
+                """
+                INSERT INTO dream_cycles
+                    (cycle_id, project_id, completed_at, status, provider,
+                     insights_input, merged_count, dropped_count, archived_count,
+                     flagged_count, report_path)
+                VALUES (?, ?, ?, 'completed', 'kimi', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    cycle_id,
+                    project_id,
+                    datetime.now(timezone.utc).isoformat(),
+                    total_input,
+                    merged_count,
+                    dropped_count,
+                    archived_count,
+                    flagged_count,
+                    str(review_path),
+                ),
+            )
+            conn.commit()
 
-    _emit_dream_event(
-        {
-            "event_type": "dream_cycle_completed",
+        return {
             "cycle_id": cycle_id,
-            "project_id": project_id,
             "input_count": total_input,
             "merged_count": merged_count,
             "dropped_count": dropped_count,
@@ -259,42 +360,8 @@ def run_dream_cycle(
             "flagged_count": flagged_count,
             "review_path": str(review_path),
         }
-    )
-
-    if not dry_run:
-        conn.execute(
-            """
-            INSERT INTO dream_cycles
-                (cycle_id, project_id, completed_at, status, provider,
-                 insights_input, merged_count, dropped_count, archived_count,
-                 flagged_count, report_path)
-            VALUES (?, ?, ?, 'completed', 'kimi', ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                cycle_id,
-                project_id,
-                datetime.now(timezone.utc).isoformat(),
-                total_input,
-                merged_count,
-                dropped_count,
-                archived_count,
-                flagged_count,
-                str(review_path),
-            ),
-        )
-        conn.commit()
-
-    conn.close()
-
-    return {
-        "cycle_id": cycle_id,
-        "input_count": total_input,
-        "merged_count": merged_count,
-        "dropped_count": dropped_count,
-        "archived_count": archived_count,
-        "flagged_count": flagged_count,
-        "review_path": str(review_path),
-    }
+    finally:
+        conn.close()
 
 
 def main() -> None:
@@ -315,6 +382,8 @@ def main() -> None:
 
     result = run_dream_cycle(args.project_id, db_path, args.dry_run)
     print(json.dumps(result, indent=2))
+    if result.get("status") == "timeout":
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -226,6 +227,17 @@ def _make_fresh_receipts(tmp_path: Path) -> None:
     (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
 
 
+def _seed_pattern(db_path: Path) -> None:
+    """Insert one success_pattern so the insufficient-data guard passes."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO success_patterns (project_id, title) VALUES (?, ?)",
+        ("vnx-dev", "seeded-pattern"),
+    )
+    conn.commit()
+    conn.close()
+
+
 class TestDryRun:
     def test_dry_run_no_db_write(self, tmp_path):
         """Dry-run emits NDJSON and writes pending-review.json but skips dream_cycles INSERT."""
@@ -235,6 +247,7 @@ class TestDryRun:
         conn.commit()
         conn.close()
         _make_fresh_receipts(tmp_path)
+        _seed_pattern(db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -265,6 +278,7 @@ class TestDryRun:
         conn.commit()
         conn.close()
         _make_fresh_receipts(tmp_path)
+        _seed_pattern(db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -296,6 +310,7 @@ class TestDryRun:
         conn.commit()
         conn.close()
         _make_fresh_receipts(tmp_path)
+        _seed_pattern(db_path)
 
         with (
             patch("consolidator.resolve_project_root", return_value=tmp_path),
@@ -430,6 +445,7 @@ class TestRunDreamCycleReceiptPreflight:
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
+        _seed_pattern(db_path)
 
         # Create a fresh receipt file
         processed = tmp_path / ".vnx-data" / "receipts" / "processed"
@@ -447,3 +463,152 @@ class TestRunDreamCycleReceiptPreflight:
 
         assert result.get("status") != "skipped"
         assert "cycle_id" in result
+
+
+# ---------------------------------------------------------------------------
+# Insufficient-data guard (empty DB with fresh receipts)
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_receipts(tmp_path: Path, *, with_patterns: bool = False) -> Path:
+    """Return a fresh DB path with receipts ready. Optionally seed one success pattern."""
+    db_path = tmp_path / "state" / "quality_intelligence.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_DREAM_SCHEMA)
+    if with_patterns:
+        conn.execute(
+            "INSERT INTO success_patterns (project_id, title) VALUES (?, ?)",
+            ("vnx-dev", "a-pattern"),
+        )
+    conn.commit()
+    conn.close()
+
+    processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+    processed.mkdir(parents=True, exist_ok=True)
+    (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+    return db_path
+
+
+class TestInsufficientDataGuard:
+    """Fresh receipts present but 0 core patterns → skip without calling kimi."""
+
+    def test_empty_db_returns_skipped(self, tmp_path):
+        """run_dream_cycle skips quickly when success_patterns + antipatterns = 0."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation") as mock_kimi,
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "insufficient_data"
+        mock_kimi.assert_not_called()
+
+    def test_empty_db_emits_skipped_ndjson_event(self, tmp_path):
+        """Skipped-on-empty emits dream_cycle_skipped NDJSON event (ADR-005)."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation"),
+        ):
+            consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        assert event_files, "No NDJSON event file written"
+        events = [
+            json.loads(line)
+            for line in event_files[0].read_text().strip().splitlines()
+        ]
+        skipped = [e for e in events if e.get("event_type") == "dream_cycle_skipped"]
+        assert skipped, "dream_cycle_skipped event not emitted"
+        assert skipped[0]["reason"] == "insufficient_data"
+
+    def test_non_empty_db_proceeds_to_kimi(self, tmp_path):
+        """run_dream_cycle calls kimi when at least one success pattern exists."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch(
+                "consolidator._dispatch_kimi_consolidation",
+                return_value=_FAKE_CONSOLIDATION,
+            ) as mock_kimi,
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+
+        mock_kimi.assert_called_once()
+        assert result.get("status") != "skipped"
+        assert "cycle_id" in result
+
+
+# ---------------------------------------------------------------------------
+# Kimi timeout guard
+# ---------------------------------------------------------------------------
+
+
+class TestKimiTimeout:
+    """Slow/stuck kimi must not hang the cycle indefinitely."""
+
+    def _make_timeout_error(self):
+        return subprocess.TimeoutExpired(cmd=["kimi"], timeout=1)
+
+    def test_timeout_returns_timeout_status(self, tmp_path):
+        """run_dream_cycle returns status='timeout' when kimi times out."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch(
+                "consolidator._dispatch_kimi_consolidation",
+                side_effect=self._make_timeout_error(),
+            ),
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        assert result["status"] == "timeout"
+        assert result["reason"] == "kimi_timeout"
+        assert "cycle_id" in result
+
+    def test_timeout_emits_timeout_ndjson_event(self, tmp_path):
+        """Timeout emits dream_cycle_timeout NDJSON event (ADR-005)."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch(
+                "consolidator._dispatch_kimi_consolidation",
+                side_effect=self._make_timeout_error(),
+            ),
+        ):
+            consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        assert event_files, "No NDJSON event file written"
+        events = [
+            json.loads(line)
+            for line in event_files[0].read_text().strip().splitlines()
+        ]
+        timeout_events = [e for e in events if e.get("event_type") == "dream_cycle_timeout"]
+        assert timeout_events, "dream_cycle_timeout event not emitted"
+
+    def test_timeout_env_override(self, tmp_path, monkeypatch):
+        """VNX_DREAM_KIMI_TIMEOUT env var is passed to _dispatch_kimi_consolidation."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        monkeypatch.setenv("VNX_DREAM_KIMI_TIMEOUT", "42")
+        captured = {}
+
+        def _capture_timeout(patterns, project_id, timeout=180.0):
+            captured["timeout"] = timeout
+            return _FAKE_CONSOLIDATION
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation", side_effect=_capture_timeout),
+        ):
+            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+
+        assert captured["timeout"] == 42.0


### PR DESCRIPTION
## Summary

- **Empty-DB hang fixed**: after fetching patterns, `run_dream_cycle` now checks `success_patterns + antipatterns >= 1` before invoking kimi. Below threshold: emits `dream_cycle_skipped` NDJSON event, returns `{status: 'skipped', reason: 'insufficient_data'}`, exits cleanly. No kimi call.
- **Kimi timeout**: `_dispatch_kimi_consolidation` now passes an explicit timeout (default 180s, env-overridable via `VNX_DREAM_KIMI_TIMEOUT`) to `kimi_exec`. `subprocess.TimeoutExpired` is caught in `run_dream_cycle`, emits `dream_cycle_timeout` NDJSON event, returns `{status: 'timeout'}`. `main()` exits non-zero on timeout.
- **Resource safety**: `conn.close()` moved to `finally` block — no SQLite handle leak on early returns.
- **ADR-005 preserved**: all NDJSON events emitted before any DB write. **ADR-007 preserved**: `project_id` stamped on all events and DB writes.

## Test plan

- [ ] `python3 -m pytest tests/test_dream_consolidator.py -q` — 28/28 green
- [ ] `python3 -m pytest tests/test_dream_consolidator.py tests/test_dream_scheduler.py tests/test_dream_cli.py tests/test_quality_db_dream_migration.py -q` — 64/64 green
- Test: empty DB with fresh receipts → `run_dream_cycle` returns `status='skipped'`, kimi not called ✓
- Test: kimi raises `TimeoutExpired` → cycle returns `status='timeout'`, no hang ✓
- Test: `VNX_DREAM_KIMI_TIMEOUT=42` env var → timeout=42.0 passed to kimi ✓
- Test: non-empty DB → normal path still calls kimi, returns `cycle_id` ✓

Dispatch-ID: 20260529-164641-dream-hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)