### PR TITLE
feat(ra4-human-gate): human approval gate primitive for roadmap advance

### DIFF
--- a/scripts/commands/roadmap.sh
+++ b/scripts/commands/roadmap.sh
@@ -4,14 +4,17 @@
 cmd_roadmap() {
   if [ "$#" -eq 0 ]; then
     cat <<'HELP'
-Usage: vnx roadmap <init|status|load|reconcile|advance> [args]
+Usage: vnx roadmap <init|status|load|reconcile|advance|approve> [args]
 
 Commands:
-  init <ROADMAP.yaml>    Initialize roadmap registry state
-  status                 Show current roadmap status
-  load <feature_id>      Materialize one feature into root FEATURE_PLAN.md + PR_QUEUE.md
-  reconcile              Verify closure truth and detect blocking drift
-  advance                Auto-load next feature after merged + verified closure
+  init <ROADMAP.yaml>                         Initialize roadmap registry state
+  status                                      Show current roadmap status
+  load <feature_id>                           Materialize one feature into root FEATURE_PLAN.md + PR_QUEUE.md
+  reconcile                                   Verify closure truth and detect blocking drift
+  advance                                     Auto-load next feature after merged + verified closure
+  approve <feature_id> --actor <name> --justification <text>
+                                              Issue a single-use human approval token (required for
+                                              merge_policy=human or risk_class=high features)
 HELP
     return 0
   fi

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -31,6 +31,8 @@ from vnx_worktree import worktree_start
 
 ALLOWED_DRIFT_CATEGORIES = {"bugfix", "post_cleanup", "governance_gap", "path/runtime regression"}
 
+APPROVALS_SUBDIR = "roadmap_approvals"
+
 
 def _root_file(project_root: Path, name: str) -> Path:
     return project_root / name
@@ -455,6 +457,87 @@ Implement the minimum blocking fix required before the roadmap may advance.
         )
         return result
 
+    def _approvals_dir(self) -> Path:
+        d = self.state_dir / APPROVALS_SUBDIR
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _approval_token_path(self, feature_id: str) -> Path:
+        safe_id = feature_id.replace("/", "_")
+        return self._approvals_dir() / f"{safe_id}.json"
+
+    def _feature_requires_human_approval(self, feature: Dict[str, Any]) -> bool:
+        """ADR-007: human gate required when merge_policy=human OR risk_class=high."""
+        return feature.get("merge_policy") == "human" or feature.get("risk_class") == "high"
+
+    def _load_valid_approval_token(self, feature_id: str) -> Optional[Dict[str, Any]]:
+        """Return an unconsumed, project_id-stamped, feature-pinned token — or None."""
+        token_path = self._approval_token_path(feature_id)
+        if not token_path.exists():
+            return None
+        try:
+            token = json.loads(token_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        if token.get("project_id") != self.project_id:
+            return None
+        if token.get("feature_id") != feature_id:
+            return None
+        if token.get("consumed"):
+            return None
+        return token
+
+    def _consume_approval_token(self, feature_id: str) -> None:
+        """Invalidate the token (single-use). Atomic write."""
+        token_path = self._approval_token_path(feature_id)
+        try:
+            token = json.loads(token_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, FileNotFoundError):
+            return
+        token["consumed"] = True
+        token["consumed_at"] = utc_now_iso()
+        tmp = token_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(token, indent=2), encoding="utf-8")
+        os.replace(str(tmp), str(token_path))
+
+    def approve(self, feature_id: str, actor: str, justification: str) -> Dict[str, Any]:
+        """Issue a single-use human approval token for feature_id.
+
+        ADR-007: token is project_id-stamped and feature-pinned.
+        """
+        state = self.load_state()
+        features = state.get("features") or []
+        feature = next((f for f in features if f["feature_id"] == feature_id), None)
+        if not feature:
+            raise ValueError(f"Unknown feature_id: {feature_id}")
+
+        issued_at = utc_now_iso()
+        token: Dict[str, Any] = {
+            "project_id": self.project_id,
+            "feature_id": feature_id,
+            "actor": actor,
+            "justification": justification,
+            "issued_at": issued_at,
+            "consumed": False,
+            "consumed_at": None,
+        }
+        token_path = self._approval_token_path(feature_id)
+        tmp = token_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(token, indent=2), encoding="utf-8")
+        os.replace(str(tmp), str(token_path))
+
+        emit_governance_receipt(
+            "roadmap_human_approval",
+            status="success",
+            action="approve",
+            project_id=self.project_id,
+            feature_id=feature_id,
+            actor=actor,
+            justification=justification,
+            issued_at=issued_at,
+        )
+        return token
+
     def advance(self) -> Dict[str, Any]:
         state = self.load_state()
         reconcile_result = self.reconcile()
