### PR TITLE
fix(hygiene): size findings are advisory (warning), not blocking + OI backfill

### DIFF
--- a/scripts/lib/quality_advisory.py
+++ b/scripts/lib/quality_advisory.py
@@ -169,11 +169,11 @@ def check_file_size(file_path: Path) -> List[QualityCheck]:
         if line_count > blocking_threshold:
             checks.append(QualityCheck(
                 check_id="file_size_blocking",
-                severity="blocking",
+                severity="warning",
                 file=str(file_path),
-                message=f"File exceeds blocking threshold: {line_count} lines (max {blocking_threshold})",
+                message=f"File is large: {line_count} lines (soft max {blocking_threshold})",
                 evidence=f"lines={line_count},max={blocking_threshold}",
-                action_required=True,
+                action_required=False,
             ))
         elif line_count > warning_threshold:
             checks.append(QualityCheck(
@@ -219,12 +219,12 @@ def _check_python_function_sizes(file_path: Path) -> List[QualityCheck]:
             if length > FUNCTION_SIZE_BLOCKING_PYTHON:
                 checks.append(QualityCheck(
                     check_id="function_size_blocking",
-                    severity="blocking",
+                    severity="warning",
                     file=str(file_path),
                     symbol=node.name,
-                    message=f"Function exceeds blocking threshold: {length} lines (max {FUNCTION_SIZE_BLOCKING_PYTHON})",
+                    message=f"Function is large: {length} lines (soft max {FUNCTION_SIZE_BLOCKING_PYTHON})",
                     evidence=f"function={node.name},lines={length},max={FUNCTION_SIZE_BLOCKING_PYTHON}",
-                    action_required=True,
+                    action_required=False,
                 ))
             elif length > FUNCTION_SIZE_WARNING_PYTHON:
                 checks.append(QualityCheck(
@@ -271,12 +271,12 @@ def _check_shell_function_sizes(file_path: Path) -> List[QualityCheck]:
             if length > FUNCTION_SIZE_BLOCKING_SHELL:
                 checks.append(QualityCheck(
                     check_id="function_size_blocking",
-                    severity="blocking",
+                    severity="warning",
                     file=str(file_path),
                     symbol=function_name,
-                    message=f"Function exceeds blocking threshold: {length} lines (max {FUNCTION_SIZE_BLOCKING_SHELL})",
+                    message=f"Function is large: {length} lines (soft max {FUNCTION_SIZE_BLOCKING_SHELL})",
                     evidence=f"function={function_name},lines={length},max={FUNCTION_SIZE_BLOCKING_SHELL}",
-                    action_required=True,
+                    action_required=False,
                 ))
             elif length > FUNCTION_SIZE_WARNING_SHELL:
                 checks.append(QualityCheck(

--- a/scripts/maintenance/reclassify_size_ois.py
+++ b/scripts/maintenance/reclassify_size_ois.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""reclassify_size_ois.py — Backfill: downgrade size-blocker OIs to warn.
+
+Size findings (file size > threshold, function size > threshold) were
+previously emitted as severity="blocking" and stored as severity="blocker".
+Policy change (dispatch 20260530-102058-hyg-policy): size findings are
+ADVISORY — they must be severity="warn", not "blocker".
+
+This script finds every open OI with severity=="blocker" that carries a size
+signature (via dedup_key prefix or title pattern) and reclassifies it to
+severity="warn". Idempotent — running twice is safe.
+
+Usage:
+    python3 scripts/maintenance/reclassify_size_ois.py          # dry-run
+    python3 scripts/maintenance/reclassify_size_ois.py --apply  # apply
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+STATE_DIR = REPO_ROOT / ".vnx-data" / "state"
+OPEN_ITEMS_FILE = STATE_DIR / "open_items.json"
+AUDIT_LOG = STATE_DIR / "open_items_audit.jsonl"
+
+RECLASSIFY_REASON = (
+    "size-finding reclassified advisory per quality_advisory policy change"
+)
+AUDIT_ACTOR = "reclassify_size_ois"
+
+
+def _is_size_oi(item: dict) -> bool:
+    """Return True if this OI is a size-based finding."""
+    dedup = item.get("dedup_key", "")
+    if dedup.startswith(("qa:function_size_", "qa:file_size_")):
+        return True
+    title = item.get("title", "")
+    if "exceeds blocking threshold" in title:
+        return True
+    title_lower = title.lower()
+    if "exceeds threshold" in title_lower and (
+        title_lower.startswith("function ") or title_lower.startswith("file ")
+    ):
+        return True
+    return False
+
+
+def _load(store_path: Path) -> dict:
+    if not store_path.exists():
+        return {"schema_version": "1.0", "items": [], "next_id": 1}
+    return json.loads(store_path.read_text(encoding="utf-8"))
+
+
+def _save(store_path: Path, data: dict) -> None:
+    data["last_updated"] = datetime.now().isoformat()
+    tmp = store_path.with_suffix(".json.tmp")
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, store_path)
+
+
+def _write_audit(audit_path: Path, entries: list) -> None:
+    if not entries:
+        return
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = "".join(json.dumps(e) + "\n" for e in entries)
+    with open(audit_path, "a", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.write(lines)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def reclassify(
+    store_path: Path,
+    audit_path: Path,
+    apply: bool = False,
+) -> dict:
+    """Core reclassification logic.
+
+    Returns {"found": N, "reclassified": N}.
+    Thread-safe: acquires fcntl.LOCK_EX on a sidecar lock file.
+    """
+    lock_path = store_path.with_suffix(".json.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open("a+", encoding="utf-8") as lf:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+        try:
+            data = _load(store_path)
+            targets = [
+                item for item in data.get("items", [])
+                if item.get("status") == "open"
+                and item.get("severity") == "blocker"
+                and _is_size_oi(item)
+            ]
+
+            if not apply:
+                return {"found": len(targets), "reclassified": 0}
+
+            now = datetime.now().isoformat()
+            audit_entries = []
+            for item in targets:
+                item["severity"] = "warn"
+                item["updated_at"] = now
+                audit_entries.append({
+                    "timestamp": now,
+                    "actor": AUDIT_ACTOR,
+                    "action": "reclassify",
+                    "item_id": item["id"],
+                    "from_severity": "blocker",
+                    "to_severity": "warn",
+                    "reason": RECLASSIFY_REASON,
+                })
+
+            _save(store_path, data)
+            _write_audit(audit_path, audit_entries)
+            return {"found": len(targets), "reclassified": len(targets)}
+        finally:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually reclassify OIs (default is dry-run)",
+    )
+    args = parser.parse_args()
+
+    result = reclassify(OPEN_ITEMS_FILE, AUDIT_LOG, apply=args.apply)
+    found = result["found"]
+    reclassified = result["reclassified"]
+
+    print(f"Open size-blocker OIs found: {found}")
+
+    if found == 0:
+        print("Nothing to do.")
+        return 0
+
+    if not args.apply:
+        print(f"DRY RUN — would reclassify {found} OI(s) blocker→warn.")
+        print("Re-run with --apply to write changes.")
+    else:
+        print(f"Reclassified {reclassified}/{found}.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_quality_advisory_pipeline.py
+++ b/tests/test_quality_advisory_pipeline.py
@@ -49,16 +49,16 @@ class TestFileSizeGates:
         assert "600" in checks[0].message
 
     def test_python_file_blocking_threshold(self, tmp_path):
-        """Python file over blocking threshold should produce blocking check."""
+        """Python file over soft-max threshold should produce advisory warning (not blocking)."""
         test_file = tmp_path / "test.py"
-        test_file.write_text("\n" * 900)  # 900 lines, over 800 blocking
+        test_file.write_text("\n" * 900)  # 900 lines, over 800 soft max
 
         checks = check_file_size(test_file)
 
         assert len(checks) == 1
-        assert checks[0].severity == "blocking"
+        assert checks[0].severity == "warning"
         assert checks[0].check_id == "file_size_blocking"
-        assert checks[0].action_required is True
+        assert checks[0].action_required is False
 
     def test_shell_file_warning_threshold(self, tmp_path):
         """Shell file over warning threshold should produce warning."""
@@ -71,14 +71,15 @@ class TestFileSizeGates:
         assert checks[0].severity == "warning"
 
     def test_shell_file_blocking_threshold(self, tmp_path):
-        """Shell file over blocking threshold should produce blocking check."""
+        """Shell file over soft-max threshold should produce advisory warning (not blocking)."""
         test_file = tmp_path / "test.sh"
-        test_file.write_text("\n" * 650)  # 650 lines, over 600 blocking for shell
+        test_file.write_text("\n" * 650)  # 650 lines, over 600 soft max for shell
 
         checks = check_file_size(test_file)
 
         assert len(checks) == 1
-        assert checks[0].severity == "blocking"
+        assert checks[0].severity == "warning"
+        assert checks[0].action_required is False
 
 
 class TestFunctionSizeGates:
@@ -114,9 +115,9 @@ def small_function():
         assert checks[0].symbol == "large_function"
 
     def test_python_function_blocking_threshold(self, tmp_path):
-        """Python function over blocking threshold should produce blocking check."""
+        """Python function over soft-max threshold should produce advisory warning (not blocking)."""
         test_file = tmp_path / "test.py"
-        # Create a 75-line function (over 70 blocking threshold)
+        # Create a 75-line function (over 70 soft max threshold)
         lines = ["def huge_function():"]
         for i in range(75):
             lines.append(f"    x{i} = {i}")
@@ -125,8 +126,8 @@ def small_function():
         checks = check_function_sizes(test_file)
 
         assert len(checks) == 1
-        assert checks[0].severity == "blocking"
-        assert checks[0].action_required is True
+        assert checks[0].severity == "warning"
+        assert checks[0].action_required is False
 
     def test_shell_function_warning_threshold(self, tmp_path):
         """Shell function over warning threshold should produce warning."""
@@ -142,6 +143,72 @@ def small_function():
 
         assert len(checks) == 1
         assert checks[0].severity == "warning"
+
+
+class TestSizeAdvisoryPolicy:
+    """Size findings are advisory (warning), never blocking."""
+
+    def test_900_line_python_file_is_warning_not_blocking(self, tmp_path):
+        test_file = tmp_path / "big.py"
+        test_file.write_text("\n" * 900)
+
+        checks = check_file_size(test_file)
+
+        assert len(checks) == 1
+        assert checks[0].severity == "warning"
+        assert checks[0].check_id == "file_size_blocking"
+        assert checks[0].action_required is False
+
+    def test_100_line_python_function_is_warning_not_blocking(self, tmp_path):
+        test_file = tmp_path / "big.py"
+        lines = ["def fat():"]
+        for i in range(100):
+            lines.append(f"    x{i} = {i}")
+        test_file.write_text("\n".join(lines))
+
+        checks = check_function_sizes(test_file)
+
+        assert len(checks) == 1
+        assert checks[0].severity == "warning"
+        assert checks[0].check_id == "function_size_blocking"
+        assert checks[0].action_required is False
+
+    def test_70_line_shell_function_is_warning_not_blocking(self, tmp_path):
+        test_file = tmp_path / "big.sh"
+        lines = ["large_fn() {"]
+        for i in range(70):
+            lines.append(f"  echo {i}")
+        lines.append("}")
+        test_file.write_text("\n".join(lines))
+
+        checks = check_function_sizes(test_file)
+
+        assert len(checks) == 1
+        assert checks[0].severity == "warning"
+        assert checks[0].check_id == "function_size_blocking"
+        assert checks[0].action_required is False
+
+    def test_no_size_check_ever_emits_blocking(self, tmp_path):
+        """Exhaustive: no size check path can emit severity='blocking'."""
+        py_file = tmp_path / "x.py"
+        # 1500-line file with a 200-line function — worst case
+        lines = ["def monster():"]
+        for i in range(1499):
+            lines.append(f"    x{i} = {i}")
+        py_file.write_text("\n".join(lines))
+
+        sh_file = tmp_path / "x.sh"
+        sh_lines = ["big_fn() {"]
+        for i in range(200):
+            sh_lines.append(f"  echo {i}")
+        sh_lines.append("}")
+        sh_file.write_text("\n".join(sh_lines))
+
+        for f in [py_file, sh_file]:
+            for check in check_file_size(f) + check_function_sizes(f):
+                assert check.severity != "blocking", (
+                    f"Size check emitted blocking for {f}: {check}"
+                )
 
 
 class TestRiskScoring:

--- a/tests/test_reclassify_size_ois.py
+++ b/tests/test_reclassify_size_ois.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Tests for reclassify_size_ois backfill script."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "maintenance"))
+
+from reclassify_size_ois import _is_size_oi, reclassify
+
+
+def _make_store(tmp_path, items):
+    store = tmp_path / "open_items.json"
+    data = {"schema_version": "1.0", "items": items, "next_id": len(items) + 1}
+    store.write_text(json.dumps(data, indent=2))
+    return store
+
+
+def _audit(tmp_path):
+    return tmp_path / "open_items_audit.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# _is_size_oi matching
+# ---------------------------------------------------------------------------
+
+class TestIsSizeOi:
+    def test_dedup_key_function_size(self):
+        assert _is_size_oi({"dedup_key": "qa:function_size_blocking:foo"})
+
+    def test_dedup_key_file_size(self):
+        assert _is_size_oi({"dedup_key": "qa:file_size_blocking:bar"})
+
+    def test_title_exceeds_blocking_threshold(self):
+        assert _is_size_oi({"title": "Function exceeds blocking threshold: 80 lines"})
+
+    def test_title_file_exceeds_blocking_threshold(self):
+        assert _is_size_oi({"title": "File exceeds blocking threshold: 900 lines (max 800)"})
+
+    def test_title_exceeds_threshold_function(self):
+        assert _is_size_oi({"title": "function foo exceeds threshold: 50 lines"})
+
+    def test_unrelated_oi_not_matched(self):
+        assert not _is_size_oi({"title": "Missing test coverage for src/foo.py"})
+
+    def test_lint_oi_not_matched(self):
+        assert not _is_size_oi({"dedup_key": "qa:lint_e501:bar", "title": "Long line"})
+
+    def test_empty_item_not_matched(self):
+        assert not _is_size_oi({})
+
+
+# ---------------------------------------------------------------------------
+# reclassify — dry-run mode
+# ---------------------------------------------------------------------------
+
+class TestReclassifyDryRun:
+    def test_dry_run_does_not_modify_store(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+        original = store.read_text()
+
+        result = reclassify(store, _audit(tmp_path), apply=False)
+
+        assert result["found"] == 1
+        assert result["reclassified"] == 0
+        assert store.read_text() == original
+
+    def test_dry_run_no_audit_entries(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+        audit = _audit(tmp_path)
+
+        reclassify(store, audit, apply=False)
+
+        assert not audit.exists()
+
+    def test_dry_run_returns_correct_found_count(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+            {"id": "OI-002", "status": "open", "severity": "blocker",
+             "dedup_key": "qa:function_size_blocking:foo", "title": "x", "updated_at": "2026-01-01"},
+            {"id": "OI-003", "status": "open", "severity": "warn",
+             "title": "Missing test coverage", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+
+        result = reclassify(store, _audit(tmp_path), apply=False)
+
+        assert result["found"] == 2
+
+
+# ---------------------------------------------------------------------------
+# reclassify — apply mode
+# ---------------------------------------------------------------------------
+
+class TestReclassifyApply:
+    def test_apply_reclassifies_size_blockers(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+
+        result = reclassify(store, _audit(tmp_path), apply=True)
+
+        assert result["found"] == 1
+        assert result["reclassified"] == 1
+        data = json.loads(store.read_text())
+        assert data["items"][0]["severity"] == "warn"
+
+    def test_apply_does_not_touch_non_size_blockers(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+            {"id": "OI-002", "status": "open", "severity": "blocker",
+             "title": "Missing test coverage", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+
+        result = reclassify(store, _audit(tmp_path), apply=True)
+
+        assert result["found"] == 1
+        data = json.loads(store.read_text())
+        oi2 = next(i for i in data["items"] if i["id"] == "OI-002")
+        assert oi2["severity"] == "blocker"
+
+    def test_apply_does_not_touch_closed_items(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "done", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+
+        result = reclassify(store, _audit(tmp_path), apply=True)
+
+        assert result["found"] == 0
+        data = json.loads(store.read_text())
+        assert data["items"][0]["severity"] == "blocker"
+
+    def test_apply_writes_audit_entries(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "dedup_key": "qa:file_size_blocking:scripts/lib/foo.py",
+             "title": "x", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+        audit = _audit(tmp_path)
+
+        reclassify(store, audit, apply=True)
+
+        assert audit.exists()
+        entries = [json.loads(line) for line in audit.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["action"] == "reclassify"
+        assert entries[0]["item_id"] == "OI-001"
+        assert entries[0]["from_severity"] == "blocker"
+        assert entries[0]["to_severity"] == "warn"
+
+    def test_apply_idempotent(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "title": "File exceeds blocking threshold: 900 lines", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+        audit = _audit(tmp_path)
+
+        reclassify(store, audit, apply=True)
+        result2 = reclassify(store, audit, apply=True)
+
+        assert result2["found"] == 0
+        assert result2["reclassified"] == 0
+
+    def test_apply_matches_dedup_key_prefix(self, tmp_path):
+        items = [
+            {"id": "OI-001", "status": "open", "severity": "blocker",
+             "dedup_key": "qa:function_size_blocking:scripts/lib/bar.py:my_func",
+             "title": "x", "updated_at": "2026-01-01"},
+        ]
+        store = _make_store(tmp_path, items)
+
+        result = reclassify(store, _audit(tmp_path), apply=True)
+
+        assert result["reclassified"] == 1
+
+    def test_apply_empty_store_no_error(self, tmp_path):
+        store = _make_store(tmp_path, [])
+
+        result = reclassify(store, _audit(tmp_path), apply=True)
+
+        assert result["found"] == 0
+        assert result["reclassified"] == 0


### PR DESCRIPTION
## Summary

- **quality_advisory.py**: All three size-check branches (`check_file_size`, `_check_python_function_sizes`, `_check_shell_function_sizes`) now emit `severity="warning"`, `action_required=False` for the blocking-threshold branch. `check_id` strings kept stable (`file_size_blocking`, `function_size_blocking`) so existing dedup keys are not invalidated.
- **Tests**: 3 existing tests updated to expect `warning` instead of `blocking`; new `TestSizeAdvisoryPolicy` class adds 4 tests including an exhaustive guard that no size check emits `severity="blocking"`.
- **scripts/maintenance/reclassify_size_ois.py**: one-shot backfill — finds open OIs with `severity=="blocker"` and size signature (dedup_key prefix `qa:function_size_`/`qa:file_size_` or title containing "exceeds blocking threshold"), sets `severity="warn"`, writes audit entries, atomic save. Dry-run by default.

## Verification

**Grep — no blocking path remains:**
```
grep severity=\"blocking\" scripts/lib/quality_advisory.py
(no output)
```

**Test run — 53 passed, 1 pre-existing unrelated failure (TestTerminalSnapshot::test_snapshot_terminal_fields):**
```
python3 -m pytest tests/test_quality_advisory_pipeline.py tests/test_reclassify_size_ois.py -q
53 passed, 1 failed (pre-existing: test_snapshot_terminal_fields – unrelated to size checks)
```

**Backfill dry-run (worktree store had 0 open size-blockers):**
```
$ python3 scripts/maintenance/reclassify_size_ois.py
Open size-blocker OIs found: 0
Nothing to do.

$ python3 scripts/maintenance/reclassify_size_ois.py --apply
Open size-blocker OIs found: 0
Nothing to do.
```

**ADR-007**: No schema or table changes in this PR. No `project_id` impact.

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)