### PR TITLE
fix(resolver-unify): unify project_id + DB path resolution for pool, dream, init

### DIFF
--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -57,7 +57,13 @@ SpawnFn = Callable[[str, str, str, str, str], SpawnResult]
 
 
 def _default_db_path(project_id: str) -> Path:
-    """Resolve default DB path via canonical data-root chain (XDG-aware for pip installs)."""
+    """Env-var-anchored fallback DB path. CLI callers should pass an explicit db_path."""
+    vnx_state = os.environ.get("VNX_STATE_DIR") or ""
+    if vnx_state:
+        return Path(vnx_state) / "runtime_coordination.db"
+    vnx_data = os.environ.get("VNX_DATA_DIR") or ""
+    if vnx_data:
+        return Path(vnx_data) / "state" / "runtime_coordination.db"
     try:
         from vnx_paths import resolve_data_root as _resolve_data_root  # type: ignore
         return _resolve_data_root(Path.cwd()) / "state" / "runtime_coordination.db"

--- a/tests/test_dream_cli.py
+++ b/tests/test_dream_cli.py
@@ -361,40 +361,37 @@ class TestReviewGateListsOnlyPending:
 
 
 class TestResolvePathsCanonical:
-    """_resolve_paths must use vnx_paths.resolve_state_dir, not the hardcoded local path.
+    """_resolve_paths(project_dir) must anchor on _engine.resolve_data_root, not ambient env.
 
