### PR TITLE
fix(blk-initpath): guard _scaffold_vnx_data_local behind inside_project

### DIFF
--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from vnx_cli.commands.init_cmd import vnx_init
 from vnx_cli import __version__
+from vnx_cli._engine import resolve_data_root
 
 
 def _args(tmp_path, **overrides):
@@ -40,16 +41,59 @@ class TestVnxInitCli:
         assert (tmp_path / ".claude" / "skills").is_dir()
         assert (tmp_path / ".claude" / "settings.json").is_file()
 
-    def test_init_creates_vnx_data_dir(self, tmp_path):
+    def test_init_creates_vnx_data_dir(self, tmp_path, monkeypatch):
+        # Force the data root to be project-local so we can assert local layout.
+        local_data = tmp_path / ".vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(local_data))
+
         rc = vnx_init(_args(tmp_path))
         assert rc == 0
-        vnx_data = tmp_path / ".vnx-data"
-        assert vnx_data.is_dir()
-        assert (vnx_data / "dispatches" / "pending").is_dir()
-        assert (vnx_data / "dispatches" / "active").is_dir()
-        assert (vnx_data / "dispatches" / "completed").is_dir()
-        assert (vnx_data / "events").is_dir()
-        assert (vnx_data / "unified_reports").is_dir()
+        assert local_data.is_dir()
+        assert (local_data / "dispatches" / "pending").is_dir()
+        assert (local_data / "dispatches" / "active").is_dir()
+        assert (local_data / "dispatches" / "completed").is_dir()
+        assert (local_data / "events").is_dir()
+        assert (local_data / "unified_reports").is_dir()
+
+    def test_init_no_local_vnx_data_when_xdg(self, tmp_path, tmp_path_factory, monkeypatch):
+        # When data_root is outside the project dir, vnx init must NOT create
+        # a local .vnx-data/ — that would cause the resolver to prefer the
+        # local dir on the next call, contradicting the config (PR-PIP-2).
+        external_data = tmp_path_factory.mktemp("external_data")
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(external_data))
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        assert not (tmp_path / ".vnx-data").exists(), (
+            "Local .vnx-data must not be created when data root is outside the project"
+        )
+
+    def test_init_reported_path_matches_resolver(self, tmp_path, tmp_path_factory, monkeypatch):
+        # Core consistency invariant: what init writes into config.yml must
+        # equal what resolve_data_root returns post-init (no XDG-vs-local drift).
+        external_data = tmp_path_factory.mktemp("external_data")
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(external_data))
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+
+        config_text = (tmp_path / ".vnx" / "config.yml").read_text()
+        config_data_dir = None
+        for line in config_text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("vnx_data_dir:"):
+                config_data_dir = Path(stripped.split('"')[1]).resolve()
+                break
+        assert config_data_dir is not None, "config.yml must contain vnx_data_dir"
+
+        resolved = resolve_data_root(tmp_path)
+        assert config_data_dir == resolved, (
+            f"Path drift: init configured {config_data_dir!r} "
+            f"but resolver returned {resolved!r}"
+        )
 
     def test_init_writes_vnx_version(self, tmp_path):
         rc = vnx_init(_args(tmp_path))

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -345,7 +345,14 @@ def vnx_init(args) -> int:
         "vnx_version": __version__,
     }
     _scaffold_claude_dir(project_dir, tmpl_root, ctx, force)
-    _scaffold_vnx_data_local(project_dir)
+    # Only create the project-local .vnx-data/ scaffold when the resolved
+    # data root is already inside the project directory. For fresh
+    # XDG/external installs the runtime dirs are under data_root (created
+    # above); silently creating a second local .vnx-data/ would cause the
+    # next resolver call to prefer it (step-4 "existing dev checkout" branch),
+    # contradicting the config and the init output (PR-PIP-2 clean-footprint).
+    if inside_project:
+        _scaffold_vnx_data_local(project_dir)
 
     written = _write_vnx_version(project_dir, __version__, force)
     print(f"  {'created' if written else 'exists '} .vnx-version ({__version__})")


### PR DESCRIPTION
## Summary

- **Root cause**: `vnx init` unconditionally called `_scaffold_vnx_data_local(project_dir)`, creating `<project_dir>/.vnx-data/` regardless of where the resolved data root points. The resolver's step-4 "existing dev checkout" branch then found this local dir on the next call and returned it instead of the XDG path — contradicting the config written by init and the PR-PIP-2 clean-footprint claim.
- **Fix**: wrapped `_scaffold_vnx_data_local` in `if inside_project:`. The `inside_project` flag was already computed at line 337; no new logic introduced. For fresh XDG/external installs the runtime dirs are created at `data_root`; no conflicting local `.vnx-data/` is created. Config path and post-init resolver path now agree.
- **ADR-007 compliance**: `_resolve_state_root` forms all per-project dirs from a validated `project_id` (steps 2–5), never a shared default. No new central-DB tables introduced. Project_id-scoped resolution is preserved.

## Verify (fresh venv + clean temp dir)

```bash
# 1. init in a clean temp project
tmp=$(mktemp -d) && python3 -m vnx_cli.main init "$tmp" --project-id test-pr-init

# 2. local .vnx-data must NOT exist
ls "$tmp/.vnx-data" 2>&1 || echo "PASS: no local .vnx-data"

# 3. config path must match resolver
python3 - <<'PY'
from pathlib import Path
import sys
sys.path.insert(0, '.')
from vnx_cli._engine import resolve_data_root

tmp = Path(sys.argv[1])
config_text = (tmp / '.vnx' / 'config.yml').read_text()
for line in config_text.splitlines():
    if 'vnx_data_dir' in line:
        config_path = Path(line.split('"')[1]).resolve()
        break
resolved = resolve_data_root(tmp)
assert config_path == resolved, f"DRIFT: config={config_path} resolver={resolved}"
print(f"PASS: both resolve to {resolved}")
PY
"$tmp"
```

## Test plan

- [x] `test_init_creates_vnx_data_dir` — updated to use explicit local data root override; verifies local subdirs including `events`
- [x] `test_init_no_local_vnx_data_when_xdg` — new; asserts `.vnx-data` is absent when data root is external
- [x] `test_init_reported_path_matches_resolver` — new; asserts `config.yml#vnx_data_dir == resolve_data_root(project_dir)` post-init
- [x] `python3 -m pytest tests/test_cli_init.py tests/test_vnx_init.py tests/test_project_root_resolution.py tests/test_vnx_paths_central.py tests/test_vnx_paths_overrides.py tests/test_vnx_paths_traversal.py -q` — 120 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)