### PR TITLE
PR-5: Claude headless = explicit audited opt-in lane (+ kimi HIGH fixes, green isolation suite)

### DIFF
--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -131,6 +131,10 @@ Single-entry gate (VNX_SINGLE_ENTRY_DISPATCH=1).
   <pending-id>        Dispatch ID resolved to dispatches/pending/<id>/dispatch-spec.json
   --dry-run           Print plan + fingerprint; spawn nothing
   VNX_DISPATCH_LEGACY=1  Force legacy path even when gate is on
+
+Headless (api_metered) lane: set allow_headless=true + headless_reason in dispatch-spec.json.
+  The --adapter subprocess / VNX_ADAPTER / VNX_AUTO_ROUTE flags are LEGACY-ONLY
+  (cmd_dispatch path when VNX_SINGLE_ENTRY_DISPATCH is unset) and have no effect here.
 HELP
         return 0 ;;
       -*)
@@ -362,6 +366,8 @@ HELP
   # VNX_AUTO_ROUTE=1 overrides the bare default tmux lane so smart routing
   # is honoured. Yields to any explicit adapter choice (--adapter flag,
   # Adapter: header, or VNX_ADAPTER env).
+  # LEGACY PATH ONLY — has no effect when VNX_SINGLE_ENTRY_DISPATCH=1.
+  # For headless claude via the door, set allow_headless=true in dispatch-spec.json.
   if [[ "${VNX_AUTO_ROUTE:-0}" == "1" ]] && \
      [[ -z "$adapter_override" ]] && \
      [[ -z "$adapter_header" ]] && \

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -86,6 +86,14 @@ def _resolve_repo_root() -> Path:
 # Spec loading from JSON
 # ---------------------------------------------------------------------------
 
+def _sanitize_headless_reason(raw: object) -> "str | None":
+    """Strip newlines/control chars from headless_reason so multi-line values can't break log formatting."""
+    if not raw or not isinstance(raw, str):
+        return None
+    cleaned = _re.sub(r"[\x00-\x1f\x7f]+", " ", raw).strip()
+    return cleaned or None
+
+
 def load_spec(spec_file: Path) -> DispatchSpec:
     """Parse a DispatchSpec from a JSON dispatch-spec.json file."""
     raw = json.loads(spec_file.read_text(encoding="utf-8"))
@@ -95,7 +103,7 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         DispatchPath(
             path=PurePosixPath(str(p["path"])),
             access=PathAccess(p.get("access", "read_write")),
-            materialize_at_cwd=bool(p.get("materialize_at_cwd", False)),
+            materialize_at_cwd=p.get("materialize_at_cwd") is True,
         )
         for p in raw_paths
     )
@@ -118,12 +126,12 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         deadline_seconds=int(raw.get("deadline_seconds", 3600)),
         base_ref=str(raw.get("base_ref", "origin/main")),
         isolation=Isolation(raw.get("isolation", "worktree")),
-        requires_mcp=bool(raw.get("requires_mcp", False)),
+        requires_mcp=raw.get("requires_mcp") is True,
         target_id_override=(raw.get("target_id_override") or None),
         tags=tuple(str(t) for t in (raw.get("tags") or [])),
         instruction_sha256=(raw.get("instruction_sha256") or None),
-        allow_headless=bool(raw.get("allow_headless", False)),
-        headless_reason=(raw.get("headless_reason") or None),
+        allow_headless=raw.get("allow_headless") is True,
+        headless_reason=_sanitize_headless_reason(raw.get("headless_reason")),
     )
 
 

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -47,7 +47,7 @@ from dispatch_internal import (  # noqa: E402
     issue_permit,
     require_permit,
 )
-from dispatch_envelope import run_envelope_plan  # noqa: E402
+from dispatch_envelope import run_envelope_plan, run_envelope_headless_plan  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +122,8 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         target_id_override=(raw.get("target_id_override") or None),
         tags=tuple(str(t) for t in (raw.get("tags") or [])),
         instruction_sha256=(raw.get("instruction_sha256") or None),
+        allow_headless=bool(raw.get("allow_headless", False)),
+        headless_reason=(raw.get("headless_reason") or None),
     )
 
 
