### PR TITLE
feat(planning): turn-on — vnx objective sync (auto-seed, human-gated) + advisory drift-gate

### DIFF
--- a/dashboard/api_planning.py
+++ b/dashboard/api_planning.py
@@ -66,6 +66,31 @@ def _load_open_items_index(state_dir: Path) -> dict[str, dict]:
         return {}
 
 
+def _load_planning_drift(state_dir: Path) -> dict:
+    """Read the advisory drift summary written by `vnx objective drift`.
+
+    Read-only: returns {} when the file is absent or unreadable. Surfaced as an
+    advisory panel; never blocks the planning view.
+    """
+    path = state_dir / "planning_drift.json"
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except Exception as exc:
+        _logger.debug("Failed to load planning_drift.json: %s", exc)
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        "generated_at": raw.get("generated_at"),
+        "divergent_count": raw.get("divergent_count", 0),
+        "total_tracks": raw.get("total_tracks", 0),
+        "divergent": raw.get("divergent", []),
+        "note": raw.get("note", ""),
+    }
+
+
 def _fetch_tracks(conn: sqlite3.Connection, project_id: str, has_horizon: bool) -> list[dict]:
     if has_horizon:
         rows = conn.execute(
@@ -309,4 +334,5 @@ def _operator_get_planning(state_dir: Path | None = None) -> dict[str, Any]:
         "horizons": horizons,
         "total_tracks": total,
         "schema_v27": has_horizon and has_del_view,
+        "drift": _load_planning_drift(s_dir),
     }

