### PR TITLE
fix(tmux): hook-driven version-agnostic lane signals (SessionStart ready / UserPromptSubmit submit / Stop receipt-guarantee) + wire subagent-block

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/pretooluse_block_subagent.sh\"'",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -32,6 +42,28 @@
             "command": "python3 scripts/build_t0_state.py --output .vnx-data/state/t0_state.json 2>/dev/null; exit 0"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/tmux_signal_session_ready.sh\"'",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/tmux_signal_prompt_received.sh\"'",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "Stop": [
@@ -41,6 +73,16 @@
           {
             "type": "command",
             "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel)/scripts/hooks/stop_report_hook.sh\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/tmux_signal_stop_receipt.sh\"'",
+            "timeout": 5000
           }
         ]
       }

--- a/scripts/hooks/pretooluse_block_subagent.sh
+++ b/scripts/hooks/pretooluse_block_subagent.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# PreToolUse Hook: Block subagents (Task tool)
+#
+# Purpose: Enforce T0 governance rule — all work must route through governed
+#          VNX lanes (tmux-spawn / provider_dispatch), never via subagents.
+#          Subagents bypass the governance receipt trail; governed lanes
+#          always emit a receipt.
+#
+# Claude Code hook contract (2.1+):
+#   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
+#   stdout : {"decision":"block","reason":"..."} to block, empty to allow
+#   exit   : 0 always — decision is communicated via JSON output
+#
+# Token budget: ~40 tokens/call — fast-path exits for non-Task tools
+
+set -euo pipefail
+
+# ── Read hook payload ─────────────────────────────────────────────────────────
+INPUT="$(cat)"
+
+# ── Extract tool name ─────────────────────────────────────────────────────────
+TOOL_NAME=""
+if command -v jq >/dev/null 2>&1; then
+  TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")"
+fi
+
+# ── Only block the Task (subagent) tool ──────────────────────────────────────
+if [[ "$TOOL_NAME" != "Task" ]]; then
+  exit 0
+fi
+
+# ── Emit block decision ──────────────────────────────────────────────────────
+printf '{"decision":"block","reason":"Subagents (Task tool) are disabled in this project. Route work through governed VNX lanes: tmux-spawn (scripts/lib/tmux_interactive_dispatch.py) or provider_dispatch.py — these emit receipts. See T0 CLAUDE.md worker-dispatch policy."}\n'
+
+# Exit 0 always — block/allow is communicated via JSON stdout, not exit code
+exit 0

--- a/scripts/hooks/tmux_signal_prompt_received.sh
+++ b/scripts/hooks/tmux_signal_prompt_received.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# VNX tmux-lane UserPromptSubmit sentinel
+#
+# Fires on Claude Code's UserPromptSubmit hook. Writes a "prompt_received"
+# sentinel into $VNX_TMUX_SIGNAL_DIR so the tmux interactive lane can confirm the
+# dispatch instruction was actually submitted via the stable HOOK CONTRACT,
+# instead of inferring it from version-specific TUI pane scraping.
+#
+# Scoped HARD to tmux-spawn workers: fires ONLY when BOTH VNX_TMUX_SIGNAL_DIR and
+# VNX_DISPATCH_ID are set. For any normal T0/interactive session (env unset) it
+# drains stdin and exits 0 — completely no-op, no behavior change.
+#
+# Atomic write (.tmp then mv). Never blocks. Any error -> exit 0.
+
+# Drain stdin so the hook caller never blocks on an unread pipe.
+cat >/dev/null 2>&1 || true
+
+# ── Guard: only fire for tmux-spawn workers ──────────────────────────────────
+if [ -z "${VNX_TMUX_SIGNAL_DIR:-}" ] || [ -z "${VNX_DISPATCH_ID:-}" ]; then
+  exit 0
+fi
+
+# Best-effort atomic sentinel write.
+{
+  mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
+  _tmp="$VNX_TMUX_SIGNAL_DIR/prompt_received.$$.tmp"
+  printf '%s\n' "${VNX_DISPATCH_ID}" >"$_tmp" 2>/dev/null \
+    && mv -f "$_tmp" "$VNX_TMUX_SIGNAL_DIR/prompt_received" 2>/dev/null
+} || true
+
+exit 0

