### PR TITLE
feat(dispatch): PR-1 flag-gated dispatch envelope (codex lane, VNX_UNIFIED_ENVELOPE, legacy default)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -1,0 +1,361 @@
+"""dispatch_envelope.py — Flag-gated unified dispatch envelope (PR-1, codex lane only).
+
+Strangler-fig approach: legacy default OFF, codex-lane only in this PR.
+Activate with VNX_UNIFIED_ENVELOPE=1 and VNX_UNIFIED_ENVELOPE_LANES containing "codex".
+
+Seams: PREPARE -> ROUTE -> EXECUTE -> GOVERN
+
+GOVERN is fail-closed: a missing receipt_path raises EnvelopeGovernError — never
+silently loses a receipt. Report is emitted before the receipt so the receipt carries
+the linkage even when the report file is new (ADR-005).
+
+Reuses:
+  - spawn_codex from provider_spawns.codex_spawn (no reimplementation)
+  - emit_dispatch_receipt + emit_unified_report from governance_emit
+
+No new hooks. Idempotent receipts (governance_emit uses fcntl.flock).
+EventStore wiring and cost emission are open items for later PRs (PR-1 scope: flag-gate only).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnvelopeSpec:
+    """Normalized dispatch parameters passed through PREPARE -> ROUTE -> EXECUTE -> GOVERN."""
+
+    dispatch_id: str
+    terminal_id: str
+    provider: str
+    model: str
+    instruction: str
+    role: Optional[str]
+    pr_id: Optional[str]
+    state_dir: Path
+    data_dir: Path
+
+
+@dataclass
+class EnvelopeResult:
+    """Outcome from a complete envelope run."""
+
+    status: str           # "success" | "failure" | "timeout"
+    returncode: int
+    report_path: Optional[Path]
+    receipt_path: Optional[Path]
+    completion_text: str = ""
+    error: Optional[str] = None
+
+
+class EnvelopeGovernError(RuntimeError):
+    """Raised when GOVERN cannot emit or confirm a receipt (fail-closed contract)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal adapter result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AdapterResult:
+    returncode: int
+    completion_text: str
+    status: str           # "success" | "failure" | "timeout"
+    token_usage: Dict[str, int] = field(default_factory=dict)
+    error: Optional[str] = None
+    timed_out: bool = False
+    event_writer_failures: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+class CodexAdapter:
+    """Wraps spawn_codex — reuses existing spawn without reimplementation.
+
+    event_writer is not wired in PR-1 (no EventStore setup here); the audit
+    stream gap is documented in Open Items and closed in a later PR.
+    """
+
+    def run(
+        self,
+        spec: EnvelopeSpec,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from provider_spawns.codex_spawn import spawn_codex  # noqa: PLC0415
+
+        try:
+            result = spawn_codex(
+                prompt=spec.instruction,
+                model=spec.model,
+                dispatch_id=spec.dispatch_id,
+                terminal_id=spec.terminal_id,
+                event_writer=event_writer,
+                cwd=cwd,
+            )
+        except BrokenPipeError as exc:
+            return _AdapterResult(
+                returncode=1,
+                completion_text="",
+                status="failure",
+                error=f"codex spawn BrokenPipeError: {exc}",
+            )
+
+        token_usage: Dict[str, int] = {}
+        raw_usage = getattr(result, "token_usage", None)
+        if isinstance(raw_usage, dict):
+            token_usage = {
+                "input": int(
+                    raw_usage.get("input_tokens", raw_usage.get("input", 0)) or 0
+                ),
+                "output": int(
+                    raw_usage.get("output_tokens", raw_usage.get("output", 0)) or 0
+                ),
+                "cache_hit": int(
+                    raw_usage.get(
+                        "cache_read_tokens", raw_usage.get("cache_hit", 0)
+                    ) or 0
+                ),
+            }
+
+        if result.error:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="failure",
+                token_usage=token_usage,
+                error=result.error,
+                event_writer_failures=result.event_writer_failures,
+            )
+        if result.timed_out:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="timeout",
+                token_usage=token_usage,
+                timed_out=True,
+                event_writer_failures=result.event_writer_failures,
+            )
+        status = "success" if result.returncode == 0 else "failure"
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status=status,
+            token_usage=token_usage,
+            event_writer_failures=result.event_writer_failures,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lane router
+# ---------------------------------------------------------------------------
+
+_LANE_REGISTRY: Dict[str, type] = {
+    "codex": CodexAdapter,
+}
+
+
+class LaneRouter:
+    """Maps a lane name to an adapter instance."""
+
+    def get(self, lane: str) -> object:
+        cls = _LANE_REGISTRY.get(lane)
+        if cls is None:
+            raise ValueError(f"LaneRouter: no adapter registered for lane={lane!r}")
+        return cls()
+
+
+# ---------------------------------------------------------------------------
+# PREPARE
+# ---------------------------------------------------------------------------
+
+
+def _prepare(spec: EnvelopeSpec) -> str:
+    """Enrich instruction with intelligence context and repo map (best-effort).
+
+    Mirrors _enrich_instruction in provider_dispatch.py but operates on EnvelopeSpec.
+    Both layers fall back silently to the original instruction on any failure.
+    """
+    instruction = spec.instruction
+
+    try:
+        from intelligence_injection import build_intelligence_section  # noqa: PLC0415
+
+        instruction = build_intelligence_section(
+            instruction=instruction,
+            dispatch_id=spec.dispatch_id,
+            role=spec.role,
+            state_dir=spec.state_dir,
+            pr_id=spec.pr_id,
+            dispatch_paths=None,
+        )
+    except ImportError:
+        pass
+    except Exception as exc:
+        logger.warning(
+            "envelope._prepare: intelligence injection failed (%s) — skipping", exc
+        )
+
+    try:
+        from dispatch_enricher import apply_repo_map_layer  # noqa: PLC0415
+
+        instruction = apply_repo_map_layer(instruction, {"role": spec.role})
+    except Exception as exc:
+        logger.warning(
+            "envelope._prepare: repo map layer failed (%s) — skipping", exc
+        )
+
+    return instruction
+
+
+# ---------------------------------------------------------------------------
+# GOVERN
+# ---------------------------------------------------------------------------
+
+
+def _govern(
+    spec: EnvelopeSpec,
+    adapter_result: _AdapterResult,
+    start_time: datetime,
+    end_time: datetime,
+) -> tuple:
+    """Emit unified_report then dispatch receipt. Returns (report_path, receipt_path).
+
+    Fail-closed contract: raises EnvelopeGovernError when receipt_path is None or
+    absent on disk after emit — never silently loses a receipt.
+    Report is emitted first so the receipt can carry the linkage (ADR-005 ordering).
+    """
+    from governance_emit import emit_dispatch_receipt, emit_unified_report  # noqa: PLC0415
+
+    duration = (end_time - start_time).total_seconds()
+
+    # REPORT first — idempotent: worker-written file is preserved, not overwritten
+    report_path: Optional[Path] = None
+    try:
+        report_path = emit_unified_report(
+            dispatch_id=spec.dispatch_id,
+            terminal_id=spec.terminal_id,
+            provider=spec.provider,
+            instruction=spec.instruction,
+            response_text=adapter_result.completion_text,
+            findings=[],
+            duration_seconds=duration,
+            data_dir=spec.data_dir,
+        )
+    except Exception as exc:
+        logger.error(
+            "envelope._govern: report emit failed dispatch=%s: %s — proceeding to receipt",
+            spec.dispatch_id,
+            exc,
+        )
+
+    # RECEIPT second — fail-closed
+    receipt_path: Optional[Path] = None
+    try:
+        receipt_path = emit_dispatch_receipt(
+            dispatch_id=spec.dispatch_id,
+            terminal_id=spec.terminal_id,
+            provider=spec.provider,
+            model=spec.model,
+            pr_id=spec.pr_id,
+            status=adapter_result.status,
+            completion_pct=100 if adapter_result.status == "success" else 0,
+            risk=0.0,
+            findings=[],
+            duration_seconds=duration,
+            token_usage=adapter_result.token_usage,
+            cost_usd=None,
+            state_dir=spec.state_dir,
+            report_path=str(report_path) if report_path else None,
+        )
+    except Exception as exc:
+        raise EnvelopeGovernError(
+            f"envelope._govern: receipt emit raised for dispatch={spec.dispatch_id}: {exc}"
+        ) from exc
+
+    if receipt_path is None:
+        raise EnvelopeGovernError(
+            f"envelope._govern: receipt_path is None after emit "
+            f"(fail-closed) dispatch={spec.dispatch_id}"
+        )
+    if not receipt_path.exists():
+        raise EnvelopeGovernError(
+            f"envelope._govern: receipt file absent on disk after emit "
+            f"path={receipt_path} dispatch={spec.dispatch_id} (fail-closed)"
+        )
+
+    logger.info(
+        "envelope._govern: dispatch=%s status=%s report=%s receipt=%s",
+        spec.dispatch_id,
+        adapter_result.status,
+        report_path,
+        receipt_path,
+    )
+    return report_path, receipt_path
+
+
+# ---------------------------------------------------------------------------
+# Envelope entry point
+# ---------------------------------------------------------------------------
+
+
+def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
+    """Run PREPARE -> ROUTE -> EXECUTE -> GOVERN for the given lane.
+
+    Returns EnvelopeResult on success / failure / timeout.
+    Raises EnvelopeGovernError when GOVERN cannot confirm a receipt (fail-closed).
+    """
+    # ROUTE
+    router = LaneRouter()
+    adapter = router.get(lane)
+
+    # PREPARE — enrich instruction (best-effort; failure falls back to original)
+    enriched_instruction = _prepare(spec)
+    enriched_spec = EnvelopeSpec(
+        dispatch_id=spec.dispatch_id,
+        terminal_id=spec.terminal_id,
+        provider=spec.provider,
+        model=spec.model,
+        instruction=enriched_instruction,
+        role=spec.role,
+        pr_id=spec.pr_id,
+        state_dir=spec.state_dir,
+        data_dir=spec.data_dir,
+    )
+
+    # EXECUTE
+    start_time = datetime.now(timezone.utc)
+    adapter_result = adapter.run(enriched_spec)
+    end_time = datetime.now(timezone.utc)
+
+    # GOVERN (fail-closed on receipt)
+    report_path, receipt_path = _govern(enriched_spec, adapter_result, start_time, end_time)
+
+    returncode = 0 if adapter_result.status == "success" else 1
+    return EnvelopeResult(
+        status=adapter_result.status,
+        returncode=returncode,
+        report_path=report_path,
+        receipt_path=receipt_path,
+        completion_text=adapter_result.completion_text,
+        error=adapter_result.error,
+    )

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -848,6 +848,42 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
             _remove_provider_worktree(args.dispatch_id)
 
 