@@ -473,6 +556,25 @@ Implement the minimum blocking fix required before the roadmap may advance.
 
         state = self.load_state()
         current_id = state.get("current_active_feature")
+
+        # Human approval gate: merge_policy=human OR risk_class=high requires a valid token.
+        # conditional_auto + low delegates to auto_merge_policy (no token required).
+        if current_id:
+            cur_feature = next((f for f in state.get("features", []) if f["feature_id"] == current_id), None)
+            if cur_feature and self._feature_requires_human_approval(cur_feature):
+                token = self._load_valid_approval_token(current_id)
+                if not token:
+                    return {"advanced": False, "reason": "awaiting_human_approval", "feature_id": current_id}
+                self._consume_approval_token(current_id)
+                emit_governance_receipt(
+                    "roadmap_human_approval",
+                    status="success",
+                    action="consumed",
+                    project_id=self.project_id,
+                    feature_id=current_id,
+                    actor=token.get("actor"),
+                )
+
         if current_id and current_id not in state.get("merged_features", []):
             state.setdefault("merged_features", []).append(current_id)
             for item in state.get("features", []):
@@ -535,6 +637,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     advance_parser = sub.add_parser("advance")
     advance_parser.add_argument("--json", action="store_true")
 
+    approve_parser = sub.add_parser("approve")
+    approve_parser.add_argument("feature_id")
+    approve_parser.add_argument("--actor", required=True)
+    approve_parser.add_argument("--justification", required=True)
+    approve_parser.add_argument("--json", action="store_true")
+
     args = parser.parse_args(argv)
     manager = RoadmapManager()
 
@@ -548,6 +656,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         result = manager.reconcile()
     elif args.command == "advance":
         result = manager.advance()
+    elif args.command == "approve":
+        result = manager.approve(args.feature_id, actor=args.actor, justification=args.justification)
     else:
         raise AssertionError("unreachable")
 

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -408,3 +408,200 @@ def test_optional_gate_missing_does_not_block(roadmap_env, monkeypatch):
     result = manager.reconcile()
 
     assert result["verdict"] == "pass", "optional gate absence must not produce gates_incomplete"