@@ -483,6 +485,23 @@ def _execute_claude(
     return 0 if result.success else 1
 
 
+def _execute_claude_headless(
+    plan: ExecutionPlan,
+    permit: ExecutionPermit,
+    *,
+    state_dir: Path,
+    data_dir: Path,
+    role: Optional[str] = None,
+) -> int:
+    """Execute a validated claude_headless plan via ClaudeSubprocessAdapter (headless api_metered).
+
+    Delegates all permit verification, TOCTOU check, and GOVERN to
+    run_envelope_headless_plan — same security contract as the provider lane.
+    """
+    result = run_envelope_headless_plan(plan, permit, state_dir=state_dir, data_dir=data_dir, role=role)
+    return result.returncode
+
+
 # ---------------------------------------------------------------------------
 # run_dispatch — the single door
 # ---------------------------------------------------------------------------
@@ -532,6 +551,14 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             return result.returncode
         elif plan.lane == "claude_tmux_subscription":
             return _execute_claude(
+                plan,
+                permit,
+                state_dir=state_dir,
+                data_dir=data_dir,
+                role=vspec.spec.role,
+            )
+        elif plan.lane == "claude_headless":
+            return _execute_claude_headless(
                 plan,
                 permit,
                 state_dir=state_dir,

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -887,3 +887,103 @@ def run_envelope_plan(
         completion_text=result.completion_text,
         error=result.error,
     )
+
+
+def run_envelope_headless_plan(
+    plan: "ExecutionPlan",
+    permit: "ExecutionPermit",
+    *,
+    state_dir: Path,
+    data_dir: Path,
+    role: Optional[str] = None,
+) -> EnvelopeResult:
+    """Execute a validated ExecutionPlan for the claude_headless lane (api_metered billing).
+
+    Headless lane routes to ClaudeSubprocessAdapter (spawn_claude, claude -p) with the
+    same require_permit + instruction-sha256 TOCTOU verify + fail-closed GOVERN as the
+    provider lane. ClaudeSubprocessAdapter is reused — not reimplemented.
+
+    Raises:
+        PermissionError: permit was not issued by issue_permit for this plan.
+        ValueError: plan.lane is not "claude_headless".
+        EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
+    """
+    from dispatch_internal import is_valid_instruction_hash, require_permit  # noqa: PLC0415
+
+    require_permit(plan, permit)  # un-evadable backstop — FIRST action
+
+    if plan.lane != "claude_headless":
+        raise ValueError(
+            f"run_envelope_headless_plan handles lane='claude_headless' only; "
+            f"got lane={plan.lane!r}"
+        )
+
+    # P0-3: REQUIRE a valid 64-hex plan hash before delivery — fail-CLOSED.
+    if not is_valid_instruction_hash(plan.instruction_sha256):
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=None,
+            receipt_path=None,
+            completion_text="",
+            error=(
+                f"plan.instruction_sha256 is not a valid 64-hex digest "
+                f"(got {plan.instruction_sha256!r}); refusing to deliver (fail-closed)"
+            ),
+        )
+
+    # TOCTOU verification — re-read and verify sha256 before delivering
+    instruction = Path(plan.instruction_file).read_text(encoding="utf-8")
+    actual = hashlib.sha256(instruction.encode("utf-8")).hexdigest()
+    if actual != plan.instruction_sha256:
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=None,
+            receipt_path=None,
+            completion_text="",
+            error=(
+                f"instruction file mutated after permit: sha256 mismatch "
+                f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
+            ),
+        )
+
+    spec = EnvelopeSpec(
+        dispatch_id=plan.dispatch_id,
+        terminal_id=plan.target_id,
+        provider="claude",
+        model=plan.model,
+        instruction=instruction,
+        role=role,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    enriched_instruction = _prepare(spec)
+    enriched_spec = EnvelopeSpec(
+        dispatch_id=spec.dispatch_id,
+        terminal_id=spec.terminal_id,
+        provider=spec.provider,
+        model=spec.model,
+        instruction=enriched_instruction,
+        role=spec.role,
+        pr_id=spec.pr_id,
+        state_dir=spec.state_dir,
+        data_dir=spec.data_dir,
+    )
+
+    start = datetime.now(timezone.utc)
+    result = ClaudeSubprocessAdapter().run(enriched_spec)
+    end = datetime.now(timezone.utc)
+
+    report_path, receipt_path = _govern(enriched_spec, result, start, end)
+
+    return EnvelopeResult(
+        status=result.status,
+        returncode=0 if result.status == "success" else 1,
+        report_path=report_path,
+        receipt_path=receipt_path,
+        completion_text=result.completion_text,
+        error=result.error,
+    )

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -151,7 +151,12 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
             "AUTO must be resolved by the capability seam before compile_plan",
         )
     is_claude_lane = provider == Provider.CLAUDE
-    if is_claude_lane:
+    is_claude_headless = is_claude_lane and spec.allow_headless
+    if is_claude_headless:
+        lane = "claude_headless"
+        adapter = "claude_subprocess"
+        warnings.append(f"HEADLESS API-billing opted-in: {spec.headless_reason}")
+    elif is_claude_lane:
         lane = "claude_tmux_subscription"
         adapter = "tmux_claude"
     else:
@@ -160,7 +165,12 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     fired.append("D1")
 
     # D2 — billing
-    billing = "subscription" if is_claude_lane else "provider_metered"
+    if is_claude_headless:
+        billing = "api_metered"
+    elif is_claude_lane:
+        billing = "subscription"
+    else:
+        billing = "provider_metered"
     fired.append("D2")
 
     # D4 — model tier; warn-only pins are NOT a Reject
@@ -181,9 +191,9 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         model = spec.model or "default"
     fired.append("D4")
 
-    # D5 — serialization class
+    # D5 — serialization class; headless lane has no tmux serial lock
     serialization_class: Optional[str]
-    if is_claude_lane and snapshot.claude_serial_enabled:
+    if is_claude_lane and not is_claude_headless and snapshot.claude_serial_enabled:
         serialization_class = "claude-tmux"
     else:
         serialization_class = None
@@ -207,8 +217,8 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     report_contract = "required"
     fired.append("D9")
 
