### PR TITLE
feat(t0-state): fabric-freshness — reconcile central tracks SSOT before SessionStart projection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 scripts/build_t0_state.py --output .vnx-data/state/t0_state.json 2>/dev/null; exit 0"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo .); mkdir -p \"$ROOT/.vnx-data/logs\" 2>/dev/null; python3 \"$ROOT/scripts/build_t0_state.py\" --output \"$ROOT/.vnx-data/state/t0_state.json\" 2>\"$ROOT/.vnx-data/logs/build_t0_state.err\"; exit 0'"
           }
         ]
       },

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -8,8 +8,18 @@ reconcile_terminal_state.py). Called by SessionStart hook.
 Usage:
     python3 scripts/build_t0_state.py [--output PATH] [--format {state,brief}]
 
-Output schema: schema_version "2.1" (t0_state.json)
+Output schema: schema_version "2.2" (t0_state.json)
 With --format brief: schema 1.0 backward-compat (t0_brief.json format)
+
+Schema 2.2 changes (fabric-freshness):
+  - Additive, backward-compatible: a top-level ``track_freshness`` marker
+    {reconciled, tracks, drifted, drifted_tracks, reason, seconds, store}.
+    Before projecting, the builder runs the advisory track reconciler against
+    the central tracks SSOT and records declared-vs-derived drift here, so the
+    SessionStart snapshot carries its own freshness. A compact form
+    {reconciled, drifted, tracks, reason} is also surfaced in t0_index.json
+    (the always-loaded cold-start file). Consumers that predate 2.2 ignore the
+    new key (no removals/renames).
 
 Schema 2.1 changes (W4E / OI-1199):
   - feature_state union-merges register-canonical aggregation with the
