### PR TITLE
fix(routing): resolve kimi lane/constraint conflict + generalize raw-spawn guard to provider CLIs

### DIFF
--- a/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
+++ b/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# PreToolUse Hook: Block raw claude worker spawns
+# PreToolUse Hook: Block raw provider CLI spawns (claude / kimi / codex)
 #
-# Purpose: Enforce governance receipt trail by blocking direct 'claude -p' /
-#          '--dangerously-skip-permissions' invocations. All worker dispatch
-#          must go via subprocess_dispatch.py or provider_dispatch.py, which
-#          spawn claude via Popen and always emit a receipt.
+# Purpose: Enforce governance receipt trail by blocking direct prompt-executing
+#          invocations of provider CLIs. All worker dispatch must go via
+#          subprocess_dispatch.py or provider_dispatch.py, which spawn CLIs via
+#          Popen and always emit a receipt.
 #
 # Claude Code hook contract (2.1+):
 #   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
@@ -17,12 +17,15 @@
 # Blocked patterns:
 #   claude -p / claude --print               (non-interactive print mode)
 #   claude --dangerously-skip-permissions    (headless/background spawn)
+#   kimi --print / kimi -p                   (prompt-executing kimi CLI)
+#   codex exec <args>                        (prompt-executing codex CLI)
 #
 # Always allowed:
 #   python3 scripts/lib/subprocess_dispatch.py ...  (governed wrapper)
 #   python3 scripts/lib/provider_dispatch.py ...    (governed wrapper)
-#   claude --version / claude --help                (benign read-only)
-#   claude (interactive, no blocked flags)
+#   claude --version / claude --help / claude       (benign / interactive)
+#   kimi --version / kimi login / kimi              (benign / auth)
+#   codex --version / codex --help                  (benign read-only)
 #
 # Token budget: ~80 tokens/call — fast-path exits for non-Bash tools
 
@@ -58,7 +61,7 @@ DECISION="$(echo "$INPUT" | python3 "$DETECTOR")"
 
 # ── Emit JSON decision ────────────────────────────────────────────────────────
 if [[ "$DECISION" == "block" ]]; then
-  printf '{"decision":"block","reason":"Worker-dispatch moet via scripts/lib/subprocess_dispatch.py of provider_dispatch.py (governed, emit receipt). Rauwe claude -p/--dangerously-skip-permissions bypast de governance receipt-trail. Gebruik: python3 scripts/lib/subprocess_dispatch.py <dispatch_id>"}\n'
+  printf '{"decision":"block","reason":"Worker-dispatch moet via scripts/lib/subprocess_dispatch.py of provider_dispatch.py (governed, emit receipt). Rauwe claude -p/--dangerously-skip-permissions, kimi --print/-p, en codex exec bypassen de governance receipt-trail. Gebruik: python3 scripts/lib/provider_dispatch.py --provider <claude|kimi|codex> <dispatch_id>"}\n'
 fi
 
 # Exit 0 always — block/allow is communicated via JSON stdout, not exit code

--- a/scripts/hooks/pretooluse_spawn_detector.py
+++ b/scripts/hooks/pretooluse_spawn_detector.py
@@ -4,44 +4,101 @@
 Reads the Claude Code PreToolUse hook JSON payload from stdin.
 Outputs "allow" or "block" (no newline stripping needed; shell trims).
 
-Blocked: 'claude -p', 'claude --print', 'claude --dangerously-skip-permissions'
-Allowed: subprocess_dispatch.py, provider_dispatch.py calls; benign claude invocations.
+Blocked:
+  claude:  -p / --print / --dangerously-skip-permissions (raw worker spawn)
+  kimi:    --print / -p  (prompt-executing invocation outside governed path)
+  codex:   exec <args>   (prompt-executing invocation outside governed path)
+
+Allowed:
+  subprocess_dispatch.py / provider_dispatch.py (governed wrappers — always)
+  claude --version / claude --help / claude (interactive)
+  kimi --version / kimi login / kimi (no prompt-executing flags)
+  codex --version / codex --help (benign read-only)
 
 Exit code is always 0. Decision is in stdout text, not exit code.
+
+Live-proven gap (2026-06-09): a raw `kimi --print` invocation bypassed receipts
+the same way `claude -p` did. This detector now covers all three provider CLIs.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 
 
 # ── Allowlist patterns ─────────────────────────────────────────────────────────
-# These scripts invoke claude internally via Popen — invisible to this hook.
+# These scripts invoke provider CLIs internally via Popen — invisible to this hook.
 # Allow any Bash command that explicitly calls one of these governed wrappers.
 ALLOWLIST_PATTERN = re.compile(
     r"(subprocess_dispatch|provider_dispatch)\.py"
 )
 
-# ── Claude-as-command-token pattern ───────────────────────────────────────────
-# Match 'claude' when preceded by string-start, whitespace, or shell operators
-# (&, ;, |, (, ), backtick-equivalent via \x60, $, ', ").
-# Covers: 'claude ...', 'nohup claude ...', '&& claude ...', 'bash -c "claude ..."',
-#         pipes, subshell spawns, background jobs, etc.
-CLAUDE_TOKEN_PATTERN = re.compile(
-    r"(?:^|[\s;&|()\x60$'\"])claude(?=\s|$|[\"';\x60\\])"
-)
+# ── CLI command-token patterns ────────────────────────────────────────────────
+# Match the CLI binary name when preceded by string-start, whitespace, or shell
+# operators (&, ;, |, (, ), backtick via \x60, $, ', ").
+# Covers: 'kimi ...', 'nohup kimi ...', '&& codex ...', 'bash -c "kimi ..."', etc.
+_TOKEN_BOUNDARY = r"(?:^|[\s;&|()\x60$'\"])"
+_CMD_SUFFIX = r"(?=\s|$|[\"';\x60\\])"
 
-# ── Blocked flag patterns ──────────────────────────────────────────────────────
+CLAUDE_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"claude" + _CMD_SUFFIX)
+KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
+CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
+
+# ── Blocked flag patterns — claude ────────────────────────────────────────────
 # -p / --print : non-interactive print mode (worker spawn indicator)
 # --dangerously-skip-permissions : headless/background execution indicator
-BLOCKED_FLAG_PATTERNS = [
+CLAUDE_BLOCKED_FLAG_PATTERNS = [
     re.compile(r"(?:^|\s)-p(?:\s|$)"),
     re.compile(r"(?:^|\s)--print(?:\s|$)"),
     re.compile(r"(?:^|\s)--dangerously-skip-permissions(?:\s|$)"),
 ]
+
+# ── Blocked flag patterns — kimi ──────────────────────────────────────────────
+# --print / -p : prompt-executing invocations that bypass the receipt trail.
+# kimi login, kimi --version, kimi --help, bare `kimi` (interactive) are allowed.
+KIMI_BLOCKED_FLAG_PATTERNS = [
+    re.compile(r"(?:^|\s)--print(?:\s|$)"),
+    re.compile(r"(?:^|\s)-p(?:\s|$)"),
+]
+
+# ── Allowed kimi sub-commands / flags (benign, no prompt execution) ───────────
+# login, --version, --help: read-only / auth operations.
+KIMI_ALLOWED_PATTERN = re.compile(
+    r"(?:^|\s)kimi\s+(?:login|--version|-v|--help|-h)(?:\s|$)"
+)
+
+# ── Blocked sub-command patterns — codex ──────────────────────────────────────
+# `codex exec` is the prompt-executing form. `codex --version` / `codex --help`
+# are benign; bare `codex` (interactive) is allowed.
+CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$)")
+
+
+def _classify_claude(cmd: str) -> str:
+    """Return "allow" or "block" for a command containing the claude token."""
+    for pattern in CLAUDE_BLOCKED_FLAG_PATTERNS:
+        if pattern.search(cmd):
+            return "block"
+    return "allow"
+
+
+def _classify_kimi(cmd: str) -> str:
+    """Return "allow" or "block" for a command containing the kimi token."""
+    # Benign invocations are always allowed regardless of other flags.
+    if KIMI_ALLOWED_PATTERN.search(cmd):
+        return "allow"
+    for pattern in KIMI_BLOCKED_FLAG_PATTERNS:
+        if pattern.search(cmd):
+            return "block"
+    return "allow"
+
+
+def _classify_codex(cmd: str) -> str:
+    """Return "allow" or "block" for a command containing the codex token."""
+    if CODEX_EXEC_PATTERN.search(cmd):
+        return "block"
+    return "allow"
 
 
 def classify(cmd: str) -> str:
