### PR TITLE
feat(planning): Phase 2 — deliverable plane + proposed->ready human gate (vnx deliverable add/list/promote)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -2050,6 +2050,9 @@ main() {
     objective)
       python3 "$VNX_HOME/scripts/planning_cli.py" objective "$@"
       ;;
+    deliverable)
+      python3 "$VNX_HOME/scripts/planning_cli.py" deliverable "$@"
+      ;;
     suggest)
       python3 "$VNX_HOME/scripts/apply_suggested_edits.py" "$@"
       ;;

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -33,6 +33,7 @@ DB_FILENAME = "runtime_coordination.db"
 # ---------------------------------------------------------------------------
 
 DISPATCH_STATES = frozenset({
+    "proposed", "ready",
     "queued", "claimed", "delivering", "accepted", "running",
     "completed", "timed_out", "failed_delivery", "expired", "recovered", "dead_letter",
 })
@@ -43,6 +44,10 @@ ACCEPTED_OR_BEYOND_STATES = frozenset({
 LEASE_STATES = frozenset({"idle", "leased", "expired", "recovering", "released"})
 
 DISPATCH_TRANSITIONS: Dict[str, frozenset] = {
+    # Planning gate: proposed (un-approved) -> ready (operator-approved)
+    "proposed":        frozenset({"ready"}),
+    # Execution gate: ready -> claimed (dispatchable once promoted)
+    "ready":           frozenset({"claimed", "expired"}),
     "queued":          frozenset({"claimed", "expired"}),
     "claimed":         frozenset({"delivering", "expired", "recovered"}),
     "delivering":      frozenset({"accepted", "failed_delivery", "timed_out"}),

--- a/scripts/lib/dispatch_broker.py
+++ b/scripts/lib/dispatch_broker.py
@@ -348,10 +348,15 @@ class DispatchBroker:
                 raise BrokerError(f"Cannot claim: dispatch not found: {dispatch_id!r}")
 
             current_state = row["state"]
-            if current_state != "queued":
+            if current_state == "proposed":
+                raise BrokerError(
+                    f"Cannot claim dispatch {dispatch_id!r}: state is 'proposed' "
+                    f"(deliverable not yet approved). Run: vnx deliverable promote {dispatch_id}"
+                )
+            if current_state not in ("queued", "ready"):
                 raise BrokerError(
                     f"Cannot claim dispatch {dispatch_id!r}: "
-                    f"expected state 'queued', found {current_state!r}"
+                    f"expected state 'queued' or 'ready', found {current_state!r}"
                 )
 
             updated_row = transition_dispatch(

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -51,7 +51,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "intelligence-import", "init-feature", "bootstrap-skills",
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings", "regen-worker-permissions",
     "patch-agent-files", "register", "list-projects", "unregister",
-    "roadmap", "insights", "objective",
+    "roadmap", "insights", "objective", "deliverable",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",
     "init-db",
 })

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -328,6 +328,8 @@ def _ensure_dispatches_output_columns(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
     if "output_kind" not in cols:
         conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    if "operator_approved_at" not in cols:
+        conn.execute("ALTER TABLE dispatches ADD COLUMN operator_approved_at TEXT")
 
     conn.execute(
         "UPDATE dispatches SET output_ref = pr_ref, output_kind = 'pr' "

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python3
-"""planning_cli.py — read surface for the VNX planning layer (Phase 1).
+"""planning_cli.py — planning layer read/write surface (Phase 1 + Phase 2).
 
 Delegated from `bin/vnx`:
   vnx objective list [--horizon now|next|later] [--phase ...] [--json]
   vnx objective show <track_id> [--json]
+  vnx deliverable add --objective <track_id> --output-kind <kind> --title "..."
+  vnx deliverable list [--objective <track_id>] [--json]
+  vnx deliverable promote <dispatch_id>
 
-Reads the live `tracks` table (the strategic layer of the NO-NODE model) and
-renders feature_id/title/phase/horizon/depends_on/pr_ref, grouped by horizon
-(now/next/later). This is the cold-start "what's next" answer — one query from
-the live DB, no handoff doc.
-
-`vnx promote` is deliberately NOT added here: the top-level `promote` verb is
-already taken by the PR-queue staging command (bin/vnx). The planning promote
-lands in Phase 2 as `vnx deliverable promote`.
+NO-NODE model: a deliverable is a proposed dispatch row with output_kind.
+`vnx deliverable promote` is the human gate (proposed -> ready).
+`vnx promote` (top-level) is the PR-queue command — NOT the same.
 """
 
 from __future__ import annotations
@@ -20,7 +18,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import sys
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -153,6 +154,299 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     return 0
 
 
+_VALID_OUTPUT_KINDS = ("pr", "post", "deal", "doc")
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _db_conn(state_dir: Path) -> sqlite3.Connection:
+    db = state_dir / tracks_lib.DB_FILENAME
+    conn = sqlite3.connect(str(db), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    return any(
+        row[1] == col for row in conn.execute(f"PRAGMA table_info('{table}')")
+    )
+
+
+def _has_table(conn: sqlite3.Connection, table: str) -> bool:
+    return bool(conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone())
+
+
+def _append_coordination_event(
+    conn: sqlite3.Connection,
+    *,
+    event_type: str,
+    dispatch_id: str,
+    from_state: Optional[str],
+    to_state: Optional[str],
+    actor: str,
+    reason: Optional[str] = None,
+    project_id: str = "vnx-dev",
+) -> None:
+    if not _has_table(conn, "coordination_events"):
+        return
+    event_id = str(uuid.uuid4()).replace("-", "")[:16]
+    ts = _now_utc()
+    has_pid = _has_col(conn, "coordination_events", "project_id")
+    if has_pid:
+        conn.execute(
+            """
+            INSERT INTO coordination_events
+                (event_id, event_type, entity_type, entity_id,
+                 from_state, to_state, actor, reason, metadata_json, occurred_at, project_id)
+            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, '{}', ?, ?)
+            """,
+            (event_id, event_type, dispatch_id,
+             from_state, to_state, actor, reason, ts, project_id),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO coordination_events
+                (event_id, event_type, entity_type, entity_id,
+                 from_state, to_state, actor, reason, metadata_json, occurred_at)
+            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, '{}', ?)
+            """,
+            (event_id, event_type, dispatch_id,
+             from_state, to_state, actor, reason, ts),
+        )
+
+
+def cmd_deliverable_add(args: argparse.Namespace) -> int:
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.objective
+    output_kind = args.output_kind
+    title = args.title
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"Objective not found: {track_id!r} (project {project_id!r}). "
+            "Create it with `vnx objective add` or seed from ROADMAP first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dispatch_id = f"dlv-{uuid.uuid4().hex[:12]}"
+    output_ref = f"{output_kind}:{dispatch_id}"
+    metadata = json.dumps({"title": title, "deliverable": True})
+    now = _now_utc()
+
+    conn = _db_conn(state_dir)
+    try:
+        has_oaa = _has_col(conn, "dispatches", "operator_approved_at")
+        has_ok = _has_col(conn, "dispatches", "output_kind")
+        has_or = _has_col(conn, "dispatches", "output_ref")
+
+        cols = ["dispatch_id", "project_id", "state", "track", "metadata_json", "created_at", "updated_at"]
+        vals: list[Any] = [dispatch_id, project_id, "proposed", track_id, metadata, now, now]
+
+        if has_ok:
+            cols.append("output_kind")
+            vals.append(output_kind)
+        if has_or:
+            cols.append("output_ref")
+            vals.append(output_ref)
+        if has_oaa:
+            cols.append("operator_approved_at")
+            vals.append(None)
+
+        placeholders = ", ".join("?" * len(vals))
+        col_list = ", ".join(cols)
+        conn.execute(f"INSERT INTO dispatches ({col_list}) VALUES ({placeholders})", vals)
+
+        _append_coordination_event(
+            conn,
+            event_type="deliverable_created",
+            dispatch_id=dispatch_id,
+            from_state=None,
+            to_state="proposed",
+            actor="operator",
+            reason=f"deliverable add: {title!r}",
+            project_id=project_id,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    print(f"Deliverable created: {dispatch_id}")
+    print(f"  objective  : {track_id}")
+    print(f"  output_kind: {output_kind}")
+    print(f"  output_ref : {output_ref}")
+    print(f"  state      : proposed")
+    print(f"  title      : {title}")
+    print(f"  next       : vnx deliverable promote {dispatch_id}")
+    return 0
+
+
+def cmd_deliverable_list(args: argparse.Namespace) -> int:
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+
+    conn = _db_conn(state_dir)
+    try:
+        has_view = any(
+            row[0] == "deliverables"
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='view'")
+        )
+        if has_view:
+            if args.objective:
+                rows = conn.execute(
+                    """
+                    SELECT deliverable_ref, output_kind, track, dispatch_count,
+                           derived_status, last_activity
+                    FROM deliverables
+                    WHERE project_id = ? AND track = ?
+                    ORDER BY last_activity DESC
+                    """,
+                    (project_id, args.objective),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT deliverable_ref, output_kind, track, dispatch_count,
+                           derived_status, last_activity
+                    FROM deliverables
+                    WHERE project_id = ?
+                    ORDER BY track, last_activity DESC
+                    """,
+                    (project_id,),
+                ).fetchall()
+            records = [dict(r) for r in rows]
+        else:
+            # Fallback: read raw dispatches when view hasn't been applied yet
+            filter_clause = "AND track = ?" if args.objective else ""
+            params: list[Any] = [project_id]
+            if args.objective:
+                params.append(args.objective)
+            raw = conn.execute(
+                f"""
+                SELECT dispatch_id, state, track, output_kind, output_ref, metadata_json, updated_at
+                FROM dispatches
+                WHERE project_id = ? AND state IN ('proposed', 'ready') {filter_clause}
+                ORDER BY track, updated_at DESC
+                """,
+                params,
+            ).fetchall()
+            records = []
+            for r in raw:
+                meta = json.loads(r["metadata_json"] or "{}")
+                records.append({
+                    "deliverable_ref": r["output_ref"] or r["dispatch_id"],
+                    "output_kind": r["output_kind"] or "-",
+                    "track": r["track"] or "-",
+                    "dispatch_count": 1,
+                    "derived_status": r["state"],
+                    "last_activity": r["updated_at"],
+                    "title": meta.get("title", ""),
+                })
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps(records, indent=2, default=str))
+        return 0
+
+    if not records:
+        print(f"No deliverables for project '{project_id}'.")
+        if args.objective:
+            print(f"Add one: vnx deliverable add --objective {args.objective} --output-kind post --title '...'")
+        return 0
+
+    print(f"\nVNX deliverables — project '{project_id}'\n")
+    cur_track = None
+    for r in records:
+        track = r.get("track") or "-"
+        if track != cur_track:
+            print(f"  [{track}]")
+            cur_track = track
+        ref = r.get("deliverable_ref") or "-"
+        status = r.get("derived_status") or "-"
+        kind = r.get("output_kind") or "-"
+        count = r.get("dispatch_count", 1)
+        print(f"    {ref:<36} {kind:<6} {status:<12} ({count} dispatch(es))")
+    print()
+    return 0
+
+
+def cmd_deliverable_promote(args: argparse.Namespace) -> int:
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    dispatch_id = args.dispatch_id
+
+    conn = _db_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+            (dispatch_id, project_id),
+        ).fetchone()
+
+        if row is None:
+            print(
+                f"Dispatch not found: {dispatch_id!r} (project {project_id!r})",
+                file=sys.stderr,
+            )
+            return 1
+
+        current_state = row["state"]
+        if current_state != "proposed":
+            print(
+                f"Cannot promote dispatch {dispatch_id!r}: "
+                f"expected state 'proposed', found {current_state!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        now = _now_utc()
+        has_oaa = _has_col(conn, "dispatches", "operator_approved_at")
+        if has_oaa:
+            conn.execute(
+                """
+                UPDATE dispatches
+                SET state = 'ready', operator_approved_at = ?, updated_at = ?
+                WHERE dispatch_id = ? AND project_id = ?
+                """,
+                (now, now, dispatch_id, project_id),
+            )
+        else:
+            conn.execute(
+                """
+                UPDATE dispatches
+                SET state = 'ready', updated_at = ?
+                WHERE dispatch_id = ? AND project_id = ?
+                """,
+                (now, dispatch_id, project_id),
+            )
+
+        _append_coordination_event(
+            conn,
+            event_type="deliverable_promoted",
+            dispatch_id=dispatch_id,
+            from_state="proposed",
+            to_state="ready",
+            actor="operator",
+            reason="operator gate: proposed -> ready",
+            project_id=project_id,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    print(f"Promoted {dispatch_id}: proposed -> ready")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vnx", description="VNX planning read surface")
     sub = parser.add_subparsers(dest="domain", required=True)
@@ -175,6 +469,34 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_show)
     p_show.add_argument("track_id")
     p_show.set_defaults(func=cmd_objective_show)
+
+    # ------------------------------------------------------------------
+    # deliverable subcommand (Phase 2)
+    # ------------------------------------------------------------------
+    dlv = sub.add_parser("deliverable", help="deliverable plane (proposed dispatches)")
+    dlv_sub = dlv.add_subparsers(dest="action", required=True)
+
+    p_dadd = dlv_sub.add_parser("add", help="plan a deliverable (proposed dispatch)")
+    _common(p_dadd)
+    p_dadd.add_argument("--objective", required=True, metavar="TRACK_ID",
+                        help="track/objective this deliverable belongs to")
+    p_dadd.add_argument("--output-kind", required=True, choices=_VALID_OUTPUT_KINDS,
+                        metavar="KIND", dest="output_kind")
+    p_dadd.add_argument("--title", required=True)
+    p_dadd.set_defaults(func=cmd_deliverable_add)
+
+    p_dlist = dlv_sub.add_parser("list", help="list deliverables grouped by objective")
+    _common(p_dlist)
+    p_dlist.add_argument("--objective", default=None, metavar="TRACK_ID")
+    p_dlist.set_defaults(func=cmd_deliverable_list)
+
+    p_dpromote = dlv_sub.add_parser(
+        "promote",
+        help="human gate: promote deliverable from proposed -> ready",
+    )
+    _common(p_dpromote)
+    p_dpromote.add_argument("dispatch_id")
+    p_dpromote.set_defaults(func=cmd_deliverable_promote)
 
     return parser
 

--- a/tests/test_planning_deliverables.py
+++ b/tests/test_planning_deliverables.py
@@ -1,0 +1,413 @@
+"""tests/test_planning_deliverables.py — deliverable plane (Phase 2) tests.
+
+Covers:
+- `deliverable add` creates a dispatch row in state='proposed' under a track
+- `deliverable list` shows the proposed deliverable (raw fallback + view path)
+- `deliverable promote` transitions proposed->ready, stamps operator_approved_at
+- A proposed deliverable is NOT claimable (BrokerError with actionable message)
+- A ready deliverable IS claimable via the dispatch broker
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration
+import planning_cli
+import tracks as tracks_lib
+
+
+PROJECT_ID = "test-proj"
+
+
+def _build_db(tmp_path: Path) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 + 0027 applied."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    # events dir for track audit ledger
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch',
+            entity_id TEXT NOT NULL,
+            from_state TEXT,
+            to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatch_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_id TEXT NOT NULL UNIQUE,
+            dispatch_id TEXT NOT NULL,
+            terminal_id TEXT NOT NULL,
+            attempt_number INTEGER NOT NULL DEFAULT 1,
+            state TEXT NOT NULL DEFAULT 'started',
+            actor TEXT NOT NULL DEFAULT 'broker',
+            metadata_json TEXT DEFAULT '{}',
+            started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            completed_at TEXT
+        )
+    """)
+    conn.commit()
+
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    # Pre-add output_ref + output_kind (as structural-doctor would on live DB)
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn,
+        27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+@pytest.fixture()
+def state_with_track(tmp_path: Path) -> tuple[Path, str]:
+    """DB with migration applied + one seeded track. Returns (state_dir, track_id)."""
+    state_dir = _build_db(tmp_path)
+    track_id = "feat-alpha"
+    tracks_lib.create_track(
+        state_dir,
+        track_id,
+        PROJECT_ID,
+        title="Feature Alpha",
+        goal_state="ship Feature Alpha",
+        phase="queued",
+        horizon="now",
+    )
+    return state_dir, track_id
+
+
+# ---------------------------------------------------------------------------
+# deliverable add
+# ---------------------------------------------------------------------------
+
+def test_deliverable_add_creates_proposed(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Q3 launch post",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Output should contain dispatch_id and state info
+    assert "proposed" in out
+
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM dispatches WHERE project_id = ? AND state = 'proposed'",
+        (PROJECT_ID,),
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["track"] == track_id
+    assert row["output_kind"] == "post"
+    assert row["operator_approved_at"] is None
+    meta = json.loads(row["metadata_json"])
+    assert meta["title"] == "Q3 launch post"
+
+
+def test_deliverable_add_unknown_objective_exits_nonzero(state_with_track, capsys):
+    state_dir, _ = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", "no-such-track",
+        "--output-kind", "doc",
+        "--title", "Test",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# deliverable list
+# ---------------------------------------------------------------------------
+
+def test_deliverable_list_shows_proposed(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    # Add two deliverables
+    for title in ("Post One", "Post Two"):
+        planning_cli.main([
+            "deliverable", "add",
+            "--objective", track_id,
+            "--output-kind", "post",
+            "--title", title,
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+    capsys.readouterr()  # discard add output
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert track_id in out
+
+
+def test_deliverable_list_json(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "pr",
+        "--title", "Implement alpha",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+        "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data) == 1
+    assert data[0]["output_kind"] == "pr"
+    assert data[0]["derived_status"] == "proposed"
+
+
+def test_deliverable_list_filter_by_objective(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    # Create a second track and add a deliverable to it
+    tracks_lib.create_track(
+        state_dir, "feat-beta", PROJECT_ID,
+        title="Feature Beta", goal_state="ship Beta", phase="queued",
+    )
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Alpha post",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", "feat-beta",
+        "--output-kind", "doc",
+        "--title", "Beta doc",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--objective", track_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+        "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert all(r["track"] == track_id for r in data)
+    assert len(data) == 1
+
+
+# ---------------------------------------------------------------------------
+# deliverable promote
+# ---------------------------------------------------------------------------
+
+def test_deliverable_promote_sets_ready_and_stamps_approved_at(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    # Add deliverable
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Promote me",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT dispatch_id FROM dispatches WHERE project_id = ? AND state = 'proposed'",
+        (PROJECT_ID,),
+    ).fetchone()
+    dispatch_id = row["dispatch_id"]
+    conn.close()
+
+    rc = planning_cli.main([
+        "deliverable", "promote", dispatch_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ready" in out
+
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    updated = dict(conn.execute(
+        "SELECT state, operator_approved_at FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+        (dispatch_id, PROJECT_ID),
+    ).fetchone())
+    conn.close()
+
+    assert updated["state"] == "ready"
+    assert updated["operator_approved_at"] is not None
+
+
+def test_deliverable_promote_wrong_state_exits_nonzero(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    # Insert a queued (non-proposed) dispatch directly
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?, ?, 'queued', ?)",
+        ("already-queued-1", PROJECT_ID, track_id),
+    )
+    conn.commit()
+    conn.close()
+
+    rc = planning_cli.main([
+        "deliverable", "promote", "already-queued-1",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# dispatch guard: proposed not claimable, ready is claimable
+# ---------------------------------------------------------------------------
+
+def _extract_dispatch_id(output: str) -> str:
+    """Parse dispatch_id from planning_cli deliverable add output."""
+    for line in output.splitlines():
+        if line.startswith("Deliverable created:"):
+            return line.split(": ", 1)[1].strip()
+    raise ValueError(f"dispatch_id not found in output:\n{output}")
+
+
+def test_proposed_dispatch_not_claimable(state_with_track: tuple[Path, str], tmp_path: Path):
+    state_dir, track_id = state_with_track
+    from dispatch_broker import DispatchBroker, BrokerError
+
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        planning_cli.main([
+            "deliverable", "add",
+            "--objective", track_id,
+            "--output-kind", "deal",
+            "--title", "Proposed deal",
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+    dispatch_id = _extract_dispatch_id(buf.getvalue())
+
+    broker = DispatchBroker(state_dir, dispatch_dir)
+    with pytest.raises(BrokerError, match="proposed"):
+        broker.claim(dispatch_id, terminal_id="T1")
+
+
+def test_ready_dispatch_is_claimable(state_with_track: tuple[Path, str], tmp_path: Path):
+    state_dir, track_id = state_with_track
+    from dispatch_broker import DispatchBroker
+
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        planning_cli.main([
+            "deliverable", "add",
+            "--objective", track_id,
+            "--output-kind", "post",
+            "--title", "Ready post",
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+    dispatch_id = _extract_dispatch_id(buf.getvalue())
+
+    planning_cli.main([
+        "deliverable", "promote", dispatch_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+
+    broker = DispatchBroker(state_dir, dispatch_dir)
+    result = broker.claim(dispatch_id, terminal_id="T1")
+    assert result.dispatch_row["state"] == "claimed"
+    assert result.dispatch_row["dispatch_id"] == dispatch_id

--- a/tests/test_runtime_coordination.py
+++ b/tests/test_runtime_coordination.py
@@ -56,6 +56,7 @@ from runtime_coordination import (
 class TestStateEnumerations(unittest.TestCase):
     def test_dispatch_states_complete(self):
         expected = {
+            "proposed", "ready",
             "queued", "claimed", "delivering", "accepted", "running",
             "completed", "timed_out", "failed_delivery", "expired", "recovered",
             "dead_letter",


### PR DESCRIPTION
## Summary

- **Deliverable plane (NO-NODE):** a deliverable is a `proposed` dispatch row with `output_kind`. No new table.
- **`vnx deliverable add`**: creates a dispatch in `state='proposed'` under a track with `output_kind` + `title` in `metadata_json`. Requires the track to exist.
- **`vnx deliverable list`**: reads the `deliverables` VIEW (grouped by `output_ref`), optionally filtered by `--objective`. Falls back to raw dispatches query if view isn't present.
- **`vnx deliverable promote <dispatch_id>`**: the human gate — transitions `proposed -> ready` + stamps `operator_approved_at`.
- **Guard**: `dispatch_broker.claim()` raises `BrokerError` with actionable message for `proposed` state; `ready` dispatches are claimable (new `ready -> claimed` transition).
- `proposed` and `ready` added to canonical `DISPATCH_STATES` + `DISPATCH_TRANSITIONS`.
- `bin/vnx deliverable` arm delegates to `planning_cli.py`.
- `_ensure_dispatches_output_columns` preflight adds `operator_approved_at` when missing (0022 already owns it on live DBs).

## Test plan

- [x] `pytest tests/test_planning_deliverables.py` — 9 tests: add/list/promote/guard/claimable — all pass
- [x] `pytest tests/test_planning_cli_objective.py` — Phase 1 tests unaffected (6 pass)
- [x] `pytest tests/test_dispatch_broker.py tests/test_runtime_coordination.py` — 130 pass, 0 new failures
- [x] Pre-existing `test_auto_apply.py` failures confirmed unrelated (pre-exist on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)