--- a/scripts/hooks/tmux_signal_session_ready.sh
+++ b/scripts/hooks/tmux_signal_session_ready.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# VNX tmux-lane SessionStart sentinel
+#
+# Fires on Claude Code's SessionStart hook. Writes a "session_ready" sentinel
+# into $VNX_TMUX_SIGNAL_DIR so the tmux interactive lane can detect readiness via
+# the stable HOOK CONTRACT instead of scraping version-specific TUI banners
+# (which break on ~weekly Claude Code bumps).
+#
+# Scoped HARD to tmux-spawn workers: fires ONLY when BOTH VNX_TMUX_SIGNAL_DIR and
+# VNX_DISPATCH_ID are set. For any normal T0/interactive session (env unset) it
+# drains stdin and exits 0 — completely no-op, no behavior change.
+#
+# Atomic write (.tmp then mv). Never blocks. Any error -> exit 0.
+
+# Drain stdin so the hook caller never blocks on an unread pipe.
+cat >/dev/null 2>&1 || true
+
+# ── Guard: only fire for tmux-spawn workers ──────────────────────────────────
+if [ -z "${VNX_TMUX_SIGNAL_DIR:-}" ] || [ -z "${VNX_DISPATCH_ID:-}" ]; then
+  exit 0
+fi
+
+# Best-effort atomic sentinel write.
+{
+  mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
+  _tmp="$VNX_TMUX_SIGNAL_DIR/session_ready.$$.tmp"
+  printf '%s\n' "${VNX_DISPATCH_ID}" >"$_tmp" 2>/dev/null \
+    && mv -f "$_tmp" "$VNX_TMUX_SIGNAL_DIR/session_ready" 2>/dev/null
+} || true
+
+exit 0

--- a/scripts/hooks/tmux_signal_stop_receipt.sh
+++ b/scripts/hooks/tmux_signal_stop_receipt.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# VNX tmux-lane Stop hook — deterministic receipt-guarantee for tmux-spawn workers
+#
+# WHY THIS EXISTS:
+#   The F37 stop_report_hook.sh detects the worker terminal by CWD path
+#   (.claude/terminals/T1) and is gated on VNX_AUTO_REPORT=1. tmux-spawn workers
+#   run in the shared/isolated worktree ROOT (no terminals/T{n} segment) and
+#   without VNX_AUTO_REPORT, so F37 SKIPS them — which is exactly why tmux-spawn
+#   workers hit "receipt deadline exceeded": their unified_report existed but no
+#   receipt was emitted until the lane's deadline fallback fired much later.
+#
+#   This hook is scoped to tmux-spawn workers via the worker env (VNX_DISPATCH_ID
+#   + VNX_TMUX_SIGNAL_DIR), independent of cwd-based detection and independent of
+#   VNX_AUTO_REPORT. On stop it (a) drops a "stopped" sentinel and (b) emits the
+#   governed receipt PROMPTLY by reusing the #788 report->receipt converter, so
+#   the receipt arrives on stop rather than after the deadline.
+#
+# COEXISTENCE: This does NOT replace F37. Both Stop hooks run — F37 for
+#   terminal-pinned workers, this one for tmux-spawn workers. The converter
+#   dedups by file hash, so no double receipt is produced.
+#
+# Scoped HARD: fires ONLY when BOTH VNX_DISPATCH_ID and VNX_TMUX_SIGNAL_DIR are
+#   set. Normal T0/interactive sessions (env unset) drain stdin and exit 0.
+#
+# Best-effort, < 5s, never blocks. Any error -> exit 0.
+
+# Drain stdin so the hook caller never blocks on an unread pipe.
+cat >/dev/null 2>&1 || true
+
+# ── Guard: only fire for tmux-spawn workers ──────────────────────────────────
+if [ -z "${VNX_DISPATCH_ID:-}" ] || [ -z "${VNX_TMUX_SIGNAL_DIR:-}" ]; then
+  exit 0
+fi
+
+# ── (a) Drop the "stopped" sentinel (atomic) ─────────────────────────────────
+{
+  mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
+  _tmp="$VNX_TMUX_SIGNAL_DIR/stopped.$$.tmp"
+  printf '%s\n' "${VNX_DISPATCH_ID}" >"$_tmp" 2>/dev/null \
+    && mv -f "$_tmp" "$VNX_TMUX_SIGNAL_DIR/stopped" 2>/dev/null
+} || true
+
+# ── (b) Receipt-guarantee via the #788 converter ─────────────────────────────
+# Resolve project root and the state/data dirs. Prefer explicit env; fall back
+# to git toplevel of CWD. Everything best-effort; never let a failure block stop.
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$PROJECT_ROOT" ]; then
+  if [ -n "${VNX_DATA_DIR:-}" ]; then
+    PROJECT_ROOT="$(dirname "$VNX_DATA_DIR")"
+  fi
+fi
+
+VNX_DATA="${VNX_DATA_DIR:-$PROJECT_ROOT/.vnx-data}"
+STATE_DIR="${VNX_STATE_DIR:-$VNX_DATA/state}"
+REPORTS_DIR="$VNX_DATA/unified_reports"
+
+if [ -z "$PROJECT_ROOT" ] || ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+LIB_DIR="$PROJECT_ROOT/scripts/lib"
+SCRIPTS_DIR="$PROJECT_ROOT/scripts"
+
+# Bound the converter to keep stop fast (< 5s). `timeout` is absent on stock
+# macOS; use it only when present (or gtimeout from coreutils), else run direct.
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout 4"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout 4"
+fi
+
+# Hand off to python with all paths via env (no shell-quoting hazards). The
+# converter dedups by file hash, so re-runs do NOT double-write a receipt.
+VNX_HOOK_PROJECT_ROOT="$PROJECT_ROOT" \
+VNX_HOOK_LIB_DIR="$LIB_DIR" \
+VNX_HOOK_SCRIPTS_DIR="$SCRIPTS_DIR" \
+VNX_HOOK_STATE_DIR="$STATE_DIR" \
+VNX_HOOK_REPORTS_DIR="$REPORTS_DIR" \
+VNX_HOOK_DISPATCH_ID="$VNX_DISPATCH_ID" \
+$TIMEOUT_CMD python3 - <<'PY' 2>/dev/null || true
+import os
+import sys
+from pathlib import Path
+
+lib_dir = os.environ.get("VNX_HOOK_LIB_DIR", "")
+scripts_dir = os.environ.get("VNX_HOOK_SCRIPTS_DIR", "")
+for p in (scripts_dir, lib_dir):
+    if p and p not in sys.path:
+        sys.path.insert(0, p)
+
+try:
+    from report_to_receipt_converter import (
+        convert_report_to_receipt,
+        scan_and_convert,
+    )
+except Exception:
+    sys.exit(0)
+
+dispatch_id = os.environ.get("VNX_HOOK_DISPATCH_ID", "")
+state_dir = Path(os.environ.get("VNX_HOOK_STATE_DIR", ""))
+reports_dir = Path(os.environ.get("VNX_HOOK_REPORTS_DIR", ""))
+receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+# Prefer the dispatch's own unified_report (prompt, single-file convert).
+candidates = [
+    reports_dir / f"{dispatch_id}.md",
+    reports_dir / f"{dispatch_id}_report.md",
+]
+report_path = next((c for c in candidates if c.is_file()), None)
+
+try:
+    if report_path is not None:
+        convert_report_to_receipt(report_path, receipts_file=receipts_file)
+    else:
+        # No dispatch-named report yet — scan the dir (still hash-deduped).
+        scan_and_convert([reports_dir], state_dir=state_dir)
+except Exception:
+    pass
+sys.exit(0)
+PY
+
+exit 0

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -552,10 +552,31 @@ class TmuxInteractiveDispatch:
         ready_markers: "tuple[str, ...]",
         warmup_timeout: float,
         poll_interval: float,