@@ -53,16 +110,19 @@ def classify(cmd: str) -> str:
     if ALLOWLIST_PATTERN.search(cmd):
         return "allow"
 
-    # Must have 'claude' as a command token to be relevant
-    if not CLAUDE_TOKEN_PATTERN.search(cmd):
-        return "allow"
-
-    # Check for blocked flags — any match is enough to block
-    for pattern in BLOCKED_FLAG_PATTERNS:
-        if pattern.search(cmd):
+    # Check each provider CLI independently; first "block" wins.
+    if CLAUDE_TOKEN_PATTERN.search(cmd):
+        if _classify_claude(cmd) == "block":
             return "block"
 
-    # 'claude' present but no blocked flags → interactive / --version / --help
+    if KIMI_TOKEN_PATTERN.search(cmd):
+        if _classify_kimi(cmd) == "block":
+            return "block"
+
+    if CODEX_TOKEN_PATTERN.search(cmd):
+        if _classify_codex(cmd) == "block":
+            return "block"
+
     return "allow"
 
 

--- a/scripts/lib/providers/routing_policy.yaml
+++ b/scripts/lib/providers/routing_policy.yaml
@@ -28,13 +28,13 @@ rules:
       complexity: ["medium"]
       opt_in_flag: "VNX_USE_CHEAP_LANE"  # operator opt-in only
     lane: "litellm:deepseek:deepseek-v4-pro"  # $0.28/$0.40 - 10x cheaper input than Sonnet
-    rationale: "Mid-complexity code with operator opt-in; DeepSeek V3.2 ranks competitive on coding"
+    rationale: "Mid-complexity code with operator opt-in; deepseek-v4-pro ranks competitive on coding benchmarks"
 
   - name: review-analysis
     when:
       task_class: ["code-review", "analysis", "summarization"]
-    lane: "litellm:moonshot:kimi-k2-0905-default"  # $0.60/$2.50 - 5x cheaper
-    rationale: "Long-context review benefits from Kimi K2-0905-preview's depth at lower cost"
+    lane: "kimi"  # kimi CLI OAuth lane — kimi-via-cli-only constraint enforced
+    rationale: "Long-context review/analysis routes to the Kimi K2 CLI lane (OAuth, $0 subscription quota). litellm:moonshot is blocked by kimi-via-cli-only (provider_constraints.yaml)."
 
   - name: research-deep
     when:
@@ -44,10 +44,17 @@ rules:
     rationale: "Architect-level work warrants Opus quality"
 
 # Fallback chain when preferred lane fails (API down, rate-limited, etc)
+#
+# STATUS (2026-06-11, sweep H4 routing-conflict fix): this block is ADVISORY
+# only. No runner or dispatcher currently reads fallback_chain at runtime.
+# Entries document intended fallback behaviour; they do NOT trigger automatic
+# lane switching on their own. The kimi entry below reflects the corrected
+# kimi CLI lane — litellm:moonshot:* entries are kept for reference but
+# litellm:moonshot routing is blocked by kimi-via-cli-only (OI-223).
 fallback_chain:
-  "litellm:deepseek:*": ["litellm:moonshot:kimi-k2-0905-default", "claude/sonnet-4-6"]
-  "litellm:moonshot:*": ["litellm:deepseek:deepseek-v4-pro", "claude/sonnet-4-6"]
-  "litellm:zai:*": ["litellm:moonshot:kimi-k2-0905-default", "claude/sonnet-4-6"]
+  "litellm:deepseek:*": ["kimi", "claude/sonnet-4-6"]
+  "kimi": ["litellm:deepseek:deepseek-v4-pro", "claude/sonnet-4-6"]
+  "litellm:zai:*": ["kimi", "claude/sonnet-4-6"]
   "claude/haiku-4-5": ["claude/sonnet-4-6"]
   # Sonnet and Opus have no fallback (they are the safety net)
 

