### PR TITLE
chore(audit): backfill utility for recent worktree-only receipts (dry-run-first)

### DIFF
--- a/scripts/backfill_wt_receipts.py
+++ b/scripts/backfill_wt_receipts.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Backfill recent worktree-only receipts into the central receipt ledger.
+
+Dry-run is the default. Pass --apply to create a verified backup and append the
+selected archive lines with a provenance marker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_ARCHIVE = Path(
+    "/Users/vincentvandeth/Backups/vnx-data-wt-archive-20260614/state/"
+    "t0_receipts.ndjson"
+)
+DEFAULT_CENTRAL = Path(
+    "/Users/vincentvandeth/.vnx-data/vnx-dev/state/t0_receipts.ndjson"
+)
+CUTOFF_DATE = "20260515"
+BACKFILLED_FROM = "wt-archive-20260614"
+KEY_FIELDS = ("dispatch_id", "cmd_id", "trace_token", "task_id")
+
+
+@dataclass(frozen=True)
+class ReceiptLine:
+    key: str
+    key_field: str | None
+    raw: str
+    record: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ParsedLedger:
+    path: Path
+    receipts: tuple[ReceiptLine, ...]
+    blank_lines: int
+    unparseable_lines: int
+
+    @property
+    def keys(self) -> frozenset[str]:
+        return frozenset(receipt.key for receipt in self.receipts)
+
+
+@dataclass(frozen=True)
+class BackfillPlan:
+    archive: ParsedLedger
+    central: ParsedLedger
+    selected_keys: tuple[str, ...]
+    lines_to_append: tuple[ReceiptLine, ...]
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    backup_path: Path | None
+    appended_count: int
+    verbatim_count: int
+    old_line_count: int
+    new_line_count: int
+
+
+def receipt_key(record: dict[str, Any], raw_line: str) -> str:
+    """Return the first usable receipt identifier, or a stable raw-line hash."""
+    field = receipt_key_field(record)
+    if field is not None:
+        return str(record[field]).strip()
+    return hashlib.sha1(raw_line.encode("utf-8")).hexdigest()
+
+
+def receipt_key_field(record: dict[str, Any]) -> str | None:
+    """Return the field supplying the stable key, or None for SHA-1 fallback."""
+    for field in KEY_FIELDS:
+        value = record.get(field)
+        if value is not None and str(value).strip():
+            return field
+    return None
+
+
+def parse_ledger(path: Path) -> ParsedLedger:
+    """Parse an NDJSON ledger, counting and skipping blank or invalid lines."""
+    receipts: list[ReceiptLine] = []
+    blank_lines = 0
+    unparseable_lines = 0
+
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for raw_with_newline in handle:
+            raw = raw_with_newline.rstrip("\r\n")
+            if not raw.strip():
+                blank_lines += 1
+                continue
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError:
+                unparseable_lines += 1
+                continue
+            if not isinstance(record, dict):
+                unparseable_lines += 1
+                continue
+            receipts.append(
+                ReceiptLine(receipt_key(record, raw), receipt_key_field(record), raw, record)
+            )
+
+    return ParsedLedger(path, tuple(receipts), blank_lines, unparseable_lines)
+
+
+def _receipt_date(record: dict[str, Any]) -> str | None:
+    """Return an eight-digit receipt date when the timestamp exposes one."""
+    timestamp = str(record.get("timestamp") or "").strip()
+    candidate = timestamp[:10].replace("-", "")
+    return candidate if len(candidate) == 8 and candidate.isdigit() else None
+
+
+def _non_date_key_is_not_known_old(receipts: Sequence[ReceiptLine]) -> bool:
+    """Keep non-date IDs unless their receipt timestamps prove they are old.
+
+    The archive contains old non-date dispatch IDs and SHA-1 fallback keys. Without
+    this guard, the general non-date inclusion rule would cross the deliberate
+    archive boundary. Missing timestamps remain included because their age cannot
+    be proven.
+    """
+    dates = [_receipt_date(receipt.record) for receipt in receipts]
+    if any(date is None for date in dates):
+        return True
+    return any(date > CUTOFF_DATE for date in dates if date is not None)
+
+
+def build_plan(archive_path: Path, central_path: Path) -> BackfillPlan:
+    """Build an ordered, read-only plan of archive receipt lines to append."""
+    archive = parse_ledger(archive_path)
+    central = parse_ledger(central_path)
+    archive_only = archive.keys - central.keys
+    archive_by_key: dict[str, list[ReceiptLine]] = defaultdict(list)
+    for receipt in archive.receipts:
+        archive_by_key[receipt.key].append(receipt)
+
+    selected_keys: list[str] = []
+    selected_set: set[str] = set()
+    for receipt in archive.receipts:
+        prefix = receipt.key[:8]
+        has_date_prefix = receipt.key_field is not None and prefix.isdigit()
+        non_date_allowed = (
+            not has_date_prefix
+            and _non_date_key_is_not_known_old(archive_by_key[receipt.key])
+        )
+        if (
+            receipt.key in archive_only
+            and receipt.key not in selected_set
+            and (has_date_prefix and prefix > CUTOFF_DATE or non_date_allowed)
+        ):
+            selected_keys.append(receipt.key)
+            selected_set.add(receipt.key)
+
+    lines_to_append = tuple(
+        receipt for receipt in archive.receipts if receipt.key in selected_set
+    )
+    return BackfillPlan(archive, central, tuple(selected_keys), lines_to_append)
+
+
+def _line_count(path: Path) -> int:
+    """Count physical lines, including a final line without a newline."""
+    line_count = 0
+    final_byte = b""
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            line_count += chunk.count(b"\n")
+            final_byte = chunk[-1:]
+    if final_byte and final_byte != b"\n":
+        line_count += 1
+    return line_count
+
+
+def _ends_with_newline(path: Path) -> bool:
+    if path.stat().st_size == 0:
+        return True
+    with path.open("rb") as handle:
+        handle.seek(-1, 2)
+        return handle.read(1) == b"\n"
+
+
+def _render_backfilled_line(raw_line: str) -> tuple[str, bool]:
+    """Add the provenance marker, falling back to verbatim for invalid JSON."""
+    try:
+        record = json.loads(raw_line)
+    except json.JSONDecodeError:
+        return raw_line, True
+    if not isinstance(record, dict):
+        return raw_line, True
+    record["backfilled_from"] = BACKFILLED_FROM
+    return json.dumps(record, ensure_ascii=False, separators=(",", ":")), False
+
+
+def apply_plan(plan: BackfillPlan) -> ApplyResult:
+    """Back up central and append the planned lines, then verify line counts."""
+    central_path = plan.central.path
+    old_line_count = _line_count(central_path)
+    appended_count = len(plan.lines_to_append)
+    if appended_count == 0:
+        return ApplyResult(None, 0, 0, old_line_count, old_line_count)
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_path = Path(f"{central_path}.bak-backfill-{stamp}")
+    if backup_path.exists():
+        raise RuntimeError(f"refusing to overwrite existing backup: {backup_path}")
+    shutil.copy2(central_path, backup_path)
+    if backup_path.stat().st_size != central_path.stat().st_size:
+        raise RuntimeError(
+            f"backup size mismatch: central={central_path.stat().st_size}, "
+            f"backup={backup_path.stat().st_size}"
+        )
+
+    needs_separator = not _ends_with_newline(central_path)
+    verbatim_count = 0
+    with central_path.open("a", encoding="utf-8", newline="\n") as handle:
+        if needs_separator:
+            handle.write("\n")
+        for receipt in plan.lines_to_append:
+            rendered, verbatim = _render_backfilled_line(receipt.raw)
+            handle.write(rendered)
+            handle.write("\n")
+            verbatim_count += int(verbatim)
+
+    new_line_count = _line_count(central_path)
+    expected_line_count = old_line_count + appended_count
+    if new_line_count != expected_line_count:
+        raise RuntimeError(
+            f"line-count verification failed: expected {expected_line_count}, "
+            f"found {new_line_count}"
+        )
+
+    return ApplyResult(
+        backup_path,
+        appended_count,
+        verbatim_count,
+        old_line_count,
+        new_line_count,
+    )
+
+
+def print_plan(plan: BackfillPlan) -> None:
+    print(f"Archive: {plan.archive.path}")
+    print(f"Central: {plan.central.path}")
+    print(
+        "Archive skipped lines: "
+        f"blank={plan.archive.blank_lines}, "
+        f"unparseable={plan.archive.unparseable_lines}"
+    )
+    print(
+        "Central skipped lines: "
+        f"blank={plan.central.blank_lines}, "
+        f"unparseable={plan.central.unparseable_lines}"
+    )
+    print(f"Selected key count: {len(plan.selected_keys)}")
+    print(f"Total line count to append: {len(plan.lines_to_append)}")
+    print("Selected dispatch_ids:")
+    for key in plan.selected_keys:
+        print(f"- {key}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, default=DEFAULT_ARCHIVE)
+    parser.add_argument("--central", type=Path, default=DEFAULT_CENTRAL)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Back up central and append selected receipts (default: dry-run).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        plan = build_plan(args.archive, args.central)
+        print_plan(plan)
+        if not args.apply:
+            print("Mode: DRY-RUN (no changes made)")
+            return 0
+
+        result = apply_plan(plan)
+        if result.appended_count == 0:
+            print("Mode: APPLY; selected 0 lines, no backup or append performed")
+            print(
+                f"Line-count verification: old={result.old_line_count}, "
+                f"new={result.new_line_count}, appended=0"
+            )
+            return 0
+
+        print(f"Mode: APPLY; backup={result.backup_path}")
+        print(f"Appended lines: {result.appended_count}")
+        print(f"Verbatim unparseable lines appended: {result.verbatim_count}")
+        print(
+            f"Line-count verification: old={result.old_line_count}, "
+            f"new={result.new_line_count}, appended={result.appended_count}"
+        )
+        return 0
+    except (OSError, RuntimeError) as exc:
+        print(f"backfill_wt_receipts: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_wt_receipts.py
+++ b/tests/test_backfill_wt_receipts.py
@@ -1,0 +1,127 @@
+"""Tests for the worktree receipt-ledger backfill."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from scripts.backfill_wt_receipts import BACKFILLED_FROM, build_plan, main, receipt_key
+
+
+def _json_line(**values: str) -> str:
+    return json.dumps(values, separators=(",", ":"))
+
+
+def _write_lines(path: Path, lines: list[str], *, final_newline: bool = True) -> None:
+    text = "\n".join(lines)
+    if final_newline and lines:
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_ledgers(tmp_path: Path) -> tuple[Path, Path]:
+    archive = tmp_path / "archive.ndjson"
+    central = tmp_path / "central.ndjson"
+    _write_lines(
+        archive,
+        [
+            "",
+            "{bad-json",
+            _json_line(dispatch_id="20260515-old", event_type="task_complete"),
+            _json_line(dispatch_id="20260516-recent", event_type="task_started"),
+            _json_line(dispatch_id="20260516-recent", event_type="task_complete"),
+            _json_line(
+                dispatch_id="bench-debug-1",
+                event_type="task_complete",
+                timestamp="2026-06-04T12:00:00Z",
+            ),
+            _json_line(
+                dispatch_id="headless-review:old",
+                event_type="task_complete",
+                timestamp="2026-04-01T12:00:00Z",
+            ),
+            _json_line(dispatch_id="20260601-existing", event_type="task_complete"),
+        ],
+    )
+    _write_lines(
+        central,
+        [_json_line(dispatch_id="20260601-existing", event_type="task_complete")],
+        final_newline=False,
+    )
+    return archive, central
+
+
+def test_receipt_key_uses_required_precedence_and_stable_sha1_fallback() -> None:
+    raw = _json_line(event_type="task_complete")
+
+    assert receipt_key(
+        {
+            "dispatch_id": "dispatch",
+            "cmd_id": "command",
+            "trace_token": "trace",
+            "task_id": "task",
+        },
+        raw,
+    ) == "dispatch"
+    assert receipt_key({"cmd_id": "command", "task_id": "task"}, raw) == "command"
+    assert receipt_key({}, raw) == hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def test_selection_includes_recent_and_non_date_but_excludes_old_and_existing(
+    tmp_path: Path,
+) -> None:
+    archive, central = _make_ledgers(tmp_path)
+
+    plan = build_plan(archive, central)
+
+    assert plan.selected_keys == ("20260516-recent", "bench-debug-1")
+    assert [line.key for line in plan.lines_to_append] == [
+        "20260516-recent",
+        "20260516-recent",
+        "bench-debug-1",
+    ]
+    assert "20260515-old" not in plan.selected_keys
+    assert "headless-review:old" not in plan.selected_keys
+    assert "20260601-existing" not in plan.selected_keys
+    assert plan.archive.blank_lines == 1
+    assert plan.archive.unparseable_lines == 1
+
+
+def test_apply_appends_selected_lines_with_marker_backs_up_and_is_idempotent(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    archive, central = _make_ledgers(tmp_path)
+    original_central = central.read_bytes()
+    args = ["--archive", str(archive), "--central", str(central), "--apply"]
+
+    assert main(args) == 0
+    first_output = capsys.readouterr().out
+
+    backups = list(tmp_path.glob("central.ndjson.bak-backfill-*"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == original_central
+    records = [
+        json.loads(line)
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 4
+    appended = records[1:]
+    assert [record["dispatch_id"] for record in appended] == [
+        "20260516-recent",
+        "20260516-recent",
+        "bench-debug-1",
+    ]
+    assert all(record["backfilled_from"] == BACKFILLED_FROM for record in appended)
+    assert "Line-count verification: old=1, new=4, appended=3" in first_output
+
+    after_first_apply = central.read_bytes()
+    assert main(args) == 0
+    second_output = capsys.readouterr().out
+
+    assert central.read_bytes() == after_first_apply
+    assert len(list(tmp_path.glob("central.ndjson.bak-backfill-*"))) == 1
+    assert "Selected key count: 0" in second_output
+    assert "selected 0 lines, no backup or append performed" in second_output


### PR DESCRIPTION
Adds `scripts/backfill_wt_receipts.py` to close the receipt-audit gap found by the 2026-06-15 migration-review panel (kimi): central's `t0_receipts.ndjson` was missing 52 lines (43 dispatch-ids) of **recent** (post-2026-05-15) operational receipts that the old worktree wrote during the dual-data-dir divergence — 6 Jun-3 smoke/router/gate, 8 worktree-isolation tests, ~29 Jun-4/7 benchmarks.

- Dry-run by default; `--apply` backs up central first, dedups by stable receipt key, tags lines with `backfilled_from`, verifies line counts, idempotent (second apply selects 0).
- Excludes the 256 deliberately-archived Apr1–May15 receipts (defensive timestamp guard for non-date / hash-fallback keys — the naive rule would have re-pulled 224 incl. April).
- Unit-tested: selection, multi-line preservation, backup, markers, idempotency (3 passed).

`--apply` against live central is an operator step (run after merge/approval); this PR is the tool + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)