### PR TITLE
PR-9: de-evade the PreToolUse spawn guard (delete allowlist, detect lane-script/python smuggling, shadow-mode)

### DIFF
--- a/scripts/hooks/pretooluse_spawn_detector.py
+++ b/scripts/hooks/pretooluse_spawn_detector.py
@@ -14,6 +14,7 @@ Shadow-detected (allow + log when VNX_HOOK_ENFORCE unset/0; block when =1):
     subprocess_dispatch.py, provider_dispatch.py, dispatch_cli.py
   python[3] -m <lane_module>
   python[3] -c "..." containing an import of a lane module
+  importlib.import_module("<lane_module>")
 
 Allowed (no rule match):
   claude --version / claude --help / claude (interactive)
@@ -28,6 +29,11 @@ Telemetry: every block AND every shadow detection → one JSON line appended to
   <VNX_DATA_DIR>/events/hook_blocks.ndjson. Telemetry errors never block.
 
 Exit code is always 0. Decision is stdout text.
+
+Known limitation: a renamed copy of a lane script (e.g. `python /tmp/pd.py`)
+cannot be detected by static command inspection — no lane name appears in the
+command. The in-process ExecutionPermit (require_permit) is the real backstop
+for that vector; this hook is the first layer, not the only one.
 
 Live-proven gap (2026-06-09): a raw `kimi --print` invocation bypassed receipts
 the same way `claude -p` did. This detector now covers all three provider CLIs.
@@ -56,22 +62,56 @@ except ImportError:
 # Match the CLI binary name when preceded by string-start, whitespace, or shell
 # operators (&, ;, |, (, ), backtick via \x60, $, ', ").
 # Covers: 'kimi ...', 'nohup kimi ...', '&& codex ...', 'bash -c "kimi ..."', etc.
+# Path-form detection (/usr/bin/claude, ./claude) is handled via _normalize_command()
+# before this pattern is applied, so path separators need not be in the boundary.
 _TOKEN_BOUNDARY = r"(?:^|[\s;&|()\x60$'\"])"
-_CMD_SUFFIX = r"(?=\s|$|[\"';\x60\\])"
+# CMD_SUFFIX: binary name must be followed by whitespace, EOL, or shell/redirect chars.
+# <, >, & added so "claude -p<<<x" (here-string) is detected — the binary token
+# "claude" is followed by space before the flag, and the flag by "<" (redirect).
+_CMD_SUFFIX = r"(?=\s|$|[\"';\x60\\<>&])"
+
+# ── _normalize_command: collapse evasion obfuscation before hard-block matching ─
+# Collapses empty quote pairs (cla""ude → claude, co''dex → codex) and
+# stray backslash-escapes before letters (\c\l\a\u\d\e → claude).
+# Also strips a leading directory path so /usr/local/bin/claude → claude.
+# The raw command string is preserved for telemetry; only normalization is used
+# for rule matching.
+_EMPTY_QUOTES_RE = re.compile(r'""' + r"|''")
+_BACKSLASH_LETTER_RE = re.compile(r'\\([A-Za-z])')
+_LEADING_PATH_RE = re.compile(r'(?:^|\s)(?:[./][^\s]*/)?([^\s/]+)')
+
+
+def _normalize_command(cmd: str) -> str:
+    """Return a de-obfuscated form of cmd for hard-block matching.
+
+    Steps applied (in order):
+    1. Remove empty quote pairs ('' and "").
+    2. Remove backslash-escapes before letters (\\c → c).
+    3. Strip leading directory paths from binary names
+       (/usr/local/bin/claude → claude, ./codex → codex).
+    """
+    out = _EMPTY_QUOTES_RE.sub("", cmd)
+    out = _BACKSLASH_LETTER_RE.sub(r"\1", out)
+    # Strip leading path components from each token that starts with / or ./
+    # so /usr/bin/claude becomes (treated as) claude.
+    # We do a simple regex replacement: any /path/to/name token → space + name.
+    out = re.sub(r'(?<!\w)(?:[./][^\s]*/)', ' ', out)
+    return out
+
 
 # ── Hard-block patterns — claude ───────────────────────────────────────────────
 CLAUDE_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"claude" + _CMD_SUFFIX)
 CLAUDE_BLOCKED_FLAG_PATTERNS = [
-    re.compile(r"(?:^|\s)-p(?:\s|$)"),
-    re.compile(r"(?:^|\s)--print(?:\s|$)"),
-    re.compile(r"(?:^|\s)--dangerously-skip-permissions(?:\s|$)"),
+    re.compile(r"(?:^|\s)-p(?:\s|$|[<>&])"),
+    re.compile(r"(?:^|\s)--print(?:\s|$|[<>&])"),
+    re.compile(r"(?:^|\s)--dangerously-skip-permissions(?:\s|$|[<>&])"),
 ]
 
 # ── Hard-block patterns — kimi ─────────────────────────────────────────────────
 KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
 KIMI_BLOCKED_FLAG_PATTERNS = [
-    re.compile(r"(?:^|\s)--print(?:\s|$)"),
-    re.compile(r"(?:^|\s)-p(?:\s|$)"),
+    re.compile(r"(?:^|\s)--print(?:\s|$|[<>&])"),
+    re.compile(r"(?:^|\s)-p(?:\s|$|[<>&])"),
 ]
 # login, --version, --help: benign / auth — always allowed
 KIMI_ALLOWED_PATTERN = re.compile(
@@ -80,7 +120,7 @@ KIMI_ALLOWED_PATTERN = re.compile(
 
 # ── Hard-block patterns — codex ────────────────────────────────────────────────
 CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
-CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$)")
+CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$|[<>&])")
 
 # ── Shadow evasion patterns (new, PR-9) ────────────────────────────────────────
 # Lane/provider module names — the only permitted entry point post-PR-12 is
@@ -89,24 +129,47 @@ _LANE_MODS = (
     r"(?:tmux_interactive_dispatch|subprocess_dispatch|provider_dispatch|dispatch_cli)"
 )
 
-# Direct lane-script invocation: [/any/path/]lane_module.py at a token boundary.
-# Covers: python3 scripts/lib/provider_dispatch.py, ./dispatch_cli.py, etc.
+# Execution-position boundary: string-start or shell operator position.
+# A lane .py appearing after echo/cat/grep/git (as an argument) must NOT match.
+# We require the lane .py to be an execution target:
+#   - preceded by python/python3 (+ optional flags), OR
+#   - at command-position: string-start or after ;/&&/||/|/backtick/( optionally
+#     via ./ or an absolute path.
+# A lane .py appearing as an argument to echo/cat/grep/git/in a comment → no match.
+_EXEC_BOUNDARY = r"(?:^|[;|&(]\s*|\|\|\s*|&&\s*|\x60\s*)"
+
 LANE_SCRIPT_PATTERN = re.compile(
-    _TOKEN_BOUNDARY + r"(?:\S*/)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60])"
+    # python[3] [flags] path/lane.py
+    r"(?:" + _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*(?:\S+/)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60<>&])"
+    # OR lane.py at execution position (command-position token)
+    # Covers: ./lane.py, scripts/lib/lane.py, /abs/path/lane.py, bare lane.py
+    r"|" + _EXEC_BOUNDARY + r"(?:/?(?:[^\s/]+/)*)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60<>&])"
+    r")"
 )
 
-# python[3] [flags] -m <lane_module>
+# python[3] [flags] -m<lane_module> (accept no-space form: -mprovider_dispatch)
 PYTHON_M_LANE_PATTERN = re.compile(
-    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-m\s+" + _LANE_MODS + r"(?:\s|$)"
+    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-m\s*" + _LANE_MODS + r"(?:\s|$)"
 )
 
-# python[3] -c "..." presence (combined with _LANE_IMPORT_PATTERN below)
+# python[3] -c<string> (accept no-space form: -c'import ...')
 _PYTHON_C_PATTERN = re.compile(
-    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-c\s+"
+    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-c\s*"
 )
-# import / from-import of a lane module anywhere in the command string
+
+# import of a lane module that looks like a real statement, NOT a string-literal mention.
+# Best-effort: exclude imports immediately preceded by `('` or `("` (nested function arg).
+# Handles: python -c "import X", python -c'import X', python3 -c 'from X import ...'
+# Residual: a mention like `python -c "print('import X')"` does not match because
+# `import` is preceded by `('`, which the negative lookbehind blocks.
+# A mention like `python -c "x = 'import X'"` may still match (documented limitation).
 _LANE_IMPORT_PATTERN = re.compile(
-    r"(?:import\s+" + _LANE_MODS + r"|from\s+" + _LANE_MODS + r"\s+import)"
+    r"(?<!\(')(?<!\(\")(?:import\s+" + _LANE_MODS + r"|from\s+" + _LANE_MODS + r"\s+import)"
+)
+
+# importlib.import_module("<lane_module>") — dynamic-import form
+_IMPORTLIB_PATTERN = re.compile(
+    r"import_module\([\"']" + _LANE_MODS
 )
 
 
@@ -118,6 +181,8 @@ def _detect_shadow(cmd: str) -> str | None:
         return "python_m_lane_module"
     if _PYTHON_C_PATTERN.search(cmd) and _LANE_IMPORT_PATTERN.search(cmd):
         return "python_c_lane_import"
+    if _IMPORTLIB_PATTERN.search(cmd):
+        return "importlib_lane_import"
     return None
 
 
@@ -131,25 +196,28 @@ def _classify_full(cmd: str, enforce_mode: bool) -> tuple[str, str | None, str]:
     if not cmd:
         return "allow", None, "allow"
 
+    # Normalize for hard-block matching (raw cmd kept for telemetry)
+    norm = _normalize_command(cmd)
+
     # Hard-block: claude raw CLI (always block, VNX_HOOK_ENFORCE irrelevant)
-    if CLAUDE_TOKEN_PATTERN.search(cmd):
+    if CLAUDE_TOKEN_PATTERN.search(norm):
         for pat in CLAUDE_BLOCKED_FLAG_PATTERNS:
-            if pat.search(cmd):
+            if pat.search(norm):
                 return "block", "claude_raw_cli", "block"
 
     # Hard-block: kimi raw CLI
-    if KIMI_TOKEN_PATTERN.search(cmd):
-        if not KIMI_ALLOWED_PATTERN.search(cmd):
+    if KIMI_TOKEN_PATTERN.search(norm):
+        if not KIMI_ALLOWED_PATTERN.search(norm):
             for pat in KIMI_BLOCKED_FLAG_PATTERNS:
-                if pat.search(cmd):
+                if pat.search(norm):
                     return "block", "kimi_raw_cli", "block"
 
     # Hard-block: codex exec
-    if CODEX_TOKEN_PATTERN.search(cmd):
-        if CODEX_EXEC_PATTERN.search(cmd):
+    if CODEX_TOKEN_PATTERN.search(norm):
+        if CODEX_EXEC_PATTERN.search(norm):
             return "block", "codex_exec_cli", "block"
 
-    # Shadow evasion (new rules — respect VNX_HOOK_ENFORCE)
+    # Shadow evasion (new rules — respect VNX_HOOK_ENFORCE); use raw cmd
     shadow_rule = _detect_shadow(cmd)
     if shadow_rule:
         if enforce_mode:
@@ -188,25 +256,45 @@ def _append_telemetry(cmd: str, matched_rule: str, severity: str, mode: str) -> 
 
 
 def main() -> None:
-    raw = sys.stdin.read()
     try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        # Malformed JSON — fail open to avoid blocking valid work
