### PR TITLE
feat(assembly): report-contract directive on tmux fallback path (gap #3b)

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -455,15 +455,12 @@ class TmuxInteractiveDispatch:
             "0", "false", "no", "off"
         ):
             return body
-        try:
-            import report_body_contract as _rbc  # noqa: PLC0415
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "_append_report_contract_directive: report_body_contract import "
-                "failed (%s); skipping directive",
-                exc,
-            )
-            return body
+        # Import unguarded — same fail-closed semantics as dispatch_prepare.prepare():
+        # report_body_contract is a core lib present in every tree. If it cannot be
+        # imported the runtime is broken; surface that loudly rather than silently
+        # shipping an ungoverned (directive-less) body, which is the exact failure
+        # this directive exists to prevent.
+        import report_body_contract as _rbc  # noqa: PLC0415
         return body + "\n\n" + _rbc.build_directive(dispatch_id or "", pr_id=pr_id)
 
     def _govern_report(

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -352,8 +352,10 @@ class TmuxInteractiveDispatch:
 
         When VNX_SHARED_PREPARE=1, delegates to dispatch_prepare.prepare() so both
         Claude lanes share identical enrichment (permission preamble + worker-rules
-        footer + report-contract directive + trailer sentinel). Default ("0") is
-        byte-identical to pre-T1 behavior.
+        footer + report-contract directive + trailer sentinel). The default ("0")
+        path runs skill + intelligence enrichment and still appends the
+        report-contract directive (gap #3b) so every dispatch — on either path —
+        tells the worker the required report sections and stays governed.
 
         Reuses subprocess lane enrichers (_inject_skill_context) so the tmux-spawn
         worker receives the same skill body + intelligence treatment as a headless
@@ -422,11 +424,47 @@ class TmuxInteractiveDispatch:
             if smart_context:
                 parts.append(smart_context)
             parts.append(instruction)
-            return "\n\n".join(parts)
-
-        if smart_context:
+            enriched = "\n\n".join(parts)
+        elif smart_context:
             enriched = f"{smart_context}\n\n{enriched}"
-        return enriched
+
+        # Report-contract directive on the fallback path too (gap #3b parity with
+        # dispatch_prepare.prepare()). Without VNX_SHARED_PREPARE the worker would
+        # otherwise never be told the required report sections, so its report fails
+        # the body contract -> no governed receipt -> ungoverned dispatch. Honors the
+        # same VNX_REPORT_CONTRACT_DIRECTIVE gate (default on) as prepare().
+        return self._append_report_contract_directive(
+            enriched, dispatch_id=dispatch_id, pr_id=pr_id
+        )
+
+    @staticmethod
+    def _append_report_contract_directive(
+        body: str,
+        *,
+        dispatch_id: "str | None",
+        pr_id: "str | None" = None,
+    ) -> str:
+        """Append the report-body-contract directive when enabled.
+
+        Mirrors dispatch_prepare.prepare()'s step 5: same VNX_REPORT_CONTRACT_DIRECTIVE
+        gate (default on). Ensures the tmux fallback path (no VNX_SHARED_PREPARE) still
+        enumerates the required report sections so the worker's report passes the body
+        contract and the dispatch stays governed.
+        """
+        if os.environ.get("VNX_REPORT_CONTRACT_DIRECTIVE", "1").strip().lower() in (
+            "0", "false", "no", "off"
+        ):
+            return body
+        try:
+            import report_body_contract as _rbc  # noqa: PLC0415
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "_append_report_contract_directive: report_body_contract import "
+                "failed (%s); skipping directive",
+                exc,
+            )
+            return body
+        return body + "\n\n" + _rbc.build_directive(dispatch_id or "", pr_id=pr_id)
 
     def _govern_report(
         self,

--- a/tests/test_bench_equal_context.py
+++ b/tests/test_bench_equal_context.py
@@ -122,7 +122,10 @@ def test_tmux_without_equal_context_invokes_existing_enricher(monkeypatch, tmp_p
             instruction=RAW_INSTRUCTION,
         )
 
-    assert result == "skill-context-added"
+    # Enricher output is used; the fallback path also appends the report-contract
+    # directive (gap #3b) so the dispatch stays governed without VNX_SHARED_PREPARE.
+    assert "skill-context-added" in result
+    assert "<!-- VNX-REPORT-CONTRACT-DIRECTIVE -->" in result
     inject_skill.assert_called_once()
 
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1412,6 +1412,108 @@ class TestSharedPrepareWiringTmux(unittest.TestCase):
         self.assertNotIn(_WORKER_RULES_FOOTER_SENTINEL, result)
         self.assertNotIn(_TRAILER_SENTINEL, result)
 
+    def test_shared_prepare_0_default_contains_report_contract_directive(self):
+        """VNX_SHARED_PREPARE=0 (default): fallback still appends the report-contract directive.
+
+        Gap #3b: without the directive the worker is never told the required report
+        sections, so its report fails the body contract and the dispatch is ungoverned.
+        """
+        lane = self._make_lane()
+        fake_enriched = "## Skill Context\n\nDo the thing."
+
+        with patch.dict(
+            os.environ,
+            {"VNX_SHARED_PREPARE": "0", "VNX_REPORT_CONTRACT_DIRECTIVE": "1"},
+        ):
+            with patch(
+                "subprocess_dispatch_internals.skill_injection._inject_skill_context",
+                return_value=fake_enriched,
+            ):
+                result = lane._assemble_context(
+                    role="backend-developer",
+                    terminal_id="T1",
+                    dispatch_id="default-directive-test",
+                    instruction="Do the thing.",
+                )
+
+        self.assertIn("<!-- VNX-REPORT-CONTRACT-DIRECTIVE -->", result)
+        self.assertIn("## Report Body Contract", result)
+        # The skill body must still be present (directive is appended, not replacing).
+        self.assertIn("## Skill Context", result)
+
+    def test_shared_prepare_0_directive_suppressed_by_env(self):
+        """VNX_REPORT_CONTRACT_DIRECTIVE=0: fallback path omits the directive (override honored)."""
+        lane = self._make_lane()
+        fake_enriched = "## Skill Context\n\nDo the thing."
+
+        with patch.dict(
+            os.environ,
+            {"VNX_SHARED_PREPARE": "0", "VNX_REPORT_CONTRACT_DIRECTIVE": "0"},
+        ):
+            with patch(
+                "subprocess_dispatch_internals.skill_injection._inject_skill_context",
+                return_value=fake_enriched,
+            ):
+                result = lane._assemble_context(
+                    role="backend-developer",
+                    terminal_id="T1",
+                    dispatch_id="directive-off-test",
+                    instruction="Do the thing.",
+                )
+
+        self.assertNotIn("<!-- VNX-REPORT-CONTRACT-DIRECTIVE -->", result)
+
+    def test_shared_prepare_0_legacy_label_fallback_carries_directive(self):
+        """Deepest fallback (skill injection raises -> legacy label) is still governed."""
+        lane = self._make_lane()
+
+        with patch.dict(
+            os.environ,
+            {"VNX_SHARED_PREPARE": "0", "VNX_REPORT_CONTRACT_DIRECTIVE": "1"},
+        ):
+            with patch(
+                "subprocess_dispatch_internals.skill_injection._inject_skill_context",
+                side_effect=RuntimeError("skill injection blew up"),
+            ):
+                result = lane._assemble_context(
+                    role="backend-developer",
+                    terminal_id="T1",
+                    dispatch_id="legacy-label-directive-test",
+                    instruction="Do the thing.",
+                )
+
+        # Legacy role label header is present AND the directive was appended.
+        self.assertIn("operating as a **backend-developer** worker", result)
+        self.assertIn("<!-- VNX-REPORT-CONTRACT-DIRECTIVE -->", result)
+
+    def test_shared_prepare_1_prepare_error_fallback_carries_directive(self):
+        """VNX_SHARED_PREPARE=1 but prepare() raises: standard-enrichment fallback is governed.
+
+        Mirrors test_shared_prepare_fallback_on_prepare_error but asserts the directive
+        is present so even the error path keeps the dispatch governed.
+        """
+        lane = self._make_lane()
+        fake_enriched = "STANDARD_ENRICHMENT_BODY"
+
+        with patch.dict(
+            os.environ,
+            {"VNX_SHARED_PREPARE": "1", "VNX_REPORT_CONTRACT_DIRECTIVE": "1"},
+        ):
+            with patch("dispatch_prepare.prepare", side_effect=RuntimeError("simulated error")):
+                with patch(
+                    "subprocess_dispatch_internals.skill_injection._inject_skill_context",
+                    return_value=fake_enriched,
+                ):
+                    result = lane._assemble_context(
+                        role="backend-developer",
+                        terminal_id="T1",
+                        dispatch_id="prepare-error-directive-test",
+                        instruction="Do the thing.",
+                    )
+
+        self.assertIn("STANDARD_ENRICHMENT_BODY", result)
+        self.assertIn("<!-- VNX-REPORT-CONTRACT-DIRECTIVE -->", result)
+
     def test_shared_prepare_1_smart_context_prepended(self):
         """VNX_SHARED_PREPARE=1: smart_context is prepended before the prepare() body."""
         from dispatch_prepare import _WORKER_RULES_FOOTER_SENTINEL


### PR DESCRIPTION
## Summary

Assembly-route enforcement, step 2 (the quick win). The tmux dispatch lane's `_assemble_context` had two enrichment paths: with `VNX_SHARED_PREPARE=1` it delegates to `dispatch_prepare.prepare()` (full enrichment incl. the report-body-contract directive); with the env unset (the default — how MC + SEOcrawler currently run) the fallback path ran skill+intelligence injection but never appended the report-contract directive. Without it the worker is never told the required report sections (`## Summary/## Changes/## Verification/## Open Items`), so its report fails the body contract → no governed receipt → ungoverned dispatch.

This appends the directive on the fallback path too, so every dispatch — on either path — stays governed.

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`: `_assemble_context` converges both fallback sub-cases (skill-injection success AND the legacy-label deepest fallback) and calls a new `_append_report_contract_directive` helper. Honors the same `VNX_REPORT_CONTRACT_DIRECTIVE` gate (default on) as `prepare()`. Import is fail-closed (unguarded, mirroring `prepare()`) so a broken core lib surfaces loudly instead of silently shipping a directive-less body. Docstring updated to drop the stale "byte-identical to pre-T1" claim.
- `tests/test_tmux_interactive_dispatch.py`: 4 new tests — default fallback carries directive, `VNX_REPORT_CONTRACT_DIRECTIVE=0` opt-out, legacy-label fallback governed, `prepare()`-error fallback governed.
- `tests/test_bench_equal_context.py`: updated the byte-identical fallback assertion to containment (the fallback now appends the directive by design).

## Verification

- `pytest tests/test_tmux_interactive_dispatch.py tests/test_dispatch_prepare.py tests/test_bench_equal_context.py tests/test_report_body_contract.py` → 238 passed.
- Focused re-run after the fail-closed fix → 60 passed.
- Codex diff-gate: VERDICT PASS (round 1 flagged the swallowed import; fixed to fail-closed; round 2 clean).

## Open Items

None. Follow-on program steps (separate PRs): door default-flip (#10, human gate), raw-dispatch PreToolUse guard, bake into install template + sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC