### PR TITLE
feat(reports): uniform frontmatter on worker-authored reports (GAP 1)

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -181,6 +181,47 @@ class GovernedOutcome:
     error: Optional[str] = None
 
 
+def _has_yaml_frontmatter(text: str) -> bool:
+    """Return True if text begins with a YAML frontmatter block (--- ... ---)."""
+    stripped = text.lstrip("\n")
+    return stripped.startswith("---\n") or stripped.startswith("---\r\n")
+
+
+def _split_yaml_frontmatter(text: str) -> "tuple[dict, str]":
+    """Split text at YAML frontmatter boundary.
+
+    Returns (frontmatter_dict, body_text) where body_text is the content
+    after the closing --- delimiter with leading blank lines stripped.
+    If no valid frontmatter found, returns ({}, original text).
+    Best-effort: never raises.
+    """
+    try:
+        import yaml  # noqa: PLC0415
+        stripped = text.lstrip("\n")
+        if not stripped.startswith("---\n") and not stripped.startswith("---\r\n"):
+            return {}, text
+        lines = stripped.split("\n")
+        # lines[0] == "---"; find closing ---
+        close_line: Optional[int] = None
+        for i, line in enumerate(lines[1:], 1):
+            if line.rstrip("\r") == "---":
+                close_line = i
+                break
+        if close_line is None:
+            return {}, text
+        fm_text = "\n".join(lines[1:close_line])
+        body_lines = lines[close_line + 1:]
+        while body_lines and not body_lines[0].strip():
+            body_lines = body_lines[1:]
+        body = "\n".join(body_lines)
+        fm = yaml.safe_load(fm_text)
+        if not isinstance(fm, dict):
+            return {}, text
+        return fm, body
+    except Exception:  # noqa: BLE001
+        return {}, text
+
+
 def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
     """Produce the final unified report for a dispatch, stamped with contract metadata.
 
@@ -313,7 +354,10 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     permission_enforcement = "strict" if enforce else "soft"
 
     # -- d. Emit report with final body ---------------------------------------
-    # authored: idempotent (no overwrite) — worker already wrote the valid file.
+    # authored: force-write with frontmatter so ALL reports are schema-uniform.
+    #   The worker body is preserved; the frontmatter block is prepended.
+    #   If the worker already wrote frontmatter (defensive), merge — govern's
+    #   required fields take precedence.
     # synthesized/violated: overwrite=True so a stale placeholder is replaced.
     is_authored = contract_status == "authored"
 
@@ -362,6 +406,18 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
 
     status = (raw.receipt or {}).get("status", "unknown") if raw.receipt else "timeout"
 
+    # Determine the exact body and frontmatter to write.
+    # Authored path: detect if worker already wrote frontmatter (defensive merge);
+    # otherwise use the worker body as-is with our govern frontmatter prepended.
+    if is_authored and _has_yaml_frontmatter(body):
+        existing_fm, body_only = _split_yaml_frontmatter(body)
+        # Govern's required fields take precedence to guarantee schema-uniform output.
+        emit_frontmatter: dict = {**existing_fm, **frontmatter}
+        emit_body: str = body_only
+    else:
+        emit_frontmatter = frontmatter
+        emit_body = body
+
     try:
         report_path = emit_unified_report(
             dispatch_id=dispatch_id,
@@ -372,9 +428,9 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
             findings=[],
             duration_seconds=raw.duration_seconds,
             data_dir=spec.data_dir,
-            frontmatter=frontmatter,
-            body_override=body if not is_authored else None,
-            overwrite=not is_authored,
+            frontmatter=emit_frontmatter,
+            body_override=emit_body,
+            overwrite=True,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("govern: emit_unified_report failed for %s: %s", dispatch_id, exc)

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -102,24 +102,117 @@ def test_govern_authored_uses_worker_report(tmp_data, tmp_state, monkeypatch):
     assert outcome.report_path is not None
 
 
-def test_govern_authored_does_not_overwrite_worker_report(tmp_data, tmp_state, monkeypatch):
-    """Authored body is not re-written by govern() (idempotency via emit_unified_report)."""
+def test_govern_authored_stamps_frontmatter_on_worker_report(tmp_data, tmp_state, monkeypatch):
+    """After govern(), a frontmatter-less worker report has a YAML frontmatter block stamped."""
     monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
 
     reports_dir = tmp_data / "unified_reports"
     reports_dir.mkdir(parents=True)
     report_file = reports_dir / "test-govern-001.md"
-    original_body = _valid_body()
-    report_file.write_text(original_body, encoding="utf-8")
-    original_mtime = report_file.stat().st_mtime
+    report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    content = report_file.read_text(encoding="utf-8")
+    assert content.startswith("---\n"), "Authored report must begin with YAML frontmatter after govern()"
+    assert "schema_version: 1" in content
+    assert "contract_status: authored" in content
+    assert "provider: claude" in content
+    assert "terminal_id: T1" in content
+    assert "lane: tmux_interactive" in content
+
+
+def test_govern_authored_preserves_worker_body(tmp_data, tmp_state, monkeypatch):
+    """Worker body is preserved below the stamped frontmatter."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    worker_body = _valid_body()
+    report_file.write_text(worker_body, encoding="utf-8")
 
     spec = _make_spec(tmp_data, tmp_state)
     raw = _make_raw()
     govern(spec, raw, lane="tmux_interactive")
 