+        raw = sys.stdin.read()
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            sys.stdout.write("allow\n")
+            return
+
+        # Guard: data must be a dict
+        if not isinstance(data, dict):
+            sys.stdout.write("allow\n")
+            return
+
+        tool_input = data.get("tool_input") or {}
+
+        # Guard: tool_input must be a dict
+        if not isinstance(tool_input, dict):
+            sys.stdout.write("allow\n")
+            return
+
+        raw_cmd = tool_input.get("command", "")
+
+        # Guard: command must be a string; list commands (e.g. ["claude", "-p"]) → allow
+        if not isinstance(raw_cmd, str):
+            sys.stdout.write("allow\n")
+            return
+
+        cmd = raw_cmd
+        enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
+        decision, matched_rule, severity = _classify_full(cmd, enforce_mode)
+
+        if matched_rule is not None:
+            mode = "enforce" if enforce_mode else "shadow"
+            _append_telemetry(cmd, matched_rule, severity, mode)
+
+        sys.stdout.write(decision + "\n")
+    except Exception:  # noqa: BLE001
+        # Absolute fail-open: any unexpected error → allow, never crash the hook
         sys.stdout.write("allow\n")
-        return
-
-    tool_input = data.get("tool_input") or {}
-    cmd = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
-
-    enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
-    decision, matched_rule, severity = _classify_full(cmd, enforce_mode)
-
-    if matched_rule is not None:
-        mode = "enforce" if enforce_mode else "shadow"
-        _append_telemetry(cmd, matched_rule, severity, mode)
-
-    sys.stdout.write(decision + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/pretooluse_spawn_detector.py
+++ b/scripts/hooks/pretooluse_spawn_detector.py
@@ -2,28 +2,46 @@
 """PreToolUse spawn detector — subprocess_dispatch governance enforcement.
 
 Reads the Claude Code PreToolUse hook JSON payload from stdin.
-Outputs "allow" or "block" (no newline stripping needed; shell trims).
+Outputs "allow" or "block" (shell trims the trailing newline).
+
+PR-9c model — shell-aware, per-segment, tokenized argv classification
+─────────────────────────────────────────────────────────────────────
+The raw-string regex hard-block of PR-9/9b leaked against shell quoting
+(`cl'a'ude -p`, `claude "-p"`, `codex "exec"`), masked a whole command on a
+benign first segment (`kimi --version && kimi --print x`), and produced
+arg-position false-positives (`git log --grep claude -p`). PR-9c replaces the
+regex hard-block with a tokenizer:
+
+  1. Split the command into SEGMENTS on the shell operators ; && || | & and
+     newlines (quote-aware: operators inside quotes do not split). Each segment
+     is classified on its own — this alone kills the kimi allow-mask.
+  2. Tokenize each segment with a POSIX shlex lexer (punctuation_chars=True so
+     redirects like `<<<` split off cleanly). shlex dequotes cl'a'ude→claude,
+     claude "-p"→claude -p, codex "exec"→codex exec, and resolves escapes.
+  3. HARD-BLOCK on the basename of argv[0] (strips paths: /usr/bin/claude →
+     claude) plus an exact blocked-flag token in argv[1:]. This is airtight
+     against quoting AND immune to arg-position false-positives — a provider
+     name that appears as an ARGUMENT has a different argv[0].
+  4. Recurse into `bash -c` / `sh -c` strings and transparent command-prefix
+     runners (nohup/env/setsid/stdbuf), bounded to depth 3.
+  5. Shadow-detect lane invocations on the tokenized argv (allow+log by
+     default; block when VNX_HOOK_ENFORCE=1). A lane name as a non-executable
+     argument (`echo provider_dispatch.py`) does not match.
+  6. Fail-open absolutely: any stdin → exactly one allow/block line, never a
+     traceback. An unbalanced-quote segment falls back to a best-effort legacy
+     regex scan, which still BLOCKS a raw provider spawn — no blanket allow.
 
 Hard-blocked (always, regardless of VNX_HOOK_ENFORCE):
   claude:  -p / --print / --dangerously-skip-permissions
   kimi:    --print / -p
-  codex:   exec <args>
+  codex:   exec <subcommand>
 
 Shadow-detected (allow + log when VNX_HOOK_ENFORCE unset/0; block when =1):
   Direct lane-script invocation: tmux_interactive_dispatch.py,
     subprocess_dispatch.py, provider_dispatch.py, dispatch_cli.py
   python[3] -m <lane_module>
-  python[3] -c "..." containing an import of a lane module
+  python[3] -c "..." importing a lane module
   importlib.import_module("<lane_module>")
-
-Allowed (no rule match):
-  claude --version / claude --help / claude (interactive)
-  kimi --version / kimi login / kimi (no prompt-executing flags)
-  codex --version / codex --help (benign read-only)
-  Any command that doesn't match a block or shadow pattern.
-
-VNX_HOOK_ENFORCE: unset/0 = shadow rules log-and-allow; 1 = shadow rules block.
-  Hard-block rules ALWAYS block regardless of this flag.
 
 Telemetry: every block AND every shadow detection → one JSON line appended to
   <VNX_DATA_DIR>/events/hook_blocks.ndjson. Telemetry errors never block.
@@ -32,11 +50,13 @@ Exit code is always 0. Decision is stdout text.
 
 Known limitation: a renamed copy of a lane script (e.g. `python /tmp/pd.py`)
 cannot be detected by static command inspection — no lane name appears in the
-command. The in-process ExecutionPermit (require_permit) is the real backstop
-for that vector; this hook is the first layer, not the only one.
+command. Likewise a non-listed command-prefix runner that takes positional
+arguments (e.g. `timeout 5 claude -p`) is not unwrapped. The in-process
+ExecutionPermit (require_permit) is the real backstop for those vectors; this
+hook is the first layer, not the only one.
 
 Live-proven gap (2026-06-09): a raw `kimi --print` invocation bypassed receipts
-the same way `claude -p` did. This detector now covers all three provider CLIs.
+the same way `claude -p` did. This detector covers all three provider CLIs.
 """
 
 from __future__ import annotations
@@ -44,6 +64,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -58,126 +79,109 @@ try:
 except ImportError:
     project_root = None  # type: ignore[assignment]
 
-# ── Token boundary helpers ─────────────────────────────────────────────────────
-# Match the CLI binary name when preceded by string-start, whitespace, or shell
-# operators (&, ;, |, (, ), backtick via \x60, $, ', ").
-# Covers: 'kimi ...', 'nohup kimi ...', '&& codex ...', 'bash -c "kimi ..."', etc.
-# Path-form detection (/usr/bin/claude, ./claude) is handled via _normalize_command()
-# before this pattern is applied, so path separators need not be in the boundary.
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+MAX_RECURSION_DEPTH = 3
+
+# Hard-block flag tables — exact token match against the dequoted argv[1:].
+_CLAUDE_BLOCKED_FLAGS = frozenset({"-p", "--print", "--dangerously-skip-permissions"})
+_KIMI_BLOCKED_FLAGS = frozenset({"-p", "--print"})
+
+# Shell wrappers whose `-c <string>` argument is itself a command to classify.
+_SHELL_WRAPPERS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
+
+# Transparent command-prefix runners: argv[0] launches the real command which
+# follows after the runner's own options/assignments. nohup/setsid/stdbuf take
+# only dash-options; env additionally takes NAME=VALUE assignments. Runners with
+# positional arguments (timeout/nice) are intentionally excluded — see the
+# module "Known limitation"; the ExecutionPermit is the backstop for those.
+_PREFIX_RUNNERS = frozenset({"nohup", "setsid", "stdbuf", "env"})
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Lane/provider module names — the only permitted entry point post-PR-12 is
+# `vnx dispatch`. Direct invocation of these bypasses governance receipts.
+_LANE_MODULE_NAMES = frozenset({
+    "tmux_interactive_dispatch",
+    "subprocess_dispatch",
+    "provider_dispatch",
+    "dispatch_cli",
+})
+# Longest-first alternation so a shorter name never shadows a longer one.
+_LANE_MODS_RE = r"(?:" + r"|".join(
+    sorted(_LANE_MODULE_NAMES, key=len, reverse=True)
+) + r")"
+
+_PYTHON_RE = re.compile(r"python[0-9.]*$")
+
+# Operator/redirect tokens produced by the punctuation-aware lexer
+# (subshell parens, redirects, any quoted-away pipe/amp remnant).
+_OP_CHARS = frozenset("();<>|&")
+
+# Lane-import detection inside a `python -c` code string. The negative
+# lookbehind blocks a string-literal mention (`print('import provider_dispatch')`)
+# while still catching a real statement-position import.
+_LANE_IMPORT_PATTERN = re.compile(
+    r"(?<!\(')(?<!\(\")(?:import\s+" + _LANE_MODS_RE
+    + r"|from\s+" + _LANE_MODS_RE + r"\s+import)"
+)
+# importlib.import_module("<lane_module>") — dynamic-import form.
+_IMPORTLIB_PATTERN = re.compile(r"import_module\([\"']" + _LANE_MODS_RE)
+
+
+# ── Legacy regex fallback (unbalanced-quote segments only) ─────────────────────
+# Used ONLY when shlex cannot tokenize a segment (unbalanced quotes). It must
+# still BLOCK a raw provider spawn — never blanket-allow malformed input.
 _TOKEN_BOUNDARY = r"(?:^|[\s;&|()\x60$'\"])"
-# CMD_SUFFIX: binary name must be followed by whitespace, EOL, or shell/redirect chars.
-# <, >, & added so "claude -p<<<x" (here-string) is detected — the binary token
-# "claude" is followed by space before the flag, and the flag by "<" (redirect).
 _CMD_SUFFIX = r"(?=\s|$|[\"';\x60\\<>&])"
-
-# ── _normalize_command: collapse evasion obfuscation before hard-block matching ─
-# Collapses empty quote pairs (cla""ude → claude, co''dex → codex) and
-# stray backslash-escapes before letters (\c\l\a\u\d\e → claude).
-# Also strips a leading directory path so /usr/local/bin/claude → claude.
-# The raw command string is preserved for telemetry; only normalization is used
-# for rule matching.
 _EMPTY_QUOTES_RE = re.compile(r'""' + r"|''")
-_BACKSLASH_LETTER_RE = re.compile(r'\\([A-Za-z])')
-_LEADING_PATH_RE = re.compile(r'(?:^|\s)(?:[./][^\s]*/)?([^\s/]+)')
+_BACKSLASH_LETTER_RE = re.compile(r"\\([A-Za-z])")
 
-
-def _normalize_command(cmd: str) -> str:
-    """Return a de-obfuscated form of cmd for hard-block matching.
-
-    Steps applied (in order):
-    1. Remove empty quote pairs ('' and "").
-    2. Remove backslash-escapes before letters (\\c → c).
-    3. Strip leading directory paths from binary names
-       (/usr/local/bin/claude → claude, ./codex → codex).
-    """
-    out = _EMPTY_QUOTES_RE.sub("", cmd)
-    out = _BACKSLASH_LETTER_RE.sub(r"\1", out)
-    # Strip leading path components from each token that starts with / or ./
-    # so /usr/bin/claude becomes (treated as) claude.
-    # We do a simple regex replacement: any /path/to/name token → space + name.
-    out = re.sub(r'(?<!\w)(?:[./][^\s]*/)', ' ', out)
-    return out
-
-
-# ── Hard-block patterns — claude ───────────────────────────────────────────────
-CLAUDE_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"claude" + _CMD_SUFFIX)
-CLAUDE_BLOCKED_FLAG_PATTERNS = [
+_CLAUDE_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"claude" + _CMD_SUFFIX)
+_CLAUDE_FLAG_PATTERNS = [
     re.compile(r"(?:^|\s)-p(?:\s|$|[<>&])"),
     re.compile(r"(?:^|\s)--print(?:\s|$|[<>&])"),
     re.compile(r"(?:^|\s)--dangerously-skip-permissions(?:\s|$|[<>&])"),
 ]
-
-# ── Hard-block patterns — kimi ─────────────────────────────────────────────────
-KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
-KIMI_BLOCKED_FLAG_PATTERNS = [
+_KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
+_KIMI_FLAG_PATTERNS = [
     re.compile(r"(?:^|\s)--print(?:\s|$|[<>&])"),
     re.compile(r"(?:^|\s)-p(?:\s|$|[<>&])"),
 ]
-# login, --version, --help: benign / auth — always allowed
-KIMI_ALLOWED_PATTERN = re.compile(
+_KIMI_ALLOWED_PATTERN = re.compile(
     r"(?:^|\s)kimi\s+(?:login|--version|-v|--help|-h)(?:\s|$)"
 )
+_CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
+_CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$|[<>&])")
 
-# ── Hard-block patterns — codex ────────────────────────────────────────────────
-CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
-CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$|[<>&])")
-
-# ── Shadow evasion patterns (new, PR-9) ────────────────────────────────────────
-# Lane/provider module names — the only permitted entry point post-PR-12 is
-# `vnx dispatch`. Direct invocation of these scripts bypasses governance.
-_LANE_MODS = (
-    r"(?:tmux_interactive_dispatch|subprocess_dispatch|provider_dispatch|dispatch_cli)"
-)
-
-# Execution-position boundary: string-start or shell operator position.
-# A lane .py appearing after echo/cat/grep/git (as an argument) must NOT match.
-# We require the lane .py to be an execution target:
-#   - preceded by python/python3 (+ optional flags), OR
-#   - at command-position: string-start or after ;/&&/||/|/backtick/( optionally
-#     via ./ or an absolute path.
-# A lane .py appearing as an argument to echo/cat/grep/git/in a comment → no match.
 _EXEC_BOUNDARY = r"(?:^|[;|&(]\s*|\|\|\s*|&&\s*|\x60\s*)"
-
-LANE_SCRIPT_PATTERN = re.compile(
-    # python[3] [flags] path/lane.py
-    r"(?:" + _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*(?:\S+/)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60<>&])"
-    # OR lane.py at execution position (command-position token)
-    # Covers: ./lane.py, scripts/lib/lane.py, /abs/path/lane.py, bare lane.py
-    r"|" + _EXEC_BOUNDARY + r"(?:/?(?:[^\s/]+/)*)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60<>&])"
+_LANE_SCRIPT_PATTERN = re.compile(
+    r"(?:" + _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*(?:\S+/)?"
+    + _LANE_MODS_RE + r"\.py(?:\s|$|[\"';\x60<>&])"
+    r"|" + _EXEC_BOUNDARY + r"(?:/?(?:[^\s/]+/)*)?"
+    + _LANE_MODS_RE + r"\.py(?:\s|$|[\"';\x60<>&])"
     r")"
 )
