### PR TITLE
docs: truth-pass for 1.0 launch — version labels, ADR amendments, surface sync, provenance

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -3,7 +3,8 @@
 This guide covers migration paths from legacy VNX patterns to the upgraded system. Each section describes what changed, why, and how to migrate.
 
 Plain `vnx` means the pip-installed Python CLI and is intentionally limited to
-`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, and `update`.
+`init`, `migrate`, `doctor`, `status`, `dispatch-agent`, `track`, `pool`,
+`dream`, `version`, and `update`.
 Operator commands in this guide run through the repo-local bash entrypoint
 `./bin/vnx` from the repository root.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,8 +1,8 @@
 # VNX in 5 Minutes
 
 This quickstart uses the pip-installed Python CLI. Plain `vnx` commands below
-are limited to the stable pip surface: `init`, `doctor`, `status`,
-`dispatch-agent`, `pool`, `version`, and `update`.
+are limited to the stable pip surface: `init`, `migrate`, `doctor`, `status`,
+`dispatch-agent`, `track`, `pool`, `dream`, `version`, and `update`.
 
 ## Step 1: Install
 
@@ -75,7 +75,7 @@ Operator commands run via the bash entrypoint `bin/vnx`. See Appendix A.
 ## Appendix A: Two binaries
 
 VNX ships TWO `vnx` entry-points with different scopes:
-- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `doctor`, `status`, `dispatch-agent`, `pool`, `version`, `update`).
+- **`vnx`** (pip-installed Python CLI at `vnx_cli/main.py`): user-facing essentials (`init`, `migrate`, `doctor`, `status`, `dispatch-agent`, `track`, `pool`, `dream`, `version`, `update`).
 - **`./bin/vnx`** (bash CLI in the repo): operator + automation surface (`gate-check`, `new-worktree`, `finish-worktree`, `merge-preflight`, `demo`, `start`, `recover`, `cost-report`). Run from the repo root.
 
 This split is intentional: the pip surface is stable + minimal; the bash surface is rich + repo-local.

--- a/docs/core/00_VNX_ARCHITECTURE.md
+++ b/docs/core/00_VNX_ARCHITECTURE.md
@@ -1,11 +1,11 @@
 # VNX Orchestration System - Complete Architecture
 
 **Status**: Active
-**Last Updated**: 2026-04-10
+**Last Updated**: 2026-06-11
 **Owner**: T-MANAGER
 **Purpose**: Single source of truth for VNX system architecture, components, and data flow.
 
-**Version**: 12.0.0
+**Version**: 1.0.0
 
 ---
 
@@ -60,7 +60,7 @@ VNX uses **one feature worktree per feature/fix** as the standard development mo
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    VNX ORCHESTRATION SYSTEM V8.2                │
+│                    VNX ORCHESTRATION SYSTEM V1.0                │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
@@ -167,7 +167,7 @@ The dashboard "Jump" button calls `POST /api/jump/{terminal}` which executes `vn
 
 ### 1. Dispatcher V8 (`dispatcher_minimal.sh`)
 
-**Purpose**: Native skill activation and instruction routing (V8.2 - Current Production)
+**Purpose**: Native skill activation and instruction routing (Dispatcher component V8.2, shipped in VNX 1.0.0)
 
 **Functionality**:
 - Maps dispatch roles to native Claude Code skills
@@ -187,7 +187,7 @@ The dashboard "Jump" button calls `POST /api/jump/{terminal}` which executes `vn
 - Intelligence integration maintained
 - Provider-aware dispatch (detects Claude/Codex/Gemini per terminal)
 
-**Receipt Footer** (V8.2):
+**Receipt Footer** (Dispatcher V8.2):
 - Task Completion Guidelines section
 - Report Metadata block (parsed by receipt processor)
 - Expected Outputs section (implementation summary, files modified, testing evidence, open items)
@@ -302,7 +302,7 @@ The dashboard "Jump" button calls `POST /api/jump/{terminal}` which executes `vn
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                  ORCHESTRATION LOOP V8.2                        │
+│                  ORCHESTRATION LOOP (VNX 1.0.0)                 │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
 │  1. T0 Creates Dispatch                                         │
@@ -522,7 +522,7 @@ Terminal status is determined by receipt-based activity detection.
 - `recommendations_engine.pid` — `recommendations_engine_daemon.sh`
 - `vnx_supervisor.pid` — self
 
