### PR TITLE
feat(fsr-a1): ADR-007 dispatches in-place rebuild — composite UNIQUE, 12-step, fail-closed tenant

### DIFF
--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -115,18 +115,36 @@ _IDENT_RE = re.compile(r'"[^"]+"|`[^`]+`|\[[^\]]+\]|[A-Za-z_][A-Za-z0-9_]*')
 _CONSTRAINT_KW = ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT")
 
 
-def _paren_group(sql: str, open_pos: int) -> str:
-    """Return the substring inside the parentheses that open at *open_pos*."""
+def _matching_paren(sql: str, open_pos: int) -> int:
+    """Index of the ``)`` matching the ``(`` at *open_pos*, skipping string literals.
+
+    String-literal aware (G): a paren inside '...' / "..." / `...` never affects the
+    depth count, so a column ``DEFAULT '('`` cannot mis-balance the scan. A doubled
+    quote nets to two toggles with no chars between (same quote-state logic as
+    _split_columns_and_constraints), so escaped quotes are handled correctly.
+    """
     depth = 0
+    in_str, quote = False, ""
     for i in range(open_pos, len(sql)):
         ch = sql[i]
-        if ch == "(":
+        if in_str:
+            if ch == quote:
+                in_str = False
+            continue
+        if ch in ("'", '"', "`"):
+            in_str, quote = True, ch
+        elif ch == "(":
             depth += 1
         elif ch == ")":
             depth -= 1
             if depth == 0:
-                return sql[open_pos + 1:i]
+                return i
     raise ValueError("unbalanced parentheses in SQL")
+
+
+def _paren_group(sql: str, open_pos: int) -> str:
+    """Return the substring inside the parentheses that open at *open_pos* (G)."""
+    return sql[open_pos + 1:_matching_paren(sql, open_pos)]
 
 
 def _referenced_columns(spec: str, dispatch_cols) -> set[str]:
