### PR TITLE
feat(smart-router): quality_tier discriminator + per-task min/max gates (PR-SR-FIX-3)

### DIFF
--- a/scripts/lib/providers/routing_recommendations.yaml
+++ b/scripts/lib/providers/routing_recommendations.yaml
@@ -38,38 +38,40 @@ routing_by_task:
     cost_usd_per_call: null
     model_id: kimi-k2-6
   02_code_review:
-  - avg_duration_seconds: 90.934
-    composite_score: 10.0
-    cost_usd_per_call: null
-    model_id: claude-opus-4-6
-  - avg_duration_seconds: 72.516
-    composite_score: 9.5
-    cost_usd_per_call: null
-    model_id: claude-sonnet-4-6
-  - avg_duration_seconds: 29.571
-    composite_score: 9.5
-    cost_usd_per_call: null
-    model_id: deepseek-v4-flash
-  - avg_duration_seconds: 152.5
-    composite_score: 9.5
-    cost_usd_per_call: null
-    model_id: deepseek-v4-pro
-  - avg_duration_seconds: 25.713
-    composite_score: 1.0
-    cost_usd_per_call: null
-    model_id: claude-haiku-4-5
-  - avg_duration_seconds: 0.775
-    composite_score: 1.0
-    cost_usd_per_call: null
-    model_id: glm-5-1
-  - avg_duration_seconds: 1.163
-    composite_score: 1.0
-    cost_usd_per_call: null
-    model_id: kimi-k2-0905
-  - avg_duration_seconds: 1.121
-    composite_score: 1.0
-    cost_usd_per_call: null
-    model_id: kimi-k2-6
+    min_quality_tier: 3
+    candidates:
+    - avg_duration_seconds: 90.934
+      composite_score: 10.0
+      cost_usd_per_call: null
+      model_id: claude-opus-4-6
+    - avg_duration_seconds: 72.516
+      composite_score: 9.5
+      cost_usd_per_call: null
+      model_id: claude-sonnet-4-6
+    - avg_duration_seconds: 29.571
+      composite_score: 9.5
+      cost_usd_per_call: null
+      model_id: deepseek-v4-flash
+    - avg_duration_seconds: 152.5
+      composite_score: 9.5
+      cost_usd_per_call: null
+      model_id: deepseek-v4-pro
+    - avg_duration_seconds: 25.713
+      composite_score: 1.0
+      cost_usd_per_call: null
+      model_id: claude-haiku-4-5
+    - avg_duration_seconds: 0.775
+      composite_score: 1.0
+      cost_usd_per_call: null
+      model_id: glm-5-1
+    - avg_duration_seconds: 1.163
+      composite_score: 1.0
+      cost_usd_per_call: null
+      model_id: kimi-k2-0905
+    - avg_duration_seconds: 1.121
+      composite_score: 1.0
+      cost_usd_per_call: null
+      model_id: kimi-k2-6
   03_refactoring:
   - avg_duration_seconds: 209.001
     composite_score: 8.5

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -32,6 +32,7 @@ class RouteCandidate:
     avg_duration_seconds: float
     cost_usd_per_call: Optional[float] = None
     cost_tier: Optional[int] = None  # 0 = local/free; None = standard billing
+    quality_tier: Optional[int] = None  # 1=low, 2=mid, 3=premium capability
 
 
 @dataclass
