### PR TITLE
feat(smart-lanes): PR-2 Smart Router cost-tier classifier (flag-gated, default-off)

### DIFF
--- a/scripts/lib/providers/smart_router/__init__.py
+++ b/scripts/lib/providers/smart_router/__init__.py
@@ -1,8 +1,16 @@
-"""smart_router — Pip-installable smart router submodule re-exports.
+"""smart_router — Smart router submodule re-exports.
 
-New canonical import: from providers.smart_router.classifier import classify_task, decide
-Old import (backward compat): from smart_router import classify_task, decide
+Canonical import: from providers.smart_router import classify_task, decide, route_dispatch
+Backward-compat: from smart_router import classify_task, decide
+
+PR-2 additions: classify_dispatch(), TierRoute, resolve_tier_route(), route_dispatch().
+route_dispatch() is default-off; returns None unless VNX_AUTO_ROUTE=1.
 """
+from __future__ import annotations
+
+import os as _os
+from typing import Optional
+
 from .classifier import (  # noqa: F401
     RouteCandidate,
     RouteDecision,
@@ -12,6 +20,8 @@ from .classifier import (  # noqa: F401
     recommend,
     write_route_decision,
 )
+from .cost_tier import classify_dispatch  # noqa: F401
+from .tier_routing import TierRoute, resolve_tier_route  # noqa: F401
 
 __all__ = [
     "classify_task",
@@ -21,4 +31,30 @@ __all__ = [
     "write_route_decision",
     "RouteCandidate",
     "RouteDecision",
+    "classify_dispatch",
+    "TierRoute",
+    "resolve_tier_route",
+    "route_dispatch",
 ]
+
+
+def route_dispatch(
+    task_spec: dict,
+    file_paths: Optional[list] = None,
+    loc_estimate: int = 0,
+    env: Optional[dict] = None,
+) -> Optional[TierRoute]:
+    """Smart router entry point. Returns None when VNX_AUTO_ROUTE is unset.
+
+    Default-off per memory smart-router-built-not-operative: the router is built
+    but not operative until VNX_AUTO_ROUTE=1 is set. Callers fall back to the
+    existing dispatch path on None return.
+
+    When VNX_AUTO_ROUTE=1: classifies via classify_dispatch() and resolves a
+    TierRoute via resolve_tier_route().
+    """
+    _env = env if env is not None else dict(_os.environ)
+    if not _env.get("VNX_AUTO_ROUTE"):
+        return None
+    tier = classify_dispatch(task_spec, file_paths or [], loc_estimate)
+    return resolve_tier_route(tier, _env)

--- a/scripts/lib/providers/smart_router/cost_tier.py
+++ b/scripts/lib/providers/smart_router/cost_tier.py
@@ -1,0 +1,83 @@
+"""cost_tier.py — Cost-tier classifier for smart router dispatches.
+
+classify_dispatch(task_spec, file_paths, loc_estimate) -> str
+Returns one of: 'tier-zero', 'tier-low', 'tier-mid', 'tier-high'.
+
+Tier definitions:
+  tier-zero  Trivial reformat; ≤30 LOC, single file, no elevated keywords.
+  tier-low   Script edit; >30–150 LOC, no arch/schema changes.
+  tier-mid   Multi-file or schema/design choices; 150–300 LOC.
+  tier-high  Architectural, cross-component, or security-touching.
+"""
+from __future__ import annotations
+
+TIER_ZERO = "tier-zero"
+TIER_LOW = "tier-low"
+TIER_MID = "tier-mid"
+TIER_HIGH = "tier-high"
+
+_LOC_ZERO_MAX = 30
+_LOC_LOW_MAX = 150
+_LOC_MID_MAX = 300
+
+_SECURITY_KEYWORDS: frozenset[str] = frozenset({
+    "auth", "authentication", "authorization", "oauth", "jwt", "token",
+    "password", "credential", "secret", "encryption", "decrypt",
+    "vulnerability", "cve", "exploit", "injection", "xss", "csrf",
+    "rbac", "acl", "permission", "privilege", "security",
+})
+
+_SCHEMA_KEYWORDS: frozenset[str] = frozenset({
+    "schema", "migration", "database", "table", "column", "index",
+    "constraint", "adr", "architecture", "design", "interface",
+    "event stream", "ndjson",
+})
+
+_ARCH_KEYWORDS: frozenset[str] = frozenset({
+    "orchestrat", "cross-component", "refactor", "restructure", "rewrite",
+    "rearchitect", "breaking change", "backward compat", "deprecat",
+})
+
+
+def _has_keyword(text: str, keywords: frozenset) -> bool:
+    lower = text.lower()
+    return any(kw in lower for kw in keywords)
+
+
+def classify_dispatch(
+    task_spec: dict,
+    file_paths: list,
+    loc_estimate: int,
+) -> str:
+    """Classify a dispatch into one of four cost tiers.
+
+    Rules applied in priority order (first match wins):
+    1. Security-touching keywords or 'security' tag → tier-high
+    2. Architectural/cross-component keywords → tier-high
+    3. LOC > 300 → tier-high
+    4. Schema/design keywords → tier-mid
+    5. Multi-file (>1) AND LOC > 30 → tier-mid
+    6. LOC > 150 → tier-mid
+    7. LOC > 30 → tier-low
+    8. Default (≤30 LOC, single file, no elevated keywords) → tier-zero
+    """
+    instruction = (task_spec.get("instruction") or task_spec.get("prompt") or "")
+    tags = [t.lower() for t in (task_spec.get("tags") or [])]
+    full_text = f"{instruction} {' '.join(tags)}"
+    n_files = len(file_paths) if file_paths else 0
+
+    if "security" in tags or _has_keyword(full_text, _SECURITY_KEYWORDS):
+        return TIER_HIGH
+    if _has_keyword(full_text, _ARCH_KEYWORDS):
+        return TIER_HIGH
+    if loc_estimate > _LOC_MID_MAX:
+        return TIER_HIGH
+    if _has_keyword(full_text, _SCHEMA_KEYWORDS):
+        return TIER_MID
+    if n_files > 1 and loc_estimate > _LOC_ZERO_MAX:
+        return TIER_MID
+    if loc_estimate > _LOC_LOW_MAX:
+        return TIER_MID
+    if loc_estimate > _LOC_ZERO_MAX:
+        return TIER_LOW
+    return TIER_ZERO

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -1,0 +1,110 @@
+"""tier_routing.py — Map cost tiers to provider/lane routing specs.
+
+Tier→provider mappings (honoring provider_constraints.yaml):
+  tier-zero → local Gemma e4b via MLX; fallback Ollama
+  tier-low  → DeepSeek via Claude-harness key-auth (DEEPSEEK_API_KEY required)
+               OR Kimi via CLI (kimi-via-cli-only constraint)
+  tier-mid  → claude-sonnet-4-6
+  tier-high → claude-opus-4-7
+
+Constraint references (provider_constraints.yaml):
+  kimi-via-cli-only: Kimi must use lane='kimi_cli', never via=api/moonshot
+  deepseek-harness-subscription-blocked: DEEPSEEK_API_KEY required; subscription-
+    redirect blocked. Allowed only with via=claude_harness_keyed + own key.
+  zai-via-openrouter-only: GLM only via OpenRouter (no direct Zhipu API)
+  deprecated-glm-models: GLM-4.5/4.6 blocked; use glm-5.1 via OpenRouter
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .cost_tier import TIER_ZERO, TIER_LOW, TIER_MID, TIER_HIGH
+
+
+@dataclass(frozen=True)
+class TierRoute:
+    """Provider routing spec for a cost tier."""
+
+    tier: str
+    provider: str
+    model: str
+    lane: str
+    env_requirements: tuple = field(default_factory=tuple)
+    fallback: Optional["TierRoute"] = None
+
+
+_ROUTE_ZERO_FALLBACK = TierRoute(
+    tier=TIER_ZERO,
+    provider="ollama",
+    model="gemma:4b",
+    lane="ollama",
+)
+
+_ROUTE_ZERO = TierRoute(
+    tier=TIER_ZERO,
+    provider="local-gemma",
+    model="gemma-4b-e4b-mlx",
+    lane="mlx",
+    fallback=_ROUTE_ZERO_FALLBACK,
+)
+
+_ROUTE_KIMI = TierRoute(
+    tier=TIER_LOW,
+    provider="kimi",
+    model="kimi-k2",
+    lane="kimi_cli",  # kimi-via-cli-only: never via=api or moonshot
+)
+
+_ROUTE_MID = TierRoute(
+    tier=TIER_MID,
+    provider="claude",
+    model="claude-sonnet-4-6",
+    lane="tmux_interactive",
+)
+
+_ROUTE_HIGH = TierRoute(
+    tier=TIER_HIGH,
+    provider="claude",
+    model="claude-opus-4-7",
+    lane="tmux_interactive",
+)
+
+
+def _deepseek_available(env: dict) -> bool:
+    """DeepSeek harness is allowed only when DEEPSEEK_API_KEY is present.
+
+    Implements deepseek-harness-subscription-blocked: own key + hardening required;
+    routing through the production OAuth subscription is blocked.
+    """
+    return bool(env.get("DEEPSEEK_API_KEY"))
+
+
+def resolve_tier_route(tier: str, env: Optional[dict] = None) -> TierRoute:
+    """Resolve a cost tier to a TierRoute.
+
+    For tier-low: prefers DeepSeek claude-harness (key-auth) when DEEPSEEK_API_KEY
+    is present, falls back to Kimi CLI. Unknown tier strings default to tier-high.
+    """
+    _env = env if env is not None else dict(os.environ)
+
+    if tier == TIER_ZERO:
+        return _ROUTE_ZERO
+
+    if tier == TIER_LOW:
+        if _deepseek_available(_env):
+            return TierRoute(
+                tier=tier,
+                provider="deepseek",
+                model="deepseek-chat",
+                lane="claude_harness_keyed",
+                env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
+                fallback=_ROUTE_KIMI,
+            )
+        return _ROUTE_KIMI
+
+    if tier == TIER_MID:
+        return _ROUTE_MID
+
+    return _ROUTE_HIGH

