### PR TITLE
fix(dream): route file I/O to canonical vnx_paths data root (blk-dreamio)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -29,7 +29,7 @@ _MIN_PATTERN_THRESHOLD: int = 1
 _DEFAULT_KIMI_TIMEOUT: int = 180
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
-from project_root import resolve_project_root
+import vnx_paths as _vnx_paths
 
 # Sort column per table — each table uses a different timestamp column name.
 _TABLE_SORT_COL: dict[str, str] = {
@@ -37,6 +37,18 @@ _TABLE_SORT_COL: dict[str, str] = {
     "antipatterns": "first_seen",
     "intelligence_injections": "injected_at",
 }
+
+
+def _resolve_data_root(data_root: "Path | None") -> Path:
+    """Return canonical VNX data root.
+
+    Uses vnx_paths so central installs resolve to ~/.vnx-data/<project_id> (or
+    VNX_DATA_HOME / XDG) rather than resolve_project_root(__file__)/.vnx-data.
+    ADR-007: project_id-scoped canonical paths.
+    """
+    if data_root is not None:
+        return data_root
+    return Path(_vnx_paths.resolve_paths()["VNX_DATA_DIR"])
 
 
 def _check_receipt_completeness(
@@ -73,10 +85,14 @@ def _check_receipt_completeness(
     return True, "ok"
 
 
-def _emit_dream_event(event: dict[str, Any]) -> None:
-    """Emit NDJSON event BEFORE any DB mutation (ADR-005)."""
-    root = resolve_project_root(__file__)
-    events_dir = root / ".vnx-data" / "events" / "dream"
+def _emit_dream_event(event: dict[str, Any], data_root: Path) -> None:
+    """Emit NDJSON event BEFORE any DB mutation (ADR-005).
+
+    ``data_root`` must be the canonical VNX data root (from _resolve_data_root),
+    NOT resolve_project_root(__file__)/.vnx-data — that path is the source repo
+    and breaks on central installs.
+    """
+    events_dir = data_root / "events" / "dream"
     events_dir.mkdir(parents=True, exist_ok=True)
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     event_path = events_dir / f"{today}.ndjson"
@@ -184,11 +200,14 @@ def run_dream_cycle(
     project_id: str,
     db_path: Path,
     dry_run: bool = False,
+    data_root: "Path | None" = None,
 ) -> dict[str, Any]:
     """Run a single dream consolidation cycle for a project.
 
     ADR-005: NDJSON emit before DB write.
     ADR-007: project_id required throughout.
+    ``data_root`` overrides the canonical data dir (useful in tests / CI).
+    When None, resolved via vnx_paths so central installs use ~/.vnx-data/<project_id>.
     Returns a dict with cycle_id, counts, and review_path.
     """
     cycle_id = (
@@ -196,9 +215,13 @@ def run_dream_cycle(
     )
     print(f"dream run: cycle={cycle_id} project={project_id}", flush=True)
 
+    # Resolve canonical data root once; all file I/O below uses _data_root.
+    # ADR-007: must NOT use resolve_project_root(__file__)/.vnx-data — that path
+    # is the VNX source repo and breaks on central installs.
+    _data_root = _resolve_data_root(data_root)
+
     # GAP-7: receipt-completeness preflight — skip cycle on empty/stale data
-    data_root = resolve_project_root(__file__) / ".vnx-data"
-    complete, detail = _check_receipt_completeness(data_root)
+    complete, detail = _check_receipt_completeness(_data_root)
     if not complete:
         _emit_dream_event(
             {
@@ -208,7 +231,8 @@ def run_dream_cycle(
                 "reason": "incomplete_data",
                 "detail": detail,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-            }
+            },
+            _data_root,
         )
         return {
             "status": "skipped",
@@ -223,7 +247,8 @@ def run_dream_cycle(
             "cycle_id": cycle_id,
             "project_id": project_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
+        },
+        _data_root,
     )
 
     kimi_timeout = float(
@@ -252,7 +277,8 @@ def run_dream_cycle(
                         f"core_count={core_count} below threshold={_MIN_PATTERN_THRESHOLD}"
                     ),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
+                },
+                _data_root,
             )
             return {
                 "status": "skipped",
@@ -273,7 +299,8 @@ def run_dream_cycle(
                     "project_id": project_id,
                     "timeout_seconds": int(kimi_timeout),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
+                },
+                _data_root,
             )
             return {
                 "status": "timeout",
@@ -288,12 +315,12 @@ def run_dream_cycle(
                     "cycle_id": cycle_id,
                     "project_id": project_id,
                     "error": str(exc)[:500],
-                }
+                },
+                _data_root,
             )
             raise
 
-        root = resolve_project_root(__file__)
-        review_dir = root / ".vnx-data" / "state" / "dream"
+        review_dir = _data_root / "state" / "dream"
         review_dir.mkdir(parents=True, exist_ok=True)
         review_path = review_dir / f"{cycle_id}-pending-review.json"
         review_path.write_text(
@@ -326,7 +353,8 @@ def run_dream_cycle(
                 "archived_count": archived_count,
                 "flagged_count": flagged_count,
                 "review_path": str(review_path),
-            }
+            },
+            _data_root,
         )
 
         if not dry_run:
@@ -374,14 +402,15 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    root = resolve_project_root(__file__)
+    paths = _vnx_paths.resolve_paths()
+    data_root = Path(paths["VNX_DATA_DIR"])
     db_path = (
         Path(args.db_path)
         if args.db_path
-        else root / ".vnx-data" / "state" / "quality_intelligence.db"
+        else data_root / "state" / "quality_intelligence.db"
     )
 
-    result = run_dream_cycle(args.project_id, db_path, args.dry_run)
+    result = run_dream_cycle(args.project_id, db_path, args.dry_run, data_root=data_root)
     print(json.dumps(result, indent=2))
     if result.get("status") == "timeout":
         sys.exit(1)

--- a/scripts/dream/review_gate.py
+++ b/scripts/dream/review_gate.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
-from project_root import resolve_project_root  # noqa: E402
+import vnx_paths as _vnx_paths
 
 _ARCHIVE_REASON_MAP: dict[str, str] = {
     "dropped": "stale_30d",
@@ -58,8 +58,15 @@ def _emit_review_event(event: dict[str, Any], data_root: Path) -> None:
         fh.write(json.dumps(event) + "\n")
 
 
-def _resolve_data_root(data_root: Path | None) -> Path:
-    return data_root if data_root is not None else (resolve_project_root(__file__) / ".vnx-data")
+def _resolve_data_root(data_root: "Path | None") -> Path:
+    """Return canonical VNX data root (ADR-007: central-install compatible).
+
+    Uses vnx_paths so central installs resolve to ~/.vnx-data/<project_id> rather
+    than resolve_project_root(__file__)/.vnx-data (the VNX source repo).
+    """
+    if data_root is not None:
+        return data_root
+    return Path(_vnx_paths.resolve_paths()["VNX_DATA_DIR"])
 
 
 def _load_review(state_dir: Path, cycle_id: str, project_id: str) -> dict:

--- a/scripts/dream/scheduler.py
+++ b/scripts/dream/scheduler.py
@@ -17,7 +17,7 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
-from project_root import resolve_project_root  # noqa: E402
+import vnx_paths as _vnx_paths
 
 _PLIST_LABEL = "com.vnx.auto-dream"
 _PLIST_NAME = f"{_PLIST_LABEL}.plist"
@@ -130,7 +130,7 @@ def install_scheduler(
     ADR-007: project_id on plist/cron for isolation.
     """
     if project_root is None:
-        project_root = resolve_project_root(__file__)
+        project_root = Path(_vnx_paths.resolve_paths()["PROJECT_ROOT"])
     if vnx_bin is None:
         vnx_bin = shutil.which("vnx") or "vnx"
 

--- a/tests/test_dream_cli.py
+++ b/tests/test_dream_cli.py
@@ -134,10 +134,9 @@ class TestDreamReviewApprove:
         _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T12:00:00+00:00")
         _write_pending_review(tmp_path, cycle_id, "vnx-dev")
 
-        with patch("review_gate.resolve_project_root", return_value=tmp_path):
-            review_gate.approve_cycle(
-                cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
-            )
+        review_gate.approve_cycle(
+            cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+        )
 
         conn = sqlite3.connect(str(db_path))
         archive_rows = conn.execute(
@@ -164,10 +163,9 @@ class TestDreamReviewApprove:
         _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T13:00:00+00:00")
         _write_pending_review(tmp_path, cycle_id, "vnx-dev")
 
-        with patch("review_gate.resolve_project_root", return_value=tmp_path):
-            review_gate.approve_cycle(
-                cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
-            )
+        review_gate.approve_cycle(
+            cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+        )
 
         events = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
         assert len(events) == 1
@@ -183,11 +181,10 @@ class TestDreamReviewReject:
         _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T14:00:00+00:00")
         _write_pending_review(tmp_path, cycle_id, "vnx-dev")
 
-        with patch("review_gate.resolve_project_root", return_value=tmp_path):
-            review_gate.reject_cycle(
-                cycle_id, "vnx-dev", "test rejection", db_path,
-                data_root=tmp_path / ".vnx-data",
-            )
+        review_gate.reject_cycle(
+            cycle_id, "vnx-dev", "test rejection", db_path,
+            data_root=tmp_path / ".vnx-data",
+        )
 
         conn = sqlite3.connect(str(db_path))
         archive_count = conn.execute(
@@ -209,11 +206,10 @@ class TestDreamReviewReject:
         _insert_cycle(db_path, cycle_id, "vnx-dev", "2026-05-29T15:00:00+00:00")
         review_path = _write_pending_review(tmp_path, cycle_id, "vnx-dev")
 
-        with patch("review_gate.resolve_project_root", return_value=tmp_path):
-            review_gate.reject_cycle(
-                cycle_id, "vnx-dev", "low confidence", db_path,
-                data_root=tmp_path / ".vnx-data",
-            )
+        review_gate.reject_cycle(
+            cycle_id, "vnx-dev", "low confidence", db_path,
+            data_root=tmp_path / ".vnx-data",
+        )
 
         review = json.loads(review_path.read_text())
         assert review["rejected_reason"] == "low confidence"
@@ -319,11 +315,10 @@ class TestApproveArchiveFailure:
         conn.close()
         _write_pending_review(tmp_path, cycle_id, "vnx-dev")
 
-        with patch("review_gate.resolve_project_root", return_value=tmp_path):
-            with pytest.raises(sqlite3.OperationalError):
-                review_gate.approve_cycle(
-                    cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
-                )
+        with pytest.raises(sqlite3.OperationalError):
+            review_gate.approve_cycle(
+                cycle_id, "vnx-dev", db_path, data_root=tmp_path / ".vnx-data"
+            )
 
         conn = sqlite3.connect(str(db_path))
         row = conn.execute(
@@ -403,3 +398,22 @@ class TestResolvePathsCanonical:
         assert db_path != local_root / ".vnx-data" / "state" / "quality_intelligence.db", (
             "db_path must not be the hardcoded local worktree path"
         )
+
+
+class TestReviewGateResolveDataRoot:
+    """_resolve_data_root uses vnx_paths when no override is passed."""
+
+    def test_explicit_data_root_returned_unchanged(self, tmp_path):
+        """An explicit data_root argument is returned directly."""
+        explicit = tmp_path / "my-data"
+        result = review_gate._resolve_data_root(explicit)
+        assert result == explicit
+
+    def test_none_delegates_to_vnx_paths(self, tmp_path):
+        """When data_root is None, falls back to vnx_paths.resolve_paths()."""
+        import vnx_paths as _vnx_paths_mod
+        sentinel = tmp_path / "vnx-paths-dir"
+        paths_return = {"VNX_DATA_DIR": str(sentinel), "PROJECT_ROOT": str(tmp_path)}
+        with patch.object(_vnx_paths_mod, "resolve_paths", return_value=paths_return):
+            result = review_gate._resolve_data_root(None)
+        assert result == sentinel

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -7,6 +7,7 @@ Coverage:
 - test_dry_run_no_db_write: dry-run skips dream_cycles INSERT
 - test_run_dream_cycle_happy_path: full cycle with mocked kimi
 - GAP-7 receipt-completeness preflight: stale/empty → skip with warning event
+- TestCentralDataRootRespected: file I/O uses data_root param, not source-repo .vnx-data
 """
 from __future__ import annotations
 
@@ -106,16 +107,16 @@ def _make_in_memory_db() -> sqlite3.Connection:
 class TestEmitDreamEvent:
     def test_emit_dream_event_writes_ndjson(self, tmp_path):
         """NDJSON event is written to events/dream/<date>.ndjson (ADR-005)."""
+        data_root = tmp_path / ".vnx-data"
         event = {
             "event_type": "dream_cycle_started",
             "cycle_id": "dream-test-001",
             "project_id": "vnx-dev",
             "timestamp": "2026-05-29T00:00:00+00:00",
         }
-        with patch("consolidator.resolve_project_root", return_value=tmp_path):
-            consolidator._emit_dream_event(event)
+        consolidator._emit_dream_event(event, data_root)
 
-        ndjson_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        ndjson_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         assert len(ndjson_files) == 1
 
         lines = ndjson_files[0].read_text(encoding="utf-8").strip().splitlines()
@@ -126,11 +127,11 @@ class TestEmitDreamEvent:
 
     def test_emit_dream_event_appends(self, tmp_path):
         """Multiple emits append to the same NDJSON file, not overwrite."""
-        with patch("consolidator.resolve_project_root", return_value=tmp_path):
-            consolidator._emit_dream_event({"event_type": "a"})
-            consolidator._emit_dream_event({"event_type": "b"})
+        data_root = tmp_path / ".vnx-data"
+        consolidator._emit_dream_event({"event_type": "a"}, data_root)
+        consolidator._emit_dream_event({"event_type": "b"}, data_root)
 
-        ndjson_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        ndjson_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         lines = ndjson_files[0].read_text(encoding="utf-8").strip().splitlines()
         assert len(lines) == 2
         assert json.loads(lines[0])["event_type"] == "a"
@@ -220,9 +221,9 @@ class TestExtractKimiText:
         assert consolidator._extract_kimi_text(stdout) == ""
 
 
-def _make_fresh_receipts(tmp_path: Path) -> None:
+def _make_fresh_receipts(data_root: Path) -> None:
     """Create a fresh processed receipt so the GAP-7 preflight passes."""
-    processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+    processed = data_root / "receipts" / "processed"
     processed.mkdir(parents=True, exist_ok=True)
     (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
 
@@ -241,22 +242,22 @@ def _seed_pattern(db_path: Path) -> None:
 class TestDryRun:
     def test_dry_run_no_db_write(self, tmp_path):
         """Dry-run emits NDJSON and writes pending-review.json but skips dream_cycles INSERT."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "quality_intelligence.db"
         conn = sqlite3.connect(str(db_path))
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
-        _make_fresh_receipts(tmp_path)
+        _make_fresh_receipts(data_root)
         _seed_pattern(db_path)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                return_value=_FAKE_CONSOLIDATION,
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
         ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
 
         # dream_cycles table must be empty (no INSERT in dry-run)
         conn = sqlite3.connect(str(db_path))
@@ -272,22 +273,22 @@ class TestDryRun:
 
     def test_happy_path_db_write(self, tmp_path):
         """Non-dry-run inserts one row into dream_cycles after emitting NDJSON."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "quality_intelligence.db"
         conn = sqlite3.connect(str(db_path))
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
-        _make_fresh_receipts(tmp_path)
+        _make_fresh_receipts(data_root)
         _seed_pattern(db_path)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                return_value=_FAKE_CONSOLIDATION,
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
         ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=False, data_root=data_root
+            )
 
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute(
@@ -304,24 +305,24 @@ class TestDryRun:
 
     def test_happy_path_ndjson_emitted_before_db(self, tmp_path):
         """NDJSON dream_cycle_completed event is written (ADR-005 emit-first)."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "quality_intelligence.db"
         conn = sqlite3.connect(str(db_path))
         conn.executescript(_DREAM_SCHEMA)
         conn.commit()
         conn.close()
-        _make_fresh_receipts(tmp_path)
+        _make_fresh_receipts(data_root)
         _seed_pattern(db_path)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                return_value=_FAKE_CONSOLIDATION,
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
         ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=False, data_root=data_root
+            )
 
-        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         assert len(event_files) == 1
 
         events = [
@@ -388,6 +389,7 @@ class TestCheckReceiptCompleteness:
 class TestRunDreamCycleReceiptPreflight:
     def test_skips_when_no_receipts(self, tmp_path):
         """run_dream_cycle returns status=skipped when receipts/processed absent."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "state" / "quality_intelligence.db"
         db_path.parent.mkdir(parents=True)
         conn = __import__("sqlite3").connect(str(db_path))
@@ -395,14 +397,16 @@ class TestRunDreamCycleReceiptPreflight:
         conn.commit()
         conn.close()
 
-        with patch("consolidator.resolve_project_root", return_value=tmp_path):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+        result = consolidator.run_dream_cycle(
+            "vnx-dev", db_path, dry_run=False, data_root=data_root
+        )
 
         assert result["status"] == "skipped"
         assert result["reason"] == "incomplete_data"
 
     def test_skip_emits_ndjson_warning_event(self, tmp_path):
         """Skipped cycle emits dream_cycle_skipped NDJSON event (ADR-005)."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "state" / "quality_intelligence.db"
         db_path.parent.mkdir(parents=True)
         conn = __import__("sqlite3").connect(str(db_path))
@@ -410,10 +414,11 @@ class TestRunDreamCycleReceiptPreflight:
         conn.commit()
         conn.close()
 
-        with patch("consolidator.resolve_project_root", return_value=tmp_path):
-            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=False)
+        consolidator.run_dream_cycle(
+            "vnx-dev", db_path, dry_run=False, data_root=data_root
+        )
 
-        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         assert len(event_files) == 1
         lines = [json.loads(l) for l in event_files[0].read_text().strip().splitlines()]
         assert any(e["event_type"] == "dream_cycle_skipped" for e in lines)
@@ -422,6 +427,7 @@ class TestRunDreamCycleReceiptPreflight:
 
     def test_skip_does_not_call_kimi(self, tmp_path):
         """Skipped cycle must not invoke kimi consolidation."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "state" / "quality_intelligence.db"
         db_path.parent.mkdir(parents=True)
         conn = __import__("sqlite3").connect(str(db_path))
@@ -429,16 +435,14 @@ class TestRunDreamCycleReceiptPreflight:
         conn.commit()
         conn.close()
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch("consolidator._dispatch_kimi_consolidation") as mock_kimi,
-        ):
-            consolidator.run_dream_cycle("vnx-dev", db_path)
+        with patch("consolidator._dispatch_kimi_consolidation") as mock_kimi:
+            consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
 
         mock_kimi.assert_not_called()
 
     def test_proceeds_when_fresh_receipts_present(self, tmp_path):
         """run_dream_cycle proceeds normally when fresh receipts exist."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "state" / "quality_intelligence.db"
         db_path.parent.mkdir(parents=True)
         conn = __import__("sqlite3").connect(str(db_path))
@@ -446,20 +450,15 @@ class TestRunDreamCycleReceiptPreflight:
         conn.commit()
         conn.close()
         _seed_pattern(db_path)
+        _make_fresh_receipts(data_root)
 
-        # Create a fresh receipt file
-        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
-        processed.mkdir(parents=True)
-        (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
-
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                return_value=_FAKE_CONSOLIDATION,
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
         ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
 
         assert result.get("status") != "skipped"
         assert "cycle_id" in result
@@ -470,8 +469,8 @@ class TestRunDreamCycleReceiptPreflight:
 # ---------------------------------------------------------------------------
 
 
-def _make_db_with_receipts(tmp_path: Path, *, with_patterns: bool = False) -> Path:
-    """Return a fresh DB path with receipts ready. Optionally seed one success pattern."""
+def _make_db_with_receipts(tmp_path: Path, *, with_patterns: bool = False) -> tuple[Path, Path]:
+    """Return (db_path, data_root) with receipts ready. Optionally seed one success pattern."""
     db_path = tmp_path / "state" / "quality_intelligence.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path))
@@ -484,10 +483,11 @@ def _make_db_with_receipts(tmp_path: Path, *, with_patterns: bool = False) -> Pa
     conn.commit()
     conn.close()
 
-    processed = tmp_path / ".vnx-data" / "receipts" / "processed"
+    data_root = tmp_path / ".vnx-data"
+    processed = data_root / "receipts" / "processed"
     processed.mkdir(parents=True, exist_ok=True)
     (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
-    return db_path
+    return db_path, data_root
 
 
 class TestInsufficientDataGuard:
@@ -495,13 +495,12 @@ class TestInsufficientDataGuard:
 
     def test_empty_db_returns_skipped(self, tmp_path):
         """run_dream_cycle skips quickly when success_patterns + antipatterns = 0."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=False)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch("consolidator._dispatch_kimi_consolidation") as mock_kimi,
-        ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+        with patch("consolidator._dispatch_kimi_consolidation") as mock_kimi:
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, data_root=data_root
+            )
 
         assert result["status"] == "skipped"
         assert result["reason"] == "insufficient_data"
@@ -509,15 +508,12 @@ class TestInsufficientDataGuard:
 
     def test_empty_db_emits_skipped_ndjson_event(self, tmp_path):
         """Skipped-on-empty emits dream_cycle_skipped NDJSON event (ADR-005)."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=False)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch("consolidator._dispatch_kimi_consolidation"),
-        ):
-            consolidator.run_dream_cycle("vnx-dev", db_path)
+        with patch("consolidator._dispatch_kimi_consolidation"):
+            consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
 
-        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         assert event_files, "No NDJSON event file written"
         events = [
             json.loads(line)
@@ -529,16 +525,15 @@ class TestInsufficientDataGuard:
 
     def test_non_empty_db_proceeds_to_kimi(self, tmp_path):
         """run_dream_cycle calls kimi when at least one success pattern exists."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                return_value=_FAKE_CONSOLIDATION,
-            ) as mock_kimi,
-        ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
+        ) as mock_kimi:
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
 
         mock_kimi.assert_called_once()
         assert result.get("status") != "skipped"
