### PR TITLE
feat(tmux): CAPTURE — tmux-spawn conversation into EventStore (observable + minable, uniform)

### DIFF
--- a/scripts/lib/tmux_conversation_normalizer.py
+++ b/scripts/lib/tmux_conversation_normalizer.py
@@ -137,10 +137,10 @@ def normalize_conversation(
     clean_lines: list[str] = []
 
     for raw_line in raw_content.split('\n'):
-        # Skip lines dominated by TUI cursor/clear sequences (full-frame redraws).
-        if is_redraw_frame(raw_line):
-            continue
-        # Strip all remaining ANSI/OSC/control sequences.
+        # Strip ANSI/OSC/control sequences first so that real assistant text
+        # embedded inside TUI redraw frames is preserved.  A line is dropped only
+        # if it is entirely empty after stripping — not based on raw escape-sequence
+        # heuristics that would discard the text along with the chrome.
         clean = strip_ansi_osc(raw_line).strip()
         if not clean:
             continue

--- a/scripts/lib/tmux_conversation_normalizer.py
+++ b/scripts/lib/tmux_conversation_normalizer.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""tmux_conversation_normalizer.py — normalize raw pipe-pane log to CanonicalEvents.
+
+Reads the raw pipe-pane conversation log produced by the tmux-spawn lane,
+strips ANSI/OSC/control sequences and TUI redraw noise, deduplicates redraw
+frames, and appends CanonicalEvent records to the EventStore so the tmux-spawn
+lane is observable in the dashboard live-stream and minable by the learning loop.
+
+Called at dispatch close-out by TmuxInteractiveDispatch._run_capture_normalizer.
+Best-effort: callers must wrap in try/except.
+
+BILLING SAFETY: No Anthropic SDK imports. Local filesystem only.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from event_store import EventStore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ANSI / OSC stripping
+# ---------------------------------------------------------------------------
+
+# Comprehensive escape-sequence pattern covering:
+# - CSI sequences: ESC [ <params> <final-byte>  (colours, cursor movement, etc.)
+# - OSC sequences: ESC ] <body> ST (window titles, hyperlinks, etc.)
+#   ST is either BEL (\x07) or ESC \
+# - DCS / SOS / PM / APC: ESC [PX^_] <body> ST
+# - Any other two-character ESC + one-byte sequence
+# - Carriage returns (\r) and NUL bytes (\x00)
+_ANSI_ESCAPE_RE = re.compile(
+    r'(?:'
+    r'\x1b\[[0-9;?]*[a-zA-Z@]'               # CSI: ESC [ params final
+    r'|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)'    # OSC: ESC ] body ST
+    r'|\x1b[PX\^_][^\x1b]*\x1b\\'            # DCS/SOS/PM/APC
+    r'|\x1b.'                                  # Any other ESC + 1 char
+    r'|\r'                                     # CR
+    r'|\x00'                                   # NUL
+    r')'
+)
+
+# TUI "redraw frame" detection: cursor-absolute-position sequences (ESC [ row ; col H/f)
+# and screen-clear sequences (ESC [ 2J, ESC [ J, ESC [ K).
+# A line containing >= 3 absolute cursor-positioning sequences is a TUI redraw artefact.
+_CURSOR_ABS_RE = re.compile(r'\x1b\[\d+;\d+[Hf]')
+_SCREEN_CLEAR_RE = re.compile(r'\x1b\[(?:2J|[JK])')
+
+_CURSOR_ABS_THRESHOLD = 3
+_SCREEN_CLEAR_THRESHOLD = 2
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def strip_ansi_osc(text: str) -> str:
+    """Strip ANSI escape, OSC, DCS, and common control sequences from terminal output."""
+    return _ANSI_ESCAPE_RE.sub('', text)
+
+
+def is_redraw_frame(raw_line: str) -> bool:
+    """Return True if *raw_line* is dominated by TUI cursor/clear sequences.
+
+    Lines with >= 3 absolute cursor-positioning hits OR >= 2 screen-clear hits
+    are TUI redraw artefacts (full-screen redraws of the Claude Code TUI chrome)
+    and do not contribute conversation content.
+    """
+    if len(_CURSOR_ABS_RE.findall(raw_line)) >= _CURSOR_ABS_THRESHOLD:
+        return True
+    if len(_SCREEN_CLEAR_RE.findall(raw_line)) >= _SCREEN_CLEAR_THRESHOLD:
+        return True
+    return False
+
+
+def normalize_conversation(
+    raw_log: Path,
+    event_store: "EventStore",
+    terminal_id: str,
+    dispatch_id: str,
+    model: str,
+) -> int:
+    """Read raw pipe-pane log, strip noise, append CanonicalEvents to EventStore.
+
+    Strategy:
+    1. Read the full raw log under LOCK_SH.
+    2. Process line-by-line: skip TUI redraw-heavy lines, strip ANSI/OSC from
+       the rest, drop empty lines, deduplicate identical lines.
+    3. Emit one ``text`` CanonicalEvent with all unique cleaned lines joined.
+    4. Emit one ``complete`` CanonicalEvent as a terminal marker.
+
+    Returns the number of CanonicalEvents appended (0 if nothing to normalize).
+
+    ``provider_meta`` fields:
+    - ``lane``:     ``tmux_interactive``
+    - ``source``:   ``tmux_pipe_pane``
+    - ``raw_log``:  path to the raw log file (absolute string)
+    """
+    if not raw_log.exists():
+        return 0
+
+    try:
+        if raw_log.stat().st_size == 0:
+            return 0
+    except OSError:
+        return 0
+
+    # Read the full raw log under a shared lock.
+    try:
+        with raw_log.open("r", encoding="utf-8", errors="replace") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+            try:
+                raw_content = fh.read()
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError as exc:
+        logger.debug("normalizer: read failed for %s: %s", raw_log, exc)
+        return 0
+
+    # Ensure lib dir is on sys.path for sibling imports.
+    _lib_dir = str(Path(__file__).resolve().parent)
+    if _lib_dir not in sys.path:
+        sys.path.insert(0, _lib_dir)
+
+    from canonical_event import CanonicalEvent  # noqa: PLC0415
+
+    # Process line-by-line: skip redraw frames, strip, deduplicate.
+    seen: set[str] = set()
+    clean_lines: list[str] = []
+
+    for raw_line in raw_content.split('\n'):
+        # Skip lines dominated by TUI cursor/clear sequences (full-frame redraws).
+        if is_redraw_frame(raw_line):
+            continue
+        # Strip all remaining ANSI/OSC/control sequences.
+        clean = strip_ansi_osc(raw_line).strip()
+        if not clean:
+            continue
+        # Deduplicate: identical lines that appear multiple times in the raw log
+        # (e.g. repeated TUI chrome that survived redraw filtering) are emitted once.
+        if clean in seen:
+            continue
+        seen.add(clean)
+        clean_lines.append(clean)
+
+    if not clean_lines:
+        return 0
+
+    provider_meta: dict = {
+        "lane": "tmux_interactive",
+        "source": "tmux_pipe_pane",
+        "raw_log": str(raw_log),
+    }
+
+    events_appended = 0
+
+    # Text event: all unique cleaned lines as a single joined string.
+    text_event = CanonicalEvent(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        provider="claude",
+        sub_provider="anthropic",
+        event_type="text",
+        data={"text": "\n".join(clean_lines)},
+        model=model,
+        provider_meta=provider_meta,
+    )
+    event_store.append(terminal_id, text_event, dispatch_id=dispatch_id)
+    events_appended += 1
+
+    # Complete event: terminal marker for the learning loop and dashboard.
+    complete_event = CanonicalEvent(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        provider="claude",
+        sub_provider="anthropic",
+        event_type="complete",
+        data={},
+        model=model,
+        provider_meta=provider_meta,
+    )
+    event_store.append(terminal_id, complete_event, dispatch_id=dispatch_id)
+    events_appended += 1
+
+    logger.debug(
+        "normalizer: appended %d events for dispatch=%s terminal=%s",
+        events_appended,
+        dispatch_id,
+        terminal_id,
+    )
+    return events_appended

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -703,9 +703,28 @@ class TmuxInteractiveDispatch:
         if capture_flag in ("0", "false", "no", "off"):
             return None
         try:
+            # Sanitize dispatch_id: reject any id that contains path separators,
+            # '..' components, or characters outside [A-Za-z0-9._-].  shlex.quote
+            # stops shell meta-chars but '../' still escapes the log directory.
+            if not re.match(r'^[A-Za-z0-9._-]+$', dispatch_id):
+                logger.warning(
+                    "interactive: capture skipped — unsafe dispatch_id %r",
+                    dispatch_id,
+                )
+                return None
             log_dir = self._state_dir.parent / "logs" / "conversations"
             log_dir.mkdir(parents=True, exist_ok=True)
-            raw_log = log_dir / f"{dispatch_id}.log"
+            raw_log = (log_dir / f"{dispatch_id}.log").resolve()
+            # Path containment guard: resolved path must stay under log_dir.
+            try:
+                raw_log.relative_to(log_dir.resolve())
+            except ValueError:
+                logger.warning(
+                    "interactive: capture skipped — log path %s escaped %s",
+                    raw_log,
+                    log_dir,
+                )
+                return None
             # pipe-pane receives a single shell-command string; use shlex.quote
             # so paths with spaces or special characters are safe.
             shell_cmd = f"cat >> {shlex.quote(str(raw_log))}"
@@ -1056,7 +1075,18 @@ class TmuxInteractiveDispatch:
                 metadata={"session": session, "pane_id": pane_id, "window_id": window_id},
             )
 
