### PR TITLE
feat(dashboard): planning kanban — objectives/deliverables/open-items by horizon (reuses design system)

### DIFF
--- a/dashboard/api_planning.py
+++ b/dashboard/api_planning.py
@@ -1,0 +1,312 @@
+"""Planning kanban API handler.
+
+GET /api/operator/planning — tracks grouped by horizon (now|next|later) with
+deliverables and linked open items.
+
+Reads live runtime_coordination.db (+ open_items.json for OI details).
+Gracefully degrades when migration 0027 has not been applied (no horizon
+column, no deliverables VIEW).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+VNX_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = VNX_DIR
+CANONICAL_STATE_DIR = Path(
+    os.environ.get("VNX_STATE_DIR", str(PROJECT_ROOT / ".vnx-data" / "state"))
+)
+
+DB_PATH = CANONICAL_STATE_DIR / "runtime_coordination.db"
+OPEN_ITEMS_PATH = CANONICAL_STATE_DIR / "open_items.json"
+
+_HORIZONS = ("now", "next", "later")
+
+
+# ---------------------------------------------------------------------------
+# Schema capability detection
+# ---------------------------------------------------------------------------
+
+def _has_horizon_column(conn: sqlite3.Connection) -> bool:
+    rows = conn.execute("PRAGMA table_info('tracks')").fetchall()
+    return any(row[1] == "horizon" for row in rows)
+
+
+def _has_deliverables_view(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='view' AND name='deliverables'"
+    ).fetchone()
+    return row is not None
+
+
+# ---------------------------------------------------------------------------
+# Data loaders
+# ---------------------------------------------------------------------------
+
+def _load_open_items_index(state_dir: Path) -> dict[str, dict]:
+    """Return oi_id -> item dict from open_items.json. Returns {} on any error."""
+    path = state_dir / "open_items.json"
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        items = raw.get("items", [])
+        return {str(item.get("id", "")): item for item in items if item.get("id")}
+    except Exception as exc:
+        _logger.debug("Failed to load open_items.json: %s", exc)
+        return {}
+
+
+def _fetch_tracks(conn: sqlite3.Connection, project_id: str, has_horizon: bool) -> list[dict]:
+    if has_horizon:
+        rows = conn.execute(
+            """
+            SELECT track_id, project_id, title, phase, sort_order, priority,
+                   next_up, horizon, pr_ref, created_at, metadata_json
+            FROM tracks
+            WHERE project_id = ?
+            ORDER BY next_up DESC, sort_order ASC, track_id ASC
+            """,
+            (project_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT track_id, project_id, title, phase, sort_order, priority,
+                   next_up, NULL AS horizon, pr_ref, created_at, metadata_json
+            FROM tracks
+            WHERE project_id = ?
+            ORDER BY next_up DESC, sort_order ASC, track_id ASC
+            """,
+            (project_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _fetch_dependencies(conn: sqlite3.Connection, project_id: str) -> dict[str, list[dict]]:
+    """Return track_id -> list of outgoing dependency edges."""
+    rows = conn.execute(
+        """
+        SELECT from_track_id, to_track_id, to_project_id, kind, confidence
+        FROM track_dependencies
+        WHERE from_project_id = ?
+        """,
+        (project_id,),
+    ).fetchall()
+    deps: dict[str, list] = {}
+    for row in rows:
+        r = dict(row)
+        deps.setdefault(r["from_track_id"], []).append({
+            "to_track_id": r["to_track_id"],
+            "to_project_id": r["to_project_id"],
+            "kind": r["kind"],
+            "confidence": r["confidence"],
+        })
+    return deps
+
+
+def _fetch_dispatch_counts(conn: sqlite3.Connection, project_id: str) -> dict[str, int]:
+    """Return track_id -> dispatch count."""
+    rows = conn.execute(
+        "SELECT track, COUNT(*) AS cnt FROM dispatches WHERE project_id = ? AND track IS NOT NULL GROUP BY track",
+        (project_id,),
+    ).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def _fetch_deliverables(
+    conn: sqlite3.Connection, project_id: str, has_view: bool
+) -> dict[str, list[dict]]:
+    """Return track_id -> list of deliverable dicts."""
+    result: dict[str, list] = {}
+    if has_view:
+        try:
+            rows = conn.execute(
+                """
+                SELECT track, deliverable_ref, output_kind, derived_status, dispatch_count
+                FROM deliverables
+                WHERE project_id = ? AND track IS NOT NULL
+                """,
+                (project_id,),
+            ).fetchall()
+            for row in rows:
+                r = dict(row)
+                result.setdefault(r["track"], []).append({
+                    "deliverable_ref": r["deliverable_ref"],
+                    "output_kind": r["output_kind"],
+                    "derived_status": r["derived_status"],
+                    "dispatch_count": r["dispatch_count"],
+                })
+        except Exception as exc:
+            _logger.debug("Deliverables view query failed: %s", exc)
+    else:
+        # Fallback: one deliverable per distinct output_ref in dispatches
+        try:
+            rows = conn.execute(
+                """
+                SELECT track,
+                       output_ref AS deliverable_ref,
+                       MIN(output_kind) AS output_kind,
+                       COUNT(*) AS dispatch_count,
+                       SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END) AS completed_count
+                FROM dispatches
+                WHERE project_id = ? AND track IS NOT NULL AND output_ref IS NOT NULL
+                GROUP BY project_id, track, output_ref
+                """,
+                (project_id,),
+            ).fetchall()
+            for row in rows:
+                r = dict(row)
+                completed = r.get("completed_count", 0) or 0
+                total = r.get("dispatch_count", 0) or 0
+                derived_status = "done" if completed == total and total > 0 else "proposed"
+                result.setdefault(r["track"], []).append({
+                    "deliverable_ref": r["deliverable_ref"],
+                    "output_kind": r["output_kind"],
+                    "derived_status": derived_status,
+                    "dispatch_count": total,
+                })
+        except Exception as exc:
+            _logger.debug("Fallback deliverables query failed: %s", exc)
+    return result
+
+
+def _fetch_track_oi_links(
+    conn: sqlite3.Connection, project_id: str
+) -> dict[str, list[dict]]:
+    """Return track_id -> list of {oi_id, link_type}."""
+    rows = conn.execute(
+        """
+        SELECT track_id, oi_id, link_type
+        FROM track_open_items
+        WHERE project_id = ?
+        ORDER BY link_type ASC, linked_at DESC
+        """,
+        (project_id,),
+    ).fetchall()
+    result: dict[str, list] = {}
+    for row in rows:
+        r = dict(row)
+        result.setdefault(r["track_id"], []).append({
+            "oi_id": r["oi_id"],
+            "link_type": r["link_type"],
+        })
+    return result
+
+
+def _resolve_project_id(conn: sqlite3.Connection) -> str:
+    """Resolve the project_id from env or from the most common value in tracks."""
+    pid = os.environ.get("VNX_PROJECT_ID", "").strip()
+    if pid:
+        return pid
+    row = conn.execute(
+        "SELECT project_id, COUNT(*) AS cnt FROM tracks GROUP BY project_id ORDER BY cnt DESC LIMIT 1"
+    ).fetchone()
+    if row:
+        return row[0]
+    return "vnx-dev"
+
+
+# ---------------------------------------------------------------------------
+# Main handler
+# ---------------------------------------------------------------------------
+
+def _operator_get_planning(state_dir: Path | None = None) -> dict[str, Any]:
+    """GET /api/operator/planning — tracks grouped by horizon with deliverables + OIs."""
+    s_dir = state_dir or CANONICAL_STATE_DIR
+    db_path = s_dir / "runtime_coordination.db"
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not db_path.exists():
+        return {
+            "queried_at": now,
+            "horizons": {"now": [], "next": [], "later": []},
+            "total_tracks": 0,
+            "degraded": True,
+            "degraded_reasons": ["runtime_coordination.db not found"],
+        }
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+
+        try:
+            has_horizon = _has_horizon_column(conn)
+            has_del_view = _has_deliverables_view(conn)
+            project_id = _resolve_project_id(conn)
+
+            tracks = _fetch_tracks(conn, project_id, has_horizon)
+            deps_by_track = _fetch_dependencies(conn, project_id)
+            dispatch_counts = _fetch_dispatch_counts(conn, project_id)
+            deliverables_by_track = _fetch_deliverables(conn, project_id, has_del_view)
+            oi_links_by_track = _fetch_track_oi_links(conn, project_id)
+        finally:
+            conn.close()
+
+    except Exception as exc:
+        _logger.warning("Planning API query failed: %s", exc)
+        return {
+            "queried_at": now,
+            "horizons": {"now": [], "next": [], "later": []},
+            "total_tracks": 0,
+            "degraded": True,
+            "degraded_reasons": [str(exc)],
+        }
+
+    oi_index = _load_open_items_index(s_dir)
+
+    horizons: dict[str, list] = {"now": [], "next": [], "later": []}
+
+    for track in tracks:
+        track_id = track["track_id"]
+        horizon = track.get("horizon") or "later"
+        if horizon not in horizons:
+            horizon = "later"
+
+        oi_links = oi_links_by_track.get(track_id, [])
+        enriched_ois = []
+        for link in oi_links:
+            oi_id = link["oi_id"]
+            oi_detail = oi_index.get(oi_id, {})
+            enriched_ois.append({
+                "oi_id": oi_id,
+                "link_type": link["link_type"],
+                "title": oi_detail.get("title") or oi_detail.get("description") or oi_id,
+                "severity": oi_detail.get("severity"),
+                "status": oi_detail.get("status"),
+            })
+
+        card: dict[str, Any] = {
+            "track_id": track_id,
+            "title": track["title"],
+            "phase": track["phase"],
+            "horizon": horizon,
+            "priority": track.get("priority"),
+            "next_up": bool(track.get("next_up")),
+            "pr_ref": track.get("pr_ref"),
+            "dispatch_count": dispatch_counts.get(track_id, 0),
+            "depends_on": deps_by_track.get(track_id, []),
+            "deliverables": deliverables_by_track.get(track_id, []),
+            "open_items": enriched_ois,
+        }
+        horizons[horizon].append(card)
+
+    total = sum(len(v) for v in horizons.values())
+    return {
+        "queried_at": now,
+        "project_id": project_id if tracks else "",
+        "horizons": horizons,
+        "total_tracks": total,
+        "schema_v27": has_horizon and has_del_view,
+    }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1120,6 +1120,129 @@
       padding: 1.5rem 0;
       font-size: 0.9rem;
     }