--- a/tests/test_pretooluse_block_raw_claude_spawn.py
+++ b/tests/test_pretooluse_block_raw_claude_spawn.py
@@ -1,6 +1,7 @@
 """Tests for pretooluse_block_raw_claude_spawn.sh and pretooluse_spawn_detector.py.
 
 Covers:
+  claude:
   - BLOCK: claude -p, claude --print, claude --dangerously-skip-permissions
   - BLOCK: background/nohup/bash-c/pipe variants of the above
   - BLOCK: combined flags in any order
@@ -8,8 +9,19 @@ Covers:
   - ALLOW: python3 scripts/lib/provider_dispatch.py   (governed wrapper)
   - ALLOW: claude --version, claude --help (benign)
   - ALLOW: interactive claude (no blocked flags)
-  - ALLOW: non-Bash tool calls (Write, Read, etc.)
   - ALLOW: grep -p (grep's -p should not trigger claude guard)
+
+  kimi (live-proven bypass gap 2026-06-09):
+  - BLOCK: kimi --print / kimi -p (prompt-executing, bypasses receipt trail)
+  - BLOCK: nohup/background/pipe variants of kimi --print
+  - ALLOW: kimi login / kimi --version / kimi --help / bare kimi (benign)
+
+  codex:
+  - BLOCK: codex exec <args> (prompt-executing, bypasses receipt trail)
+  - ALLOW: codex --version / codex --help / bare codex (benign)
+
+  general:
+  - ALLOW: non-Bash tool calls (Write, Read, etc.)
   - JSON output contract: decision + reason on block, empty on allow
   - Exit code always 0
 """
@@ -165,6 +177,108 @@ class TestClassifyDirect:
         assert classify("cat /home/user/.config/claude/settings.json") == "allow"
 
 
+# ── Kimi provider tests ───────────────────────────────────────────────────────
+
+class TestClassifyKimi:
+    """Unit tests for kimi CLI spawn detection.
+
+    Live-proven bypass gap (2026-06-09): raw `kimi --print` bypassed the receipt
+    trail the same way `claude -p` did. These tests lock the guard in place.
+    """
+
+    # Blocked cases
+    def test_classify_blocks_kimi_print(self):
+        assert classify("kimi --print 'write me a summary'") == "block"
+
+    def test_classify_blocks_kimi_dash_p(self):
+        assert classify('kimi -p "do the thing"') == "block"
+
+    def test_classify_blocks_kimi_print_background(self):
+        assert classify('kimi --print "task" &') == "block"
+
+    def test_classify_blocks_kimi_print_nohup(self):
+        assert classify('nohup kimi --print "task" &') == "block"
+
+    def test_classify_blocks_kimi_print_pipe(self):
+        assert classify('kimi --print "task" | grep result') == "block"
+
+    def test_classify_blocks_kimi_print_after_and(self):
+        assert classify('setup && kimi --print "go"') == "block"
+
+    def test_classify_blocks_kimi_dash_p_after_semicolon(self):
+        assert classify('cd /tmp; kimi -p "go"') == "block"
+
+    # Allowed cases
+    def test_classify_allows_kimi_login(self):
+        assert classify("kimi login") == "allow"
+
+    def test_classify_allows_kimi_version(self):
+        assert classify("kimi --version") == "allow"
+
+    def test_classify_allows_kimi_short_version(self):
+        assert classify("kimi -v") == "allow"
+
+    def test_classify_allows_kimi_help(self):
+        assert classify("kimi --help") == "allow"
+
+    def test_classify_allows_kimi_short_help(self):
+        assert classify("kimi -h") == "allow"
+
+    def test_classify_allows_bare_kimi(self):
+        assert classify("kimi") == "allow"
+
+    def test_classify_allows_kimi_in_path(self):
+        """'kimi' in a file path must not trigger the guard."""
+        assert classify("cat /home/user/.kimi/config.json") == "allow"
+
+    def test_classify_allows_provider_dispatch_kimi(self):
+        """Governed wrapper invocation for kimi must always be allowed."""
+        assert classify("python3 scripts/lib/provider_dispatch.py --provider kimi") == "allow"
+
+
+# ── Codex provider tests ──────────────────────────────────────────────────────
+
+class TestClassifyCodex:
+    """Unit tests for codex CLI spawn detection."""
+
+    # Blocked cases
+    def test_classify_blocks_codex_exec(self):
+        assert classify("codex exec --json") == "block"
+
+    def test_classify_blocks_codex_exec_with_prompt(self):
+        assert classify('codex exec --json "write a function"') == "block"
+
+    def test_classify_blocks_codex_exec_background(self):
+        assert classify("codex exec --json &") == "block"
+
+    def test_classify_blocks_codex_exec_nohup(self):
+        assert classify("nohup codex exec --json &") == "block"
+
+    def test_classify_blocks_codex_exec_pipe(self):
+        assert classify("codex exec --json | tee output.json") == "block"
+
+    def test_classify_blocks_codex_exec_after_and(self):
+        assert classify("setup && codex exec --json") == "block"
+
+    # Allowed cases
+    def test_classify_allows_codex_version(self):
+        assert classify("codex --version") == "allow"
+
+    def test_classify_allows_codex_help(self):
+        assert classify("codex --help") == "allow"
+
+    def test_classify_allows_bare_codex(self):
+        assert classify("codex") == "allow"
+
+    def test_classify_allows_provider_dispatch_codex(self):
+        """Governed wrapper invocation for codex must always be allowed."""
+        assert classify("python3 scripts/lib/provider_dispatch.py --provider codex") == "allow"
+
+    def test_classify_allows_codex_in_path(self):
+        """'codex' in a file path must not trigger the guard."""
+        assert classify("ls /home/user/.codex/") == "allow"
+
+
 # ── Integration tests (full bash hook via subprocess) ─────────────────────────
 
 class TestHookBlockedCases:
