### PR TITLE
feat(governance): activate governance-profile selector in GOVERN path (flag-gated, folder-scope-driven) — prereq for track_type mapping

### DIFF
--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -105,8 +105,14 @@ class GateRequestHandlerMixin:
     ) -> Dict[str, Any]:
         from review_gate_manager import DEFAULT_REVIEW_STACK, _utc_now, emit_governance_receipt
 
-        review_stack_list = [item.strip() for item in (review_stack or DEFAULT_REVIEW_STACK) if str(item).strip()]
         changed_files = [str(path).strip() for path in changed_files if str(path).strip()]
+
+        if review_stack is not None:
+            review_stack_list = [item.strip() for item in review_stack if str(item).strip()]
+        else:
+            from profile_gate_resolver import resolve_gate_stack as _resolve_gate_stack
+            _profile_stack = _resolve_gate_stack(changed_files)
+            review_stack_list = _profile_stack if _profile_stack is not None else list(DEFAULT_REVIEW_STACK)
         requested: List[Dict[str, Any]] = []
 
         for gate in review_stack_list:

--- a/scripts/lib/profile_gate_resolver.py
+++ b/scripts/lib/profile_gate_resolver.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""profile_gate_resolver.py — Resolve the review gate stack from governance profiles.
+
+Activated by VNX_PROFILE_SELECTOR=1 (default off, reversible).  Consults
+governance_profiles.yaml scope mappings to resolve the most restrictive
+profile across all changed files, then returns that profile's required_gates
+as the effective review gate stack.
+
+"Most restrictive" is the profile with the most required gates (longest
+required_gates list).  Any file mapping to "default" (e.g. scripts/ or
+dashboard/) escalates the whole dispatch to the full gate stack.
+
+Safety invariant: scripts/ and dashboard/ always map to "default" in
+governance_profiles.yaml, so this resolver can never weaken gates for those
+paths.  On any failure (missing YAML, import error) it returns None so the
+caller falls back to DEFAULT_REVIEW_STACK unchanged.
+
+BILLING SAFETY: No Anthropic SDK. No network calls.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Map gate names from governance_profiles.yaml to dispatch gate identifiers.
+# The YAML uses "ci" while the dispatch system calls it "ci_gate".
+_GATE_NAME_ALIASES: Dict[str, str] = {"ci": "ci_gate"}
+
+
+def _normalize_gate_name(name: str) -> str:
+    return _GATE_NAME_ALIASES.get(name, name)
+
+
+def resolve_gate_stack(
+    changed_files: List[str],
+    project_root: Optional[Path] = None,
+) -> Optional[List[str]]:
+    """Resolve required_gates for the most-restrictive profile across changed_files.
+
+    Returns None when:
+      - VNX_PROFILE_SELECTOR != "1" (flag off — caller uses DEFAULT_REVIEW_STACK)
+      - changed_files is empty (no scope to resolve)
+      - any error occurs (YAML missing, import failure, etc.)
+
+    Returns List[str] of normalized gate names when the flag is on and files
+    are provided.  An empty list means the resolved profile has no required
+    gates (e.g. "minimal").
+
+    Args:
+        changed_files:  Normalized list of changed file paths (relative or absolute).
+        project_root:   Optional project root for locating .vnx/governance_profiles.yaml.
+                        When None, governance_profiles walks up from cwd.
+
+    Returns:
+        List[str] of gate names, or None when disabled/empty/failed.
+    """
+    if os.environ.get("VNX_PROFILE_SELECTOR", "0") != "1":
+        return None
+
+    if not changed_files:
+        return None
+
+    _lib_dir = Path(__file__).resolve().parent
+    if str(_lib_dir) not in sys.path:
+        sys.path.insert(0, str(_lib_dir))
+
+    try:
+        from governance_profiles import load_scope_config, resolve_profile  # noqa: PLC0415
+
+        scope_config = load_scope_config(project_root)
+        most_restrictive = None
+
+        for fpath in changed_files:
+            profile = resolve_profile(
+                fpath, scope_config=scope_config, project_root=project_root,
+            )
+            if (
+                most_restrictive is None
+                or len(profile.required_gates) > len(most_restrictive.required_gates)
+            ):
+                most_restrictive = profile
+
+        if most_restrictive is None:
+            return None
+
+        return [_normalize_gate_name(g) for g in most_restrictive.required_gates]
+
+    except Exception:
+        return None

--- a/tests/test_governance_profile_selector.py
+++ b/tests/test_governance_profile_selector.py
@@ -507,3 +507,111 @@ class TestAuditability:
         line = sel.to_audit_line()
         assert "blocked-001" in line
         assert "coding_strict" in line  # override was rejected
