### PR TITLE
PR-6: Claude-tmux subscription serial lock (providers + headless stay parallel)

### DIFF
--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -106,6 +106,7 @@ _d_single_entry_dispatch() {
   local spec_file=""
   local dry_run_flag=""
   local pending_id=""
+  local force_release_class=""
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -121,16 +122,30 @@ _d_single_entry_dispatch() {
         spec_file="${1#*=}"; shift ;;
       --dry-run|-n)
         dry_run_flag="--dry-run"; shift ;;
+      --force-release-lock)
+        # Optional positional after the flag: next arg without leading -- is class name.
+        if [ -n "${2:-}" ] && [[ "${2:-}" != --* ]]; then
+          force_release_class="$2"; shift
+        else
+          force_release_class="claude-tmux"
+        fi
+        shift ;;
+      --force-release-lock=*)
+        force_release_class="${1#*=}"; shift ;;
       -h|--help)
         cat <<HELP
 Usage: vnx dispatch [--spec-file <abs>] [--dry-run]
        vnx dispatch <pending-id> [--dry-run]
+       vnx dispatch --force-release-lock [<class>]
 
 Single-entry gate (VNX_SINGLE_ENTRY_DISPATCH=1).
-  --spec-file <abs>   Absolute path to dispatch-spec.json
-  <pending-id>        Dispatch ID resolved to dispatches/pending/<id>/dispatch-spec.json
-  --dry-run           Print plan + fingerprint; spawn nothing
-  VNX_DISPATCH_LEGACY=1  Force legacy path even when gate is on
+  --spec-file <abs>            Absolute path to dispatch-spec.json
+  <pending-id>                 Dispatch ID resolved to dispatches/pending/<id>/dispatch-spec.json
+  --dry-run                    Print plan + fingerprint; spawn nothing
+  --force-release-lock [CLASS] Release stale serial lock for CLASS (default: claude-tmux).
+                               Prints prior holder pid+dispatch_id; removes lock file.
+                               Does NOT kill the holder — use the printed pid if needed.
+  VNX_DISPATCH_LEGACY=1        Force legacy path even when gate is on
 
 Headless (api_metered) lane: set allow_headless=true + headless_reason in dispatch-spec.json.
   The --adapter subprocess / VNX_ADAPTER / VNX_AUTO_ROUTE flags are LEGACY-ONLY
@@ -148,6 +163,19 @@ HELP
         pending_id="$1"; shift ;;
     esac
   done
+
+  # --force-release-lock: operator escape, independent of spec-file.
+  if [ -n "$force_release_class" ]; then
+    local dispatch_cli_script="${VNX_HOME}/scripts/lib/dispatch_cli.py"
+    if [ ! -f "$dispatch_cli_script" ]; then
+      err "[dispatch] single-entry gate: dispatch_cli.py not found: $dispatch_cli_script"
+      return 1
+    fi
+    log "[dispatch] force-release-lock: class=$force_release_class"
+    PYTHONPATH="${VNX_HOME}/scripts/lib${PYTHONPATH:+:${PYTHONPATH}}" \
+      python3 "$dispatch_cli_script" --force-release-lock "$force_release_class"
+    return $?
+  fi
 
   if [ -z "$spec_file" ]; then
     if [ -z "$pending_id" ]; then

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -48,6 +48,7 @@ from dispatch_internal import (  # noqa: E402
     require_permit,
 )
 from dispatch_envelope import run_envelope_plan, run_envelope_headless_plan  # noqa: E402
+from dispatch_serialization import force_release, serialize_lane  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -554,29 +555,30 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             _print_plan(plan, fp)
             return 0
 
-        if plan.lane == "provider":
-            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
-            return result.returncode
-        elif plan.lane == "claude_tmux_subscription":
-            return _execute_claude(
-                plan,
-                permit,
-                state_dir=state_dir,
-                data_dir=data_dir,
-                role=vspec.spec.role,
-            )
-        elif plan.lane == "claude_headless":
-            return _execute_claude_headless(
-                plan,
-                permit,
-                state_dir=state_dir,
-                data_dir=data_dir,
-                role=vspec.spec.role,
-            )
-        else:
-            raise ValueError(
-                f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
-            )
+        with serialize_lane(plan.serialization_class, dispatch_id=vspec.spec.dispatch_id):
+            if plan.lane == "provider":
+                result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+                return result.returncode
+            elif plan.lane == "claude_tmux_subscription":
+                return _execute_claude(
+                    plan,
+                    permit,
+                    state_dir=state_dir,
+                    data_dir=data_dir,
+                    role=vspec.spec.role,
+                )
+            elif plan.lane == "claude_headless":
+                return _execute_claude_headless(
+                    plan,
+                    permit,
+                    state_dir=state_dir,
+                    data_dir=data_dir,
+                    role=vspec.spec.role,
+                )
+            else:
+                raise ValueError(
+                    f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
+                )
 
     except Exception as exc:
         print(f"[dispatch_cli] REJECT [runtime-error]: {exc}", file=sys.stderr)