+        signal_dir: "Path | None" = None,
     ) -> bool:
-        """Poll capture-pane until a readiness marker appears or timeout."""
+        """Wait until the worker session is ready, or timeout.
+
+        PRIMARY signal: the SessionStart hook sentinel ("<signal_dir>/session_ready").
+        It is checked first on every poll and confirms readiness via the stable hook
+        contract — version-agnostic, independent of any TUI banner wording. The
+        capture-pane marker scan is only a tolerant fallback for when the sentinel is
+        unavailable.
+        """
+        ready_sentinel = (signal_dir / "session_ready") if signal_dir else None
         deadline = time.monotonic() + warmup_timeout
         while time.monotonic() < deadline:
+            # PRIMARY: SessionStart hook fired → session is ready.
+            if ready_sentinel is not None:
+                try:
+                    if ready_sentinel.exists():
+                        logger.info(
+                            "interactive: readiness via SessionStart sentinel for %s",
+                            pane_id,
+                        )
+                        return True
+                except OSError:
+                    pass
+            # FALLBACK: tolerant TUI marker scan.
             cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
             content = cap.stdout if cap.returncode == 0 else ""
             if content and any(m in content for m in ready_markers):
@@ -587,14 +608,40 @@ class TmuxInteractiveDispatch:
 
     # Sentinel appended to every dispatch body (END_OF_INSTRUCTION_SENTINEL from dispatch_prepare).
     _END_SENTINEL = "<!-- VNX-END-OF-INSTRUCTION -->"
-    # Pane content that proves Claude is actively running (not idle at the input box).
-    _WORKING_MARKER = "esc to interrupt"
+    # ── Tolerant TUI fallback heuristics — NOT the primary signal ──────────────
+    # Hooks are PRIMARY (SessionStart ready / UserPromptSubmit submit) and the
+    # receipt is AUTHORITATIVE for completion. The pane-scrape below is only a
+    # backstop for when the hook sentinels are unavailable, and MUST stay
+    # version-robust: never hard-depend on a Claude Code version's exact wording.
+    #
+    # Evidence: claude 2.1.160 dropped "esc to interrupt" in favour of a
+    # random-gerund spinner + token-counter, e.g. "✢ Smooshing… (18s · ↓ 739 tokens)".
+    # So the working-detector matches the STRUCTURAL token-counter shape
+    # ("(<n>s · ↓/↑ <n> tokens)"), OR a tolerant set of legacy literals.
+    _WORKING_TOKEN_RE = re.compile(r"\(\s*\d+\s*s\b[^)\n]*tokens?\b", re.IGNORECASE)
+    _WORKING_LITERALS = ("esc to interrupt", "to interrupt")
     # Bottom N lines of the pane constitute the "input region" for staged-paste detection.
     _INPUT_REGION_LINES = 10
     # Leading chars of the body used as a fingerprint to detect it in the input region.
     _BODY_FINGERPRINT_LEN = 80
 
