### PR TITLE
fix(blk-readme): make quickstart work on clean pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The closest spiritual cousin is [dmux](https://github.com/standardagents/dmux), 
 
 I built this for my own work. It is open source because the architecture is portable. Use at your own discretion.
 
-Public 1.0 status as of this README merge on 2026-05-28: the package is pip-installable, `VERSION` is `1.0.0-rc3`, and the operator binary is still required for the full command surface. Open governance and release items are tracked in [ROADMAP.md](ROADMAP.md), [FEATURE_PLAN.md](FEATURE_PLAN.md), and the open-items tooling under [scripts/open_items_manager.py](scripts/open_items_manager.py).
+Public 1.0 status as of this README merge on 2026-05-28: the package is pip-installable, `VERSION` is `1.0.0`, and the operator binary is still required for the full command surface. Open governance and release items are tracked in [ROADMAP.md](ROADMAP.md), [FEATURE_PLAN.md](FEATURE_PLAN.md), and the open-items tooling under [scripts/open_items_manager.py](scripts/open_items_manager.py).
 
 ## Credits
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,27 +27,18 @@ vnx doctor
 `vnx init` creates the tracked project scaffold (`.vnx/`, `.vnx-project-id`,
 and `agents/`) and a resolved runtime state directory.
 
-## Step 3: Create the Hello-World Agent
+## Step 3: Run the Hello-World Demo
 
-`dispatch-agent` resolves agents from either `agents/<name>/CLAUDE.md` or
-`examples/<name>/CLAUDE.md`. Create the quickstart example in `examples/`:
+The `hello-world` example agent ships with VNX. No files to create:
 
 ```bash
-mkdir -p examples/hello-world
-cat > examples/hello-world/CLAUDE.md <<'EOF'
-# Hello World Agent
-
-Write a friendly, professional greeting for a new VNX user.
-
-Create a file called greeting.md in the current directory with:
-- A welcoming header
-- 2-3 sentences about VNX
-- Today's date
-- A sign-off
-EOF
+vnx dispatch-agent --agent hello-world
 ```
 
-## Step 4: Dispatch
+`dispatch-agent` finds the packaged `hello-world` example automatically and uses
+its built-in default instruction. Pass `--instruction "..."` to override.
+
+## Step 4: Dispatch with a Custom Instruction
 
 ```bash
 vnx dispatch-agent --agent hello-world --instruction "Write a greeting for a new VNX user"

--- a/examples/hello-world/config.yaml
+++ b/examples/hello-world/config.yaml
@@ -1,5 +1,6 @@
 governance_profile: minimal
 description: "Demonstration agent for the VNX quickstart guide"
+default_instruction: "Write a greeting for a new VNX user"
 isolation:
   scope_type: example
   allowed_paths:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,5 @@ vnx_orchestration = [
     "templates/**/*",
     "configs/**/*",
     "hooks/**/*",
+    "examples/**/*",
 ]

--- a/tests/test_dispatch_agent_default_instruction.py
+++ b/tests/test_dispatch_agent_default_instruction.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Tests for dispatch-agent default instruction and engine-root fallback (PR-README-QS).
+
+Covers:
+  1. _read_default_instruction parses quoted and unquoted values
+  2. _read_default_instruction returns None for missing key / unreadable file
+  3. _resolve_agent_path falls back to engine_root when not in project_dir
+  4. vnx_dispatch_agent uses default_instruction when --instruction omitted
+  5. vnx_dispatch_agent errors when no instruction and no default
+  6. hello-world example ships default_instruction in config.yaml
+  7. examples/ is declared in pyproject.toml package-data
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.dispatch_agent import (
+    _read_default_instruction,
+    _resolve_agent_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1-2. _read_default_instruction
+# ---------------------------------------------------------------------------
+
+class TestReadDefaultInstruction:
+    def test_reads_double_quoted_value(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('governance_profile: minimal\ndefault_instruction: "Hello world"\n')
+        assert _read_default_instruction(cfg) == "Hello world"
+
+    def test_reads_single_quoted_value(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("default_instruction: 'Do something'\n")
+        assert _read_default_instruction(cfg) == "Do something"
+
+    def test_reads_unquoted_value(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("default_instruction: Write a greeting\n")
+        assert _read_default_instruction(cfg) == "Write a greeting"
+
+    def test_missing_key_returns_none(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("governance_profile: minimal\n")
+        assert _read_default_instruction(cfg) is None
+
+    def test_nonexistent_file_returns_none(self, tmp_path):
+        assert _read_default_instruction(tmp_path / "nonexistent.yaml") is None
+
+    def test_empty_value_returns_none(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("default_instruction:\n")
+        assert _read_default_instruction(cfg) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. _resolve_agent_path engine-root fallback
+# ---------------------------------------------------------------------------
+
+class TestResolveAgentPathFallback:
+    def test_finds_agent_in_project_agents(self, tmp_path):
+        agent_dir = tmp_path / "agents" / "my-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "CLAUDE.md").write_text("# Agent")
+        result = _resolve_agent_path(tmp_path, "my-agent")
+        assert result is not None
+        assert result == agent_dir / "CLAUDE.md"
+
+    def test_finds_agent_in_project_examples(self, tmp_path):
+        ex_dir = tmp_path / "examples" / "demo-agent"
+        ex_dir.mkdir(parents=True)
+        (ex_dir / "CLAUDE.md").write_text("# Demo")
+        result = _resolve_agent_path(tmp_path, "demo-agent")
+        assert result is not None
+        assert result == ex_dir / "CLAUDE.md"
+
+    def test_falls_back_to_engine_root(self, tmp_path):
+        """When agent not in project_dir, falls back to engine_root/examples/."""
+        fake_engine = tmp_path / "engine"
+        ex_dir = fake_engine / "examples" / "hello-world"
+        ex_dir.mkdir(parents=True)
+        (ex_dir / "CLAUDE.md").write_text("# Hello World")
+
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=fake_engine):
+            result = _resolve_agent_path(tmp_path / "empty-project", "hello-world")
+
+        assert result is not None
+        assert result == ex_dir / "CLAUDE.md"
+
+    def test_unknown_agent_returns_none(self, tmp_path):
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=tmp_path):
+            result = _resolve_agent_path(tmp_path, "nonexistent-xyz")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 4-5. vnx_dispatch_agent uses default_instruction when --instruction omitted
+# ---------------------------------------------------------------------------
+
+class TestDispatchAgentDefaultInstruction:
+    def _make_agent(self, base: Path, name: str, default_instruction: str | None = None):
+        """Create a minimal agent CLAUDE.md + config.yaml under base/examples/<name>/."""
+        agent_dir = base / "examples" / name
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "CLAUDE.md").write_text(f"# {name} agent")
+        cfg = "governance_profile: minimal\n"
+        if default_instruction:
+            cfg += f'default_instruction: "{default_instruction}"\n'
+        (agent_dir / "config.yaml").write_text(cfg)
+        return agent_dir
+
+    def test_uses_default_instruction_when_none_given(self, tmp_path):
+        """When instruction is None and config.yaml has default_instruction, dispatch proceeds."""
+        self._make_agent(tmp_path, "hello-world", "Write a greeting")
+
+        captured_instruction = []
+
+        def fake_deliver(**kwargs):
+            captured_instruction.append(kwargs.get("instruction"))
+            return True
+
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=tmp_path), \
+             patch("vnx_cli.commands.dispatch_agent._engine.ensure_engine_on_path"), \
+             patch.dict("sys.modules", {"subprocess_dispatch": MagicMock(deliver_with_recovery=fake_deliver)}):
+            from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
+            args = Namespace(agent="hello-world", instruction=None, model="sonnet", project_dir=str(tmp_path))
+            rc = vnx_dispatch_agent(args)
+
+        assert rc == 0
+        assert captured_instruction == ["Write a greeting"]
+
+    def test_errors_when_no_instruction_and_no_default(self, tmp_path, capsys):
+        """When instruction is None and config.yaml has no default, error is printed."""
+        self._make_agent(tmp_path, "bare-agent", default_instruction=None)
+
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=tmp_path):
+            from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
+            args = Namespace(agent="bare-agent", instruction=None, model="sonnet", project_dir=str(tmp_path))
+            rc = vnx_dispatch_agent(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "--instruction" in captured.err
+
+    def test_explicit_instruction_overrides_default(self, tmp_path):
+        """Explicit --instruction takes precedence over default_instruction."""
+        self._make_agent(tmp_path, "hello-world", "Default instruction")
+
+        captured_instruction = []
+
+        def fake_deliver(**kwargs):
+            captured_instruction.append(kwargs.get("instruction"))
+            return True
+
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=tmp_path), \
+             patch("vnx_cli.commands.dispatch_agent._engine.ensure_engine_on_path"), \
+             patch.dict("sys.modules", {"subprocess_dispatch": MagicMock(deliver_with_recovery=fake_deliver)}):
+            from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
+            args = Namespace(agent="hello-world", instruction="Override", model="sonnet", project_dir=str(tmp_path))
+            rc = vnx_dispatch_agent(args)
+
+        assert rc == 0
+        assert captured_instruction == ["Override"]
+
+
+# ---------------------------------------------------------------------------
+# 6. hello-world ships default_instruction
+# ---------------------------------------------------------------------------
+
+def test_hello_world_config_has_default_instruction():
+    """examples/hello-world/config.yaml must have default_instruction."""
+    config_path = REPO_ROOT / "examples" / "hello-world" / "config.yaml"
+    assert config_path.is_file(), "examples/hello-world/config.yaml missing"
+    instruction = _read_default_instruction(config_path)
+    assert instruction, "default_instruction must be non-empty in hello-world config.yaml"
+
+
+def test_hello_world_resolves_without_project_dir():
+    """hello-world resolves from engine root even in an empty project dir."""
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = Path(tmp)
+        result = _resolve_agent_path(empty, "hello-world")
+    assert result is not None, "hello-world not found via engine root fallback"
+    assert result.name == "CLAUDE.md"
+
+
+# ---------------------------------------------------------------------------
+# 7. pyproject.toml declares examples/ in package-data
+# ---------------------------------------------------------------------------
+
+def test_pyproject_includes_examples():
+    """pyproject.toml must declare examples/**/* in vnx_orchestration package-data."""
+    pyproject = REPO_ROOT / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    assert '"examples/**/*"' in content or "'examples/**/*'" in content, (
+        "examples/**/* not found in pyproject.toml package-data"
+    )

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -9,10 +9,11 @@ from vnx_cli import _engine
 
 
 def _resolve_agent_path(project_dir: Path, agent: str) -> Path | None:
-    """Resolve an agent CLAUDE.md from project agents/ or examples/."""
+    """Resolve an agent CLAUDE.md from project agents/, examples/, or packaged examples."""
     candidates = [
         project_dir / "agents" / agent / "CLAUDE.md",
         project_dir / "examples" / agent / "CLAUDE.md",
+        _engine.engine_root() / "examples" / agent / "CLAUDE.md",
     ]
     for candidate in candidates:
         if candidate.exists():
@@ -20,9 +21,26 @@ def _resolve_agent_path(project_dir: Path, agent: str) -> Path | None:
     return None
 
 
+def _read_default_instruction(config_path: Path) -> str | None:
+    """Read default_instruction value from config.yaml using line-by-line parse.
+
+    Avoids a PyYAML dependency in the pip console-script package.
+    Only handles top-level scalar values (not multi-line or anchored YAML).
+    """
+    try:
+        for line in config_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("default_instruction:"):
+                value = stripped.split(":", 1)[1].strip()
+                return value.strip('"').strip("'") or None
+    except OSError:
+        pass
+    return None
+
+
 def vnx_dispatch_agent(args) -> int:
     agent = args.agent
-    instruction = args.instruction
+    instruction = getattr(args, "instruction", None)
     model = getattr(args, "model", "sonnet")
     project_dir = Path(getattr(args, "project_dir", ".")).resolve()
 
@@ -32,6 +50,19 @@ def vnx_dispatch_agent(args) -> int:
         print(
             f"Error: agent '{agent}' not found. "
             f"Expected: agents/{agent}/CLAUDE.md or examples/{agent}/CLAUDE.md",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve instruction: explicit arg > default_instruction in config.yaml
+    if not instruction:
+        config_path = agent_claude_md.parent / "config.yaml"
+        instruction = _read_default_instruction(config_path)
+
+    if not instruction:
+        print(
+            f"Error: --instruction is required for agent '{agent}' "
+            "(no default_instruction found in config.yaml).",
             file=sys.stderr,
         )
         return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -161,9 +161,10 @@ def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
     )
     dispatch_parser.add_argument(
         "--instruction",
-        required=True,
+        required=False,
+        default=None,
         metavar="TEXT",
-        help="instruction text to send to the agent",
+        help="instruction text to send to the agent (optional for agents with default_instruction in config.yaml)",
     )
     dispatch_parser.add_argument(
         "--model",


### PR DESCRIPTION
## Summary

- `vnx dispatch-agent --agent hello-world` now works without `--instruction` on a fresh pip install
- `examples/**/*` added to wheel package-data so hello-world ships in the installed package
- `_resolve_agent_path` falls back to the packaged engine root when the agent isn't in the project dir
- `--instruction` made optional; agents can declare `default_instruction` in `config.yaml`
- QUICKSTART.md Step 3 updated: no manual file creation needed
- README version string fixed: `1.0.0-rc3` → `1.0.0`

## Root cause

`--instruction` was `required=True` in argparse, so the documented command `vnx dispatch-agent --agent hello-world` exited immediately with an error. Additionally `examples/` wasn't in `package-data` so the hello-world CLAUDE.md wasn't in the installed wheel.

## Test plan

- [x] 16 new tests in `tests/test_dispatch_agent_default_instruction.py` — all green
- [x] All quickstart validation tests pass (25/27 in `test_vnx_cli.py` + `test_quickstart_validation.py`; 2 failures are pre-existing `init_cmd` bugs confirmed on unmodified branch)
- [x] `vnx dispatch-agent --agent hello-world` (no `--instruction`) resolves default and dispatches
- [x] `--instruction` flag still works when provided (overrides default)
- [x] Unknown agent still errors with clear message

## Pre-existing failures (not caused by this PR)

`test_init_creates_vnx_data_subdirs` and `test_init_idempotent` fail on the unmodified `main` branch — verified by stashing this PR's changes and running the tests.

## Verify (wheel install)

In a fresh venv:
```bash
pip install vnx-orchestration
vnx init
vnx dispatch-agent --agent hello-world
vnx status
```

All commands exit 0, no missing-file or missing-arg errors.

---
Dispatch-ID: 20260529-221216-blk-readme