### PR TITLE
fix(dream): kill process group on kimi timeout — fix persistent hang (PR-DREAM-HANG-2)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -194,6 +194,7 @@ def run_dream_cycle(
     cycle_id = (
         f"dream-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid4().hex[:8]}"
     )
+    print(f"dream run: cycle={cycle_id} project={project_id}", flush=True)
 
     # GAP-7: receipt-completeness preflight — skip cycle on empty/stale data
     data_root = resolve_project_root(__file__) / ".vnx-data"

--- a/scripts/lib/kimi_wrapper.py
+++ b/scripts/lib/kimi_wrapper.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -92,24 +93,32 @@ def kimi_exec(
         cmd.extend(["-m", model])
 
     with open(os.devnull, "r") as devnull:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=devnull,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
         try:
-            result = subprocess.run(
-                cmd,
-                stdin=devnull,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=timeout,
-                text=True,
-                start_new_session=True,
-            )
+            stdout_data, stderr_data = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
+            # Kill the entire process group so pipe-holding children also die.
+            # start_new_session=True guarantees kimi is its own process group leader,
+            # so os.killpg reaches all child processes that hold the pipe open.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait()
             logger.error(
                 "kimi_exec timed out after %.0fs (model=%s dispatch=%s)",
                 timeout, model, dispatch_id,
             )
             raise
 
-    stdout = result.stdout or ""
+    stdout = stdout_data or ""
     token_usage = _parse_kimi_token_usage(stdout)
     input_tokens = token_usage.get("input_tokens") if token_usage else None
     output_tokens = token_usage.get("output_tokens") if token_usage else None
@@ -126,9 +135,9 @@ def kimi_exec(
         metadata={"billing_mode": "subscription"},
     )
 
-    if result.returncode != 0:
+    if proc.returncode != 0:
         raise RuntimeError(
-            f"kimi_exec failed: returncode={result.returncode} stderr={result.stderr[:500]!r}"
+            f"kimi_exec failed: returncode={proc.returncode} stderr={stderr_data[:500]!r}"
         )
 
     return stdout

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -612,3 +612,74 @@ class TestKimiTimeout:
             consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
 
         assert captured["timeout"] == 42.0
+
+
+# ---------------------------------------------------------------------------
+# Entry-print: no more zero-output hangs
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPrint:
+    """run_dream_cycle prints cycle_id+project at entry — before any blocking call."""
+
+    def test_entry_print_emitted_on_skipped_cycle(self, tmp_path, capsys):
+        """Entry print fires even when the cycle skips due to missing receipts."""
+        db_path = tmp_path / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        with patch("consolidator.resolve_project_root", return_value=tmp_path):
+            consolidator.run_dream_cycle("vnx-dev", db_path)
+
+        out = capsys.readouterr().out
+        assert "dream run: cycle=" in out
+        assert "vnx-dev" in out
+
+    def test_entry_print_emitted_before_kimi_call(self, tmp_path, capsys):
+        """Entry print fires before any kimi invocation — ordering guarantee."""
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        call_order: list[str] = []
+
+        def _record_print(*args, **kwargs):
+            call_order.append("print")
+
+        def _fake_kimi(patterns, project_id, timeout=180.0):
+            call_order.append("kimi")
+            return _FAKE_CONSOLIDATION
+
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("builtins.print", side_effect=_record_print),
+            patch("consolidator._dispatch_kimi_consolidation", side_effect=_fake_kimi),
+        ):
+            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+
+        assert "print" in call_order
+        assert "kimi" in call_order
+        assert call_order.index("print") < call_order.index("kimi")
+
+    def test_empty_db_returns_skipped_under_5s(self, tmp_path):
+        """Empty DB with fresh receipts must return in <5s — no kimi spawn."""
+        import time
+        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+        called = []
+
+        def _no_kimi(*a, **kw):
+            called.append(True)
+            raise AssertionError("kimi must not be called on empty DB")
+
+        t0 = time.monotonic()
+        with (
+            patch("consolidator.resolve_project_root", return_value=tmp_path),
+            patch("consolidator._dispatch_kimi_consolidation", side_effect=_no_kimi),
+        ):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+        elapsed = time.monotonic() - t0
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "insufficient_data"
+        assert not called, "kimi was invoked on empty DB"
+        assert elapsed < 5.0, f"took {elapsed:.2f}s — exceeded 5s threshold"

--- a/tests/test_kimi_wrapper.py
+++ b/tests/test_kimi_wrapper.py
@@ -5,16 +5,17 @@ Tests:
 - stdin=DEVNULL per cli-headless-subprocess-pattern
 - Token usage is extracted from stream-json output
 - emit_provider_cost called with cost_usd_estimate=None (subscription-flat)
-- TimeoutExpired propagates
+- TimeoutExpired propagates + kills entire process group (pipe-hold fix)
 - Non-zero returncode raises RuntimeError
 """
 
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -41,12 +42,12 @@ _KIMI_NDJSON_NO_USAGE = (
 )
 
 
-def _make_run_result(stdout="", returncode=0):
-    result = MagicMock(spec=subprocess.CompletedProcess)
-    result.stdout = stdout
-    result.stderr = ""
-    result.returncode = returncode
-    return result
+def _make_popen_result(stdout="", returncode=0, pid=12345):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = (stdout, "")
+    mock_proc.returncode = returncode
+    mock_proc.pid = pid
+    return mock_proc
 
 
 # ---------------------------------------------------------------------------
@@ -56,14 +57,15 @@ def _make_run_result(stdout="", returncode=0):
 class TestKimiExec:
     def test_subprocess_called_with_p_flag(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result()
 
-        with patch("kimi_wrapper.subprocess.run", return_value=_make_run_result()) as mock_run, \
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch("provider_costs.emit_provider_cost"):
 
             kimi_wrapper.kimi_exec("my prompt", dispatch_id="d-k001")
 
-        mock_run.assert_called_once()
-        args, kwargs = mock_run.call_args
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
         cmd = args[0]
         assert "kimi" in cmd
         assert "-p" in cmd
@@ -74,21 +76,24 @@ class TestKimiExec:
 
     def test_stdin_is_devnull(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result()
 
-        with patch("kimi_wrapper.subprocess.run", return_value=_make_run_result()) as mock_run, \
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch("provider_costs.emit_provider_cost"):
 
             kimi_wrapper.kimi_exec("prompt", dispatch_id="d-k002")
 
-        _, kwargs = mock_run.call_args
-        # stdin is handled via open(os.devnull) context manager and passed as stdin
+        _, kwargs = mock_popen.call_args
         assert kwargs.get("text") is True
+        # stdin is open(os.devnull) — verify start_new_session for process group isolation
+        assert kwargs.get("start_new_session") is True
 
     def test_returns_stdout(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
         expected = '{"event_type":"complete"}\n'
+        mock_proc = _make_popen_result(stdout=expected)
 
-        with patch("kimi_wrapper.subprocess.run", return_value=_make_run_result(stdout=expected)), \
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
              patch("provider_costs.emit_provider_cost"):
 
             result = kimi_wrapper.kimi_exec("test", dispatch_id="d-k003")
@@ -97,8 +102,9 @@ class TestKimiExec:
 
     def test_emit_called_with_subscription_flat(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result()
 
-        with patch("kimi_wrapper.subprocess.run", return_value=_make_run_result()), \
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
              patch("provider_costs.emit_provider_cost") as mock_emit:
 
             kimi_wrapper.kimi_exec("prompt", model="kimi-k2.6", dispatch_id="d-k004")
@@ -112,15 +118,58 @@ class TestKimiExec:
 
     def test_timeout_propagates(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="kimi", timeout=1)
+        mock_proc.pid = 12345
 
-        with patch("kimi_wrapper.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="kimi", timeout=1)):
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("kimi_wrapper.os.killpg"), \
+             patch("kimi_wrapper.os.getpgid", return_value=12345):
             with pytest.raises(subprocess.TimeoutExpired):
                 kimi_wrapper.kimi_exec("prompt", timeout=1)
 
+    def test_process_group_killed_on_timeout(self, monkeypatch):
+        """On timeout, os.killpg kills the entire process group — not just the parent.
+
+        This prevents pipe-hold hangs where kimi's child processes survive after
+        the parent is killed and keep stdout/stderr pipes open indefinitely.
+        """
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="kimi", timeout=1)
+        mock_proc.pid = 42
+        mock_proc.wait.return_value = None
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("kimi_wrapper.os.killpg") as mock_killpg, \
+             patch("kimi_wrapper.os.getpgid", return_value=99) as mock_getpgid:
+            with pytest.raises(subprocess.TimeoutExpired):
+                kimi_wrapper.kimi_exec("prompt", timeout=1)
+
+        mock_getpgid.assert_called_once_with(42)
+        mock_killpg.assert_called_once_with(99, signal.SIGKILL)
+        mock_proc.wait.assert_called_once()
+
+    def test_process_lookup_error_on_killpg_is_swallowed(self, monkeypatch):
+        """ProcessLookupError during killpg is silenced — process already gone."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="kimi", timeout=1)
+        mock_proc.pid = 42
+        mock_proc.wait.return_value = None
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("kimi_wrapper.os.killpg", side_effect=ProcessLookupError), \
+             patch("kimi_wrapper.os.getpgid", return_value=99):
+            with pytest.raises(subprocess.TimeoutExpired):
+                kimi_wrapper.kimi_exec("prompt", timeout=1)
+        # If we reach here without further exception, the swallow worked.
+
     def test_nonzero_returncode_raises(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result(returncode=1)
 
-        with patch("kimi_wrapper.subprocess.run", return_value=_make_run_result(returncode=1)), \
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
              patch("provider_costs.emit_provider_cost"):
 
             with pytest.raises(RuntimeError, match="kimi_exec failed"):


### PR DESCRIPTION
## Root Cause

`subprocess.run` with `start_new_session=True` sends SIGKILL to the **parent** kimi process on `TimeoutExpired`. Kimi 1.44.0 spawns child processes (networking, session daemon) that survive and continue holding the stdout/stderr pipes open. Python's `communicate()` then blocks in `selectors.select()` waiting for EOF — indefinitely.

Stack trace captured before fix:
```
consolidator.py:264 → _dispatch_kimi_consolidation
kimi_wrapper.py:96 → subprocess.run
subprocess.py → communicate → _communicate → selectors.select (HUNG HERE)
```

The `#711` GAP-7 guards (receipt preflight + insufficient-data) are correctly implemented and work when triggered. The persistent hang occurs on the **non-empty DB path** because it reaches `kimi_exec` and `communicate()` never returns.

## Fix

**`scripts/lib/kimi_wrapper.py`**: Replace `subprocess.run` with `Popen` + manual `communicate`. On `TimeoutExpired`, kill the **entire process group** via `os.killpg(os.getpgid(proc.pid), SIGKILL)`. Since `start_new_session=True` is already set, kimi is its own process group leader — all pipe-holding children are torn down atomically.

**`scripts/dream/consolidator.py`**: Add `print(f"dream run: cycle={cycle_id} project={project_id}", flush=True)` at entry of `run_dream_cycle`. No more zero-output hangs — if it blocks after this line, the cycle ID is visible for diagnosis.

## Verification

**Before fix** (stack trace evidence):
```
subprocess.py:2115 in _communicate: ready = selector.select(timeout)  ← hung here
```

**After fix — kimi timeout resolves in exactly timeout+epsilon:**
```
kimi_exec timed out after 2s (model=kimi-k2.6 dispatch=None)
Exception TimeoutExpired in 2.01s
```

**Empty DB with fresh receipts returns in <5ms:**
```
dream run: cycle=dream-20260529-152755-bd1c75e0 project=vnx-dev
Returned in 0.001s
{"status": "skipped", "cycle_id": "...", "reason": "insufficient_data", "detail": "core_count=0"}
```
No kimi process spawned. ✓

## Test Plan
- `pytest tests/test_kimi_wrapper.py tests/test_dream_consolidator.py tests/test_dream_cli.py tests/test_dream_scheduler.py tests/test_memory_consolidator.py -q` → **84 passed**
- New tests: `test_process_group_killed_on_timeout`, `test_process_lookup_error_on_killpg_is_swallowed`, `test_empty_db_returns_skipped_under_5s`, `test_entry_print_emitted_on_skipped_cycle`, `test_entry_print_emitted_before_kimi_call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)