@@ -558,16 +553,15 @@ class TestKimiTimeout:
 
     def test_timeout_returns_timeout_status(self, tmp_path):
         """run_dream_cycle returns status='timeout' when kimi times out."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                side_effect=self._make_timeout_error(),
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            side_effect=self._make_timeout_error(),
         ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, data_root=data_root
+            )
 
         assert result["status"] == "timeout"
         assert result["reason"] == "kimi_timeout"
@@ -575,18 +569,15 @@ class TestKimiTimeout:
 
     def test_timeout_emits_timeout_ndjson_event(self, tmp_path):
         """Timeout emits dream_cycle_timeout NDJSON event (ADR-005)."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch(
-                "consolidator._dispatch_kimi_consolidation",
-                side_effect=self._make_timeout_error(),
-            ),
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            side_effect=self._make_timeout_error(),
         ):
-            consolidator.run_dream_cycle("vnx-dev", db_path)
+            consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
 
-        event_files = list((tmp_path / ".vnx-data" / "events" / "dream").glob("*.ndjson"))
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
         assert event_files, "No NDJSON event file written"
         events = [
             json.loads(line)
@@ -597,7 +588,7 @@ class TestKimiTimeout:
 
     def test_timeout_env_override(self, tmp_path, monkeypatch):
         """VNX_DREAM_KIMI_TIMEOUT env var is passed to _dispatch_kimi_consolidation."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
         monkeypatch.setenv("VNX_DREAM_KIMI_TIMEOUT", "42")
         captured = {}
 
@@ -605,11 +596,10 @@ class TestKimiTimeout:
             captured["timeout"] = timeout
             return _FAKE_CONSOLIDATION
 
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch("consolidator._dispatch_kimi_consolidation", side_effect=_capture_timeout),
-        ):
-            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+        with patch("consolidator._dispatch_kimi_consolidation", side_effect=_capture_timeout):
+            consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
 
         assert captured["timeout"] == 42.0
 
@@ -624,6 +614,7 @@ class TestEntryPrint:
 
     def test_entry_print_emitted_on_skipped_cycle(self, tmp_path, capsys):
         """Entry print fires even when the cycle skips due to missing receipts."""
+        data_root = tmp_path / ".vnx-data"
         db_path = tmp_path / "quality_intelligence.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(db_path))
@@ -631,8 +622,7 @@ class TestEntryPrint:
         conn.commit()
         conn.close()
 
-        with patch("consolidator.resolve_project_root", return_value=tmp_path):
-            consolidator.run_dream_cycle("vnx-dev", db_path)
+        consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
 
         out = capsys.readouterr().out
         assert "dream run: cycle=" in out
@@ -640,7 +630,7 @@ class TestEntryPrint:
 
     def test_entry_print_emitted_before_kimi_call(self, tmp_path, capsys):
         """Entry print fires before any kimi invocation — ordering guarantee."""
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=True)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
         call_order: list[str] = []
 
         def _record_print(*args, **kwargs):
@@ -651,11 +641,12 @@ class TestEntryPrint:
             return _FAKE_CONSOLIDATION
 
         with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
             patch("builtins.print", side_effect=_record_print),
             patch("consolidator._dispatch_kimi_consolidation", side_effect=_fake_kimi),
         ):
-            consolidator.run_dream_cycle("vnx-dev", db_path, dry_run=True)
+            consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
 
         assert "print" in call_order
         assert "kimi" in call_order
@@ -664,7 +655,7 @@ class TestEntryPrint:
     def test_empty_db_returns_skipped_under_5s(self, tmp_path):
         """Empty DB with fresh receipts must return in <5s — no kimi spawn."""
         import time
-        db_path = _make_db_with_receipts(tmp_path, with_patterns=False)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=False)
         called = []
 
         def _no_kimi(*a, **kw):
@@ -672,14 +663,121 @@ class TestEntryPrint:
             raise AssertionError("kimi must not be called on empty DB")
 
         t0 = time.monotonic()
-        with (
-            patch("consolidator.resolve_project_root", return_value=tmp_path),
-            patch("consolidator._dispatch_kimi_consolidation", side_effect=_no_kimi),
-        ):
-            result = consolidator.run_dream_cycle("vnx-dev", db_path)
+        with patch("consolidator._dispatch_kimi_consolidation", side_effect=_no_kimi):
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
         elapsed = time.monotonic() - t0
 
         assert result["status"] == "skipped"
         assert result["reason"] == "insufficient_data"
         assert not called, "kimi was invoked on empty DB"
         assert elapsed < 5.0, f"took {elapsed:.2f}s — exceeded 5s threshold"
+
+
+# ---------------------------------------------------------------------------
+# Central data root regression: file I/O must use data_root, not source repo
+# ---------------------------------------------------------------------------
+
+
+class TestCentralDataRootRespected:
+    """File I/O (events, pending-review, receipt-preflight) must use the injected
+    data_root, not resolve_project_root(__file__)/.vnx-data (the VNX source repo).
+    This is the core regression guard for the central-install blocker fix.
+    ADR-007: canonical paths are project_id-scoped.
+    """
+
+    def _make_db(self, path: Path, seed_pattern: bool = True) -> Path:
+        db_path = path / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(_DREAM_SCHEMA)
+        if seed_pattern:
+            conn.execute(
+                "INSERT INTO success_patterns (project_id, title) VALUES (?, ?)",
+                ("vnx-dev", "p"),
+            )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_events_written_to_data_root_not_source_repo(self, tmp_path):
+        """Events and pending-review.json go to data_root, not the source repo .vnx-data."""
+        data_root = tmp_path / "central-data"
+        db_path = self._make_db(tmp_path)
+
+        _make_fresh_receipts(data_root)
+
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
+        ):
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
+
+        # Events must be in data_root
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
+        assert len(event_files) == 1, "Events not written to data_root"
+
+        # Pending-review must be under data_root
+        review_path = Path(result["review_path"])
+        assert str(data_root) in str(review_path), (
+            f"review_path {review_path} not under data_root {data_root}"
+        )
+
+    def test_receipt_preflight_reads_from_data_root(self, tmp_path):
+        """GAP-7 preflight reads receipts from data_root, not source-repo .vnx-data."""
+        data_root = tmp_path / "central-data"
+        other_dir = tmp_path / "source-repo" / ".vnx-data"
+
+        # Fresh receipts ONLY in data_root
+        _make_fresh_receipts(data_root)
+        # other_dir exists but has no receipts — if code reads from it, preflight fails
+        other_dir.mkdir(parents=True)
+
+        db_path = self._make_db(tmp_path)
+
+        with patch(
+            "consolidator._dispatch_kimi_consolidation",
+            return_value=_FAKE_CONSOLIDATION,
+        ):
+            result = consolidator.run_dream_cycle(
+                "vnx-dev", db_path, dry_run=True, data_root=data_root
+            )
+
+        # Cycle must NOT be skipped (receipts found in data_root, not source repo)
+        assert result.get("status") != "skipped", (
+            "Preflight incorrectly read from source repo or elsewhere"
+        )
+        assert "cycle_id" in result
+
+    def test_skipped_event_written_to_data_root(self, tmp_path):
+        """Skip event (missing receipts) is written to data_root, not source repo."""
+        data_root = tmp_path / "central-data"
+        # No receipts anywhere — cycle will skip
+        db_path = self._make_db(tmp_path)
+
+        consolidator.run_dream_cycle(
+            "vnx-dev", db_path, dry_run=False, data_root=data_root
+        )
+
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
+        assert len(event_files) == 1, "Skip event not written to data_root"
+        events = [
+            json.loads(line)
+            for line in event_files[0].read_text().strip().splitlines()
+        ]
+        assert any(e["event_type"] == "dream_cycle_skipped" for e in events)
+
+    def test_resolve_data_root_uses_vnx_paths_when_no_override(self, tmp_path):
+        """_resolve_data_root(None) delegates to vnx_paths, not resolve_project_root."""
+        import vnx_paths as _vnx_paths_mod
+        sentinel = tmp_path / "vnx-paths-resolved"
+        paths_return = {"VNX_DATA_DIR": str(sentinel), "PROJECT_ROOT": str(tmp_path)}
+        with patch.object(_vnx_paths_mod, "resolve_paths", return_value=paths_return):
+            result = consolidator._resolve_data_root(None)
+        assert result == sentinel
+
+    def test_resolve_data_root_explicit_override_wins(self, tmp_path):
+        """_resolve_data_root(explicit_path) returns that path unchanged."""
+        explicit = tmp_path / "my-override"
+        result = consolidator._resolve_data_root(explicit)
+        assert result == explicit

--- a/tests/test_dream_scheduler.py
+++ b/tests/test_dream_scheduler.py
@@ -43,7 +43,6 @@ class TestInstallSchedulerMacOS:
             patch("scheduler.platform.system", return_value="Darwin"),
             patch("scheduler.Path.home", return_value=tmp_path),
             patch("scheduler.subprocess.run", return_value=completed_ok) as mock_run,
-            patch("scheduler.resolve_project_root", return_value=tmp_path),
         ):
             result = scheduler.install_scheduler(
                 project_id="vnx-dev",
@@ -74,7 +73,6 @@ class TestInstallSchedulerMacOS:
             patch("scheduler.platform.system", return_value="Darwin"),
             patch("scheduler.Path.home", return_value=tmp_path),
             patch("scheduler.subprocess.run", return_value=ok),
-            patch("scheduler.resolve_project_root", return_value=tmp_path),
         ):
             scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")
             scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")
@@ -103,7 +101,6 @@ class TestInstallSchedulerMacOS:
             patch("scheduler.platform.system", return_value="Darwin"),
             patch("scheduler.Path.home", return_value=tmp_path),
             patch("scheduler.subprocess.run", side_effect=mock_run),
-            patch("scheduler.resolve_project_root", return_value=tmp_path),
         ):
             with pytest.raises(RuntimeError, match="launchctl load failed"):
                 scheduler.install_scheduler("vnx-dev", project_root=tmp_path, vnx_bin="vnx")


### PR DESCRIPTION
## Summary

- `consolidator.py`, `review_gate.py`, and `scheduler.py` used `resolve_project_root(__file__)/.vnx-data` for all dream file I/O — the VNX **source repo** path, not the canonical central data dir. On central installs this broke `vnx dream run/status/review` entirely.
- Fix: replaced all three offending path derivations with `_resolve_data_root()` backed by `vnx_paths.resolve_paths()["VNX_DATA_DIR"]` — same resolution chain the DB path already used since #722.
- ADR-007: canonical paths are project_id-scoped.

**Locations fixed:**
| File | Old path | Fixed via |
|---|---|---|
| `consolidator.py` `_emit_dream_event` | `resolve_project_root(__file__)/.vnx-data/events/dream` | `data_root` param + `_resolve_data_root()` |
| `consolidator.py` `run_dream_cycle` receipt preflight | `resolve_project_root(__file__)/.vnx-data` | `_data_root = _resolve_data_root(data_root)` |
| `consolidator.py` `run_dream_cycle` review_dir | `resolve_project_root(__file__)/.vnx-data/state/dream` | `_data_root / "state" / "dream"` |
| `consolidator.py` `main()` db_path default | `resolve_project_root(__file__)/.vnx-data/state/quality_intelligence.db` | `resolve_paths()["VNX_DATA_DIR"]` |
| `review_gate.py` `_resolve_data_root` fallback | `resolve_project_root(__file__)/.vnx-data` | `vnx_paths.resolve_paths()["VNX_DATA_DIR"]` |
| `scheduler.py` `install_scheduler` fallback | `resolve_project_root(__file__)` | `vnx_paths.resolve_paths()["PROJECT_ROOT"]` |

## Verify

- `vnx dream run --project-id X` writes events + pending-review to canonical data dir (not source repo `.vnx-data`) — tested by `TestCentralDataRootRespected`.
- Receipt-preflight reads from canonical data dir — `test_receipt_preflight_reads_from_data_root` places receipts ONLY in `data_root`, source dir has no receipts; cycle must NOT skip.
- `python3 -m pytest tests/test_dream_consolidator.py tests/test_dream_cli.py tests/test_dream_scheduler.py tests/test_quality_db_dream_migration.py -v` → **75 passed**.

## Test plan

- [x] `TestCentralDataRootRespected` (5 new tests) — events, pending-review, receipt-preflight all use injected `data_root`
- [x] `TestReviewGateResolveDataRoot` (2 new tests) — `_resolve_data_root(None)` delegates to vnx_paths; explicit override returns unchanged
- [x] All 68 pre-existing dream tests still green
- [x] `bash -n` passes on all modified shell files (none modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)