### PR TITLE
feat(ra1-projectid): ADR-007 project_id stamp on roadmap_state.json + receipts

### DIFF
--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -21,6 +22,7 @@ from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt, utc_now_iso
 from pr_queue_manager import PRQueueManager
 from closure_verifier import verify_closure
+from project_scope import current_project_id
 
 
 ALLOWED_DRIFT_CATEGORIES = {"bugfix", "post_cleanup", "governance_gap", "path/runtime regression"}
@@ -43,6 +45,7 @@ class RoadmapManager:
         paths = ensure_env()
         self.project_root = Path(paths["PROJECT_ROOT"]).resolve()
         self.state_dir = Path(paths["VNX_STATE_DIR"]).resolve()
+        self.project_id = current_project_id()
         self.paths = RoadmapPaths(
             project_root=self.project_root,
             state_dir=self.state_dir,
@@ -56,22 +59,42 @@ class RoadmapManager:
 
     def _save_state(self, state: Dict[str, Any]) -> None:
         self.paths.state_file.parent.mkdir(parents=True, exist_ok=True)
-        self.paths.state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        tmp = self.paths.state_file.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        os.replace(str(tmp), str(self.paths.state_file))
+
+    def _blank_state(self) -> Dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "roadmap_file": None,
+            "current_active_feature": None,
+            "features": [],
+            "inserted_fixups": [],
+            "merged_features": [],
+            "last_verified_merge_commit": None,
+            "last_closure_verification_result": None,
+            "blocked_reason": None,
+            "updated_at": utc_now_iso(),
+        }
 
     def load_state(self) -> Dict[str, Any]:
         if not self.paths.state_file.exists():
-            return {
-                "roadmap_file": None,
-                "current_active_feature": None,
-                "features": [],
-                "inserted_fixups": [],
-                "merged_features": [],
-                "last_verified_merge_commit": None,
-                "last_closure_verification_result": None,
-                "blocked_reason": None,
-                "updated_at": utc_now_iso(),
-            }
-        return json.loads(self.paths.state_file.read_text(encoding="utf-8"))
+            return self._blank_state()
+
+        state = json.loads(self.paths.state_file.read_text(encoding="utf-8"))
+
+        file_pid = state.get("project_id")
+        if file_pid is None:
+            # One-shot migration: stamp unstamped legacy state, preserve feature progress.
+            state["project_id"] = self.project_id
+            self._save_state(state)
+            return state
+
+        if file_pid != self.project_id:
+            # ADR-007: cross-tenant contamination guard — re-initialize rather than leak.
+            return self._blank_state()
+
+        return state
 
     def _normalize_feature(self, raw: Dict[str, Any]) -> Dict[str, Any]:
         review_stack = raw.get("review_stack") or []
@@ -105,6 +128,7 @@ class RoadmapManager:
         state = self.load_state()
         state.update(
             {
+                "project_id": self.project_id,
                 "roadmap_file": str(roadmap_file.resolve()),
                 "features": features,
                 "current_active_feature": None,
@@ -121,6 +145,7 @@ class RoadmapManager:
             "roadmap_transition",
             status="success",
             action="init",
+            project_id=self.project_id,
             roadmap_file=str(roadmap_file.resolve()),
             feature_count=len(features),
         )
@@ -160,6 +185,7 @@ class RoadmapManager:
             "roadmap_transition",
             status="success",
             action="load_feature",
+            project_id=self.project_id,
             feature_id=feature_id,
             title=feature["title"],
             branch_name=feature["branch_name"],
@@ -375,7 +401,7 @@ Implement the minimum blocking fix required before the roadmap may advance.
             state["blocked_reason"] = None
             state["updated_at"] = utc_now_iso()
             self._save_state(state)
-            emit_governance_receipt("roadmap_transition", status="success", action="advance_complete", merged_features=sorted(merged))
+            emit_governance_receipt("roadmap_transition", status="success", action="advance_complete", project_id=self.project_id, merged_features=sorted(merged))
             return {"advanced": False, "reason": "no_remaining_features"}
 
         self.load_feature(next_feature["feature_id"])

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -135,6 +135,42 @@ def test_advance_loads_next_feature_after_verified_merge(roadmap_env, monkeypatc
     assert "feature-a" in state["merged_features"]
 
 
+def test_project_id_mismatch_reinitializes_state(roadmap_env, monkeypatch):
+    """ADR-007: load_state() must refuse/re-initialize when file's project_id mismatches."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "project-a")
+    manager_a = rm.RoadmapManager()
+    manager_a.init_roadmap(roadmap_env["roadmap_file"])
+    manager_a.load_feature("feature-a")
+
+    # Switch to project-b — load_state() must not return project-a's features.
+    monkeypatch.setenv("VNX_PROJECT_ID", "project-b")
+    manager_b = rm.RoadmapManager()
+    state = manager_b.load_state()
+
+    assert state["current_active_feature"] is None, "cross-tenant feature must not leak"
+    assert state["features"] == [], "cross-tenant features must not leak"
+    assert state["project_id"] == "project-b"
+
+
+def test_unstamped_state_migrated_on_first_load(roadmap_env, monkeypatch):
+    """ADR-007: existing state file without project_id is stamped on first load, feature progress preserved."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "project-a")
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+
+    # Simulate legacy unstamped file: remove project_id key.
+    state_path = roadmap_env["state_dir"] / "roadmap_state.json"
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    del raw["project_id"]
+    state_path.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+
+    # Re-load — should stamp project_id and preserve feature progress.
+    state = manager.load_state()
+    assert state["project_id"] == "project-a"
+    assert state["current_active_feature"] == "feature-a", "feature progress must be preserved after migration"
+
+
 def test_advance_inserts_fixup_when_blocking_drift_detected(roadmap_env, monkeypatch):
     manager = rm.RoadmapManager()
     manager.init_roadmap(roadmap_env["roadmap_file"])


### PR DESCRIPTION
## ADR-007 Cite

Per ADR-007 (`docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md`): every tenant-scoped state store must carry `project_id`. `roadmap_state.json` was unstamped, creating cross-tenant contamination risk in the central `.vnx-data` model where multiple projects share storage.

## Changes (~120 LOC)

**`scripts/roadmap_manager.py`**
- Import `current_project_id()` from `project_scope` (same helper as `pr_queue_manager`)
- `RoadmapManager.__init__`: resolve `self.project_id` once at construction time
- `_blank_state()`: new helper that always stamps `project_id` on fresh state objects
- `load_state()`:
  - Returns blank state (stamped) when file is absent
  - **One-shot migration**: stamps legacy unstamped files (no `project_id` key) with current project_id, preserving feature progress
  - **Mismatch guard**: if file's `project_id` ≠ current project_id, returns blank state — no cross-tenant feature leak (ADR-007)
- `_save_state()`: atomic write via `.tmp` + `os.replace()` (Codex defense checklist)
- `init_roadmap()`, `load_feature()`, `advance()`: all `roadmap_transition` receipts stamped with `project_id`

**`tests/test_roadmap_manager.py`**
- `test_project_id_mismatch_reinitializes_state`: init under project-a; switch VNX_PROJECT_ID to project-b; assert load_state() returns empty state (no feature leak)
- `test_unstamped_state_migrated_on_first_load`: init → remove project_id key → reload; assert project_id stamped and feature progress preserved

## Verify

```
python3 -m pytest tests/test_roadmap_manager.py -q
5 passed in 0.23s
```

All 5 tests green (3 pre-existing + 2 new regression tests).

Dispatch-ID: 20260529-165442-ra1-projectid