@@ -594,14 +596,28 @@ def main(argv: Optional[list] = None) -> int:
         description="VNX single-entry dispatch gate (PR-4)"
     )
     parser.add_argument(
-        "--spec-file", required=True, type=Path, dest="spec_file",
+        "--spec-file", type=Path, dest="spec_file",
         help="Absolute path to dispatch-spec.json",
     )
     parser.add_argument(
         "--dry-run", action="store_true", dest="dry_run",
         help="Print plan + fingerprint; spawn nothing",
     )
+    parser.add_argument(
+        "--force-release-lock", dest="force_release_class",
+        metavar="CLASS", nargs="?", const="claude-tmux", default=None,
+        help="Release stale lock for CLASS (default: claude-tmux); "
+             "prints prior holder and removes lock file",
+    )
     args = parser.parse_args(argv)
+
+    if args.force_release_class is not None:
+        force_release(args.force_release_class)
+        return 0
+
+    if args.spec_file is None:
+        parser.error("--spec-file is required")
+
     return run_dispatch(args.spec_file, dry_run=args.dry_run)
 
 

--- a/scripts/lib/dispatch_serialization.py
+++ b/scripts/lib/dispatch_serialization.py
@@ -1,0 +1,211 @@
+"""dispatch_serialization.py — Claude subscription serial lock (PR-6).
+
+serialize_lane(serialization_class) context manager: serializes the claude-tmux
+lane (one at a time per account); provider + headless lanes pass None -> no-op.
+
+Lock is account-level: $VNX_LOCK_DIR or ~/.vnx-data/locks — shared across all
+projects and worktrees that use the same Claude subscription.
+
+Posix-only: requires fcntl (unavailable on Windows).
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+try:
+    import fcntl
+    _FLOCK_AVAILABLE = True
+except ImportError:
+    fcntl = None  # type: ignore[assignment]
+    _FLOCK_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _lock_dir() -> Path:
+    """Account-level lock directory: $VNX_LOCK_DIR or ~/.vnx-data/locks."""
+    env = os.environ.get("VNX_LOCK_DIR", "")
+    if env:
+        return Path(env)
+    return Path.home() / ".vnx-data" / "locks"
+
+
+def _warn_seconds() -> float:
+    try:
+        return float(os.environ.get("VNX_CLAUDE_LOCK_WAIT_WARN_SECONDS", "60"))
+    except (ValueError, TypeError):
+        return 60.0
+
+
+def _timeout_seconds() -> float:
+    try:
+        return float(os.environ.get("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", "0"))
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _iso_now() -> str:
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
+# ---------------------------------------------------------------------------
+# Lock acquisition with wait-warn
+# ---------------------------------------------------------------------------
+
+_POLL_INTERVAL = 0.2  # seconds between LOCK_NB retries
+
+
+def _acquire_with_warn(
+    fd: int,
+    lock_path: Path,
+    dispatch_id: Optional[str],
+) -> None:
+    """Acquire LOCK_EX on fd with wait-warn and optional hard timeout.
+
+    Polls with LOCK_NB so we can emit a warning after warn_seconds and enforce
+    an optional hard ceiling without relying on SIGALRM (thread-unsafe).
+    """
+    warn_secs = _warn_seconds()
+    timeout_secs = _timeout_seconds()
+    start = time.monotonic()
+    warned = False
+
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return  # acquired
+        except OSError:
+            pass
+
+        elapsed = time.monotonic() - start
+
+        if not warned and elapsed >= warn_secs:
+            try:
+                raw = lock_path.read_text(encoding="utf-8")
+                holder = json.loads(raw)
+                holder_info = (
+                    f"pid={holder.get('pid')}, "
+                    f"dispatch_id={holder.get('dispatch_id')!r}, "
+                    f"since={holder.get('timestamp')}"
+                )
+            except Exception:
+                holder_info = "unknown holder (lock file unreadable)"
+            logger.warning(
+                "[dispatch_serialization] WAITING for %s serial lock "
+                "— held by %s (%.0fs elapsed) — still waiting; "
+                "use --force-release-lock to clear a stale lock",
+                lock_path.name,
+                holder_info,
+                elapsed,
+            )
+            warned = True
+
+        if timeout_secs > 0 and elapsed >= timeout_secs:
+            raise TimeoutError(
+                f"claude-tmux serial lock not acquired within {timeout_secs:.0f}s "
+                f"(elapsed {elapsed:.0f}s); "
+                f"use --force-release-lock to clear a stale lock"
+            )
+
+        time.sleep(_POLL_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def serialize_lane(
+    serialization_class: Optional[str],
+    *,
+    dispatch_id: Optional[str] = None,
+):
+    """Serialize execution for the given serialization_class.
+
+    None -> no-op: yield immediately, touch nothing (providers + headless).
+    "claude-tmux" -> acquire exclusive flock on <lock_dir>/claude-tmux.lock
+    and hold it through the entire with-body (execution + receipt/GOVERN).
+    Lock is released unconditionally in finally, including on exception.
+    flock auto-releases on process death; no manual stale-lock cleanup needed.
+    """
+    if not serialization_class:
+        yield
+        return
+
+    if not _FLOCK_AVAILABLE:
+        raise RuntimeError(
+            "VNX dispatch lock requires a posix flock (fcntl module not available; "
+            "dispatch_serialization is posix-only)"
+        )
+
+    lock_dir = _lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{serialization_class}.lock"
+
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        _acquire_with_warn(fd, lock_path, dispatch_id)
+
+        # Write holder metadata for diagnostics + wait-warn + force-release.
+        # Written AFTER acquiring so only the true current holder is recorded.
+        metadata = {
+            "pid": os.getpid(),
+            "dispatch_id": dispatch_id,
+            "timestamp": _iso_now(),
+        }
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, json.dumps(metadata).encode("utf-8"))
+
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def force_release(serialization_class: str = "claude-tmux") -> None:
+    """Operator escape: print holder metadata and remove the lock file.
+
+    Does NOT kill the holder process — prints pid + dispatch_id so the operator
+    can act. After removal, a new acquire can succeed immediately.
+
+    Note: flock auto-releases on holder process death, so force-release is only
+    needed when a holder process is hung (not dead, not making progress).
+    """
+    lock_dir = _lock_dir()
+    lock_path = lock_dir / f"{serialization_class}.lock"
+
+    if not lock_path.exists():
+        print(f"[force-release] No lock file found: {lock_path}")
+        print("[force-release] No stale lock to clear.")
+        return
+
+    try:
+        raw = lock_path.read_text(encoding="utf-8")
+        holder = json.loads(raw)
+        print(f"[force-release] Prior holder metadata: {holder}")
+        print(f"[force-release]   pid          = {holder.get('pid')}")
+        print(f"[force-release]   dispatch_id  = {holder.get('dispatch_id')}")
+        print(f"[force-release]   timestamp    = {holder.get('timestamp')}")
+    except Exception as exc:
+        print(f"[force-release] Could not read holder metadata: {exc}")
+
+    lock_path.unlink(missing_ok=True)
+    print(f"[force-release] Lock file removed: {lock_path}")
+    print(
+        "[force-release] NOTE: flock auto-releases on holder process death. "
+        "Force-release is only needed for a hung holder (process alive, not progressing)."
+    )

--- a/tests/test_dispatch_serialization.py
+++ b/tests/test_dispatch_serialization.py
@@ -1,0 +1,233 @@
+"""test_dispatch_serialization.py — Tests for serialize_lane + force_release (PR-6).
+
+Covers: intra-thread serialization, no-op for None, exception release,
+force_release escape, and account-level lock directory resolution.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_serialization import force_release, serialize_lane
+
+
+# ---------------------------------------------------------------------------
+# test_parallel_claude_serializes
+# ---------------------------------------------------------------------------
+
+def test_parallel_claude_serializes(tmp_path, monkeypatch):
+    """Two threads entering serialize_lane("claude-tmux") never hold body concurrently."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    concurrent_count = 0
+    overlap_detected = False
+    count_lock = threading.Lock()
+
+    def worker():
+        nonlocal concurrent_count, overlap_detected
+        with serialize_lane("claude-tmux", dispatch_id="test-serial"):
+            with count_lock:
+                concurrent_count += 1
+                if concurrent_count > 1:
+                    overlap_detected = True
+            time.sleep(0.05)
+            with count_lock:
+                concurrent_count -= 1
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not t1.is_alive(), "thread 1 did not finish within timeout"
+    assert not t2.is_alive(), "thread 2 did not finish within timeout"
+    assert not overlap_detected, "two threads held serialize_lane body concurrently"
+
+
+# ---------------------------------------------------------------------------
+# test_provider_lanes_stay_parallel
+# ---------------------------------------------------------------------------
+
+def test_provider_lanes_stay_parallel(tmp_path, monkeypatch):
+    """Two concurrent serialize_lane(None) callers both enter body concurrently (no blocking)."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    barrier = threading.Barrier(2, timeout=5)
+    both_entered = threading.Event()
+    errors = []
+
+    def worker():
+        try:
+            with serialize_lane(None):
+                barrier.wait()  # both must reach here simultaneously
+                both_entered.set()
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not errors, f"unexpected errors in provider-lane workers: {errors}"
+    assert both_entered.is_set(), "provider lanes did not enter body concurrently"
+    # Lock file must NOT be created for None lanes
+    assert not (tmp_path / "locks" / "None.lock").exists()
+
+
+# ---------------------------------------------------------------------------
+# test_claude_headless_not_locked
+# ---------------------------------------------------------------------------
+
+def test_claude_headless_not_locked(tmp_path, monkeypatch):
+    """serialize_lane(None) (headless) is a no-op and does not block a concurrent claude-tmux holder."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    tmux_holding = threading.Event()
+    headless_elapsed = []
+    errors = []
+
+    def claude_tmux_worker():
+        try:
+            with serialize_lane("claude-tmux", dispatch_id="tmux-holder"):
+                tmux_holding.set()
+                time.sleep(0.3)
+        except Exception as exc:
+            errors.append(("tmux", exc))
+
+    def headless_worker():
+        tmux_holding.wait(timeout=5)
+        t_start = time.monotonic()
+        try:
+            with serialize_lane(None):
+                pass  # should not block
+        except Exception as exc:
+            errors.append(("headless", exc))
+        headless_elapsed.append(time.monotonic() - t_start)
+
+    t1 = threading.Thread(target=claude_tmux_worker)
+    t2 = threading.Thread(target=headless_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert headless_elapsed, "headless worker did not complete"
+    assert headless_elapsed[0] < 0.15, (
+        f"headless lane blocked unexpectedly ({headless_elapsed[0]:.3f}s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_lock_released_on_exception
+# ---------------------------------------------------------------------------
+
+def test_lock_released_on_exception(tmp_path, monkeypatch):
+    """Exception inside serialize_lane body releases the lock; a subsequent acquire succeeds."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    with pytest.raises(RuntimeError, match="intentional test error"):
+        with serialize_lane("claude-tmux", dispatch_id="will-fail"):
+            raise RuntimeError("intentional test error")
+
+    # After exception, a new acquire must succeed immediately (not deadlock)
+    acquired = threading.Event()
+
+    def try_acquire():
+        with serialize_lane("claude-tmux", dispatch_id="after-exception"):
+            acquired.set()
+
+    t = threading.Thread(target=try_acquire)
+    t.start()
+    t.join(timeout=5)
+
+    assert acquired.is_set(), "lock was not released after exception in with-body"
+
+
+# ---------------------------------------------------------------------------
+# test_force_release
+# ---------------------------------------------------------------------------
+
+def test_force_release(tmp_path, monkeypatch, capsys):
+    """force_release prints prior holder and removes lock file; new acquire succeeds after."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / "claude-tmux.lock"
+
+    # Write a stale lock file — simulates a prior holder whose process exited
+    # without releasing (or whose pid no longer exists).
+    stale_meta = {
+        "pid": 99999,
+        "dispatch_id": "stale-dispatch-id",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    lock_file.write_text(json.dumps(stale_meta))
+
+    force_release("claude-tmux")
+    captured = capsys.readouterr()
+
+    assert "stale-dispatch-id" in captured.out, "prior dispatch_id not printed"
+    assert "99999" in captured.out, "prior pid not printed"
+    assert not lock_file.exists(), "lock file not removed by force_release"
+
+    # Confirm a fresh acquire succeeds post-release
+    acquired = threading.Event()
+
+    def try_acquire():
+        with serialize_lane("claude-tmux", dispatch_id="post-release"):
+            acquired.set()
+
+    t = threading.Thread(target=try_acquire)
+    t.start()
+    t.join(timeout=5)
+
+    assert acquired.is_set(), "new acquire failed after force_release"
+
+
+# ---------------------------------------------------------------------------
+# test_lock_dir_is_account_level
+# ---------------------------------------------------------------------------
+
+def test_lock_dir_is_account_level(tmp_path, monkeypatch):
+    """Lock resolves under VNX_LOCK_DIR, not the repo-local VNX_DATA_DIR."""
+    account_lock_dir = tmp_path / "account-locks"
+    project_data_dir = tmp_path / "project-data"
+    project_data_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_LOCK_DIR", str(account_lock_dir))
+    monkeypatch.setenv("VNX_DATA_DIR", str(project_data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with serialize_lane("claude-tmux", dispatch_id="dir-scope-test"):
+        # Lock file must be in VNX_LOCK_DIR
+        assert (account_lock_dir / "claude-tmux.lock").exists(), (
+            "lock file not created in VNX_LOCK_DIR"
+        )
+        # Lock file must NOT be in VNX_DATA_DIR
+        assert not (project_data_dir / "claude-tmux.lock").exists(), (
+            "lock file incorrectly created in project VNX_DATA_DIR"
+        )
+
+    # Default (no VNX_LOCK_DIR) resolves to ~/.vnx-data/locks — verify shape
+    monkeypatch.delenv("VNX_LOCK_DIR", raising=False)
+    from dispatch_serialization import _lock_dir
+    default_dir = _lock_dir()
+    home = Path.home()
+    assert default_dir == home / ".vnx-data" / "locks", (
+        f"default lock dir {default_dir} is not ~/.vnx-data/locks"
+    )


### PR DESCRIPTION
## Summary

Serializes the Claude **subscription** tmux lane so two concurrent `vnx dispatch` claude-tmux runs cannot drive the same Claude subscription session at once (account-level contention → interleaved tmux send-keys, dropped deliveries). Provider lanes (codex/kimi/gemini/litellm) and `claude_headless` (API-metered) carry `serialization_class=None` and take **no lock** — they stay fully parallel.

6th increment of the dispatch-determinism build (PR-1→5 on main).

## Changes

- **NEW `scripts/lib/dispatch_serialization.py`** — `serialize_lane(serialization_class, *, dispatch_id)` context manager:
  - `None` → no-op (providers + headless never block / never touch the lock file).
  - `"claude-tmux"` → exclusive `fcntl.flock` on an **account-level** lock (`$VNX_LOCK_DIR` or `~/.vnx-data/locks/claude-tmux.lock`), held through the whole `with` body (execution + GOVERN/receipt), released in `finally` (incl. exception). flock auto-releases on process death.
  - Wait-warn (`VNX_CLAUDE_LOCK_WAIT_WARN_SECONDS`, default 60) names the holder and keeps waiting; hard ceiling (`VNX_CLAUDE_LOCK_TIMEOUT_SECONDS`, default 0=forever) raises — **never proceeds unlocked**. Posix-only (`fcntl`) or raises.
  - `force_release()` + `--force-release-lock [CLASS]` operator escape.
- **`dispatch_cli.run_dispatch`** — wraps the three-lane executor block in `serialize_lane(plan.serialization_class, ...)`. Routing/billing/permit unchanged; lock keyed off `serialization_class` so providers + headless are a no-op. (Door executes the tmux lane directly post-PR-5, so `run_dispatch` is the single uniform wrap-point.)
- **`dispatch.sh`** — `--force-release-lock [CLASS]` flag (works without `--spec-file`).
- **NEW `tests/test_dispatch_serialization.py`** — serialization, no-op parallelism, headless-not-locked, release-on-exception, force-release, account-level lock dir.

## Verification

- **279 passed** (door + provider + isolation + the 6 new serialization tests); ADR-003 PASS.
- **Review gate (locked decision: T0 + CI + kimi):**
  - **kimi — VERDICT: GREEN** (`provider_dispatch --provider kimi`): P0 none; executor fully wrapped; `None` is a true no-op. Full review: `claudedocs/dispatch-determinism-2026-06-15/REVIEW-PR6-kimi.md`.
  - **T0 — GREEN**: core serialization correct, no normal-path double-run or unlocked-execute window.

## Open Items

Both reviewers flagged a **manual-escape** hardening (not a normal-path bug) → fast-follow **PR-6b**:
- P1: `force_release` on a *live* (not hung) holder unlinks the lock file while the holder keeps the flock on the old inode → a new dispatch's `O_CREAT` makes a fresh inode and both can run. Acceptable as a documented manual escape, but the printed warning + docstring must state the double-run risk explicitly (and add a holder pid-liveness check).
- P2: `datetime.utcnow()` deprecation (line 59); `chmod 0o700` lock dir / `0o600` file; narrow the `OSError` catch in the poll loop (re-raise unexpected errno like `EBADF`); document macOS same-process nested self-deadlock + NFS advisory-flock caveat.

Dispatch-ID: 20260615-pr6-claude-serial-lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)