### PR TITLE
feat(ra6-autopilot-tick): autopilot_tick + scheduler wiring (DARK)

### DIFF
--- a/scripts/commands/roadmap.sh
+++ b/scripts/commands/roadmap.sh
@@ -4,7 +4,7 @@
 cmd_roadmap() {
   if [ "$#" -eq 0 ]; then
     cat <<'HELP'
-Usage: vnx roadmap <init|status|load|reconcile|advance|approve|step> [args]
+Usage: vnx roadmap <init|status|load|reconcile|advance|approve|step|autopilot> [args]
 
 Commands:
   init <ROADMAP.yaml>                         Initialize roadmap registry state
@@ -16,6 +16,7 @@ Commands:
                                               Issue a single-use human approval token (required for
                                               merge_policy=human or risk_class=high features)
   step                                        Dispatch the next dependency-ready PR for the active feature
+  autopilot                                   Run one autopilot tick (requires VNX_ROADMAP_AUTOPILOT=1)
 HELP
     return 0
   fi

--- a/scripts/headless_trigger.py
+++ b/scripts/headless_trigger.py
@@ -203,6 +203,27 @@ def _haiku_enabled() -> bool:
     return os.environ.get("VNX_HAIKU_CLASSIFY", "0") not in ("0", "", "false", "False")
 
 
+def _autopilot_enabled() -> bool:
+    return os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("0", "", "false", "False")
+
+
+def _maybe_autopilot_tick(state_dir: Path, dry_run: bool) -> None:
+    """Call roadmap_manager.autopilot_tick if VNX_ROADMAP_AUTOPILOT=1.
+
+    ADR-018 Rule 2: no new daemon — reuses the existing silence_watchdog scheduler.
+    dry_run=True skips the tick to match headless_trigger dry-run semantics.
+    """
+    if dry_run or not _autopilot_enabled():
+        return
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+    try:
+        from roadmap_manager import RoadmapManager  # noqa: PLC0415
+        result = RoadmapManager().autopilot_tick()
+        _LOG.info("autopilot_tick: status=%s", result.get("status"))
+    except Exception as exc:
+        _LOG.error("autopilot_tick error: %s", exc)
+
+
 def llm_triage(anomalies: list[str]) -> str:
     """Ask haiku to classify: 'stuck' | 'normal' | 'recovering'. Fail-open on timeout."""
     prompt = (
@@ -299,6 +320,8 @@ def silence_watchdog(
             trigger_headless_t0("silence_anomaly", anomalies, state_dir, dry_run, trigger_state)
     else:
         _LOG.debug("Layer 2: no anomalies detected")
+
+    _maybe_autopilot_tick(state_dir, dry_run)
 
     if not trigger_state.shutdown_event.is_set():
         t = threading.Timer(interval, silence_watchdog, [state_dir, interval, trigger_state, dry_run])

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -677,6 +677,47 @@ Implement the minimum blocking fix required before the roadmap may advance.
             "dispatch_id": dispatch_id,
         }
 
+    def autopilot_tick(self) -> Dict[str, Any]:
+        """Single-iteration autopilot tick. Feature-flag gated (VNX_ROADMAP_AUTOPILOT=1).
+
+        Sequence: run_feature_step → (if queue drained) advance.
+        advance() runs reconcile() internally (RA-3/3b gate enforcement) then the
+        human approval check (RA-4), so this tick composes the full RA-1..5 loop.
+
+        ADR-007: project_id-scoped via existing primitives — no extra scoping needed.
+        ADR-018 Rule 2: single-claim, no loop. Caller (silence_watchdog) schedules repetition.
+        """
+        if os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("1", "true", "True"):
+            return {"status": "disabled", "reason": "VNX_ROADMAP_AUTOPILOT not set"}
+
+        state = self.load_state()
+        if not state.get("current_active_feature"):
+            return {"status": "idle", "reason": "no_active_feature"}
+
+        step_result = self.run_feature_step()
+
+        if step_result["status"] == "dispatched":
+            return {
+                "status": "stepped",
+                "feature_id": step_result["feature_id"],
+                "pr_id": step_result["pr_id"],
+                "dispatch_id": step_result["dispatch_id"],
+            }
+
+        if step_result["status"] in ("failed", "no_active_feature"):
+            return {"status": step_result["status"], "step": step_result}
+
+        # Queue drained (no_ready_pr) → reconcile (via advance) + approval gate.
+        advance_result = self.advance()
+        if advance_result.get("advanced"):
+            return {"status": "advanced", "advance": advance_result}
+
+        return {
+            "status": "blocked",
+            "reason": advance_result.get("reason"),
+            "advance": advance_result,
+        }
+
     def status(self) -> Dict[str, Any]:
         state = self.load_state()
         return {
@@ -721,6 +762,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     step_parser = sub.add_parser("step")
     step_parser.add_argument("--json", action="store_true")
 
+    autopilot_parser = sub.add_parser("autopilot")
+    autopilot_parser.add_argument("--json", action="store_true")
+
     args = parser.parse_args(argv)
     manager = RoadmapManager()
 
@@ -738,6 +782,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         result = manager.approve(args.feature_id, actor=args.actor, justification=args.justification)
     elif args.command == "step":
         result = manager.run_feature_step()
+    elif args.command == "autopilot":
+        result = manager.autopilot_tick()
     else:
         raise AssertionError("unreachable")
 

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -820,3 +820,105 @@ def test_step_no_active_feature_returns_status(roadmap_env, monkeypatch):
     result = manager.run_feature_step()
 
     assert result["status"] == "no_active_feature"
+
+
+# ---------------------------------------------------------------------------
+# RA-6: autopilot tick
+# ---------------------------------------------------------------------------
+
+
+def test_autopilot_tick_disabled_when_flag_unset(roadmap_env, monkeypatch):
+    """VNX_ROADMAP_AUTOPILOT unset → tick returns disabled, no progression."""
+    monkeypatch.delenv("VNX_ROADMAP_AUTOPILOT", raising=False)
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    result = manager.autopilot_tick()
+
+    assert result["status"] == "disabled"
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-a", "flag off must not cause progression"
+
+
+def test_autopilot_tick_full_loop_advances_a_to_b(roadmap_env, monkeypatch):
+    """Full simulated loop: tick1 dispatches PR, tick2 (queue drained + gates pass) advances A→B."""
+    monkeypatch.setenv("VNX_ROADMAP_AUTOPILOT", "1")
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"])
+
+    # feature-a is conditional_auto + low risk → no approval token required
+    tick1 = manager.autopilot_tick()
+    assert tick1["status"] == "stepped", f"expected stepped, got: {tick1}"
+    assert tick1["pr_id"] == "PR-0"
+
+    # PR-0 is now in_progress; queue is drained → second tick advances
+    tick2 = manager.autopilot_tick()
+    assert tick2["status"] == "advanced", f"expected advanced, got: {tick2}"
+
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-b"
+    assert "feature-a" in state["merged_features"]
+
+
+def test_autopilot_tick_blocked_when_gates_incomplete(roadmap_env, monkeypatch):
+    """Queue drained but gates incomplete (RA-3) → tick blocked, no advancement."""
+    monkeypatch.setenv("VNX_ROADMAP_AUTOPILOT", "1")
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a", no_worktree=True)
+
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    # No gate results written → gates_incomplete
+
+    tick1 = manager.autopilot_tick()
+    assert tick1["status"] == "stepped"
+
+    tick2 = manager.autopilot_tick()
+    assert tick2["status"] == "blocked"
+    assert tick2["reason"] == "gates_incomplete"
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-a", "must not advance with incomplete gates"
+
+
+def test_autopilot_tick_blocked_awaiting_human_approval(roadmap_env, monkeypatch):
+    """High-risk feature: queue drained + gates pass but no approval token → tick blocked (RA-4)."""
+    project_root = roadmap_env["project_root"]
+    roadmap_file = _make_high_risk_roadmap(project_root)
+
+    monkeypatch.setenv("VNX_ROADMAP_AUTOPILOT", "1")
+    monkeypatch.setenv("VNX_QUEUE_POPUP_ENABLED", "0")
+
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+    _setup_passing_gates(roadmap_env["state_dir"], branch="feature/hi")
+
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_file)
+    manager.load_feature("feature-hi", no_worktree=True)
+
+    tick1 = manager.autopilot_tick()
+    assert tick1["status"] == "stepped"
+
+    tick2 = manager.autopilot_tick()
+    assert tick2["status"] == "blocked"
+    assert tick2["reason"] == "awaiting_human_approval"
+    state = manager.load_state()
+    assert state["current_active_feature"] == "feature-hi", "must not advance without approval token"


### PR DESCRIPTION
## Summary

- Adds `autopilot_tick()` to `RoadmapManager`: composes RA-1..5 into a single tick — `run_feature_step` → (queue drained) → `advance` (which runs `reconcile` + gate enforcement + human approval check)
- Feature-flag gated on `VNX_ROADMAP_AUTOPILOT=1` (default OFF) — tick returns `{status: disabled}` when unset
- Wired into `scripts/headless_trigger.py` via `_maybe_autopilot_tick()` called from `silence_watchdog` — reuses the existing 10-min scheduler (ADR-018 Rule 2: no new daemon)
- `vnx roadmap autopilot` subcommand added to CLI + help text

## ADR citations

- **ADR-007**: project_id-scoping handled by existing `RoadmapManager` primitives (no extra scoping needed in tick)
- **ADR-018 Rule 2**: single-claim, no loop — `autopilot_tick` does one decision and returns; `silence_watchdog` in `headless_trigger.py` provides the repeat schedule without a new daemon

## Verify

- Test: full simulated loop (mock `verify_closure` PASS + gate results) advances feature A→B in two-tick sequence
- Test: `VNX_ROADMAP_AUTOPILOT` unset → tick is a no-op (`status: disabled`), no progression
- Test: `gates_incomplete` (RA-3) → tick returns `blocked`, feature does not advance
- Test: missing approval token (RA-4, high-risk feature) → tick returns `blocked`, feature does not advance
- `python3 -m pytest tests/test_roadmap_manager.py -q` → **31 passed**

## Test run

```
31 passed
```

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)