### PR TITLE
fix(db-maintenance): atomic prune transaction (OI-2328)

### DIFF
--- a/scripts/vnx_db_maintenance.py
+++ b/scripts/vnx_db_maintenance.py
@@ -184,8 +184,11 @@ def apply(db_path: Optional[str] = None, retention_days: int = DEFAULT_RETENTION
 
     conn = sqlite3.connect(str(path))
     pruned_counts = {}
+    prune_error = None
 
     try:
+        conn.execute("BEGIN")
+
         for spec in PRUNABLE_TABLES:
             table = spec["table"]
             date_col = spec["date_col"]
@@ -223,27 +226,37 @@ def apply(db_path: Optional[str] = None, retention_days: int = DEFAULT_RETENTION
             except sqlite3.OperationalError as exc:
                 pruned_counts[table] = 0
                 pruned_counts[f"{table}_error"] = str(exc)
+                prune_error = exc
+                break
 
-        conn.commit()
-        conn.execute("VACUUM")
+        if prune_error:
+            conn.rollback()
+            # Zero out rowcounts captured before the error — nothing was committed.
+            for key in list(pruned_counts.keys()):
+                if not key.endswith("_error"):
+                    pruned_counts[key] = 0
+        else:
+            conn.commit()
+            conn.execute("VACUUM")
     finally:
         conn.close()
 
     size_after = _db_size_bytes(path)
     reclaimed = max(0, size_before - size_after)
 
-    # Write append-only audit ledger (durable record of destructive maintenance).
-    audit_path = path.parent / "db_maintenance_audit.ndjson"
-    audit_record = {
-        "ts": dt.datetime.now(dt.timezone.utc).isoformat(),
-        "op": "db_maintenance",
-        "db_path": str(path),
-        "retention_days": retention_days,
-        "pruned": pruned_counts,
-        "bytes_reclaimed": reclaimed,
-        "vacuumed": True,
-    }
-    _write_audit_record(audit_path, audit_record)
+    # Write append-only audit ledger only when the prune committed successfully.
+    if not prune_error:
+        audit_path = path.parent / "db_maintenance_audit.ndjson"
+        audit_record = {
+            "ts": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "op": "db_maintenance",
+            "db_path": str(path),
+            "retention_days": retention_days,
+            "pruned": pruned_counts,
+            "bytes_reclaimed": reclaimed,
+            "vacuumed": True,
+        }
+        _write_audit_record(audit_path, audit_record)
 
     return {
         "dry_run": False,

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -280,6 +280,42 @@ class TestApply:
         )
         assert result["pruned"].get("code_snippets", 0) > 0
 
+    def test_apply_prune_is_transactional_mid_loop_error_rolls_back(self, tmp_path):
+        """Prune is all-or-nothing: mid-loop error rolls back, no partial prune."""
+        db = tmp_path / "quality_intelligence.db"
+        conn = _make_db(db)
+        _insert_snippets(conn, ["2020-01-01", "2020-02-01"])
+        _insert_sessions(conn, ["2020-01-01", "2020-02-01"])
+        conn.close()
+
+        # Sabotage: drop session_analytics (3rd in PRUNABLE_TABLES order:
+        # code_snippets → snippet_metadata → session_analytics).
+        # code_snippets+snippet_metadata DELETE succeeds, then
+        # session_analytics DELETE fails mid-loop → rollback everything.
+        conn = sqlite3.connect(str(db))
+        conn.execute("DROP TABLE session_analytics")
+        conn.commit()
+        conn.close()
+
+        result = apply(db_path=str(db), retention_days=30)
+
+        # Verify no partial prune — code_snippets + snippet_metadata rolled back.
+        conn = sqlite3.connect(str(db))
+        cs_count = conn.execute("SELECT COUNT(*) FROM code_snippets").fetchone()[0]
+        sm_count = conn.execute("SELECT COUNT(*) FROM snippet_metadata").fetchone()[0]
+        conn.close()
+
+        assert cs_count == 2, f"code_snippets: expected 2 (rolled back), got {cs_count}"
+        assert sm_count == 2, f"snippet_metadata: expected 2 (rolled back), got {sm_count}"
+        assert "session_analytics_error" in result["pruned"], (
+            "session_analytics should have recorded an error"
+        )
+        # Audit ledger must NOT be written when the prune was rolled back.
+        audit_path = db.parent / "db_maintenance_audit.ndjson"
+        assert not audit_path.exists(), (
+            "Audit ledger must not exist when prune was rolled back"
+        )
+
     def test_apply_writes_audit_ledger(self, tmp_path):
         """apply() must write exactly one NDJSON line to db_maintenance_audit.ndjson."""
         db = tmp_path / "quality_intelligence.db"


### PR DESCRIPTION
## What

Makes the `apply()` prune loop in `scripts/vnx_db_maintenance.py` atomic by wrapping all per-table DELETEs in an explicit transaction.

## Why (OI-2328)

Under Python 3.12 autocommit, each DELETE committed individually. A crash mid-loop left orphan state — some tables pruned, others not. No partial prune survives now: any error rolls back the entire transaction.

## Changes

- **`scripts/vnx_db_maintenance.py`** — `apply()`: `BEGIN` before the prune loop, `COMMIT` after all DELETEs succeed (before VACUUM), `ROLLBACK` on any `sqlite3.OperationalError`. VACUUM and the durable audit-ledger write are gated on successful commit.
- **`tests/test_db_maintenance.py`** — New test `test_apply_prune_is_transactional_mid_loop_error_rolls_back`: populates code_snippets + snippet_metadata, drops session_analytics to force mid-loop error, verifies both tables roll back to original row counts and no audit ledger is written.

## Verification

```
$ pytest tests/test_db_maintenance.py -q
..................                                                       [100%]
18 passed in 0.19s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)