-### Project-Scoped Process Isolation (V8.2)
+### Project-Scoped Process Isolation (shipped VNX 1.0.0)
 
 **Problem**: `vnx_proc_find_pids_by_fingerprint()` used bare script names in `grep -F`, matching processes from all VNX projects system-wide.
 
@@ -825,7 +825,7 @@ project-root/
 
 ---
 
-## Current System Status (V8.2)
+## Current System Status (VNX 1.0.0)
 
 ### Active Components ✅
 - Smart Tap V7 (JSON/Markdown auto-translation)
@@ -1032,7 +1032,7 @@ python .claude/vnx-system/scripts/pr_queue_manager.py promote <dispatch-id>
 | **Claude Code** | `/skill-name` | `/model opus` | `/clear` | Primary |
 | **Codex CLI** | `$skill-name` | N/A | `/new` | T1 alternative |
 | **Gemini CLI** | `@skill-name` | N/A | `/clear` | Experimental |
-| **Kimi** | N/A | N/A | N/A | Future |
+| **Kimi** | CLI OAuth | N/A | N/A | Production (CLI lane, 6/6 skill-injection verified) |
 
 ### Skill Sync
 
@@ -1164,7 +1164,7 @@ VNX_T1_PROVIDER=codex         # T1 can use different provider
 **`config.yml`** (`.vnx/config.yml`): Project metadata:
 ```yaml
 project_name: my-project
-vnx_version: 8.2.0
+vnx_version: 1.0.0
 created_at: 2026-02-18
 ```
 
@@ -1200,9 +1200,9 @@ Creates a complete LeadFlow SaaS project with:
 
 ---
 
-**Document Status**: Production Active (V12.0 — Dashboard Attention Model + Self-Learning Pipeline)
+**Document Status**: Production Active (V1.0.0 — Dashboard Attention Model + Self-Learning Pipeline)
 **Last Major Update**: 2026-03-28 (Attention model, jump command, worker intelligence injection, adoption tracking, nightly pipeline, 3-section quality digest)
-**Dispatcher Version**: V8.2 Minimal (Native Skills + Multi-Provider + Expected Outputs)
+**Dispatcher Version**: V8.2 Minimal (Native Skills + Multi-Provider + Expected Outputs; VNX 1.0.0)
 **Token Reduction**: 87% (200 vs 1500 tokens per dispatch)
 **Intelligence Version**: v2.0.0 (Adoption tracking, worker injection, pairwise tag matching, 3-section digest)
 **Dashboard**: Vanilla HTML/JS + Python HTTP server (port 4173, read-only, attention model)

--- a/docs/core/technical/DISPATCHER_SYSTEM.md
+++ b/docs/core/technical/DISPATCHER_SYSTEM.md
@@ -2,21 +2,21 @@
 **Owner**: T-MANAGER
 
 **Version**: V7.3 (Template Compilation System) — **LEGACY REFERENCE**
-**Status**: Reference (V8.2 is current production)
+**Status**: Reference (Dispatcher V8.2 is the production component in VNX 1.0.0)
 **Last Updated**: 2026-02-18
 **Purpose**: V7.3 template compilation reference. For current production dispatcher, see V8 section below.
 
 ---
 
 > **NOTE**: This document describes the V7.3 template compilation dispatcher which is no longer
-> the production dispatcher. **V8.2 Minimal** (`dispatcher_minimal.sh`) is the current
-> production system. V7 is maintained as a reference and rollback option.
+> the production dispatcher. **Dispatcher V8.2 Minimal** (`dispatcher_minimal.sh`) is the current
+> production component (VNX 1.0.0). V7 is maintained as a reference and rollback option.
 >
 > For architecture overview, see `core/00_VNX_ARCHITECTURE.md`.
 
 ---
 
-## V8.2 Production Dispatcher (Current)
+## Dispatcher Component V8.2 — Production in VNX 1.0.0
 
 ### Overview
 
@@ -24,7 +24,7 @@ The V8 dispatcher (`dispatcher_minimal.sh`) replaces V7's template compilation w
 
 ### Key Differences from V7
 
-| Feature | V7.3 | V8.2 |
+| Feature | Dispatcher V7.3 | Dispatcher V8.2 |
 |---------|------|------|
 | Token per dispatch | ~1500 | ~200 |
 | Template compilation | Yes (agent library) | No (native skills) |
