### PR TITLE
PR-E (future-state): kanban honesty — degraded signal, no silent drops, staleness truth

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1050,10 +1050,17 @@ def _read_dir_dispatch(subdir: Path) -> tuple[Dict[str, Any], bool]:
         started_at = None
     try:
         data = _safe_json(subdir / "manifest.json")
+        if data is None:
+            # Missing file or non-object JSON — flag as artifact error (Warning 3)
+            return {
+                "dispatch_id": dispatch_id,
+                "track": None, "gate": None, "started_at": started_at,
+                "artifact_error": "manifest missing or non-object",
+            }, True
         return {
             "dispatch_id": dispatch_id,
-            "track": (data or {}).get("track"),
-            "gate": (data or {}).get("gate"),
+            "track": data.get("track"),
+            "gate": data.get("gate"),
             "started_at": started_at,
         }, False
     except json.JSONDecodeError as exc:
@@ -1838,13 +1845,21 @@ def _resolve_output_path(args: argparse.Namespace) -> Path:
 
 
 def _write_all_state_outputs(
-    state: Dict[str, Any], state_dir: Path, strategic_heavy: Any
+    state: Dict[str, Any], state_dir: Path, strategic_heavy: Any,
+    *,
+    project_root: Optional[Path] = None,
+    skip_paths: Optional[set] = None,
 ) -> bool:
     """Write secondary outputs (index, detail, brief, status). All best-effort.
 
     Returns True if any core state-file write failed (caller should mark build degraded).
     Optional helper modules (build_project_status, build_feature_plan) are not
     counted as write failures when unavailable — only atomic state-file writes are.
+
+    project_root: project root for FEATURE_PLAN.md resolution (defaults to _PROJECT_ROOT).
+                  Tests pass an isolated tmp path to prevent touching the real file (Error 2).
+    skip_paths: resolved Path objects to skip (prevents double-writing the primary output
+                when --format brief is used; caller passes {output_path.resolve()}).
     """
     write_failed = False
     try:
@@ -1872,20 +1887,25 @@ def _write_all_state_outputs(
     except Exception as exc:
         log.warning("Failed to write pr_queue_state.json: %s", exc)
         write_failed = True
+    # Warning 4: guard against double-write when output_path == brief_path
+    brief_path = state_dir / "t0_brief.json"
+    if skip_paths is None or brief_path.resolve() not in skip_paths:
+        try:
+            _write_atomic(brief_path, _state_to_brief(state))
+        except Exception as exc:
+            log.warning("Failed to write t0_brief.json: %s", exc)
+            write_failed = True
+    effective_root = project_root if project_root is not None else _PROJECT_ROOT
     try:
-        _write_atomic(state_dir / "t0_brief.json", _state_to_brief(state))
-    except Exception as exc:
-        log.warning("Failed to write t0_brief.json: %s", exc)
-        write_failed = True
-    try:
-        sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+        sys.path.insert(0, str(effective_root / "scripts"))
         from build_project_status import write_project_status
         write_project_status(state_dir)
     except Exception as exc:
         log.debug("build_project_status unavailable or failed (non-critical): %s", exc)
+    # Error 2: derive FEATURE_PLAN.md path from effective_root so tests can isolate it
     try:
         from build_feature_plan import write_feature_plan
-        write_feature_plan(_PROJECT_ROOT / "FEATURE_PLAN.md", state_dir=state_dir)
+        write_feature_plan(effective_root / "FEATURE_PLAN.md", state_dir=state_dir)
     except Exception as exc:
         log.debug("build_feature_plan unavailable or failed (non-critical): %s", exc)
     return write_failed
@@ -1945,7 +1965,27 @@ def main() -> int:
         _strategic_heavy = state.pop("_strategic_state_heavy", None)
         payload = _state_to_brief(state) if args.format == "brief" else state
         _write_atomic(output_path, payload)
-        write_failed = _write_all_state_outputs(state, _STATE_DIR, _strategic_heavy)
+        write_failed = _write_all_state_outputs(
+            state, _STATE_DIR, _strategic_heavy,
+            project_root=_PROJECT_ROOT,
+            skip_paths={output_path.resolve()},
+        )
+        # Error 1: patch health + re-persist BEFORE the beacon fires so on-disk state is honest
+        if write_failed:
+            sh = state.get("system_health") or {}
+            if sh.get("status") not in ("degraded", "failed"):
+                state["system_health"] = {**sh, "status": "degraded"}
+            try:
+                re_payload = _state_to_brief(state) if args.format == "brief" else state
+                _write_atomic(output_path, re_payload)
+            except Exception as exc:
+                log.warning("Failed to re-persist patched state after write errors: %s", exc)
+            brief_path = _STATE_DIR / "t0_brief.json"
+            if brief_path.resolve() != output_path.resolve():
+                try:
+                    _write_atomic(brief_path, _state_to_brief(state))
+                except Exception as exc:
+                    log.warning("Failed to re-write brief with degraded status: %s", exc)
         elapsed = time.monotonic() - t_start
         _build_succeeded = True
     except Exception as exc:
@@ -1954,15 +1994,10 @@ def main() -> int:
     if _build_succeeded:
         _emit_build_signal(output_path, elapsed)
 
-    _emit_health_beacon(output_path, args.format, elapsed, _build_succeeded)
+    # Error 1: beacon status reflects both build success AND write health
+    _emit_health_beacon(output_path, args.format, elapsed, _build_succeeded and not write_failed)
 
-    # R6.1/Fix-3: non-zero exit when DB health, artifact errors, or write failures degrade state.
-    # write_failed is folded into system_health before the check so the health dict is honest.
     if _build_succeeded and state is not None:
-        if write_failed:
-            sh = state.get("system_health") or {}
-            if sh.get("status") not in ("degraded", "failed"):
-                state["system_health"] = {**sh, "status": "degraded"}
         sh_status = (state.get("system_health") or {}).get("status", "healthy")
         if sh_status in ("degraded", "failed"):
             return 1

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -99,11 +99,14 @@ def _now_iso() -> str:
 
 
 def _safe_json(path: Path) -> Optional[Dict[str, Any]]:
+    """Load JSON from path. Returns None on OSError (absent file).
+    Raises json.JSONDecodeError if the file exists but contains malformed JSON (R7.3)."""
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else None
-    except Exception:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
         return None
+    data = json.loads(text)  # propagates JSONDecodeError to caller
+    return data if isinstance(data, dict) else None
 
 
 def _central_state_dir_for(state_dir: Path) -> Optional[Path]:
@@ -164,6 +167,76 @@ def _count_md(directory: Path) -> int:
         return sum(1 for f in directory.iterdir() if f.is_file() and f.suffix == ".md")
     except Exception:
         return 0
+
+
+# ---------------------------------------------------------------------------
+# DB health classification (R6.1)
+# ---------------------------------------------------------------------------
+
+_PREMIGRATION_OPS_MSGS: frozenset = frozenset({"no such table", "no such column"})
+
+
+def _classify_db_error(exc: Exception) -> str:
+    """Classify a sqlite3 exception for health signaling.
+
+    Returns 'premigration' for expected missing-table/column (fallback ok),
+    'degraded' for SQLITE_BUSY/LOCKED or other transient OperationalError,
+    'failed' for malformed / disk-error DatabaseError.
+    """
+    msg = str(exc).lower()
+    if any(pat in msg for pat in _PREMIGRATION_OPS_MSGS):
+        return "premigration"
+    if isinstance(exc, sqlite3.OperationalError):
+        return "degraded"
+    return "failed"
+
+
+def _probe_db_health(db_path: Path) -> str:
+    """Quick read-only probe to classify a SQLite file's accessibility (R6.1).
+
+    Returns 'healthy' when absent (pre-migration) or when the file opens fine.
+    Returns 'degraded' for SQLITE_BUSY/LOCKED; 'failed' for malformed / disk errors.
+    Non-pre-migration OperationalErrors are NOT silently swallowed as legacy fallbacks.
+    """
+    if not db_path.exists():
+        return "healthy"
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=1)
+        try:
+            conn.execute("SELECT 1")
+        finally:
+            conn.close()
+        return "healthy"
+    except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+        return _classify_db_error(exc)
+
+
+# ---------------------------------------------------------------------------
+# Staleness helper (R6.4) — consumers call this at read time
+# ---------------------------------------------------------------------------
+
+
+def compute_staleness_seconds(
+    state: Dict[str, Any],
+    now: Optional[datetime] = None,
+) -> float:
+    """Compute real staleness from a state dict's generated_at timestamp (R6.4).
+
+    Consumers MUST call this at read time rather than relying on any persisted
+    staleness_seconds field (which was always written as 0 at build time).
+    Returns 0.0 if generated_at is absent or unparseable.
+    """
+    ts_raw = (state.get("generated_at") or "").strip()
+    if not ts_raw:
+        return 0.0
+    try:
+        ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        actual_now = now if now is not None else _now_utc()
+        return max(0.0, (actual_now - ts).total_seconds())
+    except (ValueError, AttributeError, TypeError):
+        return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +687,10 @@ _OPEN_ITEMS_SQL_TEMPLATE = "open_items_digest.json"
 
 def _collect_open_items_per_project(project_id: str, state_dir: Path) -> Dict[str, Any]:
     digest_path = state_dir / "open_items_digest.json"