-    # D10 — warmup
-    warmup = "verify_strict" if is_claude_lane else "n/a"
+    # D10 — warmup; headless lane has no tmux warmup
+    warmup = "verify_strict" if (is_claude_lane and not is_claude_headless) else "n/a"
     fired.append("D10")
 
     # D12 — target resolution; claude lane is leaseless (ephemeral), skip health checks

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -85,6 +85,8 @@ class DispatchSpec:
     target_id_override: Optional[str] = None
     tags: tuple[str, ...] = ()
     instruction_sha256: Optional[str] = None  # P0-3: caller may pre-bind hash; validate() verifies
+    allow_headless: bool = False              # PR-5: explicit opt-in to api_metered headless lane
+    headless_reason: Optional[str] = None    # PR-5: mandatory non-empty reason when allow_headless=True
     # DERIVED-not-declared (deliberately absent): lane, billing, serialization_class
     # — compile_plan owns them. Do not add here.
 
@@ -251,6 +253,16 @@ def validate(
             "bad-deadline",
             f"deadline_seconds must be in [60, 14400], got {spec.deadline_seconds}",
         )
+
+    # Rule 12 — headless opt-in requires a non-empty reason (PR-5)
+    if spec.allow_headless:
+        reason = (spec.headless_reason or "").strip()
+        if not reason:
+            return Reject(
+                "headless-reason-required",
+                "allow_headless=True requires a non-empty headless_reason explaining "
+                "the API billing opt-in; set headless_reason to a human-readable justification",
+            )
 
     return ValidatedSpec(
         spec=spec,

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -263,6 +263,13 @@ def validate(
                 "allow_headless=True requires a non-empty headless_reason explaining "
                 "the API billing opt-in; set headless_reason to a human-readable justification",
             )
+        # MED: headless is only valid for claude (or auto that could resolve to claude)
+        if spec.provider not in (Provider.CLAUDE, Provider.AUTO):
+            return Reject(
+                "headless-claude-only",
+                f"allow_headless is only valid for provider=claude, got provider={spec.provider.value!r}; "
+                "headless api-metered billing is a claude-only lane",
+            )
 
     return ValidatedSpec(
         spec=spec,

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1605,17 +1605,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if provider == "claude":
-        _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"
-        _envelope_lanes = [
-            lane.strip()
-            for lane in (os.environ.get("VNX_UNIFIED_ENVELOPE_LANES") or "").split(",")
-            if lane.strip()
-        ]
-        if _envelope_on and (
-            "claude-subprocess" in _envelope_lanes or "claude" in _envelope_lanes
-        ):
-            return _dispatch_claude_via_envelope(args)
-        return _dispatch_claude(args)
+        # PR-5: claude is not a provider-lane provider. The single-entry door owns
+        # all Claude routing. Silent headless auto-selection via provider_dispatch is
+        # removed — use DispatchSpec with allow_headless=true through the door instead.
+        print(
+            "[provider_dispatch] REJECT: 'claude' is not a provider-lane provider. "
+            "Claude dispatches route via the single-entry dispatch door. "
+            "Use 'vnx dispatch <pending-id>' (VNX_SINGLE_ENTRY_DISPATCH=1) or "
+            "'python3 scripts/lib/dispatch_cli.py --spec-file <path>'. "
+            "For headless/api-billed runs set allow_headless=true in the DispatchSpec.",
+            file=sys.stderr,
+        )
+        return _EX_USAGE
 
     if provider == "codex":
         _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1202,3 +1202,164 @@ def test_legacy_env_vars_do_not_bypass_headless_gate(tmp_path, monkeypatch):
     mock_headless.assert_not_called()
     plan_arg = mock_tmux.call_args[0][0]
     assert plan_arg.lane == "claude_tmux_subscription"
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1 — load_spec strict bool coercion for allow_headless / requires_mcp
+# ---------------------------------------------------------------------------
+
+class TestLoadSpecStrictBoolCoercion:
+    """load_spec must parse allow_headless strictly: only JSON boolean true enables it.
+
+    Closes the bool("false") == True coercion trap where a JSON string "false"
+    would have been interpreted as True, silently enabling headless billing.
+    """
+
+    def _write_coercion_spec(self, tmp_path, allow_headless_raw, provider="claude"):
+        instruction = _make_instruction(tmp_path)
+        spec = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260615-coercion-test",
+            "staging_id": "test-stage",
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": provider,
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "allow_headless": allow_headless_raw,
+        }
+        spec_file = tmp_path / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec), encoding="utf-8")
+        return spec_file
+
+    def test_string_false_does_not_enable_headless(self, tmp_path):
+        """JSON string 'false' → allow_headless=False (was bool('false')==True before fix)."""
+        spec_file = self._write_coercion_spec(tmp_path, "false")
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False, (
+            "allow_headless='false' (string) must NOT enable headless; bool('false') is the old bug"
+        )
+
+    def test_string_true_does_not_enable_headless(self, tmp_path):
+        """JSON string 'true' → allow_headless=False (only JSON boolean true enables)."""
+        spec_file = self._write_coercion_spec(tmp_path, "true")
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+    def test_integer_0_does_not_enable_headless(self, tmp_path):
+        """JSON integer 0 → allow_headless=False."""
+        spec_file = self._write_coercion_spec(tmp_path, 0)
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+    def test_integer_1_does_not_enable_headless(self, tmp_path):
+        """JSON integer 1 → allow_headless=False (only JSON boolean true, not numeric 1)."""
+        spec_file = self._write_coercion_spec(tmp_path, 1)
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+    def test_empty_string_does_not_enable_headless(self, tmp_path):
+        """JSON empty string '' → allow_headless=False."""
+        spec_file = self._write_coercion_spec(tmp_path, "")
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+    def test_json_bool_true_enables_headless(self, tmp_path):
+        """JSON boolean true → allow_headless=True (the ONLY accepted value)."""
+        spec_file = self._write_coercion_spec(tmp_path, True)
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is True
+
+    def test_json_bool_false_does_not_enable_headless(self, tmp_path):
+        """JSON boolean false → allow_headless=False."""
+        spec_file = self._write_coercion_spec(tmp_path, False)
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+    def test_string_false_on_non_claude_does_not_trigger_headless_claude_only_reject(self, tmp_path):
+        """Regression: string 'false' on a codex spec must not enable headless.
+
+        Before the fix, bool('false')==True would have enabled headless on a codex spec,
+        causing validate() to reject it with headless-claude-only instead of passing cleanly.
+        """
+        spec_file = self._write_coercion_spec(tmp_path, "false", provider="codex")
+        loaded = load_spec(spec_file)
+        assert loaded.allow_headless is False
+
+
+# ---------------------------------------------------------------------------
+# LOW — headless_reason sanitization in load_spec
+# ---------------------------------------------------------------------------
+
+class TestLoadSpecHeadlessReasonSanitization:
+
+    def _write_spec_with_reason(self, tmp_path, headless_reason_raw):
+        instruction = _make_instruction(tmp_path)
+        spec = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260615-reason-sanitize-test",
+            "staging_id": "test-stage",
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "allow_headless": True,
+            "headless_reason": headless_reason_raw,
+        }
+        spec_file = tmp_path / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec), encoding="utf-8")
+        return spec_file
+
+    def test_multiline_reason_has_newlines_removed(self, tmp_path):
+        """Newlines in headless_reason are replaced so the reason stays on one log line."""
+        spec_file = self._write_spec_with_reason(tmp_path, "line one\nline two\nline three")
+        loaded = load_spec(spec_file)
+        assert "\n" not in (loaded.headless_reason or "")
+        assert "line one" in (loaded.headless_reason or "")
+
+    def test_control_chars_stripped(self, tmp_path):
+        """Control chars (\\r, \\x00, etc.) are stripped from headless_reason."""
+        spec_file = self._write_spec_with_reason(tmp_path, "benchmark\x00run\r\nfast")
+        loaded = load_spec(spec_file)
+        reason = loaded.headless_reason or ""
+        assert "\x00" not in reason
+        assert "\r" not in reason
+        assert "\n" not in reason
+
+    def test_clean_reason_unchanged(self, tmp_path):
+        """A clean single-line reason passes through unchanged."""
+        spec_file = self._write_spec_with_reason(tmp_path, "burst benchmark run")
+        loaded = load_spec(spec_file)
+        assert loaded.headless_reason == "burst benchmark run"
+
+    def test_none_reason_stays_none(self, tmp_path):
+        """Missing headless_reason stays None."""
+        instruction = _make_instruction(tmp_path)
+        spec = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260615-no-reason-test",
+            "staging_id": "test-stage",
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "allow_headless": False,
+        }
+        spec_file = tmp_path / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec), encoding="utf-8")
+        loaded = load_spec(spec_file)
+        assert loaded.headless_reason is None

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib
 
 from dispatch_cli import (
     _execute_claude,
+    _execute_claude_headless,
     build_runtime_snapshot,
     fingerprint,
     load_spec,
@@ -1063,3 +1064,141 @@ def test_forbid_route_blocking_verdict_rejects_dispatch(tmp_path):
 
     assert rc == 1, "Blocking forbid_route verdict must cause a Reject"
     mock_exec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PR-5 — headless opt-in lane
+# ---------------------------------------------------------------------------
+
+@patch("dispatch_cli.build_runtime_snapshot")
+@patch("dispatch_cli.run_envelope_headless_plan")
+def test_headless_optin_routes_to_subprocess_adapter(mock_headless, mock_snapshot, tmp_path):
+    """allow_headless=True + non-empty reason → routes to run_envelope_headless_plan.
+    tmux NOT called; permit is passed to the envelope.
+    """
+    mock_snapshot.return_value = _clean_snapshot()
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_headless.return_value = mock_result
+
+    spec_file = _make_spec_file(tmp_path, provider="claude", extra={
+        "allow_headless": True,
+        "headless_reason": "burst benchmark run",
+    })
+
+    with patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch") as mock_tmux:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_headless.assert_called_once()
+    mock_tmux.assert_not_called()
+
+    plan_arg = mock_headless.call_args[0][0]
+    assert plan_arg.lane == "claude_headless"
+    assert plan_arg.billing == "api_metered"
+    assert plan_arg.adapter == "claude_subprocess"
+
+
+@patch("dispatch_cli.build_runtime_snapshot")
+def test_headless_empty_reason_rejected(mock_snapshot, tmp_path, capsys):
+    """allow_headless=True + empty headless_reason → Reject at validate() → rc=1, no spawn."""
+    mock_snapshot.return_value = _clean_snapshot()
+
+    spec_file = _make_spec_file(tmp_path, provider="claude", extra={
+        "allow_headless": True,
+        "headless_reason": "",
+    })
+
+    with patch("dispatch_cli._execute_claude_headless") as mock_headless:
+        with patch("dispatch_cli._execute_claude") as mock_tmux:
+            rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    mock_headless.assert_not_called()
+    mock_tmux.assert_not_called()
+    err = capsys.readouterr().err
+    assert "headless-reason-required" in err
+
+
+def test_default_claude_still_routes_tmux(tmp_path, monkeypatch):
+    """allow_headless absent/false → claude_tmux_subscription (unchanged default behavior)."""
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260615-staging-default-tmux"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    inst = bundle_dir / "instruction.md"
+    inst.write_text("# Default claude test\n\nDo something safe.\n", encoding="utf-8")
+    spec_data = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-default-claude-tmux",
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec_data), encoding="utf-8")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
+        with patch("dispatch_cli._execute_claude_headless") as mock_headless:
+            rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_tmux.assert_called_once()
+    mock_headless.assert_not_called()
+    plan_arg = mock_tmux.call_args[0][0]
+    assert plan_arg.lane == "claude_tmux_subscription"
+
+
+def test_legacy_env_vars_do_not_bypass_headless_gate(tmp_path, monkeypatch):
+    """VNX_AUTO_ROUTE=1 + VNX_ADAPTER=subprocess env vars have no effect through the door.
+    Without allow_headless=true in the spec, the plan is always claude_tmux_subscription.
+    """
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260615-legacy-env-probe"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_AUTO_ROUTE", "1")
+    monkeypatch.setenv("VNX_ADAPTER", "subprocess")
+
+    inst = bundle_dir / "instruction.md"
+    inst.write_text("# Legacy env test\n\nDo something safe.\n", encoding="utf-8")
+    spec_data = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260615-legacy-env-probe",
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec_data), encoding="utf-8")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
+        with patch("dispatch_cli._execute_claude_headless") as mock_headless:
+            rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    mock_tmux.assert_called_once()
+    mock_headless.assert_not_called()
+    plan_arg = mock_tmux.call_args[0][0]
+    assert plan_arg.lane == "claude_tmux_subscription"

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -386,6 +386,33 @@ class TestInstructionSha256InPlan:
             "Plans with different instruction_sha256 must produce different digests"
         )
 
+    def test_headless_plan_hash_is_valid(self, tmp_path: Path) -> None:
+        """claude_headless plan always carries a valid 64-hex instruction hash."""
+        spec = DispatchSpec(
+            schema_version=1,
+            project_id="vnx-dev",
+            dispatch_id="test-headless-hash",
+            staging_id="staging-headless",
+            instruction_file=_fake_instruction_file(tmp_path),
+            role="backend-developer",
+            target_slot="T1",
+            gate="human-promoted",
+            dispatch_paths=(),
+            provider=Provider.CLAUDE,
+            allow_headless=True,
+            headless_reason="benchmark",
+        )
+        instruction_text = "# Test instruction\n"
+        vspec = ValidatedSpec(
+            spec=spec,
+            instruction_text=instruction_text,
+            normalized_paths=(),
+            instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+        )
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert is_valid_instruction_hash(plan.instruction_sha256)
+
     def test_default_sha256_is_empty_string(self, tmp_path: Path) -> None:
         """ExecutionPlan constructed without instruction_sha256 defaults to empty string."""
         ifile = tmp_path / "instruction.md"
@@ -413,3 +440,88 @@ class TestInstructionSha256InPlan:
             route_reason="D1",
         )
         assert plan.instruction_sha256 == ""
+
+
+# ---------------------------------------------------------------------------
+# PR-5 — claude_headless lane
+# ---------------------------------------------------------------------------
+
+def _make_vspec_headless(
+    *,
+    headless_reason: str = "burst benchmark",
+    target_slot: str = "T1",
+    model: str | None = None,
+    tmp_path: Path,
+) -> ValidatedSpec:
+    """Build a ValidatedSpec with allow_headless=True for headless lane tests."""
+    spec = DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-headless-dispatch",
+        staging_id="staging-headless-001",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        model=model,
+        allow_headless=True,
+        headless_reason=headless_reason,
+    )
+    instruction_text = "# Test instruction\n"
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+    )
+
+
+class TestClaudeHeadlessLane:
+    def test_headless_optin_lane_fields(self, tmp_path: Path) -> None:
+        """allow_headless=True → lane=claude_headless, adapter=claude_subprocess, billing=api_metered."""
+        vspec = _make_vspec_headless(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_headless"
+        assert plan.adapter == "claude_subprocess"
+        assert plan.billing == "api_metered"
+        assert plan.serialization_class is None
+        assert plan.warmup == "n/a"
+        assert plan.target_id == "ephemeral"
+
+    def test_headless_warning_contains_reason(self, tmp_path: Path) -> None:
+        """Headless plan carries a LOUD warning containing the headless_reason."""
+        reason = "quarterly burst load benchmark"
+        vspec = _make_vspec_headless(headless_reason=reason, tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert any("HEADLESS API-billing opted-in" in w for w in plan.warnings)
+        assert any(reason in w for w in plan.warnings)
+
+    def test_default_claude_remains_tmux(self, tmp_path: Path) -> None:
+        """Default Claude (allow_headless=False) → claude_tmux_subscription unchanged."""
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
+        assert plan.billing == "subscription"
+        assert plan.serialization_class == "claude-tmux"
+        assert plan.warmup == "verify_strict"
+        assert not any("HEADLESS" in w for w in plan.warnings)
+
+    def test_headless_isolation_always_worktree(self, tmp_path: Path) -> None:
+        """claude_headless inherits the universal isolation=WORKTREE rule."""
+        vspec = _make_vspec_headless(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.isolation == Isolation.WORKTREE
+        assert plan.require_worktree is True
+
+    def test_headless_serial_disabled_still_no_serial_class(self, tmp_path: Path) -> None:
+        """claude_headless never gets serialization_class even when claude_serial_enabled=True."""
+        vspec = _make_vspec_headless(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot(claude_serial_enabled=True))
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.serialization_class is None

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -451,3 +451,45 @@ class TestHeadlessOptin:
         spec = _valid_spec(ifile, allow_headless=False, headless_reason=None)
         result = _do_validate(spec, monkeypatch)
         assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 12 — headless opt-in: non-claude provider rejection (MED fix)
+# ---------------------------------------------------------------------------
+
+class TestHeadlessNonClaudeProvider:
+    @pytest.mark.parametrize("non_claude_provider", [
+        Provider.CODEX,
+        Provider.GEMINI,
+        Provider.KIMI,
+        Provider.LITELLM_DEEPSEEK,
+        Provider.LITELLM_ZAI,
+    ])
+    def test_non_claude_provider_with_allow_headless_rejected(self, tmp_path, monkeypatch, non_claude_provider):
+        """allow_headless=True + non-claude provider → Reject(headless-claude-only)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason="benchmark", provider=non_claude_provider)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "headless-claude-only"
+
+    def test_auto_provider_with_allow_headless_passes(self, tmp_path, monkeypatch):
+        """allow_headless=True + provider=auto → ValidatedSpec (auto could resolve to claude)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason="benchmark", provider=Provider.AUTO)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    def test_claude_provider_with_allow_headless_passes(self, tmp_path, monkeypatch):
+        """allow_headless=True + provider=claude + reason → ValidatedSpec."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason="benchmark", provider=Provider.CLAUDE)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    def test_non_claude_with_allow_headless_false_passes(self, tmp_path, monkeypatch):
+        """allow_headless=False + non-claude provider → ValidatedSpec (check only fires when True)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=False, headless_reason=None, provider=Provider.CODEX)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -408,3 +408,46 @@ class TestRule11Deadline:
         spec = _valid_spec(ifile, deadline_seconds=good_deadline)
         result = _do_validate(spec, monkeypatch)
         assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 12 — headless opt-in (PR-5)
+# ---------------------------------------------------------------------------
+
+class TestHeadlessOptin:
+    def test_allow_headless_requires_reason(self, tmp_path, monkeypatch):
+        """allow_headless=True + headless_reason=None → Reject(headless-reason-required)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason=None)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "headless-reason-required"
+
+    def test_allow_headless_empty_reason_rejected(self, tmp_path, monkeypatch):
+        """allow_headless=True + whitespace-only reason → Reject(headless-reason-required)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason="   ")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "headless-reason-required"
+
+    def test_allow_headless_with_reason_passes(self, tmp_path, monkeypatch):
+        """allow_headless=True + non-empty reason → ValidatedSpec."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=True, headless_reason="burst benchmark run")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    def test_default_no_headless_passes(self, tmp_path, monkeypatch):
+        """Default spec (allow_headless=False, headless_reason=None) → ValidatedSpec without extra check."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    def test_allow_headless_false_with_no_reason_passes(self, tmp_path, monkeypatch):
+        """allow_headless=False + no reason → ValidatedSpec (rule only fires when allow_headless=True)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, allow_headless=False, headless_reason=None)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -237,18 +237,32 @@ class TestModuleImportability:
         import sys
 
         # Remove spawn modules and provider_dispatch from sys.modules so we can
-        # observe what loading provider_dispatch alone pulls in.
+        # observe what loading provider_dispatch alone pulls in. Save the original
+        # module objects and restore them in `finally` — re-importing creates a NEW
+        # provider_dispatch object, and leaving that in sys.modules desyncs every
+        # later test that bound `provider_dispatch` at collection time (their
+        # patch("provider_dispatch.X") would target the new object while their code
+        # under test still references the old one). The swap must not leak.
         to_remove = [
             k for k in sys.modules
             if any(s in k for s in ("codex_spawn", "gemini_spawn", "litellm_spawn", "provider_dispatch"))
         ]
+        saved = {k: sys.modules[k] for k in to_remove}
         for k in to_remove:
             del sys.modules[k]
 
-        importlib.import_module("provider_dispatch")
+        try:
+            importlib.import_module("provider_dispatch")
 
-        # None of the optional spawn modules should have been imported as side effects.
-        for mod_name in sys.modules:
-            assert "codex_spawn" not in mod_name, f"codex_spawn imported at module load: {mod_name}"
-            assert "gemini_spawn" not in mod_name, f"gemini_spawn imported at module load: {mod_name}"
-            assert "litellm_spawn" not in mod_name, f"litellm_spawn imported at module load: {mod_name}"
+            # None of the optional spawn modules should have been imported as side effects.
+            for mod_name in sys.modules:
+                assert "codex_spawn" not in mod_name, f"codex_spawn imported at module load: {mod_name}"
+                assert "gemini_spawn" not in mod_name, f"gemini_spawn imported at module load: {mod_name}"
+                assert "litellm_spawn" not in mod_name, f"litellm_spawn imported at module load: {mod_name}"
+        finally:
+            # Restore the exact module objects every other test bound at import time.
+            for k in [k for k in sys.modules if any(
+                s in k for s in ("codex_spawn", "gemini_spawn", "litellm_spawn", "provider_dispatch")
+            )]:
+                del sys.modules[k]
+            sys.modules.update(saved)

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Wave 4.6 PR-4.6.3/R3 — provider_dispatch.py entry-point tests.
+"""Wave 4.6 / PR-5 — provider_dispatch.py entry-point tests.
 
 Covers:
-- Claude provider delegates to subprocess_dispatch with unchanged argv semantics.
+- Claude provider is explicitly rejected (PR-5: claude is not a provider-lane provider).
 - Codex provider routes to _dispatch_codex (PR-4.6.3 wired).
 - Gemini provider routes to _dispatch_gemini (PR-4.6.4 wired).
 - LiteLLM provider raises SystemExit(64) with PR reference in message.
@@ -43,107 +43,45 @@ def _make_claude_argv(**overrides) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Test: claude provider delegates to subprocess_dispatch
+# Test: claude provider is rejected from the provider lane (PR-5)
 # ---------------------------------------------------------------------------
 
-class TestProviderClaudeDelegatesToSubprocessDispatch:
+class TestProviderClaudeRejectedFromProviderLane:
+    """PR-5: claude is not a provider-lane provider.
 
-    def test_delegates_on_success(self):
-        """deliver_with_recovery is called and its return value gates exit code."""
-        mock_deliver = MagicMock(return_value=True)
-        mock_extract = MagicMock(return_value=None)
+    The single-entry dispatch door (dispatch_cli.py) owns all Claude routing.
+    Direct --provider claude invocations via provider_dispatch must be hard-rejected
+    so operators get a clear error pointing to the correct path.
+    """
 
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", mock_extract):
-            result = provider_dispatch.main(_make_claude_argv())
+    def test_claude_returns_exit_64(self):
+        """--provider claude returns exit code EX_USAGE (64), not 0 or 1."""
+        result = provider_dispatch.main(_make_claude_argv())
+        assert result == 64
 
-        assert result == 0
-        mock_deliver.assert_called_once()
+    def test_claude_emits_reject_to_stderr(self, capsys):
+        """--provider claude prints a REJECT message to stderr."""
+        provider_dispatch.main(_make_claude_argv())
+        err = capsys.readouterr().err
+        assert "REJECT" in err
 
-    def test_delegates_core_kwargs(self):
-        """terminal_id, dispatch_id, instruction forwarded to deliver_with_recovery."""
-        mock_deliver = MagicMock(return_value=True)
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
+    def test_claude_does_not_call_subprocess_dispatch(self):
+        """--provider claude must NOT delegate to subprocess_dispatch.deliver_with_recovery."""
+        with patch("subprocess_dispatch.deliver_with_recovery") as mock_deliver:
             provider_dispatch.main(_make_claude_argv())
+        mock_deliver.assert_not_called()
 
-        call_kwargs = mock_deliver.call_args[1]
-        assert call_kwargs["terminal_id"] == "T1"
-        assert call_kwargs["dispatch_id"] == "test-pr461-smoke"
-        assert call_kwargs["instruction"] == "noop"
+    def test_claude_error_references_dispatch_door(self, capsys):
+        """Error message references the single-entry door so the operator knows the next step."""
+        provider_dispatch.main(_make_claude_argv())
+        err = capsys.readouterr().err
+        assert "dispatch" in err.lower()
 
