### PR TITLE
PR-0 (future-state): enforced test-isolation guard (no test mutates the live DB)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1363,7 +1363,8 @@ def _build_strategic_state_heavy(
 def _pytest_db_isolation_guard(state_dir: Path) -> None:
     """Refuse to read/mutate a DB when running under pytest without explicit isolation.
 
-    Active only when PYTEST_CURRENT_TEST is set. Two conditions must hold:
+    Active whenever pytest is loaded (collection OR execution), so an
+    import-time module-level call is also guarded. Two conditions must hold:
     1. VNX_DATA_DIR_EXPLICIT=1 must be set.
     2. The resolved state_dir must be under tempfile.gettempdir() and NOT
        under ~/.vnx-data.
@@ -1371,9 +1372,9 @@ def _pytest_db_isolation_guard(state_dir: Path) -> None:
     The second check prevents tests from passing the flag while still resolving
     to the real canonical data location — a false sense of isolation.
 
-    Production is unaffected: PYTEST_CURRENT_TEST is only set by pytest.
+    Production is unaffected: pytest is never in sys.modules outside a test run.
     """
-    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+    if os.environ.get("PYTEST_CURRENT_TEST") is None and "pytest" not in sys.modules:
         return
     if os.environ.get("VNX_DATA_DIR_EXPLICIT") != "1":
         raise RuntimeError(

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1363,21 +1363,45 @@ def _build_strategic_state_heavy(
 def _pytest_db_isolation_guard(state_dir: Path) -> None:
     """Refuse to read/mutate a DB when running under pytest without explicit isolation.
 
-    Active only when PYTEST_CURRENT_TEST is set. Callers must set
-    VNX_DATA_DIR_EXPLICIT=1 (via the _fsr_migration_module_isolation fixture
-    in tests/conftest.py) to signal proper isolation is in place.
+    Active only when PYTEST_CURRENT_TEST is set. Two conditions must hold:
+    1. VNX_DATA_DIR_EXPLICIT=1 must be set.
+    2. The resolved state_dir must be under tempfile.gettempdir() and NOT
+       under ~/.vnx-data.
+
+    The second check prevents tests from passing the flag while still resolving
+    to the real canonical data location — a false sense of isolation.
+
     Production is unaffected: PYTEST_CURRENT_TEST is only set by pytest.
     """
     if os.environ.get("PYTEST_CURRENT_TEST") is None:
         return
-    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
-        return
-    raise RuntimeError(
-        "[TEST ISOLATION GUARD] build_t0_state() called under pytest "
-        "without VNX_DATA_DIR_EXPLICIT=1. This would read/mutate the live database. "
-        "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
-        "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") != "1":
+        raise RuntimeError(
+            "[TEST ISOLATION GUARD] build_t0_state() called under pytest "
+            "without VNX_DATA_DIR_EXPLICIT=1. This would read/mutate the live database. "
+            "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
+            "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+        )
+    # Flag is set — validate the resolved state_dir is actually temp-owned.
+    resolved = state_dir.resolve()
+    tmp_root = Path(tempfile.gettempdir()).resolve()
+    canonical = (Path.home() / ".vnx-data").resolve()
+    _sep = os.sep
+    under_tmp = (
+        str(resolved) == str(tmp_root)
+        or str(resolved).startswith(str(tmp_root) + _sep)
     )
+    under_canonical = (
+        str(resolved) == str(canonical)
+        or str(resolved).startswith(str(canonical) + _sep)
+    )
+    if under_canonical or not under_tmp:
+        raise RuntimeError(
+            f"[TEST ISOLATION GUARD] VNX_DATA_DIR_EXPLICIT=1 is set but state_dir "
+            f"'{resolved}' is NOT under the system temp directory ('{tmp_root}'). "
+            "Setting the flag while pointing at the canonical ~/.vnx-data location is unsafe. "
+            "Ensure state_dir is a pytest-managed tmp_path."
+        )
 
 
 def build_t0_state(

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1360,11 +1360,36 @@ def _build_strategic_state_heavy(
 # Main builder
 # ---------------------------------------------------------------------------
 
+def _pytest_db_isolation_guard(state_dir: Path) -> None:
+    """Refuse to read/mutate a DB when running under pytest without explicit isolation.
+
+    Active only when PYTEST_CURRENT_TEST is set. Callers must set
+    VNX_DATA_DIR_EXPLICIT=1 (via the _fsr_migration_module_isolation fixture
+    in tests/conftest.py) to signal proper isolation is in place.
+    Production is unaffected: PYTEST_CURRENT_TEST is only set by pytest.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        return
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+        return
+    raise RuntimeError(
+        "[TEST ISOLATION GUARD] build_t0_state() called under pytest "
+        "without VNX_DATA_DIR_EXPLICIT=1. This would read/mutate the live database. "
+        "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
+        "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+    )
+
+
 def build_t0_state(
     state_dir: Path,
     dispatch_dir: Path,
 ) -> Dict[str, Any]:
-    """Build the full T0 state document. Never raises — errors produce safe fallbacks."""
+    """Build the full T0 state document. Never raises — errors produce safe fallbacks.
+
+    Raises RuntimeError under pytest when VNX_DATA_DIR_EXPLICIT=1 is not set
+    (test isolation guard, R8.6 / PR-0).
+    """
+    _pytest_db_isolation_guard(state_dir)
     start = time.monotonic()
 
     # Wave 1: resolve project_id for shadow-read dispatchers

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import sys
+import tempfile
 import warnings
 from pathlib import Path
 
@@ -44,25 +45,49 @@ import schema_migration
 # Test isolation guard (R8.6 / PR-0) — active only under pytest
 # ---------------------------------------------------------------------------
 
-def _pytest_db_isolation_guard() -> None:
+def _pytest_db_isolation_guard(project_root: Path) -> None:
     """Refuse to open any DB when running under pytest without explicit isolation.
 
     Active only when PYTEST_CURRENT_TEST is set (i.e. inside a pytest process).
-    Callers must set VNX_DATA_DIR_EXPLICIT=1 (and VNX_DATA_DIR=<tmp path>)
-    to signal that the _fsr_migration_module_isolation fixture is active.
+    Two conditions must hold:
+    1. VNX_DATA_DIR_EXPLICIT=1 must be set.
+    2. The resolved .vnx-data root derived from project_root must be under
+       tempfile.gettempdir() and NOT under ~/.vnx-data.
+
+    The second check prevents tests from passing the flag while still resolving
+    to the real canonical data location — a false sense of isolation.
 
     Production code is never affected: PYTEST_CURRENT_TEST is only set by pytest.
     """
     if os.environ.get("PYTEST_CURRENT_TEST") is None:
         return
-    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
-        return
-    raise RuntimeError(
-        "[TEST ISOLATION GUARD] migrate_future_system.run() called under pytest "
-        "without VNX_DATA_DIR_EXPLICIT=1. This would open the live database. "
-        "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
-        "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") != "1":
+        raise RuntimeError(
+            "[TEST ISOLATION GUARD] migrate_future_system.run() called under pytest "
+            "without VNX_DATA_DIR_EXPLICIT=1. This would open the live database. "
+            "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
+            "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+        )
+    # Flag is set — validate the resolved data root is actually temp-owned.
+    data_root = (project_root / ".vnx-data").resolve()
+    tmp_root = Path(tempfile.gettempdir()).resolve()
+    canonical = (Path.home() / ".vnx-data").resolve()
+    _sep = os.sep
+    under_tmp = (
+        str(data_root) == str(tmp_root)
+        or str(data_root).startswith(str(tmp_root) + _sep)
     )
+    under_canonical = (
+        str(data_root) == str(canonical)
+        or str(data_root).startswith(str(canonical) + _sep)
+    )
+    if under_canonical or not under_tmp:
+        raise RuntimeError(
+            f"[TEST ISOLATION GUARD] VNX_DATA_DIR_EXPLICIT=1 is set but the resolved "
+            f"data root '{data_root}' is NOT under the system temp directory ('{tmp_root}'). "
+            "Setting the flag while pointing at the canonical ~/.vnx-data location is unsafe. "
+            "Pass a pytest tmp_path-based project_root to migrate_future_system.run()."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -558,10 +583,9 @@ def apply_migration_v30(conn: sqlite3.Connection, project_root: Path) -> None:
 
 def run(project_root: Path | None = None) -> None:
     """Apply track layer migrations: 0022, 0024, 0027, 0028, 0029, 0030."""
-    _pytest_db_isolation_guard()
-
     if project_root is None:
         project_root = resolve_project_root(__file__)
+    _pytest_db_isolation_guard(project_root)
 
     state_dir = project_root / ".vnx-data" / "state"
     state_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -59,7 +59,7 @@ def _pytest_db_isolation_guard(project_root: Path) -> None:
 
     Production code is never affected: PYTEST_CURRENT_TEST is only set by pytest.
     """
-    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+    if os.environ.get("PYTEST_CURRENT_TEST") is None and "pytest" not in sys.modules:
         return
     if os.environ.get("VNX_DATA_DIR_EXPLICIT") != "1":
         raise RuntimeError(

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -18,6 +18,7 @@ Steps:
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import warnings
@@ -37,6 +38,31 @@ if str(_LIB) not in sys.path:
 
 from project_root import resolve_project_root
 import schema_migration
+
+
+# ---------------------------------------------------------------------------
+# Test isolation guard (R8.6 / PR-0) — active only under pytest
+# ---------------------------------------------------------------------------
+
+def _pytest_db_isolation_guard() -> None:
+    """Refuse to open any DB when running under pytest without explicit isolation.
+
+    Active only when PYTEST_CURRENT_TEST is set (i.e. inside a pytest process).
+    Callers must set VNX_DATA_DIR_EXPLICIT=1 (and VNX_DATA_DIR=<tmp path>)
+    to signal that the _fsr_migration_module_isolation fixture is active.
+
+    Production code is never affected: PYTEST_CURRENT_TEST is only set by pytest.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        return
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+        return
+    raise RuntimeError(
+        "[TEST ISOLATION GUARD] migrate_future_system.run() called under pytest "
+        "without VNX_DATA_DIR_EXPLICIT=1. This would open the live database. "
+        "Ensure the _fsr_migration_module_isolation fixture is active (tests/conftest.py), "
+        "or set VNX_DATA_DIR_EXPLICIT=1 and VNX_DATA_DIR=<tmp_path> in your test."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +558,8 @@ def apply_migration_v30(conn: sqlite3.Connection, project_root: Path) -> None:
 
 def run(project_root: Path | None = None) -> None:
     """Apply track layer migrations: 0022, 0024, 0027, 0028, 0029, 0030."""
+    _pytest_db_isolation_guard()
+
     if project_root is None:
         project_root = resolve_project_root(__file__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,25 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 import uuid
 from pathlib import Path
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level isolation pin (import-time / collection-time guard)
+# ---------------------------------------------------------------------------
+# _pytest_db_isolation_guard detects pytest via sys.modules (active from
+# collection onward, before PYTEST_CURRENT_TEST is set). This pin ensures
+# VNX_DATA_DIR_EXPLICIT=1 and a temp VNX_DATA_DIR are in place from the
+# moment conftest loads, so any module-level run() call during collection
+# hits the guard instead of touching ~/.vnx-data.
+# Per-module (_fsr_migration_module_isolation) and per-test (_vnx_data_dir_isolation)
+# fixtures re-pin to tighter tmp dirs; this is the fallback floor.
+_CONFTEST_ISOLATION_TMP = tempfile.mkdtemp(prefix="vnx_conftest_")
+os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+os.environ["VNX_DATA_DIR"] = _CONFTEST_ISOLATION_TMP
 
 # Make scripts/lib importable for all tests
 _LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ test_vnx_snapshot_tooling.py, and the burn-in CI workflow tests.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import uuid
 from pathlib import Path
@@ -27,6 +28,40 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "integration: end-to-end integration tests (slower; opt-in via -m integration)",
     )
+
+
+# ---------------------------------------------------------------------------
+# Future-state / migration module-level isolation (R8.6, PR-0)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def _fsr_migration_module_isolation(tmp_path_factory: pytest.TempPathFactory):
+    """Module-scoped isolation for future-state and migration test modules.
+
+    Ensures VNX_DATA_DIR_EXPLICIT=1 + VNX_DATA_DIR pointing at a per-module
+    tmp dir for the duration of each test module. Complements the per-function
+    _vnx_data_dir_isolation fixture below.
+
+    Cannot use monkeypatch (function-scoped); uses os.environ directly and
+    restores it via yield teardown.
+
+    Targets: test_future_state_reconciliation.py, test_migrate_future_system.py,
+    test_migrate_0022_preflight.py — and is harmlessly applied to all other
+    modules in this directory (extra isolation is always safe).
+    """
+    isolated = tmp_path_factory.mktemp("_fsr_module")
+    _prev = {
+        "VNX_DATA_DIR": os.environ.get("VNX_DATA_DIR"),
+        "VNX_DATA_DIR_EXPLICIT": os.environ.get("VNX_DATA_DIR_EXPLICIT"),
+    }
+    os.environ["VNX_DATA_DIR"] = str(isolated)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+    yield isolated
+    for key, val in _prev.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fsr_isolation_guard.py
+++ b/tests/test_fsr_isolation_guard.py
@@ -1,0 +1,224 @@
+"""tests/test_fsr_isolation_guard.py — R8.6 / PR-0 acceptance tests.
+
+Verifies the enforced test-isolation guard for migrate_future_system.run()
+and build_t0_state():
+
+(a) A deliberately mis-written call (VNX_DATA_DIR_EXPLICIT not set) fails
+    with the guard RuntimeError.
+(b) A correctly-pinned call (VNX_DATA_DIR_EXPLICIT=1 via autouse fixture)
+    passes the guard and proceeds to actual logic.
+(c) CI canary: canonical ~/.vnx-data/vnx-dev/state DB file hashes are
+    unchanged after invoking migration helpers in an isolated tmp dir.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+_LIB = _SCRIPTS / "lib"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _get_migrate_module():
+    spec = importlib.util.spec_from_file_location(
+        "migrate_future_system",
+        _SCRIPTS / "migrate_future_system.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_v21_project(tmp_path: Path) -> Path:
+    """Minimal project with a v21-style dispatches table (passes preflight)."""
+    project_dir = tmp_path / "v21project"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE coordination_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT,
+            event_type  TEXT,
+            entity_type TEXT,
+            entity_id   TEXT,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT,
+            reason      TEXT,
+            metadata_json TEXT,
+            occurred_at TEXT,
+            project_id  TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return project_dir
+
+
+# ---------------------------------------------------------------------------
+# (a) Mis-written test: guard fires when VNX_DATA_DIR_EXPLICIT is absent
+# ---------------------------------------------------------------------------
+
+class TestIsolationGuardFires:
+    """Guard raises RuntimeError when VNX_DATA_DIR_EXPLICIT=1 is not set under pytest."""
+
+    def test_guard_fires_without_isolation_pin(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Simulates a mis-written test: VNX_DATA_DIR_EXPLICIT removed, run() blocked.
+
+        The global autouse fixture normally sets this flag. Removing it with
+        monkeypatch simulates what would happen if a test author forgot to
+        activate the isolation fixture (or wrote the test before #856/#PR-0).
+        """
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+        mod = _get_migrate_module()
+        project_dir = _make_v21_project(tmp_path)
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            mod.run(project_dir)
+
+    def test_guard_error_message_is_actionable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Guard error message names the fixture so the developer knows how to fix it."""
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+        mod = _get_migrate_module()
+        project_dir = _make_v21_project(tmp_path)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mod.run(project_dir)
+
+        msg = str(exc_info.value)
+        assert "_fsr_migration_module_isolation" in msg or "VNX_DATA_DIR_EXPLICIT" in msg
+
+
+# ---------------------------------------------------------------------------
+# (b) Correctly-pinned test: guard passes, run() proceeds to actual logic
+# ---------------------------------------------------------------------------
+
+class TestIsolationGuardPasses:
+    """With VNX_DATA_DIR_EXPLICIT=1 (from autouse fixture), guard lets run() proceed."""
+
+    def test_guard_passes_with_isolation_pin(self, tmp_path: Path) -> None:
+        """VNX_DATA_DIR_EXPLICIT=1 is set by the autouse fixture; guard is satisfied."""
+        assert os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1", (
+            "autouse fixture _fsr_migration_module_isolation must set VNX_DATA_DIR_EXPLICIT=1"
+        )
+
+        mod = _get_migrate_module()
+        project_dir = _make_v21_project(tmp_path)
+
+        try:
+            mod.run(project_dir)
+        except RuntimeError as exc:
+            assert "TEST ISOLATION GUARD" not in str(exc), (
+                f"Isolation guard must not fire when VNX_DATA_DIR_EXPLICIT=1 is set: {exc}"
+            )
+
+    def test_explicit_env_override_also_passes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Explicitly setting VNX_DATA_DIR_EXPLICIT=1 (not via autouse) also passes."""
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "_override"))
+
+        mod = _get_migrate_module()
+        project_dir = _make_v21_project(tmp_path)
+
+        try:
+            mod.run(project_dir)
+        except RuntimeError as exc:
+            assert "TEST ISOLATION GUARD" not in str(exc), (
+                f"Guard should not fire when VNX_DATA_DIR_EXPLICIT=1 is explicitly set: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (c) CI canary: canonical DB hash unchanged after migration helpers run
+# ---------------------------------------------------------------------------
+
+class TestCanonicalDbHashUnchanged:
+    """Prove the canonical ~/.vnx-data live DB is untouched by isolated migration runs."""
+
+    def _canonical_db_files(self) -> list[Path]:
+        canonical_dir = Path.home() / ".vnx-data" / "vnx-dev" / "state"
+        if not canonical_dir.exists():
+            return []
+        return sorted(canonical_dir.glob("*.db"))
+
+    def _compute_hashes(self, db_files: list[Path]) -> dict[str, str]:
+        return {
+            f.name: hashlib.sha256(f.read_bytes()).hexdigest()
+            for f in db_files
+        }
+
+    def test_canonical_db_hash_unchanged_after_migration_run(
+        self, tmp_path: Path
+    ) -> None:
+        """Canonical DB hashes are identical before and after running migration in isolation.
+
+        If the canonical DB is absent (CI, fresh env), this test is skipped gracefully.
+        """
+        db_files = self._canonical_db_files()
+        if not db_files:
+            pytest.skip("Canonical DB absent — CI or fresh environment, skipping canary")
+
+        before = self._compute_hashes(db_files)
+
+        # Run a representative migration helper in isolation.
+        # VNX_DATA_DIR_EXPLICIT=1 is already set by the autouse fixture,
+        # so the guard is satisfied and run() writes only to tmp_path.
+        mod = _get_migrate_module()
+        project_dir = _make_v21_project(tmp_path)
+        try:
+            mod.run(project_dir)
+        except Exception:
+            pass  # migration may raise for reasons unrelated to canonical DB
+
+        after = self._compute_hashes(db_files)
+
+        assert after == before, (
+            "CANARY FAILURE: Canonical DB was mutated during isolated migration run! "
+            "The TEST ISOLATION GUARD may have failed to protect the live database. "
+            f"Changed files: {[k for k in before if before[k] != after.get(k)]}"
+        )

--- a/tests/test_fsr_isolation_guard.py
+++ b/tests/test_fsr_isolation_guard.py
@@ -131,6 +131,23 @@ class TestIsolationGuardFires:
         msg = str(exc_info.value)
         assert "_fsr_migration_module_isolation" in msg or "VNX_DATA_DIR_EXPLICIT" in msg
 
+    def test_flag_set_but_canonical_path_still_trips_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VNX_DATA_DIR_EXPLICIT=1 pointing at the real ~/.vnx-data still trips the guard.
+
+        The flag alone is insufficient — the resolved .vnx-data root must also be
+        a temp-owned directory, not the canonical production location. This test
+        proves that setting the flag while passing Path.home() as project_root
+        (whose .vnx-data resolves to the real live directory) still raises.
+        """
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        mod = _get_migrate_module()
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            mod.run(Path.home())
+
 
 # ---------------------------------------------------------------------------
 # (b) Correctly-pinned test: guard passes, run() proceeds to actual logic
@@ -184,7 +201,10 @@ class TestCanonicalDbHashUnchanged:
         canonical_dir = Path.home() / ".vnx-data" / "vnx-dev" / "state"
         if not canonical_dir.exists():
             return []
-        return sorted(canonical_dir.glob("*.db"))
+        db_files: list[Path] = []
+        for pattern in ("*.db", "*.db-wal", "*.db-shm", "*.db-journal"):
+            db_files.extend(canonical_dir.glob(pattern))
+        return sorted(db_files)
 
     def _compute_hashes(self, db_files: list[Path]) -> dict[str, str]:
         return {
@@ -210,10 +230,7 @@ class TestCanonicalDbHashUnchanged:
         # so the guard is satisfied and run() writes only to tmp_path.
         mod = _get_migrate_module()
         project_dir = _make_v21_project(tmp_path)
-        try:
-            mod.run(project_dir)
-        except Exception:
-            pass  # migration may raise for reasons unrelated to canonical DB
+        mod.run(project_dir)
 
         after = self._compute_hashes(db_files)
 

--- a/tests/test_fsr_isolation_guard.py
+++ b/tests/test_fsr_isolation_guard.py
@@ -148,6 +148,26 @@ class TestIsolationGuardFires:
         with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
             mod.run(Path.home())
 
+    def test_guard_blocks_at_collection_time_via_sys_modules(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard fires via sys.modules detection even when PYTEST_CURRENT_TEST is absent.
+
+        PYTEST_CURRENT_TEST is set only during test execution, not during collection.
+        Removing it here simulates a module-level run() call at import/collection time.
+        The guard must detect pytest via sys.modules (true from collection onward)
+        to block an unguarded run() against ~/.vnx-data before any fixture runs.
+        """
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+        assert "pytest" in sys.modules, "pytest must be in sys.modules during test execution"
+
+        mod = _get_migrate_module()
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            mod.run(Path.home())
+
 
 # ---------------------------------------------------------------------------
 # (b) Correctly-pinned test: guard passes, run() proceeds to actual logic
@@ -157,7 +177,11 @@ class TestIsolationGuardPasses:
     """With VNX_DATA_DIR_EXPLICIT=1 (from autouse fixture), guard lets run() proceed."""
 
     def test_guard_passes_with_isolation_pin(self, tmp_path: Path) -> None:
-        """VNX_DATA_DIR_EXPLICIT=1 is set by the autouse fixture; guard is satisfied."""
+        """VNX_DATA_DIR_EXPLICIT=1 is set by the autouse fixture; guard is satisfied.
+
+        Any exception raised by run() (guard or otherwise) fails this test — the
+        try/except pattern that masked unrelated RuntimeErrors has been removed.
+        """
         assert os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1", (
             "autouse fixture _fsr_migration_module_isolation must set VNX_DATA_DIR_EXPLICIT=1"
         )
@@ -165,29 +189,23 @@ class TestIsolationGuardPasses:
         mod = _get_migrate_module()
         project_dir = _make_v21_project(tmp_path)
 
-        try:
-            mod.run(project_dir)
-        except RuntimeError as exc:
-            assert "TEST ISOLATION GUARD" not in str(exc), (
-                f"Isolation guard must not fire when VNX_DATA_DIR_EXPLICIT=1 is set: {exc}"
-            )
+        mod.run(project_dir)
 
     def test_explicit_env_override_also_passes(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Explicitly setting VNX_DATA_DIR_EXPLICIT=1 (not via autouse) also passes."""
+        """Explicitly setting VNX_DATA_DIR_EXPLICIT=1 (not via autouse) also passes.
+
+        Any exception raised by run() (guard or otherwise) fails this test — the
+        try/except pattern that masked unrelated RuntimeErrors has been removed.
+        """
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
         monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "_override"))
 
         mod = _get_migrate_module()
         project_dir = _make_v21_project(tmp_path)
 
-        try:
-            mod.run(project_dir)
-        except RuntimeError as exc:
-            assert "TEST ISOLATION GUARD" not in str(exc), (
-                f"Guard should not fire when VNX_DATA_DIR_EXPLICIT=1 is explicitly set: {exc}"
-            )
+        mod.run(project_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -217,13 +235,17 @@ class TestCanonicalDbHashUnchanged:
     ) -> None:
         """Canonical DB hashes are identical before and after running migration in isolation.
 
+        Re-globs the canonical dir AFTER the operation to also catch newly-created
+        files (WAL, SHM, journal entries) that the before-list would otherwise miss.
+
         If the canonical DB is absent (CI, fresh env), this test is skipped gracefully.
         """
-        db_files = self._canonical_db_files()
-        if not db_files:
+        db_files_before = self._canonical_db_files()
+        if not db_files_before:
             pytest.skip("Canonical DB absent — CI or fresh environment, skipping canary")
 
-        before = self._compute_hashes(db_files)
+        before_names = {f.name for f in db_files_before}
+        before_hashes = self._compute_hashes(db_files_before)
 
         # Run a representative migration helper in isolation.
         # VNX_DATA_DIR_EXPLICIT=1 is already set by the autouse fixture,
@@ -232,10 +254,20 @@ class TestCanonicalDbHashUnchanged:
         project_dir = _make_v21_project(tmp_path)
         mod.run(project_dir)
 
-        after = self._compute_hashes(db_files)
+        # Re-glob after to detect newly created canonical files.
+        db_files_after = self._canonical_db_files()
+        after_names = {f.name for f in db_files_after}
+        after_hashes = self._compute_hashes(db_files_after)
 
-        assert after == before, (
+        new_files = after_names - before_names
+        assert not new_files, (
+            "CANARY FAILURE: New canonical DB files were created during isolated migration run! "
+            "The TEST ISOLATION GUARD may have failed to protect the live database. "
+            f"New files: {sorted(new_files)}"
+        )
+
+        assert after_hashes == before_hashes, (
             "CANARY FAILURE: Canonical DB was mutated during isolated migration run! "
             "The TEST ISOLATION GUARD may have failed to protect the live database. "
-            f"Changed files: {[k for k in before if before[k] != after.get(k)]}"
+            f"Changed files: {[k for k in before_hashes if before_hashes[k] != after_hashes.get(k)]}"
         )


### PR DESCRIPTION
## Summary
First deliverable of the approved future-state PRD (claudedocs/PRD-future-state-reconciliation-v1.1.md §5 PR-0 / R8.6). Enforces that no test can open/mutate the real ~/.vnx-data live DB — the prerequisite that protects every subsequent migration PR's tests.

## Changes
- `tests/conftest.py`: autouse fixture pins VNX_DATA_DIR_EXPLICIT=1 + tmp VNX_DATA_DIR for future-state/migration test modules (extends the #856 events guard, does not duplicate)
- `scripts/migrate_future_system.py` + `scripts/build_t0_state.py`: under pytest (PYTEST_CURRENT_TEST), run() refuses to open a DB unless the resolved root is a test-owned temp dir
- `tests/test_fsr_isolation_guard.py`: negative (unpinned → guard raises) + positive + canonical-DB-hash-unchanged canary

## Verification
Built via tmux interactive lane (receipt: 20260613-fsr-pr0). codex gate pending.

## Open Items
PR-A1..E follow per the PRD dependency graph. Note: shares build_t0_state.py with PR-E (kanban) — merge order PR-0 then PR-E.