### PR TITLE
fix(t0-skill): correct dead dispatch path + intelligence.sh paths + §12 prefixes

### DIFF
--- a/skills/t0-orchestrator/SKILL.md
+++ b/skills/t0-orchestrator/SKILL.md
@@ -444,7 +444,7 @@ For any feature work (code edit + PR + tests), dispatches to T1/T2/T3 MUST go vi
 ```bash
 export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
 
-python3 .claude/vnx-system/scripts/lib/subprocess_dispatch.py \
+python3 scripts/lib/subprocess_dispatch.py \
   --terminal-id T1 \
   --dispatch-id "$(date +%Y%m%d-%H%M%S)-<slug>" \
   --model sonnet \
@@ -511,22 +511,22 @@ python3 scripts/validate_skill.py --list
 
 ## 12. Recommended Script Toolbox
 
-1. `scripts/queue_status.sh`
+1. `.claude/skills/t0-orchestrator/scripts/queue_status.sh`
 - queue/staging/terminal summary
 
-2. `scripts/deliverable_review.sh`
+2. `.claude/skills/t0-orchestrator/scripts/deliverable_review.sh`
 - PR-focused open-item checks
 
-3. `scripts/dispatch_guard.sh`
+3. `.claude/skills/t0-orchestrator/scripts/dispatch_guard.sh`
 - go/no-go guard
 
-4. `scripts/provider_capabilities.sh`
+4. `.claude/skills/t0-orchestrator/scripts/provider_capabilities.sh`
 - provider constraints and routing hints
 
-5. `scripts/staging_helper.sh`
+5. `.claude/skills/t0-orchestrator/scripts/staging_helper.sh`
 - staging convenience wrapper
 
-6. `scripts/intelligence.sh`
+6. `.claude/skills/t0-orchestrator/scripts/intelligence.sh`
 - intelligence read helpers
 
 ## 13. Decision Outputs

--- a/skills/t0-orchestrator/scripts/intelligence.sh
+++ b/skills/t0-orchestrator/scripts/intelligence.sh
@@ -2,9 +2,9 @@
 # Intelligence queries for T0 orchestration
 # Live state monitoring and orchestration pattern queries
 
-INTEL_SCRIPT=".claude/vnx-system/scripts/gather_intelligence.py"
-STATE_DIR=".claude/vnx-system/state"
-DISPATCH_DIR=".claude/vnx-system/dispatches"
+INTEL_SCRIPT="scripts/gather_intelligence.py"
+STATE_DIR=".vnx-data/state"
+DISPATCH_DIR=".vnx-data/dispatches"
 
 # ============================================
 # LIVE STATE QUERIES
@@ -30,7 +30,7 @@ check_queue() {
 
 # Check open items digest (deliverables)
 check_open_items() {
-    python3 ".claude/vnx-system/scripts/open_items_manager.py" digest 2>/dev/null || echo "No open items data"
+    python3 "scripts/open_items_manager.py" digest 2>/dev/null || echo "No open items data"
 }
 
 # Get orchestration recommendations


### PR DESCRIPTION
## Summary
Fixes two launch-blockers in the repo-shipped t0-orchestrator skill found by a governed tmux-lane audit: SKILL.md §9.2 cited a non-existent `.claude/vnx-system/scripts/lib/subprocess_dispatch.py` (T0 following it hit No such file), and intelligence.sh pointed all paths at the removed `.claude/vnx-system/` layout (every function failed). Also fixed §12 toolbox paths missing the skill-scripts prefix.

## Changes
- SKILL.md §9.2: dispatch path -> `scripts/lib/subprocess_dispatch.py`
- SKILL.md §12: all six toolbox entries prefixed `.claude/skills/t0-orchestrator/scripts/`
- intelligence.sh: `.claude/vnx-system/` -> live `.vnx-data/state/`, `.vnx-data/dispatches/`, `scripts/gather_intelligence.py`, `scripts/open_items_manager.py` (audit's "gather_intelligence.py is gone" was wrong — it exists; path corrected)

## Verification
No residual `.claude/vnx-system/` refs in SKILL.md or intelligence.sh on this branch. Built via tmux interactive lane (receipt: 20260613-t0skill-fix). codex gate pending.

## Open Items
CLAUDE.md tense/bug-list fixes (rc9 shipped, --receipts-file no-op removed) live as a local working-tree change, not in this PR (worker mis-flagged CLAUDE.md as gitignored). To be committed separately.