--- a/tests/smart_router/__init__.py
+++ b/tests/smart_router/__init__.py
@@ -1,0 +1,28 @@
+"""Package shim — merges scripts/lib/smart_router.py into this test package namespace.
+
+pytest treats tests/smart_router/ as the 'smart_router' package (because __init__.py
+exists). When classifier.py does `from smart_router import ROLE_TO_TASK_CLASS`, Python
+looks in this package and finds nothing — unless we load the real module and merge its
+public API here. This shim does that without replacing sys.modules['smart_router'].
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parents[2] / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+# Load the real smart_router.py, registering it under a private key so that the
+# dataclass decorator can resolve cls.__module__ via sys.modules.
+_KEY = "_smart_router_impl"
+if _KEY not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(_KEY, _LIB / "smart_router.py")
+    _impl = importlib.util.module_from_spec(_spec)
+    sys.modules[_KEY] = _impl  # register before exec so @dataclass resolves __module__
+    _spec.loader.exec_module(_impl)
+else:
+    _impl = sys.modules[_KEY]
+
+# Merge public API into this package so `from smart_router import X` resolves here.
+globals().update({k: v for k, v in vars(_impl).items() if not k.startswith("__")})

--- a/tests/smart_router/test_cost_tier_classifier.py
+++ b/tests/smart_router/test_cost_tier_classifier.py
@@ -1,0 +1,101 @@
+"""Tests for classify_dispatch cost-tier classifier (PR-2).
+
+Covers all four tiers with parameterized cases and critical boundary cases:
+  - 30 LOC single-file → tier-zero; 31 LOC → tier-low
+  - schema-touch → tier-mid; security-touch → tier-high
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.smart_router.cost_tier import (
+    TIER_HIGH,
+    TIER_LOW,
+    TIER_MID,
+    TIER_ZERO,
+    classify_dispatch,
+)
+
+# (task_spec, file_paths, loc, expected_tier)
+_CASES = [
+    # tier-zero
+    ({"instruction": "fix whitespace"}, ["foo.py"], 30, TIER_ZERO),
+    ({"instruction": "rename variable"}, ["bar.py"], 1, TIER_ZERO),
+    ({"instruction": "reformat"}, ["x.py"], 0, TIER_ZERO),
+    # tier-low (boundary: 31 LOC single file)
+    ({"instruction": "fix whitespace"}, ["foo.py"], 31, TIER_LOW),
+    ({"instruction": "add helper function"}, ["scripts/foo.py"], 100, TIER_LOW),
+    ({"instruction": "update config value"}, ["config.yaml"], 150, TIER_LOW),
+    # tier-mid (schema keyword, multi-file >30 LOC, or LOC 151-300)
+    ({"instruction": "add schema migration"}, ["migrations/v2.sql"], 50, TIER_MID),
+    ({"instruction": "update database table"}, ["db.py"], 20, TIER_MID),
+    ({"instruction": "add handler"}, ["a.py", "b.py"], 50, TIER_MID),
+    ({"instruction": "edit function"}, ["a.py"], 200, TIER_MID),
+    ({"instruction": "add adr for caching"}, ["docs/adr.md"], 80, TIER_MID),
+    ({"instruction": "update interface contract"}, ["api.py"], 40, TIER_MID),
+    # tier-high (security, arch, or LOC > 300)
+    ({"instruction": "fix auth token validation"}, ["auth.py"], 20, TIER_HIGH),
+    ({"instruction": "patch security vulnerability"}, ["core.py"], 10, TIER_HIGH),
+    ({"instruction": "rewrite the orchestrator"}, ["core.py"], 100, TIER_HIGH),
+    ({"instruction": "add feature"}, [], 350, TIER_HIGH),
+    ({"instruction": "add button", "tags": ["security"]}, ["ui.py"], 5, TIER_HIGH),
+    ({"instruction": "update rbac permission check"}, ["perm.py"], 30, TIER_HIGH),
+]
+
+
+@pytest.mark.parametrize("task_spec,file_paths,loc,expected", _CASES)
+def test_classify_dispatch_parametrized(task_spec, file_paths, loc, expected):
+    assert classify_dispatch(task_spec, file_paths, loc) == expected
+
+
+def test_boundary_30_loc_is_zero():
+    """Exactly 30 LOC single file → tier-zero."""
+    assert classify_dispatch({"instruction": "reformat"}, ["x.py"], 30) == TIER_ZERO
+
+
+def test_boundary_31_loc_is_low():
+    """31 LOC single file → tier-low (first tier above zero)."""
+    assert classify_dispatch({"instruction": "reformat"}, ["x.py"], 31) == TIER_LOW
+
+
+def test_multi_file_at_or_below_30_stays_zero():
+    """Multi-file but ≤30 LOC → tier-zero (multi-file rule requires LOC > 30)."""
+    assert classify_dispatch({"instruction": "rename"}, ["a.py", "b.py"], 10) == TIER_ZERO
+
+
+def test_schema_touch_forces_mid():
+    """Schema keyword forces tier-mid regardless of LOC or file count."""
+    assert classify_dispatch({"instruction": "add index to schema"}, ["m.sql"], 5) == TIER_MID
+
+
+def test_security_touch_forces_high():
+    """Security keyword forces tier-high regardless of LOC."""
+    assert classify_dispatch({"instruction": "update jwt token"}, ["x.py"], 5) == TIER_HIGH
+
+
+def test_empty_spec_zero_loc_is_zero():
+    assert classify_dispatch({}, [], 0) == TIER_ZERO
+
+
+def test_prompt_field_accepted():
+    """task_spec 'prompt' key is equivalent to 'instruction'."""
+    assert classify_dispatch({"prompt": "update schema migration"}, ["db.py"], 20) == TIER_MID
+
+
+def test_security_tag_forces_high():
+    assert classify_dispatch({"instruction": "update tooltip", "tags": ["security"]}, ["ui.py"], 5) == TIER_HIGH
+
+
+def test_loc_301_forces_high():
+    """LOC = 301 crosses the tier-high threshold."""
+    assert classify_dispatch({"instruction": "add feature"}, ["x.py"], 301) == TIER_HIGH
+
+
+def test_loc_300_mid():
+    """LOC = 300 stays at tier-mid (boundary inclusive)."""
+    assert classify_dispatch({"instruction": "add feature"}, ["x.py"], 300) == TIER_MID

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -1,0 +1,111 @@
+"""Tests for tier_routing — constraint enforcement and route resolution (PR-2).
+
+Covers: kimi-via-cli-only, deepseek-harness-subscription-blocked, default-off
+VNX_AUTO_ROUTE flag, and route_dispatch() wiring.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER_ZERO
+from providers.smart_router.tier_routing import TierRoute, resolve_tier_route
+
+
+def test_tier_zero_uses_local_gemma():
+    route = resolve_tier_route(TIER_ZERO, env={})
+    assert route.provider == "local-gemma"
+    assert route.lane == "mlx"
+    assert route.fallback is not None
+    assert route.fallback.provider == "ollama"
+
+
+def test_tier_mid_uses_sonnet():
+    route = resolve_tier_route(TIER_MID, env={})
+    assert route.provider == "claude"
+    assert route.model == "claude-sonnet-4-6"
+
+
+def test_tier_high_uses_opus():
+    route = resolve_tier_route(TIER_HIGH, env={})
+    assert route.provider == "claude"
+    assert route.model == "claude-opus-4-7"
+
+
+def test_tier_low_no_key_uses_kimi_cli():
+    """Without DEEPSEEK_API_KEY, tier-low uses Kimi CLI (kimi-via-cli-only)."""
+    route = resolve_tier_route(TIER_LOW, env={})
+    assert route.provider == "kimi"
+    assert route.lane == "kimi_cli"  # kimi-via-cli-only: never api/moonshot
+
+
+def test_kimi_lane_never_api_or_moonshot():
+    """Kimi provider must always use kimi_cli lane, never api or moonshot."""
+    route = resolve_tier_route(TIER_LOW, env={})
+    assert route.provider == "kimi"
+    assert "api" not in route.lane
+    assert "moonshot" not in route.lane
+
+
+def test_tier_low_with_deepseek_key_uses_harness():
+    """With DEEPSEEK_API_KEY, tier-low uses DeepSeek claude_harness_keyed."""
+    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
+    route = resolve_tier_route(TIER_LOW, env=env)
+    assert route.provider == "deepseek"
+    assert route.lane == "claude_harness_keyed"
+    assert "DEEPSEEK_API_KEY" in route.env_requirements
+
+
+def test_deepseek_harness_blocked_without_key():
+    """Empty DEEPSEEK_API_KEY falls back to Kimi (subscription route blocked)."""
+    route = resolve_tier_route(TIER_LOW, env={"DEEPSEEK_API_KEY": ""})
+    assert route.provider == "kimi"
+
+
+def test_deepseek_harness_fallback_is_kimi():
+    """DeepSeek harness route's fallback is Kimi CLI."""
+    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
+    route = resolve_tier_route(TIER_LOW, env=env)
+    assert route.fallback is not None
+    assert route.fallback.provider == "kimi"
+    assert route.fallback.lane == "kimi_cli"
+
+
+def test_unknown_tier_defaults_to_opus():
+    """Unknown tier strings default to tier-high (safe over silent skip)."""
+    route = resolve_tier_route("tier-unknown", env={})
+    assert route.model == "claude-opus-4-7"
+
+
+def test_route_dispatch_default_off():
+    """route_dispatch() returns None when VNX_AUTO_ROUTE is not set."""
+    from providers.smart_router import route_dispatch
+
+    result = route_dispatch({"instruction": "add function"}, ["x.py"], 50, env={})
+    assert result is None
+
+
+def test_route_dispatch_auto_route_enabled():
+    """route_dispatch() returns a TierRoute when VNX_AUTO_ROUTE=1."""
+    from providers.smart_router import route_dispatch
+
+    env = {"VNX_AUTO_ROUTE": "1"}
+    result = route_dispatch({"instruction": "add function"}, ["x.py"], 50, env=env)
+    assert result is not None
+    assert isinstance(result, TierRoute)
+    assert result.tier == TIER_LOW
+
+
+def test_route_dispatch_high_loc():
+    """route_dispatch() with LOC=350 → tier-high → Opus."""
+    from providers.smart_router import route_dispatch
+
+    env = {"VNX_AUTO_ROUTE": "1"}
+    result = route_dispatch({"instruction": "implement feature"}, ["x.py"], 350, env=env)
+    assert result is not None
+    assert result.tier == TIER_HIGH
+    assert result.model == "claude-opus-4-7"


