### PR TITLE
feat(dispatch): door-flip D2 — single-entry door default ON (ADR-024)

### DIFF
--- a/docs/governance/decisions/ADR-024-single-entry-door-default-dispatch-lane.md
+++ b/docs/governance/decisions/ADR-024-single-entry-door-default-dispatch-lane.md
@@ -1,0 +1,110 @@
+# ADR-024 — Single-entry Door as the Default Dispatch Lane
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Decided by:** Operator (Vincent van Deth)
+**Resolves:** The door-flip (item E). Companion to ADR-025 (raw-file dispatch deprecation, item B).
+
+## Context
+
+PR-12 built the single-entry door: every governed dispatch funnels through one
+`validate → snapshot → compile_plan → permit → execute` gate (`dispatch_cli.run_dispatch`),
+with `dispatch_bridge` as the sanctioned bridge for the legacy callers. The door shipped behind a
+flag (`VNX_SINGLE_ENTRY_DISPATCH`) with the default OFF (`dispatch_flags._DEFAULT_ENABLED = False`).
+
+Until this ADR, the default lane was the legacy path. The flip — making the door the default — was
+gated on burn-in and an explicit operator go. The naïve flip (just `_DEFAULT_ENABLED = True`) was
+unsafe: it surfaced a real contract mismatch. The door (`_d_single_entry_dispatch`) accepts only
+STAGED forms (`--spec-file`, a `<pending-id>` resolving to a promoted bundle), but the documented,
+still-used raw form `vnx dispatch <file.md>` routed to the door post-flip and was rejected. The raw
+form is rich (file-search, `--terminal/--model/--adapter` overrides, lane precedence
+`--adapter > Adapter: > VNX_ADAPTER > VNX_AUTO_ROUTE`, active→completed lifecycle). Routing it
+through the door's bridge would silently drop `--adapter` (the bridge defaults claude→tmux).
+
+The flip therefore required a routing-split first (D1, shipped separately as the routing-split PR):
+STAGED forms route through the door; the RAW form stays on the legacy lane (deprecated per ADR-025).
+This ADR records the flip itself and the lane decision.
+
+## Decision
+
+**`dispatch_flags._DEFAULT_ENABLED` is True: the single-entry door is the DEFAULT dispatch lane.
+Unset `VNX_SINGLE_ENTRY_DISPATCH` resolves to the door. The legacy lane is reachable via the
+rollback hatch `VNX_DISPATCH_LEGACY=1` (always wins) or the explicit opt-out
+`VNX_SINGLE_ENTRY_DISPATCH=0`.**
+
+Routing split (Option X1):
+
+- STAGED forms (`--spec-file`, `<pending-id>` with a promoted bundle, `--force-release-lock`) route
+  through the door (`_d_single_entry_dispatch` → `dispatch_cli`, directly; the bridge is the door's
+  delivery for the in-process/daemon callers).
+- The RAW `vnx dispatch <file.md>` form stays on the legacy tmux/subprocess delivery — preserving
+  its full lane precedence — and emits a one-time deprecation warning (ADR-025; removed in 1.x).
+- The dead `dispatch.sh:475` bridge branch was removed: under the narrowed intercept a raw form
+  falls through to legacy delivery, NOT the bridge (routing it through the bridge would drop
+  `--adapter`).
+- Provider propagation: the daemon subprocess delivery forwards `--provider` to the bridge so a
+  non-claude terminal-pinned worker keeps its provider lane post-flip (with the `claude_code`
+  domain-string aliased to `claude`).
+
+## Reasoning
+
+1. **One governed door.** Per ADR-006 (staging→promote human gate) and the PR-12 design, the goal is
+   that every dispatch funnels through `run_dispatch`. Making the door the default moves production
+   onto that single gate by default instead of by opt-in.
+2. **The flip is safe only with the routing-split.** Backward-compat first (the operator chose A over
+   a hard cutover): the documented raw form must keep working on day one. The routing-split keeps it
+   on the legacy lane (deprecated, ADR-025) rather than breaking it.
+3. **Reversibility.** `VNX_DISPATCH_LEGACY=1` is an absolute rollback honored by the single-source
+   predicate at every reader, so the flip is reversible without a code change.
+
+## Consequences
+
+### Accepted
+
+- The door is the default; unset resolves to it. Production callers (already staged) route through
+  `run_dispatch` by default.
+- The raw form keeps working on the legacy lane with a deprecation warning (ADR-025); item B removes
+  it later.
+- Rollback is `VNX_DISPATCH_LEGACY=1` (always wins) or `VNX_SINGLE_ENTRY_DISPATCH=0`.
+- The daemon tmux-send-keys path (`dispatch_deliver.sh`, interactive panes) is NOT door-gated — it is
+  a separate delivery structure, tracked as a structural-consolidation follow-up, not part of this
+  flip.
+
+### Rejected
+
+- **The naïve flip (flip the constant only).** Rejected — it breaks the documented raw form (the
+  door rejects it). The routing-split is the precondition.
+- **Routing the raw form through the door/bridge (Option Y).** Rejected — it silently drops
+  `--adapter`/lane precedence, or requires replicating legacy lane features in the bridge.
+- **A conditional raw split (Option Z).** Rejected — too complex for a deprecated path.
+
+## Reconciliation with ADR-010 (superseded-in-part)
+
+ADR-010 ("Subprocess Adapter (`claude -p`) as Canonical Claude Routing") established the subprocess
+adapter as the canonical Claude lane. ADR-024 supersedes it on the canonical-lane question, while
+ADR-010's SDK/LiteLLM ban remains binding. Per clause:
+
+- ADR-010 Decision *"`subprocess_dispatch.py` is the canonical Claude invocation path"* and *"All
+  Claude worker terminals route through this adapter by default"* → **SUPERSEDED**: post-June-15
+  cutover, headless `claude -p` bills API credits, so the subscription-preserving tmux-spawn lane is
+  now canonical for Claude (the provider→lane rule); the door routes claude→tmux-spawn.
+- ADR-010 Accepted *"Any new Claude integration MUST extend `subprocess_dispatch.py`"* → **AMENDED**:
+  new Claude integrations route via the door (`run_dispatch` → tmux-spawn).
+- ADR-010 Accepted *"T0 progressive migration to subprocess continues"* → **SUPERSEDED**: claude
+  routes via tmux-spawn-subscription as the primary.
+- ADR-010 Rejected *"Direct `claude` CLI invocation that doesn't capture stream-json … shelling out
+  to `claude` interactively … is rejected"* → **SUPERSEDED**: ADR-024's tmux-spawn lane IS
+  interactive claude. Post-June-15, subscription preservation (no API-credit burn) outweighs the
+  stream-json event surface; the tmux-spawn lane has its own receipt/event capture.
+- ADR-010 *"The Anthropic Python SDK is never imported"* + the LiteLLM-Claude ban → **UNCHANGED /
+  BINDING**: both lanes run the claude CLI, never the SDK or LiteLLM.
+
+## See also
+
+- ADR-025 — Raw-file dispatch deprecation (the deprecation half of the door-flip)
+- ADR-006 — Staging→promote with mandatory human approval gate
+- ADR-010 — Subprocess adapter as canonical Claude routing (superseded-in-part here)
+- `scripts/lib/dispatch_flags.py` — `_DEFAULT_ENABLED` (the flip), `single_entry_enabled`
+- `scripts/commands/dispatch.sh` — `cmd_dispatch`, `_d_is_staged_form`, `_d_valid_dispatch_id`
+- Memory: `plan-gate-glm-parse-flake-blocks-pass` (the gate-tooling note from this flip's plan-gate)
+- Memory: `dispatch-structure-not-consolidated-friction` (the daemon tmux-path follow-up)

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -292,8 +292,10 @@ cmd_dispatch() {
   #       -> DOOR (_d_single_entry_dispatch)
   #   door enabled  + raw form (a path, *.md, or a bare slug without a bundle)
   #       -> LEGACY lane + a one-time DEPRECATED warning (stderr)
-  #   door disabled (VNX_DISPATCH_LEGACY=1, or VNX_SINGLE_ENTRY_DISPATCH=0/unset pre-flip)
+  #   door disabled (rollback VNX_DISPATCH_LEGACY=1, or explicit VNX_SINGLE_ENTRY_DISPATCH=0)
   #       -> LEGACY lane, byte-identical, no warning
+  # POST-FLIP (door-flip D2, ADR-024): the door is the DEFAULT — unset VNX_SINGLE_ENTRY_DISPATCH
+  # now resolves to the door. Pre-flip the default was the legacy lane.
   # The rollback hatch (VNX_DISPATCH_LEGACY=1) always wins (single-source helper).
   # _door_on is captured ONCE here (not re-evaluated) so the warning fires iff the door is the
   # reason we fell through to legacy (door on + raw), never under explicit legacy/rollback.

--- a/scripts/lib/dispatch_flags.py
+++ b/scripts/lib/dispatch_flags.py
@@ -14,21 +14,23 @@ every reader through single_entry_enabled() closes that.
 Truth table (env value → enabled):
     VNX_DISPATCH_LEGACY == "1"   -> False   (rollback always wins, regardless of the other flag)
     VNX_SINGLE_ENTRY_DISPATCH:
-        unset / ""               -> _DEFAULT_ENABLED   (the flip default)
-        "0"                      -> False
-        "1" / any other non-"0"  -> True   (NOTE: semantics widened from the old ==\"1\" to !=\"0\")
+        unset / ""               -> _DEFAULT_ENABLED   (POST-FLIP: the single-entry door)
+        "0"                      -> False   (explicit opt-out — legacy lane)
+        "1" / any other non-"0"  -> True
 
-E (the flip) flips _DEFAULT_ENABLED to True, gated on the burn-in + the operator's explicit go.
-Until then the default is False — pre-flip behavior is byte-identical for the canonical
-unset/"0"/"1" values; only non-canonical truthy values ("2", "yes") now enable (documented).
+FLIPPED 2026-06-24 (door-flip D2, ADR-024): _DEFAULT_ENABLED is now True — the single-entry door
+is the DEFAULT dispatch lane. The routing-split (D1, ADR-025) keeps the documented raw
+`vnx dispatch <file.md>` form working on the legacy lane (deprecated) so the flip is safe.
+Rollback to the legacy lane: VNX_DISPATCH_LEGACY=1 (always wins) or VNX_SINGLE_ENTRY_DISPATCH=0.
 """
 from __future__ import annotations
 
 import os
 from typing import Mapping, Optional
 
-# Pre-flip default. Item E flips this to True (after burn-in + operator go).
-_DEFAULT_ENABLED = False
+# Post-flip default (door-flip D2, ADR-024, 2026-06-24): the single-entry door is the default lane.
+# Rollback: VNX_DISPATCH_LEGACY=1 or VNX_SINGLE_ENTRY_DISPATCH=0.
+_DEFAULT_ENABLED = True
 
 _LEGACY_ENV = "VNX_DISPATCH_LEGACY"
 _SINGLE_ENTRY_ENV = "VNX_SINGLE_ENTRY_DISPATCH"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -387,8 +387,9 @@ def test_reject_on_unpromoted_staging(mock_snapshot, tmp_path):
 # test_flag_off_legacy_unchanged
 # ---------------------------------------------------------------------------
 
-def test_flag_off_legacy_unchanged(tmp_path):
-    """With VNX_SINGLE_ENTRY_DISPATCH unset, cmd_dispatch uses the legacy dry-run path."""
+def test_raw_md_legacy_under_default_on(tmp_path):
+    """Post-flip (ADR-024): VNX_SINGLE_ENTRY_DISPATCH unset resolves to the door (default ON), but a
+    raw .md still falls through to the legacy dry-run path (Option X1) — NOT the single-entry gate."""
     dispatch_md = tmp_path / "test-dispatch.md"
     dispatch_md.write_text(
         "[[TARGET:T1]]\nRole: backend-developer\nGate: human-promoted\n\nTest dispatch.\n",

--- a/tests/test_dispatch_flags.py
+++ b/tests/test_dispatch_flags.py
@@ -14,10 +14,12 @@ import dispatch_flags
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _FLAGS_SH = _REPO_ROOT / "scripts" / "lib" / "vnx_dispatch_flags.sh"
 
-# (env-overlay, expected_enabled). Default is OFF pre-flip (dispatch_flags._DEFAULT_ENABLED).
+# (env-overlay, expected_enabled). Default is ON post-flip (dispatch_flags._DEFAULT_ENABLED,
+# flipped 2026-06-24 / ADR-024). Explicit VNX_SINGLE_ENTRY_DISPATCH=0 or VNX_DISPATCH_LEGACY=1
+# still opt out.
 CASES = [
-    ({}, False),                                        # unset -> default OFF
-    ({"VNX_SINGLE_ENTRY_DISPATCH": ""}, False),          # empty -> default OFF
+    ({}, True),                                          # unset -> default ON (post-flip)
+    ({"VNX_SINGLE_ENTRY_DISPATCH": ""}, True),           # empty -> default ON (post-flip)
     ({"VNX_SINGLE_ENTRY_DISPATCH": "0"}, False),         # explicit 0 -> OFF
     ({"VNX_SINGLE_ENTRY_DISPATCH": "1"}, True),          # 1 -> ON
     ({"VNX_SINGLE_ENTRY_DISPATCH": "2"}, True),          # widened: any non-0 truthy -> ON
@@ -28,9 +30,12 @@ CASES = [
 ]
 
 
-def test_default_is_off_pre_flip():
-    assert dispatch_flags.default_enabled() is False
-    assert dispatch_flags.single_entry_enabled({}) is False
+def test_default_is_on_post_flip():
+    # Door-flip D2 (ADR-024, 2026-06-24): the single-entry door is the default route.
+    assert dispatch_flags.default_enabled() is True
+    assert dispatch_flags.single_entry_enabled({}) is True
+    # The absolute rollback still wins, uniformly.
+    assert dispatch_flags.single_entry_enabled({"VNX_DISPATCH_LEGACY": "1"}) is False
 
 
 def test_python_truth_table():

--- a/tests/test_dispatch_sh_contract.py
+++ b/tests/test_dispatch_sh_contract.py
@@ -107,8 +107,9 @@ cmd_dispatch '{dispatch_md}' --dry-run
     assert "single-entry gate" not in (r.stdout + r.stderr).lower()
 
 
-def test_default_off_does_not_invoke_door(tmp_path):
-    """Pre-flip default (flag unset) → legacy; the door stub is never invoked."""
+def test_raw_md_falls_through_to_legacy(tmp_path):
+    """Post-flip (ADR-024): flag unset resolves to the door (default ON), but a raw .md falls through
+    to the legacy lane (Option X1) — the door stub is never invoked — and emits the deprecation warning."""
     stub_home = _make_stub_home(tmp_path)
     dispatch_dir = tmp_path / "dispatches"
     dispatch_dir.mkdir()
@@ -122,3 +123,4 @@ cmd_dispatch '{dispatch_md}' --dry-run
     r = _run(cmd)
     assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
     assert not marker.exists()
+    assert "DEPRECATED" in (r.stdout + r.stderr), "deprecation warning expected for raw .md under the door default"

--- a/tests/test_door_flip_d1_routing.py
+++ b/tests/test_door_flip_d1_routing.py
@@ -255,14 +255,29 @@ def test_door_on_raw_md_adapter_subprocess_honored(tmp_path):
     assert not e["bridge_marker"].exists()
 
 
-def test_default_off_raw_md_legacy_no_warning(tmp_path):
+def test_rollback_raw_md_legacy_no_warning(tmp_path):
+    # Door off via explicit rollback (post-flip the default is ON, so we opt out explicitly):
+    # raw .md -> legacy, and NO deprecation warning (the raw form is the sanctioned path here).
     e = _make_home(tmp_path)
     raw = _write_raw(e)
-    r = _run_cmd(e, str(raw), flag=None)  # unset -> default OFF (pre-flip)
+    r = _run_cmd(e, str(raw), flag=None, legacy="1")
     assert r.returncode == 0, r.stderr
     assert e["lane_marker"].exists()
     assert "DEPRECATED" not in r.stderr, "deprecation warning must not fire when the door is off"
     assert not e["door_marker"].exists()
+
+
+def test_default_on_raw_md_legacy_with_warning(tmp_path):
+    # Post-flip: unset VNX_SINGLE_ENTRY_DISPATCH resolves to the door (default ON). A raw .md still
+    # falls through to legacy delivery, now WITH the deprecation warning.
+    e = _make_home(tmp_path)
+    raw = _write_raw(e)
+    r = _run_cmd(e, str(raw), flag=None)  # unset -> default ON (post-flip)
+    assert r.returncode == 0, r.stderr
+    assert e["lane_marker"].exists()
+    assert not e["door_marker"].exists()
+    assert not e["bridge_marker"].exists()
+    assert "DEPRECATED" in r.stderr, "deprecation warning must fire under the door default + raw"
 
 
 def test_rollback_staged_pending_id_legacy_with_hint(tmp_path):
@@ -362,11 +377,12 @@ def test_deliver_door_on_forwards_provider_to_bridge(tmp_path):
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
-def test_deliver_default_off_legacy_unbroken_by_7th_arg(tmp_path):
-    # Default OFF: the 7-arg call still routes to subprocess_dispatch.py (legacy), no breakage.
+def test_deliver_optout_legacy_unbroken_by_7th_arg(tmp_path):
+    # Explicit opt-out (VNX_SINGLE_ENTRY_DISPATCH=0, post-flip the default is ON): the 7-arg call
+    # still routes to subprocess_dispatch.py (legacy), proving the signature change is backward-safe.
     proc, argv = _run_deliver(
         tmp_path, "T2", "d-2", "PROMPT", "sonnet", f"{tmp_path}/dispatch.md", "test-engineer", "claude_code",
-        flag=None,
+        flag="0",
     )
     assert proc.returncode == 0, proc.stderr
     assert any("subprocess_dispatch.py" in a for a in argv), f"legacy lane broken by 7th arg: {argv}"
@@ -385,6 +401,51 @@ def test_claude_code_canonicalizes_to_claude():
     assert dispatch_bridge._canonical_provider("claude_code").value == "claude"
     assert dispatch_bridge._canonical_provider("codex_cli").value == "codex"
     assert dispatch_bridge._canonical_provider("gemini_cli").value == "gemini"
+
+
+# --------------------------------------------------------------------------- #
+# Receipt-lane: the staged spec's provider is the lane determinant
+# (dispatch_cli.py: is_claude_lane = spec.provider == Provider.CLAUDE -> tmux-spawn; else provider lane)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("emitted,canonical", [
+    ("claude_code", "claude"),   # -> claude_tmux_subscription lane
+    ("codex_cli", "codex"),      # -> provider lane (NOT claude tmux)
+    ("gemini_cli", "gemini"),    # -> provider lane
+])
+def test_staged_spec_carries_canonical_provider_lane_determinant(tmp_path, emitted, canonical):
+    import sys
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+    import dispatch_bridge
+    spec_file = dispatch_bridge.stage_spec_bundle(
+        instruction_text="do it",
+        dispatch_id="20260624-lane-A",
+        role="backend-developer",
+        target_slot="T1",
+        provider=emitted,
+        data_dir=tmp_path,
+    )
+    payload = json.loads(spec_file.read_text(encoding="utf-8"))
+    assert payload["provider"] == canonical, (
+        f"provider '{emitted}' must canonicalize to '{canonical}' in the spec (the lane determinant)"
+    )
+
+
+def test_deliver_via_door_routes_to_bridge_under_default_on(tmp_path, monkeypatch):
+    # Post-flip default ON: deliver_via_door routes the in-process callers (incl.
+    # vnx_cli/commands/dispatch_agent.py) through the bridge, not the legacy callable.
+    import sys
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+    import dispatch_bridge
+    monkeypatch.delenv("VNX_SINGLE_ENTRY_DISPATCH", raising=False)  # unset -> default ON
+    monkeypatch.delenv("VNX_DISPATCH_LEGACY", raising=False)
+    calls = {"bridge": 0, "legacy": 0}
+    monkeypatch.setattr(dispatch_bridge, "bridge_dispatch", lambda **kw: calls.__setitem__("bridge", calls["bridge"] + 1) or 0)
+    dispatch_bridge.deliver_via_door(
+        lambda: calls.__setitem__("legacy", calls["legacy"] + 1) or True,
+        instruction_text="x", dispatch_id="20260624-agent-A", target_slot="T1", role="agent",
+    )
+    assert calls["bridge"] == 1 and calls["legacy"] == 0, f"default-ON must route via the bridge: {calls}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**The flip.** `dispatch_flags._DEFAULT_ENABLED` → True: the single-entry door is now the DEFAULT dispatch lane. Unset `VNX_SINGLE_ENTRY_DISPATCH` resolves to the door. Rollback: `VNX_DISPATCH_LEGACY=1` (always wins) or `VNX_SINGLE_ENTRY_DISPATCH=0`.

Safe to flip because **D1 (#908) landed first**: STAGED forms route through the door; raw `vnx dispatch <file.md>` stays on the legacy lane with a deprecation warning (ADR-025). This is the second deliverable of the same plan-gated track as D1 (no separate plan-gate needed).

## Changes

- **dispatch_flags.py**: `_DEFAULT_ENABLED = True` + docstring/truth-table updated for the post-flip default.
- **dispatch.sh**: routing comment updated (unset now resolves to the door).
- **ADR-024**: records the lane decision + the partial supersession of ADR-010 (post-June-15 the subscription tmux-spawn lane is canonical for Claude; the SDK/LiteLLM ban remains binding).
- **Tests reconciled to default-ON**: `test_dispatch_flags` (CASES unset/empty → True, `test_default_is_on_post_flip`), `test_dispatch_cli`/`test_dispatch_sh_contract` renamed (raw .md → legacy under default-ON, + deprecation-warning assertion), `test_door_flip_d1_routing` (rollback/opt-out variants + `test_default_on_raw_md_legacy_with_warning` + receipt-lane provider/lane determinant + `deliver_via_door` routes-to-bridge-under-default-ON).

## Verification

- Focused dispatch suite green under default-ON (130).
- The flip introduces ZERO new failures: the broader flip-sensitive set has the SAME 8 pre-existing failures on this branch as on clean `main` (verified by comparison — they fail on `main` too, unrelated to the flip).
- kimi-gate on the diff: PASS (0 blocking).
- Plan-gate (the D1+D2 plan): opus PASS 5×.

## Open Items

None. Rollback hatch: `VNX_DISPATCH_LEGACY=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC