### PR TITLE
fix(audit-chain): distinguish unchained from broken ledger in verify (LB-5)

### DIFF
--- a/scripts/audit_chain.py
+++ b/scripts/audit_chain.py
@@ -22,12 +22,31 @@ def main():
     args = parser.parse_args()
 
     if args.cmd == "verify":
-        ok, violations = verify_chain(args.path)
-        if ok:
-            print(json.dumps({"verified": True, "path": str(args.path)}))
+        ok, violations, status = verify_chain(args.path)
+        if status == "unchained":
+            print(json.dumps({
+                "verified": True,
+                "status": "unchained",
+                "path": str(args.path),
+                "warning": (
+                    "Hash-chain verification not possible: no entries carry prev_hash. "
+                    "Enable chaining by setting VNX_CHAIN_RECEIPTS=1."
+                ),
+            }, indent=2))
+            sys.exit(0)
+        elif status == "verified":
+            print(json.dumps({
+                "verified": True,
+                "status": "verified",
+                "path": str(args.path),
+            }))
             sys.exit(0)
         else:
-            print(json.dumps({"verified": False, "violations": violations[:20]}, indent=2))
+            print(json.dumps({
+                "verified": False,
+                "status": "broken",
+                "violations": violations[:20],
+            }, indent=2))
             sys.exit(1)
     elif args.cmd == "walk":
         for line_no, entry, hash_ in walk_chain(args.path):

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -198,11 +198,11 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
 
     # All parseable entries chained and intact.
     if chained_count < total:
