### PR TITLE
fix(provider-dispatch): uniform central-path resolution (OI-126)

### DIFF
--- a/scripts/lib/project_root.py
+++ b/scripts/lib/project_root.py
@@ -86,6 +86,17 @@ def resolve_data_dir(caller_file: str | None = None) -> Path:
     return root / ".vnx-data"
 
 
+def resolve_central_data_dir(project_id: str) -> Path:
+    """Resolve the CENTRAL VNX data directory for a project.
+
+    Returns $HOME/.vnx-data/<project_id> — the same root watched by the
+    receipt processor and subprocess_dispatch.py (consistent with ADR-007).
+    Distinct from resolve_data_dir() which returns the local
+    $PROJECT_ROOT/.vnx-data for the current git worktree.
+    """
+    return Path.home() / ".vnx-data" / project_id
+
+
 def resolve_state_dir(caller_file: str | None = None) -> Path:
     """Resolve VNX_STATE_DIR: $VNX_DATA_DIR/state by default."""
     data = resolve_data_dir(caller_file)

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -66,15 +66,27 @@ _SUB_PROVIDER_DEFAULT_ALIAS: dict = {
 }
 
 
+def _resolve_data_dir() -> Path:
+    """Resolve VNX data directory: CENTRAL ($HOME/.vnx-data/<project_id>) by default.
+
+    VNX_DATA_DIR override is honored ONLY when VNX_DATA_DIR_EXPLICIT=1 is also set
+    (same guard as project_root.resolve_data_dir) to prevent cross-project pollution
+    from inherited shell environments. Fixes OI-126.
+    """
+    explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    explicit_val = os.environ.get("VNX_DATA_DIR", "")
+    if explicit_flag and explicit_val:
+        return Path(explicit_val).resolve()
+    project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    return Path.home() / ".vnx-data" / project_id
+
+
 def _resolve_state_dir() -> Path:
-    """Resolve VNX state directory from environment."""
+    """Resolve VNX state directory: CENTRAL by default; VNX_STATE_DIR honored when set."""
     env = os.environ.get("VNX_STATE_DIR", "")
     if env:
         return Path(env)
-    data_dir = os.environ.get("VNX_DATA_DIR", "")
-    if data_dir:
-        return Path(data_dir) / "state"
-    return Path(".vnx-data") / "state"
+    return _resolve_data_dir() / "state"
 
 
 def _resolve_dispatch_paths(raw: str) -> "list[str] | None":
@@ -404,8 +416,8 @@ def _emit_governance(
     """
     from governance_emit import emit_dispatch_receipt, emit_unified_report
 
-    state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+    state_dir = _resolve_state_dir()
+    data_dir = _resolve_data_dir()
     duration = (end_time - start_time).total_seconds()
     token_usage = _extract_token_usage(result, provider)
     cost_usd = _compute_cost(provider, model_used, token_usage)
@@ -604,7 +616,7 @@ def _emit_constraint_failure_receipt(
     failure_reason: str,
 ) -> None:
     """Record fail-closed pre-flight failures before any provider spawn."""
-    state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+    state_dir = _resolve_state_dir()
     receipt_path = state_dir / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -869,7 +881,7 @@ def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
 
     model = os.environ.get("VNX_CODEX_MODEL", "") or _resolve_codex_model()
     state_dir = _resolve_state_dir()
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+    data_dir = _resolve_data_dir()
 
     spec = EnvelopeSpec(
         dispatch_id=args.dispatch_id,
@@ -909,7 +921,7 @@ def _dispatch_claude_via_envelope(args: argparse.Namespace) -> int:
     from dispatch_envelope import EnvelopeGovernError, EnvelopeSpec, run_envelope  # noqa: PLC0415
 
     state_dir = _resolve_state_dir()
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+    data_dir = _resolve_data_dir()
 
     spec = EnvelopeSpec(
         dispatch_id=args.dispatch_id,

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -68,6 +68,7 @@ def patch_env_dirs(tmp_path, monkeypatch):
     data_dir.mkdir()
     monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
     return state_dir, data_dir
 
 
@@ -407,3 +408,48 @@ def test_unified_report_uses_clean_md_suffix(tmp_path):
     legacy_path = data_dir / "unified_reports" / "suffix-check-001_report.md"
     assert clean_path.exists(), f"Expected {clean_path} to exist"
     assert not legacy_path.exists(), f"Legacy path {legacy_path} must not exist"
+
+
+# ---------------------------------------------------------------------------
+# OI-126: central-path resolution (no explicit override → uses CENTRAL)
+# ---------------------------------------------------------------------------
+
+def test_resolve_data_dir_uses_central_when_no_explicit_flag(monkeypatch):
+    """_resolve_data_dir must return $HOME/.vnx-data/<project_id> when VNX_DATA_DIR_EXPLICIT is unset.
+
+    Regression for OI-126: previously fell back to local .vnx-data when VNX_DATA_DIR
+    was unset, making kimi/codex/gemini reports invisible to the receipt processor
+    which watches the CENTRAL path.
+    """
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.setenv("VNX_PROJECT_ID", "test-project-oi126")
+
+    result = provider_dispatch._resolve_data_dir()
+
+    expected = Path.home() / ".vnx-data" / "test-project-oi126"
+    assert result == expected, (
+        f"Expected central path {expected}, got {result}. "
+        "OI-126: provider_dispatch must route reports to the CENTRAL store."
+    )
+
+
+def test_resolve_data_dir_explicit_flag_honors_vnx_data_dir(tmp_path, monkeypatch):
+    """When VNX_DATA_DIR_EXPLICIT=1, _resolve_data_dir uses VNX_DATA_DIR override."""
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "override"))
+
+    result = provider_dispatch._resolve_data_dir()
+
+    assert result == (tmp_path / "override").resolve()
+
+
+def test_resolve_data_dir_default_project_id(monkeypatch):
+    """_resolve_data_dir defaults to project_id='vnx-dev' when VNX_PROJECT_ID unset."""
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    result = provider_dispatch._resolve_data_dir()
+
+    assert result == Path.home() / ".vnx-data" / "vnx-dev"


### PR DESCRIPTION
## Summary

Fixes OI-126: `provider_dispatch.py` was resolving report/receipt paths to the local `.vnx-data/` instead of the central `~/.vnx-data/<project_id>/` that the receipt processor watches. As a result, kimi/codex/gemini/local-gemma reports landed in local `.vnx-data/` and were invisible to the receipt processor.

## Root cause

- `subprocess_dispatch.py` uses `VNX_PROJECT_ID`-based resolution → CENTRAL ✓
- `provider_dispatch.py` used `os.environ.get("VNX_DATA_DIR", ".vnx-data")` → LOCAL fallback ✗

Inconsistency surfaced during live smart-router benchmark wave 2026-06-03: kimi reports landed in local, receipt processor (watching central) never saw them, no receipts delivered to T0.

## Fix

- New `resolve_central_data_dir(project_id)` helper in `project_root.py`
- New `_resolve_data_dir()` helper in `provider_dispatch.py` with `VNX_DATA_DIR_EXPLICIT=1` guard (mirrors `project_root.resolve_data_dir` pattern)
- 4 inline `VNX_DATA_DIR` fallbacks + 2 `VNX_STATE_DIR` fallbacks replaced with helper calls
- 3 regression tests covering: default central path, explicit-flag override, project-id resolution

## Verification

54 tests pass (existing + 3 new). Central path resolution verified via smoke check.

LOC delta: +79 / -10 (+69 net, well within 120 target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)