### PR TITLE
feat(dispatch): ProviderAdapter + run_envelope_plan for the provider lane (PR-3)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -27,6 +27,7 @@ EventStore wiring and cost emission are open items for later PRs (PR-1 scope: fl
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -488,4 +489,370 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         receipt_path=receipt_path,
         completion_text=adapter_result.completion_text,
         error=adapter_result.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-3: ProviderAdapter + plan-based provider execution
+# ---------------------------------------------------------------------------
+
+
+def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
+    """Map codex/kimi/gemini/litellm:* spawn result to _AdapterResult.
+
+    Normalises token fields via _extract_token_usage from provider_dispatch.
+    Handles error, timeout, and success/failure by returncode. Does NOT handle
+    the deepseek-harness stopped_early or local-gemma error-condition variant —
+    those are handled inline in ProviderAdapter.run().
+    """
+    from provider_dispatch import _extract_token_usage  # noqa: PLC0415
+
+    token_usage: Dict[str, int] = _extract_token_usage(result, provider_str)
+    ewf = getattr(result, "event_writer_failures", 0)
+
+    if result.error:
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status="failure",
+            token_usage=token_usage,
+            error=result.error,
+            event_writer_failures=ewf,
+        )
+    if result.timed_out:
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status="timeout",
+            token_usage=token_usage,
+            timed_out=True,
+            event_writer_failures=ewf,
+        )
+    status = "success" if result.returncode == 0 else "failure"
+    return _AdapterResult(
+        returncode=result.returncode,
+        completion_text=(result.completion_text or ""),
+        status=status,
+        token_usage=token_usage,
+        event_writer_failures=ewf,
+    )
+
+
+class ProviderAdapter:
+    """Routes provider-lane ExecutionPlan to the correct spawn function.
+
+    Mirrors CodexAdapter's shape but routes by plan.provider to the correct
+    spawn function. Reuses existing resolution helpers and raw spawn functions
+    from provider_dispatch and provider_spawns.*. Does NOT call the governing
+    _dispatch_* wrappers in provider_dispatch — those govern; the envelope
+    governs once via _govern.
+
+    Supported plan.provider values: codex, kimi, gemini, litellm:deepseek,
+    litellm:zai, litellm:moonshot, deepseek-harness, local-gemma.
+    Provider.CLAUDE and Provider.AUTO are programming errors → ValueError.
+
+    event_writer is not wired in PR-3 (EventStore setup is an open item for a
+    later PR); the audit gap is documented in Open Items.
+    """
+
+    def run(
+        self,
+        plan: "ExecutionPlan",
+        instruction: str,
+        *,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from dispatch_spec import Provider  # noqa: PLC0415
+        from provider_dispatch import (  # noqa: PLC0415
+            _MLX_MODEL_MAP,
+            _build_lane_key,
+            _extract_token_usage,
+            _resolve_codex_model,
+            _resolve_deepseek_model,
+            _resolve_kimi_model_label,
+            _resolve_moonshot_model,
+            _resolve_zai_model,
+        )
+
+        pv: "Provider" = plan.provider  # type: ignore[assignment]
+
+        # ---- codex ----
+        if pv == Provider.CODEX:
+            from provider_spawns.codex_spawn import spawn_codex  # noqa: PLC0415
+
+            model = (
+                plan.model if plan.model not in ("default", "") else _resolve_codex_model()
+            )
+            try:
+                result = spawn_codex(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"codex spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- kimi ----
+        if pv == Provider.KIMI:
+            from provider_spawns.kimi_spawn import spawn_kimi  # noqa: PLC0415
+
+            # None signals kimi CLI to use its own default; label used only for logging
+            model = plan.model if plan.model not in ("default", "") else None
+            try:
+                result = spawn_kimi(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"kimi spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- gemini ----
+        if pv == Provider.GEMINI:
+            from provider_spawns.gemini_spawn import spawn_gemini  # noqa: PLC0415
+
+            model = (
+                plan.model
+                if plan.model not in ("default", "sonnet", "")
+                else os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+            )
+            try:
+                result = spawn_gemini(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"gemini spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- litellm:deepseek | litellm:zai | litellm:moonshot ----
+        if pv in (Provider.LITELLM_DEEPSEEK, Provider.LITELLM_ZAI, Provider.LITELLM_MOONSHOT):
+            from provider_spawns.litellm_spawn import spawn_litellm  # noqa: PLC0415
+
+            # Extract sub-provider from the enum value: "litellm:deepseek" -> "deepseek"
+            base_sub = pv.value.split(":", 1)[1]
+            if plan.model not in ("default", ""):
+                model = plan.model
+            elif pv == Provider.LITELLM_DEEPSEEK:
+                model = _resolve_deepseek_model()
+            elif pv == Provider.LITELLM_ZAI:
+                model = _resolve_zai_model()
+            else:
+                model = _resolve_moonshot_model()
+            lane_key = _build_lane_key(base_sub, None)
+            try:
+                result = spawn_litellm(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    sub_provider=base_sub,
+                    lane=lane_key,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"litellm spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- deepseek-harness ----
+        if pv == Provider.DEEPSEEK_HARNESS:
+            from provider_spawns.deepseek_harness_spawn import (  # noqa: PLC0415
+                resolve_harness_model,
+                spawn_deepseek_harness,
+            )
+
+            raw_model = (
+                plan.model if plan.model not in ("default", "sonnet", "") else None
+            )
+            model = resolve_harness_model(raw_model)
+            try:
+                result = spawn_deepseek_harness(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"deepseek-harness spawn BrokenPipeError: {exc}",
+                )
+            token_usage: Dict[str, int] = _extract_token_usage(result, pv.value)
+            if result.error:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="failure",
+                    token_usage=token_usage,
+                    error=result.error,
+                )
+            if result.timed_out:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="timeout",
+                    token_usage=token_usage,
+                    timed_out=True,
+                )
+            if getattr(result, "stopped_early", False):
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="success",
+                    token_usage=token_usage,
+                )
+            status = "success" if result.returncode == 0 else "failure"
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status=status,
+                token_usage=token_usage,
+            )
+
+        # ---- local-gemma ----
+        if pv == Provider.LOCAL_GEMMA:
+            from provider_spawns.local_gemma_spawn import spawn_local_gemma  # noqa: PLC0415
+
+            raw_model = (
+                plan.model if plan.model not in ("default", "sonnet", "") else "gemma-4b-local"
+            )
+            canonical_model = _MLX_MODEL_MAP.get(raw_model, raw_model)
+            result = spawn_local_gemma(
+                instruction=instruction,
+                model=canonical_model,
+                role=None,
+                deadline_seconds=300,
+                dispatch_id=plan.dispatch_id,
+                project_id="vnx-dev",
+            )
+            token_usage = _extract_token_usage(result, pv.value)
+            if result.error and result.returncode != 0:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="failure",
+                    token_usage=token_usage,
+                    error=result.error,
+                )
+            if result.timed_out:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="timeout",
+                    token_usage=token_usage,
+                    timed_out=True,
+                )
+            status = "success" if result.returncode == 0 else "failure"
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status=status,
+                token_usage=token_usage,
+            )
+
+        # Provider.CLAUDE, Provider.AUTO, or any unexpected value — programming error
+        raise ValueError(
+            f"ProviderAdapter: unsupported provider {pv!r} — "
+            f"claude and auto do not route through the provider envelope "
+            f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
+        )
+
+
+def run_envelope_plan(
+    plan: "ExecutionPlan",
+    permit: "ExecutionPermit",
+    *,
+    state_dir: Path,
+    data_dir: Path,
+) -> EnvelopeResult:
+    """Execute a validated ExecutionPlan for the provider lane.
+
+    Provider lane covers codex, kimi, gemini, litellm:*, deepseek-harness,
+    local-gemma. The claude_tmux_subscription lane is wired separately in PR-4.
+
+    require_permit is the first action — un-evadable and cannot be moved.
+
+    Raises:
+        PermissionError: permit was not issued by issue_permit for this plan.
+        ValueError: plan.lane is not "provider".
+        EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
+    """
+    from dispatch_internal import require_permit  # noqa: PLC0415
+
+    require_permit(plan, permit)  # un-evadable backstop — FIRST action
+
+    if plan.lane != "provider":
+        raise ValueError(
+            f"run_envelope_plan handles the provider lane only; got lane={plan.lane!r} "
+            f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
+        )
+
+    instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+
+    spec = EnvelopeSpec(
+        dispatch_id=plan.dispatch_id,
+        terminal_id=plan.target_id,
+        provider=plan.provider.value,
+        model=plan.model,
+        instruction=instruction,
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    enriched_instruction = _prepare(spec)
+    enriched_spec = EnvelopeSpec(
+        dispatch_id=spec.dispatch_id,
+        terminal_id=spec.terminal_id,
+        provider=spec.provider,
+        model=spec.model,
+        instruction=enriched_instruction,
+        role=spec.role,
+        pr_id=spec.pr_id,
+        state_dir=spec.state_dir,
+        data_dir=spec.data_dir,
+    )
+
+    start = datetime.now(timezone.utc)
+    result = ProviderAdapter().run(plan, enriched_spec.instruction)
+    end = datetime.now(timezone.utc)
+
+    report_path, receipt_path = _govern(enriched_spec, result, start, end)
+
+    return EnvelopeResult(
+        status=result.status,
+        returncode=0 if result.status == "success" else 1,
+        report_path=report_path,
+        receipt_path=receipt_path,
+        completion_text=result.completion_text,
+        error=result.error,
     )

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -1,0 +1,415 @@
+"""test_dispatch_envelope_plan.py — Tests for PR-3: ProviderAdapter + run_envelope_plan.
+
+Covers:
+1. require_permit backstop: forged/bare permit raises PermissionError; valid permit proceeds.
+2. Non-provider lane rejection: claude_tmux_subscription → ValueError.
+3. Provider routing: each provider routes to its spawn_* fn; no _dispatch_* wrapper invoked.
+4. File-ref instruction delivery: instruction read from file, spawn receives raw text.
+5. Governance emit: _govern produces receipt line + report (real governance_emit pipeline).
+6. Legacy path unchanged: run_envelope(spec, "codex") still routes to CodexAdapter.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+from dispatch_envelope import (
+    EnvelopeGovernError,
+    EnvelopeSpec,
+    LaneRouter,
+    ProviderAdapter,
+    _AdapterResult,
+    run_envelope,
+    run_envelope_plan,
+)
+from dispatch_internal import ExecutionPermit, issue_permit
+from dispatch_plan import ExecutionPlan
+from dispatch_spec import DispatchPath, Isolation, Provider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_plan(
+    tmp_path: Path,
+    *,
+    provider: Provider = Provider.CODEX,
+    model: str = "gpt-test",
+    dispatch_id: str = "test-dispatch-pr3",
+    target_id: str = "T1",
+    instruction_file: Optional[Path] = None,
+) -> ExecutionPlan:
+    if instruction_file is None:
+        instruction_file = tmp_path / f"instruction-{provider.value.replace(':', '-')}.md"
+        instruction_file.write_text("# Test dispatch\nDo something.", encoding="utf-8")
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=provider,
+        model=model,
+        lane="provider",
+        adapter="provider",
+        target_id=target_id,
+        billing="provider_metered",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D1,D2,D3,D4,D5,D6,D7,D8,D9,D10,D11,D12",
+    )
+
+
+def _make_claude_plan(tmp_path: Path) -> ExecutionPlan:
+    instruction_file = tmp_path / "claude_inst.md"
+    instruction_file.write_text("# Claude dispatch", encoding="utf-8")
+    return ExecutionPlan(
+        dispatch_id="test-claude-dispatch",
+        project_id="vnx-dev",
+        provider=Provider.CLAUDE,
+        model="sonnet",
+        lane="claude_tmux_subscription",
+        adapter="tmux_claude",
+        target_id="ephemeral",
+        billing="subscription",
+        serialization_class="claude-tmux",
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="verify_strict",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D1,D2,D3",
+    )
+
+
+@dataclass
+class _FakeSpawnResult:
+    returncode: int = 0
+    completion_text: str = "done"
+    timed_out: bool = False
+    stopped_early: bool = False
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+    token_usage: Dict[str, Any] = field(default_factory=dict)
+
+
+def _fake_adapter_success() -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: require_permit backstop
+# ---------------------------------------------------------------------------
+
+
+def test_run_envelope_plan_requires_permit(tmp_path):
+    plan = _make_provider_plan(tmp_path)
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    # Bare permit (default _sentinel=None) must be rejected
+    bare_permit = ExecutionPermit(dispatch_id=plan.dispatch_id, plan_digest=plan.digest())
+    with pytest.raises(PermissionError):
+        run_envelope_plan(plan, bare_permit, state_dir=state_dir, data_dir=data_dir)
+
+    # Wrong digest must be rejected even if sentinel were somehow set
+    forged = ExecutionPermit(dispatch_id=plan.dispatch_id, plan_digest="bad-digest")
+    with pytest.raises(PermissionError):
+        run_envelope_plan(plan, forged, state_dir=state_dir, data_dir=data_dir)
+
+    # Valid permit: proceed (mock spawn + govern to avoid real I/O)
+    valid_permit = issue_permit(plan)
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch.object(ProviderAdapter, "run", return_value=_fake_adapter_success()):
+        with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, valid_permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success"
+    assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: non-provider lane rejection
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_provider_lane(tmp_path):
+    plan = _make_claude_plan(tmp_path)
+    permit = issue_permit(plan)
+
+    with pytest.raises(ValueError, match="provider lane"):
+        run_envelope_plan(plan, permit, state_dir=tmp_path / "state", data_dir=tmp_path / "data")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: provider routing — each provider calls its spawn, no _dispatch_* wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
+    """Each supported provider routes to its spawn_*; no _dispatch_* wrappers invoked."""
+    calls: Dict[str, Dict[str, Any]] = {}
+    litellm_calls: list = []
+
+    def _make_spawn(name):
+        def fake(*args, **kwargs):
+            calls[name] = {"args": args, "kwargs": kwargs}
+            return _FakeSpawnResult()
+        return fake
+
+    def fake_litellm(*args, **kwargs):
+        litellm_calls.append({"args": args, "kwargs": kwargs})
+        return _FakeSpawnResult()
+
+    monkeypatch.setattr("provider_spawns.codex_spawn.spawn_codex", _make_spawn("codex"))
+    monkeypatch.setattr("provider_spawns.kimi_spawn.spawn_kimi", _make_spawn("kimi"))
+    monkeypatch.setattr("provider_spawns.gemini_spawn.spawn_gemini", _make_spawn("gemini"))
+    monkeypatch.setattr("provider_spawns.litellm_spawn.spawn_litellm", fake_litellm)
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness", _make_spawn("deepseek_harness")
+    )
+    monkeypatch.setattr(
+        "provider_spawns.local_gemma_spawn.spawn_local_gemma", _make_spawn("local_gemma")
+    )
+
+    # Stub resolution helpers and token extractor to avoid registry/env access
+    monkeypatch.setattr("provider_dispatch._resolve_codex_model", lambda: "gpt-codex-test")
+    monkeypatch.setattr("provider_dispatch._resolve_kimi_model_label", lambda: "kimi-test")
+    monkeypatch.setattr("provider_dispatch._resolve_deepseek_model", lambda: "deepseek/test")
+    monkeypatch.setattr("provider_dispatch._resolve_zai_model", lambda m=None: "openrouter/glm-test")
+    monkeypatch.setattr("provider_dispatch._resolve_moonshot_model", lambda m=None: "moonshot/kimi-test")
+    monkeypatch.setattr("provider_dispatch._extract_token_usage", lambda r, p: {})
+    monkeypatch.setattr("provider_dispatch._build_lane_key", lambda b, m: f"litellm:{b}:test")
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.resolve_harness_model", lambda m: "deepseek-v4-test"
+    )
+    monkeypatch.setattr(
+        "provider_dispatch._MLX_MODEL_MAP", {"gemma-4b-local": "mlx-community/gemma-3-4b-it-4bit"}
+    )
+
+    # Track _dispatch_* calls — must all remain uncalled
+    dispatch_wrapper_called = []
+    for fn_name in [
+        "_dispatch_codex", "_dispatch_kimi", "_dispatch_gemini",
+        "_dispatch_litellm", "_dispatch_deepseek_harness", "_dispatch_local_gemma",
+    ]:
+        def _make_bad(n):
+            def _bad(*a, **k):
+                dispatch_wrapper_called.append(n)
+            return _bad
+        monkeypatch.setattr(f"provider_dispatch.{fn_name}", _make_bad(fn_name))
+
+    adapter = ProviderAdapter()
+    instruction_file = tmp_path / "inst.md"
+    instruction_file.write_text("test instruction", encoding="utf-8")
+
+    # codex
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.CODEX, model="default"), "prompt")
+    assert r.status == "success", f"codex: {r}"
+    assert "codex" in calls
+
+    # kimi
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.KIMI, model="default"), "prompt")
+    assert r.status == "success", f"kimi: {r}"
+    assert "kimi" in calls
+
+    # gemini
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.GEMINI, model="default"), "prompt")
+    assert r.status == "success", f"gemini: {r}"
+    assert "gemini" in calls
+
+    # litellm:deepseek
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_DEEPSEEK, model="default"), "prompt")
+    assert r.status == "success", f"litellm:deepseek: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:deepseek"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "deepseek"
+    assert litellm_calls[-1]["kwargs"].get("model") == "deepseek/test"
+
+    # litellm:zai — model resolved to the zai registry model
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_ZAI, model="default"), "prompt")
+    assert r.status == "success", f"litellm:zai: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:zai"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "zai"
+    assert litellm_calls[-1]["kwargs"].get("model") == "openrouter/glm-test"
+
+    # litellm:moonshot
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_MOONSHOT, model="default"), "prompt")
+    assert r.status == "success", f"litellm:moonshot: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:moonshot"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "moonshot"
+
+    # deepseek-harness
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.DEEPSEEK_HARNESS, model="default"), "prompt")
+    assert r.status == "success", f"deepseek-harness: {r}"
+    assert "deepseek_harness" in calls
+
+    # local-gemma
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LOCAL_GEMMA, model="default"), "prompt")
+    assert r.status == "success", f"local-gemma: {r}"
+    assert "local_gemma" in calls
+
+    # No _dispatch_* wrappers must have been invoked
+    assert dispatch_wrapper_called == [], f"_dispatch_* wrappers were invoked: {dispatch_wrapper_called}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: instruction read from file (file-ref neutralises injection text)
+# ---------------------------------------------------------------------------
+
+
+def test_instruction_read_from_file(tmp_path, monkeypatch):
+    """Instruction file containing 'claude -p' is passed verbatim to spawn; no injection."""
+    raw_text = "claude -p 'rm -rf /'\n"
+    inst_file = tmp_path / "inst.md"
+    inst_file.write_text(raw_text, encoding="utf-8")
+
+    plan = _make_provider_plan(tmp_path, provider=Provider.CODEX, instruction_file=inst_file)
+    permit = issue_permit(plan)
+
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    received_prompts: list = []
+
+    def fake_codex(prompt, model, dispatch_id, terminal_id, event_writer, cwd):
+        received_prompts.append(prompt)
+        return _FakeSpawnResult()
+
+    monkeypatch.setattr("provider_spawns.codex_spawn.spawn_codex", fake_codex)
+    monkeypatch.setattr("provider_dispatch._extract_token_usage", lambda r, p: {})
+    # _prepare falls back silently (intelligence_injection not available in tests)
+
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success"
+    assert received_prompts, "spawn_codex was not called"
+    # The raw text (possibly enriched, but since intelligence_injection is absent,
+    # it equals the file content) must reach the spawn unmodified in its base form
+    assert "claude -p" in received_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 5: _govern emits receipt line + report (real governance_emit pipeline)
+# ---------------------------------------------------------------------------
+
+
+def test_govern_emits_receipt_and_report(tmp_path, monkeypatch):
+    """_govern with a tmp state_dir/data_dir produces a receipt line + report file."""
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    dispatch_id = "test-govern-emit-pr3"
+    spec = EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction="do something",
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+    fake_result = _AdapterResult(returncode=0, completion_text="all good", status="success")
+    start = end = datetime.now(timezone.utc)
+
+    report_path, receipt_path = dispatch_envelope._govern(spec, fake_result, start, end)
+
+    # Receipt line written
+    assert receipt_path is not None
+    assert receipt_path.exists()
+    receipt_text = receipt_path.read_text(encoding="utf-8")
+    assert dispatch_id in receipt_text
+
+    # Report written
+    assert report_path is not None
+    assert report_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: legacy run_envelope unchanged — CodexAdapter still routes correctly
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_run_envelope_unchanged(tmp_path, monkeypatch):
+    """run_envelope(spec, 'codex') still routes to CodexAdapter (legacy path intact)."""
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    spec = EnvelopeSpec(
+        dispatch_id="test-legacy-codex",
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction="legacy dispatch",
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    codex_adapter_calls = []
+
+    original_run = dispatch_envelope.CodexAdapter.run
+
+    def spy_run(self, spec_arg, event_writer=None, cwd=None):
+        codex_adapter_calls.append(spec_arg.dispatch_id)
+        return _AdapterResult(returncode=0, completion_text="legacy done", status="success")
+
+    monkeypatch.setattr(dispatch_envelope.CodexAdapter, "run", spy_run)
+
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+        result = run_envelope(spec, lane="codex")
+
+    assert result.status == "success"
+    assert codex_adapter_calls == ["test-legacy-codex"], (
+        f"CodexAdapter.run was not called; got: {codex_adapter_calls}"
+    )


### PR DESCRIPTION
## What
PR-3 of the single-entry dispatch refactor: the first WIRING PR. Extends `dispatch_envelope.py` so a compiled `ExecutionPlan` can be EXECUTED for the PROVIDER lane, gated by the in-process `ExecutionPermit`.

- `ProviderAdapter` — generalizes `CodexAdapter` to every provider (codex / kimi / gemini / litellm:deepseek / litellm:zai=GLM / litellm:moonshot / deepseek-harness / local-gemma), reusing the `spawn_*` functions + `_resolve_*` model helpers. It does **not** call the self-governing `_dispatch_*` wrappers (those govern; the envelope governs once via `_govern`).
- `run_envelope_plan(plan, permit, *, state_dir, data_dir)` — `require_permit(plan, permit)` is the FIRST action (un-evadable backstop), then rejects any non-provider lane (the claude tmux lane is self-governing, executed by the door in PR-4), reads the instruction from `plan.instruction_file` (file-ref delivery), PREPARE → ProviderAdapter → fail-closed GOVERN.

Legacy `run_envelope`, `CodexAdapter`, `ClaudeSubprocessAdapter`, `LaneRouter` are untouched (no behavior change to the flag-gated path).

## Verification (full local CI gate, clean worktree)
- `pytest tests/test_dispatch_envelope_plan.py` → **6 passed**: permit-required (bare/forged permit raises), non-provider lane rejected, each provider routes to its spawn fn (no `_dispatch_*` wrapper invoked), instruction-with-`claude -p` read from file still runs, GOVERN emits receipt+report, legacy `run_envelope` intact.
- `check_adr_003_no_sdk_imports.py` → PASS.

## Stack / merge order
Stacked on #882 (PR-2), which stacks on #880 (PR-1). Merge order: **#880 → #882 → this**. Non-squash to keep the stack; GitHub retargets on merge.

## Governance
tmux subscription lane (sonnet), staging→pending→promote (ADR-006), central data dir (0 missing-table warnings). Report + receipt in the central ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)