### PR TITLE
feat(ra3-gate-enforce): enforce review-gate evidence in reconcile/advance

### DIFF
--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -22,7 +23,8 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt, utc_now_iso
 from pr_queue_manager import PRQueueManager
-from closure_verifier import verify_closure
+from closure_verifier import verify_closure, _find_gate_result
+from gate_status import is_pass as gate_is_pass
 from project_scope import current_project_id
 from vnx_worktree import worktree_start
 
@@ -365,6 +367,41 @@ Implement the minimum blocking fix required before the roadmap may advance.
         )
         return state
 
+    def _gates_incomplete(self, feature: Dict[str, Any], gate_results_dir: Path) -> bool:
+        """Return True when any required gate lacks a PASS result for the feature's PRs.
+
+        Required gates: every entry in review_stack except claude_github_optional.
+        ADR-007: project_id stamping is preserved — this check is additive.
+        """
+        review_stack = feature.get("review_stack") or []
+        required_gates = [g for g in review_stack if g != "claude_github_optional"]
+        if not required_gates:
+            return False
+
+        feature_plan_path = _root_file(self.project_root, "FEATURE_PLAN.md")
+        pr_ids: List[str] = []
+        if feature_plan_path.exists():
+            content = feature_plan_path.read_text(encoding="utf-8")
+            pr_ids = re.findall(r"^##\s+(PR-\d+):", content, re.MULTILINE)
+
+        if not pr_ids:
+            return True
+
+        if not gate_results_dir.exists():
+            return True
+
+        branch = feature.get("branch_name", "")
+        for pr_id in pr_ids:
+            for gate in required_gates:
+                result = _find_gate_result(gate, pr_id, gate_results_dir, branch=branch)
+                if result is None:
+                    return True
+                passed, _ = gate_is_pass(result)
+                if not passed:
+                    return True
+
+        return False
+
     def reconcile(self) -> Dict[str, Any]:
         state = self.load_state()
         current_id = state.get("current_active_feature")
@@ -388,15 +425,26 @@ Implement the minimum blocking fix required before the roadmap may advance.
             claim_file=(self.paths.state_dir / "closure_claim.json") if (self.paths.state_dir / "closure_claim.json").exists() else None,
         )
         drift_items = self._detect_blocking_drift() if verification["verdict"] == "pass" else []
+        if verification["verdict"] == "pass" and drift_items:
+            verdict = "drift_blocked"
+        elif verification["verdict"] == "pass":
+            gate_results_dir = self.state_dir / "review_gates" / "results"
+            verdict = "gates_incomplete" if self._gates_incomplete(feature, gate_results_dir) else "pass"
+        else:
+            verdict = "blocked"
         result = {
-            "verdict": "pass" if verification["verdict"] == "pass" and not drift_items else ("drift_blocked" if drift_items else "blocked"),
+            "verdict": verdict,
             "feature_id": current_id,
             "closure_verification": verification,
             "drift_items": drift_items,
         }
         state["last_closure_verification_result"] = result
         state["last_verified_merge_commit"] = (((verification.get("pr") or {}).get("mergeCommit") or {}).get("oid"))