@@ -44,7 +44,7 @@ The V8 dispatcher (`dispatcher_minimal.sh`) replaces V7's template compilation w
 
 The dispatcher detects the terminal's provider and uses the correct invocation format.
 
-### Receipt Footer (V8.2)
+### Receipt Footer (Dispatcher V8.2)
 
 Every dispatch includes a structured footer with:
 - **Report Metadata** block (Dispatch ID, PR, Track, Gate, Status) — parsed by receipt processor
@@ -53,7 +53,7 @@ Every dispatch includes a structured footer with:
 
 ### Parallel PR Queue Support
 
-V8.2 supports multiple PRs in progress simultaneously across different tracks:
+Dispatcher V8.2 supports multiple PRs in progress simultaneously across different tracks:
 - `pr_queue_state.yaml` stores `in_progress` as a list (not a single string)
 - Multiple tracks can run in parallel (e.g., PR-2 on Track A + PR-5 on Track B)
 - Backward compatible: reads old single-string format
@@ -1386,7 +1386,7 @@ cp /tmp/test_intelligence.md $VNX_HOME/dispatches/pending/
 - Pattern injection (top 5)
 - Prevention rules
 
-**V8.2** (Current Production — see top of document):
+**Dispatcher V8.2** (Current Production in VNX 1.0.0 — see top of document):
 - Native skill activation (87% token reduction)
 - Multi-provider dispatch (Claude/Codex/Gemini)
 - Rich receipt footer with Expected Outputs
@@ -1429,7 +1429,7 @@ cp /tmp/test_intelligence.md $VNX_HOME/dispatches/pending/
 
 ---
 
-**Document Status**: Legacy Reference (V8.2 is current production)
+**Document Status**: Legacy Reference (Dispatcher V8.2 is the production component in VNX 1.0.0)
 **Maintainer**: T-MANAGER (VNX Orchestration Expert)
 **Related Documents**:
 - `core/00_VNX_ARCHITECTURE.md` — Current architecture (V10.0)

--- a/docs/governance/decisions/ADR-015-wave7-litellm-path-b.md
+++ b/docs/governance/decisions/ADR-015-wave7-litellm-path-b.md
@@ -1,6 +1,6 @@
 # ADR-015: Wave 7 — DeepSeek/Kimi/GLM via LiteLLM Path B
 
-**Status**: Accepted
+**Status**: Accepted with Amendment (see CL3 below)
 **Date**: 2026-05-15
 **Deciders**: Vincent van Deth (operator)
 **Related ADRs**: ADR-003 (no SDK), ADR-010 (CLI subprocess canonical), ADR-016 (unified event shape)
@@ -75,6 +75,22 @@ Wave 7 lands in 5 PRs (plus 1 research-only):
 - **PR-7.6** (research-only): Tier-C network-namespace sandbox onderzoek voor Path D
 
 Effort: 5 elapsed days with VNX 3-track parallel, 9.5 days sequential.
+
+## Amendment (CL3, 2026-05-26)
+
+**Path D status updated from BLOCKED to Accepted with conditions.**
+
+Operator measurement on `claude` v2.1.150 (2026-05-26) with key-auth hardening showed the 8x telemetry leak documented in the original Path D assessment was specific to OAuth-subscription mode in v2.1.136. With own DeepSeek API key + hardening (`ANTHROPIC_BASE_URL` redirect + `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` + MCP disabled), operator measurement confirmed 0 calls to `api.anthropic.com` — the telemetry and OAuth-subscription-validation traffic that caused the original block is eliminated entirely in key-auth mode.
+
+**Amended constraints for Path D:**
+
+- PERMITTED: `ANTHROPIC_BASE_URL` redirect with own DeepSeek API key + hardening flags + MCP off.
+- BLOCKED: Same redirect while running on the production OAuth subscription without own key (subscription identity rides along = same ban risk as `no-anthropic-sdk` per ADR-003).
+- The Tier-C network-namespace sandbox (PR-7.6) remains recommended for production hardening but is no longer a prerequisite for operator use.
+
+This amendment does not modify the original text above. The original block reasoning was accurate for the conditions it described (v2.1.136, OAuth-subscription mode).
+
+Reference: `provider_constraints.yaml` constraint `deepseek-harness-subscription-blocked` encodes the amended rule as the machine-readable SSOT.
 
 ## See also
 

