### PR TITLE
feat(planning): Phase 1 — tracks seeder + horizon + deliverables view + vnx objective list

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -316,6 +316,11 @@ Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
 
+Planning commands (strategic-layer read surface):
+  objective list      List objectives (tracks) grouped by horizon (now/next/later)
+                        Options: --horizon, --phase, --json
+  objective show <id> Show one objective: phase/horizon/deps/pr_ref
+
 Process commands (visibility and control):
   status             Show terminal health, dispatch queue, and gate results
   status --terminals   Just terminal health
@@ -2041,6 +2046,9 @@ main() {
       ;;
     queue-status)
       python3 "$VNX_HOME/scripts/pr_queue_manager.py" queue-status "$@"
+      ;;
+    objective)
+      python3 "$VNX_HOME/scripts/planning_cli.py" objective "$@"
       ;;
     suggest)
       python3 "$VNX_HOME/scripts/apply_suggested_edits.py" "$@"

--- a/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
+++ b/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
@@ -3,14 +3,17 @@
 -- Purpose: Phase 1 of the planning layer ("future-state flow", NO-NODE model).
 --          Adds the strategic-layer `horizon` field to tracks (now|next|later)
 --          and a derived `deliverables` VIEW that rolls dispatches up by their
---          pluggable output identity (output_ref/output_kind already on dispatches).
+--          pluggable output identity (output_ref/output_kind).
 --
 -- Design: claudedocs/FSF-BUILDPLAN-opus.md §7 + §4,
 --         claudedocs/PLANNING-OBJECT-MODEL-SYNTHESIS-2026-06-01.md
 --
--- Pre-migration state (v26, after 0026): tracks has no `horizon`; dispatches
---          carries output_ref/output_kind (added by vnx_structural_doctor) but
---          no derived rollup view exists.
+-- Pre-migration state (v24-v26): tracks has no `horizon`; dispatches may or
+--          may not carry output_ref/output_kind (added by structural-doctor on
+--          live DBs, absent on fresh DBs that only have the 0024 schema).
+--          A preflight hook in migrate_future_system.py idempotently adds
+--          output_ref + output_kind (+ backfill from pr_ref) before this SQL
+--          runs, so the deliverables VIEW always sees those columns.
 -- Post-migration state (v27): tracks.horizon TEXT CHECK(now|next|later);
 --          deliverables VIEW (GROUP BY project_id, output_ref).
 --
@@ -27,6 +30,10 @@
 --          user_version >= 27. ALTER TABLE ADD COLUMN is additive (no rebuild).
 --          The view uses CREATE VIEW IF NOT EXISTS. SAVEPOINT wraps all
 --          statements in apply_script_if_below.
+--
+-- Self-contained: works on a fresh DB that only has the 0024 schema — the
+--          preflight hook _ensure_dispatches_output_columns adds output_ref +
+--          output_kind if absent (no dependency on vnx_structural_doctor).
 --
 -- Applied by: scripts/migrate_future_system.py
 -- Tested by:  tests/test_migrate_0027_planning_horizon.py

--- a/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
+++ b/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
@@ -1,0 +1,87 @@
+-- VNX Migration 0027 — planning horizon column + deliverables derived view
+--
+-- Purpose: Phase 1 of the planning layer ("future-state flow", NO-NODE model).
+--          Adds the strategic-layer `horizon` field to tracks (now|next|later)
+--          and a derived `deliverables` VIEW that rolls dispatches up by their
+--          pluggable output identity (output_ref/output_kind already on dispatches).
+--
+-- Design: claudedocs/FSF-BUILDPLAN-opus.md §7 + §4,
+--         claudedocs/PLANNING-OBJECT-MODEL-SYNTHESIS-2026-06-01.md
+--
+-- Pre-migration state (v26, after 0026): tracks has no `horizon`; dispatches
+--          carries output_ref/output_kind (added by vnx_structural_doctor) but
+--          no derived rollup view exists.
+-- Post-migration state (v27): tracks.horizon TEXT CHECK(now|next|later);
+--          deliverables VIEW (GROUP BY project_id, output_ref).
+--
+-- NO-NODE model: a deliverable is NOT a table. It is the derived GROUP BY over
+--          dispatches sharing one output_ref. This view IS the deliverable plane.
+--
+-- ADR-007 compliance: this migration adds no new central-DB *table*. The view
+--          carries project_id in its GROUP BY + projection, so every consumer
+--          filters `WHERE project_id = ?` — same composite-scoping contract as
+--          the underlying dispatches table (UNIQUE(dispatch_id, project_id)).
+--          See docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+--
+-- Idempotency: apply_script_if_below skips the entire script when
+--          user_version >= 27. ALTER TABLE ADD COLUMN is additive (no rebuild).
+--          The view uses CREATE VIEW IF NOT EXISTS. SAVEPOINT wraps all
+--          statements in apply_script_if_below.
+--
+-- Applied by: scripts/migrate_future_system.py
+-- Tested by:  tests/test_migrate_0027_planning_horizon.py
+
+-- ============================================================================
+-- STEP 1: tracks.horizon — strategic-layer scheduling band (now|next|later)
+-- ============================================================================
+--
+-- horizon lives ONLY on the strategic layer (the track), per the 4-architect
+-- synthesis. Nullable + no DEFAULT: the seeder backfills it from ROADMAP
+-- milestone. CHECK constrains the allowed band values.
+
+ALTER TABLE tracks ADD COLUMN horizon TEXT
+    CHECK (horizon IS NULL OR horizon IN ('now', 'next', 'later'));
+
+CREATE INDEX IF NOT EXISTS idx_tracks_horizon
+    ON tracks(project_id, horizon, sort_order);
+
+-- ============================================================================
+-- STEP 2: deliverables VIEW — derived rollup GROUP BY output_ref
+-- ============================================================================
+--
+-- One row per (project_id, output_ref): the set of dispatches that produce the
+-- same pluggable output (pr | post | deal | doc | ...). derived_status is a
+-- coarse, computed rollup — never hand-set, never authoritative.
+
+CREATE VIEW IF NOT EXISTS deliverables AS
+SELECT
+    project_id                                                  AS project_id,
+    output_ref                                                  AS deliverable_ref,
+    MIN(output_kind)                                            AS output_kind,
+    MIN(track)                                                  AS track,
+    COUNT(*)                                                    AS dispatch_count,
+    SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END)        AS completed_count,
+    SUM(CASE WHEN state IN ('active', 'running', 'delivering', 'claimed', 'accepted')
+             THEN 1 ELSE 0 END)                                 AS in_flight_count,
+    SUM(CASE WHEN state IN ('proposed', 'ready', 'queued')
+             THEN 1 ELSE 0 END)                                 AS planned_count,
+    CASE
+        WHEN SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END) = COUNT(*)
+            THEN 'done'
+        WHEN SUM(CASE WHEN state IN ('active', 'running', 'delivering', 'claimed', 'accepted')
+                      THEN 1 ELSE 0 END) > 0
+            THEN 'in_progress'
+        WHEN SUM(CASE WHEN state IN ('failed', 'failed_delivery', 'dead_letter', 'expired', 'timed_out')
+                      THEN 1 ELSE 0 END) = COUNT(*)
+            THEN 'failed'
+        WHEN SUM(CASE WHEN state = 'ready' THEN 1 ELSE 0 END) > 0
+            THEN 'ready'
+        ELSE 'proposed'
+    END                                                         AS derived_status,
+    MAX(updated_at)                                             AS last_activity
+FROM dispatches
+WHERE output_ref IS NOT NULL
+GROUP BY project_id, output_ref;
+
+-- Bump schema version
+PRAGMA user_version = 27;