-    # File unchanged (emit_unified_report idempotency)
-    assert report_file.stat().st_mtime == original_mtime
-    assert report_file.read_text(encoding="utf-8") == original_body
+    content = report_file.read_text(encoding="utf-8")
+    # Body sections from the worker report must survive below the frontmatter.
+    assert "## Summary" in content
+    assert "## Changes" in content
+    assert "## Verification" in content
+    assert "## Open Items" in content
+    # Worker's specific text content must be preserved.
+    assert "Implemented the feature correctly" in content
+
+
+def test_govern_authored_not_double_stamped(tmp_data, tmp_state, monkeypatch):
+    """Defensive: a worker report that already has frontmatter is not double-stamped."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    # Pre-stamp a frontmatter block simulating a future worker that authors its own.
+    existing_fm_body = (
+        "---\n"
+        "schema_version: 1\n"
+        "dispatch_id: test-govern-001\n"
+        "some_extra_field: worker-value\n"
+        "---\n\n"
+        + _valid_body()
+    )
+    report_file.write_text(existing_fm_body, encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = _make_raw()
+    govern(spec, raw, lane="tmux_interactive")
+
+    content = report_file.read_text(encoding="utf-8")
+    # Exactly one opening --- fence at the start.
+    assert content.count("---\n") >= 2, "Frontmatter fences missing"
+    # No double frontmatter: the content after the first closing --- should be body text.
+    fm_end = content.find("\n---\n", 4)  # find closing ---
+    assert fm_end != -1, "No closing --- found"
+    body_part = content[fm_end + 5:]
+    # Second --- must not immediately follow (no double-stamp).
+    assert not body_part.lstrip("\n").startswith("---\n"), (
+        "Double-stamp detected: body begins with another frontmatter block"
+    )
+    # Required fields must be present.
+    assert "schema_version: 1" in content
+    assert "contract_status: authored" in content
+
+
+def test_govern_authored_schema_strict_valid(tmp_data, tmp_state, monkeypatch):
+    """VNX_SCHEMA_STRICT=1: authored report frontmatter validates against the schema."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_SCHEMA_STRICT", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    assert outcome.error is None, f"govern() returned error under strict mode: {outcome.error}"
+    assert outcome.report_path is not None and outcome.report_path.exists()
+
+    content = outcome.report_path.read_text(encoding="utf-8")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+    from unified_report_schema import UnifiedReportValidator
+    validator = UnifiedReportValidator()
+    result = validator.validate(content)
+    assert result.valid, (
+        f"Authored report fails schema validation under strict mode: {result.errors}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Worker-authored unified reports had no YAML frontmatter while synthesized reports did. `govern()` now force-writes the same frontmatter (`schema_version`/`provider`/`model`/`contract_status=authored`/`lane`/`terminal_id`/all 15 schema-required fields) onto the worker body so all reports are schema-uniform and minable by one parser.
- Reuses the #772 schema-complete frontmatter construction and `emit_unified_report` atomic-write path. Safe under `VNX_SCHEMA_STRICT=1`. Best-effort: never crashes the lane.
- Defensive: if a worker body already has frontmatter, fields are merged (govern's required fields take precedence) — no double-stamp.

## Changes

- `scripts/lib/dispatch_govern.py`: added `_has_yaml_frontmatter()` + `_split_yaml_frontmatter()` helpers; updated authored path to force-write frontmatter via `emit_unified_report(body_override=body, overwrite=True, frontmatter=frontmatter)` instead of the old no-op `(body_override=None, overwrite=False)`.
- `tests/test_dispatch_govern.py`: updated the now-incorrect no-overwrite test; added 4 new tests covering authored frontmatter stamp, body preservation, defensive no-double-stamp, and `VNX_SCHEMA_STRICT=1` validity.

## Test plan

- [x] `python3 -m pytest tests/test_dispatch_govern.py tests/test_tmux_interactive_dispatch.py -q` → 147 passed
- [x] `VNX_SCHEMA_STRICT=1 python3 -m pytest tests/test_dispatch_govern.py -q` → 49 passed
- [x] `python3 -m py_compile scripts/lib/dispatch_govern.py` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)