### PR TITLE
feat(oi): bulk pattern subcommands + 1.0 closing sprint (96→48 open, 0 blockers)

### DIFF
--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -10,7 +10,7 @@ import fcntl
 import os
 import re
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from contextlib import contextmanager
 from typing import List, Optional, Literal, Tuple
 import sys
@@ -696,6 +696,105 @@ def rescan_items(args):
         generate_digest()
 
 
+def _filter_items_by_pattern(
+    items: list,
+    title_match: str,
+    severity: Optional[str] = None,
+    older_than_days: Optional[int] = None,
+) -> list:
+    """Filter items by regex title, optional severity, and optional age."""
+    try:
+        pattern = re.compile(title_match, re.IGNORECASE)
+    except re.error as exc:
+        raise SystemExit(f"Invalid regex '{title_match}': {exc}")
+
+    result = [i for i in items if pattern.search(i.get("title", ""))]
+
+    if severity:
+        result = [i for i in result if i.get("severity") == severity]
+
+    if older_than_days is not None:
+        cutoff = datetime.now() - timedelta(days=older_than_days)
+        result = [
+            i for i in result
+            if datetime.fromisoformat(i["created_at"]) < cutoff
+        ]
+
+    return result
+
+
+def _apply_pattern(args, new_status: str) -> int:
+    """Bulk-close open items matching a title regex.
+
+    Dry-run (default): print count + sample, no mutation.
+    --apply: mutate items and write audit entries.
+    """
+    title_match = args.title_match
+    severity_filter = getattr(args, "severity", None)
+    older_than_days = getattr(args, "older_than_days", None)
+    apply = getattr(args, "apply", False)
+    reason = args.reason
+
+    # Load once for preview (no lock needed for read)
+    data = load_items()
+    preview = _filter_items_by_pattern(
+        [i for i in data["items"] if i["status"] == "open"],
+        title_match,
+        severity_filter,
+        older_than_days,
+    )
+
+    if not apply:
+        print(f"[DRY RUN] {new_status}: {len(preview)} items match '{title_match}'")
+        for item in preview[:5]:
+            print(f"  {item['id']} [{item['severity']}]: {item['title'][:72]}")
+        if len(preview) > 5:
+            print(f"  ... and {len(preview) - 5} more")
+        return 0
+
+    mutated_ids = []
+    with _with_items_lock():
+        data = load_items()
+        for item in data["items"]:
+            if item["status"] != "open":
+                continue
+            if not _filter_items_by_pattern(
+                [item], title_match, severity_filter, older_than_days
+            ):
+                continue
+            item["status"] = new_status
+            item["closed_reason"] = reason
+            item["closed_at"] = datetime.now().isoformat()
+            item["updated_at"] = datetime.now().isoformat()
+            item["closed_by"] = f"pattern:{title_match}"
+            mutated_ids.append(item["id"])
+
+        if mutated_ids:
+            save_items(data)
+
+        for item_id in mutated_ids:
+            audit_log_entry(
+                "pattern_close",
+                item_id=item_id,
+                to_status=new_status,
+                reason=reason,
+                pattern=title_match,
+            )
+
+    print(f"[OK] {new_status}: {len(mutated_ids)} items closed (pattern: '{title_match}')")
+    if mutated_ids:
+        generate_digest()
+    return 0
+
+
+def defer_pattern(args) -> int:
+    return _apply_pattern(args, "deferred")
+
+
+def wontfix_pattern(args) -> int:
+    return _apply_pattern(args, "wontfix")
+
+
 def count_items_closed_by_dispatch(dispatch_id: str) -> int:
     """Count items where closed_by_dispatch_id matches."""
     data = load_items()
@@ -768,6 +867,56 @@ def main():
     rescan_parser.add_argument('--dry-run', action='store_true', dest='dry_run',
                               help='Show what would be closed without closing')
 
