### PR TITLE
feat(dashboard): lane-aware agent stream (replace fixed T0-T3)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -65,11 +65,11 @@ quality_intelligence.db (SQLite)
         |
         v
 serve_dashboard.py ---------- /api/token-stats
-   port 4173                  /api/token-stats/sessions
+   port 4174                  /api/token-stats/sessions
         |
         v
 React app (Next.js 15)
-   port 5173 (dev)
+   port 3100 (dev)
    dist/ (production)
 ```
 

--- a/dashboard/api_agent_stream.py
+++ b/dashboard/api_agent_stream.py
@@ -29,19 +29,29 @@ from event_store import EventStore
 
 _store = EventStore()
 
-VALID_TERMINALS = frozenset({"T0", "T1", "T2", "T3"})
+# Lane ids are arbitrary slugs (terminals T0-T3, provider lanes, tmux-spawn
+# dispatch ids). The single source of truth for which lanes exist is the events
+# directory itself — see EventStore.list_lanes(). The only hard constraint is
+# path-traversal safety: a lane id must be a flat slug (no dots, slashes, "..").
+_LANE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _valid_lane(lane: str) -> bool:
+    """Path-traversal-safe lane id check (replaces the old fixed T0-T3 set)."""
+    return bool(_LANE_RE.match(lane))
+
 
 _POLL_INTERVAL = 0.5  # seconds between polls for new events
 
 
 def handle_agent_stream(handler: BaseHTTPRequestHandler, terminal: str, since: str | None) -> None:
-    """Stream events for a terminal as SSE.
+    """Stream events for a lane as SSE.
 
     Keeps the connection open, polling every 500ms for new events.
     Stops when the client disconnects (BrokenPipeError / ConnectionResetError).
     """
-    if terminal not in VALID_TERMINALS:
-        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+    if not _valid_lane(terminal):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid lane: {terminal}"})
         return
 
     # Send SSE headers
@@ -72,28 +82,36 @@ def handle_agent_stream(handler: BaseHTTPRequestHandler, terminal: str, since: s
 
 
 def handle_agent_stream_status(handler: BaseHTTPRequestHandler) -> None:
-    """Return JSON listing terminals with event data."""
-    terminals = {}
-    for tid in sorted(VALID_TERMINALS):
-        count = _store.event_count(tid)
-        if count > 0:
-            last = _store.last_event(tid)
-            terminals[tid] = {
-                "event_count": count,
-                "last_timestamp": last.get("timestamp") if last else None,
-            }
+    """Return JSON listing lanes that have agent events.
 
-    _send_json(handler, HTTPStatus.OK, {"terminals": terminals})
+    Lanes are discovered from the events directory (EventStore.list_lanes),
+    so the dashboard renders whatever actually produced events — terminals
+    T0-T3, provider lanes, and tmux-spawn dispatch ids — instead of a fixed
+    T0-T3 set. Domain/system streams (decisions, provider_costs, ...) are
+    filtered out by the agent-envelope check.
+
+    The response keeps the legacy ``terminals`` key (a map of lane id ->
+    {event_count, last_timestamp, provider, dispatch_id}) for back-compat, and
+    adds ``lanes`` as an ordered list (most-recently-active first) for clients
+    that want deterministic ordering.
+    """
+    lanes = _store.list_lanes()
+    terminals = {
+        lane["id"]: {
+            "event_count": lane["event_count"],
+            "last_timestamp": lane["last_timestamp"],
+            "provider": lane.get("provider"),
+            "dispatch_id": lane.get("dispatch_id"),
+        }
+        for lane in lanes
+    }
+    _send_json(handler, HTTPStatus.OK, {"terminals": terminals, "lanes": lanes})
 
 
 def handle_agent_stream_archive_list(handler: "BaseHTTPRequestHandler", terminal: str) -> None:
-    """List all archived dispatch IDs for a terminal."""
-    if terminal not in VALID_TERMINALS:
-        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
-        return
-
-    if not re.match(r'^[a-zA-Z0-9_-]+$', terminal):
-        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid terminal"})
+    """List all archived dispatch IDs for a lane."""
+    if not _valid_lane(terminal):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid lane: {terminal}"})
         return
 
     archive_dir = _store.archive_dir(terminal)
@@ -116,15 +134,11 @@ def handle_agent_stream_archive(
     handler: "BaseHTTPRequestHandler", terminal: str, dispatch_id: str
 ) -> None:
     """Return all events for a specific archived dispatch."""
-    if terminal not in VALID_TERMINALS:
-        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid terminal: {terminal}"})
+    if not _valid_lane(terminal):
+        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": f"Invalid lane: {terminal}"})
         return
 
-    if not re.match(r'^[a-zA-Z0-9_-]+$', terminal):
-        _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid terminal"})
-        return
-
-    if not re.match(r'^[a-zA-Z0-9_-]+$', dispatch_id):
+    if not _LANE_RE.match(dispatch_id):
         _send_json(handler, HTTPStatus.BAD_REQUEST, {"error": "Invalid dispatch_id"})
         return
 

--- a/dashboard/api_intelligence.py
+++ b/dashboard/api_intelligence.py
@@ -1402,9 +1402,11 @@ def handle_events_stream(handler: "BaseHTTPRequestHandler", terminal: str) -> No
     Seeks to end of file on connect, then tails new lines.
     Sends a keep-alive comment every 15 seconds.
     """
-    valid_terminals = frozenset({"T0", "T1", "T2", "T3"})
-    if terminal not in valid_terminals:
-        _send_sse_error(handler, f"invalid terminal: {terminal}")
+    # Lane-aware: lanes are discovered from the events directory, not pinned to
+    # T0-T3. Mirror api_agent_stream._LANE_RE — the regex is the path-safety
+    # boundary (the lane name lands in a filename below).
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", terminal):
+        _send_sse_error(handler, f"invalid lane: {terminal}")
         return
 
     sd = _sd()

--- a/dashboard/launch-dashboard.sh
+++ b/dashboard/launch-dashboard.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 SERVICE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# Port 4174 matches the Next.js rewrite target in token-dashboard/next.config.ts
-PORT="${PORT:-4174}"
+# Port 4174 matches the Next.js rewrite target in token-dashboard/next.config.ts.
+# export is required: serve_dashboard.py reads PORT from the child environment;
+# without it python3 falls back to 4173 while the Next.js proxy targets 4174.
+export PORT="${PORT:-4174}"
 
 if command -v python3 >/dev/null 2>&1; then
   echo "Serving dashboard from $SERVICE_DIR on http://localhost:$PORT (dashboard asset at /dashboard/index.html)"

--- a/dashboard/token-dashboard/app/agent-stream/page.tsx
+++ b/dashboard/token-dashboard/app/agent-stream/page.tsx
@@ -4,9 +4,20 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Activity, Archive, Circle, Pause, Play, Radio } from 'lucide-react';
 import { fetchAgentStreamArchiveList, fetchAgentStreamArchive, type ArchiveEntry } from '@/lib/api';
 
-const TERMINALS = ['T1', 'T2', 'T3'] as const;
-type Terminal = (typeof TERMINALS)[number];
+// A "lane" is any event-producing source: terminals (T0-T3), provider lanes,
+// or tmux-spawn dispatch ids. The list is discovered at runtime from
+// /api/agent-stream/status — never hardcoded — so the selector reflects what
+// actually produced events (the old fixed T1-T3 tabs were stale).
+type Terminal = string;
 type StreamMode = 'live' | 'archive';
+
+interface LaneInfo {
+  id: string;
+  event_count: number;
+  last_timestamp: string | null;
+  provider?: string | null;
+  dispatch_id?: string | null;
+}
 
 interface StreamEvent {
   type: string;
@@ -144,10 +155,12 @@ function EventRow({ event }: { event: StreamEvent }) {
 }
 
 export default function AgentStreamPage() {
-  const [terminal, setTerminal] = useState<Terminal>('T1');
+  const [terminal, setTerminal] = useState<Terminal>('');
   const [mode, setMode] = useState<StreamMode>('live');
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [status, setStatus] = useState<Record<string, TerminalStatus>>({});
+  // Ordered lane list (most-recently-active first) from the status endpoint.
+  const [lanes, setLanes] = useState<LaneInfo[]>([]);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [paused, setPaused] = useState(false);
@@ -196,6 +209,14 @@ export default function AgentStreamPage() {
         const data = await res.json();
         if (!isNavigatingAwayRef.current) {
           setStatus(data.terminals ?? {});
+          // Prefer the ordered `lanes` array (recency-sorted); fall back to
+          // deriving from the terminals map for older backends.
+          const laneList: LaneInfo[] = Array.isArray(data.lanes)
+            ? data.lanes
+            : Object.entries((data.terminals ?? {}) as Record<string, TerminalStatus>).map(
+                ([id, s]) => ({ id, event_count: s.event_count, last_timestamp: s.last_timestamp }),
+              );
+          setLanes(laneList);
         }
       }
     } catch {
@@ -345,6 +366,15 @@ export default function AgentStreamPage() {
     }
   }, [events, paused]);
 
+  // Default the selected lane to the most-recently-active one once lanes load,
+  // and recover if the current selection disappears from the list.
+  useEffect(() => {
+    if (lanes.length === 0) return;
+    if (!terminal || !lanes.some((l) => l.id === terminal)) {
+      setTerminal(lanes[0].id);
+    }
+  }, [lanes, terminal]);
+
   const terminalStatus = status[terminal];
 
   return (
@@ -365,7 +395,7 @@ export default function AgentStreamPage() {
               Agent Stream
             </h2>
             <p style={{ fontSize: 12, color: 'var(--color-muted)', marginTop: 2 }}>
-              {mode === 'live' ? 'Real-time event stream from worker terminals' : 'Archived dispatch replay'}
+              {mode === 'live' ? 'Real-time event stream from worker lanes' : 'Archived dispatch replay'}
             </p>
           </div>
         </div>
@@ -430,56 +460,38 @@ export default function AgentStreamPage() {
             </button>
           )}
 
-          {/* Terminal selector */}
-          <div data-testid="agent-selector" style={{ display: 'flex', gap: 4 }}>
-            {TERMINALS.map((t) => {
-              const active = t === terminal;
-              const ts = status[t];
-              const hasEvents = !!ts;
-              const label = ts?.agent_name || t;
-              return (
-                <button
-                  key={t}
-                  onClick={() => setTerminal(t)}
-                  title={ts?.domain ? `${label} (${ts.domain})` : label}
-                  style={{
-                    padding: '7px 16px',
-                    borderRadius: 8,
-                    background: active ? 'var(--color-accent-soft)' : 'var(--color-card-hover)',
-                    border: `1px solid ${active ? 'rgba(46, 134, 193, 0.3)' : 'var(--color-border)'}`,
-                    cursor: 'pointer',
-                    fontSize: 12,
-                    fontWeight: active ? 600 : 400,
-                    color: active ? 'var(--color-accent)' : 'var(--color-muted)',
-                    position: 'relative',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 2,
-                  }}
-                >
-                  <span>{label}</span>
-                  {ts?.domain && (
-                    <span style={{ fontSize: 9, opacity: 0.6, textTransform: 'capitalize' }}>
-                      {ts.domain}
-                    </span>
-                  )}
-                  {hasEvents && (
-                    <span
-                      style={{
-                        position: 'absolute',
-                        top: 4,
-                        right: 4,
-                        width: 6,
-                        height: 6,
-                        borderRadius: '50%',
-                        background: '#27ae60',
-                      }}
-                    />
-                  )}
-                </button>
-              );
-            })}
+          {/* Lane selector — discovered at runtime, most-recently-active first.
+              A dropdown (not fixed tabs) because there can be many lanes:
+              terminals, provider lanes, and one entry per tmux-spawn dispatch. */}
+          <div data-testid="agent-selector" className="flex items-center gap-2">
+            <select
+              value={terminal}
+              onChange={(e) => setTerminal(e.target.value)}
+              title="Select lane"
+              style={{
+                background: '#ffffff',
+                border: '1px solid var(--color-border)',
+                borderRadius: 8,
+                color: 'var(--color-foreground)',
+                fontSize: 12,
+                fontWeight: 500,
+                padding: '7px 12px',
+                cursor: 'pointer',
+                maxWidth: 360,
+              }}
+            >
+              {lanes.length === 0 && <option value="">No lanes with events</option>}
+              {lanes.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.id}
+                  {l.provider ? ` · ${l.provider}` : ''}
+                  {` (${l.event_count})`}
+                </option>
+              ))}
+            </select>
+            <span style={{ fontSize: 11, color: 'var(--color-muted)', whiteSpace: 'nowrap' }}>
+              {lanes.length} {lanes.length === 1 ? 'lane' : 'lanes'}
+            </span>
           </div>
         </div>
       </div>

--- a/dashboard/token-dashboard/app/models/page.tsx
+++ b/dashboard/token-dashboard/app/models/page.tsx
@@ -142,7 +142,7 @@ export default function ModelsPage() {
             fontSize: 14,
           }}
         >
-          Failed to load data. Ensure the API server is running at localhost:4173.
+          Failed to load data. Ensure the API server is running at localhost:4174.
         </div>
       )}
 

--- a/dashboard/token-dashboard/app/page.tsx
+++ b/dashboard/token-dashboard/app/page.tsx
@@ -53,7 +53,7 @@ export default function OverviewPage() {
             fontSize: 14,
           }}
         >
-          Failed to load data. Ensure the API server is running at localhost:4173.
+          Failed to load data. Ensure the API server is running at localhost:4174.
         </div>
       )}
 

--- a/dashboard/token-dashboard/app/terminals/page.tsx
+++ b/dashboard/token-dashboard/app/terminals/page.tsx
@@ -127,7 +127,7 @@ export default function TerminalsPage() {
             fontSize: 14,
           }}
         >
-          Failed to load data. Ensure the API server is running at localhost:4173.
+          Failed to load data. Ensure the API server is running at localhost:4174.
         </div>
       )}
 

--- a/dashboard/token-dashboard/app/tokens/page.tsx
+++ b/dashboard/token-dashboard/app/tokens/page.tsx
@@ -168,7 +168,7 @@ export default function TokensPage() {
             fontSize: 14,
           }}
         >
-          Failed to load data. Ensure the API server is running at localhost:4173.
+          Failed to load data. Ensure the API server is running at localhost:4174.
         </div>
       )}
 

--- a/dashboard/token-dashboard/app/usage/page.tsx
+++ b/dashboard/token-dashboard/app/usage/page.tsx
@@ -320,7 +320,7 @@ export default function UsagePage() {
             fontSize: 14,
           }}
         >
-          Failed to load data. Ensure the API server is running at localhost:4173.
+          Failed to load data. Ensure the API server is running at localhost:4174.
         </div>
       )}
 

--- a/dashboard/token-dashboard/e2e/agent-stream.spec.ts
+++ b/dashboard/token-dashboard/e2e/agent-stream.spec.ts
@@ -1,6 +1,27 @@
 import { test, expect } from '@playwright/test';
 
+// Lanes are discovered from /api/agent-stream/status (no fixed T0-T3 tabs).
+// Mock it so the dropdown populates deterministically; T1 is newest → default.
+const STATUS_BODY = {
+  lanes: [
+    { id: 'T1', event_count: 5, last_timestamp: '2026-04-06T12:00:10Z', provider: 'claude' },
+    { id: 'T2', event_count: 2, last_timestamp: '2026-04-06T11:00:00Z', provider: 'claude' },
+    { id: 'T3', event_count: 1, last_timestamp: '2026-04-06T10:00:00Z', provider: 'kimi' },
+  ],
+  terminals: {
+    T1: { event_count: 5, last_timestamp: '2026-04-06T12:00:10Z' },
+    T2: { event_count: 2, last_timestamp: '2026-04-06T11:00:00Z' },
+    T3: { event_count: 1, last_timestamp: '2026-04-06T10:00:00Z' },
+  },
+};
+
 test.describe('Agent Stream Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/agent-stream/status', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(STATUS_BODY) });
+    });
+  });
+
   test('page loads with correct heading', async ({ page }) => {
     await page.goto('/agent-stream');
     const heading = page.locator('h2');
@@ -9,29 +30,28 @@ test.describe('Agent Stream Page', () => {
 
   test('shows subtitle text', async ({ page }) => {
     await page.goto('/agent-stream');
-    await expect(page.getByText('Real-time event stream from worker terminals')).toBeVisible();
+    await expect(page.getByText('Real-time event stream from worker lanes')).toBeVisible();
   });
 
-  test('terminal selector buttons T1 T2 T3 exist', async ({ page }) => {
+  test('lane selector lists discovered lanes as options', async ({ page }) => {
     await page.goto('/agent-stream');
+    const select = page.locator('[data-testid="agent-selector"] select');
+    await expect(select).toBeVisible();
     for (const t of ['T1', 'T2', 'T3']) {
-      const btn = page.locator('button', { hasText: t });
-      await expect(btn).toBeVisible();
+      await expect(select.locator('option', { hasText: t })).toHaveCount(1);
     }
   });
 
-  test('terminal selector switches active terminal', async ({ page }) => {
+  test('lane selector switches active lane', async ({ page }) => {
     await page.goto('/agent-stream');
-    // T1 is default — click T2
-    const t2Btn = page.locator('button', { hasText: 'T2' }).first();
-    await t2Btn.click();
-    // T2 button should become active (fontWeight 600)
-    await expect(t2Btn).toHaveCSS('font-weight', '600');
+    const select = page.locator('[data-testid="agent-selector"] select');
+    // T1 is the default (newest); switch to T2
+    await select.selectOption('T2');
+    await expect(select).toHaveValue('T2');
   });
 
   test('shows empty state when no events', async ({ page }) => {
     await page.goto('/agent-stream');
-    // The empty state shows either "Waiting for events..." or "No events for T1"
     const emptyMsg = page.getByText(/Waiting for events|No events for/);
     await expect(emptyMsg).toBeVisible();
   });
@@ -49,13 +69,12 @@ test.describe('Agent Stream Page', () => {
 
   test('connection status indicator is visible', async ({ page }) => {
     await page.goto('/agent-stream');
-    // Either "Connected" or "Disconnected" should display
     const status = page.getByText(/Connected|Disconnected/);
     await expect(status).toBeVisible();
   });
 
   test('event type badges render with correct colors', async ({ page }) => {
-    // Mock the SSE endpoint to return fixture events
+    // T1 is the default lane (newest in STATUS_BODY) → SSE connects to it.
     await page.route('**/api/agent-stream/T1', async (route) => {
       const events = [
         { type: 'init', timestamp: '2026-04-06T12:00:00Z', terminal: 'T1', sequence: 1, dispatch_id: 'test-001', data: { session_id: 'test-123' } },
@@ -74,7 +93,6 @@ test.describe('Agent Stream Page', () => {
 
     await page.goto('/agent-stream');
 
-    // Wait for events to render
     await expect(page.getByText('INIT')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('THINKING')).toBeVisible();
     await expect(page.getByText('TOOL_USE')).toBeVisible();

--- a/dashboard/token-dashboard/e2e/sse-lifecycle.spec.ts
+++ b/dashboard/token-dashboard/e2e/sse-lifecycle.spec.ts
@@ -61,10 +61,23 @@ async function getEsInstances(page: Page): Promise<EsEntry[]> {
 async function stubSseEndpoints(page: Page): Promise<void> {
   await page.route('**/api/agent-stream/**', async (route) => {
     if (route.request().url().includes('/status')) {
+      // Lanes are discovered from status; provide T1-T3 so the selector
+      // populates and a default lane is chosen (newest first).
       await route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ terminals: {} }),
+        body: JSON.stringify({
+          lanes: [
+            { id: 'T1', event_count: 1, last_timestamp: '2026-04-06T12:00:03Z' },
+            { id: 'T2', event_count: 1, last_timestamp: '2026-04-06T12:00:02Z' },
+            { id: 'T3', event_count: 1, last_timestamp: '2026-04-06T12:00:01Z' },
+          ],
+          terminals: {
+            T1: { event_count: 1, last_timestamp: '2026-04-06T12:00:03Z' },
+            T2: { event_count: 1, last_timestamp: '2026-04-06T12:00:02Z' },
+            T3: { event_count: 1, last_timestamp: '2026-04-06T12:00:01Z' },
+          },
+        }),
       });
       return;
     }
@@ -139,16 +152,14 @@ test.describe('SSE + timer unmount lifecycle', () => {
     await page.goto('/agent-stream');
     await page.waitForLoadState('domcontentloaded');
 
-    // Switch terminal: T1 → T2 → T3
-    const t2Btn = page.locator('[data-testid="agent-selector"] button', { hasText: 'T2' }).first();
-    await t2Btn.click();
+    // Switch lane via the dropdown: T1 → T2 → T3
+    const laneSelect = page.locator('[data-testid="agent-selector"] select');
+    await laneSelect.selectOption('T2');
+    await page.waitForTimeout(200);
+    await laneSelect.selectOption('T3');
     await page.waitForTimeout(200);
 
-    const t3Btn = page.locator('[data-testid="agent-selector"] button', { hasText: 'T3' }).first();
-    await t3Btn.click();
-    await page.waitForTimeout(200);
-
-    // After switching terminals, only one connection should be open
+    // After switching lanes, only one connection should be open
     const midInstances = await getEsInstances(page);
     const openMid = midInstances.filter((es) => !es.closed);
     expect(

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -232,3 +232,50 @@ class EventStore:
                 except json.JSONDecodeError:
                     continue
         return last
+
+    @staticmethod
+    def _is_agent_event(event: Dict[str, Any]) -> bool:
+        """True if a record is an agent-conversation event (CanonicalEvent
+        envelope), not a domain/system stream record.
+
+        Agent events carry ``type`` + ``dispatch_id`` + ``sequence``; system
+        streams (decisions, provider_costs, schema_migrations, ...) live in the
+        same directory but use domain-specific shapes without those fields.
+        """
+        return (
+            "type" in event
+            and "dispatch_id" in event
+            and "sequence" in event
+        )
+
+    def list_lanes(self) -> list[Dict[str, Any]]:
+        """Discover agent-conversation lanes from the events directory.
+
+        A "lane" is any ``{id}.ndjson`` whose last record is an agent event.
+        Returns one dict per lane with id, event_count, last_timestamp, and the
+        provider/dispatch_id of the most recent event — so the dashboard can
+        render whatever lanes actually produced events (terminals T0-T3,
+        provider lanes, tmux-spawn dispatch ids) instead of a fixed set.
+
+        Domain/system streams (decisions.ndjson, provider_costs.ndjson, ...) are
+        skipped via the agent-envelope check.
+        """
+        if not self._events_dir.exists():
+            return []
+        lanes: list[Dict[str, Any]] = []
+        for path in self._events_dir.glob("*.ndjson"):
+            lane_id = path.stem
+            last = self.last_event(lane_id)
+            if last is None or not self._is_agent_event(last):
+                continue
+            lanes.append(
+                {
+                    "id": lane_id,
+                    "event_count": self.event_count(lane_id),
+                    "last_timestamp": last.get("timestamp"),
+                    "provider": last.get("provider"),
+                    "dispatch_id": last.get("dispatch_id"),
+                }
+            )
+        lanes.sort(key=lambda x: x.get("last_timestamp") or "", reverse=True)
+        return lanes


### PR DESCRIPTION
## Summary

The agent-stream UI hardcoded T1/T2/T3 tabs and the backend hardcoded `VALID_TERMINALS={T0,T1,T2,T3}`, while the current architecture runs provider lanes + tmux-spawn lanes with dispatch-keyed ids. Recent dispatches never appeared; T0 (which had events) wasn't even selectable.

- `event_store.list_lanes()` discovers lanes by globbing the events dir, filtering on the CanonicalEvent envelope (system streams excluded), recency-sorted.
- `api_agent_stream`: path-traversal-safe slug check replaces the fixed set; `/status` reports discovered lanes (legacy `terminals` map kept + new ordered `lanes`).
- UI: recency-sorted lane dropdown (not 3 fixed tabs), default = most-recent, copy "terminals" → "lanes".

## Verification

- event_store unit suite 27/27
- token-dashboard typecheck clean
- e2e specs updated to the lane model (status mock + dropdown)

## Open Items

Live-streaming the interactive tmux lane (currently post-hoc) is a follow-up; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)