--- a/schemas/migrations/0027_planning_horizon_and_deliverable_view_down.sql
+++ b/schemas/migrations/0027_planning_horizon_and_deliverable_view_down.sql
@@ -1,0 +1,71 @@
+-- VNX Migration 0027 (DOWN) — drop deliverables view + tracks.horizon
+--
+-- Reverses 0027_planning_horizon_and_deliverable_view.sql.
+--
+-- Pre-state (v27): tracks.horizon present, deliverables VIEW + idx_tracks_horizon.
+-- Post-state (v26): tracks without horizon, no deliverables view.
+--
+-- SQLite < 3.35 has no DROP COLUMN, so tracks is rebuilt to the v26 column set
+-- (the v24 composite-key schema, which v25/v26 did not alter). Composite PK
+-- (track_id, project_id) and all data are preserved via INSERT ... SELECT.
+--
+-- Idempotency: guarded by the runner, which only invokes this when stepping
+--          user_version 27 -> 26. SAVEPOINT atomicity applies.
+
+-- ============================================================================
+-- STEP 1: drop the derived view + horizon index (additive surfaces)
+-- ============================================================================
+
+DROP VIEW IF EXISTS deliverables;
+DROP INDEX IF EXISTS idx_tracks_horizon;
+
+-- ============================================================================
+-- STEP 2: rebuild tracks WITHOUT horizon (preserves composite PK + data)
+-- ============================================================================
+
+ALTER TABLE tracks RENAME TO tracks_pre_0027_down;
+
+CREATE TABLE tracks (
+    track_id                    TEXT    NOT NULL,
+    project_id                  TEXT    NOT NULL DEFAULT 'vnx-dev',
+    title                       TEXT    NOT NULL,
+    goal_state                  TEXT,
+    phase                       TEXT    NOT NULL DEFAULT 'queued'
+                                        CHECK (phase IN ('queued','active','parked','done')),
+    next_up                     INTEGER NOT NULL DEFAULT 0,
+    sort_order                  INTEGER NOT NULL DEFAULT 0,
+    priority                    TEXT    DEFAULT 'medium',
+    requires_operator_promotion INTEGER NOT NULL DEFAULT 1,
+    instruction_template        TEXT,
+    context_composer_rules      TEXT    DEFAULT '{}',
+    pr_ref                      TEXT,
+    trigger_condition           TEXT,
+    created_at                  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    phase_changed_at            TEXT,
+    completed_at                TEXT,
+    metadata_json               TEXT    DEFAULT '{}',
+    PRIMARY KEY (track_id, project_id)
+);
+
+INSERT INTO tracks (
+    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+    requires_operator_promotion, instruction_template, context_composer_rules,
+    pr_ref, trigger_condition, created_at, phase_changed_at, completed_at, metadata_json
+)
+SELECT
+    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+    requires_operator_promotion, instruction_template, context_composer_rules,
+    pr_ref, trigger_condition, created_at, phase_changed_at, completed_at, metadata_json
+FROM tracks_pre_0027_down;
+
+DROP TABLE tracks_pre_0027_down;
+
+-- Restore the v24 track indexes that referenced the rebuilt tracks table
+CREATE INDEX IF NOT EXISTS idx_tracks_project_phase_nextup
+    ON tracks(project_id, phase, next_up DESC, sort_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tracks_next_up_per_project
+    ON tracks(project_id) WHERE next_up = 1 AND phase = 'queued';
+
+-- Step schema version back down
+PRAGMA user_version = 26;

--- a/schemas/migrations/0027_planning_horizon_and_deliverable_view_down.sql
+++ b/schemas/migrations/0027_planning_horizon_and_deliverable_view_down.sql
@@ -9,8 +9,16 @@
 -- (the v24 composite-key schema, which v25/v26 did not alter). Composite PK
 -- (track_id, project_id) and all data are preserved via INSERT ... SELECT.
 --
+-- FK safety: the ALTER TABLE RENAME retargets child FKs (track_dependencies,
+-- track_phase_history, track_open_items) to the renamed table. PRAGMA
+-- foreign_keys=OFF is required to DROP the renamed table without SQLite
+-- rejecting it due to those still-present FK references. This is the standard
+-- SQLite table-rebuild guard (same pattern as the 0024 up-migration).
+--
 -- Idempotency: guarded by the runner, which only invokes this when stepping
---          user_version 27 -> 26. SAVEPOINT atomicity applies.
+--          user_version 27 -> 26.
+
+PRAGMA foreign_keys = OFF;
 
 -- ============================================================================
 -- STEP 1: drop the derived view + horizon index (additive surfaces)
@@ -69,3 +77,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_tracks_next_up_per_project
 
 -- Step schema version back down
 PRAGMA user_version = 26;
+
+PRAGMA foreign_keys = ON;

--- a/scripts/lib/append_receipt_internals/idempotency.py
+++ b/scripts/lib/append_receipt_internals/idempotency.py
@@ -34,6 +34,40 @@ IDEMPOTENCY_FIELDS = (
 )
 
 
+# Hash-chain primitives live in scripts/lib/ndjson_hash_chain.py. Imported
+# lazily inside the lock path so the flag-OFF append path takes on no
+# import-time dependency.
+_LIB_DIR = Path(__file__).resolve().parent.parent
+
+
+def _chain_receipts_enabled() -> bool:
+    """True when VNX_CHAIN_RECEIPTS opts the append path into hash-chaining.
+
+    Default OFF. Recognised truthy values: 1, true, yes, on (case-insensitive).
+    When OFF the append path is byte-for-byte unchanged.
+    """
+    value = os.environ.get("VNX_CHAIN_RECEIPTS", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _last_hash_under_lock(receipt_path: Path) -> str:
+    """Inline tail-hash read for the chained append.
+
+    Returns the canonical hash of the file's last entry, or GENESIS_HASH for an
+    empty/missing ledger. MUST be called while holding the append lock — it is
+    the read half of the read-tail + stamp + write + cache-update critical
+    section. Deliberately inlined (not ``append_chained_entry``) so no second
+    file handle is opened outside the VNX lock (fork risk).
+    """
+    import sys as _sys
+
+    if str(_LIB_DIR) not in _sys.path:
+        _sys.path.insert(0, str(_LIB_DIR))
+    from ndjson_hash_chain import GENESIS_HASH, _read_last_hash
+
+    return _read_last_hash(receipt_path) or GENESIS_HASH
+
+
 def _resolve_receipts_file(receipts_file: Optional[str] = None) -> Path:
     if receipts_file:
         return Path(receipts_file).expanduser()
@@ -147,6 +181,16 @@ def _write_receipt_under_lock(
                     receipts_file=receipt_path,
                     idempotency_key=idempotency_key,
                 )
+
+            # Hash-chain stamping (flag-gated). The read-tail + stamp happens
+            # here, INSIDE the LOCK_EX block and BEFORE the receipt write, so
+            # the read-tail + stamp + write + cache-update sequence is fully
+            # serialized under the one append lock. Without this serialization
+            # concurrent appends would read the same tail hash and fork the
+            # chain. When the flag is OFF this block is skipped entirely and the
+            # receipt is written byte-for-byte as before.
+            if _chain_receipts_enabled():
+                receipt["prev_hash"] = _last_hash_under_lock(receipt_path)
 
             try:
                 with receipt_path.open("a", encoding="utf-8") as receipts_handle:

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -23,6 +23,12 @@ _TRACK_EVENTS_FILE = "track_events.ndjson"
 
 VALID_PHASES = frozenset({"queued", "active", "parked", "done"})
 
+VALID_HORIZONS = frozenset({"now", "next", "later"})
+
+
+class InvalidHorizonError(ValueError):
+    pass
+
 ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "queued":  frozenset({"active", "parked"}),
     "active":  frozenset({"done", "parked"}),
@@ -119,30 +125,58 @@ def create_track(
     pr_ref: Optional[str] = None,
     trigger_condition: Optional[str] = None,
     metadata_json: Optional[str] = None,
+    horizon: Optional[str] = None,
 ) -> dict[str, Any]:
     if phase not in VALID_PHASES:
         raise InvalidPhaseError(f"Invalid phase: {phase!r}. Must be one of {sorted(VALID_PHASES)}")
+    if horizon is not None and horizon not in VALID_HORIZONS:
+        raise InvalidHorizonError(
+            f"Invalid horizon: {horizon!r}. Must be one of {sorted(VALID_HORIZONS)} or None"
+        )
 
     now = _now_utc()
     _emit_track_event(state_dir, "track_created", track_id, project_id, "system", {"title": title})
     conn = _get_conn(state_dir)
     try:
-        conn.execute(
-            """
-            INSERT INTO tracks (
-                track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
-                requires_operator_promotion, instruction_template, context_composer_rules,
-                pr_ref, trigger_condition, created_at, phase_changed_at,
-                metadata_json
-            ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                track_id, project_id, title, goal_state, phase, sort_order, priority,
-                requires_operator_promotion, instruction_template, context_composer_rules,
-                pr_ref, trigger_condition, now, now,
-                metadata_json or "{}",
-            ),
+        # horizon (migration 0027) is optional: only reference the column when it
+        # exists, so the DAL stays compatible with pre-0027 (v24-era) databases.
+        has_horizon = any(
+            row[1] == "horizon" for row in conn.execute("PRAGMA table_info('tracks')")
         )
+        if has_horizon:
+            conn.execute(
+                """
+                INSERT INTO tracks (
+                    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+                    requires_operator_promotion, instruction_template, context_composer_rules,
+                    pr_ref, trigger_condition, created_at, phase_changed_at,
+                    metadata_json, horizon
+                ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    track_id, project_id, title, goal_state, phase, sort_order, priority,
+                    requires_operator_promotion, instruction_template, context_composer_rules,
+                    pr_ref, trigger_condition, now, now,
+                    metadata_json or "{}", horizon,
+                ),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO tracks (
+                    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+                    requires_operator_promotion, instruction_template, context_composer_rules,
+                    pr_ref, trigger_condition, created_at, phase_changed_at,
+                    metadata_json
+                ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    track_id, project_id, title, goal_state, phase, sort_order, priority,
+                    requires_operator_promotion, instruction_template, context_composer_rules,
+                    pr_ref, trigger_condition, now, now,
+                    metadata_json or "{}",
+                ),
+            )
         conn.commit()
         row = conn.execute(
             "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
@@ -152,6 +186,80 @@ def create_track(
     finally:
         conn.close()
     return result
+
+
+def update_authored_fields(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+    *,
+    title: Optional[str] = None,
+    goal_state: Optional[str] = None,
+    priority: Optional[str] = None,
+    sort_order: Optional[int] = None,
+    horizon: Optional[str] = None,
+    pr_ref: Optional[str] = None,
+    metadata_json: Optional[str] = None,
+    actor: str = "system",
+) -> dict[str, Any]:
+    """Update ONLY authored-derived fields on an existing track.
+
+    Used by the ROADMAP seeder for idempotent re-runs. Deliberately NEVER
+    touches `phase` (declared status is operator/T0/reconciler territory) or
+    `next_up`. Only the fields passed (non-None) are written. Emits a
+    `track_authored_synced` audit event listing the changed columns.
+
+    Raises TrackNotFoundError if the track does not exist.
+    """
+    if horizon is not None and horizon not in VALID_HORIZONS:
+        raise InvalidHorizonError(
+            f"Invalid horizon: {horizon!r}. Must be one of {sorted(VALID_HORIZONS)} or None"
+        )
+
+    updates: dict[str, Any] = {}
+    if title is not None:
+        updates["title"] = title
+    if goal_state is not None:
+        updates["goal_state"] = goal_state
+    if priority is not None:
+        updates["priority"] = priority
+    if sort_order is not None:
+        updates["sort_order"] = sort_order
+    if horizon is not None:
+        updates["horizon"] = horizon
+    if pr_ref is not None:
+        updates["pr_ref"] = pr_ref
+    if metadata_json is not None:
+        updates["metadata_json"] = metadata_json
+
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        if not row:
+            raise TrackNotFoundError(f"Track not found: ({track_id!r}, {project_id!r})")
+
+        if updates:
+            _emit_track_event(
+                state_dir, "track_authored_synced", track_id, project_id, actor,
+                {"fields": sorted(updates.keys())},
+            )
+            set_clause = ", ".join(f"{col} = ?" for col in updates)
+            conn.execute(
+                f"UPDATE tracks SET {set_clause} WHERE track_id = ? AND project_id = ?",
+                (*updates.values(), track_id, project_id),
+            )
+            conn.commit()
+
+        updated = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        return dict(updated)
+    finally:
+        conn.close()
 
 
 def get_track(

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -51,7 +51,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "intelligence-import", "init-feature", "bootstrap-skills",
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings", "regen-worker-permissions",
     "patch-agent-files", "register", "list-projects", "unregister",
-    "roadmap", "insights",
+    "roadmap", "insights", "objective",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",
     "init-db",
 })

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -6,6 +6,8 @@ Steps:
   2. Apply schemas/migrations/0022_track_layer.sql (idempotent via user_version)
   3. PRAGMA pre-flight: assert tracks v22 schema intact before composite-key rebuild
   4. Apply schemas/migrations/0024_tracks_tenant_scoping.sql (idempotent via user_version)
+  5. PRAGMA pre-flight: assert tracks composite-key schema intact before adding horizon
+  6. Apply schemas/migrations/0027_planning_horizon_and_deliverable_view.sql (idempotent)
 """
 
 from __future__ import annotations
@@ -302,6 +304,63 @@ def apply_migration_v24(conn: sqlite3.Connection, project_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 5: PRAGMA pre-flight for 0027 — assert composite-key tracks intact
+# ---------------------------------------------------------------------------
+
+def _assert_tracks_v24_intact(conn: sqlite3.Connection) -> None:
+    """Assert tracks is in the composite-key (v24+) state before adding horizon.
+
+    0027 is purely additive (ALTER TABLE ADD COLUMN + a VIEW), so it only needs
+    the tracks table to exist with its composite-key index. It must NOT run on a
+    pre-v24 single-column-PK tracks table.
+    """
+    tables = {row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    if 'tracks' not in tables:
+        raise RuntimeError(
+            "Required table 'tracks' not found. Run migrations 0022 + 0024 before 0027."
+        )
+    indexes = [row[1] for row in conn.execute("PRAGMA index_list('tracks')")]
+    if 'ux_tracks_next_up_per_project' not in indexes:
+        raise RuntimeError(
+            "tracks missing composite-key index 'ux_tracks_next_up_per_project' "
+            "(from 0024). Run migration 0024 before 0027."
+        )
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('tracks')")}
+    if 'horizon' in cols:
+        raise RuntimeError(
+            "tracks already has 'horizon' column. Migration 0027 should be "
+            "skipped (user_version should be >= 27)."
+        )
+
+
+schema_migration.register_preflight(27, _assert_tracks_v24_intact)
+
+
+# ---------------------------------------------------------------------------
+# Step 6: apply 0027 migration
+# ---------------------------------------------------------------------------
+
+def apply_migration_v27(conn: sqlite3.Connection, project_root: Path) -> None:
+    migration_path = _MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    sql = migration_path.read_text(encoding="utf-8")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 27:
+        print(f"  [skip] migration 0027 already applied (user_version={current_version})")
+        return
+
+    _assert_tracks_v24_intact(conn)
+    print("  [apply] migration 0027_planning_horizon_and_deliverable_view.sql ...")
+    schema_migration.apply_script_if_below(conn, 27, sql)
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -338,6 +397,10 @@ def run(project_root: Path | None = None) -> None:
 
         # Apply 0024 — rebuilds track tables with composite (track_id, project_id) PKs
         apply_migration_v24(conn, project_root)
+        conn.commit()
+
+        # Apply 0027 — additive: tracks.horizon column + deliverables derived view
+        apply_migration_v27(conn, project_root)
         conn.commit()
 
         print(f"\n  Migration complete. Schema at user_version={schema_migration.get_user_version(conn)}.\n")

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -307,6 +307,34 @@ def apply_migration_v24(conn: sqlite3.Connection, project_root: Path) -> None:
 # Step 5: PRAGMA pre-flight for 0027 — assert composite-key tracks intact
 # ---------------------------------------------------------------------------
 
+def _ensure_dispatches_output_columns(conn: sqlite3.Connection) -> None:
+    """Idempotently ensure dispatches carries output_ref + output_kind columns.
+
+    Migration 0027 creates the deliverables VIEW which reads dispatches.output_ref
+    and dispatches.output_kind. On the live DB these columns were added by the
+    structural-doctor repair step, but a fresh DB that arrives at v24 without the
+    structural-doctor pass (or via tests) will not have them. The VIEW creation
+    does not fail at DDL time (SQLite resolves view columns at query time), but
+    any SELECT from deliverables would fail.
+
+    This preflight adds the columns additively when they are absent, then back-
+    fills output_ref=pr_ref, output_kind='pr' for rows where pr_ref is set.
+    It is idempotent: column-existence checks guard the ALTER TABLE calls so
+    they are never attempted twice, and the UPDATE is a no-op after the first run.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+
+    if "output_ref" not in cols:
+        conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    if "output_kind" not in cols:
+        conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+
+    conn.execute(
+        "UPDATE dispatches SET output_ref = pr_ref, output_kind = 'pr' "
+        "WHERE pr_ref IS NOT NULL AND output_ref IS NULL"
+    )
+
+
 def _assert_tracks_v24_intact(conn: sqlite3.Connection) -> None:
     """Assert tracks is in the composite-key (v24+) state before adding horizon.
 
@@ -335,6 +363,7 @@ def _assert_tracks_v24_intact(conn: sqlite3.Connection) -> None:
         )
 
 
+schema_migration.register_preflight(27, _ensure_dispatches_output_columns)
 schema_migration.register_preflight(27, _assert_tracks_v24_intact)
 
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""planning_cli.py — read surface for the VNX planning layer (Phase 1).
+
+Delegated from `bin/vnx`:
+  vnx objective list [--horizon now|next|later] [--phase ...] [--json]
+  vnx objective show <track_id> [--json]
+
+Reads the live `tracks` table (the strategic layer of the NO-NODE model) and
+renders feature_id/title/phase/horizon/depends_on/pr_ref, grouped by horizon
+(now/next/later). This is the cold-start "what's next" answer — one query from
+the live DB, no handoff doc.
+
+`vnx promote` is deliberately NOT added here: the top-level `promote` verb is
+already taken by the PR-queue staging command (bin/vnx). The planning promote
+lands in Phase 2 as `vnx deliverable promote`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+_HERE = Path(__file__).resolve().parent
+_LIB = _HERE / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import tracks as tracks_lib  # noqa: E402
+
+_HORIZON_ORDER = ["now", "next", "later"]
+_HORIZON_LABEL = {"now": "NOW", "next": "NEXT", "later": "LATER", None: "UNSCHEDULED"}
+
+
+def _resolve_state_dir(explicit: str) -> Path:
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get("VNX_STATE_DIR", "")
+    if env:
+        return Path(env)
+    from project_root import resolve_project_root
+    return resolve_project_root(__file__) / ".vnx-data" / "state"
+
+
+def _dependencies_for(state_dir: Path, track_id: str, project_id: str) -> list[str]:
+    """Return the to_track_ids this track depends on (hard/soft edges)."""
+    import sqlite3
+    db = Path(state_dir) / tracks_lib.DB_FILENAME
+    conn = sqlite3.connect(str(db), timeout=10.0)
+    try:
+        rows = conn.execute(
+            """
+            SELECT to_track_id FROM track_dependencies
+            WHERE from_track_id = ? AND from_project_id = ?
+            ORDER BY to_track_id
+            """,
+            (track_id, project_id),
+        ).fetchall()
+        return [r[0] for r in rows]
+    finally:
+        conn.close()
+
+
+def _horizon_key(track: dict[str, Any]) -> Optional[str]:
+    h = track.get("horizon")
+    return h if h in _HORIZON_ORDER else None
+
+
+def cmd_objective_list(args: argparse.Namespace) -> int:
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    tracks = tracks_lib.list_tracks(state_dir, project_id, phase=args.phase)
+
+    if args.horizon:
+        tracks = [t for t in tracks if _horizon_key(t) == args.horizon]
+
+    if args.json:
+        out = [
+            {
+                "track_id": t["track_id"],
+                "title": t["title"],
+                "phase": t["phase"],
+                "horizon": t.get("horizon"),
+                "priority": t.get("priority"),
+                "pr_ref": t.get("pr_ref"),
+                "next_up": bool(t.get("next_up")),
+                "depends_on": _dependencies_for(state_dir, t["track_id"], project_id),
+            }
+            for t in tracks
+        ]
+        print(json.dumps(out, indent=2))
+        return 0
+
+    if not tracks:
+        print(f"No objectives found for project '{project_id}'.")
+        print("Seed from ROADMAP: python3 scripts/seed_tracks_from_roadmap.py --apply")
+        return 0
+
+    # Group by horizon band.
+    grouped: dict[Optional[str], list[dict[str, Any]]] = {h: [] for h in _HORIZON_ORDER}
+    grouped[None] = []
+    for t in tracks:
+        grouped[_horizon_key(t)].append(t)
+
+    print(f"\nVNX objectives — project '{project_id}'\n")
+    for band in _HORIZON_ORDER + [None]:
+        items = grouped.get(band) or []
+        if not items:
+            continue
+        print(f"=== {_HORIZON_LABEL[band]} ({len(items)}) ===")
+        for t in items:
+            deps = _dependencies_for(state_dir, t["track_id"], project_id)
+            marker = "*" if t.get("next_up") else " "
+            dep_str = f"  deps: {', '.join(deps)}" if deps else ""
+            pr_str = f"  pr: {t['pr_ref']}" if t.get("pr_ref") else ""
+            print(
+                f" {marker} {t['track_id']:<28} [{t['phase']:<7}] "
+                f"{t.get('priority') or '-':<3} {t['title']}{pr_str}{dep_str}"
+            )
+        print()
+    return 0
+
+
+def cmd_objective_show(args: argparse.Namespace) -> int:
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track = tracks_lib.get_track(state_dir, args.track_id, project_id)
+    if track is None:
+        print(f"Objective not found: {args.track_id!r} (project {project_id!r})", file=sys.stderr)
+        return 1
+
+    deps = _dependencies_for(state_dir, args.track_id, project_id)
+
+    if args.json:
+        out = dict(track)
+        out["depends_on"] = deps
+        print(json.dumps(out, indent=2, default=str))
+        return 0
+
+    print(f"\nObjective: {track['track_id']}  (project {project_id})")
+    print(f"  title    : {track['title']}")
+    print(f"  phase    : {track['phase']}")
+    print(f"  horizon  : {track.get('horizon') or '(unscheduled)'}")
+    print(f"  priority : {track.get('priority') or '-'}")
+    print(f"  next_up  : {bool(track.get('next_up'))}")
+    print(f"  pr_ref   : {track.get('pr_ref') or '-'}")
+    print(f"  goal     : {track.get('goal_state') or '-'}")
+    print(f"  depends  : {', '.join(deps) if deps else '(none)'}")
+    print()
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vnx", description="VNX planning read surface")
+    sub = parser.add_subparsers(dest="domain", required=True)
+
+    obj = sub.add_parser("objective", help="strategic-layer objectives (tracks)")
+    obj_sub = obj.add_subparsers(dest="action", required=True)
+
+    def _common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--project-id", default=os.environ.get("VNX_PROJECT_ID", "vnx-dev"))
+        p.add_argument("--state-dir", default="")
+        p.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+
+    p_list = obj_sub.add_parser("list", help="list objectives grouped by horizon")
+    _common(p_list)
+    p_list.add_argument("--horizon", choices=_HORIZON_ORDER, default=None)
+    p_list.add_argument("--phase", choices=sorted(tracks_lib.VALID_PHASES), default=None)
+    p_list.set_defaults(func=cmd_objective_list)
+
+    p_show = obj_sub.add_parser("show", help="show one objective")
+    _common(p_show)
+    p_show.add_argument("track_id")
+    p_show.set_defaults(func=cmd_objective_show)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_tracks_from_roadmap.py
+++ b/scripts/seed_tracks_from_roadmap.py
@@ -163,7 +163,11 @@ def _row_matches(existing: dict[str, Any], desired: dict[str, Any]) -> bool:
     """True if the existing track already reflects the authored fields.
 
     Compares only the authored-derived fields (NOT phase — phase drift is
-    reported separately, never auto-synced).
+    reported separately, never auto-synced). Also deliberately excludes
+    `depends_on`: dependencies live in a separate table and are always
+    reconciled unconditionally (via _seed_dependencies), even for rows that
+    are otherwise unchanged. This prevents dependency-only changes from being
+    silently ignored.
     """
     for col in ("title", "goal_state", "priority", "sort_order", "horizon", "pr_ref", "metadata_json"):
         if (existing.get(col) or None) != (desired.get(col) or None):
@@ -241,6 +245,8 @@ def seed(
             })
 
         if _row_matches(existing, desired):
+            if apply:
+                _seed_dependencies(state_dir, track_id, project_id, desired["depends_on"])
             report["unchanged"].append(track_id)
             continue
 

--- a/scripts/seed_tracks_from_roadmap.py
+++ b/scripts/seed_tracks_from_roadmap.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""seed_tracks_from_roadmap.py — project authored ROADMAP.yaml into the tracks DB.
+
+One-directional projection: ROADMAP.yaml `features[]` (the SINGLE authored
+planning surface) -> `tracks` rows via the tracks.py DAL. Phase 1 of the
+planning layer (NO-NODE model): TRACK = ROADMAP feature, one row per feature.
+
+Idempotent + dry-run default:
+  python3 scripts/seed_tracks_from_roadmap.py            # DRY-RUN — prints plan, no writes
+  python3 scripts/seed_tracks_from_roadmap.py --apply    # writes rows + emits track events
+  python3 scripts/seed_tracks_from_roadmap.py --apply --project-id vnx-dev
+  python3 scripts/seed_tracks_from_roadmap.py --roadmap path/to/ROADMAP.yaml --state-dir /tmp/s
+
+Drift handling (load-bearing):
+  - row absent           -> created (in --apply)
+  - row present, equal   -> unchanged (no-op)
+  - row present, differs -> updated (authored fields only; NEVER overwrites phase)
+  - row present, status<>phase drift -> reported (phase_drift), NOT auto-resolved
+  - row in DB, gone from ROADMAP -> reported as orphan (never auto-deleted)
+
+Mapping (ROADMAP feature -> tracks row):
+  feature_id      -> track_id          (stable identity)
+  title           -> title
+  notes/synth     -> goal_state         (synthesize "<feature_id> done" if absent)
+  status          -> phase              (declared; create-only, see below)
+  milestone+order -> sort_order
+  risk_class      -> priority           (high->P1, else P2)
+  pr_queue        -> pr_ref + metadata_json.pr_queue
+  depends_on      -> track_dependencies (kind=hard, derivation_source=manual)
+  milestone       -> horizon            (1.0->now/next, 1.x->later)
+
+The seeder NEVER writes ROADMAP.yaml and NEVER runs --apply against the live DB
+on your behalf. Tests drive it against a temp DB + sample ROADMAP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Bootstrap sys.path so lib modules resolve regardless of cwd
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).resolve().parent
+_LIB = _HERE / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import tracks as tracks_lib  # noqa: E402
+
+# ROADMAP status -> declared phase. shipped-dark counts as done (it shipped;
+# "dark" is a runtime-exposure flag, not a planning phase).
+_STATUS_TO_PHASE = {
+    "done": "done",
+    "shipped-dark": "done",
+    "in-progress": "active",
+    "in_progress": "active",
+    "active": "active",
+    "planned": "queued",
+    "queued": "queued",
+    "blocked": "parked",
+    "parked": "parked",
+}
+
+# Milestone rank for stable sort_order (lower = earlier).
+_MILESTONE_RANK = {
+    "1.0": 0,
+    "1.0.1": 1,
+    "1.1": 2,
+    "1.2": 3,
+    "1.x": 9,
+}
+
+
+def _milestone_rank(milestone: Optional[str]) -> int:
+    return _MILESTONE_RANK.get(str(milestone), 5)
+
+
+def _horizon_for(milestone: Optional[str], status: Optional[str]) -> str:
+    """Derive the strategic horizon band from milestone + status.
+
+    1.0 features are the launch focus -> 'now' if not yet done, else 'next'.
+    1.0.x / 1.1 -> 'next'. 1.x and anything later -> 'later'.
+    """
+    m = str(milestone)
+    phase = _STATUS_TO_PHASE.get(str(status), "queued")
+    if m == "1.0":
+        return "next" if phase == "done" else "now"
+    if m in ("1.0.1", "1.1", "1.2"):
+        return "next"
+    return "later"
+
+
+def _priority_for(risk_class: Optional[str]) -> str:
+    return "P1" if str(risk_class).lower() == "high" else "P2"
+
+
+def _goal_state_for(feature: dict[str, Any]) -> str:
+    """Synthesize goal_state if the feature has no usable notes.
+
+    Tolerates the 0022 NOT NULL vs 0024 nullable goal_state divergence by always
+    producing a non-empty string.
+    """
+    notes = feature.get("notes")
+    if isinstance(notes, str) and notes.strip():
+        return notes.strip().splitlines()[0].strip()
+    return f"{feature.get('feature_id', 'feature')} done"
+
+
+def _pr_ref_for(feature: dict[str, Any]) -> Optional[str]:
+    """Pick a representative pr_ref: first open (non-merged) else last in queue."""
+    queue = feature.get("pr_queue") or []
+    if not isinstance(queue, list) or not queue:
+        return None
+    for item in queue:
+        if isinstance(item, dict) and item.get("status") not in ("merged", "closed"):
+            return item.get("pr_id")
+    last = queue[-1]
+    return last.get("pr_id") if isinstance(last, dict) else None
+
+
+def _metadata_for(feature: dict[str, Any]) -> str:
+    queue = feature.get("pr_queue") or []
+    meta: dict[str, Any] = {
+        "milestone": feature.get("milestone"),
+        "roadmap_status": feature.get("status"),
+        "risk_class": feature.get("risk_class"),
+    }
+    if isinstance(queue, list) and queue:
+        meta["pr_queue"] = [
+            item.get("pr_id") for item in queue if isinstance(item, dict) and item.get("pr_id")
+        ]
+    return json.dumps(meta, sort_keys=True)
+
+
+def _desired_row(feature: dict[str, Any], index: int) -> dict[str, Any]:
+    """Build the authored-derived field set for one ROADMAP feature."""
+    feature_id = feature.get("feature_id")
+    milestone = feature.get("milestone")
+    status = feature.get("status")
+    return {
+        "track_id": feature_id,
+        "title": feature.get("title") or feature_id,
+        "goal_state": _goal_state_for(feature),
+        "phase": _STATUS_TO_PHASE.get(str(status), "queued"),
+        "priority": _priority_for(feature.get("risk_class")),
+        "sort_order": _milestone_rank(milestone) * 1000 + index,
+        "horizon": _horizon_for(milestone, status),
+        "pr_ref": _pr_ref_for(feature),
+        "metadata_json": _metadata_for(feature),
+        "depends_on": list(feature.get("depends_on") or []),
+    }
+
+
+def _row_matches(existing: dict[str, Any], desired: dict[str, Any]) -> bool:
+    """True if the existing track already reflects the authored fields.
+
+    Compares only the authored-derived fields (NOT phase — phase drift is
+    reported separately, never auto-synced).
+    """
+    for col in ("title", "goal_state", "priority", "sort_order", "horizon", "pr_ref", "metadata_json"):
+        if (existing.get(col) or None) != (desired.get(col) or None):
+            return False
+    return True
+
+
+def _load_roadmap(roadmap_path: Path) -> list[dict[str, Any]]:
+    data = yaml.safe_load(roadmap_path.read_text(encoding="utf-8")) or {}
+    features = data.get("features") or []
+    if not isinstance(features, list):
+        raise ValueError(f"ROADMAP.yaml `features` is not a list in {roadmap_path}")
+    return [f for f in features if isinstance(f, dict) and f.get("feature_id")]
+
+
+def seed(
+    state_dir: str | Path,
+    roadmap_path: str | Path,
+    project_id: str,
+    *,
+    apply: bool = False,
+) -> dict[str, Any]:
+    """Run the seed. Returns a drift report dict (counts + per-track records).
+
+    Pure projection: when apply=False, nothing is written.
+    """
+    roadmap_path = Path(roadmap_path)
+    features = _load_roadmap(roadmap_path)
+
+    report: dict[str, Any] = {
+        "apply": apply,
+        "project_id": project_id,
+        "roadmap_path": str(roadmap_path),
+        "created": [],
+        "updated": [],
+        "unchanged": [],
+        "phase_drift": [],
+        "orphan": [],
+    }
+
+    seen_ids: set[str] = set()
+
+    for index, feature in enumerate(features):
+        desired = _desired_row(feature, index)
+        track_id = desired["track_id"]
+        seen_ids.add(track_id)
+
+        existing = tracks_lib.get_track(state_dir, track_id, project_id)
+
+        if existing is None:
+            if apply:
+                tracks_lib.create_track(
+                    state_dir,
+                    track_id,
+                    project_id,
+                    desired["title"],
+                    desired["goal_state"],
+                    phase=desired["phase"],
+                    sort_order=desired["sort_order"],
+                    priority=desired["priority"],
+                    pr_ref=desired["pr_ref"],
+                    metadata_json=desired["metadata_json"],
+                    horizon=desired["horizon"],
+                )
+                _seed_dependencies(state_dir, track_id, project_id, desired["depends_on"])
+            report["created"].append(track_id)
+            continue
+
+        # Existing row: detect phase drift (declared status divergence) separately.
+        if existing.get("phase") != desired["phase"]:
+            report["phase_drift"].append({
+                "track_id": track_id,
+                "db_phase": existing.get("phase"),
+                "roadmap_phase": desired["phase"],
+            })
+
+        if _row_matches(existing, desired):
+            report["unchanged"].append(track_id)
+            continue
+
+        if apply:
+            tracks_lib.update_authored_fields(
+                state_dir,
+                track_id,
+                project_id,
+                title=desired["title"],
+                goal_state=desired["goal_state"],
+                priority=desired["priority"],
+                sort_order=desired["sort_order"],
+                horizon=desired["horizon"],
+                pr_ref=desired["pr_ref"],
+                metadata_json=desired["metadata_json"],
+            )
+            _seed_dependencies(state_dir, track_id, project_id, desired["depends_on"])
+        report["updated"].append(track_id)
+
+    # Orphans: in DB but no longer authored in ROADMAP.
+    for row in tracks_lib.list_tracks(state_dir, project_id):
+        if row["track_id"] not in seen_ids:
+            report["orphan"].append(row["track_id"])
+
+    report["summary"] = {
+        "created": len(report["created"]),
+        "updated": len(report["updated"]),
+        "unchanged": len(report["unchanged"]),
+        "phase_drift": len(report["phase_drift"]),
+        "orphan": len(report["orphan"]),
+    }
+    return report
+
+
+def _seed_dependencies(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+    depends_on: list[str],
+) -> None:
+    """Add manual hard-dependency edges. INSERT OR REPLACE makes this idempotent.
+
+    Skips dependency targets not yet present in the tracks table (forward refs
+    are tolerated — the seeder is single-pass and the FK requires the target row).
+    """
+    for dep_id in depends_on:
+        if tracks_lib.get_track(state_dir, dep_id, project_id) is None:
+            continue
+        tracks_lib.add_dependency(
+            state_dir,
+            track_id,
+            project_id,
+            dep_id,
+            project_id,
+            kind="hard",
+            derivation_source="manual",
+            confidence=1.0,
+        )
+
+
+def _print_report(report: dict[str, Any]) -> None:
+    mode = "APPLY" if report["apply"] else "DRY-RUN (no writes)"
+    s = report["summary"]
+    print(f"\nVNX seed_tracks_from_roadmap — {mode}")
+    print(f"  project_id : {report['project_id']}")
+    print(f"  roadmap    : {report['roadmap_path']}")
+    print(
+        f"  created={s['created']}  updated={s['updated']}  unchanged={s['unchanged']}"
+        f"  phase_drift={s['phase_drift']}  orphan={s['orphan']}"
+    )
+    if report["created"]:
+        print(f"  + created : {', '.join(report['created'])}")
+    if report["updated"]:
+        print(f"  ~ updated : {', '.join(report['updated'])}")
+    if report["phase_drift"]:
+        print("  ! phase drift (declared status differs — reported, NOT auto-synced):")
+        for d in report["phase_drift"]:
+            print(f"      {d['track_id']}: db={d['db_phase']} roadmap={d['roadmap_phase']}")
+    if report["orphan"]:
+        print(f"  ? orphan (in DB, gone from ROADMAP — not deleted): {', '.join(report['orphan'])}")
+    if not report["apply"]:
+        print("  (dry-run: re-run with --apply to write)")
+    print()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Seed tracks from authored ROADMAP.yaml (dry-run default).")
+    parser.add_argument("--apply", action="store_true", help="write rows (default: dry-run, no writes)")
+    parser.add_argument("--project-id", default=os.environ.get("VNX_PROJECT_ID", "vnx-dev"))
+    parser.add_argument("--roadmap", default=None, help="path to ROADMAP.yaml (default: project root)")
+    parser.add_argument("--state-dir", default=os.environ.get("VNX_STATE_DIR", ""),
+                        help="state dir containing runtime_coordination.db")
+    parser.add_argument("--report", default=None, help="write the JSON drift report to this path")
+    args = parser.parse_args(argv)
+
+    if args.state_dir:
+        state_dir = Path(args.state_dir)
+    else:
+        from project_root import resolve_project_root
+        state_dir = resolve_project_root(__file__) / ".vnx-data" / "state"
+
+    if args.roadmap:
+        roadmap_path = Path(args.roadmap)
+    else:
+        from project_root import resolve_project_root
+        roadmap_path = resolve_project_root(__file__) / "ROADMAP.yaml"
+
+    report = seed(state_dir, roadmap_path, args.project_id, apply=args.apply)
+    _print_report(report)
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_migrate_0027_planning_horizon.py
+++ b/tests/test_migrate_0027_planning_horizon.py
@@ -1,0 +1,215 @@
+"""tests/test_migrate_0027_planning_horizon.py — migration 0027 up/down validation.
+
+Verifies:
+- 0027 applies cleanly on a v24-equivalent DB (tracks composite key + dispatches
+  with output_ref/output_kind, mirroring the live v26 state)
+- tracks.horizon column added with the now|next|later CHECK
+- deliverables VIEW created and rolls dispatches up by output_ref
+- derived_status computed correctly across mixed dispatch states
+- migration is idempotent (second apply is a no-op, version unchanged)
+- the _down migration removes horizon + the view and preserves track data
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_MIGRATIONS = Path(__file__).resolve().parent.parent / "schemas" / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration
+
+
+def _base_v26_db(tmp_path: Path) -> sqlite3.Connection:
+    """Build a DB at the live-equivalent state: 0022 + 0024 applied, plus the
+    output_ref/output_kind columns the structural-doctor adds to dispatches.
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    # Apply 0022 then 0024 (track layer + tenant scoping).
+    schema_migration.apply_script_if_below(
+        conn, 22, (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 24, (_MIGRATIONS / "0024_tracks_tenant_scoping.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    # Mirror the structural-doctor additions present in the live v26 DB.
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    return conn
+
+
+def _apply_0027(conn: sqlite3.Connection) -> bool:
+    sql = (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8")
+    applied = schema_migration.apply_script_if_below(conn, 27, sql)
+    conn.commit()
+    return applied
+
+
+def _cols(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def test_0027_applies_and_bumps_version(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    assert schema_migration.get_user_version(conn) == 26
+    assert _apply_0027(conn) is True
+    assert schema_migration.get_user_version(conn) == 27
+
+
+def test_horizon_column_added(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    assert "horizon" in _cols(conn, "tracks")
+
+
+def test_horizon_check_rejects_invalid(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, horizon) "
+        "VALUES ('t-ok', 'vnx-dev', 'T', 'g', 'now')"
+    )
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state, horizon) "
+            "VALUES ('t-bad', 'vnx-dev', 'T', 'g', 'someday')"
+        )
+
+
+def test_horizon_nullable(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('t-null', 'vnx-dev', 'T', 'g')"
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT horizon FROM tracks WHERE track_id='t-null'"
+    ).fetchone()
+    assert row[0] is None
+
+
+def test_deliverables_view_exists(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    views = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='view'")}
+    assert "deliverables" in views
+
+
+def test_deliverables_view_groups_by_output_ref(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    # Two dispatches share one output_ref (a "deliverable"); one is separate.
+    conn.executemany(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track, output_ref, output_kind) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("d1", "vnx-dev", "completed", "feat-x", "pr:#100", "pr"),
+            ("d2", "vnx-dev", "active", "feat-x", "pr:#100", "pr"),
+            ("d3", "vnx-dev", "completed", "feat-y", "post:q3-1", "post"),
+            ("d4", "vnx-dev", "queued", "feat-z", None, None),  # excluded (null output_ref)
+        ],
+    )
+    conn.commit()
+    rows: dict[str, dict] = {}
+    for r in conn.execute(
+        "SELECT deliverable_ref, output_kind, track, dispatch_count, derived_status "
+        "FROM deliverables WHERE project_id='vnx-dev'"
+    ):
+        rows[r[0]] = {"output_kind": r[1], "track": r[2], "count": r[3], "derived": r[4]}
+
+    assert set(rows.keys()) == {"pr:#100", "post:q3-1"}
+    assert rows["pr:#100"]["count"] == 2
+    assert rows["pr:#100"]["derived"] == "in_progress"  # one active
+    assert rows["pr:#100"]["output_kind"] == "pr"
+    assert rows["post:q3-1"]["count"] == 1
+    assert rows["post:q3-1"]["derived"] == "done"  # all completed
+
+
+def test_deliverables_view_failed_status(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    conn.executemany(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, output_ref, output_kind) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f1", "vnx-dev", "failed", "pr:#200", "pr"),
+            ("f2", "vnx-dev", "dead_letter", "pr:#200", "pr"),
+        ],
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT derived_status FROM deliverables WHERE deliverable_ref='pr:#200'"
+    ).fetchone()
+    assert row[0] == "failed"
+
+
+def test_0027_idempotent(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    assert _apply_0027(conn) is True
+    # Second apply is skipped (version already >= 27).
+    assert _apply_0027(conn) is False
+    assert schema_migration.get_user_version(conn) == 27
+
+
+def test_0027_down_removes_horizon_and_view(tmp_path):
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+    # Seed a track to confirm data survives the down rebuild.
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, phase, horizon) "
+        "VALUES ('keep-me', 'vnx-dev', 'Keep', 'goal', 'active', 'now')"
+    )
+    conn.commit()
+
+    down_sql = (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view_down.sql").read_text(encoding="utf-8")
+    for stmt in schema_migration._split_sql_statements(down_sql):
+        conn.execute(stmt)
+    conn.commit()
+
+    assert schema_migration.get_user_version(conn) == 26
+    assert "horizon" not in _cols(conn, "tracks")
+    views = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='view'")}
+    assert "deliverables" not in views
+    # Data preserved.
+    row = conn.execute(
+        "SELECT title, phase FROM tracks WHERE track_id='keep-me' AND project_id='vnx-dev'"
+    ).fetchone()
+    assert row == ("Keep", "active")

--- a/tests/test_migrate_0027_planning_horizon.py
+++ b/tests/test_migrate_0027_planning_horizon.py
@@ -1,13 +1,16 @@
 """tests/test_migrate_0027_planning_horizon.py — migration 0027 up/down validation.
 
 Verifies:
-- 0027 applies cleanly on a v24-equivalent DB (tracks composite key + dispatches
-  with output_ref/output_kind, mirroring the live v26 state)
+- 0027 applies cleanly on a v24-equivalent DB (tracks composite key + dispatches)
+- Preflight adds output_ref + output_kind to dispatches when absent (self-contained
+  on fresh DBs that never ran the structural-doctor)
+- deliverables VIEW created and queryable on a fresh DB (no structural-doctor pass)
 - tracks.horizon column added with the now|next|later CHECK
-- deliverables VIEW created and rolls dispatches up by output_ref
+- deliverables VIEW rolls dispatches up by output_ref
 - derived_status computed correctly across mixed dispatch states
 - migration is idempotent (second apply is a no-op, version unchanged)
 - the _down migration removes horizon + the view and preserves track data
+- down migration succeeds when track_dependencies rows reference tracks (FK-safety)
 """
 
 from __future__ import annotations
@@ -20,11 +23,15 @@ import pytest
 
 _LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
 _MIGRATIONS = Path(__file__).resolve().parent.parent / "schemas" / "migrations"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 
 if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
 import schema_migration
+import migrate_future_system  # noqa: F401 — registers preflight hooks for v27
 
 
 def _base_v26_db(tmp_path: Path) -> sqlite3.Connection:
@@ -82,6 +89,132 @@ def _apply_0027(conn: sqlite3.Connection) -> bool:
 
 def _cols(conn: sqlite3.Connection, table: str) -> list[str]:
     return [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def _fresh_v24_db(tmp_path: Path) -> sqlite3.Connection:
+    """Build a DB at v24 WITHOUT structural-doctor output_ref/output_kind additions.
+
+    Simulates a fresh DB that only went through 0022+0024, never ran the
+    structural-doctor. The 0027 preflight must add those columns itself.
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 22, (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 24, (_MIGRATIONS / "0024_tracks_tenant_scoping.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    return conn
+
+
+def _apply_0027_down(conn: sqlite3.Connection) -> None:
+    sql = (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view_down.sql").read_text(encoding="utf-8")
+    for stmt in schema_migration._split_sql_statements(sql):
+        conn.execute(stmt)
+    conn.commit()
+
+
+def test_deliverables_view_queryable_on_fresh_db(tmp_path):
+    """BLOCKER-1: deliverables VIEW must be queryable on a fresh DB where
+    output_ref/output_kind do NOT exist before 0027 runs. The preflight
+    in migrate_future_system.py adds them idempotently.
+    """
+    conn = _fresh_v24_db(tmp_path)
+    assert "output_ref" not in _cols(conn, "dispatches")
+    assert "output_kind" not in _cols(conn, "dispatches")
+
+    applied = _apply_0027(conn)
+    assert applied is True
+
+    # Columns added by preflight before the view was created.
+    assert "output_ref" in _cols(conn, "dispatches")
+    assert "output_kind" in _cols(conn, "dispatches")
+
+    # Insert a dispatch and verify the view is queryable (no column-not-found).
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track, output_ref, output_kind) "
+        "VALUES ('d1', 'vnx-dev', 'completed', 'feat-x', 'pr:#100', 'pr')"
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT deliverable_ref, output_kind, derived_status FROM deliverables WHERE project_id='vnx-dev'"
+    ).fetchone()
+    assert row[0] == "pr:#100"
+    assert row[1] == "pr"
+    assert row[2] == "done"
+
+
+def test_0027_down_succeeds_with_track_dependencies(tmp_path):
+    """BLOCKER-2: down migration must succeed when track_dependencies has rows
+    referencing tracks via FK. PRAGMA foreign_keys=OFF guards the rebuild.
+    """
+    conn = _base_v26_db(tmp_path)
+    _apply_0027(conn)
+
+    # Seed two tracks and a dependency edge (FK to tracks).
+    conn.executemany(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, phase, horizon) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("dep-from", "vnx-dev", "From", "goal", "active", "now"),
+            ("dep-to", "vnx-dev", "To", "goal", "active", "now"),
+        ],
+    )
+    conn.commit()
+    conn.execute(
+        "INSERT INTO track_dependencies "
+        "(from_track_id, from_project_id, to_track_id, to_project_id, kind, derivation_source) "
+        "VALUES ('dep-from', 'vnx-dev', 'dep-to', 'vnx-dev', 'hard', 'manual')"
+    )
+    conn.commit()
+
+    # Verify FK is active before the down migration.
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    # Apply down — must NOT raise an FK constraint error. The PRAGMA
+    # foreign_keys=OFF guard in the down SQL prevents the DROP TABLE from
+    # failing when child FKs are retargeted by the ALTER TABLE RENAME.
+    _apply_0027_down(conn)
+    assert schema_migration.get_user_version(conn) == 26
+
+    # Tracks data preserved (horizon column gone).
+    assert "horizon" not in _cols(conn, "tracks")
+    row = conn.execute(
+        "SELECT track_id, title FROM tracks WHERE track_id='dep-from' AND project_id='vnx-dev'"
+    ).fetchone()
+    assert row == ("dep-from", "From")
+
+    # track_dependencies rows survived the rebuild.
+    deps = conn.execute("SELECT * FROM track_dependencies").fetchone()
+    assert deps is not None
 
 
 def test_0027_applies_and_bumps_version(tmp_path):

--- a/tests/test_planning_cli_objective.py
+++ b/tests/test_planning_cli_objective.py
@@ -1,0 +1,172 @@
+"""tests/test_planning_cli_objective.py — `vnx objective list/show` read surface.
+
+Verifies (against a temp DB seeded from a sample ROADMAP):
+- `objective list` renders rows grouped by horizon
+- `objective list --json` is machine-readable with deps
+- `objective list --horizon now` filters
+- `objective show <id>` renders one objective + deps
+- `objective show` on a missing id exits non-zero
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration
+import seed_tracks_from_roadmap as seeder
+import planning_cli
+
+
+SAMPLE_ROADMAP = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: high
+    depends_on: []
+    milestone: "1.0"
+    status: planned
+    notes: Build A.
+  - feature_id: feat-b
+    title: Feature B
+    risk_class: low
+    depends_on: [feat-a]
+    milestone: "1.0"
+    status: done
+  - feature_id: feat-c
+    title: Feature C
+    risk_class: medium
+    depends_on: []
+    milestone: "1.x"
+    status: planned
+"""
+
+
+@pytest.fixture()
+def seeded_state(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 27, (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.close()
+
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(SAMPLE_ROADMAP, encoding="utf-8")
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    return state_dir
+
+
+def test_objective_list_renders(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "list", "--project-id", "vnx-dev", "--state-dir", str(seeded_state),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "feat-a" in out
+    assert "feat-b" in out
+    assert "feat-c" in out
+    # Grouped by horizon bands.
+    assert "NOW" in out
+    assert "LATER" in out
+
+
+def test_objective_list_json(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "list", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state), "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    by_id = {d["track_id"]: d for d in data}
+    assert set(by_id) == {"feat-a", "feat-b", "feat-c"}
+    # feat-b depends on feat-a.
+    assert by_id["feat-b"]["depends_on"] == ["feat-a"]
+    assert by_id["feat-a"]["phase"] == "queued"  # planned -> queued
+    assert by_id["feat-c"]["horizon"] == "later"
+
+
+def test_objective_list_horizon_filter(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "list", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state), "--horizon", "now", "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    ids = {d["track_id"] for d in data}
+    # feat-a is 1.0 + planned -> horizon now; feat-c (1.x) excluded.
+    assert "feat-a" in ids
+    assert "feat-c" not in ids
+
+
+def test_objective_show(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "show", "feat-b", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "feat-b" in out
+    assert "feat-a" in out  # dependency listed
+
+
+def test_objective_show_json(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "show", "feat-b", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state), "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["track_id"] == "feat-b"
+    assert data["depends_on"] == ["feat-a"]
+
+
+def test_objective_show_missing_returns_nonzero(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "show", "does-not-exist", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state),
+    ])
+    assert rc == 1

--- a/tests/test_receipt_hashchain.py
+++ b/tests/test_receipt_hashchain.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""GAP 3b: per-append hash-chain wiring tests (flag-gated VNX_CHAIN_RECEIPTS).
+
+Covers:
+  - flag OFF: append behavior unchanged (no prev_hash field) — byte-for-byte.
+  - flag ON: appends carry prev_hash; verify_chain passes on the result.
+  - CONCURRENCY (the critical one): 12 concurrent processes each append a
+    receipt under the lock with the flag ON; verify_chain passes (zero forks:
+    every prev_hash matches the prior entry's hash, no duplicate prev_hash,
+    no GENESIS after line 1).
+  - replay/idempotency: re-running verify on the chained file is stable.
+
+The concurrency test exercises the exact correctness invariant from the spec:
+read-tail + stamp + write + cache-update must be serialized under the single
+append lock or concurrent appends fork the chain.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from append_receipt_internals.idempotency import (  # noqa: E402
+    _cache_file_for,
+    _compute_idempotency_key,
+    _write_receipt_under_lock,
+)
+from ndjson_hash_chain import GENESIS_HASH, compute_entry_hash, verify_chain  # noqa: E402
+
+
+def _append_one(receipt_path: Path, receipt: dict) -> None:
+    """Append a single receipt through the canonical lock-scoped writer."""
+    cache_path = _cache_file_for(receipt_path)
+    key = _compute_idempotency_key(receipt, receipt.get("event_type", "test_event"))
+    _write_receipt_under_lock(
+        receipt,
+        receipt_path,
+        cache_path,
+        key,
+        cache_window_seconds=300,
+    )
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Flag OFF: byte-for-byte unchanged, no prev_hash field
+# --------------------------------------------------------------------------- #
+def test_flag_off_no_prev_hash(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+
+    for i in range(5):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == 5
+    for entry in entries:
+        assert "prev_hash" not in entry, "flag OFF must not stamp prev_hash"
+
+
+def test_flag_off_explicit_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "0")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": "d0", "n": 0})
+    entries = _read_lines(receipt_path)
+    assert "prev_hash" not in entries[0]
+
+
+# --------------------------------------------------------------------------- #
+# Flag ON: chained, verify_chain passes
+# --------------------------------------------------------------------------- #
+def test_flag_on_chains_and_verifies(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "1")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+
+    for i in range(6):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == 6
+
+    # First entry is genesis, every subsequent entry chains to the prior body.
+    assert entries[0]["prev_hash"] == GENESIS_HASH
+    for idx in range(1, len(entries)):
+        assert entries[idx]["prev_hash"] == compute_entry_hash(entries[idx - 1])
+
+    is_valid, violations = verify_chain(receipt_path)
+    assert is_valid, f"chain should verify, violations: {violations}"
+
+
+def test_flag_on_genesis_only_first_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "true")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    for i in range(4):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    entries = _read_lines(receipt_path)
+    genesis_count = sum(1 for e in entries if e.get("prev_hash") == GENESIS_HASH)
+    assert genesis_count == 1, "GENESIS_HASH must appear only on line 1"
+
+
+# --------------------------------------------------------------------------- #
+# CONCURRENCY: the critical fork-test
+# --------------------------------------------------------------------------- #
+def _concurrent_worker(receipt_path_str: str, worker_id: int) -> None:
+    """Subprocess body: enable flag, append one receipt under the lock."""
+    os.environ["VNX_CHAIN_RECEIPTS"] = "1"
+    # Re-resolve imports inside the spawned process.
+    for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+        if _p not in sys.path:
+            sys.path.insert(0, _p)
+    from append_receipt_internals.idempotency import (
+        _cache_file_for as cf,
+        _compute_idempotency_key as ck,
+        _write_receipt_under_lock as wr,
+    )
+
+    receipt_path = Path(receipt_path_str)
+    receipt = {
+        "event_type": "test_event",
+        "dispatch_id": f"worker-{worker_id}",
+        "worker": worker_id,
+        "pid": os.getpid(),
+    }
+    cache_path = cf(receipt_path)
+    key = ck(receipt, "test_event")
+    wr(receipt, receipt_path, cache_path, key, cache_window_seconds=300)
+
+
+@pytest.mark.parametrize("n_workers", [8, 16])
+def test_concurrent_appends_no_fork(tmp_path, n_workers):
+    receipt_path = tmp_path / f"t0_receipts_{n_workers}.ndjson"
+
+    ctx = mp.get_context("spawn")
+    procs = [
+        ctx.Process(target=_concurrent_worker, args=(str(receipt_path), wid))
+        for wid in range(n_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker exited non-zero: {p.exitcode}"
+
+    entries = _read_lines(receipt_path)
+    assert len(entries) == n_workers, "every worker must have appended exactly once"
+
+    # 1. verify_chain passes — the single source of truth for "no fork".
+    is_valid, violations = verify_chain(receipt_path)
+    assert is_valid, f"CHAIN FORKED under concurrency, violations: {violations}"
+
+    # 2. Exactly one GENESIS, on line 1.
+    assert entries[0]["prev_hash"] == GENESIS_HASH
+    genesis_count = sum(1 for e in entries if e.get("prev_hash") == GENESIS_HASH)
+    assert genesis_count == 1, "fork: GENESIS_HASH appears more than once"
+
+    # 3. No duplicate prev_hash (a fork manifests as two entries sharing a parent).
+    prev_hashes = [e["prev_hash"] for e in entries]
+    assert len(prev_hashes) == len(set(prev_hashes)), "fork: duplicate prev_hash"
+
+    # 4. Each prev_hash matches the prior entry's body hash (explicit, beyond verify).
+    for idx in range(1, len(entries)):
+        assert entries[idx]["prev_hash"] == compute_entry_hash(entries[idx - 1])
+
+
+# --------------------------------------------------------------------------- #
+# Replay / idempotency: verify is stable across repeated runs
+# --------------------------------------------------------------------------- #
+def test_verify_is_stable_on_replay(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "1")
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    for i in range(5):
+        _append_one(receipt_path, {"event_type": "test_event", "dispatch_id": f"d{i}", "n": i})
+
+    first = verify_chain(receipt_path)
+    second = verify_chain(receipt_path)
+    third = verify_chain(receipt_path)
+    assert first[0] is True
+    assert first == second == third, "verify must be deterministic across replays"

--- a/tests/test_seed_tracks_from_roadmap.py
+++ b/tests/test_seed_tracks_from_roadmap.py
@@ -190,6 +190,74 @@ def test_phase_drift_reported_not_synced(tmp_path, roadmap):
     assert tracks_lib.get_track(state_dir, "feat-b", "vnx-dev")["phase"] == "active"
 
 
+def test_dependency_only_change_reseeded(tmp_path, roadmap):
+    """ADVISORY: when a ROADMAP feature's ONLY change is depends_on,
+    the seeder must re-seed the track_dependencies row (not skip as
+    'unchanged').
+    """
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+
+    # feat-b depends on feat-a initially.
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        edges = conn.execute(
+            "SELECT from_track_id, to_track_id FROM track_dependencies"
+        ).fetchall()
+        assert ("feat-b", "feat-a") in edges
+    finally:
+        conn.close()
+
+    # Modify ROADMAP: feat-b now also depends on feat-c (no other field changes).
+    modified = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: high
+    depends_on: []
+    milestone: "1.0"
+    status: done
+    notes: Feature A is shipped.
+    pr_queue:
+      - pr_id: "#10"
+        title: a
+        status: merged
+        risk_class: high
+  - feature_id: feat-b
+    title: Feature B
+    risk_class: low
+    depends_on: [feat-a, feat-c]
+    milestone: "1.0"
+    status: planned
+  - feature_id: feat-c
+    title: Feature C (no notes, future)
+    risk_class: medium
+    depends_on: []
+    milestone: "1.x"
+    status: planned
+"""
+    modified_path = tmp_path / "ROADMAP_modified.yaml"
+    modified_path.write_text(modified, encoding="utf-8")
+
+    report = seeder.seed(state_dir, modified_path, "vnx-dev", apply=True)
+    # feat-b row is otherwise unchanged — but dependencies were reconciled.
+    assert "feat-b" in report["unchanged"]
+
+    # Verify the new dependency edge was added.
+    conn = sqlite3.connect(str(db))
+    try:
+        edges = conn.execute(
+            "SELECT from_track_id, to_track_id FROM track_dependencies ORDER BY from_track_id, to_track_id"
+        ).fetchall()
+        assert ("feat-b", "feat-a") in edges
+        assert ("feat-b", "feat-c") in edges
+    finally:
+        conn.close()
+
+
 def test_events_emitted(tmp_path, roadmap):
     state_dir = _make_db(tmp_path)
     seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)

--- a/tests/test_seed_tracks_from_roadmap.py
+++ b/tests/test_seed_tracks_from_roadmap.py
@@ -1,0 +1,200 @@
+"""tests/test_seed_tracks_from_roadmap.py — ROADMAP -> tracks seeder.
+
+Verifies:
+- dry-run (default) writes NOTHING
+- --apply creates one track per feature with correct field mapping
+- idempotent: re-apply leaves rows unchanged (no dupes, no churn)
+- goal_state-absent feature tolerated (synthesized)
+- depends_on -> track_dependencies edges
+- horizon derivation (1.0 -> now/next, 1.x -> later)
+- phase drift reported, not auto-synced
+- track_created / track_authored_synced events emitted to track_events.ndjson
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration
+import tracks as tracks_lib
+import seed_tracks_from_roadmap as seeder
+
+
+SAMPLE_ROADMAP = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: high
+    depends_on: []
+    milestone: "1.0"
+    status: done
+    notes: Feature A is shipped.
+    pr_queue:
+      - pr_id: "#10"
+        title: a
+        status: merged
+        risk_class: high
+  - feature_id: feat-b
+    title: Feature B
+    risk_class: low
+    depends_on: [feat-a]
+    milestone: "1.0"
+    status: planned
+  - feature_id: feat-c
+    title: Feature C (no notes, future)
+    risk_class: medium
+    depends_on: []
+    milestone: "1.x"
+    status: planned
+"""
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a v27 coordination DB in tmp_path/state and return the state dir."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 22, (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 24, (_MIGRATIONS / "0024_tracks_tenant_scoping.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 27, (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+@pytest.fixture()
+def roadmap(tmp_path: Path) -> Path:
+    p = tmp_path / "ROADMAP.yaml"
+    p.write_text(SAMPLE_ROADMAP, encoding="utf-8")
+    return p
+
+
+def test_dry_run_writes_nothing(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    report = seeder.seed(state_dir, roadmap, "vnx-dev", apply=False)
+    assert report["summary"]["created"] == 3
+    # Nothing actually written.
+    assert tracks_lib.list_tracks(state_dir, "vnx-dev") == []
+
+
+def test_apply_creates_rows(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    report = seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    assert report["summary"]["created"] == 3
+    rows = {t["track_id"]: t for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    assert set(rows) == {"feat-a", "feat-b", "feat-c"}
+    # feat-a: done status -> done phase, high risk -> P1.
+    assert rows["feat-a"]["phase"] == "done"
+    assert rows["feat-a"]["priority"] == "P1"
+    # feat-b: planned -> queued.
+    assert rows["feat-b"]["phase"] == "queued"
+
+
+def test_horizon_derivation(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    rows = {t["track_id"]: t for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    # 1.0 done -> next; 1.0 not-done -> now; 1.x -> later.
+    assert rows["feat-a"]["horizon"] == "next"   # 1.0 + done
+    assert rows["feat-b"]["horizon"] == "now"    # 1.0 + planned
+    assert rows["feat-c"]["horizon"] == "later"  # 1.x
+
+
+def test_goal_state_synthesized_when_absent(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    feat_c = tracks_lib.get_track(state_dir, "feat-c", "vnx-dev")
+    # No notes on feat-c -> synthesized non-empty goal_state.
+    assert feat_c["goal_state"] == "feat-c done"
+
+
+def test_dependencies_created(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        edges = conn.execute(
+            "SELECT from_track_id, to_track_id FROM track_dependencies"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert ("feat-b", "feat-a") in edges
+
+
+def test_idempotent_reapply(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    report2 = seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    assert report2["summary"]["created"] == 0
+    assert report2["summary"]["unchanged"] == 3
+    assert report2["summary"]["updated"] == 0
+    # Still exactly 3 rows (no dupes).
+    assert len(tracks_lib.list_tracks(state_dir, "vnx-dev")) == 3
+
+
+def test_phase_drift_reported_not_synced(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    # Operator transitions feat-b queued -> active in the DB (declared status).
+    tracks_lib.transition_phase(state_dir, "feat-b", "vnx-dev", "active", actor="operator")
+    report = seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    drift_ids = {d["track_id"] for d in report["phase_drift"]}
+    assert "feat-b" in drift_ids
+    # Phase NOT overwritten back to queued.
+    assert tracks_lib.get_track(state_dir, "feat-b", "vnx-dev")["phase"] == "active"
+
+
+def test_events_emitted(tmp_path, roadmap):
+    state_dir = _make_db(tmp_path)
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    events_file = state_dir.parent / "events" / "track_events.ndjson"
+    assert events_file.exists()
+    lines = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+    types = {e["event_type"] for e in lines}
+    assert "track_created" in types


### PR DESCRIPTION
## What this enables

Phase 1 of the VNX planning layer (the "future-state flow"). The smallest slice that lets a cold-start orchestrator answer **"what's next"** directly from the live `tracks` DB instead of a handoff doc — one query, from the live state.

Model (NO-NODE, as decided by the opus + deepseek architect convergence): `TRACK (= ROADMAP feature, one row per feature) -> DISPATCH (execution leaf) -> output/receipt`. A deliverable is a derived view, not a table. Horizon (now/next/later) is a status field on tracks.

## What's in it

**Migration 0027** (`schemas/migrations/0027_*.sql` + `_down.sql`, idempotent via `apply_script_if_below` / PRAGMA user_version):
- `tracks.horizon TEXT CHECK (now|next|later)` (nullable, backfilled by seeder) + `idx_tracks_horizon`
- a derived `deliverables` VIEW = `GROUP BY project_id, output_ref` over dispatches, exposing `deliverable_ref`, `output_kind`, `track`, `dispatch_count`, `completed/in_flight/planned` counts, a computed `derived_status`, and `last_activity`
- ADR-007: no new table; the view carries `project_id` in its GROUP BY + projection, inheriting the dispatches composite scoping
- wired into `migrate_future_system.py` with a v24-intact preflight (self-heals the central install)

**`scripts/seed_tracks_from_roadmap.py`** — projects authored `ROADMAP.yaml` features into `tracks` rows via the `tracks.py` DAL:
- **dry-run default**, `--apply` to write; **idempotent** (read-then-branch: created / unchanged / updated)
- maps `feature_id->track_id`, `status->phase` (create-only — phase drift is **reported, never auto-synced**), `depends_on->track_dependencies` (manual/hard), `pr_queue->pr_ref` + `metadata_json`, `milestone->horizon` (1.0 -> now/next, 1.x -> later)
- synthesizes `goal_state` when absent (tolerates the 0022 NOT NULL vs 0024 nullable divergence)
- emits `track_created` / `track_authored_synced` events to `track_events.ndjson`
- prints an added/updated/unchanged/phase_drift/orphan drift report

**DAL** (`scripts/lib/tracks.py`): `horizon` param on `create_track` (column-aware so it stays compatible with pre-0027 DBs) + a new `update_authored_fields()` helper that never touches `phase`/`next_up`.

**CLI** (`scripts/planning_cli.py` + `bin/vnx` arm + `vnx_mode` tier): `vnx objective list [--horizon/--phase/--json]` and `vnx objective show <id>`, grouped by horizon — the read surface. No `vnx promote` (collides with the existing PR-queue promote; deferred to Phase 2 as `vnx deliverable promote`).

## Tests

23 new tests, all passing:
- `test_migrate_0027_planning_horizon.py` — up/down on a temp DB, horizon CHECK, view rollup + derived_status, idempotency
- `test_seed_tracks_from_roadmap.py` — dry-run writes nothing, --apply creates rows, idempotent re-apply, goal_state-absent tolerated, deps, phase-drift-not-synced, events
- `test_planning_cli_objective.py` — `objective list`/`show` (table + JSON) render from a temp DB

Existing track DAL suites stay green (123 passing in the consolidated run). The `tests/test_track_cli.py` failures are pre-existing on the base branch (require `--project-id` per FUT-2a) and unrelated to this PR.

## Safety

The live `.vnx-data/` DB was NOT touched. The seeder defaults to dry-run and `--apply` was never run against the live DB. Tests use temp DBs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)