### PR TITLE
feat(planning): Phase 3 — advisory rollup reconciler (derived_status, idempotent, never auto-writes ROADMAP)

### DIFF
--- a/schemas/migrations/0028_tracks_derived_status.sql
+++ b/schemas/migrations/0028_tracks_derived_status.sql
@@ -1,0 +1,36 @@
+-- VNX Migration 0028 — tracks.derived_status advisory column
+--
+-- Purpose: Phase 3 of the planning layer — advisory rollup reconciler.
+--          Adds derived_status to the tracks table for the computed/advisory
+--          status computed by track_reconciler.py.
+--
+-- Column semantics (ADVISORY ONLY):
+--   derived_status TEXT  NULL        = not yet reconciled
+--                        'queued'    — no active or terminal dispatches
+--                        'in_progress' — dispatches in flight
+--                        'blocked'   — blocker OI or unmet dependency
+--                        'done'      — all dispatches terminal + PR merged
+--                                       (or no pr_ref on track)
+--
+-- Separation of concerns:
+--   tracks.phase (declared status) = authoritative, operator/T0-gated
+--   tracks.derived_status          = advisory, reconciler-written, never auto-advances
+--
+-- NEVER modified by: seeder, roadmap_manager.reconcile(), ROADMAP.yaml
+-- ONLY written by:   track_reconciler.reconcile_track / reconcile_all_tracks
+--
+-- Design: claudedocs/FSF-BUILDPLAN-opus.md §5 (rollup reconciler)
+-- ADR-007: column is per-row (track_id, project_id)-scoped; no new table.
+--
+-- Idempotency: apply_script_if_below skips if user_version >= 28.
+--              ALTER TABLE ADD COLUMN is additive; no rebuild needed.
+--
+-- Applied by: scripts/migrate_future_system.py
+-- Tested by:  tests/test_track_reconciler.py
+
+ALTER TABLE tracks ADD COLUMN derived_status TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tracks_derived_status
+    ON tracks(project_id, derived_status);
+
+PRAGMA user_version = 28;

