### PR TITLE
feat(ra2-materialize): branch + worktree provisioning in load_feature

### DIFF
--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +24,7 @@ from governance_receipts import emit_governance_receipt, utc_now_iso
 from pr_queue_manager import PRQueueManager
 from closure_verifier import verify_closure
 from project_scope import current_project_id
+from vnx_worktree import worktree_start
 
 
 ALLOWED_DRIFT_CATEGORIES = {"bugfix", "post_cleanup", "governance_gap", "path/runtime regression"}
@@ -156,7 +158,41 @@ class RoadmapManager:
         manager = PRQueueManager()
         manager.load_feature_plan(str(_root_file(self.project_root, "FEATURE_PLAN.md")))
 
-    def load_feature(self, feature_id: str) -> Dict[str, Any]:
+    def _ensure_feature_branch(self, branch_name: str) -> bool:
+        """Create feature branch from origin/main if absent. Idempotent; returns True if created."""
+        cwd = str(self.project_root)
+        probe = subprocess.run(["git", "-C", cwd, "rev-parse", "--git-dir"], capture_output=True)
+        if probe.returncode != 0:
+            return False
+        subprocess.run(["git", "-C", cwd, "fetch", "origin", "main"], capture_output=True)
+        exists = subprocess.run(
+            ["git", "-C", cwd, "show-ref", "--verify", f"refs/heads/{branch_name}"],
+            capture_output=True,
+        )
+        if exists.returncode == 0:
+            return False
+        for base in ("origin/main", "HEAD"):
+            r = subprocess.run(["git", "-C", cwd, "branch", branch_name, base], capture_output=True)
+            if r.returncode == 0:
+                return True
+        return False
+
+    def _provision_feature_worktree(self, branch_name: str) -> str:
+        """Create a git worktree for branch_name and initialize .vnx-data isolation. Returns path or empty."""
+        slug = branch_name.replace("/", "-")
+        wt_path = self.state_dir.parent / "worktrees" / slug
+        cwd = str(self.project_root)
+        if not wt_path.exists():
+            r = subprocess.run(
+                ["git", "-C", cwd, "worktree", "add", str(wt_path), branch_name],
+                capture_output=True,
+            )
+            if r.returncode != 0:
+                return ""
+        result = worktree_start(project_root=str(wt_path))
+        return str(wt_path) if result.success else ""
+
+    def load_feature(self, feature_id: str, no_worktree: bool = False) -> Dict[str, Any]:
         state = self.load_state()
         features = state.get("features") or []
         feature = next((item for item in features if item["feature_id"] == feature_id), None)
@@ -170,6 +206,10 @@ class RoadmapManager:
             raise FileNotFoundError(f"Feature plan not found: {plan_path}")
 
         self._materialize_plan(plan_path)
+
+        branch_name = feature["branch_name"]
+        branch_created = self._ensure_feature_branch(branch_name)
+        worktree_path = "" if no_worktree else self._provision_feature_worktree(branch_name)
 
         for item in features:
             if item["feature_id"] == feature_id:
@@ -188,10 +228,12 @@ class RoadmapManager:
             project_id=self.project_id,
             feature_id=feature_id,
             title=feature["title"],
-            branch_name=feature["branch_name"],
+            branch_name=branch_name,
             risk_class=feature["risk_class"],
             merge_policy=feature["merge_policy"],
             review_stack=feature["review_stack"],
+            branch_created=branch_created,
+            worktree_path=worktree_path,
         )
         return state
 
@@ -434,6 +476,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     load_parser = sub.add_parser("load")
     load_parser.add_argument("feature_id")
     load_parser.add_argument("--json", action="store_true")
+    load_parser.add_argument("--no-worktree", action="store_true", dest="no_worktree")
 
     reconcile_parser = sub.add_parser("reconcile")
     reconcile_parser.add_argument("--json", action="store_true")
@@ -449,7 +492,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     elif args.command == "status":
         result = manager.status()
     elif args.command == "load":
-        result = manager.load_feature(args.feature_id)
+        result = manager.load_feature(args.feature_id, no_worktree=getattr(args, "no_worktree", False))
     elif args.command == "reconcile":
         result = manager.reconcile()
     elif args.command == "advance":

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+import subprocess as _subprocess
 import sys
 from pathlib import Path
 
