### PR TITLE
fix(packaging): exclude benchmark dev-tooling from wheel (LB-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is not a security sandbox; it isolates work with tmux sessions and git work
 
 - **pip-installable.** `pip install vnx-orchestration`, then `vnx init`, `vnx migrate`, `vnx doctor`. No repo clone required to scaffold a governed project.
 - **Provider-agnostic skill injection.** One skill folder, one structured prompt (role, assignment, resource index), identical for claude, kimi, codex, and deepseek workers. [ADR-022](docs/governance/decisions/ADR-022-provider-agnostic-skill-injection.md).
-- **Realistic benchmark suite.** Field-tests derived from production PRs, programmatic verification per task, LLM-judge fallback, cost per quality-point. Seven lanes measured on the complex tier; methodology ships with every run.
+- **Realistic benchmark methodology.** A field-tests harness that measures provider lanes on production-derived tasks with programmatic verification per task, an LLM-judge fallback, and cost per quality-point. It lives in the repo under `scripts/benchmark/field-tests/` (not the pip package — the task seeds are repo-specific). A generalised "bring your own tasks" version is planned for 1.1.
 - **SSRF-safe URL policy.** Two-phase validator (lexical + DNS-resolution range-check, fail-closed) with an adversarial test suite. Ships as a governed building block in `scripts/lib/url_policy.py`; wiring into worker fetch paths is 1.0.1.
 - **Headless review gates in the audit trail.** Gate results land as normalized reports plus structured result records; a required gate is not complete until both exist.
 - **Receipt hash-chain verification.** `audit_chain` tooling verifies the append-only NDJSON ledger end-to-end.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,14 @@ vnx_orchestration = [
     "**/__pycache__",
     "**/*.pyc",
     "**/*.pyo",
-    "scripts/benchmark/results/**",
+    # Benchmark suite is dev/research tooling, not runtime: the harness is
+    # generalised into a shippable feature in 1.1 (OI-225). Until then it stays
+    # in the repo only — shipping it bundles repo-specific task seeds, a binary
+    # fixture (scan_quota.db), and a planted-flaw fixture string in skill_smoke
+    # that trips downstream secret scanners on install.
+    "scripts/benchmark/**",
+    "scripts/benchmarks/**",
+    "scripts/llm_benchmark.py",
     "**/*.log",
     "tests/**",
     "dist/**",


### PR DESCRIPTION
## Summary

LB-3 artifact security-grep caught the 1.0 wheel shipping 110 benchmark dev-tooling files the runtime never imports — including `skill_smoke.py` with a planted-flaw `sk-live-...` fixture string (trips downstream secret scanners on `pip install`) and a binary `scan_quota.db` fixture.

- Exclude `scripts/benchmark/**`, `scripts/benchmarks/**`, `scripts/llm_benchmark.py` from the wheel
- README benchmark bullet rewritten: repo methodology + harness, not a pip-package feature (task seeds are repo-specific)
- Generalised seeds-free shippable benchmark = 1.1 (OI-225)

## Verification (rebuilt artifact)

- 0 benchmark files, 0 `sk-live` hits in the wheel
- 2.5MB/972 files → 2.3MB/862 files
- Fresh-venv `pip install` + `vnx --help` exit 0

## Open Items

None for 1.0. Benchmark generalisation tracked as OI-225 (1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)