### PR DESCRIPTION
## Summary
PR-2 of Smart Lanes (follow-up to #809). Adds cost-tier classifier and tier-to-provider routing in `providers.smart_router` package. Default-off via `VNX_AUTO_ROUTE` flag (per `smart-router-built-not-operative` memory). 40 new tests pass, 122 existing tests green (no regressions).

## Changes
**New (production):**
- `scripts/lib/providers/smart_router/cost_tier.py` (+83) — `classify_dispatch()` returning tier-zero|low|mid|high
- `scripts/lib/providers/smart_router/tier_routing.py` (+110) — `TierRoute` + `resolve_tier_route()` with provider_constraints enforcement

**Modified:**
- `scripts/lib/providers/smart_router/__init__.py` (+39/-3) — public API: `classify_dispatch`, `TierRoute`, `resolve_tier_route`, `route_dispatch`

**Tests:**
- `tests/smart_router/test_cost_tier_classifier.py` (+101) — 28 cases (parametrized + boundary)
- `tests/smart_router/test_tier_routing.py` (+111) — 12 cases (constraint enforcement)
- `tests/smart_router/__init__.py` (+28) — package shim

## Tier rules
| Tier | Routes to | Trigger |
|---|---|---|
| zero | local-gemma MLX (fallback Ollama) | ≤30 LOC single-file, no special keywords |
| low | DeepSeek-via-harness-keyed (fallback Kimi-cli) | 31-150 LOC, no schema/arch/security |
| mid | claude-sonnet-4-6 | 151-300 LOC OR schema OR multi-file>30 |
| high | claude-opus-4-7 | >300 LOC OR architecture OR security keywords |

## Constraint compliance
- `kimi-via-cli-only`: lane="kimi_cli" enforced
- `deepseek-harness-subscription-blocked`: DeepSeek only with explicit `DEEPSEEK_API_KEY`
- `zai-via-openrouter-only`: GLM excluded from tier table
- `no-anthropic-sdk`: no `import anthropic` anywhere

## Test plan
- [x] `pytest tests/smart_router/ -v` — 40 passed
- [x] `pytest tests/test_smart_router*.py -v` — 122 passed (existing, no regressions)
- [ ] VNX CI workflow green
- [ ] codex_gate

## Notes
- Production code delta: 232 LOC (within 300 cap). Tests bring total to 472 LOC — splittable into separate test PR if reviewer requires
- Branch based on f12a3a85 (pre-#810); PR diff may show ROADMAP/FEATURE_PLAN as 'behind main' — merge will resolve cleanly via 3-way merge

Dispatch-ID: 20260603-140102-smart-lanes-pr2-cost-tier
Worker report: `.vnx-data/unified_reports/20260603-140102-smart-lanes-pr2-cost-tier.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)