### PR TITLE
feat(dispatch): atomic claim_next_queued_dispatch + migration 0026 (PR-N-1)

### DIFF
--- a/schemas/migrations/0026_dispatch_claim.sql
+++ b/schemas/migrations/0026_dispatch_claim.sql
@@ -1,0 +1,50 @@
+-- 0026_dispatch_claim.sql
+-- N-1 queue claim primitive: columns + index for atomic dispatch claiming.
+--
+-- Purpose: Add claimed_by + claimed_at provenance columns to dispatches;
+--          add composite covering index on (project_id, state, priority,
+--          created_at) for the claim_next_queued_dispatch query.
+--
+-- ADR-007 binding: claim query and claimed_by/claimed_at state are
+--          project_id-scoped. A claimer for project A MUST NEVER see
+--          project B queued rows.
+--          See docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+--
+-- Target DB: runtime_coordination.db
+-- Applied by: scripts/lib/migrations/apply_0026.py
+-- Tested by:  tests/test_claim_next_queued_dispatch.py
+--
+-- Idempotency: guarded by apply_0026.py — checks runtime_schema_version
+--              and column existence before running ALTER TABLE; stamps v15
+--              on success. The ALTER TABLE statements in this file are
+--              executed only when the Python runner confirms they are safe.
+--
+-- Pre-migration state  (v14, after 0020): dispatches has no claimed_by/claimed_at.
+-- Post-migration state (v15): claimed_by TEXT, claimed_at TEXT, composite index.
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN TRANSACTION;
+
+-- claimed_by: terminal_id that atomically pulled this dispatch from the queue.
+-- claimed_at: UTC timestamp of the claim operation.
+-- Both are project_id-scoped via the claim query (ADR-007).
+ALTER TABLE dispatches ADD COLUMN claimed_by TEXT;
+ALTER TABLE dispatches ADD COLUMN claimed_at TEXT;
+
+-- Composite covering index for claim_next_queued_dispatch:
+--   SELECT dispatch_id FROM dispatches
+--   WHERE project_id = ? AND state = 'queued'
+--   ORDER BY priority ASC, created_at ASC LIMIT 1
+CREATE INDEX IF NOT EXISTS idx_dispatch_project_state_claim
+    ON dispatches(project_id, state, priority, created_at);
+
+INSERT OR IGNORE INTO runtime_schema_version (version, description)
+VALUES (
+    15,
+    'N-1 PR-N-1: claimed_by/claimed_at columns + project_state index for atomic queue claim'
+);
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;