-    def _verify_submit(self, pane_id: str, body: str) -> bool:
+    def _looks_working(self, content: str) -> bool:
+        """Version-robust "Claude is actively working" detector (tolerant fallback).
+
+        Returns True if the pane content shows the structural token-counter the TUI
+        prints while a turn is running ("(18s · ↓ 739 tokens)", "(3s · ↑ 12 tokens)")
+        OR any tolerant legacy literal ("esc to interrupt", "to interrupt"). This is
+        only a backstop to the hook sentinels — never a hard dependency on a specific
+        Claude Code version's wording.
+        """
+        if not content:
+            return False
+        if self._WORKING_TOKEN_RE.search(content):
+            return True
+        lowered = content.lower()
+        return any(lit in lowered for lit in self._WORKING_LITERALS)
+
+    def _verify_submit(self, pane_id: str, body: str, *, signal_dir: "Path | None" = None) -> bool:
         """Confirm the instruction was actually submitted, not left staged in the input box.
 
         Submitted = working indicator present anywhere in the pane, OR the input region
@@ -609,6 +656,10 @@ class TmuxInteractiveDispatch:
         Works on both paths: VNX_SHARED_PREPARE=1 (body contains sentinel) and the legacy
         default (no sentinel in body, detected via bracketed-paste annotation or fingerprint).
 
+        PRIMARY signal: the UserPromptSubmit hook sentinel ("<signal_dir>/prompt_received").
+        When present, submission is confirmed via the stable hook contract and the
+        TUI-scrape fallback below is skipped entirely. The pane scrape is only a backstop.
+
         Uses a bounded guarded-retry loop: up to VNX_TMUX_SUBMIT_MAX_RETRIES (default 3)
         additional Enter keystrokes, each preceded by a _still_staged() check to prevent
         stray Enters landing in a running session. Each retry polls for up to
@@ -620,12 +671,22 @@ class TmuxInteractiveDispatch:
         retry_delay = float(os.environ.get("VNX_TMUX_SUBMIT_RETRY_DELAY", "0.75"))
         verify_timeout = float(os.environ.get("VNX_TMUX_SUBMIT_VERIFY_TIMEOUT", "5"))
         body_fingerprint = body.strip()[:self._BODY_FINGERPRINT_LEN]
+        _prompt_sentinel = (signal_dir / "prompt_received") if signal_dir else None
+
+        def _sentinel_submitted() -> bool:
+            try:
+                return _prompt_sentinel is not None and _prompt_sentinel.exists()
+            except OSError:
+                return False
 
         def _still_staged() -> bool:
+            # PRIMARY: UserPromptSubmit hook fired → instruction was submitted.
+            if _sentinel_submitted():
+                return False
             cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
             content = cap.stdout if cap.returncode == 0 else ""
             # Working indicator anywhere in pane → Claude is running → submitted.
-            if self._WORKING_MARKER in content:
+            if self._looks_working(content):
                 return False
             # Scope staged-paste check to the input region (bottom lines only).
             # Sentinel/instruction text in the scrollback (upper area) means Claude already
@@ -641,6 +702,12 @@ class TmuxInteractiveDispatch:
             return False      # unknown state; assume submitted (conservative)
 
         # Fast path: already submitted (first Enter from _deliver_instruction worked).
+        if _sentinel_submitted():
+            logger.info(
+                "interactive: submission confirmed via UserPromptSubmit sentinel for %s",
+                pane_id,
+            )
+            return True
         if not _still_staged():
             return True
 
@@ -922,10 +989,13 @@ class TmuxInteractiveDispatch:
         warmup_timeout: float = 30.0,
         warmup_poll_interval: float = 1.0,
         ready_markers: "tuple[str, ...]" = (
+            # Tolerant TUI-fallback markers only — the SessionStart hook sentinel is
+            # the primary readiness signal. Deliberately NOT pinned to a version
+            # banner ("Claude Code vX.Y.Z" was removed: it breaks on every bump).
             "for shortcuts",
             "? for shortcuts",
             "Welcome to Claude",
-            "Claude Code v",    # v2.1.159+ banner (additive — legacy markers kept above)
+            "❯",                # input prompt glyph (idle, ready for input)
         ),
         completion_statuses: frozenset = DEFAULT_COMPLETION_STATUSES,
         dispatch_paths: "list[str] | str | None" = None,
@@ -995,6 +1065,16 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                 )
 
+        # Per-dispatch hook signal dir: the SessionStart / UserPromptSubmit / Stop
+        # hooks (guarded by VNX_TMUX_SIGNAL_DIR + VNX_DISPATCH_ID) drop sentinels
+        # here. Best-effort: if mkdtemp fails the lane silently degrades to the
+        # TUI-marker fallback (sentinel checks just never fire).
+        signal_dir: "Path | None" = None
+        try:
+            signal_dir = Path(tempfile.mkdtemp(prefix="vnx-tmux-sig-"))
+        except OSError as exc:
+            logger.debug("interactive: signal dir mkdtemp failed (%s); TUI fallback only", exc)
+
         # Idempotency guard: teardown runs exactly once across all exit paths.
         _torn_down = False
 
@@ -1003,6 +1083,11 @@ class TmuxInteractiveDispatch:
             if _torn_down:
                 return
             _torn_down = True
+            if signal_dir is not None:
+                try:
+                    shutil.rmtree(signal_dir, ignore_errors=True)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("interactive: signal dir cleanup failed (%s)", exc)
             try:
                 self._kill_session(session)
             except Exception as exc:  # noqa: BLE001
@@ -1153,6 +1238,17 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                 )
 
+            # Inject hook-signal env so the worker's SessionStart/UserPromptSubmit/Stop
+            # hooks fire (they are guarded by these two vars). Prepended as an export
+            # so it applies across the whole compound command (source …; claude …),
+            # not just the first segment. Validated after the headless guard so the
+            # guard only ever inspects the pure builder output.
+            if signal_dir is not None:
+                launch_cmd = (
+                    f"export VNX_TMUX_SIGNAL_DIR={shlex.quote(str(signal_dir))} "
+                    f"VNX_DISPATCH_ID={shlex.quote(dispatch_id)}; {launch_cmd}"
+                )
+
             if not self._launch_claude(pane_id, launch_cmd):
                 self._emit_event(
                     "interactive_launch_failed",
@@ -1179,6 +1275,7 @@ class TmuxInteractiveDispatch:
                 ready_markers=ready_markers,
                 warmup_timeout=warmup_timeout,
                 poll_interval=warmup_poll_interval,
+                signal_dir=signal_dir,
             )
             _strict = os.environ.get("VNX_TMUX_READY_STRICT", "1").strip().lower() not in (
                 "0", "false", "no", "off"
@@ -1279,7 +1376,7 @@ class TmuxInteractiveDispatch:
                 )
 
             # 7b. Verify the instruction was actually submitted (not left staged).
-            if not self._verify_submit(pane_id, body):
+            if not self._verify_submit(pane_id, body, signal_dir=signal_dir):
                 self._emit_event(
                     "interactive_submit_failed",
                     dispatch_id=dispatch_id,

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1887,18 +1887,24 @@ class TestReceiptDedup(_LaneTestCase):
 
 
 # ---------------------------------------------------------------------------
-# FIX 1 — v2.1.159 readiness markers + VNX_TMUX_READY_STRICT fail-fast
+# Version-robust readiness markers + VNX_TMUX_READY_STRICT fail-fast
 # ---------------------------------------------------------------------------
 
 class TestReadinessV2(_LaneTestCase):
-    """Readiness marker detection for Claude Code v2.1.159 + STRICT fail-fast guard."""
+    """Version-agnostic TUI-fallback readiness markers + STRICT fail-fast guard.
 
