### PR TITLE
fix(nightly): Python 3.9 compat — lazy annotations in quality_db_init + version guard

### DIFF
--- a/scripts/nightly_intelligence_pipeline.sh
+++ b/scripts/nightly_intelligence_pipeline.sh
@@ -134,6 +134,24 @@ echo $$ > "$LOCK_FILE"
 cleanup() { rm -f "$LOCK_FILE"; }
 trap cleanup EXIT
 
+# ── Python version guard ──────────────────────────────────────────────────────
+# Warns when python3 resolves to < 3.10 so crontab PATH issues surface clearly.
+# Does NOT abort: from __future__ import annotations in quality_db_init.py
+# and other pipeline scripts covers the X|Y union-syntax crash on Python 3.9.
+_py3_path="$(command -v python3 2>/dev/null || echo "(not found)")"
+_py3_version="$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")"
+_py3_major="$(python3 -c 'import sys; print(sys.version_info.major)' 2>/dev/null || echo "0")"
+_py3_minor="$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null || echo "0")"
+if [ "$_py3_major" -lt 3 ] || { [ "$_py3_major" -eq 3 ] && [ "$_py3_minor" -lt 10 ]; }; then
+    log_msg "WARN: python3 at '$_py3_path' is version $_py3_version (< 3.10)."
+    log_msg "WARN: This is typically /usr/bin/python3 (system Python) because crontab"
+    log_msg "WARN: does not inherit the Homebrew PATH. Scripts use 'from __future__ import"
+    log_msg "WARN: annotations' to avoid X|Y union-syntax crashes on 3.9, but full 3.10+"
+    log_msg "WARN: features are unavailable. Fix: add the following line above your nightly"
+    log_msg "WARN: crontab entry:  PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+fi
+unset _py3_path _py3_version _py3_major _py3_minor
+
 # ── Start ─────────────────────────────────────────────────────────────────────
 
 log_msg "=== VNX Nightly Intelligence Pipeline starting (PID $$) ==="

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -5,6 +5,8 @@ Version: 8.0.2 (Phase 2)
 Purpose: Initialize SQLite Quality Intelligence Database from schema
 """
 
+from __future__ import annotations  # PEP 563: lazy annotation evaluation — Python 3.9 compat
+
 import sqlite3
 import sys
 from pathlib import Path

--- a/tests/test_nightly_python39_compat.py
+++ b/tests/test_nightly_python39_compat.py
@@ -1,0 +1,143 @@
+"""Python 3.9 compatibility regression tests for the nightly pipeline.
+
+Verifies that quality_db_init.py (and any other nightly pipeline script that
+carries X | Y union annotations) has a ``from __future__ import annotations``
+guard, so the module loads without TypeError on Python 3.9.
+
+These tests use ast + compile so they run on any Python version that can
+import the test itself — no subprocess needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# Scripts in the nightly pipeline that must carry the future-import when they
+# contain X | Y union annotations.
+NIGHTLY_PIPELINE_SCRIPTS: list[Path] = [
+    SCRIPTS_DIR / "quality_db_init.py",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _has_future_annotations(source: str) -> bool:
+    """Return True if the source contains ``from __future__ import annotations``."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "__future__" and any(
+                alias.name == "annotations" for alias in node.names
+            ):
+                return True
+    return False
+
+
+def _has_union_annotations(source: str) -> bool:
+    """Return True if the source contains X | Y in annotation positions.
+
+    Walks the AST and looks for BinOp nodes with BitOr operator that appear
+    inside annotation contexts (function arguments, return annotations, or
+    AnnAssign nodes).  This is more accurate than regex — it ignores ``|``
+    inside expressions, f-strings, and comments.
+    """
+    try:
+        # ast.parse succeeds on 3.9 only if the syntax is valid 3.9 syntax.
+        # Union annotations (X | Y) are *not* valid syntax in 3.9 at runtime,
+        # but they are parseable by Python 3.10+ ast.  When running under 3.9
+        # we use a text-based heuristic as a fallback.
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Fallback: regex-based check for annotation-like patterns.
+        import re
+        return bool(re.search(r"(?:->|:\s*\w).*\|\s*\w", source))
+
+    for node in ast.walk(tree):
+        # Return annotation: def f() -> A | B
+        if isinstance(node, ast.FunctionDef) and node.returns is not None:
+            if isinstance(node.returns, ast.BinOp) and isinstance(node.returns.op, ast.BitOr):
+                return True
+        # Argument annotation: def f(x: A | B)
+        if isinstance(node, ast.arg) and node.annotation is not None:
+            if isinstance(node.annotation, ast.BinOp) and isinstance(node.annotation.op, ast.BitOr):
+                return True
+        # Variable annotation: x: A | B = ...
+        if isinstance(node, ast.AnnAssign) and isinstance(node.annotation, ast.BinOp):
+            if isinstance(node.annotation.op, ast.BitOr):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("script_path", NIGHTLY_PIPELINE_SCRIPTS, ids=lambda p: p.name)
+def test_future_annotations_present_when_union_annotations_exist(script_path: Path) -> None:
+    """Scripts with X | Y annotations must carry from __future__ import annotations."""
+    assert script_path.exists(), f"Script not found: {script_path}"
+    source = script_path.read_text()
+    if _has_union_annotations(source):
+        assert _has_future_annotations(source), (
+            f"{script_path.name} contains X | Y union annotations but is missing "
+            "'from __future__ import annotations'. This causes a TypeError on Python 3.9 "
+            "when the module is imported (crashes nightly pipeline phase 0-schema-init)."
+        )
+
+
+@pytest.mark.parametrize("script_path", NIGHTLY_PIPELINE_SCRIPTS, ids=lambda p: p.name)
+def test_script_compiles_cleanly(script_path: Path) -> None:
+    """Script must compile without SyntaxError using the current Python interpreter."""
+    assert script_path.exists(), f"Script not found: {script_path}"
+    source = script_path.read_text()
+    try:
+        compile(source, str(script_path), "exec")
+    except SyntaxError as exc:
+        pytest.fail(
+            f"{script_path.name} failed to compile: {exc}\n"
+            "Check for Python 3.10+ syntax that requires 'from __future__ import annotations'."
+        )
+
+
+def test_quality_db_init_importable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """quality_db_init must be importable without crashing at module level.
+
+    Uses a fresh subprocess so the import happens in isolation and any
+    module-level crash (the original bug: TypeError on X | Y annotation
+    evaluation before main() runs) surfaces as a non-zero exit code.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                f"sys.path.insert(0, '{SCRIPTS_DIR!s}'); "
+                f"sys.path.insert(0, '{SCRIPTS_DIR / 'lib'!s}'); "
+                "import quality_db_init"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"quality_db_init failed to import (exit={result.returncode}).\n"
+        f"stderr: {result.stderr.strip()}\n"
+        "This is the Python 3.9 union-annotation crash that was the root cause "
+        "of 9 consecutive nightly pipeline failures (Jun 1-9)."
+    )


### PR DESCRIPTION
## Summary

- **Root cause of 9-night failure (Jun 1–9)**: crontab runs without Homebrew PATH, so `python3` resolves to `/usr/bin/python3` (3.9.6). The `Path | None` union annotation on `bootstrap_qi_db` line 905 raises `TypeError` at module load on Python 3.9 — before `main()` runs. Phase `0-schema-init` exits 1, migrations v22/v23 are skipped, `user_version` stays at 21.
- **Fix**: `from __future__ import annotations` on `quality_db_init.py` makes all annotations lazy (PEP 563) — covers the one `Path | None` union and guards against future `X | Y` annotations in this file.
- **Signal**: version guard in the pipeline logs a clear WARN with the resolved `python3` path and version when < 3.10. Does not abort — the future-import removes the crash.

## Changes

- `scripts/quality_db_init.py`: added `from __future__ import annotations` as first import (line 8).
- `scripts/nightly_intelligence_pipeline.sh`: Python version guard block inserted after lock file setup, before the pipeline start banner. Logs WARN with path, version, and operator remediation step.
- `tests/test_nightly_python39_compat.py`: three regression tests — AST-based future-import presence check, compile check, and subprocess import smoke test.

## Verification

```
pytest tests/test_nightly_python39_compat.py -v
# 3 passed in 0.18s

pytest tests/test_central_quality_db_bootstrap.py tests/test_quality_db_dream_migration.py -v
# 28 passed, 1 pre-existing failure (test_user_version_is_highest_after_bootstrap
# asserts == 22 but HIGHEST_QI_VERSION is already 23 on main — unrelated to this PR)
```

**Nightly pipeline scan scope**: all 19 `python3` invocations in `nightly_intelligence_pipeline.sh` were checked. `event_analyzer.py` and `weekly_digest.py` have union annotations but already carry `from __future__ import annotations`. No other script in the nightly path is affected.

## Operator step (machine config — not in repo)

Add the following line **above** the nightly crontab entry to give cron access to Homebrew Python:

```
PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
```

The `from __future__ import annotations` fix makes the pipeline survive on 3.9 without this, but Homebrew Python is the correct long-term environment. The version guard will log a WARN on every nightly run until the crontab PATH is set.

## ROADMAP reference

Feature: `nightly-pipeline-python-compat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)