### PR TITLE
feat(receipts): uniform provider/model/lane across all lanes + resolve unknown-intermediate

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -43,12 +43,22 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
 # Receipt dedup — authored > synthesized, newest timestamp wins within tier
 # ---------------------------------------------------------------------------
 
+_AUTHORITATIVE_STATUSES = frozenset({"done", "failed"})
+
+
+def _receipt_authority(receipt: dict) -> int:
+    """Return authority rank: 1 = authoritative (done/failed), 0 = unknown/other."""
+    return 1 if (receipt.get("status") or "") in _AUTHORITATIVE_STATUSES else 0
+
+
 def dedup_completion_receipts(receipts: list) -> "dict | None":
     """Pick the preferred receipt from multiple completion receipts for one dispatch.
 
-    Preference: non-synthesized (worker-authored) receipts always win over
-    synthesized ones. Within the same tier, pick newest by ISO 8601 timestamp
-    (lexicographic sort). Fallback: last entry in list order.
+    Preference order (highest to lowest):
+      1. Authoritative status (done/failed) > unknown/other
+      2. Non-synthesized (worker-authored) > synthesized within the same authority tier
+      3. Newest ISO 8601 timestamp within the same authority+authored tier
+    Fallback: last entry in list order.
 
     Never raises.
     """
@@ -57,9 +67,15 @@ def dedup_completion_receipts(receipts: list) -> "dict | None":
     if len(receipts) == 1:
         return receipts[0]
 
-    authored = [r for r in receipts if not r.get("synthesized")]
-    pool = authored if authored else receipts
+    # Tier 1: authoritative status outranks unknown
+    authoritative = [r for r in receipts if _receipt_authority(r)]
+    pool = authoritative if authoritative else receipts
 
+    # Tier 2: authored (non-synthesized) outranks synthesized within the pool
+    authored = [r for r in pool if not r.get("synthesized")]
+    pool = authored if authored else pool
+
+    # Tier 3: newest timestamp
     try:
         return max(pool, key=lambda r: str(r.get("timestamp") or ""))
     except Exception:  # noqa: BLE001
@@ -108,6 +124,10 @@ def ensure_receipt(
         "contract_status": contract_status,
         "permission_enforcement": permission_enforcement,
         "timestamp": ts,
+        "provider": "claude",
+        "sub_provider": "anthropic",
+        "model": spec.model or "unknown",
+        "lane": lane,
     }
     if report_path is not None:
         synthesized_receipt["report_path"] = str(report_path)
@@ -142,6 +162,7 @@ class GovernSpec:
     pr_id: Optional[str] = None
     base_sha: Optional[str] = None
     worktree_path: Optional[Path] = None
+    model: Optional[str] = None
 
 
 @dataclass

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -117,6 +117,7 @@ def ensure_receipt(
         "event_type": "subprocess_completion",
         "dispatch_id": spec.dispatch_id,
         "terminal": spec.terminal_id,
+        "terminal_id": spec.terminal_id,
         "status": "failed",
         "source": "tmux_interactive_lane_synthesized",
         "synthesized": True,

--- a/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
+++ b/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
@@ -100,6 +100,10 @@ def _write_receipt(
     token_usage: dict | None = None,
     cost_usd: float | None = None,
     pr_id: str | None = None,
+    provider: str | None = None,
+    sub_provider: str | None = None,
+    model: str | None = None,
+    lane: str | None = None,
 ) -> Path:
     """Append a subprocess completion receipt to t0_receipts.ndjson.
 
@@ -122,6 +126,10 @@ def _write_receipt(
         token_usage=token_usage,
         cost_usd=cost_usd,
         pr_id=pr_id,
+        provider=provider,
+        sub_provider=sub_provider,
+        model=model,
+        lane=lane,
     )
     return _persist_receipt(receipt, dispatch_id, terminal_id, status)
 
@@ -144,6 +152,10 @@ def _build_receipt_payload(
     token_usage: dict | None = None,
     cost_usd: float | None = None,
     pr_id: str | None = None,
+    provider: str | None = None,
+    sub_provider: str | None = None,
+    model: str | None = None,
+    lane: str | None = None,
 ) -> dict:
     """Assemble the receipt dict from the named fields."""
     receipt = {
@@ -156,6 +168,14 @@ def _build_receipt_payload(
         "session_id": session_id,
         "source": "subprocess",
     }
+    if provider is not None:
+        receipt["provider"] = provider
+    if sub_provider is not None:
+        receipt["sub_provider"] = sub_provider
+    if model is not None:
+        receipt["model"] = model
+    if lane is not None:
+        receipt["lane"] = lane
     if commit_hash_before:
         receipt["commit_hash_before"] = commit_hash_before
     if commit_hash_after:

--- a/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
+++ b/scripts/lib/subprocess_dispatch_internals/receipt_writer.py
@@ -163,6 +163,7 @@ def _build_receipt_payload(
         "event_type": "subprocess_completion",
         "dispatch_id": dispatch_id,
         "terminal": terminal_id,
+        "terminal_id": terminal_id,
         "status": status,
         "event_count": event_count,
         "session_id": session_id,

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -189,6 +189,10 @@ def _handle_success(
         token_usage=token_usage,
         cost_usd=cost_usd,
         pr_id=pr_id,
+        provider="claude",
+        sub_provider="anthropic",
+        model=model,
+        lane="subprocess",
     )
     quality_db = _sd._default_state_dir() / "quality_intelligence.db"
     patt_updated = _sd._update_pattern_confidence(dispatch_id, "success", quality_db)
@@ -258,6 +262,10 @@ def _handle_final_failure(
         token_usage=token_usage,
         cost_usd=cost_usd,
         pr_id=pr_id,
+        provider="claude",
+        sub_provider="anthropic",
+        model=model,
+        lane="subprocess",
     )
     quality_db = _sd._default_state_dir() / "quality_intelligence.db"
     patt_updated = _sd._update_pattern_confidence(dispatch_id, "failure", quality_db)

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -397,6 +397,7 @@ class TmuxInteractiveDispatch:
         pr_id: "str | None" = None,
         base_sha: "str | None" = None,
         worktree_path: "Path | None" = None,
+        model: "str | None" = None,
     ) -> "Path | None":
         """Emit governance unified_report via the shared govern() step.
 
@@ -425,6 +426,7 @@ class TmuxInteractiveDispatch:
             pr_id=pr_id,
             base_sha=base_sha,
             worktree_path=worktree_path,
+            model=model,
         )
         raw = GovernRaw(receipt=receipt, duration_seconds=duration_seconds)
         outcome = govern(spec, raw, lane="tmux_interactive")
@@ -1168,6 +1170,7 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
+                    model=model,
                 )
                 _teardown("ready_timeout")
                 return InteractiveDispatchResult(
@@ -1263,6 +1266,7 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
+                    model=model,
                 )
                 _teardown("submit_failed")
                 return InteractiveDispatchResult(
@@ -1295,6 +1299,7 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
+                    model=model,
                 )
                 _teardown("timeout")
                 return InteractiveDispatchResult(
@@ -1329,6 +1334,7 @@ class TmuxInteractiveDispatch:
                 duration_seconds=time.monotonic() - start_time,
                 base_sha=worktree_handle.base_sha if worktree_handle else None,
                 worktree_path=worktree_handle.path if worktree_handle else None,
+                model=model,
             )
             # A governed-completion path (worker OK) with no linked report is an
             # audit-trail gap — do not report success with an unlinked report.

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -444,7 +444,9 @@ class TmuxInteractiveDispatch:
             )
         return outcome.report_path
 
