### PR TITLE
feat(governance): enforce /pending dispatch path (close T0 direct-call bypass)

### DIFF
--- a/scripts/lib/staging_validator.py
+++ b/scripts/lib/staging_validator.py
@@ -10,20 +10,39 @@ Closes the T0 direct-call bypass tracked in issue #17.
 """
 from __future__ import annotations
 
+import getpass
+import json
 import logging
+import os
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Allowlist: alphanumeric start, then alphanumeric/underscore/dot/hyphen, max 128 chars total.
+# Rejects slashes, backslashes, null bytes, shell metacharacters, and relative traversal.
+_DISPATCH_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$')
+
 
 def _exists_in_dir(base: Path, dispatch_id: str) -> bool:
-    """True if dispatch_id is present under *base* as a directory, bare file, or <id>.md."""
+    """True if dispatch_id is present under *base* as a directory, bare file, or <id>.md.
+
+    Includes defense-in-depth: the resolved candidate path must stay within base.
+    """
+    candidate = base / dispatch_id
+    # Defense-in-depth: resolved path must not escape base (belt + regex suspenders).
+    try:
+        if not candidate.resolve().is_relative_to(base.resolve()):
+            return False
+    except (OSError, ValueError):
+        return False
     return (
-        (base / dispatch_id / "dispatch.json").exists()
-        or (base / dispatch_id).is_dir()
-        or (base / dispatch_id).is_file()
+        (candidate / "dispatch.json").exists()
+        or candidate.is_dir()
+        or candidate.is_file()
         or (base / f"{dispatch_id}.md").is_file()
     )
 
@@ -52,10 +71,15 @@ def validate_staging_path(
         logger.warning(
             "staging_validator: unstaged dispatch override — reason=%r", reason
         )
+        _data = _resolve_data_dir(data_dir)
+        _write_audit_event(_data, from_staging_id, reason)
         return
 
     if from_staging_id and from_staging_id.strip():
         sid = from_staging_id.strip()
+        # PATH TRAVERSAL FIX — validate format before any path join
+        if not _DISPATCH_ID_RE.match(sid):
+            _reject("staging-pending-flow violated: invalid dispatch_id format")
         _data = _resolve_data_dir(data_dir)
         dispatches = _data / "dispatches"
         if _exists_in_dir(dispatches / "pending", sid) or _exists_in_dir(
@@ -88,3 +112,25 @@ def _resolve_data_dir(data_dir: Optional[Path]) -> Path:
     except Exception as exc:
         _reject(f"Cannot resolve VNX data dir: {exc}")
         raise  # unreachable; _reject exits
+
+
+def _write_audit_event(
+    data_dir: Path,
+    dispatch_id: Optional[str],
+    reason: str,
+) -> None:
+    """Append NDJSON audit event for unstaged override (ADR-005)."""
+    events_dir = data_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "dispatch_id": dispatch_id,
+        "reason": reason,
+        "event_type": "unstaged_override",
+        "actor": getpass.getuser(),
+        "pid": os.getpid(),
+    }
+    audit_file = events_dir / "staging_validator.ndjson"
+    with audit_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event) + "\n")
+    logger.debug("staging_validator: ADR-005 audit event written to %s", audit_file)

--- a/scripts/lib/staging_validator.py
+++ b/scripts/lib/staging_validator.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""staging_validator.py — Enforce staging→pending→promote dispatch gate (ADR-006).
+
+Every dispatch fired via subprocess_dispatch or tmux_interactive_dispatch must
+originate from .vnx-data/dispatches/pending/ (or /staging/) — the mandatory
+human approval gate. Callers bypassing the gate must pass
+--allow-unstaged --reason '<text>' for an explicit audit-logged override.
+
+Closes the T0 direct-call bypass tracked in issue #17.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _exists_in_dir(base: Path, dispatch_id: str) -> bool:
+    """True if dispatch_id is present under *base* as a directory, bare file, or <id>.md."""
+    return (
+        (base / dispatch_id / "dispatch.json").exists()
+        or (base / dispatch_id).is_dir()
+        or (base / dispatch_id).is_file()
+        or (base / f"{dispatch_id}.md").is_file()
+    )
+
+
+def validate_staging_path(
+    from_staging_id: Optional[str],
+    allow_unstaged: bool,
+    reason: Optional[str],
+    *,
+    data_dir: Optional[Path] = None,
+) -> None:
+    """Enforce the staging→pending→promote dispatch gate.
+
+    Passes silently on success. Writes to stderr and calls sys.exit(1) on
+    violation so callers can rely on the process exit code.
+
+    Args:
+        from_staging_id: Dispatch ID to validate against pending/ or staging/.
+        allow_unstaged:  Explicit bypass (requires non-empty reason for audit trail).
+        reason:          Audit reason string — required with allow_unstaged.
+        data_dir:        VNX data root (auto-resolved via project_root when None).
+    """
+    if allow_unstaged:
+        if not reason or not reason.strip():
+            _reject("--allow-unstaged requires a non-empty --reason")
+        logger.warning(
+            "staging_validator: unstaged dispatch override — reason=%r", reason
+        )
+        return
+
+    if from_staging_id and from_staging_id.strip():
+        sid = from_staging_id.strip()
+        _data = _resolve_data_dir(data_dir)
+        dispatches = _data / "dispatches"
+        if _exists_in_dir(dispatches / "pending", sid) or _exists_in_dir(
+            dispatches / "staging", sid
+        ):
+            logger.debug("staging_validator: dispatch %r found — OK", sid)
+            return
+        _reject(
+            f"staging-pending-flow violated: dispatch {sid!r} not found in "
+            f"pending/ or staging/ under {dispatches}"
+        )
+
+    _reject(
+        "staging-pending-flow violated: pass --from-staging-id <id> (must exist in "
+        ".vnx-data/dispatches/pending/ or /staging/) or --allow-unstaged --reason '<text>'"
+    )
+
+
+def _reject(message: str) -> None:
+    print(f"[staging_validator] ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _resolve_data_dir(data_dir: Optional[Path]) -> Path:
+    if data_dir is not None:
+        return data_dir
+    try:
+        from project_root import resolve_data_dir  # noqa: PLC0415
+        return resolve_data_dir(caller_file=__file__)
+    except Exception as exc:
+        _reject(f"Cannot resolve VNX data dir: {exc}")
+        raise  # unreachable; _reject exits

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -361,7 +361,28 @@ if __name__ == "__main__":
         "--requires-mcp", action="store_true", default=False,
         help="Preserve ambient MCP config for this dispatch (Requires-MCP: true in dispatch file).",
     )
+    # ADR-006: staging→pending→promote gate enforcement.
+    parser.add_argument(
+        "--from-staging-id", default=None, dest="from_staging_id",
+        help="Dispatch ID that exists in .vnx-data/dispatches/pending/ or /staging/.",
+    )
+    parser.add_argument(
+        "--allow-unstaged", action="store_true", default=False,
+        help="Bypass staging gate (requires --reason for audit trail).",
+    )
+    parser.add_argument(
+        "--reason", default=None,
+        help="Audit reason required when --allow-unstaged is set.",
+    )
     args = parser.parse_args()
+
+    # ADR-006: staging→pending→promote gate — must pass before any dispatch work.
+    from staging_validator import validate_staging_path as _validate_staging  # noqa: PLC0415
+    _validate_staging(
+        getattr(args, "from_staging_id", None),
+        getattr(args, "allow_unstaged", False),
+        getattr(args, "reason", None),
+    )
 
     # Wave-5 ADR injection opt-out: set env var before instruction assembly (INT-2)
     if getattr(args, "no_adr_inject", False):

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1611,8 +1611,30 @@ def main(argv: "list[str] | None" = None) -> int:
         help="spawn worker in the main repo checkout (opt-out of isolation)",
     )
     parser.add_argument("--base-ref", default="origin/main")
+    # ADR-006: staging→pending→promote gate enforcement.
+    parser.add_argument(
+        "--from-staging-id", default=None, dest="from_staging_id",
+        help="Dispatch ID that exists in .vnx-data/dispatches/pending/ or /staging/.",
+    )
+    parser.add_argument(
+        "--allow-unstaged", action="store_true", default=False,
+        help="Bypass staging gate (requires --reason for audit trail).",
+    )
+    parser.add_argument(
+        "--reason", default=None,
+        help="Audit reason required when --allow-unstaged is set.",
+    )
 
     args = parser.parse_args(argv)
+
+    # ADR-006: staging→pending→promote gate — must pass before any dispatch work.
+    from staging_validator import validate_staging_path as _validate_staging  # noqa: PLC0415
+    _validate_staging(
+        getattr(args, "from_staging_id", None),
+        getattr(args, "allow_unstaged", False),
+        getattr(args, "reason", None),
+    )
+
     lane = TmuxInteractiveDispatch(_resolve_state_dir())
 
     result = lane.dispatch(

--- a/tests/dispatch/test_staging_enforcement.py
+++ b/tests/dispatch/test_staging_enforcement.py
@@ -5,9 +5,17 @@ Covers the four required cases from dispatch 20260603-140019-pending-governance-
   (ii)  --allow-unstaged + --reason → pass
   (iii) Neither arg provided → exit 1, stderr contains 'staging-pending-flow violated'
   (iv)  --from-staging-id pointing to non-existent dispatch → exit 1, same message
+
+Also covers path-traversal hardening (dispatch 20260603-141935-pending-governance-fix1-pathtraversal):
+  (v)   Path traversal via .. rejected before any path join
+  (vi)  Absolute path as dispatch_id rejected
+  (vii) Slashes in dispatch_id rejected
+  (viii) Shell-special chars in dispatch_id rejected
+  (ix)  --allow-unstaged override writes ADR-005 audit NDJSON event
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -156,3 +164,81 @@ class TestArgWiring:
         assert "--allow-unstaged" in src
         assert "--reason" in src
         assert "validate_staging_path" in src
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal hardening (dispatch 20260603-141935-pending-governance-fix1-pathtraversal)
+# ---------------------------------------------------------------------------
+
+class TestPathTraversalHardening:
+
+    def test_rejects_path_traversal_dotdot(self, tmp_path: Path, capsys) -> None:
+        """../../etc/passwd as dispatch_id is rejected before any path join."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "../../etc/passwd",
+                False,
+                None,
+                data_dir=tmp_path,
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+        assert "invalid dispatch_id format" in captured.err
+
+    def test_rejects_absolute_path_dispatch_id(self, tmp_path: Path, capsys) -> None:
+        """/etc/passwd as dispatch_id is rejected (absolute paths fail regex)."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "/etc/passwd",
+                False,
+                None,
+                data_dir=tmp_path,
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "invalid dispatch_id format" in captured.err
+
+    def test_rejects_dispatch_id_with_slashes(self, tmp_path: Path, capsys) -> None:
+        """foo/bar as dispatch_id is rejected (slash not in allowlist)."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "foo/bar",
+                False,
+                None,
+                data_dir=tmp_path,
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "invalid dispatch_id format" in captured.err
+
+    def test_rejects_dispatch_id_with_special_chars(self, tmp_path: Path, capsys) -> None:
+        """Shell-special chars ($, `, ;, |, &) in dispatch_id are rejected."""
+        for bad_id in ["foo$bar", "foo`bar", "foo;bar", "foo|bar", "foo&bar"]:
+            with pytest.raises(SystemExit) as exc_info:
+                validate_staging_path(bad_id, False, None, data_dir=tmp_path)
+            assert exc_info.value.code == 1, f"Expected exit 1 for {bad_id!r}"
+            captured = capsys.readouterr()
+            assert "invalid dispatch_id format" in captured.err, (
+                f"Expected format error for {bad_id!r}"
+            )
+
+    def test_unstaged_override_writes_audit_event(self, tmp_path: Path) -> None:
+        """--allow-unstaged writes an NDJSON audit event to events/staging_validator.ndjson."""
+        validate_staging_path(
+            "20260603-test-dispatch",
+            True,
+            "emergency hotfix reason",
+            data_dir=tmp_path,
+        )
+        audit_file = tmp_path / "events" / "staging_validator.ndjson"
+        assert audit_file.exists(), "Audit file must exist after unstaged override"
+        lines = audit_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "unstaged_override"
+        assert event["dispatch_id"] == "20260603-test-dispatch"
+        assert event["reason"] == "emergency hotfix reason"
+        assert "timestamp" in event
+        assert "actor" in event
+        assert "pid" in event