-
-# python[3] [flags] -m<lane_module> (accept no-space form: -mprovider_dispatch)
-PYTHON_M_LANE_PATTERN = re.compile(
-    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-m\s*" + _LANE_MODS + r"(?:\s|$)"
+_PYTHON_M_LANE_PATTERN = re.compile(
+    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-m\s*" + _LANE_MODS_RE + r"(?:\s|$)"
 )
-
-# python[3] -c<string> (accept no-space form: -c'import ...')
 _PYTHON_C_PATTERN = re.compile(
     _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-c\s*"
 )
 
-# import of a lane module that looks like a real statement, NOT a string-literal mention.
-# Best-effort: exclude imports immediately preceded by `('` or `("` (nested function arg).
-# Handles: python -c "import X", python -c'import X', python3 -c 'from X import ...'
-# Residual: a mention like `python -c "print('import X')"` does not match because
-# `import` is preceded by `('`, which the negative lookbehind blocks.
-# A mention like `python -c "x = 'import X'"` may still match (documented limitation).
-_LANE_IMPORT_PATTERN = re.compile(
-    r"(?<!\(')(?<!\(\")(?:import\s+" + _LANE_MODS + r"|from\s+" + _LANE_MODS + r"\s+import)"
-)
 
-# importlib.import_module("<lane_module>") — dynamic-import form
-_IMPORTLIB_PATTERN = re.compile(
-    r"import_module\([\"']" + _LANE_MODS
-)
+def _normalize_command(cmd: str) -> str:
+    """Collapse simple obfuscation for the legacy fallback scan."""
+    out = _EMPTY_QUOTES_RE.sub("", cmd)
+    out = _BACKSLASH_LETTER_RE.sub(r"\1", out)
+    out = re.sub(r"(?<!\w)(?:[./][^\s]*/)", " ", out)
+    return out
 
 
-def _detect_shadow(cmd: str) -> str | None:
-    """Return shadow rule name if an evasion vector is detected, else None."""
-    if LANE_SCRIPT_PATTERN.search(cmd):
+def _detect_shadow_legacy(cmd: str) -> str | None:
+    """Shadow rule name via the legacy regex patterns (fallback path)."""
+    if _LANE_SCRIPT_PATTERN.search(cmd):
         return "lane_script_direct"
-    if PYTHON_M_LANE_PATTERN.search(cmd):
+    if _PYTHON_M_LANE_PATTERN.search(cmd):
         return "python_m_lane_module"
     if _PYTHON_C_PATTERN.search(cmd) and _LANE_IMPORT_PATTERN.search(cmd):
         return "python_c_lane_import"
@@ -186,39 +190,191 @@ def _detect_shadow(cmd: str) -> str | None:
     return None
 
 
-def _classify_full(cmd: str, enforce_mode: bool) -> tuple[str, str | None, str]:
-    """Return (decision, matched_rule, severity).
-
-    decision    : "allow" or "block"
-    matched_rule: rule name, or None for plain allow
-    severity    : "block", "shadow", or "allow"
-    """
-    if not cmd:
-        return "allow", None, "allow"
-
-    # Normalize for hard-block matching (raw cmd kept for telemetry)
-    norm = _normalize_command(cmd)
-
-    # Hard-block: claude raw CLI (always block, VNX_HOOK_ENFORCE irrelevant)
-    if CLAUDE_TOKEN_PATTERN.search(norm):
-        for pat in CLAUDE_BLOCKED_FLAG_PATTERNS:
+def _legacy_scan_segment(segment: str, enforce_mode: bool) -> tuple[str, str | None, str]:
+    """Best-effort scan for a segment shlex could not tokenize. Blocks a raw
+    provider spawn; never blanket-allows malformed input."""
+    norm = _normalize_command(segment)
+    if _CLAUDE_TOKEN_PATTERN.search(norm):
+        for pat in _CLAUDE_FLAG_PATTERNS:
             if pat.search(norm):
                 return "block", "claude_raw_cli", "block"
+    if _KIMI_TOKEN_PATTERN.search(norm) and not _KIMI_ALLOWED_PATTERN.search(norm):
+        for pat in _KIMI_FLAG_PATTERNS:
+            if pat.search(norm):
+                return "block", "kimi_raw_cli", "block"
+    if _CODEX_TOKEN_PATTERN.search(norm) and _CODEX_EXEC_PATTERN.search(norm):
+        return "block", "codex_exec_cli", "block"
+    shadow_rule = _detect_shadow_legacy(segment)
+    if shadow_rule:
+        if enforce_mode:
+            return "block", shadow_rule, "block"
+        return "allow", shadow_rule, "shadow"
+    return "allow", None, "allow"
 
-    # Hard-block: kimi raw CLI
-    if KIMI_TOKEN_PATTERN.search(norm):
-        if not KIMI_ALLOWED_PATTERN.search(norm):
-            for pat in KIMI_BLOCKED_FLAG_PATTERNS:
-                if pat.search(norm):
-                    return "block", "kimi_raw_cli", "block"
 
-    # Hard-block: codex exec
-    if CODEX_TOKEN_PATTERN.search(norm):
-        if CODEX_EXEC_PATTERN.search(norm):
-            return "block", "codex_exec_cli", "block"
+# ── Tokenized classification ───────────────────────────────────────────────────
 
-    # Shadow evasion (new rules — respect VNX_HOOK_ENFORCE); use raw cmd
-    shadow_rule = _detect_shadow(cmd)
+def _split_segments(command: str) -> list[str]:
+    """Quote-aware split into top-level segments on ; && || | & and newlines.
+
+    Operators inside single/double quotes (or backslash-escaped) do not split,
+    so a `bash -c "claude -p; echo"` string stays whole for recursion.
+    """
+    segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote is not None:
+            buf.append(ch)
+            # backslash escapes the next char only inside double quotes
+            if quote == '"' and ch == "\\" and i + 1 < n:
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n:
+            buf.append(ch)
+            buf.append(command[i + 1])
+            i += 2
+            continue
+        if ch in (";", "\n"):
+            segments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        if ch in ("&", "|"):
+            segments.append("".join(buf))
+            buf = []
+            i += 2 if (i + 1 < n and command[i + 1] == ch) else 1
+            continue
+        buf.append(ch)
+        i += 1
+    segments.append("".join(buf))
+    return [s for s in segments if s.strip()]
+
+
+def _tokenize(text: str) -> list[str]:
+    """POSIX shlex tokens with shell operators split off as their own tokens.
+
+    Raises ValueError on unbalanced quotes (handled by the caller via the
+    legacy fallback). punctuation_chars=True keeps redirects (`<<<`, `>`) from
+    gluing onto an adjacent flag, so `claude -p<<<x` → ['claude','-p','<<<','x'].
+    """
+    lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _is_operator_token(tok: str) -> bool:
+    """True for a token made up entirely of shell operator/redirect chars."""
+    return bool(tok) and all(c in _OP_CHARS for c in tok)
+
+
+def _value_for_flag(rest: list[str], flag: str) -> str | None:
+    """Value passed to a flag, handling both 'flag value' and 'flagvalue' forms
+    (e.g. '-m provider_dispatch' and '-mprovider_dispatch')."""
+    for i, tok in enumerate(rest):
+        if tok == flag:
+            return rest[i + 1] if i + 1 < len(rest) else None
+        if tok.startswith(flag) and len(tok) > len(flag):
+            return tok[len(flag):]
+    return None
+
+
+def _is_lane_script(basename: str) -> bool:
+    """True if a file basename is a lane module .py (provider_dispatch.py, …)."""
+    return basename.endswith(".py") and basename[:-3] in _LANE_MODULE_NAMES
+
+
+def _strip_prefix_runner(argv: list[str]) -> list[str] | None:
+    """Inner command argv if argv[0] is a transparent prefix runner, else None.
+
+    Drops the runner plus its leading dash-options and NAME=VALUE assignments;
+    returns the remaining argv (the real command), or None if nothing remains.
+    """
+    if os.path.basename(argv[0]) not in _PREFIX_RUNNERS:
+        return None
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok.startswith("-") or _ENV_ASSIGN_RE.match(tok):
+            i += 1
+            continue
+        break
+    return argv[i:] if i < n else None
+
+
+def _detect_shadow_argv(argv: list[str]) -> str | None:
+    """Shadow rule name for a tokenized argv, else None."""
+    exe = os.path.basename(argv[0])
+    # Direct lane-script invocation: argv[0] IS the lane .py.
+    if _is_lane_script(exe):
+        return "lane_script_direct"
+    # python / python3 / python3.x forms.
+    if _PYTHON_RE.match(exe):
+        rest = argv[1:]
+        # python <path>/lane.py  (the lane .py is the script being executed)
+        for tok in rest:
+            if not tok.startswith("-") and _is_lane_script(os.path.basename(tok)):
+                return "lane_script_direct"
+        # python -m <lane_module>
+        m_target = _value_for_flag(rest, "-m")
+        if m_target and m_target in _LANE_MODULE_NAMES:
+            return "python_m_lane_module"
+        # python -c "<code importing a lane>"
+        code = _value_for_flag(rest, "-c")
+        if code:
+            if _IMPORTLIB_PATTERN.search(code):
+                return "importlib_lane_import"
+            if _LANE_IMPORT_PATTERN.search(code):
+                return "python_c_lane_import"
+    return None
+
+
+def _classify_argv(argv: list[str], enforce_mode: bool, depth: int) -> tuple[str, str | None, str]:
+    """Classify a single tokenized command (one shell segment)."""
+    if not argv:
+        return "allow", None, "allow"
+    exe = os.path.basename(argv[0])
+    rest = argv[1:]
+
+    # Hard-block — always block, VNX_HOOK_ENFORCE irrelevant.
+    if exe == "claude" and any(a in _CLAUDE_BLOCKED_FLAGS for a in rest):
+        return "block", "claude_raw_cli", "block"
+    if exe == "kimi" and any(a in _KIMI_BLOCKED_FLAGS for a in rest):
+        return "block", "kimi_raw_cli", "block"
+    if exe == "codex" and "exec" in rest:
+        return "block", "codex_exec_cli", "block"
+
+    # Transparent prefix runner (nohup/env/setsid/stdbuf) → classify inner cmd.
+    if depth < MAX_RECURSION_DEPTH:
+        inner = _strip_prefix_runner(argv)
+        if inner is not None:
+            return _classify_argv(inner, enforce_mode, depth + 1)
+
+    # Shell wrapper -c "<command>" → recurse on the dequoted command string.
+    if exe in _SHELL_WRAPPERS and depth < MAX_RECURSION_DEPTH:
+        inner_code = _value_for_flag(rest, "-c")
+        if inner_code:
+            sub = _classify_command(inner_code, enforce_mode, depth + 1)
+            if sub[2] != "allow":
+                return sub
+
+    # Shadow evasion (respects VNX_HOOK_ENFORCE).
+    shadow_rule = _detect_shadow_argv(argv)
     if shadow_rule:
         if enforce_mode:
             return "block", shadow_rule, "block"
@@ -227,11 +383,53 @@ def _classify_full(cmd: str, enforce_mode: bool) -> tuple[str, str | None, str]:
     return "allow", None, "allow"
 
 
+def _classify_segment(segment: str, enforce_mode: bool, depth: int) -> tuple[str, str | None, str]:
+    """Tokenize and classify one segment; fall back to legacy scan on bad quotes."""
+    seg = segment.strip()
+    if not seg:
+        return "allow", None, "allow"
+    try:
+        tokens = _tokenize(seg)
+    except ValueError:
+        return _legacy_scan_segment(seg, enforce_mode)
+    argv = [t for t in tokens if not _is_operator_token(t)]
+    return _classify_argv(argv, enforce_mode, depth)
+
+
+_SEV_RANK = {"allow": 0, "shadow": 1, "block": 2}
+
+
+def _classify_command(command: str, enforce_mode: bool, depth: int = 0) -> tuple[str, str | None, str]:
+    """Split a command into segments and return the strongest decision.
+
+    Block beats shadow beats allow; the first block short-circuits.
+    """
+    if not command or not command.strip():
+        return "allow", None, "allow"
+    try:
+        segments = _split_segments(command)
+    except Exception:  # noqa: BLE001
+        segments = [command]
+    if not segments:
+        return "allow", None, "allow"
+    best: tuple[str, str | None, str] = ("allow", None, "allow")
+    for seg in segments:
+        dec = _classify_segment(seg, enforce_mode, depth)
+        if dec[2] == "block":
+            return dec
+        if _SEV_RANK[dec[2]] > _SEV_RANK[best[2]]:
+            best = dec
+    return best
+
+
 def classify(cmd: str) -> str:
     """Return 'allow' or 'block'. Reads VNX_HOOK_ENFORCE from environment."""
     enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
-    decision, _, _ = _classify_full(cmd, enforce_mode)
-    return decision
+    try:
+        decision, _, _ = _classify_command(cmd or "", enforce_mode)
+        return decision
+    except Exception:  # noqa: BLE001
+        return "allow"  # absolute fail-open
 
 
 def _append_telemetry(cmd: str, matched_rule: str, severity: str, mode: str) -> None:
@@ -285,7 +483,11 @@ def main() -> None:
 
         cmd = raw_cmd
         enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
-        decision, matched_rule, severity = _classify_full(cmd, enforce_mode)
+        try:
+            decision, matched_rule, severity = _classify_command(cmd, enforce_mode)
+        except Exception:  # noqa: BLE001
+            sys.stdout.write("allow\n")
+            return
 
         if matched_rule is not None:
             mode = "enforce" if enforce_mode else "shadow"

--- a/scripts/hooks/pretooluse_spawn_detector.py
+++ b/scripts/hooks/pretooluse_spawn_detector.py
@@ -48,12 +48,15 @@ Telemetry: every block AND every shadow detection → one JSON line appended to
 
 Exit code is always 0. Decision is stdout text.
 
-Known limitation: a renamed copy of a lane script (e.g. `python /tmp/pd.py`)
-cannot be detected by static command inspection — no lane name appears in the
-command. Likewise a non-listed command-prefix runner that takes positional
-arguments (e.g. `timeout 5 claude -p`) is not unwrapped. The in-process
-ExecutionPermit (require_permit) is the real backstop for those vectors; this
-hook is the first layer, not the only one.
+Known limitation (accepted by design): static command-string inspection cannot be
+airtight against a Turing-complete shell; esoteric constructs (command/process
+substitution, backticks, brace/case groups, prefix runners like sudo/timeout/xargs,
+$IFS word-splitting, ANSI-C $'...', nesting beyond the recursion bound) can route a
+raw provider spawn past this hook undetected. These are accepted as out-of-scope: the
+hook is a defense-in-depth first layer that catches the common and accidental cases (the
+only kind a governed worker actually produces); the in-process ExecutionPermit
+(`require_permit`) is the authoritative, un-evadable control. Do not chase esoteric
+evasion hardening here — that arms race cannot be won.
 
 Live-proven gap (2026-06-09): a raw `kimi --print` invocation bypassed receipts
 the same way `claude -p` did. This detector covers all three provider CLIs.
@@ -127,6 +130,12 @@ _LANE_IMPORT_PATTERN = re.compile(
 # importlib.import_module("<lane_module>") — dynamic-import form.
 _IMPORTLIB_PATTERN = re.compile(r"import_module\([\"']" + _LANE_MODS_RE)
 
+# FP-1 fix: import must appear at statement position (line/semicolon start), not inside
+# a string literal. E.g. `s = 'import provider_dispatch'` must NOT match.
+_LANE_IMPORT_STMT_PATTERN = re.compile(
+    r"^\s*(?:import\s+" + _LANE_MODS_RE + r"|from\s+" + _LANE_MODS_RE + r"\s+import)"
+)
+
 
 # ── Legacy regex fallback (unbalanced-quote segments only) ─────────────────────
 # Used ONLY when shlex cannot tokenize a segment (unbalanced quotes). It must
@@ -167,6 +176,20 @@ _PYTHON_M_LANE_PATTERN = re.compile(
 _PYTHON_C_PATTERN = re.compile(
     _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-c\s*"
 )
+
+
+def _has_lane_import_at_statement(code: str) -> bool:
+    """Return True iff a lane import appears at statement position in the code string.
+
+    Splits on `;` and newlines to get individual statements, then checks each against
+    _LANE_IMPORT_STMT_PATTERN. This avoids FP-1: an import token inside a string
+    literal (e.g. `s = 'import provider_dispatch'`) does not start a statement and
+    therefore does not match.
+    """
+    for stmt in re.split(r"[;\n]", code):
+        if _LANE_IMPORT_STMT_PATTERN.match(stmt):
+            return True
+    return False
 
 
 def _normalize_command(cmd: str) -> str:
@@ -326,20 +349,35 @@ def _detect_shadow_argv(argv: list[str]) -> str | None:
     # python / python3 / python3.x forms.
     if _PYTHON_RE.match(exe):
         rest = argv[1:]
-        # python <path>/lane.py  (the lane .py is the script being executed)
-        for tok in rest:
+
+        # FP-2 fix: a lane .py that appears AFTER `-c <code>` is a program argument
+        # passed to the code string, not the script python executes. Find the -c index
+        # so we can limit the lane-script scan to tokens that precede it.
+        c_idx: int | None = None
+        for j, tok in enumerate(rest):
+            if tok == "-c" or (tok.startswith("-c") and len(tok) > 2):
+                c_idx = j
+                break
+
+        # python <path>/lane.py — only tokens BEFORE the -c position are candidates.
+        scan_limit = c_idx if c_idx is not None else len(rest)
+        for tok in rest[:scan_limit]:
             if not tok.startswith("-") and _is_lane_script(os.path.basename(tok)):
                 return "lane_script_direct"
+
         # python -m <lane_module>
         m_target = _value_for_flag(rest, "-m")
         if m_target and m_target in _LANE_MODULE_NAMES:
             return "python_m_lane_module"
+
         # python -c "<code importing a lane>"
+        # FP-1 fix: use statement-position check instead of bare _LANE_IMPORT_PATTERN
+        # so an import token inside a string literal does not trigger shadow.
         code = _value_for_flag(rest, "-c")
         if code:
             if _IMPORTLIB_PATTERN.search(code):
                 return "importlib_lane_import"
-            if _LANE_IMPORT_PATTERN.search(code):
+            if _has_lane_import_at_statement(code):
                 return "python_c_lane_import"
     return None
 

--- a/scripts/hooks/pretooluse_spawn_detector.py
+++ b/scripts/hooks/pretooluse_spawn_detector.py
@@ -4,18 +4,30 @@
 Reads the Claude Code PreToolUse hook JSON payload from stdin.
 Outputs "allow" or "block" (no newline stripping needed; shell trims).
 
-Blocked:
-  claude:  -p / --print / --dangerously-skip-permissions (raw worker spawn)
-  kimi:    --print / -p  (prompt-executing invocation outside governed path)
-  codex:   exec <args>   (prompt-executing invocation outside governed path)
+Hard-blocked (always, regardless of VNX_HOOK_ENFORCE):
+  claude:  -p / --print / --dangerously-skip-permissions
+  kimi:    --print / -p
+  codex:   exec <args>
 
-Allowed:
-  subprocess_dispatch.py / provider_dispatch.py (governed wrappers — always)
+Shadow-detected (allow + log when VNX_HOOK_ENFORCE unset/0; block when =1):
+  Direct lane-script invocation: tmux_interactive_dispatch.py,
+    subprocess_dispatch.py, provider_dispatch.py, dispatch_cli.py
+  python[3] -m <lane_module>
+  python[3] -c "..." containing an import of a lane module
+
+Allowed (no rule match):
   claude --version / claude --help / claude (interactive)
   kimi --version / kimi login / kimi (no prompt-executing flags)
   codex --version / codex --help (benign read-only)
+  Any command that doesn't match a block or shadow pattern.
 
-Exit code is always 0. Decision is in stdout text, not exit code.
+VNX_HOOK_ENFORCE: unset/0 = shadow rules log-and-allow; 1 = shadow rules block.
+  Hard-block rules ALWAYS block regardless of this flag.
+
+Telemetry: every block AND every shadow detection → one JSON line appended to
+  <VNX_DATA_DIR>/events/hook_blocks.ndjson. Telemetry errors never block.
+
+Exit code is always 0. Decision is stdout text.
 
 Live-proven gap (2026-06-09): a raw `kimi --print` invocation bypassed receipts
 the same way `claude -p` did. This detector now covers all three provider CLIs.
@@ -24,106 +36,155 @@ the same way `claude -p` did. This detector now covers all three provider CLIs.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
+# ── Make scripts/lib importable for project_root ───────────────────────────────
+_SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "lib"
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
 
-# ── Allowlist patterns ─────────────────────────────────────────────────────────
-# These scripts invoke provider CLIs internally via Popen — invisible to this hook.
-# Allow any Bash command that explicitly calls one of these governed wrappers.
-ALLOWLIST_PATTERN = re.compile(
-    r"(subprocess_dispatch|provider_dispatch)\.py"
-)
+try:
+    import project_root
+except ImportError:
+    project_root = None  # type: ignore[assignment]
 
-# ── CLI command-token patterns ────────────────────────────────────────────────
+# ── Token boundary helpers ─────────────────────────────────────────────────────
 # Match the CLI binary name when preceded by string-start, whitespace, or shell
 # operators (&, ;, |, (, ), backtick via \x60, $, ', ").
 # Covers: 'kimi ...', 'nohup kimi ...', '&& codex ...', 'bash -c "kimi ..."', etc.
 _TOKEN_BOUNDARY = r"(?:^|[\s;&|()\x60$'\"])"
 _CMD_SUFFIX = r"(?=\s|$|[\"';\x60\\])"
 
+# ── Hard-block patterns — claude ───────────────────────────────────────────────
 CLAUDE_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"claude" + _CMD_SUFFIX)
-KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
-CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
-
-# ── Blocked flag patterns — claude ────────────────────────────────────────────
-# -p / --print : non-interactive print mode (worker spawn indicator)
-# --dangerously-skip-permissions : headless/background execution indicator
 CLAUDE_BLOCKED_FLAG_PATTERNS = [
     re.compile(r"(?:^|\s)-p(?:\s|$)"),
     re.compile(r"(?:^|\s)--print(?:\s|$)"),
     re.compile(r"(?:^|\s)--dangerously-skip-permissions(?:\s|$)"),
 ]
 
-# ── Blocked flag patterns — kimi ──────────────────────────────────────────────
-# --print / -p : prompt-executing invocations that bypass the receipt trail.
-# kimi login, kimi --version, kimi --help, bare `kimi` (interactive) are allowed.
+# ── Hard-block patterns — kimi ─────────────────────────────────────────────────
+KIMI_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"kimi" + _CMD_SUFFIX)
 KIMI_BLOCKED_FLAG_PATTERNS = [
     re.compile(r"(?:^|\s)--print(?:\s|$)"),
     re.compile(r"(?:^|\s)-p(?:\s|$)"),
 ]
-
-# ── Allowed kimi sub-commands / flags (benign, no prompt execution) ───────────
-# login, --version, --help: read-only / auth operations.
+# login, --version, --help: benign / auth — always allowed
 KIMI_ALLOWED_PATTERN = re.compile(
     r"(?:^|\s)kimi\s+(?:login|--version|-v|--help|-h)(?:\s|$)"
 )
 
-# ── Blocked sub-command patterns — codex ──────────────────────────────────────
-# `codex exec` is the prompt-executing form. `codex --version` / `codex --help`
-# are benign; bare `codex` (interactive) is allowed.
+# ── Hard-block patterns — codex ────────────────────────────────────────────────
+CODEX_TOKEN_PATTERN = re.compile(_TOKEN_BOUNDARY + r"codex" + _CMD_SUFFIX)
 CODEX_EXEC_PATTERN = re.compile(r"(?:^|\s)codex\s+exec(?:\s|$)")
 
+# ── Shadow evasion patterns (new, PR-9) ────────────────────────────────────────
+# Lane/provider module names — the only permitted entry point post-PR-12 is
+# `vnx dispatch`. Direct invocation of these scripts bypasses governance.
+_LANE_MODS = (
+    r"(?:tmux_interactive_dispatch|subprocess_dispatch|provider_dispatch|dispatch_cli)"
+)
 
-def _classify_claude(cmd: str) -> str:
-    """Return "allow" or "block" for a command containing the claude token."""
-    for pattern in CLAUDE_BLOCKED_FLAG_PATTERNS:
-        if pattern.search(cmd):
-            return "block"
-    return "allow"
+# Direct lane-script invocation: [/any/path/]lane_module.py at a token boundary.
+# Covers: python3 scripts/lib/provider_dispatch.py, ./dispatch_cli.py, etc.
+LANE_SCRIPT_PATTERN = re.compile(
+    _TOKEN_BOUNDARY + r"(?:\S*/)?" + _LANE_MODS + r"\.py(?:\s|$|[\"';\x60])"
+)
+
+# python[3] [flags] -m <lane_module>
+PYTHON_M_LANE_PATTERN = re.compile(
+    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-m\s+" + _LANE_MODS + r"(?:\s|$)"
+)
+
+# python[3] -c "..." presence (combined with _LANE_IMPORT_PATTERN below)
+_PYTHON_C_PATTERN = re.compile(
+    _TOKEN_BOUNDARY + r"python3?\s+(?:[^\s]+\s+)*-c\s+"
+)
+# import / from-import of a lane module anywhere in the command string
+_LANE_IMPORT_PATTERN = re.compile(
+    r"(?:import\s+" + _LANE_MODS + r"|from\s+" + _LANE_MODS + r"\s+import)"
+)
 
 
-def _classify_kimi(cmd: str) -> str:
-    """Return "allow" or "block" for a command containing the kimi token."""
-    # Benign invocations are always allowed regardless of other flags.
-    if KIMI_ALLOWED_PATTERN.search(cmd):
-        return "allow"
-    for pattern in KIMI_BLOCKED_FLAG_PATTERNS:
-        if pattern.search(cmd):
-            return "block"
-    return "allow"
+def _detect_shadow(cmd: str) -> str | None:
+    """Return shadow rule name if an evasion vector is detected, else None."""
+    if LANE_SCRIPT_PATTERN.search(cmd):
+        return "lane_script_direct"
+    if PYTHON_M_LANE_PATTERN.search(cmd):
+        return "python_m_lane_module"
+    if _PYTHON_C_PATTERN.search(cmd) and _LANE_IMPORT_PATTERN.search(cmd):
+        return "python_c_lane_import"
+    return None
 
 
-def _classify_codex(cmd: str) -> str:
-    """Return "allow" or "block" for a command containing the codex token."""
-    if CODEX_EXEC_PATTERN.search(cmd):
-        return "block"
-    return "allow"
+def _classify_full(cmd: str, enforce_mode: bool) -> tuple[str, str | None, str]:
+    """Return (decision, matched_rule, severity).
+
+    decision    : "allow" or "block"
+    matched_rule: rule name, or None for plain allow
+    severity    : "block", "shadow", or "allow"
+    """
+    if not cmd:
+        return "allow", None, "allow"
+
+    # Hard-block: claude raw CLI (always block, VNX_HOOK_ENFORCE irrelevant)
+    if CLAUDE_TOKEN_PATTERN.search(cmd):
+        for pat in CLAUDE_BLOCKED_FLAG_PATTERNS:
+            if pat.search(cmd):
+                return "block", "claude_raw_cli", "block"
+
+    # Hard-block: kimi raw CLI
+    if KIMI_TOKEN_PATTERN.search(cmd):
+        if not KIMI_ALLOWED_PATTERN.search(cmd):
+            for pat in KIMI_BLOCKED_FLAG_PATTERNS:
+                if pat.search(cmd):
+                    return "block", "kimi_raw_cli", "block"
+
+    # Hard-block: codex exec
+    if CODEX_TOKEN_PATTERN.search(cmd):
+        if CODEX_EXEC_PATTERN.search(cmd):
+            return "block", "codex_exec_cli", "block"
+
+    # Shadow evasion (new rules — respect VNX_HOOK_ENFORCE)
+    shadow_rule = _detect_shadow(cmd)
+    if shadow_rule:
+        if enforce_mode:
+            return "block", shadow_rule, "block"
+        return "allow", shadow_rule, "shadow"
+
+    return "allow", None, "allow"
 
 
 def classify(cmd: str) -> str:
-    """Return "allow" or "block" for the given bash command string."""
-    if not cmd:
-        return "allow"
+    """Return 'allow' or 'block'. Reads VNX_HOOK_ENFORCE from environment."""
+    enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
+    decision, _, _ = _classify_full(cmd, enforce_mode)
+    return decision
 
-    # Allowlist: governed dispatch wrappers are always permitted
-    if ALLOWLIST_PATTERN.search(cmd):
-        return "allow"
 
-    # Check each provider CLI independently; first "block" wins.
-    if CLAUDE_TOKEN_PATTERN.search(cmd):
-        if _classify_claude(cmd) == "block":
-            return "block"
-
-    if KIMI_TOKEN_PATTERN.search(cmd):
-        if _classify_kimi(cmd) == "block":
-            return "block"
-
-    if CODEX_TOKEN_PATTERN.search(cmd):
-        if _classify_codex(cmd) == "block":
-            return "block"
-
-    return "allow"
+def _append_telemetry(cmd: str, matched_rule: str, severity: str, mode: str) -> None:
+    """Append one JSON event to <data_dir>/events/hook_blocks.ndjson. Fail-open."""
+    try:
+        if project_root is None:
+            return
+        data_dir = project_root.resolve_data_dir(__file__)
+        events_dir = data_dir / "events"
+        events_dir.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "command": cmd[:2000],
+            "matched_rule": matched_rule,
+            "severity": severity,
+            "mode": mode,
+        }
+        with (events_dir / "hook_blocks.ndjson").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except Exception:  # noqa: BLE001
+        pass  # fail-open: telemetry must never block valid work or crash the hook
 
 
 def main() -> None:
@@ -138,7 +199,13 @@ def main() -> None:
     tool_input = data.get("tool_input") or {}
     cmd = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
 
-    decision = classify(cmd)
+    enforce_mode = os.environ.get("VNX_HOOK_ENFORCE", "0") == "1"
+    decision, matched_rule, severity = _classify_full(cmd, enforce_mode)
+
+    if matched_rule is not None:
+        mode = "enforce" if enforce_mode else "shadow"
+        _append_telemetry(cmd, matched_rule, severity, mode)
+
     sys.stdout.write(decision + "\n")
 
 

--- a/tests/test_pretooluse_spawn_detector.py
+++ b/tests/test_pretooluse_spawn_detector.py
@@ -776,3 +776,57 @@ class TestPR9cTelemetryRules:
         decision, entries = _run_main("git log --grep claude -p", tmp_path, enforce=True)
         assert decision == "allow"
         assert entries == []
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PR-9d — enforce-mode shadow false-positive fixes
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFP1StringLiteralImport:
+    """FP-1: import inside a string literal must NOT trigger shadow block under enforce."""
+
+    def test_string_assign_import_enforce_allows(self):
+        # `s = 'import provider_dispatch'` — import is a string value, not a statement.
+        cmd = """python -c "s = 'import provider_dispatch'" """
+        assert _classify(cmd, enforce=True) == "allow"
+
+    def test_print_string_import_enforce_allows(self):
+        # `print('import provider_dispatch')` — import is inside a function call string.
+        cmd = """python -c "print('import provider_dispatch')" """
+        assert _classify(cmd, enforce=True) == "allow"
+
+    def test_string_assign_import_shadow_allows(self):
+        cmd = """python -c "s = 'import provider_dispatch'" """
+        assert _classify(cmd, enforce=False) == "allow"
+
+    def test_real_statement_import_enforce_blocks(self):
+        # A genuine statement-position import must still shadow-block under enforce.
+        assert _classify("python -c 'import provider_dispatch'", enforce=True) == "block"
+
+    def test_real_statement_import_shadow_allows(self):
+        assert _classify("python -c 'import provider_dispatch'", enforce=False) == "allow"
+
+    def test_semicolon_statement_import_enforce_blocks(self):
+        # `x=1; import provider_dispatch` — the import IS at statement position.
+        assert _classify("python -c 'x=1; import provider_dispatch'", enforce=True) == "block"
+
+
+class TestFP2LaterArgNotExecutedScript:
+    """FP-2: lane.py appearing after `python -c <code>` is a program arg — must not shadow."""
+
+    def test_python_c_code_then_lane_py_enforce_allows(self):
+        assert _classify('python -c "print(1)" provider_dispatch.py', enforce=True) == "allow"
+
+    def test_python_c_code_then_lane_py_shadow_allows(self):
+        assert _classify('python -c "print(1)" provider_dispatch.py', enforce=False) == "allow"
+
+    def test_python_script_first_positional_enforce_blocks(self):
+        # Script as first positional arg (no -c) must still shadow-block under enforce.
+        assert _classify("python provider_dispatch.py", enforce=True) == "block"
+
+    def test_python3_script_first_positional_enforce_blocks(self):
+        assert _classify("python3 scripts/lib/provider_dispatch.py", enforce=True) == "block"
+
+    def test_python_script_first_positional_shadow_allows(self):
+        assert _classify("python provider_dispatch.py", enforce=False) == "allow"