+
+    /* ── Planning Kanban ── */
+    .planning-board {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.75rem;
+      margin-top: 0.8rem;
+      overflow-x: auto;
+    }
+    @media (max-width: 900px) { .planning-board { grid-template-columns: 1fr; } }
+
+    .planning-column { display: flex; flex-direction: column; gap: 0.5rem; min-width: 220px; }
+
+    .planning-col-header {
+      font-size: 0.75rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.12em; color: var(--muted);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 0.2rem 0.5rem; border-bottom: 1px solid var(--border-soft);
+    }
+    .planning-col-now .planning-col-header    { color: var(--brand-orange); border-bottom-color: rgba(249,115,22,0.4); }
+    .planning-col-next .planning-col-header   { color: var(--brand-gold);   border-bottom-color: rgba(250,204,21,0.4); }
+    .planning-col-later .planning-col-header  { color: var(--muted); }
+
+    .planning-card {
+      padding: 0.7rem 0.8rem;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: rgba(255,255,255,0.05);
+      display: grid; gap: 0.4rem;
+      transition: border-color 0.18s, background 0.18s, box-shadow 0.18s;
+    }
+    .planning-card:hover {
+      border-color: rgba(250,204,21,0.35);
+      background: rgba(250,204,21,0.04);
+      box-shadow: 0 4px 20px rgba(250,204,21,0.08);
+    }
+    .planning-card-title {
+      font-size: 0.9rem; font-weight: 600; color: var(--text);
+      line-height: 1.35;
+    }
+    .planning-card-meta {
+      display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center;
+    }
+    .phase-badge {
+      display: inline-block; padding: 0.1rem 0.45rem;
+      border-radius: 6px; font-size: 0.68rem; font-weight: 700;
+      letter-spacing: 0.05em; text-transform: uppercase;
+      border: 1px solid rgba(255,255,255,0.12);
+    }
+    .phase-badge.phase-active  { background: rgba(249,115,22,0.18); color: var(--brand-orange); border-color: rgba(249,115,22,0.3); }
+    .phase-badge.phase-queued  { background: rgba(250,204,21,0.14); color: var(--brand-gold);   border-color: rgba(250,204,21,0.3); }
+    .phase-badge.phase-parked  { background: rgba(255,255,255,0.06); color: var(--muted); }
+    .phase-badge.phase-done    { background: rgba(80,250,123,0.14); color: var(--green); border-color: rgba(80,250,123,0.3); }
+
+    .dep-badge {
+      display: inline-block; padding: 0.1rem 0.4rem;
+      border-radius: 6px; font-size: 0.65rem; font-weight: 600;
+      background: rgba(96,165,250,0.12); color: #60a5fa;
+      border: 1px solid rgba(96,165,250,0.2);
+      white-space: nowrap;
+    }
+
+    .planning-deliverables {
+      display: flex; flex-wrap: wrap; gap: 0.28rem;
+      margin-top: 0.1rem;
+    }
+    .deliverable-chip {
+      display: inline-flex; align-items: center; gap: 0.28rem;
+      padding: 0.15rem 0.5rem; border-radius: 999px;
+      font-size: 0.68rem; font-weight: 600;
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(255,255,255,0.05);
+      color: var(--muted); white-space: nowrap;
+    }
+    .deliverable-chip.status-done       { color: var(--green);         border-color: rgba(80,250,123,0.25); }
+    .deliverable-chip.status-in_progress { color: var(--brand-orange); border-color: rgba(249,115,22,0.25); }
+    .deliverable-chip.status-ready      { color: var(--brand-gold);    border-color: rgba(250,204,21,0.25); }
+
+    .planning-oi-list {
+      display: grid; gap: 0.25rem; margin-top: 0.2rem;
+    }
+    .planning-oi {
+      display: flex; align-items: center; gap: 0.4rem;
+      font-size: 0.72rem; color: var(--muted);
+      padding: 0.18rem 0.4rem; border-radius: 6px;
+    }
+    .planning-oi.oi-blocks  { color: var(--red);         background: rgba(255,107,107,0.08); }
+    .planning-oi.oi-warns   { color: var(--brand-gold);  background: rgba(250,204,21,0.07); }
+    .planning-oi.oi-related { color: var(--muted);       background: rgba(255,255,255,0.03); }
+
+    .planning-footer {
+      display: flex; align-items: center; justify-content: space-between;
+      font-size: 0.72rem; color: var(--muted); margin-top: 0.1rem;
+    }
+    .planning-dispatch-count {
+      background: rgba(255,255,255,0.07); border-radius: 4px;
+      padding: 0.1rem 0.38rem;
+    }
+    .planning-dispatch-link {
+      color: var(--brand-gold); text-decoration: none; font-weight: 600;
+      font-size: 0.72rem;
+    }
+    .planning-dispatch-link:hover { text-decoration: underline; }
+
+    .planning-empty {
+      font-size: 0.82rem; color: var(--muted); padding: 0.9rem 0.3rem; opacity: 0.55; text-align: center;
+    }
+
+    .planning-error {
+      font-size: 0.82rem; color: var(--red); padding: 0.6rem;
+      background: rgba(255,107,107,0.07); border-radius: 8px;
+      border: 1px solid rgba(255,107,107,0.2);
+    }
+
+    /* nav link */
+    .planning-nav-link {
+      display: inline-flex; align-items: center; padding: 0.4rem 0.85rem;
+      border-radius: 999px; border: 1px solid var(--border-soft);
+      background: rgba(255,255,255,0.04); color: var(--muted);
+      font-size: 0.82rem; text-decoration: none; white-space: nowrap;
+      transition: border-color 0.18s, color 0.18s;
+    }
+    .planning-nav-link:hover { border-color: rgba(250,204,21,0.4); color: var(--brand-gold); }
   </style>
 </head>
 <body>