-    def test_failed_deliver_returns_exit_code_1(self):
-        """When deliver_with_recovery returns False, main returns 1."""
-        with patch("subprocess_dispatch.deliver_with_recovery", return_value=False), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
-            result = provider_dispatch.main(_make_claude_argv())
-        assert result == 1
-
-    def test_no_auto_commit_forwarded(self):
-        """--no-auto-commit flips auto_commit=False in deliver_with_recovery."""
-        mock_deliver = MagicMock(return_value=True)
-        argv = _make_claude_argv() + ["--no-auto-commit"]
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
-            provider_dispatch.main(argv)
-
-        assert mock_deliver.call_args[1]["auto_commit"] is False
-
-    def test_role_extracted_from_instruction_when_absent(self):
-        """When --role is omitted, role is extracted from instruction body."""
-        mock_deliver = MagicMock(return_value=True)
-        argv = [
-            "--provider", "claude",
-            "--terminal-id", "T1",
-            "--dispatch-id", "test-role-extraction",
-            "--instruction", "Role: security-engineer\n\nDo the thing.",
-        ]
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver):
-            provider_dispatch.main(argv)
-
-        assert mock_deliver.call_args[1]["role"] == "security-engineer"
-
-    def test_explicit_role_not_overridden_by_instruction(self):
-        """--role flag takes precedence over Role: header in instruction."""
-        mock_deliver = MagicMock(return_value=True)
-        argv = [
-            "--provider", "claude",
-            "--terminal-id", "T1",
-            "--dispatch-id", "test-explicit-role",
-            "--instruction", "Role: backend-developer\n\nTask.",
-            "--role", "architect",
-        ]
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value="backend-developer"):
-            provider_dispatch.main(argv)
-
-        assert mock_deliver.call_args[1]["role"] == "architect"
-
-    def test_dispatch_paths_split_on_comma(self):
-        """--dispatch-paths is split into a list for deliver_with_recovery."""
-        mock_deliver = MagicMock(return_value=True)
-        argv = _make_claude_argv(**{"--dispatch-paths": "scripts/lib,tests"})
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
-            provider_dispatch.main(argv)
-
-        assert mock_deliver.call_args[1]["dispatch_paths"] == ["scripts/lib", "tests"]
-
-    def test_pr_id_forwarded(self):
-        """--pr-id is forwarded to deliver_with_recovery."""
-        mock_deliver = MagicMock(return_value=True)
-        argv = _make_claude_argv() + ["--pr-id", "488"]
-
-        with patch("subprocess_dispatch.deliver_with_recovery", mock_deliver), \
-             patch("subprocess_dispatch._extract_role_from_instruction", return_value=None):
-            provider_dispatch.main(argv)
-
-        assert mock_deliver.call_args[1]["pr_id"] == "488"
+    def test_claude_with_extra_args_still_rejected(self):
+        """--provider claude with extra flags (model, role, etc.) is still rejected."""
+        argv = _make_claude_argv(**{"--model": "opus", "--role": "architect"})
+        result = provider_dispatch.main(argv)
+        assert result == 64
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -51,7 +51,7 @@ def _make_spawn_result(returncode: int = 0) -> MagicMock:
     return r
 
 