--- a/docs/governance/decisions/ADR-020-parallel-track-execution.md
+++ b/docs/governance/decisions/ADR-020-parallel-track-execution.md
@@ -63,6 +63,10 @@ The track layer (FUT-1, FUT-2a, FUT-2b) is shipped. Four build items remain for 
 - **(c)** Serialize `git worktree add` calls (lock around creation to fix `.git/config` race observed 2026-05-30)
 - **(d)** Serialized-merge + auto-rebase-and-regate orchestration in `roadmap_manager`/autopilot-tick
 
+## Implementation Status (as of VNX 1.0.0)
+
+Design accepted; substrate shipped (per-dispatch worktree isolation, atomic dispatch claiming, N-worker lanes, track DAL + CLI, human-gate primitive — all in 1.0.0). True parallel concurrent activation remains **Tier 3 — designed, not built**. The four build items listed in the Implementation section above (file_scope field, wave-scheduler, git-config race fix, serialized-merge + auto-rebase) are not shipped. Sequential single-active-plus-park is the operational mode in 1.0.0. Do not claim parallel activation as a shipped feature.
+
 ## Cross-references
 
 - ADR-007 — Multi-tenant composite PK/UNIQUE over `project_id` (binding for all track tables)

--- a/docs/manifesto/ARCHITECTURE.md
+++ b/docs/manifesto/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Author**: Vincent van de Th
 **Date**: February 2026
-**Status**: Reference Architecture — Daily-Use Prototype
+**Status**: Reference Architecture — pip-installable production release (1.0.0)
 **Usage**: 6 months daily use on local system · 1466 dispatches processed · 4 concurrent terminals
 
 ---
@@ -141,17 +141,16 @@ Screenshot pointer: `SCREENSHOTS.md` (S5: Quality Advisory).
 - MIT-licensed and open for inspection
 
 **This is not:**