+    # defer-pattern command
+    defer_pattern_parser = subparsers.add_parser(
+        'defer-pattern',
+        help='Defer all open items whose title matches a regex'
+    )
+    defer_pattern_parser.add_argument(
+        '--title-match', required=True, dest='title_match', metavar='REGEX',
+        help='Regex matched against item title (case-insensitive)'
+    )
+    defer_pattern_parser.add_argument(
+        '--severity', choices=['blocker', 'warn', 'info'],
+        help='Optional: only affect items with this severity'
+    )
+    defer_pattern_parser.add_argument(
+        '--older-than-days', type=int, dest='older_than_days', metavar='N',
+        help='Optional: only affect items older than N days'
+    )
+    defer_pattern_parser.add_argument(
+        '--reason', required=True, help='Deferral reason recorded in item'
+    )
+    defer_pattern_parser.add_argument(
+        '--apply', action='store_true', default=False,
+        help='Apply mutation (omit for dry-run preview)'
+    )
+
+    # wontfix-pattern command
+    wontfix_pattern_parser = subparsers.add_parser(
+        'wontfix-pattern',
+        help='Mark as wontfix all open items whose title matches a regex'
+    )
+    wontfix_pattern_parser.add_argument(
+        '--title-match', required=True, dest='title_match', metavar='REGEX',
+        help='Regex matched against item title (case-insensitive)'
+    )
+    wontfix_pattern_parser.add_argument(
+        '--severity', choices=['blocker', 'warn', 'info'],
+        help='Optional: only affect items with this severity'
+    )
+    wontfix_pattern_parser.add_argument(
+        '--older-than-days', type=int, dest='older_than_days', metavar='N',
+        help='Optional: only affect items older than N days'
+    )
+    wontfix_pattern_parser.add_argument(
+        '--reason', required=True, help='Wontfix reason recorded in item'
+    )
+    wontfix_pattern_parser.add_argument(
+        '--apply', action='store_true', default=False,
+        help='Apply mutation (omit for dry-run preview)'
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -795,6 +944,10 @@ def main():
         generate_digest()
     elif args.command == 'rescan':
         rescan_items(args)
+    elif args.command == 'defer-pattern':
+        defer_pattern(args)
+    elif args.command == 'wontfix-pattern':
+        wontfix_pattern(args)
 
     return 0
 

--- a/tests/oi/test_pattern_subcommands.py
+++ b/tests/oi/test_pattern_subcommands.py
@@ -1,0 +1,161 @@
+"""Tests for defer-pattern and wontfix-pattern subcommands."""
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import open_items_manager as oim
+
+
+def _make_item(item_id, title, severity="warn", status="open", created_days_ago=0):
+    return {
+        "id": item_id,
+        "status": status,
+        "severity": severity,
+        "title": title,
+        "details": "",
+        "origin_dispatch_id": "test-dispatch",
+        "origin_report_path": "",
+        "pr_id": "",
+        "created_at": (datetime.now() - timedelta(days=created_days_ago)).isoformat(),
+        "updated_at": datetime.now().isoformat(),
+        "closed_reason": None,
+    }
+
+
+def _write_items(oi_file, items):
+    data = {"schema_version": "1.0", "items": items, "next_id": len(items) + 1}
+    with open(oi_file, "w") as f:
+        json.dump(data, f)
+    return data
+
+
+def _make_args(title_match, reason, severity=None, older_than_days=None, apply=False):
+    return argparse.Namespace(
+        title_match=title_match,
+        reason=reason,
+        severity=severity,
+        older_than_days=older_than_days,
+        apply=apply,
+    )
+
+
+@pytest.fixture
+def oi_state(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    oi_file = state / "open_items.json"
+    monkeypatch.setattr(oim, "STATE_DIR", state)
+    monkeypatch.setattr(oim, "OPEN_ITEMS_FILE", oi_file)
+    monkeypatch.setattr(oim, "DIGEST_FILE", state / "open_items_digest.json")
+    monkeypatch.setattr(oim, "MARKDOWN_FILE", state / "open_items.md")
+    monkeypatch.setattr(oim, "AUDIT_LOG", state / "open_items_audit.jsonl")
+    yield state, oi_file
+
+
+class TestDryRun:
+    def test_dry_run_shows_count_no_mutation(self, oi_state):
+        state, oi_file = oi_state
+        items = [
+            _make_item("OI-001", "Function exceeds warning threshold: 50 lines"),
+            _make_item("OI-002", "Some other item"),
+        ]
+        _write_items(oi_file, items)
+
+        args = _make_args("exceeds.*threshold", "hygiene wave", apply=False)
+        oim._apply_pattern(args, "deferred")
+
+        with open(oi_file) as f:
+            data = json.load(f)
+        assert all(i["status"] == "open" for i in data["items"]), "dry-run must not mutate"
+
+        audit_file = state / "open_items_audit.jsonl"
+        assert not audit_file.exists(), "dry-run must not write audit entries"
+
+
+class TestApplyMutates:
+    def test_apply_mutates_and_writes_audit(self, oi_state):
+        state, oi_file = oi_state
+        items = [
+            _make_item("OI-001", "Function exceeds warning threshold: 50 lines"),
+            _make_item("OI-002", "Function exceeds warning threshold: 30 lines"),
+            _make_item("OI-003", "Unrelated item"),
+        ]
+        _write_items(oi_file, items)
+
+        args = _make_args("exceeds.*threshold", "hygiene wave", apply=True)
+        oim._apply_pattern(args, "deferred")
+
+        with open(oi_file) as f:
+            data = json.load(f)
+
+        deferred = [i for i in data["items"] if i["status"] == "deferred"]
+        open_items = [i for i in data["items"] if i["status"] == "open"]
+        assert len(deferred) == 2, "two matching items must be deferred"
+        assert len(open_items) == 1
+        assert open_items[0]["id"] == "OI-003"
+        assert all(i["closed_reason"] == "hygiene wave" for i in deferred)
+
+        audit_file = state / "open_items_audit.jsonl"
+        assert audit_file.exists(), "audit log must be written on apply"
+        entries = [
+            json.loads(line)
+            for line in audit_file.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(entries) == 2
+        assert all(e["action"] == "pattern_close" for e in entries)
+        assert all(e["to_status"] == "deferred" for e in entries)
+
+
+class TestNoMatch:
+    def test_regex_non_match_returns_empty(self, oi_state):
+        state, oi_file = oi_state
+        items = [
+            _make_item("OI-001", "Module level import not at top"),
+            _make_item("OI-002", "Some other item"),
+        ]
+        _write_items(oi_file, items)
+
+        args = _make_args("tool_unavailable.*vulture", "no match reason", apply=True)
+        oim._apply_pattern(args, "wontfix")
+
+        with open(oi_file) as f:
+            data = json.load(f)
+        assert all(i["status"] == "open" for i in data["items"]), "no items mutated on no-match"
+
+        audit_file = state / "open_items_audit.jsonl"
+        empty = not audit_file.exists() or audit_file.read_text().strip() == ""
+        assert empty, "no audit entries on no-match"
+
+
+class TestSeverityFilter:
+    def test_severity_filter_only_affects_matching_severity(self, oi_state):
+        state, oi_file = oi_state
+        items = [
+            _make_item("OI-001", "File exceeds threshold: 100 lines", severity="warn"),
+            _make_item("OI-002", "File exceeds threshold: 200 lines", severity="info"),
+            _make_item("OI-003", "File exceeds threshold: 300 lines", severity="blocker"),
+        ]
+        _write_items(oi_file, items)
+
+        args = _make_args("exceeds threshold", "hygiene", severity="warn", apply=True)
+        oim._apply_pattern(args, "deferred")
+
+        with open(oi_file) as f:
+            data = json.load(f)
+
+        deferred = [i for i in data["items"] if i["status"] == "deferred"]
+        assert len(deferred) == 1
+        assert deferred[0]["id"] == "OI-001"
+
+        open_items = [i for i in data["items"] if i["status"] == "open"]
+        assert len(open_items) == 2
+        assert {i["id"] for i in open_items} == {"OI-002", "OI-003"}


### PR DESCRIPTION
## Summary
Extends `open_items_manager.py` with `defer-pattern` and `wontfix-pattern` subcommands (title-regex + severity + age filters, dry-run by default). Executes 1.0 closing sprint reducing open OIs from 96 to 48 (0 blockers remaining).

## Changes
- **scripts/open_items_manager.py** — `defer-pattern` + `wontfix-pattern` subcommands with `_filter_items_by_pattern()` + `_apply_pattern()` shared helpers, fcntl-locked + audit trail
- **tests/oi/test_pattern_subcommands.py** — 4 unit tests (dry-run, apply mutates, no-match, severity-filter)
- **tests/oi/__init__.py** — package marker

## Sprint result
| Pattern | Result |
|---|---|
| `defer 'exceeds.*threshold'` | 30 deferred |
| `defer 'Module level import not at top'` | 4 deferred |
| `wontfix 'tool_unavailable: vulture'` | 12 wontfix |
| `wontfix 'Local variable.*assigned.*never used'` | 2 wontfix |
| `defer --severity info --older-than-days 30` | 0 matches |
| **Total** | **96 → 48 open (0 blockers)** |

## Test plan
- [x] `pytest tests/oi/test_pattern_subcommands.py -v` — 4 passed
- [ ] VNX CI workflow green
- [ ] codex_gate

## Notes
- **Backup snapshot at `.vnx-data/state/snapshots/oi-pre-sprint-2026-06-03.ndjson` was written to worker-worktree's local .vnx-data and is NOT on main** — recoverable via git log of state if needed
- **Sprint memo `claudedocs/OI-SPRINT-RESULT-2026-06-03.md` lost in worktree teardown** (claudedocs/ is gitignored) — sprint data captured in this PR body instead
- T0 followup options: `defer 'Function is large'` → ~23 open (per worker report)

Dispatch-ID: 20260603-140046-oi-closing-sprint
Worker report: `.vnx-data/unified_reports/20260603-140046-oi-closing-sprint.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)