-            # 2b. Wire pipe-pane capture (before claude launch so the full session is logged).
+            # 2b. Clear/archive EventStore terminal stream for this dispatch (mirror
+            # subprocess adapter behavior) so normalized events form a clean stream.
+            try:
+                from event_store import EventStore  # noqa: PLC0415
+                _pre_es = EventStore()
+                _prev_ev = _pre_es.last_event(label)
+                _prev_did = (_prev_ev or {}).get("dispatch_id") or None
+                _pre_es.clear(label, archive_dispatch_id=_prev_did)
+            except Exception as _pre_exc:  # noqa: BLE001
+                logger.debug("interactive: pre-capture EventStore clear failed (%s)", _pre_exc)
+
+            # Wire pipe-pane capture (before claude launch so the full session is logged).
             _raw_log[0] = self._start_pipe_pane(pane_id, dispatch_id)
 
             # 3. Build launch command

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -690,6 +690,70 @@ class TmuxInteractiveDispatch:
         )
         return False
 
+    # -- capture (pipe-pane) -----------------------------------------------
+    def _start_pipe_pane(self, pane_id: str, dispatch_id: str) -> "Path | None":
+        """Wire tmux pipe-pane to stream pane output to a raw log file.
+
+        Gate-controlled by VNX_TMUX_CAPTURE (default "1").
+        Creates the log directory if needed.
+        Returns the raw log Path on success, None if disabled or on failure.
+        Never raises.
+        """
+        capture_flag = os.environ.get("VNX_TMUX_CAPTURE", "1").strip().lower()
+        if capture_flag in ("0", "false", "no", "off"):
+            return None
+        try:
+            log_dir = self._state_dir.parent / "logs" / "conversations"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            raw_log = log_dir / f"{dispatch_id}.log"
+            # pipe-pane receives a single shell-command string; use shlex.quote
+            # so paths with spaces or special characters are safe.
+            shell_cmd = f"cat >> {shlex.quote(str(raw_log))}"
+            res = self._runner.run(["pipe-pane", "-o", "-t", pane_id, shell_cmd])
+            if res.returncode != 0:
+                logger.warning(
+                    "interactive: pipe-pane wiring failed pane=%s: %s",
+                    pane_id,
+                    res.stderr.strip(),
+                )
+                return None
+            logger.debug("interactive: pipe-pane wired dispatch=%s log=%s", dispatch_id, raw_log)
+            return raw_log
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("interactive: _start_pipe_pane failed (%s)", exc)
+            return None
+
+    def _run_capture_normalizer(
+        self,
+        raw_log: "Path",
+        terminal_id: str,
+        dispatch_id: str,
+        model: str,
+    ) -> None:
+        """Normalize the raw pipe-pane log into EventStore CanonicalEvents.
+
+        Best-effort — never raises. Errors are logged at DEBUG level.
+        Called at teardown after kill-session so the log is fully flushed.
+        """
+        try:
+            from tmux_conversation_normalizer import normalize_conversation  # noqa: PLC0415
+            from event_store import EventStore  # noqa: PLC0415
+            event_store = EventStore()
+            count = normalize_conversation(raw_log, event_store, terminal_id, dispatch_id, model)
+            if count:
+                logger.info(
+                    "interactive: capture normalized %d events dispatch=%s terminal=%s",
+                    count,
+                    dispatch_id,
+                    terminal_id,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "interactive: capture normalizer skipped dispatch=%s (%s)",
+                dispatch_id,
+                exc,
+            )
+
     # -- receipt polling ---------------------------------------------------
     def _matching_receipts(
         self,
@@ -856,6 +920,7 @@ class TmuxInteractiveDispatch:
         # never spawns a tmux session with an uncontrolled cwd.
         worktree_handle: "WorktreeHandle | None" = None
         _wt_state: "list[str | None]" = [None]
+        _raw_log: "list[Path | None]" = [None]
 
         if isolated_worktree:
             try:
@@ -892,6 +957,13 @@ class TmuxInteractiveDispatch:
                 self._kill_session(session)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("interactive: teardown kill-session %s: %s", session, exc)
+            # Normalize captured conversation into EventStore (best-effort, after kill
+            # so pipe-pane has flushed its final bytes to the log).
+            if _raw_log[0] is not None:
+                try:
+                    self._run_capture_normalizer(_raw_log[0], label, dispatch_id, model)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("interactive: teardown normalizer dispatch=%s: %s", dispatch_id, exc)
             if worktree_handle is not None:
                 try:
                     cls = classify(worktree_handle)
@@ -983,6 +1055,9 @@ class TmuxInteractiveDispatch:
                 reason=f"spawned interactive claude in {session}",
                 metadata={"session": session, "pane_id": pane_id, "window_id": window_id},
             )
