### PR TITLE
fix(kimi): robust spawn — drop default --yolo + graceful 403/non-JSON handling

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,27 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-05-29T21:06:09.831069+00:00
+**Last updated**: 2026-05-30T20:28:50.626334+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #753 — chore(security): remove dead prep-applier + de-advertise private products from public wheel (#753) (2026-05-30)
+- #752 — fix(security): pre-publish hardening — bash_check RCE + heartbeat shell-injection + strip private portfolio from wheel (#752) (2026-05-30)
+- #750 — refactor(hygiene): extract _validate_review_evidence helpers (no behavior change) (#750) (2026-05-30)
+- #749 — fix(hygiene): size findings are advisory (warning), not blocking + OI backfill (#749) (2026-05-30)
+- #747 — fix(migrate): create runtime_schema_version table before stamping it (#747) (2026-05-30)
+- #746 — fix(resolver-unify): unify project_id + DB path resolution for pool, dream, init (#746) (2026-05-30)
+- #745 — fix(migrate): seed default pool_config row + stamp runtime_schema_version (#745) (2026-05-30)
+- #743 — fix(migrate): bootstrap runtime_coordination.db + fix XDG path resolution for track/pool (#743) (2026-05-30)
+- #742 — chore(release): bump version rc3 → 1.0.0 for public launch (#742) (2026-05-29)
+- #740 — fix(blk-initmigrate): bootstrap runtime DBs in vnx init; add vnx migrate command (#740) (2026-05-29)
+- #741 — fix(selflearn): unify canonical DB path + add nightly dream phase (#741) (2026-05-29)
+- #738 — docs(1.0): update roadmap + archive superseded docs for 1.0 launch state (#738) (2026-05-29)
+- #730 — feat(ci): add Profile D pip-install smoke test (PR-CI-SMOKE) (#730) (2026-05-29)
+- #737 — fix(dream): guided exit when resolve_project_root fails outside git repo (#737) (2026-05-29)
+- #736 — feat(dispatch): scope register_dispatch to composite (dispatch_id, project_id) — ADR-007 (#736) (2026-05-29)
 - #732 — chore(packaging): wheel hygiene — exclude pycache/tests/benchmarks, remove stale dist/ (#732) (2026-05-29)
 - #735 — fix(dream): route all file I/O through canonical vnx_paths data root (#735) (2026-05-29)
 - #733 — fix(blk-readme): make quickstart work on clean pip install (#733) (2026-05-29)
@@ -149,8 +164,6 @@ _Last 14 days — sourced from git merge commits._
 - #551 — feat(p0a): intelligence injection for all providers (codex/gemini/litellm) (#551) (2026-05-17)
 - #548 — data(benchmark): 56-dispatch model comparison results + routing recommendations (#548) (2026-05-17)
 - #547 — feat(benchmark): suite infrastructure (9 models x 7 tasks orchestrator + judge + analyzer) (#547) (2026-05-16)
-- #537 — fix(oi-1479): token_usage extraction + cost_usd computation per provider (#537) (2026-05-16)
-- #533 — fix(oi-1476): align project_id regex + yaml placeholder substitution (#533) (2026-05-16)
 
 **WAVE 5**
 - #601 — docs: refresh README + ROADMAP for 1.0.0-rc2 (Wave 5/6/7/8 shipped + central install) (#601) (2026-05-18)
@@ -173,41 +186,18 @@ _Last 14 days — sourced from git merge commits._
 - #629 — fix(install-central): write install-mode marker, export VNX_PROJECT_ROOT from shim, fix verify_install (PR-WAVE4-2) (#629) (2026-05-25)
 - #628 — fix(install-central): separate PROJECT_ROOT from VNX_HOME in central-install mode (PR-WAVE4-1) (#628) (2026-05-25)
 
-**WAVE5**
-- #532 — feat(wave5): PR-5.7 — operator demo runbook + Control Centre docs + completion report (#532) (2026-05-16)
-- #530 — feat(wave5): PR-5.6 — hybrid dispatch routing with receipt-tail lifecycle tracker (#530) (2026-05-16)
-- #528 — feat(wave5): PR-5.5 — Control Centre CLI shell skill + operator commands (#528) (2026-05-16)
-- #525 — feat(wave5): PR-5.2 — per-project T0 lifecycle management (spawn/heartbeat/kill/reap) (#525) (2026-05-16)
-- #524 — feat(wave5): PR-5.4 — cross-project intelligence aggregator (global + per-project facets) (#524) (2026-05-16)
-- #523 — feat(wave5): PR-5.3 — multi-tenant lease isolation (schema v12) (#523) (2026-05-16)
-- #522 — feat(wave5): PR-5.1 — multi-project state aggregator write-pad (#522) (2026-05-16)
-- #521 — docs(wave5): PR-5.0 — ADR-017 Control Centre product-shape architecture (#521) (2026-05-16)
-
 **WAVE6**
 - #698 — fix(wave6-pool-lease-spawn): insert terminal_leases row before add_member in pool scale_up (#698) (2026-05-29)
 - #575 — fix(wave6): real spawn impl + config field reads + single heartbeat threshold (3 blockers) (#575) (2026-05-17)
 - #546 — fix(wave6): OI cleanup group 1 (idempotency + regex + ledger + audit) (#546) (2026-05-16)
 - #544 — feat(wave6): PR-6.8 — Control Centre pool-integration (cross-project pool view + supervisor) (#544) (2026-05-16)
 - #543 — feat(wave6): PR-6.7 — vnx pool CLI (status/scale/config/reap subcommands) (#543) (2026-05-16)
-- #542 — feat(wave6): PR-6.6 — health monitoring + dead-worker reap (tick = reap → decide → execute) (#542) (2026-05-16)
-- #541 — feat(wave6): PR-6.5 — provider-mix per pool with lowest-share-first allocation (#541) (2026-05-16)
-- #540 — feat(wave6): PR-6.4 — pluggable scaling policies (queue_depth_v1 + cost_aware_v1) (#540) (2026-05-16)
-- #539 — feat(wave6): PR-6.3 — PoolManager core (decision engine + state repo + manager) (#539) (2026-05-16)
-- #538 — feat(wave6): PR-6.2 — schema v14 elastic worker pool tables + migration scripts (#538) (2026-05-16)
-- #535 — feat(wave6): PR-6.1 — vnx_workers.yaml + WORKER_REGISTRY (ADR-013 implementation) (#535) (2026-05-16)
-- #534 — feat(wave6): PR-6.0 — ADR-018 elastic worker pool design freeze (#534) (2026-05-16)
 
 **WAVE7**
 - #579 — fix(wave7): claude cost tracking + kimi audit-gap status + redact prompt in logs (3 blockers) (#579) (2026-05-17)
 - #577 — fix(wave7): claude cost tracking + kimi audit-gap status + redact prompt in logs (3 blockers) (#577) (2026-05-17)
 - #550 — feat(wave7): PR-7.7 — Kimi CLI as 5th provider (OAuth via kimi login) (#550) (2026-05-17)
 - #545 — fix(wave7): OI cleanup group 2 — litellm usage stream + unified report .md suffix (#545) (2026-05-16)
-- #536 — feat(wave7): PR-7.6 — provider governance unification (receipt + unified report for all providers) (#536) (2026-05-16)
-- #531 — feat(wave7): vnx.env loader + DeepSeek V4-Pro/V4-Flash model registry update (#531) (2026-05-16)
-- #520 — feat(wave7): PR-7.5 — provider behavior contracts (capabilities + tool-shape + cache-control) (#520) (2026-05-15)
-- #519 — feat(wave7): PR-7.4 — cost-routing policy engine (feature-flag gated) (#519) (2026-05-15)
-- #518 — feat(wave7): PR-7.3 — GLM-5.1 lane via OpenRouter (z.AI direct deferred) (#518) (2026-05-15)
-- #517 — feat(wave7): PR-7.2 — Kimi K2.6 + K2-0905 lane via LiteLLM Moonshot endpoint (#517) (2026-05-15)
 
 ## Active features
 

--- a/PRE_PUBLISH_SECURITY_SWEEP_1.0.0.md
+++ b/PRE_PUBLISH_SECURITY_SWEEP_1.0.0.md
@@ -1,0 +1,133 @@
+# VNX Orchestration 1.0.0 — Pre-Publish Security Sweep Report
+
+**Date:** 2026-05-30  
+**Scope:** Full wheel (`vnx_orchestration-1.0.0-py3-none-any.whl`, 815 files) + repo tip  
+**Baseline:** gitleaks clean (0 leaks over 1852 commits), `/Users/vincentvandeth` guard scripts already known  
+**Angle:** hardcoded-paths / machine-specific-assumptions / config-env-leaks / supply-chain / code vulnerabilities  
+
+---
+
+## VERDICT: NO-GO
+
+**One blocker prevents an immutable public PyPI publish.** Fix the command-injection vulnerability below, rebuild the wheel, and re-scan before publishing.
+
+The remainder of the package is in reasonable shape: no leaked secrets, no build-time arbitrary code execution, no unsafe deserialization, and no `.env` files in the wheel. The warnings are hygiene issues that should be cleaned up but do not block publication on their own.
+
+---
+
+## BLOCKER (1)
+
+### B-1 — Command Injection via `shell=True` in heartbeat monitor
+- **File:** `vnx_orchestration/scripts/heartbeat_ack_monitor.py:489–490`
+- **Code:**
+  ```python
+  cmd = f"tmux list-panes -a -F '#{{session_name}}:#{{window_name}} #{{pane_current_command}}' | grep -i {terminal}"
+  result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=1)
+  ```
+- **Why it matters for a PUBLIC immutable publish:**  
+  The `terminal` variable is read directly from the Unix socket server (`_socket_server`, line 752–767) without validation before it reaches `_check_terminal_activity`. A crafted dispatch message (or any process that can write to `$VNX_DATA_DIR/sockets/heartbeat_ack_monitor.sock`) can inject arbitrary shell commands. On a shared host, or if the socket path has loose permissions, this is remote code execution as the user running the monitor.
+- **Fix:** Replace `shell=True` with a list argument and `grep` as a separate pipeline stage, or shell-escape `terminal` with `shlex.quote()`:
+  ```python
+  import shlex
+  cmd = (
+      f"tmux list-panes -a -F '#{{session_name}}:#{{window_name}} #{{pane_current_command}}' "
+      f"| grep -i {shlex.quote(terminal)}"
+  )
+  result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=1)
+  ```
+  Better: avoid `shell=True` entirely by piping `tmux` stdout into a Python regex match.
+
+---
+
+## WARNINGS (4)
+
+### W-1 — Machine-specific memory paths baked into shipped SKILL.md docs
+- **Files:**
+  - `vnx_orchestration/skills/security-engineer/SKILL.md:55`
+  - `vnx_orchestration/skills/database-engineer/SKILL.md:37`
+  - `vnx_orchestration/skills/architect/SKILL.md:28`
+  - `vnx_orchestration/skills/debugger/SKILL.md:43`
+  - `vnx_orchestration/skills/intelligence-engineer/SKILL.md:37`
+- **Content:** Each references  
+  `~/.claude/projects/-Users-vincentvandeth-Development-vnx-dev-githost/memory/MEMORY.md`
+- **Why it matters:** These are shipped to every pip install. They expose the author's local directory structure, confuse other users (the path will not exist on their machines), and signal that the skill documentation was not sanitized before packaging.
+- **Fix:** Replace the absolute path with a generic placeholder:
+  `~/.claude/projects/<project-slug>/memory/MEMORY.md`
+
+### W-2 — `vnx_doctor.sh` ships a hardcoded `/Users/` search pattern
+- **File:** `vnx_orchestration/scripts/vnx_doctor.sh:10`
+- **Content:** `PATTERN='\.claude/vnx-system|/Users/|\.nvm/versions/node/v[0-9]'`
+- **Assessment:** The `/Users/` segment is there by design (the script searches for forbidden local paths in other files). It is **not** a leaked secret. However, it is a hardcoded platform-specific path string in a shipped runtime script.
+- **Fix:** Acceptable as-is if documented; ideally the pattern should be generated from `uname` detection or moved to a config file so macOS-specific paths do not fire on Linux installs.
+
+### W-3 — `check_installer_no_template_leak.sh` ships developer username
+- **File:** `vnx_orchestration/scripts/check_installer_no_template_leak.sh:26`
+- **Content:** `"/Users/vincentvandeth"` appears in the `FORBIDDEN_PATTERNS` array.
+- **Assessment:** This is a CI leak-guard script; the string is a **search target**, not a leaked path. It is intentionally hunting for the developer's own path in installer output. Benign by design.
+- **Fix:** None required. Consider adding a comment explaining the pattern is a guard, not a leak.
+
+### W-4 — Inline test code writes to `/tmp` in a production module
+- **File:** `vnx_orchestration/scripts/pr_queue_manager.py` (lines ~1993–2031)
+- **Content:** Dead `if __name__ == "__main__":` test blocks that write `/tmp/test_valid_plan.md`, `/tmp/test_no_feature.md`, etc.
+- **Why it matters:** Test code should not ship in production wheels. It clutters the attack surface and writes predictable filenames in `/tmp` (race-condition risk, though low severity here).
+- **Fix:** Move the tests to a `tests/` directory (already excluded from the wheel via `pyproject.toml`) or delete the inline test blocks.
+
+---
+
+## INFO / CLEAN AREAS (Explicitly checked)
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| `.env` / `.envrc` files in wheel | **NONE FOUND** | `find` across wheel returned 0 hits |
+| `eval()` / `exec()` calls in Python | **NONE FOUND** | `grep` for `\beval(` and `\bexec(` returned empty |
+| `yaml.load` (unsafe) | **NONE** | All YAML parsing uses `yaml.safe_load` |
+| `pickle.load` / `pickle.loads` | **NONE** | Not present in wheel |
+| `os.system` / `os.popen` | **NONE** | Not present in Python files |
+| Secrets (API keys, tokens, passwords) in configs | **NONE** | Configs only reference env-var *names* (`ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`, etc.); no values |
+| Build hooks / custom `setup.py` | **NONE** | `pyproject.toml` uses standard `setuptools.build_meta`; no `setup.py`, `build.py`, or post-install scripts in wheel |
+| `.pth` / `egg-link` files | **NONE** | Not present in wheel |
+| Console script entry points | **1 only** | `vnx = vnx_cli.main:main` — standard argparse CLI |
+| `requests` library usage | **NONE** | Only `urllib.request` used (Vertex AI, Ollama local) |
+| SSRF via user-controlled URLs | **LOW RISK** | `vertex_ai_runner.py` builds URL from gcloud project ID; Ollama adapters default to `localhost:11434` via env override |
+| SQL injection (SQLite) | **LOW RISK** | A few f-strings in `PRAGMA` / `CREATE TABLE` / `DROP TABLE`, but table/alias names are internally generated, not user-facing |
+| Path traversal from dispatch IDs | **MITIGATED** | `tmux_worktree.py` validates dispatch IDs with `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$` |
+| Unsafe temp files | **MOSTLY CLEAN** | `heartbeat_ack_monitor.py` uses `NamedTemporaryFile(delete=False)` and correctly `os.unlink`s; `intelligence_daemon.py` uses atomic rename after temp write |
+| `subprocess` with `shell=True` (Python) | **1 ONLY** | The blocker above (B-1). `tmux_worktree.py` correctly uses list args with `shell=False` |
+| `vincentvandeth` in wheel | **3 hits** | `METADATA` (author email, expected), `check_installer_no_template_leak.sh` (guard), 5× `SKILL.md` (W-1) |
+| `install.sh` in wheel | **NOT PRESENT** | Only referenced in comments/docs |
+
+---
+
+## SUPPLY-CHAIN ASSESSMENT
+
+- **Build backend:** `setuptools.build_meta` (standard, no custom hooks).
+- **Dependencies:** `watchdog`, `opentelemetry-*`, `jinja2` — all well-known, no pinned malicious versions.
+- **Optional deps:** `vulture`, `ruff` — dev-quality tools, harmless.
+- **No `setup.py` / `build.py` / `MANIFEST.in` / post-install scripts** in the wheel.
+- **No code execution on `pip install`** beyond normal setuptools file extraction.
+- **Entry point:** `vnx_cli.main:main` is a plain argparse CLI; no import-time side effects in `vnx_cli/__init__.py` other than reading `VERSION`.
+
+**Supply-chain verdict:** Clean.
+
+---
+
+## SUMMARY TABLE
+
+| ID | Severity | File | Line | Issue | Fix |
+|----|----------|------|------|-------|-----|
+| B-1 | **BLOCKER** | `scripts/heartbeat_ack_monitor.py` | 489–490 | `shell=True` with unsanitized `terminal` from socket JSON → command injection | Use `shlex.quote(terminal)` or replace `shell=True` with list args + Python regex |
+| W-1 | WARN | `skills/*/SKILL.md` (5 files) | — | Hardcoded `~/.claude/projects/-Users-vincentvandeth-...` path in docs | Replace with `<project-slug>` placeholder |
+| W-2 | WARN | `scripts/vnx_doctor.sh` | 10 | Ships `/Users/` as a search pattern | Document or make platform-conditional |
+| W-3 | WARN | `scripts/check_installer_no_template_leak.sh` | 26 | Ships developer username as forbidden pattern | Add explanatory comment |
+| W-4 | WARN | `scripts/pr_queue_manager.py` | ~1993–2031 | Inline test code writes to `/tmp` in production module | Move tests out of shipped code |
+
+---
+
+## RECOMMENDATION
+
+1. **Fix B-1** (command injection) immediately.
+2. **Rebuild the wheel** (`python -m build`).
+3. **Re-run this sweep** on the new wheel to confirm the fix and verify no new artifacts appeared.
+4. **Address W-1** (SKILL.md paths) before publish — it looks unprofessional and leaks local structure.
+5. **Address W-4** (inline tests) in a follow-up PR — not blocking but poor hygiene.
+6. **After fixes:** Publish. The package is otherwise ready for an immutable public release.

--- a/scripts/lib/kimi_wrapper.py
+++ b/scripts/lib/kimi_wrapper.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """kimi_wrapper.py — Lightweight Kimi CLI wrapper with cost emission.
 
-Wraps `kimi --print --output-format stream-json --yolo -p <prompt>` and emits
+Wraps `kimi --print --output-format stream-json [-p <prompt>]` and emits
 a provider cost event to .vnx-data/events/provider_costs.ndjson per ADR-005.
+
+--yolo (auto-approve) is opt-in via VNX_KIMI_YOLO=1 (default OFF). Without it,
+kimi's --print mode is non-interactive and does not require auto-approval grants.
+
+Non-JSON / quota-403 stdout is detected and raises a structured RuntimeError
+(provider=kimi, reason=quota_or_auth) rather than a raw JSON parse error.
 
 Authentication via `kimi login` (OAuth). No API key required.
 Kimi is subscription-flat; cost_usd_estimate=None is emitted with billing_mode=subscription.
@@ -30,6 +36,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_KIMI_MODEL = "kimi-k2.6"
 DEFAULT_TIMEOUT = 300.0
+
+# Markers that identify quota / auth / 403-style rejection bodies.
+_QUOTA_AUTH_MARKERS = frozenset({
+    "403", "401", "quota", "unauthorized", "auth", "forbidden",
+    "rate limit", "rate_limit", "token expired", "authentication",
+})
+
+
+def _is_quota_or_auth_line(text: str) -> bool:
+    """Return True if text looks like a quota/auth/403 rejection body."""
+    lower = text.lower()
+    return any(m in lower for m in _QUOTA_AUTH_MARKERS)
 
 
 def _parse_kimi_token_usage(stdout: str) -> Optional[dict]:
@@ -75,20 +93,27 @@ def kimi_exec(
     project_id: Optional[str] = None,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> str:
-    """Spawn `kimi --print --output-format stream-json --yolo -p <prompt>`.
+    """Spawn `kimi --print --output-format stream-json [-p <prompt>]`.
 
     stdin=DEVNULL per cli-headless-subprocess-pattern (prevents interactive hang).
     Kimi is subscription-flat: cost_usd_estimate=None, billing_mode=subscription.
 
+    --yolo (auto-approve) is opt-in via VNX_KIMI_YOLO=1 (default OFF).
+
     Emits a provider cost event via emit_provider_cost() and returns captured stdout.
 
     Raises subprocess.TimeoutExpired on timeout.
-    Raises RuntimeError on non-zero exit.
+    Raises RuntimeError on non-zero exit. When the stdout looks like a 403/quota/auth
+    rejection body, the RuntimeError message includes provider=kimi reason=quota_or_auth
+    and the first line of stdout for diagnosis.
     """
     from provider_costs import emit_provider_cost  # noqa: PLC0415
 
     effective_project_id = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
-    cmd = ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p", prompt]
+    cmd = ["kimi", "--print", "--output-format", "stream-json"]
+    if os.environ.get("VNX_KIMI_YOLO", "0") == "1":
+        cmd.append("--yolo")
+    cmd.extend(["-p", prompt])
     if model and model != DEFAULT_KIMI_MODEL:
         cmd.extend(["-m", model])
 
@@ -136,6 +161,13 @@ def kimi_exec(
     )
 
     if proc.returncode != 0:
+        first_stdout_line = next(
+            (ln.strip() for ln in stdout.splitlines() if ln.strip()), ""
+        )
+        if first_stdout_line and _is_quota_or_auth_line(first_stdout_line):
+            raise RuntimeError(
+                f"kimi_exec: provider=kimi reason=quota_or_auth raw={first_stdout_line[:200]}"
+            )
         raise RuntimeError(
             f"kimi_exec failed: returncode={proc.returncode} stderr={stderr_data[:500]!r}"
         )

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -4,7 +4,15 @@ Owns: spawn + stream-json parsing + canonical event normalization.
 Caller (provider_dispatch.py) handles: receipt, unified report, lease, etc.
 
 Kimi CLI invocation:
-    kimi --print --output-format stream-json --yolo -p "<prompt>"
+    kimi --print --output-format stream-json [-p "<prompt>"]
+
+--yolo is opt-in via VNX_KIMI_YOLO=1 (default OFF). Without --yolo, kimi's
+--print mode is non-interactive and does not require auto-approval grants.
+Running without --yolo avoids failures when the kimi CLI denies the flag.
+
+Non-JSON / quota-403 output is detected and surfaced as a structured error
+(provider=kimi, reason=quota_or_auth) rather than a raw JSON parse error or
+unhandled exception.
 
 Authentication: OAuth via `kimi login` (operator-managed). No API key in spawn.
 
@@ -31,6 +39,18 @@ from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+# Markers that identify quota / auth / 403-style rejection bodies (non-JSON kimi output).
+_QUOTA_AUTH_MARKERS = frozenset({
+    "403", "401", "quota", "unauthorized", "auth", "forbidden",
+    "rate limit", "rate_limit", "token expired", "authentication",
+})
+
+
+def _is_quota_or_auth_line(text: str) -> bool:
+    """Return True if text looks like a quota/auth/403 rejection body."""
+    lower = text.lower()
+    return any(m in lower for m in _QUOTA_AUTH_MARKERS)
 
 
 @dataclass
@@ -186,8 +206,18 @@ class _KimiNormalizerHost(StreamingDrainerMixin):
 
 
 def _build_kimi_cmd(prompt: str, model: Optional[str], work_dir: Optional[Any]) -> list:
-    """Build the kimi argv list."""
-    cmd = ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p", prompt]
+    """Build the kimi argv list.
+
+    --yolo (auto-approve) is opt-in via VNX_KIMI_YOLO=1 (default OFF).
+    Kimi's --print mode is non-interactive by design; --yolo is not required
+    for headless operation and can be denied by the CLI, causing spurious
+    failures. Guard it behind an explicit env opt-in so production dispatches
+    are robust by default.
+    """
+    cmd = ["kimi", "--print", "--output-format", "stream-json"]
+    if os.environ.get("VNX_KIMI_YOLO", "0") == "1":
+        cmd.append("--yolo")
+    cmd.extend(["-p", prompt])
     if model:
         cmd.extend(["-m", model])
     if work_dir:
@@ -279,8 +309,17 @@ def _consume_kimi_stream(
             reason = (data.get("reason") or "").lower()
             if "timeout" in reason or "deadline" in reason:
                 timed_out = True
-            msg = data.get("message") or data.get("reason") or str(data)[:200]
-            errors_captured.append(str(msg))
+            raw_line = (data.get("raw") or "").strip()
+            base_msg = data.get("message") or data.get("reason") or str(data)[:200]
+            if raw_line and _is_quota_or_auth_line(raw_line):
+                # Classify 403/quota/auth bodies from non-JSON kimi output
+                msg = f"provider=kimi reason=quota_or_auth raw={raw_line[:200]}"
+            elif raw_line:
+                # Include raw line for other parse failures so callers can diagnose
+                msg = f"{base_msg} (raw={raw_line[:100]})"
+            else:
+                msg = str(base_msg)
+            errors_captured.append(msg)
 
         if health_monitor is not None:
             health_monitor.update(canonical_event)
@@ -363,7 +402,7 @@ def spawn_kimi(
     event_store: Optional[Any] = None,
     **kwargs: Any,
 ) -> KimiSpawnResult:
-    """Spawn ``kimi --print --output-format stream-json --yolo -p <prompt>``.
+    """Spawn ``kimi --print --output-format stream-json [-p <prompt>]``.
 
     Returns KimiSpawnResult on completion (success OR controlled failure).
     Returns KimiSpawnResult(returncode=127) when the kimi binary is absent.

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -42,6 +42,7 @@ from adapter_types import (
     SpawnResult,
     StopResult,
 )
+from worker_permissions import build_claude_scoping_args, worker_scoping_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -209,9 +210,16 @@ class SubprocessAdapter:
         effective_instruction = instruction or config.get("instruction", dispatch_id)
         effective_model = model or config.get("model", "sonnet")
 
-        cmd = [
-            "claude",
-            "--dangerously-skip-permissions",
+        # Interim worker-capability scoping (WORKER-CAPABILITY-SCOPING-DESIGN.md §5).
+        # Default ON: drop the --dangerously-skip-permissions blanket for a scoped
+        # posture (empty ambient MCP + acceptEdits + a code-worker allow-list).
+        # VNX_WORKER_SCOPED=0 restores the legacy skip-permissions spawn.
+        cmd = ["claude"]
+        if worker_scoping_enabled():
+            cmd += build_claude_scoping_args()
+        else:
+            cmd.append("--dangerously-skip-permissions")
+        cmd += [
             "-p",
             "--output-format", "stream-json",
             "--verbose",

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -38,6 +38,7 @@ if sys_path_dir not in sys.path:
 logger = logging.getLogger(__name__)
 
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
+from worker_permissions import build_claude_scoping_args, worker_scoping_enabled  # noqa: E402
 
 DEFAULT_COMPLETION_STATUSES = frozenset({"done", "completed", "failed", "blocked"})
 
@@ -148,7 +149,16 @@ def _default_launch_command(
                 )
     flags = ""
     if skip_permissions:
-        flags = " --dangerously-skip-permissions"
+        # Detached (autonomous) runs cannot answer permission prompts. Interim
+        # scoping (WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4/§5, default ON):
+        # swap the --dangerously-skip-permissions blanket for a scoped posture
+        # (empty ambient MCP + acceptEdits + code-worker allow-list).
+        # VNX_WORKER_SCOPED=0 restores the legacy skip-permissions flag.
+        if worker_scoping_enabled():
+            scoped = " ".join(shlex.quote(tok) for tok in build_claude_scoping_args())
+            flags = f" {scoped}"
+        else:
+            flags = " --dangerously-skip-permissions"
     if extra_flags:
         flags = f"{flags} {extra_flags}".rstrip()
     return f"source ~/.zshrc 2>/dev/null; claude --model {model}{flags}"

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -126,6 +126,76 @@ def generate_claude_settings(profile: PermissionProfile) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Interim worker-capability scoping
+# (WORKER-CAPABILITY-SCOPING-DESIGN.md §5 — pre-full-binding)
+# ---------------------------------------------------------------------------
+
+# Empty MCP server set. Paired with --strict-mcp-config this gives the default
+# code worker ZERO ambient MCP reach (no Supabase / n8n / Gmail side-effects).
+# This is the core security win of the interim.
+EMPTY_MCP_CONFIG = '{"mcpServers":{}}'
+
+# Tool set a headless code worker needs to function: full file CRUD + Bash
+# (incl. git) + search. Used when the dispatch role declares no profile so the
+# interim never silently strips a code worker's ability to write and commit.
+DEFAULT_CODE_WORKER_TOOLS = ["Read", "Write", "Edit", "MultiEdit", "Bash", "Glob", "Grep"]
+
+
+def default_code_worker_profile() -> PermissionProfile:
+    """Interim fallback profile for a headless code worker (no role binding yet).
+
+    Permits the full code-worker tool set. Zero-MCP isolation is enforced
+    separately by the spawn flags (build_claude_scoping_args), not by this
+    profile. The full role→capability binding lands in unified-layer Wave 2.
+    """
+    return PermissionProfile(role="code-worker", allowed_tools=list(DEFAULT_CODE_WORKER_TOOLS))
+
+
+def worker_scoping_enabled() -> bool:
+    """Whether the interim worker-capability scoping is active (default ON).
+
+    Set ``VNX_WORKER_SCOPED=0`` (or false/no/off) to revert to the legacy
+    ``--dangerously-skip-permissions`` posture. The flag makes the change
+    reversible per the design's sequencing note.
+    """
+    raw = os.environ.get("VNX_WORKER_SCOPED", "1").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def build_claude_scoping_args(
+    profile: PermissionProfile | None = None,
+    *,
+    permission_mode: str = "acceptEdits",
+) -> list[str]:
+    """Build the interim capability-scoping argv fragment for a headless claude worker.
+
+    Replaces the ``--dangerously-skip-permissions`` blanket with a scoped-but-
+    functional posture (WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4 / §5):
+
+      * ``--permission-mode <mode>`` — ``acceptEdits`` lets a no-TTY worker apply
+        edits without prompting while Bash/MCP stay gated by the allow-list.
+      * ``--strict-mcp-config`` + ``--mcp-config {"mcpServers":{}}`` — ignore all
+        ambient MCP sources and expose ZERO MCP servers (the core security win).
+      * ``--allowedTools <list>`` — materialized from ``generate_claude_settings``
+        so the worker keeps Read/Write/Edit/MultiEdit/Bash/Glob/Grep and can
+        still write code and commit.
+
+    profile defaults to the code-worker profile when not supplied.
+    """
+    if profile is None:
+        profile = default_code_worker_profile()
+    allowed = generate_claude_settings(profile).get("allowedTools", [])
+    args = [
+        "--permission-mode", permission_mode,
+        "--strict-mcp-config",
+        "--mcp-config", EMPTY_MCP_CONFIG,
+    ]
+    if allowed:
+        args += ["--allowedTools", ",".join(allowed)]
+    return args
+
+
 def generate_permission_preamble(profile: PermissionProfile) -> str:
     """Generate a CLAUDE.md-style permission block for injection into instructions.
 

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -20,6 +20,7 @@ if _LIB_DIR not in sys.path:
 from provider_spawns.kimi_spawn import (  # noqa: E402
     KimiSpawnResult,
     _build_kimi_cmd,
+    _is_quota_or_auth_line,
     normalize_kimi_event,
     spawn_kimi,
 )
@@ -45,9 +46,12 @@ def _mock_proc(stdout_events: list, returncode: int = 0) -> MagicMock:
 
 class TestBuildKimiCmd(unittest.TestCase):
     def test_constructs_correct_argv_no_model(self):
-        cmd = _build_kimi_cmd("hello world", None, None)
-        self.assertEqual(cmd[:6], ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p"])
-        self.assertEqual(cmd[6], "hello world")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_KIMI_YOLO", None)
+            cmd = _build_kimi_cmd("hello world", None, None)
+        self.assertNotIn("--yolo", cmd)
+        self.assertEqual(cmd[:5], ["kimi", "--print", "--output-format", "stream-json", "-p"])
+        self.assertEqual(cmd[5], "hello world")
 
     def test_passes_model_when_specified(self):
         cmd = _build_kimi_cmd("prompt", "kimi-k2-6", None)
@@ -174,14 +178,16 @@ class TestSpawnKimiSubprocess(unittest.TestCase):
             captured_cmd.extend(cmd)
             raise FileNotFoundError("not testing real spawn")
 
-        with patch("subprocess.Popen", side_effect=fake_popen):
-            spawn_kimi("my prompt", dispatch_id="d1", terminal_id="T1")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_KIMI_YOLO", None)
+            with patch("subprocess.Popen", side_effect=fake_popen):
+                spawn_kimi("my prompt", dispatch_id="d1", terminal_id="T1")
 
         self.assertIn("kimi", captured_cmd)
         self.assertIn("--print", captured_cmd)
         self.assertIn("--output-format", captured_cmd)
         self.assertIn("stream-json", captured_cmd)
-        self.assertIn("--yolo", captured_cmd)
+        self.assertNotIn("--yolo", captured_cmd)
         self.assertIn("-p", captured_cmd)
         self.assertIn("my prompt", captured_cmd)
 
@@ -331,6 +337,87 @@ class TestSpawnKimiIntegration(unittest.TestCase):
         self.assertIsNotNone(result.error)
         self.assertIn("rate limit exceeded", result.error)
         self.assertNotEqual(result.returncode, 0)
+
+
+class TestKimiRobustness(unittest.TestCase):
+    """Tests for --yolo opt-in and non-JSON/403 error handling (Wave 2 robustness)."""
+
+    def test_build_kimi_cmd_no_yolo_by_default(self):
+        """--yolo must NOT appear in the built command unless VNX_KIMI_YOLO=1."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_KIMI_YOLO", None)
+            cmd = _build_kimi_cmd("hello", None, None)
+        self.assertNotIn("--yolo", cmd)
+
+    def test_build_kimi_cmd_yolo_when_env_set(self):
+        """--yolo appears in the built command when VNX_KIMI_YOLO=1."""
+        with patch.dict(os.environ, {"VNX_KIMI_YOLO": "1"}):
+            cmd = _build_kimi_cmd("hello", None, None)
+        self.assertIn("--yolo", cmd)
+
+    def test_is_quota_or_auth_line_detects_403(self):
+        self.assertTrue(_is_quota_or_auth_line("HTTP/1.1 403 Forbidden"))
+        self.assertTrue(_is_quota_or_auth_line("quota exceeded for this account"))
+        self.assertTrue(_is_quota_or_auth_line("401 Unauthorized"))
+        self.assertFalse(_is_quota_or_auth_line("normal response text"))
+
+    def _run_with_raw_bytes(self, raw_bytes: bytes, returncode: int = 1) -> "KimiSpawnResult":
+        """Run spawn_kimi piping raw bytes (not pre-serialized events)."""
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            try:
+                os.write(write_fd, raw_bytes)
+            finally:
+                os.close(write_fd)
+
+        t = threading.Thread(target=_writer, daemon=True)
+        t.start()
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = returncode
+        fake_proc.poll.return_value = returncode
+        fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=returncode)
+        fake_proc.kill = MagicMock()
+
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi("prompt", dispatch_id="d1", terminal_id="T1")
+        finally:
+            t.join(timeout=5)
+        return result
+
+    def test_non_json_line_yields_structured_error_not_exception(self):
+        """A non-JSON kimi output line must produce a structured result.error, not raise."""
+        result = self._run_with_raw_bytes(b"HTTP 403 Forbidden: quota exceeded\n")
+        # Must not raise — returns a KimiSpawnResult
+        self.assertIsInstance(result, KimiSpawnResult)
+        self.assertIsNotNone(result.error)
+        # Must NOT expose a raw JSONDecodeError string
+        self.assertNotIn("Expecting value", result.error)
+
+    def test_403_line_surfaces_quota_or_auth_reason(self):
+        """A 403 body line must surface quota_or_auth in result.error (not a JSON parse error)."""
+        result = self._run_with_raw_bytes(b"HTTP/1.1 403 Forbidden\n")
+        self.assertIsNotNone(result.error)
+        self.assertIn("quota_or_auth", result.error)
+        self.assertIn("403", result.error)
+
+    def test_quota_line_surfaces_quota_or_auth_reason(self):
+        """A quota-exceeded plaintext body surfaces quota_or_auth in result.error."""
+        result = self._run_with_raw_bytes(b"quota exceeded for account\n")
+        self.assertIsNotNone(result.error)
+        self.assertIn("quota_or_auth", result.error)
+
+    def test_unknown_non_json_line_includes_raw_in_error(self):
+        """An unrecognized non-JSON line includes the raw text in result.error for diagnosis."""
+        result = self._run_with_raw_bytes(b"unexpected server error: connection reset\n")
+        self.assertIsNotNone(result.error)
+        # Not a quota/auth line — but raw should still be surfaced
+        self.assertIn("connection reset", result.error)
 
 
 class TestDispatchKimiEventStoreFailure(unittest.TestCase):

--- a/tests/test_kimi_wrapper.py
+++ b/tests/test_kimi_wrapper.py
@@ -21,6 +21,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 
+import os
+
 import kimi_wrapper
 
 
@@ -205,3 +207,114 @@ class TestKimiTokenParsing:
     def test_parse_invalid_json_returns_none(self):
         result = kimi_wrapper._parse_kimi_token_usage("not json\n")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# --yolo opt-in (Wave 2 robustness)
+# ---------------------------------------------------------------------------
+
+class TestKimiExecYoloOptIn:
+    def test_no_yolo_by_default(self, monkeypatch):
+        """--yolo must NOT appear in the argv when VNX_KIMI_YOLO is unset."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        monkeypatch.delenv("VNX_KIMI_YOLO", raising=False)
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost"):
+            kimi_wrapper.kimi_exec("prompt", dispatch_id="d-yolo-off")
+
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        assert "--yolo" not in cmd
+
+    def test_yolo_present_when_env_set(self, monkeypatch):
+        """--yolo must appear in the argv when VNX_KIMI_YOLO=1."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        monkeypatch.setenv("VNX_KIMI_YOLO", "1")
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost"):
+            kimi_wrapper.kimi_exec("prompt", dispatch_id="d-yolo-on")
+
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        assert "--yolo" in cmd
+
+    def test_yolo_absent_when_env_zero(self, monkeypatch):
+        """Explicit VNX_KIMI_YOLO=0 must still suppress --yolo."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        monkeypatch.setenv("VNX_KIMI_YOLO", "0")
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost"):
+            kimi_wrapper.kimi_exec("prompt", dispatch_id="d-yolo-zero")
+
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        assert "--yolo" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# Non-JSON / 403 error handling (Wave 2 robustness)
+# ---------------------------------------------------------------------------
+
+class TestKimiExecQuotaAuth:
+    def test_403_stdout_raises_structured_runtime_error(self, monkeypatch):
+        """A 403-style non-JSON stdout must raise RuntimeError with reason=quota_or_auth."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        stdout_403 = "HTTP/1.1 403 Forbidden"
+        mock_proc = _make_popen_result(stdout=stdout_403, returncode=1)
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("provider_costs.emit_provider_cost"):
+            with pytest.raises(RuntimeError) as exc_info:
+                kimi_wrapper.kimi_exec("prompt", dispatch_id="d-403")
+
+        msg = str(exc_info.value)
+        assert "quota_or_auth" in msg
+        assert "403" in msg
+
+    def test_quota_exceeded_stdout_raises_structured_error(self, monkeypatch):
+        """'quota exceeded' in stdout must raise RuntimeError with reason=quota_or_auth."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result(stdout="quota exceeded for account\n", returncode=1)
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("provider_costs.emit_provider_cost"):
+            with pytest.raises(RuntimeError) as exc_info:
+                kimi_wrapper.kimi_exec("prompt", dispatch_id="d-quota")
+
+        msg = str(exc_info.value)
+        assert "quota_or_auth" in msg
+
+    def test_unauthorized_stdout_raises_structured_error(self, monkeypatch):
+        """'unauthorized' in stdout must raise RuntimeError with reason=quota_or_auth."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result(stdout="401 Unauthorized: token expired", returncode=1)
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("provider_costs.emit_provider_cost"):
+            with pytest.raises(RuntimeError) as exc_info:
+                kimi_wrapper.kimi_exec("prompt", dispatch_id="d-401")
+
+        msg = str(exc_info.value)
+        assert "quota_or_auth" in msg
+
+    def test_generic_nonzero_exit_raises_plain_error(self, monkeypatch):
+        """A non-quota non-zero exit must still raise RuntimeError (plain message)."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result(stdout="", returncode=2)
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
+             patch("provider_costs.emit_provider_cost"):
+            with pytest.raises(RuntimeError, match="kimi_exec failed"):
+                kimi_wrapper.kimi_exec("prompt", dispatch_id="d-generic-fail")
+
+    def test_is_quota_or_auth_line_helper(self):
+        assert kimi_wrapper._is_quota_or_auth_line("HTTP/1.1 403 Forbidden")
+        assert kimi_wrapper._is_quota_or_auth_line("quota exceeded for account")
+        assert kimi_wrapper._is_quota_or_auth_line("401 Unauthorized")
+        assert not kimi_wrapper._is_quota_or_auth_line("normal response body")

--- a/tests/test_worker_capability_scoping.py
+++ b/tests/test_worker_capability_scoping.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tests for the interim worker-capability scoping.
+
+Covers WORKER-CAPABILITY-SCOPING-DESIGN.md §5 (interim, pre-full-binding):
+  - generate_claude_settings(default profile) yields a code-worker allow-list
+  - build_claude_scoping_args: empty ambient MCP + acceptEdits + allow-list,
+    and NO --dangerously-skip-permissions
+  - VNX_WORKER_SCOPED flag toggles scoped vs legacy posture (default ON)
+  - SubprocessAdapter.deliver() spawn argv reflects the scoped posture
+  - tmux _default_launch_command() detached spawn reflects the scoped posture
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from worker_permissions import (  # noqa: E402
+    DEFAULT_CODE_WORKER_TOOLS,
+    EMPTY_MCP_CONFIG,
+    build_claude_scoping_args,
+    default_code_worker_profile,
+    generate_claude_settings,
+    worker_scoping_enabled,
+)
+
+CODE_ESSENTIALS = {"Read", "Write", "Edit", "MultiEdit", "Bash", "Glob", "Grep"}
+
+
+# ---------------------------------------------------------------------------
+# generate_claude_settings / default profile
+# ---------------------------------------------------------------------------
+
+class TestDefaultProfileSettings:
+    def test_default_profile_allowlist_covers_code_essentials(self):
+        settings = generate_claude_settings(default_code_worker_profile())
+        allowed = set(settings["allowedTools"])
+        # The interim must NOT strip a code worker's ability to write/commit.
+        assert CODE_ESSENTIALS <= allowed, f"missing: {CODE_ESSENTIALS - allowed}"
+
+    def test_default_tools_constant_matches_essentials(self):
+        assert set(DEFAULT_CODE_WORKER_TOOLS) == CODE_ESSENTIALS
+
+    def test_denied_tools_excluded_from_allowlist(self):
+        from worker_permissions import PermissionProfile
+
+        prof = PermissionProfile(
+            role="backend-developer",
+            allowed_tools=["Read", "Write", "WebSearch"],
+            denied_tools=["WebSearch"],
+        )
+        allowed = generate_claude_settings(prof)["allowedTools"]
+        assert "WebSearch" not in allowed
+        assert "Read" in allowed and "Write" in allowed
+
+
+# ---------------------------------------------------------------------------
+# build_claude_scoping_args
+# ---------------------------------------------------------------------------
+
+class TestBuildScopingArgs:
+    def test_args_isolate_mcp_and_drop_skip_permissions(self):
+        args = build_claude_scoping_args()
+        # Core security win: zero ambient MCP.
+        assert "--strict-mcp-config" in args
+        idx = args.index("--mcp-config")
+        assert args[idx + 1] == EMPTY_MCP_CONFIG == '{"mcpServers":{}}'
+        # No blanket bypass.
+        assert "--dangerously-skip-permissions" not in args
+
+    def test_args_use_accept_edits_by_default(self):
+        args = build_claude_scoping_args()
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "acceptEdits"
+
+    def test_args_carry_code_worker_allowlist(self):
+        args = build_claude_scoping_args()
+        idx = args.index("--allowedTools")
+        allowed = set(args[idx + 1].split(","))
+        assert CODE_ESSENTIALS <= allowed
+
+    def test_permission_mode_override(self):
+        args = build_claude_scoping_args(permission_mode="default")
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "default"
+
+
+# ---------------------------------------------------------------------------
+# VNX_WORKER_SCOPED flag
+# ---------------------------------------------------------------------------
+
+class TestWorkerScopingFlag:
+    def test_default_is_enabled(self, monkeypatch):
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        assert worker_scoping_enabled() is True
+
+    def test_explicit_on(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
+        assert worker_scoping_enabled() is True
+
+    def test_off_values_disable(self, monkeypatch):
+        for val in ("0", "false", "no", "off", "OFF", "False"):
+            monkeypatch.setenv("VNX_WORKER_SCOPED", val)
+            assert worker_scoping_enabled() is False, val
+
+
+# ---------------------------------------------------------------------------
+# SubprocessAdapter.deliver() spawn argv
+# ---------------------------------------------------------------------------
+
+def _make_alive_process(pid: int = 4321) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.poll.return_value = None
+    proc.returncode = None
+    return proc
+
+
+class TestSubprocessAdapterArgv:
+    def test_scoped_argv_when_enabled(self, monkeypatch):
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        from subprocess_adapter import SubprocessAdapter
+
+        adapter = SubprocessAdapter()
+        adapter.spawn("T1", {"model": "opus", "instruction": "do work"})
+        with patch("subprocess.Popen", return_value=_make_alive_process()) as mock_popen:
+            adapter.deliver("T1", "dispatch-scoped")
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "claude"
+        # MCP isolation present, skip-permissions gone.
+        assert "--strict-mcp-config" in cmd
+        midx = cmd.index("--mcp-config")
+        assert cmd[midx + 1] == '{"mcpServers":{}}'
+        assert "--dangerously-skip-permissions" not in cmd
+        # Worker still functional: headless stream flags + model intact.
+        assert "-p" in cmd
+        assert "--output-format" in cmd and "stream-json" in cmd
+        midx = cmd.index("--model")
+        assert cmd[midx + 1] == "opus"
+        # Allow-list keeps the code-worker tools.
+        aidx = cmd.index("--allowedTools")
+        assert CODE_ESSENTIALS <= set(cmd[aidx + 1].split(","))
+
+    def test_legacy_argv_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "0")
+        from subprocess_adapter import SubprocessAdapter
+
+        adapter = SubprocessAdapter()
+        adapter.spawn("T1", {"model": "sonnet"})
+        with patch("subprocess.Popen", return_value=_make_alive_process()) as mock_popen:
+            adapter.deliver("T1", "dispatch-legacy")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--strict-mcp-config" not in cmd
+        assert "-p" in cmd
+
+
+# ---------------------------------------------------------------------------
+# tmux ephemeral _default_launch_command()
+# ---------------------------------------------------------------------------
+
+class TestTmuxLaunchCommand:
+    def test_detached_scoped_when_enabled(self, monkeypatch):
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        from tmux_interactive_dispatch import _default_launch_command
+
+        cmd = _default_launch_command("sonnet", skip_permissions=True)
+        assert "claude --model sonnet" in cmd
+        assert "--strict-mcp-config" in cmd
+        assert "--mcp-config" in cmd
+        assert "--permission-mode acceptEdits" in cmd
+        assert "--dangerously-skip-permissions" not in cmd
+        # The empty-MCP JSON survives shell quoting and re-parses to one token.
+        assert '{"mcpServers":{}}' in shlex.split(cmd)
+        # Interactive lane guarantee preserved: no headless flag.
+        assert "-p" not in shlex.split(cmd)
+
+    def test_detached_legacy_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "0")
+        from tmux_interactive_dispatch import _default_launch_command
+
+        cmd = _default_launch_command("sonnet", skip_permissions=True)
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--strict-mcp-config" not in cmd
+
+    def test_attached_run_has_no_scoping_and_no_skip(self, monkeypatch):
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        from tmux_interactive_dispatch import _default_launch_command
+
+        # Attached (human-in-the-loop) run: skip_permissions False — unchanged.
+        cmd = _default_launch_command("sonnet", skip_permissions=False)
+        assert "--dangerously-skip-permissions" not in cmd
+        assert "--strict-mcp-config" not in cmd
+        assert "claude --model sonnet" in cmd


### PR DESCRIPTION
## Summary

- **Drop `--yolo` from default spawn command** in both `kimi_spawn.py` and `kimi_wrapper.py`. `--yolo` (auto-approve) can be denied by the kimi CLI, causing spurious failures. It is now opt-in via `VNX_KIMI_YOLO=1`; kimi's `--print` mode is non-interactive by design and does not require it.
- **Graceful 403/quota/auth handling in `kimi_spawn.py`**: when `_streaming_drainer` converts a non-JSON line to an error event, `_consume_kimi_stream` now classifies lines containing 403/quota/auth markers as `provider=kimi reason=quota_or_auth` and includes the raw first line for diagnosis instead of exposing a raw `JSONDecodeError` string.
- **Graceful 403/quota/auth handling in `kimi_wrapper.py`**: `kimi_exec` inspects stdout before raising `RuntimeError` on non-zero exit; 403/quota/auth bodies raise a structured `provider=kimi reason=quota_or_auth raw=...` message instead of hiding the body.

Both paths remain CLI-only — no Moonshot API introduced. `kimi-via-cli-only` constraint intact.

## Verify

- `python3 -m pytest tests/test_kimi_spawn.py tests/test_kimi_wrapper.py tests/test_kimi_spawn_camelcase.py tests/test_wave7_kimi_smoke.py tests/test_provider_dispatch_kimi.py -v` → **114 passed**
- `python3 -c "import ast; [ast.parse(open(f).read()) for f in ['scripts/lib/kimi_wrapper.py','scripts/lib/provider_spawns/kimi_spawn.py']]"` → **AST OK**
- Non-JSON / 403 regression: `TestKimiRobustness.test_403_line_surfaces_quota_or_auth_reason` feeds `b"HTTP/1.1 403 Forbidden\n"` through a real pipe and asserts `"quota_or_auth"` in `result.error` — passes
- No-yolo default: `TestKimiRobustness.test_build_kimi_cmd_no_yolo_by_default` asserts `--yolo not in cmd` — passes
- Yolo opt-in: `TestKimiRobustness.test_build_kimi_cmd_yolo_when_env_set` sets `VNX_KIMI_YOLO=1` and asserts `--yolo in cmd` — passes

## Open Items

_None._

Dispatch-ID: 20260530-223638-kimi-robustness

🤖 Generated with [Claude Code](https://claude.com/claude-code)