-    def _build_completion_protocol(self, dispatch_id: str, label: str) -> str:
+    def _build_completion_protocol(
+        self, dispatch_id: str, label: str, model: str = "unknown"
+    ) -> str:
         """Footer instructing the worker to emit a clean receipt directly.
 
         The path to ``append_receipt.py`` is ABSOLUTE so it resolves correctly
@@ -461,10 +463,15 @@ class TmuxInteractiveDispatch:
             "event_type": "subprocess_completion",
             "dispatch_id": dispatch_id,
             "terminal": label,
+            "terminal_id": label,
             "status": "done",
             "source": "tmux_interactive",
             "timestamp": ts,
             "report_path": report_path,
+            "provider": "claude",
+            "sub_provider": "anthropic",
+            "model": model,
+            "lane": "tmux_interactive",
         }
         state_dir = shlex.quote(str(self._state_dir))
         data_dir = shlex.quote(str(self._state_dir.parent))
@@ -1210,7 +1217,7 @@ class TmuxInteractiveDispatch:
                     _TRAILER = "<!-- VNX-END-OF-INSTRUCTION -->"
                 body = (
                     _context_body
-                    + self._build_completion_protocol(dispatch_id, label)
+                    + self._build_completion_protocol(dispatch_id, label, model=model)
                     + f"\n\n{_TRAILER}\n"
                 )
             else:
@@ -1218,7 +1225,7 @@ class TmuxInteractiveDispatch:
                 body = (
                     _context_body
                     + self._scope_note(dispatch_paths)
-                    + self._build_completion_protocol(dispatch_id, label)
+                    + self._build_completion_protocol(dispatch_id, label, model=model)
                 )
 
             # 7. Deliver instruction

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -659,6 +659,20 @@ def test_ensure_receipt_carries_provider_model_lane(tmp_data, tmp_state):
     assert receipt.get("lane") == "tmux_interactive", f"lane missing or wrong: {receipt}"
 
 
+def test_ensure_receipt_carries_terminal_id(tmp_data, tmp_state):
+    """FIX 2: lane-synthesized receipt must carry terminal_id AND keep terminal as alias."""
+    spec = _make_spec(tmp_data, tmp_state, terminal_id="T1")
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="synthesized", permission_enforcement="soft")
+
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    assert receipt.get("terminal_id") == "T1", f"terminal_id missing or wrong: {receipt}"
+    assert receipt.get("terminal") == "T1", f"terminal alias missing or wrong: {receipt}"
+
+
 def test_ensure_receipt_model_unknown_when_not_set(tmp_data, tmp_state):
     """Lane-synthesized receipt uses 'unknown' for model when spec.model is not set."""
     spec = _make_spec(tmp_data, tmp_state)

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -595,6 +595,85 @@ def test_dedup_authored_newest_wins():
 
 
 # ---------------------------------------------------------------------------
+# dedup_completion_receipts — authoritative>unknown ranking (uniform receipts)
+# ---------------------------------------------------------------------------
+
+def test_dedup_authoritative_done_wins_over_unknown():
+    """done receipt outranks status=unknown regardless of timestamp or authored tier."""
+    unknown = {"dispatch_id": "x", "status": "unknown", "lane": None, "timestamp": "2026-06-01T11:00:00Z"}
+    done = {"dispatch_id": "x", "status": "done", "timestamp": "2026-06-01T10:00:00Z"}
+    result = dedup_completion_receipts([unknown, done])
+    assert result is done, "done must win over unknown even when unknown is newer"
+
+
+def test_dedup_authoritative_failed_wins_over_unknown():
+    """failed receipt outranks status=unknown."""
+    unknown = {"dispatch_id": "x", "status": "unknown", "timestamp": "2026-06-01T12:00:00Z"}
+    failed = {"dispatch_id": "x", "status": "failed", "timestamp": "2026-06-01T09:00:00Z"}
+    result = dedup_completion_receipts([unknown, failed])
+    assert result is failed, "failed must win over unknown"
+
+
+def test_dedup_unknown_alone_returns_unknown():
+    """When only an unknown receipt exists, it is returned (no authoritative exists)."""
+    unknown = {"dispatch_id": "x", "status": "unknown", "lane": None, "timestamp": "2026-06-01T10:00:00Z"}
+    result = dedup_completion_receipts([unknown])
+    assert result is unknown
+
+
+def test_dedup_done_authored_wins_over_done_synthesized_and_unknown():
+    """done(authored) beats done(synthesized) beats unknown — full three-tier stack."""
+    unknown = {"dispatch_id": "x", "status": "unknown", "timestamp": "2026-06-01T13:00:00Z"}
+    done_synth = {"dispatch_id": "x", "status": "done", "synthesized": True, "timestamp": "2026-06-01T12:00:00Z"}
+    done_authored = {"dispatch_id": "x", "status": "done", "timestamp": "2026-06-01T10:00:00Z"}
+    result = dedup_completion_receipts([unknown, done_synth, done_authored])
+    assert result is done_authored, "done(authored) must win over done(synthesized) and unknown"
+
+
+def test_dedup_multiple_done_authored_picks_newest():
+    """When two authoritative authored receipts exist, newest timestamp wins."""
+    r1 = {"dispatch_id": "x", "status": "done", "timestamp": "2026-06-01T09:00:00Z"}
+    r2 = {"dispatch_id": "x", "status": "done", "timestamp": "2026-06-01T11:00:00Z"}
+    result = dedup_completion_receipts([r1, r2])
+    assert result is r2
+
+
+# ---------------------------------------------------------------------------
+# ensure_receipt — uniform stamp: provider/sub_provider/model/lane
+# ---------------------------------------------------------------------------
+
+def test_ensure_receipt_carries_provider_model_lane(tmp_data, tmp_state):
+    """Lane-synthesized receipt must carry provider, sub_provider, model, and lane fields."""
+    spec = _make_spec(tmp_data, tmp_state)
+    spec.model = "sonnet"
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="synthesized", permission_enforcement="soft")
+
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    assert receipt.get("provider") == "claude", f"provider missing or wrong: {receipt}"
+    assert receipt.get("sub_provider") == "anthropic", f"sub_provider missing or wrong: {receipt}"
+    assert receipt.get("model") == "sonnet", f"model missing or wrong: {receipt}"
+    assert receipt.get("lane") == "tmux_interactive", f"lane missing or wrong: {receipt}"
+
+
+def test_ensure_receipt_model_unknown_when_not_set(tmp_data, tmp_state):
+    """Lane-synthesized receipt uses 'unknown' for model when spec.model is not set."""
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="synthesized", permission_enforcement="soft")
+
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    assert receipt.get("provider") == "claude"
+    assert receipt.get("model") == "unknown"
+
+
+# ---------------------------------------------------------------------------
 # ensure_receipt — unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_subprocess_canonical_receipt.py
+++ b/tests/test_subprocess_canonical_receipt.py
@@ -215,3 +215,44 @@ class TestSubprocessReceiptProviderModelLane:
         assert receipt_data["sub_provider"] == "anthropic"
         assert receipt_data["model"] == "claude-sonnet-4-6"
         assert receipt_data["lane"] == "subprocess"
+
+
+class TestSubprocessReceiptTerminalId:
+    """FIX 2: subprocess receipt must carry terminal_id (+ keep terminal alias)."""
+
+    def test_terminal_id_present_via_canonical_path(self, tmp_path):
+        """_write_receipt must emit terminal_id field equal to terminal_id arg."""
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-termid-001",
+                terminal_id="T2",
+                status="done",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg.get("terminal_id") == "T2", f"terminal_id missing or wrong: {receipt_arg}"
+        assert receipt_arg.get("terminal") == "T2", f"terminal alias missing or wrong: {receipt_arg}"
+
+    def test_terminal_and_terminal_id_both_present_via_fallback(self, tmp_path):
+        """Fallback bare-write path also has both terminal and terminal_id."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        receipt_file = state_dir / "t0_receipts.ndjson"
+
+        with patch.dict("sys.modules", {"append_receipt": None}), \
+             patch.object(sd, "_default_state_dir", return_value=state_dir):
+            sd._write_receipt(
+                dispatch_id="test-termid-002",
+                terminal_id="T3",
+                status="done",
+            )
+
+        receipt_data = json.loads(receipt_file.read_text().strip())
+        assert receipt_data.get("terminal_id") == "T3", f"terminal_id missing: {receipt_data}"
+        assert receipt_data.get("terminal") == "T3", f"terminal alias missing: {receipt_data}"

