### PR TITLE
feat(tracks): track_type + next_action_owner discriminator (additive, SQLite, 1.0.1)

### DIFF
--- a/schemas/migrations/0029_track_type_discriminator.sql
+++ b/schemas/migrations/0029_track_type_discriminator.sql
@@ -1,0 +1,61 @@
+-- VNX Migration 0029 — tracks.track_type + tracks.next_action_owner
+--
+-- Purpose: VNX 1.0.1 additive columns for the cross-T0 backbone+tracks
+--          coordination (business-backbone-SYNTHESE-2026-06-03).
+--          VNX owns the generic columns; MC owns client reconcilers +
+--          track_events + knowledge_index (separate scope).
+--
+-- Plan-path: ~/Desktop/BUSINESS/development/mission-control/claudedocs/research/
+--            vnx-track-type-spec-input.md
+--
+-- track_type semantics:
+--   coding       = PR/feature lifecycle (planned -> merged -> done)
+--   content      = editorial flow (idea -> published -> archived)
+--   deal         = commercial pipeline (lead -> won/lost/stalled)
+--   relationship = ongoing relation without terminal state (cyclical)
+--
+-- next_action_owner semantics:
+--   me       = Vincent has the ball
+--   client   = client/counterpart has the ball (silence = green for deals)
+--   waiting  = blocked on third party
+--   NULL     = unknown / not applicable
+--
+-- ADR-007: additive only — no new table, composite PK (track_id, project_id)
+--          is preserved, no table rebuild required.
+--
+-- SQLite compatibility: CHECK on ALTER TABLE ADD COLUMN is supported since
+--   SQLite 3.31.0 (2020-01-22) when the CHECK references only the new column.
+--   Both constraints here reference only their own column.
+--   NOT NULL + DEFAULT 'coding' is safe on ADD COLUMN (DEFAULT fills existing rows).
+--
+-- Idempotency: apply_script_if_below skips when user_version >= 29.
+--   Preflight hook in migrate_future_system.py also guards column presence.
+--
+-- 1.1 deferred: governance-profile mapping (track_type_profile_map) +
+--   GOVERN-path wiring deferred to V3 after V1 selector-activation.
+--
+-- Applied by: scripts/migrate_future_system.py
+-- Tested by:  tests/test_migration_track_type.py
+
+-- ============================================================================
+-- STEP 1: tracks.track_type — lifecycle discriminator
+-- ============================================================================
+
+ALTER TABLE tracks ADD COLUMN track_type TEXT NOT NULL DEFAULT 'coding'
+    CHECK (track_type IN ('coding', 'content', 'deal', 'relationship'));
+
+-- ============================================================================
+-- STEP 2: tracks.next_action_owner — current ownership signal
+-- ============================================================================
+
+ALTER TABLE tracks ADD COLUMN next_action_owner TEXT
+    CHECK (next_action_owner IN ('me', 'client', 'waiting') OR next_action_owner IS NULL);
+
+-- ============================================================================
+-- STEP 3: index for track_type queries per project
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_tracks_track_type
+    ON tracks(project_id, track_type);
+
+PRAGMA user_version = 29;

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -8,6 +8,10 @@ Steps:
   4. Apply schemas/migrations/0024_tracks_tenant_scoping.sql (idempotent via user_version)
   5. PRAGMA pre-flight: assert tracks composite-key schema intact before adding horizon
   6. Apply schemas/migrations/0027_planning_horizon_and_deliverable_view.sql (idempotent)
+  7. PRAGMA pre-flight: assert tracks has horizon (v27) before adding derived_status
+  8. Apply schemas/migrations/0028_tracks_derived_status.sql (idempotent)
+  9. PRAGMA pre-flight: assert tracks has derived_status (v28) before adding track_type
+  10. Apply schemas/migrations/0029_track_type_discriminator.sql (idempotent)
 """
 
 from __future__ import annotations
@@ -432,11 +436,56 @@ def apply_migration_v28(conn: sqlite3.Connection, project_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 8: preflight + apply 0029 migration (tracks.track_type + next_action_owner)
+# ---------------------------------------------------------------------------
+
+def _assert_tracks_v28_intact(conn: sqlite3.Connection) -> None:
+    """Assert tracks has derived_status (v28 state) before adding track_type.
+
+    Also guards against double-apply by rejecting if track_type already exists.
+    Column-presence check via PRAGMA table_info provides a secondary idempotency
+    guard beyond the user_version check in apply_script_if_below.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info('tracks')")}
+    if "derived_status" not in cols:
+        raise RuntimeError(
+            "tracks missing 'derived_status' column (from 0028). "
+            "Run migration 0028 before 0029."
+        )
+    if "track_type" in cols:
+        raise RuntimeError(
+            "tracks already has 'track_type' column. Migration 0029 should be "
+            "skipped (user_version should be >= 29)."
+        )
+
+
+schema_migration.register_preflight(29, _assert_tracks_v28_intact)
+
+
+def apply_migration_v29(conn: sqlite3.Connection, project_root: Path) -> None:
+    migration_path = _MIGRATIONS / "0029_track_type_discriminator.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    sql = migration_path.read_text(encoding="utf-8")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 29:
+        print(f"  [skip] migration 0029 already applied (user_version={current_version})")
+        return
+
+    _assert_tracks_v28_intact(conn)
+    print("  [apply] migration 0029_track_type_discriminator.sql ...")
+    schema_migration.apply_script_if_below(conn, 29, sql)
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def run(project_root: Path | None = None) -> None:
-    """Apply track layer migrations: 0022, 0024, 0027, 0028."""
+    """Apply track layer migrations: 0022, 0024, 0027, 0028, 0029."""
     if project_root is None:
         project_root = resolve_project_root(__file__)
 
@@ -476,6 +525,10 @@ def run(project_root: Path | None = None) -> None:
 
         # Apply 0028 — additive: tracks.derived_status advisory column
         apply_migration_v28(conn, project_root)
+        conn.commit()
+
+        # Apply 0029 — additive: tracks.track_type + tracks.next_action_owner
+        apply_migration_v29(conn, project_root)
         conn.commit()
 
         print(f"\n  Migration complete. Schema at user_version={schema_migration.get_user_version(conn)}.\n")

--- a/tests/test_migration_track_type.py
+++ b/tests/test_migration_track_type.py
@@ -1,0 +1,372 @@
+"""tests/test_migration_track_type.py — migration 0029 validation.
+
+Verifies:
+- 0029 applies cleanly on a v28-equivalent DB
+- tracks.track_type added with CHECK IN ('coding','content','deal','relationship')
+- track_type defaults to 'coding' for all pre-existing rows (no data impact)
+- tracks.next_action_owner added (nullable, CHECK on valid values or NULL)
+- migration is idempotent (second apply is a no-op, version unchanged)
+- row count preserved before and after migration
+- PRAGMA integrity_check passes after migration
+- invalid track_type value rejected (CHECK constraint or DAL enforcement)
+- invalid next_action_owner value rejected
+- preflight rejects double-apply (column already present)
+
+All tests use temporary DBs only — the live .vnx-data DB is never touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_MIGRATIONS = Path(__file__).resolve().parent.parent / "schemas" / "migrations"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import schema_migration
+import migrate_future_system  # noqa: F401 — registers preflight hooks for v29
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cols(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def _base_v28_db(tmp_path: Path) -> sqlite3.Connection:
+    """Build a DB in the v28-equivalent state (0022+0024+0027+0028 applied).
+
+    Mirrors the _base_v26_db pattern from test_migrate_0027_planning_horizon:
+    - dispatches starts WITHOUT output_ref/output_kind (preflight v22 rejects extras)
+    - 0022+0024 applied normally
+    - output_ref/output_kind added manually (mirrors structural-doctor) at v26
+    - 0027+0028 applied via apply_script_if_below
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 22, (_MIGRATIONS / "0022_track_layer.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 24, (_MIGRATIONS / "0024_tracks_tenant_scoping.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    # Mirror structural-doctor additions present in the live v26 DB.
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 28,
+        (_MIGRATIONS / "0028_tracks_derived_status.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    return conn
+
+
+def _apply_0029(conn: sqlite3.Connection) -> bool:
+    sql = (_MIGRATIONS / "0029_track_type_discriminator.sql").read_text(encoding="utf-8")
+    applied = schema_migration.apply_script_if_below(conn, 29, sql)
+    conn.commit()
+    return applied
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic application
+# ---------------------------------------------------------------------------
+
+def test_0029_applies_and_bumps_version(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    assert schema_migration.get_user_version(conn) == 28
+    assert _apply_0029(conn) is True
+    assert schema_migration.get_user_version(conn) == 29
+
+
+def test_track_type_column_added(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    assert "track_type" in _cols(conn, "tracks")
+
+
+def test_next_action_owner_column_added(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    assert "next_action_owner" in _cols(conn, "tracks")
+
+
+# ---------------------------------------------------------------------------
+# Tests: default value and existing row preservation
+# ---------------------------------------------------------------------------
+
+def test_track_type_defaults_to_coding_on_existing_rows(tmp_path):
+    """Existing rows get track_type='coding' from the DEFAULT — no data impact."""
+    conn = _base_v28_db(tmp_path)
+    # Seed three rows BEFORE migration.
+    conn.executemany(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) VALUES (?, ?, ?, ?)",
+        [
+            ("t1", "vnx-dev", "Alpha", "goal-a"),
+            ("t2", "vnx-dev", "Beta", "goal-b"),
+            ("t3", "proj-x", "Gamma", "goal-c"),
+        ],
+    )
+    conn.commit()
+    count_before = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_before == 3
+
+    _apply_0029(conn)
+
+    count_after = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_after == count_before, "Row count must be unchanged after migration"
+
+    # All pre-existing rows have track_type='coding'.
+    coding_count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE track_type = 'coding'"
+    ).fetchone()[0]
+    assert coding_count == 3
+
+    # next_action_owner is NULL for all pre-existing rows (no DEFAULT).
+    null_count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE next_action_owner IS NULL"
+    ).fetchone()[0]
+    assert null_count == 3
+
+
+def test_rowcount_preserved_with_empty_tracks(tmp_path):
+    """Edge case: migration on a DB with zero tracks rows."""
+    conn = _base_v28_db(tmp_path)
+    count_before = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    _apply_0029(conn)
+    count_after = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_after == count_before == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: CHECK constraints
+# ---------------------------------------------------------------------------
+
+def test_track_type_accepts_valid_values(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    for i, tt in enumerate(("coding", "content", "deal", "relationship")):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state, track_type) "
+            "VALUES (?, 'vnx-dev', ?, 'g', ?)",
+            (f"t-{i}", f"T{i}", tt),
+        )
+    conn.commit()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE track_type IN ('coding','content','deal','relationship')"
+    ).fetchone()[0]
+    assert count == 4
+
+
+def test_track_type_rejects_invalid_value(tmp_path):
+    """CHECK constraint must reject any value outside the allowed set."""
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state, track_type) "
+            "VALUES ('bad', 'vnx-dev', 'Bad', 'g', 'infrastructure')"
+        )
+
+
+def test_next_action_owner_accepts_valid_values(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    for i, owner in enumerate(("me", "client", "waiting")):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state, next_action_owner) "
+            "VALUES (?, 'vnx-dev', ?, 'g', ?)",
+            (f"o-{i}", f"O{i}", owner),
+        )
+    conn.commit()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE next_action_owner IN ('me','client','waiting')"
+    ).fetchone()[0]
+    assert count == 3
+
+
+def test_next_action_owner_accepts_null(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('null-owner', 'vnx-dev', 'T', 'g')"
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT next_action_owner FROM tracks WHERE track_id='null-owner'"
+    ).fetchone()
+    assert row[0] is None
+
+
+def test_next_action_owner_rejects_invalid_value(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state, next_action_owner) "
+            "VALUES ('bad-owner', 'vnx-dev', 'T', 'g', 'unknown')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: idempotency
+# ---------------------------------------------------------------------------
+
+def test_0029_idempotent(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    assert _apply_0029(conn) is True
+    # Second apply returns False (skipped — version already >= 29).
+    assert _apply_0029(conn) is False
+    assert schema_migration.get_user_version(conn) == 29
+
+
+def test_0029_idempotent_rowcount_stable(tmp_path):
+    """Row count must not change on a second (no-op) apply."""
+    conn = _base_v28_db(tmp_path)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('stable', 'vnx-dev', 'S', 'g')"
+    )
+    conn.commit()
+    _apply_0029(conn)
+    count_after_first = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    _apply_0029(conn)
+    count_after_second = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_after_first == count_after_second == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: integrity and ADR-007 composite key
+# ---------------------------------------------------------------------------
+
+def test_integrity_check_passes(tmp_path):
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, track_type) "
+        "VALUES ('ic-1', 'vnx-dev', 'IC', 'g', 'deal')"
+    )
+    conn.commit()
+    result = conn.execute("PRAGMA integrity_check").fetchall()
+    assert result == [("ok",)]
+
+
+def test_composite_pk_preserved(tmp_path):
+    """ADR-007: PRIMARY KEY (track_id, project_id) must survive the additive migration."""
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    # Duplicate (track_id, project_id) must be rejected.
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('dup', 'vnx-dev', 'A', 'g')"
+    )
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+            "VALUES ('dup', 'vnx-dev', 'B', 'g')"
+        )
+
+
+def test_composite_pk_allows_same_track_id_different_project(tmp_path):
+    """Same track_id in different projects is allowed (multi-tenant scope)."""
+    conn = _base_v28_db(tmp_path)
+    _apply_0029(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('shared-id', 'proj-a', 'A', 'g')"
+    )
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('shared-id', 'proj-b', 'B', 'g')"
+    )
+    conn.commit()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE track_id='shared-id'"
+    ).fetchone()[0]
+    assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: preflight guard
+# ---------------------------------------------------------------------------
+
+def test_preflight_rejects_double_apply(tmp_path):
+    """Preflight must raise if track_type already exists but version < 29 (safety belt)."""
+    conn = _base_v28_db(tmp_path)
+    # Manually add the column WITHOUT bumping user_version — simulates a
+    # partial apply or operator error.
+    conn.execute("ALTER TABLE tracks ADD COLUMN track_type TEXT DEFAULT 'coding'")
+    conn.commit()
+    # The preflight hook must now reject the migration.
+    from migrate_future_system import _assert_tracks_v28_intact
+    with pytest.raises(RuntimeError, match="already has 'track_type'"):
+        _assert_tracks_v28_intact(conn)
+
+
+def test_preflight_rejects_missing_derived_status(tmp_path):
+    """Preflight must reject if v28 prerequisite (derived_status) is missing."""
+    conn = _base_v28_db(tmp_path)
+    # We can't easily drop a column in SQLite, so we simulate v27 by checking
+    # the preflight logic directly with a minimal connection.
+    db_path = tmp_path / "v27_sim.db"
+    c = sqlite3.connect(str(db_path))
+    c.execute("""
+        CREATE TABLE tracks (
+            track_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            title TEXT NOT NULL,
+            goal_state TEXT,
+            horizon TEXT,
+            PRIMARY KEY (track_id, project_id)
+        )
+    """)
+    c.commit()
+    from migrate_future_system import _assert_tracks_v28_intact
+    with pytest.raises(RuntimeError, match="missing 'derived_status'"):
+        _assert_tracks_v28_intact(c)
+    c.close()