@@ -290,8 +308,12 @@ def _validate_existing_project_id_or_abort(conn: sqlite3.Connection,
     cols = [c for c, _ in _dispatch_table_columns(conn)]
     if "project_id" not in cols:
         return
+    # SQLite's bare TRIM() strips only the ASCII space (0x20); pass the full
+    # whitespace set so a tab/newline/CR/FF/VT-only project_id is treated as empty
+    # and aborts like '' rather than passing as a valid tenant (I).
     bad = conn.execute(
-        "SELECT COUNT(*) FROM dispatches WHERE project_id IS NULL OR TRIM(project_id)=''"
+        "SELECT COUNT(*) FROM dispatches WHERE project_id IS NULL OR "
+        "TRIM(project_id, char(32)||char(9)||char(10)||char(13)||char(11)||char(12)) = ''"
     ).fetchone()[0]
     if bad:
         raise RuntimeError(
@@ -348,12 +370,14 @@ def _is_table_constraint(item: str) -> bool:
 
 
 def _is_solo_unique_constraint(item: str, dispatch_cols) -> bool:
-    """True iff *item* is a table-level UNIQUE(...) keyed solely on dispatch_id."""
+    """True iff *item* is a table-level UNIQUE(...) or PRIMARY KEY(...) keyed solely
+    on dispatch_id (B — a table-level PRIMARY KEY(dispatch_id) is stripped the same
+    way as UNIQUE so only the composite remains)."""
     s = item.strip()
     m = re.match(r'(?is)^CONSTRAINT\s+("[^"]+"|`[^`]+`|\[[^\]]+\]|\w+)\s+(.*)$', s)
     if m:
         s = m.group(2).strip()
-    if not re.match(r'(?is)^UNIQUE\s*\(', s):
+    if not re.match(r'(?is)^(?:UNIQUE|PRIMARY\s+KEY)\s*\(', s):
         return False
     return _referenced_columns(_paren_group(s, s.index("(")), dispatch_cols) == {"dispatch_id"}
 
@@ -370,32 +394,65 @@ def _constraint_is_composite(item: str, dispatch_cols) -> bool:
 
 
 def _strip_inline_unique(coldef: str) -> str:
-    """Remove an inline column UNIQUE constraint (+ optional ON CONFLICT clause)."""
-    return re.sub(r'(?is)\s+UNIQUE(\s+ON\s+CONFLICT\s+\w+)?(?=\s|$)', " ", coldef).rstrip()
+    """Strip an inline column UNIQUE *and* PRIMARY KEY constraint from a column-def (B).
+
+    Removes a column-level UNIQUE (+ optional ON CONFLICT) and a column-level
+    PRIMARY KEY (+ optional ASC/DESC, ON CONFLICT, AUTOINCREMENT) so a solo
+    dispatch_id key cannot survive the rebuild while the repair reports success.
+    Called only on the dispatch_id column-def; the composite UNIQUE(dispatch_id,
+    project_id) is added separately.
+    """
+    coldef = re.sub(r'(?is)\s+UNIQUE(\s+ON\s+CONFLICT\s+\w+)?(?=\s|$)', " ", coldef)
+    coldef = re.sub(
+        r'(?is)\s+PRIMARY\s+KEY(\s+(?:ASC|DESC))?'
+        r'(\s+ON\s+CONFLICT\s+\w+)?(\s+AUTOINCREMENT)?(?=\s|$)',
+        " ", coldef)
+    return coldef.rstrip()
 
 
-def _dispatch_id_coldef_index(items, dispatch_cols) -> int:
+def _column_def_index(items, dispatch_cols, target: str) -> int:
+    """Index of the column-def in *items* whose leading identifier is *target*."""
     for idx, item in enumerate(items):
         if _is_table_constraint(item):
             continue
         toks = _IDENT_RE.findall(item)
-        if toks and toks[0].strip('"`[]').lower() == "dispatch_id":
+        if toks and toks[0].strip('"`[]').lower() == target:
             return idx
     return -1
 
 
+def _promote_project_id_not_null(coldef: str) -> str:
+    """Ensure an existing project_id column-def is NOT NULL (J); add no DEFAULT (A).
+
+    R1.4 guarantees zero NULL/empty project_id rows at repair time, so promoting a
+    nullable column to NOT NULL is safe and closes the tenant-isolation hole (SQLite
+    treats NULLs as distinct in a UNIQUE). An already-NOT NULL column is returned
+    verbatim (the real dispatches table keeps its existing default).
+    """
+    if re.search(r'(?is)\bNOT\s+NULL\b', coldef):
+        return coldef
+    return coldef.rstrip() + " NOT NULL"
+
+
 def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bool) -> str:
     """Mutate dispatches CREATE SQL → dispatches_new: drop solo dispatch_id
-    uniqueness, add project_id (if absent) + composite UNIQUE. Everything else
-    (FKs, CHECK, collations, generated cols) is preserved verbatim (R1.5).
+    uniqueness (inline/table UNIQUE *and* PRIMARY KEY, B) and add/keep project_id
+    as NOT NULL — added with no vnx-dev default (A), existing-nullable promoted (J),
+    existing NOT NULL untouched — plus the composite UNIQUE. FKs, CHECK, collations,
+    generated cols and the trailing table-option suffix (STRICT / WITHOUT ROWID, C)
+    are preserved verbatim (R1.5).
 
     SQLite requires every column-def to precede every table constraint, so the
     new project_id column is appended to the column section and the composite
     UNIQUE to the constraint section (never interleaved).
     """
-    body = _paren_group(orig_sql, orig_sql.index("("))
+    open_pos = orig_sql.index("(")
+    close_pos = _matching_paren(orig_sql, open_pos)
+    body = orig_sql[open_pos + 1:close_pos]
+    suffix = orig_sql[close_pos + 1:].strip().rstrip(";").strip()       # C: table options
     items = _split_columns_and_constraints(body)
-    did_idx = _dispatch_id_coldef_index(items, dispatch_cols)
+    did_idx = _column_def_index(items, dispatch_cols, "dispatch_id")
+    pid_idx = _column_def_index(items, dispatch_cols, "project_id")
     col_defs, constraints, has_composite = [], [], False
     for idx, item in enumerate(items):
         if _is_table_constraint(item):
@@ -403,14 +460,19 @@ def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bo
                 continue
             has_composite = has_composite or _constraint_is_composite(item, dispatch_cols)
             constraints.append(item)
+        elif idx == did_idx:
+            col_defs.append(_strip_inline_unique(item))                 # B: strip UNIQUE + PK
+        elif idx == pid_idx:
+            col_defs.append(_promote_project_id_not_null(item))         # J: always NOT NULL
         else:
-            col_defs.append(_strip_inline_unique(item) if idx == did_idx else item)
+            col_defs.append(item)
     if not has_project_id:
-        col_defs.append("project_id TEXT NOT NULL DEFAULT 'vnx-dev'")
+        col_defs.append("project_id TEXT NOT NULL")                     # A: no vnx-dev default
     if not has_composite:
         constraints.append("UNIQUE(dispatch_id, project_id)")
     body_items = ",\n    ".join(col_defs + constraints)
-    return "CREATE TABLE dispatches_new (\n    " + body_items + "\n)"
+    new_sql = "CREATE TABLE dispatches_new (\n    " + body_items + "\n)"
+    return new_sql + (" " + suffix if suffix else "")                   # C: re-append options
 
 
 # --- R1.3: dependent view/trigger discovery (transitive, quoted-aware) -------
@@ -475,10 +537,34 @@ def _standalone_indexes_to_recreate(conn: sqlite3.Connection, dispatch_cols):
     return keep
 
 
+def _checksum_order_clause(conn: sqlite3.Connection, table: str, cols) -> str:
+    """Deterministic ORDER BY for the content checksum (L).
+
+    Prefer ``id`` when the column is present; else ``rowid`` for a rowid table; else
+    order by all copy columns (WITHOUT ROWID / alt-PK shapes). Raise an explicit
+    error when none is available rather than crashing opaquely on a hard-coded
+    ``ORDER BY id``.
+    """
+    table_cols = {r[1].lower() for r in conn.execute(f'PRAGMA table_info("{table}")')}
+    if "id" in table_cols:
+        return "ORDER BY id"
+    try:
+        conn.execute(f'SELECT rowid FROM "{table}" LIMIT 0')
+        return "ORDER BY rowid"
+    except sqlite3.OperationalError:
+        pass
+    if cols:
+        return "ORDER BY " + ", ".join(f'"{c}"' for c in cols)
+    raise RuntimeError(
+        f"ADR-007 checksum: table {table!r} exposes no id, no rowid, and no copy "
+        "columns to order by; cannot compute a deterministic checksum (L).")
+
+
 def _content_checksum(conn: sqlite3.Connection, table: str, cols):
-    """Deterministic (row_count, sha256) over *cols* of *table* ordered by id."""
+    """Deterministic (row_count, sha256) over *cols* of *table* (L: id|rowid|cols)."""
     collist = ", ".join(f'"{c}"' for c in cols) or "1"
-    rows = conn.execute(f'SELECT {collist} FROM "{table}" ORDER BY id').fetchall()
+    order = _checksum_order_clause(conn, table, cols)
+    rows = conn.execute(f'SELECT {collist} FROM "{table}" {order}').fetchall()
     h = hashlib.sha256()
     for row in rows:
         h.update(repr(row).encode("utf-8"))
@@ -519,6 +605,24 @@ def _build_dispatches_rebuild_plan(conn: sqlite3.Connection) -> dict:
 
 # --- R7.2: bounded retry/backoff on a locked DB ------------------------------
 
+def _is_busy_or_locked(exc: sqlite3.OperationalError) -> bool:
+    """Classify a retryable lock error (M).
+
+    Prefer the structured ``sqlite_errorcode`` (Python 3.11+) against SQLITE_BUSY /
+    SQLITE_LOCKED — including extended codes via the low-byte primary mask — so a
+    localized or otherwise non-standard error message cannot bypass retry. Fall back
+    to the legacy substring check when no usable error code is available.
+    """
+    code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(code, int):
+        if code in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+            return True
+        if (code & 0xFF) in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+            return True
+    msg = str(exc).lower()
+    return "locked" in msg or "busy" in msg
+
+
 def _begin_immediate_with_retry(conn: sqlite3.Connection, max_attempts: int = 6,
                                 base_delay: float = 0.05, max_delay: float = 1.0) -> None:
     """BEGIN IMMEDIATE with bounded exponential backoff on BUSY/LOCKED (R7.2)."""
@@ -528,7 +632,7 @@ def _begin_immediate_with_retry(conn: sqlite3.Connection, max_attempts: int = 6,
             conn.execute("BEGIN IMMEDIATE")
             return
         except sqlite3.OperationalError as exc:
-            if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+            if not _is_busy_or_locked(exc):
                 raise
             last = exc
             if attempt < max_attempts:
@@ -577,14 +681,16 @@ def _drop_dependent_objects(conn: sqlite3.Connection, plan: dict) -> None:
 
 
 def _recreate_dependent_objects(conn: sqlite3.Connection, plan: dict) -> None:
-    """Step 10: recreate indexes, table triggers, dependent views (+ their
-    triggers) verbatim. Any failure propagates → whole repair rolls back (R1.3).
+    """Step 10: recreate dependent objects in dependency order (F):
+    indexes → views → table triggers → view triggers, so every view exists before
+    any trigger whose body may reference it. SQL is recreated verbatim; any failure
+    propagates → whole repair rolls back (R1.3).
     """
     for _, sql in plan["indexes"]:
         conn.execute(sql)
-    for _, sql in plan["table_triggers"]:
+    for _, sql in plan["views"]:          # base-first; views before any trigger (F)
         conn.execute(sql)
-    for _, sql in plan["views"]:          # base-first order
+    for _, sql in plan["table_triggers"]:
         conn.execute(sql)
     for _, sql in plan["view_triggers"]:
         conn.execute(sql)
@@ -600,14 +706,40 @@ def _assert_integrity_or_raise(conn: sqlite3.Connection) -> None:
         raise RuntimeError(f"ADR-007 repair integrity_check failed: {res}")
 
 
+def _rename_new_to_dispatches(conn: sqlite3.Connection, orig_legacy) -> None:
+    """Step 9: rename dispatches_new → dispatches with legacy_alter_table ON (so
+    SQLite does not auto-rewrite the dependent triggers/views we recreate verbatim),
+    restoring the PRAGMA in a finally even when the RENAME raises (E — the PRAGMA is
+    non-transactional and would otherwise leak ON to later migrations).
+    """
+    conn.execute("PRAGMA legacy_alter_table=ON")
+    try:
+        conn.execute("ALTER TABLE dispatches_new RENAME TO dispatches")
+    finally:
+        conn.execute(f"PRAGMA legacy_alter_table={orig_legacy}")
+
+
+def _assert_no_solo_unique_or_raise(conn: sqlite3.Connection) -> None:
+    """Post-rebuild guard (B): fail (→ rollback) if any solo dispatch_id uniqueness
+    survived the rebuild; never return a false success."""
+    cols = [c for c, _ in _dispatch_table_columns(conn)]
+    if _has_solo_dispatch_id_unique(conn, cols):
+        raise RuntimeError(
+            "ADR-007 repair did not eliminate solo dispatch_id uniqueness "
+            "(a column/table PRIMARY KEY or UNIQUE survived the rebuild); rolling "
+            "back rather than reporting a false success (B).")
+
+
 def _execute_dispatches_rebuild(conn: sqlite3.Connection, plan: dict, project_id: str) -> None:
     """Steps 4–12 inside one BEGIN IMMEDIATE txn. foreign_keys is already OFF
-    (caller, steps 1–2). On any failure the explicit transaction is rolled back,
-    leaving the DB consistent; the caller restores foreign_keys.
+    (caller, steps 1–2). On any failure the explicit transaction is rolled back
+    (guarded so a rollback error never masks the original, K), leaving the DB
+    consistent; the caller restores foreign_keys.
     """
     orig_legacy = conn.execute("PRAGMA legacy_alter_table").fetchone()[0]
     _begin_immediate_with_retry(conn)                                   # step 4
     try:
+        _validate_existing_project_id_or_abort(conn, project_id)        # H: re-validate in-txn
         conn.execute(plan["new_table_sql"])                             # step 5
         _copy_rows_into_new(conn, plan, project_id)                     # step 6
         after = _content_checksum(conn, "dispatches_new", plan["checksum_cols"])
@@ -617,15 +749,17 @@ def _execute_dispatches_rebuild(conn: sqlite3.Connection, plan: dict, project_id
                 f"after={after}); aborting to prevent data loss.")
         _drop_dependent_objects(conn, plan)                             # step 8a
         conn.execute("DROP TABLE dispatches")                           # step 8b
-        conn.execute("PRAGMA legacy_alter_table=ON")
-        conn.execute("ALTER TABLE dispatches_new RENAME TO dispatches")  # step 9
-        conn.execute(f"PRAGMA legacy_alter_table={orig_legacy}")
+        _rename_new_to_dispatches(conn, orig_legacy)                    # step 9 (E)
         _restore_dispatches_sequence(conn, plan)                        # step 7 (post-rename)
         _recreate_dependent_objects(conn, plan)                         # step 10
         _assert_integrity_or_raise(conn)                                # step 11
+        _assert_no_solo_unique_or_raise(conn)                           # B: post-rebuild guard
         conn.execute("COMMIT")                                          # step 12
     except Exception:
-        conn.execute("ROLLBACK")
+        try:
+            conn.execute("ROLLBACK")                                    # K: guarded rollback
+        except Exception:
+            pass
         raise
 
 
@@ -655,12 +789,15 @@ def _repair_dispatches_adr007(conn: sqlite3.Connection, project_id: str) -> bool
     """
     if not _dispatches_needs_adr007_repair(conn):
         return False
+    if conn.in_transaction:
+        raise RuntimeError(
+            "ADR-007 repair requires a connection with no open transaction; it "
+            "refuses to commit the caller's uncommitted work (D). Commit or roll "
+            "back before invoking the repair.")
     _validate_existing_project_id_or_abort(conn, project_id)            # R1.4 pre-mutation abort
     plan = _build_dispatches_rebuild_plan(conn)                         # read-only capture
     orig_fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]         # step 1
     prev_iso = conn.isolation_level
-    if conn.in_transaction:
-        conn.commit()
     conn.isolation_level = None                                         # explicit-txn control
     try:
         conn.execute("PRAGMA foreign_keys=OFF")                         # step 2 (before BEGIN)

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -212,11 +212,18 @@ def _has_composite_unique(conn: sqlite3.Connection, dispatch_cols=None) -> bool:
 
 
 def _dispatches_needs_adr007_repair(conn: sqlite3.Connection) -> bool:
-    """True when dispatches still carries single-column uniqueness on dispatch_id.
+    """True when dispatches lacks the ADR-007 composite UNIQUE(dispatch_id, project_id).
 
-    Detection is sqlite_master/PRAGMA based (R1.1). A table already keyed by the
-    composite (no solo-dispatch_id unique object) is a no-op; a missing
-    dispatches table is a no-op.
+    Detection is sqlite_master/PRAGMA based (R1.1). Repair is needed when EITHER a
+    single-column uniqueness on dispatch_id still exists OR the composite is absent
+    (N1: a table with NO solo uniqueness AND no composite was previously treated as
+    "no repair needed", so the composite was never added). Semantics:
+      already-composite (no solo)      → False  (no-op)
+      solo dispatch_id uniqueness      → True
+      neither solo nor composite       → True   (N1: composite now added)
+      composite + a stray solo unique  → True
+    A missing dispatches table is a no-op. See ADR-007
+    (docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md).
     """
     present = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dispatches'"
@@ -224,7 +231,8 @@ def _dispatches_needs_adr007_repair(conn: sqlite3.Connection) -> bool:
     if not present:
         return False
     cols = [c for c, _ in _dispatch_table_columns(conn)]
-    return _has_solo_dispatch_id_unique(conn, cols)
+    return (_has_solo_dispatch_id_unique(conn, cols)
+            or not _has_composite_unique(conn, cols))
 
 
 # --- R3.1: DB-path-anchored, fail-closed project_id resolver/validator -------
@@ -393,6 +401,34 @@ def _constraint_is_composite(item: str, dispatch_cols) -> bool:
         "dispatch_id", "project_id"}
 
 
+_INLINE_UNIQUE_RE = re.compile(r'(?is)\s+UNIQUE(\s+ON\s+CONFLICT\s+\w+)?(?=\s|$)')
+_INLINE_PK_RE = re.compile(
+    r'(?is)\s+PRIMARY\s+KEY(\s+(?:ASC|DESC))?'
+    r'(\s+ON\s+CONFLICT\s+\w+)?(\s+AUTOINCREMENT)?(?=\s|$)')
+_PK_TOKEN_RE = re.compile(r'(?is)\bPRIMARY\s+KEY\b')
+
+
+def _mask_string_literals(sql: str) -> str:
+    """Return *sql* with every char inside a '...'/"..."/`...` literal replaced by
+    NUL (quotes kept, length and indices preserved) so a regex run over the mask
+    sees keyword tokens ONLY outside quoted strings (N3). A doubled quote nets to
+    two toggles with no chars between (same quote-state logic as
+    _split_columns_and_constraints), so an escaped quote stays masked.
+    """
+    out, in_str, quote = [], False, ""
+    for ch in sql:
+        if in_str:
+            out.append(ch if ch == quote else "\x00")
+            if ch == quote:
+                in_str = False
+        elif ch in ("'", '"', "`"):
+            in_str, quote = True, ch
+            out.append(ch)
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 def _strip_inline_unique(coldef: str) -> str:
     """Strip an inline column UNIQUE *and* PRIMARY KEY constraint from a column-def (B).
 
@@ -401,13 +437,33 @@ def _strip_inline_unique(coldef: str) -> str:
     dispatch_id key cannot survive the rebuild while the repair reports success.
     Called only on the dispatch_id column-def; the composite UNIQUE(dispatch_id,
     project_id) is added separately.
+
+    N3: the keyword scan is string-literal aware — a UNIQUE / PRIMARY KEY token
+    inside a quoted DEFAULT (e.g. ``DEFAULT 'a UNIQUE b'``) is preserved verbatim;
+    only a real keyword token outside any quoted string is stripped. Match spans
+    are computed on the masked copy and deleted from the original right-to-left so
+    earlier indices stay valid (the two keyword tokens never overlap).
     """
-    coldef = re.sub(r'(?is)\s+UNIQUE(\s+ON\s+CONFLICT\s+\w+)?(?=\s|$)', " ", coldef)
-    coldef = re.sub(
-        r'(?is)\s+PRIMARY\s+KEY(\s+(?:ASC|DESC))?'
-        r'(\s+ON\s+CONFLICT\s+\w+)?(\s+AUTOINCREMENT)?(?=\s|$)',
-        " ", coldef)
+    masked = _mask_string_literals(coldef)
+    spans = [m.span() for m in _INLINE_UNIQUE_RE.finditer(masked)]
+    spans += [m.span() for m in _INLINE_PK_RE.finditer(masked)]
+    for start, end in sorted(spans, reverse=True):
+        coldef = coldef[:start] + " " + coldef[end:]
     return coldef.rstrip()
+
+
+def _coldef_has_primary_key(coldef: str) -> bool:
+    """True if *coldef* declares an inline PRIMARY KEY (string-literal aware, N4)."""
+    return bool(_PK_TOKEN_RE.search(_mask_string_literals(coldef)))
+
+
+def _constraint_is_primary_key(item: str) -> bool:
+    """True if table-constraint *item* is a PRIMARY KEY(...) (optionally CONSTRAINT-named, N4)."""
+    s = item.strip()
+    m = re.match(r'(?is)^CONSTRAINT\s+\S+\s+(.*)$', s)
+    if m:
+        s = m.group(1).strip()
+    return bool(re.match(r'(?is)^PRIMARY\s+KEY\s*\(', s))
 
 
 def _column_def_index(items, dispatch_cols, target: str) -> int:
@@ -434,17 +490,36 @@ def _promote_project_id_not_null(coldef: str) -> str:
     return coldef.rstrip() + " NOT NULL"
 
 
+def _composite_constraint_clause(col_defs, constraints, removed_solo_pk: bool) -> str:
+    """The composite (dispatch_id, project_id) clause for the rebuilt table (N4).
+
+    Emit it as PRIMARY KEY when the removed solo dispatch_id uniqueness WAS a
+    PRIMARY KEY and no other PRIMARY KEY survives the rebuild — otherwise the table
+    would lose its PK. Emit UNIQUE in every other case (a separate PK such as
+    ``id INTEGER PRIMARY KEY`` remains, or the removed solo key was a plain UNIQUE).
+    """
+    has_remaining_pk = (any(_coldef_has_primary_key(c) for c in col_defs)
+                        or any(_constraint_is_primary_key(c) for c in constraints))
+    if removed_solo_pk and not has_remaining_pk:
+        return "PRIMARY KEY(dispatch_id, project_id)"
+    return "UNIQUE(dispatch_id, project_id)"
+
+
 def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bool) -> str:
     """Mutate dispatches CREATE SQL → dispatches_new: drop solo dispatch_id
     uniqueness (inline/table UNIQUE *and* PRIMARY KEY, B) and add/keep project_id
     as NOT NULL — added with no vnx-dev default (A), existing-nullable promoted (J),
-    existing NOT NULL untouched — plus the composite UNIQUE. FKs, CHECK, collations,
+    existing NOT NULL untouched — plus the composite key. FKs, CHECK, collations,
     generated cols and the trailing table-option suffix (STRICT / WITHOUT ROWID, C)
     are preserved verbatim (R1.5).
 
+    N4: the composite is added as PRIMARY KEY(dispatch_id, project_id) when the
+    stripped solo key was a PRIMARY KEY and no other PK survives (so the table is
+    not left PK-less); otherwise as UNIQUE(dispatch_id, project_id).
+
     SQLite requires every column-def to precede every table constraint, so the
     new project_id column is appended to the column section and the composite
-    UNIQUE to the constraint section (never interleaved).
+    to the constraint section (never interleaved).
     """
     open_pos = orig_sql.index("(")
     close_pos = _matching_paren(orig_sql, open_pos)
@@ -453,14 +528,16 @@ def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bo
     items = _split_columns_and_constraints(body)
     did_idx = _column_def_index(items, dispatch_cols, "dispatch_id")
     pid_idx = _column_def_index(items, dispatch_cols, "project_id")
-    col_defs, constraints, has_composite = [], [], False
+    col_defs, constraints, has_composite, removed_solo_pk = [], [], False, False
     for idx, item in enumerate(items):
         if _is_table_constraint(item):
             if _is_solo_unique_constraint(item, dispatch_cols):
+                removed_solo_pk = removed_solo_pk or _constraint_is_primary_key(item)
                 continue
             has_composite = has_composite or _constraint_is_composite(item, dispatch_cols)
             constraints.append(item)
         elif idx == did_idx:
+            removed_solo_pk = removed_solo_pk or _coldef_has_primary_key(item)  # N4
             col_defs.append(_strip_inline_unique(item))                 # B: strip UNIQUE + PK
         elif idx == pid_idx:
             col_defs.append(_promote_project_id_not_null(item))         # J: always NOT NULL
@@ -469,7 +546,8 @@ def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bo
     if not has_project_id:
         col_defs.append("project_id TEXT NOT NULL")                     # A: no vnx-dev default
     if not has_composite:
-        constraints.append("UNIQUE(dispatch_id, project_id)")
+        constraints.append(_composite_constraint_clause(               # N4: PK vs UNIQUE
+            col_defs, constraints, removed_solo_pk))
     body_items = ",\n    ".join(col_defs + constraints)
     new_sql = "CREATE TABLE dispatches_new (\n    " + body_items + "\n)"
     return new_sql + (" " + suffix if suffix else "")                   # C: re-append options
@@ -758,8 +836,14 @@ def _execute_dispatches_rebuild(conn: sqlite3.Connection, plan: dict, project_id
     except Exception:
         try:
             conn.execute("ROLLBACK")                                    # K: guarded rollback
-        except Exception:
-            pass
+        except Exception as rb_exc:
+            # N2/K: never silently swallow the rollback failure (silent-except CI
+            # gate). Log it, then fall through to re-raise the ORIGINAL exception
+            # so K's contract holds — the original error propagates, not this one.
+            warnings.warn(
+                f"ADR-007 repair: ROLLBACK after error failed: {rb_exc}",
+                stacklevel=2,
+            )
         raise
 
 
@@ -786,6 +870,14 @@ def _repair_dispatches_adr007(conn: sqlite3.Connection, project_id: str) -> bool
     (PRD §7.1 / R1.6). *project_id* is the DB-path-anchored validated tenant
     identity (R3.1); never the 'vnx-dev' sentinel. Returns True if a rebuild ran.
     Cite ADR-007.
+
+    ADR-005 audit (N5): this primitive deliberately emits NO NDJSON ledger event.
+    It operates on a raw conn/db_path with no event-store wiring; emitting from
+    here would break temp-DB test isolation and couple the data layer to the
+    ledger. The ADR-005 event for this mutation is recorded at the GOVERNED CALLER
+    layer — run() under VNX_ROADMAP_AUTOPILOT / migration governance and the
+    operator runbook §7.2 (operator approval + unified report + completion
+    receipt). That caller layer, not this function, is the correct ledger surface.
     """
     if not _dispatches_needs_adr007_repair(conn):
         return False
@@ -813,6 +905,12 @@ def _run_adr007_dispatches_repair(conn: sqlite3.Connection, db_path) -> None:
     """run() wiring: detect → resolve tenant → repair. project_id is resolved
     ONLY when a rebuild is actually needed, so a fresh/composite DB never
     requires identity resolution. Cite ADR-007.
+
+    ADR-005 audit (N5): the repair mutation is audited at this GOVERNED CALLER
+    layer — run() under VNX_ROADMAP_AUTOPILOT / migration governance and the
+    operator runbook §7.2 (operator approval + unified report + completion
+    receipt) — NOT inside the pure repair primitive, which has no event-store
+    wiring and must stay temp-DB-isolation safe (no code-level ledger emission).
     """
     if not _dispatches_needs_adr007_repair(conn):
         return

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -42,6 +42,7 @@ if str(_LIB) not in sys.path:
 
 from project_root import resolve_project_root
 import schema_migration
+from atomic_io import audit_event_append
 
 
 # ---------------------------------------------------------------------------
@@ -111,31 +112,48 @@ def _pytest_db_isolation_guard(project_root: Path) -> None:
 # docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
 # ===========================================================================
 
-_IDENT_RE = re.compile(r'"[^"]+"|`[^`]+`|\[[^\]]+\]|[A-Za-z_][A-Za-z0-9_]*')
+_IDENT_PATTERN = r'"[^"]+"|`[^`]+`|\[[^\]]+\]|[A-Za-z_][A-Za-z0-9_]*'
+_IDENT_RE = re.compile(_IDENT_PATTERN)
 _CONSTRAINT_KW = ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT")
 
 
-def _matching_paren(sql: str, open_pos: int) -> int:
-    """Index of the ``)`` matching the ``(`` at *open_pos*, skipping string literals.
+def _mask_quoted_sql(sql: str) -> str:
+    """Mask quoted content while preserving length and quote delimiters.
 
-    String-literal aware (G): a paren inside '...' / "..." / `...` never affects the
-    depth count, so a column ``DEFAULT '('`` cannot mis-balance the scan. A doubled
-    quote nets to two toggles with no chars between (same quote-state logic as
-    _split_columns_and_constraints), so escaped quotes are handled correctly.
+    Handles SQL strings plus double-quoted, backtick-quoted, and bracket-quoted
+    identifiers, including doubled closing delimiters. This is intentionally a
+    bounded scanner for the existing CREATE TABLE/INDEX helpers, not a SQL parser.
     """
-    depth = 0
-    in_str, quote = False, ""
-    for i in range(open_pos, len(sql)):
-        ch = sql[i]
-        if in_str:
-            if ch == quote:
-                in_str = False
+    out, i = list(sql), 0
+    while i < len(sql):
+        opener = sql[i]
+        if opener not in ("'", '"', "`", "["):
+            i += 1
             continue
-        if ch in ("'", '"', "`"):
-            in_str, quote = True, ch
-        elif ch == "(":
+        closer = "]" if opener == "[" else opener
+        i += 1
+        while i < len(sql):
+            if sql[i] != closer:
+                out[i] = "\x00"
+                i += 1
+                continue
+            if i + 1 < len(sql) and sql[i + 1] == closer:
+                out[i] = out[i + 1] = "\x00"
+                i += 2
+                continue
+            i += 1
+            break
+    return "".join(out)
+
+
+def _matching_paren(sql: str, open_pos: int) -> int:
+    """Index of the ``)`` matching the ``(`` at *open_pos*, skipping quoted text."""
+    depth = 0
+    masked = _mask_quoted_sql(sql)
+    for i in range(open_pos, len(masked)):
+        if masked[i] == "(":
             depth += 1
-        elif ch == ")":
+        elif masked[i] == ")":
             depth -= 1
             if depth == 0:
                 return i
@@ -197,16 +215,49 @@ def _unique_index_rows(conn: sqlite3.Connection):
     return [r for r in conn.execute("PRAGMA index_list('dispatches')") if r[2] == 1]
 
 
+def _index_sql(conn: sqlite3.Connection, index_name: str) -> str | None:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (index_name,)
+    ).fetchone()
+    return row[0] if row and row[0] else None
+
+
+def _index_is_partial(conn: sqlite3.Connection, index_row) -> bool:
+    """True when an index is partial by PRAGMA metadata or CREATE INDEX SQL."""
+    if len(index_row) > 4 and bool(index_row[4]):
+        return True
+    sql = _index_sql(conn, index_row[1])
+    return bool(sql and re.search(r"(?i)\bWHERE\b", _mask_quoted_sql(sql)))
+
+
+def _index_key_column_names(conn: sqlite3.Connection, index_name: str) -> list[str]:
+    """Return real key-column names; expressions make the result invalid/empty."""
+    xinfo = conn.execute(f"PRAGMA index_xinfo('{index_name}')").fetchall()
+    key_rows = [r for r in xinfo if len(r) > 5 and r[5] == 1]
+    if not key_rows:
+        key_rows = conn.execute(f"PRAGMA index_info('{index_name}')").fetchall()
+    if any(r[1] < 0 or r[2] is None for r in key_rows):
+        return []
+    return [r[2].lower() for r in key_rows]
+
+
 def _has_solo_dispatch_id_unique(conn: sqlite3.Connection, dispatch_cols) -> bool:
     return any(_index_is_solo_dispatch_id(conn, r[1], dispatch_cols)
                for r in _unique_index_rows(conn))
 
 
 def _has_composite_unique(conn: sqlite3.Connection, dispatch_cols=None) -> bool:
-    """True if dispatches carries a UNIQUE keyed exactly on (dispatch_id, project_id)."""
+    """True for a full UNIQUE keyed exactly on dispatch_id + project_id.
+
+    ADR-007 requires uniqueness for every row. A partial unique index cannot
+    satisfy the contract because duplicate pairs remain possible outside its
+    WHERE predicate.
+    """
     for r in _unique_index_rows(conn):
-        names = {c[2].lower() for c in conn.execute(f"PRAGMA index_info('{r[1]}')") if c[2]}
-        if names == {"dispatch_id", "project_id"}:
+        if _index_is_partial(conn, r):
+            continue
+        names = _index_key_column_names(conn, r[1])
+        if len(names) == 2 and set(names) == {"dispatch_id", "project_id"}:
             return True
     return False
 
@@ -346,22 +397,15 @@ def _split_columns_and_constraints(body: str):
     literals never split an item.
     """
     items, depth, cur = [], 0, []
-    in_str, quote = False, ""
-    for ch in body:
-        if in_str:
-            cur.append(ch)
-            if ch == quote:
-                in_str = False
-        elif ch in ("'", '"', "`"):
-            in_str, quote = True, ch
-            cur.append(ch)
-        elif ch == "(":
+    masked = _mask_quoted_sql(body)
+    for ch, visible in zip(body, masked):
+        if visible == "(":
             depth += 1
             cur.append(ch)
-        elif ch == ")":
+        elif visible == ")":
             depth -= 1
             cur.append(ch)
-        elif ch == "," and depth == 0:
+        elif visible == "," and depth == 0:
             items.append("".join(cur).strip())
             cur = []
         else:
@@ -382,7 +426,7 @@ def _is_solo_unique_constraint(item: str, dispatch_cols) -> bool:
     on dispatch_id (B — a table-level PRIMARY KEY(dispatch_id) is stripped the same
     way as UNIQUE so only the composite remains)."""
     s = item.strip()
-    m = re.match(r'(?is)^CONSTRAINT\s+("[^"]+"|`[^`]+`|\[[^\]]+\]|\w+)\s+(.*)$', s)
+    m = re.match(rf"(?is)^CONSTRAINT\s+({_IDENT_PATTERN})\s+(.*)$", s)
     if m:
         s = m.group(2).strip()
     if not re.match(r'(?is)^(?:UNIQUE|PRIMARY\s+KEY)\s*\(', s):
@@ -392,7 +436,7 @@ def _is_solo_unique_constraint(item: str, dispatch_cols) -> bool:
 
 def _constraint_is_composite(item: str, dispatch_cols) -> bool:
     s = item.strip()
-    m = re.match(r'(?is)^CONSTRAINT\s+\S+\s+(.*)$', s)
+    m = re.match(rf"(?is)^CONSTRAINT\s+({_IDENT_PATTERN})\s+(.*)$", s)
     if m:
         s = m.group(1).strip()
     if not re.match(r'(?is)^UNIQUE\s*\(', s):
@@ -409,24 +453,8 @@ _PK_TOKEN_RE = re.compile(r'(?is)\bPRIMARY\s+KEY\b')
 
 
 def _mask_string_literals(sql: str) -> str:
-    """Return *sql* with every char inside a '...'/"..."/`...` literal replaced by
-    NUL (quotes kept, length and indices preserved) so a regex run over the mask
-    sees keyword tokens ONLY outside quoted strings (N3). A doubled quote nets to
-    two toggles with no chars between (same quote-state logic as
-    _split_columns_and_constraints), so an escaped quote stays masked.
-    """
-    out, in_str, quote = [], False, ""
-    for ch in sql:
-        if in_str:
-            out.append(ch if ch == quote else "\x00")
-            if ch == quote:
-                in_str = False
-        elif ch in ("'", '"', "`"):
-            in_str, quote = True, ch
-            out.append(ch)
-        else:
-            out.append(ch)
-    return "".join(out)
+    """Mask SQL strings and quoted identifiers for keyword-token scans (N3)."""
+    return _mask_quoted_sql(sql)
 
 
 def _strip_inline_unique(coldef: str) -> str:
@@ -460,7 +488,7 @@ def _coldef_has_primary_key(coldef: str) -> bool:
 def _constraint_is_primary_key(item: str) -> bool:
     """True if table-constraint *item* is a PRIMARY KEY(...) (optionally CONSTRAINT-named, N4)."""
     s = item.strip()
-    m = re.match(r'(?is)^CONSTRAINT\s+\S+\s+(.*)$', s)
+    m = re.match(rf"(?is)^CONSTRAINT\s+({_IDENT_PATTERN})\s+(.*)$", s)
     if m:
         s = m.group(1).strip()
     return bool(re.match(r'(?is)^PRIMARY\s+KEY\s*\(', s))
@@ -871,13 +899,9 @@ def _repair_dispatches_adr007(conn: sqlite3.Connection, project_id: str) -> bool
     identity (R3.1); never the 'vnx-dev' sentinel. Returns True if a rebuild ran.
     Cite ADR-007.
 
-    ADR-005 audit (N5): this primitive deliberately emits NO NDJSON ledger event.
-    It operates on a raw conn/db_path with no event-store wiring; emitting from
-    here would break temp-DB test isolation and couple the data layer to the
-    ledger. The ADR-005 event for this mutation is recorded at the GOVERNED CALLER
-    layer — run() under VNX_ROADMAP_AUTOPILOT / migration governance and the
-    operator runbook §7.2 (operator approval + unified report + completion
-    receipt). That caller layer, not this function, is the correct ledger surface.
+    ADR-005 audit (N5): this primitive deliberately emits no ledger event. The
+    governed caller records the mutation after a successful rebuild, preserving
+    unit-testability and the operator runbook §7.2 caller boundary.
     """
     if not _dispatches_needs_adr007_repair(conn):
         return False
@@ -901,21 +925,51 @@ def _repair_dispatches_adr007(conn: sqlite3.Connection, project_id: str) -> bool
     return True
 
 
+def _adr007_events_dir(db_path) -> Path:
+    """Resolve the ADR-005 events directory without falling back to live data.
+
+    An explicit VNX_DATA_DIR wins, matching repo event-store behavior and keeping
+    temp-DB tests isolated. Otherwise events live beside the resolved DB's state
+    directory under the same project-specific .vnx-data tree.
+    """
+    explicit = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    data_dir = (os.environ.get("VNX_DATA_DIR") or "").strip()
+    if explicit and data_dir:
+        return Path(data_dir).expanduser().resolve() / "events"
+    db = Path(db_path).expanduser().resolve()
+    return db.parent.parent / "events" if db.parent.name == "state" else db.parent / "events"
+
+
+def _emit_adr007_repair_event(db_path, project_id: str) -> None:
+    """Record the successful dispatches rebuild under ADR-005 and ADR-007."""
+    audit_event_append(
+        _adr007_events_dir(db_path),
+        "adr007_dispatches_repaired",
+        {
+            "dispatch_table": "dispatches",
+            "project_id": project_id,
+            "rebuild_occurred": True,
+            "adr": "ADR-007",
+            "db_path": str(Path(db_path).expanduser().resolve()),
+        },
+    )
+
+
 def _run_adr007_dispatches_repair(conn: sqlite3.Connection, db_path) -> None:
     """run() wiring: detect → resolve tenant → repair. project_id is resolved
     ONLY when a rebuild is actually needed, so a fresh/composite DB never
     requires identity resolution. Cite ADR-007.
 
-    ADR-005 audit (N5): the repair mutation is audited at this GOVERNED CALLER
-    layer — run() under VNX_ROADMAP_AUTOPILOT / migration governance and the
-    operator runbook §7.2 (operator approval + unified report + completion
-    receipt) — NOT inside the pure repair primitive, which has no event-store
-    wiring and must stay temp-DB-isolation safe (no code-level ledger emission).
+    ADR-005 audit (N5): this GOVERNED CALLER records a temp-safe event only after
+    a successful rebuild. The pure primitive remains event-I/O free. This is the
+    operator runbook §7.2 caller boundary. See ADR-007:
+    docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md.
     """
     if not _dispatches_needs_adr007_repair(conn):
         return
     project_id = _resolve_validated_project_id(db_path)
     if _repair_dispatches_adr007(conn, project_id):
+        _emit_adr007_repair_event(db_path, project_id)
         print(f"  [adr007] dispatches rebuilt → composite UNIQUE(dispatch_id, "
               f"project_id), tenant={project_id!r}")
 
@@ -936,15 +990,7 @@ def _assert_dispatches_schema_intact(conn: sqlite3.Connection) -> None:
             f'dispatches schema drift: missing={missing} extra={extra}. '
             'Refusing rebuild — please add migration logic for the new columns first.'
         )