-def _noop_governance(args, provider, model, result, start, end, status):
+def _noop_governance(args, provider, model, result, start, end, status, event_store=None):
     pass
 
 


### PR DESCRIPTION
## Summary

Lands the **headless-Claude opt-in lane** of the single-entry dispatch door (PR-5) plus the two kimi-gate HIGH fixes (PR-5b) and a test-green sweep. Headless Claude (`claude -p`, API-billed) is now reachable **only** via an explicit, audited `DispatchSpec.allow_headless=true` with a mandatory reason — never the default, never silently auto-selected. Default Claude continues to route to the tmux subscription lane.

This is the 5th increment of the dispatch-determinism build (PR-1→4e already on main via #884). Door modules: `dispatch_spec` / `dispatch_plan` / `dispatch_cli` / `dispatch_envelope` / `dispatch_internal`.

## Changes

**PR-5 — headless opt-in (48acda70)**
- `DispatchSpec`: `allow_headless: bool = False` + `headless_reason: Optional[str]`. `validate()` requires a non-empty reason when opted in.
- `compile_plan`: `allow_headless=true` → `lane=claude_headless`, `adapter=claude_subprocess`, `billing=api_metered`, `serialization_class=None`, LOUD opt-in warning; else `lane=claude_tmux_subscription` (unchanged default). Function stays total.
- `dispatch_cli` routing + `dispatch_envelope` headless route via existing `ClaudeSubprocessAdapter` (permit-guarded, same instruction-sha256 TOCTOU verify). `ClaudeSubprocessAdapter`/`subprocess_dispatch` **kept** — the mistake was silent/default headless, not its existence.
- Removed the silent headless auto-select routes from the door path; `provider_dispatch --provider claude` is now a hard error pointing to the door.

**PR-5b — kimi 2 HIGH (f4846860)**
- HIGH-1: strict bool parse — `allow_headless`/`requires_mcp`/`materialize_at_cwd` are `... is True` (JSON string `"false"` no longer coerces to enabled).
- HIGH-2: updated stale `provider_dispatch` Claude tests to assert the new no-route/hard-error behavior.
- MED: `allow_headless=True` on a non-Claude provider → `Reject("headless-claude-only")` (no silent ignore).
- LOW: sanitize `headless_reason` (strip newlines/control chars) before formatting the warning.

**Test-green sweep (36399e48)** — test-only, pre-existing batch pollution on main:
- `_noop_governance` mock now accepts the `event_store` kwarg production passes for every provider path.
- `test_no_optional_provider_imports_at_module_load` now saves/restores `sys.modules` (it deleted+re-imported `provider_dispatch`, swapping module identity and desyncing every later test's patch target).

## Verification

- Targeted door + provider suite: **273 passed** (`test_dispatch_spec/plan/cli/internal/envelope_plan` + `test_provider_dispatch_entry` + `test_provider_dispatch_worktree_isolation`).
- `python3 scripts/check_adr_003_no_sdk_imports.py .` → **PASS** (no Anthropic SDK imports; headless = `claude -p` CLI, not the SDK).
- The 9 isolation-suite failures and 3 collection errors present in the full suite are **identical on origin/main** (pre-existing dual-`context_assembler` collision + sys.modules pollution); this PR fixes the dispatch+provider batch and does not regress them.

## Open Items

- Pre-existing dual-`context_assembler` module collision causes 3 collection errors under the full `tests/` run (origin/main too) — out of scope here, tracked for the post-12-PR test-hardening / workspace sweep.
- Full `tests/` suite has pre-existing hanging integration tests — separate concern.

Dispatch-ID: 20260615-pr5-headless-optin / 20260615-pr5b-headless-coercion

🤖 Generated with [Claude Code](https://claude.com/claude-code)