### PR TITLE
fix(blk-initmigrate): bootstrap runtime DBs in vnx init; add vnx migrate command

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -2105,6 +2105,9 @@ main() {
     demo)
       cmd_demo "$@"
       ;;
+    migrate)
+      PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.main migrate "$@"
+      ;;
     pool)
       PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.commands.pool "$@"
       ;;

--- a/scripts/lib/migrations/apply_0022.py
+++ b/scripts/lib/migrations/apply_0022.py
@@ -1,0 +1,42 @@
+"""apply_0022.py — track layer migration (ADR-019 zero-to-tracks).
+
+Creates: tracks, track_phase_history, track_dependencies, track_open_items.
+Rebuilds dispatches with state CHECK + operator_approved_at column.
+
+Idempotent: PRAGMA user_version >= 22 → skip entirely.
+Atomicity: apply_script_if_below wraps all statements in a SAVEPOINT.
+Applied by: scripts/lib/migrations/auto_apply.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from schema_migration import apply_script_if_below
+
+log = logging.getLogger(__name__)
+
+
+def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
+    """Returns True if applied, False if skipped (already at target version)."""
+    sql = migration_sql_path.read_text()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None  # autocommit — required for SAVEPOINT semantics
+    try:
+        applied = apply_script_if_below(conn, 22, sql)
+    finally:
+        conn.close()
+
+    if applied:
+        log.info("apply_0022: track layer applied (user_version → 22)")
+    else:
+        log.debug("apply_0022: already at user_version >= 22; skipped")
+    return applied

--- a/scripts/lib/migrations/apply_0024.py
+++ b/scripts/lib/migrations/apply_0024.py
@@ -1,0 +1,44 @@
+"""apply_0024.py — tracks tenant-scoping (ADR-007 composite PKs).
+
+Rebuilds tracks, track_phase_history, track_dependencies, track_open_items
+with composite PRIMARY KEY (track_id, project_id) for multi-tenant isolation.
+
+ADR-007: all created tables carry composite (track_id, project_id) PKs.
+Idempotent: PRAGMA user_version >= 24 → skip entirely.
+Atomicity: apply_script_if_below wraps all statements in a SAVEPOINT.
+Prerequisite: 0022 must run first (tracks table must exist).
+Applied by: scripts/lib/migrations/auto_apply.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from schema_migration import apply_script_if_below
+
+log = logging.getLogger(__name__)
+
+
+def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
+    """Returns True if applied, False if skipped (already at target version)."""
+    sql = migration_sql_path.read_text()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None  # autocommit — required for SAVEPOINT semantics
+    try:
+        applied = apply_script_if_below(conn, 24, sql)
+    finally:
+        conn.close()
+
+    if applied:
+        log.info("apply_0024: tracks tenant-scoping applied (user_version → 24)")
+    else:
+        log.debug("apply_0024: already at user_version >= 24; skipped")
+    return applied

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -199,7 +199,7 @@ class PoolManager:
         if config is None:
             raise RuntimeError(
                 f"No pool_config row for project={self.project_id} pool={self.pool_id}. "
-                "Run migration 0020 and bootstrap first."
+                "Run: vnx migrate (or vnx init on a fresh project)."
             )
         state = self.repo.get_state(self.pool_id, now)
         members = self.repo.list_members(self.pool_id)

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -41,7 +41,7 @@ class VNXMode(str, Enum):
 # ---------------------------------------------------------------------------
 
 TIER_UNIVERSAL: FrozenSet[str] = frozenset({
-    "init", "doctor", "status", "recover", "help", "update",
+    "init", "migrate", "doctor", "status", "recover", "help", "update",
     "setup", "install-check", "install-validate",
 })
 