+
+            # 2b. Wire pipe-pane capture (before claude launch so the full session is logged).
+            _raw_log[0] = self._start_pipe_pane(pane_id, dispatch_id)
 
             # 3. Build launch command
             launch_cmd = self._launch_builder(

--- a/tests/test_tmux_conversation_normalizer.py
+++ b/tests/test_tmux_conversation_normalizer.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Tests for tmux_conversation_normalizer.py — ANSI stripping, text extraction, EventStore wiring."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from tmux_conversation_normalizer import (
+    is_redraw_frame,
+    normalize_conversation,
+    strip_ansi_osc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeEventStore:
+    """Minimal EventStore stand-in that records append calls."""
+
+    def __init__(self) -> None:
+        self.appended: list[tuple] = []  # (terminal, event, dispatch_id)
+
+    def append(self, terminal, event, *, dispatch_id=None):
+        self.appended.append((terminal, event, dispatch_id))
+
+
+def _write_raw_log(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# strip_ansi_osc
+# ---------------------------------------------------------------------------
+
+class TestStripAnsiOsc(unittest.TestCase):
+    """strip_ansi_osc() removes escape sequences and control characters."""
+
+    def test_strips_csi_color_sequence(self):
+        self.assertEqual(strip_ansi_osc("\x1b[31mred text\x1b[0m"), "red text")
+
+    def test_strips_csi_cursor_movement(self):
+        self.assertEqual(strip_ansi_osc("\x1b[2J\x1b[H"), "")
+
+    def test_strips_osc_window_title(self):
+        result = strip_ansi_osc("\x1b]0;window title\x07actual text")
+        self.assertEqual(result, "actual text")
+
+    def test_strips_osc_with_string_terminator(self):
+        result = strip_ansi_osc("\x1b]2;title\x1b\\text after")
+        self.assertEqual(result, "text after")
+
+    def test_strips_carriage_return(self):
+        result = strip_ansi_osc("line1\r\nline2\r")
+        self.assertEqual(result, "line1\nline2")
+
+    def test_strips_nul_byte(self):
+        result = strip_ansi_osc("hello\x00world")
+        self.assertEqual(result, "helloworld")
+
+    def test_preserves_plain_text(self):
+        text = "plain text without any escape sequences"
+        self.assertEqual(strip_ansi_osc(text), text)
+
+    def test_preserves_unicode(self):
+        text = "Claude: Ik heb het bestand gelezen"
+        self.assertEqual(strip_ansi_osc(text), text)
+
+    def test_strips_multiple_escape_sequences(self):
+        raw = "\x1b[1;32m## Summary\x1b[0m\n\x1b[36mChanges:\x1b[0m done"
+        result = strip_ansi_osc(raw)
+        self.assertNotIn("\x1b", result)
+        self.assertIn("## Summary", result)
+        self.assertIn("Changes:", result)
+
+
+# ---------------------------------------------------------------------------
+# is_redraw_frame
+# ---------------------------------------------------------------------------
+
+class TestIsRedrawFrame(unittest.TestCase):
+    """is_redraw_frame() detects TUI full-screen redraw lines."""
+
+    def test_line_with_many_cursor_positions_is_redraw(self):
+        # Three absolute cursor-position sequences → redraw frame.
+        raw = "\x1b[1;1H\x1b[2;40H\x1b[10;1H content"
+        self.assertTrue(is_redraw_frame(raw))
+
+    def test_line_with_two_screen_clears_is_redraw(self):
+        raw = "\x1b[2J\x1b[J text here"
+        self.assertTrue(is_redraw_frame(raw))
+
+    def test_plain_text_is_not_redraw(self):
+        self.assertFalse(is_redraw_frame("Normal assistant response text"))
+
+    def test_single_cursor_move_is_not_redraw(self):
+        # One cursor position → not enough to be classified as a full redraw.
+        raw = "\x1b[1;1H some text on the first line"
+        self.assertFalse(is_redraw_frame(raw))
+
+    def test_empty_line_is_not_redraw(self):
+        self.assertFalse(is_redraw_frame(""))
+
+
+# ---------------------------------------------------------------------------
+# normalize_conversation — core logic
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConversation(unittest.TestCase):
+    """normalize_conversation() reads raw log, strips noise, appends CanonicalEvents."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_dir = Path(self._tmp.name)
+        self.raw_log = self.tmp_dir / "conversations" / "test-dispatch.log"
+        self.event_store = FakeEventStore()
+
+    # -- helpers
+    def _run(self, content: str) -> int:
+        _write_raw_log(self.raw_log, content)
+        return normalize_conversation(
+            self.raw_log,
+            self.event_store,
+            terminal_id="T1",
+            dispatch_id="test-dispatch-001",
+            model="sonnet",
+        )
+
+    # -- absent / empty file
+    def test_returns_zero_when_file_missing(self):
+        count = normalize_conversation(
+            self.tmp_dir / "nonexistent.log",
+            self.event_store,
+            terminal_id="T1",
+            dispatch_id="test-dispatch-001",
+            model="sonnet",
+        )
+        self.assertEqual(count, 0)
+        self.assertEqual(self.event_store.appended, [])
+
+    def test_returns_zero_when_file_empty(self):
+        _write_raw_log(self.raw_log, "")
+        count = normalize_conversation(
+            self.raw_log,
+            self.event_store,
+            terminal_id="T1",
+            dispatch_id="test-dispatch-001",
+            model="sonnet",
+        )
+        self.assertEqual(count, 0)
+        self.assertEqual(self.event_store.appended, [])
+
+    def test_returns_zero_when_only_whitespace_after_stripping(self):
+        # Raw log contains only ANSI sequences + whitespace.
+        count = self._run("\x1b[2J\x1b[H\x1b[1;1H\x1b[2;40H\x1b[10;1H\r\r\r\n\n")
+        self.assertEqual(count, 0)
+        self.assertEqual(self.event_store.appended, [])
+
+    # -- basic extraction
+    def test_strips_ansi_and_emits_text_event(self):
+        raw = "\x1b[32mHello\x1b[0m, this is the assistant response.\n"
+        count = self._run(raw)
+        self.assertGreater(count, 0)
+        text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
+        self.assertTrue(text_events, "at least one text event must be emitted")
+        text_content = text_events[0].data.get("text", "")
+        self.assertIn("Hello", text_content)
+        self.assertIn("assistant response", text_content)
+        self.assertNotIn("\x1b", text_content)
+
+    def test_emits_complete_event(self):
+        count = self._run("Some assistant text\n")
+        self.assertGreater(count, 0)
+        event_types = [e.event_type for _, e, _ in self.event_store.appended]
+        self.assertIn("complete", event_types)
+
+    def test_text_and_complete_events_emitted(self):
+        count = self._run("Assistant says hi\n")
+        self.assertEqual(count, 2, "exactly 2 events: text + complete")
+
+    # -- correct CanonicalEvent fields
+    def test_events_have_correct_terminal_id(self):
+        self._run("Hello from Claude\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.terminal_id, "T1")
+
+    def test_events_have_correct_dispatch_id(self):
+        self._run("Hello from Claude\n")
+        for _, event, dispatch_id in self.event_store.appended:
+            self.assertEqual(dispatch_id, "test-dispatch-001")
+            self.assertEqual(event.dispatch_id, "test-dispatch-001")
+
+    def test_events_have_provider_claude(self):
+        self._run("Hello from Claude\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.provider, "claude")
+
+    def test_events_have_correct_lane_in_provider_meta(self):
+        self._run("Hello from Claude\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.provider_meta.get("lane"), "tmux_interactive")
+
+    def test_events_have_correct_source_in_provider_meta(self):
+        self._run("Hello from Claude\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.provider_meta.get("source"), "tmux_pipe_pane")
+
+    def test_events_reference_raw_log_path(self):
+        self._run("Hello from Claude\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.provider_meta.get("raw_log"), str(self.raw_log))
+
+    def test_events_have_model(self):
+        self._run("Hello\n")
+        for _, event, _ in self.event_store.appended:
+            self.assertEqual(event.model, "sonnet")
+
+    # -- deduplication: redraw frames must not produce duplicate events
+    def test_duplicate_redraw_frames_do_not_produce_duplicate_text(self):
+        """The same text rendered 5× across TUI redraw frames must appear once in the output."""
+        # Each "frame" is a TUI screen dump: lots of cursor moves + text.
+        # The real text "Task complete" appears in each frame.
+        single_frame = (
+            "\x1b[1;1H\x1b[2;40H\x1b[5;1H"  # 3 cursor positions → redraw frame filtered
+            "Task complete\n"
+        )
+        # 5 identical frames
+        raw = single_frame * 5
+        self._run(raw)
+
+        text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
+        if text_events:
+            all_text = "\n".join(e.data.get("text", "") for e in text_events)
+            occurrences = all_text.count("Task complete")
+            self.assertEqual(occurrences, 1, "deduplicated: 'Task complete' must appear exactly once")
+
+    def test_duplicate_lines_deduplicated(self):
+        """Identical text lines across different parts of the log appear once in events."""
+        # Same line repeated 10 times (e.g. TUI chrome like "? for shortcuts")
+        raw = "? for shortcuts\n" * 10 + "Real content from Claude\n"
+        self._run(raw)
+
+        text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
+        self.assertTrue(text_events)
+        all_text = text_events[0].data.get("text", "")
+        # "? for shortcuts" should appear at most once, not 10 times.
+        occurrences = all_text.count("? for shortcuts")
+        self.assertLessEqual(occurrences, 1, "duplicate TUI chrome must be deduplicated")
+
+    def test_ansi_sequences_completely_absent_from_events(self):
+        """No ANSI escape byte (0x1b) appears in any emitted event text."""
+        raw = "\x1b[32mHello\x1b[0m world\n\x1b[1mBold\x1b[0m\n"
+        self._run(raw)
+        for _, event, _ in self.event_store.appended:
+            text = event.data.get("text", "")
+            self.assertNotIn("\x1b", text, "ANSI escape must not appear in normalized event text")
+
+    def test_osc_sequences_stripped(self):
+        """OSC window-title sequences are not present in emitted event text."""
+        raw = "\x1b]0;Claude Code — T1\x07Real assistant response\n"
+        self._run(raw)
+        text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
+        self.assertTrue(text_events)
+        text = text_events[0].data.get("text", "")
+        self.assertNotIn("\x1b", text)
+        self.assertNotIn("Claude Code — T1", text, "OSC title must be stripped")
+        self.assertIn("Real assistant response", text)
+
+    def test_real_content_preserved_through_stripping(self):
+        """Meaningful assistant text survives ANSI stripping."""
+        assistant_text = "I have read the file and found 3 issues:"
+        raw = f"\x1b[1m{assistant_text}\x1b[0m\n"
+        self._run(raw)
+        text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
+        self.assertTrue(text_events)
+        self.assertIn(assistant_text, text_events[0].data.get("text", ""))
+
+
+# ---------------------------------------------------------------------------
+# normalize_conversation — EventStore integration
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConversationEventStoreIntegration(unittest.TestCase):
+    """normalize_conversation() uses the real EventStore for end-to-end wiring."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_dir = Path(self._tmp.name)
+        self.raw_log = self.tmp_dir / "test.log"
+
+    def test_events_readable_via_event_store_tail(self):
+        """Events appended by normalize_conversation are readable via EventStore.tail()."""
+        from event_store import EventStore
+
+        events_dir = self.tmp_dir / "events"
+        store = EventStore(events_dir=events_dir)
+
+        self.raw_log.write_text("Hello from the tmux lane\n", encoding="utf-8")
+
+        count = normalize_conversation(
+            self.raw_log,
+            store,
+            terminal_id="T1",
+            dispatch_id="integ-dispatch-001",
+            model="sonnet",
+        )
+        self.assertEqual(count, 2)
+
+        events = list(store.tail("T1"))
+        self.assertTrue(events, "EventStore must have events after normalize_conversation")
+        event_types = {e.get("type") for e in events}
+        self.assertIn("text", event_types)
+        self.assertIn("complete", event_types)
+
+    def test_events_carry_provider_and_lane(self):
+        """Events in EventStore have provider=claude and lane=tmux_interactive."""
+        from event_store import EventStore
+
+        events_dir = self.tmp_dir / "events"
+        store = EventStore(events_dir=events_dir)
+
+        self.raw_log.write_text("Some conversation line\n", encoding="utf-8")
+        normalize_conversation(
+            self.raw_log,
+            store,
+            terminal_id="T1",
+            dispatch_id="integ-dispatch-002",
+            model="haiku",
+        )
+
+        events = list(store.tail("T1"))
+        for ev in events:
+            self.assertEqual(ev.get("provider"), "claude")
+            self.assertEqual(ev.get("provider_meta", {}).get("lane"), "tmux_interactive")
+
+
+# ---------------------------------------------------------------------------
+# normalize_conversation — best-effort / error handling
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConversationBestEffort(unittest.TestCase):
+    """normalize_conversation() returns 0 cleanly on edge-case inputs."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_dir = Path(self._tmp.name)
+
+    def test_event_store_error_propagates_to_caller(self):
+        """EventStore.append raising is NOT silenced by normalize_conversation (caller must handle)."""
+        raw_log = self.tmp_dir / "test.log"
+        raw_log.write_text("Some text\n", encoding="utf-8")
+
+        bad_store = MagicMock()
+        bad_store.append.side_effect = RuntimeError("disk full")
+
+        with self.assertRaises(RuntimeError):
+            normalize_conversation(
+                raw_log,
+                bad_store,
+                terminal_id="T1",
+                dispatch_id="test-err",
+                model="sonnet",
+            )
+
+    def test_returns_zero_for_all_control_content(self):
+        """A log with only control sequences emits zero events."""
+        raw_log = self.tmp_dir / "ctrl.log"
+        raw_log.write_text("\x1b[2J\x1b[H\r\x00\r\n\r\n", encoding="utf-8")
+        store = FakeEventStore()
+
+        count = normalize_conversation(raw_log, store, terminal_id="T1", dispatch_id="ctrl", model="sonnet")
+        self.assertEqual(count, 0)
+        self.assertEqual(store.appended, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tmux_conversation_normalizer.py
+++ b/tests/test_tmux_conversation_normalizer.py
@@ -228,22 +228,32 @@ class TestNormalizeConversation(unittest.TestCase):
 
     # -- deduplication: redraw frames must not produce duplicate events
     def test_duplicate_redraw_frames_do_not_produce_duplicate_text(self):
-        """The same text rendered 5× across TUI redraw frames must appear once in the output."""
-        # Each "frame" is a TUI screen dump: lots of cursor moves + text.
-        # The real text "Task complete" appears in each frame.
+        """Text embedded in TUI redraw frames must appear once — not dropped, not duplicated.
+
+        Each 'frame' is a realistic Claude TUI screen dump: many cursor-position
+        escape sequences (which previously triggered the redraw-frame filter and
+        dropped the line entirely) followed by actual assistant text.
+        The normalizer must (a) extract the text and (b) deduplicate it.
+        """
+        # Realistic TUI redraw frame: 4 absolute cursor positions + real assistant text.
+        # The old is_redraw_frame check (>= 3 cursor-abs sequences) would have dropped
+        # this line entirely, yielding zero events.
         single_frame = (
-            "\x1b[1;1H\x1b[2;40H\x1b[5;1H"  # 3 cursor positions → redraw frame filtered
-            "Task complete\n"
+            "\x1b[1;1H\x1b[2;40H\x1b[5;1H\x1b[10;1H"  # 4 cursor positions (redraw noise)
+            "Task complete"                              # real assistant text on the same line
+            "\n"
         )
-        # 5 identical frames
+        # 5 identical frames — text must appear exactly once after dedup.
         raw = single_frame * 5
         self._run(raw)
 
         text_events = [e for _, e, _ in self.event_store.appended if e.event_type == "text"]
-        if text_events:
-            all_text = "\n".join(e.data.get("text", "") for e in text_events)
-            occurrences = all_text.count("Task complete")
-            self.assertEqual(occurrences, 1, "deduplicated: 'Task complete' must appear exactly once")
+        # (a) text must become events — not zero.
+        self.assertTrue(text_events, "assistant text in redraw frames must become events (not dropped)")
+        all_text = "\n".join(e.data.get("text", "") for e in text_events)
+        # (b) duplicate frames of the same text must not duplicate events.
+        occurrences = all_text.count("Task complete")
+        self.assertEqual(occurrences, 1, "deduplicated: 'Task complete' must appear exactly once")
 
     def test_duplicate_lines_deduplicated(self):
         """Identical text lines across different parts of the log appear once in events."""

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -2414,6 +2414,56 @@ class TestCapturePipePaneWiring(_LaneTestCase):
                 pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
                 self.assertEqual(pipe_cmds, [], f"pipe-pane must not be called with VNX_TMUX_CAPTURE={flag_val}")
 
+    def test_path_traversal_dispatch_id_does_not_write_outside_log_dir(self):
+        """A dispatch_id with '../' must not allow pipe-pane to write outside the log dir.
+
+        The sanitizer must reject the unsafe id (capture skipped) so pipe-pane is
+        never called with a path that escapes .vnx-data/logs/conversations.
+        """
+        traversal_ids = [
+            "../escape",
+            "../../etc/passwd",
+            "foo/../bar",
+            "valid-prefix/../escape",
+            "/absolute/path",
+            "id with spaces",
+            "id;rm -rf /",
+        ]
+        for bad_id in traversal_ids:
+            with self.subTest(dispatch_id=bad_id):
+                rf = self.state_dir / f"receipts-traversal-{hash(bad_id) & 0xFFFF}.ndjson"
+                fake = FakeTmux(receipts_file=rf, dispatch_id=self.DISPATCH_ID)
+                lane = TmuxInteractiveDispatch(
+                    self.state_dir,
+                    runner=fake,
+                    receipts_file=rf,
+                    project_root=self.state_dir,
+                )
+                with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+                    # Directly call _start_pipe_pane with the malicious id.
+                    result = lane._start_pipe_pane("fake-pane", bad_id)
+
+                # Capture must be skipped — no path returned.
+                self.assertIsNone(
+                    result,
+                    f"unsafe dispatch_id {bad_id!r} must cause capture to be skipped (returned {result})",
+                )
+                # pipe-pane must NOT have been called with a path outside the log dir.
+                pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
+                for cmd in pipe_cmds:
+                    shell_arg = cmd[-1] if cmd else ""
+                    log_dir = (self.state_dir.parent / "logs" / "conversations").resolve()
+                    # Any path in the shell command must be a child of log_dir.
+                    for token in shlex.split(shell_arg):
+                        p = Path(token)
+                        if p.is_absolute():
+                            try:
+                                p.relative_to(log_dir)
+                            except ValueError:
+                                self.fail(
+                                    f"pipe-pane shell arg {shell_arg!r} references path outside log_dir: {token}"
+                                )
+
 
 class TestCaptureNormalizerCloseout(_LaneTestCase):
     """Normalizer is called once at close-out; normalizer errors do not fail dispatch."""

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -2326,5 +2326,189 @@ class TestSubmitVerifyEchoIntegration(_LaneTestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# CAPTURE step: pipe-pane wiring + normalizer close-out
+# ---------------------------------------------------------------------------
+
+class TestCapturePipePaneWiring(_LaneTestCase):
+    """pipe-pane is wired at spawn when VNX_TMUX_CAPTURE=1 (default), not when =0."""
+
+    def test_pipe_pane_wired_when_capture_enabled(self):
+        """VNX_TMUX_CAPTURE=1: pipe-pane command recorded after new-session."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            self._fast_dispatch(lane)
+
+        pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
+        self.assertTrue(pipe_cmds, "pipe-pane must be called when VNX_TMUX_CAPTURE=1")
+
+    def test_pipe_pane_path_contains_dispatch_id(self):
+        """pipe-pane shell command embeds the dispatch_id in the log path."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            self._fast_dispatch(lane)
+
+        pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
+        self.assertTrue(pipe_cmds)
+        # The shell-command argument (last element) must contain the dispatch_id.
+        shell_arg = pipe_cmds[0][-1]
+        self.assertIn(self.DISPATCH_ID, shell_arg, "pipe-pane shell command must reference dispatch_id in log path")
+
+    def test_pipe_pane_wired_before_launch(self):
+        """pipe-pane must appear in command sequence AFTER new-session and BEFORE send-keys -l."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            self._fast_dispatch(lane)
+
+        cmds = fake.commands
+        spawn_idx = next((i for i, c in enumerate(cmds) if c and c[0] == "new-session"), None)
+        pipe_idx = next((i for i, c in enumerate(cmds) if c and c[0] == "pipe-pane"), None)
+        launch_idx = next((i for i, c in enumerate(cmds) if c and c[0] == "send-keys" and "-l" in c), None)
+
+        self.assertIsNotNone(spawn_idx, "new-session must be called")
+        self.assertIsNotNone(pipe_idx, "pipe-pane must be called")
+        self.assertIsNotNone(launch_idx, "send-keys -l (launch) must be called")
+        self.assertGreater(pipe_idx, spawn_idx, "pipe-pane must come after new-session")
+        self.assertLess(pipe_idx, launch_idx, "pipe-pane must come before launch send-keys")
+
+    def test_pipe_pane_not_wired_when_capture_disabled(self):
+        """VNX_TMUX_CAPTURE=0: pipe-pane is never called."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "0"}):
+            self._fast_dispatch(lane)
+
+        pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
+        self.assertEqual(pipe_cmds, [], "pipe-pane must NOT be called when VNX_TMUX_CAPTURE=0")
+
+    def test_pipe_pane_flag_off_variants(self):
+        """VNX_TMUX_CAPTURE=false/no/off also disable pipe-pane."""
+        for flag_val in ("false", "no", "off"):
+            with self.subTest(flag=flag_val):
+                did = f"{self.DISPATCH_ID}-{flag_val}"
+                rf = self.state_dir / f"receipts-{flag_val}.ndjson"
+                fake = FakeTmux(receipts_file=rf, dispatch_id=did)
+                lane = TmuxInteractiveDispatch(
+                    self.state_dir,
+                    runner=fake,
+                    receipts_file=rf,
+                    project_root=self.state_dir,
+                )
+                with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": flag_val}):
+                    lane.dispatch(
+                        "Do the thing.", did,
+                        model="sonnet",
+                        deadline_seconds=5.0,
+                        poll_interval=0.01,
+                        warmup_timeout=0.5,
+                        warmup_poll_interval=0.01,
+                        isolated_worktree=False,
+                    )
+                pipe_cmds = [c for c in fake.commands if c and c[0] == "pipe-pane"]
+                self.assertEqual(pipe_cmds, [], f"pipe-pane must not be called with VNX_TMUX_CAPTURE={flag_val}")
+
+
+class TestCaptureNormalizerCloseout(_LaneTestCase):
+    """Normalizer is called once at close-out; normalizer errors do not fail dispatch."""
+
+    def test_normalizer_called_at_closeout_on_success(self):
+        """On successful dispatch, _run_capture_normalizer is called once."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        normalizer_calls = []
+
+        def capturing_normalizer(raw_log, terminal_id, dispatch_id, model):
+            normalizer_calls.append((raw_log, terminal_id, dispatch_id, model))
+
+        lane._run_capture_normalizer = capturing_normalizer
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
+        self.assertEqual(
+            len(normalizer_calls), 1,
+            f"normalizer must be called exactly once on success; called {len(normalizer_calls)} times",
+        )
+
+    def test_normalizer_called_at_closeout_on_timeout(self):
+        """On timeout, _run_capture_normalizer is still called once (best-effort audit)."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+        )
+        lane = self._make_lane(fake)
+        normalizer_calls = []
+
+        def capturing_normalizer(raw_log, terminal_id, dispatch_id, model):
+            normalizer_calls.append(dispatch_id)
+
+        lane._run_capture_normalizer = capturing_normalizer
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            len(normalizer_calls), 1,
+            f"normalizer must be called once on timeout; called {len(normalizer_calls)} times",
+        )
+
+    def test_normalizer_error_does_not_fail_dispatch(self):
+        """A normalizer exception must not change dispatch success state."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        def raising_normalizer(raw_log, terminal_id, dispatch_id, model):
+            raise RuntimeError("simulated normalizer failure")
+
+        lane._run_capture_normalizer = raising_normalizer
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "1"}):
+            with patch("dispatch_govern.govern") as mock_govern:
+                from dispatch_govern import GovernedOutcome
+                mock_govern.return_value = GovernedOutcome(
+                    report_path=self.state_dir.parent / "unified_reports" / f"{self.DISPATCH_ID}.md",
+                    contract_status="authored",
+                    permission_enforcement="soft",
+                )
+                # Ensure the report file exists so govern does not degrade
+                report_dir = self.state_dir.parent / "unified_reports"
+                report_dir.mkdir(parents=True, exist_ok=True)
+                (report_dir / f"{self.DISPATCH_ID}.md").write_text("report")
+                result = self._fast_dispatch(lane)
+
+        # The raising normalizer must not crash the lane.
+        self.assertNotEqual(result.failure_reason, "unexpected_error",
+                            "normalizer exception must not propagate as unexpected_error")
+
+    def test_normalizer_not_called_when_capture_disabled(self):
+        """VNX_TMUX_CAPTURE=0: normalizer is never called (pipe-pane not started)."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        normalizer_calls = []
+
+        def capturing_normalizer(raw_log, terminal_id, dispatch_id, model):
+            normalizer_calls.append(dispatch_id)
+
+        lane._run_capture_normalizer = capturing_normalizer
+
+        with patch.dict(os.environ, {"VNX_TMUX_CAPTURE": "0"}):
+            self._fast_dispatch(lane)
+
+        self.assertEqual(
+            normalizer_calls, [],
+            "normalizer must not be called when VNX_TMUX_CAPTURE=0 (no raw_log)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Wires tmux pipe-pane on the ephemeral spawn lane to log the full interactive conversation, and normalizes it into the EventStore so the tmux-spawn lane appears in the dashboard agent-stream and feeds the learning loop, uniform with codex/kimi/gemini/subprocess. Flag VNX_TMUX_CAPTURE (default on). No dashboard API change.