### PR TITLE
feat(receipts): per-append hash-chain wiring, flag-gated VNX_CHAIN_RECEIPTS (GAP 3b)

### DIFF
--- a/scripts/lib/append_receipt_internals/idempotency.py
+++ b/scripts/lib/append_receipt_internals/idempotency.py
@@ -34,6 +34,40 @@ IDEMPOTENCY_FIELDS = (
 )
 
 
+# Hash-chain primitives live in scripts/lib/ndjson_hash_chain.py. Imported
+# lazily inside the lock path so the flag-OFF append path takes on no
+# import-time dependency.
+_LIB_DIR = Path(__file__).resolve().parent.parent
+
+
+def _chain_receipts_enabled() -> bool:
+    """True when VNX_CHAIN_RECEIPTS opts the append path into hash-chaining.
+
+    Default OFF. Recognised truthy values: 1, true, yes, on (case-insensitive).
+    When OFF the append path is byte-for-byte unchanged.
+    """
+    value = os.environ.get("VNX_CHAIN_RECEIPTS", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _last_hash_under_lock(receipt_path: Path) -> str:
+    """Inline tail-hash read for the chained append.
+
+    Returns the canonical hash of the file's last entry, or GENESIS_HASH for an
+    empty/missing ledger. MUST be called while holding the append lock — it is
+    the read half of the read-tail + stamp + write + cache-update critical
+    section. Deliberately inlined (not ``append_chained_entry``) so no second
+    file handle is opened outside the VNX lock (fork risk).
+    """
+    import sys as _sys
+
+    if str(_LIB_DIR) not in _sys.path:
+        _sys.path.insert(0, str(_LIB_DIR))
+    from ndjson_hash_chain import GENESIS_HASH, _read_last_hash
+
+    return _read_last_hash(receipt_path) or GENESIS_HASH
+
+
 def _resolve_receipts_file(receipts_file: Optional[str] = None) -> Path:
     if receipts_file:
         return Path(receipts_file).expanduser()
@@ -147,6 +181,16 @@ def _write_receipt_under_lock(
                     receipts_file=receipt_path,
                     idempotency_key=idempotency_key,
                 )
+
+            # Hash-chain stamping (flag-gated). The read-tail + stamp happens
+            # here, INSIDE the LOCK_EX block and BEFORE the receipt write, so
+            # the read-tail + stamp + write + cache-update sequence is fully
+            # serialized under the one append lock. Without this serialization
+            # concurrent appends would read the same tail hash and fork the
+            # chain. When the flag is OFF this block is skipped entirely and the
+            # receipt is written byte-for-byte as before.
+            if _chain_receipts_enabled():
+                receipt["prev_hash"] = _last_hash_under_lock(receipt_path)
 
             try:
                 with receipt_path.open("a", encoding="utf-8") as receipts_handle:

--- a/tests/test_receipt_hashchain.py
+++ b/tests/test_receipt_hashchain.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""GAP 3b: per-append hash-chain wiring tests (flag-gated VNX_CHAIN_RECEIPTS).
+
+Covers:
+  - flag OFF: append behavior unchanged (no prev_hash field) — byte-for-byte.
+  - flag ON: appends carry prev_hash; verify_chain passes on the result.
+  - CONCURRENCY (the critical one): 12 concurrent processes each append a
+    receipt under the lock with the flag ON; verify_chain passes (zero forks:
+    every prev_hash matches the prior entry's hash, no duplicate prev_hash,
+    no GENESIS after line 1).
+  - replay/idempotency: re-running verify on the chained file is stable.
+
+The concurrency test exercises the exact correctness invariant from the spec:
+read-tail + stamp + write + cache-update must be serialized under the single
+append lock or concurrent appends fork the chain.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from append_receipt_internals.idempotency import (  # noqa: E402
+    _cache_file_for,
+    _compute_idempotency_key,
+    _write_receipt_under_lock,
+)
+from ndjson_hash_chain import GENESIS_HASH, compute_entry_hash, verify_chain  # noqa: E402
+
+
+def _append_one(receipt_path: Path, receipt: dict) -> None:
+    """Append a single receipt through the canonical lock-scoped writer."""
+    cache_path = _cache_file_for(receipt_path)
+    key = _compute_idempotency_key(receipt, receipt.get("event_type", "test_event"))
+    _write_receipt_under_lock(
+        receipt,
+        receipt_path,
+        cache_path,
+        key,
+        cache_window_seconds=300,
+    )
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Flag OFF: byte-for-byte unchanged, no prev_hash field
+# --------------------------------------------------------------------------- #
+def test_flag_off_no_prev_hash(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+
+    for i in range(5):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == 5
+    for entry in entries:
+        assert "prev_hash" not in entry, "flag OFF must not stamp prev_hash"
+
+
+def test_flag_off_explicit_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "0")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": "d0", "n": 0})
+    entries = _read_lines(receipt_path)
+    assert "prev_hash" not in entries[0]
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON: chained, verify_chain passes
+# --------------------------------------------------------------------------- #
+def test_flag_on_chains_and_verifies(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "1")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+
+    for i in range(6):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == 6
+
+    # First entry is genesis, every subsequent entry chains to the prior body.
+    assert entries[0]["prev_hash"] == GENESIS_HASH
+    for idx in range(1, len(entries)):
+        assert entries[idx]["prev_hash"] == compute_entry_hash(entries[idx - 1])
+
+    is_valid, violations = verify_chain(receipt_path)
+    assert is_valid, f"chain should verify, violations: {violations}"
+
+
+def test_flag_on_genesis_only_first_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "true")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    for i in range(4):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    genesis_count = sum(1 for e in entries if e.get("prev_hash") == GENESIS_HASH)
+    assert genesis_count == 1, "GENESIS_HASH must appear only on line 1"
+
+
+# --------------------------------------------------------------------------- #
+# CONCURRENCY: the critical fork-test
+# --------------------------------------------------------------------------- #
+def _concurrent_worker(receipt_path_str: str, worker_id: int) -> None:
+    """Subprocess body: enable flag, append one receipt under the lock."""
+    os.environ["VNX_CHAIN_RECEIPTS"] = "1"
+    # Re-resolve imports inside the spawned process.
+    for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+        if _p not in sys.path:
+            sys.path.insert(0, _p)
+    from append_receipt_internals.idempotency import (
+        _cache_file_for as cf,
+        _compute_idempotency_key as ck,
+        _write_receipt_under_lock as wr,
+    )
+
+    receipt_path = Path(receipt_path_str)
+    receipt = {
+        "event_type": "test_event",
+        "dispatch_id": f"worker-{worker_id}",
+        "worker": worker_id,
+        "pid": os.getpid(),
+    }
+    cache_path = cf(receipt_path)
+    key = ck(receipt, "test_event")
+    wr(receipt, receipt_path, cache_path, key, cache_window_seconds=300)
+
+
+@pytest.mark.parametrize("n_workers", [8, 16])
+def test_concurrent_appends_no_fork(tmp_path, n_workers):
+    receipt_path = tmp_path / f"t0_receipts_{n_workers}.ndjson"
+
+    ctx = mp.get_context("spawn")
+    procs = [
+        ctx.Process(target=_concurrent_worker, args=(str(receipt_path), wid))
+        for wid in range(n_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker exited non-zero: {p.exitcode}"
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == n_workers, "every worker must have appended exactly once"
+
+    # 1. verify_chain passes — the single source of truth for "no fork".
+    is_valid, violations = verify_chain(receipt_path)
+    assert is_valid, f"CHAIN FORKED under concurrency, violations: {violations}"
+
+    # 2. Exactly one GENESIS, on line 1.
+    assert entries[0]["prev_hash"] == GENESIS_HASH
+    genesis_count = sum(1 for e in entries if e.get("prev_hash") == GENESIS_HASH)
+    assert genesis_count == 1, "fork: GENESIS_HASH appears more than once"
+
+    # 3. No duplicate prev_hash (a fork manifests as two entries sharing a parent).
+    prev_hashes = [e["prev_hash"] for e in entries]
+    assert len(prev_hashes) == len(set(prev_hashes)), "fork: duplicate prev_hash"
+
+    # 4. Each prev_hash matches the prior entry's body hash (explicit, beyond verify).
+    for idx in range(1, len(entries)):
+        assert entries[idx]["prev_hash"] == compute_entry_hash(entries[idx - 1])
+
+
+# --------------------------------------------------------------------------- #
+# Replay / idempotency: verify is stable across repeated runs
+# --------------------------------------------------------------------------- #
+def test_verify_is_stable_on_replay(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "1")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    for i in range(5):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    first = verify_chain(receipt_path)
+    second = verify_chain(receipt_path)
+    third = verify_chain(receipt_path)
+    assert first[0] is True
+    assert first == second == third, "verify must be deterministic across replays"


### PR DESCRIPTION
## What

Wires per-append hash-chaining into the canonical receipt append path, flag-gated behind `VNX_CHAIN_RECEIPTS` (default OFF). When the flag is OFF the append path is **byte-for-byte unchanged** — zero behavior change.

Touches the hot audit path (`scripts/lib/append_receipt_internals/idempotency.py`), so correctness — specifically lock-scope atomicity — is the whole point of the change.

## Lock-scope atomicity guarantee

The chaining is inlined INSIDE the existing `fcntl.LOCK_EX` block in `_write_receipt_under_lock`, after lock acquisition and BEFORE the receipt write:

```
acquire append_receipt.lock (LOCK_EX)
  load idempotency cache
  if duplicate: return
  if VNX_CHAIN_RECEIPTS on:
      receipt["prev_hash"] = read-tail-hash(receipt_path)   # read half
  write receipt (with prev_hash)                            # write half
  update idempotency cache
release lock
```

read-tail -> stamp `prev_hash` -> write receipt -> update cache are all serialized under the **single** `append_receipt.lock`. If the read and write straddled different lock acquisitions, two concurrent appenders could read the same tail hash and fork the chain — a silent, irreversible audit failure that only surfaces on verify.

The tail-hash read is **inlined** (reusing `_read_last_hash` logic from `ndjson_hash_chain.py`), not done via `append_chained_entry`, because that standalone helper opens its own file handle outside the VNX lock = fork risk. Genesis: the first entry on an empty/new ledger uses `GENESIS_HASH`.

## Concurrency test (the critical one)

`tests/test_receipt_hashchain.py::test_concurrent_appends_no_fork` spawns 8 and 16 concurrent processes (`multiprocessing` spawn context), each appending one receipt under the lock with the flag ON against a shared temp ledger. Asserts:
- `verify_chain` passes (the single source of truth for "no fork")
- exactly one `GENESIS_HASH`, on line 1
- no duplicate `prev_hash` (a fork manifests as two entries sharing a parent)
- every `prev_hash` matches the prior entry's body hash

**Result: passes at both 8 and 16 workers. Zero forks.**

## Other tests
- flag OFF: append unchanged, no `prev_hash` field
- flag ON: appends chain, `verify_chain` passes, GENESIS only on line 1
- replay/idempotency: re-running `verify_chain` on the chained file is stable

All 7 new tests pass. Existing append-receipt / idempotency / ndjson-hash-chain suites (175 tests) pass with the flag off.

## Out of scope (separate operator step)

Epoch rotation / live-ledger migration is **not** in this PR. Rotating the ~16MB live `t0_receipts.ndjson` to a legacy segment-0 + starting a fresh chained live file with a rotation sentinel is a one-time operator-run step in a low-traffic window. This PR is wiring + flag + tests only. The flag is **not** enabled by default and the live `.vnx-data/` ledger is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)