### PR TITLE
feat(infra): atomic_io.py + ADR-021 — digest D1 per architecture V2

### DIFF
--- a/docs/governance/decisions/ADR-021-exception-discipline.md
+++ b/docs/governance/decisions/ADR-021-exception-discipline.md
@@ -1,0 +1,100 @@
+# ADR-021 — Exception Discipline: Narrow Exceptions and noqa for Silent Catches
+
+**Status:** Accepted
+**Date:** 2026-06-03
+**Decided by:** Operator (Vincent van Deth)
+**References:** ADR-005 (write ordering), ADR-007 (multitenant composite keys), PR #814 (5 codex_gate blockers)
+
+## Context
+
+PR #814 (`scripts/build_decisions_digest.py`) failed codex_gate round-1 with 5 blockers, 4 of which were the same `except Exception: pass` pattern in separate functions:
+
+- `_select_top_3_decisions`: outer `except Exception: pass` swallowed an `AttributeError` from `sqlite3.Row.get()` (which does not exist on `sqlite3.Row`)
+- `_build_dream_insights`: `except Exception: pass` made DB connection failures invisible to the caller
+- `_build_health`: same pattern on the receipt-lag read path
+- `_build_tomorrow_queue`: same pattern on the DB query block
+
+Sonnet defaults to broad `except Exception: pass` as a perceived robustness measure. The governance gate correctly treats this as fault-masking. No existing ADR addressed Python exception discipline, so the gate had no clean citation target when declaring these blockers.
+
+`governance_emit.py` already documents the correct approach: "Receipt write MUST NOT silently fail — raises RuntimeError on OSError." That contract was not extended to digest code because it lives in a separate file with no shared helper to anchor the pattern.
+
+## Decision
+
+`except Exception:` in production pipeline and digest code is permitted only in two forms.
+
+**Form A — Log + re-raise (preferred for unexpected failures):**
+
+```python
+except Exception as exc:
+    logger.error("digest.health: receipt lag read failed: %s", exc)
+    raise
+```
+
+**Form B — Documented silent catch (narrow types only):**
+
+```python
+# noqa: vnx-silent-except reason=table absent in older schema -- absence is valid
+except sqlite3.OperationalError:
+    pass
+```
+
+The `reason=` string is mandatory. CI grep flags `vnx-silent-except` without a `reason=` string as a lint error.
+
+### Narrow exception types (preferred over broad)
+
+| Scenario | Correct catch |
+|---|---|
+| Schema-optional DB table absent | `sqlite3.OperationalError` |
+| Missing file on disk | `FileNotFoundError` or `OSError` |
+| Malformed NDJSON line | `json.JSONDecodeError` |
+| Timestamp parse failure | `ValueError` |
+| sqlite3.Row field access | Use `dict(row)` — eliminates AttributeError entirely |
+
+### AttributeError is never caught silently
+
+`AttributeError` indicates a coding error (`sqlite3.Row.get()` does not exist; object is not what the code assumes). The PR #814 blockers were hiding this class of error behind `except Exception: pass`. Correct fix: convert rows with `dict(row)` before field access, or use `row["column"]` with explicit `except KeyError` if key absence is expected.
+
+### Applies to all new production code in
+
+- `scripts/lib/` — shared helpers
+- `scripts/lib/digest/` — digest collectors and renderer
+- `scripts/commands/` — CLI entry points
+- Any file where a broad except previously produced a codex_gate blocker
+
+Does NOT require immediate refactor of stable production files (e.g. `governance_emit.py`, `subprocess_adapter.py`). Those carry their own inline documentation and are addressed in a dedicated 1.0.1 refactor wave (see Consequences).
+
+## Consequences
+
+**Positive:**
+
+- Gate enforcement via `scripts/lib/ci_lint_patterns.py`: the `broad-except` pattern is already a blocking rule; this ADR gives it a clean citation target (`ADR-021`).
+- `AttributeError` bugs surface at the call site instead of silently returning empty results.
+- Form B's `reason=` string creates inline documentation of why silence is acceptable, auditable in code review.
+
+**Negative / mitigations:**
+
+- Existing call-sites in `scripts/lib/` that use broad except (estimated 8-12 files) are not immediately compliant. A refactor wave in 1.0.1 converts them: each broad except is converted to Form A (log+re-raise) or Form B (narrow type + noqa + reason). Until then, existing files are grandfathered; new files and modified functions must comply.
+- Form A (`raise`) changes caller behavior if callers currently rely on silent degradation. Each conversion must be reviewed: does the caller handle the exception, or should the caller default on `OSError`/`JSONDecodeError` with an explicit fallback?
+
+**Gate enforcement:**
+
+`scripts/lib/codex_severity_policy.yaml` already lists `broad-except` as blocking. The enforcement grep is extended to also flag `vnx-silent-except` without `reason=`:
+
+```yaml
+- pattern: "# noqa: vnx-silent-except(?!.*reason=)"
+  severity: blocking
+  message: "Silent except requires reason= annotation per ADR-021"
+  citation: ADR-021
+```
+
+## Dogfooding
+
+`scripts/lib/atomic_io.py` (shipped in PR-D1, same dispatch as this ADR) applies Form A throughout: `BaseException` on temp-file cleanup re-raises after unlinking the temp; `OSError` from write failures propagates to the caller. No broad `except Exception: pass` in the helper.
+
+## References
+
+- ADR-005: NDJSON ledger-first write ordering — appenders raise on OSError
+- ADR-007: multitenant composite keys — cited as gate-enforcement model
+- PR #814: 5 codex_gate blockers (root cause analysis in NIGHTLY-DIGEST-REDESIGN-V2.md section 1)
+- `scripts/lib/codex_severity_policy.yaml`: lint patterns enforced in CI
+- `scripts/lib/governance_emit.py`: prior art — "Receipt write MUST NOT silently fail"

