### PR TITLE
PR-7: isolation fail-loud + worktree ownership to the envelope

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -873,9 +873,43 @@ def run_envelope_plan(
         data_dir=spec.data_dir,
     )
 
-    start = datetime.now(timezone.utc)
-    result = ProviderAdapter().run(plan, enriched_spec.instruction)
-    end = datetime.now(timezone.utc)
+    from dispatch_worktree_isolation import (  # noqa: PLC0415
+        create_dispatch_worktree,
+        remove_dispatch_worktree,
+    )
+
+    wt_path: Optional[Path] = None
+    try:
+        wt_path = create_dispatch_worktree(plan.dispatch_id)
+    except Exception as _wt_exc:
+        _isolation_error = (
+            f"isolation required (require_worktree) but worktree creation failed "
+            f"for {plan.dispatch_id}: {_wt_exc} — aborting; no shared-checkout fallback"
+        )
+        logger.error("run_envelope_plan: %s", _isolation_error)
+        _fail_result = _AdapterResult(
+            returncode=1,
+            completion_text="",
+            status="failure",
+            error=_isolation_error,
+        )
+        _fail_start = _fail_end = datetime.now(timezone.utc)
+        report_path, receipt_path = _govern(enriched_spec, _fail_result, _fail_start, _fail_end)
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=report_path,
+            receipt_path=receipt_path,
+            completion_text="",
+            error=_isolation_error,
+        )
+
+    try:
+        start = datetime.now(timezone.utc)
+        result = ProviderAdapter().run(plan, enriched_spec.instruction, cwd=wt_path)
+        end = datetime.now(timezone.utc)
+    finally:
+        remove_dispatch_worktree(plan.dispatch_id)
 
     report_path, receipt_path = _govern(enriched_spec, result, start, end)
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -858,23 +858,16 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
-def _create_provider_worktree(dispatch_id: str) -> Optional[Path]:
+def _create_provider_worktree(dispatch_id: str) -> Path:
     """Create an isolated worktree for a provider dispatch.
 
     Only called when VNX_ISOLATED_WORKTREE=1.  Returns the worktree Path on
-    success, None on failure (logs the error and falls back to shared path).
+    success, raises RuntimeError on failure — no shared-checkout fallback.
     """
-    try:
-        from dispatch_worktree_isolation import create_dispatch_worktree  # noqa: PLC0415
-        wt_path = create_dispatch_worktree(dispatch_id)
-        logger.info("provider isolation: worktree created at %s (dispatch=%s)", wt_path, dispatch_id)
-        return wt_path
-    except RuntimeError as exc:
-        logger.error(
-            "provider isolation: create_dispatch_worktree failed for %s: %s — running in shared worktree",
-            dispatch_id, exc,
-        )
-        return None
+    from dispatch_worktree_isolation import create_dispatch_worktree  # noqa: PLC0415
+    wt_path = create_dispatch_worktree(dispatch_id)
+    logger.info("provider isolation: worktree created at %s (dispatch=%s)", wt_path, dispatch_id)
+    return wt_path
 
 
 def _remove_provider_worktree(dispatch_id: str) -> None:
@@ -914,7 +907,15 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
     enriched_instruction = _enrich_instruction(args)
     isolation_cwd: Optional[Path] = None
     if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":
