### PR TITLE
feat(gate): governed kimi review gate (temporary, while codex usage is exhausted)

### DIFF
--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""kimi_gate.py — temporary code-review gate via the GOVERNED kimi lane.
+
+Diff-review gate that routes through the same governed mechanism the plan-gate
+panel uses: ``plan_gate_panel._make_default_dispatcher`` runs the kimi worker via
+``provider_dispatch`` (constraint-safe, emits a receipt, writes a unified report)
+and returns the report text. The verdict is extracted with the provider-agnostic
+```json``` scanner in ``codex_parser``. Writes a result record compatible with the
+codex_gate result schema (``review_gates/results/pr-<N>-kimi_gate.json``).
+
+Why this exists: codex usage is temporarily exhausted, so kimi stands in as the
+review gate until codex is available again. Raw ``kimi --print`` is intentionally
+NOT used — the governance dispatch-guard requires provider_dispatch so the review
+stays on the receipt trail.
+
+Usage:
+    python3 scripts/kimi_gate.py --pr 378 --data-dir ~/.vnx-data/<project>
+    python3 scripts/kimi_gate.py --diff-file /tmp/x.diff --pr 0   # offline diff source
+
+Exit codes: 0 = pass, 2 = fail/blocked, 1 = infra error (no diff / dispatch failed).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from codex_parser import _extract_codex_verdict  # provider-agnostic ```json``` block scan
+from plan_gate_panel import _make_default_dispatcher  # governed provider_dispatch lane
+
+DEFAULT_MODEL = "kimi-k2-7-code"
+DEFAULT_TIMEOUT = 900
+MAX_DIFF_CHARS = 50000
+
+_VERDICT_CONTRACT = (
+    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
+    "```json\n"
+    "{\n"
+    '  "verdict": "pass|fail|blocked",\n'
+    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
+    '  "residual_risk": "remaining risk or null"\n'
+    "}\n"
+    "```\n"
+    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
+    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
+)
+
+
+def _build_prompt(diff_text: str, pr: str) -> str:
+    if len(diff_text) > MAX_DIFF_CHARS:
+        diff_text = diff_text[:MAX_DIFF_CHARS] + "\n\n[... diff truncated for the gate ...]"
+    return (
+        f"You are a strict code-review gate for PR {pr}. Review ONLY the unified diff "
+        "below. Look for correctness bugs, security issues, governance/contract "
+        "violations, and regressions introduced by THIS diff. Be a skeptic; do not "
+        "rubber-stamp, but do not invent issues.\n\n"
+        f"{_VERDICT_CONTRACT}\n"
+        "DIFF:\n"
+        f"{diff_text}\n"
+    )
+
+
+def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
+    if diff_file:
+        p = Path(diff_file)
+        return p.read_text(encoding="utf-8") if p.is_file() else None
+    try:
+        res = subprocess.run(
+            ["gh", "pr", "diff", pr],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=60,
+        )
+        return res.stdout if res.returncode == 0 and res.stdout.strip() else None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def _verdict_to_status(verdict: dict) -> "tuple[str, list, str]":
+    """Map the extracted verdict to (status, blocking_findings, residual_risk)."""
+    v = (verdict.get("verdict") or "").strip().lower() if verdict else ""
+    findings = verdict.get("findings") or [] if verdict else []
+    blocking = [
+        f for f in findings
+        if isinstance(f, dict) and str(f.get("severity", "")).lower() in {"error", "blocked", "blocker"}
+    ]
+    residual = (verdict.get("residual_risk") if verdict else "") or ""
+    if v == "pass" and not blocking:
+        return "pass", [], residual
+    if v in {"fail", "blocked"} or blocking:
+        return "fail", blocking, residual or "kimi gate reported blocking findings"
+    return "fail", [], residual or "kimi gate produced no readable verdict"
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    ap = argparse.ArgumentParser(description="Temporary GOVERNED kimi review gate.")
+    ap.add_argument("--pr", required=True, help="PR number (use 0 with --diff-file for offline test)")
+    ap.add_argument("--diff-file", default=None, help="read the diff from a file instead of gh")
+    ap.add_argument("--data-dir", default=os.environ.get("VNX_DATA_DIR", ""),
+                    help="VNX data dir; report lands in <data-dir>/unified_reports/ and the "
+                         "result in <data-dir>/state/review_gates/results/")
+    ap.add_argument("--model", default=os.environ.get("VNX_KIMI_GATE_MODEL", DEFAULT_MODEL))
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--json", action="store_true", help="print the result record as JSON")
+    args = ap.parse_args(argv)
+
+    diff = _get_diff(args.pr, args.diff_file)
+    if not diff:
+        print(f"kimi_gate: no diff for PR {args.pr}", file=sys.stderr)
+        return 1
+
+    data_dir = args.data_dir or None
+    dispatch_id = f"kimi-gate-pr{args.pr}-{int(time.time())}"
+    dispatcher = _make_default_dispatcher(data_dir, args.timeout)
+
+    start = time.monotonic()
+    try:
+        # Governed lane: provider_dispatch runs kimi, writes a unified report, returns its text.
+        report_text = dispatcher("kimi", args.model, _build_prompt(diff, args.pr), dispatch_id)
+    except Exception as exc:  # noqa: BLE001 — dispatch/report-read failure
+        print(f"kimi_gate: governed kimi dispatch failed: {exc}", file=sys.stderr)
+        return 1
+    duration = time.monotonic() - start
+
+    verdict = _extract_codex_verdict(report_text or "") or {}
+    status, blocking, residual = _verdict_to_status(verdict)
+
+    record = {
+        "gate": "kimi_gate",
+        "pr_id": str(args.pr),
+        "pr_number": int(args.pr) if str(args.pr).isdigit() else None,
+        "status": status,
+        "reason": "verdict" if verdict else "no_verdict",
+        "duration_seconds": round(duration, 3),
+        "summary": f"kimi gate: {status} ({len(blocking)} blocking finding(s))",
+        "provider": "kimi",
+        "model": args.model,
+        "dispatch_id": dispatch_id,
+        "blocking_findings": blocking,
+        "advisory_findings": [
+            f for f in (verdict.get("findings") or []) if f not in blocking
+        ],
+        "required_reruns": [],
+        "residual_risk": residual,
+        "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    if data_dir:
+        results_dir = Path(data_dir) / "state" / "review_gates" / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        out = results_dir / f"pr-{args.pr}-kimi_gate.json"
+        tmp = out.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(record, indent=2), encoding="utf-8")
+        tmp.replace(out)
+        print(f"kimi_gate: wrote {out}", file=sys.stderr)
+
+    if args.json:
+        print(json.dumps(record, indent=2))
+    else:
+        print(f"VERDICT: {status.upper()}  ({len(blocking)} blocking)")
+        for f in blocking:
+            print(f"  · [{f.get('severity')}] {f.get('message')}")
+
+    return 0 if status == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -32,8 +33,29 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from codex_parser import _extract_codex_verdict  # provider-agnostic ```json``` block scan
 from plan_gate_panel import _make_default_dispatcher  # governed provider_dispatch lane