--- a/scripts/lib/atomic_io.py
+++ b/scripts/lib/atomic_io.py
@@ -1,0 +1,102 @@
+"""atomic_io.py — Shared atomic file write and NDJSON append helpers.
+
+Consolidates the tmp+os.replace pattern (4 inline implementations across
+state_writer.py, worker_permission_relay.py, tmux_interactive_dispatch.py,
+intelligence_dashboard.py) and the fcntl.flock NDJSON append used in
+governance_emit.py.
+
+ADR-005: ledger-first write ordering — appenders raise on OSError, never
+silently drop events.
+
+ADR-021: exception discipline — broad except only with explicit log+re-raise
+or # noqa: vnx-silent-except with reason= string. AttributeError never
+caught silently.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import stat
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    """Write text file atomically via temp file + os.replace.
+
+    Writes to a sibling temp file in the same directory, fsyncs, then
+    renames atomically. Preserves the target file's permission mode if the
+    target already exists. Cleans up the temp file on any failure.
+
+    Raises:
+        OSError: on write or rename failure (never partially-overwrites target)
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_mode: int | None = None
+    if path.exists():
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+
+    fd, tmp_path_str = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+
+        if existing_mode is not None:
+            os.chmod(tmp_path, existing_mode)
+
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_json(path: Path, payload: dict, indent: int = 2) -> None:
+    """Write JSON file atomically via temp file + os.replace.
+
+    Delegates to atomic_write_text. Raises OSError on write failure.
+    """
+    atomic_write_text(path, json.dumps(payload, indent=indent, ensure_ascii=False))
+
+
+def audit_event_append(events_dir: Path, event_type: str, payload: dict) -> None:
+    """Append one audit event line to events_dir/<event_type>.ndjson.
+
+    Auto-injects timestamp, pid, and actor fields into the record. Uses
+    fcntl.flock(LOCK_EX) for concurrent-writer safety. Creates the events
+    directory if absent.
+
+    ADR-005: raises OSError on write failure — never silently drops events.
+
+    Args:
+        events_dir: directory for event NDJSON files (e.g. .vnx-data/events/)
+        event_type: determines the filename (<event_type>.ndjson)
+        payload: caller-supplied fields merged into the event record
+    """
+    events_dir.mkdir(parents=True, exist_ok=True)
+    target = events_dir / f"{event_type}.ndjson"
+
+    record: dict = {
+        "event_type": event_type,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "pid": os.getpid(),
+        "actor": os.environ.get("VNX_ACTOR", "system"),
+        **payload,
+    }
+
+    with open(target, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            fh.flush()
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)

--- a/scripts/lib/atomic_io.py
+++ b/scripts/lib/atomic_io.py
@@ -19,12 +19,15 @@ import fcntl
 import json
 import logging
 import os
+import re
 import stat
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+_EVENT_TYPE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$")
 
 
 def atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
@@ -75,22 +78,35 @@ def audit_event_append(events_dir: Path, event_type: str, payload: dict) -> None
     fcntl.flock(LOCK_EX) for concurrent-writer safety. Creates the events
     directory if absent.
 
+    Reserved keys event_type, timestamp, pid, actor cannot be overridden by payload.
+
     ADR-005: raises OSError on write failure — never silently drops events.
 
     Args:
         events_dir: directory for event NDJSON files (e.g. .vnx-data/events/)
