### PR TITLE
fix(selflearn): control-for-difficulty model inference + decision-grade digest (no harmful routing, no truncation/dups)

### DIFF
--- a/scripts/build_t0_quality_digest.py
+++ b/scripts/build_t0_quality_digest.py
@@ -30,6 +30,8 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+from digest_text import smart_truncate
+
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
 QUALITY_DB = STATE_DIR / "quality_intelligence.db"
@@ -208,7 +210,7 @@ def build_prompt_config_tuning(
             "severity": "high" if is_stale else "medium",
             "detail": (
                 f"{'[STALE >7d] ' if is_stale else ''}#{item.get('id', '?')}: "
-                f"{str(item.get('description', item.get('symptom', 'no description')))[:120]}"
+                f"{smart_truncate(str(item.get('description', item.get('symptom', 'no description'))), 120)}"
             ),
             "action": "Review and accept/reject via `vnx suggested-edits review`",
             "evidence": {
@@ -244,7 +246,7 @@ def build_prompt_config_tuning(
                     "title": f"Prevention rule: [{tag_str}]",
                     "severity": "high" if float(confidence or 0) > 0.7 else "medium",
                     "detail": (
-                        f"{rule_type}: {str(recommendation or '')[:150]}"
+                        f"{rule_type}: {smart_truncate(str(recommendation or ''), 150)}"
                     ),
                     "action": "Review rule and promote to active via operator confirmation",
                     "evidence": {

--- a/scripts/generate_suggested_edits.py
+++ b/scripts/generate_suggested_edits.py
@@ -30,6 +30,9 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+from model_inference_guard import evaluate_activity_routing, HINT
+from digest_text import smart_truncate, decision_grade, dedup_suggestions
+
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
 VNX_HOME = Path(PATHS["VNX_HOME"])
@@ -87,115 +90,61 @@ def _is_already_suggested_or_applied(
 
 
 def generate_memory_suggestions(conn: sqlite3.Connection, since: str) -> List[dict]:
-    """Generate MEMORY.md suggestions from model performance patterns."""
+    """Generate MEMORY.md suggestions from difficulty-controlled model performance.
+
+    Model-vs-model comparisons run through model_inference_guard so that a "prefer
+    model X for task Y" suggestion is only emitted when the two models share a
+    task-difficulty bucket with a sufficient sample AND an infra-excluded reasoning
+    signal shows a meaningful gap. Confounded comparisons (the orchestrator model gets
+    the hard tasks; error-recovery is resilience, not failure) are dropped.
+
+    The bare per-model token-profile dump is intentionally NOT emitted: it is a
+    non-actionable raw internal, not a decision the operator can accept or reject.
+    """
     cur = conn.cursor()
 
-    # Model comparison: which model performs better for which task type
     cur.execute("""
         SELECT
             session_model,
             primary_activity,
-            COUNT(*) as total,
-            SUM(CASE WHEN has_error_recovery = 0 THEN 1 ELSE 0 END) as success_count,
-            AVG(total_output_tokens) as avg_tokens,
-            SUM(cache_read_tokens) as cache_read,
-            SUM(cache_creation_tokens) as cache_create
+            total_output_tokens,
+            duration_minutes,
+            has_error_recovery
         FROM session_analytics
         WHERE session_date >= ?
           AND session_model != 'unknown'
-        GROUP BY session_model, primary_activity
-        HAVING COUNT(*) >= ?
-        ORDER BY session_model
-    """, (since, MIN_SESSIONS_FOR_SUGGESTION))
+          AND primary_activity IS NOT NULL
+    """, (since,))
 
-    model_activity = {}
+    from collections import defaultdict as _dd
+    activity_sessions = _dd(lambda: _dd(list))
     for row in cur.fetchall():
-        model, activity, total, success, avg_tok, cache_r, cache_c = row
-        key = (model, activity)
-        model_activity[key] = {
-            "total": total, "success": success,
-            "rate": round(success / total, 2) if total > 0 else 0,
-            "avg_tokens": round(avg_tok),
-            "cache_read": cache_r, "cache_create": cache_c,
-        }
+        model, activity, tokens, duration, err = row
+        activity_sessions[activity][model].append({
+            "total_output_tokens": tokens or 0,
+            "duration_minutes": duration,
+            "has_error_recovery": bool(err),
+            "reasoning_error": None,  # no infra-excluded signal in session_analytics
+        })
 
     suggestions = []
-
-    # Find activities where models differ significantly
-    activities = set(a for _, a in model_activity.keys())
-    for activity in activities:
-        models_for_activity = {
-            m: model_activity[(m, activity)]
-            for m, a in model_activity.keys()
-            if a == activity
-        }
-        if len(models_for_activity) < 2:
+    for activity, sessions_by_model in activity_sessions.items():
+        result = evaluate_activity_routing(activity, sessions_by_model)
+        if result.get("status") != HINT:
             continue
-
-        sorted_models = sorted(models_for_activity.items(),
-                               key=lambda x: x[1]["rate"], reverse=True)
-        best, best_stats = sorted_models[0]
-        worst, worst_stats = sorted_models[-1]
-
-        rate_diff = best_stats["rate"] - worst_stats["rate"]
-        if rate_diff < 0.20:
-            continue
-
-        confidence = round(min(0.95, MIN_CONFIDENCE + rate_diff * 0.5), 2)
-        best_pct = round(best_stats["rate"] * 100)
-        worst_pct = round(worst_stats["rate"] * 100)
-
+        best = result["recommended_model"]
+        worst = result["avoid_model"]
         suggestions.append({
             "category": "memory",
             "target": "MEMORY.md",
             "section": "## Geleerde Patronen",
             "action": "append",
             "content": (
-                f"- {best}: {activity} taken {best_pct}% first-try success "
-                f"vs {worst} {worst_pct}%. Prefer {best} voor {activity}."
+                f"- Prefer {best} boven {worst} voor {activity} taken "
+                f"(vergelijkbare moeilijkheid, {result['bucket']} bucket)."
             ),
-            "evidence": (
-                f"{best_stats['success']}/{best_stats['total']} {best} vs "
-                f"{worst_stats['success']}/{worst_stats['total']} {worst} "
-                f"(afgelopen {LOOKBACK_DAYS}d)"
-            ),
-            "confidence": confidence,
-        })
-
-    # Token profile per model
-    cur.execute("""
-        SELECT
-            session_model,
-            COUNT(*) as total,
-            AVG(total_output_tokens) as avg_tokens,
-            SUM(cache_read_tokens) as cache_read,
-            SUM(cache_creation_tokens) as cache_create
-        FROM session_analytics
-        WHERE session_date >= ?
-          AND session_model != 'unknown'
-        GROUP BY session_model
-        HAVING COUNT(*) >= ?
-    """, (since, MIN_SESSIONS_FOR_SUGGESTION))
-
-    token_parts = []
-    total_sessions = 0
-    for row in cur.fetchall():
-        model, count, avg_tok, cache_r, cache_c = row
-        total_cache = (cache_r or 0) + (cache_c or 0)
-        cache_pct = round((cache_r or 0) / total_cache * 100) if total_cache > 0 else 0
-        avg_k = round((avg_tok or 0) / 1000)
-        token_parts.append(f"{model} avg={avg_k}K/sess cache={cache_pct}%")
-        total_sessions += count
-
-    if token_parts and total_sessions >= MIN_SESSIONS_FOR_SUGGESTION:
-        suggestions.append({
-            "category": "memory",
-            "target": "MEMORY.md",
-            "section": "## Geleerde Patronen",
-            "action": "append",
-            "content": f"- Model token profiel ({LOOKBACK_DAYS}d): {' | '.join(token_parts)}",
-            "evidence": f"Aggregatie van {total_sessions} sessies over {LOOKBACK_DAYS} dagen",
-            "confidence": 0.95,
+            "evidence": result["evidence"],
+            "confidence": result["confidence"],
         })
 
     return suggestions
@@ -327,6 +276,12 @@ def generate_digest_section(edits: list) -> str:
     if not pending:
         return ""
 
+    # Decision-grade: collapse near-duplicate suggestions and drop non-actionable raw
+    # internal dumps so the digest surfaces decisions, not raw rows.
+    pending = decision_grade(pending)
+    if not pending:
+        return ""
+
     lines = [
         f"## Voorgestelde Wijzigingen ({len(pending)} pending)",
         "",
@@ -355,7 +310,7 @@ def generate_digest_section(edits: list) -> str:
         evidence = edit.get("evidence", "")
 
         action_label = "Toevoegen" if action in ("append", "append_section") else "Wijzigen"
-        content_preview = content.split("\n")[0][:80]
+        content_preview = smart_truncate(content.split("\n")[0], 80)
 
         lines.append(f"### #{eid} [{cat}] {target}")
         lines.append(f"**{action_label}**: {content_preview}")
@@ -409,9 +364,11 @@ def main():
         if len(new_edits) >= MAX_SUGGESTIONS_PER_RUN:
             break
 
-    # Merge: keep existing non-applied pending edits + add new ones
+    # Merge: keep existing non-applied pending edits + add new ones, then collapse
+    # near-duplicate suggestions (same target+intent) so the persisted queue and every
+    # downstream digest carry one row per decision, not three at different sample sizes.
     kept_edits = [e for e in existing_edits if e.get("status") in ("pending", "accepted")]
-    final_edits = kept_edits + new_edits
+    final_edits = dedup_suggestions(kept_edits + new_edits)
 
     output = {
         "generated_at": datetime.now(tz=_UTC).isoformat().replace("+00:00", "Z"),

--- a/scripts/generate_t0_session_brief.py
+++ b/scripts/generate_t0_session_brief.py
@@ -25,6 +25,8 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+from model_inference_guard import evaluate_activity_routing, HINT
+
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
 DB_PATH = STATE_DIR / "quality_intelligence.db"
@@ -104,89 +106,93 @@ def get_model_performance(conn: sqlite3.Connection, since: str) -> dict:
     return result
 
 
-def get_model_routing_hints(conn: sqlite3.Connection, since: str) -> list:
-    """Generate task-type routing hints based on model success patterns."""
-    cur = conn.cursor()
+def _activity_sessions(conn: sqlite3.Connection, since: str) -> dict:
+    """Load per-session rows grouped by activity -> model -> [session dicts].
 
-    # Get activity success rates per model (error_recovery = proxy for difficulty)
+    Returns raw per-session records (not pre-aggregated) so the inference guard can
+    bucket by task-difficulty before any model-vs-model comparison. ``has_error_recovery``
+    is loaded but deliberately NOT mapped to a reasoning-error signal — it conflates
+    resilience / infra recovery with model errors (see model_inference_guard).
+    """
+    cur = conn.cursor()
     cur.execute("""
         SELECT
             session_model,
             primary_activity,
-            COUNT(*) as total,
-            SUM(CASE WHEN has_error_recovery = 0 THEN 1 ELSE 0 END) as success_count
+            total_output_tokens,
+            duration_minutes,
+            has_error_recovery
         FROM session_analytics
         WHERE session_date >= ?
           AND session_model != 'unknown'
           AND primary_activity IS NOT NULL
-        GROUP BY session_model, primary_activity
-        HAVING COUNT(*) >= 3
-        ORDER BY primary_activity, success_count DESC
     """, (since,))
 
-    activity_model_stats = defaultdict(dict)
+    activity_sessions: dict = defaultdict(lambda: defaultdict(list))
     for row in cur.fetchall():
-        model, activity, total, success = row[0], row[1], row[2], row[3]
-        rate = success / total if total > 0 else 0
-        activity_model_stats[activity][model] = {
-            "total": total,
-            "success": success,
-            "rate": rate,
-        }
+        model, activity, tokens, duration, err = row[0], row[1], row[2], row[3], row[4]
+        activity_sessions[activity][model].append({
+            "total_output_tokens": tokens or 0,
+            "duration_minutes": duration,
+            "has_error_recovery": bool(err),
+            # No infra-excluded reasoning-error signal exists in session_analytics;
+            # the guard treats this as non-diagnostic rather than blaming a model.
+            "reasoning_error": None,
+        })
+    return activity_sessions
+
+
+def get_model_routing_hints(conn: sqlite3.Connection, since: str) -> list:
+    """Generate task-type routing hints, difficulty-controlled and infra-excluded.
+
+    Routes through model_inference_guard: a hint is only emitted when two models share
+    a task-difficulty bucket with >= MIN_COMPARABLE_SAMPLE sessions each AND a clean
+    (infra-excluded) reasoning-error signal shows a meaningful gap. Otherwise the
+    activity is dropped — the loop prefers no hint over a confounded one.
+    """
+    activity_sessions = _activity_sessions(conn, since)
 
     hints = []
-    for activity, models in activity_model_stats.items():
-        if len(models) < 2:
+    for activity, sessions_by_model in activity_sessions.items():
+        result = evaluate_activity_routing(activity, sessions_by_model)
+        if result.get("status") != HINT:
             continue
-
-        sorted_models = sorted(models.items(), key=lambda x: x[1]["rate"], reverse=True)
-        best_model, best_stats = sorted_models[0]
-        second_model, second_stats = sorted_models[1]
-
-        if best_stats["rate"] - second_stats["rate"] < 0.15:
-            continue
-
-        confidence = round(min(0.95, 0.5 + (best_stats["total"] / 20) * 0.3 +
-                              (best_stats["rate"] - second_stats["rate"]) * 0.5), 2)
-
         hints.append({
-            "task_type": activity,
-            "recommended_model": best_model,
-            "confidence": confidence,
-            "evidence": (
-                f"{best_stats['success']}/{best_stats['total']} succesvol op {best_model}, "
-                f"{second_stats['success']}/{second_stats['total']} op {second_model}"
-            ),
+            "task_type": result["task_type"],
+            "recommended_model": result["recommended_model"],
+            "confidence": result["confidence"],
+            "evidence": result["evidence"],
         })
 
     return sorted(hints, key=lambda x: x["confidence"], reverse=True)
 
 
 def get_active_concerns(conn: sqlite3.Connection, since: str) -> list:
-    """Identify models with concerning error patterns."""
-    cur = conn.cursor()
-    cur.execute("""
-        SELECT
-            session_model,
-            primary_activity,
-            COUNT(*) as total,
-            SUM(CASE WHEN has_error_recovery = 1 THEN 1 ELSE 0 END) as err_count
-        FROM session_analytics
-        WHERE session_date >= ?
-          AND session_model != 'unknown'
-        GROUP BY session_model, primary_activity
-        HAVING COUNT(*) >= 3
-          AND (CAST(SUM(CASE WHEN has_error_recovery = 1 THEN 1 ELSE 0 END) AS REAL) / COUNT(*)) > 0.30
-    """, (since,))
+    """Identify models with a defensible, difficulty-controlled quality concern.
+
+    A concern is only raised when the inference guard yields a real routing hint —
+    i.e. within a comparable difficulty bucket, on an infra-excluded reasoning-error
+    signal, with a meaningful gap. A high ``has_error_recovery`` rate alone is NOT a
+    concern: it is usually resilience (the model recovered from an infra/tool failure
+    it diagnosed), so it never triggers a "switch model" recommendation here.
+    """
+    activity_sessions = _activity_sessions(conn, since)
 
     concerns = []
-    for row in cur.fetchall():
-        model, activity, total, err_count = row[0], row[1], row[2], row[3]
-        rate = round(err_count / total * 100)
+    for activity, sessions_by_model in activity_sessions.items():
+        result = evaluate_activity_routing(activity, sessions_by_model)
+        if result.get("status") != HINT:
+            continue
         concerns.append({
-            "model": model,
-            "concern": f"Hoge error recovery rate bij {activity} taken ({rate}%)",
-            "recommendation": f"Overweeg een ander model voor complexe {activity} taken",
+            "model": result["avoid_model"],
+            "concern": (
+                f"Lagere reasoning-success bij {activity} taken binnen vergelijkbare "
+                f"moeilijkheid ({result['bucket']} bucket)"
+            ),
+            "recommendation": (
+                f"Overweeg {result['recommended_model']} voor {activity} taken — "
+                f"{result['evidence']}"
+            ),
         })
 
     return concerns

--- a/scripts/lib/digest_text.py
+++ b/scripts/lib/digest_text.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+VNX Digest Text Helpers — boundary-safe truncation and suggestion de-duplication.
+
+The nightly digest used raw slicing ([:80] / [:120] / [:200]) to fit suggestion text
+into a line, which cut words mid-token ("...Pref", "that re", "skill sk", "for l") and
+produced unreadable, low-trust output. It also emitted near-duplicate suggestions (the
+same MEMORY token-profile line three times at different sample sizes, the same claim
+twice). These helpers fix both:
+
+  - :func:`smart_truncate` truncates on a word boundary and appends an explicit ellipsis,
+    so a suggestion never ends mid-word.
+  - :func:`dedup_suggestions` collapses suggestions that share the same target + intent
+    to one, keeping the highest-confidence (then latest) version.
+
+Pure functions, no I/O, no env — safe to import anywhere.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+_ELLIPSIS = "…"
+
+# Tokens that signal a non-actionable raw internal dump rather than a decision the
+# operator can say yes/no to. These are surfaced as context, not as suggestions.
+_RAW_INTERNAL_MARKERS = (
+    "token profiel",
+    "token profile",
+)
+
+
+def smart_truncate(text: str, limit: int, *, ellipsis: str = _ELLIPSIS) -> str:
+    """Truncate ``text`` to at most ``limit`` characters on a word boundary.
+
+    If truncation is needed, the result ends with ``ellipsis`` (counted within the
+    limit) and never splits a word. If the whole text fits, it is returned unchanged.
+    Falls back to a hard cut only when the first token alone exceeds the limit.
+    """
+    text = (text or "").strip()
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+
+    budget = limit - len(ellipsis)
+    if budget <= 0:
+        return text[:limit]
+
+    head = text[:budget]
+    # Back up to the last whitespace so we don't cut a word in half.
+    boundary = head.rfind(" ")
+    if boundary > 0:
+        head = head[:boundary]
+    head = head.rstrip(" ,.;:-—")
+    if not head:
+        # Single oversized token: hard-cut rather than emit an empty string.
+        head = text[:budget]
+    return head + ellipsis
+
+
+def _intent_key(suggestion: Dict[str, Any]) -> str:
+    """Derive a stable target+intent key for collapsing near-duplicate suggestions.
+
+    Two suggestions collapse when they target the same file/section with the same
+    intent. Intent is approximated by the category, target, section, and the leading
+    normalized words of the content — enough to fold "Model token profiel (7d): ..."
+    variants (which differ only in sample size) into one, while keeping genuinely
+    distinct suggestions apart.
+    """
+    category = (suggestion.get("category") or "").strip().lower()
+    target = (suggestion.get("target") or "").strip().lower()
+    section = (suggestion.get("section") or "").strip().lower()
+    content = (suggestion.get("content") or "").strip().lower()
+
+    # The intent is captured by the leading words. The 3x "Model token profiel (7d):
+    # opus ..." variants differ only in the trailing numbers (avg=1817K vs 1650K), so a
+    # leading-word prefix collapses them. Digits are intentionally NOT normalized away —
+    # that would wrongly fold genuinely distinct targets that differ only by a digit
+    # (e.g. "prefer gpt-4" vs "prefer gpt-5").
+    normalized = re.sub(r"\s+", " ", content)
+    prefix = " ".join(normalized.split(" ")[:6])
+    return f"{category}|{target}|{section}|{prefix}"
+
+
+def _confidence(suggestion: Dict[str, Any]) -> float:
+    try:
+        return float(suggestion.get("confidence", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def dedup_suggestions(suggestions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse suggestions that share a target+intent to a single best version.
+
+    Keeps the highest-confidence variant; ties break on the latest ``suggested_at``
+    (falls back to last-seen). Order of first appearance is otherwise preserved.
+    """
+    best: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+
+    for suggestion in suggestions:
+        key = _intent_key(suggestion)
+        if key not in best:
+            best[key] = suggestion
+            order.append(key)
+            continue
+
+        incumbent = best[key]
+        challenger_conf = _confidence(suggestion)
+        incumbent_conf = _confidence(incumbent)
+        if challenger_conf > incumbent_conf:
+            best[key] = suggestion
+        elif challenger_conf == incumbent_conf:
+            if str(suggestion.get("suggested_at", "")) >= str(incumbent.get("suggested_at", "")):
+                best[key] = suggestion
+
+    return [best[key] for key in order]
+
+
+def is_raw_internal_dump(suggestion: Dict[str, Any]) -> bool:
+    """True for non-actionable raw internal dumps (e.g. bare token-profile lines).
+
+    Decision-grade digests surface things the operator can accept or reject; a raw
+    token-profile aggregation is context, not a decision, so it is filtered out.
+    """
+    content = (suggestion.get("content") or "").lower()
+    return any(marker in content for marker in _RAW_INTERNAL_MARKERS)
+
+
+def decision_grade(
+    suggestions: List[Dict[str, Any]],
+    *,
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return decision-grade suggestions: deduped, raw internals dropped, top-N.
+
+    ``limit`` caps the number of surfaced suggestions (highest confidence first);
+    ``None`` keeps all of them after dedup and filtering.
+    """
+    actionable = [s for s in suggestions if not is_raw_internal_dump(s)]
+    deduped = dedup_suggestions(actionable)
+    ranked = sorted(deduped, key=_confidence, reverse=True)
+    if limit is not None:
+        ranked = ranked[:limit]
+    return ranked

--- a/scripts/lib/model_inference_guard.py
+++ b/scripts/lib/model_inference_guard.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+VNX Model-Inference Guard — difficulty-controlled, infra-excluded model routing inference.
+
+Prevents the self-learning loop from emitting harmful "route this task-class away
+from model X" hints derived from CONFOUNDED data. Two confounds are guarded:
+
+  1. Selection bias / task-difficulty. The orchestrator model (opus, which also runs
+     T0 and does the hard investigation work) receives the HARD tasks: long, high-token,
+     multi-file diagnoses. Cheaper models receive routine work. Comparing raw
+     error/success rates across models that ran vastly different task-difficulty is
+     invalid. We bucket every session by a difficulty proxy (output-token band) and
+     only compare models WITHIN the same difficulty bucket, each with a minimum
+     comparable sample.
+
+  2. Resilience mislabelled as failure. `has_error_recovery` marks a session that
+     recovered from an error. In a long orchestration session that error is usually a
+     system/infra/permission/tool/lane failure the model DIAGNOSED and worked around —
+     that is resilience, not a model-quality defect. `has_error_recovery` therefore
+     conflates model-reasoning errors with infra errors and is NOT a clean
+     model-quality signal. Absent an infra-excluded reasoning-error signal, the guard
+     refuses to emit a model-quality verdict and returns ``insufficient_comparable_data``.
+
+Governance: advisory-only. Prefer "insufficient comparable data" over a confident but
+wrong routing hint. A wrong route-away hint poisons every downstream dispatch.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+# Minimum comparable sessions PER MODEL, within a shared difficulty bucket, before a
+# model-vs-model comparison is allowed. Small samples produce noise that reads as signal.
+MIN_COMPARABLE_SAMPLE = 8
+
+# Success-rate gap below which two models are treated as indistinguishable.
+MIN_MEANINGFUL_GAP = 0.15
+
+INSUFFICIENT = "insufficient_comparable_data"
+HINT = "hint"
+
+# Difficulty buckets by output-token band. Bands are chosen so the orchestrator's heavy
+# investigation sessions (>200K output tokens) never share a bucket with routine work —
+# that separation is exactly what the difficulty control needs to enforce.
+_TOKEN_BANDS = [
+    (50_000, "trivial"),
+    (200_000, "routine"),
+    (600_000, "substantial"),
+    (float("inf"), "heavy"),
+]
+
+
+def difficulty_bucket(total_output_tokens: Optional[float]) -> str:
+    """Map a session's output-token count to a coarse difficulty band."""
+    tok = total_output_tokens or 0
+    for ceiling, label in _TOKEN_BANDS:
+        if tok < ceiling:
+            return label
+    return "heavy"
+
+
+def _reasoning_failure_signal(session: Dict[str, Any]) -> Optional[bool]:
+    """Return the session's infra-EXCLUDED reasoning-error verdict, or None.
+
+    ``True``  -> a genuine model-reasoning error occurred.
+    ``False`` -> the session completed without a model-reasoning error.
+    ``None``  -> no clean signal exists for this session.
+
+    ``has_error_recovery`` is intentionally NOT consulted: it conflates resilience /
+    infra recovery (permission hangs, tool failures, lane no-delivers the model
+    diagnosed) with model-reasoning errors, so it cannot attribute blame to a model.
+    Only an explicit ``reasoning_error`` marker — produced by a classifier that has
+    already excluded infra/system/environment errors — counts.
+    """
+    val = session.get("reasoning_error")
+    if val is None:
+        return None
+    return bool(val)
+
+
+def evaluate_activity_routing(
+    activity: str,
+    sessions_by_model: Dict[str, List[Dict[str, Any]]],
+    *,
+    min_sample: int = MIN_COMPARABLE_SAMPLE,
+    min_gap: float = MIN_MEANINGFUL_GAP,
+) -> Dict[str, Any]:
+    """Decide whether a routing hint is defensible for one activity / task-type.
+
+    ``sessions_by_model`` maps model name -> list of per-session dicts. Each session
+    dict should carry ``total_output_tokens`` (difficulty proxy) and may carry a clean
+    ``reasoning_error`` marker (infra-excluded). ``has_error_recovery`` is ignored on
+    purpose — see :func:`_reasoning_failure_signal`.
+
+    Returns one of:
+
+      {"status": "hint", "task_type", "recommended_model", "avoid_model",
+       "confidence", "bucket", "evidence"}
+
+      {"status": "insufficient_comparable_data", "task_type", "reason"}
+    """
+    # --- Gate A: difficulty-comparable sample ------------------------------------
+    by_bucket: Dict[str, Dict[str, List[Dict[str, Any]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for model, sessions in sessions_by_model.items():
+        for session in sessions:
+            band = difficulty_bucket(session.get("total_output_tokens"))
+            by_bucket[band][model].append(session)
+
+    comparable = None
+    for band, models in by_bucket.items():
+        qualified = {m: ss for m, ss in models.items() if len(ss) >= min_sample}
+        if len(qualified) >= 2:
+            comparable = (band, qualified)
+            break
+
+    if comparable is None:
+        return {
+            "status": INSUFFICIENT,
+            "task_type": activity,
+            "reason": (
+                f"No difficulty-comparable bucket with >= {min_sample} sessions per "
+                f"model. Models ran different task-difficulty; a raw comparison would "
+                f"be confounded by selection bias (the orchestrator model gets the "
+                f"hard tasks)."
+            ),
+        }
+
+    bucket_label, models = comparable
+
+    # --- Gate B: infra-excluded model-quality signal -----------------------------
+    rates: Dict[str, float] = {}
+    for model, sessions in models.items():
+        clean = [v for v in (_reasoning_failure_signal(s) for s in sessions) if v is not None]
+        if len(clean) < min_sample:
+            return {
+                "status": INSUFFICIENT,
+                "task_type": activity,
+                "reason": (
+                    "Only the infra-conflated error signal is available "
+                    "(has_error_recovery counts resilience / infra recovery as error). "
+                    "No infra-excluded reasoning-error signal exists to attribute model "
+                    "blame, so no model-quality verdict is emitted."
+                ),
+            }
+        failures = sum(1 for v in clean if v)
+        rates[model] = 1.0 - failures / len(clean)
+
+    # --- Gate C: meaningful gap --------------------------------------------------
+    ordered = sorted(rates.items(), key=lambda kv: kv[1], reverse=True)
+    best_model, best_rate = ordered[0]
+    worst_model, worst_rate = ordered[-1]
+    gap = best_rate - worst_rate
+    if gap < min_gap:
+        return {
+            "status": INSUFFICIENT,
+            "task_type": activity,
+            "reason": (
+                f"Reasoning-success gap {gap:.2f} within the '{bucket_label}' bucket is "
+                f"below the meaningful threshold {min_gap:.2f}; models are comparable."
+            ),
+        }
+
+    n_best = len(models[best_model])
+    confidence = round(min(0.95, 0.5 + (n_best / 20) * 0.3 + gap * 0.5), 2)
+    return {
+        "status": HINT,
+        "task_type": activity,
+        "recommended_model": best_model,
+        "avoid_model": worst_model,
+        "confidence": confidence,
+        "bucket": bucket_label,
+        "evidence": (
+            f"Within the '{bucket_label}' difficulty bucket: {best_model} "
+            f"{best_rate:.0%} vs {worst_model} {worst_rate:.0%} reasoning-success "
+            f"(n >= {min_sample}/model, infra errors excluded)."
+        ),
+    }
+
+
+def routing_hints(
+    activity_sessions: Dict[str, Dict[str, List[Dict[str, Any]]]],
+    *,
+    min_sample: int = MIN_COMPARABLE_SAMPLE,
+    min_gap: float = MIN_MEANINGFUL_GAP,
+) -> List[Dict[str, Any]]:
+    """Evaluate every activity and return only the defensible (hint) results.
+
+    ``activity_sessions`` maps activity -> {model -> [session dict, ...]}.
+    Insufficient-data activities are dropped (the conservative default).
+    """
+    hints: List[Dict[str, Any]] = []
+    for activity, sessions_by_model in activity_sessions.items():
+        result = evaluate_activity_routing(
+            activity, sessions_by_model, min_sample=min_sample, min_gap=min_gap
+        )
+        if result.get("status") == HINT:
+            hints.append(result)
+    return sorted(hints, key=lambda h: h["confidence"], reverse=True)

--- a/scripts/send_digest_email.py
+++ b/scripts/send_digest_email.py
@@ -35,6 +35,8 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+from digest_text import smart_truncate, decision_grade
+
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
 BRIEF_PATH = STATE_DIR / "t0_session_brief.json"
@@ -118,6 +120,11 @@ def _format_pending_edits(edits_data: dict) -> str:
     if not pending:
         return "Geen pending suggesties.\n"
 
+    # Decision-grade: dedup near-identical suggestions and drop raw internal dumps.
+    pending = decision_grade(pending)
+    if not pending:
+        return "Geen pending suggesties.\n"
+
     cat_labels = {
         "memory": "MEMORY",
         "rule": "RULE",
@@ -131,7 +138,7 @@ def _format_pending_edits(edits_data: dict) -> str:
         eid = edit.get("id", "?")
         cat = cat_labels.get(edit.get("category", ""), edit.get("category", "").upper())
         target = Path(edit.get("target", "")).name
-        content = edit.get("content", "").split("\n")[0][:80]
+        content = smart_truncate(edit.get("content", "").split("\n")[0], 80)
         confidence = edit.get("confidence", 0)
         evidence = edit.get("evidence", "")
         action = edit.get("action", "append")

--- a/tests/test_digest_quality.py
+++ b/tests/test_digest_quality.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Tests for digest_text — boundary-safe truncation and suggestion de-duplication.
+
+Covers the nightly-digest defect of 2026-06-03: suggestions truncated mid-word
+("...Pref", "that re", "skill sk", "for l") and near-duplicate suggestions (the same
+MEMORY token-profile line three times, the same claim twice).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from digest_text import (  # noqa: E402
+    smart_truncate,
+    dedup_suggestions,
+    decision_grade,
+    is_raw_internal_dump,
+)
+
+
+# ---------------------------------------------------------------------------
+# Truncation — never mid-word
+# ---------------------------------------------------------------------------
+
+def _ends_mid_word(text: str) -> bool:
+    """A suggestion ends mid-word if its last char is a letter AND the original
+    continued with a letter — approximated here: ends with a letter and no terminal
+    ellipsis/punctuation marking an intentional stop."""
+    if not text:
+        return False
+    return text[-1].isalnum() and not text.endswith("…")
+
+
+def test_smart_truncate_never_ends_mid_word():
+    text = "Prefer claude-sonnet voor debugging taken vs claude-opus 40% first-try success"
+    out = smart_truncate(text, 12)
+    assert len(out) <= 12
+    assert not out.endswith("Pref")  # the exact original defect
+    assert out.endswith("…")
+    # The visible part before the ellipsis must be whole words.
+    visible = out[:-1]
+    assert visible == "" or not visible[-1].isalnum() or " " not in text[:12] or visible in text
+
+
+def test_smart_truncate_real_defect_strings():
+    # Reconstruct the kinds of strings that produced "...Pref", "that re", "for l".
+    # Limits exceed the first word, as the real digest does (80/120/150).
+    cases = [
+        ("Prefer claude-sonnet voor debugging", 10),
+        ("ensure that recovery is logged", 12),
+        ("add skill skeleton for new agents", 11),
+        ("watch for large refactors", 9),
+    ]
+    for text, limit in cases:
+        out = smart_truncate(text, limit)
+        assert len(out) <= limit
+        # No half-words: visible text (minus ellipsis) is a prefix that ends on a
+        # whole word from the source.
+        if out.endswith("…"):
+            visible = out[:-1].rstrip()
+            words = text.split(" ")
+            # visible must be a sequence of whole leading words
+            assert visible == "" or text.startswith(visible)
+            if visible:
+                last_word = visible.split(" ")[-1]
+                assert last_word in words
+
+
+def test_smart_truncate_short_text_unchanged():
+    assert smart_truncate("short", 80) == "short"
+
+
+def test_smart_truncate_no_suggestion_ends_mid_word():
+    suggestions = [
+        "Prefer claude-sonnet boven claude-opus voor debugging taken (routine bucket).",
+        "Add rule: net-deletion sanity check that flags PRs deleting many files",
+        "Model performance summary for long sessions with cache reuse",
+    ]
+    for s in suggestions:
+        out = smart_truncate(s, 20)
+        assert not _ends_mid_word(out), f"mid-word truncation: {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# Dedup — same target+intent collapses to one
+# ---------------------------------------------------------------------------
+
+def test_dedup_collapses_token_profile_variants():
+    """Three 'Model token profiel' lines at different sample sizes -> one."""
+    suggestions = [
+        {
+            "category": "memory",
+            "target": "MEMORY.md",
+            "content": "- Model token profiel (7d): opus avg=1817K/sess cache=80%",
+            "confidence": 0.95,
+            "suggested_at": "2026-06-01T00:00:00Z",
+        },
+        {
+            "category": "memory",
+            "target": "MEMORY.md",
+            "content": "- Model token profiel (7d): opus avg=1650K/sess cache=78%",
+            "confidence": 0.95,
+            "suggested_at": "2026-06-02T00:00:00Z",
+        },
+        {
+            "category": "memory",
+            "target": "MEMORY.md",
+            "content": "- Model token profiel (7d): opus avg=1500K/sess cache=75%",
+            "confidence": 0.95,
+            "suggested_at": "2026-06-03T00:00:00Z",
+        },
+    ]
+    out = dedup_suggestions(suggestions)
+    assert len(out) == 1
+    # Keeps latest on confidence tie.
+    assert out[0]["suggested_at"] == "2026-06-03T00:00:00Z"
+
+
+def test_dedup_keeps_highest_confidence():
+    suggestions = [
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Prefer opus voor debugging taken", "confidence": 0.70},
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Prefer opus voor debugging taken", "confidence": 0.92},
+    ]
+    out = dedup_suggestions(suggestions)
+    assert len(out) == 1
+    assert out[0]["confidence"] == 0.92
+
+
+def test_dedup_preserves_distinct_suggestions():
+    suggestions = [
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Prefer opus voor debugging taken", "confidence": 0.8},
+        {"category": "prevention_rules", "target": ".claude/rules/antipatterns.md",
+         "content": "Add rule: net-deletion sanity check", "confidence": 0.8},
+    ]
+    out = dedup_suggestions(suggestions)
+    assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# Decision-grade — drop raw internals
+# ---------------------------------------------------------------------------
+
+def test_is_raw_internal_dump_flags_token_profile():
+    assert is_raw_internal_dump(
+        {"content": "- Model token profiel (7d): opus avg=1817K/sess"}
+    )
+    assert not is_raw_internal_dump(
+        {"content": "- Prefer opus voor debugging taken"}
+    )
+
+
+def test_decision_grade_drops_dumps_and_dedups():
+    suggestions = [
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Model token profiel (7d): opus avg=1817K", "confidence": 0.95},
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Prefer opus voor debugging taken", "confidence": 0.80},
+        {"category": "memory", "target": "MEMORY.md",
+         "content": "- Prefer opus voor debugging taken", "confidence": 0.85},
+    ]
+    out = decision_grade(suggestions)
+    # token-profile dropped, two prefer-lines collapsed -> 1
+    assert len(out) == 1
+    assert "token profiel" not in out[0]["content"].lower()
+    assert out[0]["confidence"] == 0.85
+
+
+def test_decision_grade_respects_limit():
+    suggestions = [
+        {"category": "memory", "target": "MEMORY.md",
+         "content": f"- Prefer model{i} voor taak{i}", "confidence": 0.5 + i * 0.05}
+        for i in range(6)
+    ]
+    out = decision_grade(suggestions, limit=3)
+    assert len(out) == 3
+    # highest confidence first
+    assert out[0]["confidence"] >= out[1]["confidence"] >= out[2]["confidence"]
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_model_inference_guard.py
+++ b/tests/test_model_inference_guard.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Regression tests for model_inference_guard — confounded model-routing inference.
+
+Covers the nightly-digest defect of 2026-06-03: the loop concluded "opus bad at
+debugging -> route debugging to sonnet" (95% confidence) from confounded data, where
+
+  - opus ran the HARD tasks (high token, ~49min, T0 orchestrator investigations) and
+  - its "errors" were recoverable system/infra failures it DIAGNOSED (resilience).
+
+The guard must refuse such a verdict and return insufficient_comparable_data.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+from model_inference_guard import (  # noqa: E402
+    INSUFFICIENT,
+    HINT,
+    MIN_COMPARABLE_SAMPLE,
+    difficulty_bucket,
+    evaluate_activity_routing,
+    routing_hints,
+)
+
+
+def _sessions(n, tokens, *, reasoning_error=None, has_error_recovery=False):
+    return [
+        {
+            "total_output_tokens": tokens,
+            "duration_minutes": 49 if tokens > 200_000 else 5,
+            "has_error_recovery": has_error_recovery,
+            "reasoning_error": reasoning_error,
+        }
+        for _ in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Defect A.4 — the core regression
+# ---------------------------------------------------------------------------
+
+def test_confounded_opus_hard_vs_sonnet_easy_yields_insufficient():
+    """opus=hard-bucket high-token + recoverable system errors, sonnet=easy-bucket.
+
+    The analyzer must NOT recommend routing debugging away from opus.
+    """
+    sessions_by_model = {
+        # opus: 12 heavy investigation sessions, each recovered from a system error
+        "claude-opus": _sessions(12, 1_817_000, has_error_recovery=True),
+        # sonnet: 12 routine sessions, no errors
+        "claude-sonnet": _sessions(12, 123_000, has_error_recovery=False),
+    }
+
+    result = evaluate_activity_routing("debugging", sessions_by_model)
+
+    assert result["status"] == INSUFFICIENT
+    # Must never name opus as a model to avoid / route away from.
+    assert "avoid_model" not in result
+    assert result.get("recommended_model") is None or "recommended_model" not in result
+
+
+def test_routing_hints_drops_confounded_activity():
+    """routing_hints() returns no hint at all for the confounded scenario."""
+    activity_sessions = {
+        "debugging": {
+            "claude-opus": _sessions(12, 1_817_000, has_error_recovery=True),
+            "claude-sonnet": _sessions(12, 123_000, has_error_recovery=False),
+        }
+    }
+    assert routing_hints(activity_sessions) == []
+
+
+def test_error_recovery_alone_never_blames_model():
+    """Even within the SAME difficulty bucket, has_error_recovery is not model-blame."""
+    sessions_by_model = {
+        "claude-opus": _sessions(10, 300_000, has_error_recovery=True),
+        "claude-sonnet": _sessions(10, 300_000, has_error_recovery=False),
+    }
+    result = evaluate_activity_routing("debugging", sessions_by_model)
+    # Same bucket -> Gate A passes, but no infra-excluded reasoning signal -> insufficient.
+    assert result["status"] == INSUFFICIENT
+    assert "infra" in result["reason"].lower() or "reasoning" in result["reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Gate behaviour
+# ---------------------------------------------------------------------------
+
+def test_below_min_sample_is_insufficient():
+    sessions_by_model = {
+        "claude-opus": _sessions(3, 300_000, reasoning_error=True),
+        "claude-sonnet": _sessions(3, 300_000, reasoning_error=False),
+    }
+    result = evaluate_activity_routing("coding", sessions_by_model)
+    assert result["status"] == INSUFFICIENT
+
+
+def test_clean_signal_same_bucket_meaningful_gap_emits_hint():
+    """With an infra-excluded reasoning signal, comparable difficulty, and a real gap,
+    the guard DOES emit a hint — proving the guard isn't merely always-insufficient."""
+    sessions_by_model = {
+        # within same 'substantial' bucket; sonnet has many reasoning errors, opus few
+        "claude-opus": _sessions(MIN_COMPARABLE_SAMPLE, 300_000, reasoning_error=False),
+        "claude-sonnet": (
+            _sessions(MIN_COMPARABLE_SAMPLE - 2, 300_000, reasoning_error=True)
+            + _sessions(2, 300_000, reasoning_error=False)
+        ),
+    }
+    result = evaluate_activity_routing("coding", sessions_by_model)
+    assert result["status"] == HINT
+    assert result["recommended_model"] == "claude-opus"
+    assert result["avoid_model"] == "claude-sonnet"
+    assert result["bucket"] == "substantial"
+
+
+def test_clean_signal_but_small_gap_is_insufficient():
+    sessions_by_model = {
+        "claude-opus": _sessions(MIN_COMPARABLE_SAMPLE, 300_000, reasoning_error=False),
+        "claude-sonnet": (
+            _sessions(1, 300_000, reasoning_error=True)
+            + _sessions(MIN_COMPARABLE_SAMPLE - 1, 300_000, reasoning_error=False)
+        ),
+    }
+    result = evaluate_activity_routing("coding", sessions_by_model)
+    assert result["status"] == INSUFFICIENT
+
+
+def test_difficulty_bucket_separates_heavy_from_routine():
+    assert difficulty_bucket(1_817_000) == "heavy"
+    assert difficulty_bucket(123_000) == "routine"
+    assert difficulty_bucket(10_000) == "trivial"
+    assert difficulty_bucket(0) == "trivial"
+    assert difficulty_bucket(None) == "trivial"
+    # The confound: opus-heavy and sonnet-routine never share a bucket.
+    assert difficulty_bucket(1_817_000) != difficulty_bucket(123_000)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Why

The nightly self-learning digest (2026-06-03) produced a **harmful and unusable** output. Two real defects.

### Defect A — confounded model-routing inference (the important one)

The loop concluded *"claude-opus bad at debugging → route debugging to claude-sonnet"* at **95% confidence** from confounded data (opus: 1817K tok/sess, ~49min, err=38%; sonnet: 123K tok/sess, err=0%). This is a measurement artifact, not a finding:

- **Selection bias.** opus runs the HARD tasks — it is the T0 orchestrator doing long, high-token, multi-file investigations. sonnet runs routine work. Comparing raw error/success rates across vastly different task-difficulty is invalid.
- **Resilience mislabelled as failure.** "Error recovery" in a long session is the model diagnosing and working around a system/infra/permission/lane failure — that's resilience, not a reasoning error. `has_error_recovery` conflates the two, and opus' recovered infra errors were counted as opus "errors" — backwards.

**Fix** (`scripts/lib/model_inference_guard.py`): control for both confounds before any model-vs-model comparison.

1. **Bucket by difficulty** (output-token band) and only compare models *within* a shared bucket — opus-heavy (>200K) never shares a bucket with sonnet-routine.
2. **Exclude infra errors from model-blame.** `has_error_recovery` is never consulted as a quality signal; only an infra-excluded `reasoning_error` marker counts. If the data can't distinguish them, emit **`insufficient_comparable_data`**, not a verdict.
3. **No route-away hint** unless: comparable difficulty bucket **AND** >= 8 sessions/model **AND** a meaningful gap (>= 0.15). Otherwise insufficient.

`get_model_routing_hints` / `get_active_concerns` / `generate_memory_suggestions` route through the guard. With current data (no clean reasoning-error signal) the guard correctly emits **zero** hints/concerns — the intended conservative behavior. Active-concerns no longer recommends "switch model" on error-recovery alone.

### Defect B — digest quality (truncation + dedup + decision-grade)

`scripts/lib/digest_text.py`:

1. **No mid-word truncation.** `smart_truncate()` cuts on a word boundary with an explicit ellipsis. Replaces the raw `[:80]`/`[:120]`/`[:150]` slices that produced `...Pref`, `that re`, `skill sk`, `for l`.
2. **Dedup.** `dedup_suggestions()` collapses suggestions with the same target+intent (e.g. the 3x identical "Model token profiel" lines) to one — highest-confidence, then latest. Applied to the persisted edit queue.
3. **Decision-grade.** `decision_grade()` dedups, drops non-actionable raw internals (bare token-profile dumps), and caps to top-N. The bare per-model token-profile suggestion is no longer generated.

## Tests

- `tests/test_model_inference_guard.py` (9) — incl. the **regression**: opus hard-bucket high-token + recoverable system errors vs sonnet easy-bucket ⇒ `insufficient_comparable_data`, **never** opus-route-away. Plus a positive-path test proving the guard *does* emit a hint given a clean infra-excluded signal, comparable difficulty, and a real gap.
- `tests/test_digest_quality.py` (8) — no suggestion ends mid-word (incl. real defect strings), dup collapse, highest-confidence kept, distinct preserved, raw-dump drop, top-N limit.

`pytest tests/test_model_inference_guard.py tests/test_digest_quality.py -q` → **17 passed**. End-to-end confounded-fixture validation confirms no opus-route-away hint and no token-profile dump.

Billing safety: no Anthropic SDK, no api.anthropic.com, no `claude -p` — pure stdlib.

Dispatch-ID: 20260603-105837-loopfix-tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)