@@ -172,6 +173,21 @@ def classify_task(
 _INCAPABLE_SCORE_FLOOR = 1.0
 
 
+def _compute_quality_tier(composite_score: float, cost_tier: Optional[int]) -> int:
+    """Derive quality tier (1-3) from composite_score and cost_tier.
+
+    cost_tier=0 (local/free) is locked to tier 1 regardless of score.
+    Otherwise: score >= 7.5 → 3, score >= 5.0 → 2, else → 1.
+    """
+    if cost_tier == 0:
+        return 1
+    if composite_score >= 7.5:
+        return 3
+    if composite_score >= 5.0:
+        return 2
+    return 1
+
+
 def _cost_aware_sort_key(c: "RouteCandidate") -> tuple:
     """Sort key for cost-aware candidate ranking.
 
@@ -252,18 +268,44 @@ def _load_recommendations(
         )
 
     result: Dict[str, List[RouteCandidate]] = {}
-    for task_class, entries in raw["routing_by_task"].items():
+    for task_class, task_node in raw["routing_by_task"].items():
+        # Support new dict shape: {candidates: [...], min_quality_tier: N, max_quality_tier: N}
+        # Plain-list shape (legacy) passes through unchanged — fully backward compatible.
+        if isinstance(task_node, dict) and "candidates" in task_node:
+            entries = task_node.get("candidates") or []
+            min_qt: Optional[int] = task_node.get("min_quality_tier")
+            max_qt: Optional[int] = task_node.get("max_quality_tier")
+        else:
+            entries = task_node or []
+            min_qt = None
+            max_qt = None
+
         candidates = []
-        for entry in (entries or []):
+        for entry in entries:
             raw_tier = entry.get("cost_tier")
+            cost_tier = int(raw_tier) if raw_tier is not None else None
+            score = float(entry["composite_score"])
+            if "quality_tier" in entry:
+                qt = int(entry["quality_tier"])
+                if qt not in (1, 2, 3):
+                    raise ValueError(
+                        f"quality_tier must be 1-3, got {qt} for {entry.get('model_id')}"
+                    )
+            else:
+                qt = _compute_quality_tier(score, cost_tier)
             candidates.append(RouteCandidate(
                 model_id=str(entry["model_id"]),
-                composite_score=float(entry["composite_score"]),
+                composite_score=score,
                 avg_duration_seconds=float(entry["avg_duration_seconds"]),
                 cost_usd_per_call=entry.get("cost_usd_per_call"),
-                cost_tier=int(raw_tier) if raw_tier is not None else None,
+                cost_tier=cost_tier,
+                quality_tier=qt,
             ))
         _enrich(candidates)
+        if min_qt is not None:
+            candidates = [c for c in candidates if (c.quality_tier or 0) >= min_qt]
+        if max_qt is not None:
+            candidates = [c for c in candidates if (c.quality_tier or 0) <= max_qt]
         candidates.sort(key=_cost_aware_sort_key)
         result[task_class] = candidates
 

--- a/tests/test_smart_router_quality_tier.py
+++ b/tests/test_smart_router_quality_tier.py
@@ -1,0 +1,136 @@
+"""Tests for quality_tier discriminator and per-task min/max gates (PR-SR-FIX-3)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from smart_router import _compute_quality_tier, recommend
+
+
+def _write_yaml(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+def _plain_task(models: list) -> dict:
+    return {"routing_by_task": {"01_code_generation": models}}
+
+
+def _gated_task(models: list, **gates) -> dict:
+    node = {"candidates": models, **gates}
+    return {"routing_by_task": {"02_code_review": node}}
+
+
+# ---------------------------------------------------------------------------
+# test_quality_tier_computation_from_score — boundary cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("score,expected_tier", [
+    (4.9, 1),
+    (5.0, 2),
+    (7.4, 2),
+    (7.5, 3),
+    (10.0, 3),
+    (1.0, 1),
+])
+def test_quality_tier_computation_from_score(score, expected_tier):
+    assert _compute_quality_tier(score, None) == expected_tier
+
+
+# ---------------------------------------------------------------------------
+# test_cost_tier_zero_forces_tier_1
+# ---------------------------------------------------------------------------
+
+def test_cost_tier_zero_forces_tier_1(tmp_path):
+    p = _write_yaml(tmp_path, _plain_task([
+        {"model_id": "local", "composite_score": 9.0, "avg_duration_seconds": 5.0, "cost_tier": 0},
+    ]))
+    candidates = recommend("01_code_generation", recommendations_path=p)
+    assert candidates[0].quality_tier == 1
+
+
+def test_cost_tier_zero_overrides_any_score():
+    assert _compute_quality_tier(9.9, 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# test_explicit_quality_tier_override
+# ---------------------------------------------------------------------------
+
+def test_explicit_quality_tier_override(tmp_path):
+    p = _write_yaml(tmp_path, _plain_task([
+        {"model_id": "special", "composite_score": 8.0, "avg_duration_seconds": 100.0, "quality_tier": 2},
+    ]))
+    candidates = recommend("01_code_generation", recommendations_path=p)
+    assert candidates[0].quality_tier == 2
+
+
+def test_invalid_explicit_quality_tier_raises(tmp_path):
+    p = _write_yaml(tmp_path, _plain_task([
+        {"model_id": "bad", "composite_score": 8.0, "avg_duration_seconds": 100.0, "quality_tier": 5},
+    ]))
+    with pytest.raises(ValueError, match="quality_tier must be 1-3"):
+        recommend("01_code_generation", recommendations_path=p)
+
+
+# ---------------------------------------------------------------------------
+# test_min_tier_filter_excludes_lower
+# ---------------------------------------------------------------------------
+
+_THREE_TIER_MODELS = [
+    {"model_id": "premium", "composite_score": 9.0, "avg_duration_seconds": 90.0},
+    {"model_id": "mid", "composite_score": 6.0, "avg_duration_seconds": 60.0},
+    {"model_id": "low", "composite_score": 1.0, "avg_duration_seconds": 10.0},
+]
+
+
+def test_min_tier_filter_excludes_lower(tmp_path):
+    p = _write_yaml(tmp_path, _gated_task(_THREE_TIER_MODELS, min_quality_tier=3))
+    ids = [c.model_id for c in recommend("02_code_review", recommendations_path=p)]
+    assert ids == ["premium"]
+
+
+# ---------------------------------------------------------------------------
+# test_max_tier_filter_caps_premium
+# ---------------------------------------------------------------------------
+
+def test_max_tier_filter_caps_premium(tmp_path):
+    p = _write_yaml(tmp_path, _gated_task(_THREE_TIER_MODELS, max_quality_tier=2))
+    ids = [c.model_id for c in recommend("02_code_review", recommendations_path=p)]
+    assert "premium" not in ids
+    assert "mid" in ids
+    assert "low" in ids
+
+
+# ---------------------------------------------------------------------------
+# test_plain_list_no_filter_no_regression
+# ---------------------------------------------------------------------------
+
+def test_plain_list_no_filter_no_regression(tmp_path):
+    p = _write_yaml(tmp_path, _plain_task(_THREE_TIER_MODELS))
+    candidates = recommend("01_code_generation", recommendations_path=p)
+    assert len(candidates) == 3
+    by_id = {c.model_id: c for c in candidates}
+    assert by_id["premium"].quality_tier == 3
+    assert by_id["mid"].quality_tier == 2
+    assert by_id["low"].quality_tier == 1
+
+
+# ---------------------------------------------------------------------------
+# test_recommend_returns_tier_on_candidate — real YAML
+# ---------------------------------------------------------------------------
+
+def test_recommend_returns_tier_on_candidate():
+    candidates = recommend("02_code_review")
+    assert len(candidates) > 0
+    assert candidates[0].quality_tier == 3
+    for c in candidates:
+        assert c.quality_tier == 3, (
+            f"{c.model_id} has quality_tier={c.quality_tier}, expected 3"
+        )


### PR DESCRIPTION
## Summary

- Adds `quality_tier` (1-3) to `RouteCandidate` — orthogonal to `cost_tier`
- `_compute_quality_tier()`: `cost_tier=0` locked to 1; `score>=7.5`→3, `>=5.0`→2, else 1
- YAML supports explicit `quality_tier:` override per entry (validated 1-3)
- `_load_recommendations()` parses new dict-shape `{candidates, min/max_quality_tier}` for per-task tier filtering; plain-list shape unchanged (fully backward compatible)
- `02_code_review` wrapped with `min_quality_tier: 3` — haiku/glm/kimi (all score 1.0) filtered from code-review candidates
- 14 new tests: boundary computation, cost_tier=0 override, explicit YAML override, min/max filter, backward compat, real-YAML smoke

## Changes

- `scripts/lib/smart_router.py` — `quality_tier` field, `_compute_quality_tier()`, updated `_load_recommendations()`
- `scripts/lib/providers/routing_recommendations.yaml` — `02_code_review` wrapped in dict-shape with `min_quality_tier: 3`
- `tests/test_smart_router_quality_tier.py` — 14 new tests (new file)

## Verification

- Branch base: `affa7adc fix(claude-spawn): capture completion_text from stream-json assistant events (#821)`
- `pytest tests/test_smart_router_quality_tier.py tests/test_smart_router.py -x -v` → **90 passed**
- Smoke: `recommend('02_code_review')` → `[('claude-opus-4-6', 10.0, 3), ('deepseek-v4-flash', 9.5, 3), ('deepseek-v4-pro', 9.5, 3), ('claude-sonnet-4-6', 9.5, 3)]`
- LOC delta: 216 insertions + 36 deletions (within 250 cap)
- Only 3 in-scope files touched

**Dispatch-ID**: 20260603-224500-pr-sr-fix-3-v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)