### PR TITLE
feat(governance): worker-permission relay — auto-accept window + catastrophic hard-list + escalation (no silent hangs)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -312,6 +312,14 @@ Pool commands (elastic worker pool management):
   pool config --project <id> [--min N] [--max N] [--policy <name>] [--cooldown <s>]
   pool reap --project <id> [--pool-id <p>] [--force]     Reap stale workers
 
+Permission relay (detached-worker prompt governance):
+  permission window-open --minutes N [--reason ...]  Open operator auto-accept window
+  permission window-close                            Close the auto-accept window
+  permission window-status                           Show window state
+  permission escalations [--all] [--json]            List pending escalations
+  permission approve <dispatch_id>                   Approve + relay "1" to the worker
+  permission deny <dispatch_id>                      Deny an escalation
+
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
@@ -2121,6 +2129,9 @@ main() {
       ;;
     pool)
       PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.commands.pool "$@"
+      ;;
+    permission)
+      PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 "$VNX_HOME/scripts/permission_relay_cli.py" "$@"
       ;;
     dream)
       PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" exec python3 -m vnx_cli.main dream "$@"

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sqlite3
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -766,6 +767,44 @@ class TmuxInteractiveDispatch:
             return False
         return self._runner.run(["paste-buffer", "-t", pane_id]).returncode == 0
 
+    # -- worker-permission relay (governance, flag-gated) ------------------
+    def _maybe_start_permission_relay(self, session: str, dispatch_id: str):
+        """Start the worker-permission relay thread when VNX_PERMISSION_RELAY=1.
+
+        Governance relay (see scripts/lib/worker_permission_relay.py): a DETACHED
+        worker has no human to answer a Claude Code permission prompt, so it would
+        silently hang. The relay polls the pane on a short interval and, per the
+        operator-controlled auto-accept WINDOW + CATASTROPHIC hard-list, either
+        auto-approves a routine prompt (send-keys "1" + a SEPARATE Enter to the
+        EXPLICIT session) or writes an escalation record for the operator (T0) to
+        surface in chat. Default off = no behavior change. Returns a RelayHandle
+        or None (disabled / unavailable). Never raises.
+        """
+        flag = os.environ.get("VNX_PERMISSION_RELAY", "0").strip().lower()
+        if flag in ("0", "false", "no", "off", ""):
+            return None
+        try:
+            from worker_permission_relay import RelayHandle, run_relay_loop  # noqa: PLC0415
+
+            interval = float(os.environ.get("VNX_PERMISSION_RELAY_INTERVAL", "3"))
+            stop_event = threading.Event()
+            thread = threading.Thread(
+                target=run_relay_loop,
+                args=(session, dispatch_id, self._runner, stop_event),
+                kwargs={"state_dir": self._state_dir, "interval": interval},
+                name=f"perm-relay-{dispatch_id}",
+                daemon=True,
+            )
+            thread.start()
+            logger.info(
+                "interactive: permission relay started dispatch=%s session=%s interval=%.1fs",
+                dispatch_id, session, interval,
+            )
+            return RelayHandle(thread=thread, stop_event=stop_event)
+        except Exception as exc:  # noqa: BLE001 — relay is best-effort, never blocks dispatch
+            logger.debug("interactive: permission relay start skipped (%s)", exc)
+            return None
+
     def _kill_session(self, session: str) -> bool:
         """Kill the dispatch session. Idempotent — absent session is success."""
         res = self._runner.run(["kill-session", "-t", session])
@@ -1041,6 +1080,8 @@ class TmuxInteractiveDispatch:
         worktree_handle: "WorktreeHandle | None" = None
         _wt_state: "list[str | None]" = [None]
         _raw_log: "list[Path | None]" = [None]
+        # Worker-permission relay handle (flag-gated); stopped in _teardown.
+        _relay_handle: "list[object | None]" = [None]
 
         if isolated_worktree:
             try:
@@ -1083,6 +1124,13 @@ class TmuxInteractiveDispatch:
             if _torn_down:
                 return
             _torn_down = True
+            # Stop the worker-permission relay thread (flag-gated; may be None).
+            if _relay_handle[0] is not None:
+                try:
+                    _relay_handle[0].stop_event.set()
+                    _relay_handle[0].thread.join(timeout=5)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("interactive: relay stop failed (%s)", exc)
             if signal_dir is not None:
                 try:
                     shutil.rmtree(signal_dir, ignore_errors=True)
@@ -1406,6 +1454,11 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                     worktree_state=_wt_state[0],
                 )
