### PR TITLE
fix(reconciler): derive done from track.pr_ref + merged-state (decouple from legacy A/B/C dispatch.track join)

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -22,10 +22,11 @@ ADR-007: all queries are (track_id, project_id)-scoped.
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +36,77 @@ TERMINAL_DISPATCH_STATES = frozenset({"completed", "expired", "dead_letter"})
 IN_FLIGHT_DISPATCH_STATES = frozenset({
     "queued", "claimed", "delivering", "accepted", "running", "active",
 })
+
+
+def _parse_pr_number(pr_ref: Optional[str]) -> Optional[int]:
+    """Parse '#756', '756', or '  #42  ' -> integer. Returns None on failure."""
+    if not pr_ref:
+        return None
+    try:
+        return int(str(pr_ref).strip().lstrip("#").strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_merged_pr_numbers(state_dir: str | Path) -> FrozenSet[int]:
+    """Load confirmed-merged PR numbers from local sources only (no network).
+
+    Sources (all optional; errors silently ignored):
+      1. {state_dir}/../events/pr_merged.ndjson  — ADR-005 event ledger
+      2. {state_dir}/t0_receipts.ndjson           — receipt log
+      3. {state_dir}/../../ROADMAP.yaml           — authoritative feature list
+         pr_queue[*].status=merged entries cover recent PRs not yet in NDJSON files
+
+    Returns frozenset[int] of confirmed-merged PR numbers.
+    Deterministic for a given file state; never calls gh or any network.
+    """
+    merged: set = set()
+    state_path = Path(state_dir)
+
+    # Sources 1 + 2: scan NDJSON files for event_type='pr_merged' records with pr_number
+    ndjson_candidates = [
+        state_path.parent / "events" / "pr_merged.ndjson",
+        state_path / "t0_receipts.ndjson",
+    ]
+    for path in ndjson_candidates:
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                event = rec.get("event_type") or rec.get("event") or ""
+                if event == "pr_merged":
+                    pn = rec.get("pr_number")
+                    if pn is not None:
+                        try:
+                            merged.add(int(pn))
+                        except (TypeError, ValueError):
+                            pass
+        except OSError:
+            pass
+
+    # Source 3: ROADMAP.yaml — authoritative for recent PRs not yet backfilled to NDJSON.
+    # Path: state_dir is .vnx-data/state; ROADMAP.yaml is at project root two levels up.
+    roadmap_path = state_path.parent.parent / "ROADMAP.yaml"
+    try:
+        import yaml  # available in all VNX environments
+        data = yaml.safe_load(roadmap_path.read_text(encoding="utf-8")) or {}
+        for feat in (data.get("features") or []):
+            for pr in (feat.get("pr_queue") or []):
+                if (pr.get("status") or "") == "merged":
+                    pn = _parse_pr_number(pr.get("pr_id"))
+                    if pn is not None:
+                        merged.add(pn)
+    except OSError:
+        pass
+    except Exception:
+        log.debug("_load_merged_pr_numbers: ROADMAP.yaml parse error (non-fatal)", exc_info=True)
+
+    return frozenset(merged)
 
 
 def _get_conn(state_dir: str | Path) -> sqlite3.Connection:
@@ -54,10 +126,17 @@ def _compute_derived_status(
     conn: sqlite3.Connection,
     track_id: str,
     project_id: str,
+    merged_pr_numbers: FrozenSet[int] = frozenset(),
 ) -> str:
     """Compute derived_status for one track. Pure read — writes nothing.
 
     Returns one of: 'done', 'blocked', 'in_progress', 'queued'.
+
+    merged_pr_numbers: confirmed-merged PR numbers from local sources. Used in
+    the additive pr_ref evidence path — derives 'done' for tracks where the
+    dispatch join yields no rows (historical dispatches used 'A'/'B'/'C' track
+    labels instead of feature track_ids). The existing dispatch-based derivation
+    is unchanged; this path only fires when dispatches is empty.
     """
     # 1. Blocker open-item check: any link_type='blocks' row → blocked.
     #    The presence of the link implies the OI is unresolved; removal clears it.
@@ -94,13 +173,28 @@ def _compute_derived_status(
         if row[0] != "done":
             return "blocked"
 
-    # 3. Dispatch state aggregation.
+    # 3. Fetch track's pr_ref once (reused in both the zero-dispatch and all-terminal paths).
+    track_row = conn.execute(
+        "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchone()
+    track_pr_ref = track_row["pr_ref"] if track_row else None
+
+    # 4. Dispatch state aggregation.
     dispatches = conn.execute(
         "SELECT dispatch_id, state FROM dispatches WHERE track = ? AND project_id = ?",
         (track_id, project_id),
     ).fetchall()
 
     if not dispatches:
+        # pr_ref evidence path: covers tracks with no matching dispatches.
+        # Historical dispatches stored 'A'/'B'/'C' in the track column instead of
+        # feature track_ids, so the join above is empty for all pre-1.0 tracks.
+        # If the track's own pr_ref is confirmed merged via local evidence (NDJSON
+        # ledger or ROADMAP.yaml), derive 'done' without a dispatch match.
+        pr_num = _parse_pr_number(track_pr_ref)
+        if pr_num is not None and pr_num in merged_pr_numbers:
+            return "done"
         return "queued"
 
     states = [d[0] for d in dispatches]  # d is (dispatch_id, state); note row_factory gives dict
@@ -111,12 +205,6 @@ def _compute_derived_status(
     all_terminal = all(s in TERMINAL_DISPATCH_STATES for s in state_values)
 
     if all_terminal:
-        track_row = conn.execute(
-            "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
-            (track_id, project_id),
-        ).fetchone()
-        track_pr_ref = track_row["pr_ref"] if track_row else None
-
         if not track_pr_ref:
             # No PR to verify — all work terminal → done.
             return "done"
@@ -176,6 +264,8 @@ def reconcile_track(
     state_dir: str | Path,
     track_id: str,
     project_id: str,
+    *,
+    _merged_pr_numbers: Optional[FrozenSet[int]] = None,
 ) -> Dict[str, Any]:
     """Compute and persist derived_status for a single track.
 
@@ -184,6 +274,10 @@ def reconcile_track(
 
     Raises RuntimeError if derived_status column is absent (migration 0028
     must be applied first).
+
+    _merged_pr_numbers: internal kwarg — pre-loaded merged PR set. When None,
+    _load_merged_pr_numbers(state_dir) is called. Pass a pre-loaded set when
+    calling from reconcile_all_tracks to avoid per-track file I/O.
     """
     conn = _get_conn(state_dir)
     try:
@@ -192,7 +286,12 @@ def reconcile_track(
                 "tracks.derived_status column absent; apply migration 0028 first."
             )
 
-        derived = _compute_derived_status(conn, track_id, project_id)
+        merged = (
+            _merged_pr_numbers
+            if _merged_pr_numbers is not None
+            else _load_merged_pr_numbers(state_dir)
+        )
+        derived = _compute_derived_status(conn, track_id, project_id, merged)
         _write_derived_status(conn, track_id, project_id, derived)
         conn.commit()
 
@@ -242,9 +341,14 @@ def reconcile_all_tracks(
     finally:
         conn.close()
 
+    merged_pr_numbers = _load_merged_pr_numbers(state_dir)
+
     results = []
     for track_id in track_ids:
-        result = reconcile_track(state_dir, track_id, project_id)
+        result = reconcile_track(
+            state_dir, track_id, project_id,
+            _merged_pr_numbers=merged_pr_numbers,
+        )
         results.append(result)
         log.debug(
             "reconciled track=%s derived=%s declared=%s drift=%s",

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -1,0 +1,465 @@
+"""tests/test_track_reconciler_prref_evidence.py — pr_ref+merged evidence path tests.
+
+Verifies the additive pr_ref evidence path added in feat/reconciler-prref-evidence:
+
+- A track with pr_ref + merged evidence derives 'done' with ZERO matching dispatches
+- A track with pr_ref but PR not merged stays 'queued' (no dispatch match)
+- Idempotent re-run of the pr_ref path
+- Determinism: two runs over identical state produce identical derived_status
+- Dispatch-based path not regressed (tracks WITH matching dispatches still use it)
+- _load_merged_pr_numbers reads from pr_merged.ndjson (NDJSON source)
+- _load_merged_pr_numbers reads from ROADMAP.yaml (YAML source)
+- _load_merged_pr_numbers returns empty frozenset when no files exist (graceful)
+- _parse_pr_number handles '#N', 'N', None, and malformed inputs
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration
+import track_reconciler
+from track_reconciler import _load_merged_pr_numbers, _parse_pr_number
+import tracks as tracks_lib
+
+
+PROJECT_ID = "test-ev-proj"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (same pattern as test_track_reconciler.py)
+# ---------------------------------------------------------------------------
+
+def _build_db(tmp_path: Path, *, deep: bool = False) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 + 0027 + 0028 applied.
+
+    deep=True uses tmp_path/.vnx-data/state so that state_dir.parent.parent == tmp_path,
+    matching the real project structure and allowing ROADMAP.yaml at tmp_path/ROADMAP.yaml.
+    """
+    if deep:
+        state_dir = tmp_path / ".vnx-data" / "state"
+    else:
+        state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch',
+            entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+    """)
+    conn.commit()
+
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn, 27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn, 28,
+        (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _seed_track(state_dir: Path, track_id: str, *, phase: str = "active", pr_ref: str | None = None) -> None:
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID,
+        title=f"Track {track_id}",
+        goal_state=f"ship {track_id}",
+        phase=phase,
+        pr_ref=pr_ref,
+    )
+
+
+def _seed_dispatch(state_dir: Path, dispatch_id: str, track_id: str, *, state: str = "completed") -> None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?,?,?,?)",
+        (dispatch_id, PROJECT_ID, state, track_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _get_derived(state_dir: Path, track_id: str) -> str | None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT derived_status FROM tracks WHERE track_id=? AND project_id=?",
+        (track_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return row["derived_status"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# _parse_pr_number
+# ---------------------------------------------------------------------------
+
+def test_parse_pr_number_hash_prefix():
+    assert _parse_pr_number("#756") == 756
+
+
+def test_parse_pr_number_bare_number():
+    assert _parse_pr_number("801") == 801
+
+
+def test_parse_pr_number_none():
+    assert _parse_pr_number(None) is None
+
+
+def test_parse_pr_number_empty():
+    assert _parse_pr_number("") is None
+
+
+def test_parse_pr_number_malformed():
+    assert _parse_pr_number("PR-FUT-1") is None
+
+
+def test_parse_pr_number_whitespace():
+    assert _parse_pr_number("  #42  ") == 42
+
+
+# ---------------------------------------------------------------------------
+# _load_merged_pr_numbers
+# ---------------------------------------------------------------------------
+
+def test_load_merged_empty_when_no_files(tmp_path):
+    """Returns empty frozenset when no NDJSON or ROADMAP.yaml exist."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    result = _load_merged_pr_numbers(state_dir)
+    assert result == frozenset()
+
+
+def test_load_merged_from_pr_merged_ndjson(tmp_path):
+    """Reads pr_number from pr_merged.ndjson."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    events_dir = tmp_path / "events"
+    events_dir.mkdir(parents=True)
+    ndjson = events_dir / "pr_merged.ndjson"
+    ndjson.write_text(
+        json.dumps({"event_type": "pr_merged", "pr_number": 756}) + "\n"
+        + json.dumps({"event_type": "pr_merged", "pr_number": 759}) + "\n"
+        + json.dumps({"event_type": "other", "pr_number": 999}) + "\n",
+        encoding="utf-8",
+    )
+    result = _load_merged_pr_numbers(state_dir)
+    assert 756 in result
+    assert 759 in result
+    assert 999 not in result
+
+
+def test_load_merged_from_roadmap_yaml(tmp_path):
+    """Reads pr_queue[*].status=merged entries from ROADMAP.yaml."""
+    # state_dir must be two levels deep so state_dir.parent.parent == tmp_path
+    state_dir = tmp_path / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(
+        "features:\n"
+        "  - feature_id: feat-a\n"
+        "    pr_queue:\n"
+        "      - pr_id: '#800'\n"
+        "        status: merged\n"
+        "      - pr_id: '#801'\n"
+        "        status: open\n"
+        "  - feature_id: feat-b\n"
+        "    pr_queue:\n"
+        "      - pr_id: '#802'\n"
+        "        status: merged\n",
+        encoding="utf-8",
+    )
+    result = _load_merged_pr_numbers(state_dir)
+    assert 800 in result
+    assert 802 in result
+    assert 801 not in result  # status=open, not merged
+
+
+def test_load_merged_combines_sources(tmp_path):
+    """Merges PR numbers from both NDJSON and ROADMAP.yaml."""
+    state_dir = tmp_path / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    events_dir = tmp_path / ".vnx-data" / "events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "pr_merged.ndjson").write_text(
+        json.dumps({"event_type": "pr_merged", "pr_number": 676}) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "ROADMAP.yaml").write_text(
+        "features:\n  - feature_id: f\n    pr_queue:\n      - pr_id: '#757'\n        status: merged\n",
+        encoding="utf-8",
+    )
+    result = _load_merged_pr_numbers(state_dir)
+    assert 676 in result
+    assert 757 in result
+
+
+def test_load_merged_graceful_on_bad_ndjson(tmp_path):
+    """Skips malformed NDJSON lines without raising."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    events_dir = tmp_path / "events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "pr_merged.ndjson").write_text(
+        "NOT JSON\n"
+        + json.dumps({"event_type": "pr_merged", "pr_number": 500}) + "\n",
+        encoding="utf-8",
+    )
+    result = _load_merged_pr_numbers(state_dir)
+    assert 500 in result  # valid line still parsed
+
+
+# ---------------------------------------------------------------------------
+# Core evidence path: zero-dispatch tracks
+# ---------------------------------------------------------------------------
+
+def test_done_when_pr_ref_merged_zero_dispatches(tmp_path):
+    """A track with pr_ref + merged evidence and NO dispatches derives 'done'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-done", pr_ref="#756")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-done", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756}),
+    )
+    assert result["derived_status"] == "done"
+    assert _get_derived(state_dir, "T-ev-done") == "done"
+
+
+def test_queued_when_pr_ref_not_in_merged_set(tmp_path):
+    """A track with pr_ref but PR not in merged set stays 'queued' (no dispatch)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-queued", pr_ref="#999")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-queued", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756}),  # 999 not in set
+    )
+    assert result["derived_status"] == "queued"
+
+
+def test_queued_when_no_pr_ref_and_no_dispatches(tmp_path):
+    """A track with no pr_ref and no dispatches stays 'queued'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-nopr", pr_ref=None)
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-nopr", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756, 757, 758}),
+    )
+    assert result["derived_status"] == "queued"
+
+
+def test_queued_when_merged_set_empty_and_no_dispatches(tmp_path):
+    """A track with pr_ref but empty merged set stays 'queued'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-empty", pr_ref="#756")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-empty", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
+    )
+    assert result["derived_status"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency and determinism
+# ---------------------------------------------------------------------------
+
+def test_idempotent_prref_evidence_path(tmp_path):
+    """Running reconcile_track twice produces the same result for the pr_ref path."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-idem", pr_ref="#800")
+
+    r1 = track_reconciler.reconcile_track(
+        state_dir, "T-ev-idem", PROJECT_ID,
+        _merged_pr_numbers=frozenset({800}),
+    )
+    r2 = track_reconciler.reconcile_track(
+        state_dir, "T-ev-idem", PROJECT_ID,
+        _merged_pr_numbers=frozenset({800}),
+    )
+    assert r1["derived_status"] == "done"
+    assert r2["derived_status"] == "done"
+
+
+def test_determinism_same_state_same_result(tmp_path):
+    """Two reconcile calls with identical DB state produce identical derived_status."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-det-1", pr_ref="#750")
+    _seed_track(state_dir, "T-det-2", pr_ref="#751")
+
+    merged = frozenset({750, 751})
+    r_a1 = track_reconciler.reconcile_track(state_dir, "T-det-1", PROJECT_ID, _merged_pr_numbers=merged)
+    r_a2 = track_reconciler.reconcile_track(state_dir, "T-det-1", PROJECT_ID, _merged_pr_numbers=merged)
+    r_b1 = track_reconciler.reconcile_track(state_dir, "T-det-2", PROJECT_ID, _merged_pr_numbers=merged)
+    r_b2 = track_reconciler.reconcile_track(state_dir, "T-det-2", PROJECT_ID, _merged_pr_numbers=merged)
+
+    assert r_a1["derived_status"] == r_a2["derived_status"] == "done"
+    assert r_b1["derived_status"] == r_b2["derived_status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# No regression: dispatch-based path still works
+# ---------------------------------------------------------------------------
+
+def test_dispatch_path_not_regressed_active_dispatch(tmp_path):
+    """A track WITH an active dispatch still uses the dispatch path (in_progress)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-reg-active", pr_ref="#900")
+    _seed_dispatch(state_dir, "D-reg-1", "T-reg-active", state="running")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-reg-active", PROJECT_ID,
+        _merged_pr_numbers=frozenset({900}),  # PR in merged set, but dispatch active
+    )
+    # Dispatch active → in_progress (dispatch path wins when dispatches exist)
+    assert result["derived_status"] == "in_progress"
+
+
+def test_dispatch_path_not_regressed_terminal_no_pr_ref(tmp_path):
+    """A track with terminal dispatch and no pr_ref still derives 'done' via dispatch path."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-reg-nopr", pr_ref=None)
+    _seed_dispatch(state_dir, "D-reg-2", "T-reg-nopr", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-reg-nopr", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_dispatch_path_not_regressed_in_progress_pr(tmp_path):
+    """A track with terminal dispatch + pr_ref but no merged event stays 'in_progress'."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-reg-inprog", pr_ref="#910")
+    _seed_dispatch(state_dir, "D-reg-3", "T-reg-inprog", state="completed")
+
+    # PR 910 NOT in merged set; no coordination_event → in_progress
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-reg-inprog", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756}),  # 910 not present
+    )
+    assert result["derived_status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# reconcile_all_tracks with evidence
+# ---------------------------------------------------------------------------
+
+def test_reconcile_all_tracks_prref_evidence(tmp_path):
+    """reconcile_all_tracks correctly applies pr_ref evidence to all tracks."""
+    state_dir = _build_db(tmp_path, deep=True)
+    # Track with pr_ref + merged: should derive 'done'
+    _seed_track(state_dir, "T-all-a", pr_ref="#756")
+    # Track with pr_ref, not merged: should stay 'queued'
+    _seed_track(state_dir, "T-all-b", pr_ref="#999")
+    # Track with no pr_ref, no dispatches: stays 'queued'
+    _seed_track(state_dir, "T-all-c", pr_ref=None)
+    # Track with dispatch (no pr_ref match): dispatch path
+    _seed_track(state_dir, "T-all-d", pr_ref=None)
+    _seed_dispatch(state_dir, "D-all-d", "T-all-d", state="running")
+
+    # ROADMAP.yaml at project root (state_dir.parent.parent == tmp_path for deep=True)
+    (tmp_path / "ROADMAP.yaml").write_text(
+        "features:\n  - feature_id: f\n    pr_queue:\n      - pr_id: '#756'\n        status: merged\n",
+        encoding="utf-8",
+    )
+
+    results = track_reconciler.reconcile_all_tracks(state_dir, PROJECT_ID)
+    by_id = {r["track_id"]: r for r in results}
+
+    assert by_id["T-all-a"]["derived_status"] == "done"
+    assert by_id["T-all-b"]["derived_status"] == "queued"
+    assert by_id["T-all-c"]["derived_status"] == "queued"
+    assert by_id["T-all-d"]["derived_status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# authoritative phase never modified
+# ---------------------------------------------------------------------------
+
+def test_phase_never_modified_by_prref_path(tmp_path):
+    """The reconciler must not touch tracks.phase even via the pr_ref evidence path."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-phase-guard", phase="done", pr_ref="#756")
+
+    before_phase = "done"
+    track_reconciler.reconcile_track(
+        state_dir, "T-phase-guard", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756}),
+    )
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT phase, derived_status FROM tracks WHERE track_id=? AND project_id=?",
+        ("T-phase-guard", PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    assert row["phase"] == before_phase
+    assert row["derived_status"] == "done"


### PR DESCRIPTION
## Summary

- **Root cause**: `_compute_derived_status` queries `dispatches WHERE track = <track_id>`, but historical dispatches stored `'A'`/`'B'`/`'C'` in `track` instead of feature track IDs. The join returns nothing for all 36 tracks → every track derives `'queued'` despite most being done.
- **Fix**: Adds an additive pr_ref evidence path. Before the `if not dispatches: return 'queued'` early return, check if the track's own `pr_ref` is confirmed merged via local sources. If yes → derive `'done'`. Fires only when the dispatch join returns nothing; the existing dispatch-based path is untouched.
- **Evidence sources** (all optional, graceful on missing files): `pr_merged.ndjson` (ADR-005 NDJSON ledger), `t0_receipts.ndjson`, and `ROADMAP.yaml` (`pr_queue[*].status=merged`) which is the authoritative source for the 1.0 launch PRs (#751, #756–#794) not yet backfilled to NDJSON.

## Preserved invariants
- Pure read — writes only `derived_status`, never `tracks.phase`, never `ROADMAP.yaml`
- Idempotent and deterministic: same DB+file state → same derived_status
- No network calls — all sources are local files
- Terminal states irreversible; active-dispatch tracks still use the dispatch path
- `reconcile_all_tracks` loads merged set once (no per-track file I/O)

## New API
- `_parse_pr_number(pr_ref)`: `'#756'` → `756`
- `_load_merged_pr_numbers(state_dir)`: returns `frozenset[int]` from 3 local sources
- `reconcile_track` gains internal `_merged_pr_numbers` kwarg for batch efficiency

## Test plan
- [x] 17 existing `test_track_reconciler.py` tests pass (no regressions)
- [x] 22 new tests in `tests/test_track_reconciler_prref_evidence.py`:
  - `_parse_pr_number` edge cases (hash prefix, bare number, None, malformed, whitespace)
  - `_load_merged_pr_numbers` from NDJSON, ROADMAP.yaml, combined, missing files, bad NDJSON
  - Zero-dispatch track with pr_ref + merged evidence → `done`
  - Zero-dispatch track with pr_ref not in merged set → `queued`
  - Idempotent re-run, determinism across two runs
  - Active dispatch still → `in_progress` (dispatch path not regressed)
  - `reconcile_all_tracks` applies evidence to all tracks
  - `tracks.phase` never modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)