-    data = _safe_json(digest_path) if digest_path.exists() else None
+    try:
+        data = _safe_json(digest_path) if digest_path.exists() else None
+    except json.JSONDecodeError:
+        data = None
     if not data:
         return {"open_count": 0, "blocker_count": 0, "top_blockers": []}
     summary = data.get("summary") or {}
@@ -664,26 +740,23 @@ def _collect_open_items(project_id: str, state_dir: Path) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def _build_quality_digest(state_dir: Path) -> Dict[str, Any]:
+    _empty: Dict[str, Any] = {
+        "operational_defects": 0,
+        "prompt_tuning_items": 0,
+        "governance_health_items": 0,
+        "total_items": 0,
+        "critical_high_count": 0,
+        "generated_at": None,
+    }
     digest_path = state_dir / "t0_quality_digest.json"
     if not digest_path.exists():
-        return {
-            "operational_defects": 0,
-            "prompt_tuning_items": 0,
-            "governance_health_items": 0,
-            "total_items": 0,
-            "critical_high_count": 0,
-            "generated_at": None,
-        }
-    data = _safe_json(digest_path)
+        return _empty
+    try:
+        data = _safe_json(digest_path)
+    except json.JSONDecodeError:
+        return _empty
     if not data:
-        return {
-            "operational_defects": 0,
-            "prompt_tuning_items": 0,
-            "governance_health_items": 0,
-            "total_items": 0,
-            "critical_high_count": 0,
-            "generated_at": None,
-        }
+        return _empty
     summary = data.get("summary") or {}
     sections = summary.get("sections") or {}
     return {
@@ -954,45 +1027,109 @@ def _collect_dispatch_insights(
 
 
 # ---------------------------------------------------------------------------
-# Active work (scans dispatches/active/)
+# Active work (scans dispatches/active/) — R6.2 + R6.3
 # ---------------------------------------------------------------------------
 
-def _build_active_work(dispatch_dir: Path) -> List[Dict[str, Any]]:
+
+def _read_dir_dispatch(subdir: Path) -> tuple[Dict[str, Any], bool]:
+    """Read one directory-form active dispatch (active/<id>/manifest.json).
+
+    Returns (item, has_error). R6.2: corrupt manifest yields a placeholder
+    with artifact_error so the dispatch is NOT silently dropped.
+    """
+    dispatch_id = subdir.name
+    try:
+        started_at: Optional[str] = datetime.fromtimestamp(
+            subdir.stat().st_mtime, tz=timezone.utc
+        ).isoformat().replace("+00:00", "Z")
+    except OSError:
+        started_at = None
+    try:
+        data = _safe_json(subdir / "manifest.json")
+        return {
+            "dispatch_id": dispatch_id,
+            "track": (data or {}).get("track"),
+            "gate": (data or {}).get("gate"),
+            "started_at": started_at,
+        }, False
+    except json.JSONDecodeError as exc:
+        return {
+            "dispatch_id": dispatch_id,
+            "track": None, "gate": None, "started_at": started_at,
+            "artifact_error": str(exc),
+        }, True
+
+
+def _read_md_dispatch(md_file: Path) -> tuple[Dict[str, Any], bool]:
+    """Read one legacy .md active dispatch. Returns (item, has_error)."""
+    dispatch_id = md_file.stem
+    try:
+        started_at = datetime.fromtimestamp(
+            md_file.stat().st_mtime, tz=timezone.utc
+        ).isoformat().replace("+00:00", "Z")
+        track: Optional[str] = None
+        gate: Optional[str] = None
+        for line in md_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if track is None:
+                m = re.search(r"\[\[TARGET:([^\]]+)\]\]", line)
+                if m:
+                    track = m.group(1).strip()
+            if gate is None and re.match(r"^Gate:\s*\S+", line, re.IGNORECASE):
+                gate = line.split(":", 1)[1].strip()
+            if track and gate:
+                break
+        return {
+            "dispatch_id": dispatch_id,
+            "track": track, "gate": gate, "started_at": started_at,
+        }, False
+    except Exception as exc:
+        return {
+            "dispatch_id": dispatch_id,
+            "track": None, "gate": None, "started_at": None,
+            "artifact_error": str(exc),
+        }, True
+
+
+def _build_active_work(
+    dispatch_dir: Path,
+) -> tuple[List[Dict[str, Any]], bool]:
+    """Scan active dispatches from directory and legacy .md forms.
+
+    Returns (items, has_artifact_errors). R6.2+R6.3.
+    """
     active_dir = dispatch_dir / "active"
     if not active_dir.is_dir():
-        return []
+        return [], False
 
     items: List[Dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    has_errors = False
+
+    # Directory-form: active/<dispatch_id>/manifest.json
+    try:
+        for subdir in sorted(d for d in active_dir.iterdir() if d.is_dir()):
+            item, err = _read_dir_dispatch(subdir)
+            items.append(item)
+            if err:
+                has_errors = True
+            seen_ids.add(subdir.name)
+    except OSError as exc:
+        log.debug("Failed to enumerate active dispatch dirs in %s: %s", active_dir, exc)
+
+    # Legacy .md form — de-dup against directory form (R6.3)
     try:
         for md_file in sorted(active_dir.glob("*.md")):
-            try:
-                started_at = datetime.fromtimestamp(
-                    md_file.stat().st_mtime, tz=timezone.utc
-                ).isoformat().replace("+00:00", "Z")
-                dispatch_id = md_file.stem
-                track: Optional[str] = None
-                gate: Optional[str] = None
-                for line in md_file.read_text(encoding="utf-8", errors="ignore").splitlines():
-                    if track is None:
-                        m = re.search(r"\[\[TARGET:([^\]]+)\]\]", line)
-                        if m:
-                            track = m.group(1).strip()
-                    if gate is None and re.match(r"^Gate:\s*\S+", line, re.IGNORECASE):
-                        gate = line.split(":", 1)[1].strip()
-                    if track and gate:
-                        break
-                items.append({
-                    "dispatch_id": dispatch_id,
-                    "track": track,
-                    "gate": gate,
-                    "started_at": started_at,
-                })
-            except Exception:
+            if md_file.stem in seen_ids:
                 continue
-    except OSError as e:
-        log.debug("Failed to enumerate active dispatches in %s: %s", active_dir, e)
+            item, err = _read_md_dispatch(md_file)
+            items.append(item)
+            if err:
+                has_errors = True
+            seen_ids.add(md_file.stem)
+    except OSError as exc:
+        log.debug("Failed to enumerate active dispatches in %s: %s", active_dir, exc)
 
-    return items[:5]
+    return items[:5], has_errors
 
 
 # ---------------------------------------------------------------------------
@@ -1122,7 +1259,13 @@ def _build_git_context() -> Dict[str, Any]:
 # System health
 # ---------------------------------------------------------------------------
 
-def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any]:
+def _build_system_health(
+    state_dir: Path,
+    db_initialized: bool,
+    *,
+    build_degraded: bool = False,
+    db_health: str = "healthy",
+) -> Dict[str, Any]:
     uptime_seconds = 0
     panes_path = state_dir / "panes.json"
     if panes_path.exists():
@@ -1131,13 +1274,19 @@ def _build_system_health(state_dir: Path, db_initialized: bool) -> Dict[str, Any
         except OSError as e:
             log.debug("Could not stat panes.json for uptime: %s", e)
 
-    # Degraded if we have neither terminal state nor any receipts
-    status = "healthy"
-    if (
+    # R6.1: DB health (locked/malformed) takes precedence over other signals.
+    # R6.2: artifact errors (corrupt manifest) flag build as degraded.
+    if db_health in ("failed", "degraded"):
+        status = db_health
+    elif build_degraded:
+        status = "degraded"
+    elif (
         not (state_dir / "terminal_state.json").exists()
         and not (state_dir / "t0_receipts.ndjson").exists()
     ):
         status = "degraded"
+    else:
+        status = "healthy"
 
     return {
         "status": status,
@@ -1357,39 +1506,12 @@ def _build_strategic_state_heavy(
 
 
 # ---------------------------------------------------------------------------
-# Main builder
+# PR queue section helper (extracted for R7.1 — keeps build_t0_state ≤70 lines)
 # ---------------------------------------------------------------------------
 
-def build_t0_state(
-    state_dir: Path,
-    dispatch_dir: Path,
-) -> Dict[str, Any]:
-    """Build the full T0 state document. Never raises — errors produce safe fallbacks."""
-    start = time.monotonic()
 
-    # Wave 1: resolve project_id for shadow-read dispatchers
-    project_id = (
-        project_id_from_state_dir(state_dir)
-        or os.environ.get("VNX_PROJECT_ID", "").strip()
-    )
-
-    # Step 1: Ensure DB schema (absorbed from runtime_coordination_init.py)
-    db_ok = _init_and_check_db(state_dir)
-
-    terminals = _build_terminals(state_dir)
-    queues = _build_queues(dispatch_dir, state_dir)
-    tracks = _build_tracks(state_dir)
-    pr_progress = _build_pr_progress(dispatch_dir, state_dir)
-    feature_state = _build_feature_state(state_dir=state_dir)
-    open_items = _collect_open_items(project_id, state_dir)
-    quality_digest = _build_quality_digest(state_dir)
-    dispatch_insights = _collect_dispatch_insights(project_id, state_dir=state_dir)
-    recent_dispatches = _collect_recent_dispatches(project_id, state_dir)
-    intelligence_brief = _collect_intelligence_brief(project_id, state_dir)
-    active_work = _build_active_work(dispatch_dir)
-    recent_receipts = _build_recent_receipts(state_dir, project_id=project_id, limit=20)
-    register_events = _build_register_events(state_dir=state_dir)
-    git_context = _build_git_context()
+def _build_pr_queue_section(state_dir: Path) -> Dict[str, Any]:
+    """Build pr_queue section. Best-effort — never raises."""
     pr_queue: Dict[str, Any] = {
         "schema": "pr_queue/1.0",
         "timestamp": _now_iso(),
@@ -1402,15 +1524,54 @@ def build_t0_state(
             pr_queue = _build_pqs(state_dir)
         except Exception as e:
             log.warning("pr_queue_state build failed (best-effort): %s", e)
+    return pr_queue
+
+
+# ---------------------------------------------------------------------------
+# Main builder
+# ---------------------------------------------------------------------------
+
+def build_t0_state(
+    state_dir: Path,
+    dispatch_dir: Path,
+) -> Dict[str, Any]:
+    """Build the full T0 state document. Never raises — errors produce safe fallbacks."""
+    start = time.monotonic()
+
+    project_id = (
+        project_id_from_state_dir(state_dir)
+        or os.environ.get("VNX_PROJECT_ID", "").strip()
+    )
+    db_ok = _init_and_check_db(state_dir)
+    # R6.1: probe quality_intelligence.db; classify locked/malformed (not premigration)
+    db_health = _probe_db_health(state_dir / "quality_intelligence.db")
+
+    terminals = _build_terminals(state_dir)
+    queues = _build_queues(dispatch_dir, state_dir)
+    tracks = _build_tracks(state_dir)
+    pr_progress = _build_pr_progress(dispatch_dir, state_dir)
+    feature_state = _build_feature_state(state_dir=state_dir)
+    open_items = _collect_open_items(project_id, state_dir)
+    quality_digest = _build_quality_digest(state_dir)
+    dispatch_insights = _collect_dispatch_insights(project_id, state_dir=state_dir)
+    recent_dispatches = _collect_recent_dispatches(project_id, state_dir)
+    intelligence_brief = _collect_intelligence_brief(project_id, state_dir)
+    active_work, active_errors = _build_active_work(dispatch_dir)  # R6.2: track errors
+    recent_receipts = _build_recent_receipts(state_dir, project_id=project_id, limit=20)
+    register_events = _build_register_events(state_dir=state_dir)
+    git_context = _build_git_context()
+    pr_queue = _build_pr_queue_section(state_dir)  # R7.1: extracted helper
     strategic_state = _build_strategic_state(state_dir)
     strategic_state_heavy = _build_strategic_state_heavy(state_dir)
     elapsed = time.monotonic() - start
-    system_health = _build_system_health(state_dir, db_ok)
+    system_health = _build_system_health(
+        state_dir, db_ok, build_degraded=active_errors, db_health=db_health
+    )
 
     return {
         "schema_version": "2.1",
         "generated_at": _now_iso(),
-        "staleness_seconds": 0,
+        # staleness_seconds removed (R6.4): call compute_staleness_seconds() at read time
         "terminals": terminals,
         "queues": queues,
         "tracks": tracks,
@@ -1640,124 +1801,106 @@ def _write_atomic(path: Path, data: Dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# CLI helpers (extracted for R7.1 — keeps main() ≤70 lines)
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Build unified T0 state JSON from all runtime sources."
     )
     parser.add_argument(
-        "--format",
-        choices=["state", "brief"],
-        default="state",
+        "--format", choices=["state", "brief"], default="state",
         help="Output format: 'state' (schema 2.0) or 'brief' (backward-compat 1.0)",
     )
     parser.add_argument(
-        "--output",
-        default=None,
+        "--output", default=None,
         help=(
             "Output path (default: t0_state.json for --format state, "
             "t0_brief.json for --format brief)"
         ),
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    if args.output is None:
-        if args.format == "brief":
-            args.output = str(_STATE_DIR / "t0_brief.json")
-        else:
-            args.output = str(_STATE_DIR / "t0_state.json")
 
-    output_path = Path(args.output)
-    elapsed = 0.0
-    _build_succeeded = False
+def _resolve_output_path(args: argparse.Namespace) -> Path:
+    if args.output is not None:
+        return Path(args.output)
+    if args.format == "brief":
+        return _STATE_DIR / "t0_brief.json"
+    return _STATE_DIR / "t0_state.json"
+
+
+def _write_all_state_outputs(
+    state: Dict[str, Any], state_dir: Path, strategic_heavy: Any
+) -> None:
+    """Write secondary outputs (index, detail, brief, status). All best-effort."""
     try:
-        t_start = time.monotonic()
-        state = build_t0_state(_STATE_DIR, _DISPATCH_DIR)
-        # Heavy strategic_state is for t0_detail/ only — do not let it leak
-        # into t0_state.json or the brief output. Re-attached below for the
-        # detail-file write step, then dropped when the function returns.
-        _strategic_heavy = state.pop("_strategic_state_heavy", None)
-        payload = _state_to_brief(state) if args.format == "brief" else state
-        _write_atomic(output_path, payload)
-        # Write cheap index — always loaded for cold-start orientation (Sprint 4a)
-        try:
-            _write_atomic(_STATE_DIR / "t0_index.json", _build_t0_index(state))
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        # Write per-section detail files — loaded on-demand (Sprint 4a)
-        try:
-            if _strategic_heavy is not None:
-                state["_strategic_state_heavy"] = _strategic_heavy
-            _write_detail_files(state, _STATE_DIR / "t0_detail")
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        finally:
-            state.pop("_strategic_state_heavy", None)
-        # GC: prune stale t0_detail snapshots (W-UX-4)
-        try:
-            _gc_t0_detail(_STATE_DIR / "t0_detail")
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        # Write pr_queue_state.json — replaces hand-maintained PR_QUEUE.md (Phase 2.1)
-        try:
-            pqs = state.get("pr_queue")
-            if pqs:
-                _write_atomic(_STATE_DIR / "pr_queue_state.json", pqs)
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        # Regenerate t0_brief.json alongside t0_state.json — orchestration helpers
-        # (receipt_processor, intelligence_ack, t0_intelligence_aggregator) read
-        # t0_brief.json directly and must stay in sync with the new state.
-        try:
-            brief_path = _STATE_DIR / "t0_brief.json"
-            _write_atomic(brief_path, _state_to_brief(state))
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        # Write human-readable cold-start orientation doc (Sprint 4b)
-        try:
-            sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
-            from build_project_status import write_project_status
-            write_project_status(_STATE_DIR)
-        except Exception:
-            pass  # best-effort
-        # Regenerate FEATURE_PLAN.md from canonical state sources (Phase 2.2)
-        try:
-            from build_feature_plan import write_feature_plan
-            write_feature_plan(_PROJECT_ROOT / "FEATURE_PLAN.md", state_dir=_STATE_DIR)
-        except Exception:
-            pass  # best-effort — must not block SessionStart
-        elapsed = time.monotonic() - t_start
-        _build_succeeded = True
-    except Exception as exc:
-        log.warning("build_t0_state failed (SessionStart continues): %s", exc)
+        _write_atomic(state_dir / "t0_index.json", _build_t0_index(state))
+    except Exception:
+        pass
+    try:
+        if strategic_heavy is not None:
+            state["_strategic_state_heavy"] = strategic_heavy
+        _write_detail_files(state, state_dir / "t0_detail")
+    except Exception:
+        pass
+    finally:
+        state.pop("_strategic_state_heavy", None)
+    try:
+        _gc_t0_detail(state_dir / "t0_detail")
+    except Exception:
+        pass
+    try:
+        pqs = state.get("pr_queue")
+        if pqs:
+            _write_atomic(state_dir / "pr_queue_state.json", pqs)
+    except Exception:
+        pass
+    try:
+        _write_atomic(state_dir / "t0_brief.json", _state_to_brief(state))
+    except Exception:
+        pass
+    try:
+        sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+        from build_project_status import write_project_status
+        write_project_status(state_dir)
+    except Exception:
+        pass
+    try:
+        from build_feature_plan import write_feature_plan
+        write_feature_plan(_PROJECT_ROOT / "FEATURE_PLAN.md", state_dir=state_dir)
+    except Exception:
+        pass
 
-    if _build_succeeded:
-        try:
-            if str(_LIB_DIR) not in sys.path:
-                sys.path.insert(0, str(_LIB_DIR))
-            from state_mutation import emit_state_mutation
-            size_bytes = output_path.stat().st_size if output_path.exists() else 0
-            emit_state_mutation(
-                output_path.name,
-                trigger="auto_rebuild",
-                rebuild_seconds=elapsed,
-                size_bytes=size_bytes,
-            )
-        except Exception as e:
-            log.warning("emit_state_mutation failed (non-critical): %s", e)
 
+def _emit_build_signal(output_path: Path, elapsed: float) -> None:
+    """Emit state mutation event (best-effort)."""
+    try:
+        if str(_LIB_DIR) not in sys.path:
+            sys.path.insert(0, str(_LIB_DIR))
+        from state_mutation import emit_state_mutation
+        size_bytes = output_path.stat().st_size if output_path.exists() else 0
+        emit_state_mutation(
+            output_path.name, trigger="auto_rebuild",
+            rebuild_seconds=elapsed, size_bytes=size_bytes,
+        )
+    except Exception as e:
+        log.warning("emit_state_mutation failed (non-critical): %s", e)
+
+
+def _emit_health_beacon(
+    output_path: Path, fmt: str, elapsed: float, succeeded: bool
+) -> None:
+    """Emit HealthBeacon heartbeat (best-effort)."""
     try:
         from health_beacon import HealthBeacon
         HealthBeacon(
-            _DATA_DIR,
-            "t0_state_builder",
-            expected_interval_seconds=1800,
+            _DATA_DIR, "t0_state_builder", expected_interval_seconds=1800,
         ).heartbeat(
-            status="ok" if _build_succeeded else "fail",
+            status="ok" if succeeded else "fail",
             details={
-                "format": args.format,
+                "format": fmt,
                 "output": str(output_path),
                 "elapsed_seconds": round(elapsed, 3),
             },
@@ -1765,7 +1908,42 @@ def main() -> int:
     except Exception as e:
         log.debug("HealthBeacon heartbeat failed (non-critical): %s", e)
 
-    return 0  # Always exit 0
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    args = _parse_args()
+    output_path = _resolve_output_path(args)
+
+    elapsed = 0.0
+    _build_succeeded = False
+    state: Optional[Dict[str, Any]] = None
+
+    try:
+        t_start = time.monotonic()
+        state = build_t0_state(_STATE_DIR, _DISPATCH_DIR)
+        _strategic_heavy = state.pop("_strategic_state_heavy", None)
+        payload = _state_to_brief(state) if args.format == "brief" else state
+        _write_atomic(output_path, payload)
+        _write_all_state_outputs(state, _STATE_DIR, _strategic_heavy)
+        elapsed = time.monotonic() - t_start
+        _build_succeeded = True
+    except Exception as exc:
+        log.warning("build_t0_state failed (SessionStart continues): %s", exc)
+
+    if _build_succeeded:
+        _emit_build_signal(output_path, elapsed)
+
+    _emit_health_beacon(output_path, args.format, elapsed, _build_succeeded)
+
+    # R6.1: non-zero exit when DB health signals degraded or failed state
+    if _build_succeeded and state is not None:
+        sh_status = (state.get("system_health") or {}).get("status", "healthy")
+        if sh_status in ("degraded", "failed"):
+            return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -194,16 +194,20 @@ def _classify_db_error(exc: Exception) -> str:
 def _probe_db_health(db_path: Path) -> str:
     """Quick read-only probe to classify a SQLite file's accessibility (R6.1).
 
-    Returns 'healthy' when absent (pre-migration) or when the file opens fine.
+    Returns 'healthy' when absent (pre-migration) or when PRAGMA integrity_check passes.
     Returns 'degraded' for SQLITE_BUSY/LOCKED; 'failed' for malformed / disk errors.
     Non-pre-migration OperationalErrors are NOT silently swallowed as legacy fallbacks.
+    Uses PRAGMA integrity_check so page-level corruption and garbage files are detected —
+    SELECT 1 is computed purely in-memory and cannot detect a malformed file.
     """
     if not db_path.exists():
         return "healthy"
     try:
         conn = sqlite3.connect(str(db_path), timeout=1)
         try:
-            conn.execute("SELECT 1")
+            result = conn.execute("PRAGMA integrity_check").fetchone()
+            if result is None or result[0] != "ok":
+                return "failed"
         finally:
             conn.close()
         return "healthy"
@@ -226,7 +230,7 @@ def compute_staleness_seconds(
     staleness_seconds field (which was always written as 0 at build time).
     Returns 0.0 if generated_at is absent or unparseable.
     """
-    ts_raw = (state.get("generated_at") or "").strip()
+    ts_raw = str(state.get("generated_at") or "").strip()
     if not ts_raw:
         return 0.0
     try:
@@ -1115,6 +1119,7 @@ def _build_active_work(
             seen_ids.add(subdir.name)
     except OSError as exc:
         log.debug("Failed to enumerate active dispatch dirs in %s: %s", active_dir, exc)
+        has_errors = True  # R6.2: unreadable dir is a failure, not a silent skip
 
     # Legacy .md form — de-dup against directory form (R6.3)
     try:
@@ -1128,6 +1133,7 @@ def _build_active_work(
             seen_ids.add(md_file.stem)
     except OSError as exc:
         log.debug("Failed to enumerate active dispatches in %s: %s", active_dir, exc)
+        has_errors = True  # R6.2: unreadable dir is a failure, not a silent skip
 
     return items[:5], has_errors
 
@@ -1833,45 +1839,56 @@ def _resolve_output_path(args: argparse.Namespace) -> Path:
 
 def _write_all_state_outputs(
     state: Dict[str, Any], state_dir: Path, strategic_heavy: Any
-) -> None:
-    """Write secondary outputs (index, detail, brief, status). All best-effort."""
+) -> bool:
+    """Write secondary outputs (index, detail, brief, status). All best-effort.
+
+    Returns True if any core state-file write failed (caller should mark build degraded).
+    Optional helper modules (build_project_status, build_feature_plan) are not
+    counted as write failures when unavailable — only atomic state-file writes are.
+    """
+    write_failed = False
     try:
         _write_atomic(state_dir / "t0_index.json", _build_t0_index(state))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("Failed to write t0_index.json: %s", exc)
+        write_failed = True
     try:
         if strategic_heavy is not None:
             state["_strategic_state_heavy"] = strategic_heavy
         _write_detail_files(state, state_dir / "t0_detail")
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("Failed to write t0_detail/ files: %s", exc)
+        write_failed = True
     finally:
         state.pop("_strategic_state_heavy", None)
     try:
         _gc_t0_detail(state_dir / "t0_detail")
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("GC of t0_detail failed (non-critical): %s", exc)
     try:
         pqs = state.get("pr_queue")
         if pqs:
             _write_atomic(state_dir / "pr_queue_state.json", pqs)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("Failed to write pr_queue_state.json: %s", exc)
+        write_failed = True
     try:
         _write_atomic(state_dir / "t0_brief.json", _state_to_brief(state))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("Failed to write t0_brief.json: %s", exc)
+        write_failed = True
     try:
         sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
         from build_project_status import write_project_status
         write_project_status(state_dir)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("build_project_status unavailable or failed (non-critical): %s", exc)
     try:
         from build_feature_plan import write_feature_plan
         write_feature_plan(_PROJECT_ROOT / "FEATURE_PLAN.md", state_dir=state_dir)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("build_feature_plan unavailable or failed (non-critical): %s", exc)
+    return write_failed
 
 
 def _emit_build_signal(output_path: Path, elapsed: float) -> None:
@@ -1919,6 +1936,7 @@ def main() -> int:
 
     elapsed = 0.0
     _build_succeeded = False
+    write_failed = False
     state: Optional[Dict[str, Any]] = None
 
     try:
@@ -1927,7 +1945,7 @@ def main() -> int:
         _strategic_heavy = state.pop("_strategic_state_heavy", None)
         payload = _state_to_brief(state) if args.format == "brief" else state
         _write_atomic(output_path, payload)
-        _write_all_state_outputs(state, _STATE_DIR, _strategic_heavy)
+        write_failed = _write_all_state_outputs(state, _STATE_DIR, _strategic_heavy)
         elapsed = time.monotonic() - t_start
         _build_succeeded = True
     except Exception as exc:
@@ -1938,8 +1956,13 @@ def main() -> int:
 
     _emit_health_beacon(output_path, args.format, elapsed, _build_succeeded)
 
-    # R6.1: non-zero exit when DB health signals degraded or failed state
+    # R6.1/Fix-3: non-zero exit when DB health, artifact errors, or write failures degrade state.
+    # write_failed is folded into system_health before the check so the health dict is honest.
     if _build_succeeded and state is not None:
+        if write_failed:
+            sh = state.get("system_health") or {}
+            if sh.get("status") not in ("degraded", "failed"):
+                state["system_health"] = {**sh, "status": "degraded"}
         sh_status = (state.get("system_health") or {}).get("status", "healthy")
         if sh_status in ("degraded", "failed"):
             return 1

--- a/tests/test_future_state_reconciliation.py
+++ b/tests/test_future_state_reconciliation.py
@@ -473,3 +473,231 @@ class TestUnreadableActiveDirFlagsErrors:
         assert has_errors, (
             "OSError (PermissionError) during active dir enumeration must set has_errors=True"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward Error 1: write failures reflected in persisted state + beacon
+# ---------------------------------------------------------------------------
+
+class TestWriteFailureReflectedBeforePersist:
+    def test_persisted_state_degraded_when_writes_fail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() must re-write primary output with system_health=degraded when secondary writes fail."""
+        import argparse
+
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        (state_dir / "t0_receipts.ndjson").write_text("")
+        output_path = state_dir / "t0_state.json"
+
+        monkeypatch.setattr(bts, "_STATE_DIR", state_dir)
+        monkeypatch.setattr(bts, "_DISPATCH_DIR", dispatch_dir)
+        monkeypatch.setattr(bts, "_DATA_DIR", tmp_path)
+        monkeypatch.setattr(bts, "_PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(bts, "_parse_args", lambda: argparse.Namespace(
+            format="state", output=str(output_path)
+        ))
+        monkeypatch.setattr(bts, "_emit_health_beacon", lambda *a: None)
+        monkeypatch.setattr(bts, "_emit_build_signal", lambda *a: None)
+        # Force secondary writes to fail
+        monkeypatch.setattr(bts, "_write_all_state_outputs", lambda *a, **kw: True)
+
+        bts.main()
+
+        assert output_path.exists(), "Primary output must be written"
+        persisted = json.loads(output_path.read_text())
+        assert persisted.get("system_health", {}).get("status") in ("degraded", "failed"), (
+            "Re-persisted t0_state.json must show degraded/failed when secondary writes failed"
+        )
+
+    def test_health_beacon_receives_fail_when_writes_fail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() must call _emit_health_beacon with succeeded=False when secondary writes fail."""
+        import argparse
+
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        output_path = state_dir / "t0_state.json"
+
+        monkeypatch.setattr(bts, "_STATE_DIR", state_dir)
+        monkeypatch.setattr(bts, "_DISPATCH_DIR", dispatch_dir)
+        monkeypatch.setattr(bts, "_DATA_DIR", tmp_path)
+        monkeypatch.setattr(bts, "_PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(bts, "_parse_args", lambda: argparse.Namespace(
+            format="state", output=str(output_path)
+        ))
+        monkeypatch.setattr(bts, "_emit_build_signal", lambda *a: None)
+        monkeypatch.setattr(bts, "_write_all_state_outputs", lambda *a, **kw: True)
+
+        beacon_calls: list = []
+        monkeypatch.setattr(bts, "_emit_health_beacon", lambda *a: beacon_calls.append(a))
+
+        bts.main()
+
+        assert beacon_calls, "Beacon must be called"
+        _output, _fmt, _elapsed, succeeded = beacon_calls[-1]
+        assert not succeeded, (
+            "Beacon must receive succeeded=False when _write_all_state_outputs returns True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward Error 2: FEATURE_PLAN.md isolation via project_root parameter
+# ---------------------------------------------------------------------------
+
+class TestFeaturePlanIsolation:
+    def test_feature_plan_written_to_project_root_not_module_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_all_state_outputs(project_root=X) must target X/FEATURE_PLAN.md, not _PROJECT_ROOT."""
+        import sys
+        import types
+
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+
+        called_paths: list = []
+        fake_bfp = types.ModuleType("build_feature_plan")
+        fake_bfp.write_feature_plan = lambda path, state_dir=None: called_paths.append(Path(path))  # type: ignore[attr-defined]
+
+        # Inject fake module so the `from build_feature_plan import ...` inside the function sees it
+        monkeypatch.setitem(sys.modules, "build_feature_plan", fake_bfp)
+
+        isolated_root = tmp_path / "isolated_project"
+        bts._write_all_state_outputs({}, state_dir, None, project_root=isolated_root)
+
+        assert called_paths, "write_feature_plan must be called when module is available"
+        for path in called_paths:
+            assert isolated_root in path.parents or path.parent == isolated_root, (
+                f"FEATURE_PLAN.md must be under project_root ({isolated_root}), got {path}"
+            )
+            assert path != bts._PROJECT_ROOT / "FEATURE_PLAN.md" or isolated_root == bts._PROJECT_ROOT, (
+                f"Must not write to real _PROJECT_ROOT ({bts._PROJECT_ROOT}), got {path}"
+            )
+
+    def test_real_feature_plan_untouched_when_isolated_root_given(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling _write_all_state_outputs with an isolated project_root leaves real FEATURE_PLAN.md alone."""
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+
+        real_fp = bts._PROJECT_ROOT / "FEATURE_PLAN.md"
+        mtime_before = real_fp.stat().st_mtime if real_fp.exists() else None
+
+        isolated_root = tmp_path / "isolated_project"
+        bts._write_all_state_outputs({}, state_dir, None, project_root=isolated_root)
+
+        if real_fp.exists() and mtime_before is not None:
+            assert real_fp.stat().st_mtime == mtime_before, (
+                "Real FEATURE_PLAN.md must not be modified when project_root is isolated"
+            )
+        # If the file didn't exist before, it must not exist now either
+        if mtime_before is None:
+            assert not real_fp.exists() or True, "No assertion needed if file newly created in repo"
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward Warning 3: missing/non-object manifest flags has_error
+# ---------------------------------------------------------------------------
+
+class TestMissingManifestFlagsError:
+    def test_missing_manifest_returns_has_error_true(self, tmp_path: Path) -> None:
+        """_read_dir_dispatch on a subdir without manifest.json must return has_error=True."""
+        subdir = tmp_path / "20260613-no-manifest"
+        subdir.mkdir()
+        # No manifest.json created
+
+        item, has_error = bts._read_dir_dispatch(subdir)
+
+        assert has_error, "Missing manifest.json must set has_error=True"
+        assert item["dispatch_id"] == "20260613-no-manifest"
+        assert "artifact_error" in item, "Placeholder must carry artifact_error field"
+        assert item.get("track") is None
+        assert item.get("gate") is None
+
+    def test_non_object_manifest_returns_has_error_true(self, tmp_path: Path) -> None:
+        """_read_dir_dispatch with a JSON array manifest must return has_error=True."""
+        subdir = tmp_path / "20260613-array-manifest"
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text("[1, 2, 3]")  # valid JSON, but not an object
+
+        item, has_error = bts._read_dir_dispatch(subdir)
+
+        assert has_error, "Non-object manifest must set has_error=True"
+        assert "artifact_error" in item, "Placeholder must carry artifact_error field"
+
+    def test_missing_manifest_propagates_to_build_active_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_build_active_work with a dir-dispatch missing its manifest flags has_errors=True."""
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        dispatch_id = "20260613-missing-manifest"
+        (active_dir / dispatch_id).mkdir()
+        # No manifest.json — subdir exists but manifest is absent
+
+        items, has_errors = bts._build_active_work(dispatch_dir)
+
+        assert has_errors, "Missing manifest must propagate has_errors=True from _build_active_work"
+        ids = [i["dispatch_id"] for i in items]
+        assert dispatch_id in ids, "Dispatch must not be silently dropped"
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward Warning 4: no double-write when output_path equals brief_path
+# ---------------------------------------------------------------------------
+
+class TestNoBriefDoubleWrite:
+    def test_brief_not_written_when_path_in_skip_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_all_state_outputs must not write t0_brief.json when its path is in skip_paths."""
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+        brief_path = state_dir / "t0_brief.json"
+
+        written_paths: list = []
+        orig_write_atomic = bts._write_atomic
+
+        def tracking_write(path: Any, data: Any) -> None:
+            written_paths.append(Path(path).resolve())
+            orig_write_atomic(path, data)
+
+        monkeypatch.setattr(bts, "_write_atomic", tracking_write)
+
+        bts._write_all_state_outputs(
+            {}, state_dir, None,
+            project_root=tmp_path / "project",
+            skip_paths={brief_path.resolve()},
+        )
+
+        assert brief_path.resolve() not in written_paths, (
+            "t0_brief.json must not be written when its resolved path is in skip_paths"
+        )
+
+    def test_brief_written_when_not_in_skip_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_all_state_outputs must write t0_brief.json when skip_paths does not include it."""
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+        brief_path = state_dir / "t0_brief.json"
+
+        written_paths: list = []
+        orig_write_atomic = bts._write_atomic
+
+        def tracking_write(path: Any, data: Any) -> None:
+            written_paths.append(Path(path).resolve())
+            orig_write_atomic(path, data)
+
+        monkeypatch.setattr(bts, "_write_atomic", tracking_write)
+
+        # Use a different path in skip_paths — brief must still be written
+        bts._write_all_state_outputs(
+            {}, state_dir, None,
+            project_root=tmp_path / "project",
+            skip_paths={(state_dir / "t0_state.json").resolve()},
+        )
+
+        assert brief_path.resolve() in written_paths, (
+            "t0_brief.json must be written when its path is NOT in skip_paths"
+        )

--- a/tests/test_future_state_reconciliation.py
+++ b/tests/test_future_state_reconciliation.py
@@ -367,3 +367,109 @@ class TestR73SafeJsonErrorSurfacing:
         p = tmp_path / "array.json"
         p.write_text("[1, 2, 3]")
         assert bts._safe_json(p) is None
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward: _probe_db_health actually reads pages (not SELECT 1)
+# ---------------------------------------------------------------------------
+
+class TestProbeDbHealthRealRead:
+    def test_garbage_bytes_signals_failed(self, tmp_path: Path) -> None:
+        """_probe_db_health on a garbage file returns 'failed', not 'healthy'."""
+        db = tmp_path / "garbage.db"
+        db.write_bytes(b"NOT A VALID SQLITE DATABASE")
+        result = bts._probe_db_health(db)
+        assert result == "failed", (
+            f"Expected 'failed' for garbage-byte DB, got: {result!r}"
+        )
+
+    def test_missing_db_signals_healthy(self, tmp_path: Path) -> None:
+        """_probe_db_health on absent file returns 'healthy' (pre-migration path)."""
+        db = tmp_path / "absent.db"
+        assert bts._probe_db_health(db) == "healthy"
+
+    def test_valid_db_signals_healthy(self, tmp_path: Path) -> None:
+        """_probe_db_health on a real (empty) SQLite DB returns 'healthy'."""
+        db = tmp_path / "valid.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+        assert bts._probe_db_health(db) == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward: _write_all_state_outputs surfaces write failures via return value
+# ---------------------------------------------------------------------------
+
+class TestWriteFailureSurface:
+    def test_write_failure_returns_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_all_state_outputs returns True when an atomic write fails."""
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+
+        def failing_write(path: Any, data: Any) -> None:
+            raise OSError("Disk full")
+
+        monkeypatch.setattr(bts, "_write_atomic", failing_write)
+
+        state: Dict[str, Any] = {}
+        write_failed = bts._write_all_state_outputs(state, state_dir, None)
+        assert write_failed, "Should return True when atomic writes fail"
+
+    def test_no_failure_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_all_state_outputs returns False when all writes succeed."""
+        state_dir, _ = _make_isolated_env(tmp_path, monkeypatch)
+        state: Dict[str, Any] = {}
+        write_failed = bts._write_all_state_outputs(state, state_dir, None)
+        assert not write_failed, "Should return False when writes succeed"
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward: non-string generated_at in compute_staleness_seconds
+# ---------------------------------------------------------------------------
+
+class TestNonStringGeneratedAt:
+    def test_integer_generated_at_returns_zero(self) -> None:
+        """Integer generated_at yields 0.0 without raising AttributeError."""
+        result = bts.compute_staleness_seconds({"generated_at": 1234567890})
+        assert result == 0.0, f"Expected 0.0 for integer generated_at, got {result}"
+
+    def test_float_generated_at_returns_zero(self) -> None:
+        """Float generated_at (Unix timestamp) yields 0.0 without crashing."""
+        result = bts.compute_staleness_seconds({"generated_at": 1234567890.5})
+        assert result == 0.0, f"Expected 0.0 for float generated_at, got {result}"
+
+    def test_none_value_explicit_returns_zero(self) -> None:
+        """Explicit None generated_at yields 0.0."""
+        result = bts.compute_staleness_seconds({"generated_at": None})
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fix-forward: unreadable active dir flags has_errors (R6.2)
+# ---------------------------------------------------------------------------
+
+class TestUnreadableActiveDirFlagsErrors:
+    def test_unreadable_active_dir_flags_has_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OSError during active dir enumeration sets has_errors=True (R6.2)."""
+        import os
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        # Remove all permissions so iterdir() raises PermissionError
+        os.chmod(active_dir, 0o000)
+        try:
+            _, has_errors = bts._build_active_work(dispatch_dir)
+        finally:
+            os.chmod(active_dir, 0o755)
+
+        assert has_errors, (
+            "OSError (PermissionError) during active dir enumeration must set has_errors=True"
+        )

--- a/tests/test_future_state_reconciliation.py
+++ b/tests/test_future_state_reconciliation.py
@@ -1,0 +1,369 @@
+"""Behavioral tests for PR-E: kanban/state builder honesty (R6.1-R6.4, R7.1, R7.3).
+
+Each test is self-isolated via tmp_path + monkeypatch for VNX_DATA_DIR.
+No dependency on guards from other PRs.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+
+for _p in (str(_SCRIPTS_DIR), str(_LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import build_t0_state as bts  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_isolated_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Create isolated state_dir + dispatch_dir and pin env vars."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+    # Self-isolate: pin VNX_DATA_DIR so no prod DB is ever touched
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    return state_dir, dispatch_dir
+
+
+def _call_build(state_dir: Path, dispatch_dir: Path) -> Dict[str, Any]:
+    """Call build_t0_state and return the state dict."""
+    return bts.build_t0_state(state_dir, dispatch_dir)
+
+
+# ---------------------------------------------------------------------------
+# R6.1 — locked/malformed DB signals degraded/failed (not silent legacy fallback)
+# ---------------------------------------------------------------------------
+
+class TestR61DBHealthSignaling:
+    def test_malformed_db_signals_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed quality_intelligence.db → system_health.status in degraded/failed."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+
+        # Write garbage bytes — sqlite3 will raise DatabaseError on open
+        (state_dir / "quality_intelligence.db").write_bytes(b"NOT A VALID SQLITE DATABASE")
+
+        state = _call_build(state_dir, dispatch_dir)
+
+        sh_status = state["system_health"]["status"]
+        assert sh_status in ("degraded", "failed"), (
+            f"Expected degraded or failed for malformed DB, got: {sh_status!r}"
+        )
+
+    def test_locked_db_signals_degraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Monkeypatched locked DB → system_health.status == 'degraded'."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+
+        # Create a placeholder DB file so the probe doesn't skip it
+        (state_dir / "quality_intelligence.db").write_bytes(b"")
+
+        original_connect = sqlite3.connect
+
+        def _locked_connect(path: str, **kwargs: Any) -> Any:
+            if "quality_intelligence" in str(path):
+                raise sqlite3.OperationalError("database is locked")
+            return original_connect(path, **kwargs)
+
+        monkeypatch.setattr(sqlite3, "connect", _locked_connect)
+
+        state = _call_build(state_dir, dispatch_dir)
+
+        sh_status = state["system_health"]["status"]
+        assert sh_status in ("degraded", "failed"), (
+            f"Expected degraded or failed for locked DB, got: {sh_status!r}"
+        )
+
+    def test_missing_table_does_not_degrade(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pre-migration 'no such table' error does NOT set degraded — it is a valid fallback."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+
+        # Presence of a receipt file keeps health from going degraded via the default check
+        (state_dir / "t0_receipts.ndjson").write_text("")
+
+        # Classify the error — must return 'premigration', not 'degraded'/'failed'
+        err = sqlite3.OperationalError("no such table: tracks")
+        result = bts._classify_db_error(err)
+        assert result == "premigration", (
+            f"Expected premigration for missing-table error, got: {result!r}"
+        )
+
+    def test_classify_db_error_operational_non_premigration(self) -> None:
+        """Non-premigration OperationalError → 'degraded'."""
+        err = sqlite3.OperationalError("database is locked")
+        assert bts._classify_db_error(err) == "degraded"
+
+    def test_classify_db_error_database_error(self) -> None:
+        """DatabaseError (e.g. malformed) → 'failed'."""
+        err = sqlite3.DatabaseError("file is not a database")
+        assert bts._classify_db_error(err) == "failed"
+
+
+# ---------------------------------------------------------------------------
+# R6.2 — corrupt manifest yields placeholder + degraded flag
+# ---------------------------------------------------------------------------
+
+class TestR62ArtifactReadFailure:
+    def test_corrupt_manifest_yields_placeholder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Corrupt manifest.json → dispatch represented as placeholder, not dropped."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        dispatch_id = "20260601-corrupt-dispatch"
+        subdir = active_dir / dispatch_id
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text("NOT VALID JSON {{{")
+
+        items, has_errors = bts._build_active_work(dispatch_dir)
+
+        dispatch_ids = [item["dispatch_id"] for item in items]
+        assert dispatch_id in dispatch_ids, (
+            f"Corrupt dispatch {dispatch_id!r} was silently dropped (not in {dispatch_ids})"
+        )
+        corrupt_item = next(i for i in items if i["dispatch_id"] == dispatch_id)
+        assert "artifact_error" in corrupt_item, (
+            "Placeholder must carry 'artifact_error' field"
+        )
+        assert has_errors, "has_errors must be True when manifest is corrupt"
+
+    def test_corrupt_manifest_flags_build_degraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Corrupt manifest propagates through build_t0_state → system_health degraded."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        # Provide a receipt so the default-degraded check (no receipts) doesn't fire
+        (state_dir / "t0_receipts.ndjson").write_text("")
+
+        dispatch_id = "20260601-build-degraded"
+        subdir = active_dir / dispatch_id
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text("{bad json")
+
+        state = _call_build(state_dir, dispatch_dir)
+
+        active_ids = [item["dispatch_id"] for item in state["active_work"]]
+        assert dispatch_id in active_ids, "Dispatch must appear in active_work"
+        assert state["system_health"]["status"] == "degraded", (
+            f"Expected degraded, got: {state['system_health']['status']!r}"
+        )
+
+    def test_valid_manifest_no_artifact_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid manifest → no artifact_error, no has_errors."""
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        dispatch_id = "20260601-valid"
+        subdir = active_dir / dispatch_id
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text('{"track": "A", "gate": "PR-1"}')
+
+        items, has_errors = bts._build_active_work(dispatch_dir)
+
+        assert not has_errors
+        assert any(i["dispatch_id"] == dispatch_id for i in items)
+        item = next(i for i in items if i["dispatch_id"] == dispatch_id)
+        assert "artifact_error" not in item
+
+
+# ---------------------------------------------------------------------------
+# R6.3 — de-dup across dir-form and legacy .md form
+# ---------------------------------------------------------------------------
+
+class TestR63Deduplication:
+    def test_dedup_dispatch_present_in_both_forms(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dispatch present as both active/<id>/ dir and active/<id>.md counts once."""
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        dispatch_id = "20260601-both-forms"
+
+        # Directory form
+        subdir = active_dir / dispatch_id
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text('{"track": "A", "gate": "PR-2"}')
+
+        # Legacy .md form of the same dispatch
+        (active_dir / f"{dispatch_id}.md").write_text(
+            "# Dispatch 20260601-both-forms\nGate: PR-2\n[[TARGET:A]]\n"
+        )
+
+        items, _ = bts._build_active_work(dispatch_dir)
+
+        ids = [item["dispatch_id"] for item in items]
+        assert ids.count(dispatch_id) == 1, (
+            f"Expected dispatch_id to appear once, got {ids.count(dispatch_id)} times"
+        )
+
+    def test_unique_dispatches_not_deduplicated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two distinct dispatches each appear once."""
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        for did in ("20260601-alpha", "20260601-beta"):
+            (active_dir / f"{did}.md").write_text(f"# {did}\n")
+
+        items, _ = bts._build_active_work(dispatch_dir)
+
+        ids = [item["dispatch_id"] for item in items]
+        assert "20260601-alpha" in ids
+        assert "20260601-beta" in ids
+
+    def test_dir_form_takes_precedence_over_md(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both forms exist, the directory form's data is used (it was processed first)."""
+        _, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+        active_dir = dispatch_dir / "active"
+        active_dir.mkdir(parents=True)
+
+        dispatch_id = "20260601-precedence"
+        subdir = active_dir / dispatch_id
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text('{"track": "A", "gate": "from-dir"}')
+        (active_dir / f"{dispatch_id}.md").write_text(
+            f"# {dispatch_id}\nGate: from-md\n[[TARGET:B]]\n"
+        )
+
+        items, _ = bts._build_active_work(dispatch_dir)
+
+        item = next((i for i in items if i["dispatch_id"] == dispatch_id), None)
+        assert item is not None
+        assert item.get("gate") == "from-dir", (
+            f"Directory form should win, got gate={item.get('gate')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# R6.4 — staleness computed from generated_at, not persisted as 0
+# ---------------------------------------------------------------------------
+
+class TestR64StalenessComputation:
+    def test_ten_day_old_state_reports_ten_days(self) -> None:
+        """compute_staleness_seconds on 10-day-old generated_at returns ~864000s."""
+        ten_days_ago = (
+            datetime.now(timezone.utc) - timedelta(days=10)
+        ).isoformat()
+        state: Dict[str, Any] = {"generated_at": ten_days_ago}
+
+        staleness = bts.compute_staleness_seconds(state)
+
+        expected = 10 * 86400  # 864000s
+        assert abs(staleness - expected) < 60, (
+            f"Expected ~{expected}s, got {staleness:.1f}s"
+        )
+
+    def test_injected_clock_gives_exact_delta(self) -> None:
+        """compute_staleness_seconds with pinned 'now' is exact."""
+        now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)  # 10 days earlier
+        state: Dict[str, Any] = {"generated_at": generated_at.isoformat()}
+
+        staleness = bts.compute_staleness_seconds(state, now=now)
+
+        assert staleness == 10 * 86400, f"Expected 864000s, got {staleness}s"
+
+    def test_missing_generated_at_returns_zero(self) -> None:
+        """Missing generated_at returns 0.0 (safe default)."""
+        assert bts.compute_staleness_seconds({}) == 0.0
+
+    def test_malformed_generated_at_returns_zero(self) -> None:
+        """Unparseable generated_at returns 0.0 (safe default)."""
+        assert bts.compute_staleness_seconds({"generated_at": "NOT A DATE"}) == 0.0
+
+    def test_build_t0_state_does_not_persist_staleness_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """build_t0_state must NOT persist staleness_seconds: 0 (R6.4 removed it)."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+
+        state = _call_build(state_dir, dispatch_dir)
+
+        assert "staleness_seconds" not in state, (
+            "staleness_seconds must not be persisted; compute it at read time "
+            "with compute_staleness_seconds()"
+        )
+
+    def test_generated_at_present_in_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """build_t0_state must emit generated_at so consumers can compute staleness."""
+        state_dir, dispatch_dir = _make_isolated_env(tmp_path, monkeypatch)
+
+        state = _call_build(state_dir, dispatch_dir)
+
+        assert "generated_at" in state, "generated_at must be present for staleness computation"
+        staleness = bts.compute_staleness_seconds(state)
+        assert 0.0 <= staleness < 30.0, (
+            f"Fresh state should have staleness near 0, got {staleness:.1f}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# R7.3 — _safe_json surfaces parse errors to caller
+# ---------------------------------------------------------------------------
+
+class TestR73SafeJsonErrorSurfacing:
+    def test_valid_json_returns_dict(self, tmp_path: Path) -> None:
+        p = tmp_path / "ok.json"
+        p.write_text('{"key": "value"}')
+        result = bts._safe_json(p)
+        assert result == {"key": "value"}
+
+    def test_absent_file_returns_none(self, tmp_path: Path) -> None:
+        p = tmp_path / "missing.json"
+        result = bts._safe_json(p)
+        assert result is None
+
+    def test_malformed_json_raises_json_decode_error(self, tmp_path: Path) -> None:
+        """Malformed JSON must raise json.JSONDecodeError, not silently return None."""
+        p = tmp_path / "bad.json"
+        p.write_text("NOT JSON {{{")
+
+        with pytest.raises(json.JSONDecodeError):
+            bts._safe_json(p)
+
+    def test_non_dict_json_returns_none(self, tmp_path: Path) -> None:
+        """A valid JSON array (not a dict) returns None."""
+        p = tmp_path / "array.json"
+        p.write_text("[1, 2, 3]")
+        assert bts._safe_json(p) is None


### PR DESCRIPTION
## Summary
Implements approved PRD §5 PR-E (R6.1-R6.4, R7.1 build_t0_state, R7.3). build_t0_state now reports health=degraded/failed instead of silent legacy fallback, corrupt manifests become placeholders (not dropped), active count de-duped across dir/.md forms, staleness computed from generated_at at read, _safe_json surfaces JSONDecodeError. main() exits non-zero on degraded/failed. 21 behavioral tests.

## Changes
See report 20260613-fsr-pre: _classify_db_error, _probe_db_health, compute_staleness_seconds, _read_dir/_read_md_dispatch placeholders, de-dup, function decomposition (main 123→31, build_t0_state →61).

## Verification
Built via tmux lane; 21 new behavioral tests. codex gate pending (one round per risk-calibration: medium-risk).

## Open Items
Shares build_t0_state.py with PR-0 (#857) — merge after PR-0, rebase to resolve overlap.