### PR TITLE
feat(roadmap): add bench-v2 smart-lanes benchmark to 1.1 milestone

### DIFF
--- a/ROADMAP.yaml
+++ b/ROADMAP.yaml
@@ -538,6 +538,29 @@ features:
     status: planned
     notes: "Systematizes the kimi #763 point fix: every provider fails loud on empty extraction; a CI canary dispatches a trivial task through each lane per CLI version; CLI versions pinned in provider_constraints.yaml."
 
+  - feature_id: bench-v2-smart-lanes
+    title: 'Smart Lanes Benchmark v2 — internal calibration + marketing publication'
+    plan_path: claudedocs/BENCHMARK-V2-DESIGN-2026-06-03.md
+    risk_class: low
+    merge_policy: human
+    review_stack: []
+    depends_on:
+      - PR-SR-CAPTURE
+      - OI-155
+    milestone: "1.1"
+    status: planned
+    notes: >
+      Bench-v1 (2026-06-03 20:50) insufficient: 1 trivial task per class, N=1,
+      capture-bug polluted all Claude lane scores (completion_text="" by design).
+      V2: 9 lanes × 5 task-classes × 3 complexity × N=3 = 405 dispatches.
+      Dependencies: PR-SR-CAPTURE (claude completion_text capture-bug fix) +
+      OI-155 (gemini default-credential timeout). Deliverables:
+      claudedocs/bench-v2-results.csv + bench-v2-summary.md; PR-SR-FIX-2
+      calibrates routing_recommendations.yaml from data; public marketing
+      comparison published on vincentvandeth.nl. Estimated effort: 1-2 dev-days
+      (2026-06-04/-05). Owner: operator. Priority: P1. Post-1.0 — not blocking
+      2026-06-09 HN/Reddit launch.
+
   - feature_id: usage-aware-routing
     title: "Usage/budget aggregator + usage-aware routing (clean-API + admin-API + receipt-OBSERVE) + Mission Control widget"
     risk_class: medium


### PR DESCRIPTION
## Summary

- Bench-v1 (run 2026-06-03 20:50) was insufficient for routing calibration: 1 trivial task per class, N=1, and a capture-bug zeroed all Claude lane scores (`completion_text=""` by design) — results were not actionable
- Formalizes bench-v2 as a 1.1 milestone item: 9 lanes × 5 task-classes × 3 complexity levels × N=3 = 405 dispatches with a proper complexity ladder and variance measurement
- Links design doc `claudedocs/BENCHMARK-V2-DESIGN-2026-06-03.md` as `plan_path`

## Dependencies

- **PR-SR-CAPTURE**: claude `completion_text` capture-bug fix (prerequisite — without it, all Claude lanes score 0)
- **OI-155**: gemini default-credential timeout fix

## Deliverables (per design doc)

- `claudedocs/bench-v2-results.csv` + `bench-v2-summary.md`
- PR-SR-FIX-2 calibrates `routing_recommendations.yaml` from measured data
- Public marketing comparison published on vincentvandeth.nl

Post-1.0 — not blocking the 2026-06-09 HN/Reddit launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)