+
+_VALID_VERDICTS = {"pass", "fail", "blocked"}
+
+
+def _extract_verdict(text: str) -> dict:
+    """Extract the worker's verdict: the LAST ```json``` block whose ``verdict`` is a
+    real verdict (pass/fail/blocked).
+
+    The governed worker report echoes the instruction, so the FIRST ```json``` block is
+    our own contract example (its ``verdict`` is the literal "pass|fail|blocked", which is
+    not a valid single verdict and is skipped). Scanning from the end and requiring a real
+    verdict value selects the worker's actual answer, never the echoed template.
+    """
+    blocks = re.findall(r"```json\s*(\{.*?\})\s*```", text or "", re.DOTALL)
+    for block in reversed(blocks):
+        try:
+            obj = json.loads(block)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and str(obj.get("verdict", "")).strip().lower() in _VALID_VERDICTS:
+            return obj
+    return {}
 
 DEFAULT_MODEL = "kimi-k2-7-code"
 DEFAULT_TIMEOUT = 900
@@ -127,7 +149,7 @@ def main(argv: "list[str] | None" = None) -> int:
         return 1
     duration = time.monotonic() - start
 
-    verdict = _extract_codex_verdict(report_text or "") or {}
+    verdict = _extract_verdict(report_text or "")
     status, blocking, residual = _verdict_to_status(verdict)
 
     record = {


### PR DESCRIPTION
## Summary

A standalone code-review gate via the GOVERNED kimi lane, used while codex usage is exhausted (until Friday). Routes through `plan_gate_panel._make_default_dispatcher` (provider_dispatch → kimi, constraint-safe, emits a receipt, writes a unified report) — NOT raw `kimi --print` (the dispatch-guard blocks that). Extracts the worker's verdict (the last ```json``` block with a real pass/fail/blocked verdict, skipping the echoed instruction example) and writes a codex_gate-compatible result record.

## Changes

- `scripts/kimi_gate.py` (new): `--pr N [--diff-file F] --data-dir D` → governed kimi review → `pr-N-kimi_gate.json` result. Exit 0=pass, 2=fail, 1=infra.

## Verification

Exercised live 3× this session: gated PR #900 (P0.1) → PASS with a sharp non-blocking advisory; gated a doc-drift slop branch → FAIL with a real blocking finding (caught a model-naming/pricing inconsistency before merge); 61–128s per run, real verdicts (not the echoed template).

## Open Items

Follow-up: the first-class `kimi_gate` in `gate_runner.py` (this standalone is the interim). When codex returns Friday, revisit the standard gate composition (codex + kimi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC