### PR TITLE
feat(dispatch): the single-entry door — validate→snapshot→compile_plan→permit→execute (PR-4)

### DIFF
--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -144,6 +144,11 @@ HELP
       err "[dispatch] single-entry gate: requires --spec-file <abs> or <pending-id>"
       return 1
     fi
+    # P0-2: validate pending-id format BEFORE interpolation into path (traversal guard)
+    if [[ ! "$pending_id" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+      err "[dispatch] single-entry gate: invalid pending-id format (must match ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$): $pending_id"
+      return 1
+    fi
     local candidate="${VNX_DISPATCH_DIR}/pending/${pending_id}/dispatch-spec.json"
     if [ ! -f "$candidate" ]; then
       err "[dispatch] single-entry gate: dispatch-spec.json not found: $candidate"
@@ -165,7 +170,8 @@ HELP
 
   log "[dispatch] single-entry gate: spec=$spec_file"
 
-  PYTHONPATH="${VNX_HOME}/scripts/lib:${PYTHONPATH:-}" \
+  # P1-#7: no trailing colon (avoids CWD on sys.path when PYTHONPATH is unset)
+  PYTHONPATH="${VNX_HOME}/scripts/lib${PYTHONPATH:+:${PYTHONPATH}}" \
     python3 "$dispatch_cli_script" --spec-file "$spec_file" ${dry_run_flag:+--dry-run}
   return $?
 }

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -98,9 +98,90 @@ _d_resolve_track() {
   esac
 }
 
+# ── Single-entry dispatch (VNX_SINGLE_ENTRY_DISPATCH=1) ───────────────────
+
+_d_single_entry_dispatch() {
+  # Accepts --spec-file <abs> or <pending-id> (resolved to its bundle's dispatch-spec.json).
+  # VNX_DISPATCH_LEGACY=1 is checked by the caller — not re-checked here.
+  local spec_file=""
+  local dry_run_flag=""
+  local pending_id=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --spec-file)
+        spec_file="$2"; shift 2 ;;
+      --spec-file=*)
+        spec_file="${1#*=}"; shift ;;
+      --dry-run|-n)
+        dry_run_flag="--dry-run"; shift ;;
+      -h|--help)
+        cat <<HELP
+Usage: vnx dispatch [--spec-file <abs>] [--dry-run]
+       vnx dispatch <pending-id> [--dry-run]
+
+Single-entry gate (VNX_SINGLE_ENTRY_DISPATCH=1).
+  --spec-file <abs>   Absolute path to dispatch-spec.json
+  <pending-id>        Dispatch ID resolved to dispatches/pending/<id>/dispatch-spec.json
+  --dry-run           Print plan + fingerprint; spawn nothing
+  VNX_DISPATCH_LEGACY=1  Force legacy path even when gate is on
+HELP
+        return 0 ;;
+      -*)
+        err "[dispatch] single-entry gate: unknown flag: $1"
+        return 1 ;;
+      *)
+        if [ -n "$pending_id" ]; then
+          err "[dispatch] single-entry gate: unexpected positional argument: $1"
+          return 1
+        fi
+        pending_id="$1"; shift ;;
+    esac
+  done
+
+  if [ -z "$spec_file" ]; then
+    if [ -z "$pending_id" ]; then
+      err "[dispatch] single-entry gate: requires --spec-file <abs> or <pending-id>"
+      return 1
+    fi
+    local candidate="${VNX_DISPATCH_DIR}/pending/${pending_id}/dispatch-spec.json"
+    if [ ! -f "$candidate" ]; then
+      err "[dispatch] single-entry gate: dispatch-spec.json not found: $candidate"
+      return 1
+    fi
+    spec_file="$candidate"
+  fi
+
+  if [ ! -f "$spec_file" ]; then
+    err "[dispatch] single-entry gate: spec file not found: $spec_file"
+    return 1
+  fi
+
+  local dispatch_cli_script="${VNX_HOME}/scripts/lib/dispatch_cli.py"
+  if [ ! -f "$dispatch_cli_script" ]; then
+    err "[dispatch] single-entry gate: dispatch_cli.py not found: $dispatch_cli_script"
+    return 1
+  fi
+
+  log "[dispatch] single-entry gate: spec=$spec_file"
+
+  PYTHONPATH="${VNX_HOME}/scripts/lib:${PYTHONPATH:-}" \
+    python3 "$dispatch_cli_script" --spec-file "$spec_file" ${dry_run_flag:+--dry-run}
+  return $?
+}
+
 # ── Main command ───────────────────────────────────────────────────────────
 
 cmd_dispatch() {
+  # VNX_SINGLE_ENTRY_DISPATCH=1 delegates to the new single-entry Python gate.
+  # VNX_DISPATCH_LEGACY=1 short-circuits back to the legacy path (rollback hatch).
+  # When neither flag is set: byte-identical legacy behavior below.
+  if [[ "${VNX_SINGLE_ENTRY_DISPATCH:-0}" == "1" ]] && \
+     [[ "${VNX_DISPATCH_LEGACY:-0}" != "1" ]]; then
+    _d_single_entry_dispatch "$@"
+    return $?
+  fi
+
   local file=""
   local terminal_override=""
   local model_override="${VNX_MODEL:-sonnet}"

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -110,6 +110,12 @@ _d_single_entry_dispatch() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --spec-file)
+        # P1 (PR-4c): guard $2 so a trailing `--spec-file` with no value emits a
+        # clean gate error instead of aborting the shell under `set -u`.
+        if [ -z "${2:-}" ]; then
+          err "[dispatch] single-entry gate: --spec-file requires a path argument"
+          return 1
+        fi
         spec_file="$2"; shift 2 ;;
       --spec-file=*)
         spec_file="${1#*=}"; shift ;;

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -339,14 +339,11 @@ def build_runtime_snapshot(
 ) -> RuntimeSnapshot:
     """Perform all I/O required by compile_plan.
 
-    P0-1: instruction_text + check_registry=True (FAIL-CLOSED); effective model; SDK scan (blocking).
+    P0-1: instruction_text + check_registry=True (FAIL-CLOSED); effective model; SDK scan (warn via constraint engine).
     P0-2: staging binding verified via spec_file containment check.
     P1-#3: model_pins from provider_constraints.yaml SSOT.
     """
-    from providers.constraint_enforcer import (  # noqa: PLC0415
-        check_constraints as _constraint_check,
-        scan_anthropic_sdk_text as _scan_sdk,
-    )
+    from providers.constraint_enforcer import check_constraints as _constraint_check  # noqa: PLC0415
     from staging_validator import _exists_in_dir as _staging_exists  # noqa: PLC0415
 
     spec = vspec.spec
@@ -392,18 +389,6 @@ def build_runtime_snapshot(
             code="registry-unavailable",
             severity="blocking",
             message=f"Constraint registry unavailable — fail-closed: {exc}",
-        ),)
-
-    # P0-1 / PR-4d: direct blocking SDK import scan (dispatch-time gate, belt-and-
-    # suspenders vs CI grep). This backstop shares the constraint engine's robust,
-    # tokenize-based scanner, so line-continuation / submodule (`from anthropic.x`)
-    # / dynamic (`__import__("anthropic")`) forms cannot slip past — both gates
-    # apply identical, bypass-resistant matching.
-    if _scan_sdk(vspec.instruction_text):
-        constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
-            code="no-anthropic-sdk",
-            severity="blocking",
-            message="Instruction references forbidden Anthropic SDK (dispatch-time gate)",
         ),)
 
     # P0-2: anchor the pending root BEFORE trusting any bundle path. A symlinked

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -55,7 +55,16 @@ from dispatch_envelope import run_envelope_plan  # noqa: E402
 # ---------------------------------------------------------------------------
 
 def _resolve_data_dir() -> Path:
-    """Resolve VNX data directory. Mirrors provider_dispatch._resolve_data_dir."""
+    """Resolve VNX data directory. Mirrors provider_dispatch._resolve_data_dir.
+
+    PR-4d trust boundary: the resolved data root is OPERATOR config, not attacker
+    input. The threat model is our own agents, not an external adversary — and an
+    operator who wants an external-drive layout would point VNX_DATA_DIR straight
+    at it. A symlinked data root is therefore legitimate and is NOT rejected (that
+    would break external-drive setups). What IS untrusted is anything PLANTED
+    INSIDE this root by a dispatch (e.g. a symlinked dispatches/pending escaping
+    it); that is closed by _check_pending_root_anchor_verdict below.
+    """
     explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
     explicit_val = os.environ.get("VNX_DATA_DIR", "")
     if explicit_flag and explicit_val:
@@ -208,6 +217,11 @@ def _check_pending_root_anchor_verdict(data_dir: Path) -> Optional[ConstraintVer
     root and every downstream containment check passes — fail-OPEN. Anchor the
     pending root first: its fully-resolved path must stay under the resolved
     data_dir, else refuse to promote. Returns None on pass.
+
+    PR-4d trust boundary: this anchor protects against symlinks PLANTED INSIDE the
+    trusted data root (a dispatch-controlled `dispatches`/`dispatches/pending`
+    that escapes it). The data root ITSELF is trusted operator config (see
+    _resolve_data_dir) and is intentionally not rejected for being a symlink.
     """
     try:
         data_root = data_dir.resolve()
@@ -380,9 +394,11 @@ def build_runtime_snapshot(
             message=f"Constraint registry unavailable — fail-closed: {exc}",
         ),)
 
-    # P0-1: direct blocking SDK import scan (dispatch-time gate, belt-and-suspenders
-    # vs CI grep). Whitespace-aware so `import\tanthropic` / `import   anthropic`
-    # cannot slip past as they did with literal-substring matching.
+    # P0-1 / PR-4d: direct blocking SDK import scan (dispatch-time gate, belt-and-
+    # suspenders vs CI grep). This backstop shares the constraint engine's robust,
+    # tokenize-based scanner, so line-continuation / submodule (`from anthropic.x`)
+    # / dynamic (`__import__("anthropic")`) forms cannot slip past — both gates
+    # apply identical, bypass-resistant matching.
     if _scan_sdk(vspec.instruction_text):
         constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
             code="no-anthropic-sdk",

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -41,7 +41,12 @@ from dispatch_plan import (  # noqa: E402
     RuntimeSnapshot,
     compile_plan,
 )
-from dispatch_internal import ExecutionPermit, issue_permit, require_permit  # noqa: E402
+from dispatch_internal import (  # noqa: E402
+    ExecutionPermit,
+    is_valid_instruction_hash,
+    issue_permit,
+    require_permit,
+)
 from dispatch_envelope import run_envelope_plan  # noqa: E402
 
 
@@ -194,6 +199,37 @@ import re as _re
 _PENDING_ID_RE = _re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$')
 
 
+def _check_pending_root_anchor_verdict(data_dir: Path) -> Optional[ConstraintVerdict]:
+    """Return BLOCKING ConstraintVerdict if dispatches/pending escapes the data root.
+
+    P0-2: the binding/existence checks resolve bundle paths *relative to* the
+    pending root. If `dispatches` or `pending` is a symlink that hops outside the
+    trusted data_dir, an external bundle resolves "inside" the (escaped) pending
+    root and every downstream containment check passes — fail-OPEN. Anchor the
+    pending root first: its fully-resolved path must stay under the resolved
+    data_dir, else refuse to promote. Returns None on pass.
+    """
+    try:
+        data_root = data_dir.resolve()
+        pending_root = (data_dir / "dispatches" / "pending").resolve()
+    except (ValueError, OSError) as exc:
+        return ConstraintVerdict(
+            code="ADR-006-untrusted-root",
+            severity="blocking",
+            message=f"pending root resolution failed: {exc}",
+        )
+    if not pending_root.is_relative_to(data_root):
+        return ConstraintVerdict(
+            code="ADR-006-untrusted-root",
+            severity="blocking",
+            message=(
+                f"dispatches/pending escapes the trusted data root: resolved "
+                f"{pending_root} is not under {data_root} — refusing to promote"
+            ),
+        )
+    return None
+
+
 def _check_staging_binding_verdict(
     spec_file: Path,
     instruction_file: Path,
@@ -204,9 +240,24 @@ def _check_staging_binding_verdict(
     """Return BLOCKING ConstraintVerdict if spec_file or instruction_file escape the bundle.
 
     Follows symlinks via resolve() so symlink escapes are caught. Returns None on pass.
+
+    P0-2: the bundle dir is anchored under the resolved data root before the
+    per-file containment checks, so a symlinked `staging_id` (or any symlink in
+    the pending path) that resolves outside the data root is rejected rather than
+    silently trusted.
     """
     try:
+        data_root = data_dir.resolve()
         bundle_dir = (data_dir / "dispatches" / "pending" / staging_id).resolve()
+        if not bundle_dir.is_relative_to(data_root):
+            return ConstraintVerdict(
+                code="ADR-006-untrusted-root",
+                severity="blocking",
+                message=(
+                    f"bundle pending/{staging_id}/ escapes the trusted data root: "
+                    f"resolved {bundle_dir} is not under {data_root}"
+                ),
+            )
         sf_resolved = spec_file.resolve()
         if not sf_resolved.is_relative_to(bundle_dir):
             return ConstraintVerdict(
@@ -266,15 +317,6 @@ def _via_for_provider(provider_value: str, sub_provider: Optional[str]) -> Optio
     return None
 
 
-# P0-1: SDK import patterns for dispatch-time blocking gate
-_SDK_PATTERNS = [
-    "import anthropic",
-    "from anthropic import",
-    "anthropic.anthropic(",
-    "@anthropic-ai/sdk",
-]
-
-
 def build_runtime_snapshot(
     vspec: ValidatedSpec,
     *,
@@ -287,7 +329,10 @@ def build_runtime_snapshot(
     P0-2: staging binding verified via spec_file containment check.
     P1-#3: model_pins from provider_constraints.yaml SSOT.
     """
-    from providers.constraint_enforcer import check_constraints as _constraint_check  # noqa: PLC0415
+    from providers.constraint_enforcer import (  # noqa: PLC0415
+        check_constraints as _constraint_check,
+        scan_anthropic_sdk_text as _scan_sdk,
+    )
     from staging_validator import _exists_in_dir as _staging_exists  # noqa: PLC0415
 
     spec = vspec.spec
@@ -335,14 +380,22 @@ def build_runtime_snapshot(
             message=f"Constraint registry unavailable — fail-closed: {exc}",
         ),)
 
-    # P0-1: direct blocking SDK import scan (dispatch-time gate, belt-and-suspenders vs CI grep)
-    instruction_lower = (vspec.instruction_text or "").lower()
-    if any(p in instruction_lower for p in _SDK_PATTERNS):
+    # P0-1: direct blocking SDK import scan (dispatch-time gate, belt-and-suspenders
+    # vs CI grep). Whitespace-aware so `import\tanthropic` / `import   anthropic`
+    # cannot slip past as they did with literal-substring matching.
+    if _scan_sdk(vspec.instruction_text):
         constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
             code="no-anthropic-sdk",
             severity="blocking",
             message="Instruction references forbidden Anthropic SDK (dispatch-time gate)",
         ),)
+
+    # P0-2: anchor the pending root BEFORE trusting any bundle path. A symlinked
+    # dispatches/pending that escapes the data root cannot host a promoted bundle
+    # (fail-closed) — checked unconditionally so it holds even if existence is faked.
+    root_verdict = _check_pending_root_anchor_verdict(data_dir)
+    if root_verdict is not None:
+        constraint_verdicts = constraint_verdicts + (root_verdict,)
 
     # Staging existence check (belt-and-suspenders; binding check below is the specific gate)
     dispatches_dir = data_dir / "dispatches"
@@ -397,15 +450,23 @@ def _execute_claude(
 
     require_permit(plan, permit)  # un-evadable gate — FIRST action, cannot be moved
 
-    # P0-3: TOCTOU verification — re-read and verify sha256 before delivering
+    # P0-3 (PR-4c): REQUIRE a valid 64-hex plan hash before delivery — fail-CLOSED.
+    # The old `if plan.instruction_sha256:` guard fell OPEN on an empty hash, letting
+    # an empty-hash plan + valid permit spawn mutated content. No hash → no spawn.
+    if not is_valid_instruction_hash(plan.instruction_sha256):
+        raise PermissionError(
+            f"plan.instruction_sha256 is not a valid 64-hex digest "
+            f"(got {plan.instruction_sha256!r}); refusing to deliver (fail-closed)"
+        )
+
+    # TOCTOU verification — re-read and verify sha256 before delivering
     instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
-    if plan.instruction_sha256:
-        actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
-        if actual != plan.instruction_sha256:
-            raise PermissionError(
-                f"instruction file mutated after permit: sha256 mismatch "
-                f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
-            )
+    actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+    if actual != plan.instruction_sha256:
+        raise PermissionError(
+            f"instruction file mutated after permit: sha256 mismatch "
+            f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
+        )
 
     lane = TmuxInteractiveDispatch(state_dir)
     result = lane.dispatch(

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -11,6 +11,7 @@ tmux (subscription). Provider lane executes via run_envelope_plan (provider_mete
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -106,6 +107,7 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         requires_mcp=bool(raw.get("requires_mcp", False)),
         target_id_override=(raw.get("target_id_override") or None),
         tags=tuple(str(t) for t in (raw.get("tags") or [])),
+        instruction_sha256=(raw.get("instruction_sha256") or None),
     )
 
 
@@ -143,6 +145,98 @@ def _print_plan(plan: ExecutionPlan, fp: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# P1-#3: model pins from SSOT
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MODEL_PINS: dict[str, str] = {
+    "T0": "opus",
+    "T1": "sonnet",
+    "T2": "sonnet",
+    "T3": "sonnet",
+}
+
+
+def _load_model_pins_from_yaml() -> dict[str, str]:
+    """Load T0/T1/T2/T3 model pins from provider_constraints.yaml SSOT.
+
+    Falls back to DEFAULT_MODEL_PINS on any read/parse error (never raises).
+    """
+    yaml_path = _LIB_DIR / "providers" / "provider_constraints.yaml"
+    try:
+        import yaml  # noqa: PLC0415
+        with yaml_path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        if not isinstance(data, dict) or data.get("version") != 1:
+            return dict(_DEFAULT_MODEL_PINS)
+        pins: dict[str, str] = {}
+        for constraint in (data.get("constraints") or []):
+            cid = str(constraint.get("id", ""))
+            required = constraint.get("required_route") or {}
+            model = required.get("model")
+            if not model:
+                continue
+            if cid == "t0-opus-only":
+                pins["T0"] = str(model)
+            elif cid == "workers-sonnet-pinned":
+                for slot in ("T1", "T2", "T3"):
+                    pins[slot] = str(model)
+        return {**_DEFAULT_MODEL_PINS, **pins}
+    except Exception:
+        return dict(_DEFAULT_MODEL_PINS)
+
+
+# ---------------------------------------------------------------------------
+# P0-2: staging binding check helpers
+# ---------------------------------------------------------------------------
+
+# Mirrors _DISPATCH_ID_RE from staging_validator.py
+import re as _re
+_PENDING_ID_RE = _re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$')
+
+
+def _check_staging_binding_verdict(
+    spec_file: Path,
+    instruction_file: Path,
+    *,
+    data_dir: Path,
+    staging_id: str,
+) -> Optional[ConstraintVerdict]:
+    """Return BLOCKING ConstraintVerdict if spec_file or instruction_file escape the bundle.
+
+    Follows symlinks via resolve() so symlink escapes are caught. Returns None on pass.
+    """
+    try:
+        bundle_dir = (data_dir / "dispatches" / "pending" / staging_id).resolve()
+        sf_resolved = spec_file.resolve()
+        if not sf_resolved.is_relative_to(bundle_dir):
+            return ConstraintVerdict(
+                code="ADR-006-binding",
+                severity="blocking",
+                message=(
+                    f"spec_file is not inside bundle pending/{staging_id}/: "
+                    f"got {sf_resolved}"
+                ),
+            )
+        if_resolved = instruction_file.resolve()
+        if not if_resolved.is_relative_to(bundle_dir):
+            return ConstraintVerdict(
+                code="ADR-006-binding",
+                severity="blocking",
+                message=(
+                    f"instruction_file is not inside bundle pending/{staging_id}/: "
+                    f"got {if_resolved}"
+                ),
+            )
+    except (ValueError, OSError) as exc:
+        return ConstraintVerdict(
+            code="ADR-006-binding",
+            severity="blocking",
+            message=f"staging binding path resolution failed: {exc}",
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # build_runtime_snapshot — all I/O lives here
 # ---------------------------------------------------------------------------
 
@@ -172,24 +266,26 @@ def _via_for_provider(provider_value: str, sub_provider: Optional[str]) -> Optio
     return None
 
 
+# P0-1: SDK import patterns for dispatch-time blocking gate
+_SDK_PATTERNS = [
+    "import anthropic",
+    "from anthropic import",
+    "anthropic.anthropic(",
+    "@anthropic-ai/sdk",
+]
+
+
 def build_runtime_snapshot(
     vspec: ValidatedSpec,
     *,
     data_dir: Path,
+    spec_file: Path,
 ) -> RuntimeSnapshot:
     """Perform all I/O required by compile_plan.
 
-    Constraint enforcement runs for ALL providers including claude — this is the
-    door's per-provider correctness gate. compile_plan's D3 then rejects on any
-    blocking verdict before a single subprocess is spawned.
-
-    Staging check reuses staging_validator._exists_in_dir logic (including path
-    containment defense-in-depth).
-
-    model_pins are derived from provider_constraints.yaml tiers:
-      T0 → opus, T1/T2/T3 → sonnet
-
-    Target health defaults to healthy (best-effort; the tmux lane is leaseless).
+    P0-1: instruction_text + check_registry=True (FAIL-CLOSED); effective model; SDK scan (blocking).
+    P0-2: staging binding verified via spec_file containment check.
+    P1-#3: model_pins from provider_constraints.yaml SSOT.
     """
     from providers.constraint_enforcer import check_constraints as _constraint_check  # noqa: PLC0415
     from staging_validator import _exists_in_dir as _staging_exists  # noqa: PLC0415
@@ -199,40 +295,70 @@ def build_runtime_snapshot(
     sub_provider = _sub_provider_for(provider_value)
     via = _via_for_provider(provider_value, sub_provider)
 
-    model = spec.model or "sonnet"
+    # P1-#3: model_pins from SSOT
+    model_pins = _load_model_pins_from_yaml()
 
-    raw_violations = _constraint_check(
-        provider=provider_value,
-        sub_provider=sub_provider,
-        model=model,
-        terminal_id=spec.target_slot,
-        role=spec.role,
-        via=via,
-        env=os.environ,
-        check_registry=False,
-    )
+    # P0-1: effective model — same computation compile_plan uses in D4
+    is_claude_lane = spec.provider == Provider.CLAUDE
+    if is_claude_lane:
+        effective_model = model_pins.get(spec.target_slot) or spec.model or "sonnet"
+    else:
+        effective_model = spec.model or "default"
 
-    constraint_verdicts = tuple(
-        ConstraintVerdict(
-            code=v.code,
-            severity=v.severity,
-            message=v.message,
-            override_applied=v.override_applied,
+    # P0-1: constraint check with instruction_text + check_registry=True; FAIL-CLOSED on error
+    constraint_verdicts: tuple[ConstraintVerdict, ...] = ()
+    try:
+        raw_violations = _constraint_check(
+            provider=provider_value,
+            sub_provider=sub_provider,
+            model=effective_model,
+            terminal_id=spec.target_slot,
+            role=spec.role,
+            via=via,
+            env=os.environ,
+            check_registry=True,
+            instruction_text=vspec.instruction_text,
         )
-        for v in raw_violations
-    )
+        constraint_verdicts = tuple(
+            ConstraintVerdict(
+                code=v.code,
+                severity=v.severity,
+                message=v.message,
+                override_applied=v.override_applied,
+            )
+            for v in raw_violations
+        )
+    except Exception as exc:
+        constraint_verdicts = (ConstraintVerdict(
+            code="registry-unavailable",
+            severity="blocking",
+            message=f"Constraint registry unavailable — fail-closed: {exc}",
+        ),)
 
+    # P0-1: direct blocking SDK import scan (dispatch-time gate, belt-and-suspenders vs CI grep)
+    instruction_lower = (vspec.instruction_text or "").lower()
+    if any(p in instruction_lower for p in _SDK_PATTERNS):
+        constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
+            code="no-anthropic-sdk",
+            severity="blocking",
+            message="Instruction references forbidden Anthropic SDK (dispatch-time gate)",
+        ),)
+
+    # Staging existence check (belt-and-suspenders; binding check below is the specific gate)
     dispatches_dir = data_dir / "dispatches"
     staging_promoted = _staging_exists(dispatches_dir / "pending", spec.staging_id)
 
-    model_pins: dict[str, str] = {
-        "T0": "opus",
-        "T1": "sonnet",
-        "T2": "sonnet",
-        "T3": "sonnet",
-    }
+    # P0-2: staging binding — spec_file and instruction_file must be inside the bundle dir
+    if staging_promoted:
+        binding_verdict = _check_staging_binding_verdict(
+            spec_file,
+            spec.instruction_file,
+            data_dir=data_dir,
+            staging_id=spec.staging_id,
+        )
+        if binding_verdict is not None:
+            constraint_verdicts = constraint_verdicts + (binding_verdict,)
 
-    is_claude_lane = spec.provider == Provider.CLAUDE
     if is_claude_lane:
         target_health: dict[str, str] = {"ephemeral": "healthy"}
         target_capable: dict[str, bool] = {"ephemeral": True}
@@ -264,16 +390,22 @@ def _execute_claude(
 ) -> int:
     """Execute a validated claude_tmux_subscription plan via TmuxInteractiveDispatch.
 
-    require_permit is the first action — un-evadable. The tmux lane self-governs
-    (emits its own receipt + report); the door's job is validate + permit +
-    plan-faithful invocation. The claude serial lock and warmup are owned by the
-    tmux lane itself.
+    require_permit is the first action — un-evadable. P0-3: sha256 of the instruction
+    file is re-verified immediately before delivery to detect TOCTOU swaps.
     """
     from tmux_interactive_dispatch import TmuxInteractiveDispatch  # noqa: PLC0415
 
     require_permit(plan, permit)  # un-evadable gate — FIRST action, cannot be moved
 
+    # P0-3: TOCTOU verification — re-read and verify sha256 before delivering
     instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+    if plan.instruction_sha256:
+        actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+        if actual != plan.instruction_sha256:
+            raise PermissionError(
+                f"instruction file mutated after permit: sha256 mismatch "
+                f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
+            )
 
     lane = TmuxInteractiveDispatch(state_dir)
     result = lane.dispatch(
@@ -315,36 +447,43 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
         _emit_reject(vspec)
         return 1
 
-    snapshot = build_runtime_snapshot(vspec, data_dir=data_dir)
+    # P1-#1: wrap everything after validate in try/except — door never panics
+    try:
+        snapshot = build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
 
-    plan = compile_plan(vspec, snapshot)
-    if isinstance(plan, Reject):
-        _emit_reject(plan)
+        plan = compile_plan(vspec, snapshot)
+        if isinstance(plan, Reject):
+            _emit_reject(plan)
+            return 1
+
+        permit = issue_permit(plan)
+        require_permit(plan, permit)  # P1-#6: door backstop for BOTH lanes
+        fp = fingerprint(permit)
+        logger.info("[dispatch_cli] permit fingerprint: %s", fp)
+
+        if dry_run:
+            _print_plan(plan, fp)
+            return 0
+
+        if plan.lane == "provider":
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+            return result.returncode
+        elif plan.lane == "claude_tmux_subscription":
+            return _execute_claude(
+                plan,
+                permit,
+                state_dir=state_dir,
+                data_dir=data_dir,
+                role=vspec.spec.role,
+            )
+        else:
+            raise ValueError(
+                f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
+            )
+
+    except Exception as exc:
+        print(f"[dispatch_cli] REJECT [runtime-error]: {exc}", file=sys.stderr)
         return 1
-
-    permit = issue_permit(plan)
-    fp = fingerprint(permit)
-    logger.info("[dispatch_cli] permit fingerprint: %s", fp)
-
-    if dry_run:
-        _print_plan(plan, fp)
-        return 0
-
-    if plan.lane == "provider":
-        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
-        return result.returncode
-    elif plan.lane == "claude_tmux_subscription":
-        return _execute_claude(
-            plan,
-            permit,
-            state_dir=state_dir,
-            data_dir=data_dir,
-            role=vspec.spec.role,
-        )
-    else:
-        raise ValueError(
-            f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1,0 +1,373 @@
+"""dispatch_cli.py — Single-entry dispatch gate (PR-4).
+
+spec -> validate -> snapshot -> compile_plan -> permit -> execute
+
+Feature-gated by VNX_SINGLE_ENTRY_DISPATCH=1 in dispatch.sh. When the flag is
+unset the bash layer uses the legacy path; this module's logic is unchanged.
+
+BILLING SAFETY: no anthropic SDK import. Claude lane executes via interactive
+tmux (subscription). Provider lane executes via run_envelope_plan (provider_metered).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+logger = logging.getLogger(__name__)
+
+from dispatch_spec import (  # noqa: E402
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    PathAccess,
+    Provider,
+    Reject,
+    ValidatedSpec,
+    validate,
+)
+from dispatch_plan import (  # noqa: E402
+    ConstraintVerdict,
+    ExecutionPlan,
+    RuntimeSnapshot,
+    compile_plan,
+)
+from dispatch_internal import ExecutionPermit, issue_permit, require_permit  # noqa: E402
+from dispatch_envelope import run_envelope_plan  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_data_dir() -> Path:
+    """Resolve VNX data directory. Mirrors provider_dispatch._resolve_data_dir."""
+    explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    explicit_val = os.environ.get("VNX_DATA_DIR", "")
+    if explicit_flag and explicit_val:
+        return Path(explicit_val).resolve()
+    project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    return Path.home() / ".vnx-data" / project_id
+
+
+def _resolve_project_id() -> str:
+    return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+
+
+def _resolve_repo_root() -> Path:
+    """scripts/lib/dispatch_cli.py -> repo root (parents[2])."""
+    return Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Spec loading from JSON
+# ---------------------------------------------------------------------------
+
+def load_spec(spec_file: Path) -> DispatchSpec:
+    """Parse a DispatchSpec from a JSON dispatch-spec.json file."""
+    raw = json.loads(spec_file.read_text(encoding="utf-8"))
+
+    raw_paths = raw.get("dispatch_paths") or []
+    dispatch_paths = tuple(
+        DispatchPath(
+            path=PurePosixPath(str(p["path"])),
+            access=PathAccess(p.get("access", "read_write")),
+            materialize_at_cwd=bool(p.get("materialize_at_cwd", False)),
+        )
+        for p in raw_paths
+    )
+
+    return DispatchSpec(
+        schema_version=int(raw["schema_version"]),
+        project_id=str(raw["project_id"]),
+        dispatch_id=str(raw["dispatch_id"]),
+        staging_id=str(raw["staging_id"]),
+        instruction_file=Path(raw["instruction_file"]),
+        role=str(raw["role"]),
+        target_slot=str(raw["target_slot"]),
+        gate=str(raw.get("gate", "")),
+        dispatch_paths=dispatch_paths,
+        provider=Provider(raw.get("provider", "auto")),
+        model=(raw.get("model") or None),
+        skill=(raw.get("skill") or None),
+        task_class=(raw.get("task_class") or None),
+        pr_id=(raw.get("pr_id") or None),
+        deadline_seconds=int(raw.get("deadline_seconds", 3600)),
+        base_ref=str(raw.get("base_ref", "origin/main")),
+        isolation=Isolation(raw.get("isolation", "worktree")),
+        requires_mcp=bool(raw.get("requires_mcp", False)),
+        target_id_override=(raw.get("target_id_override") or None),
+        tags=tuple(str(t) for t in (raw.get("tags") or [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Permit fingerprint helper
+# ---------------------------------------------------------------------------
+
+def fingerprint(permit: ExecutionPermit) -> str:
+    """Short stable display string: plan_digest[:12]-dispatch_id.
+
+    Unforgeable (anchored to plan digest) yet human-readable for log lines.
+    """
+    return f"{permit.plan_digest[:12]}-{permit.dispatch_id}"
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _emit_reject(r: Reject) -> None:
+    print(f"[dispatch_cli] REJECT [{r.code}]: {r.reason}", file=sys.stderr)
+
+
+def _print_plan(plan: ExecutionPlan, fp: str) -> None:
+    print(f"[dispatch_cli] DRY RUN — fingerprint: {fp}")
+    print(f"  dispatch_id:  {plan.dispatch_id}")
+    print(f"  provider:     {plan.provider.value}")
+    print(f"  model:        {plan.model}")
+    print(f"  lane:         {plan.lane}")
+    print(f"  target_id:    {plan.target_id}")
+    print(f"  billing:      {plan.billing}")
+    print(f"  route_reason: {plan.route_reason}")
+    for w in plan.warnings:
+        print(f"  [WARN] {w}")
+
+
+# ---------------------------------------------------------------------------
+# build_runtime_snapshot — all I/O lives here
+# ---------------------------------------------------------------------------
+
+def _sub_provider_for(provider_value: str) -> Optional[str]:
+    if provider_value.startswith("litellm:"):
+        return provider_value.split(":", 1)[1].split(":", 1)[0] or None
+    if provider_value == "deepseek-harness":
+        return "deepseek"
+    return None
+
+
+def _via_for_provider(provider_value: str, sub_provider: Optional[str]) -> Optional[str]:
+    via_per_sub = {
+        "deepseek": "litellm",
+        "moonshot": "moonshot",
+        "openrouter": "openrouter",
+        "zai": "openrouter",
+    }
+    if provider_value.startswith("litellm:") or provider_value == "litellm":
+        return via_per_sub.get(sub_provider or "", "litellm")
+    if provider_value == "deepseek-harness":
+        return "claude_harness_keyed"
+    if provider_value in ("claude", "codex", "gemini", "kimi"):
+        return "cli"
+    if provider_value == "local-gemma":
+        return "local"
+    return None
+
+
+def build_runtime_snapshot(
+    vspec: ValidatedSpec,
+    *,
+    data_dir: Path,
+) -> RuntimeSnapshot:
+    """Perform all I/O required by compile_plan.
+
+    Constraint enforcement runs for ALL providers including claude — this is the
+    door's per-provider correctness gate. compile_plan's D3 then rejects on any
+    blocking verdict before a single subprocess is spawned.
+
+    Staging check reuses staging_validator._exists_in_dir logic (including path
+    containment defense-in-depth).
+
+    model_pins are derived from provider_constraints.yaml tiers:
+      T0 → opus, T1/T2/T3 → sonnet
+
+    Target health defaults to healthy (best-effort; the tmux lane is leaseless).
+    """
+    from providers.constraint_enforcer import check_constraints as _constraint_check  # noqa: PLC0415
+    from staging_validator import _exists_in_dir as _staging_exists  # noqa: PLC0415
+
+    spec = vspec.spec
+    provider_value = spec.provider.value
+    sub_provider = _sub_provider_for(provider_value)
+    via = _via_for_provider(provider_value, sub_provider)
+
+    model = spec.model or "sonnet"
+
+    raw_violations = _constraint_check(
+        provider=provider_value,
+        sub_provider=sub_provider,
+        model=model,
+        terminal_id=spec.target_slot,
+        role=spec.role,
+        via=via,
+        env=os.environ,
+        check_registry=False,
+    )
+
+    constraint_verdicts = tuple(
+        ConstraintVerdict(
+            code=v.code,
+            severity=v.severity,
+            message=v.message,
+            override_applied=v.override_applied,
+        )
+        for v in raw_violations
+    )
+
+    dispatches_dir = data_dir / "dispatches"
+    staging_promoted = _staging_exists(dispatches_dir / "pending", spec.staging_id)
+
+    model_pins: dict[str, str] = {
+        "T0": "opus",
+        "T1": "sonnet",
+        "T2": "sonnet",
+        "T3": "sonnet",
+    }
+
+    is_claude_lane = spec.provider == Provider.CLAUDE
+    if is_claude_lane:
+        target_health: dict[str, str] = {"ephemeral": "healthy"}
+        target_capable: dict[str, bool] = {"ephemeral": True}
+    else:
+        target_id = spec.target_id_override or spec.target_slot
+        target_health = {target_id: "healthy"}
+        target_capable = {target_id: True}
+
+    return RuntimeSnapshot(
+        constraint_verdicts=constraint_verdicts,
+        staging_promoted=staging_promoted,
+        target_health=target_health,
+        target_capable=target_capable,
+        model_pins=model_pins,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lane executors
+# ---------------------------------------------------------------------------
+
+def _execute_claude(
+    plan: ExecutionPlan,
+    permit: ExecutionPermit,
+    *,
+    state_dir: Path,
+    data_dir: Path,
+    role: Optional[str] = None,
+) -> int:
+    """Execute a validated claude_tmux_subscription plan via TmuxInteractiveDispatch.
+
+    require_permit is the first action — un-evadable. The tmux lane self-governs
+    (emits its own receipt + report); the door's job is validate + permit +
+    plan-faithful invocation. The claude serial lock and warmup are owned by the
+    tmux lane itself.
+    """
+    from tmux_interactive_dispatch import TmuxInteractiveDispatch  # noqa: PLC0415
+
+    require_permit(plan, permit)  # un-evadable gate — FIRST action, cannot be moved
+
+    instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+
+    lane = TmuxInteractiveDispatch(state_dir)
+    result = lane.dispatch(
+        instruction,
+        plan.dispatch_id,
+        role=role,
+        model=plan.model,
+        dispatch_paths=[str(dp.path) for dp in plan.dispatch_paths],
+        deadline_seconds=plan.deadline_seconds,
+        base_ref=plan.base_ref,
+        isolated_worktree=True,
+    )
+    return 0 if result.success else 1
+
+
+# ---------------------------------------------------------------------------
+# run_dispatch — the single door
+# ---------------------------------------------------------------------------
+
+def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
+    """Turn a spec file into a governed dispatch for BOTH lanes.
+
+    Returns 0 on success, 1 on any reject or execution failure.
+    When dry_run=True, prints plan + permit fingerprint and spawns nothing.
+    """
+    project_id = _resolve_project_id()
+    repo_root = _resolve_repo_root()
+    data_dir = _resolve_data_dir()
+    state_dir = data_dir / "state"
+
+    try:
+        spec = load_spec(spec_file)
+    except Exception as exc:
+        print(f"[dispatch_cli] REJECT [spec-parse-error]: {exc}", file=sys.stderr)
+        return 1
+
+    vspec = validate(spec, project_id=project_id, repo_root=repo_root)
+    if isinstance(vspec, Reject):
+        _emit_reject(vspec)
+        return 1
+
+    snapshot = build_runtime_snapshot(vspec, data_dir=data_dir)
+
+    plan = compile_plan(vspec, snapshot)
+    if isinstance(plan, Reject):
+        _emit_reject(plan)
+        return 1
+
+    permit = issue_permit(plan)
+    fp = fingerprint(permit)
+    logger.info("[dispatch_cli] permit fingerprint: %s", fp)
+
+    if dry_run:
+        _print_plan(plan, fp)
+        return 0
+
+    if plan.lane == "provider":
+        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+        return result.returncode
+    elif plan.lane == "claude_tmux_subscription":
+        return _execute_claude(
+            plan,
+            permit,
+            state_dir=state_dir,
+            data_dir=data_dir,
+            role=vspec.spec.role,
+        )
+    else:
+        raise ValueError(
+            f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="VNX single-entry dispatch gate (PR-4)"
+    )
+    parser.add_argument(
+        "--spec-file", required=True, type=Path, dest="spec_file",
+        help="Absolute path to dispatch-spec.json",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", dest="dry_run",
+        help="Print plan + fingerprint; spawn nothing",
+    )
+    args = parser.parse_args(argv)
+    return run_dispatch(args.spec_file, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -27,6 +27,7 @@ EventStore wiring and cost emission are open items for later PRs (PR-1 scope: fl
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -488,4 +489,370 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         receipt_path=receipt_path,
         completion_text=adapter_result.completion_text,
         error=adapter_result.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-3: ProviderAdapter + plan-based provider execution
+# ---------------------------------------------------------------------------
+
+
+def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
+    """Map codex/kimi/gemini/litellm:* spawn result to _AdapterResult.
+
+    Normalises token fields via _extract_token_usage from provider_dispatch.
+    Handles error, timeout, and success/failure by returncode. Does NOT handle
+    the deepseek-harness stopped_early or local-gemma error-condition variant —
+    those are handled inline in ProviderAdapter.run().
+    """
+    from provider_dispatch import _extract_token_usage  # noqa: PLC0415
+
+    token_usage: Dict[str, int] = _extract_token_usage(result, provider_str)
+    ewf = getattr(result, "event_writer_failures", 0)
+
+    if result.error:
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status="failure",
+            token_usage=token_usage,
+            error=result.error,
+            event_writer_failures=ewf,
+        )
+    if result.timed_out:
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status="timeout",
+            token_usage=token_usage,
+            timed_out=True,
+            event_writer_failures=ewf,
+        )
+    status = "success" if result.returncode == 0 else "failure"
+    return _AdapterResult(
+        returncode=result.returncode,
+        completion_text=(result.completion_text or ""),
+        status=status,
+        token_usage=token_usage,
+        event_writer_failures=ewf,
+    )
+
+
+class ProviderAdapter:
+    """Routes provider-lane ExecutionPlan to the correct spawn function.
+
+    Mirrors CodexAdapter's shape but routes by plan.provider to the correct
+    spawn function. Reuses existing resolution helpers and raw spawn functions
+    from provider_dispatch and provider_spawns.*. Does NOT call the governing
+    _dispatch_* wrappers in provider_dispatch — those govern; the envelope
+    governs once via _govern.
+
+    Supported plan.provider values: codex, kimi, gemini, litellm:deepseek,
+    litellm:zai, litellm:moonshot, deepseek-harness, local-gemma.
+    Provider.CLAUDE and Provider.AUTO are programming errors → ValueError.
+
+    event_writer is not wired in PR-3 (EventStore setup is an open item for a
+    later PR); the audit gap is documented in Open Items.
+    """
+
+    def run(
+        self,
+        plan: "ExecutionPlan",
+        instruction: str,
+        *,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from dispatch_spec import Provider  # noqa: PLC0415
+        from provider_dispatch import (  # noqa: PLC0415
+            _MLX_MODEL_MAP,
+            _build_lane_key,
+            _extract_token_usage,
+            _resolve_codex_model,
+            _resolve_deepseek_model,
+            _resolve_kimi_model_label,
+            _resolve_moonshot_model,
+            _resolve_zai_model,
+        )
+
+        pv: "Provider" = plan.provider  # type: ignore[assignment]
+
+        # ---- codex ----
+        if pv == Provider.CODEX:
+            from provider_spawns.codex_spawn import spawn_codex  # noqa: PLC0415
+
+            model = (
+                plan.model if plan.model not in ("default", "") else _resolve_codex_model()
+            )
+            try:
+                result = spawn_codex(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"codex spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- kimi ----
+        if pv == Provider.KIMI:
+            from provider_spawns.kimi_spawn import spawn_kimi  # noqa: PLC0415
+
+            # None signals kimi CLI to use its own default; label used only for logging
+            model = plan.model if plan.model not in ("default", "") else None
+            try:
+                result = spawn_kimi(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"kimi spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- gemini ----
+        if pv == Provider.GEMINI:
+            from provider_spawns.gemini_spawn import spawn_gemini  # noqa: PLC0415
+
+            model = (
+                plan.model
+                if plan.model not in ("default", "sonnet", "")
+                else os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
+            )
+            try:
+                result = spawn_gemini(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"gemini spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- litellm:deepseek | litellm:zai | litellm:moonshot ----
+        if pv in (Provider.LITELLM_DEEPSEEK, Provider.LITELLM_ZAI, Provider.LITELLM_MOONSHOT):
+            from provider_spawns.litellm_spawn import spawn_litellm  # noqa: PLC0415
+
+            # Extract sub-provider from the enum value: "litellm:deepseek" -> "deepseek"
+            base_sub = pv.value.split(":", 1)[1]
+            if plan.model not in ("default", ""):
+                model = plan.model
+            elif pv == Provider.LITELLM_DEEPSEEK:
+                model = _resolve_deepseek_model()
+            elif pv == Provider.LITELLM_ZAI:
+                model = _resolve_zai_model()
+            else:
+                model = _resolve_moonshot_model()
+            lane_key = _build_lane_key(base_sub, None)
+            try:
+                result = spawn_litellm(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    sub_provider=base_sub,
+                    lane=lane_key,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"litellm spawn BrokenPipeError: {exc}",
+                )
+            return _map_generic_spawn_result(result, pv.value)
+
+        # ---- deepseek-harness ----
+        if pv == Provider.DEEPSEEK_HARNESS:
+            from provider_spawns.deepseek_harness_spawn import (  # noqa: PLC0415
+                resolve_harness_model,
+                spawn_deepseek_harness,
+            )
+
+            raw_model = (
+                plan.model if plan.model not in ("default", "sonnet", "") else None
+            )
+            model = resolve_harness_model(raw_model)
+            try:
+                result = spawn_deepseek_harness(
+                    prompt=instruction,
+                    model=model,
+                    dispatch_id=plan.dispatch_id,
+                    terminal_id=plan.target_id,
+                    event_writer=event_writer,
+                    cwd=cwd,
+                )
+            except BrokenPipeError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"deepseek-harness spawn BrokenPipeError: {exc}",
+                )
+            token_usage: Dict[str, int] = _extract_token_usage(result, pv.value)
+            if result.error:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="failure",
+                    token_usage=token_usage,
+                    error=result.error,
+                )
+            if result.timed_out:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="timeout",
+                    token_usage=token_usage,
+                    timed_out=True,
+                )
+            if getattr(result, "stopped_early", False):
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="success",
+                    token_usage=token_usage,
+                )
+            status = "success" if result.returncode == 0 else "failure"
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status=status,
+                token_usage=token_usage,
+            )
+
+        # ---- local-gemma ----
+        if pv == Provider.LOCAL_GEMMA:
+            from provider_spawns.local_gemma_spawn import spawn_local_gemma  # noqa: PLC0415
+
+            raw_model = (
+                plan.model if plan.model not in ("default", "sonnet", "") else "gemma-4b-local"
+            )
+            canonical_model = _MLX_MODEL_MAP.get(raw_model, raw_model)
+            result = spawn_local_gemma(
+                instruction=instruction,
+                model=canonical_model,
+                role=None,
+                deadline_seconds=300,
+                dispatch_id=plan.dispatch_id,
+                project_id="vnx-dev",
+            )
+            token_usage = _extract_token_usage(result, pv.value)
+            if result.error and result.returncode != 0:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="failure",
+                    token_usage=token_usage,
+                    error=result.error,
+                )
+            if result.timed_out:
+                return _AdapterResult(
+                    returncode=result.returncode,
+                    completion_text=(result.completion_text or ""),
+                    status="timeout",
+                    token_usage=token_usage,
+                    timed_out=True,
+                )
+            status = "success" if result.returncode == 0 else "failure"
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status=status,
+                token_usage=token_usage,
+            )
+
+        # Provider.CLAUDE, Provider.AUTO, or any unexpected value — programming error
+        raise ValueError(
+            f"ProviderAdapter: unsupported provider {pv!r} — "
+            f"claude and auto do not route through the provider envelope "
+            f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
+        )
+
+
+def run_envelope_plan(
+    plan: "ExecutionPlan",
+    permit: "ExecutionPermit",
+    *,
+    state_dir: Path,
+    data_dir: Path,
+) -> EnvelopeResult:
+    """Execute a validated ExecutionPlan for the provider lane.
+
+    Provider lane covers codex, kimi, gemini, litellm:*, deepseek-harness,
+    local-gemma. The claude_tmux_subscription lane is wired separately in PR-4.
+
+    require_permit is the first action — un-evadable and cannot be moved.
+
+    Raises:
+        PermissionError: permit was not issued by issue_permit for this plan.
+        ValueError: plan.lane is not "provider".
+        EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
+    """
+    from dispatch_internal import require_permit  # noqa: PLC0415
+
+    require_permit(plan, permit)  # un-evadable backstop — FIRST action
+
+    if plan.lane != "provider":
+        raise ValueError(
+            f"run_envelope_plan handles the provider lane only; got lane={plan.lane!r} "
+            f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
+        )
+
+    instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+
+    spec = EnvelopeSpec(
+        dispatch_id=plan.dispatch_id,
+        terminal_id=plan.target_id,
+        provider=plan.provider.value,
+        model=plan.model,
+        instruction=instruction,
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    enriched_instruction = _prepare(spec)
+    enriched_spec = EnvelopeSpec(
+        dispatch_id=spec.dispatch_id,
+        terminal_id=spec.terminal_id,
+        provider=spec.provider,
+        model=spec.model,
+        instruction=enriched_instruction,
+        role=spec.role,
+        pr_id=spec.pr_id,
+        state_dir=spec.state_dir,
+        data_dir=spec.data_dir,
+    )
+
+    start = datetime.now(timezone.utc)
+    result = ProviderAdapter().run(plan, enriched_spec.instruction)
+    end = datetime.now(timezone.utc)
+
+    report_path, receipt_path = _govern(enriched_spec, result, start, end)
+
+    return EnvelopeResult(
+        status=result.status,
+        returncode=0 if result.status == "success" else 1,
+        report_path=report_path,
+        receipt_path=receipt_path,
+        completion_text=result.completion_text,
+        error=result.error,
     )

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -806,7 +806,7 @@ def run_envelope_plan(
         ValueError: plan.lane is not "provider".
         EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
     """
-    from dispatch_internal import require_permit  # noqa: PLC0415
+    from dispatch_internal import is_valid_instruction_hash, require_permit  # noqa: PLC0415
 
     require_permit(plan, permit)  # un-evadable backstop — FIRST action
 
@@ -816,22 +816,37 @@ def run_envelope_plan(
             f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
         )
 
-    # P0-3: TOCTOU verification — re-read and verify sha256 before delivering
+    # P0-3 (PR-4c): REQUIRE a valid 64-hex plan hash before delivery — fail-CLOSED.
+    # The old `if plan.instruction_sha256:` guard fell OPEN on an empty hash, letting
+    # an empty-hash plan + valid permit spawn mutated content. No hash → no spawn.
+    if not is_valid_instruction_hash(plan.instruction_sha256):
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=None,
+            receipt_path=None,
+            completion_text="",
+            error=(
+                f"plan.instruction_sha256 is not a valid 64-hex digest "
+                f"(got {plan.instruction_sha256!r}); refusing to deliver (fail-closed)"
+            ),
+        )
+
+    # TOCTOU verification — re-read and verify sha256 before delivering
     instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
-    if plan.instruction_sha256:
-        actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
-        if actual != plan.instruction_sha256:
-            return EnvelopeResult(
-                status="failure",
-                returncode=1,
-                report_path=None,
-                receipt_path=None,
-                completion_text="",
-                error=(
-                    f"instruction file mutated after permit: sha256 mismatch "
-                    f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
-                ),
-            )
+    actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+    if actual != plan.instruction_sha256:
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=None,
+            receipt_path=None,
+            completion_text="",
+            error=(
+                f"instruction file mutated after permit: sha256 mismatch "
+                f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
+            ),
+        )
 
     spec = EnvelopeSpec(
         dispatch_id=plan.dispatch_id,

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -26,6 +26,7 @@ EventStore wiring and cost emission are open items for later PRs (PR-1 scope: fl
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import sys
@@ -815,7 +816,22 @@ def run_envelope_plan(
             f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
         )
 
+    # P0-3: TOCTOU verification — re-read and verify sha256 before delivering
     instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+    if plan.instruction_sha256:
+        actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+        if actual != plan.instruction_sha256:
+            return EnvelopeResult(
+                status="failure",
+                returncode=1,
+                report_path=None,
+                receipt_path=None,
+                completion_text="",
+                error=(
+                    f"instruction file mutated after permit: sha256 mismatch "
+                    f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
+                ),
+            )
 
     spec = EnvelopeSpec(
         dispatch_id=plan.dispatch_id,

--- a/scripts/lib/dispatch_internal.py
+++ b/scripts/lib/dispatch_internal.py
@@ -9,6 +9,7 @@ Any plan-like object that satisfies PlanLike is accepted.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
@@ -16,6 +17,16 @@ from typing import Protocol, runtime_checkable
 # via ExecutionPermit(...) without access to this object yields a broken permit
 # that require_permit() will reject.
 _PERMIT_SENTINEL = object()
+
+# P0-3 (PR-4c): a plan's instruction hash must be a 64-char lowercase hex sha256.
+# An empty / short / non-hex value disables TOCTOU verification (fail-OPEN), so it
+# is refused at permit-mint time and again at the executor (defense-in-depth).
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def is_valid_instruction_hash(value: object) -> bool:
+    """True iff *value* is a 64-char lowercase hex sha256 digest."""
+    return isinstance(value, str) and bool(_SHA256_RE.match(value))
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +72,19 @@ class ExecutionPermit:
 # ---------------------------------------------------------------------------
 
 def issue_permit(plan: PlanLike) -> ExecutionPermit:
-    """Mint a permit for a validated plan. Called ONLY by the envelope/executor."""
+    """Mint a permit for a validated plan. Called ONLY by the envelope/executor.
+
+    P0-3 (PR-4c) defense-in-depth: refuse to mint a permit for a plan whose
+    instruction_sha256 is present but not a valid 64-hex digest. An empty/invalid
+    hash would let the executor's TOCTOU guard fall open. A missing attribute
+    (loose PlanLike used by lower-level callers) is allowed for back-compat.
+    """
+    sha = getattr(plan, "instruction_sha256", None)
+    if sha is not None and not is_valid_instruction_hash(sha):
+        raise PermissionError(
+            "cannot mint permit: plan.instruction_sha256 is not a valid 64-hex "
+            f"digest (got {sha!r}) — an empty/invalid hash disables TOCTOU verification"
+        )
     return ExecutionPermit(
         dispatch_id=plan.dispatch_id,
         plan_digest=plan.digest(),

--- a/scripts/lib/dispatch_internal.py
+++ b/scripts/lib/dispatch_internal.py
@@ -1,0 +1,77 @@
+"""dispatch_internal.py — ExecutionPermit: the un-evadable in-process gate.
+
+A lane adapter must hold a valid ExecutionPermit to execute. The permit is
+unforgeable outside this module because _PERMIT_SENTINEL is module-private.
+
+Does NOT import dispatch_plan or ExecutionPlan (those live in PR-2).
+Any plan-like object that satisfies PlanLike is accepted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+# Module-private sentinel. Cannot be reconstructed from outside — construction
+# via ExecutionPermit(...) without access to this object yields a broken permit
+# that require_permit() will reject.
+_PERMIT_SENTINEL = object()
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class PlanLike(Protocol):
+    """Structural type accepted by issue_permit / require_permit.
+
+    Any object with a dispatch_id property and a digest() method qualifies.
+    Intentionally loose so PR-1 is not coupled to the concrete ExecutionPlan
+    type introduced in PR-2.
+    """
+
+    @property
+    def dispatch_id(self) -> str: ...
+
+    def digest(self) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Permit dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExecutionPermit:
+    """Proof that a lane adapter was launched through the validated dispatch core.
+
+    Do not construct directly — use issue_permit(). A hand-constructed permit
+    without _PERMIT_SENTINEL will be rejected by require_permit().
+    """
+
+    dispatch_id: str
+    plan_digest: str
+    _sentinel: object = field(default=_PERMIT_SENTINEL, repr=False, compare=False)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def issue_permit(plan: PlanLike) -> ExecutionPermit:
+    """Mint a permit for a validated plan. Called ONLY by the envelope/executor."""
+    return ExecutionPermit(
+        dispatch_id=plan.dispatch_id,
+        plan_digest=plan.digest(),
+        _sentinel=_PERMIT_SENTINEL,
+    )
+
+
+def require_permit(plan: PlanLike, permit: ExecutionPermit) -> None:
+    """Raise PermissionError unless the permit was minted by issue_permit for THIS plan."""
+    if (
+        permit._sentinel is not _PERMIT_SENTINEL
+        or permit.plan_digest != plan.digest()
+        or permit.dispatch_id != plan.dispatch_id
+    ):
+        raise PermissionError("lane execution requires a validated dispatch plan permit")

--- a/scripts/lib/dispatch_internal.py
+++ b/scripts/lib/dispatch_internal.py
@@ -45,13 +45,15 @@ class PlanLike(Protocol):
 class ExecutionPermit:
     """Proof that a lane adapter was launched through the validated dispatch core.
 
-    Do not construct directly — use issue_permit(). A hand-constructed permit
-    without _PERMIT_SENTINEL will be rejected by require_permit().
+    Do not construct directly — use issue_permit(). The _sentinel field defaults
+    to None (deliberately a non-matching value), so any permit built via the public
+    constructor without explicit _sentinel access is rejected by require_permit().
+    Only issue_permit() attaches the real _PERMIT_SENTINEL.
     """
 
     dispatch_id: str
     plan_digest: str
-    _sentinel: object = field(default=_PERMIT_SENTINEL, repr=False, compare=False)
+    _sentinel: object = field(default=None, repr=False, compare=False)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/dispatch_internal.py
+++ b/scripts/lib/dispatch_internal.py
@@ -18,15 +18,20 @@ from typing import Protocol, runtime_checkable
 # that require_permit() will reject.
 _PERMIT_SENTINEL = object()
 
-# P0-3 (PR-4c): a plan's instruction hash must be a 64-char lowercase hex sha256.
-# An empty / short / non-hex value disables TOCTOU verification (fail-OPEN), so it
-# is refused at permit-mint time and again at the executor (defense-in-depth).
-_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+# P0-3 (PR-4c) / PR-4d: a plan's instruction hash must be EXACTLY a 64-char
+# lowercase hex sha256. An empty / short / non-hex value disables TOCTOU
+# verification (fail-OPEN), so it is refused at permit-mint time, at the gate, and
+# again at the executor (defense-in-depth).
+#
+# PR-4d: the earlier `^[0-9a-f]{64}$` accepted a trailing newline — `$` matches
+# just before a final `\n`, so a `<64hex>\n` value passed. `fullmatch` anchors
+# both ends with no newline exception.
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
 
 
 def is_valid_instruction_hash(value: object) -> bool:
-    """True iff *value* is a 64-char lowercase hex sha256 digest."""
-    return isinstance(value, str) and bool(_SHA256_RE.match(value))
+    """True iff *value* is exactly a 64-char lowercase hex sha256 (no trailing newline)."""
+    return isinstance(value, str) and _SHA256_RE.fullmatch(value) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -37,13 +42,17 @@ def is_valid_instruction_hash(value: object) -> bool:
 class PlanLike(Protocol):
     """Structural type accepted by issue_permit / require_permit.
 
-    Any object with a dispatch_id property and a digest() method qualifies.
-    Intentionally loose so PR-1 is not coupled to the concrete ExecutionPlan
-    type introduced in PR-2.
+    Any object with a dispatch_id, a 64-hex instruction_sha256, and a digest()
+    method qualifies. PR-4d makes instruction_sha256 mandatory (defense-in-depth):
+    a hashless plan disables the executors' TOCTOU verification, so the permit
+    layer refuses it at both mint and check time — execution can never be reached
+    with a plan whose content hash is missing or malformed.
     """
 
     @property
     def dispatch_id(self) -> str: ...
+
+    instruction_sha256: str
 
     def digest(self) -> str: ...
 
@@ -74,16 +83,17 @@ class ExecutionPermit:
 def issue_permit(plan: PlanLike) -> ExecutionPermit:
     """Mint a permit for a validated plan. Called ONLY by the envelope/executor.
 
-    P0-3 (PR-4c) defense-in-depth: refuse to mint a permit for a plan whose
-    instruction_sha256 is present but not a valid 64-hex digest. An empty/invalid
-    hash would let the executor's TOCTOU guard fall open. A missing attribute
-    (loose PlanLike used by lower-level callers) is allowed for back-compat.
+    PR-4d defense-in-depth: instruction_sha256 is MANDATORY. Refuse to mint a
+    permit for a plan whose instruction_sha256 is missing or not a valid 64-hex
+    digest — an empty/invalid/absent hash would let the executor's TOCTOU guard
+    fall open. There is no back-compat exception: a hashless plan never gets a
+    permit, so it can never be spawned.
     """
     sha = getattr(plan, "instruction_sha256", None)
-    if sha is not None and not is_valid_instruction_hash(sha):
+    if not is_valid_instruction_hash(sha):
         raise PermissionError(
-            "cannot mint permit: plan.instruction_sha256 is not a valid 64-hex "
-            f"digest (got {sha!r}) — an empty/invalid hash disables TOCTOU verification"
+            "cannot mint permit: plan.instruction_sha256 is missing or not a valid "
+            f"64-hex digest (got {sha!r}) — a hashless plan disables TOCTOU verification"
         )
     return ExecutionPermit(
         dispatch_id=plan.dispatch_id,
@@ -93,7 +103,18 @@ def issue_permit(plan: PlanLike) -> ExecutionPermit:
 
 
 def require_permit(plan: PlanLike, permit: ExecutionPermit) -> None:
-    """Raise PermissionError unless the permit was minted by issue_permit for THIS plan."""
+    """Raise PermissionError unless the permit was minted by issue_permit for THIS plan.
+
+    PR-4d: the plan's own instruction_sha256 must be a valid 64-hex digest —
+    checked here as well, so a hashless plan is rejected at the gate even on a
+    path that somehow holds a sentinel-bearing permit (defense-in-depth).
+    """
+    sha = getattr(plan, "instruction_sha256", None)
+    if not is_valid_instruction_hash(sha):
+        raise PermissionError(
+            "lane execution requires a plan with a valid 64-hex instruction_sha256 "
+            f"(got {sha!r}) — a hashless/invalid plan disables TOCTOU verification"
+        )
     if (
         permit._sentinel is not _PERMIT_SENTINEL
         or permit.plan_digest != plan.digest()

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -1,0 +1,246 @@
+"""dispatch_plan.py — compile_plan: pure, total routing decision function.
+
+Maps a ValidatedSpec + RuntimeSnapshot to exactly one ExecutionPlan or one Reject.
+No I/O, no env reads, no filesystem access — every side-effectful input arrives
+via the snapshot argument.
+
+PR-2 of the single-entry dispatch gate. Nothing imports this module yet.
+ADR-007 not triggered — pure in-process types only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional
+
+from dispatch_spec import (
+    DispatchPath,
+    Isolation,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot types (caller computes via I/O, compile_plan only reads)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ConstraintVerdict:
+    code: str            # e.g. "kimi-via-cli-only"
+    severity: str        # "blocking" | "warn"
+    message: str
+    override_applied: bool = False
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    constraint_verdicts: tuple[ConstraintVerdict, ...] = ()
+    staging_promoted: bool = False
+    target_health: Mapping[str, str] = field(default_factory=dict)    # target_id -> "healthy"|"unhealthy"|"offline"
+    target_capable: Mapping[str, bool] = field(default_factory=dict)  # target_id -> capability match
+    model_pins: Mapping[str, str] = field(default_factory=dict)       # target_slot -> pinned model
+    claude_serial_enabled: bool = True
+
+
+# ---------------------------------------------------------------------------
+# ExecutionPlan
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    dispatch_id: str
+    project_id: str
+    provider: Provider
+    model: str
+    lane: str                           # "claude_tmux_subscription" | "provider"
+    adapter: str                        # "tmux_claude" | "provider"
+    target_id: str                      # "ephemeral" for the leaseless claude lane
+    billing: str                        # "subscription" | "provider_metered"
+    serialization_class: Optional[str]  # "claude-tmux" | None
+    isolation: Isolation                # always Isolation.WORKTREE
+    require_worktree: bool              # always True
+    seed_materialize: bool
+    instruction_delivery: str           # always "file_ref"
+    report_contract: str                # always "required"
+    warmup: str                         # "verify_strict" (claude) | "n/a"
+    deadline_seconds: int
+    base_ref: str
+    dispatch_paths: tuple[DispatchPath, ...]
+    instruction_file: Path
+    route_reason: str                   # comma-joined rule ids, e.g. "D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12"
+    warnings: tuple[str, ...] = ()
+
+    def digest(self) -> str:
+        """Stable sha256 over the canonical, order-independent field set.
+
+        Excludes advisory warnings. Used by ExecutionPermit (satisfies PlanLike).
+        """
+        canonical = {
+            "dispatch_id": self.dispatch_id,
+            "project_id": self.project_id,
+            "provider": self.provider.value,
+            "model": self.model,
+            "lane": self.lane,
+            "adapter": self.adapter,
+            "target_id": self.target_id,
+            "billing": self.billing,
+            "serialization_class": self.serialization_class,
+            "isolation": self.isolation.value,
+            "require_worktree": self.require_worktree,
+            "seed_materialize": self.seed_materialize,
+            "instruction_delivery": self.instruction_delivery,
+            "report_contract": self.report_contract,
+            "warmup": self.warmup,
+            "deadline_seconds": self.deadline_seconds,
+            "base_ref": self.base_ref,
+            "instruction_file": str(self.instruction_file),
+            "route_reason": self.route_reason,
+            "dispatch_paths": [
+                {
+                    "path": str(dp.path),
+                    "access": dp.access.value,
+                    "materialize_at_cwd": dp.materialize_at_cwd,
+                }
+                for dp in self.dispatch_paths
+            ],
+        }
+        blob = json.dumps(canonical, sort_keys=True, ensure_ascii=True)
+        return hashlib.sha256(blob.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# compile_plan — pure, total
+# ---------------------------------------------------------------------------
+
+def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPlan | Reject:
+    """Map ValidatedSpec + RuntimeSnapshot to exactly one ExecutionPlan or one Reject.
+
+    Pure and total: no I/O, no env reads, no filesystem access. Every input
+    arrives via arguments. First failing hard rule returns a Reject; no None,
+    no fallthrough, no raise.
+    """
+    spec = vspec.spec
+    warnings: list[str] = []
+    fired: list[str] = []
+
+    # D11 — staging gate (ADR-006)
+    if not snapshot.staging_promoted:
+        return Reject("ADR-006", "dispatch rejected: staging not promoted (ADR-006 gate)")
+    fired.append("D11")
+
+    # D3 — constraint verdicts; blocking → Reject immediately; warn → collect
+    for v in snapshot.constraint_verdicts:
+        if v.severity == "blocking":
+            return Reject(v.code, v.message)
+        elif v.severity == "warn":
+            warnings.append(f"constraint-warn: {v.code}: {v.message}")
+    fired.append("D3")
+
+    # D1 — lane resolution from provider
+    provider = spec.provider
+    if provider == Provider.AUTO:
+        return Reject(
+            "unresolved-provider",
+            "AUTO must be resolved by the capability seam before compile_plan",
+        )
+    is_claude_lane = provider == Provider.CLAUDE
+    if is_claude_lane:
+        lane = "claude_tmux_subscription"
+        adapter = "tmux_claude"
+    else:
+        lane = "provider"
+        adapter = "provider"
+    fired.append("D1")
+
+    # D2 — billing
+    billing = "subscription" if is_claude_lane else "provider_metered"
+    fired.append("D2")
+
+    # D4 — model tier; warn-only pins are NOT a Reject
+    target_slot = spec.target_slot
+    if is_claude_lane:
+        pinned = snapshot.model_pins.get(target_slot)
+        requested = spec.model
+        if pinned:
+            if requested and requested != pinned:
+                warnings.append(
+                    f"model-tier: requested {requested}, pinned {pinned}"
+                    f" for {target_slot} (override-able)"
+                )
+            model = pinned
+        else:
+            model = requested or "sonnet"
+    else:
+        model = spec.model or "default"
+    fired.append("D4")
+
+    # D5 — serialization class
+    serialization_class: Optional[str]
+    if is_claude_lane and snapshot.claude_serial_enabled:
+        serialization_class = "claude-tmux"
+    else:
+        serialization_class = None
+    fired.append("D5")
+
+    # D6 — isolation; always worktree
+    isolation = Isolation.WORKTREE
+    require_worktree = True
+    fired.append("D6")
+
+    # D7 — seed materialize
+    dispatch_paths = vspec.normalized_paths
+    seed_materialize = bool(dispatch_paths) or any(dp.materialize_at_cwd for dp in dispatch_paths)
+    fired.append("D7")
+
+    # D8 — instruction delivery
+    instruction_delivery = "file_ref"
+    fired.append("D8")
+
+    # D9 — report contract
+    report_contract = "required"
+    fired.append("D9")
+
+    # D10 — warmup
+    warmup = "verify_strict" if is_claude_lane else "n/a"
+    fired.append("D10")
+
+    # D12 — target resolution; claude lane is leaseless (ephemeral), skip health checks
+    if is_claude_lane:
+        target_id = "ephemeral"
+    else:
+        target_id = spec.target_id_override or spec.target_slot
+        health = snapshot.target_health.get(target_id)
+        if health != "healthy":
+            return Reject("R-6", f"target {target_id!r} is not healthy (status={health!r})")
+        if not snapshot.target_capable.get(target_id, True):
+            return Reject("R-5", f"target {target_id!r} is not capable for this dispatch")
+    fired.append("D12")
+
+    return ExecutionPlan(
+        dispatch_id=spec.dispatch_id,
+        project_id=spec.project_id,
+        provider=provider,
+        model=model,
+        lane=lane,
+        adapter=adapter,
+        target_id=target_id,
+        billing=billing,
+        serialization_class=serialization_class,
+        isolation=isolation,
+        require_worktree=require_worktree,
+        seed_materialize=seed_materialize,
+        instruction_delivery=instruction_delivery,
+        report_contract=report_contract,
+        warmup=warmup,
+        deadline_seconds=spec.deadline_seconds,
+        base_ref=spec.base_ref,
+        dispatch_paths=dispatch_paths,
+        instruction_file=spec.instruction_file,
+        route_reason=",".join(fired),
+        warnings=tuple(warnings),
+    )

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -73,6 +73,7 @@ class ExecutionPlan:
     dispatch_paths: tuple[DispatchPath, ...]
     instruction_file: Path
     route_reason: str                   # comma-joined rule ids, e.g. "D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12"
+    instruction_sha256: str = ""        # P0-3: sha256 of instruction content at validate() time
     warnings: tuple[str, ...] = ()
 
     def digest(self) -> str:
@@ -99,6 +100,7 @@ class ExecutionPlan:
             "deadline_seconds": self.deadline_seconds,
             "base_ref": self.base_ref,
             "instruction_file": str(self.instruction_file),
+            "instruction_sha256": self.instruction_sha256,
             "route_reason": self.route_reason,
             "dispatch_paths": [
                 {
@@ -242,5 +244,6 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         dispatch_paths=dispatch_paths,
         instruction_file=spec.instruction_file,
         route_reason=",".join(fired),
+        instruction_sha256=vspec.instruction_sha256,
         warnings=tuple(warnings),
     )

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -1,0 +1,243 @@
+"""dispatch_spec.py — DispatchSpec: the typed input surface for the single-entry dispatch gate.
+
+Pure types + one validate() function. No side effects beyond reading the instruction file.
+Nothing imports this module in PR-1; it is wired in later PRs.
+
+ADR-006: provider constraint enum enforces legal routing strings.
+ADR-007: not triggered here — no new table, pure in-process types only.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class Provider(str, Enum):
+    """CLOSED set — the ONLY legal provider strings. Mirrors scripts/benchmark/models.yaml ids."""
+    AUTO              = "auto"             # capability-seam fills provider+model before planning
+    CLAUDE            = "claude"
+    CODEX             = "codex"
+    KIMI              = "kimi"             # CLI OAuth (kimi-via-cli-only)
+    GEMINI            = "gemini"
+    LITELLM_DEEPSEEK  = "litellm:deepseek"
+    LITELLM_ZAI       = "litellm:zai"      # GLM via OpenRouter (NOT direct Zhipu)
+    LITELLM_MOONSHOT  = "litellm:moonshot"  # BENCHMARK-BASELINE ONLY (prod kimi uses Provider.KIMI)
+    DEEPSEEK_HARNESS  = "deepseek-harness"
+    LOCAL_GEMMA       = "local-gemma"
+
+
+class Isolation(str, Enum):
+    WORKTREE = "worktree"  # the ONLY legal value in 1.0 — every worker spawn is isolated, fail-loud
+
+
+class PathAccess(str, Enum):
+    READ       = "read"
+    WRITE      = "write"
+    READ_WRITE = "read_write"
+    CREATE     = "create"
+
+
+# ---------------------------------------------------------------------------
+# Path type
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DispatchPath:
+    path: PurePosixPath
+    access: PathAccess = PathAccess.READ_WRITE
+    materialize_at_cwd: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Core spec
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DispatchSpec:
+    """Immutable, typed dispatch input. Produced by callers, consumed by validate()."""
+    schema_version: int
+    project_id: str
+    dispatch_id: str
+    staging_id: str
+    instruction_file: Path   # absolute path to the instruction file — NEVER inline text
+    role: str
+    target_slot: str         # "T0" | "T1" | "T2" | "T3"
+    gate: str
+    dispatch_paths: tuple[DispatchPath, ...]
+    provider: Provider = Provider.AUTO
+    model: Optional[str] = None
+    skill: Optional[str] = None
+    task_class: Optional[str] = None
+    pr_id: Optional[str] = None
+    deadline_seconds: int = 3600
+    base_ref: str = "origin/main"
+    isolation: Isolation = Isolation.WORKTREE
+    requires_mcp: bool = False
+    target_id_override: Optional[str] = None
+    tags: tuple[str, ...] = ()
+    # DERIVED-not-declared (deliberately absent): lane, billing, serialization_class
+    # — compile_plan owns them. Do not add here.
+
+
+# ---------------------------------------------------------------------------
+# Validation result types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Reject:
+    code: str     # e.g. "ADR-006", "bad-provider", "instruction-unreadable"
+    reason: str
+
+
+@dataclass(frozen=True)
+class ValidatedSpec:
+    spec: DispatchSpec
+    instruction_text: str                    # loaded from instruction_file during validate()
+    normalized_paths: tuple[DispatchPath, ...]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$")
+
+_BLOCKED_FIRST_COMPONENTS = frozenset({".git", ".vnx-data"})
+
+_VALID_TARGET_SLOTS = frozenset({"T0", "T1", "T2", "T3"})
+
+
+def _resolve_project_id() -> str:
+    return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+
+
+def _validate_dispatch_path(dp: DispatchPath) -> Optional[str]:
+    """Return an error string if the DispatchPath is invalid, else None."""
+    raw = str(dp.path)
+    if not raw or raw.strip() == "":
+        return "empty path"
+
+    p = PurePosixPath(raw)
+
+    # Reject absolute paths
+    if p.is_absolute():
+        return f"absolute path not allowed: {raw}"
+
+    parts = p.parts
+    if not parts:
+        return "empty path after normalization"
+
+    # Reject .. components anywhere
+    if ".." in parts:
+        return f"'..' component not allowed: {raw}"
+
+    # Reject blocked first-component names
+    if parts[0] in _BLOCKED_FIRST_COMPONENTS:
+        return f"path may not start with '{parts[0]}': {raw}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate(
+    spec: DispatchSpec,
+    *,
+    project_id: str,
+    repo_root: Path,
+) -> ValidatedSpec | Reject:
+    """Validate a DispatchSpec. Returns ValidatedSpec on success, Reject on first failure.
+
+    Never raises — all errors are returned as typed Reject values.
+    Existence-at-base_ref, registry validation for model, and skill presence
+    are compile_plan rules, not validated here.
+    """
+
+    # Rule 1 — schema version
+    if spec.schema_version != 1:
+        return Reject("bad-schema", f"schema_version must be 1, got {spec.schema_version!r}")
+
+    # Rule 2 — project_id must match the caller's resolved project_id
+    resolved = _resolve_project_id()
+    if spec.project_id != resolved:
+        return Reject(
+            "project-mismatch",
+            f"spec.project_id={spec.project_id!r} != resolved project_id={resolved!r}; "
+            "caller cannot redirect state to another project",
+        )
+
+    # Rule 3 — dispatch_id format
+    if not _ID_RE.match(spec.dispatch_id):
+        return Reject("bad-dispatch-id", f"dispatch_id {spec.dispatch_id!r} does not match id regex")
+
+    # Rule 4 — staging_id format (presence + format only; promotion check is a plan rule)
+    if not _ID_RE.match(spec.staging_id):
+        return Reject("bad-staging-id", f"staging_id {spec.staging_id!r} does not match id regex")
+
+    # Rule 5 — instruction_file must be absolute, regular, non-symlink, readable
+    ifile = spec.instruction_file
+    if not ifile.is_absolute():
+        return Reject("instruction-unreadable", f"instruction_file must be absolute, got {ifile}")
+    try:
+        stat = ifile.stat()
+    except OSError as exc:
+        return Reject("instruction-unreadable", f"instruction_file not accessible: {exc}")
+    import stat as stat_mod
+    if not stat_mod.S_ISREG(stat.st_mode):
+        return Reject("instruction-unreadable", f"instruction_file is not a regular file: {ifile}")
+    if ifile.is_symlink():
+        return Reject("instruction-unreadable", f"instruction_file must not be a symlink: {ifile}")
+    try:
+        instruction_text = ifile.read_text(encoding="utf-8")
+    except OSError as exc:
+        return Reject("instruction-unreadable", f"instruction_file not readable: {exc}")
+
+    # Rule 6 — DO NOT scan instruction_text for spawn tokens (claude -p, codex exec, etc.).
+    # The file-reference design already neutralizes prompt injection; a content scan would
+    # falsely reject legitimate instructions that discuss CLI invocation patterns.
+
+    # Rule 7 — role non-empty.
+    # Tight role/skill validation (against the installed skill registry) is deferred to
+    # compile_plan, which has access to runtime paths. Here we only require non-empty.
+    if not spec.role or not spec.role.strip():
+        return Reject("bad-role", "role must be a non-empty string")
+
+    # Rule 8 — target_slot
+    if spec.target_slot not in _VALID_TARGET_SLOTS:
+        return Reject("bad-target-slot", f"target_slot must be one of {sorted(_VALID_TARGET_SLOTS)}, got {spec.target_slot!r}")
+
+    # Rule 9 — provider is valid by type (it's an enum member); model format if set
+    if spec.model is not None and not spec.model.strip():
+        return Reject("bad-model", "model must be a non-empty string when set")
+
+    # Rule 10 — dispatch_paths structural validation
+    normalized: list[DispatchPath] = []
+    for dp in spec.dispatch_paths:
+        err = _validate_dispatch_path(dp)
+        if err is not None:
+            return Reject("bad-path", f"invalid dispatch_path ({err}): {dp.path}")
+        norm_p = PurePosixPath(str(dp.path))
+        normalized.append(DispatchPath(norm_p, dp.access, dp.materialize_at_cwd))
+
+    # Rule 11 — deadline bounds
+    if not (60 <= spec.deadline_seconds <= 14400):
+        return Reject(
+            "bad-deadline",
+            f"deadline_seconds must be in [60, 14400], got {spec.deadline_seconds}",
+        )
+
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=tuple(normalized),
+    )

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -204,6 +204,10 @@ def validate(
         instruction_text = ifile.read_text(encoding="utf-8")
     except OSError as exc:
         return Reject("instruction-unreadable", f"instruction_file not readable: {exc}")
+    except UnicodeDecodeError as exc:
+        # P1 (PR-4c): a non-UTF-8 instruction must Reject, not raise out of the door.
+        # The "door never panics" invariant must cover validation, not just runtime.
+        return Reject("instruction-unreadable", f"instruction_file is not valid UTF-8: {exc}")
 
     # P0-3: compute sha256 over instruction content; verify against DispatchSpec field if set
     computed_sha256 = hashlib.sha256(instruction_text.encode("utf-8")).hexdigest()

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -9,6 +9,7 @@ ADR-007: not triggered here — no new table, pure in-process types only.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from dataclasses import dataclass
@@ -83,6 +84,7 @@ class DispatchSpec:
     requires_mcp: bool = False
     target_id_override: Optional[str] = None
     tags: tuple[str, ...] = ()
+    instruction_sha256: Optional[str] = None  # P0-3: caller may pre-bind hash; validate() verifies
     # DERIVED-not-declared (deliberately absent): lane, billing, serialization_class
     # — compile_plan owns them. Do not add here.
 
@@ -102,6 +104,7 @@ class ValidatedSpec:
     spec: DispatchSpec
     instruction_text: str                    # loaded from instruction_file during validate()
     normalized_paths: tuple[DispatchPath, ...]
+    instruction_sha256: str                  # sha256 of instruction_text, computed in validate()
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +205,15 @@ def validate(
     except OSError as exc:
         return Reject("instruction-unreadable", f"instruction_file not readable: {exc}")
 
+    # P0-3: compute sha256 over instruction content; verify against DispatchSpec field if set
+    computed_sha256 = hashlib.sha256(instruction_text.encode("utf-8")).hexdigest()
+    if spec.instruction_sha256 is not None and spec.instruction_sha256 != computed_sha256:
+        return Reject(
+            "instruction-hash-mismatch",
+            f"instruction_file sha256 mismatch: spec declared {spec.instruction_sha256[:12]}…, "
+            f"computed {computed_sha256[:12]}…",
+        )
+
     # Rule 6 — DO NOT scan instruction_text for spawn tokens (claude -p, codex exec, etc.).
     # The file-reference design already neutralizes prompt injection; a content scan would
     # falsely reject legitimate instructions that discuss CLI invocation patterns.
@@ -240,4 +252,5 @@ def validate(
         spec=spec,
         instruction_text=instruction_text,
         normalized_paths=tuple(normalized),
+        instruction_sha256=computed_sha256,
     )

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Optional

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -210,6 +211,40 @@ def _model_in_registry(provider: Optional[str], sub_provider: Optional[str], mod
     return False
 
 
+# P0-1 (PR-4c): whitespace-aware Anthropic SDK detection.
+#
+# Literal-substring matching ("import anthropic" in text) was bypassable with
+# `import\tanthropic` / `import   anthropic` (tab / multiple spaces — both valid
+# Python that reached the executor). These regexes tolerate arbitrary whitespace
+# between tokens, `import anthropic as x`, and `from anthropic import ...`, while
+# `\b` word boundaries match the import shape anywhere in the text (preserving the
+# prior "flag any occurrence" contract, not just line-leading imports). IGNORECASE
+# preserves the prior lowercase-haystack behaviour.
+_ANTHROPIC_SDK_REGEXES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bimport\s+anthropic\b", re.IGNORECASE),
+    re.compile(r"\bfrom\s+anthropic\s+import\b", re.IGNORECASE),
+    re.compile(r"\banthropic\s*\.\s*Anthropic\s*\(", re.IGNORECASE),
+)
+# Literals with no internal whitespace to make regex-tolerant — matched as substrings.
+_ANTHROPIC_SDK_LITERALS: tuple[str, ...] = (
+    "@anthropic-ai/sdk",
+)
+
+
+def scan_anthropic_sdk_text(text: Optional[str]) -> bool:
+    """True if *text* references the forbidden Anthropic SDK (whitespace-aware).
+
+    Shared by the constraint engine's forbid_import rule and the dispatch_cli
+    blocking backstop so both gates apply identical, bypass-resistant matching.
+    """
+    if not text:
+        return False
+    lowered = text.lower()
+    if any(lit in lowered for lit in _ANTHROPIC_SDK_LITERALS):
+        return True
+    return any(rgx.search(text) for rgx in _ANTHROPIC_SDK_REGEXES)
+
+
 def _scan_anthropic_sdk_references(
     constraint: Mapping[str, Any],
     instruction_text: Optional[str],
@@ -225,8 +260,8 @@ def _scan_anthropic_sdk_references(
         env.get("VNX_PROVIDER_ENV", ""),
         env.get("VNX_INSTRUCTION", ""),
     ]
-    haystack = "\n".join([instruction_text or "", *env_fragments]).lower()
-    return any(str(pattern).lower() in haystack for pattern in patterns)
+    haystack = "\n".join([instruction_text or "", *env_fragments])
+    return scan_anthropic_sdk_text(haystack)
 
 
 def _violation_from_constraint(

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
+import io
 import logging
 import os
 import re
+import tokenize
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -211,38 +214,153 @@ def _model_in_registry(provider: Optional[str], sub_provider: Optional[str], mod
     return False
 
 
-# P0-1 (PR-4c): whitespace-aware Anthropic SDK detection.
+# P0 (PR-4d): robust, tokenize-based Anthropic SDK detection.
 #
-# Literal-substring matching ("import anthropic" in text) was bypassable with
-# `import\tanthropic` / `import   anthropic` (tab / multiple spaces — both valid
-# Python that reached the executor). These regexes tolerate arbitrary whitespace
-# between tokens, `import anthropic as x`, and `from anthropic import ...`, while
-# `\b` word boundaries match the import shape anywhere in the text (preserving the
-# prior "flag any occurrence" contract, not just line-leading imports). IGNORECASE
-# preserves the prior lowercase-haystack behaviour.
-_ANTHROPIC_SDK_REGEXES: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bimport\s+anthropic\b", re.IGNORECASE),
-    re.compile(r"\bfrom\s+anthropic\s+import\b", re.IGNORECASE),
-    re.compile(r"\banthropic\s*\.\s*Anthropic\s*\(", re.IGNORECASE),
-)
-# Literals with no internal whitespace to make regex-tolerant — matched as substrings.
+# The PR-4c regex-only scanner was fail-OPEN for line-continuation, submodule,
+# and dynamic import forms that still reach the executor (codex-proven, rc=0):
+#   import \<nl>    anthropic as a       (backslash line continuation)
+#   from anthropic \<nl> import Client   (continuation inside a from-import)
+#   from anthropic.client import Client  (submodule)
+#   __import__("anthropic")              (dynamic)
+#   importlib.import_module("anthropic") (dynamic)
+# Fix: tokenize the text and flag an `anthropic` NAME/STRING in any import
+# context. The tokenizer joins line-continuations, exposes submodules as the
+# first dotted NAME, and surfaces dynamic-import string args, so every form is
+# caught structurally instead of by brittle line-shape regexes.
+#
+# Non-Python / garbled instruction text (markdown with apostrophes, unbalanced
+# brackets, stray indentation) raises tokenize.TokenError / IndentationError. We
+# catch that and fall back to a line-continuation-normalized regex pass so a
+# partial/garbled snippet never silently passes the gate (fail-CLOSED).
+
+_ANTHROPIC_NAME = "anthropic"
+_DYNAMIC_IMPORT_FUNCS = frozenset({"__import__", "import_module"})
+
+# JS SDK — no internal whitespace to tolerate; matched as a literal substring.
 _ANTHROPIC_SDK_LITERALS: tuple[str, ...] = (
     "@anthropic-ai/sdk",
 )
 
+# Built-in default forbid_import patterns (mirror provider_constraints.yaml).
+# Always applied IN ADDITION to the tokenize pass so detection never depends on
+# the SSOT being present; the constraint engine overlays the YAML patterns on top
+# (so a future / second forbid_import rule is actually enforced — SSOT governs).
+_DEFAULT_ANTHROPIC_PATTERNS: tuple[str, ...] = (
+    "import anthropic",
+    "from anthropic import",
+    "anthropic.Anthropic(",
+    "@anthropic-ai/sdk",
+)
 
-def scan_anthropic_sdk_text(text: Optional[str]) -> bool:
-    """True if *text* references the forbidden Anthropic SDK (whitespace-aware).
+# Backslash line-continuation: join physical lines before the fallback / pattern
+# regexes so `import \<nl> anthropic` reads as one logical line.
+_LINE_CONT_RE = re.compile(r"\\\r?\n")
+
+# Fallback regexes — run only when tokenize cannot complete. Cover the import
+# statement shapes plus submodule (`from anthropic.x`) and the SDK call/dynamic
+# import; with continuations joined first, these also catch the continuation forms.
+_FALLBACK_SDK_REGEXES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bimport\s+anthropic\b", re.IGNORECASE),
+    re.compile(r"\bfrom\s+anthropic\b", re.IGNORECASE),
+    re.compile(r"\banthropic\s*\.\s*Anthropic\s*\(", re.IGNORECASE),
+    re.compile(r"(?:__import__|import_module)\s*\(\s*['\"]\s*anthropic", re.IGNORECASE),
+)
+
+
+@lru_cache(maxsize=256)
+def _compiled_pattern(pattern: str) -> Optional[re.Pattern[str]]:
+    r"""Compile a configured forbid_import pattern, whitespace-normalized.
+
+    Runs of whitespace in the pattern become ``\s+`` so ``import anthropic`` also
+    matches ``import\tanthropic`` / ``import   anthropic``; every other character
+    is escaped and matched literally, case-insensitively.
+    """
+    parts = pattern.split()
+    if not parts:
+        return None
+    body = r"\s+".join(re.escape(part) for part in parts)
+    return re.compile(body, re.IGNORECASE)
+
+
+def _scan_tokens_for_anthropic(text: str) -> Optional[bool]:
+    """Tokenize-based scan for an `anthropic` reference in an import context.
+
+    Returns True on a match, False if tokenization completed cleanly with no
+    match, and None if the text could not be tokenized (the caller must then run
+    the regex fallback so a garbled snippet never silently passes).
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError, ValueError):
+        return None
+
+    seq = [
+        (tok.type, tok.string)
+        for tok in tokens
+        if tok.type in (tokenize.NAME, tokenize.STRING, tokenize.OP)
+    ]
+    for i, (ttype, tstr) in enumerate(seq):
+        prev = seq[i - 1] if i > 0 else None
+        nxt = seq[i + 1] if i + 1 < len(seq) else None
+        if ttype == tokenize.NAME and tstr == _ANTHROPIC_NAME:
+            # after `import` / `from`  ->  import anthropic / from anthropic[...]
+            if prev and prev[0] == tokenize.NAME and prev[1] in ("import", "from"):
+                return True
+            # first dotted segment  ->  anthropic.client / anthropic.Anthropic(
+            preceded_by_dot = bool(prev and prev[0] == tokenize.OP and prev[1] == ".")
+            followed_by_dot = bool(nxt and nxt[0] == tokenize.OP and nxt[1] == ".")
+            if followed_by_dot and not preceded_by_dot:
+                return True
+        elif ttype == tokenize.STRING and _ANTHROPIC_NAME in tstr.lower():
+            # string arg to __import__("anthropic") / import_module("anthropic")
+            if (
+                prev and prev[0] == tokenize.OP and prev[1] == "("
+                and i >= 2
+                and seq[i - 2][0] == tokenize.NAME
+                and seq[i - 2][1] in _DYNAMIC_IMPORT_FUNCS
+            ):
+                return True
+    return False
+
+
+def scan_anthropic_sdk_text(
+    text: Optional[str],
+    patterns: Optional[list] = None,
+) -> bool:
+    """True if *text* references the forbidden Anthropic SDK.
 
     Shared by the constraint engine's forbid_import rule and the dispatch_cli
-    blocking backstop so both gates apply identical, bypass-resistant matching.
+    blocking backstop so both gates apply identical, bypass-resistant matching:
+      1. JS SDK literal substring (`@anthropic-ai/sdk`).
+      2. Robust tokenize pass (line-continuation / submodule / dynamic imports),
+         with a line-continuation-normalized regex fallback for garbled text.
+      3. Configured forbid_import patterns applied IN ADDITION — defaults to the
+         built-in set; the constraint engine passes the SSOT patterns so the YAML
+         governs (a future / second forbid_import rule is actually enforced).
     """
     if not text:
         return False
+
     lowered = text.lower()
     if any(lit in lowered for lit in _ANTHROPIC_SDK_LITERALS):
         return True
-    return any(rgx.search(text) for rgx in _ANTHROPIC_SDK_REGEXES)
+
+    token_verdict = _scan_tokens_for_anthropic(text)
+    if token_verdict is True:
+        return True
+    if token_verdict is None:
+        joined = _LINE_CONT_RE.sub(" ", text)
+        if any(rgx.search(joined) for rgx in _FALLBACK_SDK_REGEXES):
+            return True
+
+    configured = _DEFAULT_ANTHROPIC_PATTERNS if patterns is None else patterns
+    if configured:
+        joined = _LINE_CONT_RE.sub(" ", text)
+        for pat in configured:
+            rgx = _compiled_pattern(str(pat))
+            if rgx is not None and rgx.search(joined):
+                return True
+    return False
 
 
 def _scan_anthropic_sdk_references(
@@ -253,7 +371,8 @@ def _scan_anthropic_sdk_references(
     forbidden = constraint.get("forbidden_import") or {}
     patterns = forbidden.get("patterns") if isinstance(forbidden, Mapping) else None
     if not isinstance(patterns, list):
-        return False
+        # No SSOT patterns configured -> tokenize pass + built-in defaults still run.
+        patterns = None
     env_fragments = [
         env.get("VNX_WORKER_ENV", ""),
         env.get("WORKER_ENV", ""),
@@ -261,7 +380,7 @@ def _scan_anthropic_sdk_references(
         env.get("VNX_INSTRUCTION", ""),
     ]
     haystack = "\n".join([instruction_text or "", *env_fragments])
-    return scan_anthropic_sdk_text(haystack)
+    return scan_anthropic_sdk_text(haystack, patterns=patterns)
 
 
 def _violation_from_constraint(

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import subprocess
 import sys
+import textwrap
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, call, patch
 
@@ -26,6 +27,10 @@ from dispatch_cli import (
     run_dispatch,
 )
 from dispatch_internal import ExecutionPermit, issue_permit
+from providers.constraint_enforcer import (
+    ConstraintEnforcer,
+    scan_anthropic_sdk_text,
+)
 from dispatch_plan import (
     ConstraintVerdict,
     ExecutionPlan,
@@ -786,3 +791,166 @@ def test_permit_fingerprint_stable(tmp_path):
     assert fp_a1.startswith(permit_a1.plan_digest[:12])
     assert fp_a1.endswith(plan_a.dispatch_id)
     assert "-" in fp_a1
+
+
+# ---------------------------------------------------------------------------
+# PR-4d P0 — tokenize-robust SDK scanner closes the codex-proven deep forms
+# ---------------------------------------------------------------------------
+
+# codex re-probe forms that the PR-4c regex scanner let through (rc=0). Each is
+# stored inside a Python string literal (never a bare source-line import) so the
+# ADR-003 file scanner does not flag this test file.
+_CODEX_SDK_FORMS = [
+    ("line_continuation_import", "import \\\n    anthropic as a"),
+    ("line_continuation_from", "from anthropic \\\n    import Client"),
+    ("submodule_from", "from anthropic.client import Client"),
+    ("submodule_import", "import anthropic.client"),
+    ("dunder_import", '__import__("anthropic")'),
+    ("importlib_module", 'importlib.import_module("anthropic")'),
+    ("spaced_attr_call", "client = anthropic . Anthropic ( )"),
+    ("js_sdk_literal", 'const x = require("@anthropic-ai/sdk")'),
+]
+
+
+@pytest.mark.parametrize("form_id,snippet", _CODEX_SDK_FORMS, ids=[f[0] for f in _CODEX_SDK_FORMS])
+def test_scanner_blocks_codex_deep_forms(form_id, snippet):
+    """Gate #1 (shared scanner): every codex-proven deep form is detected."""
+    text = f"# Dispatch\n\n{snippet}\n"
+    assert scan_anthropic_sdk_text(text) is True, f"{form_id!r} slipped past the scanner"
+
+
+@pytest.mark.parametrize("form_id,snippet", _CODEX_SDK_FORMS, ids=[f[0] for f in _CODEX_SDK_FORMS])
+def test_constraint_engine_blocks_codex_deep_forms(form_id, snippet):
+    """Gate #2 (constraint engine): the forbid_import rule flags every deep form."""
+    text = f"# Dispatch\n\n{snippet}\n"
+    violations = ConstraintEnforcer().check_constraints(instruction_text=text)
+    assert any(v.code == "no-anthropic-sdk" for v in violations), (
+        f"constraint engine missed {form_id!r}"
+    )
+
+
+@pytest.mark.parametrize("form_id,snippet", _CODEX_SDK_FORMS, ids=[f[0] for f in _CODEX_SDK_FORMS])
+def test_dispatch_gate_blocks_codex_deep_forms(form_id, snippet, tmp_path, monkeypatch):
+    """End-to-end via run_dispatch: every codex deep form → fail-closed Reject, no spawn.
+
+    run_dispatch exercises BOTH gates inside the single door (constraint engine in
+    build_runtime_snapshot AND the blocking backstop)."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text=f"# Dispatch\n\n{snippet}\n",
+        staging_id=f"20260615-codex-{form_id.replace('_', '-')}",
+        dispatch_id=f"20260615-codex-{form_id.replace('_', '-')}",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, f"Expected fail-closed Reject for {form_id!r}"
+    mock_execute.assert_not_called()
+
+
+def test_scanner_allows_clean_prose_with_anthropic_word():
+    """Sanity: prose mentioning 'anthropic' without an import shape is not flagged."""
+    text = "# Dispatch\n\nDocument the anthropic routing policy clearly.\n"
+    assert scan_anthropic_sdk_text(text) is False
+
+
+def test_scanner_handles_garbled_non_python_text():
+    """Garbled text that breaks tokenization (unbalanced brackets) must not crash the
+    scanner and must still catch a hidden import via the regex fallback (fail-CLOSED)."""
+    garbled = "Broken markdown with [an unbalanced bracket and (paren\nimport anthropic\n"
+    assert scan_anthropic_sdk_text(garbled) is True
+    benign_garbled = "Broken markdown with [an unbalanced bracket and (paren only\n"
+    assert scan_anthropic_sdk_text(benign_garbled) is False
+
+
+# ---------------------------------------------------------------------------
+# PR-4d P2 — the SSOT (provider_constraints.yaml) patterns are authoritative
+# ---------------------------------------------------------------------------
+
+def test_ssot_forbid_import_pattern_is_authoritative(tmp_path):
+    """A forbid_import pattern configured ONLY in the YAML must be enforced — proving
+    the SSOT governs and the scanner is not limited to a hard-coded list."""
+    custom = tmp_path / "constraints.yaml"
+    custom.write_text(
+        textwrap.dedent(
+            """\
+            version: 1
+            constraints:
+              - id: no-anthropic-sdk
+                rule: forbid_import
+                forbidden_import:
+                  patterns:
+                    - "vnx_probe_forbidden_marker"
+                reason: SSOT-authoritative probe
+                enforcement: ci_grep
+                audit_severity: blocking
+                override_allowed: false
+            """
+        ),
+        encoding="utf-8",
+    )
+    probe = "benign instruction containing vnx_probe_forbidden_marker inline"
+
+    # Configured-pattern enforcer flags the marker...
+    violations = ConstraintEnforcer(path=custom).check_constraints(instruction_text=probe)
+    assert any(v.code == "no-anthropic-sdk" for v in violations), (
+        "configured SSOT pattern was not enforced"
+    )
+
+    # ...while the real SSOT (no such pattern) does NOT — confirming the match came
+    # from the configured pattern, not a built-in default.
+    control = ConstraintEnforcer().check_constraints(instruction_text=probe)
+    assert not any(v.code == "no-anthropic-sdk" for v in control)
+
+
+# ---------------------------------------------------------------------------
+# PR-4d — dispatches-level symlink escape is rejected (kimi P2-2 regression)
+# ---------------------------------------------------------------------------
+
+def test_symlinked_dispatches_dir_rejected(tmp_path, monkeypatch, capsys):
+    """kimi P2-2: symlink <data_dir>/dispatches (one level above pending) to an
+    external dir, drop a bundle in it. The pending-root anchor resolves THROUGH the
+    symlink, lands outside the data root → BLOCKING ADR-006-untrusted-root, no spawn."""
+    data_dir = tmp_path / "vnx-data"
+    data_dir.mkdir(parents=True)
+
+    external = tmp_path / "external-dispatches"
+    staging_id = "20260615-external-dispatches-bundle"
+    external_bundle = external / "pending" / staging_id
+    external_bundle.mkdir(parents=True)
+    inst = external_bundle / "instruction.md"
+    inst.write_text("# Looks clean\n\nDo something.\n", encoding="utf-8")
+
+    # Symlink the WHOLE dispatches dir (not just pending) to the external location
+    dispatches_link = data_dir / "dispatches"
+    dispatches_link.symlink_to(external, target_is_directory=True)
+
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-dispatches-symlink-probe",
+        "staging_id": staging_id,
+        "instruction_file": str(dispatches_link / "pending" / staging_id / "instruction.md"),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = dispatches_link / "pending" / staging_id / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_execute.assert_not_called()
+    assert "ADR-006-untrusted-root" in capsys.readouterr().err

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -540,6 +540,226 @@ cmd_dispatch '{dispatch_md}' --dry-run
 # test_permit_fingerprint_stable
 # ---------------------------------------------------------------------------
 
+def _make_bundle_spec(
+    tmp_path: Path,
+    *,
+    instruction_text: str,
+    staging_id: str = "20260615-staging-probe",
+    dispatch_id: str = "20260615-probe-dispatch",
+    provider: str = "claude",
+) -> tuple[Path, Path]:
+    """Build a promoted bundle under <tmp>/vnx-data with the given instruction.
+
+    Returns (data_dir, spec_file). spec_file + instruction live inside the bundle so
+    the staging-binding check passes and only the edge under test can reject.
+    """
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+    inst = bundle_dir / "instruction.md"
+    inst.write_text(instruction_text, encoding="utf-8")
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": provider,
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+# ---------------------------------------------------------------------------
+# P0-1 — whitespace-bypassable SDK block is closed (fail-CLOSED)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("evil_line", [
+    "import\tanthropic",            # codex probe: tab separator
+    "import    anthropic",          # codex probe: multiple spaces
+    "import anthropic as ant",      # aliased import
+    "    import anthropic",         # leading indentation
+    "from\tanthropic import Anthropic",
+    "from  anthropic  import  Anthropic",
+    "client = anthropic . Anthropic ( )",  # spaced attribute access + call
+])
+def test_sdk_block_is_whitespace_aware(tmp_path, monkeypatch, evil_line):
+    """codex PROVED `import\\tanthropic` / `import   anthropic` slip past literal
+    substring matching. The whitespace-aware gate must Reject all of these → no spawn."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text=f"# Dispatch\n\n{evil_line}\n",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, f"Expected fail-closed Reject for {evil_line!r}"
+    mock_execute.assert_not_called()
+
+
+def test_clean_import_mentioning_anthropic_word_not_blocked(tmp_path, monkeypatch):
+    """Sanity: prose mentioning 'anthropic' without an import statement is not blocked
+    (the regex requires an import/from/SDK-call shape, not the bare word)."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Dispatch\n\nDocument the anthropic routing policy clearly.\n",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# P0-2 — symlinked pending ROOT escaping the data root is rejected (fail-CLOSED)
+# ---------------------------------------------------------------------------
+
+def test_symlinked_pending_root_rejected(tmp_path, monkeypatch, capsys):
+    """codex PROVED: symlink <data_dir>/dispatches/pending → an external dir, drop a
+    bundle there → rc=0 + staging_promoted + executor called. Anchor the pending root:
+    if it resolves outside the data root → BLOCKING ADR-006-untrusted-root, no spawn."""
+    data_dir = tmp_path / "vnx-data"
+    (data_dir / "dispatches").mkdir(parents=True)
+
+    # External bundle OUTSIDE the data root
+    external = tmp_path / "external-pending"
+    staging_id = "20260615-external-bundle"
+    external_bundle = external / staging_id
+    external_bundle.mkdir(parents=True)
+    inst = external_bundle / "instruction.md"
+    inst.write_text("# Looks clean\n\nDo something.\n", encoding="utf-8")
+
+    # Symlink the pending ROOT to the external dir (the proven attack)
+    pending_link = data_dir / "dispatches" / "pending"
+    pending_link.symlink_to(external, target_is_directory=True)
+
+    # Spec references paths THROUGH the symlinked pending root
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-symlink-probe",
+        "staging_id": staging_id,
+        "instruction_file": str(pending_link / staging_id / "instruction.md"),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = pending_link / staging_id / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_execute.assert_not_called()
+    assert "ADR-006-untrusted-root" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# P0-3 — empty-hash plan never spawns on EITHER lane (fail-CLOSED)
+# ---------------------------------------------------------------------------
+
+def test_empty_hash_plan_no_spawn_either_lane(tmp_path):
+    """codex PROVED an empty-hash plan + valid permit spawns mutated content on both
+    lanes. Defense-in-depth: issue_permit refuses to mint for an empty hash, and both
+    executors fail-closed before delivery even if require_permit were bypassed."""
+    from dataclasses import replace
+
+    instruction_file = _make_instruction(tmp_path)
+
+    claude_plan = replace(
+        _make_minimal_plan(provider=Provider.CLAUDE, instruction_file=instruction_file),
+        instruction_sha256="",
+    )
+    provider_plan = replace(
+        _make_minimal_plan(provider=Provider.CODEX, instruction_file=instruction_file),
+        instruction_sha256="",
+    )
+
+    # Defense-in-depth #4: no permit can be minted for an empty-hash plan
+    with pytest.raises(PermissionError):
+        issue_permit(claude_plan)
+    with pytest.raises(PermissionError):
+        issue_permit(provider_plan)
+
+    # Claude lane: even with require_permit bypassed, the executor refuses to spawn
+    bare_claude = ExecutionPermit(dispatch_id=claude_plan.dispatch_id, plan_digest=claude_plan.digest())
+    with patch("dispatch_cli.require_permit", lambda *a, **k: None):
+        with patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch") as mock_tmux:
+            with pytest.raises(PermissionError):
+                _execute_claude(
+                    claude_plan, bare_claude,
+                    state_dir=tmp_path / "state", data_dir=tmp_path,
+                )
+            mock_tmux.assert_not_called()
+
+    # Provider lane: even with require_permit bypassed, the envelope fails closed
+    from dispatch_envelope import run_envelope_plan
+    bare_provider = ExecutionPermit(dispatch_id=provider_plan.dispatch_id, plan_digest=provider_plan.digest())
+    with patch("dispatch_internal.require_permit", lambda *a, **k: None):
+        with patch("dispatch_envelope.ProviderAdapter.run") as mock_run:
+            result = run_envelope_plan(
+                provider_plan, bare_provider,
+                state_dir=tmp_path / "state", data_dir=tmp_path,
+            )
+            assert result.returncode != 0
+            assert result.status == "failure"
+            mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# P1 — dispatch.sh `--spec-file` with no value emits a clean error (not set -u abort)
+# ---------------------------------------------------------------------------
+
+def test_spec_file_flag_without_value_clean_error(tmp_path):
+    """Under `set -u`, a trailing `--spec-file` with no path must produce a clean gate
+    error (return 1), not an unbound-variable shell abort."""
+    dispatch_sh = _REPO_ROOT / "scripts" / "commands" / "dispatch.sh"
+    dispatches_dir = tmp_path / "dispatches"
+    dispatches_dir.mkdir()
+
+    bash_cmd = f"""
+set -eu
+VNX_HOME='{_REPO_ROOT}'
+VNX_DATA_DIR='{tmp_path}'
+VNX_DISPATCH_DIR='{dispatches_dir}'
+VNX_STATE_DIR='{tmp_path}/state'
+VNX_SINGLE_ENTRY_DISPATCH=1
+log() {{ echo "[LOG] $*"; }}
+err() {{ echo "[ERR] $*" >&2; }}
+source '{dispatch_sh}'
+cmd_dispatch --spec-file
+rc=$?
+echo "EXITCODE=$rc"
+"""
+    result = subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+    combined = result.stdout + result.stderr
+    # Clean gate error, not a bash 'unbound variable' abort
+    assert "requires a path argument" in combined, combined
+    assert "unbound variable" not in combined, combined
+
+
 def test_permit_fingerprint_stable(tmp_path):
     """Same plan → same fingerprint; different plan → different fingerprint."""
     instruction = _make_instruction(tmp_path)

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -7,6 +7,7 @@ dry-run mode, permit fingerprint stability, and legacy bash flag behavior.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -124,6 +125,13 @@ def _make_minimal_plan(
     target_id = "ephemeral" if provider == Provider.CLAUDE else "T1"
     serialization_class = "claude-tmux" if provider == Provider.CLAUDE else None
     warmup = "verify_strict" if provider == Provider.CLAUDE else "n/a"
+    # Compute sha256 from file content if the file exists, else use zero-sentinel
+    if instruction_file.exists():
+        sha256 = hashlib.sha256(
+            instruction_file.read_text(encoding="utf-8").encode("utf-8")
+        ).hexdigest()
+    else:
+        sha256 = "0" * 64
     return ExecutionPlan(
         dispatch_id=dispatch_id,
         project_id="vnx-dev",
@@ -145,6 +153,7 @@ def _make_minimal_plan(
         dispatch_paths=(),
         instruction_file=instruction_file,
         route_reason="D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12",
+        instruction_sha256=sha256,
     )
 
 
@@ -178,40 +187,75 @@ def test_dry_run_prints_plan_no_spawn(mock_tmux, mock_envelope, mock_snapshot, t
 # test_claude_runs_compile_plan_and_constraints
 # ---------------------------------------------------------------------------
 
-@patch("dispatch_cli.build_runtime_snapshot")
-@patch("dispatch_cli._execute_claude")
-def test_claude_runs_compile_plan_and_constraints(mock_execute, mock_snapshot, tmp_path):
-    """Claude lane: blocking constraint → Reject (no spawn). Clean spec → routes to _execute_claude."""
-    spec_file = _make_spec_file(tmp_path, provider="claude")
+def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
+    """Real constraint engine (no mock): instruction with `import anthropic` → Reject.
+    Clean instruction inside bundle → routes to _execute_claude."""
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260615-staging-real-test"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
 
-    # Part 1: blocking constraint verdict → compile_plan returns Reject → return 1
-    mock_snapshot.return_value = RuntimeSnapshot(
-        constraint_verdicts=(
-            ConstraintVerdict(
-                code="kimi-via-cli-only",
-                severity="blocking",
-                message="Route forbidden: Kimi models must use provider kimi.",
-                override_applied=False,
-            ),
-        ),
-        staging_promoted=True,
-        target_health={"ephemeral": "healthy"},
-        target_capable={"ephemeral": True},
-        model_pins={"T0": "opus", "T1": "sonnet", "T2": "sonnet", "T3": "sonnet"},
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    # Part 1: instruction contains `import anthropic` → blocking no-anthropic-sdk → Reject
+    evil_inst = bundle_dir / "evil_instruction.md"
+    evil_inst.write_text(
+        "# Evil dispatch\n\nimport anthropic\nclient = anthropic.Anthropic()\n",
+        encoding="utf-8",
     )
+    spec_dict = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-test-evil",
+        "staging_id": staging_id,
+        "instruction_file": str(evil_inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file_evil = bundle_dir / "dispatch-spec-evil.json"
+    spec_file_evil.write_text(json.dumps(spec_dict), encoding="utf-8")
 
-    rc = run_dispatch(spec_file)
-    assert rc == 1
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file_evil)
+
+    assert rc == 1, "Expected Reject from no-anthropic-sdk constraint"
     mock_execute.assert_not_called()
 
-    # Part 2: clean spec → routes to _execute_claude
-    mock_snapshot.return_value = _clean_snapshot()
-    mock_execute.return_value = 0
+    # Part 2: clean instruction inside bundle → routes to _execute_claude
+    clean_inst = bundle_dir / "clean_instruction.md"
+    clean_inst.write_text(
+        "# Clean dispatch\n\nDo something safe and useful.\n",
+        encoding="utf-8",
+    )
+    spec_dict2 = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-test-clean",
+        "staging_id": staging_id,
+        "instruction_file": str(clean_inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file_clean = bundle_dir / "dispatch-spec-clean.json"
+    spec_file_clean.write_text(json.dumps(spec_dict2), encoding="utf-8")
 
-    rc = run_dispatch(spec_file)
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        mock_execute.return_value = 0
+        rc = run_dispatch(spec_file_clean)
+
     assert rc == 0
     mock_execute.assert_called_once()
-    # First positional arg to _execute_claude is an ExecutionPlan
     plan_arg = mock_execute.call_args[0][0]
     assert plan_arg.lane == "claude_tmux_subscription"
     assert plan_arg.provider == Provider.CLAUDE
@@ -274,7 +318,8 @@ def test_claude_routes_to_tmux_with_permit(mock_snapshot, tmp_path):
             rc = run_dispatch(spec_file)
 
     assert rc == 0
-    mock_require.assert_called_once()
+    # P1-#6 adds require_permit in run_dispatch; _execute_claude also calls it → 2 total
+    assert mock_require.call_count == 2
     mock_tmux_dispatch.assert_called_once()
 
     # Part B: tampered permit → PermissionError raised before tmux dispatch
@@ -368,6 +413,126 @@ cmd_dispatch '{dispatch_md}' --dry-run
     combined = result.stdout + result.stderr
     assert "DRY RUN" in combined
     # Confirms NOT the single-entry gate path
+    assert "single-entry gate" not in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# test_staging_binding_required (P0-2)
+# ---------------------------------------------------------------------------
+
+def test_staging_binding_required(tmp_path, monkeypatch, capsys):
+    """spec_file or instruction_file outside bundle dir → Reject(ADR-006-binding), no spawn."""
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260615-staging-bind-test"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    # Instruction file is OUTSIDE the bundle
+    instruction_file = tmp_path / "outside_instruction.md"
+    instruction_file.write_text("# Dispatch outside bundle\n", encoding="utf-8")
+
+    # spec_file is also OUTSIDE the bundle
+    spec_data = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-binding-test",
+        "staging_id": staging_id,
+        "instruction_file": str(instruction_file),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = tmp_path / "dispatch-spec-outside.json"
+    spec_file.write_text(json.dumps(spec_data), encoding="utf-8")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_execute.assert_not_called()
+    err = capsys.readouterr().err
+    assert "ADR-006-binding" in err
+
+
+# ---------------------------------------------------------------------------
+# test_instruction_mutation_rejected (P0-3)
+# ---------------------------------------------------------------------------
+
+def test_instruction_mutation_rejected(tmp_path):
+    """Mutating instruction file after permit issuance → PermissionError (sha256 mismatch), no spawn."""
+    original_content = "# Clean dispatch\n\nDo something safe.\n"
+    instruction_file = tmp_path / "instruction.md"
+    instruction_file.write_text(original_content, encoding="utf-8")
+
+    plan = _make_minimal_plan(instruction_file=instruction_file)
+    expected_sha = hashlib.sha256(original_content.encode("utf-8")).hexdigest()
+    assert plan.instruction_sha256 == expected_sha
+
+    permit = issue_permit(plan)
+
+    # Mutate the instruction file AFTER permit is issued
+    instruction_file.write_text(
+        "import anthropic\n# Evil override injected after permit",
+        encoding="utf-8",
+    )
+
+    # _execute_claude must fail-closed: sha256 mismatch → PermissionError, no tmux spawn
+    with patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch") as mock_tmux:
+        with pytest.raises(PermissionError, match="sha256 mismatch"):
+            _execute_claude(
+                plan,
+                permit,
+                state_dir=tmp_path / "state",
+                data_dir=tmp_path,
+            )
+        mock_tmux.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_legacy_rollback
+# ---------------------------------------------------------------------------
+
+def test_legacy_rollback(tmp_path):
+    """VNX_DISPATCH_LEGACY=1 forces legacy path even when VNX_SINGLE_ENTRY_DISPATCH=1."""
+    dispatch_md = tmp_path / "test-rollback.md"
+    dispatch_md.write_text(
+        "[[TARGET:T1]]\nRole: backend-developer\nGate: human-promoted\n\nTest rollback.\n",
+        encoding="utf-8",
+    )
+
+    dispatch_sh = _REPO_ROOT / "scripts" / "commands" / "dispatch.sh"
+    dispatches_dir = tmp_path / "dispatches"
+    dispatches_dir.mkdir()
+
+    bash_cmd = f"""
+set -e
+VNX_HOME='{_REPO_ROOT}'
+VNX_DATA_DIR='{tmp_path}'
+VNX_DISPATCH_DIR='{dispatches_dir}'
+VNX_STATE_DIR='{tmp_path}/state'
+VNX_SINGLE_ENTRY_DISPATCH=1
+VNX_DISPATCH_LEGACY=1
+log() {{ echo "[LOG] $*"; }}
+err() {{ echo "[ERR] $*" >&2; }}
+source '{dispatch_sh}'
+cmd_dispatch '{dispatch_md}' --dry-run
+"""
+    result = subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+
+    assert result.returncode == 0, (
+        f"Expected legacy rollback to succeed; rc={result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "DRY RUN" in combined
+    # VNX_DISPATCH_LEGACY=1 must force the legacy path, not the single-entry gate
     assert "single-entry gate" not in combined.lower()
 
 

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -193,8 +193,8 @@ def test_dry_run_prints_plan_no_spawn(mock_tmux, mock_envelope, mock_snapshot, t
 # ---------------------------------------------------------------------------
 
 def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
-    """Real constraint engine (no mock): instruction with `import anthropic` → Reject.
-    Clean instruction inside bundle → routes to _execute_claude."""
+    """Real constraint engine (no mock): instruction with `import anthropic` → PROCEEDS (warn only).
+    SDK import is no longer a blocking verdict after PR-4e. Clean instruction → same outcome."""
     data_dir = tmp_path / "vnx-data"
     staging_id = "20260615-staging-real-test"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
@@ -203,7 +203,7 @@ def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
 
-    # Part 1: instruction contains `import anthropic` → blocking no-anthropic-sdk → Reject
+    # Part 1: instruction contains `import anthropic` → SDK is warn not blocking → dispatch proceeds
     evil_inst = bundle_dir / "evil_instruction.md"
     evil_inst.write_text(
         "# Evil dispatch\n\nimport anthropic\nclient = anthropic.Anthropic()\n",
@@ -226,11 +226,11 @@ def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
     spec_file_evil = bundle_dir / "dispatch-spec-evil.json"
     spec_file_evil.write_text(json.dumps(spec_dict), encoding="utf-8")
 
-    with patch("dispatch_cli._execute_claude") as mock_execute:
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file_evil)
 
-    assert rc == 1, "Expected Reject from no-anthropic-sdk constraint"
-    mock_execute.assert_not_called()
+    assert rc == 0, "SDK instruction must PROCEED after PR-4e (warn only, not blocking)"
+    mock_execute.assert_called_once()
 
     # Part 2: clean instruction inside bundle → routes to _execute_claude
     clean_inst = bundle_dir / "clean_instruction.md"
@@ -596,8 +596,8 @@ def _make_bundle_spec(
     "client = anthropic . Anthropic ( )",  # spaced attribute access + call
 ])
 def test_sdk_block_is_whitespace_aware(tmp_path, monkeypatch, evil_line):
-    """codex PROVED `import\\tanthropic` / `import   anthropic` slip past literal
-    substring matching. The whitespace-aware gate must Reject all of these → no spawn."""
+    """PR-4e: SDK forms (whitespace variants) are DETECTED by the scanner (warn) but no longer
+    BLOCK the dispatch — the instruction proceeds. The scanner still catches every form."""
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text=f"# Dispatch\n\n{evil_line}\n",
@@ -605,11 +605,11 @@ def test_sdk_block_is_whitespace_aware(tmp_path, monkeypatch, evil_line):
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
 
-    with patch("dispatch_cli._execute_claude") as mock_execute:
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file)
 
-    assert rc == 1, f"Expected fail-closed Reject for {evil_line!r}"
-    mock_execute.assert_not_called()
+    assert rc == 0, f"SDK form must PROCEED (warn not blocked) after PR-4e: {evil_line!r}"
+    mock_execute.assert_called_once()
 
 
 def test_clean_import_mentioning_anthropic_word_not_blocked(tmp_path, monkeypatch):
@@ -830,11 +830,12 @@ def test_constraint_engine_blocks_codex_deep_forms(form_id, snippet):
 
 
 @pytest.mark.parametrize("form_id,snippet", _CODEX_SDK_FORMS, ids=[f[0] for f in _CODEX_SDK_FORMS])
-def test_dispatch_gate_blocks_codex_deep_forms(form_id, snippet, tmp_path, monkeypatch):
-    """End-to-end via run_dispatch: every codex deep form → fail-closed Reject, no spawn.
+def test_dispatch_gate_codex_deep_forms_proceed(form_id, snippet, tmp_path, monkeypatch):
+    """PR-4e: every codex SDK deep form → dispatch PROCEEDS (warn only, not blocking).
 
-    run_dispatch exercises BOTH gates inside the single door (constraint engine in
-    build_runtime_snapshot AND the blocking backstop)."""
+    The scanner and constraint engine still DETECT the form (see test_scanner_blocks_codex_deep_forms
+    and test_constraint_engine_blocks_codex_deep_forms); the change is that the dispatch no longer
+    BLOCKS on it — the executor is reachable."""
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text=f"# Dispatch\n\n{snippet}\n",
@@ -844,11 +845,11 @@ def test_dispatch_gate_blocks_codex_deep_forms(form_id, snippet, tmp_path, monke
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
 
-    with patch("dispatch_cli._execute_claude") as mock_execute:
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file)
 
-    assert rc == 1, f"Expected fail-closed Reject for {form_id!r}"
-    mock_execute.assert_not_called()
+    assert rc == 0, f"SDK deep form must PROCEED (warn) after PR-4e: {form_id!r}"
+    mock_execute.assert_called_once()
 
 
 def test_scanner_allows_clean_prose_with_anthropic_word():
@@ -954,3 +955,111 @@ def test_symlinked_dispatches_dir_rejected(tmp_path, monkeypatch, capsys):
     assert rc == 1
     mock_execute.assert_not_called()
     assert "ADR-006-untrusted-root" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# PR-4e — SDK instruction-scan WARN (not blocking); routing constraints stay blocking
+# ---------------------------------------------------------------------------
+
+def test_sdk_instruction_proceeds_warn_not_block(tmp_path, monkeypatch):
+    """PR-4e: actual `import anthropic` in instruction → dispatch PROCEEDS (warn only).
+    The SDK scan is a signal, not a gate. rc=0 proves no blocking verdict was produced."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Task\n\nimport anthropic\nclient = anthropic.Anthropic()\n",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_exec:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0, "SDK import in instruction must PROCEED after PR-4e"
+    mock_exec.assert_called_once()
+
+
+def test_sdk_instruction_url_mention_proceeds(tmp_path, monkeypatch):
+    """PR-4e: a URL mentioning 'anthropic.com' is not an SDK import → no violation at all."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Task\n\nSee https://anthropic.com/docs for the routing policy.\n",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_exec:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_exec.assert_called_once()
+
+
+def test_sdk_violation_is_warn_not_blocking_in_constraint_engine():
+    """PR-4e: forbid_import (no-anthropic-sdk) must emit WARN severity, never blocking."""
+    violations = ConstraintEnforcer().check_constraints(
+        instruction_text="import anthropic\nclient = anthropic.Anthropic()\n"
+    )
+    sdk_violations = [v for v in violations if v.code == "no-anthropic-sdk"]
+    assert sdk_violations, "Expected a no-anthropic-sdk violation from the constraint engine"
+    assert all(v.severity == "warn" for v in sdk_violations), (
+        f"SDK violation must be warn, got {sdk_violations[0].severity!r}"
+    )
+
+
+def test_forbid_route_kimi_is_blocking_in_constraint_engine():
+    """PR-4e: forbid_route kimi-via-cli-only must remain BLOCKING severity."""
+    violations = ConstraintEnforcer().check_constraints(
+        provider="litellm:moonshot",
+        sub_provider="moonshot",
+        via="moonshot",
+    )
+    kimi_v = next((v for v in violations if v.code == "kimi-via-cli-only"), None)
+    assert kimi_v is not None, "Expected kimi-via-cli-only violation for litellm:moonshot"
+    assert kimi_v.severity == "blocking"
+
+
+def test_forbid_route_deprecated_glm_is_blocking_in_constraint_engine():
+    """PR-4e: deprecated-glm-models forbid_route must remain BLOCKING severity."""
+    violations = ConstraintEnforcer().check_constraints(
+        provider="litellm:zai",
+        sub_provider="zai",
+        model="glm-4.5",
+    )
+    glm_v = next((v for v in violations if v.code == "deprecated-glm-models"), None)
+    assert glm_v is not None, "Expected deprecated-glm-models violation for glm-4.5"
+    assert glm_v.severity == "blocking"
+
+
+def test_require_route_wrong_model_is_warn_not_block():
+    """PR-4e: require_route (t0-opus-only) with wrong model → WARN, not blocking."""
+    violations = ConstraintEnforcer().check_constraints(
+        provider="claude",
+        terminal_id="T0",
+        role="T0",
+        model="sonnet",
+    )
+    t0_v = next((v for v in violations if v.code == "t0-opus-only"), None)
+    assert t0_v is not None, "Expected t0-opus-only violation when T0 runs with sonnet"
+    assert t0_v.severity == "warn"
+
+
+def test_forbid_route_blocking_verdict_rejects_dispatch(tmp_path):
+    """PR-4e: a blocking verdict from forbid_route in the snapshot → compile_plan Rejects → rc=1."""
+    spec_file = _make_spec_file(tmp_path, provider="claude")
+    blocking_snapshot = RuntimeSnapshot(
+        constraint_verdicts=(ConstraintVerdict(
+            code="kimi-via-cli-only",
+            severity="blocking",
+            message="Route forbidden: Kimi must use the kimi CLI lane",
+        ),),
+        staging_promoted=True,
+        target_health={"ephemeral": "healthy"},
+        target_capable={"ephemeral": True},
+        model_pins={"T0": "opus", "T1": "sonnet", "T2": "sonnet", "T3": "sonnet"},
+    )
+    with patch("dispatch_cli.build_runtime_snapshot", return_value=blocking_snapshot):
+        with patch("dispatch_cli._execute_claude") as mock_exec:
+            rc = run_dispatch(spec_file)
+
+    assert rc == 1, "Blocking forbid_route verdict must cause a Reject"
+    mock_exec.assert_not_called()

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1,0 +1,403 @@
+"""test_dispatch_cli.py — Tests for dispatch_cli.run_dispatch (PR-4 single-entry gate).
+
+Tests the full gate: spec load -> validate -> snapshot -> compile_plan -> permit -> execute.
+Covers both claude and provider lanes, constraint enforcement (including claude),
+dry-run mode, permit fingerprint stability, and legacy bash flag behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import (
+    _execute_claude,
+    build_runtime_snapshot,
+    fingerprint,
+    load_spec,
+    run_dispatch,
+)
+from dispatch_internal import ExecutionPermit, issue_permit
+from dispatch_plan import (
+    ConstraintVerdict,
+    ExecutionPlan,
+    RuntimeSnapshot,
+    compile_plan,
+)
+from dispatch_spec import (
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    PathAccess,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _make_instruction(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text(
+        "# Test Dispatch\n\nRole: backend-developer\n\nDo something useful.\n",
+        encoding="utf-8",
+    )
+    return f
+
+
+def _make_spec_file(
+    tmp_path: Path,
+    *,
+    provider: str = "claude",
+    model: str | None = None,
+    target_slot: str = "T1",
+    staging_id: str = "test-stage",
+    schema_version: int = 1,
+    project_id: str = "vnx-dev",
+    dispatch_id: str = "20260615-test-dispatch",
+    extra: dict | None = None,
+) -> Path:
+    """Write a minimal dispatch-spec.json and return its path."""
+    instruction_file = _make_instruction(tmp_path)
+    spec: dict = {
+        "schema_version": schema_version,
+        "project_id": project_id,
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(instruction_file),
+        "role": "backend-developer",
+        "target_slot": target_slot,
+        "gate": "human-promoted",
+        "dispatch_paths": [
+            {"path": "scripts/test.py", "access": "read_write", "materialize_at_cwd": False}
+        ],
+        "provider": provider,
+        "model": model,
+        "deadline_seconds": 3600,
+        "base_ref": "origin/main",
+        "isolation": "worktree",
+        "requires_mcp": False,
+    }
+    if extra:
+        spec.update(extra)
+    spec_file = tmp_path / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return spec_file
+
+
+def _clean_snapshot(*, staging_promoted: bool = True) -> RuntimeSnapshot:
+    """A snapshot with no constraint violations and healthy targets."""
+    return RuntimeSnapshot(
+        constraint_verdicts=(),
+        staging_promoted=staging_promoted,
+        target_health={"ephemeral": "healthy", "T1": "healthy"},
+        target_capable={"ephemeral": True, "T1": True},
+        model_pins={"T0": "opus", "T1": "sonnet", "T2": "sonnet", "T3": "sonnet"},
+    )
+
+
+def _make_minimal_plan(
+    *,
+    provider: Provider = Provider.CLAUDE,
+    dispatch_id: str = "20260615-test-dispatch",
+    instruction_file: Path | None = None,
+) -> ExecutionPlan:
+    """Build a minimal ExecutionPlan for permit / fingerprint tests."""
+    if instruction_file is None:
+        instruction_file = Path("/tmp/instruction.md")
+    lane = "claude_tmux_subscription" if provider == Provider.CLAUDE else "provider"
+    adapter = "tmux_claude" if provider == Provider.CLAUDE else "provider"
+    billing = "subscription" if provider == Provider.CLAUDE else "provider_metered"
+    target_id = "ephemeral" if provider == Provider.CLAUDE else "T1"
+    serialization_class = "claude-tmux" if provider == Provider.CLAUDE else None
+    warmup = "verify_strict" if provider == Provider.CLAUDE else "n/a"
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=provider,
+        model="sonnet",
+        lane=lane,
+        adapter=adapter,
+        target_id=target_id,
+        billing=billing,
+        serialization_class=serialization_class,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=True,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup=warmup,
+        deadline_seconds=3600,
+        base_ref="origin/main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12",
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_dry_run_prints_plan_no_spawn
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+@patch("dispatch_envelope.run_envelope_plan")
+@patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch")
+def test_dry_run_prints_plan_no_spawn(mock_tmux, mock_envelope, mock_snapshot, tmp_path, capsys):
+    """--dry-run prints plan + fingerprint and calls NO executor."""
+    mock_snapshot.return_value = _clean_snapshot()
+    spec_file = _make_spec_file(tmp_path, provider="claude")
+
+    rc = run_dispatch(spec_file, dry_run=True)
+
+    assert rc == 0
+    mock_envelope.assert_not_called()
+    mock_tmux.assert_not_called()
+
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "fingerprint" in out
+    # dispatch_id and lane must appear in the printed plan
+    assert "20260615-test-dispatch" in out
+    assert "claude" in out
+
+
+# ---------------------------------------------------------------------------
+# test_claude_runs_compile_plan_and_constraints
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+@patch("dispatch_cli._execute_claude")
+def test_claude_runs_compile_plan_and_constraints(mock_execute, mock_snapshot, tmp_path):
+    """Claude lane: blocking constraint → Reject (no spawn). Clean spec → routes to _execute_claude."""
+    spec_file = _make_spec_file(tmp_path, provider="claude")
+
+    # Part 1: blocking constraint verdict → compile_plan returns Reject → return 1
+    mock_snapshot.return_value = RuntimeSnapshot(
+        constraint_verdicts=(
+            ConstraintVerdict(
+                code="kimi-via-cli-only",
+                severity="blocking",
+                message="Route forbidden: Kimi models must use provider kimi.",
+                override_applied=False,
+            ),
+        ),
+        staging_promoted=True,
+        target_health={"ephemeral": "healthy"},
+        target_capable={"ephemeral": True},
+        model_pins={"T0": "opus", "T1": "sonnet", "T2": "sonnet", "T3": "sonnet"},
+    )
+
+    rc = run_dispatch(spec_file)
+    assert rc == 1
+    mock_execute.assert_not_called()
+
+    # Part 2: clean spec → routes to _execute_claude
+    mock_snapshot.return_value = _clean_snapshot()
+    mock_execute.return_value = 0
+
+    rc = run_dispatch(spec_file)
+    assert rc == 0
+    mock_execute.assert_called_once()
+    # First positional arg to _execute_claude is an ExecutionPlan
+    plan_arg = mock_execute.call_args[0][0]
+    assert plan_arg.lane == "claude_tmux_subscription"
+    assert plan_arg.provider == Provider.CLAUDE
+
+
+# ---------------------------------------------------------------------------
+# test_provider_routes_to_envelope
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+@patch("dispatch_cli.run_envelope_plan")
+def test_provider_routes_to_envelope(mock_envelope, mock_snapshot, tmp_path):
+    """Codex spec → run_envelope_plan called with the plan and a valid permit."""
+    mock_snapshot.return_value = _clean_snapshot()
+
+    # run_envelope_plan returns an EnvelopeResult-like object
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_envelope.return_value = mock_result
+
+    spec_file = _make_spec_file(tmp_path, provider="codex", target_slot="T1")
+
+    rc = run_dispatch(spec_file)
+    assert rc == 0
+    mock_envelope.assert_called_once()
+
+    args, kwargs = mock_envelope.call_args
+    plan_arg, permit_arg = args[0], args[1]
+
+    # Plan must be a provider-lane plan for codex
+    assert plan_arg.lane == "provider"
+    assert plan_arg.provider == Provider.CODEX
+
+    # Permit must be valid (issued by issue_permit for this plan)
+    from dispatch_internal import require_permit
+    # Should not raise — a valid permit for the correct plan
+    require_permit(plan_arg, permit_arg)
+
+
+# ---------------------------------------------------------------------------
+# test_claude_routes_to_tmux_with_permit
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+def test_claude_routes_to_tmux_with_permit(mock_snapshot, tmp_path):
+    """Claude spec → _execute_claude calls require_permit then TmuxInteractiveDispatch.dispatch.
+    Tampered permit → PermissionError before tmux dispatch is reached.
+    """
+    mock_snapshot.return_value = _clean_snapshot()
+    instruction_file = _make_instruction(tmp_path)
+    spec_file = _make_spec_file(tmp_path, provider="claude")
+
+    # Part A: valid permit → TmuxInteractiveDispatch.dispatch called
+    mock_dispatch_result = MagicMock()
+    mock_dispatch_result.success = True
+
+    with patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+               return_value=mock_dispatch_result) as mock_tmux_dispatch:
+        with patch("dispatch_cli.require_permit") as mock_require:
+            rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_require.assert_called_once()
+    mock_tmux_dispatch.assert_called_once()
+
+    # Part B: tampered permit → PermissionError raised before tmux dispatch
+    plan = _make_minimal_plan(instruction_file=instruction_file)
+    valid_permit = issue_permit(plan)
+
+    # Build a tampered permit: wrong plan_digest, sentinel is None (default)
+    tampered_permit = ExecutionPermit(
+        dispatch_id=plan.dispatch_id,
+        plan_digest="deadbeef" * 8,  # wrong digest
+    )
+    # _sentinel defaults to None, not _PERMIT_SENTINEL — require_permit will reject
+
+    with patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch") as mock_tmux:
+        with pytest.raises(PermissionError):
+            _execute_claude(
+                plan,
+                tampered_permit,
+                state_dir=tmp_path / "state",
+                data_dir=tmp_path,
+            )
+        mock_tmux.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_reject_on_validate_failure
+# ---------------------------------------------------------------------------
+
+def test_reject_on_validate_failure(tmp_path):
+    """Bad spec (wrong schema_version) → validate() returns Reject → return 1."""
+    spec_file = _make_spec_file(tmp_path, schema_version=99)
+
+    with patch("dispatch_cli.build_runtime_snapshot") as mock_snapshot:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_snapshot.assert_not_called()  # gate fires before snapshot
+
+
+# ---------------------------------------------------------------------------
+# test_reject_on_unpromoted_staging
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+def test_reject_on_unpromoted_staging(mock_snapshot, tmp_path):
+    """Unpromoted staging_id → compile_plan rejects (D11 gate) → return 1; no executor."""
+    mock_snapshot.return_value = _clean_snapshot(staging_promoted=False)
+    spec_file = _make_spec_file(tmp_path, provider="claude")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_flag_off_legacy_unchanged
+# ---------------------------------------------------------------------------
+
+def test_flag_off_legacy_unchanged(tmp_path):
+    """With VNX_SINGLE_ENTRY_DISPATCH unset, cmd_dispatch uses the legacy dry-run path."""
+    dispatch_md = tmp_path / "test-dispatch.md"
+    dispatch_md.write_text(
+        "[[TARGET:T1]]\nRole: backend-developer\nGate: human-promoted\n\nTest dispatch.\n",
+        encoding="utf-8",
+    )
+
+    dispatch_sh = _REPO_ROOT / "scripts" / "commands" / "dispatch.sh"
+    dispatches_dir = tmp_path / "dispatches"
+    dispatches_dir.mkdir()
+
+    bash_cmd = f"""
+set -e
+VNX_HOME='{_REPO_ROOT}'
+VNX_DATA_DIR='{tmp_path}'
+VNX_DISPATCH_DIR='{dispatches_dir}'
+VNX_STATE_DIR='{tmp_path}/state'
+log() {{ echo "[LOG] $*"; }}
+err() {{ echo "[ERR] $*" >&2; }}
+source '{dispatch_sh}'
+unset VNX_SINGLE_ENTRY_DISPATCH
+cmd_dispatch '{dispatch_md}' --dry-run
+"""
+    result = subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+
+    assert result.returncode == 0, (
+        f"Expected legacy dry-run to succeed; rc={result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "DRY RUN" in combined
+    # Confirms NOT the single-entry gate path
+    assert "single-entry gate" not in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# test_permit_fingerprint_stable
+# ---------------------------------------------------------------------------
+
+def test_permit_fingerprint_stable(tmp_path):
+    """Same plan → same fingerprint; different plan → different fingerprint."""
+    instruction = _make_instruction(tmp_path)
+
+    plan_a = _make_minimal_plan(dispatch_id="dispatch-alpha", instruction_file=instruction)
+    plan_b = _make_minimal_plan(dispatch_id="dispatch-alpha", instruction_file=instruction)
+    plan_c = _make_minimal_plan(dispatch_id="dispatch-beta", instruction_file=instruction)
+
+    permit_a1 = issue_permit(plan_a)
+    permit_a2 = issue_permit(plan_b)  # same plan content, different object
+    permit_c = issue_permit(plan_c)
+
+    fp_a1 = fingerprint(permit_a1)
+    fp_a2 = fingerprint(permit_a2)
+    fp_c = fingerprint(permit_c)
+
+    # Same plan → same fingerprint
+    assert fp_a1 == fp_a2, "Identical plans must produce identical fingerprints"
+
+    # Different dispatch_id → different fingerprint
+    assert fp_a1 != fp_c, "Plans with different dispatch_ids must produce different fingerprints"
+
+    # Fingerprint is <digest[:12]>-<dispatch_id>
+    assert fp_a1.startswith(permit_a1.plan_digest[:12])
+    assert fp_a1.endswith(plan_a.dispatch_id)
+    assert "-" in fp_a1

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -1,0 +1,415 @@
+"""test_dispatch_envelope_plan.py — Tests for PR-3: ProviderAdapter + run_envelope_plan.
+
+Covers:
+1. require_permit backstop: forged/bare permit raises PermissionError; valid permit proceeds.
+2. Non-provider lane rejection: claude_tmux_subscription → ValueError.
+3. Provider routing: each provider routes to its spawn_* fn; no _dispatch_* wrapper invoked.
+4. File-ref instruction delivery: instruction read from file, spawn receives raw text.
+5. Governance emit: _govern produces receipt line + report (real governance_emit pipeline).
+6. Legacy path unchanged: run_envelope(spec, "codex") still routes to CodexAdapter.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+from dispatch_envelope import (
+    EnvelopeGovernError,
+    EnvelopeSpec,
+    LaneRouter,
+    ProviderAdapter,
+    _AdapterResult,
+    run_envelope,
+    run_envelope_plan,
+)
+from dispatch_internal import ExecutionPermit, issue_permit
+from dispatch_plan import ExecutionPlan
+from dispatch_spec import DispatchPath, Isolation, Provider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_plan(
+    tmp_path: Path,
+    *,
+    provider: Provider = Provider.CODEX,
+    model: str = "gpt-test",
+    dispatch_id: str = "test-dispatch-pr3",
+    target_id: str = "T1",
+    instruction_file: Optional[Path] = None,
+) -> ExecutionPlan:
+    if instruction_file is None:
+        instruction_file = tmp_path / f"instruction-{provider.value.replace(':', '-')}.md"
+        instruction_file.write_text("# Test dispatch\nDo something.", encoding="utf-8")
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=provider,
+        model=model,
+        lane="provider",
+        adapter="provider",
+        target_id=target_id,
+        billing="provider_metered",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D1,D2,D3,D4,D5,D6,D7,D8,D9,D10,D11,D12",
+    )
+
+
+def _make_claude_plan(tmp_path: Path) -> ExecutionPlan:
+    instruction_file = tmp_path / "claude_inst.md"
+    instruction_file.write_text("# Claude dispatch", encoding="utf-8")
+    return ExecutionPlan(
+        dispatch_id="test-claude-dispatch",
+        project_id="vnx-dev",
+        provider=Provider.CLAUDE,
+        model="sonnet",
+        lane="claude_tmux_subscription",
+        adapter="tmux_claude",
+        target_id="ephemeral",
+        billing="subscription",
+        serialization_class="claude-tmux",
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="verify_strict",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D1,D2,D3",
+    )
+
+
+@dataclass
+class _FakeSpawnResult:
+    returncode: int = 0
+    completion_text: str = "done"
+    timed_out: bool = False
+    stopped_early: bool = False
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+    token_usage: Dict[str, Any] = field(default_factory=dict)
+
+
+def _fake_adapter_success() -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: require_permit backstop
+# ---------------------------------------------------------------------------
+
+
+def test_run_envelope_plan_requires_permit(tmp_path):
+    plan = _make_provider_plan(tmp_path)
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    # Bare permit (default _sentinel=None) must be rejected
+    bare_permit = ExecutionPermit(dispatch_id=plan.dispatch_id, plan_digest=plan.digest())
+    with pytest.raises(PermissionError):
+        run_envelope_plan(plan, bare_permit, state_dir=state_dir, data_dir=data_dir)
+
+    # Wrong digest must be rejected even if sentinel were somehow set
+    forged = ExecutionPermit(dispatch_id=plan.dispatch_id, plan_digest="bad-digest")
+    with pytest.raises(PermissionError):
+        run_envelope_plan(plan, forged, state_dir=state_dir, data_dir=data_dir)
+
+    # Valid permit: proceed (mock spawn + govern to avoid real I/O)
+    valid_permit = issue_permit(plan)
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch.object(ProviderAdapter, "run", return_value=_fake_adapter_success()):
+        with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, valid_permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success"
+    assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: non-provider lane rejection
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_provider_lane(tmp_path):
+    plan = _make_claude_plan(tmp_path)
+    permit = issue_permit(plan)
+
+    with pytest.raises(ValueError, match="provider lane"):
+        run_envelope_plan(plan, permit, state_dir=tmp_path / "state", data_dir=tmp_path / "data")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: provider routing — each provider calls its spawn, no _dispatch_* wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
+    """Each supported provider routes to its spawn_*; no _dispatch_* wrappers invoked."""
+    calls: Dict[str, Dict[str, Any]] = {}
+    litellm_calls: list = []
+
+    def _make_spawn(name):
+        def fake(*args, **kwargs):
+            calls[name] = {"args": args, "kwargs": kwargs}
+            return _FakeSpawnResult()
+        return fake
+
+    def fake_litellm(*args, **kwargs):
+        litellm_calls.append({"args": args, "kwargs": kwargs})
+        return _FakeSpawnResult()
+
+    monkeypatch.setattr("provider_spawns.codex_spawn.spawn_codex", _make_spawn("codex"))
+    monkeypatch.setattr("provider_spawns.kimi_spawn.spawn_kimi", _make_spawn("kimi"))
+    monkeypatch.setattr("provider_spawns.gemini_spawn.spawn_gemini", _make_spawn("gemini"))
+    monkeypatch.setattr("provider_spawns.litellm_spawn.spawn_litellm", fake_litellm)
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness", _make_spawn("deepseek_harness")
+    )
+    monkeypatch.setattr(
+        "provider_spawns.local_gemma_spawn.spawn_local_gemma", _make_spawn("local_gemma")
+    )
+
+    # Stub resolution helpers and token extractor to avoid registry/env access
+    monkeypatch.setattr("provider_dispatch._resolve_codex_model", lambda: "gpt-codex-test")
+    monkeypatch.setattr("provider_dispatch._resolve_kimi_model_label", lambda: "kimi-test")
+    monkeypatch.setattr("provider_dispatch._resolve_deepseek_model", lambda: "deepseek/test")
+    monkeypatch.setattr("provider_dispatch._resolve_zai_model", lambda m=None: "openrouter/glm-test")
+    monkeypatch.setattr("provider_dispatch._resolve_moonshot_model", lambda m=None: "moonshot/kimi-test")
+    monkeypatch.setattr("provider_dispatch._extract_token_usage", lambda r, p: {})
+    monkeypatch.setattr("provider_dispatch._build_lane_key", lambda b, m: f"litellm:{b}:test")
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.resolve_harness_model", lambda m: "deepseek-v4-test"
+    )
+    monkeypatch.setattr(
+        "provider_dispatch._MLX_MODEL_MAP", {"gemma-4b-local": "mlx-community/gemma-3-4b-it-4bit"}
+    )
+
+    # Track _dispatch_* calls — must all remain uncalled
+    dispatch_wrapper_called = []
+    for fn_name in [
+        "_dispatch_codex", "_dispatch_kimi", "_dispatch_gemini",
+        "_dispatch_litellm", "_dispatch_deepseek_harness", "_dispatch_local_gemma",
+    ]:
+        def _make_bad(n):
+            def _bad(*a, **k):
+                dispatch_wrapper_called.append(n)
+            return _bad
+        monkeypatch.setattr(f"provider_dispatch.{fn_name}", _make_bad(fn_name))
+
+    adapter = ProviderAdapter()
+    instruction_file = tmp_path / "inst.md"
+    instruction_file.write_text("test instruction", encoding="utf-8")
+
+    # codex
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.CODEX, model="default"), "prompt")
+    assert r.status == "success", f"codex: {r}"
+    assert "codex" in calls
+
+    # kimi
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.KIMI, model="default"), "prompt")
+    assert r.status == "success", f"kimi: {r}"
+    assert "kimi" in calls
+
+    # gemini
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.GEMINI, model="default"), "prompt")
+    assert r.status == "success", f"gemini: {r}"
+    assert "gemini" in calls
+
+    # litellm:deepseek
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_DEEPSEEK, model="default"), "prompt")
+    assert r.status == "success", f"litellm:deepseek: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:deepseek"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "deepseek"
+    assert litellm_calls[-1]["kwargs"].get("model") == "deepseek/test"
+
+    # litellm:zai — model resolved to the zai registry model
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_ZAI, model="default"), "prompt")
+    assert r.status == "success", f"litellm:zai: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:zai"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "zai"
+    assert litellm_calls[-1]["kwargs"].get("model") == "openrouter/glm-test"
+
+    # litellm:moonshot
+    litellm_calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_MOONSHOT, model="default"), "prompt")
+    assert r.status == "success", f"litellm:moonshot: {r}"
+    assert litellm_calls, "spawn_litellm not called for litellm:moonshot"
+    assert litellm_calls[-1]["kwargs"].get("sub_provider") == "moonshot"
+
+    # deepseek-harness
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.DEEPSEEK_HARNESS, model="default"), "prompt")
+    assert r.status == "success", f"deepseek-harness: {r}"
+    assert "deepseek_harness" in calls
+
+    # local-gemma
+    calls.clear()
+    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LOCAL_GEMMA, model="default"), "prompt")
+    assert r.status == "success", f"local-gemma: {r}"
+    assert "local_gemma" in calls
+
+    # No _dispatch_* wrappers must have been invoked
+    assert dispatch_wrapper_called == [], f"_dispatch_* wrappers were invoked: {dispatch_wrapper_called}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: instruction read from file (file-ref neutralises injection text)
+# ---------------------------------------------------------------------------
+
+
+def test_instruction_read_from_file(tmp_path, monkeypatch):
+    """Instruction file containing 'claude -p' is passed verbatim to spawn; no injection."""
+    raw_text = "claude -p 'rm -rf /'\n"
+    inst_file = tmp_path / "inst.md"
+    inst_file.write_text(raw_text, encoding="utf-8")
+
+    plan = _make_provider_plan(tmp_path, provider=Provider.CODEX, instruction_file=inst_file)
+    permit = issue_permit(plan)
+
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    received_prompts: list = []
+
+    def fake_codex(prompt, model, dispatch_id, terminal_id, event_writer, cwd):
+        received_prompts.append(prompt)
+        return _FakeSpawnResult()
+
+    monkeypatch.setattr("provider_spawns.codex_spawn.spawn_codex", fake_codex)
+    monkeypatch.setattr("provider_dispatch._extract_token_usage", lambda r, p: {})
+    # _prepare falls back silently (intelligence_injection not available in tests)
+
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success"
+    assert received_prompts, "spawn_codex was not called"
+    # The raw text (possibly enriched, but since intelligence_injection is absent,
+    # it equals the file content) must reach the spawn unmodified in its base form
+    assert "claude -p" in received_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 5: _govern emits receipt line + report (real governance_emit pipeline)
+# ---------------------------------------------------------------------------
+
+
+def test_govern_emits_receipt_and_report(tmp_path, monkeypatch):
+    """_govern with a tmp state_dir/data_dir produces a receipt line + report file."""
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    dispatch_id = "test-govern-emit-pr3"
+    spec = EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction="do something",
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+    fake_result = _AdapterResult(returncode=0, completion_text="all good", status="success")
+    start = end = datetime.now(timezone.utc)
+
+    report_path, receipt_path = dispatch_envelope._govern(spec, fake_result, start, end)
+
+    # Receipt line written
+    assert receipt_path is not None
+    assert receipt_path.exists()
+    receipt_text = receipt_path.read_text(encoding="utf-8")
+    assert dispatch_id in receipt_text
+
+    # Report written
+    assert report_path is not None
+    assert report_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: legacy run_envelope unchanged — CodexAdapter still routes correctly
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_run_envelope_unchanged(tmp_path, monkeypatch):
+    """run_envelope(spec, 'codex') still routes to CodexAdapter (legacy path intact)."""
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    spec = EnvelopeSpec(
+        dispatch_id="test-legacy-codex",
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction="legacy dispatch",
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    codex_adapter_calls = []
+
+    original_run = dispatch_envelope.CodexAdapter.run
+
+    def spy_run(self, spec_arg, event_writer=None, cwd=None):
+        codex_adapter_calls.append(spec_arg.dispatch_id)
+        return _AdapterResult(returncode=0, completion_text="legacy done", status="success")
+
+    monkeypatch.setattr(dispatch_envelope.CodexAdapter, "run", spy_run)
+
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    with patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+        result = run_envelope(spec, lane="codex")
+
+    assert result.status == "success"
+    assert codex_adapter_calls == ["test-legacy-codex"], (
+        f"CodexAdapter.run was not called; got: {codex_adapter_calls}"
+    )

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -10,6 +10,7 @@ Covers:
 """
 from __future__ import annotations
 
+import hashlib
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -54,6 +55,12 @@ def _make_provider_plan(
     if instruction_file is None:
         instruction_file = tmp_path / f"instruction-{provider.value.replace(':', '-')}.md"
         instruction_file.write_text("# Test dispatch\nDo something.", encoding="utf-8")
+    # PR-4c: executors now require a valid 64-hex plan hash before delivery, so a
+    # well-formed fixture plan carries the sha256 of its instruction file content
+    # (mirrors compile_plan, which always propagates it from the ValidatedSpec).
+    sha256 = hashlib.sha256(
+        instruction_file.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest()
     return ExecutionPlan(
         dispatch_id=dispatch_id,
         project_id="vnx-dev",
@@ -75,12 +82,18 @@ def _make_provider_plan(
         dispatch_paths=(),
         instruction_file=instruction_file,
         route_reason="D1,D2,D3,D4,D5,D6,D7,D8,D9,D10,D11,D12",
+        instruction_sha256=sha256,
     )
 
 
 def _make_claude_plan(tmp_path: Path) -> ExecutionPlan:
     instruction_file = tmp_path / "claude_inst.md"
     instruction_file.write_text("# Claude dispatch", encoding="utf-8")
+    # PR-4c: carry the instruction sha256 so the plan is well-formed under the
+    # executors' mandatory 64-hex hash gate (see _make_provider_plan note).
+    sha256 = hashlib.sha256(
+        instruction_file.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest()
     return ExecutionPlan(
         dispatch_id="test-claude-dispatch",
         project_id="vnx-dev",
@@ -102,6 +115,7 @@ def _make_claude_plan(tmp_path: Path) -> ExecutionPlan:
         dispatch_paths=(),
         instruction_file=instruction_file,
         route_reason="D1,D2,D3",
+        instruction_sha256=sha256,
     )
 
 

--- a/tests/test_dispatch_internal.py
+++ b/tests/test_dispatch_internal.py
@@ -20,9 +20,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 from dispatch_internal import (  # noqa: E402
     ExecutionPermit,
     PlanLike,
+    is_valid_instruction_hash,
     issue_permit,
     require_permit,
 )
+
+# A well-formed 64-char lowercase hex sha256 used as the default plan hash.
+_VALID_SHA = "a" * 64
 
 
 # ---------------------------------------------------------------------------
@@ -30,9 +34,16 @@ from dispatch_internal import (  # noqa: E402
 # ---------------------------------------------------------------------------
 
 class FakePlan:
-    def __init__(self, dispatch_id: str, digest_value: str = "abc123"):
+    def __init__(
+        self,
+        dispatch_id: str,
+        digest_value: str = "abc123",
+        instruction_sha256: str = _VALID_SHA,
+    ):
         self._dispatch_id = dispatch_id
         self._digest_value = digest_value
+        # PR-4d: PlanLike now requires a valid 64-hex instruction_sha256.
+        self.instruction_sha256 = instruction_sha256
 
     @property
     def dispatch_id(self) -> str:
@@ -143,3 +154,81 @@ class TestPlanLikeProtocol:
     def test_fake_plan_satisfies_planlike(self):
         plan = FakePlan("x")
         assert isinstance(plan, PlanLike)
+
+
+# ---------------------------------------------------------------------------
+# PR-4d — instruction_sha256 is MANDATORY at the permit layer (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+class TestInstructionHashRegex:
+    """_SHA256_RE must fullmatch — no trailing-newline escape (`$` accepted `\\n`)."""
+
+    def test_valid_64_hex_accepted(self):
+        assert is_valid_instruction_hash("a" * 64)
+        assert is_valid_instruction_hash("0123456789abcdef" * 4)
+
+    def test_trailing_newline_rejected(self):
+        # PR-4d: the old `^...$` form accepted a final \n; fullmatch does not.
+        assert not is_valid_instruction_hash("a" * 64 + "\n")
+
+    def test_too_long_rejected(self):
+        assert not is_valid_instruction_hash("a" * 65)
+
+    def test_too_short_rejected(self):
+        assert not is_valid_instruction_hash("a" * 63)
+
+    def test_uppercase_rejected(self):
+        assert not is_valid_instruction_hash("A" * 64)
+
+    def test_non_hex_rejected(self):
+        assert not is_valid_instruction_hash("g" * 64)
+
+    def test_non_str_rejected(self):
+        assert not is_valid_instruction_hash(None)
+        assert not is_valid_instruction_hash(12345)
+
+
+class TestPermitHashMandatory:
+    """A hashless / malformed-hash plan must never receive a permit nor pass the gate."""
+
+    def test_issue_permit_rejects_missing_hash(self):
+        """A plan with NO instruction_sha256 attribute is refused at mint time."""
+        class HashlessPlan:
+            @property
+            def dispatch_id(self) -> str:
+                return "dispatch-nohash"
+
+            def digest(self) -> str:
+                return "digest-nohash"
+
+        with pytest.raises(PermissionError, match="instruction_sha256"):
+            issue_permit(HashlessPlan())
+
+    def test_issue_permit_rejects_empty_hash(self):
+        plan = FakePlan("dispatch-empty", instruction_sha256="")
+        with pytest.raises(PermissionError, match="instruction_sha256"):
+            issue_permit(plan)
+
+    def test_issue_permit_rejects_newline_padded_hash(self):
+        """A 64-hex value with a trailing newline (65 chars) is rejected — no permit."""
+        plan = FakePlan("dispatch-newline", instruction_sha256="b" * 64 + "\n")
+        with pytest.raises(PermissionError, match="instruction_sha256"):
+            issue_permit(plan)
+
+    def test_require_permit_rejects_hashless_plan_even_with_sentinel(self):
+        """Even a sentinel-bearing permit cannot satisfy require_permit for a
+        plan whose own instruction_sha256 is invalid (defense-in-depth at gate)."""
+        good_plan = FakePlan("dispatch-mutate", digest_value="same-digest")
+        permit = issue_permit(good_plan)  # legitimate sentinel-bearing permit
+        # Mutate the plan's hash to an invalid value after minting.
+        bad_plan = FakePlan(
+            "dispatch-mutate", digest_value="same-digest", instruction_sha256=""
+        )
+        with pytest.raises(PermissionError, match="instruction_sha256"):
+            require_permit(bad_plan, permit)
+
+    def test_valid_hash_plan_round_trips(self):
+        """Sanity: a plan with a valid 64-hex hash mints and passes the gate."""
+        plan = FakePlan("dispatch-ok", instruction_sha256="c" * 64)
+        permit = issue_permit(plan)
+        require_permit(plan, permit)  # must not raise

--- a/tests/test_dispatch_internal.py
+++ b/tests/test_dispatch_internal.py
@@ -1,0 +1,145 @@
+"""test_dispatch_internal.py — Tests for dispatch_internal permit system.
+
+Verifies that:
+- issue_permit() mints a valid permit for a plan
+- require_permit() passes for a legitimately minted permit
+- require_permit() raises PermissionError for hand-constructed permits (missing sentinel)
+- require_permit() raises PermissionError for mismatched plan_digest
+- require_permit() raises PermissionError for mismatched dispatch_id
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from dispatch_internal import (  # noqa: E402
+    ExecutionPermit,
+    PlanLike,
+    issue_permit,
+    require_permit,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake plan — satisfies PlanLike
+# ---------------------------------------------------------------------------
+
+class FakePlan:
+    def __init__(self, dispatch_id: str, digest_value: str = "abc123"):
+        self._dispatch_id = dispatch_id
+        self._digest_value = digest_value
+
+    @property
+    def dispatch_id(self) -> str:
+        return self._dispatch_id
+
+    def digest(self) -> str:
+        return self._digest_value
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestIssuedPermitPasses:
+    def test_require_permit_passes_for_issued_permit(self):
+        plan = FakePlan("dispatch-001")
+        permit = issue_permit(plan)
+        require_permit(plan, permit)  # must not raise
+
+    def test_issued_permit_has_correct_fields(self):
+        plan = FakePlan("dispatch-002", "sha256xyz")
+        permit = issue_permit(plan)
+        assert permit.dispatch_id == "dispatch-002"
+        assert permit.plan_digest == "sha256xyz"
+
+
+# ---------------------------------------------------------------------------
+# Forgery via hand-construction (wrong/missing sentinel)
+# ---------------------------------------------------------------------------
+
+class TestHandConstructedPermitRejected:
+    def test_rejects_hand_constructed_permit_with_wrong_sentinel(self):
+        """A permit built with an arbitrary sentinel object is rejected."""
+        plan = FakePlan("dispatch-003")
+        fake_sentinel = object()
+        forged = ExecutionPermit(
+            dispatch_id="dispatch-003",
+            plan_digest=plan.digest(),
+            _sentinel=fake_sentinel,
+        )
+        with pytest.raises(PermissionError):
+            require_permit(plan, forged)
+
+    def test_rejects_hand_constructed_permit_with_default_sentinel_slot(self):
+        """Direct construction without _sentinel kwarg still inserts the module-private sentinel.
+
+        But because the module-private object is unreachable from outside the module,
+        the only way to get the real sentinel is through issue_permit(). This tests that
+        a permit constructed with the field's default (which Python resolves at class
+        definition time — i.e. _PERMIT_SENTINEL itself) would actually pass, but that
+        path is not reachable from outside since the field default IS the real sentinel.
+
+        Instead we test the observable contract: only issue_permit()-minted permits pass.
+        """
+        plan = FakePlan("dispatch-004")
+        # Hand-construct without _sentinel (uses class default = the real sentinel)
+        # This SHOULD pass because dataclass field default is the real sentinel object.
+        permit = ExecutionPermit(
+            dispatch_id=plan.dispatch_id,
+            plan_digest=plan.digest(),
+        )
+        # The sentinel default in the dataclass IS _PERMIT_SENTINEL, so this actually
+        # does succeed — which is the correct and documented behavior (the protection is
+        # against cross-module object reconstruction, not against in-module construction).
+        require_permit(plan, permit)  # must not raise — default IS the real sentinel
+
+
+# ---------------------------------------------------------------------------
+# Mismatched plan_digest
+# ---------------------------------------------------------------------------
+
+class TestMismatchedDigestRejected:
+    def test_rejects_permit_with_wrong_digest(self):
+        plan_a = FakePlan("dispatch-005", digest_value="digest-a")
+        plan_b = FakePlan("dispatch-005", digest_value="digest-b")
+        permit = issue_permit(plan_a)
+        with pytest.raises(PermissionError):
+            require_permit(plan_b, permit)
+
+    def test_rejects_permit_for_tampered_plan(self):
+        """Simulate a plan whose digest changes after permit issuance."""
+        plan = FakePlan("dispatch-006", digest_value="original")
+        permit = issue_permit(plan)
+        # Tamper: change the digest the plan returns
+        plan._digest_value = "tampered"
+        with pytest.raises(PermissionError):
+            require_permit(plan, permit)
+
+
+# ---------------------------------------------------------------------------
+# Mismatched dispatch_id
+# ---------------------------------------------------------------------------
+
+class TestMismatchedDispatchIdRejected:
+    def test_rejects_permit_for_different_dispatch_id(self):
+        plan_a = FakePlan("dispatch-007")
+        plan_b = FakePlan("dispatch-999")
+        permit = issue_permit(plan_a)
+        with pytest.raises(PermissionError):
+            require_permit(plan_b, permit)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestPlanLikeProtocol:
+    def test_fake_plan_satisfies_planlike(self):
+        plan = FakePlan("x")
+        assert isinstance(plan, PlanLike)

--- a/tests/test_dispatch_internal.py
+++ b/tests/test_dispatch_internal.py
@@ -77,27 +77,27 @@ class TestHandConstructedPermitRejected:
             require_permit(plan, forged)
 
     def test_rejects_hand_constructed_permit_with_default_sentinel_slot(self):
-        """Direct construction without _sentinel kwarg still inserts the module-private sentinel.
+        """Direct construction without _sentinel kwarg must be rejected.
 
-        But because the module-private object is unreachable from outside the module,
-        the only way to get the real sentinel is through issue_permit(). This tests that
-        a permit constructed with the field's default (which Python resolves at class
-        definition time — i.e. _PERMIT_SENTINEL itself) would actually pass, but that
-        path is not reachable from outside since the field default IS the real sentinel.
-
-        Instead we test the observable contract: only issue_permit()-minted permits pass.
+        The _sentinel field defaults to None (not the real sentinel), so any permit
+        built via the public constructor without explicit _sentinel access is rejected.
+        Only issue_permit() attaches _PERMIT_SENTINEL — that is the un-evadable backstop.
         """
         plan = FakePlan("dispatch-004")
-        # Hand-construct without _sentinel (uses class default = the real sentinel)
-        # This SHOULD pass because dataclass field default is the real sentinel object.
         permit = ExecutionPermit(
             dispatch_id=plan.dispatch_id,
             plan_digest=plan.digest(),
         )
-        # The sentinel default in the dataclass IS _PERMIT_SENTINEL, so this actually
-        # does succeed — which is the correct and documented behavior (the protection is
-        # against cross-module object reconstruction, not against in-module construction).
-        require_permit(plan, permit)  # must not raise — default IS the real sentinel
+        with pytest.raises(PermissionError):
+            require_permit(plan, permit)
+
+    def test_bare_constructed_permit_is_rejected(self):
+        """An ExecutionPermit built via the public constructor (no access to the module
+        sentinel) MUST be rejected — this is the un-evadable backstop's whole point."""
+        plan = FakePlan("dispatch-004b", "digest-bare")
+        forged = ExecutionPermit(plan.dispatch_id, plan.digest())  # no _sentinel passed
+        with pytest.raises(PermissionError):
+            require_permit(plan, forged)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -19,7 +19,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
-from dispatch_internal import issue_permit, require_permit
+from dispatch_internal import is_valid_instruction_hash, issue_permit, require_permit
 from dispatch_plan import (
     ConstraintVerdict,
     ExecutionPlan,
@@ -359,6 +359,17 @@ class TestInstructionSha256InPlan:
         assert isinstance(plan, ExecutionPlan)
         assert plan.instruction_sha256 == vspec.instruction_sha256
         assert len(plan.instruction_sha256) == 64
+
+    @pytest.mark.parametrize("provider", [p for p in Provider if p != Provider.AUTO])
+    def test_compiled_plan_hash_is_always_valid_64hex(self, provider: Provider, tmp_path: Path) -> None:
+        """P0-3 (PR-4c): a plan from compile_plan never carries an empty/invalid hash —
+        the empty default cannot flow through to an executor. Every lane is fail-closed."""
+        vspec = _make_vspec(provider=provider, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert is_valid_instruction_hash(plan.instruction_sha256), (
+            f"compile_plan produced an invalid hash for {provider.value}: {plan.instruction_sha256!r}"
+        )
 
     def test_instruction_sha256_changes_digest(self, tmp_path: Path) -> None:
         """Changing instruction_sha256 on an otherwise identical plan changes digest()."""

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -1,0 +1,344 @@
+"""test_dispatch_plan.py — Tests for compile_plan: pure, total decision function.
+
+Covers all dispatch rules D1-D12 including:
+- Plan totality: every non-AUTO provider + every target slot returns ExecutionPlan
+- AUTO rejection, staging gate, blocking constraints
+- Claude lane fields, provider lane fields
+- Model-tier pinning with warn-only overrides
+- Target health/capability gating (provider lane only)
+- Seed materialize logic
+- Digest stability and ExecutionPermit compatibility (PlanLike protocol)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_internal import issue_permit, require_permit
+from dispatch_plan import (
+    ConstraintVerdict,
+    ExecutionPlan,
+    RuntimeSnapshot,
+    compile_plan,
+)
+from dispatch_spec import (
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    PathAccess,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_instruction_file(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text("# Test instruction\n", encoding="utf-8")
+    return f
+
+
+def _make_spec(
+    *,
+    provider: Provider = Provider.CLAUDE,
+    target_slot: str = "T1",
+    model: str | None = None,
+    dispatch_paths: tuple[DispatchPath, ...] = (),
+    target_id_override: str | None = None,
+    deadline_seconds: int = 3600,
+    tmp_path: Path,
+) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-dispatch-001",
+        staging_id="staging-001",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="human-promoted",
+        dispatch_paths=dispatch_paths,
+        provider=provider,
+        model=model,
+        deadline_seconds=deadline_seconds,
+        target_id_override=target_id_override,
+    )
+
+
+def _make_vspec(
+    *,
+    provider: Provider = Provider.CLAUDE,
+    target_slot: str = "T1",
+    model: str | None = None,
+    dispatch_paths: tuple[DispatchPath, ...] = (),
+    target_id_override: str | None = None,
+    tmp_path: Path,
+) -> ValidatedSpec:
+    spec = _make_spec(
+        provider=provider,
+        target_slot=target_slot,
+        model=model,
+        dispatch_paths=dispatch_paths,
+        target_id_override=target_id_override,
+        tmp_path=tmp_path,
+    )
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text="# Test instruction\n",
+        normalized_paths=dispatch_paths,
+    )
+
+
+def _healthy_snapshot(
+    *,
+    model_pins: dict | None = None,
+    claude_serial_enabled: bool = True,
+    constraint_verdicts: tuple[ConstraintVerdict, ...] = (),
+) -> RuntimeSnapshot:
+    """Promoted snapshot with all T0-T3 slots healthy and capable."""
+    all_slots = ["T0", "T1", "T2", "T3"]
+    return RuntimeSnapshot(
+        staging_promoted=True,
+        target_health={slot: "healthy" for slot in all_slots},
+        target_capable={slot: True for slot in all_slots},
+        model_pins=model_pins or {},
+        claude_serial_enabled=claude_serial_enabled,
+        constraint_verdicts=constraint_verdicts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_plan_total
+# ---------------------------------------------------------------------------
+
+class TestPlanTotal:
+    """Every non-AUTO Provider x every target slot → ExecutionPlan; never None, never raises."""
+
+    @pytest.mark.parametrize("provider", [p for p in Provider if p != Provider.AUTO])
+    @pytest.mark.parametrize("target_slot", ["T0", "T1", "T2", "T3"])
+    def test_compile_returns_plan(self, provider: Provider, target_slot: str, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=provider, target_slot=target_slot, tmp_path=tmp_path)
+        snapshot = _healthy_snapshot()
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, ExecutionPlan), (
+            f"Expected ExecutionPlan for provider={provider.value} slot={target_slot}, got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# test_auto_rejected
+# ---------------------------------------------------------------------------
+
+class TestAutoRejected:
+    def test_auto_rejected(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.AUTO, tmp_path=tmp_path)
+        result = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(result, Reject)
+        assert result.code == "unresolved-provider"
+
+
+# ---------------------------------------------------------------------------
+# test_claude_lane
+# ---------------------------------------------------------------------------
+
+class TestClaudeLane:
+    def test_claude_lane_fields(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
+        assert plan.adapter == "tmux_claude"
+        assert plan.billing == "subscription"
+        assert plan.serialization_class == "claude-tmux"
+        assert plan.warmup == "verify_strict"
+        assert plan.target_id == "ephemeral"
+
+
+# ---------------------------------------------------------------------------
+# test_provider_lane_parallel
+# ---------------------------------------------------------------------------
+
+class TestProviderLaneParallel:
+    def test_codex_provider_lane(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "provider"
+        assert plan.adapter == "provider"
+        assert plan.serialization_class is None
+        assert plan.billing == "provider_metered"
+
+
+# ---------------------------------------------------------------------------
+# test_staging_gate
+# ---------------------------------------------------------------------------
+
+class TestStagingGate:
+    def test_staging_not_promoted_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(staging_promoted=False)
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "ADR-006"
+
+
+# ---------------------------------------------------------------------------
+# test_blocking_constraint
+# ---------------------------------------------------------------------------
+
+class TestBlockingConstraint:
+    def test_blocking_verdict_rejects(self, tmp_path: Path) -> None:
+        blocking = ConstraintVerdict(
+            code="kimi-via-cli-only",
+            severity="blocking",
+            message="Kimi must use CLI OAuth, not Moonshot API",
+        )
+        vspec = _make_vspec(tmp_path=tmp_path)
+        result = compile_plan(vspec, _healthy_snapshot(constraint_verdicts=(blocking,)))
+        assert isinstance(result, Reject)
+        assert result.code == "kimi-via-cli-only"
+
+    def test_warn_verdict_does_not_reject(self, tmp_path: Path) -> None:
+        warn = ConstraintVerdict(
+            code="t0-opus-only",
+            severity="warn",
+            message="T0 orchestrator should use opus",
+        )
+        vspec = _make_vspec(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(constraint_verdicts=(warn,)))
+        assert isinstance(plan, ExecutionPlan)
+        assert any("t0-opus-only" in w for w in plan.warnings)
+
+
+# ---------------------------------------------------------------------------
+# test_model_tier_pin
+# ---------------------------------------------------------------------------
+
+class TestModelTierPin:
+    def test_t0_pinned_to_opus(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T0", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "opus"
+        assert not any("model-tier" in w for w in plan.warnings)
+
+    def test_t0_requested_sonnet_pinned_opus_keeps_pin_and_warns(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T0", model="sonnet", tmp_path=tmp_path
+        )
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "opus"
+        assert any("model-tier" in w for w in plan.warnings)
+
+    def test_t1_pinned_to_sonnet(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T1": "sonnet"}))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# test_isolation_always_worktree
+# ---------------------------------------------------------------------------
+
+class TestIsolationAlwaysWorktree:
+    @pytest.mark.parametrize("provider", [p for p in Provider if p != Provider.AUTO])
+    def test_isolation_worktree(self, provider: Provider, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=provider, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.isolation == Isolation.WORKTREE
+        assert plan.require_worktree is True
+
+
+# ---------------------------------------------------------------------------
+# test_target_health_provider_lane
+# ---------------------------------------------------------------------------
+
+class TestTargetHealthProviderLane:
+    def test_unhealthy_target_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(
+            staging_promoted=True,
+            target_health={"T1": "unhealthy"},
+            target_capable={"T1": True},
+        )
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "R-6"
+
+    def test_incapable_target_rejects(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        snapshot = RuntimeSnapshot(
+            staging_promoted=True,
+            target_health={"T1": "healthy"},
+            target_capable={"T1": False},
+        )
+        result = compile_plan(vspec, snapshot)
+        assert isinstance(result, Reject)
+        assert result.code == "R-5"
+
+    def test_claude_lane_skips_health_check(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        # No target health/capability data — claude lane must succeed regardless
+        snapshot = RuntimeSnapshot(staging_promoted=True)
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.target_id == "ephemeral"
+
+
+# ---------------------------------------------------------------------------
+# test_seed_materialize
+# ---------------------------------------------------------------------------
+
+class TestSeedMaterialize:
+    def test_materialize_at_cwd_true(self, tmp_path: Path) -> None:
+        paths = (DispatchPath(PurePosixPath("scripts/lib"), PathAccess.READ_WRITE, True),)
+        vspec = _make_vspec(dispatch_paths=paths, tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.seed_materialize is True
+
+    def test_empty_paths_seed_false(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(dispatch_paths=(), tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.seed_materialize is False
+
+
+# ---------------------------------------------------------------------------
+# test_digest_stable_and_permit_compatible
+# ---------------------------------------------------------------------------
+
+class TestDigestStableAndPermitCompatible:
+    def test_same_plan_same_digest(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.digest() == plan.digest()
+
+    def test_changed_field_different_digest(self, tmp_path: Path) -> None:
+        snap = _healthy_snapshot()
+        vspec_claude = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        vspec_codex = _make_vspec(provider=Provider.CODEX, target_slot="T1", tmp_path=tmp_path)
+        plan_claude = compile_plan(vspec_claude, snap)
+        plan_codex = compile_plan(vspec_codex, snap)
+        assert isinstance(plan_claude, ExecutionPlan)
+        assert isinstance(plan_codex, ExecutionPlan)
+        assert plan_claude.digest() != plan_codex.digest()
+
+    def test_permit_compatible(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        permit = issue_permit(plan)
+        require_permit(plan, permit)  # must not raise PermissionError

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -11,6 +11,7 @@ Covers all dispatch rules D1-D12 including:
 """
 from __future__ import annotations
 
+import hashlib
 import sys
 from pathlib import Path, PurePosixPath
 
@@ -90,10 +91,12 @@ def _make_vspec(
         target_id_override=target_id_override,
         tmp_path=tmp_path,
     )
+    instruction_text = "# Test instruction\n"
     return ValidatedSpec(
         spec=spec,
-        instruction_text="# Test instruction\n",
+        instruction_text=instruction_text,
         normalized_paths=dispatch_paths,
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
     )
 
 
@@ -342,3 +345,60 @@ class TestDigestStableAndPermitCompatible:
         assert isinstance(plan, ExecutionPlan)
         permit = issue_permit(plan)
         require_permit(plan, permit)  # must not raise PermissionError
+
+
+# ---------------------------------------------------------------------------
+# test_instruction_sha256_in_plan
+# ---------------------------------------------------------------------------
+
+class TestInstructionSha256InPlan:
+    def test_compile_plan_sets_instruction_sha256(self, tmp_path: Path) -> None:
+        """compile_plan propagates instruction_sha256 from ValidatedSpec into ExecutionPlan."""
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.instruction_sha256 == vspec.instruction_sha256
+        assert len(plan.instruction_sha256) == 64
+
+    def test_instruction_sha256_changes_digest(self, tmp_path: Path) -> None:
+        """Changing instruction_sha256 on an otherwise identical plan changes digest()."""
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+
+        # Build a variant with a different sha256 (simulate different instruction content)
+        from dataclasses import replace
+        other_sha = hashlib.sha256(b"different content").hexdigest()
+        plan_b = replace(plan, instruction_sha256=other_sha)
+
+        assert plan.digest() != plan_b.digest(), (
+            "Plans with different instruction_sha256 must produce different digests"
+        )
+
+    def test_default_sha256_is_empty_string(self, tmp_path: Path) -> None:
+        """ExecutionPlan constructed without instruction_sha256 defaults to empty string."""
+        ifile = tmp_path / "instruction.md"
+        ifile.write_text("test", encoding="utf-8")
+        plan = ExecutionPlan(
+            dispatch_id="test-default-sha",
+            project_id="vnx-dev",
+            provider=Provider.CLAUDE,
+            model="sonnet",
+            lane="claude_tmux_subscription",
+            adapter="tmux_claude",
+            target_id="ephemeral",
+            billing="subscription",
+            serialization_class="claude-tmux",
+            isolation=Isolation.WORKTREE,
+            require_worktree=True,
+            seed_materialize=False,
+            instruction_delivery="file_ref",
+            report_contract="required",
+            warmup="verify_strict",
+            deadline_seconds=3600,
+            base_ref="origin/main",
+            dispatch_paths=(),
+            instruction_file=ifile,
+            route_reason="D1",
+        )
+        assert plan.instruction_sha256 == ""

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -336,6 +336,50 @@ class TestRule10DispatchPaths:
 
 
 # ---------------------------------------------------------------------------
+# instruction_sha256 in ValidatedSpec
+# ---------------------------------------------------------------------------
+
+class TestInstructionSha256:
+    def test_validated_spec_has_sha256(self, tmp_path, monkeypatch):
+        """validate() always populates instruction_sha256 in the returned ValidatedSpec."""
+        import hashlib
+        content = "Do the work."
+        ifile = _write_instruction(tmp_path, text=content)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        expected = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        assert result.instruction_sha256 == expected
+
+    def test_dispatch_spec_sha256_mismatch_rejects(self, tmp_path, monkeypatch):
+        """If DispatchSpec.instruction_sha256 is set and wrong, validate() returns Reject."""
+        ifile = _write_instruction(tmp_path, text="Real content here.")
+        spec = _valid_spec(ifile, instruction_sha256="0" * 64)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-hash-mismatch"
+
+    def test_dispatch_spec_sha256_correct_passes(self, tmp_path, monkeypatch):
+        """If DispatchSpec.instruction_sha256 matches the file content, validate() passes."""
+        import hashlib
+        content = "Real content here."
+        ifile = _write_instruction(tmp_path, text=content)
+        correct_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        spec = _valid_spec(ifile, instruction_sha256=correct_sha256)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert result.instruction_sha256 == correct_sha256
+
+    def test_dispatch_spec_no_sha256_skips_verification(self, tmp_path, monkeypatch):
+        """instruction_sha256=None on DispatchSpec means no pre-check; ValidatedSpec still gets sha."""
+        ifile = _write_instruction(tmp_path, text="Do the work.")
+        spec = _valid_spec(ifile, instruction_sha256=None)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert len(result.instruction_sha256) == 64  # sha256 hex digest is 64 chars
+
+
+# ---------------------------------------------------------------------------
 # Rule 11 — deadline_seconds bounds
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -1,0 +1,356 @@
+"""test_dispatch_spec.py — Tests for dispatch_spec.validate().
+
+Covers every validate() rule with a failing-case assertion on the exact Reject.code,
+plus the rule-6 design decision (instruction text containing spawn tokens still validates).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from dispatch_spec import (  # noqa: E402
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    PathAccess,
+    Provider,
+    Reject,
+    ValidatedSpec,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PROJECT_ID = "vnx-dev"  # matches VNX_PROJECT_ID default
+
+
+def _write_instruction(tmp_path: Path, text: str = "Do the work.") -> Path:
+    p = tmp_path / "instruction.md"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _valid_spec(instruction_file: Path, **overrides) -> DispatchSpec:
+    defaults: dict = dict(
+        schema_version=1,
+        project_id=_VALID_PROJECT_ID,
+        dispatch_id="20260615-test-dispatch",
+        staging_id="20260615-test-staging",
+        instruction_file=instruction_file,
+        role="backend-developer",
+        target_slot="T1",
+        gate="human-promoted",
+        dispatch_paths=(DispatchPath(PurePosixPath("scripts/lib/foo.py")),),
+    )
+    defaults.update(overrides)
+    return DispatchSpec(**defaults)
+
+
+def _do_validate(spec: DispatchSpec, monkeypatch, project_id: str = _VALID_PROJECT_ID) -> ValidatedSpec | Reject:
+    monkeypatch.setenv("VNX_PROJECT_ID", project_id)
+    return validate(spec, project_id=project_id, repo_root=Path("/fake/repo"))
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestValidSpecPasses:
+    def test_valid_spec_returns_validated_spec(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert result.spec is spec
+        assert result.instruction_text == "Do the work."
+
+    def test_validated_spec_contains_normalized_paths(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath("scripts/lib/foo.py"), PathAccess.WRITE),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert len(result.normalized_paths) == 1
+        assert str(result.normalized_paths[0].path) == "scripts/lib/foo.py"
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — schema_version
+# ---------------------------------------------------------------------------
+
+class TestRule1SchemaVersion:
+    def test_rejects_schema_version_0(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, schema_version=0)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-schema"
+
+    def test_rejects_schema_version_2(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, schema_version=2)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-schema"
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — project_id mismatch
+# ---------------------------------------------------------------------------
+
+class TestRule2ProjectMismatch:
+    def test_rejects_wrong_project_id(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, project_id="other-project")
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        result = validate(spec, project_id="other-project", repo_root=Path("/fake"))
+        # validate() resolves from env, spec.project_id=other-project != env vnx-dev
+        assert isinstance(result, Reject)
+        assert result.code == "project-mismatch"
+
+    def test_accepts_matching_project_id(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — dispatch_id format
+# ---------------------------------------------------------------------------
+
+class TestRule3DispatchId:
+    @pytest.mark.parametrize("bad_id", [
+        "",
+        "has spaces",
+        "!invalid",
+        "a" * 129,  # too long
+        "-starts-with-dash",
+    ])
+    def test_rejects_bad_dispatch_id(self, tmp_path, monkeypatch, bad_id):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_id=bad_id)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-dispatch-id"
+
+    def test_accepts_valid_dispatch_id(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_id="20260615-my.dispatch-001")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — staging_id format
+# ---------------------------------------------------------------------------
+
+class TestRule4StagingId:
+    def test_rejects_bad_staging_id(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, staging_id="!bad")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-staging-id"
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — instruction_file
+# ---------------------------------------------------------------------------
+
+class TestRule5InstructionFile:
+    def test_rejects_relative_instruction_file(self, tmp_path, monkeypatch):
+        spec = _valid_spec(Path("relative/path.md"))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-unreadable"
+
+    def test_rejects_nonexistent_instruction_file(self, tmp_path, monkeypatch):
+        spec = _valid_spec(tmp_path / "missing.md")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-unreadable"
+
+    def test_rejects_symlink_instruction_file(self, tmp_path, monkeypatch):
+        real = _write_instruction(tmp_path)
+        link = tmp_path / "link.md"
+        link.symlink_to(real)
+        spec = _valid_spec(link)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-unreadable"
+
+    def test_rejects_directory_as_instruction_file(self, tmp_path, monkeypatch):
+        spec = _valid_spec(tmp_path)  # tmp_path is a directory
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-unreadable"
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — spawn tokens in instruction text MUST still validate (design decision)
+# ---------------------------------------------------------------------------
+
+class TestRule6NoSpawnScan:
+    def test_instruction_with_spawn_tokens_still_validates(self, tmp_path, monkeypatch):
+        """Rule 6: instruction text containing 'claude -p' or 'codex exec' must NOT be rejected.
+
+        The file-reference design already neutralizes prompt injection; scanning text
+        would falsely reject legitimate instructions that discuss CLI invocation patterns.
+        """
+        ifile = _write_instruction(
+            tmp_path,
+            text="Run: claude -p 'do something'. Also: codex exec --task foo.",
+        )
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec), (
+            f"Expected ValidatedSpec but got Reject: {result}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 7 — role non-empty
+# ---------------------------------------------------------------------------
+
+class TestRule7Role:
+    def test_rejects_empty_role(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, role="")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-role"
+
+    def test_rejects_whitespace_only_role(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, role="   ")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-role"
+
+
+# ---------------------------------------------------------------------------
+# Rule 8 — target_slot
+# ---------------------------------------------------------------------------
+
+class TestRule8TargetSlot:
+    @pytest.mark.parametrize("bad_slot", ["T4", "t1", "Worker", "", "0"])
+    def test_rejects_bad_target_slot(self, tmp_path, monkeypatch, bad_slot):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, target_slot=bad_slot)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-target-slot"
+
+    @pytest.mark.parametrize("good_slot", ["T0", "T1", "T2", "T3"])
+    def test_accepts_valid_target_slots(self, tmp_path, monkeypatch, good_slot):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, target_slot=good_slot)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 9 — model format
+# ---------------------------------------------------------------------------
+
+class TestRule9Model:
+    def test_rejects_empty_model_string(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, model="")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-model"
+
+    def test_accepts_none_model(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, model=None)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    def test_accepts_nonempty_model(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, model="claude-sonnet-4-6")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 10 — dispatch_paths structural validation
+# ---------------------------------------------------------------------------
+
+class TestRule10DispatchPaths:
+    def test_rejects_absolute_path(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath("/etc/passwd")),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-path"
+
+    def test_rejects_dotdot_component(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath("scripts/../../../etc/passwd")),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-path"
+
+    def test_rejects_dotgit_prefix(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath(".git/config")),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-path"
+
+    def test_rejects_vnx_data_prefix(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath(".vnx-data/state/foo.json")),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-path"
+
+    def test_accepts_valid_paths(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath("scripts/lib/foo.py"), PathAccess.READ),
+            DispatchPath(PurePosixPath("tests/test_foo.py"), PathAccess.WRITE),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert len(result.normalized_paths) == 2
+
+
+# ---------------------------------------------------------------------------
+# Rule 11 — deadline_seconds bounds
+# ---------------------------------------------------------------------------
+
+class TestRule11Deadline:
+    @pytest.mark.parametrize("bad_deadline", [0, 59, 14401, 99999])
+    def test_rejects_out_of_range_deadline(self, tmp_path, monkeypatch, bad_deadline):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, deadline_seconds=bad_deadline)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-deadline"
+
+    @pytest.mark.parametrize("good_deadline", [60, 3600, 14400])
+    def test_accepts_boundary_deadlines(self, tmp_path, monkeypatch, good_deadline):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, deadline_seconds=good_deadline)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -194,6 +194,16 @@ class TestRule5InstructionFile:
         assert isinstance(result, Reject)
         assert result.code == "instruction-unreadable"
 
+    def test_rejects_invalid_utf8_instruction_file(self, tmp_path, monkeypatch):
+        """P1 (PR-4c): a non-UTF-8 instruction must Reject, not raise UnicodeDecodeError
+        out of the door. The 'door never panics' invariant covers validation too."""
+        ifile = tmp_path / "instruction.md"
+        ifile.write_bytes(b"# Dispatch\n\xff\xfe invalid utf-8 \x80\x81\n")
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "instruction-unreadable"
+
 
 # ---------------------------------------------------------------------------
 # Rule 6 — spawn tokens in instruction text MUST still validate (design decision)


### PR DESCRIPTION
## What
PR-4 of the enforceable single-entry dispatch refactor: **the door** (`dispatch_cli.py`). Turns a `DispatchSpec` into a governed dispatch for BOTH lanes, behind `VNX_SINGLE_ENTRY_DISPATCH` (default off → legacy path byte-identical) + a `VNX_DISPATCH_LEGACY=1` rollback. Flow: load_spec → validate → build_runtime_snapshot (constraints for BOTH lanes incl. claude) → compile_plan → issue_permit → route (provider→run_envelope_plan; claude→tmux, permit-guarded). + `--dry-run` (plan + permit fingerprint, no spawn).

This branch is the door's full history (PR-4 + hardening 4b/4c/4d/4e), gated to GREEN by a codex+kimi adversarial panel across 5 rounds.

## Security closures (codex-probed, GREEN)
- Constraints run for ALL lanes incl. claude (no L6 leak); blocking → Reject pre-spawn.
- Staging **bundle-binding** + pending-root symlink anchor (`ADR-006-binding`/`untrusted-root`) — no external bundle promotable.
- Instruction **TOCTOU**: mandatory 64-hex `instruction_sha256` in the plan + re-verify before delivery on both lanes (fullmatch).
- **ExecutionPermit** hash mandatory in `issue_permit` + `require_permit`.
- UTF-8 instruction → clean Reject; `--spec-file $2` guarded under `set -u`.
- Routing constraints (kimi-via-cli, zai-via-openrouter, deprecated-glm, deepseek-subscription) BLOCK; t0-opus/workers-sonnet warn (override-able, per SSOT).
- **no-anthropic-sdk instruction-scan is WARN-only** (operator decision): VNX is CLI-only so no dispatch path imports the SDK; account protection is structural (CLI routing) + `ci_grep` on committed code. Routing-blocking is unaffected.

## Verification
- **279 tests** pass (spec/internal/plan/envelope/cli) + ADR-003 PASS (independent T0 CI gate).
- codex re-gate: **GREEN, no findings**. kimi re-gate: **GREEN**.

## Stack / merge order
Stacked #880 → #882 → #883 → **this**. Merge after #881 (doctor/CI fix). Merge-commit/rebase, not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)