### PR TITLE
feat(dispatch): compile_plan — pure total routing decision function (PR-2)

### DIFF
--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -1,0 +1,246 @@
+"""dispatch_plan.py — compile_plan: pure, total routing decision function.
+
+Maps a ValidatedSpec + RuntimeSnapshot to exactly one ExecutionPlan or one Reject.
+No I/O, no env reads, no filesystem access — every side-effectful input arrives
+via the snapshot argument.
+
+PR-2 of the single-entry dispatch gate. Nothing imports this module yet.
+ADR-007 not triggered — pure in-process types only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional
+
+from dispatch_spec import (
+    DispatchPath,
+    Isolation,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot types (caller computes via I/O, compile_plan only reads)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ConstraintVerdict:
+    code: str            # e.g. "kimi-via-cli-only"
+    severity: str        # "blocking" | "warn"
+    message: str
+    override_applied: bool = False
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    constraint_verdicts: tuple[ConstraintVerdict, ...] = ()
+    staging_promoted: bool = False
+    target_health: Mapping[str, str] = field(default_factory=dict)    # target_id -> "healthy"|"unhealthy"|"offline"
+    target_capable: Mapping[str, bool] = field(default_factory=dict)  # target_id -> capability match
+    model_pins: Mapping[str, str] = field(default_factory=dict)       # target_slot -> pinned model
+    claude_serial_enabled: bool = True
+
+
+# ---------------------------------------------------------------------------
+# ExecutionPlan
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    dispatch_id: str
+    project_id: str
+    provider: Provider
+    model: str
+    lane: str                           # "claude_tmux_subscription" | "provider"
+    adapter: str                        # "tmux_claude" | "provider"
+    target_id: str                      # "ephemeral" for the leaseless claude lane
+    billing: str                        # "subscription" | "provider_metered"
+    serialization_class: Optional[str]  # "claude-tmux" | None
+    isolation: Isolation                # always Isolation.WORKTREE
+    require_worktree: bool              # always True
+    seed_materialize: bool
+    instruction_delivery: str           # always "file_ref"
+    report_contract: str                # always "required"
+    warmup: str                         # "verify_strict" (claude) | "n/a"
+    deadline_seconds: int
+    base_ref: str
+    dispatch_paths: tuple[DispatchPath, ...]
+    instruction_file: Path
+    route_reason: str                   # comma-joined rule ids, e.g. "D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12"
+    warnings: tuple[str, ...] = ()
+
+    def digest(self) -> str:
+        """Stable sha256 over the canonical, order-independent field set.
+
+        Excludes advisory warnings. Used by ExecutionPermit (satisfies PlanLike).
+        """
+        canonical = {
+            "dispatch_id": self.dispatch_id,
+            "project_id": self.project_id,
+            "provider": self.provider.value,
+            "model": self.model,
+            "lane": self.lane,
+            "adapter": self.adapter,
+            "target_id": self.target_id,
+            "billing": self.billing,
+            "serialization_class": self.serialization_class,
+            "isolation": self.isolation.value,
+            "require_worktree": self.require_worktree,
+            "seed_materialize": self.seed_materialize,
+            "instruction_delivery": self.instruction_delivery,
+            "report_contract": self.report_contract,
+            "warmup": self.warmup,
+            "deadline_seconds": self.deadline_seconds,
+            "base_ref": self.base_ref,
+            "instruction_file": str(self.instruction_file),
+            "route_reason": self.route_reason,
+            "dispatch_paths": [
+                {
+                    "path": str(dp.path),
+                    "access": dp.access.value,
+                    "materialize_at_cwd": dp.materialize_at_cwd,
+                }
+                for dp in self.dispatch_paths
+            ],
+        }
+        blob = json.dumps(canonical, sort_keys=True, ensure_ascii=True)
+        return hashlib.sha256(blob.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# compile_plan — pure, total
+# ---------------------------------------------------------------------------
+
+def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPlan | Reject:
+    """Map ValidatedSpec + RuntimeSnapshot to exactly one ExecutionPlan or one Reject.
+
+    Pure and total: no I/O, no env reads, no filesystem access. Every input
+    arrives via arguments. First failing hard rule returns a Reject; no None,
+    no fallthrough, no raise.
+    """
+    spec = vspec.spec
+    warnings: list[str] = []
+    fired: list[str] = []
+
+    # D11 — staging gate (ADR-006)
+    if not snapshot.staging_promoted:
+        return Reject("ADR-006", "dispatch rejected: staging not promoted (ADR-006 gate)")
+    fired.append("D11")
+
+    # D3 — constraint verdicts; blocking → Reject immediately; warn → collect
+    for v in snapshot.constraint_verdicts:
+        if v.severity == "blocking":
+            return Reject(v.code, v.message)
+        elif v.severity == "warn":
+            warnings.append(f"constraint-warn: {v.code}: {v.message}")
+    fired.append("D3")
+
+    # D1 — lane resolution from provider
+    provider = spec.provider
+    if provider == Provider.AUTO:
+        return Reject(
+            "unresolved-provider",
+            "AUTO must be resolved by the capability seam before compile_plan",
+        )
+    is_claude_lane = provider == Provider.CLAUDE
+    if is_claude_lane:
+        lane = "claude_tmux_subscription"
+        adapter = "tmux_claude"
+    else:
+        lane = "provider"
+        adapter = "provider"
+    fired.append("D1")
+
+    # D2 — billing
+    billing = "subscription" if is_claude_lane else "provider_metered"
+    fired.append("D2")
+
+    # D4 — model tier; warn-only pins are NOT a Reject
+    target_slot = spec.target_slot
+    if is_claude_lane:
+        pinned = snapshot.model_pins.get(target_slot)
+        requested = spec.model
+        if pinned:
+            if requested and requested != pinned:
+                warnings.append(
+                    f"model-tier: requested {requested}, pinned {pinned}"
+                    f" for {target_slot} (override-able)"
+                )
+            model = pinned
+        else:
+            model = requested or "sonnet"
+    else:
+        model = spec.model or "default"
+    fired.append("D4")
+
+    # D5 — serialization class
+    serialization_class: Optional[str]
+    if is_claude_lane and snapshot.claude_serial_enabled:
+        serialization_class = "claude-tmux"
+    else:
+        serialization_class = None
+    fired.append("D5")
+
+    # D6 — isolation; always worktree
+    isolation = Isolation.WORKTREE
+    require_worktree = True
+    fired.append("D6")
+
+    # D7 — seed materialize
+    dispatch_paths = vspec.normalized_paths
+    seed_materialize = bool(dispatch_paths) or any(dp.materialize_at_cwd for dp in dispatch_paths)
+    fired.append("D7")
+
+    # D8 — instruction delivery
+    instruction_delivery = "file_ref"
+    fired.append("D8")
+
+    # D9 — report contract
+    report_contract = "required"
+    fired.append("D9")
+
+    # D10 — warmup
+    warmup = "verify_strict" if is_claude_lane else "n/a"
+    fired.append("D10")
+
+    # D12 — target resolution; claude lane is leaseless (ephemeral), skip health checks
+    if is_claude_lane:
+        target_id = "ephemeral"
+    else:
+        target_id = spec.target_id_override or spec.target_slot
+        health = snapshot.target_health.get(target_id)
+        if health != "healthy":
+            return Reject("R-6", f"target {target_id!r} is not healthy (status={health!r})")
+        if not snapshot.target_capable.get(target_id, True):
+            return Reject("R-5", f"target {target_id!r} is not capable for this dispatch")
+    fired.append("D12")
+
+    return ExecutionPlan(
+        dispatch_id=spec.dispatch_id,
+        project_id=spec.project_id,
+        provider=provider,
+        model=model,
+        lane=lane,
+        adapter=adapter,
+        target_id=target_id,
+        billing=billing,
+        serialization_class=serialization_class,
+        isolation=isolation,
+        require_worktree=require_worktree,
+        seed_materialize=seed_materialize,
+        instruction_delivery=instruction_delivery,
+        report_contract=report_contract,
+        warmup=warmup,
+        deadline_seconds=spec.deadline_seconds,
+        base_ref=spec.base_ref,
+        dispatch_paths=dispatch_paths,
+        instruction_file=spec.instruction_file,
+        route_reason=",".join(fired),
+        warnings=tuple(warnings),
+    )

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -1,0 +1,344 @@
+"""test_dispatch_plan.py — Tests for compile_plan: pure, total decision function.
+
+Covers all dispatch rules D1-D12 including:
+- Plan totality: every non-AUTO provider + every target slot returns ExecutionPlan
+- AUTO rejection, staging gate, blocking constraints
+- Claude lane fields, provider lane fields
+- Model-tier pinning with warn-only overrides
+- Target health/capability gating (provider lane only)
+- Seed materialize logic
+- Digest stability and ExecutionPermit compatibility (PlanLike protocol)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_internal import issue_permit, require_permit
+from dispatch_plan import (
+    ConstraintVerdict,
+    ExecutionPlan,
+    RuntimeSnapshot,
+    compile_plan,
+)
+from dispatch_spec import (
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    PathAccess,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_instruction_file(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text("# Test instruction\n", encoding="utf-8")
+    return f
+
+
+def _make_spec(
+    *,
+    provider: Provider = Provider.CLAUDE,
+    target_slot: str = "T1",
+    model: str | None = None,
+    dispatch_paths: tuple[DispatchPath, ...] = (),
+    target_id_override: str | None = None,
+    deadline_seconds: int = 3600,
+    tmp_path: Path,
+) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-dispatch-001",
+        staging_id="staging-001",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="human-promoted",
+        dispatch_paths=dispatch_paths,
+        provider=provider,
+        model=model,
+        deadline_seconds=deadline_seconds,
+        target_id_override=target_id_override,
+    )
+
+
+def _make_vspec(
+    *,
+    provider: Provider = Provider.CLAUDE,
+    target_slot: str = "T1",
+    model: str | None = None,
+    dispatch_paths: tuple[DispatchPath, ...] = (),
+    target_id_override: str | None = None,
+    tmp_path: Path,
+) -> ValidatedSpec:
+    spec = _make_spec(
+        provider=provider,
+        target_slot=target_slot,
+        model=model,
+        dispatch_paths=dispatch_paths,
+        target_id_override=target_id_override,
+        tmp_path=tmp_path,
+    )
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text="# Test instruction\n",
+        normalized_paths=dispatch_paths,
+    )
+
+
+def _healthy_snapshot(
+    *,
+    model_pins: dict | None = None,
+    claude_serial_enabled: bool = True,
+    constraint_verdicts: tuple[ConstraintVerdict, ...] = (),
+) -> RuntimeSnapshot:
+    """Promoted snapshot with all T0-T3 slots healthy and capable."""
+    all_slots = ["T0", "T1", "T2", "T3"]
+    return RuntimeSnapshot(
+        staging_promoted=True,
+        target_health={slot: "healthy" for slot in all_slots},
+        target_capable={slot: True for slot in all_slots},
+        model_pins=model_pins or {},
+        claude_serial_enabled=claude_serial_enabled,
+        constraint_verdicts=constraint_verdicts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_plan_total
+# ---------------------------------------------------------------------------
+
+class TestPlanTotal:
+    """Every non-AUTO Provider x every target slot → ExecutionPlan; never None, never raises."""
+
+    @pytest.mark.parametrize("provider", [p for p in Provider if p != Provider.AUTO])
+    @pytest.mark.parametrize("target_slot", ["T0", "T1", "T2", "T3"])
+    def test_compile_returns_plan(self, provider: Provider, target_slot: str, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=provider, target_slot=target_slot, tmp_path=tmp_path)
+        snapshot = _healthy_snapshot()
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, ExecutionPlan), (
+            f"Expected ExecutionPlan for provider={provider.value} slot={target_slot}, got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# test_auto_rejected
+# ---------------------------------------------------------------------------
+
+class TestAutoRejected:
+    def test_auto_rejected(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.AUTO, tmp_path=tmp_path)
+        result = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(result, Reject)
+        assert result.code == "unresolved-provider"
+
+
+# ---------------------------------------------------------------------------
+# test_claude_lane
+# ---------------------------------------------------------------------------
+
+class TestClaudeLane:
+    def test_claude_lane_fields(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
+        assert plan.adapter == "tmux_claude"
+        assert plan.billing == "subscription"
+        assert plan.serialization_class == "claude-tmux"
+        assert plan.warmup == "verify_strict"
+        assert plan.target_id == "ephemeral"
+
+
+# ---------------------------------------------------------------------------
+# test_provider_lane_parallel
+# ---------------------------------------------------------------------------
+
+class TestProviderLaneParallel:
+    def test_codex_provider_lane(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "provider"
+        assert plan.adapter == "provider"
+        assert plan.serialization_class is None
+        assert plan.billing == "provider_metered"
+
+
+# ---------------------------------------------------------------------------
+# test_staging_gate
+# ---------------------------------------------------------------------------
+
+class TestStagingGate:
+    def test_staging_not_promoted_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(staging_promoted=False)
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "ADR-006"
+
+
+# ---------------------------------------------------------------------------
+# test_blocking_constraint
+# ---------------------------------------------------------------------------
+
+class TestBlockingConstraint:
+    def test_blocking_verdict_rejects(self, tmp_path: Path) -> None:
+        blocking = ConstraintVerdict(
+            code="kimi-via-cli-only",
+            severity="blocking",
+            message="Kimi must use CLI OAuth, not Moonshot API",
+        )
+        vspec = _make_vspec(tmp_path=tmp_path)
+        result = compile_plan(vspec, _healthy_snapshot(constraint_verdicts=(blocking,)))
+        assert isinstance(result, Reject)
+        assert result.code == "kimi-via-cli-only"
+
+    def test_warn_verdict_does_not_reject(self, tmp_path: Path) -> None:
+        warn = ConstraintVerdict(
+            code="t0-opus-only",
+            severity="warn",
+            message="T0 orchestrator should use opus",
+        )
+        vspec = _make_vspec(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(constraint_verdicts=(warn,)))
+        assert isinstance(plan, ExecutionPlan)
+        assert any("t0-opus-only" in w for w in plan.warnings)
+
+
+# ---------------------------------------------------------------------------
+# test_model_tier_pin
+# ---------------------------------------------------------------------------
+
+class TestModelTierPin:
+    def test_t0_pinned_to_opus(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T0", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "opus"
+        assert not any("model-tier" in w for w in plan.warnings)
+
+    def test_t0_requested_sonnet_pinned_opus_keeps_pin_and_warns(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T0", model="sonnet", tmp_path=tmp_path
+        )
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "opus"
+        assert any("model-tier" in w for w in plan.warnings)
+
+    def test_t1_pinned_to_sonnet(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T1": "sonnet"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# test_isolation_always_worktree
+# ---------------------------------------------------------------------------
+
+class TestIsolationAlwaysWorktree:
+    @pytest.mark.parametrize("provider", [p for p in Provider if p != Provider.AUTO])
+    def test_isolation_worktree(self, provider: Provider, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=provider, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.isolation == Isolation.WORKTREE
+        assert plan.require_worktree is True
+
+
+# ---------------------------------------------------------------------------
+# test_target_health_provider_lane
+# ---------------------------------------------------------------------------
+
+class TestTargetHealthProviderLane:
+    def test_unhealthy_target_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(
+            staging_promoted=True,
+            target_health={"T1": "unhealthy"},
+            target_capable={"T1": True},
+        )
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "R-6"
+
+    def test_incapable_target_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(
+            staging_promoted=True,
+            target_health={"T1": "healthy"},
+            target_capable={"T1": False},
+        )
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "R-5"
+
+    def test_claude_lane_skips_health_check(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        # No target health/capability data — claude lane must succeed regardless
+        snapshot = RuntimeSnapshot(staging_promoted=True)
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.target_id == "ephemeral"
+
+
+# ---------------------------------------------------------------------------
+# test_seed_materialize
+# ---------------------------------------------------------------------------
+
+class TestSeedMaterialize:
+    def test_materialize_at_cwd_true(self, tmp_path: Path) -> None:
+        paths = (DispatchPath(PurePosixPath("scripts/lib"), PathAccess.READ_WRITE, True),)
+        vspec = _make_vspec(dispatch_paths=paths, tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.seed_materialize is True
+
+    def test_empty_paths_seed_false(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(dispatch_paths=(), tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.seed_materialize is False
+
+
+# ---------------------------------------------------------------------------
+# test_digest_stable_and_permit_compatible
+# ---------------------------------------------------------------------------
+
+class TestDigestStableAndPermitCompatible:
+    def test_same_plan_same_digest(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.digest() == plan.digest()
+
+    def test_changed_field_different_digest(self, tmp_path: Path) -> None:
+        snap = _healthy_snapshot()
+        vspec_claude = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        vspec_codex = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        plan_claude = compile_plan(vspec_claude, snap)
+        plan_codex = compile_plan(vspec_codex, snap)
+        assert isinstance(plan_claude, ExecutionPlan)
+        assert isinstance(plan_codex, ExecutionPlan)
+        assert plan_claude.digest() != plan_codex.digest()
+
+    def test_permit_compatible(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        permit = issue_permit(plan)
+        require_permit(plan, permit)  # must not raise PermissionError


### PR DESCRIPTION
## What
PR-2 of the single-entry dispatch refactor: the **brain**. A pure, total function `compile_plan(vspec, snapshot) -> ExecutionPlan | Reject` that encodes the decision tree (rules D1–D13). No I/O, no env reads, no spawn — every side-effectful input arrives via `RuntimeSnapshot` (the caller computes it in a later PR). Nothing imports this yet → no behavior change.

- `ExecutionPlan` (frozen) with a stable, order-independent `digest()` that satisfies `dispatch_internal.PlanLike` (so the permit binds to a plan).
- Rules: D11 staging gate → D3 constraints (blocking=Reject, warn=collected) → D1 lane (claude→tmux subscription; others→provider; AUTO→Reject) → D2 billing → D4 model-tier (warn-only pins, override-able) → D5 serialize (claude→serial lock class) → D6 isolation (always worktree) → D7 seed → D8 file-ref delivery → D9 report-required → D10 warmup → D12 target (claude leaseless=ephemeral; provider→R-5/R-6 health).

## Verification (independent, full local CI gate in a clean worktree)
- `pytest tests/test_dispatch_plan.py tests/test_dispatch_spec.py tests/test_dispatch_internal.py` → **115 passed** (incl. `test_plan_total` over the full provider×slot domain).
- `check_adr_003_no_sdk_imports.py` → PASS. No legacy `.vnx-data/state/` path literals.
- T0 code review: confirmed pure + total (no None/raise/fallthrough), digest order-independent, model-tier pins are warn-only per the SSOT (override-able, as decided).

## Stack / merge order
Stacked on #880 (PR-1). This PR's diff shows **only** PR-2 (`dispatch_plan.py` + tests). Merge order: **#880 → this**. Use *Merge commit* or *Rebase and merge* (not *Squash*) to keep the stack intact; GitHub will retarget this PR to `main` once #880 merges. #881 (doctor fix) is independent.

## Governance
tmux subscription lane (sonnet), staging→pending→promote (ADR-006), central data dir (intelligence injection active — 0 missing-table warnings). Report + receipt in the central ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)