### PR TITLE
fix(selflearn): injection-history-aware suppression breaks duplicate dominance (93% dup root-cause)

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -17,7 +17,7 @@ import os
 import random
 import sqlite3
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, FrozenSet, List, Optional, Set
 
 from intelligence_sources import (  # noqa: F401  (re-exported for backward compat)
     CONFIDENCE_THRESHOLDS, EVIDENCE_THRESHOLDS, ITEM_CLASS_PRIORITY,
@@ -159,7 +159,8 @@ class IntelligenceSelector:
                 effective_scope.append(tag)
 
         candidates = apply_candidate_diversity(self._query_candidates(resolved_class, effective_scope), resolved_class)
-        selected, suppressed = self._select_standard_classes(candidates)
+        recent_ids = self._query_recent_injected_ids(resolved_class)
+        selected, suppressed = self._select_standard_classes(candidates, recent_ids=recent_ids)
         selected = self._enforce_payload_limit(selected, suppressed, list(reversed(ITEM_CLASS_PRIORITY)))
 
         now_ts = _now_utc()
@@ -179,11 +180,75 @@ class IntelligenceSelector:
 
         return InjectionResult(injection_point=injection_point, injected_at=now_ts, items=selected, suppressed=suppressed, task_class=resolved_class, dispatch_id=dispatch_id)
 
-    def _select_standard_classes(self, candidates):
+    _SUPPRESS_WINDOW_DEFAULT = 10
+
+    def _query_recent_injected_ids(self, task_class: str) -> FrozenSet[str]:
+        """Return item_ids injected in the last N dispatches for task_class from coord DB.
+
+        N is controlled by env var VNX_INTEL_SUPPRESS_WINDOW (default 10).
+        Rows with unparseable items_json are skipped — defensive, no crash.
+        Returns empty frozenset when coord DB is unavailable.
+        """
+        state_dir = self._coord_state_dir
+        if state_dir is None:
+            return frozenset()
+        try:
+            window = int(os.environ.get("VNX_INTEL_SUPPRESS_WINDOW", self._SUPPRESS_WINDOW_DEFAULT))
+        except (ValueError, TypeError):
+            window = self._SUPPRESS_WINDOW_DEFAULT
+        if window <= 0:
+            return frozenset()
+        try:
+            from runtime_coordination import get_connection
+        except ImportError:
+            return frozenset()
+        item_ids: Set[str] = set()
+        try:
+            with get_connection(state_dir) as conn:
+                rows = conn.execute(
+                    """SELECT items_json FROM intelligence_injections
+                       WHERE task_class = ?
+                       ORDER BY injected_at DESC
+                       LIMIT ?""",
+                    (task_class, window),
+                ).fetchall()
+            for row in rows:
+                raw = row["items_json"] if isinstance(row, sqlite3.Row) else row[0]
+                if not raw:
+                    continue
+                try:
+                    items = json.loads(raw)
+                    if not isinstance(items, list):
+                        continue
+                    for item in items:
+                        if isinstance(item, dict) and item.get("item_id"):
+                            item_ids.add(str(item["item_id"]))
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    logger.debug(
+                        "_query_recent_injected_ids: skipping malformed items_json row for task_class=%s",
+                        task_class,
+                    )
+                    continue
+        except Exception as exc:
+            logger.debug(
+                "_query_recent_injected_ids: coord DB query failed for task_class=%s: %s",
+                task_class,
+                exc,
+            )
+        return frozenset(item_ids)
+
+    def _select_standard_classes(
+        self, candidates, *, recent_ids: FrozenSet[str] = frozenset()
+    ):
         selected: List[IntelligenceItem] = []
         suppressed: List[SuppressionRecord] = []
         seen_hashes: set = set()
         governance_used = 0
+        window = self._SUPPRESS_WINDOW_DEFAULT
+        try:
+            window = int(os.environ.get("VNX_INTEL_SUPPRESS_WINDOW", self._SUPPRESS_WINDOW_DEFAULT))
+        except (ValueError, TypeError):
+            pass
         for item_class in ITEM_CLASS_PRIORITY:
             class_candidates = candidates.get(item_class, [])
             if not class_candidates:
@@ -208,7 +273,33 @@ class IntelligenceSelector:
                 parts = ([f"{dropped_dup} duplicates removed by content hash"] if dropped_dup else []) + ([f"{dropped_gov} governance items past per-batch cap"] if dropped_gov else [])
                 suppressed.append(SuppressionRecord(item_class=item_class, reason=f"diversity filter dropped all eligible items ({'; '.join(parts) or 'no diverse candidates remain'})"))
                 continue
-            best = max(diverse, key=lambda c: c.confidence)
+            # Recency suppression: filter candidates recently injected for this task_class.
+            # VANGNET: if suppression would leave the pool empty, let best candidate through.
+            if recent_ids and window > 0:
+                not_recent = [c for c in diverse if c.item_id not in recent_ids]
+                recently_suppressed = [c for c in diverse if c.item_id in recent_ids]
+                if not not_recent and recently_suppressed:
+                    # Vangnet: all diverse candidates were recently injected; allow best to prevent empty injection.
+                    best = max(diverse, key=lambda c: c.confidence)
+                    logger.debug(
+                        "_select_standard_classes: recency vangnet — all %d %s candidates recently injected, "
+                        "allowing best (%s) through to prevent empty injection",
+                        len(diverse),
+                        item_class,
+                        best.item_id,
+                    )
+                else:
+                    for cand in recently_suppressed:
+                        suppressed.append(SuppressionRecord(
+                            item_class=item_class,
+                            reason=f"recently injected (within last {window} dispatches for task_class)",
+                        ))
+                    diverse = not_recent
+                    if not diverse:
+                        continue
+                    best = max(diverse, key=lambda c: c.confidence)
+            else:
+                best = max(diverse, key=lambda c: c.confidence)
             selected.append(best)
             if best.content_hash:
                 seen_hashes.add(best.content_hash)

--- a/tests/test_intelligence_recency.py
+++ b/tests/test_intelligence_recency.py
@@ -179,8 +179,12 @@ class TestInjectionDiversity:
 
     @pytest.mark.xfail(
         strict=False,
+        # strict=False stays intentionally — graduate to strict=True after 7-day soak
+        # with >=20 coding_interactive injections showing dup<=40% (see ROADMAP self-learning restpunt).
         reason="2026-04-30 audit: production DB has 90%+ identical injections; "
-        "see claudedocs/2026-04-30-self-learning-loop-audit.md",
+        "threshold raised from 0.10 to 0.40 after injection-history suppression fix "
+        "(fix/injection-history-suppression). "
+        "See claudedocs/2026-04-30-self-learning-loop-audit.md",
     )
     def test_recent_injections_not_all_identical(self, coord_db: Path) -> None:
         conn = _open(coord_db)
@@ -198,9 +202,12 @@ class TestInjectionDiversity:
 
         payloads = [r["items_json"] for r in rows]
         unique = set(payloads)
-        # Audit found 90%+ duplication.  Healthy is < 90% duplication.
+        # Threshold raised to 0.40 after injection-history suppression fix breaks duplicate dominance.
+        # Pre-fix baseline: 34 unique / 512 injections = 6.6% unique (93.4% dup).
+        # Post-fix target: >40% unique within 7-day soak of >=20 coding_interactive injections.
         unique_ratio = len(unique) / len(payloads)
-        assert unique_ratio > 0.10, (
+        assert unique_ratio > 0.40, (
             f"{len(payloads)} injections collapsed to {len(unique)} unique payloads "
-            f"({unique_ratio:.0%} unique). Diversity bug: selector echoing identical content."
+            f"({unique_ratio:.0%} unique). Diversity still below 40% target — "
+            "injection-history suppression may not be active or pool is too small."
         )

--- a/tests/test_intelligence_recency_suppression.py
+++ b/tests/test_intelligence_recency_suppression.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Unit tests for injection-history-aware recency suppression.
+
+Verifies that IntelligenceSelector._select_standard_classes and
+_query_recent_injected_ids suppress candidates whose item_ids appear in the
+last N dispatches for the same task_class (root-cause fix for 93.4% duplicate
+injection rate in coding_interactive).
+
+Test matrix:
+  (a) item recently injected → suppressed, alternative selected
+  (b) pool goes empty after suppression → vangnet passes best through + logs reason
+  (c) different task_class → no suppression applied
+  (d) window size respects VNX_INTEL_SUPPRESS_WINDOW env var
+  (e) corrupt items_json row → skipped without crash
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import List
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from intelligence_selector import (
+    CONFIDENCE_THRESHOLDS,
+    EVIDENCE_THRESHOLDS,
+    IntelligenceItem,
+    IntelligenceSelector,
+    SuppressionRecord,
+)
+from runtime_coordination import get_connection, init_schema
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_item(
+    item_id: str,
+    item_class: str = "proven_pattern",
+    confidence: float = 0.85,
+    evidence_count: int = 5,
+    content: str = "Some pattern content",
+) -> IntelligenceItem:
+    return IntelligenceItem(
+        item_id=item_id,
+        item_class=item_class,
+        title=f"Pattern {item_id}",
+        content=content,
+        confidence=confidence,
+        evidence_count=evidence_count,
+        last_seen="2026-06-01T00:00:00Z",
+        scope_tags=["coding_interactive"],
+        content_hash=f"hash_{item_id}",
+    )
+
+
+def _setup_coord_db(state_dir: Path) -> None:
+    """Initialise a minimal runtime_coordination.db with intelligence_injections table."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    init_schema(str(state_dir))
+
+
+def _insert_injection(
+    state_dir: Path,
+    dispatch_id: str,
+    task_class: str,
+    item_ids: List[str],
+    injected_at: str = "2026-06-10T12:00:00Z",
+) -> None:
+    """Insert a synthetic intelligence_injections row into the coord DB."""
+    items_json = json.dumps([{"item_id": iid} for iid in item_ids])
+    injection_id = str(uuid.uuid4())
+    with get_connection(state_dir) as conn:
+        conn.execute(
+            """INSERT INTO intelligence_injections
+               (injection_id, dispatch_id, injection_point, task_class,
+                items_injected, items_suppressed, payload_chars,
+                items_json, suppressed_json, injected_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                injection_id, dispatch_id, "dispatch_create", task_class,
+                len(item_ids), 0, 200,
+                items_json, "[]", injected_at,
+            ),
+        )
+        conn.commit()
+
+
+def _make_selector(state_dir: Path) -> IntelligenceSelector:
+    return IntelligenceSelector(quality_db_path=None, coord_db_state_dir=state_dir)
+
+
+# ---------------------------------------------------------------------------
+# (a) Recently injected item → suppressed, alternative selected
+# ---------------------------------------------------------------------------
+
+class TestRecentlyInjectedItemSuppressed:
+    """Candidate with item_id in recent injection history gets suppressed."""
+
+    def test_dominant_item_suppressed_alternative_selected(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        # item A has been injected in the last 10 dispatches for coding_interactive
+        dominant_id = "intel_sp_1"
+        alt_id = "intel_sp_2"
+
+        for i in range(3):
+            _insert_injection(state_dir, f"dispatch-{i}", "coding_interactive", [dominant_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert dominant_id in recent_ids, "Dominant item must appear in recent_ids"
+
+        dominant = _make_item(dominant_id, confidence=1.0, evidence_count=10)
+        alternative = _make_item(alt_id, confidence=0.75, evidence_count=4)
+        candidates = {"proven_pattern": [dominant, alternative], "failure_prevention": [], "recent_comparable": []}
+
+        selected, suppressed = selector._select_standard_classes(candidates, recent_ids=recent_ids)
+
+        selected_ids = [i.item_id for i in selected]
+        assert alt_id in selected_ids, "Alternative must be selected when dominant is suppressed"
+        assert dominant_id not in selected_ids, "Dominant item must not be injected"
+
+        suppression_reasons = [s.reason for s in suppressed]
+        assert any("recently injected" in r for r in suppression_reasons), (
+            f"Expected suppression reason mentioning 'recently injected', got: {suppression_reasons}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Pool empty after suppression → vangnet passes best through
+# ---------------------------------------------------------------------------
+
+class TestVangnetWhenPoolGoesEmpty:
+    """When all diverse candidates are recently injected, the best is allowed through."""
+
+    def test_best_passes_through_when_all_suppressed(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        item_id = "intel_sp_1"
+        _insert_injection(state_dir, "dispatch-0", "coding_interactive", [item_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        recent_ids = frozenset({item_id})
+
+        only_candidate = _make_item(item_id, confidence=0.9, evidence_count=3)
+        candidates = {"proven_pattern": [only_candidate], "failure_prevention": [], "recent_comparable": []}
+
+        with caplog.at_level(logging.DEBUG, logger="intelligence_selector"):
+            selected, suppressed = selector._select_standard_classes(candidates, recent_ids=recent_ids)
+
+        selected_ids = [i.item_id for i in selected]
+        assert item_id in selected_ids, (
+            "Vangnet: best candidate must pass through when entire pool is recently injected"
+        )
+
+        vangnet_logged = any(
+            "vangnet" in record.message.lower() or "vangnet" in record.getMessage().lower()
+            for record in caplog.records
+        )
+        assert vangnet_logged, "Vangnet activation must be logged at DEBUG level"
+
+
+# ---------------------------------------------------------------------------
+# (c) Different task_class → no suppression
+# ---------------------------------------------------------------------------
+
+class TestDifferentTaskClassNotSuppressed:
+    """Injection history for a different task_class must not affect current selection."""
+
+    def test_other_task_class_injection_does_not_suppress(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        item_id = "intel_sp_1"
+        # Record injection only under research_structured, not coding_interactive
+        _insert_injection(state_dir, "dispatch-0", "research_structured", [item_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        # Query for coding_interactive — must return empty set
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert item_id not in recent_ids, (
+            "Item injected under a different task_class must not appear in recent_ids for current class"
+        )
+
+        candidate = _make_item(item_id, confidence=0.9, evidence_count=5)
+        candidates = {"proven_pattern": [candidate], "failure_prevention": [], "recent_comparable": []}
+
+        selected, suppressed = selector._select_standard_classes(candidates, recent_ids=recent_ids)
+
+        selected_ids = [i.item_id for i in selected]
+        assert item_id in selected_ids, (
+            "Candidate must be selected when its injection was for a different task_class"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (d) Window size respects VNX_INTEL_SUPPRESS_WINDOW env var
+# ---------------------------------------------------------------------------
+
+class TestWindowSizeEnvVar:
+    """VNX_INTEL_SUPPRESS_WINDOW controls how many recent dispatches are checked."""
+
+    def test_window_zero_disables_suppression(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        item_id = "intel_sp_1"
+        _insert_injection(state_dir, "dispatch-0", "coding_interactive", [item_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "0")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert len(recent_ids) == 0, (
+            "Window=0 must disable suppression; recent_ids must be empty"
+        )
+
+    def test_window_one_captures_only_latest_dispatch(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        old_item = "intel_sp_old"
+        new_item = "intel_sp_new"
+
+        # Insert old dispatch first (earlier timestamp), then new
+        _insert_injection(
+            state_dir, "dispatch-old", "coding_interactive", [old_item],
+            injected_at="2026-06-01T00:00:00Z",
+        )
+        _insert_injection(
+            state_dir, "dispatch-new", "coding_interactive", [new_item],
+            injected_at="2026-06-10T12:00:00Z",
+        )
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "1")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert new_item in recent_ids, "Most recent item must be in window=1 suppression set"
+        assert old_item not in recent_ids, "Older dispatch must be outside window=1"
+
+    def test_window_large_captures_all(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        item_ids = [f"intel_sp_{i}" for i in range(5)]
+        for i, iid in enumerate(item_ids):
+            _insert_injection(
+                state_dir, f"dispatch-{i}", "coding_interactive", [iid],
+                injected_at=f"2026-06-0{i+1}T00:00:00Z",
+            )
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "100")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        for iid in item_ids:
+            assert iid in recent_ids, f"{iid} must be in suppression set with window=100"
+
+
+# ---------------------------------------------------------------------------
+# (e) Corrupt items_json row → skipped without crash
+# ---------------------------------------------------------------------------
+
+class TestCorruptItemsJsonRow:
+    """Malformed items_json in the DB must not crash _query_recent_injected_ids."""
+
+    def _insert_raw_injection(
+        self,
+        state_dir: Path,
+        dispatch_id: str,
+        task_class: str,
+        items_json_raw: str,
+    ) -> None:
+        injection_id = str(uuid.uuid4())
+        with get_connection(state_dir) as conn:
+            conn.execute(
+                """INSERT INTO intelligence_injections
+                   (injection_id, dispatch_id, injection_point, task_class,
+                    items_injected, items_suppressed, payload_chars,
+                    items_json, suppressed_json)
+                   VALUES (?, ?, ?, ?, 0, 0, 0, ?, '[]')""",
+                (injection_id, dispatch_id, "dispatch_create", task_class, items_json_raw),
+            )
+            conn.commit()
+
+    def test_corrupt_json_skipped(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        # Insert one corrupt row and one valid row
+        self._insert_raw_injection(state_dir, "bad-dispatch", "coding_interactive", "NOT_VALID_JSON{{{")
+        valid_id = "intel_sp_42"
+        _insert_injection(state_dir, "good-dispatch", "coding_interactive", [valid_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        # Must not raise
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert valid_id in recent_ids, "Valid row must be parsed correctly despite corrupt sibling"
+
+    def test_non_list_json_skipped(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        _setup_coord_db(state_dir)
+
+        # items_json is valid JSON but not a list
+        self._insert_raw_injection(
+            state_dir, "obj-dispatch", "coding_interactive", '{"item_id": "intel_sp_1"}'
+        )
+        valid_id = "intel_sp_99"
+        _insert_injection(state_dir, "good-dispatch", "coding_interactive", [valid_id])
+
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert valid_id in recent_ids, "Valid list row must be parsed even when another row is non-list JSON"
+        # Non-list row must not contribute random keys
+        assert "intel_sp_1" not in recent_ids, "Non-list JSON row must be skipped entirely"
+
+    def test_missing_coord_db_returns_empty(self, tmp_path, monkeypatch):
+        # state_dir exists but no DB file — must return frozenset() gracefully
+        state_dir = tmp_path / "nonexistent_state"
+        # Do not call _setup_coord_db — directory absent
+        monkeypatch.setenv("VNX_INTEL_SUPPRESS_WINDOW", "10")
+
+        selector = _make_selector(state_dir)
+        recent_ids = selector._query_recent_injected_ids("coding_interactive")
+
+        assert recent_ids == frozenset(), "Absent coord DB must return empty frozenset without raising"


### PR DESCRIPTION
## Summary

- **Root-cause fixed**: `intel_sp_1` (confidence 1.0, 219 uses) won every `proven_pattern` slot for `coding_interactive` because `_select_standard_classes` had no memory of previous dispatches. Result: 93.4% duplicate injection rate (512 injections, 34 unique payloads over 14 days).
- **Mechanism**: `IntelligenceSelector._query_recent_injected_ids` queries `intelligence_injections` in the coord DB for `item_id`s injected in the last N dispatches (default 10, tunable via `VNX_INTEL_SUPPRESS_WINDOW`) for the same `task_class`. `_select_standard_classes` filters those ids before the `max(confidence)` pick. Suppression is visible in `suppressed_json` / `items_suppressed` audit fields.
- **Vangnet**: if suppression would empty the entire diverse pool, the best candidate passes through with a DEBUG-level log entry — no silent injection gaps.

## Changes

- `scripts/lib/intelligence_selector.py`: added `_query_recent_injected_ids()` and integrated recency filter + vangnet into `_select_standard_classes()`. Import surface: `FrozenSet`, `Set` added; existing public API untouched.
- `tests/test_intelligence_recency.py`: canary xfail threshold raised from `0.10` to `0.40`; `strict=False` stays intentionally (see graduation path below).
- `tests/test_intelligence_recency_suppression.py`: 9 new unit tests covering all specified test cases (a–e).

## Verification

```
tests/test_intelligence_recency_suppression.py  9 passed
tests/test_intelligence_selector.py            121 passed (6 pre-existing failures, zero regressions)
tests/test_intelligence_selector_exception_handling.py  passed
tests/test_intelligence_fixes.py               passed
tests/test_intelligence_per_provider.py        passed
tests/test_intelligence_sources/test_proven_pattern.py  passed
tests/test_intelligence_recency.py             5 skipped (canaries, no runtime DB in CI)
Total: 130 passed, 5 skipped, 6 pre-existing failures (confirmed on main before patch)
```

Pre-existing failures (`TestCodeAnchorInjection`, `TestOperatorMemoryInjection`, `TestSchemaSectionInjection`) fail on `adr_indexer._INDEX` and `_DIRECT_INJECTION_CLASSES` import — neither touched by this PR. Verified identical on `main` before patch.

## Operator instructions — 7-day soak + canary graduation

After merge, monitor `intelligence_injections` in the runtime coord DB:

```sql
SELECT task_class,
       COUNT(*) AS total_injections,
       COUNT(DISTINCT items_json) AS unique_payloads,
       ROUND(1.0 * COUNT(DISTINCT items_json) / COUNT(*), 3) AS unique_ratio
FROM intelligence_injections
WHERE injected_at >= datetime('now', '-7 days')
  AND task_class = 'coding_interactive'
GROUP BY task_class;
```

**Graduate canary to `strict=True`** in `tests/test_intelligence_recency.py` when:
- `unique_ratio > 0.40` sustained over 7 days
- `total_injections >= 20` for `coding_interactive`

Until then `strict=False` prevents CI breakage in case the runtime DB is not yet refreshed.

**Tune suppression window** via `VNX_INTEL_SUPPRESS_WINDOW` env var (default 10). Set lower (e.g. 5) if the proven_pattern pool is very small and fallback vangnet fires frequently (visible as DEBUG log lines containing "recency vangnet").

🤖 Generated with [Claude Code](https://claude.com/claude-code)