### PR TITLE
feat(roadmap): park sales-copilot VNX upgrade (1.0.1)

### DIFF
--- a/ROADMAP.yaml
+++ b/ROADMAP.yaml
@@ -785,3 +785,13 @@ features:
       Atomic prune transaction for the DB maintenance script
       (scripts/vnx_db_maintenance.py). Ensures transactional safety on prune
       operations. Merged #794 on 2026-06-02.
+
+  - feature_id: sales-copilot-vnx-upgrade
+    title: "Sales-copilot project — VNX install upgrade to post-1.0"
+    risk_class: low
+    merge_policy: human
+    review_stack: []
+    depends_on: []
+    milestone: "1.0.1"
+    status: planned
+    notes: "Bring sales-copilot's VNX install current with main (~3 weken gap, MC-cutover shape)."


### PR DESCRIPTION
## Summary
Park sales-copilot VNX upgrade as 1.0.1 entry. Project is ~3-4 weken / 150+ commits achter main. MC-cutover precedent applies (1-2 dagen post-launch).

Public entry stays slim (1-liner). Details in `.vnx-data/state/roadmap-private/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)