### PR TITLE
feat(planning): vnx objective close — human-gated close-the-loop drift resolver

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -328,6 +328,9 @@ Planning commands (strategic-layer read surface):
   objective list      List objectives (tracks) grouped by horizon (now/next/later)
                         Options: --horizon, --phase, --json
   objective show <id> Show one objective: phase/horizon/deps/pr_ref
+  objective drift     Advisory: report tracks whose declared phase != derived status
+  objective close <id> Close-the-loop: advance declared phase to a terminal derived
+                        status (human-gated: dry-run default; --apply --approval-id to write)
 
 Process commands (visibility and control):
   status             Show terminal health, dispatch queue, and gate results

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -334,6 +334,44 @@ def reconcile_track(
         conn.close()
 
 
+def peek_derived_status(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """READ-ONLY: compute derived_status for one track WITHOUT persisting it.
+
+    Same derivation as reconcile_track (all sources: dispatch states, blocker
+    OIs, dependency tracks, and the merged-PR evidence path) but writes nothing —
+    so a dry-run preview never mutates DB state. Returns the same dict shape as
+    reconcile_track (track_id, project_id, derived_status, declared_phase, drifted).
+
+    Raises RuntimeError if the derived_status column is absent (migration 0028).
+    """
+    conn = _get_conn(state_dir)
+    try:
+        if not _has_col(conn, "tracks", "derived_status"):
+            raise RuntimeError(
+                "tracks.derived_status column absent; apply migration 0028 first."
+            )
+        merged = _load_merged_pr_numbers(state_dir)
+        derived = _compute_derived_status(conn, track_id, project_id, merged)
+        track_row = conn.execute(
+            "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        declared = track_row["phase"] if track_row else None
+        return {
+            "track_id": track_id,
+            "project_id": project_id,
+            "derived_status": derived,
+            "declared_phase": declared,
+            "drifted": declared != derived,
+        }
+    finally:
+        conn.close()
+
+
 def reconcile_all_tracks(
     state_dir: str | Path,
     project_id: str,

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -379,6 +379,236 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
     return 0
 
 
+def _close_evidence(state_dir: Path, track_id: str, project_id: str) -> dict[str, Any]:
+    """Summarize WHY a track derives terminal, so the operator gate is INFORMED.
+
+    The reconciler's 'done' counts ALL terminal dispatch states — including the
+    FAILURE states expired/dead_letter (track_reconciler.TERMINAL_DISPATCH_STATES).
+    So a track whose every dispatch failed (no completed run, no merged PR) still
+    derives 'done'. Surface the breakdown + a ``has_success_signal`` flag so the
+    operator does not blind-close a failed track. Best-effort; never raises.
+    """
+    ev: dict[str, Any] = {
+        "completed": 0, "failed_terminal": 0, "in_flight": 0,
+        "pr_ref": None, "pr_merged": False, "has_success_signal": False,
+    }
+    db = Path(state_dir) / "runtime_coordination.db"
+    try:
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        try:
+            for r in conn.execute(
+                "SELECT state, COUNT(*) c FROM dispatches "
+                "WHERE track=? AND project_id=? GROUP BY state",
+                (track_id, project_id),
+            ):
+                st = (r["state"] or "").lower()
+                if st == "completed":
+                    ev["completed"] += r["c"]
+                elif st in ("expired", "dead_letter"):
+                    ev["failed_terminal"] += r["c"]
+                else:
+                    ev["in_flight"] += r["c"]
+            row = conn.execute(
+                "SELECT pr_ref FROM tracks WHERE track_id=? AND project_id=?",
+                (track_id, project_id),
+            ).fetchone()
+            ev["pr_ref"] = row["pr_ref"] if row else None
+            merged = conn.execute(
+                "SELECT COUNT(*) FROM coordination_events "
+                "WHERE event_type='pr_merged' AND project_id=? AND entity_id IN "
+                "(SELECT dispatch_id FROM dispatches WHERE track=? AND project_id=?)",
+                (project_id, track_id, project_id),
+            ).fetchone()[0]
+            ev["pr_merged"] = merged > 0
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("close evidence query failed: %s", exc)
+    # Match the reconciler's OTHER merge source: pr_ref against the local
+    # merged-PR set (not only coordination_events), so the signal does not
+    # falsely read 'no merge' when the reconciler in fact saw one.
+    try:
+        if ev["pr_ref"]:
+            num = track_reconciler._parse_pr_number(ev["pr_ref"])
+            if num is not None and num in track_reconciler._load_merged_pr_numbers(state_dir):
+                ev["pr_merged"] = True
+    except Exception as exc:
+        logger.debug("close evidence merged-PR check failed: %s", exc)
+    ev["has_success_signal"] = ev["completed"] > 0 or ev["pr_merged"]
+    return ev
+
+
+def _phase_path_to(start: str, target: str) -> Optional[list[str]]:
+    """Shortest list of phases to transition THROUGH to reach ``target`` from
+    ``start``, following ``tracks.ALLOWED_TRANSITIONS``. Excludes ``start``;
+    returns ``[]`` when already at target, ``None`` when unreachable.
+
+    BFS over the (tiny, fixed) phase graph; ``seen`` guards the parked<->queued
+    cycle.
+    """
+    if start == target:
+        return []
+    seen = {start}
+    queue: list[tuple[str, list[str]]] = [(start, [])]
+    while queue:
+        node, path = queue.pop(0)
+        for nxt in sorted(tracks_lib.ALLOWED_TRANSITIONS.get(node, frozenset())):
+            if nxt in seen:
+                continue
+            new_path = path + [nxt]
+            if nxt == target:
+                return new_path
+            seen.add(nxt)
+            queue.append((nxt, new_path))
+    return None
+
+
+def cmd_objective_close(args: argparse.Namespace) -> int:
+    """Close-the-loop: resolve phase_drift by advancing a track's DECLARED phase
+    to its derived_status when the work is genuinely done (PR merged).
+
+    `objective drift` / `objective sync` only REPORT drift; nothing advances the
+    declared phase, so a merged-and-deployed track stays queued/parked forever
+    (the gap that bit the MC #284 sprint). This closes that loop — but as a
+    HUMAN-GATED operation, never an automatic side effect of merge:
+
+      - Default is a dry-run (--check); --apply is required to write.
+      - --apply additionally requires --approval-id (the operator's gate token).
+      - Only a TERMINAL derived_status ('done') closes; a non-terminal derived
+        status is a no-op (nothing to close yet).
+      - The write goes through tracks.transition_phase (the single-writer): it
+        enforces ALLOWED_TRANSITIONS, stamps completed_at, and records a
+        track_phase_history row + event with the approval_id (full audit trail).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    try:
+        # Dry-run is READ-ONLY: peek computes derived_status without persisting.
+        # --apply reconciles fresh (and persists derived_status) right before the
+        # write, so the transition acts on current state.
+        if args.apply:
+            result = track_reconciler.reconcile_track(state_dir, track_id, project_id)
+        else:
+            result = track_reconciler.peek_derived_status(state_dir, track_id, project_id)
+    except Exception as exc:
+        print(f"objective close failed: cannot reconcile {track_id}: {exc}", file=sys.stderr)
+        return 1
+
+    derived = result["derived_status"]
+    declared = result["declared_phase"]
+    target = "done"  # only 'done' closes the loop; other derived states are interim
+
+    payload = {
+        "track_id": track_id,
+        "project_id": project_id,
+        "declared_phase": declared,
+        "derived_status": derived,
+        "action": None,
+        "applied": False,
+    }
+
+    def _emit(action: str, applied: bool, message: str, rc: int) -> int:
+        payload["action"] = action
+        payload["applied"] = applied
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close — {track_id} (project '{project_id}')\n")
+            print(f"  declared={declared or '-'}  derived={derived}")
+            ev = payload.get("evidence")
+            if ev:
+                print(
+                    f"  evidence: completed={ev['completed']} "
+                    f"failed_terminal={ev['failed_terminal']} in_flight={ev['in_flight']} "
+                    f"pr_ref={ev['pr_ref'] or '-'} pr_merged={ev['pr_merged']}"
+                )
+                if not ev["has_success_signal"]:
+                    print("  ! WARNING: derived 'done' has NO success signal "
+                          "(no completed dispatch, no merged PR) — likely all-failed. "
+                          "Confirm this is really done before --apply.")
+            print(f"  {message}\n")
+        return rc
+
+    if derived != target:
+        return _emit(
+            "noop_not_terminal", False,
+            f"nothing to close: derived_status={derived} is not terminal ('{target}').", 0,
+        )
+    if declared == target:
+        return _emit("noop_already_closed", False, f"already closed (phase={declared}).", 0)
+
+    # 'parked' is a DELIBERATE human stop-signal (stronger than 'queued'). Walking
+    # parked -> queued -> active -> done would silently un-park it. Require an
+    # explicit --include-parked so closing a parked track is never accidental.
+    if declared == "parked" and not getattr(args, "include_parked", False):
+        return _emit(
+            "rejected_parked", False,
+            "track is PARKED (a deliberate stop). Pass --include-parked to close "
+            "it anyway, or un-park it first. No change made.", 2,
+        )
+
+    # Surface the done-evidence so the operator gate is informed: the reconciler
+    # derives 'done' from ANY terminal dispatch state, including expired/dead_letter.
+    payload["evidence"] = _close_evidence(state_dir, track_id, project_id)
+
+    # The state machine forbids skips (e.g. queued -> done is illegal: a track
+    # must pass through 'active'). A merged track stuck at queued/parked is
+    # exactly the MC scenario, so walk the SHORTEST legal path to 'done' rather
+    # than reject it. No path -> reject (don't force an illegal write).
+    path = _phase_path_to(declared, target)
+    if path is None:
+        return _emit("rejected_no_path", False,
+                     f"ERROR: no legal transition path {declared} -> {target} "
+                     f"(ALLOWED_TRANSITIONS). No change made.", 2)
+    payload["path"] = [declared, *path]
+
+    if not args.apply:
+        return _emit(
+            "dry_run", False,
+            f"[dry-run] would transition {' -> '.join([declared, *path])}. "
+            f"Re-run with --apply --approval-id <id> to write.", 0,
+        )
+    if not args.approval_id:
+        return _emit(
+            "rejected_no_approval", False,
+            "ERROR: --apply requires --approval-id (the human gate). No change made.", 2,
+        )
+
+    # The walk is NOT atomic: each transition_phase commits on its own
+    # (tracks.py), so a mid-path failure (e.g. a concurrent writer moved the
+    # phase) leaves the track at an intermediate phase. That is recoverable —
+    # this command re-walks from the CURRENT declared phase, so re-running it
+    # resumes and finishes. We surface where it stopped so the operator can.
+    cur = declared
+    try:
+        for step in path:
+            tracks_lib.transition_phase(
+                state_dir, track_id, project_id, step,
+                actor="operator",
+                reason=f"close-the-loop ({declared}->{target}, derived={derived})",
+                approval_id=args.approval_id,
+            )
+            cur = step
+    except tracks_lib.TrackNotFoundError as exc:
+        return _emit("rejected_not_found", False, f"ERROR: {exc}", 2)
+    except Exception as exc:
+        # Any mid-walk failure (illegal transition from a concurrent writer, a DB
+        # error, etc.) leaves the track at the last committed phase. Never crash
+        # with a traceback — report where it stopped; the walk is resumable.
+        payload["declared_phase"] = cur
+        return _emit("rejected_walk_failed", False,
+                     f"ERROR: transition failed at '{cur}': {type(exc).__name__}: {exc}. "
+                     f"Track left at '{cur}' — re-run `objective close` to resume.", 2)
+
+    payload["declared_phase"] = target
+    return _emit("closed", True,
+                 f"closed: {' -> '.join([declared, *path])} "
+                 f"(actor=operator, approval={args.approval_id}).", 0)
+
+
 def maybe_auto_seed(
     state_dir: str | Path | None = None,
     roadmap_path: str | Path | None = None,
@@ -1017,6 +1247,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _common(p_drift)
     p_drift.set_defaults(func=cmd_objective_drift)
+
+    p_close = obj_sub.add_parser(
+        "close",
+        help="close-the-loop: advance declared phase to a terminal derived_status (human-gated)",
+    )
+    _common(p_close)
+    p_close.add_argument("track_id")
+    p_close.add_argument("--apply", action="store_true",
+                         help="write the transition (default: dry-run check)")
+    p_close.add_argument("--approval-id", default="",
+                         help="operator approval token (REQUIRED with --apply)")
+    p_close.add_argument("--include-parked", action="store_true",
+                         help="allow closing a PARKED track (un-parks it; off by default)")
+    p_close.set_defaults(func=cmd_objective_close)
 
     p_add = obj_sub.add_parser(
         "add",

--- a/tests/test_objective_close.py
+++ b/tests/test_objective_close.py
@@ -1,0 +1,273 @@
+"""tests/test_objective_close.py — close-the-loop `vnx objective close`.
+
+Self-contained. Verifies the human-gated drift-resolver that advances a track's
+declared phase to a terminal derived_status:
+- dry-run (default) never writes
+- non-terminal derived_status is a no-op
+- --apply without --approval-id is rejected fail-closed (no write)
+- --apply --approval-id walks the LEGAL path to done (active->done, queued->active->done)
+  via the single-writer, leaving a phase_history audit trail
+- a track already at done is a no-op (idempotent)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import planning_cli  # noqa: E402
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-proj"
+
+
+def _build_db(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL, project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for ver, fname in ((27, "0027_planning_horizon_and_deliverable_view.sql"),
+                       (28, "0028_tracks_derived_status.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _seed_done_track(state_dir: Path, track_id: str, *, phase: str) -> None:
+    """Track whose work is terminal (completed dispatch, no pr_ref) => derived 'done'."""
+    tracks_lib.create_track(state_dir, track_id, PROJECT_ID,
+                            title=track_id, goal_state="ship", phase=phase)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?,?,?,?)",
+        (f"D-{track_id}", PROJECT_ID, "completed", track_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _phase(state_dir: Path, track_id: str) -> str:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute("SELECT phase FROM tracks WHERE track_id=? AND project_id=?",
+                       (track_id, PROJECT_ID)).fetchone()
+    conn.close()
+    return row[0] if row else ""
+
+
+def _history_count(state_dir: Path, track_id: str) -> int:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    n = conn.execute("SELECT count(*) FROM track_phase_history WHERE track_id=? AND project_id=?",
+                     (track_id, PROJECT_ID)).fetchone()[0]
+    conn.close()
+    return n
+
+
+def _args(state_dir: Path, track_id: str, *, apply=False, approval_id="",
+          include_parked=False) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir), project_id=PROJECT_ID, track_id=track_id,
+        apply=apply, approval_id=approval_id, json=False, include_parked=include_parked,
+    )
+
+
+def test_dry_run_does_not_change_phase(tmp_path, capsys):
+    # Dry-run reconciles derived_status (advisory, exactly like `objective drift`)
+    # but NEVER touches the declared phase — that is the meaningful guarantee.
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-active", phase="active")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-active"))
+    assert rc == 0
+    assert "dry-run" in capsys.readouterr().out
+    assert _phase(sd, "T-active") == "active"  # phase unchanged
+
+
+def test_non_terminal_derived_is_noop(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    # No dispatches => derived 'queued' (not terminal) => nothing to close.
+    tracks_lib.create_track(sd, "T-queued", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-queued", apply=True, approval_id="OK-1"))
+    assert rc == 0
+    assert "not terminal" in capsys.readouterr().out
+    assert _phase(sd, "T-queued") == "queued"
+
+
+def test_apply_without_approval_is_rejected(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-active", phase="active")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-active", apply=True, approval_id=""))
+    assert rc == 2
+    assert "approval-id" in capsys.readouterr().out
+    assert _phase(sd, "T-active") == "active"  # no write
+
+
+def test_close_active_to_done(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-active", phase="active")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-active", apply=True, approval_id="APR-1"))
+    assert rc == 0
+    assert _phase(sd, "T-active") == "done"
+    assert _history_count(sd, "T-active") == 1
+
+
+def test_close_queued_walks_legal_path(tmp_path):
+    sd = _build_db(tmp_path)
+    # queued -> done is illegal directly; close must walk queued->active->done.
+    _seed_done_track(sd, "T-queued", phase="queued")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-queued", apply=True, approval_id="APR-2"))
+    assert rc == 0
+    assert _phase(sd, "T-queued") == "done"
+    assert _history_count(sd, "T-queued") == 2  # queued->active, active->done
+
+
+def test_parked_is_guarded_without_include_flag(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-parked", phase="parked")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-parked", apply=True, approval_id="P"))
+    assert rc == 2
+    assert "parked" in capsys.readouterr().out.lower()
+    assert _phase(sd, "T-parked") == "parked"  # not un-parked
+
+
+def test_close_parked_walks_three_steps_with_include_flag(tmp_path):
+    sd = _build_db(tmp_path)
+    # parked -> done is parked->queued->active->done (3 legal steps); needs the flag.
+    _seed_done_track(sd, "T-parked", phase="parked")
+    rc = planning_cli.cmd_objective_close(
+        _args(sd, "T-parked", apply=True, approval_id="APR-P", include_parked=True))
+    assert rc == 0
+    assert _phase(sd, "T-parked") == "done"
+    assert _history_count(sd, "T-parked") == 3
+
+
+def test_already_done_is_noop(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-done", phase="done")
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-done", apply=True, approval_id="APR-3"))
+    assert rc == 0
+    assert "already closed" in capsys.readouterr().out
+    assert _history_count(sd, "T-done") == 0  # no transition
+
+
+def test_partial_walk_failure_leaves_intermediate_and_is_resumable(tmp_path, monkeypatch):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-q", phase="queued")  # queued->active->done
+    real = planning_cli.tracks_lib.transition_phase
+
+    def flaky(state_dir, tid, pid, to_phase, **kw):
+        if to_phase == "done":  # fail the 2nd step
+            raise planning_cli.tracks_lib.InvalidTransitionError("injected mid-walk failure")
+        return real(state_dir, tid, pid, to_phase, **kw)
+
+    monkeypatch.setattr(planning_cli.tracks_lib, "transition_phase", flaky)
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-q", apply=True, approval_id="A"))
+    assert rc == 2
+    assert _phase(sd, "T-q") == "active"  # non-atomic: stuck at the intermediate phase
+
+    # Recovery: the walk re-computes from the CURRENT phase, so a re-run resumes.
+    monkeypatch.setattr(planning_cli.tracks_lib, "transition_phase", real)
+    rc2 = planning_cli.cmd_objective_close(_args(sd, "T-q", apply=True, approval_id="A"))
+    assert rc2 == 0
+    assert _phase(sd, "T-q") == "done"
+
+
+def test_evidence_warns_when_done_has_no_success_signal(tmp_path, capsys):
+    # A track whose only dispatch EXPIRED (failure) + no pr_ref still derives
+    # 'done' (all-terminal). The operator must see that there is no success
+    # signal before closing.
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-failed", PROJECT_ID, title="x", goal_state="y", phase="active")
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute("INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?,?,?,?)",
+                 ("D-exp", PROJECT_ID, "expired", "T-failed"))
+    conn.commit()
+    conn.close()
+
+    ev = planning_cli._close_evidence(sd, "T-failed", PROJECT_ID)
+    assert ev["failed_terminal"] == 1 and ev["completed"] == 0
+    assert ev["has_success_signal"] is False
+
+    rc = planning_cli.cmd_objective_close(_args(sd, "T-failed"))  # dry-run
+    out = capsys.readouterr().out.lower()
+    assert rc == 0
+    assert "warning" in out and "no success signal" in out
+
+
+def test_evidence_has_success_signal_for_completed(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-ok", phase="active")  # a completed dispatch
+    ev = planning_cli._close_evidence(sd, "T-ok", PROJECT_ID)
+    assert ev["completed"] == 1 and ev["has_success_signal"] is True
+
+
+def test_evidence_success_signal_from_merged_pr_without_completed_dispatch(tmp_path):
+    # A merged PR is a success signal even when no dispatch shows 'completed'
+    # (the dispatch expired but the PR landed). Must NOT false-warn.
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-pr", PROJECT_ID, title="x", goal_state="y",
+                            phase="active", pr_ref="PR-500")
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute("INSERT INTO dispatches (dispatch_id, project_id, state, track, pr_ref) VALUES (?,?,?,?,?)",
+                 ("D-exp", PROJECT_ID, "expired", "T-pr", "PR-500"))
+    conn.execute(
+        "INSERT INTO coordination_events (event_id, event_type, entity_type, entity_id, occurred_at, project_id) "
+        "VALUES (?, 'pr_merged', 'dispatch', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), ?)",
+        ("ev-1", "D-exp", PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+    ev = planning_cli._close_evidence(sd, "T-pr", PROJECT_ID)
+    assert ev["completed"] == 0 and ev["pr_merged"] is True
+    assert ev["has_success_signal"] is True
+
+
+def test_phase_path_unreachable_returns_none():
+    # 'done' is terminal (no outgoing transitions) so it can reach nothing.
+    assert planning_cli._phase_path_to("done", "active") is None
+    assert planning_cli._phase_path_to("active", "active") == []
+    assert planning_cli._phase_path_to("queued", "done") == ["active", "done"]


### PR DESCRIPTION
## Summary

`objective drift`/`sync` only **report** declared-vs-derived drift; nothing advances the declared phase. So a merged-and-deployed track stays `queued`/`parked` forever — the gap that bit the MC #284 sprint (PRs merged + prod-live, no track reached `done`). This adds the **resolve** path as a human-gated operation, never an automatic side effect of merge (per the human-in-the-loop principle). Companion to the fabric-freshness *see-the-drift* work (#904).

## Changes

- **`vnx objective close <track_id>`** (`scripts/planning_cli.py`):
  - Default = read-only **dry-run** (`peek_derived_status` computes without persisting); only `--apply` reconciles fresh and writes. `--apply` requires `--approval-id` (operator gate).
  - Only a **terminal** `derived_status='done'` closes; non-terminal is a no-op.
  - Walks the **shortest legal `ALLOWED_TRANSITIONS` path** to done (`active→done`, `queued→active→done`, `parked→…→done`) via `tracks.transition_phase` — the state machine forbids skips, and a merged track stuck at queued/parked is the target case. Non-atomic but **resumable** (re-run re-walks from current phase); any mid-walk failure reports where it stopped, never crashes.
  - **Informed gate**: `TERMINAL_DISPATCH_STATES` includes `expired`/`dead_letter`, so 'done' can derive from *failed* dispatches. `_close_evidence` surfaces the dispatch-state breakdown + `pr_ref` + `pr_merged` (via both `coordination_events` AND the local merged-PR set) and warns when there is no success signal.
  - `parked` is a deliberate stop: closing it requires `--include-parked`.
- **`track_reconciler.peek_derived_status`** — public read-only derived-status compute (so dry-run never mutates DB state).
- **`bin/vnx`** usage entry for `objective close` (+ `objective drift`).

## Verification

- Plan-gate (opus + kimi + glm) **PASS** after 4 rounds. Each round caught real issues, all fixed: illegal direct `queued→done` (→ legal path-walk), non-atomic partial-failure (→ resumable + reported), `done`-from-failure-states (→ informed evidence gate), dry-run mutating `derived_status` (→ read-only `peek`), silent un-parking (→ `--include-parked`), incomplete merge-evidence sources (→ both sources).
- **13 self-contained tests** (`tests/test_objective_close.py`): dry-run-no-phase-write, non-terminal no-op, `--apply`-without-approval fail-closed, the 1/2/3-step paths, already-done no-op, partial-failure-resumable, path-unreachable→None, evidence success/warning, parked-guard, merged-PR-without-completed-dispatch.
- 192/192 planning + tracks suite green; 67/67 close + reconciler + freshness (no regression to fabric-freshness).

## Open Items

- Auto-advance-on-merge (a PR-merge webhook → phase) is deliberately **out of scope** (a separate governance decision).
- ROADMAP-drift after close (DB ahead of ROADMAP.yaml) is documented: the DB is the runtime SSOT for phase; `objective sync` reconciles ROADMAP separately. Mostly affects ROADMAP-authored tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)