--- a/scripts/dispatcher_minimal.sh
+++ b/scripts/dispatcher_minimal.sh
@@ -592,6 +592,7 @@ process_dispatches() {
     _maybe_runtime_supervise
     _cleanup_stuck_dispatches
     _unified_supervisor_lease_sweep_tick
+    _maybe_auto_seed_tracks
 
     for dispatch in "$PENDING_DIR"/*.md; do
         [ -f "$dispatch" ] || continue

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -40,6 +40,19 @@ _maybe_runtime_supervise() {
     echo "$now" > "$state_file"
 }
 
+# _maybe_auto_seed_tracks — flag-gated planning auto-seed tick.
+# When VNX_AUTO_SEED_TRACKS=1, run the idempotent `vnx objective sync --apply`
+# once per prelude tick to keep tracks current with ROADMAP.yaml. Best-effort,
+# non-blocking, logged. Default (unset) = no behaviour change. This NEVER writes
+# ROADMAP.yaml and NEVER promotes deliverables (the human gate is preserved).
+_maybe_auto_seed_tracks() {
+    [[ "${VNX_AUTO_SEED_TRACKS:-0}" == "1" ]] || return 0
+    local log_file="$VNX_LOGS_DIR/auto_seed_tracks.log"
+    mkdir -p "$(dirname "$log_file")"
+    python3 "$SCRIPT_DIR/planning_cli.py" objective sync --apply \
+        >> "$log_file" 2>&1 || true
+}
+
 # _unified_supervisor_lease_sweep_tick — throttled lease_sweep tick (SUP-PR2).
 # Invokes scripts/lib/lease_sweep.py at most once per
 # VNX_LEASE_SWEEP_INTERVAL_SEC seconds when VNX_SUPERVISOR_MODE=unified.

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -4,6 +4,8 @@
 Delegated from `bin/vnx`:
   vnx objective list [--horizon now|next|later] [--phase ...] [--json]
   vnx objective show <track_id> [--json]
+  vnx objective sync [--apply] [--roadmap PATH] [--json]
+  vnx objective drift [--json]
   vnx deliverable add --objective <track_id> --output-kind <kind> --title "..."
   vnx deliverable list [--objective <track_id>] [--json]
   vnx deliverable promote <dispatch_id>
@@ -11,6 +13,16 @@ Delegated from `bin/vnx`:
 NO-NODE model: a deliverable is a proposed dispatch row with output_kind.
 `vnx deliverable promote` is the human gate (proposed -> ready).
 `vnx promote` (top-level) is the PR-queue command — NOT the same.
+
+Planning turn-on (auto-seed + advisory drift):
+  `objective sync` re-projects ROADMAP.yaml -> tracks via the shipped seeder.
+    Default = CHECK (dry-run): report would-change set, write nothing.
+    --apply  = idempotent projection of ROADMAP onto tracks. NEVER writes
+               ROADMAP.yaml and NEVER promotes deliverables (human gate kept).
+  `objective drift` runs the advisory reconciler and reports tracks whose
+    declared phase != derived_status. ADVISORY: always exits 0, writes
+    planning_drift.json for the dashboard / T0. Never writes ROADMAP.
+  `maybe_auto_seed()` is the flag-gated prelude hook (VNX_AUTO_SEED_TRACKS=1).
 """
 
 from __future__ import annotations
@@ -27,10 +39,13 @@ from typing import Any, Optional
 
 _HERE = Path(__file__).resolve().parent
 _LIB = _HERE / "lib"
-if str(_LIB) not in sys.path:
-    sys.path.insert(0, str(_LIB))
+for _p in (_LIB, _HERE):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
 
 import tracks as tracks_lib  # noqa: E402
+import seed_tracks_from_roadmap as seeder  # noqa: E402
+import track_reconciler  # noqa: E402
 
 _HORIZON_ORDER = ["now", "next", "later"]
 _HORIZON_LABEL = {"now": "NOW", "next": "NEXT", "later": "LATER", None: "UNSCHEDULED"}
@@ -44,6 +59,33 @@ def _resolve_state_dir(explicit: str) -> Path:
         return Path(env)
     from project_root import resolve_project_root
     return resolve_project_root(__file__) / ".vnx-data" / "state"
+
+
+def _resolve_roadmap_path(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit)
+    env = os.environ.get("VNX_ROADMAP_PATH", "")
+    if env:
+        return Path(env)
+    from project_root import resolve_project_root
+    return resolve_project_root(__file__) / "ROADMAP.yaml"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically: temp file in the same dir + os.replace."""
+    import tempfile
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
 
 
 def _dependencies_for(state_dir: Path, track_id: str, project_id: str) -> list[str]:
@@ -155,6 +197,209 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     print(f"  depends  : {', '.join(deps) if deps else '(none)'}")
     print()
     return 0
+
+
+def cmd_objective_sync(args: argparse.Namespace) -> int:
+    """Re-project ROADMAP.yaml -> tracks via the shipped idempotent seeder.
+
+    CHECK mode (default): dry-run — report the would-change set, write nothing.
+    --apply: idempotent projection. NEVER writes ROADMAP.yaml, NEVER promotes
+    deliverables (the human gate is preserved).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    roadmap_path = _resolve_roadmap_path(args.roadmap)
+    project_id = args.project_id
+
+    if not roadmap_path.exists():
+        print(f"ROADMAP not found: {roadmap_path}", file=sys.stderr)
+        return 1
+
+    # Pure reuse: the seeder owns all projection logic. Dry-run writes nothing.
+    report = seeder.seed(state_dir, roadmap_path, project_id, apply=args.apply)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return 0
+
+    s = report["summary"]
+    mode = "APPLY (idempotent)" if args.apply else "CHECK (dry-run, no writes)"
+    print(f"\nvnx objective sync — {mode}")
+    print(f"  project_id : {project_id}")
+    print(f"  roadmap    : {roadmap_path}")
+    print(
+        f"  created={s['created']}  updated={s['updated']}  unchanged={s['unchanged']}"
+        f"  phase_drift={s['phase_drift']}  orphan={s['orphan']}"
+    )
+    if report["created"]:
+        verb = "+ created" if args.apply else "+ would create"
+        print(f"  {verb} : {', '.join(report['created'])}")
+    if report["updated"]:
+        verb = "~ updated" if args.apply else "~ would update"
+        print(f"  {verb} : {', '.join(report['updated'])}")
+    if report["phase_drift"]:
+        print("  ! phase drift (declared status differs — reported, NOT synced):")
+        for d in report["phase_drift"]:
+            print(f"      {d['track_id']}: db={d['db_phase']} roadmap={d['roadmap_phase']}")
+    if report["orphan"]:
+        print(f"  ? orphan (in DB, gone from ROADMAP — not deleted): {', '.join(report['orphan'])}")
+    if not args.apply and (report["created"] or report["updated"]):
+        print("  (check mode: re-run with --apply to project onto tracks)")
+    print()
+    return 0
+
+
+def _drift_reason(
+    state_dir: Path,
+    track_id: str,
+    project_id: str,
+    declared: Optional[str],
+    derived: str,
+) -> str:
+    """Best-effort explanation for why derived_status diverges from declared phase.
+
+    Mirrors the reconciler's decision order (blocker OI -> unmet dep -> dispatch
+    evidence) without duplicating its computation — purely for operator-readable
+    signal. Falls back to a generic message when no specific cause is found.
+    """
+    conn = _db_conn(state_dir)
+    try:
+        if derived == "blocked":
+            if _has_table(conn, "track_open_items"):
+                has_pid = _has_col(conn, "track_open_items", "project_id")
+                if has_pid:
+                    blocker = conn.execute(
+                        "SELECT 1 FROM track_open_items WHERE track_id = ? AND project_id = ? "
+                        "AND link_type = 'blocks' LIMIT 1",
+                        (track_id, project_id),
+                    ).fetchone()
+                else:
+                    blocker = conn.execute(
+                        "SELECT 1 FROM track_open_items WHERE track_id = ? AND link_type = 'blocks' LIMIT 1",
+                        (track_id,),
+                    ).fetchone()
+                if blocker:
+                    return "blocked by open item"
+            unmet = conn.execute(
+                """
+                SELECT td.to_track_id
+                FROM track_dependencies td
+                JOIN tracks t ON t.track_id = td.to_track_id AND t.project_id = td.to_project_id
+                WHERE td.from_track_id = ? AND td.from_project_id = ? AND t.phase != 'done'
+                LIMIT 1
+                """,
+                (track_id, project_id),
+            ).fetchone()
+            if unmet:
+                return f"blocked by dependency: {unmet[0]}"
+            return "blocked"
+
+        count = conn.execute(
+            "SELECT COUNT(*) FROM dispatches WHERE track = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()[0]
+        if count == 0:
+            return "no linked dispatch/PR evidence"
+        if derived == "in_progress":
+            return "dispatches complete; PR merge not yet confirmed" \
+                if (declared or "") == "done" else "linked dispatches in flight"
+        if derived == "done" and (declared or "") != "done":
+            return "all linked work terminal/merged; declared phase lags"
+    finally:
+        conn.close()
+    return "derived from linked dispatch/event state"
+
+
+def cmd_objective_drift(args: argparse.Namespace) -> int:
+    """ADVISORY drift-gate: report tracks where declared phase != derived_status.
+
+    Runs the shipped reconciler (advisory; writes only tracks.derived_status,
+    never ROADMAP, never tracks.phase). Writes a drift summary to
+    planning_drift.json for the dashboard / T0. ALWAYS exits 0 — this is a
+    planning signal, not a CI gate.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+
+    results = track_reconciler.reconcile_all_tracks(state_dir, project_id)
+
+    divergent = []
+    for r in results:
+        if r["drifted"]:
+            divergent.append({
+                "track_id": r["track_id"],
+                "declared_phase": r["declared_phase"],
+                "derived_status": r["derived_status"],
+                "reason": _drift_reason(
+                    state_dir, r["track_id"], project_id,
+                    r["declared_phase"], r["derived_status"],
+                ),
+            })
+
+    note = (
+        "Advisory only. Many initial divergences reflect historical dispatches "
+        "not yet linked to tracks (linkage backfill is a separate step). Read "
+        "this as a planning signal, not a failure."
+    )
+    summary = {
+        "generated_at": _now_utc(),
+        "project_id": project_id,
+        "total_tracks": len(results),
+        "divergent_count": len(divergent),
+        "divergent": divergent,
+        "note": note,
+    }
+
+    # Persist for the dashboard / T0 (atomic). Never blocks on write failure.
+    drift_path = state_dir / "planning_drift.json"
+    _atomic_write_json(drift_path, summary)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, default=str))
+        return 0
+
+    print(f"\nvnx objective drift — ADVISORY (project '{project_id}')\n")
+    print(f"  tracks reconciled : {len(results)}")
+    print(f"  divergent         : {len(divergent)}")
+    if divergent:
+        print()
+        for d in divergent:
+            print(
+                f"  ~ {d['track_id']:<28} declared={d['declared_phase'] or '-':<7} "
+                f"derived={d['derived_status']:<12} ({d['reason']})"
+            )
+    print(f"\n  note: {note}")
+    print(f"  written: {drift_path}\n")
+    return 0
+
+
+def maybe_auto_seed(
+    state_dir: str | Path | None = None,
+    roadmap_path: str | Path | None = None,
+    project_id: Optional[str] = None,
+    env: Optional[dict] = None,
+) -> dict[str, Any]:
+    """Flag-gated prelude hook: idempotent `objective sync --apply` when opted in.
+
+    Wired into the dispatcher prelude (where lease_sweep is ticked). Default
+    (VNX_AUTO_SEED_TRACKS unset/!=1) is a no-op. When set, projects ROADMAP onto
+    tracks idempotently. NEVER writes ROADMAP.yaml; NEVER promotes deliverables.
+
+    Returns a result dict: {"skipped": True, ...} when disabled, else
+    {"skipped": False, "summary": {...}}.
+    """
+    env = env if env is not None else os.environ
+    if env.get("VNX_AUTO_SEED_TRACKS", "") != "1":
+        return {"skipped": True, "reason": "VNX_AUTO_SEED_TRACKS not set"}
+
+    s_dir = _resolve_state_dir(str(state_dir) if state_dir else env.get("VNX_STATE_DIR", ""))
+    r_path = _resolve_roadmap_path(str(roadmap_path) if roadmap_path else None)
+    pid = project_id or env.get("VNX_PROJECT_ID", "vnx-dev")
+
+    if not Path(r_path).exists():
+        return {"skipped": True, "reason": f"ROADMAP not found: {r_path}"}
+
+    report = seeder.seed(s_dir, r_path, pid, apply=True)
+    return {"skipped": False, "summary": report.get("summary", {})}
 
 
 _VALID_OUTPUT_KINDS = ("pr", "post", "deal", "doc")
@@ -472,6 +717,23 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_show)
     p_show.add_argument("track_id")
     p_show.set_defaults(func=cmd_objective_show)
+
+    p_sync = obj_sub.add_parser(
+        "sync",
+        help="re-project ROADMAP.yaml -> tracks (CHECK by default; --apply to write)",
+    )
+    _common(p_sync)
+    p_sync.add_argument("--apply", action="store_true",
+                        help="apply the idempotent projection (default: dry-run check)")
+    p_sync.add_argument("--roadmap", default=None, help="path to ROADMAP.yaml (default: project root)")
+    p_sync.set_defaults(func=cmd_objective_sync)
+
+    p_drift = obj_sub.add_parser(
+        "drift",
+        help="advisory drift-gate: report declared-vs-derived divergence (exit 0)",
+    )
+    _common(p_drift)
+    p_drift.set_defaults(func=cmd_objective_drift)
 
     # ------------------------------------------------------------------
     # deliverable subcommand (Phase 2)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -36,6 +37,8 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 _HERE = Path(__file__).resolve().parent
 _LIB = _HERE / "lib"
@@ -349,9 +352,13 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
         "note": note,
     }
 
-    # Persist for the dashboard / T0 (atomic). Never blocks on write failure.
+    # Persist for the dashboard / T0 (atomic, best-effort). Write failure must
+    # not break the advisory exit-0 contract.
     drift_path = state_dir / "planning_drift.json"
-    _atomic_write_json(drift_path, summary)
+    try:
+        _atomic_write_json(drift_path, summary)
+    except Exception as exc:
+        logger.warning("drift: could not persist state file %s: %s", drift_path, exc)
 
     if args.json:
         print(json.dumps(summary, indent=2, default=str))

--- a/tests/test_planning_turnon.py
+++ b/tests/test_planning_turnon.py
@@ -1,0 +1,285 @@
+"""tests/test_planning_turnon.py — planning-layer turn-on surface.
+
+Covers the three turn-on pieces, all against temp DBs + ROADMAP fixtures
+(NEVER the live .vnx-data DB):
+
+- `vnx objective sync` CHECK mode reports the would-change set and mutates
+  nothing; `--apply` mutates idempotently (2nd --apply = no-op).
+- the flag-gated prelude hook `maybe_auto_seed`: unset -> no-op;
+  VNX_AUTO_SEED_TRACKS=1 -> runs sync --apply (asserted via temp DB + a
+  monkeypatched seeder recording apply=True).
+- `vnx objective drift` reports the divergent set, writes planning_drift.json,
+  exits 0 even when divergence > 0, and never touches any ROADMAP-write path.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration  # noqa: E402
+import seed_tracks_from_roadmap as seeder  # noqa: E402
+import planning_cli  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+
+SAMPLE_ROADMAP = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: high
+    depends_on: []
+    milestone: "1.0"
+    status: planned
+    notes: Build A.
+  - feature_id: feat-b
+    title: Feature B
+    risk_class: low
+    depends_on: [feat-a]
+    milestone: "1.0"
+    status: done
+  - feature_id: feat-c
+    title: Feature C
+    risk_class: medium
+    depends_on: []
+    milestone: "1.x"
+    status: planned
+"""
+
+
+def _init_schema(state_dir: Path) -> None:
+    """Build a v28 runtime_coordination.db (track layer + derived_status)."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 28,
+        (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def empty_state(tmp_path: Path) -> tuple[Path, Path]:
+    """Schema-only state (no tracks) + a ROADMAP fixture file."""
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(SAMPLE_ROADMAP, encoding="utf-8")
+    return state_dir, roadmap
+
+
+@pytest.fixture()
+def seeded_state(empty_state) -> tuple[Path, Path]:
+    """Schema + tracks seeded from the ROADMAP fixture (apply=True)."""
+    state_dir, roadmap = empty_state
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    return state_dir, roadmap
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — vnx objective sync
+# ---------------------------------------------------------------------------
+
+def test_sync_check_mode_reports_would_change_and_does_not_mutate(empty_state, capsys):
+    state_dir, roadmap = empty_state
+    rc = planning_cli.main([
+        "objective", "sync", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--roadmap", str(roadmap), "--json",
+    ])
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["apply"] is False
+    assert set(report["created"]) == {"feat-a", "feat-b", "feat-c"}
+    # CHECK mode must not write anything.
+    assert tracks_lib.list_tracks(state_dir, "vnx-dev") == []
+
+
+def test_sync_apply_mutates_then_idempotent(empty_state, capsys):
+    state_dir, roadmap = empty_state
+    rc = planning_cli.main([
+        "objective", "sync", "--apply", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--roadmap", str(roadmap), "--json",
+    ])
+    assert rc == 0
+    first = json.loads(capsys.readouterr().out)
+    assert set(first["created"]) == {"feat-a", "feat-b", "feat-c"}
+    seeded = {t["track_id"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    assert seeded == {"feat-a", "feat-b", "feat-c"}
+
+    # Second --apply is a no-op (idempotent): nothing created/updated.
+    rc = planning_cli.main([
+        "objective", "sync", "--apply", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--roadmap", str(roadmap), "--json",
+    ])
+    assert rc == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second["created"] == []
+    assert second["updated"] == []
+    assert set(second["unchanged"]) == {"feat-a", "feat-b", "feat-c"}
+
+
+def test_sync_missing_roadmap_returns_nonzero(empty_state, capsys):
+    state_dir, _ = empty_state
+    rc = planning_cli.main([
+        "objective", "sync", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--roadmap", str(state_dir / "nope.yaml"),
+    ])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — flag-gated auto-seed prelude hook
+# ---------------------------------------------------------------------------
+
+def test_auto_seed_unset_is_noop(empty_state):
+    state_dir, roadmap = empty_state
+    result = planning_cli.maybe_auto_seed(
+        state_dir=state_dir, roadmap_path=roadmap, project_id="vnx-dev",
+        env={},  # VNX_AUTO_SEED_TRACKS unset
+    )
+    assert result["skipped"] is True
+    # No mutation when disabled.
+    assert tracks_lib.list_tracks(state_dir, "vnx-dev") == []
+
+
+def test_auto_seed_enabled_runs_sync_apply(empty_state):
+    state_dir, roadmap = empty_state
+    result = planning_cli.maybe_auto_seed(
+        state_dir=state_dir, roadmap_path=roadmap, project_id="vnx-dev",
+        env={"VNX_AUTO_SEED_TRACKS": "1"},
+    )
+    assert result["skipped"] is False
+    assert result["summary"]["created"] == 3
+    seeded = {t["track_id"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    assert seeded == {"feat-a", "feat-b", "feat-c"}
+
+
+def test_auto_seed_enabled_calls_seeder_with_apply_true(empty_state, monkeypatch):
+    state_dir, roadmap = empty_state
+    calls: list[dict] = []
+
+    def _spy(s_dir, r_path, project_id, *, apply=False):
+        calls.append({"apply": apply, "project_id": project_id})
+        return {"summary": {"created": 0, "updated": 0, "unchanged": 0,
+                            "phase_drift": 0, "orphan": 0}}
+
+    monkeypatch.setattr(planning_cli.seeder, "seed", _spy)
+    planning_cli.maybe_auto_seed(
+        state_dir=state_dir, roadmap_path=roadmap, project_id="vnx-dev",
+        env={"VNX_AUTO_SEED_TRACKS": "1"},
+    )
+    assert calls == [{"apply": True, "project_id": "vnx-dev"}]
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — advisory drift-gate
+# ---------------------------------------------------------------------------
+
+def test_drift_reports_divergent_and_writes_state_file(seeded_state, capsys):
+    state_dir, _ = seeded_state
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--json",
+    ])
+    # Advisory: exit 0 even though divergence > 0.
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["divergent_count"] >= 1
+    ids = {d["track_id"] for d in summary["divergent"]}
+    # feat-b declared 'done' but blocked by unmet dependency feat-a.
+    assert "feat-b" in ids
+    feat_b = next(d for d in summary["divergent"] if d["track_id"] == "feat-b")
+    assert feat_b["declared_phase"] == "done"
+    assert feat_b["derived_status"] == "blocked"
+    assert "feat-a" in feat_b["reason"]
+    assert "linkage backfill" in summary["note"]
+
+    # State file written atomically for the dashboard / T0.
+    drift_path = state_dir / "planning_drift.json"
+    assert drift_path.exists()
+    on_disk = json.loads(drift_path.read_text(encoding="utf-8"))
+    assert on_disk["divergent_count"] == summary["divergent_count"]
+
+
+def test_drift_exit_zero_when_divergent(seeded_state):
+    state_dir, _ = seeded_state
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+
+
+def test_drift_never_writes_roadmap_or_calls_seeder(seeded_state, monkeypatch):
+    state_dir, roadmap = seeded_state
+    before_roadmap = roadmap.read_text(encoding="utf-8")
+    before_phases = {
+        t["track_id"]: t["phase"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")
+    }
+
+    # Drift must never reach any seeder write-path.
+    def _boom(*a, **k):
+        raise AssertionError("drift must not invoke the ROADMAP->tracks seeder")
+
+    monkeypatch.setattr(planning_cli.seeder, "seed", _boom)
+
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--json",
+    ])
+    assert rc == 0
+
+    # ROADMAP file untouched.
+    assert roadmap.read_text(encoding="utf-8") == before_roadmap
+    # Declared phases untouched (reconciler writes only derived_status).
+    after_phases = {
+        t["track_id"]: t["phase"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")
+    }
+    assert after_phases == before_phases

--- a/tests/test_planning_turnon.py
+++ b/tests/test_planning_turnon.py
@@ -257,6 +257,28 @@ def test_drift_exit_zero_when_divergent(seeded_state):
     assert rc == 0
 
 
+def test_drift_exit_zero_and_stdout_even_when_state_write_fails(seeded_state, monkeypatch, capsys):
+    """Advisory contract: drift must exit 0 and emit its report even if the
+    planning_drift.json write fails (permissions error, disk full, etc.)."""
+    state_dir, _ = seeded_state
+
+    def _raise(*_a, **_kw):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(planning_cli, "_atomic_write_json", _raise)
+
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--json",
+    ])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    summary = json.loads(out)
+    assert "divergent_count" in summary
+    assert "total_tracks" in summary
+
+
 def test_drift_never_writes_roadmap_or_calls_seeder(seeded_state, monkeypatch):
     state_dir, roadmap = seeded_state
     before_roadmap = roadmap.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Turns on the planning layer by wiring the already-shipped primitives together — no projection or reconciliation logic was rebuilt.

- **`vnx objective sync`** — re-projects `ROADMAP.yaml` -> tracks via the existing idempotent seeder (`seed_tracks_from_roadmap`). Default is CHECK/dry-run (reports the would-change set, writes nothing, `+ --json`). `--apply` runs the idempotent projection. It **does NOT write ROADMAP.yaml** and **does NOT promote deliverables** — the human gate is preserved.
- **Opt-in auto-seed in the runtime prelude** — `maybe_auto_seed()` + `_maybe_auto_seed_tracks` wired into the dispatcher prelude (where `lease_sweep` is ticked). When `VNX_AUTO_SEED_TRACKS=1`, runs `sync --apply` once per prelude tick (best-effort, non-blocking, logged). Default (unset) = no behavior change. Never writes ROADMAP / never auto-promotes.
- **`vnx objective drift`** — ADVISORY drift-gate. Runs the existing `reconcile_all_tracks` and reports tracks where declared phase != `derived_status`, with a per-track reason (`blocked by dependency` / `no linked dispatch/PR evidence` / etc.). Always **exits 0** (planning signal, not a CI gate) and writes `$VNX_STATE_DIR/planning_drift.json` atomically for the dashboard / T0. Output carries a note that many initial divergences are historical dispatches not yet linked to tracks (linkage backfill is a separate step).
- **Dashboard** — `dashboard/api_planning.py` surfaces `planning_drift.json` as a read-only `"drift"` advisory key on `GET /api/operator/planning`.

## Reuse, not rebuild

`seeder.seed()` and `track_reconciler.reconcile_all_tracks()` are imported and called as-is. The reconciler writes only `tracks.derived_status` (never `phase`, never ROADMAP); the seeder is idempotent and never writes ROADMAP.

## Tests

`tests/test_planning_turnon.py` — 9 tests, all against temp DBs/fixtures (never the live `.vnx-data` DB):

- `objective sync` CHECK reports would-change + mutates nothing; `--apply` mutates then is idempotent (2nd apply = no-op); missing ROADMAP -> exit 1.
- auto-seed hook: unset -> no-op; `=1` -> seeds (temp-DB mutation) **and** asserts `seeder.seed(..., apply=True)` via monkeypatch.
- `objective drift` reports the divergent set + writes `planning_drift.json`, exits 0 with divergence > 0, and never reaches any ROADMAP-write path (ROADMAP file + declared phases unchanged).

```
python3 -m pytest tests/test_planning_turnon.py -q          # 9 passed
python3 -m pytest tests/test_planning_cli_objective.py \
  tests/test_planning_deliverables.py \
  tests/test_docs_command_validation.py -q                  # 27 passed
python3 -m pytest tests/test_track_reconciler.py -q         # 17 passed
bash -n scripts/dispatcher_minimal.sh scripts/lib/dispatcher_supervisor_ticks.sh
```

## Notes

- `vnx_mode.py` tiers unchanged: `objective` is already in `TIER_STARTER_OPERATOR`; `sync`/`drift` are sub-actions of that branch, so `test_bin_commands_covered_by_mode_tiers` stays green (it inspects top-level `bin/vnx` case branches). Adding bare `sync`/`drift` tier strings would break tier disjointness.
- `bin/vnx` not modified — the existing `objective) planning_cli.py objective "$@"` branch already routes the new sub-actions.

Dispatch-ID: 20260602-174958-planning-turnon

🤖 Generated with [Claude Code](https://claude.com/claude-code)