--- a/schemas/migrations/0028_tracks_derived_status_down.sql
+++ b/schemas/migrations/0028_tracks_derived_status_down.sql
@@ -1,0 +1,69 @@
+-- VNX Migration 0028 (DOWN) — drop tracks.derived_status
+--
+-- Reverses 0028_tracks_derived_status.sql.
+--
+-- Pre-state (v28): tracks.derived_status present, idx_tracks_derived_status.
+-- Post-state (v27): tracks without derived_status.
+--
+-- SQLite < 3.35 has no DROP COLUMN, so tracks is rebuilt to the v27 column
+-- set (horizon present, derived_status absent). All other data preserved.
+--
+-- FK safety: same PRAGMA foreign_keys=OFF guard as the 0027 down migration.
+-- track_dependencies, track_phase_history, track_open_items retain their rows.
+
+PRAGMA foreign_keys = OFF;
+
+DROP INDEX IF EXISTS idx_tracks_derived_status;
+
+ALTER TABLE tracks RENAME TO tracks_pre_0028_down;
+
+CREATE TABLE tracks (
+    track_id                    TEXT    NOT NULL,
+    project_id                  TEXT    NOT NULL DEFAULT 'vnx-dev',
+    title                       TEXT    NOT NULL,
+    goal_state                  TEXT,
+    phase                       TEXT    NOT NULL DEFAULT 'queued'
+                                        CHECK (phase IN ('queued','active','parked','done')),
+    next_up                     INTEGER NOT NULL DEFAULT 0,
+    sort_order                  INTEGER NOT NULL DEFAULT 0,
+    priority                    TEXT    DEFAULT 'medium',
+    requires_operator_promotion INTEGER NOT NULL DEFAULT 1,
+    instruction_template        TEXT,
+    context_composer_rules      TEXT    DEFAULT '{}',
+    pr_ref                      TEXT,
+    trigger_condition           TEXT,
+    created_at                  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    phase_changed_at            TEXT,
+    completed_at                TEXT,
+    metadata_json               TEXT    DEFAULT '{}',
+    horizon                     TEXT    CHECK (horizon IS NULL OR horizon IN ('now','next','later')),
+    PRIMARY KEY (track_id, project_id)
+);
+
+INSERT INTO tracks (
+    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+    requires_operator_promotion, instruction_template, context_composer_rules,
+    pr_ref, trigger_condition, created_at, phase_changed_at, completed_at,
+    metadata_json, horizon
+)
+SELECT
+    track_id, project_id, title, goal_state, phase, next_up, sort_order, priority,
+    requires_operator_promotion, instruction_template, context_composer_rules,
+    pr_ref, trigger_condition, created_at, phase_changed_at, completed_at,
+    metadata_json, horizon
+FROM tracks_pre_0028_down;
+
+DROP TABLE tracks_pre_0028_down;
+
+CREATE INDEX IF NOT EXISTS idx_tracks_project_phase_nextup
+    ON tracks(project_id, phase, next_up DESC, sort_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tracks_next_up_per_project
+    ON tracks(project_id) WHERE next_up = 1 AND phase = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_tracks_horizon
+    ON tracks(project_id, horizon, sort_order);
+
+PRAGMA user_version = 27;
+
+PRAGMA foreign_keys = ON;

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""track_reconciler.py — advisory rollup reconciler for the track layer (Phase 3).
+
+Reads dispatch/event state and computes a per-track derived_status.
+
+ADVISORY ONLY — hard contract:
+  - Writes ONLY tracks.derived_status (never tracks.phase).
+  - Never touches ROADMAP.yaml.
+  - Never auto-advances any track.
+
+Idempotent and replay-safe:
+  - Re-running over the same DB state produces the same derived_status.
+  - A duplicate pr_merged coordination event cannot double-advance a track
+    (presence check, not counter).
+  - Terminal dispatch states are irreversible; they cannot regress.
+
+VNX_ROADMAP_AUTOPILOT gate: this module is always callable; the gate lives
+in roadmap_manager.RoadmapManager.reconcile_tracks() for autopilot integration.
+
+ADR-007: all queries are (track_id, project_id)-scoped.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+DB_FILENAME = "runtime_coordination.db"
+
+TERMINAL_DISPATCH_STATES = frozenset({"completed", "expired", "dead_letter"})
+IN_FLIGHT_DISPATCH_STATES = frozenset({
+    "queued", "claimed", "delivering", "accepted", "running", "active",
+})
+
+
+def _get_conn(state_dir: str | Path) -> sqlite3.Connection:
+    db_path = Path(state_dir) / DB_FILENAME
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def _compute_derived_status(
+    conn: sqlite3.Connection,
+    track_id: str,
+    project_id: str,
+) -> str:
+    """Compute derived_status for one track. Pure read — writes nothing.
+
+    Returns one of: 'done', 'blocked', 'in_progress', 'queued'.
+    """
+    # 1. Blocker open-item check: any link_type='blocks' row → blocked.
+    #    The presence of the link implies the OI is unresolved; removal clears it.
+    if _has_col(conn, "track_open_items", "project_id"):
+        blocker = conn.execute(
+            """
+            SELECT 1 FROM track_open_items
+            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
+            LIMIT 1
+            """,
+            (track_id, project_id),
+        ).fetchone()
+    else:
+        blocker = conn.execute(
+            "SELECT 1 FROM track_open_items WHERE track_id = ? AND link_type = 'blocks' LIMIT 1",
+            (track_id,),
+        ).fetchone()
+    if blocker:
+        return "blocked"
+
+    # 2. Dependency check: any dependency whose declared phase is not 'done' blocks this track.
+    #    Uses declared phase (authoritative) to avoid circular dependency on derived_status.
+    dep_phases = conn.execute(
+        """
+        SELECT t.phase
+        FROM track_dependencies td
+        JOIN tracks t
+          ON t.track_id = td.to_track_id AND t.project_id = td.to_project_id
+        WHERE td.from_track_id = ? AND td.from_project_id = ?
+        """,
+        (track_id, project_id),
+    ).fetchall()
+    for row in dep_phases:
+        if row[0] != "done":
+            return "blocked"
+
+    # 3. Dispatch state aggregation.
+    dispatches = conn.execute(
+        "SELECT dispatch_id, state FROM dispatches WHERE track = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchall()
+
+    if not dispatches:
+        return "queued"
+
+    states = [d[0] for d in dispatches]  # d is (dispatch_id, state); note row_factory gives dict
+    # With row_factory = sqlite3.Row, index by name or position:
+    dispatch_ids = [row["dispatch_id"] for row in dispatches]
+    state_values = [row["state"] for row in dispatches]
+
+    all_terminal = all(s in TERMINAL_DISPATCH_STATES for s in state_values)
+
+    if all_terminal:
+        track_row = conn.execute(
+            "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        track_pr_ref = track_row["pr_ref"] if track_row else None
+
+        if not track_pr_ref:
+            # No PR to verify — all work terminal → done.
+            return "done"
+
+        # Check for a pr_merged coordination event on any dispatch in this track.
+        placeholders = ",".join("?" * len(dispatch_ids))
+        merged_event = conn.execute(
+            f"""
+            SELECT 1 FROM coordination_events
+            WHERE event_type = 'pr_merged'
+              AND entity_id IN ({placeholders})
+            LIMIT 1
+            """,
+            dispatch_ids,
+        ).fetchone()
+        if merged_event:
+            return "done"
+
+        # All dispatches terminal but PR not confirmed merged yet.
+        return "in_progress"
+
+    # Some dispatches still in flight.
+    if any(s in IN_FLIGHT_DISPATCH_STATES for s in state_values):
+        return "in_progress"
+
+    # Remaining dispatches are in planned states (proposed, ready).
+    return "queued"
+
+
+def _write_derived_status(
+    conn: sqlite3.Connection,
+    track_id: str,
+    project_id: str,
+    derived: str,
+) -> None:
+    """Write derived_status for one track. Raises if derived_status column absent."""
+    conn.execute(
+        "UPDATE tracks SET derived_status = ? WHERE track_id = ? AND project_id = ?",
+        (derived, track_id, project_id),
+    )
+
+
+def _log_drift(
+    track_id: str,
+    project_id: str,
+    declared: Optional[str],
+    derived: str,
+) -> None:
+    if declared != derived:
+        log.info(
+            "track_drift: track=%s project=%s declared=%s derived=%s",
+            track_id, project_id, declared, derived,
+        )
+
+
+def reconcile_track(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """Compute and persist derived_status for a single track.
+
+    Returns a result dict with track_id, project_id, derived_status,
+    declared_phase, and drifted flag.
+
+    Raises RuntimeError if derived_status column is absent (migration 0028
+    must be applied first).
+    """
+    conn = _get_conn(state_dir)
+    try:
+        if not _has_col(conn, "tracks", "derived_status"):
+            raise RuntimeError(
+                "tracks.derived_status column absent; apply migration 0028 first."
+            )
+
+        derived = _compute_derived_status(conn, track_id, project_id)
+        _write_derived_status(conn, track_id, project_id, derived)
+        conn.commit()
+
+        track_row = conn.execute(
+            "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        declared = track_row["phase"] if track_row else None
+
+        _log_drift(track_id, project_id, declared, derived)
+
+        return {
+            "track_id": track_id,
+            "project_id": project_id,
+            "derived_status": derived,
+            "declared_phase": declared,
+            "drifted": declared != derived,
+        }
+    finally:
+        conn.close()
+
+
+def reconcile_all_tracks(
+    state_dir: str | Path,
+    project_id: str,
+) -> List[Dict[str, Any]]:
+    """Compute and persist derived_status for all tracks in project_id.
+
+    Idempotent: re-running produces the same results for the same DB state.
+    Returns list of per-track result dicts (see reconcile_track).
+
+    Raises RuntimeError if derived_status column is absent (migration 0028
+    must be applied first).
+    """
+    conn = _get_conn(state_dir)
+    try:
+        if not _has_col(conn, "tracks", "derived_status"):
+            raise RuntimeError(
+                "tracks.derived_status column absent; apply migration 0028 first."
+            )
+
+        tracks = conn.execute(
+            "SELECT track_id FROM tracks WHERE project_id = ? ORDER BY sort_order ASC, track_id ASC",
+            (project_id,),
+        ).fetchall()
+        track_ids = [r["track_id"] for r in tracks]
+    finally:
+        conn.close()
+
+    results = []
+    for track_id in track_ids:
+        result = reconcile_track(state_dir, track_id, project_id)
+        results.append(result)
+        log.debug(
+            "reconciled track=%s derived=%s declared=%s drift=%s",
+            track_id, result["derived_status"], result["declared_phase"], result["drifted"],
+        )
+
+    log.info(
+        "track_reconciler: project=%s tracks=%d drifted=%d",
+        project_id, len(results), sum(1 for r in results if r["drifted"]),
+    )
+    return results

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -392,11 +392,51 @@ def apply_migration_v27(conn: sqlite3.Connection, project_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 7: preflight + apply 0028 migration (tracks.derived_status)
+# ---------------------------------------------------------------------------
+
+def _assert_tracks_v27_intact(conn: sqlite3.Connection) -> None:
+    """Assert tracks has horizon column (v27 state) before adding derived_status."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('tracks')")}
+    if "horizon" not in cols:
+        raise RuntimeError(
+            "tracks missing 'horizon' column (from 0027). "
+            "Run migration 0027 before 0028."
+        )
+    if "derived_status" in cols:
+        raise RuntimeError(
+            "tracks already has 'derived_status' column. Migration 0028 should be "
+            "skipped (user_version should be >= 28)."
+        )
+
+
+schema_migration.register_preflight(28, _assert_tracks_v27_intact)
+
+
+def apply_migration_v28(conn: sqlite3.Connection, project_root: Path) -> None:
+    migration_path = _MIGRATIONS / "0028_tracks_derived_status.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    sql = migration_path.read_text(encoding="utf-8")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 28:
+        print(f"  [skip] migration 0028 already applied (user_version={current_version})")
+        return
+
+    _assert_tracks_v27_intact(conn)
+    print("  [apply] migration 0028_tracks_derived_status.sql ...")
+    schema_migration.apply_script_if_below(conn, 28, sql)
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def run(project_root: Path | None = None) -> None:
-    """Apply track layer migrations: 0022 (track tables) + 0024 (tenant-scoping)."""
+    """Apply track layer migrations: 0022, 0024, 0027, 0028."""
     if project_root is None:
         project_root = resolve_project_root(__file__)
 
@@ -432,6 +472,10 @@ def run(project_root: Path | None = None) -> None:
 
         # Apply 0027 — additive: tracks.horizon column + deliverables derived view
         apply_migration_v27(conn, project_root)
+        conn.commit()
+
+        # Apply 0028 — additive: tracks.derived_status advisory column
+        apply_migration_v28(conn, project_root)
         conn.commit()
 
         print(f"\n  Migration complete. Schema at user_version={schema_migration.get_user_version(conn)}.\n")

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -84,6 +84,7 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
                 "track_id": t["track_id"],
                 "title": t["title"],
                 "phase": t["phase"],
+                "derived_status": t.get("derived_status"),
                 "horizon": t.get("horizon"),
                 "priority": t.get("priority"),
                 "pr_ref": t.get("pr_ref"),
@@ -117,8 +118,10 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
             marker = "*" if t.get("next_up") else " "
             dep_str = f"  deps: {', '.join(deps)}" if deps else ""
             pr_str = f"  pr: {t['pr_ref']}" if t.get("pr_ref") else ""
+            derived = t.get("derived_status")
+            drift_badge = f" ~{derived}" if derived and derived != t["phase"] else ""
             print(
-                f" {marker} {t['track_id']:<28} [{t['phase']:<7}] "
+                f" {marker} {t['track_id']:<28} [{t['phase']:<7}]{drift_badge} "
                 f"{t.get('priority') or '-':<3} {t['title']}{pr_str}{dep_str}"
             )
         print()

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -718,6 +718,38 @@ Implement the minimum blocking fix required before the roadmap may advance.
             "advance": advance_result,
         }
 
+    def reconcile_tracks(self) -> Dict[str, Any]:
+        """Advisory track-layer rollup (Phase 3). Gated by VNX_ROADMAP_AUTOPILOT.
+
+        Calls track_reconciler.reconcile_all_tracks to compute derived_status for
+        every track in the project.
+
+        ADVISORY ONLY: writes tracks.derived_status, NEVER tracks.phase or
+        ROADMAP.yaml. Idempotent and replay-safe.
+
+        Returns {"status": "disabled"} when VNX_ROADMAP_AUTOPILOT is unset/off.
+        """
+        if os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("1", "true", "True"):
+            return {"status": "disabled", "reason": "VNX_ROADMAP_AUTOPILOT not set"}
+
+        from track_reconciler import reconcile_all_tracks  # noqa: PLC0415
+        results = reconcile_all_tracks(self.state_dir, self.project_id)
+        drifted_count = sum(1 for r in results if r.get("drifted"))
+
+        emit_governance_receipt(
+            "track_reconcile_advisory",
+            status="success",
+            project_id=self.project_id,
+            track_count=len(results),
+            drifted_count=drifted_count,
+        )
+        return {
+            "status": "ok",
+            "track_count": len(results),
+            "drifted_count": drifted_count,
+            "results": results,
+        }
+
     def status(self) -> Dict[str, Any]:
         state = self.load_state()
         return {
@@ -765,6 +797,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     autopilot_parser = sub.add_parser("autopilot")
     autopilot_parser.add_argument("--json", action="store_true")
 
+    reconcile_tracks_parser = sub.add_parser("reconcile-tracks")
+    reconcile_tracks_parser.add_argument("--json", action="store_true")
+
     args = parser.parse_args(argv)
     manager = RoadmapManager()
 
@@ -784,6 +819,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         result = manager.run_feature_step()
     elif args.command == "autopilot":
         result = manager.autopilot_tick()
+    elif args.command == "reconcile-tracks":
+        result = manager.reconcile_tracks()
     else:
         raise AssertionError("unreachable")
 

--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -1,0 +1,508 @@
+"""tests/test_track_reconciler.py — Phase 3 advisory rollup reconciler tests.
+
+Verifies:
+- derived_status='done' when all dispatches are terminal + pr_merged event exists
+- derived_status='blocked' when a blocker OI is linked (link_type='blocks')
+- derived_status='blocked' when a dependency track's declared phase is not 'done'
+- derived_status='queued' when no dispatches exist
+- derived_status='in_progress' when dispatches are active
+- derived_status='done' when all dispatches terminal and no pr_ref on track
+- derived_status='in_progress' when all dispatches terminal but pr_ref set with no merged event
+- Idempotent: re-running produces the same result
+- Duplicate pr_merged event does not double-advance (presence check, not counter)
+- ROADMAP.yaml is NEVER written by the reconciler
+- tracks.phase (authoritative) is NEVER modified by the reconciler
+- Migration 0028 up adds derived_status column + down rebuilds without it
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration
+import track_reconciler
+import tracks as tracks_lib
+
+
+PROJECT_ID = "test-proj"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _build_db(tmp_path: Path) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 + 0027 + 0028 applied."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch',
+            entity_id TEXT NOT NULL,
+            from_state TEXT,
+            to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+    """)
+    conn.commit()
+
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn, 27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn, 28,
+        (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _seed_track(
+    state_dir: Path,
+    track_id: str,
+    *,
+    phase: str = "active",
+    pr_ref: str | None = None,
+) -> None:
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID,
+        title=f"Track {track_id}",
+        goal_state=f"ship {track_id}",
+        phase=phase,
+        pr_ref=pr_ref,
+    )
+
+
+def _seed_dispatch(
+    state_dir: Path,
+    dispatch_id: str,
+    track_id: str,
+    *,
+    state: str = "completed",
+    pr_ref: str | None = None,
+) -> None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track, pr_ref) VALUES (?,?,?,?,?)",
+        (dispatch_id, PROJECT_ID, state, track_id, pr_ref),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pr_merged_event(state_dir: Path, dispatch_id: str) -> None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        INSERT INTO coordination_events
+            (event_id, event_type, entity_type, entity_id, occurred_at, project_id)
+        VALUES (?, 'pr_merged', 'dispatch', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), ?)
+        """,
+        (f"ev-{dispatch_id}", dispatch_id, PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _get_track_row(state_dir: Path, track_id: str) -> dict:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM tracks WHERE track_id=? AND project_id=?",
+        (track_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else {}
+
+
+# ---------------------------------------------------------------------------
+# Core derived_status tests
+# ---------------------------------------------------------------------------
+
+def test_done_when_all_dispatches_terminal_and_pr_merged(tmp_path):
+    """derived_status='done' when all dispatches terminal + pr_merged event."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-done", pr_ref="PR-100")
+    _seed_dispatch(state_dir, "D-done-1", "T-done", state="completed", pr_ref="PR-100")
+    _seed_pr_merged_event(state_dir, "D-done-1")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-done", PROJECT_ID)
+    assert result["derived_status"] == "done"
+    assert result["declared_phase"] == "active"
+    assert result["drifted"] is True
+
+    row = _get_track_row(state_dir, "T-done")
+    assert row["derived_status"] == "done"
+    assert row["phase"] == "active"  # authoritative phase unchanged
+
+
+def test_done_when_no_pr_ref_and_all_terminal(tmp_path):
+    """derived_status='done' when track has no pr_ref and all dispatches terminal."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-nopr", pr_ref=None)
+    _seed_dispatch(state_dir, "D-nopr-1", "T-nopr", state="completed")
+    _seed_dispatch(state_dir, "D-nopr-2", "T-nopr", state="dead_letter")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-nopr", PROJECT_ID)
+    assert result["derived_status"] == "done"
+
+
+def test_in_progress_when_all_terminal_but_no_merged_event(tmp_path):
+    """derived_status='in_progress' when all terminal but pr_ref set and no merged event."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-pr-pending", pr_ref="PR-200")
+    _seed_dispatch(state_dir, "D-pp-1", "T-pr-pending", state="completed")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-pr-pending", PROJECT_ID)
+    assert result["derived_status"] == "in_progress"
+
+
+def test_blocked_by_blocker_oi(tmp_path):
+    """derived_status='blocked' when a link_type='blocks' OI is linked."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-blocked-oi")
+    _seed_dispatch(state_dir, "D-boi-1", "T-blocked-oi", state="completed")
+    _seed_pr_merged_event(state_dir, "D-boi-1")
+
+    tracks_lib.link_open_item(state_dir, "T-blocked-oi", PROJECT_ID, "OI-999", "blocks", "manual")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-blocked-oi", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+
+
+def test_blocked_by_dependency_not_done(tmp_path):
+    """derived_status='blocked' when a dependency track's declared phase is not 'done'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-dep-parent", phase="queued")
+    _seed_track(state_dir, "T-dep-child")
+    tracks_lib.add_dependency(
+        state_dir,
+        "T-dep-child", PROJECT_ID,
+        "T-dep-parent", PROJECT_ID,
+        kind="hard", derivation_source="manual",
+    )
+    _seed_dispatch(state_dir, "D-dep-1", "T-dep-child", state="completed")
+    _seed_pr_merged_event(state_dir, "D-dep-1")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-dep-child", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+
+
+def test_not_blocked_when_dependency_done(tmp_path):
+    """derived_status='done' when dependency's declared phase is 'done'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-prereq", phase="done")
+    _seed_track(state_dir, "T-downstream")
+    tracks_lib.add_dependency(
+        state_dir,
+        "T-downstream", PROJECT_ID,
+        "T-prereq", PROJECT_ID,
+        kind="hard", derivation_source="manual",
+    )
+    _seed_dispatch(state_dir, "D-ds-1", "T-downstream", state="completed")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-downstream", PROJECT_ID)
+    assert result["derived_status"] == "done"
+
+
+def test_queued_when_no_dispatches(tmp_path):
+    """derived_status='queued' when no dispatches are linked."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-nowork")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-nowork", PROJECT_ID)
+    assert result["derived_status"] == "queued"
+
+
+def test_in_progress_when_dispatches_active(tmp_path):
+    """derived_status='in_progress' when dispatches are in-flight."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-active")
+    _seed_dispatch(state_dir, "D-act-1", "T-active", state="running")
+    _seed_dispatch(state_dir, "D-act-2", "T-active", state="completed")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-active", PROJECT_ID)
+    assert result["derived_status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency and replay-safety
+# ---------------------------------------------------------------------------
+
+def test_idempotent_rerun(tmp_path):
+    """Running the reconciler twice produces the same derived_status."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-idem", pr_ref="PR-300")
+    _seed_dispatch(state_dir, "D-idem-1", "T-idem", state="completed")
+    _seed_pr_merged_event(state_dir, "D-idem-1")
+
+    r1 = track_reconciler.reconcile_track(state_dir, "T-idem", PROJECT_ID)
+    r2 = track_reconciler.reconcile_track(state_dir, "T-idem", PROJECT_ID)
+
+    assert r1["derived_status"] == "done"
+    assert r2["derived_status"] == "done"
+    assert r1["derived_status"] == r2["derived_status"]
+
+
+def test_duplicate_event_no_double_advance(tmp_path):
+    """A duplicate pr_merged event does not cause inconsistent state."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-dup", pr_ref="PR-400")
+    _seed_dispatch(state_dir, "D-dup-1", "T-dup", state="completed")
+
+    # Insert the pr_merged event twice (simulates duplicate/replay).
+    _seed_pr_merged_event(state_dir, "D-dup-1")
+    _seed_pr_merged_event(state_dir, "D-dup-1")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-dup", PROJECT_ID)
+    assert result["derived_status"] == "done"
+
+    # Second reconcile pass: still 'done', not some unexpected state.
+    result2 = track_reconciler.reconcile_track(state_dir, "T-dup", PROJECT_ID)
+    assert result2["derived_status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Contract: ROADMAP.yaml and authoritative phase must never be written
+# ---------------------------------------------------------------------------
+
+def test_roadmap_yaml_never_written(tmp_path):
+    """The reconciler must not create or modify ROADMAP.yaml."""
+    state_dir = _build_db(tmp_path)
+    project_root = tmp_path
+    roadmap_yaml = project_root / "ROADMAP.yaml"
+
+    _seed_track(state_dir, "T-nowrite")
+    _seed_dispatch(state_dir, "D-nw-1", "T-nowrite", state="completed")
+    _seed_pr_merged_event(state_dir, "D-nw-1")
+
+    track_reconciler.reconcile_all_tracks(state_dir, PROJECT_ID)
+
+    assert not roadmap_yaml.exists(), "reconciler must not create ROADMAP.yaml"
+
+
+def test_authoritative_phase_never_modified(tmp_path):
+    """The reconciler must not touch tracks.phase."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-phase", phase="active")
+    _seed_dispatch(state_dir, "D-ph-1", "T-phase", state="completed")
+    _seed_pr_merged_event(state_dir, "D-ph-1")
+
+    before = _get_track_row(state_dir, "T-phase")["phase"]
+
+    track_reconciler.reconcile_track(state_dir, "T-phase", PROJECT_ID)
+
+    after = _get_track_row(state_dir, "T-phase")["phase"]
+    assert before == after == "active"
+
+
+# ---------------------------------------------------------------------------
+# reconcile_all_tracks
+# ---------------------------------------------------------------------------
+
+def test_reconcile_all_tracks_processes_all(tmp_path):
+    """reconcile_all_tracks handles multiple tracks and returns one result per track."""
+    state_dir = _build_db(tmp_path)
+    for tid in ("T-all-1", "T-all-2", "T-all-3"):
+        _seed_track(state_dir, tid)
+
+    _seed_dispatch(state_dir, "D-all-1", "T-all-1", state="running")
+    _seed_dispatch(state_dir, "D-all-2", "T-all-2", state="completed")
+    # T-all-3: no dispatches → queued
+
+    results = track_reconciler.reconcile_all_tracks(state_dir, PROJECT_ID)
+
+    by_id = {r["track_id"]: r for r in results}
+    assert set(by_id.keys()) == {"T-all-1", "T-all-2", "T-all-3"}
+    assert by_id["T-all-1"]["derived_status"] == "in_progress"
+    assert by_id["T-all-2"]["derived_status"] == "done"  # no pr_ref on track
+    assert by_id["T-all-3"]["derived_status"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Migration 0028 up/down
+# ---------------------------------------------------------------------------
+
+def _base_v27_db(tmp_path: Path) -> tuple[sqlite3.Connection, Path]:
+    """Build a DB at user_version=27 (0022+0024+0027 applied)."""
+    db_path = tmp_path / "rc.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    return conn, db_path
+
+
+def _cols(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def test_0028_up_adds_derived_status_column(tmp_path):
+    conn, _ = _base_v27_db(tmp_path)
+    assert "derived_status" not in _cols(conn, "tracks")
+    assert schema_migration.get_user_version(conn) == 27
+
+    sql = (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8")
+    applied = schema_migration.apply_script_if_below(conn, 28, sql)
+    conn.commit()
+
+    assert applied is True
+    assert schema_migration.get_user_version(conn) == 28
+    assert "derived_status" in _cols(conn, "tracks")
+
+
+def test_0028_idempotent(tmp_path):
+    conn, _ = _base_v27_db(tmp_path)
+    sql = (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 28, sql)
+    conn.commit()
+    applied_again = schema_migration.apply_script_if_below(conn, 28, sql)
+    assert applied_again is False
+    assert schema_migration.get_user_version(conn) == 28
+
+
+def test_0028_down_removes_derived_status(tmp_path):
+    conn, _ = _base_v27_db(tmp_path)
+    sql_up = (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 28, sql_up)
+    conn.commit()
+    assert "derived_status" in _cols(conn, "tracks")
+
+    # Seed a track to verify data survives
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, phase, horizon, derived_status) "
+        "VALUES ('t-down', 'vnx-dev', 'T', 'g', 'queued', 'now', 'queued')"
+    )
+    conn.commit()
+
+    sql_down = (_MIGRATIONS / "0028_tracks_derived_status_down.sql").read_text(encoding="utf-8")
+    for stmt in schema_migration._split_sql_statements(sql_down):
+        conn.execute(stmt)
+    conn.commit()
+
+    assert schema_migration.get_user_version(conn) == 27
+    assert "derived_status" not in _cols(conn, "tracks")
+    assert "horizon" in _cols(conn, "tracks")  # horizon preserved
+
+    row = conn.execute(
+        "SELECT track_id, phase FROM tracks WHERE track_id='t-down'"
+    ).fetchone()
+    assert row == ("t-down", "queued")
+
+
+def test_0028_down_preserves_track_dependencies(tmp_path):
+    """Down migration must not break FK-referenced data."""
+    conn, _ = _base_v27_db(tmp_path)
+    sql_up = (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8")
+    schema_migration.apply_script_if_below(conn, 28, sql_up)
+    conn.commit()
+
+    conn.executemany(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, phase) VALUES (?,?,?,?,?)",
+        [("t-a", "vnx-dev", "A", "g", "active"), ("t-b", "vnx-dev", "B", "g", "queued")],
+    )
+    conn.commit()
+    conn.execute(
+        "INSERT INTO track_dependencies "
+        "(from_track_id, from_project_id, to_track_id, to_project_id, kind, derivation_source) "
+        "VALUES ('t-a','vnx-dev','t-b','vnx-dev','hard','manual')"
+    )
+    conn.commit()
+
+    sql_down = (_MIGRATIONS / "0028_tracks_derived_status_down.sql").read_text(encoding="utf-8")
+    for stmt in schema_migration._split_sql_statements(sql_down):
+        conn.execute(stmt)
+    conn.commit()
+
+    dep = conn.execute("SELECT * FROM track_dependencies").fetchone()
+    assert dep is not None
+    assert dep[0] == "t-a"


### PR DESCRIPTION
## Summary

- Migration 0028 adds `tracks.derived_status TEXT` (nullable, advisory-only, distinct from the authoritative `tracks.phase`)
- `scripts/lib/track_reconciler.py`: idempotent reconciler that reads dispatch/event state and writes only `derived_status` — never `ROADMAP.yaml`, never `tracks.phase`
- `RoadmapManager.reconcile_tracks()`: gated dark by `VNX_ROADMAP_AUTOPILOT` env flag (default off, no auto-advance)
- `vnx objective list --json` surfaces `derived_status` alongside declared phase for drift visibility

## Derived status logic

| Condition | derived_status |
|---|---|
| Any `link_type='blocks'` OI linked | `blocked` |
| Any dependency track's `phase != 'done'` | `blocked` |
| No dispatches | `queued` |
| All dispatches terminal + no `pr_ref` on track | `done` |
| All dispatches terminal + `pr_merged` event exists | `done` |
| All dispatches terminal + `pr_ref` set but no merged event | `in_progress` |
| Any dispatch in-flight | `in_progress` |
| All dispatches in planned state | `queued` |

## Test plan

- [x] `pytest tests/test_track_reconciler.py -q` → 17 passed
- [x] `done/blocked/queued/in_progress` paths verified independently
- [x] Idempotency: re-run produces same result
- [x] Duplicate `pr_merged` event: no double-advance
- [x] `ROADMAP.yaml` never created by reconciler
- [x] `tracks.phase` (authoritative) never modified
- [x] Migration 0028 up/down, idempotent apply, FK-safe rebuild
- [x] Regression: `test_migrate_0027`, `test_planning_deliverables`, `test_tracks_lib`, `test_planning_cli_objective` all pass (59+29 tests)

Dispatch-ID: 20260601-232816-planning-phase3

🤖 Generated with [Claude Code](https://claude.com/claude-code)