@@ -203,3 +204,85 @@ def test_advance_inserts_fixup_when_blocking_drift_detected(roadmap_env, monkeyp
     assert result["reason"] == "blocking_fixup_inserted"
     assert state["current_active_feature"].startswith("fixup-")
     assert state["inserted_fixups"]
+
+
+# ---------------------------------------------------------------------------
+# RA-2: git branch materialization
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def git_roadmap_env(roadmap_env):
+    """roadmap_env with an initialized git repo for branch creation tests."""
+    project_root = roadmap_env["project_root"]
+    _subprocess.run(["git", "init", "-b", "main"], cwd=str(project_root), capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(project_root), capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "Test"], cwd=str(project_root), capture_output=True)
+    (project_root / "README.md").write_text("init", encoding="utf-8")
+    _subprocess.run(["git", "add", "README.md"], cwd=str(project_root), capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "init"], cwd=str(project_root), capture_output=True)
+    return roadmap_env
+
+
+def test_load_feature_creates_branch(git_roadmap_env, monkeypatch):
+    """load_feature creates the feature branch in git when absent."""
+    project_root = git_roadmap_env["project_root"]
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(git_roadmap_env["roadmap_file"])
+
+    manager.load_feature("feature-a", no_worktree=True)
+
+    r = _subprocess.run(
+        ["git", "-C", str(project_root), "show-ref", "--verify", "refs/heads/feature/a"],
+        capture_output=True,
+    )
+    assert r.returncode == 0, "feature/a branch must exist in git after load_feature"
+
+
+def test_load_feature_branch_creation_idempotent(git_roadmap_env, monkeypatch):
+    """Second load_feature call is a no-op: branch_created=False when branch already exists."""
+    receipts = []
+    monkeypatch.setattr(rm, "emit_governance_receipt", lambda *a, **kw: receipts.append(kw))
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(git_roadmap_env["roadmap_file"])
+
+    manager.load_feature("feature-a", no_worktree=True)
+    receipts.clear()
+
+    manager.load_feature("feature-a", no_worktree=True)
+
+    load_receipt = next((r for r in receipts if r.get("action") == "load_feature"), None)
+    assert load_receipt is not None
+    assert load_receipt["branch_created"] is False, "second call must be no-op (branch already exists)"
+
+
+def test_load_feature_receipt_carries_branch_info(git_roadmap_env, monkeypatch):
+    """roadmap_transition receipt carries branch_created, worktree_path, and project_id (ADR-007)."""
+    receipts = []
+    monkeypatch.setattr(rm, "emit_governance_receipt", lambda *a, **kw: receipts.append(kw))
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(git_roadmap_env["roadmap_file"])
+
+    manager.load_feature("feature-a", no_worktree=True)
+
+    load_receipt = next((r for r in receipts if r.get("action") == "load_feature"), None)
+    assert load_receipt is not None, "load_feature receipt not emitted"
+    assert "branch_created" in load_receipt, "receipt must carry branch_created"
+    assert "worktree_path" in load_receipt, "receipt must carry worktree_path"
+    assert load_receipt.get("project_id") is not None, "ADR-007: receipt must carry project_id"
+
+
+def test_load_feature_no_worktree_flag_skips_provisioning(git_roadmap_env, monkeypatch):
+    """--no-worktree prevents worktree_start from being called."""
+    start_calls = []
+
+    def _mock_worktree_start(*a, **kw):
+        start_calls.append(kw)
+        return type("R", (), {"success": True, "message": "/fake"})()
+
+    monkeypatch.setattr(rm, "worktree_start", _mock_worktree_start)
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(git_roadmap_env["roadmap_file"])
+
+    manager.load_feature("feature-a", no_worktree=True)
+
+    assert len(start_calls) == 0, "worktree_start must not be called when no_worktree=True"


### PR DESCRIPTION
## Summary

- `load_feature` now ensures the feature's `branch_name` exists in git (creates from `origin/main`, falls back to `HEAD` if remote unavailable; idempotent on repeat calls)
- Optionally provisions an isolated worktree via `worktree_start` from `vnx_worktree.py`; skipped with `--no-worktree` flag (for CI/tests)
- `roadmap_transition` receipt now carries `branch_created` (bool) and `worktree_path` (str) alongside existing `project_id` (ADR-007 preserved)

## Verify

```
python3 -m pytest tests/test_roadmap_manager.py -q
# 9 passed
```

All 4 new cases green:
- `test_load_feature_creates_branch` — creates `feature/a` in temp git repo
- `test_load_feature_branch_creation_idempotent` — second call sets `branch_created=False`
- `test_load_feature_receipt_carries_branch_info` — receipt has `branch_created`, `worktree_path`, `project_id`
- `test_load_feature_no_worktree_flag_skips_provisioning` — `worktree_start` never called with `no_worktree=True`

## Files changed

- `scripts/roadmap_manager.py` — `_ensure_feature_branch`, `_provision_feature_worktree`, `load_feature` signature + receipt, CLI `--no-worktree`
- `tests/test_roadmap_manager.py` — `git_roadmap_env` fixture + 4 regression tests

## ADR-007

`project_id` stamping on receipt preserved from RA-1. No new state columns; materialization data goes into the NDJSON receipt only.

Dispatch-ID: 20260529-170126-ra2-materialize