--- a/scripts/lib/migrations/apply_0026.py
+++ b/scripts/lib/migrations/apply_0026.py
@@ -1,0 +1,176 @@
+"""apply_0026.py — N-1 dispatch claim primitive migration.
+
+Applies 0026_dispatch_claim.sql logic to runtime_coordination.db:
+  - Adds claimed_by TEXT column to dispatches (if absent)
+  - Adds claimed_at TEXT column to dispatches (if absent)
+  - Creates composite covering index idx_dispatch_project_state_claim
+  - Stamps runtime_schema_version with v15
+
+Idempotent: skips if MAX(version) >= 15. Column existence checked
+individually so partial re-runs (e.g. claimed_by added, claimed_at missing)
+complete safely. CREATE INDEX IF NOT EXISTS handles re-runs.
+
+ADR-007: claimed_by/claimed_at are project_id-scoped. The composite index
+and claim query in claim_next_queued_dispatch ensure cross-project isolation.
+See docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md.
+
+ADR-005: emits NDJSON audit events to .vnx-data/events/schema_migrations.ndjson.
+
+Tested by: tests/test_claim_next_queued_dispatch.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+from coordination_db import get_connection_for_db
+
+log = logging.getLogger(__name__)
+
+_TARGET_VERSION = 15
+_MIGRATION_NAME = "0026_dispatch_claim"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DEFAULT_MIGRATION_SQL = _REPO_ROOT / "schemas" / "migrations" / "0026_dispatch_claim.sql"
+
+
+def _emit_migration_event(vnx_data_dir: Path, event_type: str, payload: dict) -> None:
+    events_path = vnx_data_dir / "events" / "schema_migrations.ndjson"
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event_type": event_type,
+        "source": "schema_migration",
+        "migration": _MIGRATION_NAME,
+        **payload,
+    }
+    with open(events_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event) + "\n")
+
+
+def _col_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """Return True if *column* exists in *table* (checked via PRAGMA table_info)."""
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def apply_migration(
+    db_path: Path,
+    migration_sql_path: Path,
+    vnx_data_dir: Path | None = None,
+) -> bool:
+    """Apply the 0026 up-migration to db_path.
+
+    Returns True when applied, False when the DB was already at or above
+    the target version (idempotent skip). Raises sqlite3.Error on failure.
+
+    migration_sql_path is accepted for API compatibility with auto_apply;
+    the actual schema changes are applied directly via Python for column
+    existence guards.
+    """
+    if vnx_data_dir is None:
+        vnx_data_dir = Path(db_path).parent.parent
+
+    current_version = 0
+
+    with get_connection_for_db(db_path) as conn:
+        try:
+            row = conn.execute(
+                "SELECT MAX(version) FROM runtime_schema_version"
+            ).fetchone()
+            current_version = int(row[0]) if (row and row[0] is not None) else 0
+
+            if current_version >= _TARGET_VERSION:
+                log.info("apply_0026: already at v%s; idempotent skip", _TARGET_VERSION)
+                return False
+
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_started",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
+            )
+
+            # Self-heal: project_id is required for the composite index (added by migration 0010).
+            # On DBs that skipped 0010 (e.g. fresh test installs), add it here.
+            if not _col_exists(conn, "dispatches", "project_id"):
+                conn.execute(
+                    "ALTER TABLE dispatches ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev'"
+                )
+
+            # Add claimed_by + claimed_at columns (idempotent: check each individually)
+            if not _col_exists(conn, "dispatches", "claimed_by"):
+                conn.execute("ALTER TABLE dispatches ADD COLUMN claimed_by TEXT")
+            if not _col_exists(conn, "dispatches", "claimed_at"):
+                conn.execute("ALTER TABLE dispatches ADD COLUMN claimed_at TEXT")
+
+            # Composite covering index for claim query (IF NOT EXISTS = safe on re-run)
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_dispatch_project_state_claim
+                    ON dispatches(project_id, state, priority, created_at)
+                """
+            )
+
+            # Stamp version
+            conn.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (?, ?)",
+                (
+                    _TARGET_VERSION,
+                    "N-1 PR-N-1: claimed_by/claimed_at columns + project_state index for atomic queue claim",
+                ),
+            )
+            conn.commit()
+
+            log.info(
+                "apply_0026: migrated from v%s to v%s", current_version, _TARGET_VERSION
+            )
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_completed",
+                {"from_version": current_version, "to_version": _TARGET_VERSION},
+            )
+            return True
+
+        except sqlite3.Error as e:
+            conn.rollback()
+            log.error("apply_0026: error during migration; transaction rolled back")
+            _emit_migration_event(
+                vnx_data_dir,
+                "migration_failed",
+                {"from_version": current_version, "error": str(e)},
+            )
+            raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    p = argparse.ArgumentParser(
+        description="Apply 0026 dispatch claim migration (N-1 PR-N-1)"
+    )
+    p.add_argument("--db", required=True, help="Path to runtime_coordination.db")
+    p.add_argument(
+        "--migration",
+        default=str(_DEFAULT_MIGRATION_SQL),
+        help="Path to 0026_dispatch_claim.sql",
+    )
+    p.add_argument(
+        "--vnx-data-dir",
+        default=None,
+        help="Path to .vnx-data directory for audit events",
+    )
+    args = p.parse_args()
+    applied = apply_migration(
+        Path(args.db),
+        Path(args.migration),
+        Path(args.vnx_data_dir) if args.vnx_data_dir else None,
+    )
+    print("applied" if applied else "skipped (already at target version)")

--- a/scripts/lib/migrations/apply_0026.py
+++ b/scripts/lib/migrations/apply_0026.py
@@ -37,6 +37,7 @@ from coordination_db import get_connection_for_db
 log = logging.getLogger(__name__)
 
 _TARGET_VERSION = 15