-    Regression guard: before the fix, _resolve_paths returned
-    resolve_project_root() / '.vnx-data' / 'state' / 'quality_intelligence.db'
-    (the local worktree DB, schema v19, 951 patterns — causing the kimi hang).
-    After the fix it must use vnx_paths.resolve_state_dir() so the canonical
-    central DB is targeted (ADR-007: path is project_id-scoped).
+    Regression guard: before PR-RESOLVER-UNIFY, _resolve_paths called
+    resolve_state_dir() with no args, reading VNX_HOME/ambient env — so dream
+    opened a different DB than migrate wrote. After the fix it uses
+    _engine.resolve_data_root(project_dir)/state so pool/dream are co-located.
     """
 
-    def test_returns_canonical_db_path(self, tmp_path):
-        """db_path comes from resolve_state_dir(), not project_root/.vnx-data/state/."""
-        # Simulate: central state dir (e.g. ~/.vnx-data/vnx-dev/state)
-        # is different from the local project root's .vnx-data/state.
-        central_state = tmp_path / "central" / "vnx-dev" / "state"
-        local_root = tmp_path / "local-project"
-        local_root.mkdir(parents=True, exist_ok=True)
+    def test_returns_engine_anchored_db_path(self, tmp_path):
+        """db_path comes from _engine.resolve_data_root(project_dir), not resolve_state_dir()."""
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir(parents=True, exist_ok=True)
+        central_data = tmp_path / "central" / "vnx-dev"
+        local_root = project_dir
 
-        # Ensure vnx_cli is importable
         repo_root = Path(__file__).resolve().parents[1]
         if str(repo_root) not in sys.path:
             sys.path.insert(0, str(repo_root))
 
-        import vnx_paths
         import project_root as pr_mod
+        import vnx_cli._engine as engine_mod
         import vnx_cli.commands.dream as dream_mod
 
-        with patch.object(vnx_paths, "resolve_state_dir", return_value=central_state), \
+        with patch.object(engine_mod, "resolve_data_root", return_value=central_data) as mock_rdr, \
              patch.object(pr_mod, "resolve_project_root", return_value=local_root):
-            _, db_path = dream_mod._resolve_paths()
+            _, db_path = dream_mod._resolve_paths(project_dir)
 
-        assert db_path == central_state / "quality_intelligence.db", (
-            f"Expected canonical central path, got {db_path}"
+        mock_rdr.assert_called_once_with(project_dir)
+        assert db_path == central_data / "state" / "quality_intelligence.db", (
+            f"Expected engine-anchored path, got {db_path}"
         )
-        # Must NOT be the old hardcoded local path
         assert db_path != local_root / ".vnx-data" / "state" / "quality_intelligence.db", (
             "db_path must not be the hardcoded local worktree path"
         )
@@ -478,13 +475,14 @@ class TestDreamGracefulExitOutsideProject:
         self._assert_guided_exit(capsys, exc_info)
 
     def test_resolve_paths_raises_system_exit_on_no_project(self, capsys):
-        """_resolve_paths() itself raises SystemExit(1) — not a raw RuntimeError."""
+        """_resolve_paths(project_dir) raises SystemExit(1) — not a raw RuntimeError."""
+        from pathlib import Path
         import project_root as pr_mod
         import vnx_cli.commands.dream as dream_mod
 
         with patch.object(pr_mod, "resolve_project_root", side_effect=RuntimeError("no git")):
             with pytest.raises(SystemExit) as exc_info:
-                dream_mod._resolve_paths()
+                dream_mod._resolve_paths(Path("."))
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "vnx init" in captured.err

--- a/tests/test_migrate_pool_seed.py
+++ b/tests/test_migrate_pool_seed.py
@@ -298,3 +298,79 @@ class TestPoolStatusAfterMigrate:
         mgr = PoolManager(project_id="myproject", pool_id="default", db_path=db)
         config, state, members = mgr.load_state()
         assert config.pool_id == "default"
+
+
+# ---------------------------------------------------------------------------
+# Resolver alignment: pool + dream must derive the SAME project_id + DB path
+# as migrate/init (PR-RESOLVER-UNIFY)
+# ---------------------------------------------------------------------------
+
+class TestResolverAlignment:
+    """pool and dream must resolve the same project_id + db_path as migrate.
+
+    ADR-007: every resolved id must be marker-backed (never 'default').
+    """
+
+    def test_pool_resolves_same_project_id_as_migrate(self, tmp_path, monkeypatch):
+        """vnx pool derive_project_id matches what migrate stamps in pool_config."""
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        data_root = tmp_path / "data"
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        from vnx_cli import _engine
+        derived_id = _engine.derive_project_id(project_dir)
+        assert derived_id == "myproject", f"derive_project_id returned {derived_id!r}"
+
+        db = _engine.resolve_data_root(project_dir) / "state" / "runtime_coordination.db"
+        assert db.exists(), f"DB not found at {db}"
+
+        count = _row_count(db, "pool_config", derived_id)
+        assert count == 1, (
+            f"pool_config row must exist for derived_id={derived_id!r}; got {count}"
+        )
+
+    def test_pool_db_path_matches_migrate_db_path(self, tmp_path, monkeypatch):
+        """_engine.resolve_data_root(project_dir)/state/runtime_coordination.db == migrate's DB."""
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        data_root = tmp_path / "data"
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.migrate import vnx_migrate
+        vnx_migrate(_migrate_args(project_dir))
+
+        from vnx_cli import _engine
+        pool_db = _engine.resolve_data_root(project_dir) / "state" / "runtime_coordination.db"
+        migrate_db = data_root / "state" / "runtime_coordination.db"
+
+        assert pool_db.resolve() == migrate_db.resolve(), (
+            f"pool db_path {pool_db} != migrate db_path {migrate_db}"
+        )
+
+    def test_runtime_schema_version_table_created_on_bootstrap(self, tmp_path, monkeypatch):
+        """CREATE TABLE IF NOT EXISTS guard ensures runtime_schema_version never raises."""
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(tmp_path)
+
+        import sqlite3
+        db = tmp_path / "state" / "runtime_coordination.db"
+        assert db.exists()
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='runtime_schema_version'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 1, "runtime_schema_version table must exist after bootstrap"