@@ -1130,6 +1253,7 @@
         <p>7-second refresh · powered by `dashboard_status.json`</p>
       </div>
       <div class="header-right">
+        <a href="#planning-kanban" class="planning-nav-link">Planning</a>
         <div id="health-indicator" class="health-indicator">
           <span id="health-dot" class="health-dot"></span>
           <span id="health-label">Checking...</span>
@@ -1245,6 +1369,36 @@
           <div class="kanban-column kanban-col-done">
             <div class="kanban-col-header">Done <span class="kanban-col-count" id="kanban-count-done">0</span></div>
             <div id="kanban-cards-done"></div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section id="planning-kanban">
+      <article class="panel">
+        <h2>Planning <span id="planning-total" style="font-size:0.82rem; color:var(--muted); font-weight:400;"></span></h2>
+        <div id="planning-error" class="planning-error" style="display:none;"></div>
+        <div class="planning-board" id="planning-board">
+          <div class="planning-column planning-col-now">
+            <div class="planning-col-header">
+              Now
+              <span class="kanban-col-count" id="planning-count-now">0</span>
+            </div>
+            <div id="planning-cards-now"></div>
+          </div>
+          <div class="planning-column planning-col-next">
+            <div class="planning-col-header">
+              Next
+              <span class="kanban-col-count" id="planning-count-next">0</span>
+            </div>
+            <div id="planning-cards-next"></div>
+          </div>
+          <div class="planning-column planning-col-later">
+            <div class="planning-col-header">
+              Later
+              <span class="kanban-col-count" id="planning-count-later">0</span>
+            </div>
+            <div id="planning-cards-later"></div>
           </div>
         </div>
       </article>
