### PR TITLE
fix(receipts): dedup recent_receipts per dispatch_id (keep best status)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -999,6 +999,15 @@ def _build_active_work(dispatch_dir: Path) -> List[Dict[str, Any]]:
 # Recent receipts (last N lines from t0_receipts.ndjson)
 # ---------------------------------------------------------------------------
 
+_STATUS_PRIORITY: Dict[str, int] = {
+    "done": 0, "success": 0, "completed": 0, "pass": 0,
+    "failed": 1, "failure": 1, "timeout": 1, "blocked": 1,
+    "running": 2, "queued": 2, "requested": 2,
+    "not_configured": 3, "not_executable": 3,
+    "unknown": 9, "": 9, None: 9,  # type: ignore[misc]
+}
+
+
 def _infer_next_action(r: Dict[str, Any]) -> str:
     s = (r.get("status") or "").lower()
     if s in ("done", "success"):
@@ -1032,7 +1041,9 @@ def _build_recent_receipts(
     except OSError:
         return []
 
-    recs: List[Dict[str, Any]] = []
+    best_by_dispatch: Dict[str, Dict[str, Any]] = {}
+    no_dispatch_recs: List[Dict[str, Any]] = []
+
     for line in lines[-2000:]:
         line = line.strip()
         if not line:
@@ -1048,7 +1059,7 @@ def _build_recent_receipts(
         pid = (r.get("project_id") or "").strip()
         if project_id and pid and pid != project_id:
             continue
-        recs.append({
+        view: Dict[str, Any] = {
             "timestamp": r.get("timestamp"),
             "dispatch_id": r.get("dispatch_id"),
             "status": r.get("status"),
@@ -1057,8 +1068,26 @@ def _build_recent_receipts(
             "pr_id": r.get("pr_id") or r.get("pr"),
             "report_evidence_path": r.get("report_path") or r.get("evidence"),
             "next_action": _infer_next_action(r),
-        })
+        }
+        did = (view.get("dispatch_id") or "").strip()
+        if not did or did in ("?", "unknown"):
+            no_dispatch_recs.append(view)
+            continue
+        cur_best = best_by_dispatch.get(did)
+        if cur_best is None:
+            best_by_dispatch[did] = view
+            continue
+        new_prio = _STATUS_PRIORITY.get(view.get("status"), 9)
+        cur_prio = _STATUS_PRIORITY.get(cur_best.get("status"), 9)
+        if new_prio < cur_prio:
+            best_by_dispatch[did] = view
+        elif new_prio == cur_prio:
+            new_terminal_known = bool(view.get("terminal") and view.get("terminal") != "unknown")
+            cur_terminal_known = bool(cur_best.get("terminal") and cur_best.get("terminal") != "unknown")
+            if new_terminal_known and not cur_terminal_known:
+                best_by_dispatch[did] = view
 
+    recs = list(best_by_dispatch.values()) + no_dispatch_recs
     return sorted(recs, key=lambda x: str(x.get("timestamp") or ""), reverse=True)[:limit]
 
 

--- a/tests/test_receipt_t0_view_filter.py
+++ b/tests/test_receipt_t0_view_filter.py
@@ -292,6 +292,60 @@ class TestBuildRecentReceipts:
         assert by_id["done-with-pr"]["next_action"] == "review"
         assert by_id["failed"]["next_action"] == "fix_needed"
 
+    def test_dedup_keeps_done_over_unknown_for_same_dispatch(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="disp-1", status="done", terminal="T1", timestamp="2026-06-03T10:00:00Z"),
+            _make_receipt(dispatch_id="disp-1", status="unknown", terminal="unknown", timestamp="2026-06-03T10:10:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        assert len(result) == 1
+        assert result[0]["status"] == "done"
+
+    def test_dedup_keeps_failed_over_unknown_for_same_dispatch(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="disp-2", status="failed", terminal="T2", timestamp="2026-06-03T10:00:00Z"),
+            _make_receipt(dispatch_id="disp-2", status="unknown", terminal="unknown", timestamp="2026-06-03T10:10:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        assert len(result) == 1
+        assert result[0]["status"] == "failed"
+
+    def test_dedup_tiebreak_prefers_known_terminal(self, tmp_path: Path) -> None:
+        entries = [
+            _make_receipt(dispatch_id="disp-3", status="unknown", terminal="unknown", timestamp="2026-06-03T10:05:00Z"),
+            _make_receipt(dispatch_id="disp-3", status="unknown", terminal="T1", timestamp="2026-06-03T10:00:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        assert len(result) == 1
+        assert result[0]["terminal"] == "T1"
+
+    def test_dedup_no_dispatch_id_passes_through(self, tmp_path: Path) -> None:
+        entry = _make_receipt(dispatch_id="", status="done", terminal="T1", timestamp="2026-06-03T10:00:00Z")
+        entry["dispatch_id"] = ""
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, [entry])
+        result = self._fn(state_dir)
+        assert len(result) == 1
+
+    def test_recent_receipts_after_dedup_max_one_per_dispatch_id(self, tmp_path: Path) -> None:
+        entries = []
+        for i in range(5):
+            did = f"dup-{i:02d}"
+            entries.append(_make_receipt(dispatch_id=did, status="done", terminal="T1", timestamp=f"2026-06-03T{i:02d}:00:00Z"))
+            entries.append(_make_receipt(dispatch_id=did, status="unknown", terminal="unknown", timestamp=f"2026-06-03T{i:02d}:10:00Z"))
+        state_dir = tmp_path / "state"
+        _make_ndjson(tmp_path, entries)
+        result = self._fn(state_dir)
+        dispatch_ids = [r["dispatch_id"] for r in result if r.get("dispatch_id")]
+        assert len(dispatch_ids) == len(set(dispatch_ids)), "duplicate dispatch_ids found after dedup"
+        assert len(result) == 5
+
     def test_malformed_lines_skipped_gracefully(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
         state_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- `_build_recent_receipts` now deduplicates per `dispatch_id`, keeping the entry with the best status priority
- Status priority: done/success/completed/pass (0) > failed/failure/timeout/blocked (1) > running/queued/requested (2) > not_configured/not_executable (3) > unknown (9)
- Tie-break at equal priority: prefer entry with known terminal (not `"unknown"`) over post-processing entries
- Entries without a `dispatch_id` (or `dispatch_id="?"/"unknown"`) pass through unchanged

## Test plan

- [x] `pytest tests/test_receipt_t0_view_filter.py -v` — 32/32 passed
- [x] `python3 scripts/build_t0_state.py` — rebuilt global state
- [x] Verified `t0_state.json` has 0 duplicate `dispatch_id`s after rebuild (was 7 before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)