--- a/tests/test_subprocess_canonical_receipt.py
+++ b/tests/test_subprocess_canonical_receipt.py
@@ -140,3 +140,78 @@ class TestCanonicalReceiptPath:
 
         assert result_path == expected_path
         append_mod.append_receipt_payload.assert_called_once()
+
+
+class TestSubprocessReceiptProviderModelLane:
+    """Test that subprocess receipts carry provider/sub_provider/model/lane (uniform receipts)."""
+
+    def test_subprocess_receipt_carries_provider_model_lane(self, tmp_path):
+        """_write_receipt with provider/model/lane kwargs stamps all three fields."""
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-uniform-001",
+                terminal_id="T1",
+                status="done",
+                provider="claude",
+                sub_provider="anthropic",
+                model="sonnet",
+                lane="subprocess",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert receipt_arg["provider"] == "claude"
+        assert receipt_arg["sub_provider"] == "anthropic"
+        assert receipt_arg["model"] == "sonnet"
+        assert receipt_arg["lane"] == "subprocess"
+        assert receipt_arg["source"] == "subprocess"
+
+    def test_subprocess_receipt_no_provider_when_omitted(self, tmp_path):
+        """Without provider/model/lane kwargs, receipt omits those fields (backward compat)."""
+        expected_path = tmp_path / "t0_receipts.ndjson"
+        mock_result = _make_append_result(status="appended", path=expected_path)
+
+        append_mod = MagicMock()
+        append_mod.append_receipt_payload.return_value = mock_result
+
+        with patch.dict("sys.modules", {"append_receipt": append_mod}):
+            sd._write_receipt(
+                dispatch_id="test-uniform-002",
+                terminal_id="T1",
+                status="done",
+            )
+
+        receipt_arg = append_mod.append_receipt_payload.call_args[0][0]
+        assert "provider" not in receipt_arg
+        assert "model" not in receipt_arg
+        assert "lane" not in receipt_arg
+
+    def test_subprocess_receipt_via_fallback_carries_provider_model_lane(self, tmp_path):
+        """Fallback (bare write) path also stamps provider/sub_provider/model/lane."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        receipt_file = state_dir / "t0_receipts.ndjson"
+
+        with patch.dict("sys.modules", {"append_receipt": None}), \
+             patch.object(sd, "_default_state_dir", return_value=state_dir):
+            sd._write_receipt(
+                dispatch_id="test-uniform-003",
+                terminal_id="T1",
+                status="done",
+                provider="claude",
+                sub_provider="anthropic",
+                model="claude-sonnet-4-6",
+                lane="subprocess",
+            )
+
+        assert receipt_file.exists()
+        receipt_data = json.loads(receipt_file.read_text().strip())
+        assert receipt_data["provider"] == "claude"
+        assert receipt_data["sub_provider"] == "anthropic"
+        assert receipt_data["model"] == "claude-sonnet-4-6"
+        assert receipt_data["lane"] == "subprocess"

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -233,6 +233,25 @@ class TestSingleShotSuccess(_LaneTestCase):
             "absolute path to append_receipt.py must appear in the delivered body",
         )
 
+    def test_worker_receipt_carries_provider_model_lane(self):
+        """FIX 1: completion protocol receipt (WORKER path) must carry provider/sub_provider/model/lane."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        self._fast_dispatch(lane, model="sonnet")
+
+        delivered = "\n".join(fake.pasted)
+        m = re.search(r"```bash\n(.+?)\n```", delivered, re.DOTALL)
+        self.assertIsNotNone(m, "could not extract bash command from delivered body")
+        argv = shlex.split(m.group(1).strip())
+        receipt_idx = argv.index("--receipt")
+        receipt = json.loads(argv[receipt_idx + 1])
+        self.assertEqual(receipt.get("provider"), "claude", f"provider missing/wrong: {receipt}")
+        self.assertEqual(receipt.get("sub_provider"), "anthropic", f"sub_provider missing/wrong: {receipt}")
+        self.assertEqual(receipt.get("model"), "sonnet", f"model missing/wrong: {receipt}")
+        self.assertEqual(receipt.get("lane"), "tmux_interactive", f"lane missing/wrong: {receipt}")
+        # terminal_id alias also present
+        self.assertIn("terminal_id", receipt, f"terminal_id missing from worker receipt: {receipt}")
+
     def test_enter_is_separate_keystroke(self):
         """Launch cmd and body paste each submit Enter as a standalone send-keys call."""
         fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1594,6 +1594,40 @@ class TestReceiptFallback(_LaneTestCase):
                 f"VNX_RECEIPT_FALLBACK=0 must suppress synthesized receipt: {synthesized}",
             )
 