--- a/tests/dispatch/test_staging_enforcement.py
+++ b/tests/dispatch/test_staging_enforcement.py
@@ -1,0 +1,158 @@
+"""test_staging_enforcement.py — Parameterized tests for staging→pending gate enforcement.
+
+Covers the four required cases from dispatch 20260603-140019-pending-governance-enforcement:
+  (i)   --from-staging-id with a valid pending dispatch.json present → pass
+  (ii)  --allow-unstaged + --reason → pass
+  (iii) Neither arg provided → exit 1, stderr contains 'staging-pending-flow violated'
+  (iv)  --from-staging-id pointing to non-existent dispatch → exit 1, same message
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from staging_validator import validate_staging_path  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pending_dispatch(tmp_path: Path, dispatch_id: str) -> None:
+    """Create a canonical pending dispatch directory with dispatch.json."""
+    d = tmp_path / "dispatches" / "pending" / dispatch_id
+    d.mkdir(parents=True)
+    (d / "dispatch.json").write_text(
+        f'{{"dispatch_id": "{dispatch_id}", "terminal_id": "T1"}}',
+        encoding="utf-8",
+    )
+
+
+def _make_staging_dispatch(tmp_path: Path, dispatch_id: str) -> None:
+    """Create a staging dispatch as a .md file (convention used in this repo)."""
+    staging = tmp_path / "dispatches" / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    (staging / f"{dispatch_id}.md").write_text(
+        f"# Dispatch {dispatch_id}\n\nInstruction body here.",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestStagingEnforcement:
+
+    def test_accepts_from_staging_id_with_valid_pending_dispatch(self, tmp_path: Path) -> None:
+        """(i) --from-staging-id pointing to an existing pending dispatch.json passes."""
+        _make_pending_dispatch(tmp_path, "20260601-test-dispatch")
+        # Must not raise or exit
+        validate_staging_path(
+            "20260601-test-dispatch",
+            False,
+            None,
+            data_dir=tmp_path,
+        )
+
+    def test_accepts_from_staging_id_in_staging_dir(self, tmp_path: Path) -> None:
+        """(i-b) --from-staging-id pointing to an existing staging .md file passes."""
+        _make_staging_dispatch(tmp_path, "20260601-staging-only")
+        validate_staging_path(
+            "20260601-staging-only",
+            False,
+            None,
+            data_dir=tmp_path,
+        )
+
+    def test_accepts_allow_unstaged_with_reason(self, tmp_path: Path) -> None:
+        """(ii) --allow-unstaged with a non-empty reason bypasses file check."""
+        validate_staging_path(
+            None,
+            True,
+            "emergency hotfix: CI speed test, no dispatch file needed",
+            data_dir=tmp_path,
+        )
+
+    def test_rejects_without_either_arg(self, tmp_path: Path, capsys) -> None:
+        """(iii) Neither --from-staging-id nor --allow-unstaged: exits 1 with clear message."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(None, False, None, data_dir=tmp_path)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+
+    def test_rejects_from_staging_id_pointing_to_nonexistent_dispatch(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """(iv) --from-staging-id with a non-existent ID: exits 1 with 'staging-pending-flow violated'."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "20260601-does-not-exist",
+                False,
+                None,
+                data_dir=tmp_path,
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+
+    def test_rejects_allow_unstaged_without_reason(self, tmp_path: Path, capsys) -> None:
+        """--allow-unstaged without --reason exits 1 (audit trail requires reason)."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(None, True, None, data_dir=tmp_path)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--allow-unstaged requires" in captured.err
+
+    def test_rejects_allow_unstaged_with_empty_reason(self, tmp_path: Path, capsys) -> None:
+        """--allow-unstaged with blank reason also exits 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(None, True, "   ", data_dir=tmp_path)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--allow-unstaged requires" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Wiring checks — validate that both CLI entry-points declare the new args
+# ---------------------------------------------------------------------------
+
+class TestArgWiring:
+
+    def test_subprocess_dispatch_declares_staging_args(self) -> None:
+        """subprocess_dispatch __main__ parser must accept --from-staging-id etc."""
+        import argparse
+        import importlib.util
+        import types
+
+        spec = importlib.util.spec_from_file_location(
+            "subprocess_dispatch",
+            Path(__file__).resolve().parents[2]
+            / "scripts" / "lib" / "subprocess_dispatch.py",
+        )
+        # We only need to verify the argument declarations, not execute the module.
+        # Parse the source for the argparse add_argument calls.
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "scripts" / "lib" / "subprocess_dispatch.py"
+        ).read_text(encoding="utf-8")
+        assert "--from-staging-id" in src
+        assert "--allow-unstaged" in src
+        assert "--reason" in src
+        assert "validate_staging_path" in src
+
+    def test_tmux_interactive_dispatch_declares_staging_args(self) -> None:
+        """tmux_interactive_dispatch main() parser must accept --from-staging-id etc."""
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "scripts" / "lib" / "tmux_interactive_dispatch.py"
+        ).read_text(encoding="utf-8")
+        assert "--from-staging-id" in src
+        assert "--allow-unstaged" in src
+        assert "--reason" in src
+        assert "validate_staging_path" in src


### PR DESCRIPTION
## Summary
Closes T0 direct-call bypass (issue #17). Both `subprocess_dispatch.py` and `tmux_interactive_dispatch.py` now require either `--from-staging-id <id>` (matching a dispatch in `.vnx-data/dispatches/pending/` or `/staging/`) OR explicit `--allow-unstaged --reason '<text>'` override. Rejection: `staging-pending-flow violated` to stderr, exit 1.

## Changes
- **New:** `scripts/lib/staging_validator.py` (~70 LOC) — common validation helper
- **New:** `tests/dispatch/test_staging_enforcement.py` — 9 parametrized cases
- **Modified:** `scripts/lib/subprocess_dispatch.py` + `scripts/lib/tmux_interactive_dispatch.py` — wire args + call validator before any work
- **LOC delta:** +291 / -0 (5 files)

## Test plan
- [x] `pytest tests/dispatch/test_staging_enforcement.py -v` — 9 passed
- [x] `python3 -m py_compile` on modified files
- [ ] VNX CI workflow green
- [ ] codex_gate + gemini_review

## Notes
- Env-not-inherited workaround preserved (validation in same process)
- ADR-006 (human-gate) now machine-enforced, was previously doc-only
- Bypasses /pending → /staging → promote flow; per memory `staging-pending-flow-discipline`

Dispatch-ID: 20260603-140019-pending-governance-enforcement
Worker report: `.vnx-data/unified_reports/20260603-140019-pending-governance-enforcement.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)