### PR TITLE
fix(migration): 0031 ADR-007 runtime tenant + FK repair

### DIFF
--- a/schemas/migrations/0031_runtime_tenant_fk_repair.sql
+++ b/schemas/migrations/0031_runtime_tenant_fk_repair.sql
@@ -1,0 +1,215 @@
+-- VNX Migration 0031 — ADR-007 runtime tenant + FK repair
+--
+-- Repairs central runtime tables left behind by the dispatches v22 rebuild.
+-- ADR-007 requires project_id on every central tenant table and composite
+-- UNIQUE/PK constraints over tenant natural keys:
+-- docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+--
+-- Crash safety/idempotency are owned by apply_migration_v31. The runner verifies
+-- the exact legacy shape, disables foreign_keys before BEGIN IMMEDIATE, executes
+-- this static DDL atomically, and checks foreign_key_check + integrity_check
+-- before commit. The lease-token partial UNIQUE remains intentionally global
+-- because it is an incarnation token, not a tenant natural key.
+
+PRAGMA foreign_keys = OFF;
+
+-- dispatch_attempts: tenant stamp + composite dispatch FK/natural key.
+DROP TABLE IF EXISTS dispatch_attempts_new;
+
+CREATE TABLE dispatch_attempts_new (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    attempt_id      TEXT    NOT NULL,
+    dispatch_id     TEXT    NOT NULL,
+    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    attempt_number  INTEGER NOT NULL DEFAULT 1,
+    terminal_id     TEXT    NOT NULL,
+    state           TEXT    NOT NULL DEFAULT 'pending',
+    started_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    ended_at        TEXT,
+    failure_reason  TEXT,
+    metadata_json   TEXT    DEFAULT '{}',
+    UNIQUE(attempt_id, project_id),
+    FOREIGN KEY (dispatch_id, project_id)
+        REFERENCES dispatches(dispatch_id, project_id)
+);
+
+INSERT INTO dispatch_attempts_new (
+    id, attempt_id, dispatch_id, project_id, attempt_number, terminal_id,
+    state, started_at, ended_at, failure_reason, metadata_json
+)
+SELECT
+    id, attempt_id, dispatch_id, 'vnx-dev', attempt_number, terminal_id,
+    state, started_at, ended_at, failure_reason, metadata_json
+FROM dispatch_attempts;
+
+DROP TABLE dispatch_attempts;
+ALTER TABLE dispatch_attempts_new RENAME TO dispatch_attempts;
+
+CREATE INDEX idx_attempt_dispatch
+    ON dispatch_attempts(dispatch_id, attempt_number);
+CREATE INDEX idx_attempt_state
+    ON dispatch_attempts(state, started_at DESC);
+CREATE INDEX idx_attempt_terminal
+    ON dispatch_attempts(terminal_id, started_at DESC);
+CREATE INDEX idx_attempt_project
+    ON dispatch_attempts(project_id);
+
+-- headless_runs: tenant stamp + composite dispatch/attempt FKs/natural key.
+DROP TABLE IF EXISTS headless_runs_new;
+
+CREATE TABLE headless_runs_new (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id                  TEXT    NOT NULL,
+    dispatch_id             TEXT    NOT NULL,
+    project_id              TEXT    NOT NULL DEFAULT 'vnx-dev',
+    attempt_id              TEXT    NOT NULL,
+    target_id               TEXT    NOT NULL,
+    target_type             TEXT    NOT NULL,
+    task_class              TEXT    NOT NULL,
+    terminal_id             TEXT,
+    pid                     INTEGER,
+    pgid                    INTEGER,
+    state                   TEXT    NOT NULL DEFAULT 'init',
+    failure_class           TEXT,
+    exit_code               INTEGER,
+    started_at              TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    subprocess_started_at   TEXT,
+    heartbeat_at            TEXT,
+    last_output_at          TEXT,
+    completed_at            TEXT,
+    duration_seconds        REAL,
+    log_artifact_path       TEXT,
+    output_artifact_path    TEXT,
+    receipt_id              TEXT,
+    metadata_json           TEXT    DEFAULT '{}',
+    UNIQUE(run_id, project_id),
+    FOREIGN KEY (dispatch_id, project_id)
+        REFERENCES dispatches(dispatch_id, project_id),
+    FOREIGN KEY (attempt_id, project_id)
+        REFERENCES dispatch_attempts(attempt_id, project_id)
+);
+
+INSERT INTO headless_runs_new (
+    id, run_id, dispatch_id, project_id, attempt_id, target_id, target_type,
+    task_class, terminal_id, pid, pgid, state, failure_class, exit_code,
+    started_at, subprocess_started_at, heartbeat_at, last_output_at,
+    completed_at, duration_seconds, log_artifact_path, output_artifact_path,
+    receipt_id, metadata_json
+)
+SELECT
+    id, run_id, dispatch_id, 'vnx-dev', attempt_id, target_id, target_type,
+    task_class, terminal_id, pid, pgid, state, failure_class, exit_code,
+    started_at, subprocess_started_at, heartbeat_at, last_output_at,
+    completed_at, duration_seconds, log_artifact_path, output_artifact_path,
+    receipt_id, metadata_json
+FROM headless_runs;
+
+DROP TABLE headless_runs;
+ALTER TABLE headless_runs_new RENAME TO headless_runs;
+
+CREATE INDEX idx_headless_run_state
+    ON headless_runs(state, started_at DESC);
+CREATE INDEX idx_headless_run_dispatch
+    ON headless_runs(dispatch_id);
+CREATE INDEX idx_headless_run_target
+    ON headless_runs(target_id, state);
+CREATE INDEX idx_headless_run_heartbeat
+    ON headless_runs(state, heartbeat_at)
+    WHERE state = 'running';
+CREATE INDEX idx_headless_run_project
+    ON headless_runs(project_id);
+
+-- terminal_leases: tenant stamp + composite dispatch FK/natural key.
+DROP TABLE IF EXISTS terminal_leases_new;
+
+CREATE TABLE terminal_leases_new (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id         TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    state               TEXT    NOT NULL DEFAULT 'idle',
+    dispatch_id         TEXT,
+    generation          INTEGER NOT NULL DEFAULT 1,
+    leased_at           TEXT,
+    expires_at          TEXT,
+    last_heartbeat_at   TEXT,
+    released_at         TEXT,
+    worker_pid          INTEGER,
+    metadata_json       TEXT    DEFAULT '{}',
+    lease_token         TEXT    NOT NULL DEFAULT '',
+    UNIQUE(terminal_id, project_id),
+    FOREIGN KEY (dispatch_id, project_id)
+        REFERENCES dispatches(dispatch_id, project_id)
+);
+
+INSERT INTO terminal_leases_new (
+    id, terminal_id, project_id, state, dispatch_id, generation, leased_at,
+    expires_at, last_heartbeat_at, released_at, worker_pid, metadata_json,
+    lease_token
+)
+SELECT
+    id, terminal_id, 'vnx-dev', state, dispatch_id, generation, leased_at,
+    expires_at, last_heartbeat_at, released_at, worker_pid, metadata_json,
+    lease_token
+FROM terminal_leases;
+
+DROP TABLE terminal_leases;
+ALTER TABLE terminal_leases_new RENAME TO terminal_leases;
+
+CREATE INDEX idx_lease_state
+    ON terminal_leases(state);
+CREATE INDEX idx_lease_dispatch
+    ON terminal_leases(dispatch_id);
+CREATE INDEX idx_lease_project
+    ON terminal_leases(project_id);
+CREATE INDEX idx_lease_terminal_project
+    ON terminal_leases(terminal_id, project_id);
+CREATE UNIQUE INDEX idx_terminal_leases_token
+    ON terminal_leases(lease_token)
+    WHERE lease_token != '';
+
+-- worker_states: tenant stamp + composite PK and runtime-parent FKs.
+DROP TABLE IF EXISTS worker_states_new;
+
+CREATE TABLE worker_states_new (
+    terminal_id      TEXT    NOT NULL,
+    project_id       TEXT    NOT NULL DEFAULT 'vnx-dev',
+    dispatch_id      TEXT    NOT NULL,
+    state            TEXT    NOT NULL DEFAULT 'initializing',
+    last_output_at   TEXT,
+    state_entered_at TEXT    NOT NULL,
+    stall_count      INTEGER NOT NULL DEFAULT 0,
+    blocked_reason   TEXT,
+    metadata_json    TEXT,
+    created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (terminal_id, project_id),
+    FOREIGN KEY (terminal_id, project_id)
+        REFERENCES terminal_leases(terminal_id, project_id),
+    FOREIGN KEY (dispatch_id, project_id)
+        REFERENCES dispatches(dispatch_id, project_id)
+);
+
+INSERT INTO worker_states_new (
+    terminal_id, project_id, dispatch_id, state, last_output_at,
+    state_entered_at, stall_count, blocked_reason, metadata_json,
+    created_at, updated_at
+)
+SELECT
+    terminal_id, 'vnx-dev', dispatch_id, state, last_output_at,
+    state_entered_at, stall_count, blocked_reason, metadata_json,
+    created_at, updated_at
+FROM worker_states;
+
+DROP TABLE worker_states;
+ALTER TABLE worker_states_new RENAME TO worker_states;
+
+CREATE INDEX idx_worker_state
+    ON worker_states(state);
+CREATE INDEX idx_worker_dispatch
+    ON worker_states(dispatch_id);
+CREATE INDEX idx_worker_states_project
+    ON worker_states(project_id);
+
+PRAGMA user_version = 31;
+
+PRAGMA foreign_keys = ON;

