### PR TITLE
fix(bench): track dotenv task seed .env so worktree checkout materializes it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,10 @@ schemas/prep_migrations/
 # Environment files
 .env
 .env.*
+# ...but benchmark task seed .env fixtures ARE tracked (dummy placeholders only) so a
+# clean worktree checkout materializes them. Without this the seed .env is absent in the
+# worker worktree → verify.py crashes (infra-fail, not a model capability fail).
+!scripts/benchmark/field-tests/tasks/**/seed/.env
 
 # VNX provider secrets
 vnx.env

--- a/scripts/benchmark/field-tests/tasks/t1_trivial/03_dotenv_script/seed/.env
+++ b/scripts/benchmark/field-tests/tasks/t1_trivial/03_dotenv_script/seed/.env
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://benchmark.supabase.local
+SUPABASE_KEY=benchmark-placeholder-value-not-a-real-secret


### PR DESCRIPTION
## What

Track the `03_dotenv_script` benchmark task's seed `.env` so a clean worktree checkout materializes it.

## Why

The field-test worker runs in a git worktree created from `origin/main`. `materialize_benchmark_seed` copies the seed dir **from that checkout**, which only contains tracked files. The seed `.env` was gitignored (`.gitignore: .env`), so it was never checked out → never materialized → `03_dotenv_script/verify.py` crashed with `No such file: .../seed/.env` on **every** lane (composite ~1.47, an infra-fail, not a model-capability fail). The rest of the task (`backfill_check.py`, `verify.py`) is already tracked on main; the seed `.env` belongs there with them.

Caught by a pre-run smoke (all 3 lanes crashed identically on the dotenv task).

## Changes

- `.gitignore`: negation `!scripts/benchmark/field-tests/tasks/**/seed/.env` so task seed `.env` fixtures are tracked (overrides the blanket `.env` ignore).
- Add `scripts/benchmark/field-tests/tasks/t1_trivial/03_dotenv_script/seed/.env` — **dummy placeholder values only** (`SUPABASE_URL=https://benchmark.supabase.local`, `SUPABASE_KEY=benchmark-placeholder-value-not-a-real-secret`); the verify only checks that `load_dotenv()` loads them, never the values.

## Verification

- Value is gitleaks-safe (no `sk_*`/`AKIA`/PEM/`secret_key` patterns); the secret-scan gate verifies this.
- No code change; only the tracked fixture + gitignore negation.

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