--- a/tests/test_pretooluse_spawn_detector.py
+++ b/tests/test_pretooluse_spawn_detector.py
@@ -1,0 +1,378 @@
+"""Tests for pretooluse_spawn_detector.py PR-9 changes.
+
+Covers:
+  - Evasion #1 closed: ALLOWLIST_PATTERN removed; provider_dispatch.py + claude -p → block
+  - Clean governed wrapper invocations still allow in shadow mode
+  - Shadow evasion: lane-script direct / python -m / python -c → allow+log in default mode
+  - Enforce mode (VNX_HOOK_ENFORCE=1): shadow evasions → block
+  - Hard-block rules unchanged in both modes
+  - Benign commands unchanged
+  - Telemetry: shadow/block → one ndjson line; failure → fail-open
+  - Malformed stdin JSON → allow
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "hooks"))
+
+import pretooluse_spawn_detector as det  # noqa: E402
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _classify(cmd: str, enforce: bool = False) -> str:
+    env = {"VNX_HOOK_ENFORCE": "1" if enforce else "0"}
+    with mock.patch.dict(os.environ, env):
+        return det.classify(cmd)
+
+
+def _run_main(cmd: str, tmp_path: Path, enforce: bool = False) -> tuple[str, list[dict]]:
+    """Run main() with mock stdin; return (decision, ndjson_entries)."""
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+    data_dir = tmp_path / "_vnx_test_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    env = {
+        "VNX_DATA_DIR": str(data_dir),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_HOOK_ENFORCE": "1" if enforce else "0",
+    }
+    captured = io.StringIO()
+    with mock.patch.dict(os.environ, env):
+        with mock.patch("sys.stdin", io.StringIO(payload)):
+            with mock.patch("sys.stdout", captured):
+                det.main()
+    decision = captured.getvalue().strip()
+    ndjson = data_dir / "events" / "hook_blocks.ndjson"
+    entries: list[dict] = []
+    if ndjson.exists():
+        for line in ndjson.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entries.append(json.loads(line))
+    return decision, entries
+
+
+# ── Evasion #1: old allowlist bypass is closed ───────────────────────────────
+
+class TestEvasion1Closed:
+    """The ALLOWLIST_PATTERN early-return is gone. claude -p after provider_dispatch.py blocks."""
+
+    def test_provider_dispatch_then_claude_p_blocks(self):
+        cmd = "python3 scripts/lib/provider_dispatch.py --provider codex ; claude -p 'x'"
+        assert _classify(cmd) == "block"
+
+    def test_subprocess_dispatch_then_claude_p_blocks(self):
+        cmd = "subprocess_dispatch.py --provider claude ; claude -p 'prompt'"
+        assert _classify(cmd) == "block"
+
+    def test_provider_dispatch_then_kimi_print_blocks(self):
+        cmd = "python3 scripts/lib/provider_dispatch.py --provider kimi ; kimi --print 'x'"
+        assert _classify(cmd) == "block"
+
+    def test_provider_dispatch_then_codex_exec_blocks(self):
+        cmd = "python3 scripts/lib/provider_dispatch.py --provider codex ; codex exec --json"
+        assert _classify(cmd) == "block"
+
+    def test_clean_provider_dispatch_allows_shadow_mode(self):
+        # shadow rule matches but VNX_HOOK_ENFORCE=0 → decision is still "allow"
+        cmd = "python3 scripts/lib/provider_dispatch.py --provider codex --dispatch-id test-123"
+        assert _classify(cmd, enforce=False) == "allow"
+
+    def test_clean_subprocess_dispatch_allows_shadow_mode(self):
+        cmd = "python3 scripts/lib/subprocess_dispatch.py dispatch-id-456"
+        assert _classify(cmd, enforce=False) == "allow"
+
+
+# ── Hard-block rules: unchanged in both modes ─────────────────────────────────
+
+class TestHardBlocksUnchanged:
+    """Existing blocking rules must block regardless of VNX_HOOK_ENFORCE."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_claude_p_blocks(self, enforce):
+        assert _classify("claude -p 'x'", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_claude_print_blocks(self, enforce):
+        assert _classify("claude --print 'task'", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_claude_dangerously_skip_blocks(self, enforce):
+        assert _classify("claude --dangerously-skip-permissions", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_kimi_print_blocks(self, enforce):
+        assert _classify("kimi --print 'x'", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_kimi_p_blocks(self, enforce):
+        assert _classify("kimi -p 'x'", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_codex_exec_blocks(self, enforce):
+        assert _classify("codex exec --json", enforce=enforce) == "block"
+
+
+# ── Benign commands: always allow ─────────────────────────────────────────────
+
+class TestBenignAllow:
+
+    def test_claude_version(self):
+        assert _classify("claude --version") == "allow"
+
+    def test_claude_help(self):
+        assert _classify("claude --help") == "allow"
+
+    def test_bare_claude(self):
+        assert _classify("claude") == "allow"
+
+    def test_kimi_login(self):
+        assert _classify("kimi login") == "allow"
+
+    def test_kimi_version(self):
+        assert _classify("kimi --version") == "allow"
+
+    def test_kimi_help(self):
+        assert _classify("kimi --help") == "allow"
+
+    def test_bare_kimi(self):
+        assert _classify("kimi") == "allow"
+
+    def test_codex_help(self):
+        assert _classify("codex --help") == "allow"
+
+    def test_codex_version(self):
+        assert _classify("codex --version") == "allow"
+
+    def test_bare_codex(self):
+        assert _classify("codex") == "allow"
+
+    def test_empty_command(self):
+        assert _classify("") == "allow"
+
+    def test_git_status(self):
+        assert _classify("git status") == "allow"
+
+    def test_grep_p(self):
+        assert _classify("grep -p pattern file.txt") == "allow"
+
+    def test_mkdir_p(self):
+        assert _classify("mkdir -p /some/path") == "allow"
+
+    def test_unrelated_python_script(self):
+        assert _classify("python3 scripts/build_t0_state.py") == "allow"
+
+
+# ── Shadow evasion: direct lane script ────────────────────────────────────────
+
+class TestShadowLaneScriptDirect:
+
+    def test_provider_dispatch_direct_shadow_allows(self):
+        assert _classify("python3 scripts/lib/provider_dispatch.py --provider codex", enforce=False) == "allow"
+
+    def test_provider_dispatch_direct_enforce_blocks(self):
+        assert _classify("python3 scripts/lib/provider_dispatch.py --provider codex", enforce=True) == "block"
+
+    def test_subprocess_dispatch_direct_shadow_allows(self):
+        assert _classify("python3 scripts/lib/subprocess_dispatch.py prompt", enforce=False) == "allow"
+
+    def test_subprocess_dispatch_direct_enforce_blocks(self):
+        assert _classify("python3 scripts/lib/subprocess_dispatch.py prompt", enforce=True) == "block"
+
+    def test_tmux_interactive_dispatch_shadow_allows(self):
+        assert _classify("python3 scripts/lib/tmux_interactive_dispatch.py --provider claude", enforce=False) == "allow"
+
+    def test_tmux_interactive_dispatch_enforce_blocks(self):
+        assert _classify("python3 scripts/lib/tmux_interactive_dispatch.py --provider claude", enforce=True) == "block"
+
+    def test_dispatch_cli_shadow_allows(self):
+        assert _classify("scripts/lib/dispatch_cli.py --provider claude", enforce=False) == "allow"
+
+    def test_dispatch_cli_enforce_blocks(self):
+        assert _classify("scripts/lib/dispatch_cli.py --provider claude", enforce=True) == "block"
+
+    def test_absolute_path_lane_script_shadow_allows(self):
+        assert _classify("/home/user/proj/scripts/lib/provider_dispatch.py --provider kimi", enforce=False) == "allow"
+
+    def test_absolute_path_lane_script_enforce_blocks(self):
+        assert _classify("/home/user/proj/scripts/lib/provider_dispatch.py --provider kimi", enforce=True) == "block"
+
+
+# ── Shadow evasion: python -m <lane_module> ───────────────────────────────────
+
+class TestShadowPythonMLane:
+
+    def test_python_m_provider_dispatch_shadow_allows(self):
+        assert _classify("python -m provider_dispatch", enforce=False) == "allow"
+
+    def test_python_m_provider_dispatch_enforce_blocks(self):
+        assert _classify("python -m provider_dispatch", enforce=True) == "block"
+
+    def test_python3_m_subprocess_dispatch_shadow_allows(self):
+        assert _classify("python3 -m subprocess_dispatch", enforce=False) == "allow"
+
+    def test_python3_m_subprocess_dispatch_enforce_blocks(self):
+        assert _classify("python3 -m subprocess_dispatch", enforce=True) == "block"
+
+    def test_python_m_tmux_interactive_shadow_allows(self):
+        assert _classify("python -m tmux_interactive_dispatch", enforce=False) == "allow"
+
+    def test_python_m_tmux_interactive_enforce_blocks(self):
+        assert _classify("python -m tmux_interactive_dispatch", enforce=True) == "block"
+
+    def test_python_m_dispatch_cli_shadow_allows(self):
+        assert _classify("python -m dispatch_cli --provider claude", enforce=False) == "allow"
+
+    def test_python_m_dispatch_cli_enforce_blocks(self):
+        assert _classify("python -m dispatch_cli --provider claude", enforce=True) == "block"
+
+    def test_python3_m_with_flags_shadow_allows(self):
+        assert _classify("python3 -W ignore -m provider_dispatch", enforce=False) == "allow"
+
+    def test_python3_m_with_flags_enforce_blocks(self):
+        assert _classify("python3 -W ignore -m provider_dispatch", enforce=True) == "block"
+
+
+# ── Shadow evasion: python -c "import <lane_module>" ─────────────────────────
+
+class TestShadowPythonCImport:
+
+    def test_python_c_import_subprocess_dispatch_shadow_allows(self):
+        assert _classify('python -c "import subprocess_dispatch"', enforce=False) == "allow"
+
+    def test_python_c_import_subprocess_dispatch_enforce_blocks(self):
+        assert _classify('python -c "import subprocess_dispatch"', enforce=True) == "block"
+
+    def test_python3_c_from_import_shadow_allows(self):
+        assert _classify("python3 -c 'from provider_dispatch import main; main()'", enforce=False) == "allow"
+
+    def test_python3_c_from_import_enforce_blocks(self):
+        assert _classify("python3 -c 'from provider_dispatch import main; main()'", enforce=True) == "block"
+
+    def test_python_c_import_tmux_shadow_allows(self):
+        assert _classify('python3 -c "import tmux_interactive_dispatch"', enforce=False) == "allow"
+
+    def test_python_c_import_tmux_enforce_blocks(self):
+        assert _classify('python3 -c "import tmux_interactive_dispatch"', enforce=True) == "block"
+
+    def test_python_c_import_dispatch_cli_shadow_allows(self):
+        assert _classify('python -c "import dispatch_cli; dispatch_cli.run()"', enforce=False) == "allow"
+
+    def test_python_c_import_dispatch_cli_enforce_blocks(self):
+        assert _classify('python -c "import dispatch_cli; dispatch_cli.run()"', enforce=True) == "block"
+
+    def test_python_c_no_lane_import_allows(self):
+        # -c with unrelated import must not trigger
+        assert _classify('python -c "import os; os.listdir(\'.\')"', enforce=False) == "allow"
+
+    def test_python_without_c_flag_allows(self):
+        # bare python with import in a .py file: not a -c pattern
+        assert _classify("python import_provider_dispatch.py", enforce=False) == "allow"
+
+
+# ── Telemetry ─────────────────────────────────────────────────────────────────
+
+class TestTelemetry:
+
+    def test_shadow_hit_writes_one_ndjson_line(self, tmp_path):
+        decision, entries = _run_main("python -m provider_dispatch", tmp_path, enforce=False)
+        assert decision == "allow"
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["matched_rule"] == "python_m_lane_module"
+        assert entry["severity"] == "shadow"
+        assert entry["mode"] == "shadow"
+
+    def test_hard_block_writes_one_ndjson_line(self, tmp_path):
+        decision, entries = _run_main("claude -p 'x'", tmp_path, enforce=False)
+        assert decision == "block"
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["matched_rule"] == "claude_raw_cli"
+        assert entry["severity"] == "block"
+
+    def test_shadow_enforce_writes_block_severity(self, tmp_path):
+        decision, entries = _run_main("python -m subprocess_dispatch", tmp_path, enforce=True)
+        assert decision == "block"
+        assert len(entries) == 1
+        assert entries[0]["severity"] == "block"
+        assert entries[0]["mode"] == "enforce"
+
+    def test_ndjson_entry_has_all_required_fields(self, tmp_path):
+        _, entries = _run_main('python -c "import subprocess_dispatch"', tmp_path)
+        assert len(entries) == 1
+        entry = entries[0]
+        for field in ("timestamp", "command", "matched_rule", "severity", "mode"):
+            assert field in entry, f"Missing field: {field}"
+
+    def test_ndjson_command_truncated_to_2000(self, tmp_path):
+        long_cmd = "python -m provider_dispatch " + "x" * 3000
+        _, entries = _run_main(long_cmd, tmp_path)
+        assert len(entries) == 1
+        assert len(entries[0]["command"]) <= 2000
+
+    def test_benign_command_writes_no_telemetry(self, tmp_path):
+        decision, entries = _run_main("git status", tmp_path)
+        assert decision == "allow"
+        assert entries == []
+
+    def test_telemetry_failure_still_allows(self, tmp_path):
+        """Telemetry write error must never change the hook decision."""
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "python -m provider_dispatch"}})
+        captured = io.StringIO()
+        with mock.patch("pretooluse_spawn_detector.project_root") as mock_pr:
+            mock_pr.resolve_data_dir.side_effect = OSError("disk full")
+            with mock.patch.dict(os.environ, {"VNX_HOOK_ENFORCE": "0"}):
+                with mock.patch("sys.stdin", io.StringIO(payload)):
+                    with mock.patch("sys.stdout", captured):
+                        det.main()
+        assert captured.getvalue().strip() == "allow"
+
+    def test_lane_script_direct_telemetry(self, tmp_path):
+        cmd = "scripts/lib/dispatch_cli.py --provider claude"
+        _, entries = _run_main(cmd, tmp_path, enforce=False)
+        assert len(entries) == 1
+        assert entries[0]["matched_rule"] == "lane_script_direct"
+        assert entries[0]["severity"] == "shadow"
+
+    def test_python_c_import_telemetry(self, tmp_path):
+        cmd = 'python3 -c "import subprocess_dispatch"'
+        _, entries = _run_main(cmd, tmp_path, enforce=False)
+        assert len(entries) == 1
+        assert entries[0]["matched_rule"] == "python_c_lane_import"
+
+
+# ── Malformed stdin ───────────────────────────────────────────────────────────
+
+class TestMalformedInput:
+
+    def test_malformed_json_allows(self):
+        captured = io.StringIO()
+        with mock.patch("sys.stdin", io.StringIO("not valid json {")):
+            with mock.patch("sys.stdout", captured):
+                det.main()
+        assert captured.getvalue().strip() == "allow"
+
+    def test_empty_stdin_allows(self):
+        captured = io.StringIO()
+        with mock.patch("sys.stdin", io.StringIO("")):
+            with mock.patch("sys.stdout", captured):
+                det.main()
+        assert captured.getvalue().strip() == "allow"
+
+    def test_missing_tool_input_allows(self):
+        payload = json.dumps({"tool_name": "Bash"})
+        captured = io.StringIO()
+        with mock.patch("sys.stdin", io.StringIO(payload)):
+            with mock.patch("sys.stdout", captured):
+                det.main()
+        assert captured.getvalue().strip() == "allow"

--- a/tests/test_pretooluse_spawn_detector.py
+++ b/tests/test_pretooluse_spawn_detector.py
@@ -1,4 +1,4 @@
-"""Tests for pretooluse_spawn_detector.py PR-9 changes.
+"""Tests for pretooluse_spawn_detector.py PR-9 / PR-9b changes.
 
 Covers:
   - Evasion #1 closed: ALLOWLIST_PATTERN removed; provider_dispatch.py + claude -p → block
@@ -9,6 +9,10 @@ Covers:
   - Benign commands unchanged
   - Telemetry: shadow/block → one ndjson line; failure → fail-open
   - Malformed stdin JSON → allow
+  - P0-A: fail-open invariant for all malformed payloads
+  - P0-B: raw-CLI bypass closures (path-form, de-quoting, redirect/here-string)
+  - P1-A: enforce-mode shadow over-match (mentions vs invocations)
+  - P1-A: -m/-c no-space forms; importlib.import_module detection
 """
 
 from __future__ import annotations
@@ -59,6 +63,167 @@ def _run_main(cmd: str, tmp_path: Path, enforce: bool = False) -> tuple[str, lis
             if line.strip():
                 entries.append(json.loads(line))
     return decision, entries
+
+
+def _run_main_raw(raw_stdin: str, tmp_path: Path, enforce: bool = False) -> str:
+    """Run main() with raw stdin string; return decision only."""
+    data_dir = tmp_path / "_vnx_test_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    env = {
+        "VNX_DATA_DIR": str(data_dir),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_HOOK_ENFORCE": "1" if enforce else "0",
+    }
+    captured = io.StringIO()
+    with mock.patch.dict(os.environ, env):
+        with mock.patch("sys.stdin", io.StringIO(raw_stdin)):
+            with mock.patch("sys.stdout", captured):
+                det.main()
+    return captured.getvalue().strip()
+
+
+# ── P0-A: Fail-open invariant ─────────────────────────────────────────────────
+
+class TestFailOpen:
+    """main() must emit exactly 'allow' for every malformed payload — no traceback."""
+
+    def test_list_payload_allows(self, tmp_path):
+        # [] is valid JSON but not a dict → allow
+        result = _run_main_raw("[]", tmp_path)
+        assert result == "allow"
+
+    def test_list_command_allows(self, tmp_path):
+        # command is a list instead of str → allow
+        payload = json.dumps({"tool_input": {"command": ["claude", "-p"]}})
+        result = _run_main_raw(payload, tmp_path)
+        assert result == "allow"
+
+    def test_tool_input_int_allows(self, tmp_path):
+        # tool_input is not a dict → allow
+        payload = json.dumps({"tool_input": 42})
+        result = _run_main_raw(payload, tmp_path)
+        assert result == "allow"
+
+    def test_empty_stdin_allows(self, tmp_path):
+        result = _run_main_raw("", tmp_path)
+        assert result == "allow"
+
+    def test_non_json_allows(self, tmp_path):
+        result = _run_main_raw("not valid json {", tmp_path)
+        assert result == "allow"
+
+    def test_null_json_allows(self, tmp_path):
+        # null is valid JSON but not a dict
+        result = _run_main_raw("null", tmp_path)
+        assert result == "allow"
+
+    def test_number_json_allows(self, tmp_path):
+        result = _run_main_raw("42", tmp_path)
+        assert result == "allow"
+
+
+# ── P0-B: Raw-CLI bypass closures ─────────────────────────────────────────────
+
+class TestHardBlockBypasses:
+    """Bypass vectors that previously evaded hard-block must now BLOCK."""
+
+    # Path-form
+    def test_path_claude_p_blocks(self):
+        assert _classify("/usr/local/bin/claude -p 'x'") == "block"
+
+    def test_path_kimi_print_blocks(self):
+        assert _classify("/usr/bin/kimi --print x") == "block"
+
+    def test_path_codex_exec_blocks(self):
+        assert _classify("/usr/bin/codex exec") == "block"
+
+    def test_dotslash_claude_p_blocks(self):
+        assert _classify("./claude -p 'x'") == "block"
+
+    # De-quoting (empty quote pair collapse)
+    def test_dequote_claude_p_blocks(self):
+        assert _classify("cla\"\"ude -p 'x'") == "block"
+
+    def test_dequote_kimi_print_blocks(self):
+        assert _classify("ki\"\"mi --print x") == "block"
+
+    def test_dequote_codex_exec_blocks(self):
+        assert _classify("co\"\"dex exec") == "block"
+
+    def test_dequote_codex_exec2_blocks(self):
+        assert _classify("codex e\"\"xec --json") == "block"
+
+    # Here-string / redirect suffix
+    def test_redirect_claude_p_blocks(self):
+        assert _classify("claude -p<<<'x'") == "block"
+
+    def test_redirect_kimi_print_blocks(self):
+        assert _classify("kimi --print<<<x") == "block"
+
+    def test_redirect_codex_exec_blocks(self):
+        assert _classify("codex exec<<<x") == "block"
+
+    # Wrapped in bash -c
+    def test_bash_c_claude_p_blocks(self):
+        assert _classify('bash -c "claude -p<<<x"') == "block"
+
+    # Both modes block for hard-block rules
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_path_claude_p_both_modes(self, enforce):
+        assert _classify("/usr/local/bin/claude -p 'x'", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_dequote_kimi_both_modes(self, enforce):
+        assert _classify("ki\"\"mi --print x", enforce=enforce) == "block"
+
+
+# ── P1-A: Enforce-mode over-match (mentions must NOT block) ───────────────────
+
+class TestEnforceModeOverMatch:
+    """Commands that mention a lane .py as an argument must NOT be blocked."""
+
+    def test_echo_provider_dispatch_allows(self):
+        assert _classify("echo provider_dispatch.py", enforce=True) == "allow"
+
+    def test_cat_provider_dispatch_allows(self):
+        assert _classify("cat docs/provider_dispatch.py", enforce=True) == "allow"
+
+    def test_git_grep_provider_dispatch_allows(self):
+        assert _classify("git grep provider_dispatch.py", enforce=True) == "allow"
+
+    def test_python_c_string_mention_allows(self):
+        # Mention in a string literal — best-effort: not a statement-position import
+        # Residual known: some nested-quote forms may still match; documented.
+        assert _classify("python -c \"print('import provider_dispatch')\"", enforce=True) == "allow"
+
+
+# ── P1-A: Shadow invocation forms must still DETECT ───────────────────────────
+
+class TestShadowInvocationDetected:
+    """These forms must be shadow-detected (block in enforce mode)."""
+
+    def test_python_m_nospace_provider_dispatch_enforce(self):
+        assert _classify("python -mprovider_dispatch", enforce=True) == "block"
+
+    def test_python_m_nospace_provider_dispatch_shadow(self):
+        assert _classify("python -mprovider_dispatch", enforce=False) == "allow"
+
+    def test_python3_m_nospace_subprocess_dispatch_enforce(self):
+        assert _classify("python3 -msubprocess_dispatch", enforce=True) == "block"
+
+    def test_python_c_nospace_import_enforce(self):
+        assert _classify("python -c'import provider_dispatch'", enforce=True) == "block"
+
+    def test_python3_c_nospace_import_shadow(self):
+        assert _classify("python3 -c'import provider_dispatch'", enforce=False) == "allow"
+
+    def test_importlib_import_module_enforce(self):
+        cmd = "python3 -c 'import importlib; importlib.import_module(\"provider_dispatch\")'"
+        assert _classify(cmd, enforce=True) == "block"
+
+    def test_importlib_import_module_shadow(self):
+        cmd = "python3 -c 'import importlib; importlib.import_module(\"provider_dispatch\")'"
+        assert _classify(cmd, enforce=False) == "allow"
 
 
 # ── Evasion #1: old allowlist bypass is closed ───────────────────────────────

--- a/tests/test_pretooluse_spawn_detector.py
+++ b/tests/test_pretooluse_spawn_detector.py
@@ -1,4 +1,4 @@
-"""Tests for pretooluse_spawn_detector.py PR-9 / PR-9b changes.
+"""Tests for pretooluse_spawn_detector.py PR-9 / PR-9b / PR-9c changes.
 
 Covers:
   - Evasion #1 closed: ALLOWLIST_PATTERN removed; provider_dispatch.py + claude -p → block
@@ -13,6 +13,13 @@ Covers:
   - P0-B: raw-CLI bypass closures (path-form, de-quoting, redirect/here-string)
   - P1-A: enforce-mode shadow over-match (mentions vs invocations)
   - P1-A: -m/-c no-space forms; importlib.import_module detection
+
+PR-9c (shlex-tokenized argv model):
+  - Quote-dequoting closed: cl'a'ude -p, claude "-p", codex "exec", e"x"ec → block
+  - kimi allow-mask killed: kimi --version && kimi --print x → block (2nd segment)
+  - Nested bash -c: bash -c "cla""ude -p" → block
+  - Arg-position false-positives allowed: echo/ls/git ... claude -p, lane.py as arg
+  - Unbalanced-quote fallback: still blocks a raw provider spawn, never blanket-allows
 """
 
 from __future__ import annotations
@@ -541,3 +548,231 @@ class TestMalformedInput:
             with mock.patch("sys.stdout", captured):
                 det.main()
         assert captured.getvalue().strip() == "allow"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PR-9c — shlex-tokenized argv model
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Every shell-quoting bypass codex re-gated must hard-block in BOTH modes.
+QUOTE_DEQUOTE_BLOCK_CASES = [
+    "cl'a'ude -p 'x'",
+    'c"l"a"u"de -p \'x\'',
+    'claude "-p" \'x\'',
+    'kimi "--print" x',
+    "kimi '-p' x",
+    'codex "exec" --json',
+    'codex e"x"ec --json',
+    'bash -c "cla""ude -p"',          # nested: outer shlex → inner cla""ude -p → recurse
+]
+
+# kimi allow-mask: the benign segment must NOT short-circuit a sibling block.
+KIMI_MASK_BLOCK_CASES = [
+    "kimi --version && kimi --print x",
+    "kimi --print x && kimi --version",
+    "kimi login && kimi -p x",
+    "kimi --version; kimi --print x",
+]
+
+# Already-closed bypass set (regression guard under the new model).
+PRIOR_CLOSED_BLOCK_CASES = [
+    "/usr/local/bin/claude -p 'x'",   # path-form
+    "./codex exec",                    # dotslash path-form
+    "claude -p<<<'x'",                 # here-string redirect
+    "kimi --print<<<x",
+    "codex exec<<<x",
+    'co""dex exec',                    # empty-quote collapse
+]
+
+# Arg-position false-positives: provider/lane name is an ARGUMENT, not argv[0].
+FALSE_POSITIVE_ALLOW_CASES = [
+    "echo /tmp/claude -p",
+    "ls /tmp/claude -p",
+    "git log --grep claude -p",
+    "git log -p",
+    "echo provider_dispatch.py",
+    "git grep provider_dispatch.py",
+    "cat docs/provider_dispatch.py",
+    "python -c \"print('import provider_dispatch')\"",
+]
+
+# Benign invocations of the provider CLIs themselves.
+BENIGN_PROVIDER_ALLOW_CASES = [
+    "claude --version",
+    "kimi login",
+    "claude",
+    "codex --help",
+]
+
+# Shadow invocation forms: allow+log by default, block under VNX_HOOK_ENFORCE=1.
+SHADOW_CASES = [
+    "python -mprovider_dispatch",
+    "python -c'import provider_dispatch'",
+    "python3 -c 'import importlib; importlib.import_module(\"provider_dispatch\")'",
+    "tmux_interactive_dispatch.py",
+]
+
+
+class TestPR9cQuoteDequoting:
+    """Shell quoting must not evade the hard-block (codex P0)."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    @pytest.mark.parametrize("cmd", QUOTE_DEQUOTE_BLOCK_CASES)
+    def test_quote_dequote_blocks(self, cmd, enforce):
+        assert _classify(cmd, enforce=enforce) == "block"
+
+
+class TestPR9cKimiAllowMask:
+    """A benign kimi segment must not mask a blocking sibling segment (codex P0)."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    @pytest.mark.parametrize("cmd", KIMI_MASK_BLOCK_CASES)
+    def test_kimi_mask_blocks(self, cmd, enforce):
+        assert _classify(cmd, enforce=enforce) == "block"
+
+
+class TestPR9cPriorBypassesStillBlock:
+    """Path-form / here-string / empty-quote bypasses stay closed."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    @pytest.mark.parametrize("cmd", PRIOR_CLOSED_BLOCK_CASES)
+    def test_prior_bypass_blocks(self, cmd, enforce):
+        assert _classify(cmd, enforce=enforce) == "block"
+
+
+class TestPR9cArgPositionFalsePositives:
+    """Provider/lane name as an argument (not argv[0]) must ALLOW in both modes."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    @pytest.mark.parametrize("cmd", FALSE_POSITIVE_ALLOW_CASES)
+    def test_false_positive_allows(self, cmd, enforce):
+        assert _classify(cmd, enforce=enforce) == "allow"
+
+
+class TestPR9cBenignProvidersAllow:
+    """Benign provider invocations always allow."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    @pytest.mark.parametrize("cmd", BENIGN_PROVIDER_ALLOW_CASES)
+    def test_benign_provider_allows(self, cmd, enforce):
+        assert _classify(cmd, enforce=enforce) == "allow"
+
+
+class TestPR9cShadowForms:
+    """Shadow forms: allow+log by default, block under enforce."""
+
+    @pytest.mark.parametrize("cmd", SHADOW_CASES)
+    def test_shadow_default_allows(self, cmd):
+        assert _classify(cmd, enforce=False) == "allow"
+
+    @pytest.mark.parametrize("cmd", SHADOW_CASES)
+    def test_shadow_enforce_blocks(self, cmd):
+        assert _classify(cmd, enforce=True) == "block"
+
+    def test_lane_name_as_argument_no_shadow(self):
+        # A lane name passed to a non-python tool is not a lane invocation.
+        assert _classify("git grep provider_dispatch.py", enforce=True) == "allow"
+
+    def test_python_c_string_literal_mention_no_shadow(self):
+        # Mention inside a string literal must not match (negative lookbehind).
+        assert _classify(
+            "python -c \"print('import provider_dispatch')\"", enforce=True
+        ) == "allow"
+
+
+class TestPR9cPrefixRunners:
+    """Transparent command-prefix runners are unwrapped, then classified."""
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_nohup_claude_p_blocks(self, enforce):
+        assert _classify('nohup claude -p "task" &', enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_nohup_kimi_print_blocks(self, enforce):
+        assert _classify('nohup kimi --print "task" &', enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_nohup_codex_exec_blocks(self, enforce):
+        assert _classify("nohup codex exec --json &", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_env_assignment_claude_p_blocks(self, enforce):
+        assert _classify('env FOO=bar claude -p "task"', enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_setsid_claude_p_blocks(self, enforce):
+        assert _classify("setsid claude -p x", enforce=enforce) == "block"
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_nohup_bash_c_claude_p_blocks(self, enforce):
+        assert _classify('nohup bash -c "claude -p"', enforce=enforce) == "block"
+
+    def test_bare_nohup_allows(self):
+        assert _classify("nohup", enforce=True) == "allow"
+
+
+class TestPR9cUnbalancedQuoteFallback:
+    """shlex.ValueError → legacy scan: still blocks a raw spawn, never blanket-allows."""
+
+    def test_unbalanced_quote_claude_p_blocks(self):
+        assert _classify('claude -p "unterminated') == "block"
+
+    def test_unbalanced_quote_kimi_print_blocks(self):
+        assert _classify("kimi --print 'unterminated") == "block"
+
+    def test_unbalanced_quote_benign_allows(self):
+        assert _classify('echo "unterminated') == "allow"
+
+    def test_unbalanced_quote_main_single_line(self, tmp_path):
+        # main() must emit exactly one decision line, never a traceback.
+        payload = json.dumps({"tool_input": {"command": 'claude -p "unterminated'}})
+        data_dir = tmp_path / "_vnx_test_data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        env = {"VNX_DATA_DIR": str(data_dir), "VNX_DATA_DIR_EXPLICIT": "1"}
+        captured = io.StringIO()
+        with mock.patch.dict(os.environ, env):
+            with mock.patch("sys.stdin", io.StringIO(payload)):
+                with mock.patch("sys.stdout", captured):
+                    det.main()
+        out = captured.getvalue()
+        assert out.count("\n") == 1
+        assert out.strip() == "block"
+
+
+class TestPR9cFailOpenExtras:
+    """Additional fail-open payloads emit exactly one line, never a traceback."""
+
+    def test_list_command_claude_p_allows(self, tmp_path):
+        payload = json.dumps({"tool_input": {"command": ["claude", "-p"]}})
+        assert _run_main_raw(payload, tmp_path) == "allow"
+
+    def test_tool_input_int_allows(self, tmp_path):
+        assert _run_main_raw(json.dumps({"tool_input": 42}), tmp_path) == "allow"
+
+    def test_empty_stdin_allows(self, tmp_path):
+        assert _run_main_raw("", tmp_path) == "allow"
+
+    def test_list_payload_allows(self, tmp_path):
+        assert _run_main_raw("[]", tmp_path) == "allow"
+
+
+class TestPR9cTelemetryRules:
+    """Matched-rule names are stable under the tokenized model."""
+
+    def test_kimi_mask_second_segment_logs_kimi_rule(self, tmp_path):
+        decision, entries = _run_main("kimi --version && kimi --print x", tmp_path)
+        assert decision == "block"
+        assert len(entries) == 1
+        assert entries[0]["matched_rule"] == "kimi_raw_cli"
+        assert entries[0]["severity"] == "block"
+
+    def test_dequote_claude_logs_claude_rule(self, tmp_path):
+        decision, entries = _run_main("cl'a'ude -p 'x'", tmp_path)
+        assert decision == "block"
+        assert len(entries) == 1
+        assert entries[0]["matched_rule"] == "claude_raw_cli"
+
+    def test_false_positive_writes_no_telemetry(self, tmp_path):
+        decision, entries = _run_main("git log --grep claude -p", tmp_path, enforce=True)
+        assert decision == "allow"
+        assert entries == []


### PR DESCRIPTION
## Summary

The PreToolUse spawn guard blocked raw provider-CLI spawns but was evadable: the substring allowlist (`subprocess_dispatch|provider_dispatch.py`) returned `allow` first, so a command mentioning a governed wrapper could smuggle a raw provider spawn after a `;`, and nothing blocked direct lane-script or `python -m`/`-c import` smuggling. PR-9 de-evades the hook and adds shadow-mode + telemetry. The blocking flip of the NEW rules waits for PR-12 (door default-on + caller migration), so they ship in **shadow** (log would-block, still allow); existing raw-CLI rules stay actually-blocking.

9th increment of the dispatch-determinism build (PR-1 through PR-8 on main).

## Changes (`scripts/hooks/pretooluse_spawn_detector.py`)

- **Deleted the evadable substring allowlist.** Governed wrapper invocations still pass the per-provider checks naturally (verified by test).
- **Hard-block (always, `VNX_HOOK_ENFORCE`-independent):** the raw provider-CLI print/exec invocations — unchanged severity.
- **New shadow-detected evasion vectors:** direct lane scripts (`tmux_interactive_dispatch.py`, `subprocess_dispatch.py`, `provider_dispatch.py`, `dispatch_cli.py`), `python -m <lane module>`, `python -c "<import lane module>"`.
- **Shadow vs enforce:** `VNX_HOOK_ENFORCE` unset/`0` (default) → new rules log-and-allow; `=1` → new rules block. Raw-CLI rules always block.
- **Telemetry:** every block + every shadow detection → one JSON line in `<data_dir>/events/hook_blocks.ndjson` (fail-open: telemetry errors never block or crash).
- **Fail-open preserved** (malformed JSON / read / telemetry errors → allow).

## Verification

- **75 hook tests pass**; ADR-003 PASS.
- T0 verified against real dispatch commands: in default (shadow) mode the tmux lane + `provider_dispatch` kimi-review commands resolve to `allow`; raw provider-CLI print invocations resolve to `block`; `VNX_HOOK_ENFORCE=1` makes lane scripts `block` (intended post-PR-12 state). Merging does not change this session's live hook (working tree is not on main) and does not break the governed dispatch path.
- Review gate (security/evasion surface): codex (primary) + kimi — in progress, noted before merge.

## Open Items

- Flip `VNX_HOOK_ENFORCE` to enforce only AFTER PR-12 (door default-on + caller migration) + a shadow burn-in across real sessions. HELD for Vincent.

Dispatch-ID: 20260615-pr9-hook-deevade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