### PR DESCRIPTION
## Summary

- Adds `tracks.track_type TEXT NOT NULL DEFAULT 'coding'` with `CHECK IN ('coding','content','deal','relationship')` — SQLite-translated from the Postgres spec in `vnx-track-type-spec-input.md`
- Adds `tracks.next_action_owner TEXT` nullable with `CHECK IN ('me','client','waiting') OR NULL`
- Adds `scripts/migrate_future_system.py` step 9+10 with preflight guard and `apply_migration_v29`

## Key properties

- **Additive only** — no table rebuild, `ALTER TABLE ADD COLUMN` only; ADR-007 composite PK `(track_id, project_id)` preserved
- **Idempotent** — primary guard via `user_version >= 29` in `apply_script_if_below`; secondary preflight via `PRAGMA table_info(tracks)` column-presence check
- **SQLite-translated** — `ADD COLUMN IF NOT EXISTS` (Postgres) replaced by `user_version` + preflight guard (SQLite pattern); CHECK on ADD COLUMN supported since SQLite 3.31.0 and validated in tests
- **1.1 deferred** — governance-profile mapping (`track_type_profile_map`) + GOVERN-path wiring deferred to V3 after V1 selector-activation

## Plan-path

`~/Desktop/BUSINESS/development/mission-control/claudedocs/research/vnx-track-type-spec-input.md`

## Test plan

- [x] `pytest tests/test_migration_track_type.py -q` — 17 tests, all pass
- [x] `pytest tests/test_migrate_0027_planning_horizon.py tests/test_track_reconciler.py -q` — 28 existing tests, all pass
- [x] `python3 -c "import ast; ast.parse(...)"` — no syntax errors in migrate_future_system.py
- [x] Covers: column presence, CHECK enforcement, default 'coding' on existing rows, idempotency, rowcount preserved, integrity_check, composite PK, preflight rejection on double-apply and missing prerequisite

🤖 Generated with [Claude Code](https://claude.com/claude-code)