@@ -241,6 +355,49 @@ class TestHookAllowedCases:
     def test_allows_non_bash_grep_tool(self):
         assert_allowed("Grep")
 
+    def test_allows_kimi_login(self):
+        assert_allowed("Bash", "kimi login")
+
+    def test_allows_kimi_version(self):
+        assert_allowed("Bash", "kimi --version")
+
+    def test_allows_kimi_help(self):
+        assert_allowed("Bash", "kimi --help")
+
+    def test_allows_codex_version(self):
+        assert_allowed("Bash", "codex --version")
+
+    def test_allows_codex_help(self):
+        assert_allowed("Bash", "codex --help")
+
+
+class TestHookBlockedProviderCLIs:
+    """Full hook execution — kimi and codex blocked cases."""
+
+    def test_blocks_kimi_print(self):
+        assert_blocked("Bash", 'kimi --print "write a summary"')
+
+    def test_blocks_kimi_dash_p(self):
+        assert_blocked("Bash", 'kimi -p "do the thing"')
+
+    def test_blocks_kimi_print_background(self):
+        assert_blocked("Bash", 'kimi --print "task" &')
+
+    def test_blocks_kimi_print_after_and(self):
+        assert_blocked("Bash", 'setup && kimi --print "go"')
+
+    def test_blocks_codex_exec(self):
+        assert_blocked("Bash", "codex exec --json")
+
+    def test_blocks_codex_exec_background(self):
+        assert_blocked("Bash", "codex exec --json &")
+
+    def test_blocks_codex_exec_after_and(self):
+        assert_blocked("Bash", "setup && codex exec --json")
+
+    def test_blocks_codex_exec_with_pipe(self):
+        assert_blocked("Bash", "codex exec --json | tee output.json")
+
 
 class TestHookOutputContract:
     """Block output must be valid JSON with the required fields."""
@@ -265,6 +422,14 @@ class TestHookOutputContract:
 
     def test_reason_mentions_receipt(self):
         data = assert_blocked("Bash", 'claude --dangerously-skip-permissions')
+        assert "receipt" in data["reason"].lower()
+
+    def test_block_kimi_has_receipt_in_reason(self):
+        data = assert_blocked("Bash", 'kimi --print "task"')
+        assert "receipt" in data["reason"].lower()
+
+    def test_block_codex_has_receipt_in_reason(self):
+        data = assert_blocked("Bash", "codex exec --json")
         assert "receipt" in data["reason"].lower()
 
     def test_allow_produces_no_stdout(self):

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -133,13 +133,15 @@ def test_opt_in_deepseek_requires_flag() -> None:
 
 def test_review_routes_to_kimi() -> None:
     decision = decide_lane("code-review", complexity="medium", env=_env())
-    assert decision.lane == "litellm:moonshot:kimi-k2-0905-default"
+    # review-analysis must route to the kimi CLI lane, not litellm:moonshot
+    # (kimi-via-cli-only constraint: litellm:moonshot is blocking).
+    assert decision.lane == "kimi"
     assert decision.rule_name == "review-analysis"
 
 
 def test_analysis_routes_to_kimi() -> None:
     decision = decide_lane("analysis", complexity="low", env=_env())
-    assert decision.lane == "litellm:moonshot:kimi-k2-0905-default"
+    assert decision.lane == "kimi"
 
 
 def test_research_high_routes_to_opus() -> None:
@@ -155,8 +157,8 @@ def test_research_high_routes_to_opus() -> None:
 
 def test_fallback_chain_resolution_deepseek() -> None:
     decision = decide_lane("code-review", complexity="medium", env=_env())
-    # review-analysis -> litellm:moonshot:kimi-k2-0905-default
-    # Its fallback chain: litellm:moonshot:* -> [litellm:deepseek:..., claude/sonnet-4-6]
+    # review-analysis -> kimi (CLI lane)
+    # Its fallback chain: kimi -> [litellm:deepseek:deepseek-v4-pro, claude/sonnet-4-6]
     assert "claude/sonnet-4-6" in decision.fallback_chain
 
 
@@ -217,3 +219,72 @@ def test_routing_decision_has_required_fields() -> None:
 def test_routing_decision_returns_rationale() -> None:
     decision = decide_lane("lint-narrow", complexity="low", env=_env())
     assert decision.rationale  # non-empty rationale from yaml
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: routing_policy lanes × provider_constraints (C2 unit test)
+#
+# Ensures that every non-Claude lane in routing_policy.yaml is NOT blocked by
+# any provider_constraints.yaml entry when passed as a plain --provider arg.
+# Catches the kimi-via-cli-only / litellm:moonshot collision structurally.
+# ---------------------------------------------------------------------------
+
+
+def _parse_lane_provider(lane: str) -> tuple:
+    """Split a lane string into (provider, sub_provider, via) for constraint check.
+
+    Examples:
+      "kimi"                               -> ("kimi", None, None)
+      "litellm:deepseek:deepseek-v4-pro"  -> ("litellm", "deepseek", None)
+      "litellm:moonshot:kimi-k2-0905-..."  -> ("litellm", "moonshot", None)
+      "claude/sonnet-4-6"                  -> ("claude", None, None)  # skip
+    """
+    if lane.startswith("litellm:"):
+        parts = lane.split(":", 2)
+        sub = parts[1] if len(parts) > 1 else None
+        return "litellm", sub, None
+    if "/" in lane:
+        return lane.split("/", 1)[0], None, None
+    return lane, None, None
+
+
+def test_policy_lanes_pass_constraint_preflight() -> None:
+    """Every non-Claude lane in routing_policy.yaml must not violate provider_constraints.
+
+    This is the structural cross-check for the kimi-via-cli-only conflict
+    (sweep H4, 2026-06-11). Any litellm:moonshot lane would trigger a blocking
+    violation here; the corrected 'kimi' lane must pass cleanly.
+    """
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+    from providers.constraint_enforcer import ConstraintEnforcer, ConstraintViolationError
+
+    policy = load_routing_policy(_POLICY_PATH)
+    enforcer = ConstraintEnforcer()
+
+    # Collect all unique lanes from rules + fallback_chain values
+    lanes: set = set()
+    for rule in policy.get("rules", []):
+        lanes.add(rule.get("lane", ""))
+    for chain in policy.get("fallback_chain", {}).values():
+        if isinstance(chain, list):
+            lanes.update(chain)
+    lanes.discard("")
+
+    # Only check non-Claude lanes (Claude lane constraint violations are warn-only
+    # and depend on terminal_id context, not on lane parsing alone)
+    non_claude_lanes = {lane for lane in lanes if not lane.startswith("claude/")}
+
+    violations_found: list[str] = []
+    for lane in sorted(non_claude_lanes):
+        provider, sub_provider, via = _parse_lane_provider(lane)
+        try:
+            enforcer.enforce(provider=provider, sub_provider=sub_provider, via=via)
+        except ConstraintViolationError as exc:
+            violations_found.append(f"lane={lane!r}: [{exc.code}] {exc.message}")
+
+    assert not violations_found, (
+        "routing_policy.yaml contains lanes that violate provider_constraints.yaml:\n"
+        + "\n".join(f"  - {v}" for v in violations_found)
+        + "\n\nFix: update the lane in routing_policy.yaml to a non-blocked provider."
+    )