+    def test_synthesized_receipt_carries_provider_model_lane(self):
+        """Lane-synthesized receipt must carry provider, sub_provider, model, and lane fields."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+        )
+        lane = self._make_lane(fake)
+
+        with patch.dict(os.environ, {"VNX_RECEIPT_FALLBACK": "1"}):
+            with patch("dispatch_govern._git_summary", return_value="timeout synthesis"):
+                with patch("dispatch_govern._git_changes", return_value="No diff"):
+                    self._fast_dispatch(
+                        lane,
+                        model="sonnet",
+                        deadline_seconds=0.2,
+                        poll_interval=0.02,
+                    )
+
+        self.assertTrue(self.receipts_file.exists())
+        lines = [ln for ln in self.receipts_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        synthesized = [json.loads(ln) for ln in lines
+                       if json.loads(ln).get("source") == "tmux_interactive_lane_synthesized"]
+        self.assertEqual(len(synthesized), 1)
+        rec = synthesized[0]
+        self.assertEqual(rec.get("provider"), "claude",
+                         f"provider missing or wrong in synthesized receipt: {rec}")
+        self.assertEqual(rec.get("sub_provider"), "anthropic",
+                         f"sub_provider missing or wrong: {rec}")
+        self.assertEqual(rec.get("model"), "sonnet",
+                         f"model missing or wrong: {rec}")
+        self.assertEqual(rec.get("lane"), "tmux_interactive",
+                         f"lane missing or wrong: {rec}")
+
 
 # ---------------------------------------------------------------------------
 # RECEIPT step: dedup — authored > synthesized; late worker wins


### PR DESCRIPTION
## Summary

- Stamps `provider/sub_provider/model/lane` on the subprocess (claude) completion receipt: threads the already-available `model` through `recovery.py` → `receipt_writer._build_receipt_payload` so every subprocess receipt carries `provider="claude"`, `sub_provider="anthropic"`, `model`, `lane="subprocess"`
- Stamps the same fields on the tmux-spawn lane-synthesized fallback receipt (`ensure_receipt` in `dispatch_govern.py`): adds `provider/sub_provider/model/lane` to the synthesized receipt; adds `model` field to `GovernSpec` and threads it from all four `_govern_report` call sites in `tmux_interactive_dispatch.py`
- Extends `dedup_completion_receipts` with a three-tier ranking: authoritative status (`done`/`failed`) > unknown/other → authored (non-synthesized) > synthesized → newest timestamp; ensures ALL consumers (headless_trigger, headless_orchestrator, tmux lane) pick the authoritative receipt over `status=unknown lane=None` intermediates when both exist for the same dispatch_id

No new central-DB table; dedup is at the read path (append-only ledger preserved).

## Test plan

- [ ] `pytest tests/test_dispatch_govern.py tests/test_subprocess_canonical_receipt.py tests/test_tmux_interactive_dispatch.py -q` — 150 passed
- [ ] `python3 -m py_compile scripts/lib/subprocess_dispatch_internals/recovery.py scripts/lib/subprocess_dispatch_internals/receipt_writer.py scripts/lib/dispatch_govern.py scripts/lib/tmux_interactive_dispatch.py` — syntax OK
- [ ] New dedup tests: `test_dedup_authoritative_done_wins_over_unknown`, `test_dedup_authoritative_failed_wins_over_unknown`, `test_dedup_unknown_alone_returns_unknown`, `test_dedup_done_authored_wins_over_done_synthesized_and_unknown`
- [ ] New ensure_receipt tests: `test_ensure_receipt_carries_provider_model_lane`, `test_ensure_receipt_model_unknown_when_not_set`
- [ ] New subprocess receipt tests: `test_subprocess_receipt_carries_provider_model_lane`, fallback path test
- [ ] New tmux test: `test_synthesized_receipt_carries_provider_model_lane`

🤖 Generated with [Claude Code](https://claude.com/claude-code)