-        state["blocked_reason"] = "blocking_drift_detected" if drift_items else (None if verification["verdict"] == "pass" else "closure_verification_failed")
+        state["blocked_reason"] = (
+            "blocking_drift_detected" if drift_items else
+            ("gates_incomplete" if verdict == "gates_incomplete" else
+             (None if verdict == "pass" else "closure_verification_failed"))
+        )
         state["updated_at"] = utc_now_iso()
         self._save_state(state)
         emit_governance_receipt(
@@ -412,6 +460,9 @@ Implement the minimum blocking fix required before the roadmap may advance.
         reconcile_result = self.reconcile()
         if reconcile_result["verdict"] == "blocked":
             return {"advanced": False, "reason": "closure_verification_failed", "reconcile": reconcile_result}
+
+        if reconcile_result["verdict"] == "gates_incomplete":
+            return {"advanced": False, "reason": "gates_incomplete", "reconcile": reconcile_result}
 
         if reconcile_result["verdict"] == "drift_blocked":
             state = self.load_state()

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -126,6 +126,18 @@ def test_advance_loads_next_feature_after_verified_merge(roadmap_env, monkeypatc
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
 
+    # RA-3: required gate evidence must be present for advance to proceed.
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    (gate_results_dir / "pr0-gemini_review-contract.json").write_text(
+        json.dumps({"pr_id": "PR-0", "gate": "gemini_review", "status": "pass"}),
+        encoding="utf-8",
+    )
+    (gate_results_dir / "pr0-codex_gate-contract.json").write_text(
+        json.dumps({"pr_id": "PR-0", "gate": "codex_gate", "status": "pass"}),
+        encoding="utf-8",
+    )
+
     result = manager.advance()
     state = manager.load_state()
 
@@ -286,3 +298,113 @@ def test_load_feature_no_worktree_flag_skips_provisioning(git_roadmap_env, monke
     manager.load_feature("feature-a", no_worktree=True)
 
     assert len(start_calls) == 0, "worktree_start must not be called when no_worktree=True"
+
+
+# ---------------------------------------------------------------------------
+# RA-3: gate evidence enforcement
+# ---------------------------------------------------------------------------
+
+
+def _write_gate_result(gate_results_dir: Path, pr_id: str, gate: str, status: str = "pass") -> None:
+    pr_slug = pr_id.lower().replace("-", "")
+    (gate_results_dir / f"{pr_slug}-{gate}-contract.json").write_text(
+        json.dumps({"pr_id": pr_id, "gate": gate, "status": status}),
+        encoding="utf-8",
+    )
+
+
+def test_reconcile_gates_incomplete_when_codex_missing(roadmap_env, monkeypatch):
+    """Closure structurally passes but codex gate result absent → gates_incomplete."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
+    # codex_gate intentionally absent
+
+    result = manager.reconcile()
+
+    assert result["verdict"] == "gates_incomplete"
+
+
+def test_advance_blocked_when_gates_incomplete(roadmap_env, monkeypatch):
+    """gates_incomplete verdict → advance does NOT progress feature."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    # gate_results_dir intentionally not created → gates_incomplete
+
+    result = manager.advance()
+
+    assert result["advanced"] is False
+    assert result["reason"] == "gates_incomplete"
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-a", "feature must not advance"
+
+
+def test_reconcile_passes_when_gemini_and_codex_both_pass(roadmap_env, monkeypatch):
+    """gemini PASS + codex PASS → reconcile passes → advance progresses to next feature."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "pass"
+
+
+def test_optional_gate_missing_does_not_block(roadmap_env, monkeypatch):
+    """claude_github_optional absent → does NOT produce gates_incomplete (advisory only)."""
+    manager = rm.RoadmapManager()
+
+    # Create a roadmap that includes claude_github_optional in review_stack.
+    project_root = roadmap_env["project_root"]
+    roadmap_with_optional = project_root / "ROADMAP_OPT.yaml"
+    roadmap_with_optional.write_text(
+        """features:
+  - feature_id: feature-opt
+    title: Feature Opt
+    plan_path: roadmap/features/feature-a/FEATURE_PLAN.md
+    branch_name: feature/opt
+    risk_class: medium
+    merge_policy: human
+    review_stack: [gemini_review, codex_gate, claude_github_optional]
+    depends_on: []
+    status: planned
+""",
+        encoding="utf-8",
+    )
+    manager.init_roadmap(roadmap_with_optional)
+    manager.load_feature("feature-opt")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+    # claude_github_optional intentionally absent
+
+    result = manager.reconcile()
+
+    assert result["verdict"] == "pass", "optional gate absence must not produce gates_incomplete"


### PR DESCRIPTION
## Summary

- `reconcile()` now calls `_gates_incomplete()` after structural closure passes, checking that every required gate (gemini_review + codex_gate) has a PASS result in `$VNX_STATE_DIR/review_gates/results/` for each PR in the active feature plan
- New distinct verdict `gates_incomplete` separates missing gate evidence from other structural closure failures
- `advance()` treats `gates_incomplete` as BLOCKED — the feature stays active, no progression until gates actually ran and passed
- `claude_github_optional` is excluded from the required set (advisory only, per dispatch spec)
- ADR-007: project_id stamping in `load_state()` is preserved — gate check is purely additive

## Gate enforcement matrix covered

| Scenario | Expected | Actual |
|---|---|---|
| Closure passes, codex absent | `gates_incomplete` | ✓ |
| `gates_incomplete` → advance | `advanced=False, reason=gates_incomplete` | ✓ |
| gemini PASS + codex PASS | `pass` → advance progresses | ✓ |
| `claude_github_optional` absent | not blocked | ✓ |

## Test plan

- `pytest tests/test_roadmap_manager.py -q` → **13 passed**
- 4 new gate enforcement tests added covering the full dispatch matrix
- 1 existing test updated (`test_advance_loads_next_feature_after_verified_merge`) to provide gate results — reflects the new real requirement that gates must have run before advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)