-    indexes = list(conn.execute("PRAGMA index_list('dispatches')"))
-    composite_unique_exists = False
-    for idx in indexes:
-        if idx[2]:  # unique flag
-            idx_cols = [c[2] for c in conn.execute(f"PRAGMA index_info('{idx[1]}')")]
-            if set(idx_cols) == {'dispatch_id', 'project_id'}:
-                composite_unique_exists = True
-                break
-    if not composite_unique_exists:
+    if not _has_composite_unique(conn):
         raise RuntimeError(
             'dispatches missing UNIQUE(dispatch_id, project_id) — '
             'was added in migration 0017, must be preserved'

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -18,10 +18,13 @@ Steps:
 
 from __future__ import annotations
 
+import hashlib
 import os
+import re
 import sqlite3
 import sys
 import tempfile
+import time
 import warnings
 from pathlib import Path
 
@@ -88,6 +91,598 @@ def _pytest_db_isolation_guard(project_root: Path) -> None:
             "Setting the flag while pointing at the canonical ~/.vnx-data location is unsafe. "
             "Pass a pytest tmp_path-based project_root to migrate_future_system.run()."
         )
+
+
+# ===========================================================================
+# ADR-007 dispatches repair (PR-A1) — general-purpose, idempotent, lossless
+# in-place rebuild that converts ANY single-column uniqueness on dispatch_id
+# into the composite UNIQUE(dispatch_id, project_id).
+#
+# Position in run() (R2.2): runs as a PRE-MIGRATION step — after the
+# _pytest_db_isolation_guard, BEFORE the numbered version walk (0022→0030).
+# It is a no-op when the schema is already composite (detected by parsing
+# sqlite_master / PRAGMA, NOT a bare column check), so the operator ordering in
+# PRD §6 ("migrate first") is preserved. This is the general robust repair; it
+# does NOT replace the narrow _strip_stale_dispatches_track_fk (v24 FK path).
+#
+# ADR-007 binding: composite UNIQUE/PK over project_id for every central-DB
+# table; NEVER default project_id to 'vnx-dev' as a sentinel for unknown
+# identity (R3.1 fail-closed). See
+# docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+# ===========================================================================
+
+_IDENT_RE = re.compile(r'"[^"]+"|`[^`]+`|\[[^\]]+\]|[A-Za-z_][A-Za-z0-9_]*')
+_CONSTRAINT_KW = ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT")
+
+
+def _paren_group(sql: str, open_pos: int) -> str:
+    """Return the substring inside the parentheses that open at *open_pos*."""
+    depth = 0
+    for i in range(open_pos, len(sql)):
+        ch = sql[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[open_pos + 1:i]
+    raise ValueError("unbalanced parentheses in SQL")
+
+
+def _referenced_columns(spec: str, dispatch_cols) -> set[str]:
+    """Identifiers in *spec* that name a real dispatches column (lower-cased).
+
+    Strips quoting; SQL keywords, collation names and function names are ignored
+    because they never coincide with a dispatches column name.
+    """
+    cols = {c.lower() for c in dispatch_cols}
+    return {tok.strip('"`[]').lower() for tok in _IDENT_RE.findall(spec)
+            if tok.strip('"`[]').lower() in cols}
+
+
+def _dispatch_table_columns(conn: sqlite3.Connection):
+    """Return [(name, is_generated)] for dispatches via PRAGMA table_xinfo.
+
+    hidden in (2, 3) marks a GENERATED column (VIRTUAL/STORED), which must be
+    excluded from any INSERT…SELECT copy — its value is recomputed (R1.5).
+    """
+    rows = conn.execute("PRAGMA table_xinfo('dispatches')").fetchall()
+    return [(r[1], r[6] in (2, 3)) for r in rows]
+
+
+def _index_is_solo_dispatch_id(conn: sqlite3.Connection, index_name: str,
+                               dispatch_cols) -> bool:
+    """True iff the unique index *index_name* is keyed SOLELY on dispatch_id.
+
+    PRAGMA index_xinfo classifies plain/decorated key columns (DESC, COLLATE);
+    an expression key (cid == -2) falls back to parsing the CREATE INDEX SQL
+    (e.g. UNIQUE(lower(dispatch_id))).
+    """
+    xinfo = conn.execute(f"PRAGMA index_xinfo('{index_name}')").fetchall()
+    key_rows = [r for r in xinfo if r[5] == 1]  # r[5] == key flag
+    if not key_rows:
+        return False
+    if all(r[1] >= 0 for r in key_rows):        # r[1] == cid; >=0 → real column
+        names = {r[2].lower() for r in key_rows if r[2] is not None}
+        return names == {"dispatch_id"}
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (index_name,)
+    ).fetchone()
+    if not row or not row[0]:
+        return False
+    spec = _paren_group(row[0], row[0].index("("))
+    return _referenced_columns(spec, dispatch_cols) == {"dispatch_id"}
+
+
+def _unique_index_rows(conn: sqlite3.Connection):
+    """PRAGMA index_list rows for dispatches that enforce uniqueness (r[2]==1)."""
+    return [r for r in conn.execute("PRAGMA index_list('dispatches')") if r[2] == 1]
+
+
+def _has_solo_dispatch_id_unique(conn: sqlite3.Connection, dispatch_cols) -> bool:
+    return any(_index_is_solo_dispatch_id(conn, r[1], dispatch_cols)
+               for r in _unique_index_rows(conn))
+
+
+def _has_composite_unique(conn: sqlite3.Connection, dispatch_cols=None) -> bool:
+    """True if dispatches carries a UNIQUE keyed exactly on (dispatch_id, project_id)."""
+    for r in _unique_index_rows(conn):
+        names = {c[2].lower() for c in conn.execute(f"PRAGMA index_info('{r[1]}')") if c[2]}
+        if names == {"dispatch_id", "project_id"}:
+            return True
+    return False
+
+
+def _dispatches_needs_adr007_repair(conn: sqlite3.Connection) -> bool:
+    """True when dispatches still carries single-column uniqueness on dispatch_id.
+
+    Detection is sqlite_master/PRAGMA based (R1.1). A table already keyed by the
+    composite (no solo-dispatch_id unique object) is a no-op; a missing
+    dispatches table is a no-op.
+    """
+    present = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dispatches'"
+    ).fetchone()
+    if not present:
+        return False
+    cols = [c for c, _ in _dispatch_table_columns(conn)]
+    return _has_solo_dispatch_id_unique(conn, cols)
+
+
+# --- R3.1: DB-path-anchored, fail-closed project_id resolver/validator -------
+
+def _project_id_from_db_path(db_path) -> str | None:
+    """Anchor project_id on the DB's physical location (R3.1).
+
+    Canonical layout: <root>/.vnx-data/<project_id>/state/runtime_coordination.db
+    Returns <project_id> when that shape matches, else None.
+    """
+    p = Path(db_path).resolve()
+    state_dir = p.parent
+    if state_dir.name != "state":
+        return None
+    pid_dir = state_dir.parent
+    if pid_dir.parent.name != ".vnx-data":
+        return None
+    return pid_dir.name or None
+
+
+def _marker_project_id(db_path) -> str | None:
+    """Read the nearest .vnx-project-id marker walking UP from the DB path.
+
+    Anchored on the DB path (NOT cwd) so a stray marker in the operator's
+    working tree cannot override the tenant of the database being repaired
+    (the codex-F1 leak class).
+    """
+    start = Path(db_path).resolve().parent
+    for ancestor in [start, *start.parents]:
+        marker = ancestor / ".vnx-project-id"
+        if marker.is_file():
+            try:
+                first = marker.read_text(encoding="utf-8").splitlines()[0].strip()
+            except (OSError, IndexError):
+                return None
+            return first or None
+    return None
+
+
+def _resolve_validated_project_id(db_path) -> str:
+    """Derive+validate project_id, FAIL CLOSED, never default to 'vnx-dev' (R3.1).
+
+    Anchor/precedence: resolved DB path → .vnx-project-id marker → VNX_PROJECT_ID.
+    Every present source MUST agree; any conflict aborts (the codex-F1 fix: env
+    can never override the DB's real tenant). No source at all → abort.
+    Cite ADR-007 (docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md).
+    """
+    sources = {
+        "db-path": _project_id_from_db_path(db_path),
+        "marker": _marker_project_id(db_path),
+        "env:VNX_PROJECT_ID": (os.environ.get("VNX_PROJECT_ID") or "").strip() or None,
+    }
+    present = {k: v for k, v in sources.items() if v}
+    distinct = set(present.values())
+    if len(distinct) > 1:
+        detail = ", ".join(f"{k}={v!r}" for k, v in present.items())
+        raise RuntimeError(
+            "ADR-007 project_id conflict — cannot stamp dispatches with an "
+            f"ambiguous tenant identity ({detail}). Resolve the conflict; "
+            "refusing to guess (R3.1)."
+        )
+    if not distinct:
+        raise RuntimeError(
+            "ADR-007 fail-closed: cannot resolve project_id for the dispatches "
+            "repair from the DB path, .vnx-project-id marker, or VNX_PROJECT_ID. "
+            "No silent 'vnx-dev' default (R3.1). See docs/governance/decisions/"
+            "ADR-007-multitenant-project-id-stamping.md"
+        )
+    return distinct.pop()
+
+
+def _validate_existing_project_id_or_abort(conn: sqlite3.Connection,
+                                           project_id: str) -> None:
+    """ABORT (pre-mutation) on a bad existing project_id column (R1.4).
+
+    NULL/empty value → abort (no COALESCE coercion). A value conflicting with the
+    validated identity → abort. The DB is left byte-unchanged because this runs
+    before any schema/data/version mutation. A MISSING column is fine — it is
+    added and stamped from the validated identity later (R1.4a).
+    """
+    cols = [c for c, _ in _dispatch_table_columns(conn)]
+    if "project_id" not in cols:
+        return
+    bad = conn.execute(
+        "SELECT COUNT(*) FROM dispatches WHERE project_id IS NULL OR TRIM(project_id)=''"
+    ).fetchone()[0]
+    if bad:
+        raise RuntimeError(
+            f"ADR-007 abort: dispatches has {bad} row(s) with NULL/empty project_id. "
+            "Refusing to coerce bad tenant data; fix the rows first (R1.4c)."
+        )
+    others = sorted({r[0] for r in conn.execute("SELECT DISTINCT project_id FROM dispatches")
+                     if r[0] != project_id})
+    if others:
+        raise RuntimeError(
+            f"ADR-007 abort: dispatches rows carry project_id {others!r} conflicting "
+            f"with the resolved tenant {project_id!r} (R1.4d). DB unchanged."
+        )
+
+
+# --- SQL transform: drop solo dispatch_id uniqueness, add project_id + composite
+
+def _split_columns_and_constraints(body: str):
+    """Split a CREATE TABLE body into top-level items by depth-1 commas.
+
+    Quote- and paren-aware so commas inside CHECK(...) / DEFAULT(...) / string
+    literals never split an item.
+    """
+    items, depth, cur = [], 0, []
+    in_str, quote = False, ""
+    for ch in body:
+        if in_str:
+            cur.append(ch)
+            if ch == quote:
+                in_str = False
+        elif ch in ("'", '"', "`"):
+            in_str, quote = True, ch
+            cur.append(ch)
+        elif ch == "(":
+            depth += 1
+            cur.append(ch)
+        elif ch == ")":
+            depth -= 1
+            cur.append(ch)
+        elif ch == "," and depth == 0:
+            items.append("".join(cur).strip())
+            cur = []
+        else:
+            cur.append(ch)
+    tail = "".join(cur).strip()
+    if tail:
+        items.append(tail)
+    return items
+
+
+def _is_table_constraint(item: str) -> bool:
+    head = item.lstrip().split("(", 1)[0].strip().upper().split()
+    return bool(head) and head[0] in _CONSTRAINT_KW
+
+
+def _is_solo_unique_constraint(item: str, dispatch_cols) -> bool:
+    """True iff *item* is a table-level UNIQUE(...) keyed solely on dispatch_id."""
+    s = item.strip()
+    m = re.match(r'(?is)^CONSTRAINT\s+("[^"]+"|`[^`]+`|\[[^\]]+\]|\w+)\s+(.*)$', s)
+    if m:
+        s = m.group(2).strip()
+    if not re.match(r'(?is)^UNIQUE\s*\(', s):
+        return False
+    return _referenced_columns(_paren_group(s, s.index("(")), dispatch_cols) == {"dispatch_id"}
+
+
+def _constraint_is_composite(item: str, dispatch_cols) -> bool:
+    s = item.strip()
+    m = re.match(r'(?is)^CONSTRAINT\s+\S+\s+(.*)$', s)
+    if m:
+        s = m.group(1).strip()
+    if not re.match(r'(?is)^UNIQUE\s*\(', s):
+        return False
+    return _referenced_columns(_paren_group(s, s.index("(")), dispatch_cols) == {
+        "dispatch_id", "project_id"}
+
+
+def _strip_inline_unique(coldef: str) -> str:
+    """Remove an inline column UNIQUE constraint (+ optional ON CONFLICT clause)."""
+    return re.sub(r'(?is)\s+UNIQUE(\s+ON\s+CONFLICT\s+\w+)?(?=\s|$)', " ", coldef).rstrip()
+
+
+def _dispatch_id_coldef_index(items, dispatch_cols) -> int:
+    for idx, item in enumerate(items):
+        if _is_table_constraint(item):
+            continue
+        toks = _IDENT_RE.findall(item)
+        if toks and toks[0].strip('"`[]').lower() == "dispatch_id":
+            return idx
+    return -1
+
+
+def _transform_create_table_sql(orig_sql: str, dispatch_cols, has_project_id: bool) -> str:
+    """Mutate dispatches CREATE SQL → dispatches_new: drop solo dispatch_id
+    uniqueness, add project_id (if absent) + composite UNIQUE. Everything else
+    (FKs, CHECK, collations, generated cols) is preserved verbatim (R1.5).
+
+    SQLite requires every column-def to precede every table constraint, so the
+    new project_id column is appended to the column section and the composite
+    UNIQUE to the constraint section (never interleaved).
+    """
+    body = _paren_group(orig_sql, orig_sql.index("("))
+    items = _split_columns_and_constraints(body)
+    did_idx = _dispatch_id_coldef_index(items, dispatch_cols)
+    col_defs, constraints, has_composite = [], [], False
+    for idx, item in enumerate(items):
+        if _is_table_constraint(item):
+            if _is_solo_unique_constraint(item, dispatch_cols):
+                continue
+            has_composite = has_composite or _constraint_is_composite(item, dispatch_cols)
+            constraints.append(item)
+        else:
+            col_defs.append(_strip_inline_unique(item) if idx == did_idx else item)
+    if not has_project_id:
+        col_defs.append("project_id TEXT NOT NULL DEFAULT 'vnx-dev'")
+    if not has_composite:
+        constraints.append("UNIQUE(dispatch_id, project_id)")
+    body_items = ",\n    ".join(col_defs + constraints)
+    return "CREATE TABLE dispatches_new (\n    " + body_items + "\n)"
+
+
+# --- R1.3: dependent view/trigger discovery (transitive, quoted-aware) -------
+
+def _object_references(sql: str, name: str) -> bool:
+    """True if *sql* references identifier *name* (bare/"quoted"/`quoted`/[quoted])."""
+    esc = re.escape(name)
+    pat = re.compile(
+        r'(?i)(?<![A-Za-z0-9_])(?:"%s"|`%s`|\[%s\]|%s)(?![A-Za-z0-9_])' % (esc, esc, esc, esc)
+    )
+    return bool(pat.search(sql or ""))
+
+
+def _discover_dependent_views(conn: sqlite3.Connection):
+    """Transitively discover views depending on dispatches (views-on-views,
+    quoted identifiers). Return [(name, sql)] in base-first RECREATE order.
+    """
+    views = [(r[0], r[1]) for r in conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type='view'")]
+    dep, targets, changed = {}, {"dispatches"}, True
+    while changed:
+        changed = False
+        for name, sql in views:
+            if name not in dep and any(_object_references(sql, t) for t in targets):
+                dep[name], changed = sql, True
+                targets.add(name)
+    ordered, remaining = [], dict(dep)
+    while remaining:
+        progressed = False
+        for name in list(remaining):
+            if not any(o != name and _object_references(remaining[name], o) for o in remaining):
+                ordered.append((name, remaining.pop(name)))
+                progressed = True
+        if not progressed:  # cycle guard (views cannot be cyclic in SQLite)
+            ordered.extend(remaining.items())
+            break
+    return ordered
+
+
+def _triggers_for(conn: sqlite3.Connection, table_names):
+    """Return [(name, sql)] for triggers whose tbl_name is in *table_names*."""
+    if not table_names:
+        return []
+    rows = conn.execute(
+        "SELECT name, sql, tbl_name FROM sqlite_master WHERE type='trigger'").fetchall()
+    return [(r[0], r[1]) for r in rows if r[2] in table_names and r[1]]
+
+
+def _standalone_indexes_to_recreate(conn: sqlite3.Connection, dispatch_cols):
+    """Standalone CREATE INDEX objects on dispatches that are NOT solo
+    dispatch_id uniques. Solo uniques are intentionally dropped (R1.1).
+    """
+    unique_flags = {r[1]: r[2] for r in conn.execute("PRAGMA index_list('dispatches')")}
+    rows = conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='dispatches' "
+        "AND sql IS NOT NULL").fetchall()
+    keep = []
+    for name, sql in rows:
+        if unique_flags.get(name) == 1 and _index_is_solo_dispatch_id(conn, name, dispatch_cols):
+            continue
+        keep.append((name, sql))
+    return keep
+
+
+def _content_checksum(conn: sqlite3.Connection, table: str, cols):
+    """Deterministic (row_count, sha256) over *cols* of *table* ordered by id."""
+    collist = ", ".join(f'"{c}"' for c in cols) or "1"
+    rows = conn.execute(f'SELECT {collist} FROM "{table}" ORDER BY id').fetchall()
+    h = hashlib.sha256()
+    for row in rows:
+        h.update(repr(row).encode("utf-8"))
+        h.update(b"\x1e")
+    return len(rows), h.hexdigest()
+
+
+def _build_dispatches_rebuild_plan(conn: sqlite3.Connection) -> dict:
+    """Capture (read-only) everything needed to rebuild dispatches (R1.5/R1.3)."""
+    col_info = _dispatch_table_columns(conn)
+    cols = [c for c, _ in col_info]
+    has_pid = "project_id" in cols
+    copy_cols = [c for c, gen in col_info if not gen]                # exclude generated
+    checksum_cols = [c for c in copy_cols if c != "project_id"]
+    orig_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='dispatches'"
+    ).fetchone()[0]
+    seq_row = conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name='dispatches'"
+    ).fetchone() if conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'"
+    ).fetchone() else None
+    views = _discover_dependent_views(conn)
+    return {
+        "has_project_id": has_pid,
+        "copy_cols": copy_cols,
+        "checksum_cols": checksum_cols,
+        "is_autoincrement": "AUTOINCREMENT" in orig_sql.upper(),
+        "old_seq": seq_row[0] if seq_row else None,
+        "new_table_sql": _transform_create_table_sql(orig_sql, cols, has_pid),
+        "views": views,
+        "table_triggers": _triggers_for(conn, {"dispatches"}),
+        "view_triggers": _triggers_for(conn, {n for n, _ in views}),
+        "indexes": _standalone_indexes_to_recreate(conn, cols),
+        "before": _content_checksum(conn, "dispatches", checksum_cols),
+    }
+
+
+# --- R7.2: bounded retry/backoff on a locked DB ------------------------------
+
+def _begin_immediate_with_retry(conn: sqlite3.Connection, max_attempts: int = 6,
+                                base_delay: float = 0.05, max_delay: float = 1.0) -> None:
+    """BEGIN IMMEDIATE with bounded exponential backoff on BUSY/LOCKED (R7.2)."""
+    delay, last = base_delay, None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+                raise
+            last = exc
+            if attempt < max_attempts:
+                time.sleep(delay)
+                delay = min(delay * 2, max_delay)
+    raise RuntimeError(
+        f"ADR-007 repair could not acquire a write lock after {max_attempts} "
+        f"BEGIN IMMEDIATE attempts (last error: {last}). Aborting — no infinite wait (R7.2)."
+    )
+
+
+# --- 12-step transactional rebuild (R1.6 / PRD §7.1) -------------------------
+
+def _copy_rows_into_new(conn: sqlite3.Connection, plan: dict, project_id: str) -> None:
+    """Step 6: copy rows into dispatches_new with the validated project_id."""
+    collist = ", ".join(f'"{c}"' for c in plan["copy_cols"])
+    if plan["has_project_id"]:
+        conn.execute(
+            f"INSERT INTO dispatches_new ({collist}) SELECT {collist} FROM dispatches")
+    else:
+        conn.execute(
+            f"INSERT INTO dispatches_new ({collist}, project_id) "
+            f"SELECT {collist}, ? FROM dispatches", (project_id,))
+
+
+def _restore_dispatches_sequence(conn: sqlite3.Connection, plan: dict) -> None:
+    """R1.2: sqlite_sequence[dispatches] = max(old_seq, current_max(id)).
+
+    Applied AFTER the rename (DROP TABLE removes the old high-water row, so it
+    must be re-asserted on the final table — empirically verified).
+    """
+    if not plan["is_autoincrement"]:
+        return
+    max_id = conn.execute("SELECT COALESCE(MAX(id), 0) FROM dispatches").fetchone()[0]
+    target = max(plan["old_seq"] or 0, max_id or 0)
+    conn.execute("DELETE FROM sqlite_sequence WHERE name='dispatches'")
+    conn.execute("INSERT INTO sqlite_sequence(name, seq) VALUES('dispatches', ?)", (target,))
+
+
+def _drop_dependent_objects(conn: sqlite3.Connection, plan: dict) -> None:
+    """Step 8a: drop dependent view-triggers then views (leaf-first)."""
+    for name, _ in plan["view_triggers"]:
+        conn.execute(f'DROP TRIGGER IF EXISTS "{name}"')
+    for name, _ in reversed(plan["views"]):
+        conn.execute(f'DROP VIEW IF EXISTS "{name}"')
+
+
+def _recreate_dependent_objects(conn: sqlite3.Connection, plan: dict) -> None:
+    """Step 10: recreate indexes, table triggers, dependent views (+ their
+    triggers) verbatim. Any failure propagates → whole repair rolls back (R1.3).
+    """
+    for _, sql in plan["indexes"]:
+        conn.execute(sql)
+    for _, sql in plan["table_triggers"]:
+        conn.execute(sql)
+    for _, sql in plan["views"]:          # base-first order
+        conn.execute(sql)
+    for _, sql in plan["view_triggers"]:
+        conn.execute(sql)
+
+
+def _assert_integrity_or_raise(conn: sqlite3.Connection) -> None:
+    """Step 11: foreign_key_check + integrity_check; raise on ANY violation."""
+    fk = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if fk:
+        raise RuntimeError(f"ADR-007 repair foreign_key_check violations: {fk}")
+    res = conn.execute("PRAGMA integrity_check").fetchall()
+    if res != [("ok",)]:
+        raise RuntimeError(f"ADR-007 repair integrity_check failed: {res}")
+
+
+def _execute_dispatches_rebuild(conn: sqlite3.Connection, plan: dict, project_id: str) -> None:
+    """Steps 4–12 inside one BEGIN IMMEDIATE txn. foreign_keys is already OFF
+    (caller, steps 1–2). On any failure the explicit transaction is rolled back,
+    leaving the DB consistent; the caller restores foreign_keys.
+    """
+    orig_legacy = conn.execute("PRAGMA legacy_alter_table").fetchone()[0]
+    _begin_immediate_with_retry(conn)                                   # step 4
+    try:
+        conn.execute(plan["new_table_sql"])                             # step 5
+        _copy_rows_into_new(conn, plan, project_id)                     # step 6
+        after = _content_checksum(conn, "dispatches_new", plan["checksum_cols"])
+        if after != plan["before"]:
+            raise RuntimeError(
+                f"ADR-007 repair content checksum mismatch (before={plan['before']} "
+                f"after={after}); aborting to prevent data loss.")
+        _drop_dependent_objects(conn, plan)                             # step 8a
+        conn.execute("DROP TABLE dispatches")                           # step 8b
+        conn.execute("PRAGMA legacy_alter_table=ON")
+        conn.execute("ALTER TABLE dispatches_new RENAME TO dispatches")  # step 9
+        conn.execute(f"PRAGMA legacy_alter_table={orig_legacy}")
+        _restore_dispatches_sequence(conn, plan)                        # step 7 (post-rename)
+        _recreate_dependent_objects(conn, plan)                         # step 10
+        _assert_integrity_or_raise(conn)                                # step 11
+        conn.execute("COMMIT")                                          # step 12
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+
+def _verify_foreign_keys_restored(conn: sqlite3.Connection, expected: int) -> None:
+    got = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    if got != expected:
+        raise RuntimeError(
+            f"ADR-007 repair could not restore PRAGMA foreign_keys "
+            f"(expected {expected}, got {got}).")
+
+
+def _repair_dispatches_adr007(conn: sqlite3.Connection, project_id: str) -> bool:
+    """Idempotent ADR-007 in-place repair of the dispatches table (PR-A1).
+
+    Converts ANY single-column uniqueness on dispatch_id (inline UNIQUE,
+    table-level UNIQUE(dispatch_id [ASC/DESC/COLLATE]), standalone/partial/
+    expression UNIQUE INDEX, auto-index) into composite UNIQUE(dispatch_id,
+    project_id) with zero data loss and full schema preservation (FKs, CHECK,
+    collations, generated cols, triggers, dependent views, non-target indexes).
+    No-op when already composite.
+
+    Position (R2.2): PRE-MIGRATION step in run() — after _pytest_db_isolation_guard,
+    before the numbered version walk. Implements the canonical 12-step procedure
+    (PRD §7.1 / R1.6). *project_id* is the DB-path-anchored validated tenant
+    identity (R3.1); never the 'vnx-dev' sentinel. Returns True if a rebuild ran.
+    Cite ADR-007.
+    """
+    if not _dispatches_needs_adr007_repair(conn):
+        return False
+    _validate_existing_project_id_or_abort(conn, project_id)            # R1.4 pre-mutation abort
+    plan = _build_dispatches_rebuild_plan(conn)                         # read-only capture
+    orig_fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]         # step 1
+    prev_iso = conn.isolation_level
+    if conn.in_transaction:
+        conn.commit()
+    conn.isolation_level = None                                         # explicit-txn control
+    try:
+        conn.execute("PRAGMA foreign_keys=OFF")                         # step 2 (before BEGIN)
+        _execute_dispatches_rebuild(conn, plan, project_id)             # steps 4–12
+    finally:
+        conn.execute("PRAGMA foreign_keys=ON" if orig_fk else "PRAGMA foreign_keys=OFF")
+        conn.isolation_level = prev_iso
+    _verify_foreign_keys_restored(conn, orig_fk)                        # step 12 verify
+    return True
+
+
+def _run_adr007_dispatches_repair(conn: sqlite3.Connection, db_path) -> None:
+    """run() wiring: detect → resolve tenant → repair. project_id is resolved
+    ONLY when a rebuild is actually needed, so a fresh/composite DB never
+    requires identity resolution. Cite ADR-007.
+    """
+    if not _dispatches_needs_adr007_repair(conn):
+        return
+    project_id = _resolve_validated_project_id(db_path)
+    if _repair_dispatches_adr007(conn, project_id):
+        print(f"  [adr007] dispatches rebuilt → composite UNIQUE(dispatch_id, "
+              f"project_id), tenant={project_id!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -604,6 +1199,11 @@ def run(project_root: Path | None = None) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
 
     try:
+        # ADR-007 pre-migration repair (R1/R2.2/R3.1): convert any single-column
+        # dispatch_id uniqueness into composite UNIQUE(dispatch_id, project_id).
+        # No-op when already composite; resolves the tenant only when needed.
+        _run_adr007_dispatches_repair(conn, db_path)
+
         current_ver = schema_migration.get_user_version(conn)
 
         if current_ver < 22:

--- a/tests/test_adr007_dispatches_repair.py
+++ b/tests/test_adr007_dispatches_repair.py
@@ -1,0 +1,625 @@
+"""Behavioral acceptance tests for the ADR-007 dispatches repair (PR-A1).
+
+Covers the four codex adversarial repros (decorated-UNIQUE retention,
+AUTOINCREMENT regression, nullable/NULL project retention, wrong-tenant
+stamping) plus the R1.5 schema-preservation suite (FK / CHECK / COLLATE /
+generated column / trigger side-effect / secondary index / content checksum),
+the R1.3 view-chain + view-trigger survival test, the R1.6 fault-injection
+recovery test, the R7.2 locked-DB retry, the R3.1 DB-path-anchored resolver,
+the R8.4 composite-UNIQUE behavioral contract, and the R7.1 function-size gate.
+
+This is a NEW behavioral module (it tests the repair function, which
+test_adr007_structural_conformance.py does not) — not a parallel _v2 of the
+structural-conformance file.
+
+ADR-007: docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+— composite UNIQUE(dispatch_id, project_id), never default project_id to
+'vnx-dev'.
+
+Hard discipline (PR-0): every test pins VNX_DATA_DIR_EXPLICIT=1 + a tmp
+VNX_DATA_DIR and operates ONLY on temp DBs; the live ~/.vnx-data is never
+opened or mutated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _PROJECT_ROOT / "scripts"
+_LIB = _SCRIPTS / "lib"
+for _p in (_LIB, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import migrate_future_system as mfs  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin temp-DB isolation (PR-0) and a deterministic, env-free identity.
+
+    VNX_DATA_DIR_EXPLICIT=1 + a tmp VNX_DATA_DIR satisfy the migration isolation
+    guard; VNX_PROJECT_ID is cleared so the DB-path anchor (R3.1) is exercised
+    without an ambient leak (tests that need an env identity set it explicitly).
+    """
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "_vnx_data"))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+def _db_path(tmp_path: Path, project_id: str = "proj-x") -> Path:
+    """Path shaped like the canonical anchor: <tmp>/.vnx-data/<pid>/state/<db>."""
+    db = tmp_path / ".vnx-data" / project_id / "state" / "runtime_coordination.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    return db
+
+
+def _seed(db: Path, ddl: str, rows=(), *, foreign_keys: bool = False) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db))            # default DELETE journal (no WAL sidecars)
+    if foreign_keys:
+        conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(ddl)
+    for sql, params in rows:
+        conn.execute(sql, params)
+    conn.commit()
+    return conn
+
+
+def _unique_index_names(conn: sqlite3.Connection):
+    return [r[1] for r in conn.execute("PRAGMA index_list('dispatches')") if r[2] == 1]
+
+
+def _dispatch_cols(conn: sqlite3.Connection):
+    return [r[1] for r in conn.execute("PRAGMA table_info('dispatches')")]
+
+
+# --------------------------------------------------------------------------- #
+# Repro 1 — decorated / partial / expression UNIQUE retention (R1.1)
+# --------------------------------------------------------------------------- #
+
+def test_repro1_decorated_partial_expression_uniques_removed(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT,
+            state TEXT
+        );
+        CREATE UNIQUE INDEX ux_desc  ON dispatches(dispatch_id DESC);
+        CREATE UNIQUE INDEX ux_coll  ON dispatches(dispatch_id COLLATE NOCASE);
+        CREATE UNIQUE INDEX ux_part  ON dispatches(dispatch_id) WHERE state='active';
+        CREATE UNIQUE INDEX ux_expr  ON dispatches(lower(dispatch_id));
+    """, rows=[
+        ("INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a','proj-x','active')", ()),
+        ("INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(2,'b','proj-x','queued')", ()),
+    ])
+
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+
+    cols = _dispatch_cols(conn)
+    # every solo-dispatch_id unique object is gone (any form)
+    for gone in ("ux_desc", "ux_coll", "ux_part", "ux_expr"):
+        assert gone not in _unique_index_names(conn)
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False
+    assert mfs._has_composite_unique(conn, cols) is True
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Repro 2 — AUTOINCREMENT high-water mark preserved (R1.2)
+# --------------------------------------------------------------------------- #
+
+def test_repro2_autoincrement_no_id_reuse(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+    """, rows=[
+        ("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x')", ()),
+        ("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(100,'b','proj-x')", ()),
+    ])
+    conn.execute("DELETE FROM dispatches WHERE id=100")
+    conn.commit()
+
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('c','proj-x')")
+    conn.commit()
+    new_id = conn.execute("SELECT id FROM dispatches WHERE dispatch_id='c'").fetchone()[0]
+    assert new_id == 101, f"id {new_id} reused the deleted high-water range (R1.2 regression)"
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Repro 3 — NULL / empty project_id aborts, DB byte-unchanged (R1.4c)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("bad_value", [None, "", "   "])
+def test_repro3_null_empty_project_aborts_db_unchanged(tmp_path: Path, bad_value) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+    """, rows=[
+        ("INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a',?, 'q')", (bad_value,)),
+    ])
+    conn.close()
+
+    before = hashlib.sha256(db.read_bytes()).hexdigest()
+    conn = sqlite3.connect(str(db))
+    with pytest.raises(RuntimeError, match="NULL/empty project_id"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.close()
+    after = hashlib.sha256(db.read_bytes()).hexdigest()
+    assert before == after, "DB was mutated despite a pre-mutation abort (R1.4c)"
+
+
+# --------------------------------------------------------------------------- #
+# Repro 4 — wrong-tenant stamping / resolver (R3.1)
+# --------------------------------------------------------------------------- #
+
+def test_repro4_resolver_aborts_on_env_db_conflict(tmp_path: Path,
+                                                    monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path, project_id="proj-x")
+    monkeypatch.setenv("VNX_PROJECT_ID", "proj-y")     # env disagrees with DB path
+    with pytest.raises(RuntimeError, match="project_id conflict"):
+        mfs._resolve_validated_project_id(db)
+
+
+def test_repro4_resolver_stamps_db_anchor_never_vnx_dev(tmp_path: Path) -> None:
+    db = _db_path(tmp_path, project_id="proj-x")       # env cleared by autouse fixture
+    resolved = mfs._resolve_validated_project_id(db)
+    assert resolved == "proj-x"
+    assert resolved != "vnx-dev"
+
+
+def test_resolver_fail_closed_when_unresolvable(tmp_path: Path) -> None:
+    # DB not under the canonical .vnx-data/<pid>/state shape, no marker, no env.
+    db = tmp_path / "loose" / "runtime_coordination.db"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"")
+    with pytest.raises(RuntimeError, match="fail-closed"):
+        mfs._resolve_validated_project_id(db)
+
+
+# --------------------------------------------------------------------------- #
+# R1.4 — ONE tenant rule
+# --------------------------------------------------------------------------- #
+
+def test_missing_project_id_column_stamped_from_identity(tmp_path: Path) -> None:
+    db = _db_path(tmp_path, project_id="proj-x")
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            state TEXT
+        );
+    """, rows=[("INSERT INTO dispatches(id,dispatch_id,state) VALUES(1,'a','q')", ())])
+
+    assert "project_id" not in _dispatch_cols(conn)
+    mfs._repair_dispatches_adr007(conn, mfs._resolve_validated_project_id(db))
+
+    assert "project_id" in _dispatch_cols(conn)
+    stamped = {r[0] for r in conn.execute("SELECT DISTINCT project_id FROM dispatches")}
+    assert stamped == {"proj-x"}
+    assert "vnx-dev" not in stamped
+    conn.close()
+
+
+def test_existing_matching_project_id_preserved(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL
+        );
+    """, rows=[
+        ("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x')", ()),
+        ("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(2,'b','proj-x')", ()),
+    ])
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    vals = {r[0] for r in conn.execute("SELECT DISTINCT project_id FROM dispatches")}
+    assert vals == {"proj-x"}
+    conn.close()
+
+
+def test_conflicting_project_id_value_aborts(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL
+        );
+    """, rows=[("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','other-tenant')", ())])
+    with pytest.raises(RuntimeError, match="conflicting"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R1.5 — schema preservation (behavioral, not name-existence)
+# --------------------------------------------------------------------------- #
+
+def test_preserve_fk_enforcement(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE parents(pid TEXT PRIMARY KEY);
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            parent TEXT,
+            FOREIGN KEY(parent) REFERENCES parents(pid)
+        );
+        INSERT INTO parents VALUES('p1');
+        INSERT INTO dispatches(id,dispatch_id,project_id,parent) VALUES(1,'a','proj-x','p1');
+    """, foreign_keys=True)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.execute("PRAGMA foreign_keys = ON")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id,parent) VALUES('b','proj-x','ghost')")
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1  # restored
+    conn.close()
+
+
+def test_preserve_check_constraint(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            amt INTEGER CHECK(amt >= 0)
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id,amt) VALUES(1,'a','proj-x',3);
+    """)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id,amt) VALUES('b','proj-x',-1)")
+    conn.close()
+
+
+def test_preserve_collation_and_secondary_index(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            label TEXT COLLATE NOCASE
+        );
+        CREATE INDEX ix_label ON dispatches(label);
+        INSERT INTO dispatches(id,dispatch_id,project_id,label) VALUES(1,'a','proj-x','Bbb');
+        INSERT INTO dispatches(id,dispatch_id,project_id,label) VALUES(2,'b','proj-x','aaa');
+        INSERT INTO dispatches(id,dispatch_id,project_id,label) VALUES(3,'c','proj-x','CCC');
+    """)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    # COLLATE NOCASE ordering preserved (case-insensitive sort)
+    order = [r[0] for r in conn.execute("SELECT label FROM dispatches ORDER BY label")]
+    assert order == ["aaa", "Bbb", "CCC"]
+    # secondary index recreated and used
+    plan = conn.execute("EXPLAIN QUERY PLAN SELECT * FROM dispatches WHERE label='aaa'").fetchall()
+    assert any("ix_label" in str(r) for r in plan), plan
+    conn.close()
+
+
+def test_preserve_generated_column(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            amount INTEGER,
+            doubled INTEGER GENERATED ALWAYS AS (amount * 2) STORED
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id,amount) VALUES(1,'a','proj-x',5);
+    """)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    assert conn.execute("SELECT doubled FROM dispatches WHERE dispatch_id='a'").fetchone()[0] == 10
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id,amount) VALUES('b','proj-x',7)")
+    assert conn.execute("SELECT doubled FROM dispatches WHERE dispatch_id='b'").fetchone()[0] == 14
+    conn.close()
+
+
+def test_preserve_trigger_side_effect(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        CREATE TABLE audit(msg TEXT);
+        CREATE TRIGGER trg_ai AFTER INSERT ON dispatches
+            BEGIN INSERT INTO audit(msg) VALUES(NEW.dispatch_id); END;
+    """)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('z','proj-x')")
+    assert conn.execute("SELECT msg FROM audit").fetchall() == [("z",)]
+    conn.close()
+
+
+def test_preserve_row_content_and_count(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    rows = [(f"INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(?,?,?,?)",
+             (i, f"d{i}", "proj-x", "queued")) for i in range(1, 26)]
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+    """, rows=rows)
+    before = conn.execute(
+        "SELECT id, dispatch_id, state FROM dispatches ORDER BY id").fetchall()
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    after = conn.execute(
+        "SELECT id, dispatch_id, state FROM dispatches ORDER BY id").fetchall()
+    assert after == before
+    assert conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0] == 25
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R1.3 — dependent view chain + view trigger survive byte-identical
+# --------------------------------------------------------------------------- #
+
+def test_view_chain_and_view_trigger_survive_verbatim(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+        CREATE VIEW v_base AS SELECT dispatch_id, state FROM dispatches;
+        CREATE VIEW v_top AS SELECT dispatch_id FROM v_base;
+        CREATE TABLE sink(d TEXT);
+        CREATE TRIGGER trg_v INSTEAD OF INSERT ON v_top
+            BEGIN INSERT INTO sink(d) VALUES(NEW.dispatch_id); END;
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a','proj-x','q');
+    """)
+
+    def _sql(name):
+        return conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (name,)).fetchone()[0]
+
+    before = {n: _sql(n) for n in ("v_base", "v_top", "trg_v")}
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    after = {n: _sql(n) for n in ("v_base", "v_top", "trg_v")}
+    assert after == before, "dependent view/trigger SQL changed (must be byte-identical, R1.3)"
+
+    # transitive view still resolves, INSTEAD OF trigger still fires
+    assert conn.execute("SELECT dispatch_id FROM v_top").fetchall() == [("a",)]
+    conn.execute("INSERT INTO v_top(dispatch_id) VALUES('via-trigger')")
+    assert ("via-trigger",) in conn.execute("SELECT d FROM sink").fetchall()
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R1.6 — fault injection mid-rebuild → full rollback → re-run recovers
+# --------------------------------------------------------------------------- #
+
+def test_fault_injection_rolls_back_then_recovers(tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+        CREATE VIEW v_d AS SELECT dispatch_id FROM dispatches;
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a','proj-x','q');
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(2,'b','proj-x','q');
+    """)
+    before_rows = conn.execute("SELECT id,dispatch_id FROM dispatches ORDER BY id").fetchall()
+
+    # Inject a failure at the recreate step (after the in-txn drop+rename).
+    def _boom(*_a, **_k):
+        raise RuntimeError("injected recreate failure")
+    monkeypatch.setattr(mfs, "_recreate_dependent_objects", _boom)
+
+    with pytest.raises(RuntimeError, match="injected recreate failure"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    monkeypatch.undo()
+
+    # Whole repair rolled back: original (solo-unique) schema + data intact,
+    # no leftover dispatches_new, dependent view restored.
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "dispatches_new" not in tables
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert conn.execute("SELECT id,dispatch_id FROM dispatches ORDER BY id").fetchall() == before_rows
+    assert conn.execute("SELECT dispatch_id FROM v_d ORDER BY dispatch_id").fetchall() == [("a",), ("b",)]
+
+    # Re-run (idempotent recovery) now succeeds and yields the composite.
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R7.2 — bounded retry/backoff on a locked DB
+# --------------------------------------------------------------------------- #
+
+def test_begin_immediate_retry_exhausts_on_locked_db(tmp_path: Path) -> None:
+    db = tmp_path / "lock.db"
+    holder = sqlite3.connect(str(db))
+    holder.isolation_level = None
+    holder.execute("CREATE TABLE t(x)")
+    holder.execute("BEGIN IMMEDIATE")
+    holder.execute("INSERT INTO t VALUES(1)")          # holds the write lock
+
+    contender = sqlite3.connect(str(db), timeout=0)    # do not wait on the lock
+    contender.isolation_level = None
+    with pytest.raises(RuntimeError, match="could not acquire a write lock"):
+        mfs._begin_immediate_with_retry(
+            contender, max_attempts=2, base_delay=0.001, max_delay=0.002)
+
+    holder.execute("COMMIT")
+    holder.close()
+    contender.close()
+
+
+def test_begin_immediate_non_lock_error_propagates(tmp_path: Path) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.isolation_level = None
+    conn.execute("BEGIN")                              # already in a transaction
+    with pytest.raises(sqlite3.OperationalError):
+        mfs._begin_immediate_with_retry(conn, max_attempts=2, base_delay=0.001)
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R8.4 — composite-UNIQUE behavioral contract
+# --------------------------------------------------------------------------- #
+
+def test_r84_composite_unique_behavioral(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'d1','projA');
+    """)
+    mfs._repair_dispatches_adr007(conn, "projA")
+
+    # old single-column UNIQUE gone
+    assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
+    # same dispatch_id across two tenants is allowed
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('d1','projB')")
+    # duplicate (d1, projA) is rejected
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('d1','projA')")
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency / no-op when already composite
+# --------------------------------------------------------------------------- #
+
+def test_repair_idempotent_second_run_is_noop(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is False
+    conn.close()
+
+
+def test_noop_when_already_composite(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            UNIQUE(dispatch_id, project_id)
+        );
+    """)
+    assert mfs._dispatches_needs_adr007_repair(conn) is False
+    # passing a deliberately wrong identity must not matter — it is a pure no-op
+    assert mfs._repair_dispatches_adr007(conn, "irrelevant") is False
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# R2.2 — repair runs inside run() (pre-migration), then the version walk
+# --------------------------------------------------------------------------- #
+
+def test_run_repairs_then_walks_to_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project_dir = tmp_path / "proj"
+    state_dir = project_dir / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    db = state_dir / "runtime_coordination.db"
+    # v21-shaped dispatches BUT keyed by a solo dispatch_id unique (needs repair),
+    # plus the coordination_events table 0022 expects.
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.executescript("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2',
+            pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}'
+        );
+        CREATE UNIQUE INDEX ux_solo_did ON dispatches(dispatch_id);
+        CREATE TABLE coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT,
+            entity_type TEXT, entity_id TEXT, from_state TEXT, to_state TEXT,
+            actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','vnx-dev');
+    """)
+    conn.commit()
+    conn.close()
+
+    # identity resolvable via env (DB is not under the canonical anchor here)
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    mfs.run(project_dir)
+
+    conn = sqlite3.connect(str(db))
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
+    assert "ux_solo_did" not in _unique_index_names(conn)
+    assert schema_migration_user_version(conn) == 30
+    conn.close()
+
+
+def schema_migration_user_version(conn: sqlite3.Connection) -> int:
+    return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+# --------------------------------------------------------------------------- #
+# R7.1 — every function in migrate_future_system.py is ≤70 lines (gate counter)
+# --------------------------------------------------------------------------- #
+
+def test_all_functions_within_70_lines_gate_counter() -> None:
+    from function_size_gate import _scan_python_functions
+
+    measurements = _scan_python_functions(Path(mfs.__file__))
+    oversized = [(m.name, m.length) for m in measurements if m.length > 70]
+    assert not oversized, (
+        "functions exceeding 70 lines by the gate's own counter "
+        f"(function_size_gate._scan_python_functions): {oversized}"
+    )

--- a/tests/test_adr007_dispatches_repair.py
+++ b/tests/test_adr007_dispatches_repair.py
@@ -24,8 +24,11 @@ opened or mutated.
 from __future__ import annotations
 
 import hashlib
+import inspect
+import re
 import sqlite3
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -1016,3 +1019,200 @@ def test_all_functions_within_70_lines_gate_counter() -> None:
         "functions exceeding 70 lines by the gate's own counter "
         f"(function_size_gate._scan_python_functions): {oversized}"
     )
+
+
+# =========================================================================== #
+# Gate round-2 fix-forward (#859) — one behavioral test per finding N1–N5.
+# Every test pins VNX_DATA_DIR_EXPLICIT=1 + a tmp VNX_DATA_DIR (autouse fixture)
+# and operates ONLY on temp DBs.
+# =========================================================================== #
+
+
+# N1 — a dispatches table whose dispatch_id has NO uniqueness at all (no solo, no
+# composite) is now detected as needing repair and gets the composite UNIQUE added.
+def test_finding_n1_no_uniqueness_gets_composite(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT,
+            state TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a','proj-x','q');
+    """)
+    cols = _dispatch_cols(conn)
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False     # no solo to begin with
+    assert mfs._has_composite_unique(conn, cols) is False            # and no composite
+    assert mfs._dispatches_needs_adr007_repair(conn) is True         # N1: still needs repair
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    cols = _dispatch_cols(conn)
+    assert mfs._has_composite_unique(conn, cols) is True             # composite now added
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False
+    # idempotent: an already-composite table is a no-op
+    assert mfs._dispatches_needs_adr007_repair(conn) is False
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is False
+    conn.close()
+
+
+# N1 — full detection truth table: already-composite→F, solo→T, neither→T, composite+stray→T
+def test_finding_n1_detection_truth_table(tmp_path: Path) -> None:
+    def _needs(name: str, ddl: str) -> bool:
+        c = sqlite3.connect(str(tmp_path / f"{name}.db"))
+        c.executescript(ddl)
+        c.commit()
+        out = mfs._dispatches_needs_adr007_repair(c)
+        c.close()
+        return out
+
+    assert _needs("composite", """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL,
+            UNIQUE(dispatch_id, project_id));
+    """) is False
+    assert _needs("solo", """
+        CREATE TABLE dispatches (dispatch_id TEXT UNIQUE, project_id TEXT);
+    """) is True
+    assert _needs("neither", """
+        CREATE TABLE dispatches (dispatch_id TEXT, project_id TEXT);
+    """) is True
+    assert _needs("composite_plus_stray", """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL,
+            UNIQUE(dispatch_id, project_id));
+        CREATE UNIQUE INDEX ux_stray ON dispatches(dispatch_id);
+    """) is True
+
+
+# N2 — a ROLLBACK failure is WARNED (not silently swallowed) and the ORIGINAL error
+# still propagates (the silent-except CI gate fix must keep K's contract).
+def test_finding_n2_rollback_failure_warns_and_propagates_original(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+
+    def _commit_then_boom(c, plan):
+        c.execute("COMMIT")              # ends the txn so the except-clause ROLLBACK fails
+        raise RuntimeError("ORIGINAL boom")
+
+    monkeypatch.setattr(mfs, "_recreate_dependent_objects", _commit_then_boom)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(RuntimeError, match="ORIGINAL boom"):   # original, not rollback error
+            mfs._repair_dispatches_adr007(conn, "proj-x")
+    assert any("ROLLBACK after error failed" in str(rec.message) for rec in caught), (
+        "N2: the rollback failure must be warned (no silent except + pass)"
+    )
+    conn.close()
+
+
+# N3 — a UNIQUE / PRIMARY KEY keyword inside a quoted string literal is preserved;
+# only a real keyword token outside any quoted string is stripped.
+def test_finding_n3_strip_inline_unique_is_string_literal_aware() -> None:
+    # quoted 'a UNIQUE b' preserved verbatim; the trailing real UNIQUE removed
+    out = mfs._strip_inline_unique("dispatch_id TEXT DEFAULT 'a UNIQUE b' UNIQUE")
+    assert "'a UNIQUE b'" in out
+    assert out.rstrip().endswith("'a UNIQUE b'")
+    # quoted 'x PRIMARY KEY y' preserved verbatim; the real inline PRIMARY KEY removed
+    out2 = mfs._strip_inline_unique("dispatch_id TEXT PRIMARY KEY DEFAULT 'x PRIMARY KEY y'")
+    assert "'x PRIMARY KEY y'" in out2
+    assert "PRIMARY" not in out2.replace("'x PRIMARY KEY y'", "")
+    # a literal with NO real keyword is returned untouched
+    assert mfs._strip_inline_unique(
+        "note TEXT DEFAULT 'has UNIQUE inside'") == "note TEXT DEFAULT 'has UNIQUE inside'"
+
+
+# N3 — end-to-end: a dispatch_id column whose DEFAULT literal contains UNIQUE is not
+# corrupted by the rebuild, while the real inline UNIQUE on dispatch_id is stripped.
+def test_finding_n3_quoted_keyword_default_survives_rebuild(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE DEFAULT 'tag UNIQUE x',
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    cols = _dispatch_cols(conn)
+    assert mfs._has_composite_unique(conn, cols) is True
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='dispatches'").fetchone()[0]
+    assert "'tag UNIQUE x'" in sql, "N3: the quoted DEFAULT literal must survive verbatim"
+    conn.close()
+
+
+# N4(a) — a sole dispatch_id PRIMARY KEY becomes PRIMARY KEY(dispatch_id, project_id)
+def test_finding_n4_sole_pk_becomes_composite_primary_key(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT PRIMARY KEY,
+            project_id TEXT,
+            state TEXT
+        );
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projA','q');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "projA") is True
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='dispatches'").fetchone()[0]
+    norm = re.sub(r"\s+", "", sql)
+    assert "PRIMARYKEY(dispatch_id,project_id)" in norm, "N4(a): composite must be the PK"
+    pk = {r[1]: r[5] for r in conn.execute("PRAGMA table_info('dispatches')")}
+    assert pk["dispatch_id"] > 0 and pk["project_id"] > 0
+    # cross-tenant reuse works; duplicate (d1, projA) rejected
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projB','q')")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projA','q')")
+    conn.close()
+
+
+# N4(b) — a separate id PK + a solo dispatch_id UNIQUE → composite stays UNIQUE, id stays PK
+def test_finding_n4_separate_pk_keeps_composite_unique(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'d1','projA','q');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "projA") is True
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='dispatches'").fetchone()[0]
+    norm = re.sub(r"\s+", "", sql)
+    assert "UNIQUE(dispatch_id,project_id)" in norm
+    assert "PRIMARYKEY(dispatch_id,project_id)" not in norm
+    pk = {r[1]: r[5] for r in conn.execute("PRAGMA table_info('dispatches')")}
+    assert pk["id"] == 1, "N4(b): id must remain the sole PRIMARY KEY"
+    assert pk["dispatch_id"] == 0 and pk["project_id"] == 0
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    conn.close()
+
+
+# N5 — the ADR-005 audit responsibility is DOCUMENTED at the governed caller layer and
+# the repair primitive emits NO ledger event itself (documentation + isolation contract).
+def test_finding_n5_adr005_caller_layer_documented_no_emission() -> None:
+    for fn in (mfs._repair_dispatches_adr007, mfs._run_adr007_dispatches_repair):
+        doc = fn.__doc__ or ""
+        assert "ADR-005" in doc, f"{fn.__name__} must document the ADR-005 caller layer (N5)"
+        assert "§7.2" in doc, f"{fn.__name__} must cite the operator runbook §7.2 (N5)"
+        assert "caller" in doc.lower(), f"{fn.__name__} must name the governed caller layer (N5)"
+    # the pure repair primitive must not wire any NDJSON ledger emission
+    prim_src = (inspect.getsource(mfs._repair_dispatches_adr007)
+                + inspect.getsource(mfs._execute_dispatches_rebuild))
+    for forbidden in ("append_receipt", ".ndjson", "incident_log", "dispatch_register"):
+        assert forbidden not in prim_src, (
+            f"N5: the repair primitive must not emit ledger events itself ({forbidden})"
+        )