@@ -1675,6 +1685,111 @@ def _build_pr_queue_section(state_dir: Path) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Track freshness (fabric-freshness): reconcile derived_status before projecting
+# ---------------------------------------------------------------------------
+
+def _resolve_tracks_store(state_dir: Path, project_id: str) -> Path:
+    """Resolve the store that actually holds the tracks for ``project_id``.
+
+    The tracks/objectives SSOT is the central per-project store
+    (``~/.vnx-data/<project>/state``). The repo-local ``.vnx-data/state`` is a
+    degraded fallback that frequently has no ``tracks`` table at all. The
+    ambient ``_STATE_DIR`` only points at central when ``VNX_DATA_DIR`` is set,
+    so resolve central explicitly (env-independent) and fall back to
+    ``state_dir`` when central cannot be resolved or has no DB yet.
+    """
+    if resolve_central_data_dir is not None and project_id:
+        try:
+            central_state = resolve_central_data_dir(project_id) / "state"
+            if (central_state / "runtime_coordination.db").exists():
+                return central_state
+        except Exception as exc:
+            log.debug("central tracks-store resolution failed: %s", exc)
+    return state_dir
+
+
+def _reconcile_tracks_fresh(
+    state_dir: Path, project_id: str, *, store: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Reconcile track ``derived_status`` BEFORE projection and return a
+    freshness marker. Advisory-only and never raises.
+
+    build_t0_state runs at EVERY SessionStart. Without this, a track whose PR
+    merged (but whose declared phase was never advanced) stays silently stale
+    until a human writes a handoff. Running the advisory reconciler here
+    recomputes derived_status from dispatch/event state and surfaces any
+    declared-vs-derived drift in the projection itself — so the SessionStart
+    snapshot carries its own freshness instead of a hand-written handoff.
+
+    Targets the CENTRAL tracks SSOT (see ``_resolve_tracks_store``): the reconcile
+    therefore performs a per-track ``UPDATE tracks.derived_status`` (tenant-scoped,
+    ADR-007-safe) on the central multi-tenant DB on every SessionStart. The
+    writes use WAL + a 10s busy-timeout (``track_reconciler._get_conn``), so
+    concurrent session starts serialize safely and contention degrades to an
+    ``error:OperationalError`` marker rather than corrupting state. The pass is
+    idempotent, so a partial batch (some tracks written, then a failure) is
+    self-healing — the next SessionStart re-reconciles.
+
+    Precondition: the ``derived_status`` column (migration 0028) is applied
+    out-of-band by ``migrate_future_system.py`` — NOT by ``_init_and_check_db``
+    (no ``apply_0028.py`` runner). On a store that has not run it, the reconcile
+    degrades to a ``precondition_unmet`` marker (safe, never raises).
+    """
+    marker: Dict[str, Any] = {
+        "reconciled": False,
+        "tracks": 0,
+        "drifted": 0,
+        "drifted_tracks": [],
+        "reason": None,
+        "seconds": 0.0,
+        "store": None,
+    }
+    pid = (project_id or "").strip()
+    if not pid:
+        marker["reason"] = "no_project_id"
+        return marker
+
+    # Use the caller-resolved store when given (guarantees coherence with the
+    # canonical projection); otherwise resolve it here.
+    store = store if store is not None else _resolve_tracks_store(state_dir, pid)
+    marker["store"] = str(store)
+    t0 = time.monotonic()
+    try:
+        if str(_LIB_DIR) not in sys.path:
+            sys.path.insert(0, str(_LIB_DIR))
+        from track_reconciler import reconcile_all_tracks
+
+        results = reconcile_all_tracks(store, pid)
+    except RuntimeError as exc:
+        # derived_status column absent (migration 0028 not applied to this
+        # store). Not an error — reconcile is N/A here.
+        marker["reason"] = "precondition_unmet"
+        log.debug("track reconcile skipped (precondition): %s", exc)
+        return marker
+    except Exception as exc:  # never break the hot path
+        marker["reason"] = f"error:{type(exc).__name__}"
+        log.warning("track reconcile failed (projection continues): %s", exc)
+        return marker
+
+    drifted = [r for r in results if r.get("drifted")]
+    marker.update(
+        reconciled=True,
+        tracks=len(results),
+        drifted=len(drifted),
+        drifted_tracks=[
+            {
+                "track_id": r.get("track_id"),
+                "declared_phase": r.get("declared_phase"),
+                "derived_status": r.get("derived_status"),
+            }
+            for r in drifted
+        ],
+        seconds=round(time.monotonic() - t0, 3),
+    )
+    return marker
+
+
+# ---------------------------------------------------------------------------
 # Main builder
 # ---------------------------------------------------------------------------
 
@@ -1698,10 +1813,20 @@ def build_t0_state(
     # R6.1: probe quality_intelligence.db; classify locked/malformed (not premigration)
     db_health = _probe_db_health(state_dir / "quality_intelligence.db")
 
+    # Fabric-freshness: resolve the tracks store ONCE (the central per-project
+    # SSOT, with local fallback) and use it for BOTH the reconcile AND the
+    # canonical projection, so the snapshot is internally coherent — the
+    # freshness marker and canonical_tracks never reflect different stores.
+    # (Migration 0028 / the derived_status column is applied out-of-band by
+    # migrate_future_system.py, NOT by _init_and_check_db; a store without it
+    # degrades to a precondition_unmet marker.)
+    tracks_store = _resolve_tracks_store(state_dir, project_id)
+    track_freshness = _reconcile_tracks_fresh(state_dir, project_id, store=tracks_store)
+
     terminals = _build_terminals(state_dir)
     queues = _build_queues(dispatch_dir, state_dir)
     tracks = _build_tracks(state_dir)
-    canonical_tracks = _build_tracks_from_db(state_dir, project_id)  # R3.2/ADR-007: tenant-scoped
+    canonical_tracks = _build_tracks_from_db(tracks_store, project_id)  # R3.2/ADR-007: tenant-scoped (central SSOT)
     pr_progress = _build_pr_progress(dispatch_dir, state_dir)
     feature_state = _build_feature_state(state_dir=state_dir)
     open_items = _collect_open_items(project_id, state_dir)
@@ -1722,12 +1847,13 @@ def build_t0_state(
     )
 
     return {
-        "schema_version": "2.1",
+        "schema_version": "2.2",
         "generated_at": _now_iso(),
         # staleness_seconds removed (R6.4): call compute_staleness_seconds() at read time
         "terminals": terminals,
         "queues": queues,
         "tracks": tracks,
+        "track_freshness": track_freshness,
         "canonical_tracks": canonical_tracks,
         "pr_progress": pr_progress,
         "feature_state": feature_state,
@@ -1869,7 +1995,24 @@ def _build_t0_index(state: Dict[str, Any]) -> Dict[str, Any]:
         "active_dispatches": [d.get("dispatch_id", "") for d in active_work],
         "recent_receipts": (state.get("recent_receipts") or [])[-3:],
         "health": state.get("system_health") or {},
+        "track_freshness": _track_freshness_summary(state.get("track_freshness")),
         "last_rebuild_seconds": state.get("_build_seconds"),
+    }
+
+
+def _track_freshness_summary(tf: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compact track-freshness marker for the always-loaded index (F3).
+
+    The full marker (with per-track drift detail) lives in the state doc; the
+    index carries only the cheap orientation fields so a cold-start session sees
+    whether the projection is fresh and how many tracks drifted.
+    """
+    tf = tf or {}
+    return {
+        "reconciled": bool(tf.get("reconciled", False)),
+        "drifted": tf.get("drifted", 0),
+        "tracks": tf.get("tracks", 0),
+        "reason": tf.get("reason"),
     }
 
 
@@ -2068,20 +2211,35 @@ def _emit_build_signal(output_path: Path, elapsed: float) -> None:
 
 
 def _emit_health_beacon(
-    output_path: Path, fmt: str, elapsed: float, succeeded: bool
+    output_path: Path, fmt: str, elapsed: float, succeeded: bool,
+    track_freshness: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Emit HealthBeacon heartbeat (best-effort)."""
+    """Emit HealthBeacon heartbeat (best-effort).
+
+    Carries a compact track-freshness summary so reconcile health (e.g.
+    ``reconciled=False`` with an ``error:*`` reason) is observable on the
+    beacon, not only inside the projection. A benign skip
+    (``no_project_id``/``precondition_unmet``) is reported but does NOT flip the
+    beacon to ``fail`` — only a real build/write failure does.
+    """
+    details: Dict[str, Any] = {
+        "format": fmt,
+        "output": str(output_path),
+        "elapsed_seconds": round(elapsed, 3),
+    }
+    if track_freshness is not None:
+        details["track_freshness"] = {
+            "reconciled": bool(track_freshness.get("reconciled", False)),
+            "drifted": track_freshness.get("drifted", 0),
+            "reason": track_freshness.get("reason"),
+        }
     try:
         from health_beacon import HealthBeacon
         HealthBeacon(
             _DATA_DIR, "t0_state_builder", expected_interval_seconds=1800,
         ).heartbeat(
             status="ok" if succeeded else "fail",
-            details={
-                "format": fmt,
-                "output": str(output_path),
-                "elapsed_seconds": round(elapsed, 3),
-            },
+            details=details,
         )
     except Exception as e:
         log.debug("HealthBeacon heartbeat failed (non-critical): %s", e)
@@ -2136,7 +2294,11 @@ def main() -> int:
         _emit_build_signal(output_path, elapsed)
 
     # Error 1: beacon status reflects both build success AND write health
-    _emit_health_beacon(output_path, args.format, elapsed, _build_succeeded and not write_failed)
+    _emit_health_beacon(
+        output_path, args.format, elapsed,
+        _build_succeeded and not write_failed,
+        track_freshness=(state or {}).get("track_freshness") if state else None,
+    )
 
     if _build_succeeded and state is not None:
         sh_status = (state.get("system_health") or {}).get("status", "healthy")

--- a/tests/test_build_t0_brief_output.py
+++ b/tests/test_build_t0_brief_output.py
@@ -163,7 +163,7 @@ class TestFormatBriefOutputPath:
         state_path = state_dir / "t0_state.json"
         assert state_path.exists(), "t0_state.json must be written when --format state"
         data = json.loads(state_path.read_text())
-        assert data.get("schema_version") == "2.1"
+        assert data.get("schema_version") == "2.2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_build_t0_state_exception_handling.py
+++ b/tests/test_build_t0_state_exception_handling.py
@@ -37,7 +37,7 @@ import build_t0_state as bts  # noqa: E402
 
 class TestRunsClean:
     def test_build_t0_state_runs_clean_on_main(self, tmp_path: Path) -> None:
-        """Script exits 0 and produces valid schema_version:2.1 JSON."""
+        """Script exits 0 and produces valid schema_version:2.2 JSON."""
         out = tmp_path / "t0_state_smoke.json"
         result = subprocess.run(
             [sys.executable, str(_SCRIPTS_DIR / "build_t0_state.py"), "--output", str(out)],
@@ -50,7 +50,7 @@ class TestRunsClean:
         )
         assert out.exists(), "output file not created"
         data = json.loads(out.read_text())
-        assert data.get("schema_version") == "2.1"
+        assert data.get("schema_version") == "2.2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -1,0 +1,246 @@
+"""tests/test_build_t0_state_freshness.py — fabric-freshness reconcile wiring.
+
+Self-contained (no cross-test-module imports). Verifies the SessionStart
+hot-path advisory reconcile that keeps the t0_state projection fresh:
+- no project_id -> skipped marker (reason="no_project_id"), never raises
+- pre-migration store (no derived_status column) -> reason="precondition_unmet"
+- a track whose PR merged but whose declared phase is stale -> drift surfaced
+- the reconcile resolves the CENTRAL tracks SSOT, not the ambient local store
+- the compact index summary mirrors the full marker
+- the SessionStart hook command is valid bash, de-swallows stderr, keeps exit 0
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import build_t0_state as bts  # noqa: E402
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-proj"
+_MARKER_KEYS = {
+    "reconciled", "tracks", "drifted", "drifted_tracks", "reason", "seconds", "store",
+}
+
+
+# ---------------------------------------------------------------------------
+# Self-contained migration-applied tracks DB (decoupled from test_track_reconciler)
+# ---------------------------------------------------------------------------
+
+def _build_tracks_db(tmp_path: Path) -> Path:
+    """state_dir with the dispatch/event tables + migrations 0022/0024/0027/0028."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL, project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for ver, fname in (
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _seed_track(state_dir: Path, track_id: str, *, phase: str = "active", pr_ref=None) -> None:
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID,
+        title=f"Track {track_id}", goal_state=f"ship {track_id}", phase=phase, pr_ref=pr_ref,
+    )
+
+
+def _seed_dispatch(state_dir: Path, dispatch_id: str, track_id: str, *, state="completed", pr_ref=None) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track, pr_ref) VALUES (?,?,?,?,?)",
+        (dispatch_id, PROJECT_ID, state, track_id, pr_ref),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pr_merged_event(state_dir: Path, dispatch_id: str) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        """
+        INSERT INTO coordination_events
+            (event_id, event_type, entity_type, entity_id, occurred_at, project_id)
+        VALUES (?, 'pr_merged', 'dispatch', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), ?)
+        """,
+        (f"ev-{dispatch_id}", dispatch_id, PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Reconcile marker
+# ---------------------------------------------------------------------------
+
+def test_no_project_id_is_skipped_not_an_error(tmp_path):
+    marker = bts._reconcile_tracks_fresh(tmp_path, "")
+    assert marker["reconciled"] is False
+    assert marker["reason"] == "no_project_id"
+    assert marker["drifted"] == 0
+    assert set(marker) == _MARKER_KEYS
+
+
+def test_pre_migration_store_reports_precondition_unmet(tmp_path, monkeypatch):
+    # Force local-only resolution (no central store) so the bare DB is the target.
+    monkeypatch.setattr(bts, "resolve_central_data_dir", None)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    sqlite3.connect(str(state_dir / "runtime_coordination.db")).close()
+
+    marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
+    assert marker["reconciled"] is False
+    assert marker["reason"] == "precondition_unmet"
+
+
+def test_drift_is_surfaced_when_pr_merged_but_phase_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(bts, "resolve_central_data_dir", None)  # use state_dir directly
+    state_dir = _build_tracks_db(tmp_path)
+    _seed_track(state_dir, "T-stale", phase="active", pr_ref="PR-900")
+    _seed_dispatch(state_dir, "D-1", "T-stale", state="completed", pr_ref="PR-900")
+    _seed_pr_merged_event(state_dir, "D-1")
+
+    marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
+
+    assert marker["reconciled"] is True
+    assert marker["tracks"] >= 1
+    assert marker["drifted"] >= 1
+    stale = next(d for d in marker["drifted_tracks"] if d["track_id"] == "T-stale")
+    assert stale["declared_phase"] == "active"
+    assert stale["derived_status"] == "done"
+
+
+def test_in_sync_track_does_not_drift(tmp_path, monkeypatch):
+    monkeypatch.setattr(bts, "resolve_central_data_dir", None)
+    state_dir = _build_tracks_db(tmp_path)
+    _seed_track(state_dir, "T-sync", phase="queued")
+
+    marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
+    assert marker["reconciled"] is True
+    assert all(d["track_id"] != "T-sync" for d in marker["drifted_tracks"])
+
+
+def test_reconcile_resolves_central_store_not_ambient(tmp_path, monkeypatch):
+    # Central holds the tracks; the ambient state_dir is an empty local store.
+    central = _build_tracks_db(tmp_path / "central_root")
+    _seed_track(central, "T-central", phase="queued")
+    ambient = tmp_path / "ambient" / "state"
+    ambient.mkdir(parents=True)
+    sqlite3.connect(str(ambient / "runtime_coordination.db")).close()
+
+    # resolve_central_data_dir(project) -> the central root that holds /state
+    monkeypatch.setattr(bts, "resolve_central_data_dir", lambda pid: central.parent)
+
+    assert bts._resolve_tracks_store(ambient, PROJECT_ID) == central
+    marker = bts._reconcile_tracks_fresh(ambient, PROJECT_ID)
+    assert marker["reconciled"] is True  # found the central tracks, not the empty ambient
+    assert marker["store"] == str(central)
+
+
+# ---------------------------------------------------------------------------
+# Index summary
+# ---------------------------------------------------------------------------
+
+def test_index_summary_is_compact_and_mirrors_marker():
+    full = {
+        "reconciled": True, "tracks": 47, "drifted": 18,
+        "drifted_tracks": [{"track_id": "x"}], "reason": None, "seconds": 0.4, "store": "/s",
+    }
+    summary = bts._track_freshness_summary(full)
+    assert summary == {"reconciled": True, "drifted": 18, "tracks": 47, "reason": None}
+    assert "drifted_tracks" not in summary  # heavy detail excluded from the index
+
+    none = bts._track_freshness_summary(None)
+    assert none == {"reconciled": False, "drifted": 0, "tracks": 0, "reason": None}
+
+
+# ---------------------------------------------------------------------------
+# SessionStart hook command (F5: a quoting bug here breaks every session start)
+# ---------------------------------------------------------------------------
+
+def _t0_sessionstart_command() -> str:
+    settings = json.loads((_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    for entry in settings["hooks"]["SessionStart"]:
+        if entry.get("matcher") == "terminals/T0":
+            return entry["hooks"][0]["command"]
+    raise AssertionError("T0 SessionStart hook not found")
+
+
+def test_sessionstart_hook_is_valid_bash_and_de_swallows():
+    cmd = _t0_sessionstart_command()
+    # 1) the whole command tokenizes (no unbalanced quotes)
+    shlex.split(cmd)
+    # 2) the inner bash -c body parses (catches quoting/escaping bugs)
+    assert cmd.startswith("bash -c ")
+    body = shlex.split(cmd)[2]
+    rc = subprocess.run(["bash", "-n", "-c", body], capture_output=True, text=True)
+    assert rc.returncode == 0, f"hook body is not valid bash: {rc.stderr}"
+    # 3) the BUILDER's stderr is captured to a log (not /dev/null), and the hook
+    #    never blocks the session. (git/mkdir may still suppress their own noise.)
+    assert 'build_t0_state.py" --output' in body
+    assert 'build_t0_state.py" --output "$ROOT/.vnx-data/state/t0_state.json" 2>/dev/null' not in body
+    assert "build_t0_state.err" in body
+    assert "exit 0" in body

--- a/tests/test_build_t0_state_strategy.py
+++ b/tests/test_build_t0_state_strategy.py
@@ -336,7 +336,7 @@ class TestBuildIntegration:
         }
         missing = required - set(state.keys())
         assert not missing, f"build_t0_state lost legacy keys: {missing}"
-        assert state["schema_version"] == "2.1"
+        assert state["schema_version"] == "2.2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vnx_status.py
+++ b/tests/test_vnx_status.py
@@ -64,7 +64,7 @@ Last updated: 2026-05-06T00:00:00Z
 """
 
 SAMPLE_T0_STATE: dict = {
-    "schema_version": "2.1",
+    "schema_version": "2.2",
     "generated_at": "2026-05-06T06:00:00Z",
     "terminals": {
         "T1": {


### PR DESCRIPTION
## Summary

`build_t0_state` runs at every SessionStart but projected the **declared** track phase without reconciling against dispatch/event state — so a merged-PR's drift stayed invisible until a human wrote a handoff. The SessionStart hook also swallowed all builder stderr (`2>/dev/null`) and masked the exit code (`; exit 0`).

This wires the advisory `track_reconciler` into the hot path against the **central tracks SSOT** and surfaces the drift in the projection itself, so the SessionStart snapshot carries its own freshness.

## Changes

- **`_resolve_tracks_store`** — resolve the central per-project tracks SSOT (env-independent via `resolve_central_data_dir`, local fallback). Used for **both** the reconcile **and** the canonical projection, so the snapshot is internally coherent (`track_freshness.tracks == canonical_tracks` count; live-verified 49/49).
- **`_reconcile_tracks_fresh`** — advisory, never-raises reconcile of `derived_status` before projection; records declared-vs-derived drift in a `track_freshness` marker. Every failure mode degrades to a marker (`no_project_id` / `precondition_unmet` / `error:*`).
- **Surfacing** — compact `{reconciled,drifted,tracks,reason}` in `t0_index.json` (the always-loaded cold-start file) + HealthBeacon details; full marker in the (deprecated) state doc.
- **Hook de-swallow** — `.claude/settings.json` T0 SessionStart: builder stderr → `.vnx-data/logs/build_t0_state.err` (not `/dev/null`); `exit 0` kept so a degraded build never blocks the session.
- **schema_version 2.1 → 2.2** (additive `track_freshness` key) + the 4 asserting consumers updated.

## Verification

- Plan-gate (opus + kimi + glm) **PASS** after 3 rounds. The gate caught real defects each round: feature inert against the degraded local store (reconciled local, not central SSOT), a false migration premise (0028 is applied out-of-band by `migrate_future_system.py`, not `_init_and_check_db`), a surfacing dead-end (marker only in the deprecated `t0_state.json`), a schema-bump that broke 4 tests, and a same-snapshot store incoherence — all fixed.
- 7 new self-contained tests (`tests/test_build_t0_state_freshness.py`): no-project-id skip, precondition-unmet, drift-surfaced, in-sync, central-store resolution, index-summary, and a `bash -n` hook smoke test.
- 159/159 in the affected suite green (build_t0_state + track_reconciler + vnx_status). Live run verified: schema 2.2, reconciled=True, 49 tracks, 20 drifted, coherent index marker.
- ADR-007: no new table; reconciler reads/writes are `(track_id, project_id)`-scoped; `derived_status` write is advisory-only (never `phase`/ROADMAP). WAL + 10s busy-timeout make the per-SessionStart central write concurrency-safe and idempotent.

## Open Items

- The broader store-resolution canonicalization (~30 resolvers) is **WS2 / pre10-store-res-full** — this PR uses the existing validated `resolve_central_data_dir` and does not touch the other callers.
- Auto-advance-on-merge (a phase write) is **pre10-close-the-loop**.
- Pre-existing: `test_build_t0_brief_output` / `test_build_t0_state_exception_handling` subprocess tests fail on the degraded **local** repo store (migration `no such column: project_id`) — identical on clean `main`, a WS2 symptom, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)