### PR TITLE
fix(ws2): QI tenant-stamping self-heal on fresh store + dispatch/intelligence arch docs

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -20,6 +20,7 @@
 | Document | Path | Description |
 |----------|------|-------------|
 | Core Architecture | `docs/core/00_VNX_ARCHITECTURE.md` | Complete system architecture and data flow, incl. *Future-State Reconciliation* (open-item → track → dispatch lifecycle, the autopilot loop, and the precise `derived_status` rule) |
+| Dispatch & Intelligence Architecture | `docs/core/DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md` | Current end-to-end flow: single-entry door → assembly (skill + intelligence injection + report-contract) → lane delivery (tmux-signal hook contract) → govern (phantom-guard) → intelligence injection + self-learning loop |
 | Scripts Index | `docs/SCRIPTS_INDEX.md` | Active script surface map |
 | Architecture Decisions | `docs/governance/decisions/` | ADRs — incl. ADR-005 (NDJSON audit ledger; D3 at-most-once bridge events) and ADR-007 (multi-tenant `project_id` / composite-key `dispatches`) |
 | Core Contracts | `docs/core/` | Operational contracts and technical references |

--- a/docs/core/DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md
+++ b/docs/core/DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md
@@ -1,0 +1,133 @@
+# Dispatch & Intelligence Architecture (current)
+
+**Status:** current as of 2026-06-23 (post single-entry-door flip, PR #896).
+**Scope:** how a dispatch flows from T0's intent to a governed receipt, and how intelligence is injected and learned. This is the end-to-end picture; the enforced ruleset T0 follows is `DISPATCH_RULES.md`, the lane detail is `PROVIDER_LANES.md`, the receipt shape is `11_RECEIPT_FORMAT.md`.
+
+---
+
+## 1. The model in one line
+
+A dispatch is not "paste text into a worker." It is: **stage an intent → route it through the single door → assemble it (skill + intelligence + report-contract) → deliver it to an isolated worker → execute → emit a receipt → govern it (phantom-guard) → advance gates.** Every step is on disk and produces evidence. Bypassing any step (hand-delivering a raw instruction) produces *ungoverned* work — no intelligence, no report-contract, no receipt.
+
+## 2. End-to-end flow
+
+```
+┌─ T0 (orchestrator) ────────────────────────────────────────────────┐
+│  composes a spec: instruction + role + dispatch_id + paths          │
+└───────────────────────────────┬────────────────────────────────────┘
+                                 ▼
+            .vnx-data/dispatches/pending/<id>/      ← staged bundle ("/pending")
+                                 │   (human gate where required: promote)
+                                 ▼
+   ┌─ THE DOOR — dispatch_cli.run_dispatch (single entry) ────────────┐
+   │  reads the bundle → compile_plan → picks the lane:               │
+   │     provider=claude              → claude tmux-spawn lane         │
+   │     provider=kimi|glm|deepseek   → provider envelope lane         │
+   │  Flag: VNX_SINGLE_ENTRY_DISPATCH (default OFF = byte-identical    │
+   │  legacy routing); VNX_DISPATCH_LEGACY=1 = hard rollback.          │
+   └───────────────────────────┬─────────────────────────────────────┘
+                                ▼
+   ┌─ ASSEMBLY — dispatch_prepare.prepare / _assemble_context ────────┐
+   │  1. repo-map (prepended)                                         │
+   │  2. skill body            (the role's SKILL.md)                  │
+   │  3. INTELLIGENCE INJECTION — _build_intelligence_section:        │
+   │       "## Relevant Intelligence (from past dispatches)"          │
+   │       "### Antipatterns to avoid"   (patterns + antipatterns)    │
+   │  4. the actual instruction                                       │
+   │  5. FOOTER — report-contract directive (## Summary / ## Changes  │
+   │       / ## Verification / ## Open Items) + END-OF-INSTRUCTION     │
+   │       sentinel                                                   │
+   │  (+ smart_context prepended)                                     │
+   └───────────────────────────┬─────────────────────────────────────┘
+                                ▼  = the assembled "body"
+   ┌─ DELIVERY ──────────────────────────────────────────────────────┐
+   │  claude lane (tmux-spawn): fresh isolated worktree + tmux pane,  │
+   │    launch interactive `claude` (NEVER `claude -p`), bracketed-   │
+   │    paste(body), settle, Enter as a SEPARATE keystroke, staged-   │
+   │    paste retry. Readiness + submit detection ride on hook        │
+   │    sentinels (§5).                                               │
+   │  provider lane (envelope): spawn kimi / glm-harness / deepseek-  │
+   │    harness, instruction passed in-process.                       │
+   └───────────────────────────┬─────────────────────────────────────┘
+                                ▼
+   worker executes → writes a unified report (because the FOOTER
+                     required it) → report on disk
+                                ▼
+   receipt processor → NDJSON receipt → t0_receipts.ndjson
+                                ▼
+   GOVERN — dispatch_govern.govern(): phantom-guard checks the receipt
+            vs the worker's real worktree/branch diff (§6)
+                                ▼
+   T0 reviews receipts + review-gate evidence + closure → advances gates
+```
+
+## 3. The two lanes (provider → lane is a hard rule)
+
+| Provider | Lane | Mechanism | Billing |
+|---|---|---|---|
+| `claude` (Opus/Sonnet) | **claude tmux-spawn** (`tmux_interactive_dispatch.py`) | interactive `claude` in an ephemeral isolated worktree; leaseless | subscription (June-15 escape) |
+| `claude` (terminal-pinned, opt-in) | **subprocess** (`subprocess_dispatch.py`) | `claude -p` headless, lease + Wave-5 smart-context + triple-gate | subscription |
+| `kimi` / `glm`(harness) / `deepseek`(harness) | **provider envelope** (`dispatch_envelope.py`) | provider CLI / harness spawn | provider-metered |
+
+Hard rules: **claude workers route via tmux-spawn, never `provider_dispatch`, never headless `claude -p` (post-cutover = API credits).** `glm` always via the claude-CLI harness (`:4141` litellm→OpenRouter proxy), never plain `litellm:zai`. Everything dispatches through the single door (`vnx dispatch`); calling a lane script directly is a side door (the `dispatch_sidedoor_audit.py` gate enforces this).
+
+The tmux-spawn lane is the default for parallel/independent feature work. The subprocess lane is opt-in (`VNX_ADAPTER_T{n}=subprocess`) for terminal-pinned PRs, >30-min workers, and burn-in measurement — it uniquely carries Wave-5 smart-context, lease management, triple-gate `contract_hash` binding, and prior-round findings.
+
+## 4. Assembly — where governance value is added
+
+Assembly runs in the lane **before** delivery (`_assemble_context` → `dispatch_prepare.prepare`, or the `_inject_skill_context` fallback). It wraps the raw instruction with three things the worker cannot produce on its own:
+
+- **Skill body** — the role's `SKILL.md` (the specialist's operating instructions).
+- **Intelligence injection** — `## Relevant Intelligence (from past dispatches)` + `### Antipatterns to avoid`, selected per-dispatch from the quality-intelligence store (§7).
+- **Report-contract footer** — the mandatory `## Summary / ## Changes / ## Verification / ## Open Items` headings + the `<!-- VNX-END-OF-INSTRUCTION -->` sentinel. This is *why* the worker writes a report — and the report is what becomes a receipt.
+
+**Consequence:** a hand-delivered raw instruction (bypassing the lane) skips assembly entirely → no intelligence, no report-contract → the worker may write no report → no receipt → the work is invisible to governance, and the phantom-guard has nothing to check. Delivery problems must be fixed in the lane, never worked around by raw delivery.
+
+## 5. Delivery reliability — the tmux-signal hook contract
+
+The claude tmux-spawn lane's readiness and submit detection ride on two hook sentinels, dropped by hooks the worker's project must wire and guarded by `VNX_TMUX_SIGNAL_DIR` + `VNX_DISPATCH_ID` (which the lane exports into the worker env):
+
+- **SessionStart** → `scripts/hooks/tmux_signal_session_ready.sh` writes `<signal_dir>/session_ready` → the lane knows the worker's input box is ready before it pastes.
+- **UserPromptSubmit** → `scripts/hooks/tmux_signal_prompt_received.sh` writes `<signal_dir>/prompt_received` → the lane knows the paste was actually submitted.
+
+When these hooks are wired, the lane uses the sentinels (reliable). When they are missing, it falls back to TUI-marker heuristics — which mis-fire across Claude Code TUI revisions (e.g. under 2.1.186 the lane can paste before the input is ready → the body never stages → the worker idles → reaped on `interactive_no_progress`). **Wiring these two hooks is a hard prerequisite for the claude tmux-spawn lane in any project.** The hook scripts also exist under `.vnx/scripts/hooks/` for vendored installs; they are no-ops without `VNX_TMUX_SIGNAL_DIR`, so they are safe to register globally.
+
+Other invariants: **Enter is ALWAYS a separate tmux keystroke** (a combined send-keys misses delivery); the worker launches scoped (`--permission-mode acceptEdits` + role allow-list) in the detached path, not blanket `--dangerously-skip-permissions`.
+
+## 6. Govern + the phantom-guard
+
+After a worker emits its completion receipt, `dispatch_govern.govern()` runs an inline **phantom-guard** (`phantom_guard.record_phantom_if_any`) for every dispatch — independent of the door flag. The rule: a *delivery-role* worker that claims completion (a GATE-GREEN status) but produced **no worktree/branch diff** is a phantom — a receipt not backed by a deliverable. Tokens spent do not exempt it (an LLM thinking is not a deliverable). Review roles are exempt (a verdict, not a diff, is expected); an unresolvable/torn-down ref ABSTAINS (never a false reject).
+
+On a phantom verdict the guard appends a corrective `failed` receipt carrying `phantom_rejected=True` (the worker's original `done` is preserved — the contradiction is recorded, not overwritten). `dedup_completion_receipts` honours that as a **Tier-0 override**: the dispatch resolves FAILED even on a same-second timestamp tie. Operator escape: `VNX_OVERRIDE_PHANTOM_GUARD=1` for a legitimate no-op delivery.
+
+This is the anti-fabrication backstop: it makes "claimed done with nothing to show" a first-class governance failure rather than a silent green.
+
+## 7. Intelligence — injection and the self-learning loop
+
+The quality-intelligence store (`quality_intelligence.db`, per-project under `~/.vnx-data/<project>/`) holds success patterns, antipatterns, prevention rules, and prior-round findings. Two flows:
+
+- **Injection (read path, per dispatch):** `IntelligenceSelector.select()` chooses the most relevant patterns/antipatterns for the dispatch's role + paths + pr_id and `_build_intelligence_section` renders them into the assembled body (§4). Prior-round findings (`prior_round_injector.py`, Wave-5) carry a `contract_hash` so a re-dispatch sees what the last round found.
+- **Learning (write path):** the intelligence daemon (`intelligence_daemon.py` + `learning_loop.py`) runs two tiers. Tier-1 auto-tunes pattern *confidence* from receipt outcomes. Tier-2 proposes new rules into an operator-gated `pending_rules.json` — the system proposes, the human approves. Nothing self-promotes a rule without a gate.
+
+Tenant isolation (ADR-007): every intelligence table is keyed by a composite over `project_id`; the store resolves its owning project fail-closed (`.vnx-project-id` marker → `VNX_PROJECT_ID` → the `~/.vnx-data/<pid>/` path), so a fresh store never silently inherits another tenant's rows.
+
+## 8. Where the evidence lives
+
+- Staged intents: `.vnx-data/dispatches/pending/<id>/`
+- Reports: `$VNX_DATA_DIR/unified_reports/<dispatch-id>.md` (interactive), `…/headless/` (review gates)
+- Receipts (the audit trail): `t0_receipts.ndjson`
+- Review-gate results: `.vnx-data/state/review_gates/results/`
+- Per-dispatch event ring buffer (subprocess lanes only): `.vnx-data/events/T{n}.ndjson` → archived per dispatch
+
+Without a report there is no receipt, and without a receipt the work is invisible to governance. The report contract (`scripts/lib/report_body_contract.py`) is the bridge.
+
+---
+
+## Cross-references
+
+- Enforced ruleset (T0 SSOT): `DISPATCH_RULES.md`
+- Lane detail + billing: `PROVIDER_LANES.md`, `docs/operations/TMUX_SPAWN_LANE.md`
+- Receipt shape: `11_RECEIPT_FORMAT.md`
+- Intelligence internals: `docs/core/technical/INTELLIGENCE_SYSTEM.md`, `docs/internal/intelligence/INTELLIGENCE_INJECTION_V1.1.md`
+- Tenant isolation: `docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md`
+- System boundaries (what stays local): `VNX_SYSTEM_BOUNDARIES.md`

--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -8,9 +8,13 @@
 > routing policy → `scripts/lib/providers/routing_policy.yaml`; pricing/registry →
 > `scripts/lib/providers/wave7_models.yaml`. The single dispatch entry is the door
 > (`vnx dispatch` / `scripts/lib/dispatch_cli.py`); it runs `compile_plan` + a permit for every lane.
-> The door is built and tested but **default-OFF** (`VNX_SINGLE_ENTRY_DISPATCH` resolves to disabled
-> via `scripts/lib/dispatch_flags.py`; `VNX_DISPATCH_LEGACY=1` is the absolute rollback) until the
-> flip lands. Until then, dispatches route through the per-lane paths in §5/§8.
+> The door is merged (PR #896) and burn-in-validated but **default-OFF** (`VNX_SINGLE_ENTRY_DISPATCH`
+> resolves to disabled via `scripts/lib/dispatch_flags.py`; `VNX_DISPATCH_LEGACY=1` is the absolute
+> rollback); activation (`_DEFAULT_ENABLED=True`) is the remaining flip step. Until activation,
+> dispatches route through the per-lane paths in §5/§8.
+>
+> End-to-end architecture (door → assembly → delivery → govern → intelligence): see
+> **`DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md`**.
 
 ## 1. Decision tree (first matching rule wins)
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -1015,6 +1015,28 @@ def bootstrap_qi_db(db_path: Path, schema_file: Path | None = None) -> bool:
 
         log('SUCCESS', 'Database schema initialized successfully')
         conn.close()
+
+        # WS2 / ADR-007: the V19/V20/V22 migrations stamp project_id with a literal
+        # ``DEFAULT 'vnx-dev'`` (and _migrate_v22 backfills legacy rows the same way).
+        # On a fresh QI store owned by a NON-vnx-dev project that silently contaminates
+        # the store with the wrong tenant. The W1 3-phase runner already re-stamps
+        # 'vnx-dev'/NULL/'' -> the owning pid and drops the DEFAULT (fail-closed), but it
+        # was only invoked by tenant_stamping.py's orchestrator — never on fresh init.
+        # Wire it here so bootstrap self-heals. Idempotent (phase guards skip correct
+        # tables); only runs for non-vnx-dev pids (vnx-dev IS the correct legacy default).
+        try:
+            import sys as _sys  # noqa: PLC0415
+            _lib = Path(__file__).resolve().parent / "lib"
+            if str(_lib) not in _sys.path:
+                _sys.path.insert(0, str(_lib))
+            from project_id_migration import resolve_init_project_id  # noqa: PLC0415
+            _pid = resolve_init_project_id(Path(db_path))
+            if _pid and _pid != 'vnx-dev':
+                run_qi_three_phase_migration(Path(db_path), _pid)
+                log('INFO', f'QI tenant-stamping reconciled to project_id={_pid!r}')
+        except Exception as _exc:  # never fail init on reconciliation (idempotent + retryable)
+            log('WARNING', f'QI tenant-stamping reconciliation skipped: {_exc}')
+
         return True
 
     except Exception as e:

--- a/tests/test_quality_db_bootstrap_tenant_reconcile.py
+++ b/tests/test_quality_db_bootstrap_tenant_reconcile.py
@@ -1,0 +1,81 @@
+"""WS2 / ADR-007: bootstrap_qi_db self-heals tenant-stamping on a fresh QI store.
+
+A fresh quality_intelligence.db owned by a NON-vnx-dev project must NOT keep the
+literal ``DEFAULT 'vnx-dev'`` that the V19/V20/V22 migrations stamp on project_id —
+otherwise rows insert under the wrong tenant. bootstrap_qi_db wires the W1 3-phase
+reconciliation to drop that default for non-vnx-dev pids. The default IS the correct
+legacy default for vnx-dev itself, so the vnx-dev path is left untouched.
+
+(codex flip-PR gate finding: there was no CI test asserting bootstrap invokes the
+runner for a non-vnx-dev fresh path — this closes that gap.)
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+for _p in (_REPO / "scripts", _REPO / "scripts" / "lib"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import quality_db_init  # noqa: E402
+
+_TENANT_TABLES = ("adrs", "dream_cycles", "dispatch_metadata")
+
+
+def _bootstrap(tmp_path: Path, monkeypatch, project_id: "str | None") -> Path:
+    if project_id is None:
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    else:
+        monkeypatch.setenv("VNX_PROJECT_ID", project_id)
+    db = tmp_path / "quality_intelligence.db"
+    assert quality_db_init.bootstrap_qi_db(db) is True
+    return db
+
+
+def _has_vnx_dev_default(db: Path, table: str) -> bool:
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return "DEFAULT 'vnx-dev'" in ((row or ("",))[0] or "")
+
+
+def test_non_vnx_dev_fresh_store_drops_vnx_dev_default(tmp_path, monkeypatch):
+    """A non-vnx-dev project's fresh store must not carry DEFAULT 'vnx-dev'."""
+    db = _bootstrap(tmp_path, monkeypatch, "seocrawler-v2")
+    for table in _TENANT_TABLES:
+        assert not _has_vnx_dev_default(db, table), (
+            f"{table} still has DEFAULT 'vnx-dev' in a seocrawler-v2 store — tenant contamination"
+        )
+
+
+def test_vnx_dev_store_is_left_untouched(tmp_path, monkeypatch):
+    """For vnx-dev, 'vnx-dev' IS the correct default — reconciliation is skipped."""
+    db = _bootstrap(tmp_path, monkeypatch, "vnx-dev")
+    # at least one tenant table should still carry the (correct) default — no needless rebuild
+    assert any(_has_vnx_dev_default(db, t) for t in _TENANT_TABLES)
+
+
+def test_bootstrap_never_fails_on_reconciliation_error(tmp_path, monkeypatch):
+    """A reconciliation failure must never break init (idempotent + retryable)."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "some-other-project")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated reconciliation failure")
+
+    monkeypatch.setattr(quality_db_init, "run_qi_three_phase_migration", _boom)
+    db = tmp_path / "quality_intelligence.db"
+    # init still succeeds despite the reconciliation raising
+    assert quality_db_init.bootstrap_qi_db(db) is True
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## WS2 — QI tenant-stamping (1.0-blocker)
A fresh `quality_intelligence.db` owned by a non-vnx-dev project silently inherited `DEFAULT 'vnx-dev'` (ADR-007 contamination). The W1 3-phase runner already re-stamps + drops the default, but was never invoked on fresh init. Wired into `bootstrap_qi_db` (idempotent, never-fail-init, gated on non-vnx-dev). Tested: seocrawler-v2 fresh store drops the default; vnx-dev untouched.

## Architecture docs (Vincent's request)
New `docs/core/DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md` — current end-to-end: door → assembly (skill + intelligence injection + report-contract) → lane delivery (tmux-signal hook contract) → govern (phantom-guard) → intelligence + self-learning. Cross-linked from DISPATCH_RULES + DOCS_INDEX.

## Gates
- Local: new test 3 passed; flip-critical 169 passed; QI suite 165 passed (2 pre-existing failures confirmed unrelated).
- codex gate: transaction-safe + clean + idempotent confirmed (no BLOCK); the flagged test-gap is closed by tests/test_quality_db_bootstrap_tenant_reconcile.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)