-- A production-grade CLI (it's a prototype proving architectural concepts)
 - A hosted service
 - A competitor to LangGraph/CrewAI/AutoGen (it's a governance layer that could complement them)
 - A promise of feature parity across all providers
 
 ### Known Limitations
 
-- Tested with 4 terminals (T0 + T1/T2/T3), Claude Code + Codex CLI
-- Gemini integration documented and validated
-- Kimi 2.5 integration planned (next experiment — testing the watcher pattern with a non-Western provider)
-- **T0 orchestrator tested exclusively with Claude Opus** (via Claude Code, which powers ~80% of the workflow). Other models (Codex 5.3, Gemini 3.0) may work as T0, but this is untested. T0's write restrictions are enforced through Claude Code hooks.
+- The interactive tmux worker lane is available and subscription-preserving; full PREPARE/GOVERN envelope parity across all lanes is targeted for 1.x (see Tier 1/2 framing in the README).
+- Gemini integration documented and validated; Kimi K2.6 is in production via CLI OAuth lane, 6/6 skill-injection verified.
+- **T0 orchestrator tested with Claude Opus** (via Claude Code, which powers ~80% of the workflow). Other models may work as T0, but this is less tested.
+- Per-worker git worktree isolation is available via `VNX_ISOLATED_WORKTREE=1` and off by default; isolation guarantees vary by lane. Parallel multi-track execution is Tier 3 — designed, not shipped (see README Tier framing).
 - File-based, local-first — not designed for distributed networks
 - Tmux dependency for terminal management
 - Python/Bash prototype — a production deployment would benefit from Rust/Go
@@ -171,4 +170,4 @@ See `OPEN_METHOD.md` for the full transparency report.
 
 ---
 
-*This is a Research Prototype. See LIMITATIONS.md for current scope.*
+*See LIMITATIONS.md for current scope and Tier 1/2/3 feature framing.*

--- a/docs/manifesto/ROADMAP.md
+++ b/docs/manifesto/ROADMAP.md
@@ -428,6 +428,14 @@ Success criteria: T0 makes correct dispatch/complete/wait decisions autonomously
 
 ---
 
+## Living Roadmap (ROADMAP.yaml)
+
+`ROADMAP.yaml` in the repository root is the single source of truth for the active feature roadmap. The document you are reading captures the architecture principles and wave history; per-feature planning, milestone assignments, and PR queues live in `ROADMAP.yaml`. Two generated views are derived from it: `FEATURE_PLAN.md` and `PR_QUEUE.md`.
+
+**1.0.1 focus:** operational hardening and provider reliability. Key items include per-append hash-chain enforcement on the receipt ledger (`audit_chain`), Kimi content-block regression suite, log-rotation bounds for the event-stream ring buffer, self-learning loop reactivation (nightly intelligence cron), tmux submit reliability hardening, and completion of the unified dispatch envelope for the Claude subprocess lane.
+
+**1.1 focus:** architectural extensibility. Key items include the full unified dispatch envelope across all lanes (`VNX_UNIFIED_ENVELOPE`), full role-to-capability binding (MCP allowlist, per-role permission mode), and OpenRouter as a provider lane.
+
 ## Roadmap Guardrails
 
 - Keep append-only receipt path as canonical audit foundation.

--- a/skills/api-developer/references/_MAPPING.md
+++ b/skills/api-developer/references/_MAPPING.md
@@ -1,11 +1,11 @@
 # Reference Mapping for api-developer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `api-quickscan.md` | `SEOCRAWLER_DOCS/21_API_QUICKSCAN.md` |
-| `api-reference.md` | `SEOCRAWLER_DOCS/22_API_REFERENCE.md` |
-| `sse-contract.md` | `SEOCRAWLER_DOCS/SSE_EVENT_CONTRACT_V2.md` |
-| `email-api.md` | `SEOCRAWLER_DOCS/23_EMAIL_SERVICE_API.md` |
+| `api-quickscan.md` | `YOUR_PROJECT_DOCS/21_API_QUICKSCAN.md` |
+| `api-reference.md` | `YOUR_PROJECT_DOCS/22_API_REFERENCE.md` |
+| `sse-contract.md` | `YOUR_PROJECT_DOCS/SSE_EVENT_CONTRACT_V2.md` |
+| `email-api.md` | `YOUR_PROJECT_DOCS/23_EMAIL_SERVICE_API.md` |

--- a/skills/architect/references/_MAPPING.md
+++ b/skills/architect/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for architect
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `architecture.md` | `SEOCRAWLER_DOCS/10_ARCHITECTURE.md` |
-| `crawler-arch.md` | `SEOCRAWLER_DOCS/11_CRAWLER_ARCHITECTURE.md` |
-| `preview-arch.md` | `SEOCRAWLER_DOCS/PREVIEW_SYSTEM_ARCHITECTURE.md` |
+| `architecture.md` | `YOUR_PROJECT_DOCS/10_ARCHITECTURE.md` |
+| `crawler-arch.md` | `YOUR_PROJECT_DOCS/11_CRAWLER_ARCHITECTURE.md` |
+| `preview-arch.md` | `YOUR_PROJECT_DOCS/PREVIEW_SYSTEM_ARCHITECTURE.md` |

--- a/skills/backend-developer/references/_MAPPING.md
+++ b/skills/backend-developer/references/_MAPPING.md
@@ -1,11 +1,11 @@
 # Reference Mapping for backend-developer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `implementation.md` | `SEOCRAWLER_DOCS/20_IMPLEMENTATION.md` |
-| `services.md` | `SEOCRAWLER_DOCS/25_SERVICES.md` |
-| `extractors.md` | `SEOCRAWLER_DOCS/30_EXTRACTORS.md` |
-| `plugins.md` | `SEOCRAWLER_DOCS/35_PLUGINS.md` |
+| `implementation.md` | `YOUR_PROJECT_DOCS/20_IMPLEMENTATION.md` |
+| `services.md` | `YOUR_PROJECT_DOCS/25_SERVICES.md` |
+| `extractors.md` | `YOUR_PROJECT_DOCS/30_EXTRACTORS.md` |
+| `plugins.md` | `YOUR_PROJECT_DOCS/35_PLUGINS.md` |

--- a/skills/data-analyst/references/_MAPPING.md
+++ b/skills/data-analyst/references/_MAPPING.md
@@ -1,9 +1,9 @@
 # Reference Mapping for data-analyst
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `business-overview.md` | `SEOCRAWLER_DOCS/70_BUSINESS_OVERVIEW.md` |
-| `competitive-analysis.md` | `SEOCRAWLER_DOCS/72_COMPETITIVE_ANALYSIS.md` |
+| `business-overview.md` | `YOUR_PROJECT_DOCS/70_BUSINESS_OVERVIEW.md` |
+| `competitive-analysis.md` | `YOUR_PROJECT_DOCS/72_COMPETITIVE_ANALYSIS.md` |

--- a/skills/debugger/references/_MAPPING.md
+++ b/skills/debugger/references/_MAPPING.md
@@ -1,9 +1,9 @@
 # Reference Mapping for debugger
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `operations.md` | `SEOCRAWLER_DOCS/60_OPERATIONS.md` |
-| `gotchas.md` | `SEOCRAWLER_DOCS/99_LINE_RANGE_TRAP.md` |
+| `operations.md` | `YOUR_PROJECT_DOCS/60_OPERATIONS.md` |
+| `gotchas.md` | `YOUR_PROJECT_DOCS/99_LINE_RANGE_TRAP.md` |

--- a/skills/excel-reporter/references/_MAPPING.md
+++ b/skills/excel-reporter/references/_MAPPING.md
@@ -1,9 +1,9 @@
 # Reference Mapping for excel-reporter
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `pdf-blueprint.md` | `SEOCRAWLER_DOCS/68_PDF_REPORT_BLUEPRINT.md` |
-| `business-overview.md` | `SEOCRAWLER_DOCS/70_BUSINESS_OVERVIEW.md` |
+| `pdf-blueprint.md` | `YOUR_PROJECT_DOCS/68_PDF_REPORT_BLUEPRINT.md` |
+| `business-overview.md` | `YOUR_PROJECT_DOCS/70_BUSINESS_OVERVIEW.md` |

--- a/skills/frontend-developer/references/_MAPPING.md
+++ b/skills/frontend-developer/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for frontend-developer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `frontend-integration.md` | `SEOCRAWLER_DOCS/62_FRONTEND_INTEGRATION.md` |
-| `scan-counter.md` | `SEOCRAWLER_DOCS/63_SCAN_COUNTER_WIDGET.md` |
-| `webvitals.md` | `SEOCRAWLER_DOCS/43_WEBVITALS_CONSOLIDATED.md` |
+| `frontend-integration.md` | `YOUR_PROJECT_DOCS/62_FRONTEND_INTEGRATION.md` |
+| `scan-counter.md` | `YOUR_PROJECT_DOCS/63_SCAN_COUNTER_WIDGET.md` |
+| `webvitals.md` | `YOUR_PROJECT_DOCS/43_WEBVITALS_CONSOLIDATED.md` |

--- a/skills/monitoring-specialist/references/_MAPPING.md
+++ b/skills/monitoring-specialist/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for monitoring-specialist
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `monitoring.md` | `SEOCRAWLER_DOCS/60_MONITORING.md` |
-| `operations.md` | `SEOCRAWLER_DOCS/60_OPERATIONS.md` |
-| `browser-pool.md` | `SEOCRAWLER_DOCS/41_BROWSER_POOL.md` |
+| `monitoring.md` | `YOUR_PROJECT_DOCS/60_MONITORING.md` |
+| `operations.md` | `YOUR_PROJECT_DOCS/60_OPERATIONS.md` |
+| `browser-pool.md` | `YOUR_PROJECT_DOCS/41_BROWSER_POOL.md` |

--- a/skills/performance-profiler/references/_MAPPING.md
+++ b/skills/performance-profiler/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for performance-profiler
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `webvitals.md` | `SEOCRAWLER_DOCS/43_WEBVITALS_CONSOLIDATED.md` |
-| `monitoring.md` | `SEOCRAWLER_DOCS/60_MONITORING.md` |
-| `operations.md` | `SEOCRAWLER_DOCS/60_OPERATIONS.md` |
+| `webvitals.md` | `YOUR_PROJECT_DOCS/43_WEBVITALS_CONSOLIDATED.md` |
+| `monitoring.md` | `YOUR_PROJECT_DOCS/60_MONITORING.md` |
+| `operations.md` | `YOUR_PROJECT_DOCS/60_OPERATIONS.md` |

--- a/skills/planner/references/_MAPPING.md
+++ b/skills/planner/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for planner
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
 | `feature-plan.md` | `FEATURE_PLAN.md` |
-| `roadmap.md` | `SEOCRAWLER_DOCS/80_ROADMAP.md` |
-| `phase2.md` | `SEOCRAWLER_DOCS/81_PHASE2_FEATURES.md` |
+| `roadmap.md` | `YOUR_PROJECT_DOCS/80_ROADMAP.md` |
+| `phase2.md` | `YOUR_PROJECT_DOCS/81_PHASE2_FEATURES.md` |

--- a/skills/python-optimizer/references/_MAPPING.md
+++ b/skills/python-optimizer/references/_MAPPING.md
@@ -1,9 +1,9 @@
 # Reference Mapping for python-optimizer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `implementation.md` | `SEOCRAWLER_DOCS/20_IMPLEMENTATION.md` |
-| `operations.md` | `SEOCRAWLER_DOCS/60_OPERATIONS.md` |
+| `implementation.md` | `YOUR_PROJECT_DOCS/20_IMPLEMENTATION.md` |
+| `operations.md` | `YOUR_PROJECT_DOCS/60_OPERATIONS.md` |

--- a/skills/quality-engineer/references/_MAPPING.md
+++ b/skills/quality-engineer/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for quality-engineer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `definition-of-done.md` | `SEOCRAWLER_DOCS/04_DEFINITION_OF_DONE.md` |
-| `test-assessment.md` | `SEOCRAWLER_DOCS/63_TEST_ASSESSMENT_REPORT.md` |
-| `quality-debt.md` | `SEOCRAWLER_DOCS/82_QUALITY_DEBT_APPENDIX.md` |
+| `definition-of-done.md` | `YOUR_PROJECT_DOCS/04_DEFINITION_OF_DONE.md` |
+| `test-assessment.md` | `YOUR_PROJECT_DOCS/63_TEST_ASSESSMENT_REPORT.md` |
+| `quality-debt.md` | `YOUR_PROJECT_DOCS/82_QUALITY_DEBT_APPENDIX.md` |

--- a/skills/reviewer/references/_MAPPING.md
+++ b/skills/reviewer/references/_MAPPING.md
@@ -1,9 +1,9 @@
 # Reference Mapping for reviewer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `definition-of-done.md` | `SEOCRAWLER_DOCS/04_DEFINITION_OF_DONE.md` |
-| `configuration.md` | `SEOCRAWLER_DOCS/50_CONFIGURATION.md` |
+| `definition-of-done.md` | `YOUR_PROJECT_DOCS/04_DEFINITION_OF_DONE.md` |
+| `configuration.md` | `YOUR_PROJECT_DOCS/50_CONFIGURATION.md` |

--- a/skills/security-engineer/references/_MAPPING.md
+++ b/skills/security-engineer/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for security-engineer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `security-privacy.md` | `SEOCRAWLER_DOCS/53_SECURITY_PRIVACY.md` |
-| `security-guidelines.md` | `SEOCRAWLER_DOCS/SECURITY_GUIDELINES.md` |
-| `security-summary.md` | `SEOCRAWLER_DOCS/SECURITY_SUMMARY.md` |
+| `security-privacy.md` | `YOUR_PROJECT_DOCS/53_SECURITY_PRIVACY.md` |
+| `security-guidelines.md` | `YOUR_PROJECT_DOCS/SECURITY_GUIDELINES.md` |
+| `security-summary.md` | `YOUR_PROJECT_DOCS/SECURITY_SUMMARY.md` |

--- a/skills/supabase-expert/references/_MAPPING.md
+++ b/skills/supabase-expert/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for supabase-expert
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `database-setup.md` | `SEOCRAWLER_DOCS/26_DEVELOPMENT_DATABASE_SETUP.md` |
-| `migration-strategy.md` | `SEOCRAWLER_DOCS/28_SUPABASE_MIGRATION_STRATEGY.md` |
-| `storage-rag.md` | `SEOCRAWLER_DOCS/40_STORAGE_AND_RAG.md` |
+| `database-setup.md` | `YOUR_PROJECT_DOCS/26_DEVELOPMENT_DATABASE_SETUP.md` |
+| `migration-strategy.md` | `YOUR_PROJECT_DOCS/28_SUPABASE_MIGRATION_STRATEGY.md` |
+| `storage-rag.md` | `YOUR_PROJECT_DOCS/40_STORAGE_AND_RAG.md` |

--- a/skills/test-engineer/references/_MAPPING.md
+++ b/skills/test-engineer/references/_MAPPING.md
@@ -1,10 +1,10 @@
 # Reference Mapping for test-engineer
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|
-| `testing-setup.md` | `SEOCRAWLER_DOCS/65_TESTING_DESIGN_SETUP.md` |
-| `testing-strategy.md` | `SEOCRAWLER_DOCS/66_TESTING_STRATEGY_PROMPT.md` |
-| `coverage.md` | `SEOCRAWLER_DOCS/64_TEST_COVERAGE_REPORT.md` |
+| `testing-setup.md` | `YOUR_PROJECT_DOCS/65_TESTING_DESIGN_SETUP.md` |
+| `testing-strategy.md` | `YOUR_PROJECT_DOCS/66_TESTING_STRATEGY_PROMPT.md` |
+| `coverage.md` | `YOUR_PROJECT_DOCS/64_TEST_COVERAGE_REPORT.md` |

--- a/skills/vnx-manager/references/_MAPPING.md
+++ b/skills/vnx-manager/references/_MAPPING.md
@@ -1,7 +1,7 @@
 # Reference Mapping for vnx-manager
 
 These references are project-specific and created during deployment.
-Below is the recommended mapping for SEOcrawler:
+Below is the recommended mapping for your project:
 
 | Reference | Target |
 |-----------|--------|


### PR DESCRIPTION
## Summary

- Version labels 12.0.0 / V8.2 / "prototype proving" cleared from user-facing docs; product version is now consistently 1.0.0 throughout
- Two manifesto/ARCHITECTURE.md falsehoods corrected: CLI status updated to pip-installable 1.0.0; Kimi 2.5 "planned" → Kimi K2.6 in production 6/6 verified
- ADR-015 amended (append-only): Path D status corrected from BLOCKED to Accepted with conditions (own-key + hardening per CL3 2026-05-26 measurement)
- ADR-020 Implementation Status section added: substrate shipped; true parallel = Tier 3 not built in 1.0.0
- Stable pip surface in QUICKSTART.md and MIGRATION_GUIDE.md synced to include `migrate`, `track`, `dream` (matches README line ~72 and vnx_cli/main.py)
- docs/manifesto/ROADMAP.md: Living Roadmap section added with ROADMAP.yaml as SSOT reference + 1.0.1/1.1 3-line summary
- 17 skills `_MAPPING.md` files: "SEOcrawler" project name and `SEOCRAWLER_DOCS/` path prefix replaced with neutral "your project" / `YOUR_PROJECT_DOCS/` — SKILL.md functional content untouched

## Changes

| File | Change |
|------|--------|
| `docs/core/00_VNX_ARCHITECTURE.md` | Version 12.0.0 → 1.0.0; diagram V8.2 → V1.0; Dispatcher V8.2 body refs disambiguated; Kimi row updated to production |
| `docs/core/technical/DISPATCHER_SYSTEM.md` | Status lines updated; component vs product version clarified throughout |
| `docs/manifesto/ARCHITECTURE.md` | Status + "This is not" section rewritten to 1.0.0 / Tier framing |
| `docs/governance/decisions/ADR-015-wave7-litellm-path-b.md` | CL3 amendment appended; status → Accepted with Amendment |
| `docs/governance/decisions/ADR-020-parallel-track-execution.md` | Implementation Status section added |
| `docs/QUICKSTART.md` | Stable pip surface list synced |
| `docs/MIGRATION_GUIDE.md` | Stable pip surface list synced |
| `docs/manifesto/ROADMAP.md` | Living Roadmap + 1.0.1/1.1 summary added |
| `skills/*/references/_MAPPING.md` (17 files) | SEOcrawler → your project; SEOCRAWLER_DOCS/ → YOUR_PROJECT_DOCS/ |

## Point-by-point decisions

**Point 1 (00_VNX_ARCHITECTURE.md):** Fixed in place, not archived. The architectural content (T0-T3 model, receipt pipeline, dispatcher, governance) is accurate and matches the 1.0.0 shipped system. Only the version labels were wrong. Archiving would have broken the DOCS_INDEX.md reference and left an HN reader with no architecture reference.

**Point 6 (claudedocs/strategy/ROADMAP.md):** File does not exist in this repo — no action taken.

## Verification

```
grep -rn "12\.0\.0|prototype proving" docs/ --include="*.md" (outside _archive) = 0 hits
grep -rn "SEOcrawler" skills/*/references/_MAPPING.md = 0 hits
```

Remaining `V8.2` hits all read "Dispatcher V8.2 … VNX 1.0.0" — component name, not product version claim.

All internal links verified: ROADMAP.yaml, LIMITATIONS.md, MIGRATION_GUIDE.md, MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md all exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)