### PR TITLE
fix(dispatch): prompt before variadic scope flags — repair broken subprocess lane (#764 regression)

### DIFF
--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -283,10 +283,15 @@ class SubprocessAdapter:
             "--verbose",
             "--model", effective_model,
         ]
-        cmd.extend(_build_worker_scope_args(effective_role, requires_mcp=requires_mcp))
         if resume_session:
             cmd.extend(["--resume", resume_session])
+        # The prompt MUST precede the capability-scoping flags. --allowedTools /
+        # --disallowedTools are variadic (<tools...>); if the instruction is appended
+        # AFTER them it is consumed as a tool value, leaving claude with no prompt
+        # ("Error: Input must be provided ... when using --print" -> exit 1). Placing
+        # the instruction before the scope args keeps it as the -p prompt positional.
         cmd.append(effective_instruction)
+        cmd.extend(_build_worker_scope_args(effective_role, requires_mcp=requires_mcp))
 
         popen_kwargs: Dict[str, Any] = {
             "stdout": subprocess.PIPE,

--- a/tests/test_worker_capability_scoping.py
+++ b/tests/test_worker_capability_scoping.py
@@ -182,13 +182,24 @@ class TestDeliverSpawnArgv:
         allowed = set(cmd[allow_idx + 1].split(","))
         assert CODE_WORKER_ESSENTIALS.issubset(allowed)
 
-    def test_instruction_still_last_arg(self):
+    def test_instruction_precedes_variadic_scope_flags(self):
+        # Regression: --allowedTools / --disallowedTools are variadic (<tools...>).
+        # If the instruction is appended AFTER them it is swallowed as a tool value,
+        # leaving claude --print with no prompt -> "Input must be provided" -> exit 1.
+        # The prompt must therefore come BEFORE the scope flags.
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
             adapter.deliver("T1", "dispatch-cap-3", instruction="the instruction")
         cmd = mock_popen.call_args[0][0]
-        assert cmd[-1] == "the instruction"
+        assert "the instruction" in cmd
+        instr_idx = cmd.index("the instruction")
+        allow_idx = cmd.index("--allowedTools")
+        assert instr_idx < allow_idx, (
+            "instruction must precede --allowedTools or it is consumed as a tool value"
+        )
+        if "--disallowedTools" in cmd:
+            assert instr_idx < cmd.index("--disallowedTools")
 
     def test_feature_flag_off_restores_skip_permissions(self, monkeypatch):
         monkeypatch.setenv("VNX_WORKER_SCOPED", "0")


### PR DESCRIPTION
## Critical lane repair

#764 replaced the blanket skip-permissions flag with the variadic `--allowedTools` / `--disallowedTools` (`<tools...>`), but `SubprocessAdapter.deliver()` still appended the dispatch instruction as the LAST argv token. The CLI parser consumes the trailing instruction as a tool value, so every real (scoped) worker dispatch on main spawns with no prompt:

`Error: Input must be provided either through stdin or as a prompt argument when using --print` -> exit 1 -> `fail-closed`.

This broke the production subprocess dispatch lane on `main` for all tool-using workers. CI missed it because unit tests never spawn a real worker end-to-end; the prior `test_instruction_still_last_arg` actually encoded the bug as correct.

## Fix
- Place the prompt before the variadic scope flags (verified end-to-end: the worker receives the prompt and runs).
- Flip the regression test to assert the instruction precedes `--allowedTools`/`--disallowedTools`.

Root-caused by reproducing the exact adapter argv against the real CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)