### PR TITLE
refactor(hygiene): extract closure_verifier._validate_review_evidence helpers (no behavior change)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -423,227 +423,168 @@ def _gate_terminal_status(result: Dict[str, Any]) -> str:
     return ""
 
 
-def _validate_review_evidence(
-    contract: ReviewContract,
-    results_dir: Path,
-    branch: Optional[str] = None,
-) -> List[CheckResult]:
-    """Validate review contract presence and gate results against the review stack.
-
-    Checks:
-    1. Review contract has required fields (pr_id, review_stack)
-    2. Each gate in the review stack has a result
-    3. Required gates (codex for high-risk) have passing verdicts
-    4. Optional gates have explicit state (contributed or intentionally absent)
-    5. Content hash consistency between contract and gate receipts
-    6. No unresolved error-severity deterministic findings
-
-    When ``branch`` is provided, gate results from a different branch are
-    rejected as stale evidence — preventing a result from a prior branch with
-    the same ``pr_id`` from satisfying current closure.
-    """
-    checks: List[CheckResult] = []
-
+def _check_contract_fields(contract: ReviewContract) -> List[CheckResult]:
+    """Validate required contract fields. Returns a single FAIL on missing field (caller should return early), or a PASS."""
     if not contract.pr_id:
-        checks.append(CheckResult("review_contract", "FAIL", "review contract missing pr_id"))
-        return checks
-
+        return [CheckResult("review_contract", "FAIL", "review contract missing pr_id")]
     if not contract.review_stack:
-        checks.append(CheckResult("review_contract", "FAIL", "review contract has empty review_stack"))
-        return checks
-
-    checks.append(CheckResult(
+        return [CheckResult("review_contract", "FAIL", "review contract has empty review_stack")]
+    return [CheckResult(
         "review_contract",
         "PASS",
         f"review contract present for {contract.pr_id} "
         f"(stack: {', '.join(contract.review_stack)})",
-    ))
+    )]
 
-    for gate in contract.review_stack:
-        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
 
-        if gate == "claude_github_optional":
-            # Fallback: explicit-absence state for the optional gate is recorded
-            # in the requests directory by gate_request_handler — not as a
-            # separate result file — so a missing result is not by itself
-            # ambiguous.  Look there before declaring no evidence.
+def _check_single_gate(
+    gate: str,
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    """Check a single gate from the review stack, returning one CheckResult."""
+    if gate == "claude_github_optional":
+        # Fallback: explicit-absence state for the optional gate is recorded
+        # in the requests directory by gate_request_handler — not as a
+        # separate result file — so a missing result is not by itself
+        # ambiguous.  Look there before declaring no evidence.
+        if result is None:
+            result = _find_gate_request_payload(gate, contract.pr_id, results_dir, branch=branch)
+        if result is None:
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                f"no evidence for optional gate {gate} — state must be explicit",
+            )
+        if (result.get("state") or "").lower() == "completed":
+            # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
+            # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
+            # gate_is_pass() handles state/result_status via gate_status._coerce_status (CFX-12).
+            passed, reason = gate_is_pass(result)
+            if passed:
+                advisory_count = int(result.get("advisory_count") or 0)
+                return CheckResult(
+                    f"gate_{gate}",
+                    "PASS",
+                    f"{gate} completed: pass (0 blocking, {advisory_count} advisory)",
+                )
+            return CheckResult(f"gate_{gate}", "FAIL", f"{gate} completed: {reason}")
+        if result.get("was_intentionally_absent") or result.get("contributed_evidence"):
+            state = result.get("state", "unknown")
+            source = result.get("__source", "result")
+            return CheckResult(
+                f"gate_{gate}",
+                "PASS",
+                f"{gate} state explicit: {state} (source: {source})",
+            )
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"{gate} state is ambiguous — neither contributed evidence nor intentionally absent",
+        )
+
+    if gate == "codex_gate":
+        enforcement = enforce_codex_gate(contract)
+        if enforcement.required:
             if result is None:
-                result = _find_gate_request_payload(gate, contract.pr_id, results_dir, branch=branch)
-            if result is None:
-                checks.append(CheckResult(
+                return CheckResult(
                     f"gate_{gate}",
                     "FAIL",
-                    f"no evidence for optional gate {gate} — state must be explicit",
-                ))
-            elif (result.get("state") or "").lower() == "completed":
-                # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
-                # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
-                # gate_is_pass() handles state/result_status via gate_status._coerce_status (CFX-12).
-                passed, reason = gate_is_pass(result)
-                if passed:
-                    advisory_count = int(result.get("advisory_count") or 0)
-                    checks.append(CheckResult(
+                    f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
+                )
+            if gate_is_terminal(result) and not result.get("report_path", ""):
+                return CheckResult(
+                    f"gate_{gate}",
+                    "FAIL",
+                    "codex_gate result is missing required report_path field",
+                )
+            # CFX-17: demote allowlisted findings before counting blocking.
+            translated = _apply_codex_severity_policy(result)
+            passed, reason = gate_is_pass(translated)
+            demoted = len(translated.get("severity_demotions") or [])
+            if passed:
+                if demoted:
+                    return CheckResult(
                         f"gate_{gate}",
                         "PASS",
-                        f"{gate} completed: pass (0 blocking, {advisory_count} advisory)",
-                    ))
-                else:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"{gate} completed: {reason}",
-                    ))
-            elif result.get("was_intentionally_absent") or result.get("contributed_evidence"):
-                state = result.get("state", "unknown")
-                source = result.get("__source", "result")
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "PASS",
-                    f"{gate} state explicit: {state} (source: {source})",
-                ))
-            else:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    f"{gate} state is ambiguous — neither contributed evidence nor intentionally absent",
-                ))
+                        f"codex gate passed after demoting {demoted} finding(s) per severity policy",
+                    )
+                return CheckResult(f"gate_{gate}", "PASS", "codex gate passed")
+            return CheckResult(f"gate_{gate}", "FAIL", f"codex gate not passing — {reason}")
+        return CheckResult(f"gate_{gate}", "PASS", "codex gate not required by risk policy")
 
-        elif gate == "codex_gate":
-            enforcement = enforce_codex_gate(contract)
-            if enforcement.required:
-                if result is None:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
-                    ))
-                elif gate_is_terminal(result) and not result.get("report_path", ""):
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        "codex_gate result is missing required report_path field",
-                    ))
-                else:
-                    # CFX-17: demote allowlisted findings before counting blocking.
-                    translated = _apply_codex_severity_policy(result)
-                    passed, reason = gate_is_pass(translated)
-                    demoted = len(translated.get("severity_demotions") or [])
-                    if passed:
-                        if demoted:
-                            checks.append(CheckResult(
-                                f"gate_{gate}",
-                                "PASS",
-                                f"codex gate passed after demoting {demoted} finding(s) per severity policy",
-                            ))
-                        else:
-                            checks.append(CheckResult(
-                                f"gate_{gate}",
-                                "PASS",
-                                "codex gate passed",
-                            ))
-                    else:
-                        checks.append(CheckResult(
-                            f"gate_{gate}",
-                            "FAIL",
-                            f"codex gate not passing — {reason}",
-                        ))
-            else:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "PASS",
-                    "codex gate not required by risk policy",
-                ))
+    if gate == "gemini_review":
+        if result is None:
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                f"no gate result for required reviewer {gate}",
+            )
+        if gate_is_terminal(result) and not result.get("report_path", ""):
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                "gemini_review result is missing required report_path field",
+            )
+        passed, reason = gate_is_pass(result)
+        advisory_count = result.get("advisory_count", 0)
+        if passed:
+            return CheckResult(
+                f"gate_{gate}",
+                "PASS",
+                f"gemini review passed ({advisory_count} advisory, 0 blocking)",
+            )
+        return CheckResult(f"gate_{gate}", "FAIL", f"gemini review not passing — {reason}")
 
-        elif gate == "gemini_review":
-            if result is None:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    f"no gate result for required reviewer {gate}",
-                ))
-            elif gate_is_terminal(result) and not result.get("report_path", ""):
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    "gemini_review result is missing required report_path field",
-                ))
-            else:
-                passed, reason = gate_is_pass(result)
-                advisory_count = result.get("advisory_count", 0)
-                if passed:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "PASS",
-                        f"gemini review passed ({advisory_count} advisory, 0 blocking)",
-                    ))
-                else:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        f"gemini review not passing — {reason}",
-                    ))
+    if gate == "ci_gate":
+        if result is None:
+            return CheckResult(f"gate_{gate}", "FAIL", "no ci_gate result found")
+        if not gate_is_terminal(result):
+            status = result.get("status", "unknown")
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                f"ci_gate checks still {status} — incomplete evidence",
+            )
+        contract_hash = result.get("contract_hash", "")
+        report_path = result.get("report_path", "")
+        if not contract_hash:
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                "ci_gate result is missing required contract_hash field",
+            )
+        if not report_path:
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                "ci_gate result is missing required report_path field",
+            )
+        passed, reason = gate_is_pass(result)
+        if passed:
+            advisory_count = result.get("advisory_count", 0)
+            return CheckResult(
+                f"gate_{gate}",
+                "PASS",
+                f"ci_gate passed ({advisory_count} advisory, 0 blocking)",
+            )
+        return CheckResult(f"gate_{gate}", "FAIL", f"ci_gate not passing — {reason}")
 
-        elif gate == "ci_gate":
-            if result is None:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    "no ci_gate result found",
-                ))
-            elif not gate_is_terminal(result):
-                status = result.get("status", "unknown")
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    f"ci_gate checks still {status} — incomplete evidence",
-                ))
-            else:
-                contract_hash = result.get("contract_hash", "")
-                report_path = result.get("report_path", "")
-                if not contract_hash:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        "ci_gate result is missing required contract_hash field",
-                    ))
-                elif not report_path:
-                    checks.append(CheckResult(
-                        f"gate_{gate}",
-                        "FAIL",
-                        "ci_gate result is missing required report_path field",
-                    ))
-                else:
-                    passed, reason = gate_is_pass(result)
-                    if passed:
-                        advisory_count = result.get("advisory_count", 0)
-                        checks.append(CheckResult(
-                            f"gate_{gate}",
-                            "PASS",
-                            f"ci_gate passed ({advisory_count} advisory, 0 blocking)",
-                        ))
-                    else:
-                        blocking_count = result.get("blocking_count", 0)
-                        checks.append(CheckResult(
-                            f"gate_{gate}",
-                            "FAIL",
-                            f"ci_gate not passing — {reason}",
-                        ))
+    # Unknown gate
+    if result is None:
+        return CheckResult(f"gate_{gate}", "FAIL", f"no gate result for unknown gate {gate}")
+    return CheckResult(f"gate_{gate}", "PASS", f"gate {gate} result present")
 
-        else:
-            if result is None:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    f"no gate result for unknown gate {gate}",
-                ))
-            else:
-                checks.append(CheckResult(
-                    f"gate_{gate}",
-                    "PASS",
-                    f"gate {gate} result present",
-                ))
 
-    # Content hash consistency
+def _check_contract_hashes(contract: ReviewContract, results_dir: Path) -> List[CheckResult]:
+    """Check content hash consistency between contract and gate receipts.
+
+    ADR-007: project_id-scoped filtering is enforced inside _find_gate_result; not added here
+    to match the same call site as the original gate-loop (branch=contract.branch, no project_id arg).
+    """
+    checks: List[CheckResult] = []
     for gate in contract.review_stack:
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
         if result and contract.content_hash:
@@ -655,10 +596,12 @@ def _validate_review_evidence(
                     f"{gate} receipt hash mismatch — evidence is stale "
                     f"(contract={contract.content_hash[:8]}.. receipt={result_hash[:8]}..)",
                 ))
+    return checks
 
-    # Report path validation — per headless review evidence contract, every
-    # pass/fail gate result must carry a report_path pointing to a real file
-    # under $VNX_DATA_DIR/unified_reports/.
+
+def _check_report_paths(contract: ReviewContract, results_dir: Path) -> List[CheckResult]:
+    """Validate that every terminal gate result carries a report_path pointing to a real file."""
+    checks: List[CheckResult] = []
     for gate in contract.review_stack:
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
         if result is not None and gate_is_terminal(result):