--- a/tests/test_adr007_dispatches_repair.py
+++ b/tests/test_adr007_dispatches_repair.py
@@ -610,6 +610,399 @@ def schema_migration_user_version(conn: sqlite3.Connection) -> int:
     return conn.execute("PRAGMA user_version").fetchone()[0]
 
 
+# =========================================================================== #
+# Gate round-1 fix-forward (#859) — one behavioral test per finding A–M.
+# Every test pins VNX_DATA_DIR_EXPLICIT=1 + a tmp VNX_DATA_DIR (autouse fixture)
+# and operates ONLY on temp DBs.
+# =========================================================================== #
+
+
+# A — added project_id has NO 'vnx-dev' default; an insert omitting it fails closed
+def test_finding_a_added_project_id_has_no_vnx_dev_default(tmp_path: Path) -> None:
+    db = _db_path(tmp_path, project_id="proj-x")
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            state TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,state) VALUES(1,'a','q');
+    """)
+    assert "project_id" not in _dispatch_cols(conn)
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    # existing rows stamped from the validated identity, NOT a silent vnx-dev
+    assert conn.execute(
+        "SELECT project_id FROM dispatches WHERE dispatch_id='a'").fetchone()[0] == "proj-x"
+    # a future insert omitting project_id now fails closed (no silent vnx-dev)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id) VALUES('b')")
+    conn.close()
+
+
+# B — column-level dispatch_id PRIMARY KEY ends composite-only; cross-tenant reuse OK
+def test_finding_b_column_level_pk_becomes_composite(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT PRIMARY KEY,
+            project_id TEXT,
+            state TEXT
+        );
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projA','q');
+    """)
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert mfs._repair_dispatches_adr007(conn, "projA") is True
+    cols = _dispatch_cols(conn)
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False
+    assert mfs._has_composite_unique(conn, cols) is True
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projB','q')")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projA','q')")
+    conn.close()
+
+
+# B — table-level PRIMARY KEY(dispatch_id) ends composite-only; cross-tenant reuse OK
+def test_finding_b_table_level_pk_becomes_composite(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT,
+            state TEXT,
+            PRIMARY KEY(dispatch_id)
+        );
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projA','q');
+    """)
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert mfs._repair_dispatches_adr007(conn, "projA") is True
+    cols = _dispatch_cols(conn)
+    assert mfs._has_solo_dispatch_id_unique(conn, cols) is False
+    assert mfs._has_composite_unique(conn, cols) is True
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','projB','q')")
+    conn.close()
+
+
+# B — a surviving solo uniqueness makes the post-rebuild guard RAISE (no false success)
+def test_finding_b_post_rebuild_guard_raises_on_surviving_solo(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    # force the inline UNIQUE to survive the transform; the guard must catch it
+    monkeypatch.setattr(mfs, "_strip_inline_unique", lambda coldef: coldef)
+    with pytest.raises(RuntimeError, match="did not eliminate solo dispatch_id uniqueness"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    monkeypatch.undo()
+    # rolled back: original solo-unique schema + data intact, still needs repair
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0] == 1
+    conn.close()
+
+
+# C — a STRICT table option survives the rebuild (type enforcement still fires)
+def test_finding_c_strict_table_option_preserved(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            amt INTEGER
+        ) STRICT;
+        INSERT INTO dispatches(id,dispatch_id,project_id,amt) VALUES(1,'a','proj-x',5);
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='dispatches'").fetchone()[0]
+    assert "STRICT" in sql.upper()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO dispatches(dispatch_id,project_id,amt) VALUES('b','proj-x','nope')")
+    conn.close()
+
+
+# D — calling with an open transaction RAISES (never silently commits the caller's work)
+def test_finding_d_open_transaction_raises_not_silent_commit(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('b','proj-x')")
+    assert conn.in_transaction
+    with pytest.raises(RuntimeError, match="no open transaction"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    # the caller's uncommitted work was NOT silently committed
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0] == 1
+    conn.close()
+
+
+# E — a RENAME failure still restores legacy_alter_table (finally guard)
+def test_finding_e_legacy_alter_table_restored_on_rename_failure(tmp_path: Path) -> None:
+    db = tmp_path / "e.db"
+    conn = sqlite3.connect(str(db))
+    conn.isolation_level = None
+    conn.execute("CREATE TABLE dispatches(x)")          # rename target already taken
+    conn.execute("CREATE TABLE dispatches_new(y)")
+    orig = conn.execute("PRAGMA legacy_alter_table").fetchone()[0]
+    with pytest.raises(sqlite3.OperationalError):
+        mfs._rename_new_to_dispatches(conn, orig)
+    assert conn.execute("PRAGMA legacy_alter_table").fetchone()[0] == orig
+    conn.close()
+
+
+# F — recreate order puts views before table triggers
+def test_finding_f_recreate_order_views_before_table_triggers() -> None:
+    executed: list[str] = []
+
+    class _Rec:
+        def execute(self, sql):
+            executed.append(sql)
+
+    plan = {
+        "indexes": [("ix", "CREATE INDEX ix ON dispatches(state)")],
+        "views": [("v", "CREATE VIEW v AS SELECT 1")],
+        "table_triggers": [("trg_tbl", "CREATE TRIGGER trg_tbl AFTER INSERT ON dispatches BEGIN SELECT 1; END")],
+        "view_triggers": [("trg_view", "CREATE TRIGGER trg_view INSTEAD OF INSERT ON v BEGIN SELECT 1; END")],
+    }
+    mfs._recreate_dependent_objects(_Rec(), plan)
+    assert executed.index(plan["views"][0][1]) < executed.index(plan["table_triggers"][0][1])
+    assert executed == [plan["indexes"][0][1], plan["views"][0][1],
+                        plan["table_triggers"][0][1], plan["view_triggers"][0][1]]
+
+
+# F — a table trigger referencing a dependent view is recreated and works after repair
+def test_finding_f_table_trigger_referencing_view_survives_repair(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+        CREATE VIEW v_active AS SELECT dispatch_id FROM dispatches WHERE state='active';
+        CREATE TABLE log(n INTEGER);
+        CREATE TRIGGER trg_ai AFTER INSERT ON dispatches
+            BEGIN INSERT INTO log(n) SELECT COUNT(*) FROM v_active; END;
+        INSERT INTO dispatches(id,dispatch_id,project_id,state) VALUES(1,'a','proj-x','active');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('b','proj-x','active')")
+    assert conn.execute("SELECT MAX(n) FROM log").fetchone()[0] == 2
+    conn.close()
+
+
+# G — _paren_group skips parens inside string literals
+def test_finding_g_paren_group_skips_string_literal_parens() -> None:
+    s = "CREATE TABLE t (a TEXT DEFAULT '(', b TEXT)"
+    assert mfs._paren_group(s, s.index("(")) == "a TEXT DEFAULT '(', b TEXT"
+
+
+# G — a default with an unbalanced paren in a string literal repairs cleanly
+def test_finding_g_default_with_unbalanced_paren_in_string(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            note TEXT DEFAULT '(unbalanced'
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('b','proj-x')")
+    assert conn.execute(
+        "SELECT note FROM dispatches WHERE dispatch_id='b'").fetchone()[0] == "(unbalanced"
+    conn.close()
+
+
+# H — the validation re-runs INSIDE the txn and aborts with the DB byte-unchanged
+def test_finding_h_in_txn_revalidation_aborts_db_unchanged(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a',NULL);
+    """)
+    conn.close()
+    # skip the FIRST (pre-BEGIN) validation so the IN-TXN re-validation is what aborts
+    real = mfs._validate_existing_project_id_or_abort
+    calls = {"n": 0}
+
+    def _skip_first(c, pid):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return
+        return real(c, pid)
+
+    monkeypatch.setattr(mfs, "_validate_existing_project_id_or_abort", _skip_first)
+    before = hashlib.sha256(db.read_bytes()).hexdigest()
+    conn = sqlite3.connect(str(db))
+    with pytest.raises(RuntimeError, match="NULL/empty project_id"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.close()
+    after = hashlib.sha256(db.read_bytes()).hexdigest()
+    assert calls["n"] == 2, "the in-transaction re-validation did not run (H)"
+    assert before == after, "DB mutated despite an in-transaction abort (H)"
+
+
+# I — a tab/newline/CR-only project_id aborts like empty (TRIM whitespace set)
+@pytest.mark.parametrize("ws", ["\t", "\n", "\r", "\x0b", "\x0c", "\t\n ", "  \r\n\t"])
+def test_finding_i_whitespace_only_project_id_aborts(tmp_path: Path, ws) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+    """, rows=[("INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a',?)", (ws,))])
+    with pytest.raises(RuntimeError, match="NULL/empty project_id"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.close()
+
+
+# J — a nullable project_id column is promoted to NOT NULL by the rebuild
+def test_finding_j_nullable_project_id_promoted_to_not_null(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+
+    def _pid_notnull():
+        return [r for r in conn.execute("PRAGMA table_info('dispatches')")
+                if r[1] == "project_id"][0][3]
+
+    assert _pid_notnull() == 0, "precondition: project_id starts nullable"
+    mfs._repair_dispatches_adr007(conn, "proj-x")
+    assert _pid_notnull() == 1, "project_id must be NOT NULL after repair (J)"
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('b',NULL)")
+    conn.close()
+
+
+# K — a ROLLBACK failure does not mask the ORIGINAL error
+def test_finding_k_rollback_failure_does_not_mask_original_error(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+
+    def _commit_then_boom(c, plan):
+        c.execute("COMMIT")              # ends the txn so the except-clause ROLLBACK fails
+        raise RuntimeError("ORIGINAL boom")
+
+    monkeypatch.setattr(mfs, "_recreate_dependent_objects", _commit_then_boom)
+    with pytest.raises(RuntimeError, match="ORIGINAL boom"):
+        mfs._repair_dispatches_adr007(conn, "proj-x")
+    conn.close()
+
+
+# L — a no-'id' shape does not crash the content checksum; falls back to rowid/cols
+def test_finding_l_no_id_table_checksum_does_not_crash(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            state TEXT
+        );
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('a','proj-x','q');
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('b','proj-x','r');
+    """)
+    assert "id" not in _dispatch_cols(conn)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
+    assert conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0] == 2
+    conn.close()
+
+
+# L — checksum ordering raises explicitly when no id/rowid/cols are available
+def test_finding_l_checksum_raises_when_no_orderable_key() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE w(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID")
+    with pytest.raises(RuntimeError, match="cannot compute a deterministic checksum"):
+        mfs._checksum_order_clause(conn, "w", [])
+    assert mfs._checksum_order_clause(conn, "w", ["k", "v"]) == 'ORDER BY "k", "v"'
+    conn.close()
+
+
+# M — a BUSY-coded error with a non-standard message is classified retryable + retried
+def test_finding_m_is_busy_or_locked_classifies_by_errorcode() -> None:
+    exc = sqlite3.OperationalError("Datenbank ist gesperrt")     # no code, no substring
+    assert mfs._is_busy_or_locked(exc) is False
+    exc.sqlite_errorcode = sqlite3.SQLITE_BUSY
+    assert mfs._is_busy_or_locked(exc) is True                   # structured code wins
+    assert mfs._is_busy_or_locked(sqlite3.OperationalError("database is locked")) is True
+
+
+def test_finding_m_busy_coded_error_is_retried() -> None:
+    class _FakeBusyConn:
+        def __init__(self, fail_times):
+            self.fail_times, self.attempts = fail_times, 0
+
+        def execute(self, sql):
+            self.attempts += 1
+            if self.attempts <= self.fail_times:
+                exc = sqlite3.OperationalError("gesperrt")       # no 'locked'/'busy' substring
+                exc.sqlite_errorcode = sqlite3.SQLITE_BUSY
+                raise exc
+            return None
+
+    conn = _FakeBusyConn(fail_times=2)
+    mfs._begin_immediate_with_retry(conn, max_attempts=5, base_delay=0.001, max_delay=0.002)
+    assert conn.attempts == 3, "a BUSY-coded error with a non-standard message was not retried (M)"
+
+
+# Lock the FALSE-POSITIVE: a doubled-quote default must not corrupt column splitting
+def test_escaped_quote_default_does_not_corrupt_split(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT,
+            owner TEXT DEFAULT 'O''Brien'
+        );
+        INSERT INTO dispatches(id,dispatch_id,project_id) VALUES(1,'a','proj-x');
+    """)
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    conn.execute("INSERT INTO dispatches(dispatch_id,project_id) VALUES('b','proj-x')")
+    assert conn.execute(
+        "SELECT owner FROM dispatches WHERE dispatch_id='b'").fetchone()[0] == "O'Brien"
+    conn.close()
+
+
 # --------------------------------------------------------------------------- #
 # R7.1 — every function in migrate_future_system.py is ≤70 lines (gate counter)
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr007_dispatches_repair.py
+++ b/tests/test_adr007_dispatches_repair.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import json
 import re
 import sqlite3
 import sys
@@ -557,6 +558,122 @@ def test_noop_when_already_composite(tmp_path: Path) -> None:
     assert mfs._dispatches_needs_adr007_repair(conn) is False
     # passing a deliberately wrong identity must not matter — it is a pure no-op
     assert mfs._repair_dispatches_adr007(conn, "irrelevant") is False
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# ADR-007 partial-index and unusual-identifier regressions
+# --------------------------------------------------------------------------- #
+
+def test_partial_composite_unique_needs_repair_and_gets_full_composite(
+        tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            state TEXT
+        );
+        CREATE UNIQUE INDEX ux_active_pair
+            ON dispatches(dispatch_id, project_id) WHERE state='active';
+        INSERT INTO dispatches(dispatch_id,project_id,state) VALUES('d1','proj-x','queued');
+    """)
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is False
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO dispatches(dispatch_id,project_id,state) "
+            "VALUES('d1','proj-x','another')")
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    ("table_name", "dispatch_id", "project_id"),
+    [
+        ('"dispatches"', '"dispatch_id"', '"project_id"'),
+        ("[dispatches]", "[dispatch_id]", "[project_id]"),
+        ("`dispatches`", "`dispatch_id`", "`project_id`"),
+    ],
+)
+def test_quoted_identifier_solo_unique_repairs(
+        tmp_path: Path, table_name: str, dispatch_id: str, project_id: str) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, f"""
+        CREATE TABLE {table_name} (
+            id INTEGER PRIMARY KEY,
+            {dispatch_id} TEXT NOT NULL,
+            {project_id} TEXT,
+            UNIQUE({dispatch_id})
+        );
+        INSERT INTO {table_name}(id,{dispatch_id},{project_id})
+            VALUES(1,'d1','proj-x');
+    """)
+    assert mfs._dispatches_needs_adr007_repair(conn) is True
+    assert mfs._repair_dispatches_adr007(conn, "proj-x") is True
+    assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    conn.close()
+
+
+def test_quoted_identifier_full_composite_is_detected(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE [dispatches] (
+            id INTEGER PRIMARY KEY,
+            "dispatch_id" TEXT NOT NULL,
+            `project_id` TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX [ux_dispatch_pair]
+            ON [dispatches]([dispatch_id], "project_id");
+    """)
+    assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
+    assert mfs._dispatches_needs_adr007_repair(conn) is False
+    assert mfs._repair_dispatches_adr007(conn, "irrelevant") is False
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# ADR-005 governed-caller audit event
+# --------------------------------------------------------------------------- #
+
+def test_governed_caller_emits_repair_event_to_temp_events_dir(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL
+        );
+        INSERT INTO dispatches VALUES(1, 'd1', 'proj-x');
+    """)
+    mfs._run_adr007_dispatches_repair(conn, db)
+    event_path = tmp_path / "_vnx_data" / "events" / "adr007_dispatches_repaired.ndjson"
+    event = json.loads(event_path.read_text(encoding="utf-8").strip())
+    assert event["event_type"] == "adr007_dispatches_repaired"
+    assert event["dispatch_table"] == "dispatches"
+    assert event["project_id"] == "proj-x"
+    assert event["rebuild_occurred"] is True
+    assert event["timestamp"]
+    conn.close()
+
+
+def test_governed_caller_noop_emits_no_repair_event(tmp_path: Path) -> None:
+    db = _db_path(tmp_path)
+    conn = _seed(db, """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            UNIQUE(dispatch_id, project_id)
+        );
+    """)
+    mfs._run_adr007_dispatches_repair(conn, db)
+    event_path = tmp_path / "_vnx_data" / "events" / "adr007_dispatches_repaired.ndjson"
+    assert not event_path.exists()
     conn.close()
 
 

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -189,8 +189,18 @@ class TestBidirectionalPreflight:
         with pytest.raises(RuntimeError, match="extra="):
             mod.run(project_dir)
 
-    def test_raises_on_missing_unique(self, tmp_path):
-        """A dispatches table without UNIQUE(dispatch_id, project_id) fails preflight."""
+    def test_raises_on_missing_unique(self, tmp_path, monkeypatch):
+        """A dispatches table missing UNIQUE(dispatch_id, project_id) must not migrate silently.
+
+        N1 (#859 round-2): a table with neither a solo dispatch_id uniqueness nor the
+        composite is now detected as needing the ADR-007 pre-migration repair (it was
+        previously a silent no-op). This DB sits at a NON-canonical .vnx-data/state
+        path with no .vnx-project-id marker and no VNX_PROJECT_ID, so the tenant is
+        unresolvable and the repair fails closed (R3.1) — run() still raises (the
+        guard property holds), just earlier and with a precise tenant-resolution
+        error instead of the legacy "missing UNIQUE" preflight message.
+        """
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
         project_dir = tmp_path / "no_unique"
         state_dir = project_dir / ".vnx-data" / "state"
         state_dir.mkdir(parents=True)
@@ -221,7 +231,8 @@ class TestBidirectionalPreflight:
         conn.commit()
         conn.close()
         mod = _get_migrate_module()
-        with pytest.raises(RuntimeError, match="UNIQUE"):
+        # N1: missing composite → ADR-007 repair fires; unresolvable tenant → fail-closed.
+        with pytest.raises(RuntimeError, match="project_id|UNIQUE"):
             mod.run(project_dir)
 
 


### PR DESCRIPTION
## Summary

PR-A1 of the future-state reconciliation (1.0.1). Builds a general-purpose, idempotent, lossless
**ADR-007 in-place repair** of the `dispatches` table: `_repair_dispatches_adr007(conn, project_id)`
in `scripts/migrate_future_system.py`, converting ANY single-column uniqueness on `dispatch_id`
(inline / table-level `UNIQUE(dispatch_id [ASC/DESC/COLLATE])` / standalone / **partial** / **expression**
`UNIQUE INDEX` incl. `lower(dispatch_id)` cid `-2` / auto-index) into composite
`UNIQUE(dispatch_id, project_id)` via the canonical 12-step procedure, with full schema preservation
and crash-safety.

Cites **ADR-007** (`docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md`): composite
UNIQUE/PK over `project_id`.

## What it does (PRD §4)
- **R1.1** drop EVERY solo-`dispatch_id` uniqueness (decorated/partial/expression detected via
  `index_xinfo` + CREATE-SQL parse), only permitted diff = `+project_id` + composite.
- **R1.2** preserve AUTOINCREMENT high-water mark (`max(old_seq, current_max)`), re-asserted post-rename.
- **R1.3** transitive, quoted-identifier-aware view/trigger discovery; verbatim recreate; rollback on failure.
- **R1.4** ONE tenant rule — missing col stamped from validated identity; existing NULL/empty/conflicting → abort, DB byte-unchanged (no COALESCE coercion).
- **R1.5** rebuild from preserved `sqlite_master` SQL; FK/CHECK/COLLATE/generated/triggers/indexes preserved (behavioral tests).
- **R1.6** crash-safe 12-step: `foreign_keys=OFF` **before** BEGIN (no-op inside txn), `foreign_key_check`+`integrity_check` before COMMIT, restore after; content checksums.
- **R3.1** DB-path-anchored, fail-closed tenant resolver — resolved DB path → `.vnx-project-id` marker → `VNX_PROJECT_ID`; conflict/unknown → abort; never `vnx-dev` (fixes codex-F1 leak; does NOT reuse the env-first `resolve_project_id`).
- **R7.1** all touched functions ≤70 lines (gate counter: max=64 `run`); **R7.2** bounded retry/backoff on `BEGIN IMMEDIATE` locked-DB.
- **R2.2** wired into `run()` as a pre-migration, guarded, idempotent step (no-op when already composite).

The narrow v24 `_strip_stale_dispatches_track_fk` path is untouched.

## Verification
- `tests/test_adr007_dispatches_repair.py` — **26 behavioral tests**, temp-DB only (PR-0 isolation guard honored), independently re-run green. Includes the 4 codex adversarial repros verbatim (decorated/partial/expression UNIQUE retention; AUTOINCREMENT no-reuse; NULL-project abort + byte-unchanged DB; wrong-tenant conflict abort + DB-anchor stamp), R1.5 preservation suite, R1.3 view→view + `INSTEAD OF` trigger byte-identical, R1.6 fault-injection rollback+recovery, R7.2 retry exhaustion, R8.4 composite behavioral, idempotency, R2.2 run()-integration.
- Broader migration suite: 110 passed. function_size_gate: PASS.

## Known pre-existing REDs (NOT introduced by this PR — confirmed on base 56ed58b1)
Out of scope per PRD §2 (non-goal: broader ADR-007 batch on other tables):
- `test_adr007_structural_conformance.py::test_every_multitenant_table_has_composite_constraint_over_project_id` fails on base via (1) an over-broad migration glob feeding `0026_dispatch_claim.sql` (separate runner, embedded `BEGIN TRANSACTION`) into the SAVEPOINT-wrapping `apply_script_if_below` → "cannot start a transaction within a transaction"; (2) `dream_pattern_archives` (0025) surrogate PK with a non-unique `(cycle_id, project_id)` index = a **genuine ADR-007 gap** for the broader batch. Left untouched rather than mask the real violation.
- `test_init_migrate_bootstrap.py::...test_pool_default_db_path_honors_vnx_data_dir` (pool_manager cache ordering) + 3 pre-existing import-ordering collection errors — all reproduce with this PR's changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)