### PR TITLE
fix(migrate): seed default pool_config row + stamp runtime_schema_version

### DIFF
--- a/tests/test_init_migrate_bootstrap.py
+++ b/tests/test_init_migrate_bootstrap.py
@@ -424,7 +424,7 @@ class TestBootstrapFailLoud:
 
         import vnx_cli.commands.init_cmd as init_mod
 
-        def _fail(data_root):
+        def _fail(data_root, **kwargs):
             raise RuntimeError("simulated DB bootstrap failure")
 
         monkeypatch.setattr(init_mod, "_bootstrap_runtime_dbs", _fail)
@@ -442,7 +442,7 @@ class TestBootstrapFailLoud:
 
         import vnx_cli.commands.migrate as migrate_mod
 
-        def _fail(data_root):
+        def _fail(data_root, **kwargs):
             raise RuntimeError("simulated migration failure")
 
         monkeypatch.setattr(migrate_mod, "_bootstrap_runtime_dbs", _fail)
@@ -460,7 +460,7 @@ class TestBootstrapFailLoud:
 
         import vnx_cli.commands.init_cmd as init_mod
 
-        def _fail(data_root):
+        def _fail(data_root, **kwargs):
             raise RuntimeError("injected failure")
 
         monkeypatch.setattr(init_mod, "_bootstrap_runtime_dbs", _fail)

