### PR TITLE
feat(dispatch): door-flip D1 — staged/raw routing-split + provider propagation (default OFF)

### DIFF
--- a/docs/governance/decisions/ADR-025-raw-file-dispatch-deprecation.md
+++ b/docs/governance/decisions/ADR-025-raw-file-dispatch-deprecation.md
@@ -1,0 +1,60 @@
+# ADR-025 — Raw-file Dispatch Deprecation
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** The deprecation half of the door-flip (item B). Companion to ADR-024 (single-entry door as default dispatch lane).
+
+## Context
+
+`vnx dispatch <file.md>` (a raw dispatch markdown path) is the original, documented manual CLI form. It carries a rich legacy contract: file-search fallback (`exact → pending/<f> → pending/<f>.md`), `--terminal/--model/--adapter` overrides, lane precedence (`--adapter > Adapter: header > VNX_ADAPTER > VNX_AUTO_ROUTE`), and an active→completed lifecycle.
+
+ADR-024 makes the single-entry door the default dispatch lane. Under that flip the routing splits (Option X1): STAGED forms (`--spec-file`, a `<pending-id>` resolving to a promoted bundle) route through the door; the RAW `vnx dispatch <file.md>` form stays on the legacy lane to preserve its lane precedence (routing it through the door's bridge would silently drop `--adapter`, since the bridge defaults claude→tmux — the regression A2 avoids).
+
+Keeping two manual forms indefinitely is structural debt. Production callers are already staged (the in-process `deliver_via_door` callers and `<pending-id>`); the raw form is the human-typed manual path. The intent is to converge on the staged form so that, eventually, ALL input is staged→governed through one door.
+
+## Decision
+
+**The raw `vnx dispatch <file.md>` form is DEPRECATED. It continues to work on the legacy delivery lane (full lane precedence preserved), but emits a one-time deprecation warning when the door is the default lane, and is scheduled for removal in a 1.x release (door-flip item B). The canonical form is `vnx dispatch <pending-id>` (a promoted staged bundle).**
+
+Concrete rules:
+
+- The raw form keeps working unchanged on the legacy lane (tmux/subprocess delivery, all overrides, file-search, lifecycle). No behavior is removed in this ADR — only a warning is added and a removal is scheduled.
+- The deprecation warning is emitted to **stderr** (not stdout — avoids breaking stdout-parsing callers; not via `err`, which would misleadingly prefix `ERROR:` for a non-fatal notice). Text: `[dispatch] DEPRECATED: raw-file dispatch (vnx dispatch <file.md>) — stage to a pending-id (vnx dispatch <pending-id>) instead. The raw form is scheduled for removal per ADR-025.`
+- The warning fires **only when the single-entry door is the default lane** (`_door_on=1`). Under explicit rollback (`VNX_DISPATCH_LEGACY=1`) or `VNX_SINGLE_ENTRY_DISPATCH=0`, the raw form is the sanctioned path, so no warning fires — warning noise there would be confusing.
+- A staged-bundle hint is added to the legacy "File not found" error: when a missing arg is a safe id resolving to a promoted bundle, the error notes it is a staged bundle requiring the door. This helps a user who typed a `<pending-id>` while the door is off.
+- `--help` documents the staged `<pending-id>` form as canonical and the raw form as deprecated (with the file-first ordering requirement).
+
+## Reasoning
+
+1. **Backward-compatibility first, removal later (warn → observe → remove).** Vincent chose option A (backward-compat now) over a hard cutover. Flipping the door default must not break the documented raw form on day one. A deprecation warning seeds the eventual removal without a flag-day break.
+2. **Lane precedence is the raw form's value.** The raw form exists to let an operator pick a lane (`--adapter subprocess`, `VNX_AUTO_ROUTE`). Routing it through the door's bridge would silently ignore `--adapter` (the bridge defaults claude→tmux). Keeping it on legacy preserves that value until removal; the deprecation steers users to the governed staged form for the future.
+3. **Convergence on one governed door.** Per ADR-024 + ADR-006 (staging→promote human gate), the governed path is staged→door. The raw manual form is the last unstaged input. Deprecating it sets the direction: when item B removes it, all input is staged→governed, and the door is the single structural entry (modulo the daemon tmux-send-keys path, tracked separately as a structural-consolidation follow-up).
+
+## Consequences
+
+### Accepted
+
+- The raw form keeps working through at least one minor release, with a deprecation warning, before removal (item B).
+- Documentation (`--help`, the routing comment in `dispatch.sh`) presents `<pending-id>` as canonical and the raw form as deprecated.
+- The deprecation warning is additive on stderr; it appears on raw-form dispatches under the door default. Existing stderr-asserting tests are updated to tolerate it.
+- The staged-bundle "File not found" hint is an additive change on an already-error path (it does not alter any happy path).
+
+### Rejected
+
+- **Hard-removing the raw form now.** Rejected — that is a flag-day break of a documented form; warn→observe→remove is the chosen path (item B does the removal).
+- **Routing the raw form through the door/bridge.** Rejected — it would silently drop `--adapter`/lane precedence (the regression Option X1 avoids), or require replicating legacy lane features in the bridge (the replication A2 explicitly avoided).
+- **Warning under explicit rollback/legacy.** Rejected — under `VNX_DISPATCH_LEGACY=1` / `VNX_SINGLE_ENTRY_DISPATCH=0` the raw form is the sanctioned path; a deprecation warning there is noise.
+
+## Implementation note
+
+- Routing split + warning live in `scripts/commands/dispatch.sh` (`cmd_dispatch`, `_d_is_staged_form`, `_d_valid_dispatch_id`). The raw form falls through to the unchanged legacy tmux/subprocess delivery.
+- The removal (item B) is a separate future change; this ADR only schedules it.
+
+## See also
+
+- ADR-024 — Single-entry door as default dispatch lane (the flip; this ADR is its deprecation half)
+- ADR-006 — Staging→promote with mandatory human approval gate (the governed staged path)
+- ADR-010 — Subprocess adapter as canonical Claude routing (superseded-in-part by ADR-024 on the canonical-lane question)
+- `scripts/commands/dispatch.sh` — `cmd_dispatch`, `_d_is_staged_form`, `_d_valid_dispatch_id`
+- Memory: `dispatch-structure-not-consolidated-friction` — the daemon tmux-send-keys path, a separate structural-consolidation follow-up

--- a/docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md
+++ b/docs/operations/SUBPROCESS_ADAPTER_FEATURE_FLAG.md
@@ -55,14 +55,19 @@ local adapter_var="VNX_ADAPTER_${terminal_id}"
 local adapter_type="${!adapter_var}"  # resolved by caller per terminal
 
 if [[ "$adapter_type" == "subprocess" ]]; then
-    _ddt_subprocess_delivery ...
+    # 7 positional args: terminal_id dispatch_id complete_prompt model dispatch_file [agent_role] [provider]
+    # provider (7th, after the optional agent_role) is forwarded to the door bridge so a non-claude
+    # terminal-pinned worker keeps its provider lane when the single-entry door is enabled (ADR-024).
+    _ddt_subprocess_delivery "$terminal_id" "$dispatch_id" "$complete_prompt" "$model" "$dispatch_file" "$agent_role" "$provider"
     return $?
 fi
 # default: tmux delivery path
 ```
 
 The subprocess delivery helper is `scripts/lib/subprocess_dispatch.py`, which calls
-`SubprocessAdapter.deliver()` and exits 0 on success, 1 on failure.
+`SubprocessAdapter.deliver()` and exits 0 on success, 1 on failure. When the single-entry door is
+enabled (`VNX_SINGLE_ENTRY_DISPATCH=1`), `_ddt_subprocess_delivery` routes through
+`dispatch_bridge.py` → `run_dispatch` instead, forwarding `--provider` (door-flip / ADR-024).
 
 ## Billing Safety
 

--- a/scripts/commands/dispatch-agent.sh
+++ b/scripts/commands/dispatch-agent.sh
@@ -106,10 +106,12 @@ PYEOF
 
 echo "[dispatch-agent] Created dispatch: $DISPATCH_ID"
 
-# --- execute via the single-entry door (gated; OFF default = legacy subprocess lane) ---
-# PR-12: when VNX_SINGLE_ENTRY_DISPATCH=1, route through dispatch_bridge -> run_dispatch so
-# this delivery funnels through the door. OFF = the legacy subprocess_dispatch call, unchanged.
-# Gap (canary-blocker): --auto-route is not yet on the bridge CLI.
+# --- execute via the single-entry door (gated by VNX_SINGLE_ENTRY_DISPATCH) ---
+# When ON, route through dispatch_bridge -> run_dispatch so this agent delivery funnels through
+# the door. This is a claude-AGENT dispatcher by design (no provider variable), so the bridge's
+# claude default is correct here. Post-flip behavior is INTENTIONAL (door-flip / ADR-024): claude
+# routes via the subscription tmux-spawn lane (never headless claude -p); --auto-route is moot
+# because run_dispatch owns deterministic lane selection, so _ar_flag stays on the legacy branch.
 _ar_flag=()
 [[ "${VNX_AUTO_ROUTE:-0}" == "1" ]] && _ar_flag=(--auto-route)
 

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -104,6 +104,60 @@ _d_resolve_track() {
   esac
 }
 
+# _d_valid_dispatch_id — the ONE id-safety predicate (P0-2 traversal guard).
+# Returns 0 iff $1 is a safe dispatch/pending id: no '/', no '..', matches the id regex.
+# Centralized so _d_is_staged_form, _d_single_entry_dispatch, and the staged-bundle hint
+# never drift on the guard (ADR-025 / door-flip D1).
+_d_valid_dispatch_id() {
+  local id="${1:-}"
+  [[ "$id" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]] || return 1
+  # The regex already forbids '/'; reject any '..' segment explicitly (defense in depth).
+  case "$id" in *..*) return 1 ;; esac
+  return 0
+}
+
+# _d_is_staged_form — decide whether the args address the single-entry DOOR (staged forms)
+# vs the LEGACY raw-file path. Consulted ONLY when the door is enabled. Door (return 0):
+# --spec-file / --force-release-lock / -h/--help (door operations), no positional (door owns
+# the "requires" error), OR a first positional that resolves to an existing pending bundle.
+# Legacy (return 1): a path (contains '/' or ends '.md' without a bundle), or a bare slug with
+# no staged bundle. Bundle-existence is checked BEFORE the '.md' heuristic so a pending-id that
+# legally ends in '.md' still routes to the door. set -u-safe: every $next peek is guarded.
+_d_is_staged_form() {
+  local a
+  # 1. door-only flags anywhere → door.
+  for a in "$@"; do
+    case "$a" in
+      --spec-file|--spec-file=*|--force-release-lock|--force-release-lock=*|-h|--help)
+        return 0 ;;
+    esac
+  done
+  # 2. first non-flag token, skipping value-taking flags (the COMPLETE legacy set:
+  #    --terminal/-t, --model/-m, --adapter). '--' ends options; the next token is positional.
+  local first="" expect_val=0 seen_ddash=0
+  for a in "$@"; do
+    if [ "$seen_ddash" -eq 1 ]; then first="$a"; break; fi
+    if [ "$expect_val" -eq 1 ]; then expect_val=0; continue; fi
+    case "$a" in
+      --) seen_ddash=1; continue ;;
+      --terminal|-t|--model|-m|--adapter) expect_val=1; continue ;;
+      --terminal=*|--model=*|--adapter=*|--dry-run|-n) continue ;;
+      --*|-*) continue ;;
+      *) first="$a"; break ;;
+    esac
+  done
+  # 3. no positional (flags only / value-flag-without-value at end) → door owns the messaging.
+  [ -n "$first" ] || return 0
+  # 4. classify the token. A path is unambiguously legacy (ids never contain '/').
+  case "$first" in */*) return 1 ;; esac
+  # Bundle wins over the .md heuristic (a pending-id may legally end in .md).
+  if _d_valid_dispatch_id "$first" \
+     && [ -f "${VNX_DISPATCH_DIR}/pending/${first}/dispatch-spec.json" ]; then
+    return 0
+  fi
+  return 1
+}
+
 # ── Single-entry dispatch (VNX_SINGLE_ENTRY_DISPATCH=1) ───────────────────
 
 _d_single_entry_dispatch() {
@@ -144,10 +198,12 @@ Usage: vnx dispatch [--spec-file <abs>] [--dry-run]
        vnx dispatch <pending-id> [--dry-run]
        vnx dispatch --force-release-lock [<class>]
 
-Single-entry gate (VNX_SINGLE_ENTRY_DISPATCH=1).
+Single-entry gate (the default lane). Staged forms route through the door:
   --spec-file <abs>            Absolute path to dispatch-spec.json
   <pending-id>                 Dispatch ID resolved to dispatches/pending/<id>/dispatch-spec.json
   --dry-run                    Print plan + fingerprint; spawn nothing
+  (The raw 'vnx dispatch <file.md>' form still works on the legacy lane but is DEPRECATED —
+   removed in 1.x per ADR-025. Stage it to a pending-id.)
   --force-release-lock [CLASS] Release stale serial lock for CLASS (default: claude-tmux).
                                Prints prior holder pid+dispatch_id; removes lock file.
                                Does NOT kill the holder — use the printed pid if needed.
@@ -158,6 +214,12 @@ Headless (api_metered) lane: set allow_headless=true + headless_reason in dispat
   (cmd_dispatch path when VNX_SINGLE_ENTRY_DISPATCH is unset) and have no effect here.
 HELP
         return 0 ;;
+      --terminal|-t|--terminal=*|--model|-m|--model=*|--adapter|--adapter=*)
+        # These are legacy raw-file overrides; a staged <pending-id>/--spec-file carries
+        # terminal/model/adapter in its spec, so the combination is invalid. Give a clear,
+        # actionable error instead of the generic unknown-flag reject.
+        err "[dispatch] single-entry gate: '${1%%=*}' is a legacy raw-file override; it is not valid with a staged <pending-id> (the spec already defines terminal/model/adapter). Drop the flag, or use the raw form (vnx dispatch <file.md>)."
+        return 1 ;;
       -*)
         err "[dispatch] single-entry gate: unknown flag: $1"
         return 1 ;;
@@ -188,9 +250,10 @@ HELP
       err "[dispatch] single-entry gate: requires --spec-file <abs> or <pending-id>"
       return 1
     fi
-    # P0-2: validate pending-id format BEFORE interpolation into path (traversal guard)
-    if [[ ! "$pending_id" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
-      err "[dispatch] single-entry gate: invalid pending-id format (must match ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$): $pending_id"
+    # P0-2: validate pending-id format BEFORE interpolation into path (traversal guard).
+    # Uses the centralized _d_valid_dispatch_id predicate (shared with _d_is_staged_form + the hint).
+    if ! _d_valid_dispatch_id "$pending_id"; then
+      err "[dispatch] single-entry gate: invalid pending-id format (must match ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$, no '..'): $pending_id"
       return 1
     fi
     local candidate="${VNX_DISPATCH_DIR}/pending/${pending_id}/dispatch-spec.json"
@@ -223,17 +286,28 @@ HELP
 # ── Main command ───────────────────────────────────────────────────────────
 
 cmd_dispatch() {
-  # Routing truth table (flag contract — also documented in --help):
-  #   VNX_SINGLE_ENTRY_DISPATCH | VNX_DISPATCH_LEGACY | route
-  #   ------------------------- | ------------------- | -----------------
-  #   "1"                       | unset / "0"         | DOOR (single-entry)
-  #   "1"                       | "1"                 | LEGACY (rollback wins)
-  #   unset / "0"               | (any)               | LEGACY  ← current default
-  # The rollback hatch (VNX_DISPATCH_LEGACY=1) always wins. NB: pre-flip the default
-  # is LEGACY; item E flips the default to DOOR in the single-source helper.
-  if vnx_single_entry_enabled; then
+  # Routing (flag contract — also documented in --help). The door owns STAGED forms only;
+  # raw `vnx dispatch <file.md>` stays on the legacy lane (deprecated, removed in 1.x per ADR-025):
+  #   door enabled  + staged form (--spec-file / <pending-id> with a bundle / --force-release-lock)
+  #       -> DOOR (_d_single_entry_dispatch)
+  #   door enabled  + raw form (a path, *.md, or a bare slug without a bundle)
+  #       -> LEGACY lane + a one-time DEPRECATED warning (stderr)
+  #   door disabled (VNX_DISPATCH_LEGACY=1, or VNX_SINGLE_ENTRY_DISPATCH=0/unset pre-flip)
+  #       -> LEGACY lane, byte-identical, no warning
+  # The rollback hatch (VNX_DISPATCH_LEGACY=1) always wins (single-source helper).
+  # _door_on is captured ONCE here (not re-evaluated) so the warning fires iff the door is the
+  # reason we fell through to legacy (door on + raw), never under explicit legacy/rollback.
+  local _door_on=0
+  vnx_single_entry_enabled && _door_on=1
+  if [ "$_door_on" = 1 ] && _d_is_staged_form "$@"; then
     _d_single_entry_dispatch "$@"
     return $?
+  fi
+  # Past here = the legacy raw-file lane. When the door is the default yet we got a raw form,
+  # warn once (stderr, no ERROR: prefix) — seeds the ADR-025 removal. Fires BEFORE file
+  # resolution so it shows regardless of a later not-found / --dry-run outcome.
+  if [ "$_door_on" = 1 ]; then
+    printf '%s\n' "[dispatch] DEPRECATED: raw-file dispatch (vnx dispatch <file.md>) — stage to a pending-id (vnx dispatch <pending-id>) instead. The raw form is scheduled for removal per ADR-025." >&2
   fi
 
   local file=""
@@ -275,7 +349,10 @@ File search order:
   2. .vnx-data/dispatches/pending/<file>
   3. .vnx-data/dispatches/pending/<file>.md
 
-Examples:
+Canonical (single-entry door):
+  vnx dispatch <pending-id>                         # a promoted dispatch bundle
+
+Raw-file form (DEPRECATED — removed in 1.x per ADR-025; the file must come FIRST):
   vnx dispatch .vnx-data/dispatches/pending/my-dispatch.md
   vnx dispatch my-dispatch.md --terminal T2
   vnx dispatch my-dispatch.md --model opus --dry-run
@@ -330,7 +407,10 @@ File search order:
   2. .vnx-data/dispatches/pending/<file>
   3. .vnx-data/dispatches/pending/<file>.md
 
-Examples:
+Canonical (single-entry door):
+  vnx dispatch <pending-id>                         # a promoted dispatch bundle
+
+Raw-file form (DEPRECATED — removed in 1.x per ADR-025; the file must come FIRST):
   vnx dispatch .vnx-data/dispatches/pending/my-dispatch.md
   vnx dispatch my-dispatch.md --terminal T2
   vnx dispatch my-dispatch.md --model opus --dry-run
@@ -357,6 +437,13 @@ HELP
       else
         err "[dispatch] File not found: $file"
         err "[dispatch] Also checked: ${VNX_DISPATCH_DIR}/pending/${file}"
+        # Staged-bundle hint: if the missing arg is a safe id that resolves to a promoted
+        # bundle, the caller likely meant the door form but the door is off (rollback/legacy).
+        # _d_valid_dispatch_id guards the path-join (no '/', no '..') before the -f check.
+        if _d_valid_dispatch_id "$file" \
+           && [ -f "${VNX_DISPATCH_DIR}/pending/${file}/dispatch-spec.json" ]; then
+          err "[dispatch] note: '${file}' is a staged dispatch bundle; the single-entry door is off (VNX_DISPATCH_LEGACY=1 or VNX_SINGLE_ENTRY_DISPATCH=0). Enable the door, or dispatch the raw .md."
+        fi
         return 1
       fi
     fi
@@ -472,20 +559,14 @@ HELP
   fi
 
   local exit_code=0
-  if vnx_single_entry_enabled; then
-    # PR-12 single-entry door. Uses the single-source predicate so VNX_DISPATCH_LEGACY=1 rolls
-    # THIS delivery back too (previously this checked only ==1 and ignored the rollback — the
-    # incomplete-rollback bug). The door owns lane selection (claude -> tmux-spawn subscription,
-    # providers -> provider lane). Gap (canary-blocker): --auto-route is not yet on the bridge CLI.
-    printf '%s' "$instruction" | PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \
-    python3 "$VNX_HOME/scripts/lib/dispatch_bridge.py" \
-      --dispatch-id "$dispatch_id" \
-      --terminal "$terminal" \
-      --model "$model_override" \
-      ${role:+--role "$role"} \
-      --instruction-stdin \
-      || exit_code=$?
-  elif [ "$adapter" = "tmux" ]; then
+  # Door-flip A / Option X1 (ADR-024): this legacy lane is reached ONLY for raw-file forms.
+  # Staged forms route through the door at cmd_dispatch's intercept and never get here, so this
+  # delivery is unconditionally the legacy tmux/subprocess lane — preserving the raw form's full
+  # lane precedence (--adapter > Adapter: > VNX_ADAPTER > VNX_AUTO_ROUTE). The old
+  # `if vnx_single_entry_enabled -> dispatch_bridge.py` branch was removed: routing raw input
+  # through the bridge would silently drop --adapter (bridge defaults claude -> tmux), the
+  # regression A2 avoids. The bridge is still the door's delivery for STAGED callers elsewhere.
+  if [ "$adapter" = "tmux" ]; then
     # DEFAULT lane: subscription-preserving ephemeral tmux-spawn.
     # Leaseless — pass the resolved terminal as the worker label for audit parity.
     PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \

--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -50,6 +50,11 @@ from dispatch_spec import _ID_RE, Provider  # noqa: E402
 _PROVIDER_ALIASES = {
     "claude": "claude",
     "claude_cli": "claude",
+    # get_terminal_provider() (dispatcher_minimal.sh) emits the tmux-domain string 'claude_code'
+    # for claude terminals (and as the default). Without this alias the door-flip provider
+    # propagation would canonicalize 'claude_code' -> Provider('claude_code') -> ValueError ->
+    # bridge REJECT on every claude subprocess-routed worker. Map it to the closed enum value.
+    "claude_code": "claude",
     "codex": "codex",
     "codex_cli": "codex",
     "kimi": "kimi",

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -472,10 +472,13 @@ _ddt_handle_failure() {
 }
 
 # _ddt_subprocess_delivery — route dispatch via SubprocessAdapter instead of tmux.
-# Params: terminal_id dispatch_id complete_prompt model dispatch_file [agent_role]
+# Params: terminal_id dispatch_id complete_prompt model dispatch_file [agent_role] [provider]
+# `provider` is the 7th param (after the optional agent_role, so existing positions don't shift).
+# It is forwarded to the door bridge so a non-claude terminal-pinned worker keeps its provider
+# lane post-flip instead of silently defaulting to claude (door-flip D1 / ADR-024).
 _ddt_subprocess_delivery() {
     local terminal_id="$1" dispatch_id="$2" complete_prompt="$3" model="$4" dispatch_file="$5"
-    local agent_role="${6:-}"
+    local agent_role="${6:-}" provider="${7:-}"
 
     # Derive requires_mcp from dispatch file header so MCP-aware dispatches keep
     # their ambient MCP config instead of getting force-emptied by the worker scope.
@@ -492,13 +495,15 @@ _ddt_subprocess_delivery() {
     local _mcp_flag=()
     [[ "$_requires_mcp" == "true" ]] && _mcp_flag=(--requires-mcp)
 
-    # PR-12 single-entry door (gated; VNX_SINGLE_ENTRY_DISPATCH default OFF = legacy path,
-    # byte-identical to before). When ON, route through dispatch_bridge → run_dispatch so this
-    # delivery funnels through validate→snapshot→compile_plan→permit→execute like every other.
-    # GAPS to close before the PR-11 flip (canary-blockers, see PR12-PR2-CALLER-AUDIT):
-    #   * --auto-route is not yet on the bridge CLI (this caller passes _ar_flag);
-    #   * provider defaults to claude → the door's tmux-spawn lane — a lane change from the
-    #     subprocess lane; assert the receipt's lane in the canary before flipping.
+    # PR-12 single-entry door (gated by VNX_SINGLE_ENTRY_DISPATCH). When ON, this staged daemon
+    # delivery funnels through dispatch_bridge → run_dispatch (validate→snapshot→compile_plan→
+    # permit→execute) like every other path. Post-flip behavior is INTENTIONAL (door-flip / ADR-024):
+    #   * the lane change for claude (subprocess → tmux-spawn) is the post-June-15 provider→lane
+    #     target — claude routes via the subscription tmux-spawn lane, never headless claude -p;
+    #   * --auto-route is moot here — run_dispatch owns deterministic provider-based lane selection,
+    #     so _ar_flag is only forwarded on the legacy else-branch below;
+    #   * --provider IS forwarded so a non-claude terminal-pinned worker keeps its provider lane
+    #     (get_terminal_provider's domain string canonicalizes via _PROVIDER_ALIASES, incl. claude_code).
     local _deliver_rc=0
     # shellcheck source=/dev/null
     source "$VNX_DIR/scripts/lib/vnx_dispatch_flags.sh"
@@ -508,6 +513,7 @@ _ddt_subprocess_delivery() {
             --terminal "$terminal_id" \
             --model "$model" \
             ${agent_role:+--role "$agent_role"} \
+            ${provider:+--provider "$provider"} \
             "${_mcp_flag[@]}" \
             --instruction-stdin || _deliver_rc=$?
     else
@@ -559,7 +565,8 @@ deliver_dispatch_to_terminal() {
 
     if [[ "$adapter_type" == "subprocess" ]]; then
         local model="${_CTM_REQUIRES_MODEL:-sonnet}"
-        _ddt_subprocess_delivery "$terminal_id" "$dispatch_id" "$complete_prompt" "$model" "$dispatch_file" "$agent_role"
+        # provider ($7) is forwarded so the door bridge keeps a non-claude worker on its lane.
+        _ddt_subprocess_delivery "$terminal_id" "$dispatch_id" "$complete_prompt" "$model" "$dispatch_file" "$agent_role" "$provider"
         return $?
     fi
 

--- a/tests/test_door_flip_d1_routing.py
+++ b/tests/test_door_flip_d1_routing.py
@@ -1,0 +1,391 @@
+"""Door-flip D1 routing tests (ADR-024 routing-split / ADR-025 deprecation).
+
+These exercise the REAL bash via subprocess (no reimplementation):
+
+  * _d_valid_dispatch_id   — the centralized id-safety guard
+  * _d_is_staged_form      — staged (door) vs raw (legacy) classifier
+  * cmd_dispatch routing   — door-ON staged -> dispatch_cli (door); door-ON raw -> legacy
+                             tmux/subprocess delivery (NOT the bridge) + a deprecation warning;
+                             rollback/off -> legacy, no warning, staged-bundle hint on not-found
+  * dispatch_deliver.sh    — provider propagation to the door bridge (G1) + default-OFF regression
+  * dispatch_bridge.py     — claude_code domain string canonicalizes to the claude lane (O1)
+
+D1 keeps the default OFF (the flip is D2), so these drive the door via an explicit
+VNX_SINGLE_ENTRY_DISPATCH=1 opt-in.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DISPATCH_SH = REPO_ROOT / "scripts" / "commands" / "dispatch.sh"
+DELIVER_SH = REPO_ROOT / "scripts" / "lib" / "dispatch_deliver.sh"
+
+
+# --------------------------------------------------------------------------- #
+# _d_is_staged_form / _d_valid_dispatch_id — direct predicate unit tests
+# --------------------------------------------------------------------------- #
+
+def _predicate_preamble(dispatch_dir: Path) -> str:
+    return (
+        "set -euo pipefail\n"
+        "log() { :; }\n"
+        "err() { :; }\n"
+        f"export VNX_DISPATCH_DIR='{dispatch_dir}'\n"
+        f"source '{DISPATCH_SH}'\n"
+    )
+
+
+def _run_predicate(dispatch_dir: Path, fn: str, *args: str) -> int:
+    """Source dispatch.sh and return the exit code of `fn args` (0/1)."""
+    quoted = " ".join(f"'{a}'" for a in args)
+    script = _predicate_preamble(dispatch_dir) + f"{fn} {quoted}\n"
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True).returncode
+
+
+def _make_bundle(dispatch_dir: Path, pending_id: str) -> None:
+    bundle = dispatch_dir / "pending" / pending_id
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "dispatch-spec.json").write_text("{}", encoding="utf-8")
+
+
+@pytest.fixture()
+def dispatch_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "dispatches"
+    (d / "pending").mkdir(parents=True)
+    return d
+
+
+# ---- _d_valid_dispatch_id -------------------------------------------------- #
+
+@pytest.mark.parametrize("arg,expected", [
+    ("20260624-foo-A", 0),       # canonical id -> valid
+    ("foo.md", 0),               # .md is allowed by the regex (bundle-check disambiguates later)
+    ("a", 0),                    # single safe char
+    ("../foo", 1),               # path traversal -> rejected (slash)
+    ("..", 1),                   # bare .. -> rejected
+    ("foo/bar", 1),              # slash -> rejected
+    ("foo..bar", 1),             # embedded .. -> rejected
+    (".hidden", 1),              # leading '.' is not [A-Za-z0-9]
+    ("", 1),                     # empty -> rejected
+])
+def test_valid_dispatch_id(dispatch_dir, arg, expected):
+    assert _run_predicate(dispatch_dir, "_d_valid_dispatch_id", arg) == expected
+
+
+# ---- _d_is_staged_form (0 = door/staged, 1 = legacy/raw) ------------------- #
+
+def test_staged_spec_file_is_door(dispatch_dir):
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--spec-file", "/abs/x.json") == 0
+
+
+def test_staged_force_release_lock_is_door(dispatch_dir):
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--force-release-lock") == 0
+
+
+def test_help_is_door(dispatch_dir):
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--help") == 0
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "-h") == 0
+
+
+def test_no_positional_is_door(dispatch_dir):
+    # No file given -> door owns the "requires" messaging.
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form") == 0
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--dry-run") == 0
+
+
+def test_pending_id_with_bundle_is_door(dispatch_dir):
+    _make_bundle(dispatch_dir, "20260624-demo-A")
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "20260624-demo-A") == 0
+
+
+def test_pending_id_ending_md_with_bundle_is_door(dispatch_dir):
+    # A pending id may legally end in .md; the bundle check wins over the .md heuristic.
+    _make_bundle(dispatch_dir, "weird.md")
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "weird.md") == 0
+
+
+def test_raw_md_path_is_legacy(dispatch_dir):
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "/path/to/x.md") == 1
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "x.md") == 1
+
+
+def test_bare_slug_without_bundle_is_legacy(dispatch_dir):
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "no-such-bundle") == 1
+
+
+def test_collision_bundle_wins_under_door(dispatch_dir):
+    # Both a bundle dir `foo` and a raw file `foo.md`: the bare slug `foo` has a bundle -> door.
+    _make_bundle(dispatch_dir, "foo")
+    (dispatch_dir / "pending" / "foo.md").write_text("[[TARGET:T1]]\n", encoding="utf-8")
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "foo") == 0
+
+
+def test_overrides_on_pending_id_still_door(dispatch_dir):
+    # value-taking flags are skipped; the bundle slug is still found -> door (then the door
+    # itself rejects the override with a clear error — covered by the integration test).
+    _make_bundle(dispatch_dir, "20260624-demo-A")
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "20260624-demo-A", "--terminal", "T2") == 0
+
+
+def test_end_of_options_marks_next_positional(dispatch_dir):
+    # `-- foo.md` -> foo.md is positional -> .md -> legacy.
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--", "foo.md") == 1
+
+
+def test_value_flag_missing_value_does_not_trip_set_u(dispatch_dir):
+    # `--terminal` with no value at the end must not crash under set -u; no positional -> door.
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "--terminal") == 0
+
+
+def test_traversal_token_is_legacy(dispatch_dir):
+    # `..` / `../x` never reach a bundle path-join; classify as legacy.
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "..") == 1
+    assert _run_predicate(dispatch_dir, "_d_is_staged_form", "../x") == 1
+
+
+# --------------------------------------------------------------------------- #
+# cmd_dispatch routing — door vs legacy delivery (stub-home pattern)
+# --------------------------------------------------------------------------- #
+
+_DOOR_STUB = (
+    "import os, sys\n"
+    'open(os.environ["VNX_DOOR_MARKER"], "w").write("\\0".join(sys.argv[1:]))\n'
+)
+_LANE_STUB = """#!/usr/bin/env python3
+import os, sys, json
+with open(os.environ["VNX_LANE_MARKER"], "w") as f:
+    json.dump({{"lane": "{lane}", "argv": sys.argv[1:]}}, f)
+sys.exit(0)
+"""
+_BRIDGE_STUB = (
+    "#!/usr/bin/env python3\n"
+    "import os, sys\n"
+    'open(os.environ["VNX_BRIDGE_MARKER"], "w").write("hit")\n'
+    "sys.exit(0)\n"
+)
+
+
+def _make_home(tmp_path: Path) -> dict:
+    home = tmp_path / "home"
+    lib = home / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "dispatch_cli.py").write_text(_DOOR_STUB, encoding="utf-8")
+    (lib / "tmux_interactive_dispatch.py").write_text(_LANE_STUB.format(lane="tmux"), encoding="utf-8")
+    (lib / "subprocess_dispatch.py").write_text(_LANE_STUB.format(lane="subprocess"), encoding="utf-8")
+    (lib / "dispatch_bridge.py").write_text(_BRIDGE_STUB, encoding="utf-8")
+    dispatch_dir = tmp_path / "dispatches"
+    (dispatch_dir / "pending").mkdir(parents=True)
+    return {
+        "home": home,
+        "dispatch_dir": dispatch_dir,
+        "door_marker": tmp_path / "door.marker",
+        "lane_marker": tmp_path / "lane.marker",
+        "bridge_marker": tmp_path / "bridge.marker",
+    }
+
+
+def _run_cmd(env_paths: dict, *args: str, flag: str | None, legacy: str | None = None) -> subprocess.CompletedProcess:
+    quoted = " ".join(f"'{a}'" for a in args)
+    flag_line = f"export VNX_SINGLE_ENTRY_DISPATCH='{flag}'\n" if flag is not None else "unset VNX_SINGLE_ENTRY_DISPATCH\n"
+    legacy_line = f"export VNX_DISPATCH_LEGACY='{legacy}'\n" if legacy is not None else ""
+    script = f"""
+set -u
+log() {{ printf '%s\\n' "$*" >&2; }}
+err() {{ printf 'ERR %s\\n' "$*" >&2; }}
+export VNX_HOME='{env_paths["home"]}'
+export VNX_DATA_DIR='{env_paths["home"]}/data'
+export VNX_STATE_DIR='{env_paths["home"]}/data/state'
+export VNX_DISPATCH_DIR='{env_paths["dispatch_dir"]}'
+export VNX_DOOR_MARKER='{env_paths["door_marker"]}'
+export VNX_LANE_MARKER='{env_paths["lane_marker"]}'
+export VNX_BRIDGE_MARKER='{env_paths["bridge_marker"]}'
+{flag_line}{legacy_line}source '{DISPATCH_SH}'
+cmd_dispatch {quoted}
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                          env={"PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"})
+
+
+def _write_raw(env_paths: dict, name: str = "demo.md") -> Path:
+    f = env_paths["dispatch_dir"] / "pending" / name
+    f.write_text("[[TARGET:T1]]\nRole: backend-developer\nGate: G1\n\nDo it.\n", encoding="utf-8")
+    return f
+
+
+def test_door_on_staged_pending_id_hits_door(tmp_path):
+    e = _make_home(tmp_path)
+    _make_bundle_home = e["dispatch_dir"] / "pending" / "20260624-demo-A"
+    _make_bundle_home.mkdir(parents=True)
+    (_make_bundle_home / "dispatch-spec.json").write_text("{}", encoding="utf-8")
+    r = _run_cmd(e, "20260624-demo-A", flag="1")
+    assert r.returncode == 0, r.stderr
+    assert e["door_marker"].exists(), "door (dispatch_cli.py) not invoked for a staged pending-id"
+    assert "--spec-file" in e["door_marker"].read_text().split("\0")
+    assert not e["lane_marker"].exists()
+    assert not e["bridge_marker"].exists()
+
+
+def test_door_on_raw_md_goes_legacy_not_bridge(tmp_path):
+    e = _make_home(tmp_path)
+    raw = _write_raw(e)
+    r = _run_cmd(e, str(raw), flag="1")
+    assert r.returncode == 0, r.stderr
+    # POSITIVE: the legacy tmux lane IS invoked; the door AND the bridge are NOT.
+    assert e["lane_marker"].exists(), "legacy delivery lane not invoked for raw .md under door-ON"
+    assert json.loads(e["lane_marker"].read_text())["lane"] == "tmux"
+    assert not e["door_marker"].exists(), "door wrongly invoked for raw .md"
+    assert not e["bridge_marker"].exists(), "bridge wrongly invoked for raw .md (Option X1 violated)"
+    assert "DEPRECATED" in r.stderr, "deprecation warning not emitted under door-ON + raw"
+
+
+def test_door_on_raw_md_adapter_subprocess_honored(tmp_path):
+    e = _make_home(tmp_path)
+    raw = _write_raw(e)
+    r = _run_cmd(e, str(raw), "--adapter", "subprocess", flag="1")
+    assert r.returncode == 0, r.stderr
+    # Lane precedence preserved on the raw form: --adapter subprocess -> subprocess lane.
+    assert json.loads(e["lane_marker"].read_text())["lane"] == "subprocess"
+    assert not e["bridge_marker"].exists()
+
+
+def test_default_off_raw_md_legacy_no_warning(tmp_path):
+    e = _make_home(tmp_path)
+    raw = _write_raw(e)
+    r = _run_cmd(e, str(raw), flag=None)  # unset -> default OFF (pre-flip)
+    assert r.returncode == 0, r.stderr
+    assert e["lane_marker"].exists()
+    assert "DEPRECATED" not in r.stderr, "deprecation warning must not fire when the door is off"
+    assert not e["door_marker"].exists()
+
+
+def test_rollback_staged_pending_id_legacy_with_hint(tmp_path):
+    e = _make_home(tmp_path)
+    bundle = e["dispatch_dir"] / "pending" / "20260624-demo-A"
+    bundle.mkdir(parents=True)
+    (bundle / "dispatch-spec.json").write_text("{}", encoding="utf-8")
+    # Door enabled but rollback wins -> legacy parse; pending-id isn't a legacy file -> not found + hint.
+    r = _run_cmd(e, "20260624-demo-A", flag="1", legacy="1")
+    assert r.returncode != 0
+    assert not e["door_marker"].exists(), "door invoked despite VNX_DISPATCH_LEGACY=1"
+    assert "staged dispatch bundle" in r.stderr, "staged-bundle hint missing on rollback + pending-id"
+    assert "DEPRECATED" not in r.stderr, "no deprecation warning under rollback"
+
+
+def test_rollback_spec_file_legacy_no_door(tmp_path):
+    e = _make_home(tmp_path)
+    # The second canonical staged form under rollback: --spec-file is a door concept; legacy can't
+    # serve it -> the door is not invoked and it errors on the legacy lane.
+    r = _run_cmd(e, "--spec-file", "/tmp/x.json", flag="1", legacy="1")
+    assert not e["door_marker"].exists(), "door invoked despite rollback for --spec-file"
+
+
+def test_door_on_help_renders_without_command_substitution(tmp_path):
+    # Regression (kimi-gate): the door --help here-doc (cat <<HELP, unquoted) must not contain
+    # backticks/$(...) — bash would command-substitute them when --help is shown, breaking the
+    # help and opening an injection surface. Assert a clean render under door-ON.
+    e = _make_home(tmp_path)
+    r = _run_cmd(e, "--help", flag="1")
+    assert r.returncode == 0, r.stderr
+    out = r.stdout + r.stderr
+    assert "Single-entry gate" in out
+    assert "DEPRECATED" in out
+    for bad in ("command not found", "syntax error", "No such file"):
+        assert bad not in out.lower(), f"help triggered shell evaluation: {bad!r} in output"
+
+
+def test_door_on_pending_id_with_override_clear_error(tmp_path):
+    e = _make_home(tmp_path)
+    bundle = e["dispatch_dir"] / "pending" / "20260624-demo-A"
+    bundle.mkdir(parents=True)
+    (bundle / "dispatch-spec.json").write_text("{}", encoding="utf-8")
+    r = _run_cmd(e, "20260624-demo-A", "--terminal", "T2", flag="1")
+    assert r.returncode != 0
+    assert "legacy raw-file override" in r.stderr, "clear-error for staged-id + override missing"
+    assert not e["door_marker"].exists()
+
+
+# --------------------------------------------------------------------------- #
+# dispatch_deliver.sh — provider propagation (G1) + default-OFF regression
+# --------------------------------------------------------------------------- #
+
+def _run_deliver(tmp_path: Path, *call_args: str, flag: str | None) -> subprocess.CompletedProcess:
+    """Stub python3 to capture argv; source dispatch_deliver.sh; call _ddt_subprocess_delivery."""
+    capture = tmp_path / "argv.txt"
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    real_py = shutil.which("python3") or "/usr/bin/python3"
+    py = stub_dir / "python3"
+    # Delegate the flag predicate's `python3 -c ...` to the REAL interpreter so
+    # vnx_single_entry_enabled resolves correctly; capture argv only for the delivery call.
+    py.write_text(
+        "#!/usr/bin/env bash\n"
+        f'if [ "$1" = "-c" ]; then exec "{real_py}" "$@"; fi\n'
+        f'printf "%s\\n" "$@" > "{capture}"\nexit 0\n'
+    )
+    py.chmod(0o755)
+    (tmp_path / "dispatch.md").write_text("[[TARGET:T2]]\n", encoding="utf-8")
+    flag_line = f'export VNX_SINGLE_ENTRY_DISPATCH="{flag}"\n' if flag is not None else "unset VNX_SINGLE_ENTRY_DISPATCH\n"
+    quoted = " ".join(f'"{a}"' for a in call_args)
+    script = (
+        f'export PATH="{stub_dir}:$PATH"\n'
+        f'export VNX_DIR="{REPO_ROOT}"\n'
+        "log() { :; }\n"
+        "log_structured_failure() { :; }\n"
+        "rc_release_on_failure() { :; }\n"
+        "release_terminal_claim() { :; }\n"
+        f"{flag_line}"
+        f'source "{DELIVER_SH}"\n'
+        f"_ddt_subprocess_delivery {quoted}\n"
+    )
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env={**os.environ})
+    proc_argv = capture.read_text().splitlines() if capture.exists() else []
+    return proc, proc_argv
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_deliver_door_on_forwards_provider_to_bridge(tmp_path):
+    proc, argv = _run_deliver(
+        tmp_path, "T2", "d-1", "PROMPT", "sonnet", f"{tmp_path}/dispatch.md", "test-engineer", "codex_cli",
+        flag="1",
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert any("dispatch_bridge.py" in a for a in argv), f"bridge not invoked under door-ON: {argv}"
+    assert "--provider" in argv, f"--provider not forwarded to the bridge: {argv}"
+    assert argv[argv.index("--provider") + 1] == "codex_cli"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_deliver_default_off_legacy_unbroken_by_7th_arg(tmp_path):
+    # Default OFF: the 7-arg call still routes to subprocess_dispatch.py (legacy), no breakage.
+    proc, argv = _run_deliver(
+        tmp_path, "T2", "d-2", "PROMPT", "sonnet", f"{tmp_path}/dispatch.md", "test-engineer", "claude_code",
+        flag=None,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert any("subprocess_dispatch.py" in a for a in argv), f"legacy lane broken by 7th arg: {argv}"
+    assert not any("dispatch_bridge.py" in a for a in argv)
+
+
+# --------------------------------------------------------------------------- #
+# dispatch_bridge.py — claude_code domain string canonicalizes (O1)
+# --------------------------------------------------------------------------- #
+
+def test_claude_code_canonicalizes_to_claude():
+    import sys
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+    import dispatch_bridge
+    # The real emitted domain strings from get_terminal_provider / vnx_init.
+    assert dispatch_bridge._canonical_provider("claude_code").value == "claude"
+    assert dispatch_bridge._canonical_provider("codex_cli").value == "codex"
+    assert dispatch_bridge._canonical_provider("gemini_cli").value == "gemini"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The routing-split that makes the door-flip (D2) safe. **Default stays OFF** — this is inert on the happy-path for default users and validated under opt-in (`VNX_SINGLE_ENTRY_DISPATCH=1`). D2 (the 1-line `_DEFAULT_ENABLED=True` flip) is gated on this merging first.

Routing (Option X1): **staged forms** (`<pending-id>` with a bundle / `--spec-file` / `--force-release-lock`) route through the single-entry door; **raw `vnx dispatch <file.md>`** stays on the legacy tmux/subprocess delivery — preserving its full lane precedence (`--adapter > Adapter: > VNX_ADAPTER > VNX_AUTO_ROUTE`) — plus a one-time DEPRECATED warning (stderr) when the door is the default lane. Companion ADRs: **ADR-025** (raw-file deprecation, this PR) + ADR-024 (the flip, D2).

## Changes

- **dispatch.sh**: centralized `_d_valid_dispatch_id` guard (no `/`, no `..`), `_d_is_staged_form` arg-scan classifier (set -u-safe; `--`/bundled handled; bundle-check before the `.md` heuristic), narrowed intercept via a pre-fork `_door_on` boolean, **removed the dead line-475 bridge branch** (would have silently dropped `--adapter` for raw input), clear-error for staged-id + legacy override flags, staged-bundle hint on the legacy "File not found" path, `--help` updates.
- **dispatch_deliver.sh**: thread `provider` as the 7th `_ddt_subprocess_delivery` param (after the optional `agent_role`) + forward `--provider` to the door bridge, so a non-claude terminal-pinned worker keeps its provider lane post-flip instead of silently defaulting to claude.
- **dispatch_bridge.py**: alias `claude_code` → `claude`. `get_terminal_provider` emits the tmux-domain string `claude_code`; without this alias the provider propagation would REJECT every claude subprocess-routed worker. The full configured domain-string set (`claude_code`/`codex_cli`/`gemini_cli`) now canonicalizes through `_PROVIDER_ALIASES`.
- **dispatch-agent.sh**: canary comment updated (claude-agent dispatcher by design; flip intentional).
- **ADR-025**: raw-file dispatch deprecation; **SUBPROCESS doc**: 7-arg signature.

## Verification

- `tests/test_door_flip_d1_routing.py` (33): predicate unit tests, door-vs-legacy routing (positive: raw → tmux/subprocess IS invoked, door AND bridge are NOT), provider propagation (`--provider` reaches the bridge under door-ON; default-OFF legacy unbroken by the 7th arg), `claude_code` canonicalization, `--help` command-substitution regression.
- Full dispatch suite green (144), no regression.
- Plan-gate: opus PASS 5× ("verified correct against the code, safe to build"). kimi-gate on the diff: PASS (caught + fixed a real `--help` backtick command-substitution bug before merge).
- **ADR-007**: N/A verified — touched files have 0 CREATE/ALTER TABLE; `project_id` is only a filesystem spec-bundle field, not a central-DB table.

## Open Items

None for D1. D2 (the flip) follows as a separate PR, gated on this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC