### PR TITLE
fix(reconciler): defer to declared phase when no dispatch/PR evidence (prevents done→queued downgrade)

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -186,12 +186,13 @@ def _compute_derived_status(
         if row[0] != "done":
             return "blocked"
 
-    # 3. Fetch track's pr_ref once (reused in both the zero-dispatch and all-terminal paths).
+    # 3. Fetch track's pr_ref and declared phase once (reused below).
     track_row = conn.execute(
-        "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+        "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
         (track_id, project_id),
     ).fetchone()
     track_pr_ref = track_row["pr_ref"] if track_row else None
+    track_phase = track_row["phase"] if track_row else None
 
     # 4. Dispatch state aggregation.
     dispatches = conn.execute(
@@ -208,6 +209,12 @@ def _compute_derived_status(
         pr_num = _parse_pr_number(track_pr_ref)
         if pr_num is not None and pr_num in merged_pr_numbers:
             return "done"
+        # Absence of evidence is not evidence of queued. Historical dispatches may
+        # be archived, so defer to declared phase (2026-06-15 migration panel).
+        if track_phase == "done":
+            return "done"
+        if track_phase == "active":
+            return "in_progress"
         return "queued"
 
     states = [d[0] for d in dispatches]  # d is (dispatch_id, state); note row_factory gives dict

--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -270,7 +270,7 @@ def test_not_blocked_when_dependency_done(tmp_path):
 def test_queued_when_no_dispatches(tmp_path):
     """derived_status='queued' when no dispatches are linked."""
     state_dir = _build_db(tmp_path)
-    _seed_track(state_dir, "T-nowork")
+    _seed_track(state_dir, "T-nowork", phase="queued")
 
     result = track_reconciler.reconcile_track(state_dir, "T-nowork", PROJECT_ID)
     assert result["derived_status"] == "queued"
@@ -365,8 +365,9 @@ def test_authoritative_phase_never_modified(tmp_path):
 def test_reconcile_all_tracks_processes_all(tmp_path):
     """reconcile_all_tracks handles multiple tracks and returns one result per track."""
     state_dir = _build_db(tmp_path)
-    for tid in ("T-all-1", "T-all-2", "T-all-3"):
+    for tid in ("T-all-1", "T-all-2"):
         _seed_track(state_dir, tid)
+    _seed_track(state_dir, "T-all-3", phase="queued")
 
     _seed_dispatch(state_dir, "D-all-1", "T-all-1", state="running")
     _seed_dispatch(state_dir, "D-all-2", "T-all-2", state="completed")

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -3,8 +3,9 @@
 Verifies the additive pr_ref evidence path added in feat/reconciler-prref-evidence:
 
 - A track with pr_ref + merged evidence derives 'done' with ZERO matching dispatches
-- A track with pr_ref but PR not merged stays 'queued' (no dispatch match)
+- Zero-dispatch tracks without merged-PR evidence defer to declared phase
 - Idempotent re-run of the pr_ref path
+- Idempotent re-run of the declared-phase fallback
 - Determinism: two runs over identical state produce identical derived_status
 - Dispatch-based path not regressed (tracks WITH matching dispatches still use it)
 - _load_merged_pr_numbers reads from pr_merged.ndjson (NDJSON source)
@@ -277,7 +278,7 @@ def test_load_merged_graceful_on_bad_ndjson(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_done_when_pr_ref_merged_zero_dispatches(tmp_path):
-    """A track with pr_ref + merged evidence and NO dispatches derives 'done'."""
+    """The existing pr_ref + merged evidence path still derives 'done'."""
     state_dir = _build_db(tmp_path)
     _seed_track(state_dir, "T-ev-done", pr_ref="#756")
 
@@ -289,40 +290,53 @@ def test_done_when_pr_ref_merged_zero_dispatches(tmp_path):
     assert _get_derived(state_dir, "T-ev-done") == "done"
 
 
-def test_queued_when_pr_ref_not_in_merged_set(tmp_path):
-    """A track with pr_ref but PR not in merged set stays 'queued' (no dispatch)."""
+def test_done_when_declared_done_without_evidence(tmp_path):
+    """A done track with no dispatch or merged-PR evidence stays done."""
     state_dir = _build_db(tmp_path)
-    _seed_track(state_dir, "T-ev-queued", pr_ref="#999")
+    _seed_track(state_dir, "T-phase-done", phase="done", pr_ref=None)
 
     result = track_reconciler.reconcile_track(
-        state_dir, "T-ev-queued", PROJECT_ID,
-        _merged_pr_numbers=frozenset({756}),  # 999 not in set
+        state_dir, "T-phase-done", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
     )
-    assert result["derived_status"] == "queued"
+    assert result["derived_status"] == "done"
+    assert _get_derived(state_dir, "T-phase-done") == "done"
 
 
-def test_queued_when_no_pr_ref_and_no_dispatches(tmp_path):
-    """A track with no pr_ref and no dispatches stays 'queued'."""
+def test_in_progress_when_declared_active_without_evidence(tmp_path):
+    """An active track with no dispatch or merged-PR evidence stays in progress."""
     state_dir = _build_db(tmp_path)
-    _seed_track(state_dir, "T-ev-nopr", pr_ref=None)
+    _seed_track(state_dir, "T-phase-active", phase="active", pr_ref=None)
 
     result = track_reconciler.reconcile_track(
-        state_dir, "T-ev-nopr", PROJECT_ID,
-        _merged_pr_numbers=frozenset({756, 757, 758}),
+        state_dir, "T-phase-active", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
     )
-    assert result["derived_status"] == "queued"
+    assert result["derived_status"] == "in_progress"
 
 
-def test_queued_when_merged_set_empty_and_no_dispatches(tmp_path):
-    """A track with pr_ref but empty merged set stays 'queued'."""
+def test_queued_when_declared_queued_without_evidence(tmp_path):
+    """A queued track with no dispatch or merged-PR evidence stays queued."""
     state_dir = _build_db(tmp_path)
-    _seed_track(state_dir, "T-ev-empty", pr_ref="#756")
+    _seed_track(state_dir, "T-phase-queued", phase="queued", pr_ref=None)
 
     result = track_reconciler.reconcile_track(
-        state_dir, "T-ev-empty", PROJECT_ID,
+        state_dir, "T-phase-queued", PROJECT_ID,
         _merged_pr_numbers=frozenset(),
     )
     assert result["derived_status"] == "queued"
+
+
+def test_in_progress_when_pr_ref_not_in_merged_set(tmp_path):
+    """An active track with unconfirmed pr_ref and no dispatches stays in progress."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-ev-unmerged", phase="active", pr_ref="#999")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-unmerged", PROJECT_ID,
+        _merged_pr_numbers=frozenset({756}),  # 999 not in set
+    )
+    assert result["derived_status"] == "in_progress"
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +355,23 @@ def test_idempotent_prref_evidence_path(tmp_path):
     r2 = track_reconciler.reconcile_track(
         state_dir, "T-ev-idem", PROJECT_ID,
         _merged_pr_numbers=frozenset({800}),
+    )
+    assert r1["derived_status"] == "done"
+    assert r2["derived_status"] == "done"
+
+
+def test_idempotent_done_phase_without_evidence(tmp_path):
+    """The declared-done fallback remains done across repeated reconciles."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-phase-done-idem", phase="done", pr_ref=None)
+
+    r1 = track_reconciler.reconcile_track(
+        state_dir, "T-phase-done-idem", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
+    )
+    r2 = track_reconciler.reconcile_track(
+        state_dir, "T-phase-done-idem", PROJECT_ID,
+        _merged_pr_numbers=frozenset(),
     )
     assert r1["derived_status"] == "done"
     assert r2["derived_status"] == "done"
@@ -416,9 +447,9 @@ def test_reconcile_all_tracks_prref_evidence(tmp_path):
     state_dir = _build_db(tmp_path, deep=True)
     # Track with pr_ref + merged: should derive 'done'
     _seed_track(state_dir, "T-all-a", pr_ref="#756")
-    # Track with pr_ref, not merged: should stay 'queued'
+    # Active track with pr_ref, not merged: defer to phase.
     _seed_track(state_dir, "T-all-b", pr_ref="#999")
-    # Track with no pr_ref, no dispatches: stays 'queued'
+    # Active track with no pr_ref or dispatches: defer to phase.
     _seed_track(state_dir, "T-all-c", pr_ref=None)
     # Track with dispatch (no pr_ref match): dispatch path
     _seed_track(state_dir, "T-all-d", pr_ref=None)
@@ -434,8 +465,8 @@ def test_reconcile_all_tracks_prref_evidence(tmp_path):
     by_id = {r["track_id"]: r for r in results}
 
     assert by_id["T-all-a"]["derived_status"] == "done"
-    assert by_id["T-all-b"]["derived_status"] == "queued"
-    assert by_id["T-all-c"]["derived_status"] == "queued"
+    assert by_id["T-all-b"]["derived_status"] == "in_progress"
+    assert by_id["T-all-c"]["derived_status"] == "in_progress"
     assert by_id["T-all-d"]["derived_status"] == "in_progress"
 
 


### PR DESCRIPTION
## Problem
`_compute_derived_status` zero-dispatch branch returned `queued` whenever a track had no matching dispatch and no merged-PR evidence — treating *absence of evidence* as *evidence of queued*. Against the consolidated central DB (0 dispatches; historical dispatches deliberately archived), running `reconcile_all_tracks` downgraded 22 `phase=done` tracks to `derived_status=queued`, which would mis-schedule the autopilot (re-dispatch finished work). Surfaced by the 2026-06-15 migration-review panel (codex+kimi+opus).

## Fix
The no-evidence branch now defers to the operator-declared `phase`:
- `done` → `done`
- `active` → `in_progress`
- otherwise (queued/parked/NULL) → `queued`

Blocker check, dependency-phase check, the confirmed-merged `pr_ref` path, and all dispatch-present logic are unchanged. ADR-007 `(track_id, project_id)` scoping preserved. Advisory-only contract intact (never writes `phase`).

## Verification
- **Empirical** (loop test against a fresh copy of central with the patch): done-phase tracks with `derived≠done` drop from **25 → 1** (the remaining one is a legitimate blocker drift); `done/done` stays 24; idempotent; live central untouched.
- **Tests**: full reconciler suite 41 passed; broad reconciler+autopilot+bridge+roadmap suite **259 passed, 0 failed**. New regression coverage in `test_track_reconciler_prref_evidence.py`; 2 legacy `test_track_reconciler.py` cases updated to seed an explicit `queued` phase (they encoded the old downgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)