+_PREDECESSOR_VERSION = 14  # 0020 elastic worker pool
 _MIGRATION_NAME = "0026_dispatch_claim"
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -92,6 +93,13 @@ def apply_migration(
             if current_version >= _TARGET_VERSION:
                 log.info("apply_0026: already at v%s; idempotent skip", _TARGET_VERSION)
                 return False
+
+            if current_version != _PREDECESSOR_VERSION:
+                raise RuntimeError(
+                    f"apply_0026: requires predecessor v{_PREDECESSOR_VERSION} "
+                    f"(0020 elastic worker pool); DB is at v{current_version}. "
+                    f"Run migrations 0019 and 0020 first."
+                )
 
             _emit_migration_event(
                 vnx_data_dir,

--- a/scripts/lib/runtime_coordination.py
+++ b/scripts/lib/runtime_coordination.py
@@ -41,6 +41,7 @@ from coordination_db import (  # noqa: F401
 # Re-exports from runtime_state_machine
 from runtime_state_machine import (  # noqa: F401
     _check_idempotent_noop,
+    claim_next_queued_dispatch,
     create_attempt,
     increment_attempt_count,
     is_accepted_or_beyond,

--- a/scripts/lib/runtime_state_machine.py
+++ b/scripts/lib/runtime_state_machine.py
@@ -251,6 +251,86 @@ def create_attempt(
     )
 
 
+def claim_next_queued_dispatch(
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    project_id: str,
+    actor: str = "runtime",
+) -> Optional[str]:
+    """Atomically claim the next queued dispatch for a project.
+
+    Uses BEGIN IMMEDIATE to serialize concurrent claimers — SQLite has no
+    SKIP LOCKED; this ensures the SELECT→UPDATE is atomic across writers.
+    Losers serialize and re-query; they get the next row or None.
+    Returns the dispatch_id string if a dispatch was claimed, None if the
+    queue is empty for this project.
+
+    ADR-007: scoped to project_id — a claimer for project A NEVER sees
+    project B queued rows. project_id is MANDATORY on every access.
+    See docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md.
+
+    Callers must pass a connection with no uncommitted DML. Setting
+    isolation_level=None (required for explicit BEGIN IMMEDIATE) commits
+    any pending implicit transaction on the connection.
+    """
+    conn.isolation_level = None  # autocommit mode for manual BEGIN IMMEDIATE control
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        row = conn.execute(
+            """
+            SELECT dispatch_id FROM dispatches
+            WHERE project_id = ? AND state = 'queued'
+            ORDER BY priority ASC, created_at ASC
+            LIMIT 1
+            """,
+            (project_id,),
+        ).fetchone()
+
+        if row is None:
+            conn.execute("ROLLBACK")
+            return None
+
+        dispatch_id = row["dispatch_id"]
+        now = _now_utc()
+
+        # State transition: queued → claimed (validates + appends coordination event)
+        transition_dispatch(
+            conn,
+            dispatch_id=dispatch_id,
+            to_state="claimed",
+            actor=actor,
+            reason=f"queue claim by terminal {terminal_id}",
+            metadata={"terminal_id": terminal_id, "project_id": project_id},
+        )
+
+        # Update terminal_id and claim provenance columns (ADR-007: scoped by project_id)
+        table_cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatches)").fetchall()}
+        if "claimed_by" in table_cols:
+            conn.execute(
+                """
+                UPDATE dispatches
+                SET terminal_id = ?, claimed_by = ?, claimed_at = ?
+                WHERE dispatch_id = ? AND project_id = ?
+                """,
+                (terminal_id, terminal_id, now, dispatch_id, project_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE dispatches SET terminal_id = ? WHERE dispatch_id = ? AND project_id = ?",
+                (terminal_id, dispatch_id, project_id),
+            )
+
+        conn.execute("COMMIT")
+        return dispatch_id
+
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        raise
+
+
 def update_attempt(
     conn: sqlite3.Connection,
     *,

--- a/scripts/lib/runtime_state_machine.py
+++ b/scripts/lib/runtime_state_machine.py
@@ -293,17 +293,21 @@ def claim_next_queued_dispatch(
         dispatch_id = row["dispatch_id"]
         now = _now_utc()
 
-        # State transition: queued → claimed (validates + appends coordination event)
-        transition_dispatch(
-            conn,
-            dispatch_id=dispatch_id,
-            to_state="claimed",
-            actor=actor,
-            reason=f"queue claim by terminal {terminal_id}",
+        # State transition: queued → claimed — composite key (ADR-007: never dispatch_id alone)
+        validate_dispatch_transition("queued", "claimed")
+        conn.execute(
+            "UPDATE dispatches SET state = 'claimed', updated_at = ? WHERE dispatch_id = ? AND project_id = ?",
+            (now, dispatch_id, project_id),
+        )
+        _append_event(
+            conn, event_type="dispatch_claimed", entity_type="dispatch",
+            entity_id=dispatch_id, from_state="queued", to_state="claimed",
+            actor=actor, reason=f"queue claim by terminal {terminal_id}",
             metadata={"terminal_id": terminal_id, "project_id": project_id},
+            project_id=project_id,
         )
 
-        # Update terminal_id and claim provenance columns (ADR-007: scoped by project_id)
+        # Provenance columns: claimed_by / claimed_at (ADR-007: composite key; ADR-005: audit event)
         table_cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatches)").fetchall()}
         if "claimed_by" in table_cols:
             conn.execute(
@@ -319,6 +323,17 @@ def claim_next_queued_dispatch(
                 "UPDATE dispatches SET terminal_id = ? WHERE dispatch_id = ? AND project_id = ?",
                 (terminal_id, dispatch_id, project_id),
             )
+        # ADR-005: ledger event for claimed_by/claimed_at provenance mutation
+        _append_event(
+            conn, event_type="dispatch_claim_provenance", entity_type="dispatch",
+            entity_id=dispatch_id, from_state=None, to_state=None,
+            actor=actor, reason=f"claim provenance stamped by terminal {terminal_id}",
+            metadata={
+                "terminal_id": terminal_id, "claimed_by": terminal_id,
+                "claimed_at": now, "dispatch_id": dispatch_id, "project_id": project_id,
+            },
+            project_id=project_id,
+        )
 
         conn.execute("COMMIT")
         return dispatch_id

--- a/tests/test_claim_next_queued_dispatch.py
+++ b/tests/test_claim_next_queued_dispatch.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import threading
@@ -43,6 +44,12 @@ _mod = _ilu.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 apply_migration_0026 = _mod.apply_migration
 
+_RUNNER_PATH_0017 = SCRIPT_DIR / "lib" / "migrations" / "apply_0017.py"
+_spec_0017 = _ilu.spec_from_file_location("apply_0017", _RUNNER_PATH_0017)
+_mod_0017 = _ilu.module_from_spec(_spec_0017)
+_spec_0017.loader.exec_module(_mod_0017)
+_rebuild_dispatches_composite = _mod_0017._rebuild_dispatches
+
 _MIGRATION_SQL = Path(__file__).resolve().parent.parent / "schemas" / "migrations" / "0026_dispatch_claim.sql"
 
 
@@ -58,7 +65,23 @@ class _DbTestCase(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.state_dir = self._tmpdir.name
         init_schema(self.state_dir)
+        # Stamp v13/v14 so apply_0026 predecessor guard passes (0019 and 0020 not applied here)
+        with get_connection(self.state_dir) as c:
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (13, 'test-stub: 0019 T0 lifecycle tokens')"
+            )
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (14, 'test-stub: 0020 elastic worker pool')"
+            )
+            c.commit()
         _apply_0026(self.state_dir)
+        # Apply composite UNIQUE(dispatch_id, project_id) after apply_0026 adds project_id.
+        # init_schema v10.sql CREATE TABLE IF NOT EXISTS is a no-op (table exists from v1);
+        # apply_0017 skips (version already 12); rebuild directly so same-dispatch_id
+        # cross-project tests can insert two rows with the same dispatch_id.
+        with get_connection(self.state_dir) as c:
+            _rebuild_dispatches_composite(c)
+            c.commit()
 
     def tearDown(self):
         self._tmpdir.cleanup()
@@ -182,6 +205,30 @@ class TestClaimCrossProjectIsolation(_DbTestCase):
         self.assertEqual(row_a["project_id"], "project-a")
         self.assertEqual(row_b["project_id"], "project-b")
 
+    def test_same_dispatch_id_only_transitions_own_project(self):
+        """ADR-007: same dispatch_id in two projects; claiming project-A ONLY transitions project-A row."""
+        self._insert_queued("shared-dispatch-001", project_id="project-a")
+        self._insert_queued("shared-dispatch-001", project_id="project-b")
+
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "project-a")
+
+        self.assertEqual(result, "shared-dispatch-001")
+
+        with self.conn() as c:
+            row_a = c.execute(
+                "SELECT state, terminal_id FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+                ("shared-dispatch-001", "project-a"),
+            ).fetchone()
+            row_b = c.execute(
+                "SELECT state FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+                ("shared-dispatch-001", "project-b"),
+            ).fetchone()
+
+        self.assertEqual(row_a["state"], "claimed", "project-a row must be claimed")
+        self.assertEqual(row_a["terminal_id"], "T1", "project-a terminal_id must be T1")
+        self.assertEqual(row_b["state"], "queued", "project-b row must not be affected")
+
 
 class TestClaimConcurrency(_DbTestCase):
     """10 threads × 5 queued dispatches → 5 distinct claims, 5 None, zero double-claims."""
@@ -266,6 +313,15 @@ class TestMigration0026Idempotency(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.state_dir = self._tmpdir.name
         init_schema(self.state_dir)
+        # Stamp v13/v14 so apply_0026 predecessor guard passes
+        with get_connection(self.state_dir) as c:
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (13, 'test-stub: 0019 T0 lifecycle tokens')"
+            )
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (14, 'test-stub: 0020 elastic worker pool')"
+            )
+            c.commit()
 
     def tearDown(self):
         self._tmpdir.cleanup()
@@ -343,6 +399,86 @@ class TestMigration0026Idempotency(unittest.TestCase):
             ).fetchone()
         self.assertIsNotNone(row)
         self.assertEqual(row["version"], 15)
+
+
+class TestMigration0026PredecessorGuard(unittest.TestCase):
+    """Migration 0026 must refuse if DB is below predecessor v14 (ADR-007 migration safety)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.state_dir = self._tmpdir.name
+        init_schema(self.state_dir)  # leaves at v12 — below predecessor v14
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_refuses_on_db_below_predecessor(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            _apply_0026(self.state_dir)
+        self.assertIn("requires predecessor", str(ctx.exception))
+        self.assertIn("14", str(ctx.exception))
+
+    def test_accepts_on_correct_predecessor_and_is_idempotent(self):
+        with get_connection(self.state_dir) as c:
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (13, 'test-stub')"
+            )
+            c.execute(
+                "INSERT OR IGNORE INTO runtime_schema_version (version, description) VALUES (14, 'test-stub')"
+            )
+            c.commit()
+        applied = _apply_0026(self.state_dir)
+        self.assertTrue(applied, "first apply on v14 DB must return True")
+
+        applied_again = _apply_0026(self.state_dir)
+        self.assertFalse(applied_again, "second apply must be idempotent skip")
+
+
+class TestClaimProvenanceAudit(_DbTestCase):
+    """ADR-005: claim mutation emits one dispatch_claim_provenance event with full provenance."""
+
+    def test_claim_emits_one_provenance_event(self):
+        self._insert_queued("prov-001", project_id="test-proj")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T1", "test-proj")
+
+        with self.conn() as c:
+            rows = c.execute(
+                "SELECT entity_id, metadata_json FROM coordination_events "
+                "WHERE event_type = 'dispatch_claim_provenance' AND entity_id = ?",
+                ("prov-001",),
+            ).fetchall()
+
+        self.assertEqual(len(rows), 1, "exactly one provenance event per claim")
+        meta = json.loads(rows[0]["metadata_json"])
+        self.assertEqual(meta["terminal_id"], "T1")
+        self.assertEqual(meta["project_id"], "test-proj")
+        self.assertEqual(meta["dispatch_id"], "prov-001")
+        self.assertIn("claimed_by", meta)
+        self.assertIn("claimed_at", meta)
+
+    def test_no_provenance_event_on_empty_queue(self):
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "test-proj")
+        self.assertIsNone(result)
+
+        with self.conn() as c:
+            row = c.execute(
+                "SELECT COUNT(*) as cnt FROM coordination_events "
+                "WHERE event_type = 'dispatch_claim_provenance'"
+            ).fetchone()
+        self.assertEqual(row["cnt"], 0)
+
+    def test_provenance_event_entity_id_matches_dispatch_id(self):
+        self._insert_queued("prov-002", project_id="test-proj")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T2", "test-proj")
+
+        with self.conn() as c:
+            row = c.execute(
+                "SELECT entity_id FROM coordination_events WHERE event_type = 'dispatch_claim_provenance'"
+            ).fetchone()
+        self.assertEqual(row["entity_id"], "prov-002")
 
 
 if __name__ == "__main__":

--- a/tests/test_claim_next_queued_dispatch.py
+++ b/tests/test_claim_next_queued_dispatch.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Tests for claim_next_queued_dispatch — N-1 queue claim primitive.
+
+Covers:
+  - Basic claim from non-empty queue
+  - Empty queue returns None
+  - Audit event emitted per claim
+  - claimed_by / claimed_at provenance columns set
+  - terminal_id updated on the dispatch row
+  - Cross-project isolation: project-A claimer never sees project-B rows (ADR-007)
+  - Concurrency: 10 threads × 5 queued dispatches → exactly 5 distinct claims,
+    5 None returns, zero double-claims
+  - Migration 0026 idempotency: run twice, no error, existing rows preserved
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR / "lib" / "migrations"))
+
+from coordination_db import DB_FILENAME, db_path_from_state_dir
+from runtime_coordination import (
+    claim_next_queued_dispatch,
+    get_connection,
+    get_events,
+    init_schema,
+    register_dispatch,
+)
+
+# Import migration runner directly
+import importlib.util as _ilu
+
+_RUNNER_PATH = SCRIPT_DIR / "lib" / "migrations" / "apply_0026.py"
+_spec = _ilu.spec_from_file_location("apply_0026", _RUNNER_PATH)
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+apply_migration_0026 = _mod.apply_migration
+
+_MIGRATION_SQL = Path(__file__).resolve().parent.parent / "schemas" / "migrations" / "0026_dispatch_claim.sql"
+
+
+def _apply_0026(state_dir: str) -> bool:
+    db_path = db_path_from_state_dir(state_dir)
+    return apply_migration_0026(db_path, _MIGRATION_SQL)
+
+
+class _DbTestCase(unittest.TestCase):
+    """Base: temp dir + schema init + migration 0026 applied."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.state_dir = self._tmpdir.name
+        init_schema(self.state_dir)
+        _apply_0026(self.state_dir)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def conn(self):
+        return get_connection(self.state_dir)
+
+    def _insert_queued(self, dispatch_id: str, project_id: str = "test-proj", priority: str = "P2") -> None:
+        """Insert a queued dispatch directly (bypasses register_dispatch default project_id)."""
+        with self.conn() as c:
+            c.execute(
+                "INSERT INTO dispatches (dispatch_id, project_id, state, priority) VALUES (?, ?, 'queued', ?)",
+                (dispatch_id, project_id, priority),
+            )
+            c.commit()
+
+
+class TestClaimBasic(_DbTestCase):
+
+    def test_claim_returns_dispatch_id(self):
+        self._insert_queued("d-001")
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "test-proj")
+        self.assertEqual(result, "d-001")
+
+    def test_claim_empty_queue_returns_none(self):
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "test-proj")
+        self.assertIsNone(result)
+
+    def test_claim_transitions_state_to_claimed(self):
+        self._insert_queued("d-002")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T1", "test-proj")
+        with self.conn() as c:
+            row = c.execute(
+                "SELECT state FROM dispatches WHERE dispatch_id = ?", ("d-002",)
+            ).fetchone()
+        self.assertEqual(row["state"], "claimed")
+
+    def test_claim_sets_terminal_id(self):
+        self._insert_queued("d-003")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T2", "test-proj")
+        with self.conn() as c:
+            row = c.execute(
+                "SELECT terminal_id FROM dispatches WHERE dispatch_id = ?", ("d-003",)
+            ).fetchone()
+        self.assertEqual(row["terminal_id"], "T2")
+
+    def test_claim_sets_claimed_by_and_claimed_at(self):
+        self._insert_queued("d-004")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T3", "test-proj")
+        with self.conn() as c:
+            row = c.execute(
+                "SELECT claimed_by, claimed_at FROM dispatches WHERE dispatch_id = ?", ("d-004",)
+            ).fetchone()
+        self.assertEqual(row["claimed_by"], "T3")
+        self.assertIsNotNone(row["claimed_at"])
+
+    def test_claim_appends_dispatch_claimed_event(self):
+        self._insert_queued("d-005")
+        with self.conn() as c:
+            claim_next_queued_dispatch(c, "T1", "test-proj")
+        with self.conn() as c:
+            events = get_events(c, entity_id="d-005")
+        event_types = [e["event_type"] for e in events]
+        self.assertIn("dispatch_claimed", event_types)
+
+    def test_second_claim_on_same_dispatch_fails(self):
+        """Once claimed, the dispatch is no longer in 'queued' state — next caller gets None."""
+        self._insert_queued("d-006")
+        with self.conn() as c:
+            r1 = claim_next_queued_dispatch(c, "T1", "test-proj")
+        with self.conn() as c:
+            r2 = claim_next_queued_dispatch(c, "T2", "test-proj")
+        self.assertEqual(r1, "d-006")
+        self.assertIsNone(r2)
+
+    def test_priority_ordering_p1_before_p2(self):
+        """P1 dispatches are claimed before P2 (alphabetical ASC ordering)."""
+        self._insert_queued("d-p2", priority="P2")
+        self._insert_queued("d-p1", priority="P1")
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "test-proj")
+        self.assertEqual(result, "d-p1")
+
+
+class TestClaimCrossProjectIsolation(_DbTestCase):
+    """ADR-007: project-A claimer must never see project-B queued rows."""
+
+    def test_claimer_does_not_see_other_project_rows(self):
+        self._insert_queued("proj-b-001", project_id="project-b")
+
+        with self.conn() as c:
+            result = claim_next_queued_dispatch(c, "T1", "project-a")
+
+        self.assertIsNone(result, "project-a claimer must not claim project-b dispatch")
+
+    def test_claimer_only_claims_own_project(self):
+        self._insert_queued("proj-a-001", project_id="project-a")
+        self._insert_queued("proj-b-001", project_id="project-b")
+
+        with self.conn() as c:
+            result_a = claim_next_queued_dispatch(c, "T1", "project-a")
+        with self.conn() as c:
+            result_b = claim_next_queued_dispatch(c, "T1", "project-b")
+
+        self.assertEqual(result_a, "proj-a-001")
+        self.assertEqual(result_b, "proj-b-001")
+
+        # project-a dispatch must NOT be in project-b and vice versa
+        with self.conn() as c:
+            row_a = c.execute(
+                "SELECT project_id FROM dispatches WHERE dispatch_id = ?", ("proj-a-001",)
+            ).fetchone()
+            row_b = c.execute(
+                "SELECT project_id FROM dispatches WHERE dispatch_id = ?", ("proj-b-001",)
+            ).fetchone()
+        self.assertEqual(row_a["project_id"], "project-a")
+        self.assertEqual(row_b["project_id"], "project-b")
+
+
+class TestClaimConcurrency(_DbTestCase):
+    """10 threads × 5 queued dispatches → 5 distinct claims, 5 None, zero double-claims."""
+
+    def setUp(self):
+        super().setUp()
+        # Insert 5 queued dispatches
+        for i in range(5):
+            self._insert_queued(f"d-conc-{i:03d}", project_id="concurrent-proj")
+
+    def test_10_threads_5_dispatches_no_double_claim(self):
+        results: list = []
+        lock = threading.Lock()
+        errors: list = []
+
+        def worker(n: int) -> None:
+            try:
+                with get_connection(self.state_dir) as c:
+                    res = claim_next_queued_dispatch(c, f"T{n % 4 + 1}", "concurrent-proj")
+                with lock:
+                    results.append(res)
+            except Exception as e:
+                with lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [], f"worker errors: {errors}")
+        self.assertEqual(len(results), 10, f"expected 10 results, got {len(results)}")
+
+        claimed = [r for r in results if r is not None]
+        none_returns = [r for r in results if r is None]
+
+        self.assertEqual(
+            len(claimed), 5,
+            f"expected exactly 5 claims, got {len(claimed)}: {claimed}",
+        )
+        self.assertEqual(
+            len(none_returns), 5,
+            f"expected exactly 5 None returns, got {len(none_returns)}",
+        )
+        self.assertEqual(
+            len(set(claimed)), 5,
+            f"duplicate claims detected: {claimed}",
+        )
+
+        # Verify each claimed dispatch has state='claimed' in DB
+        with self.conn() as c:
+            for dispatch_id in claimed:
+                row = c.execute(
+                    "SELECT state FROM dispatches WHERE dispatch_id = ?", (dispatch_id,)
+                ).fetchone()
+                self.assertEqual(
+                    row["state"], "claimed",
+                    f"dispatch {dispatch_id} state should be 'claimed', got {row['state']}",
+                )
+
+    def test_one_audit_event_per_claim(self):
+        """Each successful claim produces exactly one dispatch_claimed event."""
+        with self.conn() as c:
+            for i in range(5):
+                claim_next_queued_dispatch(c, "T1", "concurrent-proj")
+
+        with self.conn() as c:
+            rows = c.execute(
+                "SELECT entity_id FROM coordination_events WHERE event_type = 'dispatch_claimed'"
+            ).fetchall()
+        claimed_in_events = [r["entity_id"] for r in rows]
+        # 5 claims → 5 events (one per dispatch)
+        self.assertEqual(len(claimed_in_events), 5)
+        self.assertEqual(len(set(claimed_in_events)), 5)
+
+
+class TestMigration0026Idempotency(unittest.TestCase):
+    """Migration 0026 idempotency: run twice, no error, existing rows preserved."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.state_dir = self._tmpdir.name
+        init_schema(self.state_dir)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_first_apply_returns_true(self):
+        applied = _apply_0026(self.state_dir)
+        self.assertTrue(applied)
+
+    def test_second_apply_returns_false(self):
+        _apply_0026(self.state_dir)
+        applied = _apply_0026(self.state_dir)
+        self.assertFalse(applied)
+
+    def test_second_apply_no_error(self):
+        _apply_0026(self.state_dir)
+        try:
+            _apply_0026(self.state_dir)
+        except Exception as e:
+            self.fail(f"second apply raised: {e}")
+
+    def test_existing_dispatches_preserved_after_migration(self):
+        # Insert dispatch before migration
+        with get_connection(self.state_dir) as c:
+            c.execute(
+                "INSERT INTO dispatches (dispatch_id, state) VALUES ('pre-migration', 'queued')"
+            )
+            c.commit()
+
+        _apply_0026(self.state_dir)
+
+        # Row must still exist after migration
+        with get_connection(self.state_dir) as c:
+            row = c.execute(
+                "SELECT dispatch_id, state FROM dispatches WHERE dispatch_id = ?",
+                ("pre-migration",),
+            ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["dispatch_id"], "pre-migration")
+        self.assertEqual(row["state"], "queued")
+
+    def test_columns_exist_after_migration(self):
+        _apply_0026(self.state_dir)
+        db_path = db_path_from_state_dir(self.state_dir)
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(dispatches)").fetchall()}
+        finally:
+            conn.close()
+        self.assertIn("claimed_by", cols)
+        self.assertIn("claimed_at", cols)
+
+    def test_index_exists_after_migration(self):
+        _apply_0026(self.state_dir)
+        db_path = db_path_from_state_dir(self.state_dir)
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            idx_names = {
+                r["name"] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        self.assertIn("idx_dispatch_project_state_claim", idx_names)
+
+    def test_version_stamped_correctly(self):
+        _apply_0026(self.state_dir)
+        with get_connection(self.state_dir) as c:
+            row = c.execute(
+                "SELECT version FROM runtime_schema_version WHERE version = 15"
+            ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["version"], 15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `claim_next_queued_dispatch(conn, terminal_id, project_id, actor)` to `scripts/lib/runtime_state_machine.py`, re-exported from the `runtime_coordination` facade.
- Uses `BEGIN IMMEDIATE` to serialize concurrent claimers (SQLite has no `SKIP LOCKED`); losers re-query and get the next row or `None`.
- Migration `0026_dispatch_claim.sql` + `apply_0026.py`: adds `claimed_by`/`claimed_at` columns and composite covering index on `dispatches(project_id, state, priority, created_at)`.
- ADR-007 binding: `project_id` is mandatory on the claim query — cross-project claim is impossible by construction.

## Verify results

**Concurrency test**: 10 threads × 5 queued dispatches (same project) → exactly 5 distinct claims, 5 `None` returns, zero double-claims. Verified by `TestClaimConcurrency::test_10_threads_5_dispatches_no_double_claim`.

**Cross-project test**: project-A claimer never returns project-B rows. Verified by `TestClaimCrossProjectIsolation::test_claimer_does_not_see_other_project_rows` and `test_claimer_only_claims_own_project`.

**Migration idempotency**: run twice, no error, existing dispatches preserved. Verified by `TestMigration0026Idempotency` (6 tests).

**Test run**: `python3 -m pytest tests/test_claim_next_queued_dispatch.py -q` → **19 passed in 0.43s**

**Broader test suite** (`test_claim` + `test_runtime_coordination` + `test_get_terminal_claimed_by`): **97 passed**.

**Pre-existing failure note**: `tests/test_subprocess_f32_r3_claim_verification.py` hangs/fails due to a wrong mock patch target (introduced in PR #241, patches `subprocess_dispatch.SubprocessAdapter` instead of `subprocess_dispatch_internals.delivery.SubprocessAdapter`). Not introduced by this PR — confirmed by `git show --stat 087df38` which shows PR-N-1 touched only `runtime_state_machine.py`, `runtime_coordination.py`, `schemas/migrations/0026_dispatch_claim.sql`, `scripts/lib/migrations/apply_0026.py`, and `tests/test_claim_next_queued_dispatch.py`.

## Test plan
- [x] `pytest tests/test_claim_next_queued_dispatch.py` → 19/19 green
- [x] Concurrency: 10 threads × 5 dispatches, 5 distinct claims, 5 None, 0 double-claims
- [x] Cross-project isolation: project-A claimer never returns project-B rows
- [x] Migration idempotency: run twice, no error, rows preserved
- [x] `claimed_by`, `claimed_at` columns present after migration
- [x] `idx_dispatch_project_state_claim` index present after migration
- [x] Version stamped as v15 in `runtime_schema_version`
- [x] One `dispatch_claimed` audit event per claim (ADR-005 parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)