### PR TITLE
feat(benchmark): field-tests T2 medium + T3 complex task-defs

### DIFF
--- a/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/expected.json
@@ -1,0 +1,21 @@
+{
+  "expected_files": [
+    "migrations/001_add_document_scores.sql",
+    "scorer.py",
+    "cli.py",
+    "tests/test_scorer.py"
+  ],
+  "expected_checks_pass": 4,
+  "expected_style": {
+    "language": "python+sql",
+    "module_layout": "scorer.py has compute_score / score_document / score_all callables",
+    "must_use": ["sqlite3 context managers", "UPSERT via ON CONFLICT clause"],
+    "anti_patterns": [
+      "no string-concat SQL with user input",
+      "no shared cursors across functions",
+      "no bare except clauses",
+      "no print-debug left behind"
+    ]
+  },
+  "rubric_for_llm_judge": "Code quality is high when: scorer.py separates pure compute_score (formula) from score_document (persistence), uses sqlite3 context managers, UPSERT uses real ON CONFLICT(project_id, document_id) clause (not 2-step SELECT+INSERT/UPDATE), tests cover all 7 formula cases + 5 persistence cases + 3 edge cases. Low quality includes: untyped float math without rounding, string-built SQL with user input, missing UPSERT (does DELETE+INSERT instead), tests that share state."
+}

--- a/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/instruction.md
@@ -1,0 +1,100 @@
+# Task 04 — Visibility scorer task + migration + tests
+
+Source-inspiratie: Mission Control PR #244 (visibility_comment_scorer). Tier: T2 medium. Deadline: 30 minutes wallclock.
+
+## Context
+
+The seed includes a minimal SQLite project that ingests documents and needs a scoring layer. There are 50 seed documents pre-loaded. You implement:
+1. A migration that adds a `document_scores` table
+2. A `scorer.py` module that computes per-document scores
+3. A CLI entry point that runs the scorer over all documents
+4. A test suite (15 tests) covering scoring logic + persistence + edge cases
+
+This is a realistic multi-file Procrastinate-task-style pattern — bounded scope but spans schema, business logic, persistence, and tests.
+
+## Scoring formula
+
+For each document, compute `score = base * status_multiplier * age_decay` where:
+
+- `base` = `min(word_count, 1000) / 100` (clamped 0-10 from word count)
+- `status_multiplier` = `{"draft": 0.5, "published": 1.0, "archived": 0.25}[status]`
+- `age_decay` = `1.0 / (1.0 + days_since_created * 0.05)`
+- Final score: round to 2 decimal places
+- Documents with `status` NOT in the three keys: skip + log (no score row written)
+
+## Required deliverables
+
+### 1. `migrations/001_add_document_scores.sql`
+
+Idempotent migration creating `document_scores`:
+- `id INTEGER PRIMARY KEY AUTOINCREMENT`
+- `document_id INTEGER NOT NULL`
+- `project_id TEXT NOT NULL DEFAULT 'default'`  *(ADR-007)*
+- `score REAL NOT NULL`
+- `computed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`
+- UNIQUE index on `(project_id, document_id)`
+- INDEX on `(computed_at)` for time-window queries
+
+Must be re-runnable without errors.
+
+### 2. `scorer.py`
+
+Module with these callables:
+
+```python
+def compute_score(word_count: int, status: str, days_since_created: int) -> float | None:
+    """Returns score or None if status is unrecognized."""
+
+def score_document(conn, document_id: int, project_id: str = "default") -> float | None:
+    """Reads document, computes score, UPSERTs into document_scores. Returns score."""
+
+def score_all(conn, project_id: str = "default") -> dict:
+    """Iterates all documents, calls score_document. Returns {scored: N, skipped: M}."""
+```
+
+UPSERT pattern: `INSERT ... ON CONFLICT(project_id, document_id) DO UPDATE SET score = excluded.score, computed_at = CURRENT_TIMESTAMP`.
+
+### 3. `cli.py`
+
+CLI entry point: `python3 cli.py --db documents.db --project-id default` — runs `score_all` and prints `{"scored": N, "skipped": M}`. Exit 0 on success, 1 if any uncaught exception.
+
+### 4. `tests/test_scorer.py`
+
+15 tests total:
+- `test_compute_score_published_zero_days` — 100 words, published, day 0 → score 1.00
+- `test_compute_score_published_word_clamp` — 5000 words, published, day 0 → score 10.00 (clamped)
+- `test_compute_score_draft_multiplier` — 200 words, draft, day 0 → 1.00 (2.0 base × 0.5)
+- `test_compute_score_archived_multiplier` — 200 words, archived, day 0 → 0.50
+- `test_compute_score_age_decay_10_days` — 200 words, published, day 10 → ~1.33 (2.0 / 1.5)
+- `test_compute_score_unknown_status_returns_none` — status="weird" → None
+- `test_compute_score_empty_document` — 0 words, published, day 0 → 0.00
+- `test_score_document_writes_row` — score_document() inserts into document_scores
+- `test_score_document_upsert` — calling twice updates same row, not duplicate
+- `test_score_document_unknown_status_skips_persist` — status="weird" writes nothing
+- `test_score_all_counts_correctly` — 50 docs in seed → returns scored + skipped totals
+- `test_score_all_project_isolation` — same document_id under two project_ids creates two rows
+- `test_migration_idempotent` — running migrate.sql twice does not error
+- `test_score_all_handles_db_lock` — concurrent score_all calls don't crash (single retry OK)
+- `test_cli_exit_zero_on_success` — `python3 cli.py --db <fresh-db>` exits 0
+
+## Files in seed
+
+- `documents.db` — pre-loaded with 50 documents (~45 published, 3 draft, 1 archived, 1 unknown-status)
+- `schema.sql` — original `documents` table definition (for reference)
+
+## Files you may create/modify
+
+- `migrations/001_add_document_scores.sql` (create)
+- `scorer.py` (create)
+- `cli.py` (create)
+- `tests/test_scorer.py` (create)
+- `tests/__init__.py` (create, empty)
+
+Do NOT modify `documents.db` directly or `schema.sql`.
+
+## Definition of done
+
+- All 15 tests pass: `pytest tests/test_scorer.py -v`
+- Migration runs cleanly (and twice idempotently)
+- `python3 cli.py --db documents.db --project-id default` prints valid JSON `{"scored": 49, "skipped": 1}` and exits 0
+- No TODO comments, no print-debug

--- a/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/seed/init_seed_db.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/seed/init_seed_db.py
@@ -1,0 +1,71 @@
+"""Initialize seed documents.db with 50 rows for the scorer task benchmark.
+
+Run before each cell to give the worker a fresh starting state.
+
+Distribution: 45 published, 3 draft, 1 archived, 1 unknown-status (to test skip).
+Word counts span 0..5000 to exercise the clamp at 1000. Ages 0..30 days for
+age_decay sensitivity.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def build_seed_db(db_path: Path) -> None:
+    if db_path.exists():
+        db_path.unlink()
+
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            word_count INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'default'
+        )
+    """)
+    cur.execute("CREATE INDEX idx_documents_project ON documents(project_id)")
+    cur.execute("CREATE INDEX idx_documents_status ON documents(status)")
+
+    now = datetime(2026, 6, 4, 9, 0, 0, tzinfo=timezone.utc)
+    rows = []
+    for i in range(45):
+        days_old = i % 30
+        wc = (i * 137) % 5000
+        rows.append((
+            f"Doc {i+1}", f"body of doc {i+1}", wc, "published",
+            (now - timedelta(days=days_old)).isoformat(), "default",
+        ))
+    for i in range(3):
+        rows.append((
+            f"Draft {i+1}", f"draft body {i+1}", 100 + i * 50, "draft",
+            (now - timedelta(days=i * 5)).isoformat(), "default",
+        ))
+    rows.append((
+        "Archived", "archived body", 800, "archived",
+        (now - timedelta(days=45)).isoformat(), "default",
+    ))
+    rows.append((
+        "Weird-status", "should be skipped", 500, "queued",
+        now.isoformat(), "default",
+    ))
+
+    cur.executemany(
+        "INSERT INTO documents (title, body, word_count, status, created_at, project_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    here = Path(__file__).resolve().parent
+    build_seed_db(here / "documents.db")
+    print(f"seed db built at {here / 'documents.db'}")

--- a/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/seed/schema.sql
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/seed/schema.sql
@@ -1,0 +1,14 @@
+-- Original documents schema (reference only — do not modify)
+
+CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    word_count INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    project_id TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE INDEX IF NOT EXISTS idx_documents_project ON documents(project_id);
+CREATE INDEX IF NOT EXISTS idx_documents_status ON documents(status);

--- a/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/verify.py
@@ -1,0 +1,173 @@
+"""verify.py for task 04 — scorer task + migration + tests.
+
+Runs the worker's 15-test pytest suite, applies the migration, smoke-runs
+the CLI, and validates a sample score against the formula.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t2_medium/04_scorer_task/seed"
+
+
+def _required_files(seed_dir: Path) -> list[str]:
+    found = []
+    for rel in (
+        "migrations/001_add_document_scores.sql",
+        "scorer.py",
+        "cli.py",
+        "tests/test_scorer.py",
+    ):
+        if (seed_dir / rel).exists():
+            found.append(rel)
+    return found
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    init_script = seed_dir / "init_seed_db.py"
+
+    if not init_script.exists():
+        return {
+            "pass": False,
+            "evidence": f"seed init script missing at {init_script}",
+            "details": {"pass_count": 0, "expected": 4, "files_written": []},
+        }
+
+    files_written = _required_files(seed_dir)
+    missing = [f for f in (
+        "migrations/001_add_document_scores.sql", "scorer.py",
+        "cli.py", "tests/test_scorer.py",
+    ) if f not in files_written]
+    if missing:
+        return {
+            "pass": False,
+            "evidence": f"worker did not write required files: {missing}",
+            "details": {
+                "pass_count": 0, "expected": 4, "files_written": files_written,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for rel in files_written:
+            src = seed_dir / rel
+            dst = tmp_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        shutil.copy(init_script, tmp_dir / "init_seed_db.py")
+        if (seed_dir / "schema.sql").exists():
+            shutil.copy(seed_dir / "schema.sql", tmp_dir / "schema.sql")
+
+        init_proc = subprocess.run(
+            [sys.executable, "init_seed_db.py"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        if init_proc.returncode != 0:
+            return {
+                "pass": False,
+                "evidence": f"init_seed_db failed: {init_proc.stderr[-300:]}",
+                "details": {"pass_count": 0, "expected": 4, "files_written": files_written},
+            }
+
+        checks: list[tuple[str, bool, str]] = []
+
+        try:
+            mig_proc = subprocess.run(
+                ["sqlite3", "documents.db"],
+                input=(tmp_dir / "migrations" / "001_add_document_scores.sql").read_text(),
+                cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+            )
+            mig_ok = mig_proc.returncode == 0
+            checks.append((
+                "migration applies cleanly",
+                mig_ok,
+                f"rc={mig_proc.returncode} stderr={mig_proc.stderr[-200:]}",
+            ))
+        except Exception as exc:
+            checks.append(("migration applies cleanly", False, str(exc)))
+            mig_ok = False
+
+        if mig_ok:
+            try:
+                mig2 = subprocess.run(
+                    ["sqlite3", "documents.db"],
+                    input=(tmp_dir / "migrations" / "001_add_document_scores.sql").read_text(),
+                    cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+                )
+                checks.append((
+                    "migration idempotent",
+                    mig2.returncode == 0,
+                    f"rc={mig2.returncode}",
+                ))
+            except Exception as exc:
+                checks.append(("migration idempotent", False, str(exc)))
+
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "tests/test_scorer.py", "-v", "--tb=short", "-q"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=180, check=False,
+        )
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+        checks.append((
+            "15 tests pass",
+            pytest_pass >= 15 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+
+        try:
+            cli_proc = subprocess.run(
+                [sys.executable, "cli.py", "--db", "documents.db", "--project-id", "default"],
+                cwd=tmp_dir, capture_output=True, text=True, timeout=60, check=False,
+            )
+            cli_ok = cli_proc.returncode == 0
+            cli_json_ok = False
+            if cli_ok:
+                try:
+                    out = json.loads(cli_proc.stdout.strip().splitlines()[-1])
+                    cli_json_ok = (
+                        isinstance(out.get("scored"), int)
+                        and isinstance(out.get("skipped"), int)
+                        and out["scored"] + out["skipped"] == 50
+                    )
+                except (json.JSONDecodeError, KeyError, IndexError):
+                    cli_json_ok = False
+            checks.append((
+                "CLI exits 0 and prints valid {scored, skipped} json totaling 50",
+                cli_ok and cli_json_ok,
+                f"rc={cli_proc.returncode} stdout-tail={cli_proc.stdout[-200:]}",
+            ))
+        except Exception as exc:
+            checks.append(("CLI smoke", False, str(exc)))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+    expected = 4
+
+    return {
+        "pass": pass_count >= expected,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, expected),
+            "expected": expected,
+            "files_written": files_written,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t2_medium"}), indent=2))

--- a/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/expected.json
@@ -1,0 +1,16 @@
+{
+  "expected_files": ["email_link_extractor.py", "tests/test_email_link_extractor.py"],
+  "expected_checks_pass": 3,
+  "expected_style": {
+    "language": "python",
+    "inheritance": "EmailLinkExtractor(BaseExtractor) — direct subclass",
+    "name_attribute": "email_link",
+    "must_import": ["from bs4 import BeautifulSoup", "from base_extractor import BaseExtractor"],
+    "anti_patterns": [
+      "no regex-only HTML parsing",
+      "no bypass of BaseExtractor envelope contract",
+      "no leaking unhandled exceptions"
+    ]
+  },
+  "rubric_for_llm_judge": "Code quality is high when: subclass uses BeautifulSoup correctly, handles missing href gracefully, strips subject suffix idiomatically (urlparse or split on '?'), envelope is built once at return, errors collected in list. Low quality: hand-rolled HTML regex, missing href guard, side-effects in __init__, mutating class-level state."
+}

--- a/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/instruction.md
@@ -1,0 +1,69 @@
+# Task 05 — New BaseExtractor subclass (EmailLinkExtractor)
+
+Source-inspiratie: SEOcrawler v2 extractor pattern. Tier: T2 medium. Deadline: 20 minutes wallclock.
+
+## Context
+
+The seed includes a `base_extractor.py` defining an abstract `BaseExtractor` class and one concrete reference subclass `MetaTagExtractor` for orientation. You add a new subclass `EmailLinkExtractor` that pulls `mailto:` links from HTML and reports counts + unique addresses.
+
+This is a typical extractor-toevoeging task from the SEOcrawler codebase shape.
+
+## BaseExtractor contract (in seed)
+
+```python
+class BaseExtractor(ABC):
+    name: str = "unnamed"
+
+    @abstractmethod
+    def extract(self, html: str, url: str) -> dict:
+        """Return {'name': self.name, 'data': {...}, 'errors': [...]}"""
+```
+
+`MetaTagExtractor` (provided) shows the pattern: parse HTML, pull data, return the standard envelope.
+
+## Required deliverable
+
+### `email_link_extractor.py`
+
+A class `EmailLinkExtractor(BaseExtractor)` with `name = "email_link"`. The `extract(html, url)` method must:
+
+1. Parse the HTML using `BeautifulSoup` (`from bs4 import BeautifulSoup`)
+2. Find all `<a>` tags with an `href` that starts with `mailto:`
+3. Extract the email address (strip `mailto:` and any `?subject=...` query suffix)
+4. Lowercase + dedupe addresses
+5. Return:
+   ```python
+   {
+       "name": "email_link",
+       "data": {
+           "total_links": <int>,        # count of mailto links found
+           "unique_emails": <int>,      # count of unique addresses
+           "emails": [<sorted list>],
+       },
+       "errors": [],
+   }
+   ```
+6. Empty input or no matches: return zero-counts + empty list, NOT an error
+
+### `tests/test_email_link_extractor.py`
+
+5 tests:
+- `test_empty_html_returns_zero` — empty HTML → 0 total, 0 unique, [] emails
+- `test_single_mailto_link` — one `<a href="mailto:user@example.com">` → 1 total, 1 unique
+- `test_dedup_lowercases` — same email with different casing → 1 unique
+- `test_subject_suffix_stripped` — `mailto:user@example.com?subject=Hi` → `user@example.com`
+- `test_returns_standard_envelope` — return dict has `name`, `data`, `errors` keys (envelope contract)
+
+## Files you may create
+
+- `email_link_extractor.py` (create)
+- `tests/test_email_link_extractor.py` (create)
+- `tests/__init__.py` (create, empty)
+
+Do NOT modify `base_extractor.py` or `meta_tag_extractor.py`.
+
+## Definition of done
+
+- 5 tests pass: `pytest tests/test_email_link_extractor.py -v`
+- `EmailLinkExtractor().extract(html, "https://example.com")` returns the envelope shape on any input
+- No new external deps besides `bs4` (already in seed `requirements.txt`)

--- a/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/seed/base_extractor.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/seed/base_extractor.py
@@ -1,0 +1,26 @@
+"""BaseExtractor abstract contract for the bench task.
+
+Real extractors in SEOcrawler v2 inherit from this shape. The benchmark seed
+provides one reference subclass (MetaTagExtractor) so the target lane has a
+working example before writing EmailLinkExtractor.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseExtractor(ABC):
+    name: str = "unnamed"
+
+    @abstractmethod
+    def extract(self, html: str, url: str) -> dict[str, Any]:
+        """Return a standard envelope:
+
+        {
+            'name': self.name,
+            'data': {...},     # extractor-specific payload
+            'errors': [...],   # empty list if successful
+        }
+        """
+        raise NotImplementedError

--- a/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/seed/meta_tag_extractor.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/seed/meta_tag_extractor.py
@@ -1,0 +1,37 @@
+"""MetaTagExtractor — reference implementation of BaseExtractor contract.
+
+Provided so the target lane has a concrete example. Do not modify.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+from base_extractor import BaseExtractor
+
+
+class MetaTagExtractor(BaseExtractor):
+    name = "meta_tag"
+
+    def extract(self, html: str, url: str) -> dict[str, Any]:
+        errors: list[str] = []
+        meta_tags: dict[str, str] = {}
+        try:
+            soup = BeautifulSoup(html or "", "html.parser")
+            for tag in soup.find_all("meta"):
+                name = tag.get("name") or tag.get("property")
+                content = tag.get("content")
+                if name and content:
+                    meta_tags[name] = content
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"parse_error: {exc}")
+
+        return {
+            "name": self.name,
+            "data": {
+                "tag_count": len(meta_tags),
+                "tags": meta_tags,
+            },
+            "errors": errors,
+        }

--- a/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/verify.py
@@ -1,0 +1,137 @@
+"""verify.py for task 05 — EmailLinkExtractor subclass."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t2_medium/05_extractor_subclass/seed"
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    extractor_file = seed_dir / "email_link_extractor.py"
+    test_file = seed_dir / "tests" / "test_email_link_extractor.py"
+
+    files_written = []
+    for rel in ("email_link_extractor.py", "tests/test_email_link_extractor.py"):
+        if (seed_dir / rel).exists():
+            files_written.append(rel)
+
+    missing = [f for f in ("email_link_extractor.py", "tests/test_email_link_extractor.py")
+               if f not in files_written]
+    if missing:
+        return {
+            "pass": False,
+            "evidence": f"worker did not write: {missing}",
+            "details": {"pass_count": 0, "expected": 3, "files_written": files_written},
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for src_rel in (
+            "base_extractor.py", "meta_tag_extractor.py",
+            "email_link_extractor.py", "tests/test_email_link_extractor.py",
+        ):
+            src = seed_dir / src_rel
+            if src.exists():
+                dst = tmp_dir / src_rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(src, dst)
+        (tmp_dir / "tests" / "__init__.py").touch()
+
+        checks: list[tuple[str, bool, str]] = []
+
+        envelope_proc = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, '.'); "
+             "from email_link_extractor import EmailLinkExtractor; "
+             "r = EmailLinkExtractor().extract('', 'https://example.com'); "
+             "import json; print(json.dumps(r))"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        envelope_ok = False
+        if envelope_proc.returncode == 0:
+            try:
+                env = json.loads(envelope_proc.stdout.strip())
+                envelope_ok = (
+                    env.get("name") == "email_link"
+                    and isinstance(env.get("data"), dict)
+                    and isinstance(env.get("errors"), list)
+                )
+            except json.JSONDecodeError:
+                pass
+        checks.append((
+            "empty-html envelope shape correct",
+            envelope_ok,
+            f"stdout={envelope_proc.stdout[-200:]} stderr={envelope_proc.stderr[-200:]}",
+        ))
+
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest",
+             "tests/test_email_link_extractor.py", "-v", "--tb=short", "-q"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=60, check=False,
+        )
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+        checks.append((
+            "5 tests pass",
+            pytest_pass >= 5 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+
+        sample_proc = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, '.'); "
+             "from email_link_extractor import EmailLinkExtractor; "
+             'html = \'<a href="mailto:A@Example.com">x</a>'
+             '<a href="mailto:a@example.com?subject=Hi">y</a>'
+             '<a href="mailto:b@example.com">z</a>\'; '
+             "r = EmailLinkExtractor().extract(html, 'https://x'); "
+             "import json; print(json.dumps(r['data']))"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        smoke_ok = False
+        if sample_proc.returncode == 0:
+            try:
+                d = json.loads(sample_proc.stdout.strip())
+                smoke_ok = (
+                    d.get("total_links") == 3
+                    and d.get("unique_emails") == 2
+                    and sorted(d.get("emails", [])) == ["a@example.com", "b@example.com"]
+                )
+            except json.JSONDecodeError:
+                pass
+        checks.append((
+            "dedup + lowercase + subject-strip work",
+            smoke_ok,
+            f"stdout={sample_proc.stdout[-300:]}",
+        ))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+
+    return {
+        "pass": pass_count >= 3,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, 3),
+            "expected": 3,
+            "files_written": files_written,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t2_medium"}), indent=2))

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/expected.json
@@ -1,0 +1,16 @@
+{
+  "expected_files": ["tests/conftest.py"],
+  "expected_checks_pass": 3,
+  "expected_style": {
+    "language": "python",
+    "mock_pattern": "stateful — uses side_effect (list of responses OR callable with closure state)",
+    "must_preserve": "the chained-call API .table().select().range().execute()",
+    "anti_patterns": [
+      "no pytest.skip / pytest.xfail",
+      "no monkeypatching the system-under-test",
+      "no global state",
+      "no random in mock"
+    ]
+  },
+  "rubric_for_llm_judge": "High quality: uses Mock(side_effect=[r1, r2, r3]) cleanly OR a small closure that tracks call count. Each response is constructed once, not per-call. Code clearly documents the page-by-page progression. Low quality: monkey-patching globals, using a counter on the module-level mock instance, hand-rolling __call__ on a custom class when side_effect suffices."
+}

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/instruction.md
@@ -1,0 +1,53 @@
+# Task 06 — Fix flaky mock-paginatie test (Kimi hang trigger)
+
+Source-inspiratie: SEOcrawler PR #123 (mock-paginatie hang). Tier: T2 medium. Deadline: 20 minutes wallclock.
+
+## Context
+
+The seed includes a test file `test_paginated_query.py` and a helper module `paginated_query.py`. The test exercises a paginated DB query against a Supabase-like client. The mock factory `_make_supabase_mock` in `conftest.py` returns the SAME response for every paginated call, which causes the system-under-test to loop forever (next-page-cursor never decrements).
+
+Running `pytest tests/test_paginated_query.py` currently hangs indefinitely. This task is one of the known **Kimi-introspection-heavy traps** — pattern-bounded models hang on mock-state debugging.
+
+## Root cause (you must find this)
+
+The mock returns a constant `{"data": [10 rows], "next_cursor": "page-2"}` on every call. `fetch_all_pages()` keeps fetching page-2 forever because the cursor never advances to `None`.
+
+## Required fix
+
+Modify `conftest.py` so `_make_supabase_mock` returns **stateful** responses:
+- First call: 10 rows + `next_cursor="page-2"`
+- Second call: 10 rows + `next_cursor="page-3"`
+- Third call: 5 rows + `next_cursor=None` (end of data)
+- Any subsequent call: empty data + `next_cursor=None`
+
+Total rows fetched across pagination: 25.
+
+## Required deliverable
+
+### `tests/conftest.py` (modify)
+
+`_make_supabase_mock()` returns a Mock whose `.table().select().range().execute()` chain produces stateful page responses per the spec above.
+
+Use `side_effect` (list of responses, OR a callable that maintains state).
+
+### Test that must pass
+
+After your fix, `pytest tests/test_paginated_query.py -v --timeout=5` must:
+- Complete in well under 5 seconds (no infinite loop)
+- Exit 0 with the 3 contract tests passing:
+  - `test_fetch_all_pages_terminates_at_25_rows`
+  - `test_paginate_handles_short_final_page`
+  - `test_paginate_post_terminal_call_returns_empty`
+
+## Files you may modify
+
+- `tests/conftest.py` (modify — the only fix is here)
+
+Do NOT modify `paginated_query.py` or `tests/test_paginated_query.py`. The system-under-test and the test contracts are correct; only the mock is broken.
+
+## Definition of done
+
+- `pytest tests/test_paginated_query.py -v --timeout=5` exits 0
+- All 3 tests pass
+- No `pytest.skip` / `pytest.xfail` shortcuts in conftest
+- The fix maintains the original mock's chained-call API (`.table().select().range().execute()`)

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/paginated_query.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/paginated_query.py
@@ -1,0 +1,30 @@
+"""paginated_query — fetches all rows across paginated Supabase-style API.
+
+System-under-test: this code is CORRECT. The hang in the test suite is in
+the MOCK, not here. Do not modify this file.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def fetch_all_pages(client: Any, table: str, page_size: int = 10) -> list[dict]:
+    """Fetch all rows from `table` via cursor-based pagination.
+
+    Loops until next_cursor is None. Returns flat list of all rows.
+    """
+    rows: list[dict] = []
+    cursor: str | None = None
+    while True:
+        query = client.table(table).select("*")
+        if cursor is None:
+            response = query.range(0, page_size - 1).execute()
+        else:
+            response = query.range(0, page_size - 1).execute()  # cursor is server-side
+        page_rows = response.data or []
+        rows.extend(page_rows)
+        next_cursor = getattr(response, "next_cursor", None)
+        if not next_cursor:
+            break
+        cursor = next_cursor
+    return rows

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/tests/conftest.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/tests/conftest.py
@@ -1,0 +1,27 @@
+"""conftest — provides the broken Supabase mock.
+
+THIS FILE HAS THE BUG. _make_supabase_mock returns the same response on
+every paginated call → infinite loop. Worker must fix it to return
+stateful responses (see instruction.md).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_supabase_mock() -> MagicMock:
+    """Build a mock Supabase client. BROKEN: returns same response every call."""
+    response = MagicMock()
+    response.data = [{"id": i, "name": f"row_{i}"} for i in range(10)]
+    response.next_cursor = "page-2"
+
+    client = MagicMock()
+    client.table.return_value.select.return_value.range.return_value.execute.return_value = response
+    return client
+
+
+@pytest.fixture
+def supabase_mock():
+    return _make_supabase_mock()

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/tests/test_paginated_query.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed/tests/test_paginated_query.py
@@ -1,0 +1,27 @@
+"""Contract tests for fetch_all_pages — these are CORRECT, do not modify."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from paginated_query import fetch_all_pages
+
+
+def test_fetch_all_pages_terminates_at_25_rows(supabase_mock):
+    """With stateful mock: 10 + 10 + 5 = 25 rows, then terminates."""
+    rows = fetch_all_pages(supabase_mock, "documents")
+    assert len(rows) == 25, f"expected 25 rows total across pagination, got {len(rows)}"
+
+
+def test_paginate_handles_short_final_page(supabase_mock):
+    """Final page has 5 rows + next_cursor=None — loop must exit cleanly."""
+    rows = fetch_all_pages(supabase_mock, "documents")
+    assert len(rows) >= 5, "must include the short final page"
+
+
+def test_paginate_post_terminal_call_returns_empty(supabase_mock):
+    """A second invocation against the same exhausted mock returns empty (or repeats from start, but does NOT hang)."""
+    rows = fetch_all_pages(supabase_mock, "documents")
+    assert isinstance(rows, list), "must return a list even when exhausted"

--- a/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/verify.py
@@ -1,0 +1,108 @@
+"""verify.py for task 06 — flaky mock fix.
+
+Runs the worker's fixed conftest with --timeout=5. If the mock is still
+broken, pytest will timeout. If correctly fixed, 3 tests pass under 5s.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t2_medium/06_flaky_mock_fix/seed"
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    conftest = seed_dir / "tests" / "conftest.py"
+
+    if not conftest.exists():
+        return {
+            "pass": False,
+            "evidence": "tests/conftest.py missing",
+            "details": {"pass_count": 0, "expected": 3, "files_written": []},
+        }
+
+    files_written = ["tests/conftest.py"]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for src_rel in (
+            "paginated_query.py",
+            "tests/conftest.py",
+            "tests/test_paginated_query.py",
+        ):
+            src = seed_dir / src_rel
+            dst = tmp_dir / src_rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        (tmp_dir / "tests" / "__init__.py").touch()
+
+        checks: list[tuple[str, bool, str]] = []
+
+        try:
+            pytest_proc = subprocess.run(
+                [sys.executable, "-m", "pytest",
+                 "tests/test_paginated_query.py",
+                 "-v", "--tb=short", "-q",
+                 "--timeout=5"],
+                cwd=tmp_dir, capture_output=True, text=True, timeout=20, check=False,
+            )
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            return {
+                "pass": False,
+                "evidence": "pytest itself timed out (>20s) — mock still hangs even with pytest-timeout",
+                "details": {
+                    "pass_count": 0, "expected": 3,
+                    "files_written": files_written,
+                },
+            }
+
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+        timeout_failures = pytest_out.count("Timeout")
+
+        checks.append((
+            "no pytest-timeout failures",
+            timeout_failures == 0,
+            f"timeout markers in output: {timeout_failures}",
+        ))
+        checks.append((
+            "3 tests pass",
+            pytest_pass >= 3 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+        checks.append((
+            "pytest exits 0",
+            pytest_proc.returncode == 0,
+            f"rc={pytest_proc.returncode}",
+        ))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+
+    return {
+        "pass": pass_count >= 3,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, 3),
+            "expected": 3,
+            "files_written": files_written,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t2_medium"}), indent=2))

--- a/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/expected.json
@@ -1,0 +1,19 @@
+{
+  "expected_files": [
+    "state_machine.py", "persistence.py",
+    "tests/test_state_machine.py", "migrations/001_state_machine.sql"
+  ],
+  "expected_checks_pass": 3,
+  "expected_style": {
+    "language": "python+sql",
+    "transition_pattern": "transition table OR match/case dispatcher, both acceptable; must be data-driven (no nested ifs per state)",
+    "audit_pattern": "audit row written ATOMICALLY with state change (single transaction)",
+    "anti_patterns": [
+      "no bare except",
+      "no nested if-elif chains for state transitions (use mapping or match-case)",
+      "no audit-write-then-state-change race window",
+      "no bypass-audit transition() shortcut"
+    ]
+  },
+  "rubric_for_llm_judge": "High quality: transition table as a dict[tuple[from,action], to] OR explicit match-case statement, atomic transaction wraps audit+state, InvalidTransition has clear message including current state + attempted action. Low quality: hand-rolled if-elif ladder, audit written before state change without transaction, missing terminal-state guards, persistence and state-machine logic mixed in one class."
+}

--- a/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/instruction.md
@@ -1,0 +1,82 @@
+# Task 07 — Review state-machine with transition validation + audit trail
+
+Source-inspiratie: Mission Control PR #239 (HITL state-machine + SSE — scoped-down). Tier: T3 complex. Deadline: 2 hours wallclock.
+
+## Context
+
+You build a reviewable-document state-machine. A document moves through 5 states with strict allowed transitions, and every transition is auditable. This is a stripped-down version of MC's PR-239 HITL flow — the full original spanned SSE streaming + 5 FastAPI endpoints, this task focuses purely on the state-machine + persistence + invariants. That core is what discriminates architecturally-capable models from pattern-bounded ones.
+
+## States and transitions
+
+```
+DRAFT ──submit──► PENDING_REVIEW
+PENDING_REVIEW ──approve──► APPROVED
+PENDING_REVIEW ──request_changes──► CHANGES_REQUESTED
+PENDING_REVIEW ──reject──► REJECTED
+CHANGES_REQUESTED ──submit──► PENDING_REVIEW    (resubmit after edits)
+APPROVED ──(terminal)──► (no outgoing transitions)
+REJECTED ──(terminal)──► (no outgoing transitions)
+```
+
+Invariants:
+- A document is always in exactly one state
+- Terminal states (APPROVED, REJECTED) reject all transitions with `InvalidTransition`
+- Every transition writes an audit row with (from_state, to_state, actor, timestamp, reason)
+- `from_state` in audit always matches the state immediately before the transition (no skipping)
+
+## Required deliverables
+
+### 1. `state_machine.py`
+
+```python
+class ReviewableDocument:
+    def __init__(self, doc_id: int, project_id: str = "default"): ...
+
+    state: str  # one of the 5 states (DRAFT, PENDING_REVIEW, APPROVED, CHANGES_REQUESTED, REJECTED)
+
+    def transition(self, action: str, actor: str, reason: str = "") -> None:
+        """Apply transition or raise InvalidTransition."""
+
+class InvalidTransition(Exception):
+    """Raised when action is not allowed from current state."""
+```
+
+### 2. `persistence.py`
+
+```python
+def save_document(conn, doc: ReviewableDocument) -> None: ...
+def load_document(conn, doc_id: int, project_id: str = "default") -> ReviewableDocument: ...
+def get_audit_trail(conn, doc_id: int, project_id: str = "default") -> list[dict]: ...
+```
+
+SQLite tables (via migration `migrations/001_state_machine.sql`):
+- `documents`: (id, project_id, state, created_at, updated_at) — composite PK (id, project_id) per ADR-007
+- `state_transitions`: (id, document_id, project_id, from_state, to_state, actor, reason, occurred_at) — append-only audit
+
+### 3. `tests/test_state_machine.py`
+
+12 tests:
+- `test_initial_state_is_draft`
+- `test_submit_from_draft_goes_to_pending_review`
+- `test_approve_from_pending_review`
+- `test_request_changes_from_pending_review`
+- `test_reject_from_pending_review`
+- `test_resubmit_from_changes_requested`
+- `test_invalid_transition_from_draft_approve_raises`
+- `test_terminal_approved_rejects_all_actions`
+- `test_terminal_rejected_rejects_all_actions`
+- `test_audit_row_written_per_transition`
+- `test_audit_from_state_matches_pre_transition`
+- `test_project_id_isolation_two_docs_same_id`
+
+### 4. `migrations/001_state_machine.sql`
+
+Idempotent. Tables + composite PK per ADR-007.
+
+## Definition of done
+
+- All 12 tests pass: `pytest tests/test_state_machine.py -v`
+- Migration is idempotent
+- No `transition()` shortcut that bypasses audit
+- `InvalidTransition` is the only exception type for state-machine-rejected actions
+- No bare except clauses

--- a/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/verify.py
@@ -1,0 +1,118 @@
+"""verify.py for task 07 — review state-machine.
+
+Smoke-test the worker's state_machine + persistence + audit trail by:
+1. Confirming all required files exist
+2. Running the 12 pytest contract tests
+3. Applying the migration idempotently
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t3_complex/07_state_machine_sse/seed"
+REQUIRED = [
+    "state_machine.py",
+    "persistence.py",
+    "tests/test_state_machine.py",
+    "migrations/001_state_machine.sql",
+]
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    files_written = [f for f in REQUIRED if (seed_dir / f).exists()]
+    missing = [f for f in REQUIRED if f not in files_written]
+    if missing:
+        return {
+            "pass": False,
+            "evidence": f"worker did not write: {missing}",
+            "details": {"pass_count": 0, "expected": 3, "files_written": files_written},
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for rel in REQUIRED:
+            src = seed_dir / rel
+            dst = tmp_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        (tmp_dir / "tests" / "__init__.py").touch()
+
+        checks: list[tuple[str, bool, str]] = []
+
+        mig_proc = subprocess.run(
+            ["sqlite3", "test.db"],
+            input=(tmp_dir / "migrations" / "001_state_machine.sql").read_text(),
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        mig_ok = mig_proc.returncode == 0
+        checks.append((
+            "migration applies + idempotent",
+            mig_ok and subprocess.run(
+                ["sqlite3", "test.db"],
+                input=(tmp_dir / "migrations" / "001_state_machine.sql").read_text(),
+                cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+            ).returncode == 0,
+            f"first rc={mig_proc.returncode} stderr={mig_proc.stderr[-200:]}",
+        ))
+
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "tests/test_state_machine.py",
+             "-v", "--tb=short", "-q"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=180, check=False,
+        )
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+        checks.append((
+            "12 tests pass",
+            pytest_pass >= 12 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+
+        invalid_smoke = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, '.'); "
+             "from state_machine import ReviewableDocument, InvalidTransition; "
+             "d = ReviewableDocument(1); "
+             "import contextlib; raised = False\n"
+             "try:\n  d.transition('approve', 'op', 'skip-the-line')\n"
+             "except InvalidTransition: raised = True\n"
+             "print('OK' if raised else 'FAIL')"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        invalid_ok = invalid_smoke.returncode == 0 and invalid_smoke.stdout.strip().endswith("OK")
+        checks.append((
+            "InvalidTransition raised for non-allowed transition",
+            invalid_ok,
+            f"stdout={invalid_smoke.stdout[-200:]}",
+        ))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+
+    return {
+        "pass": pass_count >= 3,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, 3),
+            "expected": 3,
+            "files_written": files_written,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t3_complex"}), indent=2))

--- a/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/expected.json
@@ -1,0 +1,15 @@
+{
+  "expected_files": ["url_policy.py", "tests/test_url_policy.py"],
+  "expected_checks_pass": 3,
+  "expected_style": {
+    "language": "python",
+    "must_use": ["ipaddress.ip_address (decode decimal/hex)", "urllib.parse.urlparse", "socket.getaddrinfo (for DNS resolve)"],
+    "anti_patterns": [
+      "no string-match-only on hostname (must decode to ip)",
+      "no requests/urllib3 HTTP call in validator",
+      "no bare except clauses",
+      "no pre-resolved IP cache without TTL (TOCTOU window)"
+    ]
+  },
+  "rubric_for_llm_judge": "High quality: lexical + DNS-resolution layers separated, ipaddress module used for IP-range classification, URLPolicyViolation has clear reason taxonomy (scheme/private_ip/metadata/localhost/encoded/dns_private/no_host/crlf/userinfo), test monkeypatches socket.getaddrinfo for the DNS-resolves-to-private case. Low quality: regex-only hostname check, hand-rolled IP-range comparison via string-prefix, missing IPv6 case, missing userinfo evasion check."
+}

--- a/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/instruction.md
@@ -1,0 +1,63 @@
+# Task 08 — SSRF-safe URL validator + adversarial test suite
+
+Source-inspiratie: SEOcrawler PR #100 (SSRF-safe async fetch — scoped-down to URL policy + DNS-resolution validator). Tier: T3 complex. Deadline: 2 hours wallclock.
+
+## Context
+
+Build a `URLPolicy` validator that rejects unsafe URLs BEFORE they hit any HTTP client. This is the security boundary that prevents SSRF attacks. Full PR #100 also has DNS-pinning + browser route-abort; this scoped task focuses on the validator + adversarial test suite — the part that requires adversarial reasoning, not just code-pattern.
+
+## Threat model (the unsafe targets the validator must reject)
+
+1. **Private IP ranges** — 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16 (link-local), fc00::/7 (IPv6 ULA), ::1 (IPv6 loopback)
+2. **Cloud metadata endpoints** — 169.254.169.254, fd00:ec2::254 (AWS IMDS)
+3. **Non-HTTP schemes** — file://, gopher://, ftp://, javascript:, data:
+4. **Localhost variants** — localhost, ip6-localhost, 0.0.0.0, [::]
+5. **Decimal-encoded IPs** — http://2130706433/ (= 127.0.0.1)
+6. **Hex-encoded IPs** — http://0x7f000001/
+7. **DNS-resolves to private** — a public hostname whose A record points to RFC1918 (DNS-rebinding partial defense; validator must resolve + check)
+8. **URL with no host** — http:///path
+9. **CRLF injection** — http://example.com/\r\nHost:evil.com
+10. **Userinfo evasion** — http://example.com@127.0.0.1/
+
+## Required deliverables
+
+### 1. `url_policy.py`
+
+```python
+class URLPolicy:
+    def validate(self, url: str) -> None:
+        """Raises URLPolicyViolation with a clear reason if unsafe.
+
+        Two-step:
+        1. Lexical check (scheme, hostname, encoded-IP)
+        2. DNS resolution + IP range check
+        """
+
+class URLPolicyViolation(Exception):
+    """Raised with a reason field."""
+    def __init__(self, reason: str, url: str): ...
+```
+
+### 2. `tests/test_url_policy.py`
+
+10 adversarial tests covering each threat above. Each test:
+- Provides a malicious URL
+- Asserts `URLPolicyViolation` is raised
+- Asserts the `reason` field contains an identifying token
+
+Plus 3 positive tests:
+- `test_validate_public_http_url_allowed` — https://example.com/
+- `test_validate_public_with_path_query_allowed` — https://api.example.com/v1/data?q=1
+- `test_validate_subdomain_allowed` — https://blog.example.com/
+
+### 3. DNS resolution behavior
+
+The DNS-resolves-to-private test (#7) uses a real hostname that you can mock OR a deterministic test fixture. Recommended: use `socket.getaddrinfo` and mock it in the test via `monkeypatch`. The validator itself must call `socket.getaddrinfo` (do not short-circuit when the test runs).
+
+## Definition of done
+
+- All 13 tests pass: `pytest tests/test_url_policy.py -v`
+- 10 adversarial URLs all raise `URLPolicyViolation` with descriptive `reason`
+- 3 public URLs pass cleanly
+- Validator does NOT make any HTTP request itself (purely policy + DNS-resolve)
+- No bare except clauses

--- a/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/verify.py
@@ -1,0 +1,119 @@
+"""verify.py for task 08 — URLPolicy SSRF validator."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t3_complex/08_ssrf_async_fetch/seed"
+REQUIRED = ["url_policy.py", "tests/test_url_policy.py"]
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    files_written = [f for f in REQUIRED if (seed_dir / f).exists()]
+    missing = [f for f in REQUIRED if f not in files_written]
+    if missing:
+        return {
+            "pass": False,
+            "evidence": f"worker did not write: {missing}",
+            "details": {"pass_count": 0, "expected": 3, "files_written": files_written},
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for rel in REQUIRED:
+            src = seed_dir / rel
+            dst = tmp_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        (tmp_dir / "tests" / "__init__.py").touch()
+
+        checks: list[tuple[str, bool, str]] = []
+
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "tests/test_url_policy.py",
+             "-v", "--tb=short", "-q"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=120, check=False,
+        )
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+        checks.append((
+            "13 tests pass (10 adversarial + 3 positive)",
+            pytest_pass >= 13 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+
+        adversarial_smoke = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, '.'); "
+             "from url_policy import URLPolicy, URLPolicyViolation; "
+             "p = URLPolicy(); raised = 0; total = 0\n"
+             "urls = ['file:///etc/passwd', 'http://169.254.169.254/', "
+             "'http://127.0.0.1/', 'http://localhost/', 'javascript:alert(1)']\n"
+             "for u in urls:\n"
+             "  total += 1\n"
+             "  try: p.validate(u)\n"
+             "  except URLPolicyViolation: raised += 1\n"
+             "  except Exception: pass\n"
+             "print(f'{raised}/{total}')"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        adversarial_ok = (
+            adversarial_smoke.returncode == 0
+            and adversarial_smoke.stdout.strip().endswith("5/5")
+        )
+        checks.append((
+            "5 sentinel adversarial URLs all rejected",
+            adversarial_ok,
+            f"stdout={adversarial_smoke.stdout[-200:]}",
+        ))
+
+        public_smoke = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, '.'); "
+             "from url_policy import URLPolicy, URLPolicyViolation; "
+             "p = URLPolicy(); ok = 0\n"
+             "for u in ['https://example.com/', 'https://api.example.com/v1']:\n"
+             "  try: p.validate(u); ok += 1\n"
+             "  except URLPolicyViolation: pass\n"
+             "print(f'{ok}/2')"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=30, check=False,
+        )
+        public_ok = (
+            public_smoke.returncode == 0
+            and public_smoke.stdout.strip().endswith("2/2")
+        )
+        checks.append((
+            "public URLs not blocked",
+            public_ok,
+            f"stdout={public_smoke.stdout[-200:]}",
+        ))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+
+    return {
+        "pass": pass_count >= 3,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, 3),
+            "expected": 3,
+            "files_written": files_written,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t3_complex"}), indent=2))

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/expected.json
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/expected.json
@@ -1,0 +1,15 @@
+{
+  "expected_files": ["tests/test_query_inspector.py"],
+  "expected_checks_pass": 4,
+  "expected_style": {
+    "language": "python",
+    "diagnosis_pattern": "rewrite test to call real function, no mock.patch on the introspected fn",
+    "anti_patterns": [
+      "modifying query_inspector.py — auto-fail",
+      "try/except TypeError swallow — auto-fail",
+      "mock.patch(spec=callable) workaround — auto-fail",
+      "no diagnosis comment explaining the mock-pollution root cause"
+    ]
+  },
+  "rubric_for_llm_judge": "High quality: clear comment in rewritten test stating 'mock.patch breaks inspect.getsource because MagicMock has no source', test now calls detect_unsafe(builders.build_user_query) WITHOUT patching, 2 added tests cover real function + parameterized-safe paths. Low quality: surface-fix that swallows TypeError, missing diagnosis, kept mock with workaround instead of removing."
+}

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/instruction.md
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/instruction.md
@@ -1,0 +1,44 @@
+# Task 09 — Diagnose + fix mock-introspection trap (Kimi hang signature)
+
+Source-inspiratie: Mission Control WH-01 (`inspect.getsource()` op pollution-mocked function — Kimi hung 42+ StepBegin events). Tier: T3 complex. Deadline: 30 minutes wallclock.
+
+## Context
+
+This is the **canonical Kimi-hang trigger** — a test that introspects a function via `inspect.getsource()` while a `unittest.mock.patch` has replaced it. The mock object lacks the `__wrapped__`/source-attribute and `inspect.getsource` raises `TypeError` deep inside an unrelated assertion, masking the real bug. Pattern-bounded models loop on the introspection error without understanding the mock-pollution mechanism.
+
+This task is INTENTIONALLY HARD for goedkope modellen — that's the discriminator. Sonnet/Opus should diagnose + fix in <10 min. Kimi/DS-flash likely hang or surface-fix without addressing root cause.
+
+## Bug to fix
+
+The seed contains:
+- `query_inspector.py` — a utility that uses `inspect.getsource(fn)` to detect SQL-injection patterns in the source of query-building functions (security guard for dev-time linting)
+- `tests/test_query_inspector.py` — pytest that uses `mock.patch('builders.build_user_query', return_value='SELECT * FROM users')` then calls `inspector.detect_unsafe(build_user_query)`
+
+When the test runs:
+- `mock.patch` replaces `build_user_query` with a `MagicMock`
+- `inspector.detect_unsafe` calls `inspect.getsource(fn)` on the MagicMock
+- `inspect.getsource` raises `TypeError: module, class, method, function, traceback, frame, or code object was expected, got MagicMock`
+- The original test assertion fails with a confusing trace pointing at the inspector, NOT at the test's mock setup
+
+The actual bug is **in the test** (mock-pollution against an introspection-using function), but a Kimi-class model often "fixes" `query_inspector.py` to swallow the TypeError — wrong fix, masks the real issue.
+
+## Required fix
+
+1. Diagnose: the test's `mock.patch` is the root cause. `query_inspector.detect_unsafe` is correct.
+2. Modify `tests/test_query_inspector.py` to test the inspector against a REAL function (not a mocked one). The mock here is the bug.
+3. Add 2 new tests (in the same file):
+   - `test_detect_unsafe_real_function_with_fstring` — passes a real function with f-string SQL, asserts unsafe pattern detected
+   - `test_detect_unsafe_real_function_with_param` — passes a real function using parameterized query, asserts safe
+
+## Anti-patterns (auto-fail)
+
+- Modifying `query_inspector.py` to catch/swallow TypeError
+- Adding `inspect.unwrap` workarounds without removing the mock
+- Using `mock.patch.object(..., spec=callable)` as a band-aid
+
+## Definition of done
+
+- `pytest tests/test_query_inspector.py -v` passes (3 tests: original-fixed + 2 new)
+- `query_inspector.py` UNCHANGED from seed
+- No `try: inspect.getsource(...) except TypeError` added anywhere
+- Diagnosis explicitly stated in test file as a comment near the rewritten test

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/builders.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/builders.py
@@ -1,0 +1,12 @@
+"""builders — sample query-building functions for inspector tests."""
+from __future__ import annotations
+
+
+def build_user_query(user_id: int) -> str:
+    """UNSAFE: uses f-string SQL — query_inspector should flag this."""
+    return f"SELECT * FROM users WHERE id = {user_id}"
+
+
+def build_user_query_safe(user_id: int) -> tuple[str, tuple]:
+    """SAFE: parameterized — query_inspector should NOT flag this."""
+    return "SELECT * FROM users WHERE id = ?", (user_id,)

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/query_inspector.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/query_inspector.py
@@ -1,0 +1,25 @@
+"""query_inspector — flags potentially unsafe SQL-building functions.
+
+CORRECT as-shipped. The test that uses this is broken (mock-pollution).
+Do not modify this file.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+
+
+_UNSAFE_PATTERNS = [
+    re.compile(r"f['\"]\s*SELECT", re.IGNORECASE),
+    re.compile(r"f['\"]\s*INSERT", re.IGNORECASE),
+    re.compile(r"f['\"]\s*UPDATE", re.IGNORECASE),
+    re.compile(r"f['\"]\s*DELETE", re.IGNORECASE),
+    re.compile(r"%\s*\(.*?\)\s*s\b", re.IGNORECASE),
+    re.compile(r"\.format\s*\(", re.IGNORECASE),
+]
+
+
+def detect_unsafe(fn) -> bool:
+    """Return True if fn's source contains an unsafe SQL-building pattern."""
+    source = inspect.getsource(fn)
+    return any(p.search(source) for p in _UNSAFE_PATTERNS)

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/tests/test_query_inspector.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed/tests/test_query_inspector.py
@@ -1,0 +1,22 @@
+"""BROKEN test — uses mock.patch on a function that query_inspector then
+introspects via inspect.getsource. The MagicMock replacement makes
+inspect.getsource raise TypeError, and the test fails on a misleading line.
+
+Worker must DIAGNOSE that the test's mock is the bug (not query_inspector)
+and replace this approach with real-function tests.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def test_detect_unsafe_on_user_query():
+    """BROKEN: mocks build_user_query, then introspector tries to read its source."""
+    from query_inspector import detect_unsafe
+    with mock.patch("builders.build_user_query", return_value="SELECT * FROM users"):
+        import builders
+        assert detect_unsafe(builders.build_user_query) is True

--- a/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/verify.py
+++ b/scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/verify.py
@@ -1,0 +1,113 @@
+"""verify.py for task 09 — mock-introspection trap.
+
+Anti-patterns auto-fail:
+- query_inspector.py modified
+- try/except TypeError added in inspector
+- mock.patch.object(spec=callable) workaround
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SEED_REL = "scripts/benchmark/field-tests/tasks/t3_complex/09_mock_introspection_trap/seed"
+REQUIRED = ["tests/test_query_inspector.py"]
+ORIGINAL_INSPECTOR_SHA = None  # filled in at first run
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def verify(workdir: Path, task_meta: dict) -> dict[str, Any]:
+    seed_dir = workdir / SEED_REL
+    test_file = seed_dir / "tests" / "test_query_inspector.py"
+    inspector_file = seed_dir / "query_inspector.py"
+
+    if not test_file.exists() or not inspector_file.exists():
+        return {
+            "pass": False,
+            "evidence": "missing seed files",
+            "details": {"pass_count": 0, "expected": 4, "files_written": []},
+        }
+
+    inspector_body = inspector_file.read_text(encoding="utf-8")
+    inspector_unchanged = (
+        "_UNSAFE_PATTERNS" in inspector_body
+        and "inspect.getsource(fn)" in inspector_body
+        and "try:" not in inspector_body.split("def detect_unsafe")[1].split("def ")[0]
+    )
+
+    test_body = test_file.read_text(encoding="utf-8")
+    no_swallow = "except TypeError" not in test_body or "swallow" not in test_body.lower()
+    no_spec_band_aid = "spec=callable" not in test_body and "spec=builders.build_user_query" not in test_body
+
+    checks: list[tuple[str, bool, str]] = []
+    checks.append((
+        "query_inspector.py unchanged (no swallow-fix)",
+        inspector_unchanged,
+        "modified" if not inspector_unchanged else "intact",
+    ))
+    checks.append((
+        "no mock.patch(..., spec=...) band-aid",
+        no_spec_band_aid,
+        "found spec= workaround" if not no_spec_band_aid else "clean",
+    ))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for src_rel in ("query_inspector.py", "builders.py", "tests/test_query_inspector.py"):
+            src = seed_dir / src_rel
+            dst = tmp_dir / src_rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+        (tmp_dir / "tests" / "__init__.py").touch()
+
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "tests/test_query_inspector.py",
+             "-v", "--tb=short", "-q"],
+            cwd=tmp_dir, capture_output=True, text=True, timeout=60, check=False,
+        )
+        pytest_out = pytest_proc.stdout + "\n" + pytest_proc.stderr
+        pass_match = re.search(r"(\d+) passed", pytest_out)
+        fail_match = re.search(r"(\d+) failed", pytest_out)
+        pytest_pass = int(pass_match.group(1)) if pass_match else 0
+        pytest_fail = int(fail_match.group(1)) if fail_match else 0
+
+        checks.append((
+            "3 tests pass (rewritten + 2 new)",
+            pytest_pass >= 3 and pytest_fail == 0,
+            f"passed={pytest_pass} failed={pytest_fail}",
+        ))
+        checks.append((
+            "pytest exits 0",
+            pytest_proc.returncode == 0,
+            f"rc={pytest_proc.returncode}",
+        ))
+
+    pass_count = sum(1 for _, ok, _ in checks if ok)
+
+    return {
+        "pass": pass_count >= 4,
+        "evidence": "; ".join(
+            f"{'PASS' if ok else 'FAIL'} {name}" for name, ok, _ in checks
+        ),
+        "details": {
+            "pass_count": min(pass_count, 4),
+            "expected": 4,
+            "files_written": REQUIRED,
+            "checks": [{"name": n, "ok": ok, "note": note} for n, ok, note in checks],
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(Path.cwd(), {"tier": "t3_complex"}), indent=2))


### PR DESCRIPTION
## Summary

Completes Day 2 of bench-v2: 6 of 9 task-defs (T2×3 + T3×3) on top of T1 in #828. Day 2 totaal: 9/9 task-defs klaar voor execute.

### T2 medium (~15-25 min wallclock per cel)
- `04_scorer_task` — visibility scorer + migration + 15 tests + CLI (insp. MC #244)
- `05_extractor_subclass` — EmailLinkExtractor + 5 tests
- `06_flaky_mock_fix` — stateful Supabase pagination mock fix (Kimi-hang lite, insp. SEOcrawler #123)

### T3 complex (~1-3 uur per cel)
- `07_state_machine_sse` — 5-state review machine + audit trail + 12 tests (insp. MC #239, scoped from full HITL+SSE)
- `08_ssrf_async_fetch` — URLPolicy validator + 10 adversarial + 3 positive tests (insp. SEOcrawler #100)
- `09_mock_introspection_trap` — diagnose+fix Kimi-hang signature: mock-pollution against `inspect.getsource` (insp. MC WH-01)

Each task: instruction.md + seed/ + verify.py + expected.json.

## Test plan
- [x] All 6 verify.py smoke-tested against seed-only state — correctly report missing-worker-output as fail
- [x] T3-09 has anti-pattern checks (auto-fail if worker modifies query_inspector.py or adds try/except TypeError)

## Next

Day 3-4 (vrijdag-zaterdag): execute T1+T2+T3 = 213 cells across 13 lanes via `monthly_runner.sh`. Met parallel-cap 20-30: T1+T2 binnen 4 uur, T3 voegt 6-10 uur toe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)