-        # Partial chain detected even with no hash mismatches — entries that
-        # lack prev_hash were skipped above but their absence is itself a
-        # structural violation.  This guard covers the edge case where the
-        # first entry has no prev_hash but later entries do; the loop above
-        # already catches this as a mismatch.  Kept for completeness.
+        # Partial chain detected even with no hash mismatches.  This guard is
+        # LOAD-BEARING for the edge case where the FIRST entry carries no
+        # prev_hash (allowed by the first-entry branch) while later entries
+        # hash-link correctly to their predecessor — the loop produces zero
+        # violations there; only this count check catches the partial chain.
         return (False, [{
             "note": (
                 f"partial chain: {chained_count}/{total} entries carry prev_hash; "

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -106,14 +106,33 @@ def _read_last_hash(path: Path) -> str | None:
         return None
 
 
-def verify_chain(path: Path) -> tuple[bool, list[dict]]:
+def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
     """Verify the hash-chain integrity for an NDJSON file.
 
-    Returns (is_valid, violations_list).
-    violations_list contains dicts with: line_number, expected_prev_hash, actual_prev_hash
+    Returns (is_valid, violations_list, status) where status is one of:
+
+    - "unchained": no entry in the file carries a prev_hash field; chaining
+      was never enabled (VNX_CHAIN_RECEIPTS is off by default).  Integrity
+      cannot be verified — this is NOT an error.  is_valid is True.
+    - "verified": every entry carries prev_hash and the chain is intact.
+      is_valid is True.
+    - "broken": chain is present but has integrity violations (tampered,
+      inserted, or partially chained — some entries carry prev_hash while
+      others do not).  is_valid is False.
+
+    A partially-chained ledger (some entries with prev_hash, some without)
+    is classified as "broken", not "unchained".  A ledger must be either
+    fully unchained or fully chained to be considered healthy.
+
+    violations_list contains dicts with: line_number, expected_prev_hash,
+    actual_prev_hash (and optionally 'error' or 'note').
     """
-    violations = []
-    expected_prev = GENESIS_HASH
+    entries: list[tuple[int, dict]] = []
+
+    if not path.exists() or path.stat().st_size == 0:
+        return (True, [], "unchained")
+
+    parse_errors: list[dict] = []
 
     with path.open("r", encoding="utf-8") as f:
         for line_no, line in enumerate(f, start=1):
@@ -123,32 +142,75 @@ def verify_chain(path: Path) -> tuple[bool, list[dict]]:
             try:
                 entry = json.loads(line)
             except json.JSONDecodeError as e:
-                violations.append({
+                parse_errors.append({
                     "line_number": line_no,
                     "error": f"invalid JSON: {e}",
                 })
                 continue
+            entries.append((line_no, entry))
 
-            actual_prev = entry.get("prev_hash")
+    # Unparseable lines are always a violation regardless of chain status.
+    if parse_errors and not entries:
+        return (False, parse_errors, "broken")
 
-            if line_no == 1:
-                if actual_prev is not None and actual_prev != GENESIS_HASH:
-                    violations.append({
-                        "line_number": line_no,
-                        "expected_prev_hash": GENESIS_HASH,
-                        "actual_prev_hash": actual_prev,
-                        "note": "first entry: prev_hash must be GENESIS or absent",
-                    })
-            elif actual_prev != expected_prev:
+    if not entries:
+        return (True, [], "unchained")
+
+    # Determine whether any entry carries prev_hash.
+    chained_count = sum(1 for _, e in entries if "prev_hash" in e)
+    total = len(entries)
+
+    if chained_count == 0 and not parse_errors:
+        # No entry has prev_hash — ledger is fully unchained.  Chaining was
+        # not enabled (VNX_CHAIN_RECEIPTS default off).  Not an error.
+        return (True, [], "unchained")
+
+    # At least one entry has prev_hash (or there are parse errors mixed in).
+    # Enforce full-chain integrity.  A partially-chained ledger (some entries
+    # lack prev_hash while others have it) is a real violation — broken.
+    violations: list[dict] = list(parse_errors)
+    expected_prev = GENESIS_HASH
+
+    for line_no, entry in entries:
+        actual_prev = entry.get("prev_hash")
+
+        if line_no == entries[0][0]:
+            # First entry in the file.
+            if actual_prev is not None and actual_prev != GENESIS_HASH:
+                violations.append({
+                    "line_number": line_no,
+                    "expected_prev_hash": GENESIS_HASH,
+                    "actual_prev_hash": actual_prev,
+                    "note": "first entry: prev_hash must be GENESIS or absent",
+                })
+        else:
+            if actual_prev != expected_prev:
                 violations.append({
                     "line_number": line_no,
                     "expected_prev_hash": expected_prev,
                     "actual_prev_hash": actual_prev,
                 })
 
-            expected_prev = compute_entry_hash(entry)
+        expected_prev = compute_entry_hash(entry)
 
-    return (len(violations) == 0, violations)
+    if violations:
+        return (False, violations, "broken")
+
+    # All parseable entries chained and intact.
+    if chained_count < total:
+        # Partial chain detected even with no hash mismatches — entries that
+        # lack prev_hash were skipped above but their absence is itself a
+        # structural violation.  This guard covers the edge case where the
+        # first entry has no prev_hash but later entries do; the loop above
+        # already catches this as a mismatch.  Kept for completeness.
+        return (False, [{
+            "note": (
+                f"partial chain: {chained_count}/{total} entries carry prev_hash; "
+                "ledger must be fully unchained or fully chained"
+            )
+        }], "broken")
+
+    return (True, [], "verified")
 
 
 def walk_chain(path: Path) -> Iterator[tuple[int, dict, str]]:

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -8,6 +8,7 @@ Covers:
   - Walk chain generator
   - Empty file trivially valid
   - Backward-compat: plain NDJSON append without hash-chain
+  - LB-5: unchained vs broken distinction (verify_chain three-status contract)
 """
 
 import json
@@ -81,9 +82,10 @@ def test_verify_chain_valid_passes(tmp_path):
     p = tmp_path / "chain.ndjson"
     for i in range(5):
         append_chained_entry(p, {"seq": i, "ts": "2026-01-01"})
-    ok, violations = verify_chain(p)
+    ok, violations, status = verify_chain(p)
     assert ok is True
     assert violations == []
+    assert status == "verified"
 
 
 def test_verify_chain_tampered_entry_fails(tmp_path):
@@ -99,8 +101,9 @@ def test_verify_chain_tampered_entry_fails(tmp_path):
     lines[1] = json.dumps(tampered)
     p.write_text("\n".join(lines) + "\n")
 
-    ok, violations = verify_chain(p)
+    ok, violations, status = verify_chain(p)
     assert ok is False
+    assert status == "broken"
     # Line 3's prev_hash now points to old line 2 hash — mismatch
     assert any(v.get("line_number") == 3 for v in violations)
 
@@ -116,8 +119,9 @@ def test_verify_chain_inserted_entry_fails(tmp_path):
     lines.insert(1, json.dumps(fake))
     p.write_text("\n".join(lines) + "\n")
 
-    ok, violations = verify_chain(p)
+    ok, violations, status = verify_chain(p)
     assert ok is False
+    assert status == "broken"
     assert len(violations) >= 1
 
 
@@ -184,9 +188,10 @@ def test_walk_chain_yields_all_entries(tmp_path):
 def test_verify_empty_file_returns_valid(tmp_path):
     p = tmp_path / "empty.ndjson"
     p.touch()
-    ok, violations = verify_chain(p)
+    ok, violations, status = verify_chain(p)
     assert ok is True
     assert violations == []
+    assert status == "unchained"
 
 
 def test_chain_survives_normal_append(tmp_path):
@@ -203,3 +208,87 @@ def test_chain_survives_normal_append(tmp_path):
     # Plain entries have no prev_hash — backward-compat preserved
     _, entry0, _ = entries[0]
     assert "prev_hash" not in entry0
+
+
+# ---------------------------------------------------------------------------
+# LB-5: unchained vs broken distinction
+# ---------------------------------------------------------------------------
+
+
+def test_verify_chain_unchained_no_prev_hash_is_ok(tmp_path):
+    """Plain NDJSON without any prev_hash → status 'unchained', exit 0 equivalent.
+
+    This is the default state when VNX_CHAIN_RECEIPTS is off.  Must NOT be
+    reported as broken or verified — it is simply not chained.
+    """
+    p = tmp_path / "plain.ndjson"
+    for i in range(4):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i, "event": "dispatch", "id": f"d{i}"}) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert violations == []
+    assert status == "unchained"
+
+
+def test_verify_chain_chained_intact_is_verified(tmp_path):
+    """Fully chained ledger with correct hashes → status 'verified'."""
+    p = tmp_path / "chained.ndjson"
+    for i in range(5):
+        append_chained_entry(p, {"seq": i, "event": "dispatch"})
+
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert violations == []
+    assert status == "verified"
+
+
+def test_verify_chain_tampered_chained_is_broken(tmp_path):
+    """Tampered entry in a chained ledger → status 'broken', exit 1 equivalent."""
+    p = tmp_path / "tampered.ndjson"
+    append_chained_entry(p, {"event": "e1", "id": "1"})
+    append_chained_entry(p, {"event": "e2", "id": "2"})
+    append_chained_entry(p, {"event": "e3", "id": "3"})
+
+    lines = p.read_text().splitlines()
+    tampered = json.loads(lines[1])
+    tampered["id"] = "TAMPERED"
+    lines[1] = json.dumps(tampered)
+    p.write_text("\n".join(lines) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert len(violations) >= 1
+
+
+def test_verify_chain_partial_chain_is_broken(tmp_path):
+    """Partial chain — some entries have prev_hash, some do not — is 'broken'.
+
+    A partially-chained ledger is NOT 'unchained'.  The presence of any
+    prev_hash field means chaining was attempted; missing ones are violations.
+    """
+    p = tmp_path / "partial.ndjson"
+    # First two entries: plain NDJSON, no prev_hash
+    with p.open("a") as f:
+        f.write(json.dumps({"seq": 0, "id": "plain-0"}) + "\n")
+        f.write(json.dumps({"seq": 1, "id": "plain-1"}) + "\n")
+    # Third entry: manually inject a prev_hash to simulate partial chaining
+    with p.open("a") as f:
+        f.write(json.dumps({"seq": 2, "id": "chained-2", "prev_hash": GENESIS_HASH}) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert len(violations) >= 1
+
+
+def test_verify_chain_missing_file_is_unchained(tmp_path):
+    """Non-existent ledger file is treated as unchained (nothing written yet)."""
+    p = tmp_path / "nonexistent.ndjson"
+    assert not p.exists()
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert violations == []
+    assert status == "unchained"

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -284,6 +284,26 @@ def test_verify_chain_partial_chain_is_broken(tmp_path):
     assert len(violations) >= 1
 
 
+def test_verify_chain_first_unchained_rest_linked_is_broken(tmp_path):
+    """LOAD-BEARING guard case (kimi-gate PR #840 F1): first entry has no
+    prev_hash (allowed by the first-entry branch), later entries hash-link
+    correctly to their predecessor. The verify loop produces zero violations
+    here — only the chained_count < total guard catches the partial chain."""
+    p = tmp_path / "first-unchained.ndjson"
+    first = {"seq": 0, "id": "plain-0"}
+    with p.open("a") as f:
+        f.write(json.dumps(first, sort_keys=True, separators=(",", ":")) + "\n")
+    # Second entry links CORRECTLY to the first entry's computed hash.
+    second = {"seq": 1, "id": "chained-1", "prev_hash": compute_entry_hash(first)}
+    with p.open("a") as f:
+        f.write(json.dumps(second, sort_keys=True, separators=(",", ":")) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert any("partial chain" in str(v) for v in violations)
+
+
 def test_verify_chain_missing_file_is_unchained(tmp_path):
     """Non-existent ledger file is treated as unchained (nothing written yet)."""
     p = tmp_path / "nonexistent.ndjson"

--- a/tests/test_receipt_hashchain.py
+++ b/tests/test_receipt_hashchain.py
@@ -105,8 +105,9 @@ def test_flag_on_chains_and_verifies(tmp_path, monkeypatch):
     for idx in range(1, len(entries)):
         assert entries[idx]["prev_hash"] == compute_entry_hash(entries[idx - 1])
 
-    is_valid, violations = verify_chain(receipt_path)
+    is_valid, violations, status = verify_chain(receipt_path)
     assert is_valid, f"chain should verify, violations: {violations}"
+    assert status == "verified"
 
 
 def test_flag_on_genesis_only_first_line(tmp_path, monkeypatch):
@@ -167,8 +168,9 @@ def test_concurrent_appends_no_fork(tmp_path, n_workers):
     assert len(entries) == n_workers, "every worker must have appended exactly once"
 
     # 1. verify_chain passes — the single source of truth for "no fork".
-    is_valid, violations = verify_chain(receipt_path)
+    is_valid, violations, status = verify_chain(receipt_path)
     assert is_valid, f"CHAIN FORKED under concurrency, violations: {violations}"
+    assert status == "verified"
 
     # 2. Exactly one GENESIS, on line 1.
     assert entries[0]["prev_hash"] == GENESIS_HASH
@@ -197,4 +199,5 @@ def test_verify_is_stable_on_replay(tmp_path, monkeypatch):
     second = verify_chain(receipt_path)
     third = verify_chain(receipt_path)
     assert first[0] is True
+    assert first[2] == "verified"
     assert first == second == third, "verify must be deterministic across replays"


### PR DESCRIPTION
## Summary

- `verify_chain()` returns a 3-tuple `(is_valid, violations, status)` — status is `"unchained"` | `"verified"` | `"broken"`. Previously, a clean ledger written without `VNX_CHAIN_RECEIPTS` (the default) returned `verified=False` and exited 1, making the flagship audit feature appear broken on first use.
- A **partially-chained** ledger (some entries carry `prev_hash`, others do not) is explicitly classified as `"broken"`, not `"unchained"` — the spec-required distinction.
- `audit_chain.py verify` gains a `status` field in JSON output; exit codes: `unchained`=0, `verified`=0, `broken`=1. Backwards-compatible JSON shape preserved (existing `verified` field retained).

## Changes

- `scripts/lib/ndjson_hash_chain.py` — `verify_chain()` signature updated; three-branch logic: fully unchained / fully verified / broken (partial or tampered)
- `scripts/audit_chain.py` — unpacks 3-tuple; three output shapes with `status` field and VNX_CHAIN_RECEIPTS reference in unchained warning
- `tests/test_ndjson_hash_chain.py` — existing callers updated to 3-tuple; 5 new LB-5 tests: unchained-plain, chained-intact-verified, tampered-broken, partial-chain-broken, missing-file-unchained
- `tests/test_receipt_hashchain.py` — existing callers updated to 3-tuple

## Verification

Fixes LB-5 (sweep A2, panel-unanimous ship-blocker). Part of ROADMAP feature launch-sweep-blockers.

```
tests/test_ndjson_hash_chain.py::test_compute_entry_hash_deterministic PASSED
tests/test_ndjson_hash_chain.py::test_canonical_json_excludes_prev_hash PASSED
tests/test_ndjson_hash_chain.py::test_append_chained_entry_first_uses_genesis PASSED
tests/test_ndjson_hash_chain.py::test_append_chained_entry_links_to_previous PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_valid_passes PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_tampered_entry_fails PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_inserted_entry_fails PASSED
tests/test_ndjson_hash_chain.py::test_correction_event_requires_corrects_hash PASSED
tests/test_ndjson_hash_chain.py::test_redaction_event_requires_redacts_hash PASSED
tests/test_ndjson_hash_chain.py::test_tombstone_event_requires_tombstones_hash PASSED
tests/test_ndjson_hash_chain.py::test_backfill_event_uses_genesis_prev_hash PASSED
tests/test_ndjson_hash_chain.py::test_walk_chain_yields_all_entries PASSED
tests/test_ndjson_hash_chain.py::test_verify_empty_file_returns_valid PASSED
tests/test_ndjson_hash_chain.py::test_chain_survives_normal_append PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_unchained_no_prev_hash_is_ok PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_chained_intact_is_verified PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_tampered_chained_is_broken PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_partial_chain_is_broken PASSED
tests/test_ndjson_hash_chain.py::test_verify_chain_missing_file_is_unchained PASSED
tests/test_receipt_hashchain.py::test_flag_off_no_prev_hash PASSED
tests/test_receipt_hashchain.py::test_flag_off_explicit_false PASSED
tests/test_receipt_hashchain.py::test_flag_on_chains_and_verifies PASSED
tests/test_receipt_hashchain.py::test_flag_on_genesis_only_first_line PASSED
tests/test_receipt_hashchain.py::test_concurrent_appends_no_fork[8] PASSED
tests/test_receipt_hashchain.py::test_concurrent_appends_no_fork[16] PASSED
tests/test_receipt_hashchain.py::test_verify_is_stable_on_replay PASSED
26 passed in 0.96s
```

Pre-existing failures on main (unrelated, `test_receipt_instruction_hash.py` — WARN case-sensitivity): 2 tests, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)