### PR TITLE
fix(provider-dispatch): _dispatch_gemini respects args.model (OI-155)

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -541,7 +541,7 @@ def _constraint_model_for_provider(args: argparse.Namespace, provider: str) -> s
     if provider == "codex":
         return os.environ.get("VNX_CODEX_MODEL", "") or _resolve_codex_model()
     if provider == "gemini":
-        return os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+        return args.model if (args.model and args.model != "sonnet") else os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
     if provider == "kimi":
         return os.environ.get("VNX_KIMI_MODEL", "") or _resolve_kimi_model_label()
     if provider == "deepseek-harness":
@@ -1359,7 +1359,7 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         )
         return 1
 
-    model = os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+    model = args.model if (args.model and args.model != "sonnet") else os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
     enriched_instruction = _enrich_instruction(args)
     isolation_cwd_gemini: Optional[Path] = None
     if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":

--- a/tests/test_provider_dispatch_gemini.py
+++ b/tests/test_provider_dispatch_gemini.py
@@ -1,0 +1,79 @@
+"""Tests for gemini model-arg respecting in provider_dispatch.py (OI-155)."""
+from __future__ import annotations
+
+import os
+import sys
+import argparse
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import provider_dispatch as pd
+
+
+def _args(**kw):
+    defaults = dict(
+        provider="gemini", terminal_id="T1", dispatch_id="test-gemini-oi155",
+        instruction="test", model="sonnet", max_retries=3, no_auto_commit=False,
+        gate="", dispatch_paths="", pr_id=None, role="developer",
+        no_repo_map=False, tags=[],
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+@dataclass
+class _R:
+    returncode: int = 0
+    completion_text: str = "ok"
+    events_written: int = 1
+    session_id: Optional[str] = None
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+
+def _env_without_gemini():
+    return {k: v for k, v in os.environ.items() if k != "VNX_GEMINI_MODEL"}
+
+
+def _dispatch_with_env(args, env):
+    es = MagicMock()
+    with patch("provider_spawns.gemini_spawn.spawn_gemini", return_value=_R()) as m, \
+         patch("event_store.EventStore", return_value=es), \
+         patch.object(pd, "_emit_governance"), \
+         patch.object(pd, "_enrich_instruction", return_value="test"), \
+         patch.object(pd, "_create_provider_worktree", return_value=None), \
+         patch.dict(os.environ, env, clear=True):
+        pd._dispatch_gemini(args)
+    return m.call_args.kwargs.get("model")
+
+
+class TestDispatchGeminiArgsModel(unittest.TestCase):
+    def test_dispatch_gemini_respects_args_model(self):
+        model = _dispatch_with_env(_args(model="gemini-2.5-flash"), _env_without_gemini())
+        self.assertEqual(model, "gemini-2.5-flash")
+
+    def test_dispatch_gemini_falls_back_to_env_when_args_sonnet(self):
+        env = {**_env_without_gemini(), "VNX_GEMINI_MODEL": "gemini-2.5-flash"}
+        model = _dispatch_with_env(_args(model="sonnet"), env)
+        self.assertEqual(model, "gemini-2.5-flash")
+
+    def test_dispatch_gemini_falls_back_to_default_when_neither(self):
+        model = _dispatch_with_env(_args(model="sonnet"), _env_without_gemini())
+        self.assertEqual(model, "gemini-2.5-pro")
+
+    def test_resolve_gemini_model_respects_args_model(self):
+        with patch.dict(os.environ, _env_without_gemini(), clear=True):
+            result = pd._constraint_model_for_provider(_args(model="gemini-2.5-flash"), "gemini")
+        self.assertEqual(result, "gemini-2.5-flash")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_dispatch_gemini` (line 1362) and `_constraint_model_for_provider` (line 544) both ignored `args.model`, always running `gemini-2.5-pro` regardless of `--model` flag
- Bench-v4 (2026-06-03) recorded 3/3 gemini timeouts at 270-279s on trivial tasks because `--model gemini-2.5-flash` was silently ignored
- Fix follows the same pattern as `_dispatch_deepseek_harness` and `_dispatch_local_gemma`: prefer `args.model` when present and not the argparse default sentinel `"sonnet"`

## Test plan

- [x] `test_dispatch_gemini_respects_args_model` — `args.model="gemini-2.5-flash"` → spawn called with `"gemini-2.5-flash"`
- [x] `test_dispatch_gemini_falls_back_to_env_when_args_sonnet` — sentinel + env var → env model used
- [x] `test_dispatch_gemini_falls_back_to_default_when_neither` — sentinel + no env → `"gemini-2.5-pro"` default
- [x] `test_resolve_gemini_model_respects_args_model` — pre-flight resolver uses `args.model`
- [x] All 4 tests pass; no regression in existing `test_provider_dispatch*` suite (pre-existing failures in worktree_isolation/event_rotation unchanged)

**LOC delta**: 83 (81 insertions + 2 deletions) — within 100 LOC hard cap

Dispatch-ID: 20260603-225500-oi-155-gemini-args-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)