### PR TITLE
fix(tmux-lane): work-started watchdog — fast-abort the no-progress hang

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -121,7 +121,7 @@ def ensure_receipt(
         "status": "failed",
         "source": "tmux_interactive_lane_synthesized",
         "synthesized": True,
-        "failure_reason": "tmux_receipt_deadline_exceeded",
+        "failure_reason": raw.failure_reason,
         "contract_status": contract_status,
         "permission_enforcement": permission_enforcement,
         "timestamp": ts,
@@ -170,6 +170,10 @@ class GovernSpec:
 class GovernRaw:
     receipt: Optional[dict] = None
     duration_seconds: float = 0.0
+    # Reason recorded on a lane-synthesized fallback receipt (raw.receipt is None).
+    # Defaults to the deadline case; abort paths (ready_timeout / submit_failed /
+    # no_progress) pass their own reason so the audit trail does not mislabel them.
+    failure_reason: str = "tmux_receipt_deadline_exceeded"
 
 
 @dataclass

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -434,6 +434,7 @@ class TmuxInteractiveDispatch:
         base_sha: "str | None" = None,
         worktree_path: "Path | None" = None,
         model: "str | None" = None,
+        failure_reason: str = "tmux_receipt_deadline_exceeded",
     ) -> "Path | None":
         """Emit governance unified_report via the shared govern() step.
 
@@ -464,7 +465,11 @@ class TmuxInteractiveDispatch:
             worktree_path=worktree_path,
             model=model,
         )
-        raw = GovernRaw(receipt=receipt, duration_seconds=duration_seconds)
+        raw = GovernRaw(
+            receipt=receipt,
+            duration_seconds=duration_seconds,
+            failure_reason=failure_reason,
+        )
         outcome = govern(spec, raw, lane="tmux_interactive")
         if outcome.report_path:
             logger.info(
@@ -835,7 +840,7 @@ class TmuxInteractiveDispatch:
         signal_dir: "Path | None",
         baseline_count: int,
         baseline_pending_ids: "frozenset[str]",
-        completion_statuses: frozenset,
+        completion_statuses: "frozenset[str]",
         label: str,
     ) -> bool:
         """Confirm the worker actually STARTED working after a verified submit.
@@ -855,6 +860,12 @@ class TmuxInteractiveDispatch:
 
         Gate is on by default; set ``VNX_TMUX_WORK_START_GATE=0`` to restore the prior
         proceed-straight-to-receipt-wait behavior.
+
+        Known limitation: a worker blocked on an interactive permission prompt shows no
+        working indicator, so for an attended/permissioned session enable the permission
+        relay (``VNX_PERMISSION_RELAY=1``) so the prompt is answered before the window
+        elapses. Autonomous (skip-permissions) workers — the benchmark and headless lanes
+        — are unaffected.
         """
         if os.environ.get("VNX_TMUX_WORK_START_GATE", "1").strip().lower() in (
             "0", "false", "no", "off"
@@ -884,8 +895,11 @@ class TmuxInteractiveDispatch:
             )
             if len(canonical) > baseline_count:
                 return True
+            # Filter empty _pending_file values: a pending receipt without a file would
+            # otherwise contribute "" and read as fresh progress unless "" is already in
+            # the baseline (making the gate falsely lenient).
             if frozenset(
-                r.get("_pending_file", "") for r in pending
+                f for f in (r.get("_pending_file", "") for r in pending) if f
             ) - baseline_pending_ids:
                 return True
             return False
@@ -903,9 +917,9 @@ class TmuxInteractiveDispatch:
             if _work_observed():
                 return True
             # Guarded hand-deliver: re-submit ONCE, and only while the instruction is
-            # still staged right now — never a stray Enter into a session that just
-            # started working.
-            if not nudged and _still_staged():
+            # still staged AND not working as of this instant (both re-checked right
+            # before the send) — never a stray Enter into a session that just started.
+            if not nudged and _still_staged() and not _work_observed():
                 self._emit_event(
                     "interactive_hand_deliver",
                     dispatch_id=dispatch_id,
@@ -1652,6 +1666,7 @@ class TmuxInteractiveDispatch:
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
                     model=model,
+                    failure_reason="interactive_ready_timeout",
                 )
                 _teardown("ready_timeout")
                 return InteractiveDispatchResult(
@@ -1757,6 +1772,7 @@ class TmuxInteractiveDispatch:
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
                     model=model,
+                    failure_reason="submit_failed",
                 )
                 _teardown("submit_failed")
                 return InteractiveDispatchResult(
@@ -1776,6 +1792,8 @@ class TmuxInteractiveDispatch:
             # load; without this gate the lane would wait the full deadline for a receipt
             # that never comes (the warmup-miss/no-progress hang in DISPATCH_RULES §7).
             # Fast-abort (retryable in seconds) instead of burning deadline_seconds.
+            # baseline / baseline_pending_ids are the PRE-DELIVERY snapshot (step 5),
+            # so a pre-existing/stale receipt is never miscounted as fresh progress.
             if not self._await_work_started(
                 pane_id,
                 dispatch_id,
@@ -1785,12 +1803,21 @@ class TmuxInteractiveDispatch:
                 completion_statuses=completion_statuses,
                 label=label,
             ):
+                # Capture the pane tail so operators can see WHY no work was observed
+                # (idle prompt, permission prompt, error) and tune the heuristic.
+                _pane_tail = ""
+                try:
+                    _cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
+                    if _cap.returncode == 0 and _cap.stdout:
+                        _pane_tail = _cap.stdout[-600:]
+                except Exception as _cap_exc:  # noqa: BLE001
+                    logger.debug("interactive: no-progress pane capture failed (%s)", _cap_exc)
                 self._emit_event(
                     "interactive_no_progress",
                     dispatch_id=dispatch_id,
                     label=label,
                     reason="worker never started working after submit; fast-abort before deadline",
-                    metadata={"session": session, "pane_id": pane_id},
+                    metadata={"session": session, "pane_id": pane_id, "pane_tail": _pane_tail},
                 )
                 self._govern_report(
                     dispatch_id=dispatch_id,
@@ -1801,6 +1828,7 @@ class TmuxInteractiveDispatch:
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
                     model=model,
+                    failure_reason="interactive_no_progress",
                 )
                 _teardown("no_progress")
                 return InteractiveDispatchResult(

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -827,6 +827,97 @@ class TmuxInteractiveDispatch:
         )
         return False
 
+    def _await_work_started(
+        self,
+        pane_id: str,
+        dispatch_id: str,
+        *,
+        signal_dir: "Path | None",
+        baseline_count: int,
+        baseline_pending_ids: "frozenset[str]",
+        completion_statuses: frozenset,
+        label: str,
+    ) -> bool:
+        """Confirm the worker actually STARTED working after a verified submit.
+
+        ``_verify_submit`` confirms the input box is no longer staged, but under
+        subscription load a submit can clear the box without the worker progressing —
+        Claude idles at the prompt and never writes a receipt. Without this gate the
+        lane would then wait the FULL ``deadline_seconds`` for a receipt that never
+        comes (the recurring warmup-miss/no-progress hang in DISPATCH_RULES §7).
+
+        This bounded watchdog polls for a real work signal — the UserPromptSubmit
+        sentinel, a version-robust working indicator (``_looks_working``), or a fresh
+        receipt — and re-nudges ONCE with a guarded Enter if the instruction is still
+        staged (never a stray Enter into a running session). It returns True as soon as
+        work is observed; False if no work appears within the window, so the caller can
+        FAST-ABORT (retryable in seconds) instead of burning the full deadline.
+
+        Gate is on by default; set ``VNX_TMUX_WORK_START_GATE=0`` to restore the prior
+        proceed-straight-to-receipt-wait behavior.
+        """
+        if os.environ.get("VNX_TMUX_WORK_START_GATE", "1").strip().lower() in (
+            "0", "false", "no", "off"
+        ):
+            return True
+
+        timeout = float(os.environ.get("VNX_TMUX_WORK_START_TIMEOUT", "120"))
+        poll = float(os.environ.get("VNX_TMUX_WORK_START_POLL", "3"))
+        prompt_sentinel = (signal_dir / "prompt_received") if signal_dir else None
+
+        def _work_observed() -> bool:
+            # (a) UserPromptSubmit hook fired → worker accepted the prompt and is running.
+            try:
+                if prompt_sentinel is not None and prompt_sentinel.exists():
+                    return True
+            except OSError:
+                pass
+            # (b) version-robust working indicator anywhere in the pane.
+            cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
+            content = cap.stdout if cap.returncode == 0 else ""
+            if content and self._looks_working(content):
+                return True
+            # (c) a receipt already appeared for this dispatch (a fast worker that
+            # finished before the first poll, or any progress receipt).
+            canonical, pending = self._matching_receipts_split(
+                dispatch_id, completion_statuses
+            )
+            if len(canonical) > baseline_count:
+                return True
+            if frozenset(
+                r.get("_pending_file", "") for r in pending
+            ) - baseline_pending_ids:
+                return True
+            return False
+
+        def _still_staged() -> bool:
+            cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
+            content = cap.stdout if cap.returncode == 0 else ""
+            lines = content.splitlines()
+            region = "\n".join(lines[-self._INPUT_REGION_LINES:]) if lines else ""
+            return ("[Pasted text" in region) or (self._END_SENTINEL in region)
+
+        deadline = time.monotonic() + timeout
+        nudged = False
+        while time.monotonic() < deadline:
+            if _work_observed():
+                return True
+            # Guarded hand-deliver: re-submit ONCE, and only while the instruction is
+            # still staged right now — never a stray Enter into a session that just
+            # started working.
+            if not nudged and _still_staged():
+                self._emit_event(
+                    "interactive_hand_deliver",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="no work observed after submit; re-submitting staged instruction",
+                    metadata={"pane_id": pane_id},
+                )
+                self._runner.run(["send-keys", "-t", pane_id, "Enter"])
+                nudged = True
+            time.sleep(poll)
+        return _work_observed()
+
     def _paste(self, pane_id: str, content: str, max_inline: int = 50000) -> bool:
         """Load *content* into a tmux buffer and paste it into the pane."""
         if len(content) > max_inline:
@@ -1676,6 +1767,50 @@ class TmuxInteractiveDispatch:
                     window_id=window_id,
                     pane_id=pane_id,
                     failure_reason="submit_failed",
+                    duration_seconds=time.monotonic() - start_time,
+                    worktree_state=_wt_state[0],
+                )
+
+            # 7b-bis. Confirm the worker actually STARTED working. A verified submit can
+            # still clear the input box without the worker progressing under subscription
+            # load; without this gate the lane would wait the full deadline for a receipt
+            # that never comes (the warmup-miss/no-progress hang in DISPATCH_RULES §7).
+            # Fast-abort (retryable in seconds) instead of burning deadline_seconds.
+            if not self._await_work_started(
+                pane_id,
+                dispatch_id,
+                signal_dir=signal_dir,
+                baseline_count=baseline,
+                baseline_pending_ids=baseline_pending_ids,
+                completion_statuses=completion_statuses,
+                label=label,
+            ):
+                self._emit_event(
+                    "interactive_no_progress",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="worker never started working after submit; fast-abort before deadline",
+                    metadata={"session": session, "pane_id": pane_id},
+                )
+                self._govern_report(
+                    dispatch_id=dispatch_id,
+                    terminal_id=label,
+                    instruction=instruction,
+                    receipt=None,
+                    duration_seconds=time.monotonic() - start_time,
+                    base_sha=worktree_handle.base_sha if worktree_handle else None,
+                    worktree_path=worktree_handle.path if worktree_handle else None,
+                    model=model,
+                )
+                _teardown("no_progress")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="interactive_no_progress",
                     duration_seconds=time.monotonic() - start_time,
                     worktree_state=_wt_state[0],
                 )

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1714,6 +1714,7 @@ class TestReceiptFallback(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline synthesis path
         )
         lane = self._make_lane(fake)
 
@@ -1741,6 +1742,7 @@ class TestReceiptFallback(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline synthesis path
         )
         lane = self._make_lane(fake)
 
@@ -1815,6 +1817,7 @@ class TestReceiptFallback(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline synthesis path
         )
         lane = self._make_lane(fake)
 
@@ -2752,6 +2755,7 @@ class TestCaptureNormalizerCloseout(_LaneTestCase):
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline path (not no-progress)
             emit_receipt=False,
         )
         lane = self._make_lane(fake)

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -220,6 +220,12 @@ def _extract_protocol_python_path(text: str, block_index: int = 0) -> str:
     )
 
 
+# Pane content that satisfies BOTH a warmup-readiness marker ("? for shortcuts") and the
+# version-robust working indicator (token-counter shape + "esc to interrupt"), so the
+# work-started gate observes a genuinely-working worker and proceeds to the receipt wait.
+_READY_AND_WORKING = "? for shortcuts\n✢ Working… (3s · ↓ 120 tokens) · esc to interrupt"
+
+
 class _LaneTestCase(unittest.TestCase):
     DISPATCH_ID = "20260527-tmuxint-test"
 
@@ -254,6 +260,9 @@ class _LaneTestCase(unittest.TestCase):
             "VNX_TMUX_PASTE_SETTLE_SECONDS": "0",
             "VNX_TMUX_SUBMIT_RETRY_DELAY": "0",
             "VNX_TMUX_SUBMIT_VERIFY_TIMEOUT": "0.1",
+            # Work-started gate: keep the window tiny so tests never hang on it.
+            "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_POLL": "0.02",
         }
         with patch.dict(os.environ, _env):
             return lane.dispatch("Do the thing.", self.DISPATCH_ID, **kwargs)
@@ -463,6 +472,7 @@ class TestTimeoutTeardown(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # worker IS working → gate passes → real deadline path
         )
         lane = self._make_lane(fake)
         result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
@@ -553,12 +563,110 @@ class TestStaleReceiptGuard(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → gate passes → stale receipt still ignored at deadline
         )
         lane = self._make_lane(fake)
         result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
 
         self.assertFalse(result.success)
         self.assertIn("deadline", result.failure_reason)
+
+
+class TestWorkStartedGate(_LaneTestCase):
+    """7b-bis work-started watchdog: fast-abort a no-progress worker instead of hanging
+    to the full deadline (the warmup-miss/no-progress hang), with a guarded re-nudge."""
+
+    def test_no_progress_fast_aborts_before_deadline(self):
+        """Worker submits but never starts working: fast-abort as interactive_no_progress,
+        well before the (long) receipt deadline would fire."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,                 # never writes a receipt
+            # ready_content default ("Welcome to Claude\n? for shortcuts"): warms up
+            # but shows NO working indicator → no work ever observed.
+        )
+        lane = self._make_lane(fake)
+        # Long deadline; the gate (0.1s window via _fast_dispatch env) must abort first.
+        result = self._fast_dispatch(lane, deadline_seconds=30.0, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_reason, "interactive_no_progress")
+        # Must NOT have waited anywhere near the 30s deadline.
+        self.assertLess(result.duration_seconds, 5.0)
+        self.assertTrue(fake.killed_sessions, "kill-session must run on no-progress teardown")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn("interactive_no_progress", {e["event_type"] for e in events})
+
+    def test_working_worker_proceeds_to_receipt(self):
+        """Worker shows a working indicator (no receipt yet): gate passes, lane proceeds
+        to the receipt wait and ends on the deadline path — NOT a no-progress abort."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content=_READY_AND_WORKING,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertIn("deadline", result.failure_reason)
+        self.assertNotEqual(result.failure_reason, "interactive_no_progress")
+
+    def test_gate_disabled_restores_prior_behavior(self):
+        """VNX_TMUX_WORK_START_GATE=0: no work-started gate; a no-progress worker waits
+        the receipt deadline (the pre-fix behavior), not a fast no-progress abort."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+        )
+        lane = self._make_lane(fake)
+        with patch.dict(os.environ, {"VNX_TMUX_WORK_START_GATE": "0"}):
+            result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertIn("deadline", result.failure_reason)
+
+    def test_hand_deliver_renudges_when_still_staged(self):
+        """Unit test of the gate directly: when no work is observed AND the instruction
+        is still staged in the input region, the gate sends ONE guarded re-nudge Enter
+        and emits interactive_hand_deliver, then returns False (no work)."""
+        # Persistent staged content (would trip _verify_submit in a full dispatch, so we
+        # exercise the gate method directly): capture-pane always shows the paste
+        # annotation and no working indicator.
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content="? for shortcuts\n[Pasted text #1 +900 lines]",
+        )
+        lane = self._make_lane(fake)
+        with patch.dict(os.environ, {
+            "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_POLL": "0.02",
+        }):
+            observed = lane._await_work_started(
+                "%1",
+                self.DISPATCH_ID,
+                signal_dir=None,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                completion_statuses=frozenset({"done", "success"}),
+                label="T1",
+            )
+
+        self.assertFalse(observed, "no work was ever observed")
+        enters = [
+            c for c in fake.commands
+            if c[:1] == ["send-keys"] and c[-1] == "Enter"
+        ]
+        self.assertTrue(enters, "a guarded re-nudge Enter must be sent when still staged")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn("interactive_hand_deliver", {e["event_type"] for e in events})
 
 
 class TestHeadlessGuard(_LaneTestCase):
@@ -1135,6 +1243,7 @@ class TestUnifiedReportEmission(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline (not no-progress) path
         )
         lane = self._make_lane(fake)
 
@@ -1680,6 +1789,7 @@ class TestReceiptFallback(_LaneTestCase):
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,
             emit_receipt=False,
+            ready_content=_READY_AND_WORKING,  # working worker → real deadline (not no-progress) path
         )
         lane = self._make_lane(fake)
 


### PR DESCRIPTION
## What

A work-started watchdog for the interactive claude tmux lane: detect a worker that submitted but never started working, and **fast-abort it (retryable in seconds)** instead of waiting the full `deadline_seconds` for a receipt that never comes.

## Why

The lane already warms up (`_wait_ready`, STRICT fast-fail at 30s) and verifies submit (`_verify_submit`, guarded Enter-retries). But under subscription load a *verified* submit can clear the input box without the worker ever starting — claude idles at the prompt, never writes a receipt — and the lane then waited the **full deadline** for nothing. This is the recurring warmup-miss / no-progress hang documented in DISPATCH_RULES §7.

Observed directly in the field-test benchmark: opus-4-8 hung twice at the 1800s deadline on `02_rls_policy`, then **succeeded in 415s** once a retry caught a clean start. So the cause is start-failure, not think-time — raising the deadline does not help, fast-abort + retry does.

This fix benefits production claude dispatches and the benchmark equally.

## Changes

- **`scripts/lib/tmux_interactive_dispatch.py`**
  - New `_await_work_started(...)`: a bounded watchdog that polls for a real work signal — the `UserPromptSubmit` hook sentinel, the version-robust working indicator (`_looks_working`), or a fresh receipt — and re-nudges **once** with a guarded Enter when the instruction is still staged (reusing the existing staged-input guard, so it never sends a stray Enter into a running session). Returns as soon as work is observed; False if none within the window.
  - Wired as **step 7b-bis** between submit-verify (7b) and the receipt wait (8): on no work, emit `interactive_no_progress`, govern_report, teardown, and return `failure_reason="interactive_no_progress"` (retryable) instead of entering the full-deadline wait.
  - Knobs: `VNX_TMUX_WORK_START_TIMEOUT` (default 120s), `VNX_TMUX_WORK_START_POLL` (default 3s), `VNX_TMUX_WORK_START_GATE=0` to disable and restore prior behavior.
- **`tests/test_tmux_interactive_dispatch.py`**
  - 4 new gate tests: no-progress fast-abort (well before a 30s deadline), working-worker proceeds to the receipt/deadline path, gate-disabled restores prior behavior, guarded re-nudge fires + emits `interactive_hand_deliver` when still staged.
  - 4 existing deadline-path tests updated to simulate a *working* worker (so they exercise the real deadline path rather than the new no-progress abort), plus work-start tuning in the shared `_fast_dispatch` harness.

## Verification

- `tests/test_tmux_interactive_dispatch.py`: **163 passed**.
- Adjacent tmux suites: 83 passed; 3 pre-existing failures in `test_tmux_adapter.py` are an unrelated `ModuleNotFoundError: tmux_adapter_cli` (a stale test referencing an absent module) — not touched by this change.
- Healthy workers pass the gate within the first poll (work observed via sentinel/indicator/receipt), so there is no added latency on the happy path; only stuck workers consume the window before the fast-abort.

## Open Items

None blocking. Follow-up (separate): the stale `tmux_adapter_cli` test import is pre-existing tech debt tracked for the post-12 test-hardening sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