+
+            # 7c. Start the governance permission relay (flag-gated, default off)
+            # so a permission prompt raised DURING the run is auto-approved (open
+            # window) or escalated to the operator instead of silently hanging.
+            _relay_handle[0] = self._maybe_start_permission_relay(session, dispatch_id)
 
             # 8. Wait for receipt
             receipt = self._wait_for_receipt(

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -63,7 +63,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "smoke", "package-check",
     "dispatch", "gate", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",
-    "pool",
+    "pool", "permission",
 })
 
 TIER_DEMO_ONLY: FrozenSet[str] = frozenset({

--- a/scripts/lib/worker_permission_relay.py
+++ b/scripts/lib/worker_permission_relay.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""worker_permission_relay.py — VNX worker-permission relay governance.
+
+A DETACHED tmux worker (interactive ``claude`` on the subscription lane) has no
+human at the keyboard. When Claude Code raises a permission prompt for an
+off-allow-list tool/command ("Do you want to proceed?"), the worker silently
+HANGS until its deadline. This module is the governance mechanism that prevents
+that hang while keeping the operator as the human gate.
+
+The model
+---------
+- The operator declares a short, explicit auto-accept WINDOW (``vnx permission
+  window-open --minutes N``). Inside the window, ROUTINE prompts are auto-approved.
+- CATASTROPHIC, irreversible operations (``rm -rf``, ``DROP TABLE``, ``mkfs`` …)
+  ALWAYS escalate to the operator — even inside an open window. The window never
+  grants a blank cheque for destructive ops.
+- Outside a window, EVERY prompt escalates.
+- Escalation = a durable record on disk that T0 surfaces in chat; the operator
+  answers and the answer is relayed back into the worker's pane via send-keys.
+
+This is intentionally infrastructure-free: no popups, no IPC daemon. The
+window + the escalation records + the relay tick are plain files and tmux
+``capture-pane`` / ``send-keys`` calls.
+
+Hard send-keys rule (proven bug — see memory feedback-tmux-sendkeys-enter):
+Enter is ALWAYS a SEPARATE keystroke and send-keys ALWAYS targets the explicit
+session id. A combined "1\\n" misses delivery; an empty ``-t`` target lands in
+the wrong pane.
+
+BILLING SAFETY: no Anthropic SDK; only tmux subprocess calls via an injected
+runner abstraction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Window file lives directly under the state dir; escalation records under a
+# dedicated subdir keyed by dispatch id.
+WINDOW_FILENAME = "permission_window.json"
+ESCALATIONS_DIRNAME = "permission_escalations"
+RELAY_DIRNAME = "permission_relay"
+
+# Prompt markers the Claude Code TUI prints when it needs confirmation. Matched
+# case-insensitively and kept tolerant: never pinned to one Claude Code version's
+# exact wording (the lane has been burned by version-specific TUI scraping before).
+PROMPT_MARKERS = (
+    "do you want to proceed",
+    "do you want to make this edit",
+    "do you want to create",
+    "requires confirmation",
+    "requires your permission",
+)
+
+# Box-drawing / prompt-glyph characters stripped when recovering an echoed command.
+_BOX_CHARS = "│╭╮╰╯─━┃┏┓┗┛┌┐└┘╔╗╚╝║═❯>•*●○◍◆◇▶"
+
+# Prompt-box title rows (the command/description follow the title). Matched
+# case-insensitively; a row that is exactly a title — or ends in " command" /
+# " file" — resets the candidate scan so the COMMAND (first content after the
+# title), not the prose description, is returned.
+_TITLE_ROWS = {
+    "bash command", "shell command", "command", "tool use",
+    "edit file", "write file", "create file", "read file", "edit", "write",
+}
+
+
+# ---------------------------------------------------------------------------
+# Catastrophic hard-list
+# ---------------------------------------------------------------------------
+# Conservative by design: a false negative (a destructive op auto-approved) is
+# far worse than a false positive (a needless escalation). When in doubt, match.
+#
+# NOTE: ``git push --force`` / ``-f`` / ``--force-with-lease`` are deliberately
+# NOT catastrophic — they are recoverable (reflog/remote history) and the lane
+# already runs on disposable per-dispatch worktree branches. They are allowed.
+CATASTROPHIC_PATTERNS = [
+    # rm with BOTH a recursive and a force flag, in any flag arrangement:
+    # rm -rf, rm -fr, rm -Rf, rm -r -f, rm -f -R, rm --recursive --force.
+    re.compile(
+        r"\brm\b(?=.*(?:-[a-zA-Z]*[rR]|--recursive))(?=.*(?:-[a-zA-Z]*f|--force))"
+    ),
+    # SQL drops / truncate (DROP TABLE/DATABASE/SCHEMA, TRUNCATE …).
+    re.compile(r"\bDROP\s+(TABLE|DATABASE|SCHEMA)\b", re.IGNORECASE),
+    re.compile(r"\bTRUNCATE\b", re.IGNORECASE),
+    # Filesystem creation / raw block-device writes.
+    re.compile(r"\bmkfs(\.\w+)?\b", re.IGNORECASE),
+    re.compile(r">\s*/dev/(sd|hd|nvme|disk|vd)", re.IGNORECASE),
+    re.compile(r"\bdd\b.*\bof=/dev/", re.IGNORECASE),
+    # Hard reset onto a remote ref discards local commits to match the remote.
+    re.compile(
+        r"\bgit\s+reset\s+--hard\s+\S*\b(origin|upstream|remotes?)/", re.IGNORECASE
+    ),
+    # Large-delete heuristics.
+    re.compile(r"\bfind\b.*-delete\b", re.IGNORECASE),
+    re.compile(r"\bfind\b.*-exec\s+rm\b", re.IGNORECASE),
+    re.compile(r"\bgit\s+clean\b(?=.*-[a-z]*f)(?=.*-[a-z]*d)", re.IGNORECASE),
+    # chmod/chown -R on a filesystem root.
+    re.compile(r"\bch(mod|own)\b.*-R\b.*\s/(\s|$)", re.IGNORECASE),
+]
+
+# rm recursive targeting a filesystem/home root is catastrophic even without an
+# explicit force flag (interactive rm -r / can still wipe a tree). Checked as a
+# dedicated heuristic so the flag-pair regex above stays precise.
+_RM_RECURSIVE_RE = re.compile(r"\brm\b(?=.*(?:-[a-zA-Z]*[rR]|--recursive))")
+_RM_ROOT_TARGET_RE = re.compile(r"\brm\b.*\s(/|~|~/|\$HOME|/\*)(\s|$|/\*)")
+
+
+def is_catastrophic(command: str) -> bool:
+    """Return True if *command* is an irreversible op that must always escalate.
+
+    Conservative: matches a hard-list of regexes plus a recursive-rm-on-root
+    heuristic. False positives (needless escalation) are acceptable; false
+    negatives (destructive auto-approve) are not.
+    """
+    cmd = (command or "").strip()
+    if not cmd:
+        return False
+    for pat in CATASTROPHIC_PATTERNS:
+        if pat.search(cmd):
+            return True
+    if _RM_RECURSIVE_RE.search(cmd) and _RM_ROOT_TARGET_RE.search(cmd):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# State-dir resolution (lazy; explicit arg always wins)
+# ---------------------------------------------------------------------------
+def _default_state_dir() -> Path:
+    """Resolve the canonical VNX state dir without hard-importing at module load."""
+    try:
+        from vnx_paths import ensure_env  # noqa: PLC0415
+
+        paths = ensure_env()
+        return Path(paths["VNX_STATE_DIR"])
+    except Exception:  # noqa: BLE001 — fall back to git-resolved root
+        try:
+            from project_root import resolve_state_dir  # noqa: PLC0415
+
+            return resolve_state_dir(caller_file=__file__)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"cannot resolve VNX state dir: {exc}") from exc
+
+
+def _coerce_state_dir(state_dir: "str | Path | None") -> Path:
+    return Path(state_dir) if state_dir is not None else _default_state_dir()
+
+
+def _now_iso(now: "float | None" = None) -> str:
+    ts = now if now is not None else time.time()
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _parse_iso_epoch(value: "str | None") -> "float | None":
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    """Write JSON atomically via temp-file + os.replace (codex defense: atomic writes)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Permission window
+# ---------------------------------------------------------------------------
+class PermissionWindow:
+    """Operator-controlled auto-accept window persisted at ``permission_window.json``.
+
+    A window is OPEN only if ``open == true`` AND ``now < expires_at``. Expiry is
+    authoritative: an expired window reads as closed regardless of the ``open``
+    flag. A missing file reads as closed.
+    """
+
+    def __init__(self, state_dir: "str | Path | None" = None) -> None:
+        self._state_dir = _coerce_state_dir(state_dir)
+
+    @property
+    def path(self) -> Path:
+        return self._state_dir / WINDOW_FILENAME
+
+    def _read(self) -> "dict | None":
+        p = self.path
+        if not p.exists():
+            return None
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else None
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("permission_window: read failed (%s)", exc)
+            return None
+
+    def open(
+        self,
+        minutes: float,
+        reason: "str | None" = None,
+        *,
+        opened_by: str = "operator",
+        now: "float | None" = None,
+    ) -> dict:
+        """Open the window for *minutes* from now. Returns the written record."""
+        if minutes <= 0:
+            raise ValueError("window minutes must be > 0")
+        ts = now if now is not None else time.time()
+        expires = ts + minutes * 60.0
+        record = {
+            "open": True,
+            "opened_at": _now_iso(ts),
+            "expires_at": _now_iso(expires),
+            "opened_by": opened_by,
+            "reason": reason or "",
+        }
+        _atomic_write_json(self.path, record)
+        return record
+
+    def close(self, *, now: "float | None" = None) -> dict:
+        """Close the window. Idempotent — closing an absent/closed window is fine."""
+        existing = self._read() or {}
+        record = {
+            "open": False,
+            "opened_at": existing.get("opened_at", ""),
+            "expires_at": _now_iso(now),
+            "opened_by": existing.get("opened_by", "operator"),
+            "reason": existing.get("reason", ""),
+        }
+        _atomic_write_json(self.path, record)
+        return record
+
+    def is_open(self, *, now: "float | None" = None) -> bool:
+        data = self._read()
+        if not data or not data.get("open"):
+            return False
+        expires = _parse_iso_epoch(data.get("expires_at"))
+        if expires is None:
+            return False
+        ts = now if now is not None else time.time()
+        return ts < expires
+
+    def status(self, *, now: "float | None" = None) -> dict:
+        """Return {open, remaining_seconds, expires_at, opened_by, reason}."""
+        data = self._read() or {}
+        ts = now if now is not None else time.time()
+        expires = _parse_iso_epoch(data.get("expires_at"))
+        is_open = bool(data.get("open")) and expires is not None and ts < expires
+        remaining = int(max(0, expires - ts)) if (is_open and expires is not None) else 0
+        return {
+            "open": is_open,
+            "remaining_seconds": remaining,
+            "expires_at": data.get("expires_at", ""),
+            "opened_by": data.get("opened_by", ""),
+            "reason": data.get("reason", ""),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pending-command parsing
+# ---------------------------------------------------------------------------
+def _strip_box(line: str) -> str:
+    """Strip box-drawing chars + prompt glyphs from a captured pane line."""
+    return line.strip().strip(_BOX_CHARS).strip()
+
+
+def parse_pending_command(pane_text: str) -> Optional[str]:
+    """Extract the command/tool a permission prompt is asking about.
+
+    Returns the command string when *pane_text* shows a permission prompt, else
+    None. Two extraction strategies:
+      1. The ``Bash(<cmd>)`` / ``Tool(<arg>)`` token Claude prints for tool calls.
+      2. The command echoed inside the prompt box, just above the
+         "Do you want to proceed?" line.
+    """
+    if not pane_text:
+        return None
+    low = pane_text.lower()
+    if not any(marker in low for marker in PROMPT_MARKERS):
+        return None
+
+    # Strategy 1: explicit tool-call token, e.g. "Bash(rm -rf /tmp/x)".
+    tool_matches = re.findall(r"\b(?:Bash|Shell)\(([^)\n]*)\)", pane_text)
+    for cand in reversed(tool_matches):
+        cand = cand.strip()
+        if cand:
+            return cand
+
+    # Strategy 2: command echoed in the box above the marker line. The command
+    # is the FIRST content row after the title row ("Bash command"); the prose
+    # description follows it. Scan the lines just above the marker, resetting on
+    # the title so a leading "● I'll …" narration line is discarded.
+    lines = pane_text.splitlines()
+    marker_idx = None
+    for i, ln in enumerate(lines):
+        if any(mk in ln.lower() for mk in PROMPT_MARKERS):
+            marker_idx = i
+            break
+    if marker_idx is None:
+        return None
+
+    candidates: "list[str]" = []
+    for ln in lines[max(0, marker_idx - 12):marker_idx]:
+        cand = _strip_box(ln)
+        if not cand:
+            continue
+        low_c = cand.lower()
+        # Title row → command/description start fresh after it.
+        if low_c in _TITLE_ROWS or low_c.endswith(" command") or low_c.endswith(" file"):
+            candidates = []
+            continue
+        # Skip numbered option rows ("1. Yes", "2. No …").
+        if re.match(r"^\d+\.\s", cand):
+            continue
+        candidates.append(cand)
+    # First content row after the title is the command; the rest is description.
+    return candidates[0] if candidates else None
+
+
+# ---------------------------------------------------------------------------
+# Decision
+# ---------------------------------------------------------------------------
+def decide(command: str, window: "PermissionWindow | bool") -> str:
+    """Return "auto_approve" or "escalate".
+
+    Escalate when the command is catastrophic OR the window is closed; otherwise
+    auto-approve. *window* may be a PermissionWindow or a pre-evaluated bool.
+    """
+    if is_catastrophic(command):
+        return "escalate"
+    if isinstance(window, PermissionWindow):
+        window_open = window.is_open()
+    else:
+        window_open = bool(window)
+    return "auto_approve" if window_open else "escalate"
+
+
+# ---------------------------------------------------------------------------
+# Escalation records
+# ---------------------------------------------------------------------------
+def _escalations_dir(state_dir: Path) -> Path:
+    return state_dir / ESCALATIONS_DIRNAME
+
+
+def _escalation_path(state_dir: Path, dispatch_id: str) -> Path:
+    return _escalations_dir(state_dir) / f"{dispatch_id}.json"
+
+
+def write_escalation(
+    dispatch_id: str,
+    command: str,
+    reason: str,
+    *,
+    state_dir: "str | Path | None" = None,
+    now: "float | None" = None,
+) -> Path:
+    """Write a pending escalation record (atomic). *reason* ∈ {catastrophic, window_closed}.
+
+    Idempotent: if a pending record for the same command already exists it is
+    left untouched (so a repeated tick does not churn captured_at).
+    """
+    sd = _coerce_state_dir(state_dir)
+    path = _escalation_path(sd, dispatch_id)
+    existing = read_escalation(dispatch_id, state_dir=sd)
+    if (
+        existing
+        and existing.get("status") == "pending"
+        and existing.get("command") == command
+    ):
+        return path
+    record = {
+        "dispatch_id": dispatch_id,
+        "command": command,
+        "captured_at": _now_iso(now),
+        "reason": reason,
+        "status": "pending",
+        "resolved_at": None,
+    }
+    _atomic_write_json(path, record)
+    return path
+
+
+def read_escalation(
+    dispatch_id: str, *, state_dir: "str | Path | None" = None
+) -> "dict | None":
+    sd = _coerce_state_dir(state_dir)
+    path = _escalation_path(sd, dispatch_id)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def list_escalations(
+    *, state_dir: "str | Path | None" = None, pending_only: bool = True
+) -> "list[dict]":
+    sd = _coerce_state_dir(state_dir)
+    d = _escalations_dir(sd)
+    if not d.exists():
+        return []
+    out: "list[dict]" = []
+    for path in sorted(d.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if pending_only and (data.get("status") or "") != "pending":
+            continue
+        out.append(data)
+    return out
+
+
+def resolve_escalation(
+    dispatch_id: str,
+    approved: bool,
+    *,
+    state_dir: "str | Path | None" = None,
+    now: "float | None" = None,
+) -> "dict | None":
+    """Update a pending escalation to approved/denied. Returns the updated record."""
+    sd = _coerce_state_dir(state_dir)
+    record = read_escalation(dispatch_id, state_dir=sd)
+    if record is None:
+        return None
+    record["status"] = "approved" if approved else "denied"
+    record["resolved_at"] = _now_iso(now)
+    _atomic_write_json(_escalation_path(sd, dispatch_id), record)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint persistence (idempotency)
+# ---------------------------------------------------------------------------
+def _fingerprint_path(state_dir: Path, dispatch_id: str) -> Path:
+    return state_dir / RELAY_DIRNAME / f"{dispatch_id}.last"
+
+
+def _fingerprint(command: str) -> str:
+    return hashlib.sha1(command.encode("utf-8")).hexdigest()
+
+
+def _read_fingerprint(state_dir: Path, dispatch_id: str) -> "str | None":
+    p = _fingerprint_path(state_dir, dispatch_id)
+    if not p.exists():
+        return None
+    try:
+        return p.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _write_fingerprint(state_dir: Path, dispatch_id: str, fp: str) -> None:
+    p = _fingerprint_path(state_dir, dispatch_id)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(f"{p.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(fp, encoding="utf-8")
+        os.replace(tmp, p)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Relay tick
+# ---------------------------------------------------------------------------
+def _capture_pane(runner, session_id: str) -> str:
+    """Capture the pane for *session_id* via the injected tmux runner."""
+    res = runner.run(["capture-pane", "-t", session_id, "-p"])
+    if getattr(res, "returncode", 1) != 0:
+        return ""
+    return getattr(res, "stdout", "") or ""
+
+
+def _send_approval(runner, session_id: str) -> bool:
+    """Send the "approve" selection (option 1) then Enter as a SEPARATE keystroke.
+
+    Targets the EXPLICIT session id — never an empty target (proven wrong-pane
+    bug). Enter is always its own send-keys call (combined misses delivery).
+    """
+    if not session_id:
+        raise ValueError("send-keys requires an explicit session id; refusing empty target")
+    rc1 = runner.run(["send-keys", "-t", session_id, "1"]).returncode
+    if rc1 != 0:
+        return False
+    # Enter ALWAYS as a separate keystroke.
+    return runner.run(["send-keys", "-t", session_id, "Enter"]).returncode == 0
+
+
+def relay_tick(
+    session_id: str,
+    dispatch_id: str,
+    runner,
+    *,
+    state_dir: "str | Path | None" = None,
+    window: "PermissionWindow | None" = None,
+) -> str:
+    """Inspect the worker pane once and act on any pending permission prompt.
+
+    Returns one of:
+      - "idle"           — no prompt on the pane
+      - "auto_approve"    — routine prompt inside an open window; sent option 1+Enter
+      - "escalate"        — catastrophic or window-closed; wrote escalation record
+      - "already_handled" — same prompt already actioned this run (idempotent)
+
+    Idempotent: the last-handled prompt fingerprint is persisted, so a prompt
+    still visible on the next tick (before the TUI clears it) is not re-actioned.
+    """
+    if not session_id:
+        raise ValueError("relay_tick requires an explicit session id")
+    sd = _coerce_state_dir(state_dir)
+    win = window if window is not None else PermissionWindow(sd)
+
+    pane_text = _capture_pane(runner, session_id)
+    command = parse_pending_command(pane_text)
+    if command is None:
+        return "idle"
+
+    fp = _fingerprint(command)
+    if _read_fingerprint(sd, dispatch_id) == fp:
+        return "already_handled"
+
+    action = decide(command, win)
+    if action == "auto_approve":
+        _send_approval(runner, session_id)
+        _write_fingerprint(sd, dispatch_id, fp)
+        logger.info(
+            "permission_relay: auto-approved routine prompt dispatch=%s cmd=%r",
+            dispatch_id, command,
+        )
+        return "auto_approve"
+
+    # escalate
+    reason = "catastrophic" if is_catastrophic(command) else "window_closed"
+    write_escalation(dispatch_id, command, reason, state_dir=sd)
+    _write_fingerprint(sd, dispatch_id, fp)
+    logger.warning(
+        "permission_relay: escalated prompt dispatch=%s reason=%s cmd=%r (NO keys sent)",
+        dispatch_id, reason, command,
+    )
+    return "escalate"
+
+
+# ---------------------------------------------------------------------------
+# Relay loop (used by the lane background thread)
+# ---------------------------------------------------------------------------
+def run_relay_loop(
+    session_id: str,
+    dispatch_id: str,
+    runner,
+    stop_event,
+    *,
+    state_dir: "str | Path | None" = None,
+    interval: float = 3.0,
+) -> None:
+    """Tick ``relay_tick`` every *interval* seconds until *stop_event* is set.
+
+    Never raises out of the loop — a relay failure must not take down the lane.
+    """
+    sd = _coerce_state_dir(state_dir)
+    win = PermissionWindow(sd)
+    while not stop_event.is_set():
+        try:
+            relay_tick(session_id, dispatch_id, runner, state_dir=sd, window=win)
+        except Exception as exc:  # noqa: BLE001 — relay must never crash the lane
+            logger.debug("permission_relay: tick failed dispatch=%s (%s)", dispatch_id, exc)
+        stop_event.wait(interval)
+
+
+@dataclass
+class RelayHandle:
+    """Handle for a running relay loop thread so the lane can stop it at teardown."""
+
+    thread: object
+    stop_event: object

--- a/scripts/lib/worker_permission_relay.py
+++ b/scripts/lib/worker_permission_relay.py
@@ -53,6 +53,32 @@ WINDOW_FILENAME = "permission_window.json"
 ESCALATIONS_DIRNAME = "permission_escalations"
 RELAY_DIRNAME = "permission_relay"
 
+# dispatch_id becomes a filesystem path segment (escalation record + fingerprint
+# file). It MUST be validated before any path use: a traversal id ("../../etc/x",
+# "a/b", an absolute path) would let an attacker-controlled dispatch id escape the
+# state dir and read/write arbitrary files. Strict allow-list: one or more of
+# [A-Za-z0-9._-], and never the dot-only ids "." / ".." (which match the class).
+_SAFE_DISPATCH_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_dispatch_id(dispatch_id: str) -> str:
+    """Return *dispatch_id* unchanged if safe as a path segment, else raise ValueError.
+
+    Rejects empty / non-string ids, path separators, '..', '.', and absolute paths.
+    Called by EVERY function that turns a dispatch_id into a filesystem path so a
+    traversal id can never escape the state dir.
+    """
+    if not isinstance(dispatch_id, str) or not dispatch_id:
+        raise ValueError("dispatch_id must be a non-empty string")
+    if dispatch_id in (".", ".."):
+        raise ValueError(f"unsafe dispatch_id {dispatch_id!r}: '.'/'..' are path-traversal segments")
+    if not _SAFE_DISPATCH_ID.match(dispatch_id):
+        raise ValueError(
+            f"unsafe dispatch_id {dispatch_id!r}: must match [A-Za-z0-9._-]+ "
+            "(no path separators, '..', or absolute paths)"
+        )
+    return dispatch_id
+
 # Prompt markers the Claude Code TUI prints when it needs confirmation. Matched
 # case-insensitively and kept tolerant: never pinned to one Claude Code version's
 # exact wording (the lane has been burned by version-specific TUI scraping before).
@@ -370,7 +396,7 @@ def _escalations_dir(state_dir: Path) -> Path:
 
 
 def _escalation_path(state_dir: Path, dispatch_id: str) -> Path:
-    return _escalations_dir(state_dir) / f"{dispatch_id}.json"
+    return _escalations_dir(state_dir) / f"{_safe_dispatch_id(dispatch_id)}.json"
 
 
 def write_escalation(
@@ -386,6 +412,7 @@ def write_escalation(
     Idempotent: if a pending record for the same command already exists it is
     left untouched (so a repeated tick does not churn captured_at).
     """
+    _safe_dispatch_id(dispatch_id)
     sd = _coerce_state_dir(state_dir)
     path = _escalation_path(sd, dispatch_id)
     existing = read_escalation(dispatch_id, state_dir=sd)
@@ -410,6 +437,7 @@ def write_escalation(
 def read_escalation(
     dispatch_id: str, *, state_dir: "str | Path | None" = None
 ) -> "dict | None":
+    _safe_dispatch_id(dispatch_id)
     sd = _coerce_state_dir(state_dir)
     path = _escalation_path(sd, dispatch_id)
     if not path.exists():
@@ -450,6 +478,7 @@ def resolve_escalation(
     now: "float | None" = None,
 ) -> "dict | None":
     """Update a pending escalation to approved/denied. Returns the updated record."""
+    _safe_dispatch_id(dispatch_id)
     sd = _coerce_state_dir(state_dir)
     record = read_escalation(dispatch_id, state_dir=sd)
     if record is None:
@@ -464,7 +493,7 @@ def resolve_escalation(
 # Fingerprint persistence (idempotency)
 # ---------------------------------------------------------------------------
 def _fingerprint_path(state_dir: Path, dispatch_id: str) -> Path:
-    return state_dir / RELAY_DIRNAME / f"{dispatch_id}.last"
+    return state_dir / RELAY_DIRNAME / f"{_safe_dispatch_id(dispatch_id)}.last"
 
 
 def _fingerprint(command: str) -> str:
@@ -533,16 +562,20 @@ def relay_tick(
     """Inspect the worker pane once and act on any pending permission prompt.
 
     Returns one of:
-      - "idle"           — no prompt on the pane
-      - "auto_approve"    — routine prompt inside an open window; sent option 1+Enter
-      - "escalate"        — catastrophic or window-closed; wrote escalation record
-      - "already_handled" — same prompt already actioned this run (idempotent)
+      - "idle"               — no prompt on the pane
+      - "auto_approve"        — routine prompt inside an open window; option 1+Enter delivered
+      - "auto_approve_failed" — window open + routine, but the send-keys did NOT land;
+                                NOT marked handled, so the next tick retries
+      - "escalate"            — catastrophic or window-closed; wrote escalation record
+      - "already_handled"     — same prompt already actioned this run (idempotent)
 
     Idempotent: the last-handled prompt fingerprint is persisted, so a prompt
     still visible on the next tick (before the TUI clears it) is not re-actioned.
+    A failed auto-approve send is deliberately NOT fingerprinted so it can retry.
     """
     if not session_id:
         raise ValueError("relay_tick requires an explicit session id")
+    _safe_dispatch_id(dispatch_id)
     sd = _coerce_state_dir(state_dir)
     win = window if window is not None else PermissionWindow(sd)
 
@@ -557,7 +590,17 @@ def relay_tick(
 
     action = decide(command, win)
     if action == "auto_approve":
-        _send_approval(runner, session_id)
+        delivered = _send_approval(runner, session_id)
+        if not delivered:
+            # The send-keys did NOT land. Do NOT mark the prompt handled — leave the
+            # fingerprint unset so the next tick re-attempts delivery instead of
+            # silently treating a failed send as approved.
+            logger.warning(
+                "permission_relay: auto-approve send-keys FAILED dispatch=%s session=%s "
+                "cmd=%r — NOT marked handled, will retry next tick",
+                dispatch_id, session_id, command,
+            )
+            return "auto_approve_failed"
         _write_fingerprint(sd, dispatch_id, fp)
         logger.info(
             "permission_relay: auto-approved routine prompt dispatch=%s cmd=%r",

--- a/scripts/permission_relay_cli.py
+++ b/scripts/permission_relay_cli.py
@@ -14,16 +14,22 @@ All subcommands accept ``--json`` for machine-readable output.
 
 The relay model: outside an open window every worker permission prompt escalates;
 inside the window routine prompts auto-approve; catastrophic ops always escalate.
-``approve`` resolves the escalation record AND best-effort relays the approval
-keystroke ("1" + a SEPARATE Enter) into the worker's tmux session.
+``approve`` relays the approval keystroke ("1" + a SEPARATE Enter) into the worker's
+tmux session and marks the escalation resolved=approved ONLY on confirmed delivery.
+If the keystroke does not land (no live session / send failure) the escalation is
+left pending and ``approve`` exits non-zero with a clear message, so a failed relay
+is never silently recorded as approved.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -101,56 +107,137 @@ def _cmd_escalations(args, sd: Path) -> int:
     return 0
 
 
-def _relay_keystroke_to_worker(dispatch_id: str, sd: Path) -> "str | None":
+def _relay_keystroke_to_worker(
+    dispatch_id: str, sd: Path, *, runner=None
+) -> "tuple[str, str | None]":
     """Best-effort: send "1"+Enter into the escalated worker's tmux session.
 
     Reads the lane handle (state/tmux_interactive/<dispatch_id>.json) for the
-    session id. Returns the session id on success, None if no session/tmux.
+    session id and relays the approval keystroke ("1" + a SEPARATE Enter) to the
+    EXPLICIT session. Returns a ``(status, session)`` tuple:
+
+      - ("sent", session)        approval keystroke confirmed delivered
+      - ("no_session", None)     no live worker session found (handle / session field absent)
+      - ("send_failed", session) session exists but the send-keys did not land
+      - ("error", session|None)  operational failure (handle read / tmux / send raised)
+
+    Distinguishing a genuine "no live session" from an operational failure lets the
+    caller avoid marking an escalation approved when nothing was delivered. Never
+    raises — but, unlike before, the actual exception is logged with context so a
+    swallowed tmux/read/send failure is observable.
     """
-    handle_path = sd / "tmux_interactive" / f"{dispatch_id}.json"
+    handle_path = sd / "tmux_interactive" / f"{relay._safe_dispatch_id(dispatch_id)}.json"
     if not handle_path.exists():
-        return None
+        return ("no_session", None)
     try:
         handle = json.loads(handle_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "permission approve: handle read failed dispatch=%s path=%s (%s)",
+            dispatch_id, handle_path, exc,
+        )
+        return ("error", None)
     session = (handle or {}).get("session")
     if not session:
-        return None
+        return ("no_session", None)
     try:
-        from tmux_interactive_dispatch import TmuxCommandRunner  # noqa: PLC0415
+        if runner is None:
+            from tmux_interactive_dispatch import TmuxCommandRunner  # noqa: PLC0415
 
-        runner = TmuxCommandRunner()
+            runner = TmuxCommandRunner()
         if not runner.available():
-            return None
-        relay._send_approval(runner, session)
-        return session
-    except Exception:  # noqa: BLE001 — relay is best-effort
-        return None
+            logger.warning(
+                "permission approve: tmux unavailable, cannot relay dispatch=%s session=%s",
+                dispatch_id, session,
+            )
+            return ("error", session)
+        delivered = relay._send_approval(runner, session)
+        if not delivered:
+            logger.warning(
+                "permission approve: send-keys did NOT land dispatch=%s session=%s",
+                dispatch_id, session,
+            )
+            return ("send_failed", session)
+        return ("sent", session)
+    except Exception as exc:  # noqa: BLE001 — best-effort, but now observable
+        logger.warning(
+            "permission approve: relay to worker failed dispatch=%s session=%s (%s)",
+            dispatch_id, session, exc, exc_info=True,
+        )
+        return ("error", session)
 
 
 def _cmd_approve(args, sd: Path) -> int:
-    record = relay.resolve_escalation(args.dispatch_id, approved=True, state_dir=sd)
-    if record is None:
+    try:
+        relay._safe_dispatch_id(args.dispatch_id)
+    except ValueError as exc:
+        _emit(
+            {"error": "invalid_dispatch_id", "dispatch_id": args.dispatch_id, "detail": str(exc)},
+            args.json,
+            f"[x] invalid dispatch_id {args.dispatch_id!r}: {exc}",
+        )
+        return 2
+
+    existing = relay.read_escalation(args.dispatch_id, state_dir=sd)
+    if existing is None:
         _emit(
             {"error": "no_escalation", "dispatch_id": args.dispatch_id},
             args.json,
             f"[x] no escalation found for {args.dispatch_id}",
         )
         return 1
-    session = _relay_keystroke_to_worker(args.dispatch_id, sd)
-    record["relayed_session"] = session
-    human = f"[ok] approved {args.dispatch_id}"
-    human += (
-        f" — relayed approval to session {session}"
-        if session
-        else " — no live worker session found (record updated only)"
-    )
-    _emit(record, args.json, human)
-    return 0
+
+    # Relay FIRST; only mark the escalation approved on confirmed keystroke delivery.
+    # A failed/absent relay must NOT silently flip the record to approved.
+    status, session = _relay_keystroke_to_worker(args.dispatch_id, sd)
+
+    if status == "sent":
+        record = relay.resolve_escalation(args.dispatch_id, approved=True, state_dir=sd) or existing
+        record["relayed_session"] = session
+        _emit(
+            record,
+            args.json,
+            f"[ok] approved {args.dispatch_id} — relayed approval to session {session}",
+        )
+        return 0
+
+    # Delivery did not land — leave the escalation PENDING so it can be retried,
+    # and surface a clear failure (non-zero exit) distinguishing the cause.
+    if status == "no_session":
+        human = (
+            f"[x] approve {args.dispatch_id} NOT applied — no live worker session found; "
+            "escalation left pending (use `deny` to clear, or retry once the worker is up)"
+        )
+    elif status == "send_failed":
+        human = (
+            f"[x] approve {args.dispatch_id} FAILED — send-keys to session {session} did not land; "
+            "escalation left pending (retry)"
+        )
+    else:  # "error"
+        human = (
+            f"[x] approve {args.dispatch_id} FAILED — relay error reaching the worker "
+            "(see logs); escalation left pending"
+        )
+    payload = {
+        "error": status,
+        "dispatch_id": args.dispatch_id,
+        "approved": False,
+        "relayed_session": session,
+    }
+    _emit(payload, args.json, human)
+    return 1
 
 
 def _cmd_deny(args, sd: Path) -> int:
+    try:
+        relay._safe_dispatch_id(args.dispatch_id)
+    except ValueError as exc:
+        _emit(
+            {"error": "invalid_dispatch_id", "dispatch_id": args.dispatch_id, "detail": str(exc)},
+            args.json,
+            f"[x] invalid dispatch_id {args.dispatch_id!r}: {exc}",
+        )
+        return 2
     record = relay.resolve_escalation(args.dispatch_id, approved=False, state_dir=sd)
     if record is None:
         _emit(

--- a/scripts/permission_relay_cli.py
+++ b/scripts/permission_relay_cli.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""permission_relay_cli.py — operator CLI for the worker-permission relay.
+
+Subcommands (wired to scripts/lib/worker_permission_relay.py):
+
+  vnx permission window-open --minutes N [--reason ...]   open the auto-accept window
+  vnx permission window-close                             close it
+  vnx permission window-status                            show window state
+  vnx permission escalations                              list pending escalations
+  vnx permission approve <dispatch_id>                    approve + relay "1" to the worker
+  vnx permission deny <dispatch_id>                       deny (operator handles the worker)
+
+All subcommands accept ``--json`` for machine-readable output.
+
+The relay model: outside an open window every worker permission prompt escalates;
+inside the window routine prompts auto-approve; catastrophic ops always escalate.
+``approve`` resolves the escalation record AND best-effort relays the approval
+keystroke ("1" + a SEPARATE Enter) into the worker's tmux session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+try:
+    from vnx_paths import ensure_env
+except Exception as exc:  # noqa: BLE001
+    raise SystemExit(f"Failed to load vnx_paths: {exc}")
+
+import worker_permission_relay as relay  # noqa: E402
+
+
+def _state_dir() -> Path:
+    return Path(ensure_env()["VNX_STATE_DIR"])
+
+
+def _emit(payload: dict, as_json: bool, human: str) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(human)
+
+
+def _cmd_window_open(args, sd: Path) -> int:
+    win = relay.PermissionWindow(sd)
+    record = win.open(args.minutes, args.reason)
+    status = win.status()
+    _emit(
+        status,
+        args.json,
+        f"[ok] permission window OPEN for {args.minutes:g} min "
+        f"(expires {record['expires_at']}, remaining {status['remaining_seconds']}s)"
+        + (f" — reason: {args.reason}" if args.reason else ""),
+    )
+    return 0
+
+
+def _cmd_window_close(args, sd: Path) -> int:
+    win = relay.PermissionWindow(sd)
+    win.close()
+    _emit({"open": False}, args.json, "[ok] permission window CLOSED")
+    return 0
+
+
+def _cmd_window_status(args, sd: Path) -> int:
+    win = relay.PermissionWindow(sd)
+    status = win.status()
+    if status["open"]:
+        human = (
+            f"[~] window OPEN — {status['remaining_seconds']}s remaining "
+            f"(expires {status['expires_at']})"
+        )
+    else:
+        human = "[ ] window CLOSED — all worker prompts escalate to the operator"
+    _emit(status, args.json, human)
+    return 0
+
+
+def _cmd_escalations(args, sd: Path) -> int:
+    pending = relay.list_escalations(state_dir=sd, pending_only=not args.all)
+    if args.json:
+        print(json.dumps(pending, indent=2, sort_keys=True))
+        return 0
+    if not pending:
+        print("[ok] no pending permission escalations")
+        return 0
+    print(f"[!] {len(pending)} pending permission escalation(s):")
+    for rec in pending:
+        print(
+            f"  - {rec.get('dispatch_id')}  reason={rec.get('reason')}  "
+            f"captured={rec.get('captured_at')}\n"
+            f"      cmd: {rec.get('command')}"
+        )
+    print("\nResolve with: vnx permission approve <dispatch_id>  |  deny <dispatch_id>")
+    return 0
+
+
+def _relay_keystroke_to_worker(dispatch_id: str, sd: Path) -> "str | None":
+    """Best-effort: send "1"+Enter into the escalated worker's tmux session.
+
+    Reads the lane handle (state/tmux_interactive/<dispatch_id>.json) for the
+    session id. Returns the session id on success, None if no session/tmux.
+    """
+    handle_path = sd / "tmux_interactive" / f"{dispatch_id}.json"
+    if not handle_path.exists():
+        return None
+    try:
+        handle = json.loads(handle_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    session = (handle or {}).get("session")
+    if not session:
+        return None
+    try:
+        from tmux_interactive_dispatch import TmuxCommandRunner  # noqa: PLC0415
+
+        runner = TmuxCommandRunner()
+        if not runner.available():
+            return None
+        relay._send_approval(runner, session)
+        return session
+    except Exception:  # noqa: BLE001 — relay is best-effort
+        return None
+
+
+def _cmd_approve(args, sd: Path) -> int:
+    record = relay.resolve_escalation(args.dispatch_id, approved=True, state_dir=sd)
+    if record is None:
+        _emit(
+            {"error": "no_escalation", "dispatch_id": args.dispatch_id},
+            args.json,
+            f"[x] no escalation found for {args.dispatch_id}",
+        )
+        return 1
+    session = _relay_keystroke_to_worker(args.dispatch_id, sd)
+    record["relayed_session"] = session
+    human = f"[ok] approved {args.dispatch_id}"
+    human += (
+        f" — relayed approval to session {session}"
+        if session
+        else " — no live worker session found (record updated only)"
+    )
+    _emit(record, args.json, human)
+    return 0
+
+
+def _cmd_deny(args, sd: Path) -> int:
+    record = relay.resolve_escalation(args.dispatch_id, approved=False, state_dir=sd)
+    if record is None:
+        _emit(
+            {"error": "no_escalation", "dispatch_id": args.dispatch_id},
+            args.json,
+            f"[x] no escalation found for {args.dispatch_id}",
+        )
+        return 1
+    _emit(
+        record,
+        args.json,
+        f"[ok] denied {args.dispatch_id} — operator must handle the worker pane directly",
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    # Shared --json flag so it is accepted after the subcommand
+    # (e.g. ``vnx permission window-status --json``).
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--json", action="store_true", help="machine-readable JSON output")
+
+    parser = argparse.ArgumentParser(
+        prog="vnx permission",
+        parents=[common],
+        description="Worker-permission relay: auto-accept window + escalation control.",
+    )
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    p_open = sub.add_parser("window-open", parents=[common], help="open the operator auto-accept window")
+    p_open.add_argument("--minutes", type=float, required=True, help="window duration in minutes")
+    p_open.add_argument("--reason", default=None, help="why the window is open (audit)")
+    p_open.set_defaults(func=_cmd_window_open)
+
+    p_close = sub.add_parser("window-close", parents=[common], help="close the auto-accept window")
+    p_close.set_defaults(func=_cmd_window_close)
+
+    p_status = sub.add_parser("window-status", parents=[common], help="show window state")
+    p_status.set_defaults(func=_cmd_window_status)
+
+    p_esc = sub.add_parser("escalations", parents=[common], help="list pending permission escalations")
+    p_esc.add_argument("--all", action="store_true", help="include resolved escalations")
+    p_esc.set_defaults(func=_cmd_escalations)
+
+    p_app = sub.add_parser("approve", parents=[common], help="approve an escalation + relay to the worker")
+    p_app.add_argument("dispatch_id")
+    p_app.set_defaults(func=_cmd_approve)
+
+    p_deny = sub.add_parser("deny", parents=[common], help="deny an escalation")
+    p_deny.add_argument("dispatch_id")
+    p_deny.set_defaults(func=_cmd_deny)
+
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    sd = _state_dir()
+    return args.func(args, sd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_worker_permission_relay.py
+++ b/tests/test_worker_permission_relay.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Tests for the worker-permission relay (scripts/lib/worker_permission_relay.py).
+
+Covers: PermissionWindow open/close/status + expiry; is_catastrophic hard-list;
+parse_pending_command extraction; decide policy; relay_tick auto-approve /
+escalate / idempotency with a fake tmux runner asserting the SEPARATE-Enter +
+EXPLICIT-session send-keys contract.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+import worker_permission_relay as relay  # noqa: E402
+from worker_permission_relay import (  # noqa: E402
+    PermissionWindow,
+    decide,
+    is_catastrophic,
+    list_escalations,
+    parse_pending_command,
+    read_escalation,
+    relay_tick,
+    resolve_escalation,
+    write_escalation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake tmux runner
+# ---------------------------------------------------------------------------
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeRunner:
+    """Records every tmux invocation; returns a scripted pane for capture-pane."""
+
+    def __init__(self, pane_text=""):
+        self.pane_text = pane_text
+        self.calls = []  # list[list[str]]
+
+    def run(self, args, **kwargs):
+        self.calls.append(list(args))
+        if args[:1] == ["capture-pane"]:
+            return _FakeResult(returncode=0, stdout=self.pane_text)
+        return _FakeResult(returncode=0)
+
+    def send_key_calls(self):
+        return [c for c in self.calls if c[:1] == ["send-keys"]]
+
+
+# ---------------------------------------------------------------------------
+# Sample pane buffers
+# ---------------------------------------------------------------------------
+PROMPT_PANE = """\
+● I'll remove the temp directory.
+
+╭───────────────────────────────────────────────╮
+│ Bash command                                   │
+│                                                 │
+│   rm -rf /tmp/scratch                           │
+│   Delete the scratch directory                  │
+│                                                 │
+│ Do you want to proceed?                         │
+│ ❯ 1. Yes                                        │
+│   2. Yes, and don't ask again this session      │
+│   3. No, and tell Claude what to do differently │
+╰───────────────────────────────────────────────╯
+"""
+
+ROUTINE_PROMPT_PANE = """\
+╭───────────────────────────────────────────────╮
+│ Bash command                                   │
+│                                                 │
+│   pytest tests/test_foo.py -q                   │
+│   Run the focused test                          │
+│                                                 │
+│ Do you want to proceed?                         │
+│ ❯ 1. Yes                                        │
+│   2. No                                         │
+╰───────────────────────────────────────────────╯
+"""
+
+TOOL_TOKEN_PANE = """\
+● Running a command
+
+  Bash(chmod +x scripts/deploy.sh)
+
+  Do you want to proceed?
+  ❯ 1. Yes
+    2. No
+"""
+
+IDLE_PANE = """\
+● Done. All tests pass.
+
+› ❯
+"""
+
+
+# ---------------------------------------------------------------------------
+# PermissionWindow
+# ---------------------------------------------------------------------------
+class TestPermissionWindow:
+    def test_default_closed(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        assert win.is_open() is False
+        assert win.status()["open"] is False
+        assert win.status()["remaining_seconds"] == 0
+
+    def test_open_then_status(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10, "operator at keyboard", now=1000.0)
+        # 5 minutes later still open.
+        assert win.is_open(now=1000.0 + 300) is True
+        status = win.status(now=1000.0 + 300)
+        assert status["open"] is True
+        assert status["remaining_seconds"] == 300  # 10min - 5min
+        assert status["reason"] == "operator at keyboard"
+
+    def test_close(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10, now=1000.0)
+        win.close(now=1000.0 + 60)
+        assert win.is_open(now=1000.0 + 60) is False
+        assert win.status(now=1000.0 + 60)["open"] is False
+
+    def test_expiry_reads_closed(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(5, now=1000.0)
+        # 6 minutes later: expired even though open flag is true on disk.
+        assert win.is_open(now=1000.0 + 360) is False
+        assert win.status(now=1000.0 + 360)["open"] is False
+        assert win.status(now=1000.0 + 360)["remaining_seconds"] == 0
+
+    def test_open_rejects_nonpositive(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        with pytest.raises(ValueError):
+            win.open(0)
+
+
+# ---------------------------------------------------------------------------
+# is_catastrophic
+# ---------------------------------------------------------------------------
+class TestIsCatastrophic:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "rm -rf /x",
+            "rm -fr /tmp/data",
+            "rm -r -f build",
+            "sudo rm -rf /",
+            "DROP TABLE foo",
+            "drop database prod",
+            "TRUNCATE TABLE events",
+            "mkfs.ext4 /dev/sda1",
+            "mkfs /dev/sdb",
+            "dd if=/dev/zero of=/dev/sda bs=1M",
+            "echo boom > /dev/sda",
+            "git reset --hard origin/main",
+            "find . -name '*.log' -delete",
+            "find /tmp -exec rm {} \\;",
+            "git clean -fdx",
+        ],
+    )
+    def test_catastrophic_true(self, cmd):
+        assert is_catastrophic(cmd) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push --force-with-lease",
+            "git push --force",
+            "git push -f origin feature",
+            "chmod +x scripts/x.sh",
+            "git commit -m 'feat: thing'",
+            "pytest tests/ -q",
+            "rm file.txt",          # non-recursive single file
+            "rm -f stale.lock",     # force but not recursive
+            "git reset --hard HEAD~1",  # local reset, not onto a remote
+            "ls -la",
+            "",
+        ],
+    )
+    def test_catastrophic_false(self, cmd):
+        assert is_catastrophic(cmd) is False
+
+
+# ---------------------------------------------------------------------------
+# parse_pending_command
+# ---------------------------------------------------------------------------
+class TestParsePendingCommand:
+    def test_extracts_from_box(self):
+        assert parse_pending_command(PROMPT_PANE) == "rm -rf /tmp/scratch"
+
+    def test_extracts_routine(self):
+        assert parse_pending_command(ROUTINE_PROMPT_PANE) == "pytest tests/test_foo.py -q"
+
+    def test_extracts_bash_token(self):
+        assert parse_pending_command(TOOL_TOKEN_PANE) == "chmod +x scripts/deploy.sh"
+
+    def test_idle_returns_none(self):
+        assert parse_pending_command(IDLE_PANE) is None
+
+    def test_empty_returns_none(self):
+        assert parse_pending_command("") is None
+
+
+# ---------------------------------------------------------------------------
+# decide
+# ---------------------------------------------------------------------------
+class TestDecide:
+    def test_open_routine_auto_approve(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10, now=1000.0)
+        # window.is_open() uses real time; open for 10 min from now() so it's open.
+        assert decide("pytest -q", True) == "auto_approve"
+
+    def test_open_catastrophic_escalates(self):
+        assert decide("rm -rf /tmp/x", True) == "escalate"
+
+    def test_closed_escalates(self):
+        assert decide("pytest -q", False) == "escalate"
+
+    def test_window_object_open(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)
+        assert decide("pytest -q", win) == "auto_approve"
+
+    def test_window_object_closed(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        assert decide("pytest -q", win) == "escalate"
+
+
+# ---------------------------------------------------------------------------
+# relay_tick
+# ---------------------------------------------------------------------------
+class TestRelayTick:
+    def test_auto_approve_sends_one_then_enter_separate(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)  # open now
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE)
+        action = relay_tick("vnx-disp-1", "disp-1", runner, state_dir=tmp_path, window=win)
+        assert action == "auto_approve"
+
+        sends = runner.send_key_calls()
+        assert len(sends) == 2, sends
+        # First keystroke: literal "1" to the EXPLICIT session, never empty target.
+        assert sends[0] == ["send-keys", "-t", "vnx-disp-1", "1"]
+        # Second keystroke: Enter as its OWN separate call.
+        assert sends[1] == ["send-keys", "-t", "vnx-disp-1", "Enter"]
+        # No send-keys ever targets an empty/missing session.
+        for c in sends:
+            assert "-t" in c
+            tgt = c[c.index("-t") + 1]
+            assert tgt == "vnx-disp-1" and tgt != ""
+
+    def test_escalate_writes_record_and_sends_no_keys(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)  # window OPEN — but command is catastrophic, must escalate
+        runner = FakeRunner(pane_text=PROMPT_PANE)  # rm -rf
+        action = relay_tick("vnx-disp-2", "disp-2", runner, state_dir=tmp_path, window=win)
+        assert action == "escalate"
+        # NO send-keys issued.
+        assert runner.send_key_calls() == []
+        # Escalation record written, pending, reason=catastrophic.
+        rec = read_escalation("disp-2", state_dir=tmp_path)
+        assert rec is not None
+        assert rec["status"] == "pending"
+        assert rec["reason"] == "catastrophic"
+        assert rec["command"] == "rm -rf /tmp/scratch"
+
+    def test_window_closed_escalates_routine(self, tmp_path):
+        # No window opened => closed => even a routine prompt escalates.
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE)
+        action = relay_tick("vnx-disp-3", "disp-3", runner, state_dir=tmp_path)
+        assert action == "escalate"
+        assert runner.send_key_calls() == []
+        rec = read_escalation("disp-3", state_dir=tmp_path)
+        assert rec is not None
+        assert rec["reason"] == "window_closed"
+
+    def test_idle_pane_no_action(self, tmp_path):
+        runner = FakeRunner(pane_text=IDLE_PANE)
+        action = relay_tick("vnx-disp-4", "disp-4", runner, state_dir=tmp_path)
+        assert action == "idle"
+        assert runner.send_key_calls() == []
+
+    def test_idempotent_repeated_identical_prompt(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE)
+        first = relay_tick("vnx-disp-5", "disp-5", runner, state_dir=tmp_path, window=win)
+        assert first == "auto_approve"
+        assert len(runner.send_key_calls()) == 2
+        # Same prompt still on the pane on the next tick — must NOT re-approve.
+        second = relay_tick("vnx-disp-5", "disp-5", runner, state_dir=tmp_path, window=win)
+        assert second == "already_handled"
+        assert len(runner.send_key_calls()) == 2  # unchanged
+
+    def test_empty_session_refused(self, tmp_path):
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE)
+        with pytest.raises(ValueError):
+            relay_tick("", "disp-6", runner, state_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Escalation lifecycle
+# ---------------------------------------------------------------------------
+class TestEscalationLifecycle:
+    def test_write_list_resolve(self, tmp_path):
+        write_escalation("d1", "rm -rf /x", "catastrophic", state_dir=tmp_path)
+        write_escalation("d2", "pytest -q", "window_closed", state_dir=tmp_path)
+        pending = list_escalations(state_dir=tmp_path)
+        assert {r["dispatch_id"] for r in pending} == {"d1", "d2"}
+
+        resolve_escalation("d1", approved=True, state_dir=tmp_path)
+        rec = read_escalation("d1", state_dir=tmp_path)
+        assert rec["status"] == "approved"
+        assert rec["resolved_at"] is not None
+        # Only d2 remains pending.
+        pending = list_escalations(state_dir=tmp_path)
+        assert {r["dispatch_id"] for r in pending} == {"d2"}
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        assert resolve_escalation("nope", approved=True, state_dir=tmp_path) is None
+
+    def test_write_is_idempotent_for_same_pending(self, tmp_path):
+        p1 = write_escalation("d3", "rm -rf /x", "catastrophic", state_dir=tmp_path, now=1000.0)
+        rec1 = read_escalation("d3", state_dir=tmp_path)
+        # Second write with same command + later time keeps the original captured_at.
+        write_escalation("d3", "rm -rf /x", "catastrophic", state_dir=tmp_path, now=2000.0)
+        rec2 = read_escalation("d3", state_dir=tmp_path)
+        assert rec1["captured_at"] == rec2["captured_at"]
+        assert p1.exists()

--- a/tests/test_worker_permission_relay.py
+++ b/tests/test_worker_permission_relay.py
@@ -7,17 +7,20 @@ escalate / idempotency with a fake tmux runner asserting the SEPARATE-Enter +
 EXPLICIT-session send-keys contract.
 """
 
+import json
 import sys
 from pathlib import Path
 
 import pytest
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import worker_permission_relay as relay  # noqa: E402
 from worker_permission_relay import (  # noqa: E402
     PermissionWindow,
+    _safe_dispatch_id,
     decide,
     is_catastrophic,
     list_escalations,
@@ -27,6 +30,8 @@ from worker_permission_relay import (  # noqa: E402
     resolve_escalation,
     write_escalation,
 )
+
+import permission_relay_cli as cli  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -40,17 +45,29 @@ class _FakeResult:
 
 
 class FakeRunner:
-    """Records every tmux invocation; returns a scripted pane for capture-pane."""
+    """Records every tmux invocation; returns a scripted pane for capture-pane.
 
-    def __init__(self, pane_text=""):
+    ``send_fail`` makes every ``send-keys`` invocation return a non-zero rc so the
+    relay's send-keys-success gating can be exercised. ``capture-pane`` still
+    succeeds so the prompt is parsed normally.
+    """
+
+    def __init__(self, pane_text="", *, send_fail=False, tmux_available=True):
         self.pane_text = pane_text
+        self.send_fail = send_fail
+        self._tmux_available = tmux_available
         self.calls = []  # list[list[str]]
 
     def run(self, args, **kwargs):
         self.calls.append(list(args))
         if args[:1] == ["capture-pane"]:
             return _FakeResult(returncode=0, stdout=self.pane_text)
+        if args[:1] == ["send-keys"] and self.send_fail:
+            return _FakeResult(returncode=1)
         return _FakeResult(returncode=0)
+
+    def available(self):
+        return self._tmux_available
 
     def send_key_calls(self):
         return [c for c in self.calls if c[:1] == ["send-keys"]]
@@ -340,3 +357,187 @@ class TestEscalationLifecycle:
         rec2 = read_escalation("d3", state_dir=tmp_path)
         assert rec1["captured_at"] == rec2["captured_at"]
         assert p1.exists()
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — path-traversal: dispatch_id must be sanitized before path use
+# ---------------------------------------------------------------------------
+class TestSafeDispatchId:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../../etc/x",      # classic traversal
+            "a/b",              # path separator
+            "..",               # parent-dir segment (matches the char class!)
+            ".",                # current-dir segment
+            "/etc/passwd",      # absolute path
+            "x/../../y",        # embedded traversal
+            "a b",              # space (outside the allow-list)
+            "name;rm",          # shell metachar
+            "",                 # empty
+        ],
+    )
+    def test_rejects_unsafe(self, bad):
+        with pytest.raises(ValueError):
+            _safe_dispatch_id(bad)
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "20260602-173238-relay-fix",
+            "disp_1",
+            "a.b.c",
+            "T1-track-A",
+        ],
+    )
+    def test_accepts_safe(self, good):
+        assert _safe_dispatch_id(good) == good
+
+    def test_write_escalation_rejects_traversal(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_escalation("../../etc/x", "rm -rf /x", "catastrophic", state_dir=tmp_path)
+        # And nothing was written outside the escalations dir.
+        assert not (tmp_path.parent / "x.json").exists()
+
+    def test_read_escalation_rejects_traversal(self, tmp_path):
+        with pytest.raises(ValueError):
+            read_escalation("a/b", state_dir=tmp_path)
+
+    def test_resolve_escalation_rejects_traversal(self, tmp_path):
+        with pytest.raises(ValueError):
+            resolve_escalation("../../etc/x", approved=True, state_dir=tmp_path)
+
+    def test_relay_tick_rejects_traversal(self, tmp_path):
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE)
+        with pytest.raises(ValueError):
+            relay_tick("vnx-sess", "../../etc/x", runner, state_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — auto-approve must NOT mark handled when the send-keys fails
+# ---------------------------------------------------------------------------
+class TestAutoApproveGatesOnSendResult:
+    def test_failed_send_not_marked_handled(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)  # window OPEN — routine prompt would auto-approve
+        runner = FakeRunner(pane_text=ROUTINE_PROMPT_PANE, send_fail=True)
+        action = relay_tick("vnx-disp-f", "disp-f", runner, state_dir=tmp_path, window=win)
+        # Send failed -> explicit failure status, NOT "auto_approve".
+        assert action == "auto_approve_failed"
+        # Fingerprint NOT persisted -> a retry next tick is still possible.
+        assert relay._read_fingerprint(tmp_path, "disp-f") is None
+        # The "1" keystroke was attempted (returned rc!=0), so the first send-keys
+        # is present; Enter is short-circuited because rc1 failed.
+        sends = runner.send_key_calls()
+        assert sends[0] == ["send-keys", "-t", "vnx-disp-f", "1"]
+
+    def test_retry_after_failed_send_then_success(self, tmp_path):
+        win = PermissionWindow(tmp_path)
+        win.open(10)
+        # First tick: send fails -> not handled.
+        failing = FakeRunner(pane_text=ROUTINE_PROMPT_PANE, send_fail=True)
+        assert relay_tick("vnx-r", "disp-r", failing, state_dir=tmp_path, window=win) == "auto_approve_failed"
+        assert relay._read_fingerprint(tmp_path, "disp-r") is None
+        # Second tick (same prompt still on pane): send succeeds -> handled now.
+        ok = FakeRunner(pane_text=ROUTINE_PROMPT_PANE, send_fail=False)
+        assert relay_tick("vnx-r", "disp-r", ok, state_dir=tmp_path, window=win) == "auto_approve"
+        assert relay._read_fingerprint(tmp_path, "disp-r") is not None
+        sends = ok.send_key_calls()
+        assert sends == [
+            ["send-keys", "-t", "vnx-r", "1"],
+            ["send-keys", "-t", "vnx-r", "Enter"],
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — manual `approve` must surface send failure + gate resolved=approved
+# ---------------------------------------------------------------------------
+class _Args:
+    def __init__(self, dispatch_id, as_json=False):
+        self.dispatch_id = dispatch_id
+        self.json = as_json
+
+
+def _write_handle(sd: Path, dispatch_id: str, session: str) -> None:
+    hdir = sd / "tmux_interactive"
+    hdir.mkdir(parents=True, exist_ok=True)
+    (hdir / f"{dispatch_id}.json").write_text(
+        json.dumps({"dispatch_id": dispatch_id, "session": session}), encoding="utf-8"
+    )
+
+
+class TestManualApproveSurfacesSendFailure:
+    def test_approve_send_failure_leaves_pending_and_exits_nonzero(self, tmp_path, monkeypatch):
+        write_escalation("d-app", "pytest -q", "window_closed", state_dir=tmp_path)
+        _write_handle(tmp_path, "d-app", "vnx-d-app")
+        # Inject a runner whose send-keys fails. Capture the ORIGINAL fn first so the
+        # wrapper does not recurse into itself after monkeypatching.
+        failing = FakeRunner(send_fail=True)
+        orig = cli._relay_keystroke_to_worker
+        monkeypatch.setattr(
+            cli, "_relay_keystroke_to_worker",
+            lambda did, sd: orig(did, sd, runner=failing),
+        )
+        rc = cli._cmd_approve(_Args("d-app"), tmp_path)
+        assert rc == 1  # non-zero: send did not land
+        # Escalation MUST remain pending (NOT flipped to approved).
+        rec = read_escalation("d-app", state_dir=tmp_path)
+        assert rec["status"] == "pending"
+
+    def test_approve_no_session_leaves_pending_and_exits_nonzero(self, tmp_path):
+        write_escalation("d-nos", "pytest -q", "window_closed", state_dir=tmp_path)
+        # No handle written -> no live session.
+        rc = cli._cmd_approve(_Args("d-nos"), tmp_path)
+        assert rc == 1
+        rec = read_escalation("d-nos", state_dir=tmp_path)
+        assert rec["status"] == "pending"
+
+    def test_approve_success_marks_approved_and_exits_zero(self, tmp_path, monkeypatch):
+        write_escalation("d-ok", "pytest -q", "window_closed", state_dir=tmp_path)
+        _write_handle(tmp_path, "d-ok", "vnx-d-ok")
+        ok = FakeRunner(send_fail=False)
+        orig = cli._relay_keystroke_to_worker
+        monkeypatch.setattr(
+            cli, "_relay_keystroke_to_worker",
+            lambda did, sd: orig(did, sd, runner=ok),
+        )
+        rc = cli._cmd_approve(_Args("d-ok"), tmp_path)
+        assert rc == 0
+        rec = read_escalation("d-ok", state_dir=tmp_path)
+        assert rec["status"] == "approved"
+
+    def test_approve_missing_escalation_exits_one(self, tmp_path):
+        rc = cli._cmd_approve(_Args("ghost"), tmp_path)
+        assert rc == 1
+
+    def test_approve_rejects_traversal_dispatch_id(self, tmp_path):
+        rc = cli._cmd_approve(_Args("../../etc/x"), tmp_path)
+        assert rc == 2  # invalid dispatch_id, rejected before any path use
+
+    def test_deny_rejects_traversal_dispatch_id(self, tmp_path):
+        rc = cli._cmd_deny(_Args("a/b"), tmp_path)
+        assert rc == 2
+
+    def test_relay_keystroke_distinguishes_statuses(self, tmp_path):
+        # no handle -> no_session
+        assert cli._relay_keystroke_to_worker("none", tmp_path)[0] == "no_session"
+        # handle + failing send -> send_failed
+        _write_handle(tmp_path, "sf", "vnx-sf")
+        status, session = cli._relay_keystroke_to_worker(
+            "sf", tmp_path, runner=FakeRunner(send_fail=True)
+        )
+        assert status == "send_failed"
+        assert session == "vnx-sf"
+        # handle + ok send -> sent
+        _write_handle(tmp_path, "okk", "vnx-okk")
+        status, session = cli._relay_keystroke_to_worker(
+            "okk", tmp_path, runner=FakeRunner(send_fail=False)
+        )
+        assert status == "sent"
+        assert session == "vnx-okk"
+        # tmux unavailable -> error (operational, not "no session")
+        _write_handle(tmp_path, "noux", "vnx-noux")
+        status, session = cli._relay_keystroke_to_worker(
+            "noux", tmp_path, runner=FakeRunner(tmux_available=False)
+        )
+        assert status == "error"


### PR DESCRIPTION
## The model

A DETACHED tmux worker (interactive `claude` on the subscription lane) has no human at the keyboard. When Claude Code raises a permission prompt for an off-allow-list tool/command, the worker silently **hangs** until its deadline. This PR is the governance mechanism that prevents the hang while keeping the operator as the human gate.

- **Default — escalate to operator.** Outside an open window, EVERY worker permission prompt escalates to the operator (T0).
- **Operator window auto-approves routine.** The operator declares a short, explicit auto-accept window (`vnx permission window-open --minutes N`). Inside the window, routine prompts are auto-approved.
- **Catastrophic always escalates.** Irreversible ops (`rm -rf`, `DROP TABLE`/`DROP DATABASE`, `TRUNCATE`, `mkfs`, `dd of=/dev/…`, `> /dev/sd…`, `git reset --hard <remote>/…`, `find -delete`, `git clean -fd`) ALWAYS escalate — even inside an open window. The window is never a blank cheque for destructive ops. `git push --force` / `-f` / `--force-with-lease` are recoverable and **not** catastrophic (allowed).
- **Escalation = a record T0 surfaces in chat.** A durable JSON record is written to `$VNX_STATE_DIR/permission_escalations/<dispatch_id>.json`; the operator answers and the answer is relayed back into the pane via send-keys. No popup infrastructure.

## Flag-gated, default off

Lane integration in `tmux_interactive_dispatch.py` runs only when `VNX_PERMISSION_RELAY=1`. Unset (the default) is byte-identical to prior behavior. When on, a daemon thread ticks `relay_tick` every `VNX_PERMISSION_RELAY_INTERVAL` (default 3s) for the duration of the dispatch and is stopped at teardown.

## send-keys contract

Auto-approve sends option **"1"** then **Enter as a SEPARATE keystroke**, always targeting the **EXPLICIT session id** — never an empty `-t` target. Combined `1\n` misses delivery; an empty target hits the wrong pane (proven bug). The escalate path sends **no keys**. Idempotent via a persisted last-handled prompt fingerprint, so a prompt still on the pane on the next tick is not re-actioned.

## Components

- `scripts/lib/worker_permission_relay.py` — `PermissionWindow` (atomic `permission_window.json`, expiry authoritative), `CATASTROPHIC_PATTERNS` + `is_catastrophic`, `parse_pending_command`, `decide`, escalation record CRUD, `relay_tick`, `run_relay_loop`.
- `scripts/permission_relay_cli.py` — `vnx permission window-open|window-close|window-status|escalations|approve|deny` (`--json` on demand). `approve` resolves the record and best-effort relays "1"+Enter to the worker's session via the lane handle. Registered in `vnx_mode.py` `TIER_OPERATOR_ONLY`.
- `scripts/lib/tmux_interactive_dispatch.py` — flag-gated background relay thread + teardown stop.
- `tests/test_worker_permission_relay.py` — 50 tests.

## Verification

- `pytest tests/test_worker_permission_relay.py -q` → **50 passed**
- `pytest tests/test_docs_command_validation.py tests/test_vnx_mode.py -q` → **43 passed** (mode-tier coverage)
- `pytest tests/test_tmux_interactive_dispatch.py -q` → **107 passed** (no lane regression)
- `bash -n bin/vnx`, AST parse, `.claude/settings.json` JSON-load — all ok

Dispatch-ID: 20260602-171859-perm-relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)