### PR TITLE
feat(ra5-step-driver): add step subcommand for active feature PR queue

### DIFF
--- a/scripts/commands/roadmap.sh
+++ b/scripts/commands/roadmap.sh
@@ -4,7 +4,7 @@
 cmd_roadmap() {
   if [ "$#" -eq 0 ]; then
     cat <<'HELP'
-Usage: vnx roadmap <init|status|load|reconcile|advance|approve> [args]
+Usage: vnx roadmap <init|status|load|reconcile|advance|approve|step> [args]
 
 Commands:
   init <ROADMAP.yaml>                         Initialize roadmap registry state
@@ -15,6 +15,7 @@ Commands:
   approve <feature_id> --actor <name> --justification <text>
                                               Issue a single-use human approval token (required for
                                               merge_policy=human or risk_class=high features)
+  step                                        Dispatch the next dependency-ready PR for the active feature
 HELP
     return 0
   fi

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -602,6 +602,72 @@ Implement the minimum blocking fix required before the roadmap may advance.
         self.load_feature(next_feature["feature_id"])
         return {"advanced": True, "reason": "loaded_next_feature", "next_feature": next_feature["feature_id"]}
 
+    def run_feature_step(self) -> Dict[str, Any]:
+        """Dispatch the next dependency-ready PR for the active feature.
+
+        ADR-007: emits project_id-stamped roadmap_dispatch_step receipt.
+        Respects VNX_QUEUE_POPUP_ENABLED env switch via promote_dispatch.
+        Returns dispatch_id + pr_id on success, or a no_ready_pr status without
+        side effects when no queued PR is dependency-ready.
+        """
+        state = self.load_state()
+        current_id = state.get("current_active_feature")
+        if not current_id:
+            return {"status": "no_active_feature", "reason": "no feature is currently active"}
+
+        pr_manager = PRQueueManager()
+        next_pr = pr_manager.get_next_pr()
+
+        if not next_pr:
+            emit_governance_receipt(
+                "roadmap_dispatch_step",
+                status="no_ready_pr",
+                project_id=self.project_id,
+                feature_id=current_id,
+            )
+            return {
+                "status": "no_ready_pr",
+                "feature_id": current_id,
+                "reason": "no dependency-ready PR in queue",
+            }
+
+        pr_id = next_pr["id"]
+        dispatch_id = pr_manager.create_dispatch_from_pr(pr_id)
+        if not dispatch_id:
+            return {
+                "status": "failed",
+                "feature_id": current_id,
+                "pr_id": pr_id,
+                "reason": "dispatch creation failed",
+            }
+
+        promoted = pr_manager.promote_dispatch(dispatch_id)
+        if not promoted:
+            return {
+                "status": "failed",
+                "feature_id": current_id,
+                "pr_id": pr_id,
+                "dispatch_id": dispatch_id,
+                "reason": "dispatch promotion failed",
+            }
+
+        pr_manager.update_pr_status(pr_id, "in_progress")
+
+        emit_governance_receipt(
+            "roadmap_dispatch_step",
+            status="success",
+            project_id=self.project_id,
+            feature_id=current_id,
+            pr_id=pr_id,
+            dispatch_id=dispatch_id,
+        )
+        return {
+            "status": "dispatched",
+            "feature_id": current_id,
+            "pr_id": pr_id,
+            "dispatch_id": dispatch_id,
+        }
+
     def status(self) -> Dict[str, Any]:
         state = self.load_state()
         return {
@@ -643,6 +709,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     approve_parser.add_argument("--justification", required=True)
     approve_parser.add_argument("--json", action="store_true")
 
+    step_parser = sub.add_parser("step")
+    step_parser.add_argument("--json", action="store_true")
+
     args = parser.parse_args(argv)
     manager = RoadmapManager()
 
@@ -658,6 +727,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         result = manager.advance()
     elif args.command == "approve":
         result = manager.approve(args.feature_id, actor=args.actor, justification=args.justification)
+    elif args.command == "step":
+        result = manager.run_feature_step()
     else:
         raise AssertionError("unreachable")
 

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -605,3 +605,78 @@ def test_consumed_token_does_not_reauthorize(roadmap_env, monkeypatch):
     r2 = manager.advance()
     assert r2["advanced"] is False
     assert r2["reason"] == "awaiting_human_approval", "consumed token must not reauthorize"
+
+
+# ---------------------------------------------------------------------------
+# RA-5: per-PR dispatch driver (step)
+# ---------------------------------------------------------------------------
+
+
+def test_step_dispatches_first_ready_pr(roadmap_env, monkeypatch):
+    """step creates+promotes a dispatch for the first dependency-ready PR, returns dispatch_id+pr_id."""
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    result = manager.run_feature_step()
+
+    assert result["status"] == "dispatched", f"expected dispatched, got: {result}"
+    assert result["pr_id"] == "PR-0"
+    assert result["dispatch_id"] is not None
+    assert result["feature_id"] == "feature-a"
+
+    # Dispatch must exist in pending/ (auto-approved via VNX_QUEUE_POPUP_ENABLED=0)
+    dispatch_dir = roadmap_env["project_root"] / ".vnx-data" / "dispatches"
+    pending_files = list((dispatch_dir / "pending").glob("*.md"))
+    assert len(pending_files) == 1, "exactly one dispatch must be in pending/"
+
+
+def test_step_second_call_no_ready_pr(roadmap_env, monkeypatch):
+    """second step returns no_ready_pr when only PR is already in_progress."""
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    first = manager.run_feature_step()
+    assert first["status"] == "dispatched"
+
+    second = manager.run_feature_step()
+    assert second["status"] == "no_ready_pr"
+    assert second["feature_id"] == "feature-a"
+
+
+def test_step_receipt_project_id_stamped(roadmap_env, monkeypatch):
+    """ADR-007: roadmap_dispatch_step receipt carries project_id."""
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+    monkeypatch.setenv("VNX_PROJECT_ID", "proj-step-test")
+    receipts = []
+    monkeypatch.setattr(rm, "emit_governance_receipt", lambda *a, **kw: receipts.append(kw))
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    manager.run_feature_step()
+
+    step_receipt = next(
+        (r for r in receipts if r.get("project_id") == "proj-step-test" and "dispatch_id" in r),
+        None,
+    )
+    assert step_receipt is not None, "roadmap_dispatch_step receipt not emitted"
+    assert step_receipt["pr_id"] == "PR-0"
+    assert step_receipt["feature_id"] == "feature-a"
+
+
+def test_step_no_active_feature_returns_status(roadmap_env, monkeypatch):
+    """step with no active feature returns no_active_feature without side effects."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    # intentionally do NOT load any feature
+
+    result = manager.run_feature_step()
+
+    assert result["status"] == "no_active_feature"


### PR DESCRIPTION
## Summary

- Adds `run_feature_step()` method to `RoadmapManager`: picks next dependency-ready PR via `PRQueueManager.get_next_pr()`, creates + promotes its dispatch, marks it `in_progress`, emits `roadmap_dispatch_step` receipt stamped with `project_id` (ADR-007)
- Returns `{"status": "no_ready_pr"}` without side effects when queue is empty or all PRs are blocked/in-flight
- Wires `step` subcommand into `main()` and `scripts/commands/roadmap.sh` help text
- Respects existing `VNX_QUEUE_POPUP_ENABLED` auto-approve env switch via `promote_dispatch`

## Verify

```
python3 -m pytest tests/test_roadmap_manager.py -q
# 22 passed
```

- `test_step_dispatches_first_ready_pr`: step creates staging→pending dispatch for PR-0, returns dispatch_id+pr_id
- `test_step_second_call_no_ready_pr`: second step returns no_ready_pr (PR-0 now in_progress)
- `test_step_receipt_project_id_stamped`: receipt emitted with project_id=proj-step-test, pr_id=PR-0
- `test_step_no_active_feature_returns_status`: returns no_active_feature without side effects

## ADR-007

`roadmap_dispatch_step` receipt carries `project_id`. No new state tables introduced.

## Open Items

_(none)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)