### PR TITLE
chore(kimi): raise default per-chunk stall threshold 300s→600s

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -535,7 +535,7 @@ def spawn_kimi(
     on_event: Optional[Callable[[Any], Optional[bool]]] = None,
     extra_env: Optional[Dict[str, str]] = None,
     cwd: Optional[Any] = None,
-    chunk_timeout: float = 300.0,
+    chunk_timeout: float = 600.0,
     total_deadline: float = 900.0,
     event_store: Optional[Any] = None,
     **kwargs: Any,
@@ -546,9 +546,11 @@ def spawn_kimi(
     Returns KimiSpawnResult(returncode=127) when the kimi binary is absent.
     Caller is responsible for lease/manifest/receipt/event-archive/retry.
 
-    The per-chunk stall default is 300s (overridable via VNX_KIMI_STALL_THRESHOLD):
-    1.44.0 content-block output is end-loaded, so the first token can arrive only
-    after a long reasoning gap. A FAILURE is returned (never a silent empty
+    The per-chunk stall default is 600s (overridable via VNX_KIMI_STALL_THRESHOLD):
+    Kimi is a reasoning model whose 1.44.0 content-block output is end-loaded, so
+    the first token can arrive only after a long reasoning gap (a 300s default
+    spuriously killed adversarial-review dispatches mid-think). A FAILURE is
+    returned (never a silent empty
     success) when the CLI emits output but no answer text is extracted.
 
     event_writer signature: ``(terminal_id, event_dict, dispatch_id=...)`` called


### PR DESCRIPTION
## Summary
Kimi is a reasoning model; its 1.44.0 stream output is end-loaded, so the first token can arrive only after a long reasoning gap. The 300s per-chunk stall default spuriously kills reasoning-heavy kimi dispatches mid-think.

Observed during the PR #859 4-provider review gate: the kimi reviewer timed out at the 300s chunk-stall default and only completed once re-run with `VNX_KIMI_STALL_THRESHOLD=600`. Making 600s the default removes the need for a per-dispatch override.

## Changes
- `scripts/lib/provider_spawns/kimi_spawn.py`: `spawn_kimi` default `chunk_timeout` 300.0 → 600.0 + docstring. Still overridable via `VNX_KIMI_STALL_THRESHOLD`. `total_deadline` (900s) unchanged.

## Verification
- No test asserts kimi's 300s stall default (the 300 references in the suite are other providers — claude/gemini/subprocess — or token counts).
- File parses clean (`ast.parse`).

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)