--- a/tests/test_migrate_pool_seed.py
+++ b/tests/test_migrate_pool_seed.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Tests for migrate pool_config seeding and runtime_schema_version stamping.
+
+Verifies:
+- After vnx migrate, pool_config has a row for the derived project_id.
+- After vnx migrate, worker_pools has a row for the derived project_id.
+- Seeding is idempotent (running migrate twice produces no duplicate rows or errors).
+- runtime_schema_version has at least version 10 after bootstrap.
+- vnx init also seeds pool_config for the project_id passed to it.
+- vnx pool status returns pool state (not "not initialized") after migrate.
+
+ADR-007 binding: pool_config uses composite UNIQUE(project_id, pool_id).
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _clear_schema_preflight_hooks():
+    import importlib
+    sm = None
+    try:
+        sm = importlib.import_module("schema_migration")
+        saved = {k: list(v) for k, v in sm._PREFLIGHT_HOOKS.items()}
+        sm._PREFLIGHT_HOOKS.clear()
+    except (ImportError, AttributeError):
+        saved = None
+    yield
+    if saved is not None and sm is not None:
+        sm._PREFLIGHT_HOOKS.clear()
+        sm._PREFLIGHT_HOOKS.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _migrate_args(project_dir):
+    return argparse.Namespace(project_dir=str(project_dir))
+
+
+def _init_args(project_dir, **overrides):
+    ns = argparse.Namespace(
+        project_path=None,
+        project_dir=str(project_dir),
+        project_id=None,
+        template="default",
+        force=False,
+        non_interactive=False,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _row_count(db_path: Path, table: str, project_id: str) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE project_id = ? AND pool_id = 'default'",
+            (project_id,),
+        ).fetchone()
+        return rows[0] if rows else 0
+    finally:
+        conn.close()
+
+
+def _max_runtime_schema_version(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT MAX(version) FROM runtime_schema_version"
+        ).fetchone()
+        return int(row[0]) if (row and row[0] is not None) else 0
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# pool_config row seeding after migrate
+# ---------------------------------------------------------------------------
+
+class TestMigratePoolConfigSeed:
+    """vnx migrate must seed a pool_config row for the project's derived id."""
+
+    def test_pool_config_row_seeded_after_migrate(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        rc = vnx_migrate(_migrate_args(project_dir))
+        assert rc == 0
+
+        db = data_root / "state" / "runtime_coordination.db"
+        assert db.exists()
+
+        # project_id derived from directory name "myproject"
+        count = _row_count(db, "pool_config", "myproject")
+        assert count == 1, (
+            f"pool_config must have exactly 1 row for project_id='myproject' after migrate; got {count}"
+        )
+
+    def test_worker_pools_row_seeded_after_migrate(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        db = data_root / "state" / "runtime_coordination.db"
+        count = _row_count(db, "worker_pools", "myproject")
+        assert count == 1, (
+            f"worker_pools must have exactly 1 row for project_id='myproject' after migrate; got {count}"
+        )
+
+    def test_pool_config_seed_idempotent(self, tmp_path, monkeypatch):
+        """Running migrate twice must not duplicate pool_config rows or error."""
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        assert vnx_migrate(_migrate_args(project_dir)) == 0
+        assert vnx_migrate(_migrate_args(project_dir)) == 0
+
+        db = data_root / "state" / "runtime_coordination.db"
+        count = _row_count(db, "pool_config", "myproject")
+        assert count == 1, (
+            f"Idempotent migrate must not duplicate pool_config row; got {count} rows"
+        )
+
+    def test_pool_config_defaults_satisfy_check_constraints(self, tmp_path, monkeypatch):
+        """Seeded pool_config values must satisfy DB CHECK constraints."""
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        db = data_root / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT min_workers, max_workers, target_workers FROM pool_config "
+                "WHERE project_id = 'myproject' AND pool_id = 'default'"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None
+        min_w, max_w, target_w = row
+        assert min_w >= 0, "min_workers must be >= 0"
+        assert max_w >= min_w, "max_workers must be >= min_workers"
+        assert target_w >= min_w and target_w <= max_w, (
+            "target_workers must be in [min_workers, max_workers]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# runtime_schema_version stamped after bootstrap
+# ---------------------------------------------------------------------------
+
+class TestRuntimeSchemaVersionAfterBootstrap:
+    """runtime_schema_version must have at least version 10 after bootstrap."""
+
+    def test_runtime_schema_version_stamped_after_migrate(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        db = data_root / "state" / "runtime_coordination.db"
+        assert db.exists()
+        max_ver = _max_runtime_schema_version(db)
+        assert max_ver >= 10, (
+            f"runtime_schema_version must have at least version 10 after migrate; got {max_ver}"
+        )
+
+    def test_runtime_schema_version_stamped_after_bootstrap_call(self, tmp_path, monkeypatch):
+        """_bootstrap_runtime_dbs alone must stamp runtime_schema_version >= 10."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        db = tmp_path / "state" / "runtime_coordination.db"
+        max_ver = _max_runtime_schema_version(db)
+        assert max_ver >= 10, (
+            f"runtime_schema_version must be >= 10 after bootstrap; got {max_ver}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# vnx init seeds pool_config for the project_id
+# ---------------------------------------------------------------------------
+
+class TestInitPoolConfigSeed:
+    """vnx init must seed pool_config for the derived project_id."""
+
+    def test_init_seeds_pool_config_row(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import vnx_init
+        rc = vnx_init(_init_args(project_dir))
+        assert rc == 0
+
+        db = data_root / "state" / "runtime_coordination.db"
+        if not db.exists():
+            db = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
+
+        assert db.exists(), "runtime_coordination.db must exist after vnx init"
+        count = _row_count(db, "pool_config", "myproject")
+        assert count == 1, (
+            f"pool_config must have 1 row for 'myproject' after vnx init; got {count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: pool status not "not initialized" after init+migrate
+# ---------------------------------------------------------------------------
+
+class TestPoolStatusAfterMigrate:
+    """After migrate, pool_manager.load_state must not raise RuntimeError."""
+
+    def test_load_state_does_not_raise_after_migrate(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        db = data_root / "state" / "runtime_coordination.db"
+        assert db.exists()
+
+        from pool_manager import PoolManager
+        mgr = PoolManager(project_id="myproject", pool_id="default", db_path=db)
+        # Must not raise RuntimeError("No pool_config row...")
+        config, state, members = mgr.load_state()
+        assert config.pool_id == "default"
+        assert config.min_workers >= 0
+        assert config.max_workers >= config.min_workers
+        assert len(members) == 0  # fresh pool has no members
+
+    def test_load_state_idempotent_after_double_migrate(self, tmp_path, monkeypatch):
+        """Double migrate must leave pool in a clean, loadable state."""
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+        vnx_migrate(_migrate_args(project_dir))
+
+        db = data_root / "state" / "runtime_coordination.db"
+        from pool_manager import PoolManager
+        mgr = PoolManager(project_id="myproject", pool_id="default", db_path=db)
+        config, state, members = mgr.load_state()
+        assert config.pool_id == "default"

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -272,7 +272,44 @@ def _emit_bootstrap_event(data_root: Path, status: str, error: str = "") -> None
         f.write(line)
 
 
-def _bootstrap_runtime_dbs(data_root: Path) -> None:
+def _seed_default_pool_config(db_path: Path, project_id: str) -> None:
+    """Seed default pool_config + worker_pools rows for project_id. Idempotent.
+
+    ADR-007: UNIQUE(project_id, pool_id) is the natural guard; INSERT OR IGNORE
+    is safe to re-run on every migrate call without duplicating the row.
+    pool_config must be inserted before worker_pools (FK dependency).
+    """
+    import sqlite3 as _sqlite3
+    conn = _sqlite3.connect(str(db_path), timeout=10.0)
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO pool_config
+                (project_id, pool_id, min_workers, max_workers, target_workers,
+                 role_mix_json, provider_mix_json, scale_policy, cooldown_seconds)
+            VALUES (?, 'default', 0, 4, 1,
+                    '["backend-developer"]',
+                    '["claude"]',
+                    'queue_depth_v1', 120)
+            """,
+            (project_id,),
+        )
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO worker_pools
+                (project_id, pool_id, state, current_size, target_size)
+            VALUES (?, 'default', 'idle', 0, 0)
+            """,
+            (project_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _bootstrap_runtime_dbs(data_root: Path, project_id: str | None = None) -> None:
     """Bootstrap runtime_coordination.db and quality_intelligence.db. Idempotent.
 
     Runs after vnx init creates the directory scaffold. Applies the full
@@ -289,6 +326,9 @@ def _bootstrap_runtime_dbs(data_root: Path) -> None:
          the old dispatches table) does not fail with "no such column: project_id".
       3. auto_apply: applies numbered migration runners 0017+ (tracks, pool,
          dispatches rebuild with CHECK, dream, dispatch claim).
+
+    When project_id is provided, inserts a default pool_config + worker_pools row
+    for that project so vnx pool status works immediately after migrate.
 
     Raises RuntimeError (or the original exception) if any core step fails.
     quality_intelligence.db is advisory and warns instead of raising.
@@ -314,6 +354,22 @@ def _bootstrap_runtime_dbs(data_root: Path) -> None:
     # Step 3: numbered migration runners 0017+ (tracks, pool, dream, claim) — CORE.
     from migrations.auto_apply import auto_apply  # type: ignore
     auto_apply(db_path)
+
+    # Safety: ensure runtime_schema_version has at least version 10 stamped so
+    # vnx doctor's schema check does not warn "no such table" or "version < 10".
+    # The migration chain should stamp it, but this INSERT OR IGNORE is a
+    # defense-in-depth guard for edge cases (e.g. partial prior run).
+    import sqlite3 as _sqlite3
+    with _sqlite3.connect(str(db_path)) as _conn:
+        _conn.execute(
+            "INSERT OR IGNORE INTO runtime_schema_version (version, description) "
+            "VALUES (10, 'runtime_coordination bootstrap')"
+        )
+
+    # Seed default pool_config + worker_pools row for this project so that
+    # vnx pool status works immediately after vnx init / vnx migrate.
+    if project_id:
+        _seed_default_pool_config(db_path, project_id)
 
     print("  bootstrapped runtime_coordination.db")
 
@@ -427,7 +483,7 @@ def vnx_init(args) -> int:
 
     # --- bootstrap runtime DBs so track/pool/dream work immediately ----------
     try:
-        _bootstrap_runtime_dbs(data_root)
+        _bootstrap_runtime_dbs(data_root, project_id=project_id)
     except Exception as exc:
         print(f"\n  error: DB bootstrap failed: {exc}", file=sys.stderr)
         print(

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -34,10 +34,13 @@ def vnx_migrate(args) -> int:
         print(f"  error: cannot resolve data root: {exc}", file=sys.stderr)
         return 1
 
+    # Derive project_id so the bootstrap seeds the correct pool_config row.
+    project_id = _engine.derive_project_id(project_dir)
+
     print(f"Migrating VNX runtime databases at: {data_root}")
 
     try:
-        _bootstrap_runtime_dbs(data_root)
+        _bootstrap_runtime_dbs(data_root, project_id=project_id)
     except Exception as exc:
         print(f"\n  error: migration failed: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

- After `vnx init && vnx migrate`, `vnx pool status` returned "pool not initialized — No pool_config row for project=X pool=default" because migration 0020 only seeds a `pool_config` row for `project_id='vnx-dev'`. Fresh user projects with a different project_id got no row.
- `vnx doctor` could warn about missing `runtime_schema_version` in edge cases; added defense-in-depth stamp.

## Changes

- **`init_cmd.py`**: Add `_seed_default_pool_config(db_path, project_id)` — `INSERT OR IGNORE` into `pool_config` + `worker_pools` for the project's actual id. ADR-007: `UNIQUE(project_id, pool_id)` guards idempotency. Modify `_bootstrap_runtime_dbs(data_root, project_id=None)` to call it when `project_id` provided, plus safety stamp for `runtime_schema_version`.
- **`migrate.py`**: Derive `project_id` via `_engine.derive_project_id(project_dir)` and pass to `_bootstrap_runtime_dbs`.
- **`init_cmd.py` (vnx_init)**: Pass already-derived `project_id` to `_bootstrap_runtime_dbs`.
- **`test_init_migrate_bootstrap.py`**: Update existing `_fail` mocks to accept `**kwargs` for backward compat.
- **`tests/test_migrate_pool_seed.py`** (new): 9 tests — pool_config row seeded after migrate, worker_pools row seeded, idempotency, CHECK constraint validity, `runtime_schema_version` stamp, `PoolManager.load_state()` not raising after migrate, double-migrate idempotency.

## Test plan

- [x] `pytest tests/test_migrate_pool_seed.py -q` → 9 passed
- [x] `pytest tests/test_init_migrate_bootstrap.py -q` → 23 passed
- [x] `pytest tests/ -k "migrate or pool or runtime_coord or doctor" -q` (ignoring pre-existing unrelated collection errors) → 706 passed (doctor failures confirmed pre-existing on base branch)
- [x] Pre-existing `test_vnx_doctor_strict.py` failures verified against base commit (not introduced by this PR)

## Verify (1.0.0 acceptance)

```
# Fresh git repo
git init /tmp/testproj && cd /tmp/testproj
pip install vnx-orchestration  # or pip install -e .
vnx init && vnx migrate
vnx pool status           # shows pool (current 0, policy/min/max) — NOT "not initialized"
vnx doctor                # no runtime_schema_version warning
vnx track list            # empty list, no error
vnx migrate               # idempotent — no dup row, no error
```

Dispatch-ID: 20260530-090705-migrate-complete2

🤖 Generated with [Claude Code](https://claude.com/claude-code)