-    def test_v2_ready_marker_detected(self):
-        """'Claude Code v2.1.159' startup banner is detected as ready (no legacy marker needed)."""
+    The hook sentinel (SessionStart) is the PRIMARY readiness signal; these tests
+    cover the tolerant TUI fallback. The "Claude Code vX.Y.Z" banner is
+    deliberately NOT a marker anymore — pinning to it broke on every Claude Code
+    bump (e.g. 2.1.160 dropped "esc to interrupt").
+    """
+
+    def test_prompt_glyph_marker_detected(self):
+        """The idle input-prompt glyph '❯' is detected as ready (version-agnostic)."""
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
-            ready_content="Claude Code v2.1.159\n> ",
+            ready_content="some banner\n❯ ",
         )
         lane = self._make_lane(fake)
         result = self._fast_dispatch(lane)

--- a/tests/test_tmux_lane_signals.py
+++ b/tests/test_tmux_lane_signals.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Tests for the hook-driven tmux interactive lane signals.
+
+Covers the version-agnostic hook-contract path that replaces TUI-string scraping:
+- SessionStart sentinel → readiness (with TUI-marker fallback)
+- UserPromptSubmit sentinel → submission (with _still_staged fallback)
+- _looks_working() structural token-counter detector (2.1.160-robust)
+- The guarded hook sentinel scripts (no-op when worker env unset)
+- The Stop hook receipt-guarantee via the #788 converter (hermetic temp dirs)
+
+The receipt remains authoritative for completion; these tests assert the lane no
+longer hard-depends on a specific Claude Code version's TUI wording.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from tmux_interactive_dispatch import TmuxInteractiveDispatch, TmuxResult  # noqa: E402
+
+HOOKS_DIR = SCRIPT_DIR / "hooks"
+SESSION_READY_HOOK = HOOKS_DIR / "tmux_signal_session_ready.sh"
+PROMPT_RECEIVED_HOOK = HOOKS_DIR / "tmux_signal_prompt_received.sh"
+STOP_RECEIPT_HOOK = HOOKS_DIR / "tmux_signal_stop_receipt.sh"
+
+
+class _CaptureRunner:
+    """Minimal tmux runner stub: capture-pane returns a fixed content string."""
+
+    def __init__(self, capture_content: str = "") -> None:
+        self._capture_content = capture_content
+        self.commands: list[list[str]] = []
+
+    def available(self) -> bool:
+        return True
+
+    def run(self, args, *, timeout: int = 10, input_text=None) -> TmuxResult:
+        self.commands.append(list(args))
+        if args and args[0] == "capture-pane":
+            return TmuxResult(0, self._capture_content)
+        return TmuxResult(0, "")
+
+
+def _make_lane(runner: _CaptureRunner, root: Path) -> TmuxInteractiveDispatch:
+    return TmuxInteractiveDispatch(
+        root,
+        runner=runner,
+        receipts_file=root / "t0_receipts.ndjson",
+        project_root=root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Readiness: sentinel-first, TUI fallback
+# ---------------------------------------------------------------------------
+class TestReadinessSentinel(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def test_session_ready_sentinel_marks_ready_without_tui_marker(self) -> None:
+        # Pane content has NO TUI readiness marker — only the sentinel proves ready.
+        runner = _CaptureRunner(capture_content="(nothing recognizable here)")
+        lane = _make_lane(runner, self.root)
+        sig = self.root / "sig"
+        sig.mkdir()
+        (sig / "session_ready").write_text("dispatch-x\n", encoding="utf-8")
+
+        ready = lane._wait_ready(
+            "%1",
+            ready_markers=("for shortcuts",),
+            warmup_timeout=0.5,
+            poll_interval=0.01,
+            signal_dir=sig,
+        )
+        self.assertTrue(ready)
+
+    def test_empty_signal_dir_falls_back_to_tui_markers(self) -> None:
+        # No sentinel; pane shows a TUI marker → fallback path returns ready.
+        runner = _CaptureRunner(capture_content="Welcome\n? for shortcuts")
+        lane = _make_lane(runner, self.root)
+        sig = self.root / "sig"
+        sig.mkdir()  # empty — no session_ready file
+
+        ready = lane._wait_ready(
+            "%1",
+            ready_markers=("for shortcuts",),
+            warmup_timeout=0.5,
+            poll_interval=0.01,
+            signal_dir=sig,
+        )
+        self.assertTrue(ready)
+
+    def test_no_sentinel_no_marker_times_out(self) -> None:
+        runner = _CaptureRunner(capture_content="(no marker)")
+        lane = _make_lane(runner, self.root)
+        sig = self.root / "sig"
+        sig.mkdir()
+
+        ready = lane._wait_ready(
+            "%1",
+            ready_markers=("for shortcuts",),
+            warmup_timeout=0.1,
+            poll_interval=0.01,
+            signal_dir=sig,
+        )
+        self.assertFalse(ready)
+
+
+# ---------------------------------------------------------------------------
+# Submission: sentinel-first, _still_staged fallback
+# ---------------------------------------------------------------------------
+class TestSubmissionSentinel(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def test_prompt_received_sentinel_treated_as_submitted(self) -> None:
+        # Pane still shows the staged paste, but the hook sentinel overrides it.
+        staged = "[Pasted text +120 lines]\n<!-- VNX-END-OF-INSTRUCTION -->"
+        runner = _CaptureRunner(capture_content=staged)
+        lane = _make_lane(runner, self.root)
+        sig = self.root / "sig"
+        sig.mkdir()
+        (sig / "prompt_received").write_text("dispatch-x\n", encoding="utf-8")
+
+        with _fast_submit_env():
+            submitted = lane._verify_submit("%1", "Do the thing.", signal_dir=sig)
+        self.assertTrue(submitted)
+
+    def test_no_sentinel_uses_working_marker_fallback(self) -> None:
+        # No sentinel; pane shows the working token-counter → submitted via fallback.
+        runner = _CaptureRunner(capture_content="✢ Smooshing… (18s · ↓ 739 tokens)")
+        lane = _make_lane(runner, self.root)
+        sig = self.root / "sig"
+        sig.mkdir()  # empty
+
+        with _fast_submit_env():
+            submitted = lane._verify_submit("%1", "Do the thing.", signal_dir=sig)
+        self.assertTrue(submitted)
+
+
+# ---------------------------------------------------------------------------
+# _looks_working: version-robust structural detector
+# ---------------------------------------------------------------------------
+class TestLooksWorking(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.lane = _make_lane(_CaptureRunner(), Path(self._tmp.name))
+
+    def test_true_for_2_1_160_spinner_token_counter(self) -> None:
+        self.assertTrue(self.lane._looks_working("✢ Smooshing… (18s · ↓ 739 tokens)"))
+
+    def test_true_for_up_tokens_variant(self) -> None:
+        self.assertTrue(self.lane._looks_working("● Pondering (3s · ↑ 12 tokens)"))
+
+    def test_true_for_legacy_esc_to_interrupt(self) -> None:
+        self.assertTrue(self.lane._looks_working("... (esc to interrupt)"))
+
+    def test_false_for_idle_prompt_glyph(self) -> None:
+        self.assertFalse(self.lane._looks_working("❯ "))
+
+    def test_false_for_empty(self) -> None:
+        self.assertFalse(self.lane._looks_working(""))
+
+
+# ---------------------------------------------------------------------------
+# Hook scripts: guard behavior + sentinel writes
+# ---------------------------------------------------------------------------
+class TestHookGuards(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _run_hook(self, script: Path, env: dict, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        full_env = {"PATH": os.environ.get("PATH", "")}
+        full_env.update(env)
+        return subprocess.run(
+            ["bash", str(script)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env=full_env,
+            cwd=str(cwd) if cwd else None,
+            timeout=15,
+        )
+
+    def test_session_ready_noop_when_env_unset(self) -> None:
+        proc = self._run_hook(SESSION_READY_HOOK, env={})
+        self.assertEqual(proc.returncode, 0)
+        # No sentinel dir was provided, so nothing to assert except clean exit.
+
+    def test_session_ready_writes_sentinel_when_guarded(self) -> None:
+        sig = self.root / "sig"
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-ready",
+            },
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "session_ready").is_file())
+
+    def test_session_ready_does_not_write_when_only_one_var_set(self) -> None:
+        sig = self.root / "sig-partial"
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig)},  # missing VNX_DISPATCH_ID
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse((sig / "session_ready").exists())
+
+    def test_prompt_received_writes_sentinel_when_guarded(self) -> None:
+        sig = self.root / "sig2"
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-prompt",
+            },
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    def test_prompt_received_noop_when_env_unset(self) -> None:
+        proc = self._run_hook(PROMPT_RECEIVED_HOOK, env={})
+        self.assertEqual(proc.returncode, 0)
+
+
+# ---------------------------------------------------------------------------
+# Stop hook: receipt-guarantee via the #788 converter (hermetic)
+# ---------------------------------------------------------------------------
+_VALID_REPORT = """\
+**Dispatch-ID**: {did}
+
+## Summary
+
+This worker completed the hook-driven lane signal wiring and validated the
+version-agnostic readiness and submission path end to end.
+
+## Changes
+
+- scripts/lib/tmux_interactive_dispatch.py
+- scripts/hooks/tmux_signal_*.sh
+
+## Verification
+
+python3 -m pytest tests/test_tmux_lane_signals.py -q
+
+## Open Items
+
+None
+"""
+
+
+class TestStopReceiptGuarantee(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        # Hermetic data dir: nothing here touches the live .vnx-data.
+        self.data_dir = self.root / "data"
+        (self.data_dir / "state").mkdir(parents=True)
+        (self.data_dir / "unified_reports").mkdir(parents=True)
+        self.sig = self.root / "sig"
+
+    def _run_stop_hook(self, env: dict) -> subprocess.CompletedProcess:
+        full_env = {"PATH": os.environ.get("PATH", "")}
+        full_env.update(env)
+        # cwd = real repo root so the hook's `git rev-parse` resolves scripts/lib;
+        # VNX_DATA_DIR / VNX_STATE_DIR override keeps state writes hermetic.
+        return subprocess.run(
+            ["bash", str(STOP_RECEIPT_HOOK)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env=full_env,
+            cwd=str(REPO_ROOT),
+            timeout=20,
+        )
+
+    def test_noop_when_env_unset(self) -> None:
+        proc = self._run_stop_hook(env={})
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse((self.sig / "stopped").exists())
+
+    def test_writes_stopped_sentinel_and_emits_receipt(self) -> None:
+        did = "20260602-stoptest"
+        report = self.data_dir / "unified_reports" / f"{did}.md"
+        report.write_text(_VALID_REPORT.format(did=did), encoding="utf-8")
+
+        proc = self._run_stop_hook(
+            env={
+                "VNX_DISPATCH_ID": did,
+                "VNX_TMUX_SIGNAL_DIR": str(self.sig),
+                "VNX_DATA_DIR": str(self.data_dir),
+                "VNX_STATE_DIR": str(self.data_dir / "state"),
+            }
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        # (a) stopped sentinel written
+        self.assertTrue((self.sig / "stopped").is_file())
+
+        # (b) governed receipt emitted promptly for this dispatch
+        receipts = self.data_dir / "state" / "t0_receipts.ndjson"
+        self.assertTrue(receipts.is_file(), "receipt file should exist after stop hook")
+        lines = [
+            json.loads(line)
+            for line in receipts.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.assertTrue(
+            any(r.get("dispatch_id") == did for r in lines),
+            f"expected a receipt for {did}; got {lines}",
+        )
+
+    def test_dedup_no_double_receipt_on_rerun(self) -> None:
+        did = "20260602-dedup"
+        report = self.data_dir / "unified_reports" / f"{did}.md"
+        report.write_text(_VALID_REPORT.format(did=did), encoding="utf-8")
+        env = {
+            "VNX_DISPATCH_ID": did,
+            "VNX_TMUX_SIGNAL_DIR": str(self.sig),
+            "VNX_DATA_DIR": str(self.data_dir),
+            "VNX_STATE_DIR": str(self.data_dir / "state"),
+        }
+        self._run_stop_hook(env=env)
+        self._run_stop_hook(env=env)  # rerun must not double-write
+
+        receipts = self.data_dir / "state" / "t0_receipts.ndjson"
+        lines = [
+            json.loads(line)
+            for line in receipts.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        matching = [r for r in lines if r.get("dispatch_id") == did]
+        self.assertEqual(len(matching), 1, f"expected exactly one receipt; got {matching}")
+
+
+class _fast_submit_env:
+    """Context manager: zero out submit-verify timing env so tests run fast."""
+
+    _ENV = {
+        "VNX_TMUX_SUBMIT_RETRY_DELAY": "0",
+        "VNX_TMUX_SUBMIT_VERIFY_TIMEOUT": "0.1",
+        "VNX_TMUX_SUBMIT_MAX_RETRIES": "1",
+    }
+
+    def __enter__(self):
+        self._saved = {k: os.environ.get(k) for k in self._ENV}
+        os.environ.update(self._ENV)
+        return self
+
+    def __exit__(self, *exc):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The tmux interactive lane drove worker readiness and submission by scraping
version-specific TUI strings. That breaks on ~weekly Claude Code bumps.

**Evidence:** claude **2.1.160** dropped `esc to interrupt` — the working
indicator is now a random-gerund spinner + token-counter like
`✢ Smooshing… (18s · ↓ 739 tokens)`. Readiness had also been pinned to a
`Claude Code v2.1.159+` startup banner. Both are version-fragile.

It is ALWAYS a Claude Code spawn, so the **hook contract** is a reliable,
version-agnostic interface. The **receipt remains the authoritative completion
signal**; hooks just make it arrive promptly and make readiness/submission robust.

## What changed

**New guarded hook sentinel scripts** (`scripts/hooks/`) — each fires ONLY when
both `VNX_TMUX_SIGNAL_DIR` and `VNX_DISPATCH_ID` are set; normal T0/interactive
sessions drain stdin and exit 0 (no behavior change). Atomic writes, never block,
errors → exit 0:
- `tmux_signal_session_ready.sh` (SessionStart) → `session_ready`
- `tmux_signal_prompt_received.sh` (UserPromptSubmit) → `prompt_received`
- `tmux_signal_stop_receipt.sh` (Stop) → `stopped` + **deterministic
  receipt-guarantee**

**Deterministic Stop receipt-guarantee (fixes tmux-spawn "deadline exceeded").**
F37's `stop_report_hook.sh` detects the worker terminal by cwd
(`.claude/terminals/T1`) and is gated on `VNX_AUTO_REPORT=1`, so it **skips**
tmux-spawn workers running in the worktree root — which is exactly why they hit
"receipt deadline exceeded". The new Stop hook is scoped by the worker env instead
(independent of cwd and of `VNX_AUTO_REPORT`). On stop it reuses the #788 converter
(`convert_report_to_receipt` for this dispatch's unified_report, else
`scan_and_convert`) so a governed receipt is emitted **promptly** rather than after
the lane deadline. It relies on the converter's file-hash dedup — no parallel
emitter, no double write.

**Coexistence with F37.** Both Stop hooks are registered and run: F37 for
terminal-pinned workers, the new one for tmux-spawn workers. Nothing is removed.

**Lane wiring (`scripts/lib/tmux_interactive_dispatch.py`).** A per-dispatch signal
dir (`tempfile.mkdtemp`) is created before launch and `VNX_TMUX_SIGNAL_DIR` +
`VNX_DISPATCH_ID` are injected into the worker launch env. `_wait_ready` polls the
`session_ready` sentinel first (TUI marker scan as fallback); `_verify_submit`
checks `prompt_received` first (`_still_staged` scrape as fallback). Best-effort
cleanup at teardown. `VNX_TMUX_READY_STRICT` semantics preserved.

**Version-robust TUI fallback.** New `_looks_working()` matches a STRUCTURAL
token-counter regex (`(18s · ↓ 739 tokens)`, `(3s · ↑ 12 tokens)`) OR tolerant
legacy literals (`esc to interrupt`). Removed the `Claude Code v` banner from
`ready_markers`; added the `❯` prompt glyph. Hooks are primary; the receipt is
authoritative; the heuristics never hard-depend on a version's wording.

**Governance wiring.** Registered the existing
`scripts/hooks/pretooluse_block_subagent.sh` under PreToolUse matcher `Task`
(enforces the no-subagents rule). `pretooluse_block_raw_claude_spawn.sh` (Bash) is
untouched.

## Tests

- `tests/test_tmux_lane_signals.py` (new, 18 tests): sentinel readiness/submission,
  TUI fallback, `_looks_working` (2.1.160 spinner, ↑/↓ tokens, legacy literal, idle
  glyph false), hook guard on/off, and a hermetic Stop-hook receipt-guarantee +
  dedup check (temp `VNX_DATA_DIR`/`VNX_STATE_DIR` — never touches live `.vnx-data`).
- `tests/test_tmux_interactive_dispatch.py`: `TestReadinessV2` updated — the
  obsolete version-banner test became a version-agnostic `❯`-glyph test.

`python3 -m pytest tests/test_tmux_interactive_dispatch.py tests/test_tmux_lane_signals.py -q` → **125 passed**.

Dispatch-ID: 20260602-170339-lane-hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)