### PR TITLE
docs(cost): sync COST_TRACKING_GUIDE pricing table to MODEL_PRICING SSOT

### DIFF
--- a/docs/intelligence/COST_TRACKING_GUIDE.md
+++ b/docs/intelligence/COST_TRACKING_GUIDE.md
@@ -228,7 +228,10 @@ Default pricing (USD per 1M tokens) mirrors `MODEL_PRICING` in `cost_tracker.py`
 | claude-sonnet-4.6 | $3.00 | $15.00 |
 | claude-opus-4.5 (historical) | $15.00 | $75.00 |
 | claude-sonnet-4.5 (historical) | $3.00 | $15.00 |
+| gpt-5.3-codex | $2.00 | $16.00 |
 | gpt-5.2-codex | $1.75 | $14.00 |
+| gpt-5.1-codex | $1.25 | $10.00 |
+| gpt-5.1-codex-mini | $0.25 | $2.00 |
 | gemini-pro | $0.50 | $1.50 |
 | gemini-flash | $0.10 | $0.30 |
 


### PR DESCRIPTION
## Summary

The pricing table in `docs/intelligence/COST_TRACKING_GUIDE.md` drifted from `MODEL_PRICING` in `cost_tracker.py` — the documented source of truth. It was missing three entries: `gpt-5.3-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`.

This adds those three rows so the doc mirrors the SSOT exactly. Docs-only, no code changes.

## Changes

- `docs/intelligence/COST_TRACKING_GUIDE.md`: +3 pricing rows (the missing gpt-codex tiers), matching `MODEL_PRICING`.

This finishes the held `slop/doc-drift-pass` cleanly: the contentious `gpt-5.3→gpt-5.5` code-comment changes (which referenced a model absent from the SSOT, flagged by the earlier kimi-gate) are dropped; only the pricing-table sync is kept.

## Verification

- Programmatic check: the doc table now matches `cost_tracker.MODEL_PRICING` exactly — 10/10 rows, no doc-only or SSOT-only entries.
- Diff is docs-only (no code, no comment changes).

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)