@@ -2062,6 +2216,114 @@
     })();
 
     refreshKanban();
+
+    // ── Planning Kanban ──────────────────────────────────────────────────────
+
+    function renderPlanningCard(obj) {
+      const card = document.createElement("div");
+      card.className = "planning-card";
+
+      const phaseClass = `phase-${obj.phase || "queued"}`;
+      const phaseBadge = `<span class="phase-badge ${phaseClass}">${escHtml(obj.phase || "?")}</span>`;
+
+      const depBadges = (obj.depends_on || [])
+        .map(d => `<span class="dep-badge" title="kind: ${escHtml(d.kind || "")}">dep: ${escHtml(d.to_track_id)}</span>`)
+        .join("");
+
+      const metaHtml = `<div class="planning-card-meta">${phaseBadge}${depBadges}</div>`;
+
+      let delHtml = "";
+      if ((obj.deliverables || []).length > 0) {
+        const chips = obj.deliverables.map(d => {
+          const sc = `status-${(d.derived_status || "proposed").replace(/[^a-z_]/g, "")}`;
+          const kind = d.output_kind ? `[${escHtml(d.output_kind)}] ` : "";
+          const ref = d.deliverable_ref ? escHtml(String(d.deliverable_ref).slice(0, 20)) : "?";
+          return `<span class="deliverable-chip ${sc}">${kind}${ref}</span>`;
+        }).join("");
+        delHtml = `<div class="planning-deliverables">${chips}</div>`;
+      }
+
+      let oiHtml = "";
+      const ois = obj.open_items || [];
+      if (ois.length > 0) {
+        const items = ois.slice(0, 3).map(oi => {
+          const cls = `oi-${oi.link_type || "related"}`;
+          const icon = oi.link_type === "blocks" ? "⛔" : oi.link_type === "warns" ? "⚠" : "·";
+          const title = escHtml((oi.title || oi.oi_id || "").slice(0, 48));
+          return `<div class="planning-oi ${cls}">${icon} ${title}</div>`;
+        }).join("");
+        const more = ois.length > 3 ? `<div class="planning-oi oi-related">+${ois.length - 3} more</div>` : "";
+        oiHtml = `<div class="planning-oi-list">${items}${more}</div>`;
+      }
+
+      const dispCount = obj.dispatch_count || 0;
+      const prRef = obj.pr_ref ? `<a class="planning-dispatch-link" href="/api/dispatches?t=0" title="PR ${escHtml(obj.pr_ref)}">${escHtml(String(obj.pr_ref).slice(0, 12))}</a>` : "";
+      const footer = `<div class="planning-footer">
+        <span class="planning-dispatch-count">${dispCount} dispatch${dispCount !== 1 ? "es" : ""}</span>
+        ${prRef}
+      </div>`;
+
+      card.innerHTML = `
+        <div class="planning-card-title">${escHtml(obj.title || obj.track_id)}</div>
+        ${metaHtml}
+        ${delHtml}
+        ${oiHtml}
+        ${footer}
+      `;
+      return card;
+    }
+
+    function renderPlanning(data) {
+      const errEl = document.getElementById("planning-error");
+      const totalEl = document.getElementById("planning-total");
+
+      if (data.degraded) {
+        if (errEl) {
+          errEl.style.display = "";
+          errEl.textContent = "Planning unavailable: " + (data.degraded_reasons || []).join("; ");
+        }
+        return;
+      }
+      if (errEl) errEl.style.display = "none";
+
+      const horizons = data.horizons || {};
+      ["now", "next", "later"].forEach(h => {
+        const cards = horizons[h] || [];
+        const container = document.getElementById(`planning-cards-${h}`);
+        const counter = document.getElementById(`planning-count-${h}`);
+        if (!container) return;
+        if (counter) counter.textContent = cards.length;
+        container.innerHTML = "";
+        if (cards.length === 0) {
+          const empty = document.createElement("div");
+          empty.className = "planning-empty";
+          empty.textContent = "No objectives";
+          container.appendChild(empty);
+          return;
+        }
+        cards.forEach(obj => container.appendChild(renderPlanningCard(obj)));
+      });
+
+      if (totalEl) {
+        const total = data.total_tracks || 0;
+        totalEl.textContent = total > 0 ? `(${total} objectives)` : "";
+      }
+    }
+
+    async function refreshPlanning() {
+      try {
+        const res = await fetch("/api/operator/planning?t=" + Date.now(), { cache: "no-store" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        renderPlanning(data);
+      } catch (err) {
+        const errEl = document.getElementById("planning-error");
+        if (errEl) { errEl.style.display = ""; errEl.textContent = "Planning fetch error: " + err.message; }
+        console.error("planning refresh error", err);
+      }
+    }
+
+    refreshPlanning();
   </script>
 </body>
 </html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2177,7 +2177,7 @@
         visible.forEach(card => {
           const el = document.createElement("div");
           el.className = "kanban-card";
-          const trackClass = `track-${(card.track || "").toLowerCase()}`;
+          const trackClass = TRACK_CLASS[(card.track || "").toLowerCase()] || "";
           const shortId = card.id.length > 28 ? card.id.slice(0, 28) + "…" : card.id;
           el.innerHTML = `
             <div class="kanban-card-id" title="${escHtml(card.id)}">${escHtml(shortId)}</div>
@@ -2219,11 +2219,19 @@
 
     // ── Planning Kanban ──────────────────────────────────────────────────────
 
+    // Whitelist DB-derived values to known CSS classes (XSS hardening).
+    // No raw value from the API ever reaches a class attribute or innerHTML
+    // attribute position without passing through one of these allowlists.
+    const PHASE_CLASS = {queued:"phase-queued", active:"phase-active", parked:"phase-parked", done:"phase-done"};
+    const DELIVERABLE_STATUS_CLASS = {proposed:"status-proposed", ready:"status-ready", in_progress:"status-in_progress", done:"status-done"};
+    const OI_LINK_CLASS = {blocks:"oi-blocks", warns:"oi-warns", related:"oi-related"};
+    const TRACK_CLASS = {a:"track-a", b:"track-b", c:"track-c"};
+
     function renderPlanningCard(obj) {
       const card = document.createElement("div");
       card.className = "planning-card";
 
-      const phaseClass = `phase-${obj.phase || "queued"}`;
+      const phaseClass = PHASE_CLASS[obj.phase] || "phase-queued";
       const phaseBadge = `<span class="phase-badge ${phaseClass}">${escHtml(obj.phase || "?")}</span>`;
 
       const depBadges = (obj.depends_on || [])
@@ -2235,7 +2243,7 @@
       let delHtml = "";
       if ((obj.deliverables || []).length > 0) {
         const chips = obj.deliverables.map(d => {
-          const sc = `status-${(d.derived_status || "proposed").replace(/[^a-z_]/g, "")}`;
+          const sc = DELIVERABLE_STATUS_CLASS[d.derived_status] || "status-proposed";
           const kind = d.output_kind ? `[${escHtml(d.output_kind)}] ` : "";
           const ref = d.deliverable_ref ? escHtml(String(d.deliverable_ref).slice(0, 20)) : "?";
           return `<span class="deliverable-chip ${sc}">${kind}${ref}</span>`;
@@ -2247,7 +2255,7 @@
       const ois = obj.open_items || [];
       if (ois.length > 0) {
         const items = ois.slice(0, 3).map(oi => {
-          const cls = `oi-${oi.link_type || "related"}`;
+          const cls = OI_LINK_CLASS[oi.link_type] || "oi-related";
           const icon = oi.link_type === "blocks" ? "⛔" : oi.link_type === "warns" ? "⚠" : "·";
           const title = escHtml((oi.title || oi.oi_id || "").slice(0, 48));
           return `<div class="planning-oi ${cls}">${icon} ${title}</div>`;

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -161,6 +161,10 @@ from api_recommendations import (  # noqa: E402
     get_operator_recommendations,
 )
 
+from api_planning import (  # noqa: E402
+    _operator_get_planning,
+)
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -350,6 +354,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/recommendations":
             _json_response(self, HTTPStatus.OK, get_operator_recommendations())
+            return
+
+        if path == "/api/operator/planning":
+            _json_response(self, HTTPStatus.OK, _operator_get_planning())
             return
 
         # Register stream SSE endpoints — pass CANONICAL_STATE_DIR so the

--- a/tests/test_planning_api.py
+++ b/tests/test_planning_api.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Tests for dashboard/api_planning.py.
+
+Covers:
+  - /api/operator/planning returns grouped horizon structure
+  - Deliverables joined from dispatches (v26 fallback path)
+  - Open items from track_open_items bridge + open_items.json
+  - Graceful degradation when DB is absent
+  - Smoke: index.html references /api/operator/planning
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Make dashboard importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "dashboard"))
+
+import api_planning as ap
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA_V26 = """
+CREATE TABLE runtime_schema_version (
+    version     INTEGER PRIMARY KEY,
+    applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    description TEXT NOT NULL
+);
+
+CREATE TABLE tracks (
+    track_id    TEXT    NOT NULL,
+    project_id  TEXT    NOT NULL DEFAULT 'vnx-dev',
+    title       TEXT    NOT NULL,
+    goal_state  TEXT,
+    phase       TEXT    NOT NULL DEFAULT 'queued',
+    next_up     INTEGER NOT NULL DEFAULT 0,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    priority    TEXT    DEFAULT 'medium',
+    requires_operator_promotion INTEGER NOT NULL DEFAULT 1,
+    instruction_template TEXT,
+    context_composer_rules TEXT DEFAULT '{}',
+    pr_ref      TEXT,
+    trigger_condition TEXT,
+    created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    phase_changed_at TEXT,
+    completed_at TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    PRIMARY KEY (track_id, project_id)
+);
+
+CREATE TABLE track_dependencies (
+    from_track_id   TEXT    NOT NULL,
+    from_project_id TEXT    NOT NULL DEFAULT 'vnx-dev',
+    to_track_id     TEXT    NOT NULL,
+    to_project_id   TEXT    NOT NULL DEFAULT 'vnx-dev',
+    kind            TEXT    NOT NULL,
+    derivation_source TEXT  NOT NULL,
+    confidence      REAL    NOT NULL DEFAULT 1.0,
+    evidence_json   TEXT    DEFAULT '{}',
+    derived_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (from_track_id, from_project_id, to_track_id, to_project_id)
+);
+
+CREATE TABLE track_open_items (
+    track_id    TEXT    NOT NULL,
+    project_id  TEXT    NOT NULL DEFAULT 'vnx-dev',
+    oi_id       TEXT    NOT NULL,
+    link_type   TEXT    NOT NULL,
+    link_source TEXT    NOT NULL,
+    linked_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (track_id, project_id, oi_id, link_type)
+);
+
+CREATE TABLE dispatches (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state           TEXT    NOT NULL DEFAULT 'queued',
+    terminal_id     TEXT,
+    track           TEXT,
+    priority        TEXT    DEFAULT 'P2',
+    pr_ref          TEXT,
+    output_ref      TEXT,
+    output_kind     TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    metadata_json   TEXT    DEFAULT '{}',
+    UNIQUE(dispatch_id, project_id)
+);
+
+PRAGMA user_version = 26;
+"""
+
+_SCHEMA_V27_EXTRAS = """
+ALTER TABLE tracks ADD COLUMN horizon TEXT
+    CHECK (horizon IS NULL OR horizon IN ('now', 'next', 'later'));
+
+CREATE VIEW IF NOT EXISTS deliverables AS
+SELECT
+    project_id                                                  AS project_id,
+    output_ref                                                  AS deliverable_ref,
+    MIN(output_kind)                                            AS output_kind,
+    MIN(track)                                                  AS track,
+    COUNT(*)                                                    AS dispatch_count,
+    SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END)        AS completed_count,
+    SUM(CASE WHEN state IN ('active', 'running', 'delivering', 'claimed', 'accepted')
+             THEN 1 ELSE 0 END)                                 AS in_flight_count,
+    CASE
+        WHEN SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END) = COUNT(*)
+            THEN 'done'
+        WHEN SUM(CASE WHEN state IN ('active', 'running', 'delivering', 'claimed', 'accepted')
+                      THEN 1 ELSE 0 END) > 0
+            THEN 'in_progress'
+        ELSE 'proposed'
+    END                                                         AS derived_status,
+    MAX(updated_at)                                             AS last_activity
+FROM dispatches
+WHERE output_ref IS NOT NULL
+GROUP BY project_id, output_ref;
+
+PRAGMA user_version = 27;
+"""
+
+
+def _seed_db(db_path: Path, *, with_v27: bool = False) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA_V26)
+    if with_v27:
+        conn.executescript(_SCHEMA_V27_EXTRAS)
+
+    project_id = "test-proj"
+
+    # Two tracks
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, phase, sort_order) VALUES (?,?,?,?,?)",
+        ("T-NOW", project_id, "Ship feature X", "active", 0),
+    )
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, phase, sort_order) VALUES (?,?,?,?,?)",
+        ("T-NEXT", project_id, "Plan feature Y", "queued", 1),
+    )
+
+    # Set horizons if schema supports it
+    if with_v27:
+        conn.execute(
+            "UPDATE tracks SET horizon = ? WHERE track_id = ? AND project_id = ?",
+            ("now", "T-NOW", project_id),
+        )
+        conn.execute(
+            "UPDATE tracks SET horizon = ? WHERE track_id = ? AND project_id = ?",
+            ("next", "T-NEXT", project_id),
+        )
+
+    # Dependency: T-NEXT depends on T-NOW
+    conn.execute(
+        """
+        INSERT INTO track_dependencies
+            (from_track_id, from_project_id, to_track_id, to_project_id, kind, derivation_source)
+        VALUES (?,?,?,?,?,?)
+        """,
+        ("T-NEXT", project_id, "T-NOW", project_id, "hard", "manual"),
+    )
+
+    # Dispatch linked to T-NOW with output_ref
+    conn.execute(
+        """
+        INSERT INTO dispatches (dispatch_id, project_id, track, output_ref, output_kind, state)
+        VALUES (?,?,?,?,?,?)
+        """,
+        ("DISP-001", project_id, "T-NOW", "PR-100", "pr", "completed"),
+    )
+    conn.execute(
+        """
+        INSERT INTO dispatches (dispatch_id, project_id, track, output_ref, output_kind, state)
+        VALUES (?,?,?,?,?,?)
+        """,
+        ("DISP-002", project_id, "T-NOW", "PR-100", "pr", "active"),
+    )
+
+    # OI link for T-NOW
+    conn.execute(
+        """
+        INSERT INTO track_open_items (track_id, project_id, oi_id, link_type, link_source)
+        VALUES (?,?,?,?,?)
+        """,
+        ("T-NOW", project_id, "OI-999", "blocks", "manual"),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def _write_open_items_json(state_dir: Path) -> None:
+    payload = {
+        "items": [
+            {"id": "OI-999", "title": "Test blocker", "severity": "blocker", "status": "open"}
+        ]
+    }
+    (state_dir / "open_items.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests: planning API with v26 schema (no horizon, no deliverables view)
+# ---------------------------------------------------------------------------
+
+class TestPlanningApiV26:
+
+    def test_returns_horizon_groups(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db")
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+
+        assert "horizons" in result
+        assert set(result["horizons"].keys()) == {"now", "next", "later"}
+
+    def test_total_tracks_correct(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db")
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        assert result["total_tracks"] == 2
+
+    def test_tracks_in_later_when_no_horizon_column(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db", with_v27=False)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        # With v26 schema there's no horizon column; all tracks default to "later"
+        later = result["horizons"]["later"]
+        assert len(later) == 2
+
+    def test_dispatch_count_on_track(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db")
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        all_tracks = (
+            result["horizons"]["now"]
+            + result["horizons"]["next"]
+            + result["horizons"]["later"]
+        )
+        t_now = next((t for t in all_tracks if t["track_id"] == "T-NOW"), None)
+        assert t_now is not None
+        assert t_now["dispatch_count"] == 2
+
+    def test_deliverables_fallback_from_dispatches(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db", with_v27=False)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        all_tracks = (
+            result["horizons"]["now"]
+            + result["horizons"]["next"]
+            + result["horizons"]["later"]
+        )
+        t_now = next((t for t in all_tracks if t["track_id"] == "T-NOW"), None)
+        assert t_now is not None
+        assert len(t_now["deliverables"]) == 1
+        d = t_now["deliverables"][0]
+        assert d["deliverable_ref"] == "PR-100"
+        assert d["output_kind"] == "pr"
+
+    def test_open_items_joined_from_json(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db")
+        _write_open_items_json(state_dir)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        all_tracks = (
+            result["horizons"]["now"]
+            + result["horizons"]["next"]
+            + result["horizons"]["later"]
+        )
+        t_now = next((t for t in all_tracks if t["track_id"] == "T-NOW"), None)
+        assert t_now is not None
+        assert len(t_now["open_items"]) == 1
+        oi = t_now["open_items"][0]
+        assert oi["oi_id"] == "OI-999"
+        assert oi["link_type"] == "blocks"
+        assert oi["title"] == "Test blocker"
+
+    def test_depends_on_edges_present(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db")
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        all_tracks = (
+            result["horizons"]["now"]
+            + result["horizons"]["next"]
+            + result["horizons"]["later"]
+        )
+        t_next = next((t for t in all_tracks if t["track_id"] == "T-NEXT"), None)
+        assert t_next is not None
+        assert len(t_next["depends_on"]) == 1
+        dep = t_next["depends_on"][0]
+        assert dep["to_track_id"] == "T-NOW"
+        assert dep["kind"] == "hard"
+
+    def test_missing_db_returns_degraded(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # No DB created
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        assert result["degraded"] is True
+        assert result["total_tracks"] == 0
+        assert result["horizons"] == {"now": [], "next": [], "later": []}
+
+
+# ---------------------------------------------------------------------------
+# Tests: planning API with v27 schema (horizon + deliverables view)
+# ---------------------------------------------------------------------------
+
+class TestPlanningApiV27:
+
+    def test_tracks_grouped_by_horizon(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db", with_v27=True)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        assert len(result["horizons"]["now"]) == 1
+        assert len(result["horizons"]["next"]) == 1
+        assert len(result["horizons"]["later"]) == 0
+        assert result["schema_v27"] is True
+
+    def test_deliverables_from_view(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db", with_v27=True)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        t_now = result["horizons"]["now"][0]
+        assert len(t_now["deliverables"]) == 1
+        d = t_now["deliverables"][0]
+        assert d["deliverable_ref"] == "PR-100"
+        assert d["dispatch_count"] == 2
+
+    def test_track_has_required_fields(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _seed_db(state_dir / "runtime_coordination.db", with_v27=True)
+
+        result = ap._operator_get_planning(state_dir=state_dir)
+        t = result["horizons"]["now"][0]
+        for field in ("track_id", "title", "phase", "horizon", "dispatch_count",
+                      "depends_on", "deliverables", "open_items"):
+            assert field in t, f"missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# Smoke: index.html references the planning endpoint and renders columns
+# ---------------------------------------------------------------------------
+
+class TestPlanningSmoke:
+
+    def test_index_html_references_planning_endpoint(self):
+        html_path = Path(__file__).parent.parent / "dashboard" / "index.html"
+        assert html_path.exists(), "dashboard/index.html not found"
+        content = html_path.read_text(encoding="utf-8")
+        assert "/api/operator/planning" in content, "planning endpoint not referenced in index.html"
+
+    def test_index_html_has_planning_columns(self):
+        html_path = Path(__file__).parent.parent / "dashboard" / "index.html"
+        content = html_path.read_text(encoding="utf-8")
+        for col_id in ("planning-cards-now", "planning-cards-next", "planning-cards-later"):
+            assert col_id in content, f"column id '{col_id}' not found in index.html"
+
+    def test_index_html_has_planning_section(self):
+        html_path = Path(__file__).parent.parent / "dashboard" / "index.html"
+        content = html_path.read_text(encoding="utf-8")
+        assert "planning-kanban" in content, "planning-kanban section not found"


### PR DESCRIPTION
## Summary

- New `dashboard/api_planning.py`: `GET /api/operator/planning` returns tracks grouped by horizon (`now`/`next`/`later`) with deliverables, linked open items, and dependency edges
- New planning kanban section in `dashboard/index.html`: 3-column board (NOW/NEXT/LATER) reusing existing CSS vars, card patterns, glow, and color system — no new framework
- Route wired in `dashboard/serve_dashboard.py` following the exact existing `api_*.py` import + handler pattern
- Degrades gracefully on v26 schema (no `horizon` column, no `deliverables` VIEW) — falls back to dispatches table directly

## Test plan

- [ ] `pytest tests/test_planning_api.py -v` — 14 tests, all green (verified locally)
- [ ] Tests cover: v26 fallback path, v27 deliverables view, OI join, dep edges, missing DB degradation, smoke checks on index.html

Dispatch-ID: 20260601-224745-dashboard-planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)