### PR TITLE
feat(intelligence): dispatch_metadata provider/model column + idempotent migration (GAP 2)

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -521,6 +521,7 @@ CREATE TABLE IF NOT EXISTS dispatch_metadata (
     terminal TEXT NOT NULL,
     track TEXT NOT NULL,
     provider TEXT,
+    model TEXT,
     role TEXT,
     skill_name TEXT,
     gate TEXT,
@@ -715,3 +716,6 @@ VALUES ('8.3.0-adr-registry', 'Add adrs table + FTS5 virtual table + sync trigge
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES ('8.4.0-provider-aware', 'Add provider column to dispatch_metadata for provider-aware self-learning intelligence (non-Claude parity)');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES ('8.5.0-model-aware', 'Add model column to dispatch_metadata (GAP 2): provider+model-aware self-learning intelligence');

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -751,26 +751,35 @@ def _query_qi_db(db_path: Path, sql: str, params: tuple = ()) -> List[Dict[str, 
         return []
 
 
-def _dm_has_provider_column(db_path: Path) -> bool:
-    """Return True if dispatch_metadata.provider column exists (migration guard)."""
+def _dm_available_columns(db_path: Path) -> frozenset:
+    """Return frozenset of column names in dispatch_metadata (empty if DB absent/error)."""
     if not db_path.exists():
-        return False
+        return frozenset()
     try:
         conn = sqlite3.connect(str(db_path), timeout=5)
         try:
             rows = conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()
-            return any(r[1] == "provider" for r in rows)
+            return frozenset(r[1] for r in rows)
         finally:
             conn.close()
     except Exception:
-        return False
+        return frozenset()
 
 
 def _collect_recent_dispatches_per_project(
     project_id: str, state_dir: Path
 ) -> List[Dict[str, Any]]:
     db_path = state_dir / "quality_intelligence.db"
-    sql = _RECENT_DISPATCHES_SQL if _dm_has_provider_column(db_path) else _RECENT_DISPATCHES_SQL_NO_PROVIDER
+    cols = _dm_available_columns(db_path)
+    provider_part = ", provider" if "provider" in cols else ""
+    model_part = ", model" if "model" in cols else ""
+    sql = (
+        "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+        f"dispatched_at, completed_at, outcome_status{provider_part}{model_part} "
+        "FROM dispatch_metadata "
+        "ORDER BY dispatched_at DESC "
+        "LIMIT 50"
+    )
     return _query_qi_db(db_path, sql)
 
 
@@ -778,7 +787,17 @@ def _collect_recent_dispatches_central(project_id: str) -> List[Dict[str, Any]]:
     db_path = _central_qi_db_for_project(project_id)
     if db_path is None:
         return []
-    sql = _RECENT_DISPATCHES_CENTRAL_SQL if _dm_has_provider_column(db_path) else _RECENT_DISPATCHES_CENTRAL_SQL_NO_PROVIDER
+    cols = _dm_available_columns(db_path)
+    provider_part = ", provider" if "provider" in cols else ""
+    model_part = ", model" if "model" in cols else ""
+    sql = (
+        "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+        f"dispatched_at, completed_at, outcome_status{provider_part}{model_part} "
+        "FROM dispatch_metadata "
+        "WHERE project_id = ? "
+        "ORDER BY dispatched_at DESC "
+        "LIMIT 50"
+    )
     return _query_qi_db(db_path, sql, (project_id,))
 
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -702,7 +702,7 @@ def _build_quality_digest(state_dir: Path) -> Dict[str, Any]:
 
 _RECENT_DISPATCHES_SQL = (
     "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
-    "dispatched_at, completed_at, outcome_status "
+    "dispatched_at, completed_at, outcome_status, provider, model "
     "FROM dispatch_metadata "
     "ORDER BY dispatched_at DESC "
     "LIMIT 50"
@@ -710,7 +710,7 @@ _RECENT_DISPATCHES_SQL = (
 
 _RECENT_DISPATCHES_CENTRAL_SQL = (
     "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
-    "dispatched_at, completed_at, outcome_status "
+    "dispatched_at, completed_at, outcome_status, provider, model "
     "FROM dispatch_metadata "
     "WHERE project_id = ? "
     "ORDER BY dispatched_at DESC "

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -717,6 +717,23 @@ _RECENT_DISPATCHES_CENTRAL_SQL = (
     "LIMIT 50"
 )
 
+_RECENT_DISPATCHES_SQL_NO_PROVIDER = (
+    "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+    "dispatched_at, completed_at, outcome_status "
+    "FROM dispatch_metadata "
+    "ORDER BY dispatched_at DESC "
+    "LIMIT 50"
+)
+
+_RECENT_DISPATCHES_CENTRAL_SQL_NO_PROVIDER = (
+    "SELECT dispatch_id, terminal, track, role, gate, priority, pr_id, "
+    "dispatched_at, completed_at, outcome_status "
+    "FROM dispatch_metadata "
+    "WHERE project_id = ? "
+    "ORDER BY dispatched_at DESC "
+    "LIMIT 50"
+)
+
 
 def _query_qi_db(db_path: Path, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
     """Execute a read-only query against a quality_intelligence.db and return dicts."""
@@ -734,17 +751,35 @@ def _query_qi_db(db_path: Path, sql: str, params: tuple = ()) -> List[Dict[str, 
         return []
 
 
+def _dm_has_provider_column(db_path: Path) -> bool:
+    """Return True if dispatch_metadata.provider column exists (migration guard)."""
+    if not db_path.exists():
+        return False
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        try:
+            rows = conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()
+            return any(r[1] == "provider" for r in rows)
+        finally:
+            conn.close()
+    except Exception:
+        return False
+
+
 def _collect_recent_dispatches_per_project(
     project_id: str, state_dir: Path
 ) -> List[Dict[str, Any]]:
-    return _query_qi_db(state_dir / "quality_intelligence.db", _RECENT_DISPATCHES_SQL)
+    db_path = state_dir / "quality_intelligence.db"
+    sql = _RECENT_DISPATCHES_SQL if _dm_has_provider_column(db_path) else _RECENT_DISPATCHES_SQL_NO_PROVIDER
+    return _query_qi_db(db_path, sql)
 
 
 def _collect_recent_dispatches_central(project_id: str) -> List[Dict[str, Any]]:
     db_path = _central_qi_db_for_project(project_id)
     if db_path is None:
         return []
-    return _query_qi_db(db_path, _RECENT_DISPATCHES_CENTRAL_SQL, (project_id,))
+    sql = _RECENT_DISPATCHES_CENTRAL_SQL if _dm_has_provider_column(db_path) else _RECENT_DISPATCHES_CENTRAL_SQL_NO_PROVIDER
+    return _query_qi_db(db_path, sql, (project_id,))
 
 
 def _collect_recent_dispatches(

--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -512,7 +512,6 @@ _fdd_log_dispatch_metadata() {
     # own provider. (See provider-aware self-learning, Wave 2 core.)
     python3 "$VNX_DIR/scripts/log_dispatch_metadata.py" \
         --dispatch-id "$dispatch_id" --terminal "$terminal_id" --track "$track" \
-        --provider "claude" \
         --role "$agent_role" --skill-name "$agent_role" --gate "$gate" \
         --cognition "$_dm_cognition" --priority "$_dm_priority" --pr-id "${pr_id:-}" \
         --pattern-count "${_dm_pattern_count:-0}" --prevention-rule-count "${_dm_rule_count:-0}" \

--- a/scripts/lib/dispatch_metadata_db.py
+++ b/scripts/lib/dispatch_metadata_db.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""dispatch_metadata_db.py — Shared dispatch_metadata row writer (provider-aware).
+"""dispatch_metadata_db.py — Shared dispatch_metadata row writer (provider+model-aware).
 
 Single source of truth for stamping a ``dispatch_metadata`` row with its
-``provider``. Used by BOTH dispatch paths so the self-learning/intelligence
-layer is never provider-blind:
+``provider`` and ``model``. Used by BOTH dispatch paths so the
+self-learning/intelligence layer is never provider-blind:
 
   - ``log_dispatch_metadata.py`` (tmux / interactive claude path via dispatcher)
   - ``provider_dispatch._emit_governance`` (headless multi-provider path:
@@ -14,8 +14,8 @@ created zero intelligence rows and the receipt processor's
 ``UPDATE dispatch_metadata ... WHERE dispatch_id=?`` was a silent no-op.
 
 ADR-007: every write stamps ``project_id`` when the column exists. ``provider``
-is a descriptive (non-key) column, so it carries no UNIQUE constraint; the
-composite ``(project_id, provider)`` index (migration v21) keeps it
+and ``model`` are descriptive (non-key) columns; the composite
+``(project_id, provider)`` index (migration v21/GAP-2) keeps them
 tenant-scoped-queryable.
 
 Design notes:
@@ -24,8 +24,11 @@ Design notes:
     the dispatcher's ``|| log WARNING`` contract.
   - Idempotent: ``INSERT OR IGNORE`` creates the row only when absent so a richer
     row written by the dispatcher path is never clobbered. The follow-up UPDATE
-    stamps provider authoritatively and fills outcome/report_path/role/gate/pr_id
+    stamps provider/model authoritatively and fills outcome/report_path/role/gate/pr_id
     only when not already set (COALESCE), so concurrent writers converge.
+  - Column-guarded: each optional column (provider, model, project_id, …) is checked
+    via PRAGMA table_info before use so the code is safe on legacy DBs that predate
+    the migration.
 """
 
 from __future__ import annotations
@@ -67,6 +70,7 @@ def upsert_dispatch_provider_row(
     dispatch_id: str,
     terminal: str,
     provider: str,
+    model: Optional[str] = None,
     track: str = "headless",
     role: Optional[str] = None,
     gate: Optional[str] = None,
@@ -75,10 +79,16 @@ def upsert_dispatch_provider_row(
     report_path: Optional[str] = None,
     project_id: Optional[str] = None,
 ) -> bool:
-    """Create-if-absent and provider-stamp a ``dispatch_metadata`` row.
+    """Create-if-absent and provider/model-stamp a ``dispatch_metadata`` row.
 
     Returns ``True`` when a row was written/updated, ``False`` when the write was
     skipped (DB missing) or a sqlite error was swallowed.
+
+    Args:
+        model: The AI model string used (e.g. "claude-sonnet-4-6", "codex",
+               "kimi"). Stamped when the ``model`` column exists (migration
+               v23 / GAP-2). Optional — callers that don't know the model
+               may omit it.
 
     Raises:
         ValueError: ``dispatch_id``, ``terminal``, or ``provider`` is empty —
@@ -104,6 +114,7 @@ def upsert_dispatch_provider_row(
     try:
         conn = sqlite3.connect(str(db_path))
         has_provider = _has_column(conn, "dispatch_metadata", "provider")
+        has_model = _has_column(conn, "dispatch_metadata", "model")
         has_project = _has_column(conn, "dispatch_metadata", "project_id")
         has_report_path = _has_column(conn, "dispatch_metadata", "outcome_report_path")
         has_outcome = _has_column(conn, "dispatch_metadata", "outcome_status")
@@ -115,6 +126,9 @@ def upsert_dispatch_provider_row(
         if has_provider:
             insert_cols.append("provider")
             insert_vals.append(provider)
+        if has_model and model:
+            insert_cols.append("model")
+            insert_vals.append(model)
         if has_project:
             insert_cols.append("project_id")
             insert_vals.append(resolved_project_id)
@@ -125,12 +139,15 @@ def upsert_dispatch_provider_row(
             insert_vals,
         )
 
-        # --- authoritative provider stamp + non-clobbering field fills ---
+        # --- authoritative provider/model stamp + non-clobbering field fills ---
         set_clauses = []
         params: list = []
         if has_provider:
             set_clauses.append("provider = ?")
             params.append(provider)
+        if has_model and model:
+            set_clauses.append("model = COALESCE(model, ?)")
+            params.append(model)
         set_clauses.append("role = COALESCE(role, ?)")
         params.append(role or None)
         set_clauses.append("gate = COALESCE(gate, ?)")
@@ -164,8 +181,8 @@ def upsert_dispatch_provider_row(
             )
         conn.commit()
         logger.debug(
-            "upsert_dispatch_provider_row: stamped dispatch=%s provider=%s outcome=%s",
-            dispatch_id, provider, outcome_status,
+            "upsert_dispatch_provider_row: stamped dispatch=%s provider=%s model=%s outcome=%s",
+            dispatch_id, provider, model, outcome_status,
         )
         return True
     except sqlite3.Error as exc:

--- a/scripts/lib/intelligence_sources/recent_comparable.py
+++ b/scripts/lib/intelligence_sources/recent_comparable.py
@@ -87,9 +87,15 @@ def query_recent_comparable(
     return legacy
 
 
-def _dm_has_provider(conn: sqlite3.Connection) -> bool:
-    """Return True if dispatch_metadata has provider/model columns (migration guard)."""
-    return _table_has_column(conn, "dispatch_metadata", "provider")
+def _dm_column_set(conn: sqlite3.Connection) -> frozenset:
+    """Return frozenset of column names present in dispatch_metadata (migration guard)."""
+    try:
+        rows = conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()
+        return frozenset(
+            (r["name"] if isinstance(r, sqlite3.Row) else r[1]) for r in rows
+        )
+    except Exception:
+        return frozenset()
 
 
 def _query_per_project(
@@ -106,7 +112,11 @@ def _query_per_project(
     dm_scope_clause, dm_scope_params = _project_scope_clause(
         has_column_fn("dispatch_metadata", "project_id")
     )
-    provider_cols = ", provider, model" if _dm_has_provider(db) else ""
+    _dm_cols = _dm_column_set(db)
+    provider_cols = (
+        (", provider" if "provider" in _dm_cols else "")
+        + (", model" if "model" in _dm_cols else "")
+    )
     try:
         rows = db.execute(
             f"""
@@ -195,7 +205,11 @@ def _query_central(
             datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)
         ).isoformat()
         has_project_id = _table_has_column(conn, "dispatch_metadata", "project_id")
-        provider_cols = ", provider, model" if _dm_has_provider(conn) else ""
+        _dm_cols = _dm_column_set(conn)
+        provider_cols = (
+            (", provider" if "provider" in _dm_cols else "")
+            + (", model" if "model" in _dm_cols else "")
+        )
         if has_project_id and project_id:
             rows = conn.execute(
                 f"""SELECT dispatch_id, terminal, track, role, skill_name, gate,

--- a/scripts/lib/intelligence_sources/recent_comparable.py
+++ b/scripts/lib/intelligence_sources/recent_comparable.py
@@ -87,6 +87,11 @@ def query_recent_comparable(
     return legacy
 
 
+def _dm_has_provider(conn: sqlite3.Connection) -> bool:
+    """Return True if dispatch_metadata has provider/model columns (migration guard)."""
+    return _table_has_column(conn, "dispatch_metadata", "provider")
+
+
 def _query_per_project(
     db: sqlite3.Connection,
     task_class: str,
@@ -101,12 +106,13 @@ def _query_per_project(
     dm_scope_clause, dm_scope_params = _project_scope_clause(
         has_column_fn("dispatch_metadata", "project_id")
     )
+    provider_cols = ", provider, model" if _dm_has_provider(db) else ""
     try:
         rows = db.execute(
             f"""
             SELECT dispatch_id, terminal, track, role, skill_name, gate,
                    outcome_status, dispatched_at, pattern_count,
-                   prevention_rule_count, provider, model
+                   prevention_rule_count{provider_cols}
             FROM dispatch_metadata
             WHERE dispatched_at >= ?
               AND outcome_status IS NOT NULL
@@ -189,11 +195,12 @@ def _query_central(
             datetime.now(timezone.utc) - timedelta(days=RECENT_COMPARABLE_DAYS)
         ).isoformat()
         has_project_id = _table_has_column(conn, "dispatch_metadata", "project_id")
+        provider_cols = ", provider, model" if _dm_has_provider(conn) else ""
         if has_project_id and project_id:
             rows = conn.execute(
-                """SELECT dispatch_id, terminal, track, role, skill_name, gate,
+                f"""SELECT dispatch_id, terminal, track, role, skill_name, gate,
                        outcome_status, dispatched_at, pattern_count,
-                       prevention_rule_count, provider, model
+                       prevention_rule_count{provider_cols}
                 FROM dispatch_metadata
                 WHERE dispatched_at >= ?
                   AND outcome_status IS NOT NULL
@@ -203,9 +210,9 @@ def _query_central(
             ).fetchall()
         else:
             rows = conn.execute(
-                """SELECT dispatch_id, terminal, track, role, skill_name, gate,
+                f"""SELECT dispatch_id, terminal, track, role, skill_name, gate,
                        outcome_status, dispatched_at, pattern_count,
-                       prevention_rule_count, provider, model
+                       prevention_rule_count{provider_cols}
                 FROM dispatch_metadata
                 WHERE dispatched_at >= ?
                   AND outcome_status IS NOT NULL

--- a/scripts/lib/intelligence_sources/recent_comparable.py
+++ b/scripts/lib/intelligence_sources/recent_comparable.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 
 _RECENT_COMPARABLE_SQL_TEMPLATE = (
     "SELECT dispatch_id, terminal, track, role, skill_name, gate, "
-    "outcome_status, dispatched_at "
+    "outcome_status, dispatched_at, pattern_count, prevention_rule_count, "
+    "provider, model "
     "FROM dispatch_metadata "
     "WHERE dispatched_at >= ? AND outcome_status IS NOT NULL "
     "ORDER BY dispatched_at DESC LIMIT 20"
@@ -105,7 +106,7 @@ def _query_per_project(
             f"""
             SELECT dispatch_id, terminal, track, role, skill_name, gate,
                    outcome_status, dispatched_at, pattern_count,
-                   prevention_rule_count
+                   prevention_rule_count, provider, model
             FROM dispatch_metadata
             WHERE dispatched_at >= ?
               AND outcome_status IS NOT NULL
@@ -143,8 +144,11 @@ def _row_to_intelligence_item(
     outcome = row_d.get("outcome_status", "unknown")
     skill = row_d.get("skill_name") or row_d.get("role") or "unknown"
     gate = row_d.get("gate") or ""
+    provider_str = row_d.get("provider") or ""
+    model_str = row_d.get("model") or ""
+    provider_tag = f" [{provider_str}/{model_str}]" if provider_str else ""
     content = (
-        f"Dispatch {row_d['dispatch_id']} ({skill}, {gate}) "
+        f"Dispatch {row_d['dispatch_id']} ({skill}, {gate}){provider_tag} "
         f"completed with status: {outcome}. "
         f"Patterns used: {row_d.get('pattern_count', 0)}, "
         f"Prevention rules: {row_d.get('prevention_rule_count', 0)}."
@@ -189,7 +193,7 @@ def _query_central(
             rows = conn.execute(
                 """SELECT dispatch_id, terminal, track, role, skill_name, gate,
                        outcome_status, dispatched_at, pattern_count,
-                       prevention_rule_count
+                       prevention_rule_count, provider, model
                 FROM dispatch_metadata
                 WHERE dispatched_at >= ?
                   AND outcome_status IS NOT NULL
@@ -201,7 +205,7 @@ def _query_central(
             rows = conn.execute(
                 """SELECT dispatch_id, terminal, track, role, skill_name, gate,
                        outcome_status, dispatched_at, pattern_count,
-                       prevention_rule_count
+                       prevention_rule_count, provider, model
                 FROM dispatch_metadata
                 WHERE dispatched_at >= ?
                   AND outcome_status IS NOT NULL

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -346,8 +346,9 @@ def _record_provider_metadata(
     status: str,
     report_path: Path,
     state_dir: Path,
+    model_used: Optional[str] = None,
 ) -> None:
-    """Best-effort: upsert a provider-stamped dispatch_metadata row.
+    """Best-effort: upsert a provider+model-stamped dispatch_metadata row.
 
     This is what makes the self-learning/intelligence layer provider-aware: the
     headless multi-provider path previously wrote NO dispatch_metadata row, so
@@ -363,6 +364,7 @@ def _record_provider_metadata(
             dispatch_id=args.dispatch_id,
             terminal=terminal,
             provider=provider,
+            model=model_used or None,
             track=_TERMINAL_TRACK.get(terminal, "headless"),
             role=getattr(args, "role", None),
             gate=getattr(args, "gate", None) or None,
@@ -421,9 +423,9 @@ def _emit_governance(
     )
 
     # Provider-aware self-learning: stamp a dispatch_metadata row so EVERY governed
-    # dispatch (incl. non-Claude) feeds the intelligence layer tagged by provider.
+    # dispatch (incl. non-Claude) feeds the intelligence layer tagged by provider+model.
     # Best-effort — metadata logging is non-fatal to the dispatch.
-    _record_provider_metadata(args, provider, status, report_path, state_dir)
+    _record_provider_metadata(args, provider, status, report_path, state_dir, model_used=model_used)
 
     for attempt in range(_EMIT_MAX_RETRIES):
         try:

--- a/scripts/log_dispatch_metadata.py
+++ b/scripts/log_dispatch_metadata.py
@@ -45,6 +45,8 @@ def main():
     parser.add_argument("--gate", default="")
     parser.add_argument("--provider", default="claude",
                         help="Provider that executed this dispatch (claude/codex/gemini/kimi/litellm:*)")
+    parser.add_argument("--model", default="",
+                        help="AI model used (e.g. claude-sonnet-4-6, codex, kimi)")
     parser.add_argument("--cognition", default="normal")
     parser.add_argument("--priority", default="P1")
     parser.add_argument("--pr-id", default="")
@@ -124,12 +126,13 @@ def main():
             args.target_open_items,
             datetime.utcnow().isoformat(),
         ))
-    # Stamp provider (provider-aware self-learning). Guarded: column lands via
-    # migration v21; older DBs simply skip it. Kept separate from the two INSERT
-    # branches above so the provider stamp applies regardless of project_id state.
+    # Stamp provider + model (provider/model-aware self-learning). Guarded: columns
+    # land via migration v21/v23 (GAP 2); older DBs simply skip them. Kept separate
+    # from the INSERT branches above so stamps apply regardless of project_id state.
     # ADR-007: scope UPDATE by (project_id, dispatch_id) to prevent cross-tenant overwrite.
+    has_project = _has_column(conn, "dispatch_metadata", "project_id")
     if _has_column(conn, "dispatch_metadata", "provider"):
-        if _has_column(conn, "dispatch_metadata", "project_id"):
+        if has_project:
             cur.execute(
                 "UPDATE dispatch_metadata SET provider = ? WHERE project_id = ? AND dispatch_id = ?",
                 (args.provider or "claude", current_project_id(), args.dispatch_id),
@@ -138,6 +141,17 @@ def main():
             cur.execute(
                 "UPDATE dispatch_metadata SET provider = ? WHERE dispatch_id = ?",
                 (args.provider or "claude", args.dispatch_id),
+            )
+    if args.model and _has_column(conn, "dispatch_metadata", "model"):
+        if has_project:
+            cur.execute(
+                "UPDATE dispatch_metadata SET model = COALESCE(model, ?) WHERE project_id = ? AND dispatch_id = ?",
+                (args.model, current_project_id(), args.dispatch_id),
+            )
+        else:
+            cur.execute(
+                "UPDATE dispatch_metadata SET model = COALESCE(model, ?) WHERE dispatch_id = ?",
+                (args.model, args.dispatch_id),
             )
 
     conn.commit()

--- a/scripts/log_dispatch_metadata.py
+++ b/scripts/log_dispatch_metadata.py
@@ -43,8 +43,9 @@ def main():
     parser.add_argument("--role", default="")
     parser.add_argument("--skill-name", default="")
     parser.add_argument("--gate", default="")
-    parser.add_argument("--provider", default="claude",
-                        help="Provider that executed this dispatch (claude/codex/gemini/kimi/litellm:*)")
+    parser.add_argument("--provider", default="",
+                        help="Provider that executed this dispatch (claude/codex/gemini/kimi/litellm:*). "
+                             "Leave empty to preserve any existing provider value.")
     parser.add_argument("--model", default="",
                         help="AI model used (e.g. claude-sonnet-4-6, codex, kimi)")
     parser.add_argument("--cognition", default="normal")
@@ -72,9 +73,29 @@ def main():
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
 
+    # INSERT OR IGNORE: only inserts when the row is new so existing provider/model
+    # values are never deleted by a REPLACE. dispatched_at is set on first insert only.
+    # A follow-up UPDATE keeps all other dispatch fields current on re-calls.
+    project_id_val = current_project_id()
+    now_iso = datetime.utcnow().isoformat()
+    _dispatch_vals = (
+        args.role or None,
+        args.skill_name or None,
+        args.gate or None,
+        args.cognition,
+        args.priority,
+        args.pr_id or None,
+        args.pattern_count,
+        args.prevention_rule_count,
+        args.intelligence_json or None,
+        args.instruction_char_count,
+        args.context_file_count,
+        args.target_open_items,
+    )
+
     if _has_column(conn, "dispatch_metadata", "project_id"):
         cur.execute("""
-            INSERT OR REPLACE INTO dispatch_metadata (
+            INSERT OR IGNORE INTO dispatch_metadata (
                 dispatch_id, terminal, track, role, skill_name, gate,
                 cognition, priority, pr_id,
                 pattern_count, prevention_rule_count, intelligence_json,
@@ -82,71 +103,64 @@ def main():
                 dispatched_at, project_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
-            args.dispatch_id,
-            args.terminal,
-            args.track,
-            args.role or None,
-            args.skill_name or None,
-            args.gate or None,
-            args.cognition,
-            args.priority,
-            args.pr_id or None,
-            args.pattern_count,
-            args.prevention_rule_count,
-            args.intelligence_json or None,
-            args.instruction_char_count,
-            args.context_file_count,
-            args.target_open_items,
-            datetime.utcnow().isoformat(),
-            current_project_id(),
+            args.dispatch_id, args.terminal, args.track,
+            *_dispatch_vals, now_iso, project_id_val,
+        ))
+        cur.execute("""
+            UPDATE dispatch_metadata SET
+                terminal=?, track=?, role=?, skill_name=?, gate=?,
+                cognition=?, priority=?, pr_id=?,
+                pattern_count=?, prevention_rule_count=?, intelligence_json=?,
+                instruction_char_count=?, context_file_count=?, target_open_items=?
+            WHERE project_id=? AND dispatch_id=?
+        """, (
+            args.terminal, args.track, *_dispatch_vals,
+            project_id_val, args.dispatch_id,
         ))
     else:
         cur.execute("""
-            INSERT OR REPLACE INTO dispatch_metadata (
+            INSERT OR IGNORE INTO dispatch_metadata (
                 dispatch_id, terminal, track, role, skill_name, gate,
                 cognition, priority, pr_id,
                 pattern_count, prevention_rule_count, intelligence_json,
                 instruction_char_count, context_file_count, target_open_items, dispatched_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
+            args.dispatch_id, args.terminal, args.track,
+            *_dispatch_vals, now_iso,
+        ))
+        cur.execute("""
+            UPDATE dispatch_metadata SET
+                terminal=?, track=?, role=?, skill_name=?, gate=?,
+                cognition=?, priority=?, pr_id=?,
+                pattern_count=?, prevention_rule_count=?, intelligence_json=?,
+                instruction_char_count=?, context_file_count=?, target_open_items=?
+            WHERE dispatch_id=?
+        """, (
+            args.terminal, args.track, *_dispatch_vals,
             args.dispatch_id,
-            args.terminal,
-            args.track,
-            args.role or None,
-            args.skill_name or None,
-            args.gate or None,
-            args.cognition,
-            args.priority,
-            args.pr_id or None,
-            args.pattern_count,
-            args.prevention_rule_count,
-            args.intelligence_json or None,
-            args.instruction_char_count,
-            args.context_file_count,
-            args.target_open_items,
-            datetime.utcnow().isoformat(),
         ))
     # Stamp provider + model (provider/model-aware self-learning). Guarded: columns
-    # land via migration v21/v23 (GAP 2); older DBs simply skip them. Kept separate
-    # from the INSERT branches above so stamps apply regardless of project_id state.
-    # ADR-007: scope UPDATE by (project_id, dispatch_id) to prevent cross-tenant overwrite.
+    # land via migration v21/v23 (GAP 2); older DBs simply skip them. COALESCE keeps
+    # any real value already stamped by provider_dispatch; only fills NULL.
+    # ADR-007: scope by project_id when present to prevent cross-tenant overwrite.
     has_project = _has_column(conn, "dispatch_metadata", "project_id")
-    if _has_column(conn, "dispatch_metadata", "provider"):
+    if args.provider and _has_column(conn, "dispatch_metadata", "provider"):
         if has_project:
             cur.execute(
-                "UPDATE dispatch_metadata SET provider = ? WHERE project_id = ? AND dispatch_id = ?",
-                (args.provider or "claude", current_project_id(), args.dispatch_id),
+                "UPDATE dispatch_metadata SET provider = COALESCE(provider, ?) WHERE project_id = ? AND dispatch_id = ?",
+                (args.provider, project_id_val, args.dispatch_id),
             )
         else:
             cur.execute(
-                "UPDATE dispatch_metadata SET provider = ? WHERE dispatch_id = ?",
-                (args.provider or "claude", args.dispatch_id),
+                "UPDATE dispatch_metadata SET provider = COALESCE(provider, ?) WHERE dispatch_id = ?",
+                (args.provider, args.dispatch_id),
             )
     if args.model and _has_column(conn, "dispatch_metadata", "model"):
         if has_project:
             cur.execute(
                 "UPDATE dispatch_metadata SET model = COALESCE(model, ?) WHERE project_id = ? AND dispatch_id = ?",
-                (args.model, current_project_id(), args.dispatch_id),
+                (args.model, project_id_val, args.dispatch_id),
             )
         else:
             cur.execute(

--- a/scripts/migrate_dispatch_metadata_provider.py
+++ b/scripts/migrate_dispatch_metadata_provider.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Idempotent migration: add provider + model columns to dispatch_metadata.
+
+GAP 2 fix (POST-TMUX-LANE-GAPS-2026-06-01.md): quality_intelligence.db
+dispatch_metadata table lacked provider/model columns, so provider-aware
+DB queries failed locally even though receipts carry provider.
+
+Safe on the existing ~625MB DB:
+  - Uses ALTER TABLE ADD COLUMN only (no table rebuild, no data loss)
+  - Pragma-checks column presence before each ADD (idempotent)
+  - Adds composite (project_id, provider) index for tenant-scoped analytics
+  - Adds UNIQUE index on (project_id, dispatch_id) for ADR-007 compliance
+    without a table rebuild (all 908 existing rows are already unique)
+
+ADR-007: dispatch_metadata is a central-DB table scoped by project_id.
+Composite uniqueness is enforced via the new UNIQUE INDEX rather than a
+table-level UNIQUE constraint (which would require a rebuild).
+
+Reconciliation: #761 added dispatch_metadata_db.py which writes to the
+SAME quality_intelligence.db table — it is a helper module, not a separate
+table. The canonical table is dispatch_metadata in quality_intelligence.db.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def _has_index(conn: sqlite3.Connection, index_name: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+        (index_name,),
+    ).fetchone()
+    return row is not None
+
+
+def run_migration(db_path: Path) -> dict:
+    """Apply the migration. Returns a dict with per-step results."""
+    if not db_path.exists():
+        return {"error": f"DB not found: {db_path}"}
+
+    results: dict = {
+        "provider_added": False,
+        "model_added": False,
+        "unique_index_added": False,
+        "provider_index_updated": False,
+    }
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # --- provider column ---
+        if not _has_column(conn, "dispatch_metadata", "provider"):
+            conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN provider TEXT")
+            results["provider_added"] = True
+
+        # --- model column ---
+        if not _has_column(conn, "dispatch_metadata", "model"):
+            conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN model TEXT")
+            results["model_added"] = True
+
+        # --- ADR-007: UNIQUE INDEX on (project_id, dispatch_id) ---
+        # Enforces tenant isolation without a table rebuild.
+        # All existing rows verified unique before this migration is applied.
+        if not _has_index(conn, "idx_dispatch_meta_composite_unique"):
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_dispatch_meta_composite_unique "
+                "ON dispatch_metadata (project_id, dispatch_id)"
+            )
+            results["unique_index_added"] = True
+
+        # --- composite (project_id, provider) index for per-provider analytics ---
+        conn.execute("DROP INDEX IF EXISTS idx_dispatch_meta_provider")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dispatch_meta_provider "
+            "ON dispatch_metadata (project_id, provider)"
+        )
+        results["provider_index_updated"] = True
+
+        conn.commit()
+    finally:
+        conn.close()
+
+    return results
+
+
+def main() -> int:
+    try:
+        from vnx_paths import ensure_env
+        PATHS = ensure_env()
+        db_path = Path(PATHS["VNX_STATE_DIR"]) / "quality_intelligence.db"
+    except Exception as exc:
+        print(f"ERROR: could not resolve DB path: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Migrating: {db_path}")
+    results = run_migration(db_path)
+
+    if "error" in results:
+        print(f"ERROR: {results['error']}", file=sys.stderr)
+        return 1
+
+    for step, applied in results.items():
+        status = "APPLIED" if applied else "already present"
+        print(f"  {step}: {status}")
+
+    print("Migration complete — provider/model columns on dispatch_metadata (GAP 2)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -23,7 +23,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 22
+HIGHEST_QI_VERSION = 23
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -854,6 +854,25 @@ def _migrate_v22(conn: sqlite3.Connection) -> None:
     log('INFO', 'Migrated dispatch_metadata: composite (project_id, provider) index ensured (ADR-007)')
 
 
+def _migrate_v23(conn: sqlite3.Connection) -> None:
+    """V23: model column on dispatch_metadata (GAP 2 — provider/model-aware intelligence).
+
+    Adds the ``model`` column so the AI model string (e.g. "claude-sonnet-4-6",
+    "codex", "kimi") is recorded alongside the provider. Populating model on
+    write paths closes GAP 2 (POST-TMUX-LANE-GAPS-2026-06-01.md).
+
+    ADR-007 compliance note: the composite UNIQUE (project_id, dispatch_id) is
+    enforced on existing DBs via idx_dispatch_meta_composite_unique (a UNIQUE
+    INDEX added by migrate_dispatch_metadata_provider.py without a table rebuild).
+    Fresh DBs receive it from the base schema (v22 table rebuild runs on user_version
+    < 22 DBs). This migration only adds the model column (ALTER TABLE — no rebuild).
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+    if "model" not in cols:
+        conn.execute("ALTER TABLE dispatch_metadata ADD COLUMN model TEXT")
+        log('INFO', 'Migrated dispatch_metadata: added model column (GAP 2, v23)')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -878,6 +897,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     20: _migrate_v20,
     21: _migrate_v21,
     22: _migrate_v22,
+    23: _migrate_v23,
 }
 
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -797,6 +797,7 @@ def _migrate_v22(conn: sqlite3.Connection) -> None:
                 terminal TEXT NOT NULL,
                 track TEXT NOT NULL,
                 provider TEXT,
+                model TEXT,
                 role TEXT,
                 skill_name TEXT,
                 gate TEXT,

--- a/tests/test_dispatch_metadata_provider_migration.py
+++ b/tests/test_dispatch_metadata_provider_migration.py
@@ -8,8 +8,11 @@ Covers:
 - upsert_dispatch_provider_row stamps both provider AND model
 - log_dispatch_metadata --model argument accepted and stamped (compile + arg parse)
 - quality_db_init _migrate_v23 adds model column on a DB at user_version 22
+- log_dispatch_metadata does NOT clobber an existing (codex, gpt-probe) row (#778 FIX 1)
+- v21->v22->v23 migration path preserves model values (#778 FIX 2)
+- recent_comparable and build_t0_state SELECTs surface provider/model (#778 FIX 3)
 
-Dispatch-ID: 20260601-1620-gap2-provider-col
+Dispatch-ID: 20260601-1645-fixgap2
 ADR-007: composite uniqueness on dispatch_metadata enforced via UNIQUE INDEX
          (no table rebuild — 908 existing rows verified unique pre-migration).
 """
@@ -374,5 +377,257 @@ def test_migrate_v23_idempotent():
         cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
         assert "model" in cols
         conn.close()
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — log_dispatch_metadata must NOT clobber an existing provider/model
+# ---------------------------------------------------------------------------
+
+def test_log_dispatch_metadata_no_clobber_existing_provider_model():
+    """Calling log_dispatch_metadata with default/empty provider must not overwrite
+    an existing ('codex', 'gpt-probe') row. (#778 FIX 1)"""
+    import os
+    import subprocess
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "state" / "quality_intelligence.db"
+        db_path.parent.mkdir(parents=True)
+
+        # Seed DB with a dispatch that has real provider/model already stamped.
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                model TEXT,
+                role TEXT,
+                skill_name TEXT,
+                gate TEXT,
+                pr_id TEXT,
+                dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                target_open_items TEXT,
+                pattern_count INTEGER DEFAULT 0,
+                prevention_rule_count INTEGER DEFAULT 0,
+                intelligence_json TEXT,
+                instruction_char_count INTEGER DEFAULT 0,
+                context_file_count INTEGER DEFAULT 0,
+                cognition TEXT DEFAULT 'normal',
+                priority TEXT DEFAULT 'P1',
+                UNIQUE (project_id, dispatch_id)
+            );
+        """)
+        conn.execute(
+            "INSERT INTO dispatch_metadata "
+            "(dispatch_id, terminal, track, project_id, provider, model) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("clobber-test-001", "T1", "A", "vnx-dev", "codex", "gpt-probe"),
+        )
+        conn.commit()
+        conn.close()
+
+        scripts_dir = ROOT / "scripts"
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(db_path.parent)
+        env["VNX_DATA_DIR"] = tmpdir
+
+        # Invoke log_dispatch_metadata WITHOUT --provider / --model (defaults to empty).
+        result = subprocess.run(
+            [
+                "python3", str(scripts_dir / "log_dispatch_metadata.py"),
+                "--dispatch-id", "clobber-test-001",
+                "--terminal", "T1",
+                "--track", "A",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"script failed: {result.stderr}"
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT provider, model FROM dispatch_metadata WHERE dispatch_id=?",
+            ("clobber-test-001",),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "codex", (
+            f"provider must not be overwritten with default — expected 'codex', got {row[0]!r}"
+        )
+        assert row[1] == "gpt-probe", (
+            f"model must not be overwritten with NULL — expected 'gpt-probe', got {row[1]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — v21->v22->v23 migration path preserves model values
+# ---------------------------------------------------------------------------
+
+def test_v21_v22_v23_preserves_model_values():
+    """Running v21→v22→v23 on a DB that already has provider+model values must
+    not drop model during the v22 table rebuild. (#778 FIX 2)"""
+    import quality_db_init as QDB
+    import scripts.lib.schema_migration as SM
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        # Simulate a DB at user_version 20 with provider+model already present
+        # (e.g. added by an earlier partial migration run).
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                model TEXT
+            );
+            PRAGMA user_version = 20;
+        """)
+        conn.execute(
+            "INSERT INTO dispatch_metadata "
+            "(dispatch_id, terminal, track, project_id, provider, model) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("preserve-test-001", "T1", "A", "vnx-dev", "codex", "gpt-probe"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Apply v21, v22, v23 in sequence (simulating fresh migration run).
+        conn = sqlite3.connect(str(db_path))
+        SM.apply_if_below(conn, 21, QDB._migrate_v21)
+        conn.commit()
+        SM.apply_if_below(conn, 22, QDB._migrate_v22)
+        conn.commit()
+        SM.apply_if_below(conn, 23, QDB._migrate_v23)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT provider, model FROM dispatch_metadata WHERE dispatch_id=?",
+            ("preserve-test-001",),
+        ).fetchone()
+        conn.close()
+        assert row is not None, "row must survive the v22 rebuild"
+        assert row[0] == "codex", f"provider lost through v22 rebuild — got {row[0]!r}"
+        assert row[1] == "gpt-probe", f"model lost through v22 rebuild — got {row[1]!r}"
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 — recent_comparable and build_t0_state surface provider/model
+# ---------------------------------------------------------------------------
+
+def test_recent_comparable_select_includes_provider_model():
+    """_query_per_project SELECT must include provider and model columns so
+    _row_to_intelligence_item can surface them in content. (#778 FIX 3)"""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                model TEXT,
+                role TEXT,
+                skill_name TEXT,
+                gate TEXT,
+                pattern_count INTEGER DEFAULT 0,
+                prevention_rule_count INTEGER DEFAULT 0,
+                dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                outcome_status TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO dispatch_metadata "
+            "(dispatch_id, terminal, track, project_id, provider, model, outcome_status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("rc-test-001", "T1", "A", "vnx-dev", "codex", "gpt-probe", "success"),
+        )
+        conn.commit()
+
+        lib_path = str(ROOT / "scripts" / "lib")
+        if lib_path not in sys.path:
+            sys.path.insert(0, lib_path)
+        from intelligence_sources.recent_comparable import _query_per_project
+
+        def _has_col(table, col):
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+            return any(r[1] == col for r in rows)
+
+        items = _query_per_project(conn, "test", [], has_column_fn=_has_col)
+        assert items, "expected at least one IntelligenceItem"
+        content = items[0].content
+        assert "codex" in content, f"provider 'codex' not surfaced in content: {content!r}"
+        assert "gpt-probe" in content, f"model 'gpt-probe' not surfaced in content: {content!r}"
+        conn.close()
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_build_t0_state_recent_dispatches_sql_includes_provider_model():
+    """_RECENT_DISPATCHES_SQL must project provider and model. (#778 FIX 3)"""
+    import build_t0_state as BTS
+
+    for attr in ("_RECENT_DISPATCHES_SQL", "_RECENT_DISPATCHES_CENTRAL_SQL"):
+        sql = getattr(BTS, attr)
+        assert "provider" in sql, f"{attr} must SELECT provider"
+        assert "model" in sql, f"{attr} must SELECT model"
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                role TEXT,
+                gate TEXT,
+                priority TEXT DEFAULT 'P1',
+                pr_id TEXT,
+                provider TEXT,
+                model TEXT,
+                dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                completed_at DATETIME,
+                outcome_status TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO dispatch_metadata "
+            "(dispatch_id, terminal, track, project_id, provider, model) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("t0-test-001", "T1", "A", "vnx-dev", "codex", "gpt-probe"),
+        )
+        conn.commit()
+        conn.close()
+
+        rows = BTS._query_qi_db(db_path, BTS._RECENT_DISPATCHES_SQL)
+        assert rows, "expected at least one row"
+        assert rows[0].get("provider") == "codex", (
+            f"provider not projected — got {rows[0].get('provider')!r}"
+        )
+        assert rows[0].get("model") == "gpt-probe", (
+            f"model not projected — got {rows[0].get('model')!r}"
+        )
     finally:
         db_path.unlink(missing_ok=True)

--- a/tests/test_dispatch_metadata_provider_migration.py
+++ b/tests/test_dispatch_metadata_provider_migration.py
@@ -787,3 +787,87 @@ def test_build_t0_state_collect_recent_dispatches_migrated_surfaces_provider(tmp
     assert rows, "must return rows from migrated DB"
     assert rows[0]["provider"] == "codex", f"expected 'codex', got {rows[0].get('provider')!r}"
     assert rows[0]["model"] == "gpt-probe", f"expected 'gpt-probe', got {rows[0].get('model')!r}"
+
+
+# ---------------------------------------------------------------------------
+# FIX 3c — provider-only DB (intermediate migration state: provider present, model absent)
+# ---------------------------------------------------------------------------
+
+def test_recent_comparable_provider_only_db_no_crash():
+    """_query_per_project on a DB with provider but NOT model must not crash.
+    Must surface provider; model key absent (None via .get). (#778 guard gap)"""
+    from intelligence_sources.recent_comparable import _query_per_project
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE,
+            terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT,
+            outcome_status TEXT, dispatched_at DATETIME,
+            pattern_count INTEGER DEFAULT 0,
+            prevention_rule_count INTEGER DEFAULT 0,
+            provider TEXT
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, skill_name, gate, outcome_status, dispatched_at, provider) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("provider-only-001", "architect", "", "success", ts, "kimi"),
+    )
+    conn.commit()
+
+    def _has_col(table, col):
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        return any(r[1] == col for r in rows)
+
+    items = _query_per_project(conn, "coding_interactive", [], has_column_fn=_has_col)
+    conn.close()
+
+    assert items, "must return items from provider-only DB without crash"
+    assert "provider-only-001" in items[0].source_refs
+    assert "kimi" in items[0].content, f"provider 'kimi' must appear in content: {items[0].content!r}"
+
+
+def test_build_t0_state_provider_only_db_no_crash(tmp_path):
+    """_collect_recent_dispatches_per_project on a DB with provider but NOT model must
+    not crash; must surface provider; model absent from result dict. (#778 guard gap)"""
+    import build_t0_state as BTS
+
+    db_path = tmp_path / "state" / "quality_intelligence.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            terminal TEXT, track TEXT, role TEXT, gate TEXT,
+            priority TEXT DEFAULT 'P1', pr_id TEXT,
+            provider TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            completed_at DATETIME, outcome_status TEXT
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, terminal, track, dispatched_at, provider) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("provider-only-bts-001", "T1", "A", ts, "kimi"),
+    )
+    conn.commit()
+    conn.close()
+
+    rows = BTS._collect_recent_dispatches_per_project("vnx-dev", db_path.parent)
+
+    assert rows, "must return rows from provider-only DB without crash"
+    assert rows[0]["dispatch_id"] == "provider-only-bts-001"
+    assert rows[0].get("provider") == "kimi", f"expected 'kimi', got {rows[0].get('provider')!r}"
+    assert rows[0].get("model") is None, f"model must be absent (None), got {rows[0].get('model')!r}"

--- a/tests/test_dispatch_metadata_provider_migration.py
+++ b/tests/test_dispatch_metadata_provider_migration.py
@@ -631,3 +631,159 @@ def test_build_t0_state_recent_dispatches_sql_includes_provider_model():
         )
     finally:
         db_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# FIX 3b — defensive read on unmigrated DBs (no provider/model columns)
+# ---------------------------------------------------------------------------
+
+def test_recent_comparable_unmigrated_db_returns_rows_no_crash():
+    """_query_per_project on a DB WITHOUT provider/model must not crash and
+    must return rows with provider/model absent (None) from the IntelligenceItem content."""
+    from intelligence_sources.recent_comparable import _query_per_project
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE,
+            terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT,
+            outcome_status TEXT, dispatched_at DATETIME,
+            pattern_count INTEGER DEFAULT 0,
+            prevention_rule_count INTEGER DEFAULT 0
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, skill_name, gate, outcome_status, dispatched_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("legacy-d-001", "architect", "", "success", ts),
+    )
+    conn.commit()
+
+    items = _query_per_project(conn, "coding_interactive", [], has_column_fn=lambda t, c: False)
+    conn.close()
+
+    assert items, "must return items from unmigrated DB without crash"
+    assert "legacy-d-001" in items[0].source_refs
+    assert "codex" not in items[0].content
+    assert "None" not in items[0].content or True
+
+
+def test_recent_comparable_migrated_db_surfaces_provider_model():
+    """_query_per_project on a DB WITH provider/model must surface them in content."""
+    from intelligence_sources.recent_comparable import _query_per_project
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT UNIQUE,
+            terminal TEXT, track TEXT,
+            role TEXT, skill_name TEXT, gate TEXT,
+            outcome_status TEXT, dispatched_at DATETIME,
+            pattern_count INTEGER DEFAULT 0,
+            prevention_rule_count INTEGER DEFAULT 0,
+            provider TEXT, model TEXT
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, skill_name, gate, outcome_status, dispatched_at, provider, model) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("migrated-d-001", "architect", "", "success", ts, "codex", "gpt-probe"),
+    )
+    conn.commit()
+
+    def _has_col(table, col):
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        return any(r[1] == col for r in rows)
+
+    items = _query_per_project(conn, "coding_interactive", [], has_column_fn=_has_col)
+    conn.close()
+
+    assert items, "must return items from migrated DB"
+    content = items[0].content
+    assert "codex" in content, f"provider not surfaced: {content!r}"
+    assert "gpt-probe" in content, f"model not surfaced: {content!r}"
+
+
+def test_build_t0_state_collect_recent_dispatches_unmigrated_no_crash(tmp_path):
+    """_collect_recent_dispatches_per_project on an unmigrated DB (no provider/model)
+    must return rows without crash; provider/model absent from result dicts."""
+    import build_t0_state as BTS
+
+    db_path = tmp_path / "state" / "quality_intelligence.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            terminal TEXT, track TEXT, role TEXT, gate TEXT,
+            priority TEXT DEFAULT 'P1', pr_id TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            completed_at DATETIME, outcome_status TEXT
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, dispatched_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("legacy-bts-001", "T1", "A", ts),
+    )
+    conn.commit()
+    conn.close()
+
+    rows = BTS._collect_recent_dispatches_per_project("vnx-dev", db_path.parent)
+
+    assert rows, "must return rows from unmigrated DB without crash"
+    assert rows[0]["dispatch_id"] == "legacy-bts-001"
+    assert rows[0].get("provider") is None
+    assert rows[0].get("model") is None
+
+
+def test_build_t0_state_collect_recent_dispatches_migrated_surfaces_provider(tmp_path):
+    """_collect_recent_dispatches_per_project on a migrated DB surfaces provider/model."""
+    import build_t0_state as BTS
+
+    db_path = tmp_path / "state" / "quality_intelligence.db"
+    db_path.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            terminal TEXT, track TEXT, role TEXT, gate TEXT,
+            priority TEXT DEFAULT 'P1', pr_id TEXT,
+            provider TEXT, model TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            completed_at DATETIME, outcome_status TEXT
+        );
+    """)
+    from datetime import datetime, timedelta, timezone
+    ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, terminal, track, dispatched_at, provider, model) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("migrated-bts-001", "T1", "A", ts, "codex", "gpt-probe"),
+    )
+    conn.commit()
+    conn.close()
+
+    rows = BTS._collect_recent_dispatches_per_project("vnx-dev", db_path.parent)
+
+    assert rows, "must return rows from migrated DB"
+    assert rows[0]["provider"] == "codex", f"expected 'codex', got {rows[0].get('provider')!r}"
+    assert rows[0]["model"] == "gpt-probe", f"expected 'gpt-probe', got {rows[0].get('model')!r}"

--- a/tests/test_dispatch_metadata_provider_migration.py
+++ b/tests/test_dispatch_metadata_provider_migration.py
@@ -1,0 +1,378 @@
+"""Tests for GAP 2: dispatch_metadata provider/model migration.
+
+Covers:
+- migrate_dispatch_metadata_provider.run_migration is idempotent (runs twice without error)
+- provider + model columns are present after migration on a fresh temp DB
+- UNIQUE INDEX on (project_id, dispatch_id) is created
+- (project_id, provider) index is created
+- upsert_dispatch_provider_row stamps both provider AND model
+- log_dispatch_metadata --model argument accepted and stamped (compile + arg parse)
+- quality_db_init _migrate_v23 adds model column on a DB at user_version 22
+
+Dispatch-ID: 20260601-1620-gap2-provider-col
+ADR-007: composite uniqueness on dispatch_metadata enforced via UNIQUE INDEX
+         (no table rebuild — 908 existing rows verified unique pre-migration).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import migrate_dispatch_metadata_provider as MIG  # noqa: E402
+from dispatch_metadata_db import upsert_dispatch_provider_row  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_legacy_db(path: Path) -> None:
+    """Create dispatch_metadata without provider or model (user_version 19 state)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            terminal TEXT NOT NULL,
+            track TEXT NOT NULL,
+            role TEXT,
+            skill_name TEXT,
+            gate TEXT,
+            cognition TEXT DEFAULT 'normal',
+            priority TEXT DEFAULT 'P1',
+            pr_id TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            outcome_status TEXT,
+            outcome_report_path TEXT,
+            session_id TEXT
+        );
+        PRAGMA user_version = 19;
+    """)
+    conn.execute(
+        "INSERT INTO dispatch_metadata (dispatch_id, terminal, track) VALUES (?, ?, ?)",
+        ("existing-dispatch-001", "T1", "A"),
+    )
+    conn.execute(
+        "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, project_id) VALUES (?, ?, ?, ?)",
+        ("existing-dispatch-002", "T2", "B", "vnx-dev"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _cols(path: Path, table: str) -> set:
+    conn = sqlite3.connect(str(path))
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    conn.close()
+    return {r[1] for r in rows}
+
+
+def _indexes(path: Path) -> set:
+    conn = sqlite3.connect(str(path))
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index'"
+    ).fetchall()
+    conn.close()
+    return {r[0] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_provider_and_model_columns():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_legacy_db(db_path)
+        result = MIG.run_migration(db_path)
+        assert "error" not in result
+        cols = _cols(db_path, "dispatch_metadata")
+        assert "provider" in cols, "provider column must be present after migration"
+        assert "model" in cols, "model column must be present after migration"
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migration_idempotent_second_run():
+    """Running migration twice must not error and must not duplicate columns."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_legacy_db(db_path)
+        MIG.run_migration(db_path)
+        result2 = MIG.run_migration(db_path)
+        assert "error" not in result2
+        # Columns still present, not duplicated
+        cols = _cols(db_path, "dispatch_metadata")
+        assert "provider" in cols
+        assert "model" in cols
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migration_preserves_existing_rows():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_legacy_db(db_path)
+        MIG.run_migration(db_path)
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM dispatch_metadata").fetchone()[0]
+        conn.close()
+        assert count == 2, "existing rows must survive migration (no data loss)"
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migration_creates_unique_index():
+    """ADR-007: UNIQUE INDEX on (project_id, dispatch_id) enforced without rebuild."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_legacy_db(db_path)
+        MIG.run_migration(db_path)
+        indexes = _indexes(db_path)
+        assert "idx_dispatch_meta_composite_unique" in indexes, (
+            "ADR-007: composite UNIQUE INDEX on (project_id, dispatch_id) must exist"
+        )
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migration_creates_provider_index():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_legacy_db(db_path)
+        MIG.run_migration(db_path)
+        indexes = _indexes(db_path)
+        assert "idx_dispatch_meta_provider" in indexes
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migration_db_not_found_returns_error():
+    result = MIG.run_migration(Path("/nonexistent/path/quality_intelligence.db"))
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# upsert_dispatch_provider_row — provider + model stamping
+# ---------------------------------------------------------------------------
+
+def _make_full_db(path: Path) -> None:
+    """Create dispatch_metadata with provider + model (post-migration state)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            terminal TEXT NOT NULL,
+            track TEXT NOT NULL,
+            provider TEXT,
+            model TEXT,
+            role TEXT,
+            gate TEXT,
+            pr_id TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            completed_at DATETIME,
+            outcome_status TEXT,
+            outcome_report_path TEXT,
+            UNIQUE (project_id, dispatch_id)
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def test_upsert_stamps_provider_and_model():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_full_db(db_path)
+        ok = upsert_dispatch_provider_row(
+            db_path,
+            dispatch_id="test-dispatch-001",
+            terminal="T1",
+            provider="codex",
+            model="codex-mini-latest",
+            project_id="vnx-dev",
+        )
+        assert ok
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT provider, model FROM dispatch_metadata WHERE dispatch_id=?",
+            ("test-dispatch-001",),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "codex", f"expected provider='codex', got {row[0]!r}"
+        assert row[1] == "codex-mini-latest", f"expected model='codex-mini-latest', got {row[1]!r}"
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_upsert_provider_only_when_no_model_column():
+    """Upsert must succeed on a DB that has provider but not model (pre-v23)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        path = db_path
+        conn = sqlite3.connect(str(path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                role TEXT,
+                gate TEXT,
+                pr_id TEXT,
+                dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (project_id, dispatch_id)
+            );
+        """)
+        conn.commit()
+        conn.close()
+        ok = upsert_dispatch_provider_row(
+            path,
+            dispatch_id="test-no-model-col",
+            terminal="T2",
+            provider="kimi",
+            model="kimi-k2",
+            project_id="vnx-dev",
+        )
+        assert ok
+        conn = sqlite3.connect(str(path))
+        row = conn.execute(
+            "SELECT provider FROM dispatch_metadata WHERE dispatch_id=?",
+            ("test-no-model-col",),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "kimi"
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_upsert_idempotent_second_call_does_not_clobber_model():
+    """Second upsert (same dispatch_id) must not overwrite model once set (COALESCE)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        _make_full_db(db_path)
+        upsert_dispatch_provider_row(
+            db_path,
+            dispatch_id="idem-dispatch",
+            terminal="T1",
+            provider="claude",
+            model="claude-sonnet-4-6",
+            project_id="vnx-dev",
+        )
+        upsert_dispatch_provider_row(
+            db_path,
+            dispatch_id="idem-dispatch",
+            terminal="T1",
+            provider="claude",
+            model="claude-opus-4-8",  # different model — must not overwrite
+            project_id="vnx-dev",
+        )
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT model FROM dispatch_metadata WHERE dispatch_id=?",
+            ("idem-dispatch",),
+        ).fetchone()
+        conn.close()
+        assert row[0] == "claude-sonnet-4-6", (
+            "model must not be overwritten by a second upsert (COALESCE semantics)"
+        )
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# quality_db_init _migrate_v23
+# ---------------------------------------------------------------------------
+
+def test_migrate_v23_adds_model_column():
+    """_migrate_v23 adds model column on a DB at user_version 22 (no provider/model)."""
+    import quality_db_init as QDB  # noqa: E402 — import here to avoid side-effects at module load
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        # Simulate a DB at version 22 that has provider but not model
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                UNIQUE (project_id, dispatch_id)
+            );
+            PRAGMA user_version = 22;
+        """)
+        conn.commit()
+
+        import scripts.lib.schema_migration as SM  # noqa: E402
+        SM.apply_if_below(conn, 23, QDB._migrate_v23)
+        conn.commit()
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+        assert "model" in cols, "_migrate_v23 must add model column"
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 23
+        conn.close()
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_migrate_v23_idempotent():
+    """Running _migrate_v23 twice must not error."""
+    import quality_db_init as QDB  # noqa: E402
+    import scripts.lib.schema_migration as SM  # noqa: E402
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                UNIQUE (project_id, dispatch_id)
+            );
+            PRAGMA user_version = 22;
+        """)
+        conn.commit()
+        SM.apply_if_below(conn, 23, QDB._migrate_v23)
+        conn.commit()
+        # Run again directly (already at v23, apply_if_below skips)
+        QDB._migrate_v23(conn)
+        conn.commit()
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_metadata)").fetchall()}
+        assert "model" in cols
+        conn.close()
+    finally:
+        db_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- dispatch_metadata lacked `provider`/`model` on the local `quality_intelligence.db`, so provider-aware DB queries failed locally even though receipts are provider-aware (#761).
- Two-table investigation: `dispatch_metadata_db.py` (from #761) writes to the **same** table in the **same** DB — it is a helper module, not a separate table. One canonical table.
- Adds `provider` and `model` via an **idempotent migration** (pragma-checked ALTER TABLE ADD COLUMN, no table rebuild on the 625MB DB).
- Populates both columns on write (all dispatch paths: tmux interactive + headless multi-provider).
- ADR-007 composite-key compliance: UNIQUE INDEX on `(project_id, dispatch_id)` created without a table rebuild (all 908 existing rows verified unique pre-migration). Cited in commit body.

## Changes

| File | Change |
|---|---|
| `scripts/migrate_dispatch_metadata_provider.py` | NEW — standalone idempotent migration for existing DB |
| `schemas/quality_intelligence.sql` | Add `model TEXT` to base table definition + schema_version entry |
| `scripts/quality_db_init.py` | `_migrate_v23` (model column) + HIGHEST_QI_VERSION 22→23 |
| `scripts/lib/dispatch_metadata_db.py` | `model` param on `upsert_dispatch_provider_row` |
| `scripts/lib/provider_dispatch.py` | Thread `model_used` into `_record_provider_metadata` |
| `scripts/log_dispatch_metadata.py` | `--model` arg + column-guarded stamp |
| `tests/test_dispatch_metadata_provider_migration.py` | NEW — 11 tests, all green |

## Test plan

- [x] `pytest tests/test_dispatch_metadata_provider_migration.py` — 11/11 passed
- [x] `pytest tests/test_central_quality_db_bootstrap.py tests/test_intelligence_aggregator.py` — 26/26 passed
- [x] `python3 -m py_compile` on all modified files — clean
- [x] Idempotency: migration run twice on temp DB — no error, no duplicate columns
- [x] Existing rows preserved through migration (data loss = 0)
- [x] UNIQUE INDEX on (project_id, dispatch_id) verified with 908-row duplicate check before creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)