+def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
+    """Route codex dispatch through the unified envelope (VNX_UNIFIED_ENVELOPE=1, codex lane).
+
+    Fail-closed: EnvelopeGovernError → exit code 1. Legacy path is untouched
+    when the flag is unset (see caller in main()).
+    """
+    from dispatch_envelope import EnvelopeGovernError, EnvelopeSpec, run_envelope  # noqa: PLC0415
+
+    model = os.environ.get("VNX_CODEX_MODEL", "") or _resolve_codex_model()
+    state_dir = _resolve_state_dir()
+    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+
+    spec = EnvelopeSpec(
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+        provider="codex",
+        model=model,
+        instruction=args.instruction,
+        role=getattr(args, "role", None),
+        pr_id=getattr(args, "pr_id", None),
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    try:
+        result = run_envelope(spec, lane="codex")
+        return result.returncode
+    except EnvelopeGovernError as exc:
+        logger.error(
+            "envelope: GOVERN fail-closed dispatch=%s: %s",
+            args.dispatch_id,
+            exc,
+        )
+        return 1
+
+
 def _resolve_codex_model() -> str:
     """Load codex model key from registry (openai section), fallback to hardcoded default.
 
@@ -1384,6 +1420,14 @@ def main(argv: list[str] | None = None) -> int:
         return _dispatch_claude(args)
 
     if provider == "codex":
+        _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"
+        _envelope_lanes = [
+            lane.strip()
+            for lane in (os.environ.get("VNX_UNIFIED_ENVELOPE_LANES") or "").split(",")
+            if lane.strip()
+        ]
+        if _envelope_on and "codex" in _envelope_lanes:
+            return _dispatch_codex_via_envelope(args)
         return _dispatch_codex(args)
 
     if provider == "gemini":

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -1,0 +1,273 @@
+"""test_dispatch_envelope.py — Tests for dispatch_envelope.py (PR-1, codex lane).
+
+Verifies:
+1. Success path: spawn_codex -> 0 -> BOTH report AND receipt emitted, returncode 0.
+2. Failure path: spawn_codex error -> BOTH report AND receipt emitted, status "failure".
+3. Timeout path: spawn_codex timed_out -> BOTH report AND receipt emitted, status "timeout".
+4. Fail-closed: receipt emit raises -> EnvelopeGovernError (non-zero, no silent loss).
+5. Fail-closed: receipt_path returns None -> EnvelopeGovernError.
+6. Flag-off: VNX_UNIFIED_ENVELOPE unset -> legacy _dispatch_codex called, envelope NOT invoked.
+7. Flag-on: VNX_UNIFIED_ENVELOPE=1 + lanes contains "codex" -> envelope invoked.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+import provider_dispatch
+from dispatch_envelope import (
+    EnvelopeGovernError,
+    EnvelopeSpec,
+    LaneRouter,
+    run_envelope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCodexResult:
+    """Minimal CodexSpawnResult-compatible stub for spawn_codex mocking."""
+
+    returncode: int = 0
+    completion_text: str = "task done"
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+    def __post_init__(self):
+        if self.token_usage is None:
+            self.token_usage = {"input_tokens": 100, "output_tokens": 50}
+
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal EnvelopeSpec pointing at tmp_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def spec(tmp_path: Path) -> EnvelopeSpec:
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True)
+    (data_dir / "unified_reports").mkdir(parents=True)
+    return EnvelopeSpec(
+        dispatch_id="env-pr1-test-001",
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-5.2-codex",
+        instruction="implement the feature",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+_UNSET = object()  # sentinel distinguishing "not provided" from explicit None
+
+
+def _stub_governance(
+    spec: EnvelopeSpec,
+    *,
+    receipt_side_effect=None,
+    receipt_return=_UNSET,
+):
+    """Return (report_path, receipt_path, mock_report, mock_receipt) wired to spec."""
+    report_path = spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md"
+    receipt_path = spec.state_dir / "t0_receipts.ndjson"
+    receipt_path.write_text("")  # ensure .exists() check passes for normal cases
+
+    mock_report = MagicMock(return_value=report_path)
+    if receipt_side_effect is not None:
+        mock_receipt = MagicMock(side_effect=receipt_side_effect)
+    elif receipt_return is not _UNSET:
+        mock_receipt = MagicMock(return_value=receipt_return)
+    else:
+        mock_receipt = MagicMock(return_value=receipt_path)
+
+    return report_path, receipt_path, mock_report, mock_receipt
+
+
+# ---------------------------------------------------------------------------
+# 1-3: success / failure / timeout all emit BOTH report AND receipt
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeEmitsBothReportAndReceipt:
+    """PREPARE->ROUTE->EXECUTE->GOVERN emits report AND receipt for every outcome."""
+
+    def _run(self, spec, codex_result):
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec)
+
+        with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            result = run_envelope(spec, lane="codex")
+
+        return result, mock_report, mock_receipt
+
+    def test_success_emits_report_and_receipt(self, spec):
+        codex_result = _FakeCodexResult(returncode=0)
+        result, mock_report, mock_receipt = self._run(spec, codex_result)
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+
+    def test_failure_emits_report_and_receipt(self, spec):
+        codex_result = _FakeCodexResult(returncode=1, error="codex process exited 1")
+        result, mock_report, mock_receipt = self._run(spec, codex_result)
+
+        assert result.status == "failure"
+        assert result.returncode == 1
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["status"] == "failure"
+
+    def test_timeout_emits_report_and_receipt(self, spec):
+        codex_result = _FakeCodexResult(returncode=1, timed_out=True)
+        result, mock_report, mock_receipt = self._run(spec, codex_result)
+
+        assert result.status == "timeout"
+        assert result.returncode == 1
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["status"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# 4-5: fail-closed on missing / failed receipt
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeFailClosed:
+    """GOVERN must raise EnvelopeGovernError when receipt is missing — never silent."""
+
+    def test_receipt_emit_raises_fail_closed(self, spec):
+        _, _, mock_report, mock_receipt = _stub_governance(
+            spec, receipt_side_effect=RuntimeError("disk full")
+        )
+        codex_result = _FakeCodexResult(returncode=0)
+
+        with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            with pytest.raises(EnvelopeGovernError, match="receipt emit raised"):
+                run_envelope(spec, lane="codex")
+
+    def test_none_receipt_path_fail_closed(self, spec):
+        _, _, mock_report, mock_receipt = _stub_governance(
+            spec, receipt_return=None
+        )
+        codex_result = _FakeCodexResult(returncode=0)
+
+        with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            with pytest.raises(EnvelopeGovernError, match="receipt_path is None"):
+                run_envelope(spec, lane="codex")
+
+
+# ---------------------------------------------------------------------------
+# 6-7: flag-off = legacy path; flag-on = envelope invoked
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    """VNX_UNIFIED_ENVELOPE flag controls whether envelope or legacy path is used."""
+
+    _CODEX_ARGV = [
+        "--provider", "codex",
+        "--terminal-id", "T1",
+        "--dispatch-id", "test-flag-gate-codex",
+        "--instruction", "noop",
+    ]
+
+    def test_flag_off_calls_legacy_dispatch_codex(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE unset -> _dispatch_codex, envelope NOT invoked."""
+        monkeypatch.delenv("VNX_UNIFIED_ENVELOPE", raising=False)
+        monkeypatch.delenv("VNX_UNIFIED_ENVELOPE_LANES", raising=False)
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_codex", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_codex_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CODEX_ARGV)
+
+        mock_legacy.assert_called_once()
+        mock_via_envelope.assert_not_called()
+        assert result == 0
+
+    def test_flag_on_calls_envelope(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE=1 + codex in lanes -> _dispatch_codex_via_envelope."""
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "codex")
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_codex", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_codex_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CODEX_ARGV)
+
+        mock_via_envelope.assert_called_once()
+        mock_legacy.assert_not_called()
+        assert result == 0
+
+    def test_flag_on_wrong_lane_calls_legacy(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE=1 but codex NOT in lanes -> legacy _dispatch_codex."""
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "gemini,kimi")
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_codex", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_codex_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CODEX_ARGV)
+
+        mock_legacy.assert_called_once()
+        mock_via_envelope.assert_not_called()
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# LaneRouter unit test
+# ---------------------------------------------------------------------------
+
+
+class TestLaneRouter:
+
+    def test_codex_returns_codex_adapter(self):
+        from dispatch_envelope import CodexAdapter
+        adapter = LaneRouter().get("codex")
+        assert isinstance(adapter, CodexAdapter)
+
+    def test_unknown_lane_raises(self):
+        with pytest.raises(ValueError, match="no adapter registered"):
+            LaneRouter().get("unknown-lane")


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/dispatch_envelope.py`: unified PREPARE→ROUTE→EXECUTE→GOVERN seam, flag-gated behind `VNX_UNIFIED_ENVELOPE=1` + `VNX_UNIFIED_ENVELOPE_LANES` containing `codex`. Default OFF — legacy behavior byte-for-byte unchanged when flag is unset.
- `CodexAdapter` wraps existing `spawn_codex` (no reimplementation). `LaneRouter` maps lane names to adapters (codex only in this PR).
- GOVERN is fail-closed: `EnvelopeGovernError` raised when `receipt_path` is `None` or absent on disk after emit — never silently loses a receipt.
- Wires `_dispatch_codex_via_envelope()` into `provider_dispatch.main()` as the codex branch when both flags are set.
- 10 new tests in `tests/test_dispatch_envelope.py` covering success/failure/timeout all emit both report+receipt, fail-closed on missing receipt, flag-off=legacy path, flag-on=envelope, wrong-lane=legacy.

## Test plan

- [ ] `pytest tests/test_dispatch_envelope.py -q` → 10 passed
- [ ] `pytest tests/test_provider_dispatch_entry.py -q` → 21 passed (no regressions)
- [ ] `pytest tests/test_provider_dispatch_governance_integration.py tests/test_provider_dispatch_contract_integration.py -q` → 40 passed (no regressions)
- [ ] With `VNX_UNIFIED_ENVELOPE` unset: `--provider codex` routes to `_dispatch_codex` (legacy, unchanged)
- [ ] With `VNX_UNIFIED_ENVELOPE=1 VNX_UNIFIED_ENVELOPE_LANES=codex`: `--provider codex` routes through envelope

## Open items (documented in dispatch_envelope.py docstring)

- EventStore is not wired in PR-1 (no audit stream for envelope path); closed in a later PR
- `provider_costs.emit_provider_cost` and `_record_provider_metadata` not called in GOVERN PR-1; closes in PR-2 GOVERN parity

## Dispatch-ID

`20260601-221341-envelope-pr1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)