### PR TITLE
fix(tenant): dispatch_metadata resolver derives owning tenant from the store, not literal vnx-dev

### DIFF
--- a/scripts/lib/dispatch_metadata_db.py
+++ b/scripts/lib/dispatch_metadata_db.py
@@ -50,7 +50,19 @@ def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(row[1] == column for row in rows)
 
 
-def _resolve_project_id(explicit: Optional[str]) -> str:
+def _resolve_project_id(explicit: Optional[str], db_path: Optional[Path] = None) -> str:
+    """Resolve the project_id to stamp on a dispatch_metadata row.
+
+    Order: explicit arg → ambient project_scope → the OWNING store (derived from
+    ``db_path``) → VNX_PROJECT_ID env → 'vnx-dev'.
+
+    The store-derived step (``resolve_init_project_id``) is the tenant-correctness
+    fix: it anchors on the DB file's ``~/.vnx-data/<pid>/state/`` path layout, so a
+    write to a non-vnx-dev store (e.g. mission-control) stamps THAT tenant instead
+    of the bare literal 'vnx-dev'. A genuine source-conflict (path vs marker vs env
+    disagree) is logged and degrades to the env default rather than crashing the
+    write — never silently mis-stamps without a trace.
+    """
     if explicit:
         return explicit
     try:
@@ -59,7 +71,16 @@ def _resolve_project_id(explicit: Optional[str]) -> str:
         if pid:
             return pid
     except Exception:  # noqa: BLE001 — project_scope is optional in some contexts
-        logger.debug("project_scope unavailable; falling back to VNX_PROJECT_ID env/default", exc_info=True)
+        logger.debug("project_scope unavailable; trying store-derived project_id", exc_info=True)
+    if db_path is not None:
+        try:
+            from project_id_migration import resolve_init_project_id  # noqa: PLC0415
+            return resolve_init_project_id(Path(db_path))
+        except RuntimeError as exc:
+            # Conflicting tenant sources — surface it; do not crash the write.
+            logger.warning("dispatch_metadata project_id resolution conflict for %s: %s", db_path, exc)
+        except Exception:  # noqa: BLE001 — resolver optional; fall through to env default
+            logger.debug("store-derived project_id unavailable; falling back to env", exc_info=True)
     import os  # noqa: PLC0415
     return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
 