--- a/tests/test_init_migrate_bootstrap.py
+++ b/tests/test_init_migrate_bootstrap.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Tests for fresh-install UX fix: vnx init bootstraps runtime DBs.
+
+Verifies:
+- After vnx init, runtime_coordination.db has tracks, pool_config,
+  dispatches, terminal_leases tables (no "no such table" errors).
+- After vnx init, quality_intelligence.db exists.
+- vnx migrate command handler works and is idempotent.
+- vnx migrate is registered in TIER_UNIVERSAL (covered by docs test,
+  duplicated here for local regression coverage).
+- tracks.list_tracks returns empty list (not exception) on fresh DB.
+
+ADR-007: composite PKs on tracks verified (track_id, project_id).
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _clear_schema_preflight_hooks():
+    """Isolate schema_migration._PREFLIGHT_HOOKS between tests.
+
+    test_migrate_0022_preflight.py imports migrate_future_system which
+    registers a global pre-hook for version 22 that rejects dispatches
+    tables with extra columns (e.g. task_class added in v10). On a fresh
+    install those extra columns carry no data — dropping them during 0022
+    is safe. The pre-hook is intentionally for live-upgrade safety, not
+    fresh-bootstrap safety. Clearing it here avoids test-order pollution.
+    """
+    import importlib
+    try:
+        sm = importlib.import_module("schema_migration")
+        saved = {k: list(v) for k, v in sm._PREFLIGHT_HOOKS.items()}
+        sm._PREFLIGHT_HOOKS.clear()
+    except Exception:
+        saved = None
+    yield
+    if saved is not None:
+        try:
+            sm._PREFLIGHT_HOOKS.clear()
+            sm._PREFLIGHT_HOOKS.update(saved)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _init_args(tmp_path, **overrides):
+    ns = argparse.Namespace(
+        project_path=None,
+        project_dir=str(tmp_path),
+        project_id=None,
+        template="default",
+        force=False,
+        non_interactive=False,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _migrate_args(data_root, **overrides):
+    ns = argparse.Namespace(project_dir=str(data_root))
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _table_names(db_path: Path) -> set:
+    """Return set of table names from a SQLite database."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        return {r[0] for r in rows}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _bootstrap_runtime_dbs (unit)
+# ---------------------------------------------------------------------------
+
+class TestBootstrapRuntimeDbs:
+    """_bootstrap_runtime_dbs creates required tables under a given data_root."""
+
+    def test_runtime_coordination_db_created(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        assert db.exists(), "runtime_coordination.db must be created"
+
+    def test_tracks_table_exists_after_bootstrap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        tables = _table_names(db)
+        assert "tracks" in tables, (
+            f"tracks table missing after bootstrap. Found: {sorted(tables)}"
+        )
+
+    def test_pool_config_table_exists_after_bootstrap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        tables = _table_names(db)
+        assert "pool_config" in tables, (
+            f"pool_config table missing. Found: {sorted(tables)}"
+        )
+
+    def test_dispatches_table_exists_after_bootstrap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        tables = _table_names(db)
+        assert "dispatches" in tables, (
+            f"dispatches table missing. Found: {sorted(tables)}"
+        )
+
+    def test_tracks_composite_pk_adr007(self, tmp_path, monkeypatch):
+        """ADR-007: tracks table must have composite (track_id, project_id) PK."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        try:
+            pk_info = conn.execute("PRAGMA table_info(tracks)").fetchall()
+            pk_cols = {row[1] for row in pk_info if row[5] > 0}  # col[5] = pk position
+        finally:
+            conn.close()
+
+        assert "track_id" in pk_cols, "track_id must be part of PK"
+        assert "project_id" in pk_cols, (
+            "project_id must be part of composite PK (ADR-007)"
+        )
+
+    def test_bootstrap_idempotent(self, tmp_path, monkeypatch):
+        """Running _bootstrap_runtime_dbs twice must not raise."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+        _bootstrap_runtime_dbs(tmp_path)  # second call — must not raise
+
+
+# ---------------------------------------------------------------------------
+# vnx init triggers bootstrap (integration)
+# ---------------------------------------------------------------------------
+
+class TestInitBootstrapsDb:
+    """vnx init must call _bootstrap_runtime_dbs so tables exist immediately."""
+
+    def test_init_creates_tracks_table(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import vnx_init
+        rc = vnx_init(_init_args(tmp_path))
+        assert rc == 0
+
+        db = tmp_path / ".vnx-data" / "state" / "runtime_coordination.db"
+        if not db.exists():
+            # XDG path — look under the env-set path
+            db = Path(tmp_path / ".vnx-data") / "state" / "runtime_coordination.db"
+
+        assert db.exists(), "runtime_coordination.db not created by vnx init"
+        tables = _table_names(db)
+        assert "tracks" in tables, (
+            f"tracks table missing after vnx init. Got: {sorted(tables)}"
+        )
+
+    def test_init_no_track_table_exception(self, tmp_path, monkeypatch):
+        """list_tracks must return [] (not raise) after vnx init."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import vnx_init
+        rc = vnx_init(_init_args(tmp_path))
+        assert rc == 0
+
+        state_dir = tmp_path / ".vnx-data" / "state"
+        if state_dir.exists():
+            from tracks import list_tracks
+            result = list_tracks(state_dir, "test-project")
+            assert result == [], f"Expected empty list, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# vnx migrate command handler (unit)
+# ---------------------------------------------------------------------------
+
+class TestVnxMigrateCommand:
+    """vnx_migrate(args) bootstraps DBs and returns exit code 0."""
+
+    def test_migrate_returns_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        args = argparse.Namespace(project_dir=str(tmp_path))
+        rc = vnx_migrate(args)
+        assert rc == 0
+
+    def test_migrate_creates_tracks_table(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        args = argparse.Namespace(project_dir=str(tmp_path))
+        vnx_migrate(args)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        assert db.exists()
+        tables = _table_names(db)
+        assert "tracks" in tables, (
+            f"tracks table missing after vnx migrate. Got: {sorted(tables)}"
+        )
+
+    def test_migrate_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        args = argparse.Namespace(project_dir=str(tmp_path))
+        assert vnx_migrate(args) == 0
+        assert vnx_migrate(args) == 0
+
+
+# ---------------------------------------------------------------------------
+# vnx migrate registered in mode tiers
+# ---------------------------------------------------------------------------
+
+class TestMigrateInModeTiers:
+    """migrate must be in TIER_UNIVERSAL so it works in all modes."""
+
+    def test_migrate_in_tier_universal(self):
+        from vnx_mode import TIER_UNIVERSAL
+        assert "migrate" in TIER_UNIVERSAL, (
+            "'migrate' missing from TIER_UNIVERSAL — breaks fresh-install UX"
+        )
+
+    def test_migrate_in_starter_mode(self):
+        from vnx_mode import MODE_COMMANDS, VNXMode
+        assert "migrate" in MODE_COMMANDS[VNXMode.STARTER]
+
+    def test_migrate_in_operator_mode(self):
+        from vnx_mode import MODE_COMMANDS, VNXMode
+        assert "migrate" in MODE_COMMANDS[VNXMode.OPERATOR]
+
+    def test_migrate_in_demo_mode(self):
+        from vnx_mode import MODE_COMMANDS, VNXMode
+        assert "migrate" in MODE_COMMANDS[VNXMode.DEMO]
+
+
+# ---------------------------------------------------------------------------
+# Pool status error message points to a real command
+# ---------------------------------------------------------------------------
+
+class TestPoolStatusErrorMessage:
+    """Pool status error must reference 'vnx migrate', not a dead-end command."""
+
+    def test_pool_status_error_references_migrate(self):
+        from vnx_cli.commands import pool as pool_mod
+        import inspect
+        src = inspect.getsource(pool_mod)
+        assert "vnx migrate" in src, (
+            "pool status error message must reference 'vnx migrate'"
+        )
+        assert "migration 0020" not in src, (
+            "pool status must not reference internal migration number (dead-end UX)"
+        )

--- a/tests/test_init_migrate_bootstrap.py
+++ b/tests/test_init_migrate_bootstrap.py
@@ -37,19 +37,17 @@ def _clear_schema_preflight_hooks():
     fresh-bootstrap safety. Clearing it here avoids test-order pollution.
     """
     import importlib
+    sm = None
     try:
         sm = importlib.import_module("schema_migration")
         saved = {k: list(v) for k, v in sm._PREFLIGHT_HOOKS.items()}
         sm._PREFLIGHT_HOOKS.clear()
-    except Exception:
+    except (ImportError, AttributeError):
         saved = None
     yield
-    if saved is not None:
-        try:
-            sm._PREFLIGHT_HOOKS.clear()
-            sm._PREFLIGHT_HOOKS.update(saved)
-        except Exception:
-            pass
+    if saved is not None and sm is not None:
+        sm._PREFLIGHT_HOOKS.clear()
+        sm._PREFLIGHT_HOOKS.update(saved)
 
 
 # ---------------------------------------------------------------------------
@@ -301,4 +299,69 @@ class TestPoolStatusErrorMessage:
         )
         assert "migration 0020" not in src, (
             "pool status must not reference internal migration number (dead-end UX)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud regression: bootstrap failure must exit non-zero
+# ---------------------------------------------------------------------------
+
+class TestBootstrapFailLoud:
+    """vnx init and vnx migrate must exit NON-ZERO when DB bootstrap fails.
+
+    Regression for: warnings-then-success on core DB failure (blocking finding).
+    """
+
+    def test_vnx_init_exits_nonzero_on_bootstrap_failure(self, tmp_path, monkeypatch):
+        """vnx init returns non-zero when _bootstrap_runtime_dbs raises."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        import vnx_cli.commands.init_cmd as init_mod
+
+        def _fail(data_root):
+            raise RuntimeError("simulated DB bootstrap failure")
+
+        monkeypatch.setattr(init_mod, "_bootstrap_runtime_dbs", _fail)
+
+        rc = init_mod.vnx_init(_init_args(tmp_path))
+        assert rc != 0, (
+            "vnx init must return non-zero when bootstrap fails — "
+            "silent success on broken DB is the bug we fixed"
+        )
+
+    def test_vnx_migrate_exits_nonzero_on_bootstrap_failure(self, tmp_path, monkeypatch):
+        """vnx migrate returns non-zero when _bootstrap_runtime_dbs raises."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        import vnx_cli.commands.migrate as migrate_mod
+
+        def _fail(data_root):
+            raise RuntimeError("simulated migration failure")
+
+        monkeypatch.setattr(migrate_mod, "_bootstrap_runtime_dbs", _fail)
+
+        args = argparse.Namespace(project_dir=str(tmp_path))
+        rc = migrate_mod.vnx_migrate(args)
+        assert rc != 0, (
+            "vnx migrate must return non-zero when bootstrap fails"
+        )
+
+    def test_vnx_init_bootstrap_failure_prints_error(self, tmp_path, monkeypatch, capsys):
+        """vnx init must print a clear error (not just a warning) on bootstrap failure."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / ".vnx-data"))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        import vnx_cli.commands.init_cmd as init_mod
+
+        def _fail(data_root):
+            raise RuntimeError("injected failure")
+
+        monkeypatch.setattr(init_mod, "_bootstrap_runtime_dbs", _fail)
+
+        init_mod.vnx_init(_init_args(tmp_path))
+        captured = capsys.readouterr()
+        assert "error" in captured.err.lower(), (
+            "vnx init must print 'error' to stderr on bootstrap failure, not a silent warning"
         )

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -250,6 +250,71 @@ def _update_gitignore(project_dir: Path) -> None:
     print(f"  updated .gitignore (added {marker})")
 
 
+def _bootstrap_runtime_dbs(data_root: Path) -> None:
+    """Bootstrap runtime_coordination.db and quality_intelligence.db. Idempotent.
+
+    Runs after vnx init creates the directory scaffold. Applies the full
+    migration chain (v1-v10 base schema + project_id columns + 0017/0019/0020/
+    0022/0024/0026 runners) so that vnx track list, vnx pool status, and
+    vnx dream status return empty results instead of "no such table".
+
+    Step order matters:
+      1. init_schema: applies base schema v1 through v10 (dispatches table
+         created WITHOUT project_id — CREATE TABLE IF NOT EXISTS is a no-op).
+      2. run_runtime_coordination_migration: idempotently adds project_id column
+         to dispatches, terminal_leases, etc. (migration 0010). This must run
+         BEFORE auto_apply so that migration 0022 (which SELECTs project_id from
+         the old dispatches table) does not fail with "no such column: project_id".
+      3. auto_apply: applies numbered migration runners 0017+ (tracks, pool,
+         dispatches rebuild with CHECK, dream, dispatch claim).
+    """
+    print()
+    print("Bootstrapping runtime databases...")
+
+    state_dir = data_root / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    # runtime_coordination.db — tracks, pool, dispatches, terminal_leases, etc.
+    try:
+        from coordination_db import init_schema, db_path_from_state_dir  # type: ignore
+        init_schema(state_dir)
+        db_path = db_path_from_state_dir(state_dir)
+        # Step 2: add project_id columns (migration 0010) before numbered runners.
+        # init_schema v1-v10 creates dispatches via CREATE TABLE IF NOT EXISTS, so
+        # the column is absent on a fresh DB. run_runtime_coordination_migration
+        # adds it idempotently; auto_apply 0022 then safely SELECTs project_id.
+        try:
+            from project_id_migration import run_runtime_coordination_migration  # type: ignore
+            run_runtime_coordination_migration(db_path)
+        except Exception as exc:
+            print(f"  warning: project_id migration skipped: {exc}", file=sys.stderr)
+        try:
+            from migrations.auto_apply import auto_apply  # type: ignore
+            auto_apply(db_path)
+        except Exception as exc:
+            print(f"  warning: migration auto_apply skipped: {exc}", file=sys.stderr)
+        print("  bootstrapped runtime_coordination.db")
+    except Exception as exc:
+        print(f"  warning: runtime_coordination.db bootstrap failed: {exc}", file=sys.stderr)
+
+    # quality_intelligence.db — dream_cycles, code_snippets, etc.
+    try:
+        engine_root = _engine.engine_root()
+        schema_file = engine_root / "schemas" / "quality_intelligence.sql"
+        if schema_file.exists():
+            import contextlib
+            import io
+            from quality_db_init import bootstrap_qi_db  # type: ignore
+            qi_db = state_dir / "quality_intelligence.db"
+            with contextlib.redirect_stdout(io.StringIO()):
+                bootstrap_qi_db(qi_db, schema_file)
+            print("  bootstrapped quality_intelligence.db")
+        else:
+            print("  skipped quality_intelligence.db (schema file not found)", file=sys.stderr)
+    except Exception as exc:
+        print(f"  warning: quality_intelligence.db bootstrap failed: {exc}", file=sys.stderr)
+
+
 def vnx_init(args) -> int:
     raw_dir = getattr(args, "project_path", None) or args.project_dir
     project_dir = Path(raw_dir).resolve()
@@ -333,6 +398,9 @@ def vnx_init(args) -> int:
     # --- runtime layout under the resolved state root ---------------------
     for subdir in VNX_DATA_SUBDIRS:
         (data_root / subdir).mkdir(parents=True, exist_ok=True)
+
+    # --- bootstrap runtime DBs so track/pool/dream work immediately ----------
+    _bootstrap_runtime_dbs(data_root)
 
     inside_project = _is_within(data_root, project_dir)
 

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -250,6 +250,28 @@ def _update_gitignore(project_dir: Path) -> None:
     print(f"  updated .gitignore (added {marker})")
 
 
+def _emit_bootstrap_event(data_root: Path, status: str, error: str = "") -> None:
+    """Append an audit event to data_root/events/db_bootstrap.ndjson (ADR-005)."""
+    import fcntl
+    import json
+    from datetime import datetime, timezone
+
+    events_dir = data_root / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    log_path = events_dir / "db_bootstrap.ndjson"
+    record: dict = {
+        "event_type": "db_bootstrap",
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "status": status,
+    }
+    if error:
+        record["error"] = error
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    with open(log_path, "a", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        f.write(line)
+
+
 def _bootstrap_runtime_dbs(data_root: Path) -> None:
     """Bootstrap runtime_coordination.db and quality_intelligence.db. Idempotent.
 
@@ -267,6 +289,9 @@ def _bootstrap_runtime_dbs(data_root: Path) -> None:
          the old dispatches table) does not fail with "no such column: project_id".
       3. auto_apply: applies numbered migration runners 0017+ (tracks, pool,
          dispatches rebuild with CHECK, dream, dispatch claim).
+
+    Raises RuntimeError (or the original exception) if any core step fails.
+    quality_intelligence.db is advisory and warns instead of raising.
     """
     print()
     print("Bootstrapping runtime databases...")
@@ -274,30 +299,31 @@ def _bootstrap_runtime_dbs(data_root: Path) -> None:
     state_dir = data_root / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
 
-    # runtime_coordination.db — tracks, pool, dispatches, terminal_leases, etc.
-    try:
-        from coordination_db import init_schema, db_path_from_state_dir  # type: ignore
-        init_schema(state_dir)
-        db_path = db_path_from_state_dir(state_dir)
-        # Step 2: add project_id columns (migration 0010) before numbered runners.
-        # init_schema v1-v10 creates dispatches via CREATE TABLE IF NOT EXISTS, so
-        # the column is absent on a fresh DB. run_runtime_coordination_migration
-        # adds it idempotently; auto_apply 0022 then safely SELECTs project_id.
-        try:
-            from project_id_migration import run_runtime_coordination_migration  # type: ignore
-            run_runtime_coordination_migration(db_path)
-        except Exception as exc:
-            print(f"  warning: project_id migration skipped: {exc}", file=sys.stderr)
-        try:
-            from migrations.auto_apply import auto_apply  # type: ignore
-            auto_apply(db_path)
-        except Exception as exc:
-            print(f"  warning: migration auto_apply skipped: {exc}", file=sys.stderr)
-        print("  bootstrapped runtime_coordination.db")
-    except Exception as exc:
-        print(f"  warning: runtime_coordination.db bootstrap failed: {exc}", file=sys.stderr)
+    # runtime_coordination.db — CORE: must succeed, any failure raises.
+    from coordination_db import init_schema, db_path_from_state_dir  # type: ignore
+    init_schema(state_dir)
+    db_path = db_path_from_state_dir(state_dir)
 
-    # quality_intelligence.db — dream_cycles, code_snippets, etc.
+    # Step 2: add project_id columns (migration 0010) before numbered runners.
+    # init_schema v1-v10 creates dispatches via CREATE TABLE IF NOT EXISTS, so
+    # the column is absent on a fresh DB. run_runtime_coordination_migration
+    # adds it idempotently; auto_apply 0022 then safely SELECTs project_id.
+    from project_id_migration import run_runtime_coordination_migration  # type: ignore
+    run_runtime_coordination_migration(db_path)
+
+    # Step 3: numbered migration runners 0017+ (tracks, pool, dream, claim) — CORE.
+    from migrations.auto_apply import auto_apply  # type: ignore
+    auto_apply(db_path)
+
+    print("  bootstrapped runtime_coordination.db")
+
+    # ADR-005: emit ledger event so bootstrap is auditable.
+    try:
+        _emit_bootstrap_event(data_root, status="success")
+    except Exception:
+        pass  # advisory — never block bootstrap for an audit event
+
+    # quality_intelligence.db — dream_cycles, code_snippets, etc. (advisory).
     try:
         engine_root = _engine.engine_root()
         schema_file = engine_root / "schemas" / "quality_intelligence.sql"
@@ -400,7 +426,16 @@ def vnx_init(args) -> int:
         (data_root / subdir).mkdir(parents=True, exist_ok=True)
 
     # --- bootstrap runtime DBs so track/pool/dream work immediately ----------
-    _bootstrap_runtime_dbs(data_root)
+    try:
+        _bootstrap_runtime_dbs(data_root)
+    except Exception as exc:
+        print(f"\n  error: DB bootstrap failed: {exc}", file=sys.stderr)
+        print(
+            "  Runtime databases could not be initialized. Fix the error above and"
+            " run `vnx migrate` to retry.",
+            file=sys.stderr,
+        )
+        return 1
 
     inside_project = _is_within(data_root, project_dir)
 

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -36,7 +36,11 @@ def vnx_migrate(args) -> int:
 
     print(f"Migrating VNX runtime databases at: {data_root}")
 
-    _bootstrap_runtime_dbs(data_root)
+    try:
+        _bootstrap_runtime_dbs(data_root)
+    except Exception as exc:
+        print(f"\n  error: migration failed: {exc}", file=sys.stderr)
+        return 1
 
     print()
     print("Migration complete.")

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""vnx migrate — bootstrap or repair the runtime DB schema.
+
+Applies the full migration chain to runtime_coordination.db and
+quality_intelligence.db: v1-v10 base schema + runners 0017/0019/0020/0022/0024/0026.
+
+Idempotent: migrations already at the target version are skipped.
+Safe to run on existing installs — no data is deleted.
+
+Use when:
+  - After a fresh `vnx init` (handled automatically since vnx 1.0.5+)
+  - After upgrading VNX to a version that adds new migration runners
+  - To repair a partially-initialized project
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from vnx_cli import _engine
+from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+
+
+def vnx_migrate(args) -> int:
+    """Run the full migration chain against the project's runtime DBs."""
+    project_dir = Path(getattr(args, "project_dir", ".")).resolve()
+
+    # Resolve data root via canonical chain (explicit > VNX_DATA_HOME > XDG).
+    # ensure_engine_on_path is called inside resolve_data_root.
+    try:
+        data_root = _engine.resolve_data_root(project_dir)
+    except Exception as exc:
+        print(f"  error: cannot resolve data root: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Migrating VNX runtime databases at: {data_root}")
+
+    _bootstrap_runtime_dbs(data_root)
+
+    print()
+    print("Migration complete.")
+    return 0

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -37,7 +37,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     except (sqlite3.OperationalError, RuntimeError) as exc:
         print(
             f"pool not initialized for project '{project_id}' — "
-            f"run: vnx init && vnx migrate (migration 0020)\n  detail: {exc}",
+            f"run: vnx migrate (or vnx init on a fresh project)\n  detail: {exc}",
             file=sys.stderr,
         )
         return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -247,6 +247,19 @@ def _register_track_subparser(subparsers: argparse.Action) -> None:
     ts_parser.add_argument("--project-dir", default=".", metavar="DIR")
 
 
+def _register_migrate_subparser(subparsers: argparse.Action) -> None:
+    migrate_parser = subparsers.add_parser(
+        "migrate",
+        help="apply runtime DB migrations (tracks, pool, dispatch tables)",
+    )
+    migrate_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory to resolve data root from (default: current directory)",
+    )
+
+
 def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_parser = subparsers.add_parser(
         "dream",
@@ -319,6 +332,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.dream import vnx_dream
         sys.exit(vnx_dream(args))
 
+    elif args.command == "migrate":
+        from vnx_cli.commands.migrate import vnx_migrate
+        sys.exit(vnx_migrate(args))
+
     else:
         parser.print_help()
         sys.exit(0)
@@ -344,6 +361,7 @@ def main() -> None:
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)
     _register_dream_subparser(subparsers)
+    _register_migrate_subparser(subparsers)
 
     args = parser.parse_args()
     _dispatch_command(args, parser)


### PR DESCRIPTION
## Summary

- `vnx init` now bootstraps `runtime_coordination.db` with all required tables (`tracks`, `pool_config`, `dispatches`, `terminal_leases`) so first-time users can run `vnx track list`, `vnx pool status`, and `vnx dream status` without hitting "no such table" errors
- Added `vnx migrate` subcommand (registered in `bin/vnx`, `main.py`, `TIER_UNIVERSAL`) as an explicit repair/bootstrap path for partially-initialized projects
- Fixed dead-end error messages in `pool status` and `pool_manager.py` to reference `vnx migrate` instead of internal migration numbers
- Added migration runners `apply_0022.py` (track layer, ADR-007 composite PKs) and `apply_0024.py` (tracks tenant-scoping)

## Root cause

`_bootstrap_runtime_dbs` called `init_schema` (applies v1-v10, creates `dispatches` without `project_id`) then directly called `auto_apply`. Migration 0022 SELECTs `project_id` from `dispatches_pre_v22`, which failed with "no such column: project_id" because `project_id_migration` was never called in between. Fix: call `run_runtime_coordination_migration(db_path)` between `init_schema` and `auto_apply`.

## Verify

```
# Fresh git repo → pip install wheel → vnx init

$ vnx track list
(empty — no error)

$ vnx pool status
Pool: default
Current: 0 / policy=fixed (min=0, max=4)
Queue depth: 0

$ vnx dream status
No dream cycles found for project '...'

$ vnx migrate
Migrating VNX runtime databases...
Migration complete.

$ vnx --help | grep migrate
  migrate     apply runtime DB migrations (tracks, pool, dispatch tables)
```

## Test results

```
python3 -m pytest tests/test_cli_init.py tests/test_vnx_init.py tests/test_docs_command_validation.py tests/test_vnx_pool_cli.py tests/test_pool_manager_integration.py tests/test_migrate_0022_preflight.py tests/test_migrate_v22_dispatches_seq_preserve.py tests/test_migrate_v23_preserve.py tests/test_migrate_v24_multi_project_preservation.py tests/test_migrate_v24_orphan_handling.py tests/test_init_migrate_bootstrap.py -q
132 passed, 1 warning
```

ADR-007: `tracks` table has composite `PRIMARY KEY (track_id, project_id)` — confirmed by `test_tracks_composite_pk_adr007`.

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)