### PR TITLE
fix(ra3b-gate-holes): close 4 advance-gate bypass holes

### DIFF
--- a/ROADMAP.yaml
+++ b/ROADMAP.yaml
@@ -21,6 +21,7 @@ features:
     risk_class: medium
     merge_policy: human
     review_stack:
+      - gemini_review
       - codex_gate
     depends_on: []
     status: active
@@ -31,6 +32,7 @@ features:
     risk_class: high
     merge_policy: human
     review_stack:
+      - gemini_review
       - codex_gate
     depends_on:
       - fut-1

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -220,10 +220,14 @@ def _find_gate_result(
     pr_id: str,
     results_dir: Path,
     branch: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Search for a gate result file matching the PR and gate name.
 
-    If ``branch`` is provided, results from a different branch are rejected.
+    ADR-005: if ``branch`` is provided, results without a matching ``branch``
+    field are rejected as stale evidence from a prior feature.
+    ADR-007: if ``project_id`` is provided, results with a missing or
+    mismatched ``project_id`` field are rejected.
     If a result carries a ``report_path``, that file must exist on disk or the
     result is treated as stale and skipped.
     """
@@ -235,8 +239,16 @@ def _find_gate_result(
         data_pr_id = data.get("pr_id")
         if data_pr_id and data_pr_id != pr_id:
             return False
-        if branch and data.get("branch") and data["branch"] != branch:
-            return False
+        # ADR-007: project_id must be present and match when caller supplies one.
+        if project_id is not None:
+            data_pid = (data.get("project_id") or "").strip()
+            if not data_pid or data_pid != project_id:
+                return False
+        # ADR-005: branch must be present and match when caller supplies one.
+        # A branch-less result is stale evidence from a prior feature.
+        if branch:
+            if (data.get("branch") or "") != branch:
+                return False
         return True
 
     pr_slug = pr_id.lower().replace("-", "")

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -395,11 +395,20 @@ Implement the minimum blocking fix required before the roadmap may advance.
         branch = feature.get("branch_name", "")
         for pr_id in pr_ids:
             for gate in required_gates:
-                result = _find_gate_result(gate, pr_id, gate_results_dir, branch=branch)
+                # ADR-007 + ADR-005: scope lookup to current project_id and branch.
+                result = _find_gate_result(gate, pr_id, gate_results_dir, branch=branch, project_id=self.project_id)
                 if result is None:
                     return True
                 passed, _ = gate_is_pass(result)
                 if not passed:
+                    return True
+                # Hole 1: status-only pass is insufficient (T0 7-invariant closure contract).
+                # Evidence must exist on disk and carry a contract_hash.
+                report_path = (result.get("report_path") or "").strip()
+                contract_hash = (result.get("contract_hash") or "").strip()
+                if not report_path or not Path(report_path).exists():
+                    return True
+                if not contract_hash:
                     return True
 
         return False

--- a/tests/test_closure_verifier.py
+++ b/tests/test_closure_verifier.py
@@ -259,7 +259,7 @@ def _write_gate_result(results_dir, gate, pr_id, data):
     return path
 
 
-def _make_gemini_result(pr_id="PR-0", status="pass", blocking_count=0, advisory_count=0, contract_hash="abcdef1234567890", report_path=""):
+def _make_gemini_result(pr_id="PR-0", status="pass", blocking_count=0, advisory_count=0, contract_hash="abcdef1234567890", report_path="", branch="feature/demo"):
     return {
         "gate": "gemini_review",
         "pr_id": pr_id,
@@ -268,10 +268,11 @@ def _make_gemini_result(pr_id="PR-0", status="pass", blocking_count=0, advisory_
         "advisory_count": advisory_count,
         "contract_hash": contract_hash,
         "report_path": report_path,
+        "branch": branch,
     }
 
 
-def _make_codex_result(pr_id="PR-0", verdict="pass", contract_hash="abcdef1234567890", report_path=""):
+def _make_codex_result(pr_id="PR-0", verdict="pass", contract_hash="abcdef1234567890", report_path="", branch="feature/demo"):
     return {
         "gate": "codex_final_gate",
         "pr_id": pr_id,
@@ -280,10 +281,11 @@ def _make_codex_result(pr_id="PR-0", verdict="pass", contract_hash="abcdef123456
         "content_hash": contract_hash,
         "contract_hash": contract_hash,
         "report_path": report_path,
+        "branch": branch,
     }
 
 
-def _make_claude_result(pr_id="PR-0", state="not_configured", contract_hash="abcdef1234567890"):
+def _make_claude_result(pr_id="PR-0", state="not_configured", contract_hash="abcdef1234567890", branch="feature/demo"):
     return {
         "gate": "claude_github_optional",
         "pr_id": pr_id,
@@ -291,6 +293,7 @@ def _make_claude_result(pr_id="PR-0", state="not_configured", contract_hash="abc
         "contributed_evidence": state in ("requested", "completed"),
         "was_intentionally_absent": state in ("not_configured", "configured_dry_run"),
         "contract_hash": contract_hash,
+        "branch": branch,
     }
 
 
@@ -772,6 +775,7 @@ def _make_gate_artifact_payload(
     report_path="",
     blocking=None,
     advisory=None,
+    branch="feature/demo",
 ):
     """Build a gate result payload that mirrors gate_artifacts.materialize_artifacts.
 
@@ -794,6 +798,7 @@ def _make_gate_artifact_payload(
         "residual_risk": "",
         "duration_seconds": 12.5,
         "recorded_at": "2026-04-29T10:00:00Z",
+        "branch": branch,
     }
 
 

--- a/tests/test_closure_verifier_evidence_contract.py
+++ b/tests/test_closure_verifier_evidence_contract.py
@@ -211,6 +211,7 @@ class TestReportPathEnforcementStandardReceipt:
             "blocking_count": 0,
             "advisory_count": 0,
             "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
             # report_path intentionally absent
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
@@ -234,6 +235,7 @@ class TestReportPathEnforcementStandardReceipt:
             "blocking_count": 0,
             "advisory_count": 0,
             "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
 
@@ -257,6 +259,7 @@ class TestReportPathEnforcementStandardReceipt:
             "advisory_count": 1,
             "contract_hash": "abcdef1234567890",
             "report_path": str(report_file),
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
 
@@ -301,6 +304,7 @@ class TestGateReportContradictionCompletedStatus:
             "advisory_count": 0,
             "contract_hash": "abcdef1234567890",
             "report_path": str(report_file),
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
 
@@ -326,6 +330,7 @@ class TestGateReportContradictionCompletedStatus:
             "blocking_count": 0,
             "contract_hash": "abcdef1234567890",
             "report_path": str(report_file),
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
 
@@ -349,6 +354,7 @@ class TestGateReportContradictionCompletedStatus:
             "blocking_count": 0,
             "contract_hash": "abcdef1234567890",
             "report_path": str(report_file),
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "gemini_review", "PR-0", gemini_result)
 
@@ -593,6 +599,7 @@ class TestReportPathEnforcementCodexGate:
             "blocking_count": 0,
             "advisory_count": 0,
             "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
             # report_path intentionally absent
         }
         _write_gate_result(results_dir, "codex_gate", "PR-0", codex_result)
@@ -619,6 +626,7 @@ class TestReportPathEnforcementCodexGate:
             "advisory_count": 0,
             "contract_hash": "abcdef1234567890",
             "report_path": str(report_file),
+            "branch": "feature/demo",
         }
         _write_gate_result(results_dir, "codex_gate", "PR-0", codex_result)
 

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -129,14 +129,8 @@ def test_advance_loads_next_feature_after_verified_merge(roadmap_env, monkeypatc
     # RA-3: required gate evidence must be present for advance to proceed.
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    (gate_results_dir / "pr0-gemini_review-contract.json").write_text(
-        json.dumps({"pr_id": "PR-0", "gate": "gemini_review", "status": "pass"}),
-        encoding="utf-8",
-    )
-    (gate_results_dir / "pr0-codex_gate-contract.json").write_text(
-        json.dumps({"pr_id": "PR-0", "gate": "codex_gate", "status": "pass"}),
-        encoding="utf-8",
-    )
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/a")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch="feature/a")
 
     result = manager.advance()
     state = manager.load_state()
@@ -305,10 +299,29 @@ def test_load_feature_no_worktree_flag_skips_provisioning(git_roadmap_env, monke
 # ---------------------------------------------------------------------------
 
 
-def _write_gate_result(gate_results_dir: Path, pr_id: str, gate: str, status: str = "pass") -> None:
+def _write_gate_result(
+    gate_results_dir: Path,
+    pr_id: str,
+    gate: str,
+    status: str = "pass",
+    branch: str = "feature/a",
+    project_id: str = "vnx-dev",
+) -> None:
+    """Write a fully-valid gate result contract with report evidence on disk."""
     pr_slug = pr_id.lower().replace("-", "")
+    report_file = gate_results_dir / f"{pr_slug}-{gate}-report.md"
+    report_file.write_text(f"# {gate} report for {pr_id}\n", encoding="utf-8")
+    data: dict = {
+        "pr_id": pr_id,
+        "gate": gate,
+        "status": status,
+        "project_id": project_id,
+        "branch": branch,
+        "report_path": str(report_file),
+        "contract_hash": f"hash-{pr_slug}-{gate}",
+    }
     (gate_results_dir / f"{pr_slug}-{gate}-contract.json").write_text(
-        json.dumps({"pr_id": pr_id, "gate": gate, "status": status}),
+        json.dumps(data),
         encoding="utf-8",
     )
 
@@ -325,7 +338,7 @@ def test_reconcile_gates_incomplete_when_codex_missing(roadmap_env, monkeypatch)
 
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/a")
     # codex_gate intentionally absent
 
     result = manager.reconcile()
@@ -364,8 +377,8 @@ def test_reconcile_passes_when_gemini_and_codex_both_pass(roadmap_env, monkeypat
 
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
-    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/a")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch="feature/a")
 
     result = manager.reconcile()
     assert result["verdict"] == "pass"
@@ -401,13 +414,140 @@ def test_optional_gate_missing_does_not_block(roadmap_env, monkeypatch):
 
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
-    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/opt")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch="feature/opt")
     # claude_github_optional intentionally absent
 
     result = manager.reconcile()
 
     assert result["verdict"] == "pass", "optional gate absence must not produce gates_incomplete"
+
+
+# ---------------------------------------------------------------------------
+# RA-3b: bypass matrix — governance holes closed
+# ---------------------------------------------------------------------------
+
+
+def test_gates_incomplete_status_only_result(roadmap_env, monkeypatch):
+    """Status-only {status:pass} result (no report_path/contract_hash) → advance BLOCKED."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    # Write status-only results: missing report_path and contract_hash.
+    pr_slug = "pr0"
+    for gate in ("gemini_review", "codex_gate"):
+        (gate_results_dir / f"{pr_slug}-{gate}-contract.json").write_text(
+            json.dumps({"pr_id": "PR-0", "gate": gate, "status": "pass",
+                        "project_id": "vnx-dev", "branch": "feature/a"}),
+            encoding="utf-8",
+        )
+
+    result = manager.reconcile()
+    assert result["verdict"] == "gates_incomplete", "status-only pass must not satisfy advance"
+
+
+def test_gates_incomplete_mismatched_project_id(roadmap_env, monkeypatch):
+    """Gate result with mismatched project_id → does NOT satisfy advance (ADR-007)."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    # Write results with a different project_id — should be rejected.
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review",
+                       branch="feature/a", project_id="other-project")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate",
+                       branch="feature/a", project_id="other-project")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "gates_incomplete", "mismatched project_id must not satisfy advance"
+
+
+def test_gates_incomplete_stale_branch_result(roadmap_env, monkeypatch):
+    """Stale gate result from a different branch → rejected (ADR-005)."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    # Write results with a different branch — stale evidence from a prior feature.
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review",
+                       branch="feature/other-old-feature")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate",
+                       branch="feature/other-old-feature")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "gates_incomplete", "stale branch result must not satisfy advance"
+
+
+def test_gates_incomplete_branch_less_result(roadmap_env, monkeypatch):
+    """Branch-less gate result (no branch field) → rejected as stale evidence."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    # Write results without branch field — must be rejected as stale.
+    pr_slug = "pr0"
+    report_file = gate_results_dir / "pr0-gemini_review-report.md"
+    report_file.write_text("# report\n", encoding="utf-8")
+    for gate in ("gemini_review", "codex_gate"):
+        rep = gate_results_dir / f"pr0-{gate}-report.md"
+        rep.write_text("# report\n", encoding="utf-8")
+        (gate_results_dir / f"{pr_slug}-{gate}-contract.json").write_text(
+            json.dumps({"pr_id": "PR-0", "gate": gate, "status": "pass",
+                        "project_id": "vnx-dev",
+                        "report_path": str(rep),
+                        "contract_hash": f"hash-{gate}"}),
+            encoding="utf-8",
+        )
+
+    result = manager.reconcile()
+    assert result["verdict"] == "gates_incomplete", "branch-less result must be rejected as stale"
+
+
+def test_advance_fully_valid_gate_result_proceeds(roadmap_env, monkeypatch):
+    """Fully-valid result (status pass + report on disk + contract_hash + matching project_id + branch) → advance proceeds."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/a")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch="feature/a")
+
+    result = manager.advance()
+
+    assert result["advanced"] is True, "fully-valid gate evidence must allow advance"
+    assert result["reason"] == "loaded_next_feature"
+    assert result["next_feature"] == "feature-b"
 
 
 # ---------------------------------------------------------------------------
@@ -462,11 +602,11 @@ PR-0 (no dependencies)
     return roadmap_file
 
 
-def _setup_passing_gates(state_dir: Path) -> None:
+def _setup_passing_gates(state_dir: Path, branch: str = "feature/a", project_id: str = "vnx-dev") -> None:
     gate_results_dir = state_dir / "review_gates" / "results"
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    _write_gate_result(gate_results_dir, "PR-0", "gemini_review")
-    _write_gate_result(gate_results_dir, "PR-0", "codex_gate")
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch=branch, project_id=project_id)
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch=branch, project_id=project_id)
 
 
 def test_advance_blocked_awaiting_human_approval(roadmap_env, monkeypatch):
@@ -477,7 +617,7 @@ def test_advance_blocked_awaiting_human_approval(roadmap_env, monkeypatch):
         rm, "verify_closure",
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
-    _setup_passing_gates(roadmap_env["state_dir"])
+    _setup_passing_gates(roadmap_env["state_dir"], branch="feature/hi")
 
     manager = rm.RoadmapManager()
     manager.init_roadmap(roadmap_file)
@@ -500,7 +640,7 @@ def test_advance_proceeds_after_approve_and_token_consumed(roadmap_env, monkeypa
         rm, "verify_closure",
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
-    _setup_passing_gates(roadmap_env["state_dir"])
+    _setup_passing_gates(roadmap_env["state_dir"], branch="feature/hi")
 
     manager = rm.RoadmapManager()
     manager.init_roadmap(roadmap_file)
@@ -582,7 +722,7 @@ def test_consumed_token_does_not_reauthorize(roadmap_env, monkeypatch):
         rm, "verify_closure",
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
-    _setup_passing_gates(roadmap_env["state_dir"])
+    _setup_passing_gates(roadmap_env["state_dir"], branch="feature/hi")
 
     manager = rm.RoadmapManager()
     manager.init_roadmap(roadmap_file)


### PR DESCRIPTION
## Summary

- **Hole 1**: `_gates_incomplete` now requires non-empty `report_path` that EXISTS on disk AND non-empty `contract_hash` after `gate_is_pass`. A status-only `{"status":"pass"}` result no longer satisfies advance.
- **Hole 2**: `_find_gate_result` accepts new `project_id` parameter. Results with missing or mismatched `project_id` are rejected (ADR-007). `_gates_incomplete` passes `self.project_id` to the lookup.
- **Hole 3**: `_find_gate_result._accept` now enforces strict branch matching. Previously a result without a `branch` field was accepted when a branch was provided; now it is rejected as stale evidence from a prior feature (ADR-005).
- **Hole 4**: `gemini_review` added to `fut-1` and `fut-2` review_stack in ROADMAP.yaml so both gates are enforced on advance.

## Bypass matrix (all verified by tests)

- [x] status-only `{status:pass}` (no report_path/contract_hash) → advance BLOCKED (`gates_incomplete`)
- [x] gate result with mismatched project_id → does NOT satisfy advance (ADR-007)
- [x] stale gate result from different branch → rejected, does not satisfy current feature (ADR-005)
- [x] branch-less gate result → rejected as stale evidence
- [x] fully-valid result (status pass + existing report + contract_hash + matching project_id + branch) → advance proceeds

## Test plan

- [x] `python3 -m pytest tests/test_roadmap_manager.py -q` — 27 passed (22 original + 5 new bypass-matrix tests)
- [x] `python3 -m pytest tests/test_closure_verifier.py tests/test_closure_verifier_evidence_contract.py -q` — 56 passed (all pre-existing tests updated to include `branch` field in gate result fixtures)
- [x] 83 total, 0 failures

ADR-007 cited: project_id scope on lookups.
ADR-005 cited: branch/feature scope on gate evidence.
Dispatch-ID: 20260529-180336-ra3b-gate-holes

🤖 Generated with [Claude Code](https://claude.com/claude-code)