### PR DESCRIPTION
## Summary

- **Fix 1 (sweep H4, routing-conflict)**: `routing_policy.yaml` `review-analysis` rule was routing to `litellm:moonshot:kimi-k2-0905-default`, which hits the blocking `kimi-via-cli-only` constraint on every review/analysis dispatch under `VNX_AUTO_ROUTE=1`. Corrected lane to `"kimi"` (the provider literal `provider_dispatch` routes to `_dispatch_kimi`). Also fixed the `deepseek-v4-pro` rationale typo in `cost-optimized-code`, updated `fallback_chain` to replace all `litellm:moonshot:*` entries with `kimi` (those also violated the constraint), and added a STATUS advisory comment above `fallback_chain` (OI-223 — no code reads this block yet, matching the existing `lane_safety` STATUS comment style).

- **Fix 2 (live-proven bypass gap 2026-06-09)**: `pretooluse_spawn_detector.py` only blocked raw `claude` spawns. A raw `kimi --print` / `kimi -p` or `codex exec` invocation bypassed the receipt trail identically (GOV-1 equivalent, datapoint confirmed live on 2026-06-09). Generalized detector to block prompt-executing `kimi` (`--print`/`-p`) and `codex` (`exec`) invocations while keeping benign forms allowed: `kimi login`, `kimi --version`, `kimi --help`, `codex --version`, `codex --help`, and bare interactive invocations. Hook shell comment updated to match the expanded scope.

## Changes

- `scripts/lib/providers/routing_policy.yaml`: corrected `review-analysis` lane (`litellm:moonshot:...` → `kimi`), fixed rationale typo, fixed `fallback_chain` entries, added `fallback_chain` STATUS comment
- `scripts/hooks/pretooluse_spawn_detector.py`: generalized to detect raw kimi/codex spawns in addition to claude; false-positive guards for benign invocations
- `scripts/hooks/pretooluse_block_raw_claude_spawn.sh`: updated header comment and block reason message to name all three provider CLIs
- `tests/test_routing_policy.py`: updated two existing assertions to match corrected `kimi` lane; added `test_policy_lanes_pass_constraint_preflight` cross-check (structural C2 test — routing_policy lanes × provider_constraints preflight)
- `tests/test_pretooluse_block_raw_claude_spawn.py`: added `TestClassifyKimi` (15 cases), `TestClassifyCodex` (10 cases), `TestHookBlockedProviderCLIs` (8 integration cases), 3 output-contract cases for kimi/codex

## Verification

121 tests pass (`tests/test_routing_policy.py` + `tests/test_pretooluse_block_raw_claude_spawn.py`); 69 constraint enforcer tests pass without regression. Pre-existing failure on `test_wiring_completeness.py::TestSmartRouterRouteWiring::test_provider_dispatch_auto_route_calls_smart_router_route` is unrelated (also fails on main).

Chosen kimi lane name: **`"kimi"`** — evidence: `provider_dispatch.py:1559` (`if provider == "kimi": return _dispatch_kimi(args)`); `tier_routing.py:55` (`provider="kimi", lane="kimi_cli"`); `constraint_enforcer.py:115` (`_NATIVE_CLI_PROVIDERS = frozenset({"claude", "codex", "gemini", "kimi"})`). The `kimi_cli` label in `tier_routing.py` is the TierRoute's own `.lane` field, not a provider_dispatch routing target — the provider string that reaches provider_dispatch is always `"kimi"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)