--- a/tests/test_vnx_pool_cli.py
+++ b/tests/test_vnx_pool_cli.py
@@ -24,6 +24,8 @@ if str(_REPO_ROOT) not in sys.path:
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
+from unittest.mock import ANY  # noqa: E402
+
 from pool_decision_engine import Membership, PoolConfig, PoolDecision, PoolState  # noqa: E402
 from pool_manager import ExecResult  # noqa: E402
 from pool_reaper import ReapTarget  # noqa: E402
@@ -91,11 +93,12 @@ def _make_exec_result(
 # ---------------------------------------------------------------------------
 
 class TestCmdStatus:
-    def _args(self, project: str = "test-proj", pool_id=None, json_out=False):
+    def _args(self, project: str = "test-proj", pool_id=None, json_out=False, project_dir="."):
         args = MagicMock()
         args.project = project
         args.pool_id = pool_id
         args.json = json_out
+        args.project_dir = project_dir
         return args
 
     def test_status_outputs_pool_state(self, capsys):
@@ -140,8 +143,8 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "Project: vnx-dev" in out
         assert "Project: None" not in out
-        resolve_project_id.assert_called_once_with(None)
-        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default")
+        resolve_project_id.assert_called_once_with(None, ".")
+        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default", db_path=ANY)
 
     def test_status_json_uses_resolved_project_without_project(self, capsys):
         with (
@@ -154,15 +157,15 @@ class TestCmdStatus:
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
         assert data["project_id"] == "vnx-dev"
-        resolve_project_id.assert_called_once_with(None)
-        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default")
+        resolve_project_id.assert_called_once_with(None, ".")
+        MockMgr.assert_called_once_with(project_id="vnx-dev", pool_id="default", db_path=ANY)
 
     def test_status_with_pool_id_passed_to_manager(self):
         with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
             mgr = MockMgr.return_value
             mgr.load_state.return_value = (_make_config(pool_id="batch"), _make_state(), [])
             main(argv=["status", "--project", "proj-a", "--pool-id", "batch"])
-        MockMgr.assert_called_once_with(project_id="proj-a", pool_id="batch")
+        MockMgr.assert_called_once_with(project_id="proj-a", pool_id="batch", db_path=ANY)
 
     def test_status_empty_pool(self, capsys):
         with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
@@ -179,11 +182,12 @@ class TestCmdStatus:
 # ---------------------------------------------------------------------------
 
 class TestCmdScale:
-    def _args(self, project="proj", pool_id=None, to=3):
+    def _args(self, project="proj", pool_id=None, to=3, project_dir="."):
         args = MagicMock()
         args.project = project
         args.pool_id = pool_id
         args.to = to
+        args.project_dir = project_dir
         return args
 
     def test_scale_invokes_execute_with_correct_decision(self, capsys):
@@ -255,7 +259,7 @@ class TestCmdScale:
 # ---------------------------------------------------------------------------
 
 class TestCmdConfig:
-    def _args(self, project="proj", pool_id=None, min=None, max=None, policy=None, cooldown=None):
+    def _args(self, project="proj", pool_id=None, min=None, max=None, policy=None, cooldown=None, project_dir="."):
         args = MagicMock()
         args.project = project
         args.pool_id = pool_id
@@ -263,6 +267,7 @@ class TestCmdConfig:
         args.max = max
         args.policy = policy
         args.cooldown = cooldown
+        args.project_dir = project_dir
         return args
 
     def test_config_updates_min_max_policy_cooldown(self, capsys):
@@ -355,11 +360,12 @@ class TestCmdConfig:
 # ---------------------------------------------------------------------------
 
 class TestCmdReap:
-    def _args(self, project="proj", pool_id=None, force=False):
+    def _args(self, project="proj", pool_id=None, force=False, project_dir="."):
         args = MagicMock()
         args.project = project
         args.pool_id = pool_id
         args.force = force
+        args.project_dir = project_dir
         return args
 
     def test_reap_dry_run_default(self, capsys):
@@ -424,20 +430,30 @@ class TestCmdReap:
 # ---------------------------------------------------------------------------
 
 class TestArgparseBehavior:
-    def test_project_required_for_scale(self):
-        with pytest.raises(SystemExit) as exc:
-            main(argv=["scale", "--to", "3"])
-        assert exc.value.code != 0
+    def test_scale_works_without_project_when_project_dir_given(self, capsys):
+        """--project is optional for scale; project_id derived from --project-dir."""
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [_make_member()])
+            mgr.execute.return_value = _make_exec_result()
+            rc = main(argv=["scale", "--to", "1", "--project-dir", "."])
+        assert rc == 0
 
-    def test_project_required_for_config(self):
-        with pytest.raises(SystemExit) as exc:
-            main(argv=["config", "--max", "5"])
-        assert exc.value.code != 0
+    def test_config_works_without_project_when_project_dir_given(self, capsys):
+        """--project is optional for config; project_id derived from --project-dir."""
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.repo.get_config.return_value = _make_config()
+            rc = main(argv=["config", "--max", "5", "--project-dir", "."])
+        assert rc == 0
 
-    def test_project_required_for_reap(self):
-        with pytest.raises(SystemExit) as exc:
-            main(argv=["reap"])
-        assert exc.value.code != 0
+    def test_reap_works_without_project_when_project_dir_given(self, capsys):
+        """--project is optional for reap; project_id derived from --project-dir."""
+        with patch("vnx_cli.commands.pool.PoolManager") as MockMgr:
+            mgr = MockMgr.return_value
+            mgr.load_state.return_value = (_make_config(), _make_state(), [])
+            rc = main(argv=["reap", "--project-dir", "."])
+        assert rc == 0
 
     def test_to_required_for_scale(self):
         with pytest.raises(SystemExit) as exc:

--- a/vnx_cli/commands/dream.py
+++ b/vnx_cli/commands/dream.py
@@ -16,45 +16,42 @@ _NOT_IN_PROJECT_MSG = (
 
 def _get_project_id(args) -> str | None:
     pid = getattr(args, "project_id", None)
-    if pid:
-        return pid
-    from project_root import resolve_project_id  # type: ignore[import]
+    project_dir = Path(getattr(args, "project_dir", "."))
     try:
-        return resolve_project_id()
-    except RuntimeError:
+        return _engine.derive_project_id(project_dir, explicit=pid)
+    except (ValueError, RuntimeError):
         return None
 
 
-def _resolve_paths() -> tuple[Path, Path]:
+def _resolve_paths(project_dir: Path) -> tuple[Path, Path]:
     """Returns (project_root, db_path).
 
-    db_path resolves via vnx_paths.resolve_state_dir() — the same canonical
-    central chain the rest of the system uses. ADR-007: path is project_id-scoped.
+    db_path anchors on project_dir via _engine.resolve_data_root so pool/dream
+    resolve the SAME DB as migrate/init/track/doctor (ADR-007, PR-RESOLVER-UNIFY).
     """
     from project_root import resolve_project_root  # type: ignore[import]
-    from vnx_paths import resolve_state_dir  # type: ignore[import]
     try:
         root = resolve_project_root()
     except RuntimeError:
         print(f"error: {_NOT_IN_PROJECT_MSG}", file=sys.stderr)
         sys.exit(1)
-    state_dir = resolve_state_dir()
+    state_dir = _engine.resolve_data_root(project_dir) / "state"
     return root, state_dir / "quality_intelligence.db"
 
 
-def _resolve_data_root() -> Path:
-    """Return the canonical VNX data root (.vnx-data parent of state dir)."""
-    from vnx_paths import resolve_state_dir  # type: ignore[import]
-    return resolve_state_dir().parent
+def _resolve_data_root(project_dir: Path) -> Path:
+    """Return the canonical VNX data root anchored on project_dir."""
+    return _engine.resolve_data_root(project_dir)
 
 
 def _cmd_run(args) -> int:
+    project_dir = Path(getattr(args, "project_dir", "."))
     project_id = _get_project_id(args)
     if not project_id:
         print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
         return 1
     dry_run = getattr(args, "dry_run", False)
-    root, db_path = _resolve_paths()
+    root, db_path = _resolve_paths(project_dir)
     import consolidator  # type: ignore[import]
     result = consolidator.run_dream_cycle(project_id, db_path, dry_run=dry_run)
     print(json.dumps(result, indent=2))
@@ -62,11 +59,12 @@ def _cmd_run(args) -> int:
 
 
 def _cmd_status(args) -> int:
+    project_dir = Path(getattr(args, "project_dir", "."))
     project_id = _get_project_id(args)
     if not project_id:
         print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
         return 1
-    _, db_path = _resolve_paths()
+    _, db_path = _resolve_paths(project_dir)
     if not db_path.exists():
         print(f"No dream cycles found for project '{project_id}'.")
         return 0
@@ -95,7 +93,7 @@ def _cmd_status(args) -> int:
           f"{r['insights_input']}/{r['merged_count']}/{r['dropped_count']}/{r['flagged_count']}")
     print(f"  reviewed    : {bool(r['operator_reviewed'])}")
     import review_gate  # type: ignore[import]
-    pending = review_gate.list_pending_reviews(project_id, _resolve_data_root())
+    pending = review_gate.list_pending_reviews(project_id, _resolve_data_root(project_dir))
     if pending:
         print(f"\n  Pending reviews ({len(pending)}):")
         for p in pending:
@@ -104,13 +102,14 @@ def _cmd_status(args) -> int:
 
 
 def _cmd_review(args) -> int:
+    project_dir = Path(getattr(args, "project_dir", "."))
     cycle_id: str = args.cycle_id
     project_id = _get_project_id(args)
     if not project_id:
         print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
         return 1
-    _, db_path = _resolve_paths()
-    data_root = _resolve_data_root()
+    _, db_path = _resolve_paths(project_dir)
+    data_root = _resolve_data_root(project_dir)
     import review_gate  # type: ignore[import]
     approve = getattr(args, "approve", False)
     reject = getattr(args, "reject", False)
@@ -135,12 +134,13 @@ def _cmd_review(args) -> int:
 
 
 def _cmd_history(args) -> int:
+    project_dir = Path(getattr(args, "project_dir", "."))
     project_id = _get_project_id(args)
     if not project_id:
         print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
         return 1
     limit = getattr(args, "limit", 10)
-    _, db_path = _resolve_paths()
+    _, db_path = _resolve_paths(project_dir)
     if not db_path.exists():
         print(f"No dream cycles found for project '{project_id}'.")
         return 0
@@ -175,12 +175,12 @@ def _cmd_history(args) -> int:
 
 
 def _cmd_install_scheduler(args) -> int:
+    project_dir = Path(getattr(args, "project_dir", "."))
     project_id = _get_project_id(args)
     if not project_id:
         print("error: cannot resolve project_id; set --project-id or VNX_PROJECT_ID")
         return 1
-    from pathlib import Path
-    root, _ = _resolve_paths()
+    root, _ = _resolve_paths(project_dir)
     import scheduler  # type: ignore[import]
     try:
         msg = scheduler.install_scheduler(project_id=project_id, project_root=root)

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -355,12 +355,19 @@ def _bootstrap_runtime_dbs(data_root: Path, project_id: str | None = None) -> No
     from migrations.auto_apply import auto_apply  # type: ignore
     auto_apply(db_path)
 
-    # Safety: ensure runtime_schema_version has at least version 10 stamped so
-    # vnx doctor's schema check does not warn "no such table" or "version < 10".
-    # The migration chain should stamp it, but this INSERT OR IGNORE is a
-    # defense-in-depth guard for edge cases (e.g. partial prior run).
+    # Safety: ensure runtime_schema_version table exists and has at least version 10
+    # stamped. The migration chain creates and stamps it, but if init_schema ran
+    # against a packaged wheel where the schema SQL path resolves differently, the
+    # table may be absent — CREATE TABLE IF NOT EXISTS ensures the INSERT OR IGNORE
+    # below never hits "no such table: runtime_schema_version" (swallowed in caller).
     import sqlite3 as _sqlite3
     with _sqlite3.connect(str(db_path)) as _conn:
+        _conn.execute(
+            "CREATE TABLE IF NOT EXISTS runtime_schema_version ("
+            "version INTEGER PRIMARY KEY, "
+            "applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+            "description TEXT NOT NULL)"
+        )
         _conn.execute(
             "INSERT OR IGNORE INTO runtime_schema_version (version, description) "
             "VALUES (10, 'runtime_coordination bootstrap')"

--- a/vnx_cli/commands/pool.py
+++ b/vnx_cli/commands/pool.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 import sys
 import time
+from pathlib import Path
 from typing import List, Optional
 
 # Bootstrap scripts/lib into path so pool_manager etc. are importable. Route
@@ -30,8 +31,8 @@ from pool_state_repo import PoolStateRepository  # noqa: E402
 
 def cmd_status(args: argparse.Namespace) -> int:
     """Show current pool state for a project."""
-    project_id = _resolve_project_id(args.project)
-    mgr = _make_manager_for_project_id(project_id, args.pool_id)
+    project_id = _resolve_project_id(args.project, args.project_dir)
+    mgr = _make_manager_for_project_id(project_id, args.pool_id, args.project_dir)
     try:
         config, state, members = mgr.load_state()
     except (sqlite3.OperationalError, RuntimeError) as exc:
@@ -76,7 +77,7 @@ def cmd_scale(args: argparse.Namespace) -> int:
     """Force scale pool to a specific worker count."""
     from pool_decision_engine import PoolDecision  # noqa: E402
 
-    mgr = _make_manager(args.project, args.pool_id)
+    mgr = _make_manager(args.project, args.pool_id, args.project_dir)
     config, _, members = mgr.load_state()
     current = len([m for m in members if m.status == "active"])
     target = args.to
@@ -118,7 +119,7 @@ _VALID_POLICIES = frozenset({"fixed", "queue_depth_v1", "queue_aware", "cost_awa
 
 def cmd_config(args: argparse.Namespace) -> int:
     """Update pool config fields (min/max/policy/cooldown)."""
-    mgr = _make_manager(args.project, args.pool_id)
+    mgr = _make_manager(args.project, args.pool_id, args.project_dir)
     pool_id = args.pool_id or "default"
     config = mgr.repo.get_config(pool_id)
     if not config:
@@ -170,7 +171,7 @@ def cmd_config(args: argparse.Namespace) -> int:
 
 def cmd_reap(args: argparse.Namespace) -> int:
     """Reap stale workers; dry-run by default unless --force."""
-    mgr = _make_manager(args.project, args.pool_id)
+    mgr = _make_manager(args.project, args.pool_id, args.project_dir)
 
     if not args.force:
         from pool_reaper import ReapConfig, identify_reap_targets  # noqa: E402
@@ -190,26 +191,19 @@ def cmd_reap(args: argparse.Namespace) -> int:
     return 0
 
 
-def _resolve_project_id(explicit: Optional[str]) -> str:
-    """Return the explicit project id or derive it from the .vnx-project-id marker."""
-    if explicit is not None:
-        return explicit
-    try:
-        from vnx_paths import project_id_from_state_dir, resolve_state_dir  # noqa: E402
-        derived = project_id_from_state_dir(resolve_state_dir())
-        if derived:
-            return derived
-    except Exception:
-        pass
-    return "default"
+def _resolve_project_id(explicit: Optional[str], project_dir: str = ".") -> str:
+    """Derive project_id via marker > slug > path-hash (ADR-PIP-2). Never returns 'default'."""
+    return _engine.derive_project_id(Path(project_dir), explicit=explicit)
 
 
-def _make_manager(project: Optional[str], pool_id: Optional[str]) -> PoolManager:
-    return _make_manager_for_project_id(_resolve_project_id(project), pool_id)
+def _make_manager(project: Optional[str], pool_id: Optional[str], project_dir: str = ".") -> PoolManager:
+    project_id = _resolve_project_id(project, project_dir)
+    return _make_manager_for_project_id(project_id, pool_id, project_dir)
 
 
-def _make_manager_for_project_id(project_id: str, pool_id: Optional[str]) -> PoolManager:
-    return PoolManager(project_id=project_id, pool_id=pool_id or "default")
+def _make_manager_for_project_id(project_id: str, pool_id: Optional[str], project_dir: str = ".") -> PoolManager:
+    db_path = _engine.resolve_data_root(Path(project_dir)) / "state" / "runtime_coordination.db"
+    return PoolManager(project_id=project_id, pool_id=pool_id or "default", db_path=db_path)
 
 
 def _fmt_age(timestamp: float) -> str:
@@ -227,18 +221,26 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     p_status = sub.add_parser("status", help="show pool state")
     p_status.add_argument("--project", default=None)
+    p_status.add_argument("--project-dir", dest="project_dir", default=".",
+                          help="project directory for id/path resolution (default: .)")
     p_status.add_argument("--pool-id", dest="pool_id", default=None)
     p_status.add_argument("--json", action="store_true")
     p_status.set_defaults(func=cmd_status)
 
     p_scale = sub.add_parser("scale", help="force scale pool to N workers")
-    p_scale.add_argument("--project", required=True)
+    p_scale.add_argument("--project", default=None,
+                         help="explicit project_id (derived from --project-dir if omitted)")
+    p_scale.add_argument("--project-dir", dest="project_dir", default=".",
+                         help="project directory for id/path resolution (default: .)")
     p_scale.add_argument("--to", type=int, required=True)
     p_scale.add_argument("--pool-id", dest="pool_id", default=None)
     p_scale.set_defaults(func=cmd_scale)
 
     p_config = sub.add_parser("config", help="update pool config")
-    p_config.add_argument("--project", required=True)
+    p_config.add_argument("--project", default=None,
+                          help="explicit project_id (derived from --project-dir if omitted)")
+    p_config.add_argument("--project-dir", dest="project_dir", default=".",
+                          help="project directory for id/path resolution (default: .)")
     p_config.add_argument("--pool-id", dest="pool_id", default=None)
     p_config.add_argument("--min", type=int, dest="min")
     p_config.add_argument("--max", type=int, dest="max")
@@ -247,7 +249,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_config.set_defaults(func=cmd_config)
 
     p_reap = sub.add_parser("reap", help="reap stale workers (dry-run by default)")
-    p_reap.add_argument("--project", required=True)
+    p_reap.add_argument("--project", default=None,
+                        help="explicit project_id (derived from --project-dir if omitted)")
+    p_reap.add_argument("--project-dir", dest="project_dir", default=".",
+                        help="project directory for id/path resolution (default: .)")
     p_reap.add_argument("--pool-id", dest="pool_id", default=None)
     p_reap.add_argument("--force", action="store_true", help="actually reap (default: dry-run)")
     p_reap.set_defaults(func=cmd_reap)

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -269,26 +269,31 @@ def _register_dream_subparser(subparsers: argparse.Action) -> None:
 
     dream_run_p = dream_subs.add_parser("run", help="run a consolidation cycle")
     dream_run_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_run_p.add_argument("--project-dir", dest="project_dir", default=".", metavar="DIR")
     dream_run_p.add_argument("--dry-run", action="store_true", help="emit events but skip DB writes")
 
     dream_status_p = dream_subs.add_parser("status", help="show latest cycle results")
     dream_status_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_status_p.add_argument("--project-dir", dest="project_dir", default=".", metavar="DIR")
 
     dream_review_p = dream_subs.add_parser("review", help="approve or reject a pending cycle")
     dream_review_p.add_argument("cycle_id", metavar="CYCLE_ID")
     dream_review_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_review_p.add_argument("--project-dir", dest="project_dir", default=".", metavar="DIR")
     dream_review_p.add_argument("--approve", action="store_true", help="approve without prompting")
     dream_review_p.add_argument("--reject", action="store_true", help="reject without prompting")
     dream_review_p.add_argument("--reason", default="operator rejected", metavar="REASON")
 
     dream_history_p = dream_subs.add_parser("history", help="show recent cycles")
     dream_history_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_history_p.add_argument("--project-dir", dest="project_dir", default=".", metavar="DIR")
     dream_history_p.add_argument("--limit", type=int, default=10, metavar="N")
 
     dream_install_p = dream_subs.add_parser(
         "install-scheduler", help="install nightly auto-dream scheduler (macOS/Linux)"
     )
     dream_install_p.add_argument("--project-id", default=None, metavar="ID")
+    dream_install_p.add_argument("--project-dir", dest="project_dir", default=".", metavar="DIR")
 
     dream_subs.add_parser(
         "uninstall-scheduler", help="remove nightly auto-dream scheduler"


### PR DESCRIPTION
## Summary

- **pool**: replace ambient `project_id_from_state_dir` + `'default'` fallback with `_engine.derive_project_id(project_dir)` (marker > slug > path-hash, never `'default'`). Add `--project-dir` to all four pool subcommands; `--project` is now optional everywhere (was `required=True` for scale/config/reap). Pass explicit engine-anchored `db_path` into `PoolManager` so pool always opens the same DB that `migrate` wrote.
- **pool_manager**: `_default_db_path` checks `VNX_STATE_DIR`/`VNX_DATA_DIR` env vars before falling back to `Path.cwd()`. CLI callers always pass explicit `db_path`; fallback is safety net only.
- **dream**: `_get_project_id` → `_engine.derive_project_id(project_dir)`. `_resolve_paths`/`_resolve_data_root` anchor on `_engine.resolve_data_root(project_dir)/state` instead of no-arg `resolve_state_dir()` (ambient VNX_HOME). All `_cmd_*` functions thread `project_dir`; `main.py` adds `--project-dir` to all dream subparsers.
- **init_cmd**: add `CREATE TABLE IF NOT EXISTS runtime_schema_version` before `INSERT OR IGNORE` so the guard never raises `'no such table'` when `init_schema`'s SQL path resolves differently in a wheel install. Eliminates `vnx doctor` warning.

## ADR-007 compliance

Every resolved `project_id` is marker-backed (never `'default'`); pool/lease/dispatch rows project_id-stamped. `_engine.derive_project_id` is the single source of truth for both the writer (migrate/init) and readers (pool, dream).

## PoolManager callers audited

Only one non-test caller: `vnx_cli/commands/pool.py:_make_manager_for_project_id` — updated to pass explicit `db_path`. Scripts (`pool_worker_runner.py`, `pool_supervisor.py`) do not instantiate `PoolManager` directly.

## Test plan

- [x] `pytest tests/test_vnx_pool_cli.py` — 30 passed
- [x] `pytest tests/test_migrate_pool_seed.py` — 12 passed (incl. 3 new `TestResolverAlignment` tests)
- [x] `pytest tests/test_dream_cli.py` — 22 passed (incl. updated `TestResolvePathsCanonical`)
- [x] Pre-existing failures in `test_pool_state_repo.py` / `test_pool_manager_integration.py` confirmed pre-existing (reproduced on main before any changes)

Dispatch-ID: 20260530-093413-resolver-unify

🤖 Generated with [Claude Code](https://claude.com/claude-code)