-        event_type: determines the filename (<event_type>.ndjson)
+        event_type: determines the filename (<event_type>.ndjson); must match
+            [A-Za-z0-9_][A-Za-z0-9_-]{0,63}
         payload: caller-supplied fields merged into the event record
     """
+    if not _EVENT_TYPE_RE.match(event_type):
+        raise ValueError(
+            f"atomic_io: invalid event_type {event_type!r} — must match {_EVENT_TYPE_RE.pattern}"
+        )
+
     events_dir.mkdir(parents=True, exist_ok=True)
     target = events_dir / f"{event_type}.ndjson"
 
+    # Defense-in-depth: assert resolved target stays under events_dir.
+    if not target.resolve().is_relative_to(events_dir.resolve()):
+        raise ValueError(f"atomic_io: event_type {event_type!r} escapes events_dir")
+
+    # payload merged first so authoritative audit fields always win.
     record: dict = {
+        **payload,
         "event_type": event_type,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "pid": os.getpid(),
         "actor": os.environ.get("VNX_ACTOR", "system"),
-        **payload,
     }
 
     with open(target, "a", encoding="utf-8") as fh:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -121,3 +121,44 @@ def test_audit_event_creates_dir_if_missing(tmp_path: Path) -> None:
     audit_event_append(events_dir, "boot", {"msg": "hello"})
 
     assert (events_dir / "boot.ndjson").exists()
+
+
+# ---------------------------------------------------------------------------
+# Path traversal / reserved-field security tests
+# ---------------------------------------------------------------------------
+
+
+def test_audit_event_rejects_event_type_with_dotdot(tmp_path: Path) -> None:
+    """event_type containing .. must raise ValueError before any path join."""
+    events_dir = tmp_path / "events"
+    with pytest.raises(ValueError, match="invalid event_type"):
+        audit_event_append(events_dir, "test/../escape", {"x": 1})
+
+
+def test_audit_event_rejects_event_type_with_slashes(tmp_path: Path) -> None:
+    """event_type containing path separators must raise ValueError."""
+    events_dir = tmp_path / "events"
+    with pytest.raises(ValueError, match="invalid event_type"):
+        audit_event_append(events_dir, "foo/bar", {"x": 1})
+
+
+def test_audit_event_rejects_event_type_with_special_chars(tmp_path: Path) -> None:
+    """event_type with shell-special characters must raise ValueError."""
+    events_dir = tmp_path / "events"
+    with pytest.raises(ValueError, match="invalid event_type"):
+        audit_event_append(events_dir, "evt; rm -rf", {"x": 1})
+
+
+def test_audit_event_reserved_fields_not_overridable(tmp_path: Path) -> None:
+    """Caller-supplied reserved keys (pid, event_type) must be overwritten by authoritative values."""
+    events_dir = tmp_path / "events"
+    real_pid = os.getpid()
+
+    audit_event_append(events_dir, "realtype", {"pid": 999, "event_type": "fake", "data": "ok"})
+
+    target = events_dir / "realtype.ndjson"
+    record = json.loads(target.read_text().strip())
+
+    assert record["event_type"] == "realtype", "event_type must be authoritative, not payload value"
+    assert record["pid"] == real_pid, "pid must be authoritative, not payload value"
+    assert record["data"] == "ok", "non-reserved payload fields must survive"

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,123 @@
+"""test_atomic_io.py — Unit tests for scripts/lib/atomic_io.py.
+
+Covers: atomic write safety, mode preservation, NDJSON append correctness,
+concurrent-write safety, and directory auto-creation.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import stat
+import sys
+import threading
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from atomic_io import atomic_write_text, audit_event_append
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_text tests
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_no_partial_on_crash(tmp_path: Path) -> None:
+    """Original content must survive when os.replace raises mid-write."""
+    target = tmp_path / "state.txt"
+    original = "original content"
+    target.write_text(original, encoding="utf-8")
+
+    with mock.patch("atomic_io.os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            atomic_write_text(target, "new content")
+
+    # Target must be intact; temp file must not linger.
+    assert target.read_text(encoding="utf-8") == original
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == [], f"temp file leaked: {tmp_files}"
+
+
+def test_atomic_write_preserves_mode(tmp_path: Path) -> None:
+    """Mode of existing file is preserved after atomic overwrite."""
+    target = tmp_path / "script.sh"
+    target.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
+    target.chmod(0o750)
+
+    atomic_write_text(target, "#!/bin/sh\necho new\n")
+
+    result_mode = stat.S_IMODE(target.stat().st_mode)
+    assert result_mode == 0o750
+    assert target.read_text(encoding="utf-8") == "#!/bin/sh\necho new\n"
+
+
+# ---------------------------------------------------------------------------
+# audit_event_append tests
+# ---------------------------------------------------------------------------
+
+
+def test_audit_event_appends_ndjson_line_with_required_fields(tmp_path: Path) -> None:
+    """Each appended event contains timestamp, pid, actor, and caller payload."""
+    events_dir = tmp_path / "events"
+    audit_event_append(events_dir, "decision", {"action": "accept", "dec_id": "DEC-1"})
+
+    target = events_dir / "decision.ndjson"
+    assert target.exists()
+
+    lines = [l for l in target.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+
+    assert record["event_type"] == "decision"
+    assert "timestamp" in record
+    assert "pid" in record
+    assert "actor" in record
+    assert record["action"] == "accept"
+    assert record["dec_id"] == "DEC-1"
+
+
+def _worker_append(events_dir_str: str, n: int) -> None:
+    """Subprocess worker: append n events to the shared NDJSON file."""
+    events_dir = Path(events_dir_str)
+    for i in range(n):
+        audit_event_append(events_dir, "conctest", {"seq": i})
+
+
+def test_audit_event_concurrent_writes_no_interleave(tmp_path: Path) -> None:
+    """Concurrent writers produce valid NDJSON with no interleaved partial lines."""
+    events_dir = tmp_path / "events"
+    n_processes = 4
+    n_each = 20
+
+    procs = [
+        multiprocessing.Process(target=_worker_append, args=(str(events_dir), n_each))
+        for _ in range(n_processes)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=10)
+        assert p.exitcode == 0, f"worker exited with code {p.exitcode}"
+
+    target = events_dir / "conctest.ndjson"
+    lines = [l for l in target.read_text().splitlines() if l.strip()]
+    assert len(lines) == n_processes * n_each
+
+    for line in lines:
+        record = json.loads(line)
+        assert record["event_type"] == "conctest"
+
+
+def test_audit_event_creates_dir_if_missing(tmp_path: Path) -> None:
+    """audit_event_append creates nested directories automatically."""
+    events_dir = tmp_path / "deep" / "nested" / "events"
+    assert not events_dir.exists()
+
+    audit_event_append(events_dir, "boot", {"msg": "hello"})
+
+    assert (events_dir / "boot.ndjson").exists()


### PR DESCRIPTION
## Summary
Phase-1 of digest redesign (D1 per `docs/architecture/NIGHTLY-DIGEST-REDESIGN-V2.md`). Adds shared atomic write + audit-event infra helper + formal exception-discipline ADR. Standalone-valuable: addresses 4 inline duplicate atomic-write impls elsewhere in the codebase, and codifies the rule that prevented PR #814's 5 blockers.

## Changes
| File | LOC | Description |
|---|---|---|
| `scripts/lib/atomic_io.py` | +102 | `atomic_write_text` (tempfile+fsync+os.replace, mode-preserving), `atomic_write_json` (delegate), `audit_event_append` (fcntl.flock-protected NDJSON append to `.vnx-data/events/<event_type>.ndjson`) |
| `tests/test_atomic_io.py` | +123 | 5 tests: no-partial-on-crash, mode-preserved, NDJSON fields, concurrent-no-interleave (4×20 subprocesses), dir-creation |
| `docs/governance/decisions/ADR-021-exception-discipline.md` | +100 | Form A (log+re-raise) / Form B (noqa+reason=); AttributeError never silent; narrow types preferred; ADR-021 status=Accepted |
| **Total** | **+325 / -0** | 3 files |

## Test plan
- [x] `pytest tests/test_atomic_io.py -v` — 5 passed
- [x] atomic_io.py dogfoods ADR-021 (no broad `except Exception` in helper)
- [ ] VNX CI green
- [ ] codex_gate (governance-class)

## Notes
- **Rebased onto post-#815 main** (cherry-pick from original `dispatch/20260603-150618-digest-d1-atomic-io-adr021` branch). Worker built on pre-#815 base; original branch diff showed V2 doc as reversal. Recovery is same pattern as PR #814→#815 cherry-pick. Original branch retained on origin as audit-spoor.
- `governance_emit.py` retains its own inline atomic-write impl per V2 doc decision — dedicated refactor PR in 1.0.1 (ADR-021 consequences section).

Dispatch-ID: 20260603-150618-digest-d1-atomic-io-adr021 → 20260603-151356-digest-d1-atomic-io-rebased (cherry-pick)
Worker report: `.vnx-data/unified_reports/20260603-150618-digest-d1-atomic-io-adr021.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)