+
+
+# ---------------------------------------------------------------------------
+# 11. ProfileGateResolver — resolve_gate_stack() (VNX_PROFILE_SELECTOR flag)
+# ---------------------------------------------------------------------------
+
+# Project root for loading the live .vnx/governance_profiles.yaml scope config.
+_REPO_ROOT = Path(__file__).parent.parent
+
+
+class TestProfileGateResolver:
+    """Tests for scripts/lib/profile_gate_resolver.resolve_gate_stack().
+
+    Covers:
+      - flag off → None (caller uses DEFAULT_REVIEW_STACK unchanged)
+      - agents/* → light → [ci_gate]
+      - scripts/ → default → [codex_gate, gemini_review, ci_gate]
+      - mixed files (agents + scripts) → most-restrictive (default) wins
+      - empty changed_files → None
+    """
+
+    def _import_resolver(self):
+        """Import resolve_gate_stack (sys.path already includes scripts/lib)."""
+        from profile_gate_resolver import resolve_gate_stack  # noqa: PLC0415
+        return resolve_gate_stack
+
+    def test_flag_off_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "0")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(["scripts/lib/foo.py"], project_root=_REPO_ROOT)
+        assert result is None
+
+    def test_flag_unset_returns_none(self, monkeypatch) -> None:
+        monkeypatch.delenv("VNX_PROFILE_SELECTOR", raising=False)
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(["scripts/lib/foo.py"], project_root=_REPO_ROOT)
+        assert result is None
+
+    def test_empty_files_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack([], project_root=_REPO_ROOT)
+        assert result is None
+
+    def test_agents_path_resolves_to_light_gates(self, monkeypatch) -> None:
+        """agents/* maps to 'light' profile → required_gates = [ci_gate]."""
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["agents/blog-writer/post.md"], project_root=_REPO_ROOT,
+        )
+        assert result == ["ci_gate"]
+
+    def test_scripts_path_resolves_to_default_gates(self, monkeypatch) -> None:
+        """scripts/ maps to 'default' profile → full gate stack."""
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["scripts/lib/gate_request_handler.py"], project_root=_REPO_ROOT,
+        )
+        assert result is not None
+        assert "codex_gate" in result
+        assert "gemini_review" in result
+        assert "ci_gate" in result
+
+    def test_dashboard_path_resolves_to_default_gates(self, monkeypatch) -> None:
+        """dashboard/ maps to 'default' profile — code paths stay protected."""
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["dashboard/index.html"], project_root=_REPO_ROOT,
+        )
+        assert result is not None
+        assert "codex_gate" in result
+        assert "gemini_review" in result
+
+    def test_mixed_files_most_restrictive_wins(self, monkeypatch) -> None:
+        """When agents/ (light) + scripts/ (default) are mixed, default wins."""
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["agents/blog-writer/post.md", "scripts/lib/gate_request_handler.py"],
+            project_root=_REPO_ROOT,
+        )
+        assert result is not None
+        # default profile has more gates than light → it should win
+        assert "codex_gate" in result
+        assert "gemini_review" in result
+        assert "ci_gate" in result
+
+    def test_flag_on_returns_list_not_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["scripts/lib/profile_gate_resolver.py"], project_root=_REPO_ROOT,
+        )
+        assert isinstance(result, list)
+
+    def test_ci_name_normalized_to_ci_gate(self, monkeypatch) -> None:
+        """YAML uses 'ci' but dispatch system uses 'ci_gate'; alias must apply."""
+        monkeypatch.setenv("VNX_PROFILE_SELECTOR", "1")
+        resolve_gate_stack = self._import_resolver()
+        result = resolve_gate_stack(
+            ["scripts/lib/foo.py"], project_root=_REPO_ROOT,
+        )
+        assert result is not None
+        assert "ci" not in result   # raw alias must not appear
+        assert "ci_gate" in result  # normalized name must appear


### PR DESCRIPTION
## Summary

- Activates the dormant governance-profile selector by wiring `profile_gate_resolver.resolve_gate_stack()` into `request_reviews()` in `gate_request_handler.py`
- Flag-gated via `VNX_PROFILE_SELECTOR=1` (default off) — no behaviour change when disabled
- When enabled: folder-scope from `.vnx/governance_profiles.yaml` selects the profile; that profile's `required_gates` replaces `DEFAULT_REVIEW_STACK` for the dispatch
- Most-restrictive profile wins across all changed files: any `scripts/` or `dashboard/` file escalates the whole dispatch to the full `default` gate stack
- `ci` YAML alias normalized to `ci_gate` dispatch identifier in `profile_gate_resolver.py`
- New module: `scripts/lib/profile_gate_resolver.py`
- Tests: 9 new assertions in `tests/test_governance_profile_selector.py` (section 11) — all pass alongside existing 75

## What was dormant, what is now wired

The profile subsystem (`governance_profiles.py`, `governance_profile_selector.py`, `folder_scope.py`, `.vnx/governance_profiles.yaml`) was fully built but never called in the live dispatch path. Every dispatch got `DEFAULT_REVIEW_STACK = [gemini_review, codex_gate, claude_github_optional]` regardless of folder scope. This PR wires the folder-scope → profile → required_gates path as an additive, reversible flag.

## Safety invariants preserved

- `scripts/` and `dashboard/` map to `"default"` in YAML → full gate stack always applies to code paths
- When `VNX_PROFILE_SELECTOR=0` (default): `resolve_gate_stack()` returns `None` and the existing `DEFAULT_REVIEW_STACK` is used unchanged
- When explicit `review_stack` is passed to `request_reviews()`, it takes precedence over profile selection
- Resolver failures (missing YAML, import error) return `None` → fall through to `DEFAULT_REVIEW_STACK`

## Prerequisite for V3 track_type → profile mapping

This is the wiring layer that V3 will build on: once `VNX_PROFILE_SELECTOR=1`, T0 can drive gate selection by setting the appropriate folder scope in the dispatch rather than hardcoding a review stack.

## Test plan

- [x] `pytest tests/test_governance_profile_selector.py` — 84/84 pass
- [x] `pytest tests/test_adr_003_no_sdk_imports.py` — no SDK imports in new code
- [x] `VNX_PROFILE_SELECTOR=0`: `resolve_gate_stack()` returns `None` (flag-off path identical to today)
- [x] `agents/*` → `light` profile → `["ci_gate"]`
- [x] `scripts/` → `default` profile → `["codex_gate", "gemini_review", "ci_gate"]`
- [x] Mixed files → `default` (most restrictive) wins

Dispatch-ID: 20260603-104455-V1-selector-tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)