@@ -108,7 +129,7 @@ def upsert_dispatch_provider_row(
 
     now_iso = datetime.now(timezone.utc).isoformat()
     completed_at = now_iso if outcome_status else None
-    resolved_project_id = _resolve_project_id(project_id)
+    resolved_project_id = _resolve_project_id(project_id, db_path)
 
     conn = None
     try:

--- a/tests/test_dispatch_metadata_resolver.py
+++ b/tests/test_dispatch_metadata_resolver.py
@@ -1,0 +1,65 @@
+"""tests/test_dispatch_metadata_resolver.py — tenant-correct project_id resolution.
+
+dispatch_metadata_db._resolve_project_id used to fall back to a bare literal
+'vnx-dev', so a dispatch write to a non-vnx-dev store (e.g. mission-control)
+re-stamped the WRONG tenant on every write (the live re-contamination source
+behind the QI tenant-stamping bug). It now derives the owning tenant from the
+store's own DB-path layout (resolve_init_project_id), fail-closed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import dispatch_metadata_db as dmd  # noqa: E402
+
+
+def _store_db(tmp_path: Path, pid: str) -> Path:
+    """A DB path with the canonical ~/.vnx-data/<pid>/state/ layout."""
+    d = tmp_path / ".vnx-data" / pid / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "quality_intelligence.db"
+
+
+def test_explicit_wins(tmp_path):
+    assert dmd._resolve_project_id("seocrawler-v2", _store_db(tmp_path, "mission-control")) == "seocrawler-v2"
+
+
+def test_store_path_resolves_owning_tenant_not_vnx_dev(tmp_path, monkeypatch):
+    # The core fix: a write to mission-control's store stamps mission-control,
+    # NOT the literal 'vnx-dev'. Clear ambient sources so only the path speaks.
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    # project_scope must not short-circuit: force it unavailable.
+    monkeypatch.setitem(sys.modules, "project_scope", None)
+    db = _store_db(tmp_path, "mission-control")
+    assert dmd._resolve_project_id(None, db) == "mission-control"
+
+
+def test_vnx_dev_store_still_resolves_vnx_dev(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    monkeypatch.setitem(sys.modules, "project_scope", None)
+    db = _store_db(tmp_path, "vnx-dev")
+    assert dmd._resolve_project_id(None, db) == "vnx-dev"
+
+
+def test_source_conflict_does_not_crash_and_falls_back(tmp_path, monkeypatch):
+    # Path says mission-control, env says something else → resolve_init_project_id
+    # raises (fail-closed contamination guard). The write path must NOT crash; it
+    # logs and degrades to the env default.
+    monkeypatch.setenv("VNX_PROJECT_ID", "conflicting-proj")
+    monkeypatch.setitem(sys.modules, "project_scope", None)
+    db = _store_db(tmp_path, "mission-control")
+    result = dmd._resolve_project_id(None, db)
+    assert result == "conflicting-proj"  # degraded to env, no exception
+
+
+def test_contextless_keeps_vnx_dev_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    monkeypatch.setitem(sys.modules, "project_scope", None)
+    # No db_path, no env, no project_scope → backward-compat 'vnx-dev'.
+    assert dmd._resolve_project_id(None, None) == "vnx-dev"


### PR DESCRIPTION
## Summary

`dispatch_metadata_db._resolve_project_id` fell back to a bare literal `os.environ.get("VNX_PROJECT_ID", "vnx-dev")`. So a dispatch write to a **non-vnx-dev** QI store (e.g. mission-control) re-stamped `'vnx-dev'` on **every** write when `VNX_PROJECT_ID` was unset and `project_scope` couldn't resolve — the **live re-contamination source** behind the QI tenant-stamping bug. (MC's `dispatch_metadata` kept getting vnx-dev rows even after the bootstrap self-heal re-stamped it, because the runtime write path re-stamped vnx-dev.)

## Changes

- Thread the DB path into `_resolve_project_id` and derive the owning tenant from the store's own `~/.vnx-data/<pid>/state/` path layout via the existing fail-closed `project_id_migration.resolve_init_project_id`.
- Resolution order: explicit → `project_scope` → **store-path** → env → `'vnx-dev'`.
- A genuine source conflict (path vs marker vs env disagree) is logged and degrades to the env default rather than crashing the dispatch write — never silently mis-stamps without a trace. Contextless callers keep the backward-compat `'vnx-dev'`.

## Verification

- 5 new tests (`tests/test_dispatch_metadata_resolver.py`): explicit wins; store-path resolves the owning tenant (mission-control, **not** vnx-dev); vnx-dev store stays vnx-dev; source-conflict degrades without crashing; contextless keeps vnx-dev.
- 31/31 dispatch_metadata suite green (no regression).

## Open Items / Scope

This is the **`dispatch_metadata` write path** — the main live re-contamination source. Deliberately **out of scope** (the broader WS2 / tenant arc):
- The ~14 other `os.environ.get("VNX_PROJECT_ID", "vnx-dev")` literal-fallback sites (`provider_dispatch` ×4, `dispatch_cli`, `dispatch_spec`, the kimi/gemini/codex wrappers, `provider_costs`, `subprocess_dispatch`) — the same resolver pattern, to be canonicalized in WS2.
- The schema `.sql` `DEFAULT 'vnx-dev'` (`schemas/quality_intelligence.sql:520,684`) removal + the migration-linter allowlist + the **ADR-007 Column-rule amendment** — the latter is a governance decision (not autonomous).

This PR strictly improves one major write path without touching the schema or ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)