--- a/scripts/lib/schema_manifest.py
+++ b/scripts/lib/schema_manifest.py
@@ -9,7 +9,7 @@ v30 but is physically v27) SKIPS every migration and never trips them — leavin
 migrations silently un-applied (synthesis E-F, repro-confirmed).
 
 This module replaces that fragile, scattered mechanism with ONE declarative
-INVARIANT MANIFEST per schema version (v22-v30) plus a single reconciler engine:
+INVARIANT MANIFEST per schema version (v22-v31) plus a single reconciler engine:
 
   * The manifest declares, per version, the FULL expected shape: required tables;
     columns (name + affinity + nullability); PK column ordinals; composite UNIQUE
@@ -34,7 +34,7 @@ child-table composite PK/FK) so a tenant-broken schema can NEVER validate as
 ADR-009 (docs/governance/decisions/ADR-009-schema-first-migrations.md): the
 manifest mirrors the ACTUAL semantics of `schemas/migrations/00NN_*.sql` rather
 than a hand-typed projection — built from PRAGMA introspection of a freshly
-walked DB and pinned by the fresh-DB->v30 self-consistency test. The manifest must
+walked DB and pinned by the fresh-DB->terminal-version self-consistency test. The manifest must
 match what each migration produces or the reconciler would oscillate.
 """
 
@@ -342,6 +342,134 @@ _OI_BLOCKER_IDX = (IndexInvariant("idx_track_oi_active_blockers",
                                   where="resolved_at IS NULL"),)
 
 
+# Runtime tenant tables repaired by migration 0031 (ADR-007).
+_TERMINAL_LEASE_COLS_V31 = _cols(
+    ("id", "INTEGER", False), ("terminal_id", "TEXT", True),
+    ("project_id", "TEXT", True), ("state", "TEXT", True),
+    ("dispatch_id", "TEXT", False), ("generation", "INTEGER", True),
+    ("leased_at", "TEXT", False), ("expires_at", "TEXT", False),
+    ("last_heartbeat_at", "TEXT", False), ("released_at", "TEXT", False),
+    ("worker_pid", "INTEGER", False), ("metadata_json", "TEXT", False),
+    ("lease_token", "TEXT", True),
+)
+_DISPATCH_ATTEMPT_COLS_V31 = _cols(
+    ("id", "INTEGER", False), ("attempt_id", "TEXT", True),
+    ("dispatch_id", "TEXT", True), ("project_id", "TEXT", True),
+    ("attempt_number", "INTEGER", True), ("terminal_id", "TEXT", True),
+    ("state", "TEXT", True), ("started_at", "TEXT", True),
+    ("ended_at", "TEXT", False), ("failure_reason", "TEXT", False),
+    ("metadata_json", "TEXT", False),
+)
+_HEADLESS_RUN_COLS_V31 = _cols(
+    ("id", "INTEGER", False), ("run_id", "TEXT", True),
+    ("dispatch_id", "TEXT", True), ("project_id", "TEXT", True),
+    ("attempt_id", "TEXT", True), ("target_id", "TEXT", True),
+    ("target_type", "TEXT", True), ("task_class", "TEXT", True),
+    ("terminal_id", "TEXT", False), ("pid", "INTEGER", False),
+    ("pgid", "INTEGER", False), ("state", "TEXT", True),
+    ("failure_class", "TEXT", False), ("exit_code", "INTEGER", False),
+    ("started_at", "TEXT", True), ("subprocess_started_at", "TEXT", False),
+    ("heartbeat_at", "TEXT", False), ("last_output_at", "TEXT", False),
+    ("completed_at", "TEXT", False), ("duration_seconds", "REAL", False),
+    ("log_artifact_path", "TEXT", False), ("output_artifact_path", "TEXT", False),
+    ("receipt_id", "TEXT", False), ("metadata_json", "TEXT", False),
+)
+_WORKER_STATE_COLS_V31 = _cols(
+    ("terminal_id", "TEXT", True), ("project_id", "TEXT", True),
+    ("dispatch_id", "TEXT", True), ("state", "TEXT", True),
+    ("last_output_at", "TEXT", False), ("state_entered_at", "TEXT", True),
+    ("stall_count", "INTEGER", True), ("blocked_reason", "TEXT", False),
+    ("metadata_json", "TEXT", False), ("created_at", "TEXT", True),
+    ("updated_at", "TEXT", True),
+)
+_POOL_MEMBERSHIP_COLS_V31 = _cols(
+    ("id", "INTEGER", False), ("terminal_id", "TEXT", True),
+    ("project_id", "TEXT", True), ("pool_id", "TEXT", True),
+    ("provider", "TEXT", True), ("role", "TEXT", True),
+    ("joined_at", "TEXT", True), ("released_at", "TEXT", False),
+    ("release_reason", "TEXT", False), ("spawn_generation", "INTEGER", True),
+    ("metadata_json", "TEXT", False),
+)
+
+
+def _runtime_tables_v31() -> Tuple[TableInvariant, ...]:
+    return (
+        TableInvariant(
+            name="terminal_leases", columns=_TERMINAL_LEASE_COLS_V31, pk=("id",),
+            unique_keys=(("terminal_id", "project_id"),),
+            foreign_keys=(ForeignKeyInvariant(("dispatch_id", "project_id"), "dispatches",
+                                              ("dispatch_id", "project_id")),),
+            indexes=(
+                IndexInvariant("idx_lease_state", ("state",)),
+                IndexInvariant("idx_lease_dispatch", ("dispatch_id",)),
+                IndexInvariant("idx_lease_project", ("project_id",)),
+                IndexInvariant("idx_lease_terminal_project", ("terminal_id", "project_id")),
+                IndexInvariant("idx_terminal_leases_token", ("lease_token",), unique=True,
+                               partial=True, where="lease_token != ''"),
+            ),
+        ),
+        TableInvariant(
+            name="dispatch_attempts", columns=_DISPATCH_ATTEMPT_COLS_V31, pk=("id",),
+            unique_keys=(("attempt_id", "project_id"),),
+            foreign_keys=(ForeignKeyInvariant(("dispatch_id", "project_id"), "dispatches",
+                                              ("dispatch_id", "project_id")),),
+            indexes=(
+                IndexInvariant("idx_attempt_dispatch", ("dispatch_id", "attempt_number")),
+                IndexInvariant("idx_attempt_state", ("state", "started_at")),
+                IndexInvariant("idx_attempt_terminal", ("terminal_id", "started_at")),
+                IndexInvariant("idx_attempt_project", ("project_id",)),
+            ),
+        ),
+        TableInvariant(
+            name="headless_runs", columns=_HEADLESS_RUN_COLS_V31, pk=("id",),
+            unique_keys=(("run_id", "project_id"),),
+            foreign_keys=(
+                ForeignKeyInvariant(("dispatch_id", "project_id"), "dispatches",
+                                    ("dispatch_id", "project_id")),
+                ForeignKeyInvariant(("attempt_id", "project_id"), "dispatch_attempts",
+                                    ("attempt_id", "project_id")),
+            ),
+            indexes=(
+                IndexInvariant("idx_headless_run_state", ("state", "started_at")),
+                IndexInvariant("idx_headless_run_dispatch", ("dispatch_id",)),
+                IndexInvariant("idx_headless_run_target", ("target_id", "state")),
+                IndexInvariant("idx_headless_run_heartbeat", ("state", "heartbeat_at"),
+                               partial=True, where="state = 'running'"),
+                IndexInvariant("idx_headless_run_project", ("project_id",)),
+            ),
+        ),
+        TableInvariant(
+            name="worker_states", columns=_WORKER_STATE_COLS_V31,
+            pk=("terminal_id", "project_id"),
+            foreign_keys=(
+                ForeignKeyInvariant(("terminal_id", "project_id"), "terminal_leases",
+                                    ("terminal_id", "project_id")),
+                ForeignKeyInvariant(("dispatch_id", "project_id"), "dispatches",
+                                    ("dispatch_id", "project_id")),
+            ),
+            indexes=(
+                IndexInvariant("idx_worker_state", ("state",)),
+                IndexInvariant("idx_worker_dispatch", ("dispatch_id",)),
+                IndexInvariant("idx_worker_states_project", ("project_id",)),
+            ),
+        ),
+        TableInvariant(
+            name="worker_pool_membership", columns=_POOL_MEMBERSHIP_COLS_V31, pk=("id",),
+            foreign_keys=(
+                ForeignKeyInvariant(("terminal_id", "project_id"), "terminal_leases",
+                                    ("terminal_id", "project_id")),
+                ForeignKeyInvariant(("project_id", "pool_id"), "pool_config",
+                                    ("project_id", "pool_id")),
+            ),
+            indexes=(
+                IndexInvariant("idx_pool_membership_active", ("terminal_id", "project_id"),
+                               unique=True, partial=True, where="released_at IS NULL"),
+                IndexInvariant("idx_pool_membership_pool", ("project_id", "pool_id")),
+            ),
+        ),
+    )
+
+
 def _build_manifest() -> Dict[int, VersionManifest]:
     base_children_v24 = (_tph_v24(), _td_v24())
     return {
@@ -371,12 +499,25 @@ def _build_manifest() -> Dict[int, VersionManifest]:
             _tracks_composite(_TRACKS_COLS_V29, _TRACKS_IDX_V29),
             *base_children_v24, _toi_composite(_TOI_COLS_V30, _OI_BLOCKER_IDX)),
             (_DELIVERABLES_VIEW,)),
+        31: VersionManifest(31, (
+            _dispatches(_DISPATCH_COLS_V27),
+            _tracks_composite(_TRACKS_COLS_V29, _TRACKS_IDX_V29),
+            *base_children_v24, _toi_composite(_TOI_COLS_V30, _OI_BLOCKER_IDX),
+            *_runtime_tables_v31()),
+            (_DELIVERABLES_VIEW,)),
     }
 
 
 SCHEMA_MANIFEST: Dict[int, VersionManifest] = _build_manifest()
 TERMINAL_VERSION: int = max(SCHEMA_MANIFEST)
 MIN_VERSION: int = min(SCHEMA_MANIFEST)
+_OPTIONAL_V31_RUNTIME_TABLES = frozenset((
+    "terminal_leases",
+    "dispatch_attempts",
+    "headless_runs",
+    "worker_states",
+    "worker_pool_membership",
+))
 
 
 # ---------------------------------------------------------------------------
@@ -543,8 +684,14 @@ def validate_db_at_version(conn: sqlite3.Connection, version: int) -> List[str]:
     STRICT on PK ordinals (so a composite-PK v24+ DB never validates as v22) and on
     the declared nullability/affinity of every required column."""
     manifest = SCHEMA_MANIFEST[version]
+    skip_runtime = (
+        version == 31
+        and not any(_table_exists(conn, table) for table in _OPTIONAL_V31_RUNTIME_TABLES)
+    )
     out: List[str] = []
     for tbl in manifest.tables:
+        if skip_runtime and tbl.name in _OPTIONAL_V31_RUNTIME_TABLES:
+            continue
         out += validate_table(conn, tbl)
     for view in manifest.views:
         out += validate_view(conn, view)

--- a/scripts/lib/schema_manifest.py
+++ b/scripts/lib/schema_manifest.py
@@ -382,6 +382,10 @@ _WORKER_STATE_COLS_V31 = _cols(
     ("metadata_json", "TEXT", False), ("created_at", "TEXT", True),
     ("updated_at", "TEXT", True),
 )
+_POOL_CONFIG_PARENT_COLS_V31 = _cols(
+    ("id", "INTEGER", False), ("project_id", "TEXT", True),
+    ("pool_id", "TEXT", True),
+)
 _POOL_MEMBERSHIP_COLS_V31 = _cols(
     ("id", "INTEGER", False), ("terminal_id", "TEXT", True),
     ("project_id", "TEXT", True), ("pool_id", "TEXT", True),
@@ -454,6 +458,10 @@ def _runtime_tables_v31() -> Tuple[TableInvariant, ...]:
             ),
         ),
         TableInvariant(
+            name="pool_config", columns=_POOL_CONFIG_PARENT_COLS_V31, pk=("id",),
+            unique_keys=(("project_id", "pool_id"),),
+        ),
+        TableInvariant(
             name="worker_pool_membership", columns=_POOL_MEMBERSHIP_COLS_V31, pk=("id",),
             foreign_keys=(
                 ForeignKeyInvariant(("terminal_id", "project_id"), "terminal_leases",
@@ -511,13 +519,14 @@ def _build_manifest() -> Dict[int, VersionManifest]:
 SCHEMA_MANIFEST: Dict[int, VersionManifest] = _build_manifest()
 TERMINAL_VERSION: int = max(SCHEMA_MANIFEST)
 MIN_VERSION: int = min(SCHEMA_MANIFEST)
-_OPTIONAL_V31_RUNTIME_TABLES = frozenset((
+_V31_RUNTIME_FAMILY_TABLES = frozenset((
     "terminal_leases",
     "dispatch_attempts",
     "headless_runs",
     "worker_states",
     "worker_pool_membership",
 ))
+_CONDITIONAL_V31_RUNTIME_TABLES = _V31_RUNTIME_FAMILY_TABLES | {"pool_config"}
 
 
 # ---------------------------------------------------------------------------
@@ -686,11 +695,11 @@ def validate_db_at_version(conn: sqlite3.Connection, version: int) -> List[str]:
     manifest = SCHEMA_MANIFEST[version]
     skip_runtime = (
         version == 31
-        and not any(_table_exists(conn, table) for table in _OPTIONAL_V31_RUNTIME_TABLES)
+        and not any(_table_exists(conn, table) for table in _V31_RUNTIME_FAMILY_TABLES)
     )
     out: List[str] = []
     for tbl in manifest.tables:
-        if skip_runtime and tbl.name in _OPTIONAL_V31_RUNTIME_TABLES:
+        if skip_runtime and tbl.name in _CONDITIONAL_V31_RUNTIME_TABLES:
             continue
         out += validate_table(conn, tbl)
     for view in manifest.views:

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -6,10 +6,10 @@ run() ordering (R2.2 — repair → version-reconcile → numbered walk):
      in-place composite-UNIQUE rebuild, a PRE-walk step. NOT a numbered migration.
   B. Numbered version reconciliation (`_run_version_reconciliation`, PR-A2) — validate
      the DB's CLAIMED `user_version` against the declarative invariant manifest
-     (scripts/lib/schema_manifest.py). A DB that LIES about its version (claims v30 but
+     (scripts/lib/schema_manifest.py). A DB that LIES about its version (claims v31 but
      is physically v27) is DOWNGRADED to the exact highest version whose invariants
      fully hold, so the numbered walk re-applies whatever the downgrade exposes.
-  C. Numbered migration walk (0022 → 0030), each idempotent via user_version.
+  C. Numbered migration walk (0022 → 0031), each idempotent via user_version.
   D. Convergence guard (`_assert_manifest_converged`) — after the walk the terminal
      version's manifest MUST hold, else a downgrade+re-walk did not converge → abort
      loudly rather than loop (oscillation guard).
@@ -30,6 +30,7 @@ PRD §7.2 (Run: migrate → backfill → bridge → reconcile). The numbered wal
   10. Apply schemas/migrations/0029_track_type_discriminator.sql (idempotent)
   11. PRAGMA pre-flight: assert track_type present (v29) before adding resolved_at
   12. Apply schemas/migrations/0030_track_oi_resolved_at.sql (idempotent)
+  13. Apply schemas/migrations/0031_runtime_tenant_fk_repair.sql (idempotent)
 
 The per-version preflights (steps 3-11) are now MANIFEST-BACKED (schema_manifest):
 the name-based column/table assertions are sourced from the declarative manifest, not
@@ -121,7 +122,7 @@ def _pytest_db_isolation_guard(project_root: Path) -> None:
 # into the composite UNIQUE(dispatch_id, project_id).
 #
 # Position in run() (R2.2): runs as a PRE-MIGRATION step — after the
-# _pytest_db_isolation_guard, BEFORE the numbered version walk (0022→0030).
+# _pytest_db_isolation_guard, BEFORE the numbered version walk (0022→0031).
 # It is a no-op when the schema is already composite (detected by parsing
 # sqlite_master / PRAGMA, NOT a bare column check), so the operator ordering in
 # PRD §6 ("migrate first") is preserved. This is the general robust repair; it
@@ -1543,12 +1544,196 @@ def apply_migration_v30(conn: sqlite3.Connection, project_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 10: apply 0031 migration (ADR-007 runtime tenant + FK repair)
+# ---------------------------------------------------------------------------
+
+_RUNTIME_V31_TABLES = (
+    "terminal_leases",
+    "dispatch_attempts",
+    "headless_runs",
+    "worker_states",
+    "worker_pool_membership",
+)
+
+_RUNTIME_V30_LEGACY_COLUMNS = {
+    "terminal_leases": {
+        "id", "terminal_id", "state", "dispatch_id", "generation", "leased_at",
+        "expires_at", "last_heartbeat_at", "released_at", "worker_pid",
+        "metadata_json", "lease_token",
+    },
+    "dispatch_attempts": {
+        "id", "attempt_id", "dispatch_id", "attempt_number", "terminal_id",
+        "state", "started_at", "ended_at", "failure_reason", "metadata_json",
+    },
+    "headless_runs": {
+        "id", "run_id", "dispatch_id", "attempt_id", "target_id", "target_type",
+        "task_class", "terminal_id", "pid", "pgid", "state", "failure_class",
+        "exit_code", "started_at", "subprocess_started_at", "heartbeat_at",
+        "last_output_at", "completed_at", "duration_seconds", "log_artifact_path",
+        "output_artifact_path", "receipt_id", "metadata_json",
+    },
+    "worker_states": {
+        "terminal_id", "dispatch_id", "state", "last_output_at", "state_entered_at",
+        "stall_count", "blocked_reason", "metadata_json", "created_at", "updated_at",
+    },
+}
+
+_RUNTIME_V30_LEGACY_INDEXES = {
+    "terminal_leases": {"idx_lease_state", "idx_lease_dispatch", "idx_terminal_leases_token"},
+    "dispatch_attempts": {"idx_attempt_dispatch", "idx_attempt_state", "idx_attempt_terminal"},
+    "headless_runs": {
+        "idx_headless_run_state", "idx_headless_run_dispatch",
+        "idx_headless_run_target", "idx_headless_run_heartbeat",
+    },
+    "worker_states": {"idx_worker_state", "idx_worker_dispatch"},
+}
+
+
+def _runtime_v31_violations(conn: sqlite3.Connection) -> list[str]:
+    """Validate only the runtime tables introduced into the v31 manifest."""
+    violations: list[str] = []
+    for table in _RUNTIME_V31_TABLES:
+        invariant = schema_manifest.table_at(31, table)
+        if invariant is None:
+            violations.append(f"v31 manifest missing runtime table invariant '{table}'")
+        else:
+            violations.extend(schema_manifest.validate_table(conn, invariant))
+    return violations
+
+
+def _runtime_v31_complete(conn: sqlite3.Connection) -> bool:
+    return not _runtime_v31_violations(conn)
+
+
+def _runtime_v31_tables_absent(conn: sqlite3.Connection) -> bool:
+    """True only when the separate runtime schema has not been initialized at all."""
+    present = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    return not any(table in present for table in _RUNTIME_V31_TABLES)
+
+
+def _assert_runtime_v30_legacy_shape(conn: sqlite3.Connection) -> None:
+    """Fail before mutation if static 0031 DDL would lose unknown schema objects."""
+    _assert_required_tables(
+        conn, (*_RUNTIME_V31_TABLES, "pool_config", "dispatches"), before="0031")
+    if not _has_composite_unique(conn):
+        raise RuntimeError(
+            "0031 requires dispatches UNIQUE(dispatch_id, project_id) from PR-A1.")
+
+    for table, expected_cols in _RUNTIME_V30_LEGACY_COLUMNS.items():
+        actual_cols = {r[1] for r in conn.execute(f"PRAGMA table_info('{table}')")}
+        if actual_cols != expected_cols:
+            raise RuntimeError(
+                f"0031 legacy-shape drift in {table}: expected columns={sorted(expected_cols)} "
+                f"actual={sorted(actual_cols)}. Refusing static rebuild to prevent data loss.")
+
+        actual_indexes = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND tbl_name=? AND sql IS NOT NULL", (table,))
+        }
+        expected_indexes = _RUNTIME_V30_LEGACY_INDEXES[table]
+        if actual_indexes != expected_indexes:
+            raise RuntimeError(
+                f"0031 legacy-shape drift in {table}: expected indexes="
+                f"{sorted(expected_indexes)} actual={sorted(actual_indexes)}. "
+                "Refusing rebuild because every index must be recreated.")
+
+        triggers = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?", (table,))]
+        if triggers:
+            raise RuntimeError(
+                f"0031 found unexpected triggers on {table}: {triggers}. "
+                "Refusing rebuild rather than dropping them.")
+
+
+def _assert_runtime_v31_clean(conn: sqlite3.Connection) -> None:
+    violations = _runtime_v31_violations(conn)
+    if violations:
+        raise RuntimeError(f"0031 runtime manifest violations: {violations[:5]}")
+    try:
+        fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    except sqlite3.DatabaseError as exc:
+        raise RuntimeError(f"0031 foreign_key_check failed structurally: {exc}") from exc
+    if fk_violations:
+        raise RuntimeError(f"0031 foreign_key_check violations: {fk_violations}")
+    integrity = conn.execute("PRAGMA integrity_check").fetchall()
+    if integrity != [("ok",)]:
+        raise RuntimeError(f"0031 integrity_check failed: {integrity}")
+
+
+def _rollback_runtime_v31(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("ROLLBACK")
+    except Exception as rollback_exc:
+        warnings.warn(
+            f"0031 runtime repair: ROLLBACK after error failed: {rollback_exc}",
+            stacklevel=2,
+        )
+
+
+def _run_runtime_v31_transaction(conn: sqlite3.Connection, statements) -> None:
+    """Execute 0031 under one validated transaction with FK enforcement suspended."""
+    if conn.in_transaction:
+        raise RuntimeError(
+            "0031 requires a connection with no open transaction; commit or roll back first.")
+    original_fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    previous_isolation = conn.isolation_level
+    conn.isolation_level = None
+    try:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        _begin_immediate_with_retry(conn)
+        try:
+            for statement in statements:
+                conn.execute(statement)
+            _assert_runtime_v31_clean(conn)
+            conn.execute("COMMIT")
+        except Exception:
+            _rollback_runtime_v31(conn)
+            raise
+    finally:
+        conn.execute("PRAGMA foreign_keys=ON" if original_fk else "PRAGMA foreign_keys=OFF")
+        conn.isolation_level = previous_isolation
+    _verify_foreign_keys_restored(conn, original_fk)
+
+
+def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
+    migration_path = _MIGRATIONS / "0031_runtime_tenant_fk_repair.sql"
+    if not migration_path.exists():
+        raise FileNotFoundError(f"Migration not found: {migration_path}")
+
+    current_version = schema_migration.get_user_version(conn)
+    if current_version >= 31:
+        print(f"  [skip] migration 0031 already applied (user_version={current_version})")
+        return
+    if current_version != 30:
+        raise RuntimeError(
+            f"0031 requires user_version=30 after the prior numbered walk; got {current_version}.")
+
+    if _runtime_v31_tables_absent(conn):
+        print("  [skip] migration 0031 runtime tables absent; user_version → 31")
+        conn.execute("PRAGMA user_version = 31")
+        return
+
+    if _runtime_v31_complete(conn):
+        print("  [stamp] runtime tenant/FK repair already complete; user_version → 31")
+        _run_runtime_v31_transaction(conn, ("PRAGMA user_version = 31",))
+        return
+
+    _assert_runtime_v30_legacy_shape(conn)
+    sql = migration_path.read_text(encoding="utf-8")
+    print("  [apply] migration 0031_runtime_tenant_fk_repair.sql ...")
+    _run_runtime_v31_transaction(conn, schema_migration._split_sql_statements(sql))
+    print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def _run_numbered_walk(conn: sqlite3.Connection, project_root: Path) -> None:
-    """Step C of run(): apply the numbered migrations 0022 → 0030 in order, each
-    idempotent via user_version, committing after each. Preflights (steps 3-11) are
+    """Step C of run(): apply the numbered migrations 0022 → 0031 in order, each
+    idempotent via user_version, committing after each. Preflights (steps 3-12) are
     manifest-backed (schema_manifest). See the module docstring for the full ordering.
     """
     apply_migration(conn, project_root)       # 0022 — track tables; dispatches w/o track FK
@@ -1563,10 +1748,12 @@ def _run_numbered_walk(conn: sqlite3.Connection, project_root: Path) -> None:
     conn.commit()
     apply_migration_v30(conn, project_root)   # 0030 — track_open_items.resolved_at + reason
     conn.commit()
+    apply_migration_v31(conn, project_root)   # 0031 — runtime tenant/FK repair
+    conn.commit()
 
 
 def run(project_root: Path | None = None) -> None:
-    """Apply track layer migrations: 0022, 0024, 0027, 0028, 0029, 0030."""
+    """Apply future-system migrations through 0031."""
     if project_root is None:
         project_root = resolve_project_root(__file__)
     _pytest_db_isolation_guard(project_root)
@@ -1602,7 +1789,7 @@ def run(project_root: Path | None = None) -> None:
         if schema_migration.get_user_version(conn) < 22:
             _assert_dispatches_schema_intact(conn)
 
-        # (C) Numbered migration walk: 0022 → 0030 (each idempotent via user_version).
+        # (C) Numbered migration walk: 0022 → 0031 (each idempotent via user_version).
         _run_numbered_walk(conn, project_root)
 
         # (D) Oscillation guard (R2.1): the terminal version's manifest MUST hold;

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -1096,7 +1096,18 @@ def _run_version_reconciliation(conn: sqlite3.Connection, db_path) -> None:
 def _assert_manifest_converged(conn: sqlite3.Connection) -> None:
     """Oscillation guard (R2.1): after the numbered walk, the terminal version's
     manifest MUST hold. If a downgrade+re-walk did not converge, fail loudly rather
-    than leave a silently-broken DB (or loop on the next run). Cite ADR-009."""
+    than leave a silently-broken DB (or loop on the next run). The independent
+    foreign_key_check closes any gap in the declarative manifest. Cite ADR-009."""
+    try:
+        fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    except sqlite3.DatabaseError as exc:
+        raise schema_manifest.SchemaReconciliationError(
+            f"terminal convergence foreign_key_check failed structurally: {exc}"
+        ) from exc
+    if fk_violations:
+        raise schema_manifest.SchemaReconciliationError(
+            f"terminal convergence foreign_key_check violations: {fk_violations[:5]}")
+
     final = schema_migration.get_user_version(conn)
     if final not in schema_manifest.SCHEMA_MANIFEST:
         return
@@ -1578,21 +1589,69 @@ _RUNTIME_V30_LEGACY_COLUMNS = {
     },
 }
 
-_RUNTIME_V30_LEGACY_INDEXES = {
-    "terminal_leases": {"idx_lease_state", "idx_lease_dispatch", "idx_terminal_leases_token"},
-    "dispatch_attempts": {"idx_attempt_dispatch", "idx_attempt_state", "idx_attempt_terminal"},
-    "headless_runs": {
-        "idx_headless_run_state", "idx_headless_run_dispatch",
-        "idx_headless_run_target", "idx_headless_run_heartbeat",
+_RUNTIME_V30_LEGACY_INDEX_SQL = {
+    "terminal_leases": {
+        "idx_lease_state": "CREATE INDEX idx_lease_state ON terminal_leases(state)",
+        "idx_lease_dispatch": "CREATE INDEX idx_lease_dispatch ON terminal_leases(dispatch_id)",
+        "idx_terminal_leases_token": (
+            "CREATE UNIQUE INDEX idx_terminal_leases_token ON terminal_leases(lease_token) "
+            "WHERE lease_token != ''"
+        ),
     },
-    "worker_states": {"idx_worker_state", "idx_worker_dispatch"},
+    "dispatch_attempts": {
+        "idx_attempt_dispatch": (
+            "CREATE INDEX idx_attempt_dispatch "
+            "ON dispatch_attempts(dispatch_id, attempt_number)"
+        ),
+        "idx_attempt_state": (
+            "CREATE INDEX idx_attempt_state ON dispatch_attempts(state, started_at DESC)"
+        ),
+        "idx_attempt_terminal": (
+            "CREATE INDEX idx_attempt_terminal ON dispatch_attempts(terminal_id, started_at DESC)"
+        ),
+    },
+    "headless_runs": {
+        "idx_headless_run_state": (
+            "CREATE INDEX idx_headless_run_state ON headless_runs(state, started_at DESC)"
+        ),
+        "idx_headless_run_dispatch": (
+            "CREATE INDEX idx_headless_run_dispatch ON headless_runs(dispatch_id)"
+        ),
+        "idx_headless_run_target": (
+            "CREATE INDEX idx_headless_run_target ON headless_runs(target_id, state)"
+        ),
+        "idx_headless_run_heartbeat": (
+            "CREATE INDEX idx_headless_run_heartbeat ON headless_runs(state, heartbeat_at) "
+            "WHERE state = 'running'"
+        ),
+    },
+    "worker_states": {
+        "idx_worker_state": "CREATE INDEX idx_worker_state ON worker_states(state)",
+        "idx_worker_dispatch": "CREATE INDEX idx_worker_dispatch ON worker_states(dispatch_id)",
+    },
 }
+
+_RUNTIME_V31_PARENT_TABLES = ("pool_config",)
+_RUNTIME_V31_AUTOINCREMENT_TABLES = (
+    "terminal_leases",
+    "dispatch_attempts",
+    "headless_runs",
+)
+
+
+def _normalize_create_index_sql(sql: str | None) -> str:
+    """Normalize formatting while preserving every index semantic."""
+    normalized = re.sub(r"\s+", " ", sql or "").strip().rstrip(";").strip().lower()
+    normalized = re.sub(r"\bif\s+not\s+exists\s+", "", normalized)
+    normalized = re.sub(r"\s*([(),])\s*", r"\1", normalized)
+    normalized = re.sub(r"\s*(<=|>=|<>|!=|=|<|>)\s*", r"\1", normalized)
+    return normalized
 
 
 def _runtime_v31_violations(conn: sqlite3.Connection) -> list[str]:
-    """Validate only the runtime tables introduced into the v31 manifest."""
+    """Validate the runtime family and its required parent invariants."""
     violations: list[str] = []
-    for table in _RUNTIME_V31_TABLES:
+    for table in (*_RUNTIME_V31_TABLES, *_RUNTIME_V31_PARENT_TABLES):
         invariant = schema_manifest.table_at(31, table)
         if invariant is None:
             violations.append(f"v31 manifest missing runtime table invariant '{table}'")
@@ -1628,16 +1687,26 @@ def _assert_runtime_v30_legacy_shape(conn: sqlite3.Connection) -> None:
                 f"actual={sorted(actual_cols)}. Refusing static rebuild to prevent data loss.")
 
         actual_indexes = {
-            r[0] for r in conn.execute(
-                "SELECT name FROM sqlite_master "
+            r[0]: r[1] for r in conn.execute(
+                "SELECT name, sql FROM sqlite_master "
                 "WHERE type='index' AND tbl_name=? AND sql IS NOT NULL", (table,))
         }
-        expected_indexes = _RUNTIME_V30_LEGACY_INDEXES[table]
-        if actual_indexes != expected_indexes:
+        expected_indexes = _RUNTIME_V30_LEGACY_INDEX_SQL[table]
+        if set(actual_indexes) != set(expected_indexes):
             raise RuntimeError(
                 f"0031 legacy-shape drift in {table}: expected indexes="
                 f"{sorted(expected_indexes)} actual={sorted(actual_indexes)}. "
                 "Refusing rebuild because every index must be recreated.")
+        for index_name, expected_sql in expected_indexes.items():
+            actual_sql = actual_indexes[index_name]
+            if _normalize_create_index_sql(actual_sql) != _normalize_create_index_sql(
+                expected_sql
+            ):
+                raise RuntimeError(
+                    f"0031 legacy-shape drift in {table}: index {index_name!r} "
+                    f"definition differs from canonical legacy definition. "
+                    f"expected={expected_sql!r} actual={actual_sql!r}. "
+                    "Refusing rebuild because index semantics would be lost.")
 
         triggers = [r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?", (table,))]
@@ -1672,7 +1741,36 @@ def _rollback_runtime_v31(conn: sqlite3.Connection) -> None:
         )
 
 
-def _run_runtime_v31_transaction(conn: sqlite3.Connection, statements) -> None:
+def _capture_runtime_v31_sequences(conn: sqlite3.Connection) -> dict[str, int | None]:
+    """Capture AUTOINCREMENT high-water marks before the tables are dropped."""
+    sequences: dict[str, int | None] = {}
+    for table in _RUNTIME_V31_AUTOINCREMENT_TABLES:
+        row = conn.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name=?", (table,)
+        ).fetchone()
+        sequences[table] = row[0] if row else None
+    return sequences
+
+
+def _restore_runtime_v31_sequences(
+    conn: sqlite3.Connection, old_sequences: dict[str, int | None]
+) -> None:
+    """Restore max(pre-rebuild sequence, copied max id) after final-table rename."""
+    for table, old_seq in old_sequences.items():
+        max_id = conn.execute(
+            f'SELECT COALESCE(MAX(id), 0) FROM "{table}"'
+        ).fetchone()[0]
+        target = max(old_seq or 0, max_id or 0)
+        conn.execute("DELETE FROM sqlite_sequence WHERE name=?", (table,))
+        if old_seq is not None or target:
+            conn.execute(
+                "INSERT INTO sqlite_sequence(name, seq) VALUES(?, ?)", (table, target)
+            )
+
+
+def _run_runtime_v31_transaction(
+    conn: sqlite3.Connection, statements, *, preserve_runtime_sequences: bool = False
+) -> None:
     """Execute 0031 under one validated transaction with FK enforcement suspended."""
     if conn.in_transaction:
         raise RuntimeError(
@@ -1684,8 +1782,13 @@ def _run_runtime_v31_transaction(conn: sqlite3.Connection, statements) -> None:
         conn.execute("PRAGMA foreign_keys=OFF")
         _begin_immediate_with_retry(conn)
         try:
+            old_sequences = (
+                _capture_runtime_v31_sequences(conn) if preserve_runtime_sequences else {}
+            )
             for statement in statements:
                 conn.execute(statement)
+            if old_sequences:
+                _restore_runtime_v31_sequences(conn, old_sequences)
             _assert_runtime_v31_clean(conn)
             conn.execute("COMMIT")
         except Exception:
@@ -1723,7 +1826,11 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
     _assert_runtime_v30_legacy_shape(conn)
     sql = migration_path.read_text(encoding="utf-8")
     print("  [apply] migration 0031_runtime_tenant_fk_repair.sql ...")
-    _run_runtime_v31_transaction(conn, schema_migration._split_sql_statements(sql))
+    _run_runtime_v31_transaction(
+        conn,
+        schema_migration._split_sql_statements(sql),
+        preserve_runtime_sequences=True,
+    )
     print(f"  [ok]    user_version → {schema_migration.get_user_version(conn)}")
 
 

--- a/tests/test_fsr_version_reconciliation.py
+++ b/tests/test_fsr_version_reconciliation.py
@@ -1,16 +1,16 @@
 """R8.5 — version reconciliation / invariant manifest behavioral suite (PR-A2).
 
 Covers:
-  * the fresh-DB → v30-manifest SELF-CONSISTENCY test (the manifest matches what the
+  * the fresh-DB → v31-manifest SELF-CONSISTENCY test (the manifest matches what the
     full migration walk produces — ADR-009 schema-first);
-  * the parametrized walk-down: a DB that LIES about its `user_version` (claims v30 but
+  * the parametrized walk-down: a DB that LIES about its `user_version` (claims v31 but
     is physically vK) is downgraded to vK and the numbered walk re-applies the exposed
-    migrations until it converges at a valid v30;
+    migrations until it converges at a valid v31;
   * one case PER invariant class (missing table / missing column / wrong nullability /
     missing index / missing view) proving the manifest DETECTS the break and the
     reconciler responds (downgrade to the true version, or a loud abort when no lower
     version holds);
-  * the no-spurious-downgrade guarantee for a genuinely-complete v30 DB;
+  * the no-spurious-downgrade guarantee for a genuinely-complete v31 DB;
   * the oscillation guard: a downgrade+re-walk that cannot converge aborts with an
     explicit error rather than looping.
 
@@ -73,6 +73,7 @@ CREATE TABLE dispatches (
 _APPLY_CHAIN = (
     (22, "apply_migration"), (24, "apply_migration_v24"), (27, "apply_migration_v27"),
     (28, "apply_migration_v28"), (29, "apply_migration_v29"), (30, "apply_migration_v30"),
+    (31, "apply_migration_v31"),
 )
 
 
@@ -126,11 +127,11 @@ def _open(db: Path) -> sqlite3.Connection:
 
 
 # --------------------------------------------------------------------------- #
-# Self-consistency (ADR-009): fresh walk → exact v30 manifest
+# Self-consistency (ADR-009): fresh walk → exact v31 manifest
 # --------------------------------------------------------------------------- #
 
-def test_fresh_db_walk_satisfies_v30_manifest_exactly(tmp_path: Path) -> None:
-    """Applying the full walk to a fresh DB yields a schema that satisfies the v30
+def test_fresh_db_walk_satisfies_v31_manifest_exactly(tmp_path: Path) -> None:
+    """Applying the full walk to a fresh DB yields a schema that satisfies the v31
     invariant manifest EXACTLY (zero violations). If this fails, the manifest has
     drifted from the migration SQL and the reconciler would oscillate."""
     proj = _make_project(tmp_path)
@@ -138,7 +139,7 @@ def test_fresh_db_walk_satisfies_v30_manifest_exactly(tmp_path: Path) -> None:
     conn = _open(_db_path(proj))
     try:
         assert schema_migration.get_user_version(conn) == sm.TERMINAL_VERSION
-        assert sm.validate_db_at_version(conn, 30) == []
+        assert sm.validate_db_at_version(conn, 31) == []
     finally:
         conn.close()
 
@@ -151,7 +152,7 @@ def test_every_intermediate_version_self_consistent(tmp_path: Path) -> None:
         conn = _open(_db_path(proj))
         try:
             assert sm.validate_db_at_version(conn, ver) == [], f"v{ver} self-inconsistent"
-            assert sm.derive_correct_version(conn, max_version=30) == ver
+            assert sm.derive_correct_version(conn, max_version=ver) == ver
         finally:
             conn.close()
 
@@ -161,38 +162,38 @@ def test_every_intermediate_version_self_consistent(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 
 @pytest.mark.parametrize("true_version", [24, 27, 28, 29])
-def test_lying_v30_downgrades_to_true_version_and_rewalks(
+def test_lying_v31_downgrades_to_true_version_and_rewalks(
     tmp_path: Path, true_version: int
 ) -> None:
-    """A genuine vK DB stamped as v30 is reconciled DOWN to vK; the numbered walk then
-    re-applies 00(K+1)..0030 and converges at a clean v30 (no data dropped)."""
+    """A genuine vK DB stamped as v31 is reconciled DOWN to vK; the numbered walk then
+    re-applies 00(K+1)..0031 and converges at a clean v31 (no data dropped)."""
     proj = _build_db_at(tmp_path, true_version)
     db = _db_path(proj)
-    _stamp_user_version(db, 30)
+    _stamp_user_version(db, 31)
 
-    # Before run(): the claimed v30 manifest fails (migrations are physically un-applied)
+    # Before run(): the claimed v31 manifest fails (migrations are physically un-applied)
     conn = _open(db)
-    assert sm.validate_db_at_version(conn, 30), "claimed v30 should fail before reconcile"
+    assert sm.validate_db_at_version(conn, 31), "claimed v31 should fail before reconcile"
     conn.close()
 
     mfs.run(proj)
 
     conn = _open(db)
     try:
-        assert schema_migration.get_user_version(conn) == 30
-        assert sm.validate_db_at_version(conn, 30) == []
+        assert schema_migration.get_user_version(conn) == 31
+        assert sm.validate_db_at_version(conn, 31) == []
         # the seeded dispatch row survived the whole walk (no data loss)
         assert conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0] == 1
     finally:
         conn.close()
 
 
-def test_canonical_derived_status_absent_at_v30(tmp_path: Path) -> None:
+def test_canonical_derived_status_absent_at_v31(tmp_path: Path) -> None:
     """Acceptance example (R8.5): tracks present + derived_status absent while
-    user_version=30 → reconciler downgrades to <=27 and the walk re-runs 0028→0030."""
+    user_version=31 → reconciler downgrades to <=27 and the walk re-runs 0028→0031."""
     proj = _build_db_at(tmp_path, 27)          # genuine v27: tracks+horizon, NO derived_status
     db = _db_path(proj)
-    _stamp_user_version(db, 30)
+    _stamp_user_version(db, 31)
 
     conn = _open(db)
     cols = {r[1] for r in conn.execute("PRAGMA table_info('tracks')")}
@@ -209,7 +210,7 @@ def test_canonical_derived_status_absent_at_v30(tmp_path: Path) -> None:
     mfs.run(proj)
     conn = _open(db)
     try:
-        assert schema_migration.get_user_version(conn) == 30
+        assert schema_migration.get_user_version(conn) == 31
         new_cols = {r[1] for r in conn.execute("PRAGMA table_info('tracks')")}
         assert {"derived_status", "track_type"} <= new_cols      # 0028+0029 re-ran
         oi_cols = {r[1] for r in conn.execute("PRAGMA table_info('track_open_items')")}
@@ -218,27 +219,27 @@ def test_canonical_derived_status_absent_at_v30(tmp_path: Path) -> None:
         conn.close()
 
 
-def test_no_spurious_downgrade_on_complete_v30(tmp_path: Path) -> None:
-    """A genuinely-complete v30 DB claiming v30 is LEFT UNTOUCHED (no downgrade)."""
-    proj = _build_db_at(tmp_path, 30)
+def test_no_spurious_downgrade_on_complete_v31(tmp_path: Path) -> None:
+    """A genuinely-complete v31 DB claiming v31 is LEFT UNTOUCHED (no downgrade)."""
+    proj = _build_db_at(tmp_path, 31)
     conn = _open(_db_path(proj))
     try:
         result = sm.reconcile_user_version(conn)
         assert result.reconciled is False
-        assert result.corrected == 30
-        assert schema_migration.get_user_version(conn) == 30
+        assert result.corrected == 31
+        assert schema_migration.get_user_version(conn) == 31
     finally:
         conn.close()
 
 
-def test_complete_v30_run_is_idempotent_noop(tmp_path: Path) -> None:
-    """run() on an already-complete, truthful v30 DB leaves user_version at 30."""
-    proj = _build_db_at(tmp_path, 30)
+def test_complete_v31_run_is_idempotent_noop(tmp_path: Path) -> None:
+    """run() on an already-complete, truthful v31 DB leaves user_version at 31."""
+    proj = _build_db_at(tmp_path, 31)
     mfs.run(proj)
     conn = _open(_db_path(proj))
     try:
-        assert schema_migration.get_user_version(conn) == 30
-        assert sm.validate_db_at_version(conn, 30) == []
+        assert schema_migration.get_user_version(conn) == 31
+        assert sm.validate_db_at_version(conn, 31) == []
     finally:
         conn.close()
 

--- a/tests/test_migrate_future_system.py
+++ b/tests/test_migrate_future_system.py
@@ -127,9 +127,11 @@ class TestPragmaPreflightAssertion:
         conn.close()
         return project_dir
 
-    def test_preflight_raises_on_missing_project_id(self, tmp_path):
+    def test_preflight_raises_on_missing_project_id(self, tmp_path, monkeypatch):
         project_dir = self._v9_style_project(tmp_path)
         mod = _get_migrate_module()
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.setattr(mod, "_marker_project_id", lambda _db_path: None)
         with pytest.raises(RuntimeError, match="project_id"):
             mod.run(project_dir)
 
@@ -141,8 +143,10 @@ class TestPragmaPreflightAssertion:
         db_path = project_dir / ".vnx-data" / "state" / "runtime_coordination.db"
         conn = sqlite3.connect(str(db_path))
         cols = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
         assert "project_id" in cols
+        assert version == 31
 
 
 class TestBidirectionalPreflight:
@@ -231,6 +235,7 @@ class TestBidirectionalPreflight:
         conn.commit()
         conn.close()
         mod = _get_migrate_module()
+        monkeypatch.setattr(mod, "_marker_project_id", lambda _db_path: None)
         # N1: missing composite → ADR-007 repair fires; unresolvable tenant → fail-closed.
         with pytest.raises(RuntimeError, match="project_id|UNIQUE"):
             mod.run(project_dir)

--- a/tests/test_migration_0031_runtime_fk.py
+++ b/tests/test_migration_0031_runtime_fk.py
@@ -1,0 +1,290 @@
+"""Migration 0031: ADR-007 runtime tenant/FK repair.
+
+Builds the malformed central v30 shape in a temp DB, applies the numbered walk,
+and verifies lossless/idempotent convergence at v31. The live central DB is never
+opened by this test.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _ROOT / "scripts"
+_LIB = _SCRIPTS / "lib"
+for _path in (_SCRIPTS, _LIB):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import migrate_future_system as mfs  # noqa: E402
+import schema_manifest  # noqa: E402
+import schema_migration  # noqa: E402
+
+
+_LEGACY_RUNTIME_SQL = """
+CREATE TABLE dispatches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+    state TEXT NOT NULL DEFAULT 'queued',
+    terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+    UNIQUE(dispatch_id, project_id)
+);
+
+CREATE TABLE dispatch_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    attempt_id TEXT NOT NULL UNIQUE,
+    dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+    attempt_number INTEGER NOT NULL DEFAULT 1,
+    terminal_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    ended_at TEXT, failure_reason TEXT, metadata_json TEXT DEFAULT '{}'
+);
+CREATE INDEX idx_attempt_dispatch ON dispatch_attempts(dispatch_id, attempt_number);
+CREATE INDEX idx_attempt_state ON dispatch_attempts(state, started_at DESC);
+CREATE INDEX idx_attempt_terminal ON dispatch_attempts(terminal_id, started_at DESC);
+
+CREATE TABLE terminal_leases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id TEXT NOT NULL UNIQUE,
+    state TEXT NOT NULL DEFAULT 'idle',
+    dispatch_id TEXT REFERENCES dispatches(dispatch_id),
+    generation INTEGER NOT NULL DEFAULT 1,
+    leased_at TEXT, expires_at TEXT, last_heartbeat_at TEXT, released_at TEXT,
+    worker_pid INTEGER, metadata_json TEXT DEFAULT '{}',
+    lease_token TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_lease_state ON terminal_leases(state);
+CREATE INDEX idx_lease_dispatch ON terminal_leases(dispatch_id);
+CREATE UNIQUE INDEX idx_terminal_leases_token
+    ON terminal_leases(lease_token) WHERE lease_token != '';
+
+CREATE TABLE headless_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL UNIQUE,
+    dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+    attempt_id TEXT NOT NULL REFERENCES dispatch_attempts(attempt_id),
+    target_id TEXT NOT NULL, target_type TEXT NOT NULL, task_class TEXT NOT NULL,
+    terminal_id TEXT, pid INTEGER, pgid INTEGER,
+    state TEXT NOT NULL DEFAULT 'init',
+    failure_class TEXT, exit_code INTEGER,
+    started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    subprocess_started_at TEXT, heartbeat_at TEXT, last_output_at TEXT,
+    completed_at TEXT, duration_seconds REAL, log_artifact_path TEXT,
+    output_artifact_path TEXT, receipt_id TEXT, metadata_json TEXT DEFAULT '{}'
+);
+CREATE INDEX idx_headless_run_state ON headless_runs(state, started_at DESC);
+CREATE INDEX idx_headless_run_dispatch ON headless_runs(dispatch_id);
+CREATE INDEX idx_headless_run_target ON headless_runs(target_id, state);
+CREATE INDEX idx_headless_run_heartbeat
+    ON headless_runs(state, heartbeat_at) WHERE state = 'running';
+
+CREATE TABLE worker_states (
+    terminal_id TEXT NOT NULL,
+    dispatch_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'initializing',
+    last_output_at TEXT,
+    state_entered_at TEXT NOT NULL,
+    stall_count INTEGER NOT NULL DEFAULT 0,
+    blocked_reason TEXT, metadata_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (terminal_id),
+    FOREIGN KEY (terminal_id) REFERENCES terminal_leases(terminal_id),
+    FOREIGN KEY (dispatch_id) REFERENCES dispatches(dispatch_id)
+);
+CREATE INDEX idx_worker_state ON worker_states(state);
+CREATE INDEX idx_worker_dispatch ON worker_states(dispatch_id);
+
+CREATE TABLE pool_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    pool_id TEXT NOT NULL DEFAULT 'default',
+    UNIQUE(project_id, pool_id)
+);
+CREATE TABLE worker_pool_membership (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    terminal_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    pool_id TEXT NOT NULL DEFAULT 'default',
+    provider TEXT NOT NULL CHECK (provider IN ('claude','codex','gemini','litellm')),
+    role TEXT NOT NULL,
+    joined_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    released_at TEXT, release_reason TEXT,
+    spawn_generation INTEGER NOT NULL DEFAULT 1,
+    metadata_json TEXT DEFAULT '{}',
+    FOREIGN KEY (terminal_id, project_id)
+        REFERENCES terminal_leases(terminal_id, project_id),
+    FOREIGN KEY (project_id, pool_id)
+        REFERENCES pool_config(project_id, pool_id)
+);
+CREATE UNIQUE INDEX idx_pool_membership_active
+    ON worker_pool_membership(terminal_id, project_id) WHERE released_at IS NULL;
+CREATE INDEX idx_pool_membership_pool
+    ON worker_pool_membership(project_id, pool_id);
+
+CREATE TABLE coordination_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT, event_type TEXT NOT NULL, entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL, occurred_at TEXT NOT NULL
+);
+
+INSERT INTO terminal_leases(terminal_id, state, generation)
+VALUES ('T1','idle',1), ('T2','idle',1), ('T3','idle',1);
+INSERT INTO pool_config(project_id, pool_id) VALUES ('vnx-dev', 'default');
+"""
+
+_TRACK_CHAIN = (
+    (22, "apply_migration"),
+    (24, "apply_migration_v24"),
+    (27, "apply_migration_v27"),
+    (28, "apply_migration_v28"),
+    (29, "apply_migration_v29"),
+    (30, "apply_migration_v30"),
+)
+
+
+def _build_v30_db(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
+    project_root = tmp_path / "project"
+    state_dir = project_root / ".vnx-data" / "state"
+    state_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(_LEGACY_RUNTIME_SQL)
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    for _version, function_name in _TRACK_CHAIN:
+        getattr(mfs, function_name)(conn, project_root)
+        conn.commit()
+    assert schema_migration.get_user_version(conn) == 30
+    return project_root, conn
+
+
+def _unique_keys(conn: sqlite3.Connection, table: str) -> set[frozenset[str]]:
+    keys: set[frozenset[str]] = set()
+    for index in conn.execute(f"PRAGMA index_list('{table}')"):
+        if index[2]:
+            cols = frozenset(
+                row[2] for row in conn.execute(f"PRAGMA index_info('{index[1]}')")
+            )
+            keys.add(cols)
+    return keys
+
+
+def _foreign_keys(conn: sqlite3.Connection, table: str) -> set[tuple]:
+    grouped: dict[int, list[tuple]] = {}
+    for row in conn.execute(f"PRAGMA foreign_key_list('{table}')"):
+        grouped.setdefault(row[0], []).append(row)
+    return {
+        (
+            tuple(row[3] for row in sorted(rows, key=lambda item: item[1])),
+            rows[0][2],
+            tuple(row[4] for row in sorted(rows, key=lambda item: item[1])),
+        )
+        for rows in grouped.values()
+    }
+
+
+def _runtime_snapshot(conn: sqlite3.Connection) -> tuple:
+    targets = (*mfs._RUNTIME_V31_TABLES, "dispatches", "tracks", "coordination_events")
+    placeholders = ",".join("?" for _ in targets)
+    schema = tuple(conn.execute(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master "
+        f"WHERE tbl_name IN ({placeholders}) ORDER BY type, name",
+        targets,
+    ))
+    rows = tuple(
+        (table, tuple(conn.execute(f'SELECT * FROM "{table}" ORDER BY rowid')))
+        for table in mfs._RUNTIME_V31_TABLES
+    )
+    return schema, rows
+
+
+def test_migration_0031_repairs_runtime_tenant_fks_losslessly_and_idempotently(
+    tmp_path: Path,
+) -> None:
+    project_root, conn = _build_v30_db(tmp_path)
+    try:
+        untouched_before = {
+            table: conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()[0]
+            for table in ("dispatches", "tracks", "coordination_events")
+        }
+        lease_rows_before = tuple(conn.execute(
+            "SELECT id, terminal_id, state, generation, worker_pid, metadata_json, lease_token "
+            "FROM terminal_leases ORDER BY id"
+        ))
+        assert len(lease_rows_before) == 3
+        with pytest.raises(sqlite3.OperationalError, match="foreign key mismatch"):
+            conn.execute("PRAGMA foreign_key_check").fetchall()
+
+        mfs._run_numbered_walk(conn, project_root)
+
+        assert schema_migration.get_user_version(conn) == 31
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        assert schema_manifest.validate_db_at_version(conn, 31) == []
+        assert conn.execute("PRAGMA foreign_keys").fetchone() == (1,)
+
+        leases_after = tuple(conn.execute(
+            "SELECT id, terminal_id, state, generation, worker_pid, metadata_json, "
+            "lease_token, project_id FROM terminal_leases ORDER BY id"
+        ))
+        assert tuple(row[:-1] for row in leases_after) == lease_rows_before
+        assert {row[-1] for row in leases_after} == {"vnx-dev"}
+        assert frozenset({"terminal_id", "project_id"}) in _unique_keys(
+            conn, "terminal_leases")
+        assert frozenset({"attempt_id", "project_id"}) in _unique_keys(
+            conn, "dispatch_attempts")
+        assert frozenset({"run_id", "project_id"}) in _unique_keys(conn, "headless_runs")
+        assert mfs._table_pk(conn, "worker_states") == ("terminal_id", "project_id")
+
+        assert _foreign_keys(conn, "terminal_leases") == {
+            (("dispatch_id", "project_id"), "dispatches", ("dispatch_id", "project_id"))
+        }
+        assert _foreign_keys(conn, "dispatch_attempts") == {
+            (("dispatch_id", "project_id"), "dispatches", ("dispatch_id", "project_id"))
+        }
+        assert _foreign_keys(conn, "headless_runs") == {
+            (("dispatch_id", "project_id"), "dispatches", ("dispatch_id", "project_id")),
+            (("attempt_id", "project_id"), "dispatch_attempts", ("attempt_id", "project_id")),
+        }
+        assert _foreign_keys(conn, "worker_states") == {
+            (("terminal_id", "project_id"), "terminal_leases", ("terminal_id", "project_id")),
+            (("dispatch_id", "project_id"), "dispatches", ("dispatch_id", "project_id")),
+        }
+        assert all(
+            "dispatches_pre_v22" not in row[0]
+            for row in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND sql IS NOT NULL")
+        )
+
+        untouched_after = {
+            table: conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()[0]
+            for table in ("dispatches", "tracks", "coordination_events")
+        }
+        assert untouched_after == untouched_before
+
+        snapshot = _runtime_snapshot(conn)
+        conn.execute("PRAGMA user_version=30")
+        conn.commit()
+        mfs._run_numbered_walk(conn, project_root)
+        assert schema_migration.get_user_version(conn) == 31
+        assert _runtime_snapshot(conn) == snapshot
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        conn.close()

--- a/tests/test_migration_0031_runtime_fk.py
+++ b/tests/test_migration_0031_runtime_fk.py
@@ -207,7 +207,12 @@ def _runtime_snapshot(conn: sqlite3.Connection) -> tuple:
         (table, tuple(conn.execute(f'SELECT * FROM "{table}" ORDER BY rowid')))
         for table in mfs._RUNTIME_V31_TABLES
     )
-    return schema, rows
+    sequences = tuple(conn.execute(
+        "SELECT name, seq FROM sqlite_sequence "
+        "WHERE name IN ('terminal_leases', 'dispatch_attempts', 'headless_runs', "
+        "'worker_states', 'worker_pool_membership') ORDER BY name"
+    ))
+    return schema, rows, sequences
 
 
 def test_migration_0031_repairs_runtime_tenant_fks_losslessly_and_idempotently(
@@ -236,6 +241,7 @@ def test_migration_0031_repairs_runtime_tenant_fks_losslessly_and_idempotently(
         assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
         assert schema_manifest.validate_db_at_version(conn, 31) == []
         assert conn.execute("PRAGMA foreign_keys").fetchone() == (1,)
+        mfs._assert_manifest_converged(conn)
 
         leases_after = tuple(conn.execute(
             "SELECT id, terminal_id, state, generation, worker_pid, metadata_json, "
@@ -286,5 +292,157 @@ def test_migration_0031_repairs_runtime_tenant_fks_losslessly_and_idempotently(
         assert _runtime_snapshot(conn) == snapshot
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
         assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        conn.close()
+
+
+def test_migration_0031_preserves_runtime_autoincrement_high_water_marks(
+    tmp_path: Path,
+) -> None:
+    project_root, conn = _build_v30_db(tmp_path)
+    try:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute(
+            "INSERT INTO dispatches(dispatch_id, project_id, state) "
+            "VALUES ('d-sequence', 'vnx-dev', 'queued')"
+        )
+        conn.executemany(
+            "INSERT INTO dispatch_attempts(attempt_id, dispatch_id, terminal_id) "
+            "VALUES (?, 'd-sequence', 'T1')",
+            (("a-sequence-1",), ("a-sequence-2",), ("a-sequence-3",)),
+        )
+        conn.executemany(
+            "INSERT INTO headless_runs("
+            "run_id, dispatch_id, attempt_id, target_id, target_type, task_class"
+            ") VALUES (?, 'd-sequence', ?, 'target', 'test', 'test')",
+            (
+                ("r-sequence-1", "a-sequence-1"),
+                ("r-sequence-2", "a-sequence-2"),
+                ("r-sequence-3", "a-sequence-3"),
+            ),
+        )
+        conn.execute("DELETE FROM terminal_leases WHERE id=3")
+        conn.execute("DELETE FROM headless_runs WHERE id=3")
+        conn.execute("DELETE FROM dispatch_attempts WHERE id=3")
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        deleted_high_water = dict(conn.execute(
+            "SELECT name, seq FROM sqlite_sequence "
+            "WHERE name IN ('terminal_leases', 'dispatch_attempts', 'headless_runs')"
+        ))
+        assert deleted_high_water == {
+            "terminal_leases": 3,
+            "dispatch_attempts": 3,
+            "headless_runs": 3,
+        }
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_sequence WHERE name='worker_states'"
+        ).fetchone() is None
+
+        mfs._run_numbered_walk(conn, project_root)
+
+        new_lease_id = conn.execute(
+            "INSERT INTO terminal_leases(terminal_id, project_id) VALUES ('T4', 'vnx-dev')"
+        ).lastrowid
+        new_attempt_id = conn.execute(
+            "INSERT INTO dispatch_attempts("
+            "attempt_id, dispatch_id, project_id, terminal_id"
+            ") VALUES ('a-sequence-4', 'd-sequence', 'vnx-dev', 'T1')"
+        ).lastrowid
+        new_run_id = conn.execute(
+            "INSERT INTO headless_runs("
+            "run_id, dispatch_id, project_id, attempt_id, target_id, target_type, task_class"
+            ") VALUES ("
+            "'r-sequence-4', 'd-sequence', 'vnx-dev', 'a-sequence-1', "
+            "'target', 'test', 'test'"
+            ")"
+        ).lastrowid
+
+        assert new_lease_id > deleted_high_water["terminal_leases"]
+        assert new_attempt_id > deleted_high_water["dispatch_attempts"]
+        assert new_run_id > deleted_high_water["headless_runs"]
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_sequence WHERE name='worker_states'"
+        ).fetchone() is None
+    finally:
+        conn.close()
+
+
+def test_migration_0031_refuses_same_name_different_index_definition(
+    tmp_path: Path,
+) -> None:
+    project_root, conn = _build_v30_db(tmp_path)
+    try:
+        conn.execute("DROP INDEX idx_lease_state")
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_lease_state "
+            "ON terminal_leases(terminal_id, generation)"
+        )
+        conn.commit()
+
+        with pytest.raises(RuntimeError, match="index 'idx_lease_state'.*definition differs"):
+            mfs.apply_migration_v31(conn, project_root)
+
+        assert schema_migration.get_user_version(conn) == 30
+        assert "CREATE UNIQUE INDEX" in conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_lease_state'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_v31_manifest_and_convergence_reject_nonunique_pool_config_parent(
+    tmp_path: Path,
+) -> None:
+    project_root, conn = _build_v30_db(tmp_path)
+    try:
+        mfs._run_numbered_walk(conn, project_root)
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("DROP TABLE pool_config")
+        conn.execute(
+            "CREATE TABLE pool_config ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, project_id TEXT NOT NULL, "
+            "pool_id TEXT NOT NULL DEFAULT 'default')"
+        )
+        conn.execute(
+            "INSERT INTO pool_config(project_id, pool_id) VALUES ('vnx-dev', 'default')"
+        )
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        violations = schema_manifest.validate_db_at_version(conn, 31)
+        assert any("pool_config: missing UNIQUE('project_id', 'pool_id')" in v
+                   for v in violations), violations
+        with pytest.raises(
+            schema_manifest.SchemaReconciliationError,
+            match="foreign_key_check failed structurally",
+        ):
+            mfs._assert_manifest_converged(conn)
+    finally:
+        conn.close()
+
+
+def test_v31_convergence_foreign_key_guard_is_independent_of_manifest(
+    tmp_path: Path,
+) -> None:
+    project_root, conn = _build_v30_db(tmp_path)
+    try:
+        mfs._run_numbered_walk(conn, project_root)
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute(
+            "INSERT INTO worker_pool_membership("
+            "terminal_id, project_id, pool_id, provider, role"
+            ") VALUES ('T1', 'vnx-dev', 'missing-pool', 'codex', 'test')"
+        )
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        assert schema_manifest.validate_db_at_version(conn, 31) == []
+        with pytest.raises(
+            schema_manifest.SchemaReconciliationError,
+            match="foreign_key_check violations",
+        ):
+            mfs._assert_manifest_converged(conn)
     finally:
         conn.close()


### PR DESCRIPTION
## Problem (2026-06-15 migration-review panel, codex finding C+D)
`PRAGMA foreign_key_check` on central FAILS: `worker_pool_membership`'s composite FK referenced `terminal_leases(terminal_id, project_id)`, but `terminal_leases` had no `project_id` column (structural mismatch). Four runtime tables also carried dead FKs to a non-existent `dispatches_pre_v22`, and per ADR-007 these tenant tables need `project_id`. Pre-existing (in the v26 backup too), latent until the elastic worker-pool writes under FK enforcement.

## Fix — migration 0031 (crash-safe rebuilds)
Rebuilds `terminal_leases`, `dispatch_attempts`, `headless_runs`, `worker_states` (create-new → copy → drop-old → rename):
- adds `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` (existing rows backfilled `vnx-dev`)
- composite tenant `UNIQUE`/`PK` over `project_id` (ADR-007)
- replaces dead `dispatches_pre_v22` FKs with composite `dispatches(dispatch_id, project_id)` refs
- preserves all rows + recreates every index; `worker_pool_membership` unchanged (its composite FK now resolves)

**Robust:** no-op-skips (still stamps v31) when the runtime-table family is absent (track-only/fresh DBs); repairs when present. Idempotent. Wired into the `migrate_future_system` walk (30→31) with v31 manifest invariants + schema-loss / required-table guards.

## Verification
- On a copy of real central: `foreign_key_check` **FAIL → clean**, `integrity_check` ok, `user_version` 30→31, 3 lease rows preserved as `vnx-dev`. Live central never opened for writing.
- Both robustness proofs: track-only DB skips cleanly to v31; runtime-present DB repairs (all 5 tables get `project_id`).
- Tests: `test_migration_0031_runtime_fk` + retargeted fsr / migrate_future_system version tests — **65 passed**.
- The 5 pre-existing `test_adr007_dispatches_repair` env-sensitivity failures also fail on clean main; unrelated to this change.

ADR-007: `docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)