@@ -681,22 +624,52 @@ def _validate_review_evidence(
                     "PASS",
                     f"{gate} normalized report exists at {report_path}",
                 ))
+    return checks
 
-    # Deterministic findings — error-severity blocks closure
+
+def _check_deterministic_findings(contract: ReviewContract) -> CheckResult:
+    """Return FAIL if any error-severity deterministic findings remain unresolved."""
     error_findings = [f for f in contract.deterministic_findings if f.severity == "error"]
     if error_findings:
-        checks.append(CheckResult(
+        return CheckResult(
             "deterministic_findings",
             "FAIL",
             f"{len(error_findings)} unresolved error-severity deterministic finding(s)",
-        ))
-    else:
-        total = len(contract.deterministic_findings)
-        checks.append(CheckResult(
-            "deterministic_findings",
-            "PASS",
-            f"{total} deterministic finding(s), 0 errors",
-        ))
+        )
+    total = len(contract.deterministic_findings)
+    return CheckResult("deterministic_findings", "PASS", f"{total} deterministic finding(s), 0 errors")
+
+
+def _validate_review_evidence(
+    contract: ReviewContract,
+    results_dir: Path,
+    branch: Optional[str] = None,
+) -> List[CheckResult]:
+    """Validate review contract presence and gate results against the review stack.
+
+    Checks:
+    1. Review contract has required fields (pr_id, review_stack)
+    2. Each gate in the review stack has a result
+    3. Required gates (codex for high-risk) have passing verdicts
+    4. Optional gates have explicit state (contributed or intentionally absent)
+    5. Content hash consistency between contract and gate receipts
+    6. No unresolved error-severity deterministic findings
+
+    When ``branch`` is provided, gate results from a different branch are
+    rejected as stale evidence — preventing a result from a prior branch with
+    the same ``pr_id`` from satisfying current closure.
+    """
+    checks = _check_contract_fields(contract)
+    if any(c.status == "FAIL" for c in checks):
+        return checks
+
+    for gate in contract.review_stack:
+        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
+        checks.append(_check_single_gate(gate, contract, result, results_dir, branch))
+
+    checks.extend(_check_contract_hashes(contract, results_dir))
+    checks.extend(_check_report_paths(contract, results_dir))
+    checks.append(_check_deterministic_findings(contract))
 
     return checks
 


### PR DESCRIPTION
## Summary
- Split 276-line `_validate_review_evidence` into 5 focused private helpers: `_check_contract_fields`, `_check_single_gate`, `_check_contract_hashes`, `_check_report_paths`, `_check_deterministic_findings`
- `_validate_review_evidence` is now **34 lines** (was 276) — pure orchestration
- Zero behavior change: same inputs, same return shape, same blocking conditions, same invariants

## Verification
```
python3 -m pytest tests/ -k "closure or review_evidence or invariant or gate" -q
9 failed, 69 passed, 63 warnings
```
The 9 failures are **pre-existing** (all in `test_per_pr_closure.py`). Zero new failures introduced.

**Before/after `_validate_review_evidence` line count:** 276 → 34

**ADR-007:** project_id-scoped filtering is enforced inside `_find_gate_result`. All call sites within the extracted helpers use identical arguments (`branch=contract.branch`, no `project_id` arg) — same as the original. No ADR-007 invariant dropped or weakened.

**7-invariant checklist (behavior identical):**
1. Missing `pr_id` → FAIL + early return ✓
2. Empty `review_stack` → FAIL + early return ✓
3. Per-gate check (claude_github_optional / codex_gate / gemini_review / ci_gate / unknown) ✓
4. Hash consistency check loop ✓
5. Report path existence loop ✓
6. Deterministic error-severity findings block ✓
7. ADR-005/007 branch + project_id filtering preserved in `_find_gate_result` calls ✓

Dispatch-ID: 20260530-103046-hyg-closure