+
+
+# ---------------------------------------------------------------------------
+# RA-4: human approval gate
+# ---------------------------------------------------------------------------
+
+
+def _make_high_risk_roadmap(project_root: Path) -> Path:
+    """Write a single high-risk human-policy feature roadmap."""
+    plan_dir = project_root / "roadmap" / "features" / "feature-hi"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / "FEATURE_PLAN.md").write_text(
+        """# Feature: High Risk Feature
+
+**Status**: Draft
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: High Risk PR
+**Track**: C
+**Priority**: P0
+**Complexity**: High
+**Skill**: @architect
+**Risk-Class**: high
+**Merge-Policy**: human
+**Review-Stack**: gemini_review,codex_gate
+**Dependencies**: []
+""",
+        encoding="utf-8",
+    )
+    roadmap_file = project_root / "ROADMAP_HR.yaml"
+    roadmap_file.write_text(
+        """features:
+  - feature_id: feature-hi
+    title: High Risk Feature
+    plan_path: roadmap/features/feature-hi/FEATURE_PLAN.md
+    branch_name: feature/hi
+    risk_class: high
+    merge_policy: human
+    review_stack: [gemini_review, codex_gate]
+    depends_on: []
+    status: planned
+""",
+        encoding="utf-8",
+    )
+    return roadmap_file
+
+
+def _setup_passing_gates(state_dir: Path) -> None:
+    gate_results_dir = state_dir / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+
+
+def test_advance_blocked_awaiting_human_approval(roadmap_env, monkeypatch):
+    """high-risk feature: closure+gates pass but no approval token → awaiting_human_approval."""
+    project_root = roadmap_env["project_root"]
+    roadmap_file = _make_high_risk_roadmap(project_root)
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"])
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_file)
+    manager.load_feature("feature-hi")
+
+    result = manager.advance()
+
+    assert result["advanced"] is False
+    assert result["reason"] == "awaiting_human_approval"
+    assert result["feature_id"] == "feature-hi"
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-hi", "feature must not progress without token"
+
+
+def test_advance_proceeds_after_approve_and_token_consumed(roadmap_env, monkeypatch):
+    """After approve, advance progresses and the token is consumed (single-use)."""
+    project_root = roadmap_env["project_root"]
+    roadmap_file = _make_high_risk_roadmap(project_root)
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"])
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_file)
+    manager.load_feature("feature-hi")
+
+    # First attempt: blocked
+    first = manager.advance()
+    assert first["advanced"] is False
+    assert first["reason"] == "awaiting_human_approval"
+
+    # Issue approval
+    token = manager.approve("feature-hi", actor="vincent", justification="looks good")
+    assert token["consumed"] is False
+    assert token["feature_id"] == "feature-hi"
+
+    # Second attempt: should proceed
+    result = manager.advance()
+    assert result["advanced"] is True or result["reason"] == "no_remaining_features"
+
+    # Token must be consumed (single-use)
+    token_path = manager._approval_token_path("feature-hi")
+    stored = json.loads(token_path.read_text(encoding="utf-8"))
+    assert stored["consumed"] is True, "token must be consumed after advance"
+    assert stored["consumed_at"] is not None
+
+    # Third attempt with no new token: blocked again on whatever comes next,
+    # but the old consumed token must not re-authorize.
+    # Reload state to check feature was actually advanced.
+    state = manager.load_state()
+    assert "feature-hi" in state["merged_features"], "feature-hi must be marked merged"
+
+
+def test_conditional_auto_low_advances_without_token(roadmap_env, monkeypatch):
+    """conditional_auto + low risk feature advances without any approval token."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"])
+
+    result = manager.advance()
+
+    # feature-a is conditional_auto + low → no token required → advances
+    assert result["advanced"] is True
+    assert result["reason"] == "loaded_next_feature"
+    assert result["next_feature"] == "feature-b"
+
+
+def test_approval_token_project_id_stamped_and_feature_pinned(roadmap_env, monkeypatch):
+    """ADR-007: token carries project_id; a token issued for feature-a cannot approve feature-b."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "proj-x")
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+
+    token = manager.approve("feature-a", actor="vincent", justification="ok")
+
+    # Token must be stamped with the correct project_id
+    assert token["project_id"] == "proj-x", "ADR-007: token must carry project_id"
+    assert token["feature_id"] == "feature-a"
+
+    # Attempting to load the token as approval for feature-b must return None
+    valid_for_b = manager._load_valid_approval_token("feature-b")
+    assert valid_for_b is None, "feature-a token must not authorize feature-b"
+
+    # The token IS valid for feature-a
+    valid_for_a = manager._load_valid_approval_token("feature-a")
+    assert valid_for_a is not None, "token must be valid for feature-a"
+    assert valid_for_a["consumed"] is False
+
+
+def test_consumed_token_does_not_reauthorize(roadmap_env, monkeypatch):
+    """A consumed token must not grant a second advance."""
+    project_root = roadmap_env["project_root"]
+    roadmap_file = _make_high_risk_roadmap(project_root)
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"])
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_file)
+    manager.load_feature("feature-hi")
+    manager.approve("feature-hi", actor="vincent", justification="ok")
+
+    # First advance consumes the token
+    r1 = manager.advance()
+    assert r1["advanced"] is True or r1["reason"] == "no_remaining_features"
+
+    # Manually re-activate feature-hi to simulate a second advance attempt
+    state = manager.load_state()
+    state["current_active_feature"] = "feature-hi"
+    state["merged_features"] = [f for f in state.get("merged_features", []) if f != "feature-hi"]
+    for f in state.get("features", []):
+        if f["feature_id"] == "feature-hi":
+            f["status"] = "active"
+    manager._save_state(state)
+
+    r2 = manager.advance()
+    assert r2["advanced"] is False
+    assert r2["reason"] == "awaiting_human_approval", "consumed token must not reauthorize"


### PR DESCRIPTION
## Summary

- Adds `approve` subcommand: `vnx roadmap approve <feature_id> --actor <name> --justification <text>` — writes a single-use, feature-pinned, project_id-stamped approval token to `$VNX_STATE_DIR/roadmap_approvals/<feature_id>.json` and emits a `roadmap_human_approval` governance receipt (ADR-007)
- `advance()` now blocks with `awaiting_human_approval` for any feature where `merge_policy=human` OR `risk_class=high` unless a valid unconsumed token exists; consumes the token atomically on use
- `conditional_auto + low` features delegate to existing auto_merge_policy path — no token required
- Shell: wires `approve` into `scripts/commands/roadmap.sh` help + dispatch

## Test plan

- [x] high-risk feature, closure+gates pass → advance returns `awaiting_human_approval`, does NOT progress
- [x] after `approve`, advance progresses and token is consumed (`consumed=True`, `consumed_at` set)
- [x] consumed token does not reauthorize a second advance
- [x] `conditional_auto + low` feature advances without any token
- [x] approval token is project_id-stamped (ADR-007) and feature-pinned: token for feature-A cannot approve feature-B
- [x] all existing tests green (`python3 -m pytest tests/test_roadmap_manager.py -q` → 18 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)