-        isolation_cwd = _create_provider_worktree(args.dispatch_id)
+        try:
+            isolation_cwd = _create_provider_worktree(args.dispatch_id)
+        except RuntimeError as _wt_exc:
+            logger.error(
+                "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+                "for %s: %s — aborting dispatch; no shared-checkout fallback",
+                args.dispatch_id, _wt_exc,
+            )
+            return 1
     start_time = datetime.now(timezone.utc)
     try:
         result = spawn_codex(
@@ -1212,7 +1213,15 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
     enriched_instruction = _enrich_instruction(args)
     isolation_cwd_litellm: Optional[Path] = None
     if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":
-        isolation_cwd_litellm = _create_provider_worktree(args.dispatch_id)
+        try:
+            isolation_cwd_litellm = _create_provider_worktree(args.dispatch_id)
+        except RuntimeError as _wt_exc:
+            logger.error(
+                "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+                "for %s: %s — aborting dispatch; no shared-checkout fallback",
+                args.dispatch_id, _wt_exc,
+            )
+            return 1
     start_time = datetime.now(timezone.utc)
     try:
         result = spawn_litellm(
@@ -1281,7 +1290,15 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
     enriched_instruction = _enrich_instruction(args)
     isolation_cwd_kimi: Optional[Path] = None
     if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":
-        isolation_cwd_kimi = _create_provider_worktree(args.dispatch_id)
+        try:
+            isolation_cwd_kimi = _create_provider_worktree(args.dispatch_id)
+        except RuntimeError as _wt_exc:
+            logger.error(
+                "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+                "for %s: %s — aborting dispatch; no shared-checkout fallback",
+                args.dispatch_id, _wt_exc,
+            )
+            return 1
     start_time = datetime.now(timezone.utc)
     try:
         result = spawn_kimi(
@@ -1439,7 +1456,15 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
     enriched_instruction = _enrich_instruction(args)
     isolation_cwd_gemini: Optional[Path] = None
     if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":
-        isolation_cwd_gemini = _create_provider_worktree(args.dispatch_id)
+        try:
+            isolation_cwd_gemini = _create_provider_worktree(args.dispatch_id)
+        except RuntimeError as _wt_exc:
+            logger.error(
+                "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+                "for %s: %s — aborting dispatch; no shared-checkout fallback",
+                args.dispatch_id, _wt_exc,
+            )
+            return 1
     start_time = datetime.now(timezone.utc)
     try:
         result = spawn_gemini(

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -550,12 +550,13 @@ if __name__ == "__main__":
         except Exception as _wt_exc:
             import logging as _log_mod
             _log_mod.getLogger(__name__).error(
-                "VNX_ISOLATED_WORKTREE: worktree creation failed (%s); "
-                "falling back to shared repo root",
-                _wt_exc,
+                "VNX_ISOLATED_WORKTREE=1 worktree creation failed for %s: %s — "
+                "aborting dispatch; no shared-checkout fallback",
+                args.dispatch_id, _wt_exc,
             )
-            _isolated = False
-            _isolation_wt_path = None
+            _hb_stop.set()
+            _hb_thread.join(timeout=5)
+            sys.exit(1)
 
     try:
         ok = deliver_with_recovery(

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -427,3 +427,98 @@ def test_legacy_run_envelope_unchanged(tmp_path, monkeypatch):
     assert codex_adapter_calls == ["test-legacy-codex"], (
         f"CodexAdapter.run was not called; got: {codex_adapter_calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: PR-7 — envelope owns worktree; fail-loud on creation failure
+# ---------------------------------------------------------------------------
+
+
+_FAKE_WT_PATH = Path("/tmp/fake-worktrees/envelope-test")
+
+
+class TestEnvelopeWorktreeIsolation:
+    def test_worktree_created_and_passed_as_cwd(self, tmp_path):
+        """run_envelope_plan creates worktree and passes cwd to ProviderAdapter.run."""
+        plan = _make_provider_plan(tmp_path, dispatch_id="wt-cwd-test")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        adapter_calls: list = []
+
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+            adapter_calls.append({"cwd": cwd})
+            return _fake_adapter_success()
+
+        with patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
+             patch.object(ProviderAdapter, "run", fake_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "success"
+        mock_create.assert_called_once_with("wt-cwd-test")
+        assert adapter_calls, "ProviderAdapter.run was not called"
+        assert adapter_calls[0]["cwd"] == _FAKE_WT_PATH, (
+            f"expected cwd={_FAKE_WT_PATH}, got cwd={adapter_calls[0]['cwd']}"
+        )
+        mock_remove.assert_called_once_with("wt-cwd-test")
+
+    def test_worktree_removed_on_spawn_failure(self, tmp_path):
+        """remove_dispatch_worktree is called even when ProviderAdapter.run raises."""
+        plan = _make_provider_plan(tmp_path, dispatch_id="wt-rm-fail-test")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+
+        def bad_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+            raise RuntimeError("spawn exploded")
+
+        with patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
+             patch.object(ProviderAdapter, "run", bad_adapter_run):
+            with pytest.raises(RuntimeError, match="spawn exploded"):
+                run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        mock_remove.assert_called_once_with("wt-rm-fail-test")
+
+    def test_worktree_creation_failure_aborts_dispatch(self, tmp_path):
+        """Worktree creation failure → dispatch aborts (status=failure, rc!=0), spawn NOT called."""
+        plan = _make_provider_plan(tmp_path, dispatch_id="wt-create-fail-test")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        adapter_calls: list = []
+
+        def bad_create(dispatch_id):
+            raise RuntimeError("no disk space")
+
+        def spy_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+            adapter_calls.append({"cwd": cwd})
+            return _fake_adapter_success()
+
+        with patch("dispatch_worktree_isolation.create_dispatch_worktree", side_effect=bad_create), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
+             patch.object(ProviderAdapter, "run", spy_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)) as mock_govern:
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "failure"
+        assert result.returncode == 1
+        assert result.error is not None
+        assert "no shared-checkout fallback" in result.error
+        assert adapter_calls == [], "ProviderAdapter.run must NOT be called when worktree creation fails"
+        mock_govern.assert_called_once()
+        mock_remove.assert_not_called()

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -1,12 +1,13 @@
 """test_provider_dispatch_worktree_isolation.py — VNX_ISOLATED_WORKTREE for providers.
 
-Verifies (PR-PROVIDER-ISO):
+Verifies (PR-PROVIDER-ISO / PR-7):
 1. With VNX_ISOLATED_WORKTREE=1, each provider dispatch (codex/kimi/gemini/litellm):
    - calls create_dispatch_worktree with the dispatch_id
    - passes the worktree path as cwd to the spawn function
    - calls remove_dispatch_worktree after (success and failure paths)
 2. Without VNX_ISOLATED_WORKTREE, spawn functions receive cwd=None (no isolation).
-3. create_dispatch_worktree failure: dispatch continues in shared path (cwd=None).
+3. create_dispatch_worktree failure (VNX_ISOLATED_WORKTREE=1): dispatch ABORTS (returns 1),
+   spawn NOT called — no silent shared-checkout fallback (PR-7 fail-loud).
 """
 
 from __future__ import annotations
@@ -385,10 +386,10 @@ class TestProviderWorktreeHelpers:
         assert result == tmp_path
         mock_create.assert_called_once_with("helper-create-test")
 
-    def test_create_returns_none_on_runtime_error(self):
+    def test_create_raises_on_runtime_error(self):
         with patch("dispatch_worktree_isolation.create_dispatch_worktree", side_effect=RuntimeError("disk full")):
-            result = provider_dispatch._create_provider_worktree("helper-fail-test")
-        assert result is None
+            with pytest.raises(RuntimeError, match="disk full"):
+                provider_dispatch._create_provider_worktree("helper-fail-test")
 
     def test_remove_is_best_effort(self):
         """_remove_provider_worktree must not raise even if underlying call fails."""
@@ -399,3 +400,127 @@ class TestProviderWorktreeHelpers:
         with patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove:
             provider_dispatch._remove_provider_worktree("remove-ok-test")
         mock_remove.assert_called_once_with("remove-ok-test")
+
+
+# ---------------------------------------------------------------------------
+# PR-7: fail-loud — VNX_ISOLATED_WORKTREE=1 + create failure → ABORT, no spawn
+# ---------------------------------------------------------------------------
+
+class TestCodexIsolationFailLoud:
+    def test_isolation_create_failure_aborts_dispatch(self):
+        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        spawn_called = []
+
+        def fake_spawn(*a, **kw):
+            spawn_called.append(kw)
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        with patch.dict("os.environ", {"VNX_ISOLATED_WORKTREE": "1"}, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=_noop_governance), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("provider_dispatch._resolve_codex_model", return_value="gpt-test"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.codex_spawn.spawn_codex", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", side_effect=RuntimeError("disk full")) as mock_create:
+
+            args = provider_dispatch._build_parser().parse_args(_base_argv("codex", "fail-loud-codex"))
+            exit_code = provider_dispatch._dispatch_codex(args)
+
+        assert exit_code == 1
+        mock_create.assert_called_once_with("fail-loud-codex")
+        assert spawn_called == [], "spawn_codex must NOT be called when worktree creation fails"
+
+
+class TestGeminiIsolationFailLoud:
+    def test_isolation_create_failure_aborts_dispatch(self):
+        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        spawn_called = []
+
+        def fake_spawn(*a, **kw):
+            spawn_called.append(kw)
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        with patch.dict("os.environ", {"VNX_ISOLATED_WORKTREE": "1"}, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=_noop_governance), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.gemini_spawn.spawn_gemini", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", side_effect=RuntimeError("disk full")) as mock_create:
+
+            args = provider_dispatch._build_parser().parse_args(_base_argv("gemini", "fail-loud-gemini"))
+            exit_code = provider_dispatch._dispatch_gemini(args)
+
+        assert exit_code == 1
+        mock_create.assert_called_once_with("fail-loud-gemini")
+        assert spawn_called == [], "spawn_gemini must NOT be called when worktree creation fails"
+
+
+class TestKimiIsolationFailLoud:
+    def test_isolation_create_failure_aborts_dispatch(self):
+        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        spawn_called = []
+
+        def fake_spawn(*a, **kw):
+            spawn_called.append(kw)
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        with patch.dict("os.environ", {"VNX_ISOLATED_WORKTREE": "1"}, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=_noop_governance), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("provider_dispatch._resolve_kimi_model_label", return_value="kimi-default"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.kimi_spawn.spawn_kimi", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", side_effect=RuntimeError("disk full")) as mock_create:
+
+            args = provider_dispatch._build_parser().parse_args(_base_argv("kimi", "fail-loud-kimi"))
+            exit_code = provider_dispatch._dispatch_kimi(args)
+
+        assert exit_code == 1
+        mock_create.assert_called_once_with("fail-loud-kimi")
+        assert spawn_called == [], "spawn_kimi must NOT be called when worktree creation fails"
+
+
+class TestLiteLLMIsolationFailLoud:
+    def test_isolation_create_failure_aborts_dispatch(self):
+        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        spawn_called = []
+
+        def fake_spawn(*a, **kw):
+            spawn_called.append(kw)
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        with patch.dict("os.environ", {
+            "VNX_ISOLATED_WORKTREE": "1",
+            "VNX_LITELLM_MODEL": "deepseek/deepseek-v4-pro",
+            "DEEPSEEK_API_KEY": "sk-test",
+        }, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=_noop_governance), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.litellm_spawn.spawn_litellm", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", side_effect=RuntimeError("disk full")) as mock_create:
+
+            args = provider_dispatch._build_parser().parse_args(
+                _base_argv("litellm:deepseek", "fail-loud-litellm")
+            )
+            exit_code = provider_dispatch._dispatch_litellm(args)
+
+        assert exit_code == 1
+        mock_create.assert_called_once_with("fail-loud-litellm")
+        assert spawn_called == [], "spawn_litellm must NOT be called when worktree creation fails"


### PR DESCRIPTION
## Summary

`ExecutionPlan` already mandates `isolation=WORKTREE` + `require_worktree=True` ("the only legal value in 1.0 — every worker spawn is isolated, fail-loud"), but three code paths silently fell back to the shared checkout and the door's provider path did **no** isolation at all. PR-7 makes isolation fail-loud everywhere and gives the envelope ownership of the provider worktree.

7th increment of the dispatch-determinism build (PR-1→6b on main).

## Changes

- **`dispatch_envelope.run_envelope_plan` — envelope OWNS the provider worktree.** Creates the isolated worktree (`create_dispatch_worktree`) before spawning; passes it as `cwd` to `ProviderAdapter.run`; removes it in `finally` (teardown even if the spawn raises). **Fail-loud:** on worktree-create failure it governs a failure result (auditable receipt) and returns `EnvelopeResult(status=failure, rc=1)` — `ProviderAdapter.run` is never reached, so no provider ever spawns in the shared checkout. (Previously line 877 ran `ProviderAdapter().run(plan, instruction)` with no cwd → shared checkout always, violating `require_worktree`.)
- **`provider_dispatch.py` legacy path — fail-loud.** `_create_provider_worktree` now raises `RuntimeError` instead of returning `None`; all 4 `_dispatch_*` callers (codex/litellm/kimi/gemini) catch it and `return 1` (abort, no `cwd=None` spawn). Removed the "running in shared worktree" fallback.
- **`subprocess_dispatch.py` — fail-loud.** Replaced "falling back to shared repo root" with a `sys.exit(1)` abort (heartbeat stopped first) when `VNX_ISOLATED_WORKTREE=1` and worktree creation fails.

Env UNSET on the legacy path (isolation not requested) still runs shared — only *requested-but-failed* isolation aborts. The envelope/door path always isolates.

## Verification

- **290 passed** (envelope + provider isolation + door + serialization + entry suites); ADR-003 PASS.
- New tests assert isolation failure → **abort/FAILURE, not a warning** (kimi K27 ops note): envelope creates+passes+removes the worktree, and create-failure aborts without spawning.
- Review gate (T0 + CI + kimi): T0 GREEN; kimi review in progress (will be noted on the PR before merge).

## Open Items

- `vnx doctor` could pre-flight unwritable worktree/lock dir before dispatch (kimi K27 ops note) — deferred, not blocking.

Dispatch-ID: 20260615-pr7-isolation-failloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)