### PR TITLE
PR-6b: harden serial lock — explicit force-release double-run warning + ops nits

### DIFF
--- a/scripts/lib/dispatch_serialization.py
+++ b/scripts/lib/dispatch_serialization.py
@@ -11,6 +11,7 @@ Posix-only: requires fcntl (unavailable on Windows).
 from __future__ import annotations
 
 import datetime
+import errno
 import json
 import logging
 import os
@@ -56,7 +57,7 @@ def _timeout_seconds() -> float:
 
 
 def _iso_now() -> str:
-    return datetime.datetime.utcnow().isoformat() + "Z"
+    return datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 # ---------------------------------------------------------------------------
@@ -85,8 +86,11 @@ def _acquire_with_warn(
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             return  # acquired
-        except OSError:
-            pass
+        except OSError as exc:
+            # Only contention errnos mean "still locked — keep polling".
+            # Any other errno (e.g. EBADF) is a real fd error; re-raise immediately.
+            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES):
+                raise
 
         elapsed = time.monotonic() - start
 
@@ -138,6 +142,14 @@ def serialize_lane(
     and hold it through the entire with-body (execution + receipt/GOVERN).
     Lock is released unconditionally in finally, including on exception.
     flock auto-releases on process death; no manual stale-lock cleanup needed.
+
+    Note: flock is NOT reentrant in the same process for the same inode. A nested
+    serialize_lane("claude-tmux") within the same process self-deadlocks. This is
+    intentional for VNX's separate-process dispatch model — do not nest.
+
+    Note: advisory flock() over NFS may not serialize across all client/kernel
+    combinations. The default lock dir (~/.vnx-data/locks) is local — informational
+    only; no action needed unless running lock dir on a network filesystem.
     """
     if not serialization_class:
         yield
@@ -151,10 +163,12 @@ def serialize_lane(
 
     lock_dir = _lock_dir()
     lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_dir.chmod(0o700)  # account-level lock dir must not be other-user writable
     lock_path = lock_dir / f"{serialization_class}.lock"
 
     fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
     try:
+        os.fchmod(fd, 0o600)  # tighten existing file if it had lax permissions
         _acquire_with_warn(fd, lock_path, dispatch_id)
 
         # Write holder metadata for diagnostics + wait-warn + force-release.
@@ -179,11 +193,19 @@ def serialize_lane(
 def force_release(serialization_class: str = "claude-tmux") -> None:
     """Operator escape: print holder metadata and remove the lock file.
 
-    Does NOT kill the holder process — prints pid + dispatch_id so the operator
-    can act. After removal, a new acquire can succeed immediately.
+    Checks whether the holder process is still alive BEFORE removing:
+    - If ALIVE: prints a LOUD double-run warning and proceeds with removal.
+      A new acquire on a fresh inode can then run concurrently with the
+      original holder — true parallel double-run. Only use when the holder
+      is genuinely hung and not making progress.
+    - If DEAD: notes the holder is gone (flock auto-released) and removal is safe.
+    - If pid unreadable: removes without liveness check.
 
-    Note: flock auto-releases on holder process death, so force-release is only
-    needed when a holder process is hung (not dead, not making progress).
+    Does NOT kill the holder process. After removal, a new acquire succeeds immediately.
+
+    WARNING: force-releasing a LIVE holder allows two claude-tmux dispatches to run
+    concurrently (double-run). The flock on the old (now-unlinked) inode remains held
+    by the original process while a new dispatch acquires a lock on a fresh inode.
     """
     lock_dir = _lock_dir()
     lock_path = lock_dir / f"{serialization_class}.lock"
@@ -193,9 +215,11 @@ def force_release(serialization_class: str = "claude-tmux") -> None:
         print("[force-release] No stale lock to clear.")
         return
 
+    holder_pid = None
     try:
         raw = lock_path.read_text(encoding="utf-8")
         holder = json.loads(raw)
+        holder_pid = holder.get("pid")
         print(f"[force-release] Prior holder metadata: {holder}")
         print(f"[force-release]   pid          = {holder.get('pid')}")
         print(f"[force-release]   dispatch_id  = {holder.get('dispatch_id')}")
@@ -203,9 +227,32 @@ def force_release(serialization_class: str = "claude-tmux") -> None:
     except Exception as exc:
         print(f"[force-release] Could not read holder metadata: {exc}")
 
+    if holder_pid is not None:
+        try:
+            os.kill(holder_pid, 0)
+            # No exception -> process is alive
+            print(
+                f"WARNING: holder pid {holder_pid} is STILL ALIVE. "
+                "Force-releasing now will let a SECOND claude-tmux dispatch run "
+                "in PARALLEL with it (double-run). Only do this if that process "
+                "is hung/not-progressing."
+            )
+        except ProcessLookupError:
+            print(f"[force-release] Holder pid {holder_pid} is already gone (safe to release).")
+        except PermissionError:
+            # Process exists but belongs to another user
+            print(
+                f"WARNING: holder pid {holder_pid} is STILL ALIVE (owned by another user). "
+                "Force-releasing now will let a SECOND claude-tmux dispatch run "
+                "in PARALLEL with it (double-run). Only do this if that process "
+                "is hung/not-progressing."
+            )
+
     lock_path.unlink(missing_ok=True)
     print(f"[force-release] Lock file removed: {lock_path}")
     print(
         "[force-release] NOTE: flock auto-releases on holder process death. "
-        "Force-release is only needed for a hung holder (process alive, not progressing)."
+        "If the holder was alive, removing the lock allows a new dispatch to acquire "
+        "a fresh inode lock — running concurrently with the original holder (double-run). "
+        "Force-release is only safe when the holder is hung and not progressing."
     )

--- a/tests/test_dispatch_serialization.py
+++ b/tests/test_dispatch_serialization.py
@@ -1,22 +1,26 @@
 """test_dispatch_serialization.py — Tests for serialize_lane + force_release (PR-6).
 
 Covers: intra-thread serialization, no-op for None, exception release,
-force_release escape, and account-level lock directory resolution.
+force_release escape, account-level lock directory resolution, pid liveness
+warnings, unexpected OSError re-raise, and timezone-aware _iso_now.
 """
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
 import threading
 import time
+import warnings
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
-from dispatch_serialization import force_release, serialize_lane
+import dispatch_serialization as _ds_mod
+from dispatch_serialization import _iso_now, force_release, serialize_lane
 
 
 # ---------------------------------------------------------------------------
@@ -231,3 +235,105 @@ def test_lock_dir_is_account_level(tmp_path, monkeypatch):
     assert default_dir == home / ".vnx-data" / "locks", (
         f"default lock dir {default_dir} is not ~/.vnx-data/locks"
     )
+
+
+# ---------------------------------------------------------------------------
+# test_force_release_warns_on_live_holder
+# ---------------------------------------------------------------------------
+
+def test_force_release_warns_on_live_holder(tmp_path, monkeypatch, capsys):
+    """force_release prints LOUD double-run warning when holder pid is still alive."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / "claude-tmux.lock"
+
+    # Current pid is guaranteed alive
+    live_meta = {
+        "pid": os.getpid(),
+        "dispatch_id": "live-dispatch",
+        "timestamp": "2026-06-15T00:00:00Z",
+    }
+    lock_file.write_text(json.dumps(live_meta))
+
+    force_release("claude-tmux")
+    captured = capsys.readouterr()
+
+    assert "STILL ALIVE" in captured.out, "live-holder warning not printed"
+    assert "PARALLEL" in captured.out or "double-run" in captured.out.lower(), (
+        "double-run risk not mentioned in live-holder warning"
+    )
+    assert not lock_file.exists(), "lock file not removed after force_release on live holder"
+
+
+# ---------------------------------------------------------------------------
+# test_force_release_dead_holder_no_warning
+# ---------------------------------------------------------------------------
+
+def test_force_release_dead_holder_no_warning(tmp_path, monkeypatch, capsys):
+    """force_release notes safe removal when holder pid is already dead; no live warning."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / "claude-tmux.lock"
+
+    dead_meta = {
+        "pid": 999999,  # safely outside any realistic PID range on macOS/Linux
+        "dispatch_id": "dead-dispatch",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    lock_file.write_text(json.dumps(dead_meta))
+
+    force_release("claude-tmux")
+    captured = capsys.readouterr()
+
+    assert "STILL ALIVE" not in captured.out, (
+        "false live-holder warning printed for a dead pid"
+    )
+    assert not lock_file.exists(), "lock file not removed for dead holder"
+    # Should note that the holder is gone
+    assert "already gone" in captured.out or "dead-dispatch" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# test_acquire_reraises_unexpected_oserror
+# ---------------------------------------------------------------------------
+
+def test_acquire_reraises_unexpected_oserror(tmp_path, monkeypatch):
+    """_acquire_with_warn re-raises OSError(EBADF) immediately without spinning."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+
+    call_count = 0
+
+    def bad_flock(fd, op):
+        nonlocal call_count
+        call_count += 1
+        raise OSError(errno.EBADF, "bad file descriptor")
+
+    monkeypatch.setattr(_ds_mod.fcntl, "flock", bad_flock)
+
+    with pytest.raises(OSError, match="bad file descriptor"):
+        with serialize_lane("claude-tmux", dispatch_id="badf-test"):
+            pass  # must not reach here
+
+    # Must raise on first call — not spin
+    assert call_count == 1, f"flock called {call_count} times; expected 1 (no spin on EBADF)"
+
+
+# ---------------------------------------------------------------------------
+# test_iso_now_is_timezone_aware
+# ---------------------------------------------------------------------------
+
+def test_iso_now_is_timezone_aware():
+    """_iso_now() returns a Z-suffixed UTC timestamp with no DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        result = _iso_now()
+
+    assert result.endswith("Z"), f"_iso_now() did not end with 'Z': {result!r}"
+    # Must parse as timezone-aware
+    import datetime
+    parsed = datetime.datetime.fromisoformat(result.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None, "_iso_now() result is not timezone-aware"


### PR DESCRIPTION
## Summary

Applies the P1 + P2 hardening that **kimi + T0 flagged in the PR-6 review** (#886). The core flock serialization is unchanged — these are safety/clarity fixes around the `force_release` manual escape plus small ops hygiene.

## Changes (`scripts/lib/dispatch_serialization.py`)

- **P1 — `force_release` live-holder double-run made explicit + pid-liveness check.** Before unlinking, probe the holder pid with `os.kill(pid, 0)`: ALIVE → print a LOUD double-run warning (a new dispatch would acquire a fresh inode and run in parallel with the still-holding original); `ProcessLookupError` → note it's safe (holder gone); `PermissionError` → alive (other user) → warn. Docstring + always-printed NOTE now state the double-run risk explicitly. Still removes the file (it remains a deliberate manual hung-holder escape).
- **P2 — `datetime.utcnow()` → tz-aware** `datetime.now(timezone.utc).isoformat().replace("+00:00","Z")`.
- **P2 — lock perms**: `chmod 0o700` on the lock dir + `os.fchmod(fd, 0o600)` (tightens an existing lax-perm file).
- **P2 — narrowed the poll-loop `OSError` catch**: only `EWOULDBLOCK`/`EAGAIN`/`EACCES` mean "still locked, keep polling"; any other errno (e.g. `EBADF`) re-raises immediately (no infinite spin on a real fd error).
- **P2 — doc notes**: `flock` non-reentrancy (nested same-process `serialize_lane` self-deadlocks — don't nest) + NFS advisory-flock caveat.

## Verification

- `pytest <dispatch+serialization suites> -W error::DeprecationWarning -q` → **252 passed** (the 30 `utcnow` DeprecationWarnings are gone; +4 new tests: live-holder warning, dead-holder safe, EBADF re-raise, tz-aware `_iso_now`).
- `python3 scripts/check_adr_003_no_sdk_imports.py .` → **PASS**.
- T0 review: GREEN. Gate: this PR *is* the kimi-prescribed hardening from #886's review (kimi GREEN there); landed on T0 + CI.

## Open Items

None.

Dispatch-ID: 20260615-pr6b-lock-hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)