### PR TITLE
fix(receipts): T0-view filter — project_id alignment + recent_receipts builder

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -999,39 +999,67 @@ def _build_active_work(dispatch_dir: Path) -> List[Dict[str, Any]]:
 # Recent receipts (last N lines from t0_receipts.ndjson)
 # ---------------------------------------------------------------------------
 
-def _build_recent_receipts(state_dir: Path, n: int = 3) -> List[Dict[str, Any]]:
-    # Phase 6 P3: prefer central receipts when available (derived from state_dir, not module global)
+def _infer_next_action(r: Dict[str, Any]) -> str:
+    s = (r.get("status") or "").lower()
+    if s in ("done", "success"):
+        return "review" if r.get("pr_id") or r.get("pr") else "merge_ready"
+    if s in ("failed", "failure"):
+        return "fix_needed"
+    if s in ("requested", "queued", "running"):
+        return "wait"
+    return "verify"
+
+
+def _build_recent_receipts(
+    state_dir: Path,
+    project_id: str = "",
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """Top-N most recent receipts (any status), with T0-view filter.
+
+    Filters by project_id when provided; accepts receipts with no project_id
+    for backward compat. Returns T0-relevant fields only — token_usage and
+    contract_hash are intentionally excluded to keep the snapshot lean.
+    """
+    # Phase 6 P3: prefer central receipts when available
     _central = _central_state_dir_for(state_dir)
     receipts_path = (_central if _central is not None else state_dir) / "t0_receipts.ndjson"
     if not receipts_path.exists():
         return []
 
     try:
-        raw_lines = receipts_path.read_bytes().splitlines()
-
-        events: List[Dict[str, Any]] = []
-        for raw_line in raw_lines:
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                e = json.loads(line.decode("utf-8"))
-                if e.get("event_type") == "state_mutation":
-                    continue
-                events.append({
-                    "terminal": e.get("terminal"),
-                    "status": e.get("status"),
-                    "event_type": e.get("event_type") or e.get("event"),
-                    "timestamp": e.get("timestamp"),
-                    "dispatch_id": e.get("dispatch_id"),
-                    "gate": e.get("gate"),
-                })
-            except Exception:
-                continue
-
-        return events[-100:][-n:]
-    except Exception:
+        lines = receipts_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
         return []
+
+    recs: List[Dict[str, Any]] = []
+    for line in lines[-2000:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        # Skip internal bookkeeping events — T0 wants worker completion signals
+        if r.get("event_type") == "state_mutation":
+            continue
+        # Project-id filter: accept matching project OR no project_id (backward compat)
+        pid = (r.get("project_id") or "").strip()
+        if project_id and pid and pid != project_id:
+            continue
+        recs.append({
+            "timestamp": r.get("timestamp"),
+            "dispatch_id": r.get("dispatch_id"),
+            "status": r.get("status"),
+            "terminal": r.get("terminal"),
+            "commit_hash": r.get("commit_hash") or r.get("commit"),
+            "pr_id": r.get("pr_id") or r.get("pr"),
+            "report_evidence_path": r.get("report_path") or r.get("evidence"),
+            "next_action": _infer_next_action(r),
+        })
+
+    return sorted(recs, key=lambda x: str(x.get("timestamp") or ""), reverse=True)[:limit]
 
 
 # ---------------------------------------------------------------------------
@@ -1330,7 +1358,7 @@ def build_t0_state(
     recent_dispatches = _collect_recent_dispatches(project_id, state_dir)
     intelligence_brief = _collect_intelligence_brief(project_id, state_dir)
     active_work = _build_active_work(dispatch_dir)
-    recent_receipts = _build_recent_receipts(state_dir)
+    recent_receipts = _build_recent_receipts(state_dir, project_id=project_id, limit=20)
     register_events = _build_register_events(state_dir=state_dir)
     git_context = _build_git_context()
     pr_queue: Dict[str, Any] = {

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -1,7 +1,8 @@
-"""dispatch_envelope.py — Flag-gated unified dispatch envelope (PR-1, codex lane only).
+"""dispatch_envelope.py — Flag-gated unified dispatch envelope (PR-1 codex, PR-2 claude-subprocess).
 
-Strangler-fig approach: legacy default OFF, codex-lane only in this PR.
-Activate with VNX_UNIFIED_ENVELOPE=1 and VNX_UNIFIED_ENVELOPE_LANES containing "codex".
+Strangler-fig approach: legacy default OFF, each lane activated per VNX_UNIFIED_ENVELOPE_LANES.
+Activate with VNX_UNIFIED_ENVELOPE=1 and VNX_UNIFIED_ENVELOPE_LANES containing "codex"
+and/or "claude-subprocess".
 
 Seams: PREPARE -> ROUTE -> EXECUTE -> GOVERN
 
@@ -9,8 +10,14 @@ GOVERN is fail-closed: a missing receipt_path raises EnvelopeGovernError — nev
 silently loses a receipt. Report is emitted before the receipt so the receipt carries
 the linkage even when the report file is new (ADR-005).
 
+Per-lane dual-receipt safety: GOVERN emits both report AND receipt. When the
+receipt NDJSON already contains a line for this dispatch_id (e.g. written by
+deliver_with_recovery's internal close-out), the GOVERN receipt write is skipped
+(idempotent dedup). No double-emit.
+
 Reuses:
   - spawn_codex from provider_spawns.codex_spawn (no reimplementation)
+  - spawn_claude from provider_spawns.claude_spawn (no reimplementation)
   - emit_dispatch_receipt + emit_unified_report from governance_emit
 
 No new hooks. Idempotent receipts (governance_emit uses fcntl.flock).
@@ -165,12 +172,93 @@ class CodexAdapter:
         )
 
 
+class ClaudeSubprocessAdapter:
+    """Wraps spawn_claude — reuses existing spawn without reimplementation.
+
+    Maps ClaudeSpawnResult fields to _AdapterResult for the envelope GOVERN
+    phase.  completion_text is left empty (matching legacy _dispatch_claude
+    behavior) because the worker writes its own report via _ensure_unified_report;
+    the envelope report is a governance wrapper, not the worker's full output.
+
+    event_writer is not wired in PR-2 (SubprocessAdapter handles EventStore
+    internally); the audit stream gap is documented in Open Items.
+    """
+
+    def run(
+        self,
+        spec: EnvelopeSpec,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from provider_spawns.claude_spawn import spawn_claude  # noqa: PLC0415
+
+        try:
+            result = spawn_claude(
+                prompt=spec.instruction,
+                model=spec.model,
+                dispatch_id=spec.dispatch_id,
+                terminal_id=spec.terminal_id,
+                event_writer=event_writer,
+                cwd=cwd,
+            )
+        except BrokenPipeError as exc:
+            return _AdapterResult(
+                returncode=1,
+                completion_text="",
+                status="failure",
+                error=f"claude spawn BrokenPipeError: {exc}",
+            )
+
+        token_usage: Dict[str, int] = {}
+        raw_usage = result.token_usage
+        if isinstance(raw_usage, dict) and raw_usage:
+            token_usage = {
+                "input": int(raw_usage.get("input_tokens", 0) or 0),
+                "output": int(raw_usage.get("output_tokens", 0) or 0),
+                "cache_hit": int(
+                    raw_usage.get("cache_read_input_tokens", 0) or 0
+                ),
+            }
+
+        if result.error:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text="",
+                status="failure",
+                token_usage=token_usage,
+                error=result.error,
+            )
+        if result.timed_out:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text="",
+                status="timeout",
+                token_usage=token_usage,
+                timed_out=True,
+            )
+        if result.stopped_early:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text="",
+                status="success",
+                token_usage=token_usage,
+            )
+        status = "success" if result.returncode == 0 else "failure"
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text="",
+            status=status,
+            token_usage=token_usage,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Lane router
 # ---------------------------------------------------------------------------
 
 _LANE_REGISTRY: Dict[str, type] = {
     "codex": CodexAdapter,
+    "claude-subprocess": ClaudeSubprocessAdapter,
 }
 
 
@@ -232,6 +320,26 @@ def _prepare(spec: EnvelopeSpec) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _receipt_exists_for_dispatch(receipt_path: Path, dispatch_id: str) -> bool:
+    """Check whether the NDJSON receipt file already contains a line for dispatch_id.
+
+    Used for idempotent dedup: when the legacy path (deliver_with_recovery) already
+    wrote a receipt for this dispatch, the envelope GOVERN skips its own receipt
+    write to avoid double-emit.
+    """
+    if not receipt_path.exists():
+        return False
+    target = f'"dispatch_id":"{dispatch_id}"'
+    try:
+        with open(receipt_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if target in line:
+                    return True
+    except OSError:
+        pass
+    return False
+
+
 def _govern(
     spec: EnvelopeSpec,
     adapter_result: _AdapterResult,
@@ -243,6 +351,11 @@ def _govern(
     Fail-closed contract: raises EnvelopeGovernError when receipt_path is None or
     absent on disk after emit — never silently loses a receipt.
     Report is emitted first so the receipt can carry the linkage (ADR-005 ordering).
+
+    Idempotent dedup: when the receipt NDJSON already contains a line for this
+    dispatch_id (written by deliver_with_recovery's internal close-out as a safety
+    net), the GOVERN receipt write is skipped.  This avoids double-emit during the
+    migration period where both legacy and envelope paths may run.
     """
     from governance_emit import emit_dispatch_receipt, emit_unified_report  # noqa: PLC0415
 
@@ -268,40 +381,48 @@ def _govern(
             exc,
         )
 
-    # RECEIPT second — fail-closed
+    # RECEIPT second — fail-closed, with idempotent dedup
     receipt_path: Optional[Path] = None
-    try:
-        receipt_path = emit_dispatch_receipt(
-            dispatch_id=spec.dispatch_id,
-            terminal_id=spec.terminal_id,
-            provider=spec.provider,
-            model=spec.model,
-            pr_id=spec.pr_id,
-            status=adapter_result.status,
-            completion_pct=100 if adapter_result.status == "success" else 0,
-            risk=0.0,
-            findings=[],
-            duration_seconds=duration,
-            token_usage=adapter_result.token_usage,
-            cost_usd=None,
-            state_dir=spec.state_dir,
-            report_path=str(report_path) if report_path else None,
+    ndjson_path = spec.state_dir / "t0_receipts.ndjson"
+    if _receipt_exists_for_dispatch(ndjson_path, spec.dispatch_id):
+        logger.info(
+            "envelope._govern: receipt already exists for dispatch=%s — skipping (idempotent dedup)",
+            spec.dispatch_id,
         )
-    except Exception as exc:
-        raise EnvelopeGovernError(
-            f"envelope._govern: receipt emit raised for dispatch={spec.dispatch_id}: {exc}"
-        ) from exc
+        receipt_path = ndjson_path
+    else:
+        try:
+            receipt_path = emit_dispatch_receipt(
+                dispatch_id=spec.dispatch_id,
+                terminal_id=spec.terminal_id,
+                provider=spec.provider,
+                model=spec.model,
+                pr_id=spec.pr_id,
+                status=adapter_result.status,
+                completion_pct=100 if adapter_result.status == "success" else 0,
+                risk=0.0,
+                findings=[],
+                duration_seconds=duration,
+                token_usage=adapter_result.token_usage,
+                cost_usd=None,
+                state_dir=spec.state_dir,
+                report_path=str(report_path) if report_path else None,
+            )
+        except Exception as exc:
+            raise EnvelopeGovernError(
+                f"envelope._govern: receipt emit raised for dispatch={spec.dispatch_id}: {exc}"
+            ) from exc
 
-    if receipt_path is None:
-        raise EnvelopeGovernError(
-            f"envelope._govern: receipt_path is None after emit "
-            f"(fail-closed) dispatch={spec.dispatch_id}"
-        )
-    if not receipt_path.exists():
-        raise EnvelopeGovernError(
-            f"envelope._govern: receipt file absent on disk after emit "
-            f"path={receipt_path} dispatch={spec.dispatch_id} (fail-closed)"
-        )
+        if receipt_path is None:
+            raise EnvelopeGovernError(
+                f"envelope._govern: receipt_path is None after emit "
+                f"(fail-closed) dispatch={spec.dispatch_id}"
+            )
+        if not receipt_path.exists():
+            raise EnvelopeGovernError(
+                f"envelope._govern: receipt file absent on disk after emit "
+                f"path={receipt_path} dispatch={spec.dispatch_id} (fail-closed)"
+            )
 
     logger.info(
         "envelope._govern: dispatch=%s status=%s report=%s receipt=%s",

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -297,7 +297,9 @@ def _prepare(spec: EnvelopeSpec) -> str:
             dispatch_paths=None,
         )
     except ImportError:
-        pass
+        logger.debug(
+            "envelope._prepare: intelligence_injection not available — skipping"
+        )
     except Exception as exc:
         logger.warning(
             "envelope._prepare: intelligence injection failed (%s) — skipping", exc
@@ -335,8 +337,14 @@ def _receipt_exists_for_dispatch(receipt_path: Path, dispatch_id: str) -> bool:
             for line in fh:
                 if target in line:
                     return True
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.warning(
+            "envelope._receipt_exists_for_dispatch: cannot read receipt ledger %s: %s — "
+            "treating as unreadable (fail-closed: will skip emit to avoid double-receipt)",
+            receipt_path,
+            exc,
+        )
+        return True
     return False
 
 

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -200,6 +200,7 @@ class ClaudeSubprocessAdapter:
                 terminal_id=spec.terminal_id,
                 event_writer=event_writer,
                 cwd=cwd,
+                role=spec.role,
             )
         except BrokenPipeError as exc:
             return _AdapterResult(

--- a/scripts/lib/project_root.py
+++ b/scripts/lib/project_root.py
@@ -103,8 +103,9 @@ def resolve_project_id(project_dir: str | Path | None = None) -> str:
 
     Resolution order:
       1. VNX_PROJECT_ID env var (explicit override)
-      2. git remote 'origin' URL → last path component, stripped of .git suffix
-      3. Raise RuntimeError — no silent 'vnx-dev' default (ADR-007)
+      2. .vnx-project-id file in project dir or CWD (canonical per ADR-007)
+      3. git remote 'origin' URL → last path component, stripped of .git suffix
+      4. Raise RuntimeError — no silent default (ADR-007)
 
     Raises RuntimeError if project_id cannot be determined.
     """
@@ -117,6 +118,21 @@ def resolve_project_id(project_dir: str | Path | None = None) -> str:
         start_dirs.append(Path(project_dir).resolve())
     start_dirs.append(Path.cwd().resolve())
 
+    # Priority 2: .vnx-project-id marker file (same contract as vnx_paths.py)
+    for start in start_dirs:
+        for ancestor in [start, *start.parents]:
+            marker = ancestor / ".vnx-project-id"
+            if not marker.is_file():
+                continue
+            try:
+                first_line = marker.read_text(encoding="utf-8").splitlines()[0].strip()
+                if first_line:
+                    return first_line
+            except (OSError, IndexError):
+                pass
+            break  # found marker but couldn't read it — don't keep walking
+
+    # Priority 3: git remote URL → repo name
     for start in start_dirs:
         try:
             out = subprocess.check_output(
@@ -134,7 +150,8 @@ def resolve_project_id(project_dir: str | Path | None = None) -> str:
             continue
 
     raise RuntimeError(
-        "Cannot resolve project_id. Set VNX_PROJECT_ID env var or run from a git "
+        "Cannot resolve project_id. Set VNX_PROJECT_ID env var, add a "
+        ".vnx-project-id file in the project root, or run from a git "
         "repository with a configured 'origin' remote. "
-        "No silent 'vnx-dev' default — explicit project_id required (ADR-007)."
+        "No silent default — explicit project_id required (ADR-007)."
     )

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -884,6 +884,46 @@ def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
         return 1
 
 
+def _dispatch_claude_via_envelope(args: argparse.Namespace) -> int:
+    """Route claude dispatch through the unified envelope (VNX_UNIFIED_ENVELOPE=1, claude-subprocess lane).
+
+    Fail-closed: EnvelopeGovernError → exit code 1. Legacy path (_dispatch_claude)
+    is untouched when the flag is unset.
+
+    Dual-receipt safety: deliver_with_recovery (called from the legacy path) already
+    writes its own receipt internally as a safety net. The envelope GOVERN receipt
+    write checks for an existing receipt via _receipt_exists_for_dispatch and skips
+    if found (idempotent dedup). No double-emit.
+    """
+    from dispatch_envelope import EnvelopeGovernError, EnvelopeSpec, run_envelope  # noqa: PLC0415
+
+    state_dir = _resolve_state_dir()
+    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+
+    spec = EnvelopeSpec(
+        dispatch_id=args.dispatch_id,
+        terminal_id=args.terminal_id,
+        provider="claude",
+        model=args.model,
+        instruction=args.instruction,
+        role=getattr(args, "role", None),
+        pr_id=getattr(args, "pr_id", None),
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    try:
+        result = run_envelope(spec, lane="claude-subprocess")
+        return result.returncode
+    except EnvelopeGovernError as exc:
+        logger.error(
+            "envelope: GOVERN fail-closed dispatch=%s: %s",
+            args.dispatch_id,
+            exc,
+        )
+        return 1
+
+
 def _resolve_codex_model() -> str:
     """Load codex model key from registry (openai section), fallback to hardcoded default.
 
@@ -1417,6 +1457,16 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if provider == "claude":
+        _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"
+        _envelope_lanes = [
+            lane.strip()
+            for lane in (os.environ.get("VNX_UNIFIED_ENVELOPE_LANES") or "").split(",")
+            if lane.strip()
+        ]
+        if _envelope_on and (
+            "claude-subprocess" in _envelope_lanes or "claude" in _envelope_lanes
+        ):
+            return _dispatch_claude_via_envelope(args)
         return _dispatch_claude(args)
 
     if provider == "codex":

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -485,6 +485,81 @@ class TestEnvelopeIdempotentDedup:
         mock_report.assert_called_once()
         mock_receipt.assert_called_once()
 
+    def test_receipt_ledger_unreadable_skips_emit(self, spec_claude, caplog):
+        """When receipt NDJSON exists but cannot be read (OSError), skip emit with warning.
+
+        Fail-closed: treat the unreadable ledger as "cannot confirm dedup" and skip
+        the receipt write rather than risking a silent double-emit. A WARNING is logged
+        with the exception details.
+        """
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec_claude)
+
+        # Create the NDJSON so it passes .exists() check
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text('{"dispatch_id":"other-dispatch"}\n', encoding="utf-8")
+
+        claude_result = _FakeClaudeResult(returncode=0)
+
+        # Patch open to raise OSError for the receipt file read.
+        # Only _receipt_exists_for_dispatch opens this path during GOVERN;
+        # emit_dispatch_receipt is mocked and won't call open.
+        _real_open = open
+        def _selective_open(path, *args, **kwargs):
+            if isinstance(path, Path):
+                path = str(path)
+            if str(receipt_path) in str(path):
+                raise OSError("Permission denied")
+            return _real_open(path, *args, **kwargs)
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="dispatch_envelope"):
+            with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+                 patch("governance_emit.emit_unified_report", mock_report), \
+                 patch("governance_emit.emit_dispatch_receipt", mock_receipt), \
+                 patch("builtins.open", side_effect=_selective_open):
+                result = run_envelope(spec_claude, lane="claude-subprocess")
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path == receipt_path
+        mock_report.assert_called_once()
+        # Receipt emit is SKIPPED (fail-closed: unreadable ledger → skip to avoid double-emit)
+        mock_receipt.assert_not_called()
+        # A WARNING was logged with the exception details
+        assert any(
+            "cannot read receipt ledger" in record.message
+            and "Permission denied" in record.message
+            for record in caplog.records
+        ), f"Expected WARNING about unreadable receipt ledger, got: {[r.message for r in caplog.records]}"
+
+    def test_receipt_exists_for_dispatch_oserror_returns_true(self, tmp_path, caplog):
+        """Unit test: _receipt_exists_for_dispatch returns True on OSError (fail-closed)."""
+        receipt_path = tmp_path / "t0_receipts.ndjson"
+        receipt_path.write_text('{"dispatch_id":"some-id"}\n', encoding="utf-8")
+
+        _real_open = open
+        def _raise_oserror(path, *args, **kwargs):
+            if isinstance(path, Path):
+                path = str(path)
+            if str(receipt_path) in str(path):
+                raise OSError("Permission denied")
+            return _real_open(path, *args, **kwargs)
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="dispatch_envelope"):
+            with patch("builtins.open", side_effect=_raise_oserror):
+                result = dispatch_envelope._receipt_exists_for_dispatch(
+                    receipt_path, "some-id"
+                )
+
+        # Fail-closed: unreadable ledger → return True (skip emit, no double-receipt)
+        assert result is True
+        # Warning logged with exception details
+        assert any(
+            "cannot read receipt ledger" in record.message
+            for record in caplog.records
+        ), f"Expected WARNING log, got: {[r.message for r in caplog.records]}"
+
 
 # ---------------------------------------------------------------------------
 # Flag gate: claude - flag-off = legacy path; flag-on = envelope invoked

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -639,3 +639,83 @@ class TestFlagGateClaude:
         mock_legacy.assert_called_once()
         mock_via_envelope.assert_not_called()
         assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Role-forwarding: ClaudeSubprocessAdapter must forward spec.role to spawn_claude
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeAdapterForwardsRoleToSpawn:
+    """ClaudeSubprocessAdapter.run() must forward spec.role to spawn_claude.
+
+    Without role forwarding, SubprocessAdapter.deliver() falls back to the
+    default capability profile — too restrictive for specialised workers
+    (backend-developer, reviewer, etc.). This test ensures role is passed through.
+    """
+
+    def test_dispatch_envelope_forwards_role_to_spawn(self, spec_claude):
+        """spawn_claude is called with role=spec.role (not None / missing)."""
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec_claude)
+
+        claude_result = _FakeClaudeResult(returncode=0)
+        captured_kwargs: dict = {}
+
+        def _capturing_spawn_claude(**kwargs):
+            captured_kwargs.update(kwargs)
+            return claude_result
+
+        with patch(
+            "provider_spawns.claude_spawn.spawn_claude",
+            side_effect=_capturing_spawn_claude,
+        ), patch("governance_emit.emit_unified_report", mock_report), patch(
+            "governance_emit.emit_dispatch_receipt", mock_receipt
+        ):
+            result = run_envelope(spec_claude, lane="claude-subprocess")
+
+        assert result.status == "success"
+        assert "role" in captured_kwargs, (
+            "spawn_claude was not called with a 'role' kwarg — role is not forwarded"
+        )
+        assert captured_kwargs["role"] == spec_claude.role, (
+            f"spawn_claude got role={captured_kwargs['role']!r}, "
+            f"expected {spec_claude.role!r}"
+        )
+
+    def test_none_role_forwarded_as_none(self, tmp_path):
+        """When spec.role is None, spawn_claude receives role=None (not absent)."""
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir(parents=True)
+        (data_dir / "unified_reports").mkdir(parents=True)
+
+        spec_no_role = EnvelopeSpec(
+            dispatch_id="env-role-none-test",
+            terminal_id="T1",
+            provider="claude",
+            model="sonnet",
+            instruction="do something",
+            role=None,
+            pr_id=None,
+            state_dir=state_dir,
+            data_dir=data_dir,
+        )
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec_no_role)
+        claude_result = _FakeClaudeResult(returncode=0)
+        captured_kwargs: dict = {}
+
+        def _capturing_spawn_claude(**kwargs):
+            captured_kwargs.update(kwargs)
+            return claude_result
+
+        with patch(
+            "provider_spawns.claude_spawn.spawn_claude",
+            side_effect=_capturing_spawn_claude,
+        ), patch("governance_emit.emit_unified_report", mock_report), patch(
+            "governance_emit.emit_dispatch_receipt", mock_receipt
+        ):
+            result = run_envelope(spec_no_role, lane="claude-subprocess")
+
+        assert result.status == "success"
+        assert "role" in captured_kwargs
+        assert captured_kwargs["role"] is None

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -1,13 +1,16 @@
-"""test_dispatch_envelope.py — Tests for dispatch_envelope.py (PR-1, codex lane).
+"""test_dispatch_envelope.py — Tests for dispatch_envelope.py (PR-1 codex, PR-2 claude-subprocess).
 
 Verifies:
-1. Success path: spawn_codex -> 0 -> BOTH report AND receipt emitted, returncode 0.
-2. Failure path: spawn_codex error -> BOTH report AND receipt emitted, status "failure".
-3. Timeout path: spawn_codex timed_out -> BOTH report AND receipt emitted, status "timeout".
-4. Fail-closed: receipt emit raises -> EnvelopeGovernError (non-zero, no silent loss).
-5. Fail-closed: receipt_path returns None -> EnvelopeGovernError.
-6. Flag-off: VNX_UNIFIED_ENVELOPE unset -> legacy _dispatch_codex called, envelope NOT invoked.
-7. Flag-on: VNX_UNIFIED_ENVELOPE=1 + lanes contains "codex" -> envelope invoked.
+1. Success path: spawn_codex/spawn_claude -> 0 -> BOTH report AND receipt emitted, returncode 0.
+2. Failure path: spawn error -> BOTH report AND receipt emitted, status "failure".
+3. Timeout path: spawn timed_out -> BOTH report AND receipt emitted, status "timeout".
+4. Stopped_early path (claude-only): spawn stopped_early -> BOTH report AND receipt, status "success".
+5. Fail-closed: receipt emit raises -> EnvelopeGovernError (non-zero, no silent loss).
+6. Fail-closed: receipt_path returns None -> EnvelopeGovernError.
+7. Idempotent dedup: pre-existing receipt line -> GOVERN skips write, no double-emit.
+8. Flag-off: VNX_UNIFIED_ENVELOPE unset -> legacy dispatch called, envelope NOT invoked.
+9. Flag-on: VNX_UNIFIED_ENVELOPE=1 + lanes contains lane -> envelope invoked.
+10. Lane "claude" alias -> routes to envelope (same as "claude-subprocess").
 """
 
 from __future__ import annotations
@@ -56,6 +59,28 @@ class _FakeCodexResult:
             self.token_usage = {"input_tokens": 100, "output_tokens": 50}
 
 
+@dataclass
+class _FakeClaudeResult:
+    """Minimal ClaudeSpawnResult-compatible stub for spawn_claude mocking."""
+
+    returncode: int = 0
+    completion: Dict[str, Any] = field(default_factory=dict)
+    events_written: int = 10
+    session_id: Optional[str] = "session-001"
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+    def __post_init__(self):
+        if self.token_usage is None:
+            self.token_usage = {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "cache_read_input_tokens": 50,
+            }
+
+
 # ---------------------------------------------------------------------------
 # Fixture: minimal EnvelopeSpec pointing at tmp_path
 # ---------------------------------------------------------------------------
@@ -78,6 +103,32 @@ def spec(tmp_path: Path) -> EnvelopeSpec:
         state_dir=state_dir,
         data_dir=data_dir,
     )
+
+
+@pytest.fixture()
+def spec_claude(tmp_path: Path) -> EnvelopeSpec:
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True)
+    (data_dir / "unified_reports").mkdir(parents=True)
+    return EnvelopeSpec(
+        dispatch_id="env-pr2-test-001",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        instruction="implement the feature",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+def _touch_and_return(path: Path) -> Path:
+    """Create an empty file at path and return the path (for mock side_effect)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
 
 
 _UNSET = object()  # sentinel distinguishing "not provided" from explicit None
@@ -268,6 +319,248 @@ class TestLaneRouter:
         adapter = LaneRouter().get("codex")
         assert isinstance(adapter, CodexAdapter)
 
+    def test_claude_subprocess_returns_claude_adapter(self):
+        from dispatch_envelope import ClaudeSubprocessAdapter
+        adapter = LaneRouter().get("claude-subprocess")
+        assert isinstance(adapter, ClaudeSubprocessAdapter)
+
     def test_unknown_lane_raises(self):
         with pytest.raises(ValueError, match="no adapter registered"):
             LaneRouter().get("unknown-lane")
+
+
+# ---------------------------------------------------------------------------
+# Claude-subprocess: success / failure / timeout / stopped_early emit BOTH
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeEnvelopeEmitsBothReportAndReceipt:
+    """PREPARE->ROUTE->EXECUTE->GOVERN emits report AND receipt for every outcome (claude-subprocess lane)."""
+
+    def _run(self, spec, claude_result):
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            result = run_envelope(spec, lane="claude-subprocess")
+
+        return result, mock_report, mock_receipt
+
+    def test_success_emits_report_and_receipt(self, spec_claude):
+        claude_result = _FakeClaudeResult(returncode=0)
+        result, mock_report, mock_receipt = self._run(spec_claude, claude_result)
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+
+    def test_failure_emits_report_and_receipt(self, spec_claude):
+        claude_result = _FakeClaudeResult(returncode=1, error="claude process exited 1")
+        result, mock_report, mock_receipt = self._run(spec_claude, claude_result)
+
+        assert result.status == "failure"
+        assert result.returncode == 1
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["status"] == "failure"
+
+    def test_timeout_emits_report_and_receipt(self, spec_claude):
+        claude_result = _FakeClaudeResult(returncode=1, timed_out=True)
+        result, mock_report, mock_receipt = self._run(spec_claude, claude_result)
+
+        assert result.status == "timeout"
+        assert result.returncode == 1
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["status"] == "timeout"
+
+    def test_stopped_early_emits_report_and_receipt(self, spec_claude):
+        claude_result = _FakeClaudeResult(returncode=0, stopped_early=True)
+        result, mock_report, mock_receipt = self._run(spec_claude, claude_result)
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.report_path is not None
+        assert result.receipt_path is not None
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Claude: fail-closed on missing / failed receipt
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeEnvelopeFailClosed:
+    """GOVERN must raise EnvelopeGovernError when receipt is missing — never silent (claude lane)."""
+
+    def test_receipt_emit_raises_fail_closed(self, spec_claude):
+        _, _, mock_report, mock_receipt = _stub_governance(
+            spec_claude, receipt_side_effect=RuntimeError("disk full")
+        )
+        claude_result = _FakeClaudeResult(returncode=0)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            with pytest.raises(EnvelopeGovernError, match="receipt emit raised"):
+                run_envelope(spec_claude, lane="claude-subprocess")
+
+    def test_none_receipt_path_fail_closed(self, spec_claude):
+        _, _, mock_report, mock_receipt = _stub_governance(
+            spec_claude, receipt_return=None
+        )
+        claude_result = _FakeClaudeResult(returncode=0)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            with pytest.raises(EnvelopeGovernError, match="receipt_path is None"):
+                run_envelope(spec_claude, lane="claude-subprocess")
+
+
+# ---------------------------------------------------------------------------
+# Idempotent dedup: pre-existing receipt → GOVERN skips write
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeIdempotentDedup:
+    """When a receipt line already exists for this dispatch_id, GOVERN skips the write."""
+
+    def test_pre_existing_receipt_skips_emit(self, spec_claude):
+        """GOVERN should not call emit_dispatch_receipt when receipt already present."""
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec_claude)
+
+        # Pre-populate the NDJSON with a line for this dispatch_id
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(
+            '{"dispatch_id":"env-pr2-test-001","status":"success"}\n',
+            encoding="utf-8",
+        )
+
+        claude_result = _FakeClaudeResult(returncode=0)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            result = run_envelope(spec_claude, lane="claude-subprocess")
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path == receipt_path
+        # Report is still emitted (idempotent via emit_unified_report's early-return)
+        mock_report.assert_called_once()
+        # Receipt is NOT emitted (already exists — idempotent dedup)
+        mock_receipt.assert_not_called()
+
+    def test_no_pre_existing_receipt_emits_normally(self, spec_claude):
+        """When no receipt exists, emit_dispatch_receipt is called as normal."""
+        # Build receipt_path manually without pre-creating it (unlike _stub_governance)
+        report_path = spec_claude.data_dir / "unified_reports" / f"{spec_claude.dispatch_id}.md"
+        receipt_path = spec_claude.state_dir / "t0_receipts.ndjson"
+        mock_report = MagicMock(return_value=report_path)
+        # Side-effect creates the file on disk so _govern's .exists() check passes
+        mock_receipt = MagicMock()
+        mock_receipt.side_effect = lambda **kwargs: _touch_and_return(receipt_path)
+
+        # Ensure NDJSON does NOT exist yet (no pre-populated receipt)
+        assert not receipt_path.exists()
+
+        claude_result = _FakeClaudeResult(returncode=0)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            result = run_envelope(spec_claude, lane="claude-subprocess")
+
+        assert result.status == "success"
+        mock_report.assert_called_once()
+        mock_receipt.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Flag gate: claude - flag-off = legacy path; flag-on = envelope invoked
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGateClaude:
+    """VNX_UNIFIED_ENVELOPE flag controls whether envelope or legacy path is used for claude."""
+
+    _CLAUDE_ARGV = [
+        "--provider", "claude",
+        "--terminal-id", "T1",
+        "--dispatch-id", "test-flag-gate-claude",
+        "--instruction", "noop",
+    ]
+
+    def test_flag_off_calls_legacy_dispatch_claude(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE unset -> _dispatch_claude, envelope NOT invoked."""
+        monkeypatch.delenv("VNX_UNIFIED_ENVELOPE", raising=False)
+        monkeypatch.delenv("VNX_UNIFIED_ENVELOPE_LANES", raising=False)
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CLAUDE_ARGV)
+
+        mock_legacy.assert_called_once()
+        mock_via_envelope.assert_not_called()
+        assert result == 0
+
+    def test_flag_on_calls_envelope(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE=1 + claude-subprocess in lanes -> _dispatch_claude_via_envelope."""
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "claude-subprocess")
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CLAUDE_ARGV)
+
+        mock_via_envelope.assert_called_once()
+        mock_legacy.assert_not_called()
+        assert result == 0
+
+    def test_flag_on_claude_alias_calls_envelope(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE=1 + "claude" (alias) in lanes -> _dispatch_claude_via_envelope."""
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "claude")
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CLAUDE_ARGV)
+
+        mock_via_envelope.assert_called_once()
+        mock_legacy.assert_not_called()
+        assert result == 0
+
+    def test_flag_on_wrong_lane_calls_legacy(self, monkeypatch):
+        """VNX_UNIFIED_ENVELOPE=1 but claude NOT in lanes -> legacy _dispatch_claude."""
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
+        monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "codex,gemini")
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CLAUDE_ARGV)
+
+        mock_legacy.assert_called_once()
+        mock_via_envelope.assert_not_called()
+        assert result == 0

--- a/tests/test_receipt_t0_view_filter.py
+++ b/tests/test_receipt_t0_view_filter.py
@@ -1,0 +1,359 @@
+"""Tests for receipt T0-view filter — project_id alignment + recent_receipts builder.
+
+Covers:
+- project_root.resolve_project_id() reads .vnx-project-id (Fix 1)
+- _build_recent_receipts top-N, project_id filter, T0-view fields (Fix 2)
+- _infer_next_action per status mapping
+- Integration: build_t0_state produces >5 recent_receipts entries
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import os
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ and scripts/lib importable
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+for _p in (_SCRIPTS_DIR, _LIB_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — resolve_project_id reads .vnx-project-id
+# ---------------------------------------------------------------------------
+
+class TestResolveProjectId:
+    def test_resolve_project_id_returns_vnx_dev(self, tmp_path: Path) -> None:
+        """resolve_project_id() reads .vnx-project-id file, returns its content."""
+        from project_root import resolve_project_id
+
+        marker = tmp_path / ".vnx-project-id"
+        marker.write_text("vnx-dev\n", encoding="utf-8")
+
+        result = resolve_project_id(project_dir=tmp_path)
+        assert result == "vnx-dev"
+
+    def test_resolve_project_id_env_var_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """VNX_PROJECT_ID env var takes priority over .vnx-project-id file."""
+        from project_root import resolve_project_id
+
+        marker = tmp_path / ".vnx-project-id"
+        marker.write_text("vnx-dev\n", encoding="utf-8")
+        monkeypatch.setenv("VNX_PROJECT_ID", "from-env")
+
+        result = resolve_project_id(project_dir=tmp_path)
+        assert result == "from-env"
+
+    def test_resolve_project_id_file_in_ancestor(self, tmp_path: Path) -> None:
+        """Walks up to ancestor to find .vnx-project-id."""
+        from project_root import resolve_project_id
+
+        (tmp_path / ".vnx-project-id").write_text("parent-project\n", encoding="utf-8")
+        subdir = tmp_path / "sub" / "dir"
+        subdir.mkdir(parents=True)
+
+        result = resolve_project_id(project_dir=subdir)
+        assert result == "parent-project"
+
+    def test_resolve_project_id_real_repo_returns_vnx_dev(self) -> None:
+        """For this actual repo, resolve_project_id() returns vnx-dev via .vnx-project-id."""
+        from project_root import resolve_project_id
+
+        result = resolve_project_id(project_dir=_REPO_ROOT)
+        assert result == "vnx-dev", (
+            f"Expected 'vnx-dev' but got {result!r}. "
+            "Check .vnx-project-id in the repo root."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — _infer_next_action per status mapping
+# ---------------------------------------------------------------------------
+
+class TestInferNextAction:
+    def _fn(self, r: dict) -> str:
+        from build_t0_state import _infer_next_action
+        return _infer_next_action(r)
+
+    def test_done_no_pr_returns_merge_ready(self) -> None:
+        assert self._fn({"status": "done"}) == "merge_ready"
+
+    def test_done_with_pr_id_returns_review(self) -> None:
+        assert self._fn({"status": "done", "pr_id": "PR-123"}) == "review"
+
+    def test_success_no_pr_returns_merge_ready(self) -> None:
+        assert self._fn({"status": "success"}) == "merge_ready"
+
+    def test_success_with_pr_returns_review(self) -> None:
+        assert self._fn({"status": "success", "pr": "PR-456"}) == "review"
+
+    def test_failed_returns_fix_needed(self) -> None:
+        assert self._fn({"status": "failed"}) == "fix_needed"
+
+    def test_failure_returns_fix_needed(self) -> None:
+        assert self._fn({"status": "failure"}) == "fix_needed"
+
+    def test_running_returns_wait(self) -> None:
+        assert self._fn({"status": "running"}) == "wait"
+
+    def test_queued_returns_wait(self) -> None:
+        assert self._fn({"status": "queued"}) == "wait"
+
+    def test_unknown_returns_verify(self) -> None:
+        assert self._fn({"status": "unknown"}) == "verify"
+
+    def test_none_status_returns_verify(self) -> None:
+        assert self._fn({"status": None}) == "verify"
+
+    def test_empty_status_returns_verify(self) -> None:
+        assert self._fn({}) == "verify"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — _build_recent_receipts
+# ---------------------------------------------------------------------------
+
+def _make_ndjson(tmp_path: Path, entries: list[dict]) -> Path:
+    p = tmp_path / "state" / "t0_receipts.ndjson"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = "\n".join(json.dumps(e) for e in entries)
+    p.write_text(lines + "\n", encoding="utf-8")
+    return p
+
+
+def _make_receipt(
+    *,
+    dispatch_id: str = "disp-001",
+    status: str = "done",
+    project_id: str = "vnx-dev",
+    terminal: str = "T1",
+    timestamp: str = "2026-06-03T10:00:00Z",
+    pr_id: str | None = None,
+    commit_hash: str | None = None,
+    token_usage: int | None = None,
+    contract_hash: str | None = None,
+) -> dict:
+    r: dict = {
+        "event_type": "subprocess_completion",
+        "dispatch_id": dispatch_id,
+        "status": status,
+        "project_id": project_id,
+        "terminal": terminal,
+        "timestamp": timestamp,
+    }
+    if pr_id is not None:
+        r["pr_id"] = pr_id
+    if commit_hash is not None:
+        r["commit_hash"] = commit_hash
+    if token_usage is not None:
+        r["token_usage"] = token_usage
+    if contract_hash is not None:
+        r["contract_hash"] = contract_hash
+    return r
+
+
+class TestBuildRecentReceipts:
+    def _fn(self, state_dir: Path, project_id: str = "vnx-dev", limit: int = 20) -> list:
+        from build_t0_state import _build_recent_receipts
+        # Ensure no central DB interference
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+        return _build_recent_receipts(state_dir, project_id=project_id, limit=limit)
+
+    def test_returns_empty_when_no_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        assert self._fn(state_dir) == []
+
+    def test_returns_top_20_from_50_entries(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id=f"d-{i:03d}", timestamp=f"2026-06-03T{i:02d}:00:00Z")
+            for i in range(50)
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir, limit=20)
+        assert len(result) == 20
+
+    def test_returns_sorted_desc_by_timestamp(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="early", timestamp="2026-06-03T01:00:00Z"),
+            _make_receipt(dispatch_id="late", timestamp="2026-06-03T23:00:00Z"),
+            _make_receipt(dispatch_id="mid", timestamp="2026-06-03T12:00:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir, limit=20)
+        assert result[0]["dispatch_id"] == "late"
+        assert result[1]["dispatch_id"] == "mid"
+        assert result[2]["dispatch_id"] == "early"
+
+    def test_filters_receipts_with_wrong_project_id(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="match", project_id="vnx-dev"),
+            _make_receipt(dispatch_id="other", project_id="some-other-project"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir, project_id="vnx-dev")
+        ids = [r["dispatch_id"] for r in result]
+        assert "match" in ids
+        assert "other" not in ids
+
+    def test_accepts_no_project_id_for_backward_compat(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="no-pid", project_id=""),
+            _make_receipt(dispatch_id="has-pid", project_id="vnx-dev"),
+        ]
+        # Remove project_id key entirely from first entry
+        entries[0].pop("project_id")
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir, project_id="vnx-dev")
+        ids = [r["dispatch_id"] for r in result]
+        assert "no-pid" in ids
+        assert "has-pid" in ids
+
+    def test_t0_view_fields_present(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(
+                dispatch_id="d-001",
+                pr_id="PR-42",
+                commit_hash="abc1234",
+                token_usage=9999,
+                contract_hash="deadbeef",
+            )
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        assert len(result) == 1
+        r = result[0]
+        # Required T0-view fields
+        assert "timestamp" in r
+        assert "dispatch_id" in r
+        assert "status" in r
+        assert "terminal" in r
+        assert "commit_hash" in r
+        assert r["commit_hash"] == "abc1234"
+        assert "pr_id" in r
+        assert r["pr_id"] == "PR-42"
+        assert "report_evidence_path" in r
+        assert "next_action" in r
+        # Excluded fields
+        assert "token_usage" not in r
+        assert "contract_hash" not in r
+
+    def test_skips_state_mutation_events(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="real"),
+            {"event_type": "state_mutation", "project_id": "vnx-dev", "timestamp": "2026-06-03T09:00:00Z"},
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        ids = [r["dispatch_id"] for r in result if r.get("dispatch_id")]
+        assert "real" in ids
+        assert len(result) == 1
+
+    def test_commit_fallback_to_commit_field(self, tmp_path: Path) -> None:
+        entry = _make_receipt(dispatch_id="d-002")
+        entry["commit"] = "fallback-hash"
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, [entry])
+        result = self._fn(state_dir)
+        assert result[0]["commit_hash"] == "fallback-hash"
+
+    def test_pr_fallback_to_pr_field(self, tmp_path: Path) -> None:
+        entry = _make_receipt(dispatch_id="d-003")
+        entry["pr"] = "PR-fallback"
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, [entry])
+        result = self._fn(state_dir)
+        assert result[0]["pr_id"] == "PR-fallback"
+
+    def test_next_action_derived_from_status(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="done-no-pr", status="done"),
+            _make_receipt(dispatch_id="done-with-pr", status="done", pr_id="PR-1", timestamp="2026-06-03T02:00:00Z"),
+            _make_receipt(dispatch_id="failed", status="failed", timestamp="2026-06-03T03:00:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        by_id = {r["dispatch_id"]: r for r in result}
+        assert by_id["done-no-pr"]["next_action"] == "merge_ready"
+        assert by_id["done-with-pr"]["next_action"] == "review"
+        assert by_id["failed"]["next_action"] == "fix_needed"
+
+    def test_malformed_lines_skipped_gracefully(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        ndjson = state_dir / "t0_receipts.ndjson"
+        ndjson.write_text(
+            "not-json\n"
+            + json.dumps(_make_receipt(dispatch_id="good")) + "\n"
+            + "{broken\n",
+            encoding="utf-8",
+        )
+        result = self._fn(state_dir)
+        assert len(result) == 1
+        assert result[0]["dispatch_id"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Integration — build_t0_state end-to-end produces >5 recent_receipts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestBuildT0StateIntegration:
+    def test_produces_more_than_5_recent_receipts(self, tmp_path: Path) -> None:
+        """End-to-end: build_t0_state produces >5 recent_receipts from an NDJSON with 10."""
+        import importlib
+        import build_t0_state as bts
+
+        state_dir = tmp_path / "state"
+        dispatch_dir = tmp_path / "dispatches"
+        state_dir.mkdir(parents=True)
+        dispatch_dir.mkdir(parents=True)
+
+        # Write 10 receipts for vnx-dev
+        entries = [
+            _make_receipt(
+                dispatch_id=f"int-{i:02d}",
+                status="done",
+                timestamp=f"2026-06-03T{i:02d}:00:00Z",
+            )
+            for i in range(10)
+        ]
+        ndjson = state_dir / "t0_receipts.ndjson"
+        ndjson.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n",
+            encoding="utf-8",
+        )
+
+        # Monkey-patch _central_state_dir_for to return None (disable central mode)
+        orig = bts._central_state_dir_for
+        bts._central_state_dir_for = lambda _sd: None  # type: ignore[attr-defined]
+
+        # Patch project_id_from_state_dir to return vnx-dev
+        import vnx_paths
+        orig_pid = vnx_paths.project_id_from_state_dir
+        vnx_paths.project_id_from_state_dir = lambda _: "vnx-dev"  # type: ignore[attr-defined]
+
+        try:
+            state = bts.build_t0_state(state_dir=state_dir, dispatch_dir=dispatch_dir)
+        finally:
+            bts._central_state_dir_for = orig  # type: ignore[attr-defined]
+            vnx_paths.project_id_from_state_dir = orig_pid  # type: ignore[attr-defined]
+
+        receipts = state.get("recent_receipts", [])
+        assert len(receipts) > 5, (
+            f"Expected >5 recent_receipts but got {len(receipts)}: {receipts}"
+        )


### PR DESCRIPTION
## Summary

- **Fix 1 — `project_root.resolve_project_id()`**: adds `.vnx-project-id` file detection (priority 2, before git remote URL fallback). Returns `vnx-dev` for this repo instead of `vnx-orchestration`. Consistent with `vnx_paths.py` resolution chain.
- **Fix 2 — `_build_recent_receipts()`**: rebuilt with project_id filtering, T0-view field set (`commit_hash`, `pr_id`, `report_evidence_path`, `next_action`), limit=20, and timestamp-descending sort. Added `_infer_next_action()` helper.
- **Call site updated** in `build_t0_state()`: passes `project_id` and `limit=20`.

**Root cause**: old function had `n=3` limit, no project_id filter, and no T0-view fields. Result: `t0_state.json.recent_receipts` showed only 3 items (was filtering out all `vnx-dev` receipts when project_id resolved to `vnx-orchestration`).

**After fix**: `t0_state.json.recent_receipts` shows 20 items (verified on live NDJSON with 72 receipts in 24h).

> Note: commit `0b191319` is the receipt fix. Commits `f9bdec57`, `dfde1994`, and `d50e90a4` are envelope adapter work from the same branch.

## Test plan

- [x] `pytest tests/test_receipt_t0_view_filter.py` — 27/27 passed
- [x] `python3 scripts/build_t0_state.py` — `recent_receipts` count: 20 (was 3)
- [x] `test_resolve_project_id_returns_vnx_dev` — Fix 1 verified
- [x] `test_build_recent_receipts_returns_top_20` — 50-entry NDJSON → 20 returned
- [x] `test_build_recent_receipts_filters_project_id` — wrong project_id dropped
- [x] `test_build_recent_receipts_t0_view_fields_only` — `token_usage`/`contract_hash` absent, `commit_hash` present
- [x] `test_infer_next_action_*` — all status mappings
- [x] Integration: end-to-end `build_t0_state()` → >5 `recent_receipts`

Dispatch-ID: 20260603-receipt-t0-view-filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)