### PR TITLE
fix(dream): guided exit when resolve_project_root fails outside git repo

### DIFF
--- a/tests/test_dream_cli.py
+++ b/tests/test_dream_cli.py
@@ -417,3 +417,74 @@ class TestReviewGateResolveDataRoot:
         with patch.object(_vnx_paths_mod, "resolve_paths", return_value=paths_return):
             result = review_gate._resolve_data_root(None)
         assert result == sentinel
+
+
+# ---------------------------------------------------------------------------
+# Graceful "not-in-project" exit (blk-dreamgrace)
+# ---------------------------------------------------------------------------
+
+import argparse  # noqa: E402
+
+
+class TestDreamGracefulExitOutsideProject:
+    """All dream subcommands must emit a guided message + exit(1) when
+    resolve_project_root() raises RuntimeError (i.e. outside a git repo)."""
+
+    def _make_args(self, subcommand: str, **kwargs) -> argparse.Namespace:
+        base = {"project_id": "test-project", "dream_subcommand": subcommand}
+        base.update(kwargs)
+        return argparse.Namespace(**base)
+
+    def _assert_guided_exit(self, capsys, exc_info):
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "vnx init" in captured.err, f"Guided message missing 'vnx init': {captured.err!r}"
+        assert "VNX_CANONICAL_ROOT" in captured.err, (
+            f"Guided message missing 'VNX_CANONICAL_ROOT': {captured.err!r}"
+        )
+        assert "Traceback" not in captured.err, "Raw traceback must not appear"
+
+    def test_cmd_status_guided_exit(self, capsys):
+        """vnx dream status exits cleanly with guided message when not in a project."""
+        import project_root as pr_mod
+        import vnx_cli.commands.dream as dream_mod
+
+        args = self._make_args("status")
+        with patch.object(pr_mod, "resolve_project_root", side_effect=RuntimeError("no git")):
+            with pytest.raises(SystemExit) as exc_info:
+                dream_mod._cmd_status(args)
+        self._assert_guided_exit(capsys, exc_info)
+
+    def test_cmd_run_guided_exit(self, capsys):
+        """vnx dream run exits cleanly with guided message when not in a project."""
+        import project_root as pr_mod
+        import vnx_cli.commands.dream as dream_mod
+
+        args = self._make_args("run", dry_run=False)
+        with patch.object(pr_mod, "resolve_project_root", side_effect=RuntimeError("no git")):
+            with pytest.raises(SystemExit) as exc_info:
+                dream_mod._cmd_run(args)
+        self._assert_guided_exit(capsys, exc_info)
+
+    def test_cmd_history_guided_exit(self, capsys):
+        """vnx dream history exits cleanly with guided message when not in a project."""
+        import project_root as pr_mod
+        import vnx_cli.commands.dream as dream_mod
+
+        args = self._make_args("history", limit=10)
+        with patch.object(pr_mod, "resolve_project_root", side_effect=RuntimeError("no git")):
+            with pytest.raises(SystemExit) as exc_info:
+                dream_mod._cmd_history(args)
+        self._assert_guided_exit(capsys, exc_info)
+
+    def test_resolve_paths_raises_system_exit_on_no_project(self, capsys):
+        """_resolve_paths() itself raises SystemExit(1) — not a raw RuntimeError."""
+        import project_root as pr_mod
+        import vnx_cli.commands.dream as dream_mod
+
+        with patch.object(pr_mod, "resolve_project_root", side_effect=RuntimeError("no git")):
+            with pytest.raises(SystemExit) as exc_info:
+                dream_mod._resolve_paths()
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "vnx init" in captured.err

--- a/vnx_cli/commands/dream.py
+++ b/vnx_cli/commands/dream.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 from pathlib import Path
 
 from vnx_cli import _engine
 _engine.ensure_engine_on_path()
+
+_NOT_IN_PROJECT_MSG = (
+    "not in a VNX project — run `vnx init` inside a git repo, or set VNX_CANONICAL_ROOT"
+)
 
 
 def _get_project_id(args) -> str | None:
@@ -28,7 +33,11 @@ def _resolve_paths() -> tuple[Path, Path]:
     """
     from project_root import resolve_project_root  # type: ignore[import]
     from vnx_paths import resolve_state_dir  # type: ignore[import]
-    root = resolve_project_root()
+    try:
+        root = resolve_project_root()
+    except RuntimeError:
+        print(f"error: {_NOT_IN_PROJECT_MSG}", file=sys.stderr)
+        sys.exit(1)
     state_dir = resolve_state_dir()
     return root, state_dir / "quality_intelligence.db"
 


### PR DESCRIPTION
## Summary

- `vnx_cli/commands/dream.py` — `_resolve_paths()` now catches `RuntimeError` from `resolve_project_root()` and emits a guided message (`not in a VNX project — run \`vnx init\` inside a git repo, or set VNX_CANONICAL_ROOT`) then calls `sys.exit(1)`. No raw Python traceback for the "not in a VNX project" case.
- Audited all other `vnx_cli/commands/*.py` — `track.py` already handles this; `status`, `doctor`, `pool`, `init`, `update`, `version` do not call `resolve_project_root()` directly and are unaffected.
- Added 4 regression tests to `tests/test_dream_cli.py` covering `_cmd_status`, `_cmd_run`, `_cmd_history`, and `_resolve_paths()` directly.

## Verify: non-git temp dir

```bash
# In a fresh venv, from a non-git temp dir:
vnx dream status --project-id x   # → guided message + exit 1, NO Traceback
vnx dream run --project-id x      # → guided message + exit 1, NO Traceback
```

## Test plan

- [x] `python3 -m pytest tests/test_dream_cli.py -q` — 22 passed (was 18)
- [x] Pre-existing `test_track_cli.py` failures confirmed pre-existing (unchanged baseline)
- [x] Functional smoke: mocked `resolve_project_root` → `RuntimeError` → `SystemExit(1)` + guided message on stderr

Dispatch-ID: 20260529-224940-blk-dreamgrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)