### PR TITLE
Fix pool status project display

### DIFF
--- a/tests/test_vnx_pool_cli.py
+++ b/tests/test_vnx_pool_cli.py
@@ -121,20 +121,41 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         data = json.loads(out)
         assert data["pool_id"] == "default"
+        assert data["project_id"] == "test-proj"
         assert data["max"] == 4
         assert data["current"] == 1
         assert data["members"][0]["terminal_id"] == "WORKER-2"
         assert data["members"][0]["provider"] == "litellm"
 
     def test_status_works_without_project(self, capsys):
-        """--project defaults to 'default'; no error when omitted."""
-        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+        """--project omission displays the resolved project id."""
+        with (
+            patch("vnx_cli.commands.pool._resolve_project_id", return_value="vnx-dev") as resolve_project_id,
+            patch("vnx_cli.commands.pool.PoolManager") as MockMgr,
+        ):
             mgr = MockMgr.return_value
             mgr.load_state.return_value = (_make_config(), _make_state(), [])
             rc = main(argv=["status"])
         assert rc == 0
         out = capsys.readouterr().out
-        assert "Project: default" in out
+        assert "Project: vnx-dev" in out
+        assert "Project: None" not in out
+        resolve_project_id.assert_called_once_with(None)
+        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default")
+
+    def test_status_json_uses_resolved_project_without_project(self, capsys):
+        with (
+            patch("vnx_cli.commands.pool._resolve_project_id", return_value="vnx-dev") as resolve_project_id,
+            patch("vnx_cli.commands.pool.PoolManager") as MockMgr,
+        ):
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            rc = main(argv=["status", "--json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["project_id"] == "vnx-dev"
+        resolve_project_id.assert_called_once_with(None)
+        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default")
 
     def test_status_with_pool_id_passed_to_manager(self):
         with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -29,14 +29,15 @@ from pool_state_repo import PoolStateRepository  # noqa: E402
 
 def cmd_status(args: argparse.Namespace) -> int:
     """Show current pool state for a project."""
-    mgr = _make_manager(args.project, args.pool_id)
+    project_id = _resolve_project_id(args.project)
+    mgr = _make_manager_for_project_id(project_id, args.pool_id)
     config, state, members = mgr.load_state()
 
     active = [m for m in members if m.status == "active"]
     if args.json:
         print(json.dumps({
             "pool_id": config.pool_id,
-            "project_id": args.project,
+            "project_id": project_id,
             "current": len(active),
             "min": config.min_workers,
             "max": config.max_workers,
@@ -49,7 +50,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         }, indent=2))
     else:
         print(f"Pool: {config.pool_id}")
-        print(f"Project: {args.project}")
+        print(f"Project: {project_id}")
         print(
             f"Current: {len(active)} / policy={config.scaling_policy}"
             f" (min={config.min_workers}, max={config.max_workers})"
@@ -195,7 +196,11 @@ def _resolve_project_id(explicit: Optional[str]) -> str:
 
 
 def _make_manager(project: Optional[str], pool_id: Optional[str]) -> PoolManager:
-    return PoolManager(project_id=_resolve_project_id(project), pool_id=pool_id or "default")
+    return _make_manager_for_project_id(_resolve_project_id(project), pool_id)
+
+
+def _make_manager_for_project_id(project_id: str, pool_id: Optional[str]) -> PoolManager:
+    return PoolManager(project_id=project_id, pool_id=pool_id or "default")
 
 
 def _fmt_age(timestamp: float) -> str:
@@ -218,13 +223,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_status.set_defaults(func=cmd_status)
 
     p_scale = sub.add_parser("scale", help="force scale pool to N workers")
-    p_scale.add_argument("--project", default=None)
+    p_scale.add_argument("--project", required=True)
     p_scale.add_argument("--to", type=int, required=True)
     p_scale.add_argument("--pool-id", dest="pool_id", default=None)
     p_scale.set_defaults(func=cmd_scale)
 
     p_config = sub.add_parser("config", help="update pool config")
-    p_config.add_argument("--project", default=None)
+    p_config.add_argument("--project", required=True)
     p_config.add_argument("--pool-id", dest="pool_id", default=None)
     p_config.add_argument("--min", type=int, dest="min")
     p_config.add_argument("--max", type=int, dest="max")
@@ -233,7 +238,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_config.set_defaults(func=cmd_config)
 
     p_reap = sub.add_parser("reap", help="reap stale workers (dry-run by default)")
-    p_reap.add_argument("--project", default=None)
+    p_reap.add_argument("--project", required=True)
     p_reap.add_argument("--pool-id", dest="pool_id", default=None)
     p_reap.add_argument("--force", action="store_true", help="actually reap (default: dry-run)")
     p_reap.set_defaults(func=cmd_reap)


### PR DESCRIPTION
## Summary
- Resolve the `vnx pool status` project id once and reuse that resolved value for the manager, human output, and JSON output.
- Add regression coverage for omitted `--project` in human and JSON status output.
- Align mutating pool subcommands with their documented/tested requirement for `--project`.

## Verification
- `bin/vnx pool status` prints `Project: vnx-dev`, not `Project: None`.
- `bin/vnx pool status --json` emits `"project_id": "vnx-dev"`.
- `python3 -m pytest tests/test_vnx_pool_cli.py -q` passes: 30 passed.
- `python3 -m pytest tests/ -k "pool" -q` is not green in this worktree: pytest fails during global collection before pool-selected tests run, on unrelated missing-symbol errors in `tests/test_context_assembler.py`, `tests/test_exit_classifier.py`, `tests/test_headless_inspect.py`, `tests/test_log_artifacts.py`, `tests/test_pattern_diversity.py`, `tests/test_pattern_id_stability.py`, and shell classifier extraction tests.
