### PR TITLE
fix(store): backfill resolves the central store (WS2 down-payment) + path-traversal guard

### DIFF
--- a/scripts/backfill_dispatch_track_linkage.py
+++ b/scripts/backfill_dispatch_track_linkage.py
@@ -758,8 +758,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.db:
         db_path = args.db.resolve()
     else:
-        project_root = resolve_project_root(__file__)
-        db_path = project_root / ".vnx-data" / "state" / DB_FILENAME
+        # Store-resolution: VNX_DATA_DIR-first (explicit guard), else the CENTRAL
+        # per-project store the daemons read — NOT the repo-local <root>/.vnx-data.
+        # backfill used to default to repo-local while seed_tracks + the daemons
+        # resolved central (~/.vnx-data/<project>), so its track-linkage landed in a
+        # different store than the future-state it was meant to reconcile (WS2 split).
+        from project_root import resolve_central_data_dir
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+            data_dir = Path(os.environ["VNX_DATA_DIR"]).resolve()
+        else:
+            data_dir = resolve_central_data_dir(args.project_id)
+        db_path = data_dir / "state" / DB_FILENAME
 
     if args.roadmap:
         roadmap_path = args.roadmap.resolve()

--- a/scripts/backfill_dispatch_track_linkage.py
+++ b/scripts/backfill_dispatch_track_linkage.py
@@ -763,7 +763,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         # backfill used to default to repo-local while seed_tracks + the daemons
         # resolved central (~/.vnx-data/<project>), so its track-linkage landed in a
         # different store than the future-state it was meant to reconcile (WS2 split).
-        from project_root import resolve_central_data_dir
+        # vnx_paths (NOT project_root): vnx_paths.resolve_central_data_dir validates
+        # project_id against ^[a-z][a-z0-9-]{1,31}$ (OI-1369), rejecting dots/slashes
+        # that would escape the ~/.vnx-data sandbox via a crafted --project-id.
+        from vnx_paths import resolve_central_data_dir
         if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
             data_dir = Path(os.environ["VNX_DATA_DIR"]).resolve()
         else:


### PR DESCRIPTION
## Summary

Concrete down-payment on the WS2 store-resolution split surfaced live in the MC burn-in. `backfill_dispatch_track_linkage` defaulted its DB path to the repo-local `<repo>/.vnx-data/state`, while `seed_tracks_from_roadmap` and the daemons resolve the central per-project store (`~/.vnx-data/<project>`) — so its track-linkage landed in a different store than the future-state it reconciles. Now VNX_DATA_DIR-first (explicit guard), else the central store.

## Changes

- `scripts/backfill_dispatch_track_linkage.py`: default DB path resolves the central store via `vnx_paths.resolve_central_data_dir` (which validates `project_id` against `^[a-z][a-z0-9-]{1,31}$`, OI-1369, preventing a crafted `--project-id` from escaping the `~/.vnx-data` sandbox). VNX_DATA_DIR honored only with the explicit guard.

## Verification

- `test_backfill_dispatch_track_linkage` → 14 passed (uses explicit `--db`, unaffected).
- Path-traversal `--project-id '../../etc'` now raises ValueError (sandbox guard restored).
- Reviewed via kimi gate (codex down): round 1 FAIL caught that the first cut imported the UNVALIDATED `project_root.resolve_central_data_dir` (a real path-traversal regression); fixed to `vnx_paths`; round 2 PASS, 0 blocking.

## Open Items

The FULL store-resolution contract — consolidating the two divergent fallbacks (`project_root.resolve_data_dir` → repo-local vs the central resolvers) and migrating the ~10 repo-local callers — is the WS2 1.0-blocker proper (opus-level, tenant-bug class), tracked separately. This PR fixes the confirmed burn-in offender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC