### PR TITLE
fix(backfill): remove hardcoded /Users/ paths from backfill_wt_receipts.py

### DIFF
--- a/scripts/backfill_wt_receipts.py
+++ b/scripts/backfill_wt_receipts.py
@@ -18,13 +18,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Sequence
 
-DEFAULT_ARCHIVE = Path(
-    "/Users/vincentvandeth/Backups/vnx-data-wt-archive-20260614/state/"
-    "t0_receipts.ndjson"
-)
-DEFAULT_CENTRAL = Path(
-    "/Users/vincentvandeth/.vnx-data/vnx-dev/state/t0_receipts.ndjson"
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from project_root import resolve_state_dir  # noqa: E402
+
+DEFAULT_CENTRAL = resolve_state_dir(caller_file=__file__) / "t0_receipts.ndjson"
 CUTOFF_DATE = "20260515"
 BACKFILLED_FROM = "wt-archive-20260614"
 KEY_FIELDS = ("dispatch_id", "cmd_id", "trace_token", "task_id")
@@ -266,7 +263,12 @@ def print_plan(plan: BackfillPlan) -> None:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--archive", type=Path, default=DEFAULT_ARCHIVE)
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        required=True,
+        help="Path to the worktree-archive t0_receipts.ndjson to backfill from.",
+    )
     parser.add_argument("--central", type=Path, default=DEFAULT_CENTRAL)
     parser.add_argument(
         "--apply",


### PR DESCRIPTION
## What
`vnx doctor` (and therefore CI: `vnx-ci.yml` / `public-ci.yml` legacy-path gate) was FAILING on `scripts/backfill_wt_receipts.py` because it carried two hardcoded absolute `/Users/...` path literals (introduced in #878). This removes them:

- `DEFAULT_CENTRAL` is now resolved via `project_root.resolve_state_dir(caller_file=__file__)` instead of a literal.
- `DEFAULT_ARCHIVE` (a machine-specific backup path) is removed; `--archive` is now a **required** CLI argument.
- Dry-run-default, `--apply`, backup/dedup/provenance behavior unchanged.

## Why
Pre-existing repo-health issue blocking `vnx doctor` and CI for every PR to main. Found during a governance health-check of the VNX runtime.

## Verification (independent, in a clean worktree)
- `grep -nE "/Users/" scripts/backfill_wt_receipts.py` → no matches.
- `bash scripts/vnx_doctor.sh` → **OK: No forbidden path references**.
- `backfill_wt_receipts.py --help` → `--archive` required; runs error without it.
- `check_adr_003_no_sdk_imports.py` → PASS.

## Governance
Built via the tmux subscription lane (sonnet) through the staging→pending→promote gate (ADR-006), routed to the central VNX data dir so the dispatch fed the intelligence layer (0 missing-table warnings). Report + receipt in the central ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)