### PR TITLE
fix(plan-gate): non-scoring lanes abstain + liveness quorum

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -209,56 +209,63 @@ def _decision(decision: str, block: int, revise: int, passes: int, rationale: st
 
 
 def apply_panel_rule(results: List[PanelistResult]) -> Dict[str, Any]:
-    """The PM-SKILL pass/fail rule.
+    """The PM-SKILL pass/fail rule, with NON-SCORING lanes + a liveness quorum.
 
-    - any infra failure (a panelist returned no verdict) -> REVISE (cannot certify
-      PASS with a silent missing voice)
-    - any BLOCK -> REVISE (revise the blocking sections, re-run the delta)
-    - >= 2 REVISE -> REVISE (one revise round)
-    - <= 1 REVISE and no BLOCK -> PASS (fold the lone dissent in as a tracked note)
+    A lane with no readable verdict (undispatched, or a report whose verdict block did not
+    parse) is NON-SCORING: it ABSTAINS rather than vetoing. Rationale (2026-06-24): a
+    structurally-broken or input-degraded lane (e.g. a model that won't emit the requested
+    fence on a large doc) must not veto a substantive PASS from the readable lanes forever —
+    that is a liveness hole, not safety. The non-scoring lanes are named in the rationale so
+    the abstention is transparent, never silent.
 
-    Parse errors already map to ``revise`` (see ``parse_verdict``), so a garbled
-    verdict counts against PASS rather than being ignored.
+    Over the SCORING (readable) lanes only:
+    - quorum: require >= 2 readable verdicts to certify (a single voice can't fold to PASS).
+    - any BLOCK -> REVISE.
+    - >= 2 REVISE -> REVISE.
+    - <= 1 REVISE and no BLOCK, with passes OUTnumbering the dissent -> PASS (the lone dissent
+      folds as a tracked note); a tie is safety-first REVISE.
     """
     if not results:
         # An empty panel must never fall through to PASS (misconfigured panel=[]).
         return _decision("REVISE", 0, 0, 0, "no panelists ran — empty panel, cannot certify")
-    block = sum(1 for r in results if r.verdict == "block")
-    revise = sum(1 for r in results if r.verdict == "revise")
-    passes = sum(1 for r in results if r.verdict == "pass")
-    # No readable verdict = no signal from that panelist: either the dispatch
-    # failed (infra) or the report had no parseable verdict block. Either way it
-    # must block PASS — folding an unreadable voice into PASS is fail-open.
-    no_verdict = [r for r in results if not r.dispatched or r.parse_error]
+    # NON-SCORING: undispatched or parse_error lanes abstain (do not count toward the verdict).
+    scoring = [r for r in results if r.dispatched and not r.parse_error]
+    non_scoring = [r for r in results if not (r.dispatched and not r.parse_error)]
+    ns_note = (
+        f"; non-scoring (abstained): {', '.join(r.label for r in non_scoring)}"
+        if non_scoring else ""
+    )
+    block = sum(1 for r in scoring if r.verdict == "block")
+    revise = sum(1 for r in scoring if r.verdict == "revise")
+    passes = sum(1 for r in scoring if r.verdict == "pass")
 
-    if no_verdict:
+    # Liveness quorum: a multi-member panel must keep >= 2 readable voices to certify, so a
+    # degraded 3-panel with only one readable lane can't pass on a single voice. A DELIBERATE
+    # 1-member panel (a smoke) needs only its one voice. quorum = min(2, panel size).
+    required = min(2, len(results))
+    if len(scoring) < required:
         return _decision(
             "REVISE", block, revise, passes,
-            f"{len(no_verdict)} panelist(s) returned no readable verdict: "
-            + ", ".join(r.label for r in no_verdict),
+            f"only {len(scoring)} readable verdict(s) of {len(results)} — below quorum "
+            f"({required}); cannot certify{ns_note}",
         )
     if block >= 1:
         return _decision(
             "REVISE", block, revise, passes,
-            f"{block} BLOCK verdict(s) — revise the blocking sections, re-run the delta only",
+            f"{block} BLOCK verdict(s) — revise the blocking sections, re-run the delta only{ns_note}",
         )
     if revise >= 2:
         return _decision(
             "REVISE", block, revise, passes,
-            f"{revise} REVISE verdicts — one revise round",
+            f"{revise} REVISE verdicts — one revise round{ns_note}",
         )
-    # <=1 REVISE, no BLOCK. PASS only if the passing voices OUTNUMBER the dissent —
-    # otherwise the "lone dissent" is not lone (a degenerate 1-/2-member panel, or a
-    # 1-1 tie). This keeps the canonical 3-member result (2 pass + 1 revise -> PASS)
-    # while closing the fail-open a 1-member smoke surfaced: a single REVISE must not
-    # fold to PASS. (SKILL: "tie -> safety-first REVISE".)
     if passes > revise:
-        dissent = [r.label for r in results if r.verdict != "pass"]
-        note = f"folded dissent (tracked): {', '.join(dissent)}" if dissent else "unanimous pass"
-        return _decision("PASS", block, revise, passes, note)
+        dissent = [r.label for r in scoring if r.verdict != "pass"]
+        note = f"folded dissent (tracked): {', '.join(dissent)}" if dissent else "unanimous pass (scoring)"
+        return _decision("PASS", block, revise, passes, note + ns_note)
     return _decision(
         "REVISE", block, revise, passes,
-        "no passing majority — the dissent is not outnumbered",
+        f"no passing majority — the dissent is not outnumbered{ns_note}",
     )
 
 

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -113,11 +113,32 @@ def test_rule_any_block_revises():
     assert d["block_count"] == 1
 
 
-def test_rule_infra_fail_cannot_pass():
-    # two pass + one panelist that never returned a verdict -> not certifiable
+def test_rule_non_scoring_lane_abstains_does_not_veto():
+    # 2 readable PASS + 1 lane that never returned a verdict (non-scoring) -> PASS.
+    # The abstaining lane must not veto a substantive 2-0 pass (liveness, 2026-06-24).
     d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "pass"), _r("c", "revise", dispatched=False)])
+    assert d["decision"] == "PASS"
+    assert "non-scoring (abstained): c" in d["rationale"]
+
+
+def test_rule_parse_error_lane_is_non_scoring():
+    # A dispatched lane whose verdict block didn't parse also abstains (the glm flake case).
+    d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "pass"), _r("c", "revise", parse_error=True)])
+    assert d["decision"] == "PASS"
+    assert "non-scoring (abstained): c" in d["rationale"]
+
+
+def test_rule_quorum_one_scoring_revises():
+    # Only one readable verdict -> below quorum -> cannot certify.
+    d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "x", dispatched=False), _r("c", "x", parse_error=True)])
     assert d["decision"] == "REVISE"
-    assert "no readable verdict" in d["rationale"]
+    assert "quorum" in d["rationale"]
+
+
+def test_rule_non_scoring_with_dissent_still_revises():
+    # 1 pass + 1 revise (scoring) + 1 non-scoring -> passes do not outnumber the dissent -> REVISE.
+    d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "revise"), _r("c", "x", parse_error=True)])
+    assert d["decision"] == "REVISE"
 
 
 # --------------------------------------------------------------------------
@@ -165,10 +186,12 @@ def test_run_panel_dispatch_exception_is_no_verdict(tmp_path):
         return _report('{"verdict": "pass"}')
 
     out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
-    assert out["decision"] == "REVISE"  # cannot pass with a missing voice
+    # The failed lane abstains (non-scoring); the 2 readable PASS voices meet quorum -> PASS.
+    assert out["decision"] == "PASS"
     kimi = next(p for p in out["panelists"] if p["label"] == "kimi")
     assert kimi["dispatched"] is False
     assert "kimi cli not installed" in kimi["error"]
+    assert "non-scoring (abstained): kimi" in out["summary"]["rationale"]
 
 
 # --------------------------------------------------------------------------
@@ -258,15 +281,17 @@ def test_seed_is_tenant_scoped(tmp_path):
 # codex-review hardening (2026-06-21): fail-safe + re-seed + report integrity
 # --------------------------------------------------------------------------
 
-def test_rule_parse_error_blocks_pass():
-    # two clean passes + one panelist whose verdict could not be parsed: a missing
-    # signal must not fold into PASS (codex finding 1).
-    d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "pass"), _r("c", "revise", parse_error=True)])
+def test_rule_garbled_below_quorum_cannot_certify():
+    # Phantom-pass prevention via quorum (codex finding 1, reframed for non-scoring): a 3-panel
+    # where 2 lanes garble leaves only 1 readable voice -> below quorum -> cannot certify PASS.
+    d = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "x", parse_error=True), _r("c", "x", parse_error=True)])
     assert d["decision"] == "REVISE"
-    assert "no readable verdict" in d["rationale"]
+    assert "quorum" in d["rationale"]
 
 
-def test_run_panel_garbled_verdict_blocks_pass(tmp_path):
+def test_run_panel_one_garbled_lane_abstains_quorum_holds(tmp_path):
+    # One lane emits no verdict fence (the glm-flake case): it abstains (non-scoring); the two
+    # readable PASS voices meet quorum -> PASS. The garbled lane is NOT counted as a pass.
     doc = tmp_path / "plan.md"
     doc.write_text("## Problem\n", encoding="utf-8")
 
@@ -276,9 +301,10 @@ def test_run_panel_garbled_verdict_blocks_pass(tmp_path):
         return _report('{"verdict": "pass"}')
 
     out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
-    assert out["decision"] == "REVISE"
+    assert out["decision"] == "PASS"
     glm = next(p for p in out["panelists"] if p["provider"] == "glm-harness")
     assert glm["parse_error"] is True
+    assert "non-scoring (abstained): glm-5.2-harness" in out["summary"]["rationale"]
 
 
 def test_read_report_rejects_foreign_path(tmp_path):
@@ -488,10 +514,9 @@ def test_missing_report_maps_to_parse_error_revise(tmp_path):
     assert out["decision"] == "REVISE"
 
 
-def test_fenceless_report_cannot_produce_phantom_pass(tmp_path):
-    """Two passing + one fenceless: the fenceless panelist blocks PASS (no_verdict guard)."""
-    did_fenceless = "plan-gate-feat-fenceless-aaa00001"
-
+def test_fenceless_lane_abstains_not_counted_as_phantom_pass(tmp_path):
+    """A fenceless report does NOT produce a phantom pass: the fenceless lane is non-scoring
+    (parse_error, not counted as a pass); the decision comes only from the two REAL passes."""
     def _disp(provider, model_arg, instruction, dispatch_id):
         if provider == "glm-harness":
             return "# review\n\nLooks fine.\n"  # no verdict fence
@@ -501,9 +526,12 @@ def test_fenceless_report_cannot_produce_phantom_pass(tmp_path):
     doc.write_text("## Problem\n", encoding="utf-8")
 
     out = pgp.run_panel(doc, track_id="feat-fenceless", project_id="p1", dispatcher=_disp)
-    assert out["decision"] == "REVISE"
+    # PASS from the two real passes; the fenceless lane abstained (did not phantom-pass).
+    assert out["decision"] == "PASS"
     glm = next(p for p in out["panelists"] if p["provider"] == "glm-harness")
     assert glm["parse_error"] is True
+    assert glm["verdict"] != "pass", "a fenceless lane must never be counted as a pass"
+    assert "non-scoring (abstained): glm-5.2-harness" in out["summary"]["rationale"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A plan-gate panelist lane with **no readable verdict** (undispatched, or a report whose `vnx-plan-verdict` fence didn't parse) is now **NON-SCORING**: it ABSTAINS rather than vetoing. The old fail-closed rule (`if no_verdict -> REVISE`) was correct for safety but created a **liveness hole** — a structurally-broken or input-degraded lane vetoed every PASS forever and burned provider credits for no signal.

**Observed (door-flip plan-gate, 2026-06-24):** opus PASS 5× + kimi peeled to 0 items, yet the gate stayed REVISE every round purely because the glm-5.2 lane stopped emitting a valid fence on a very large plan doc. glm is fine on normal docs (a direct smoke produced a perfect fence) — the cause was a 13-revision doc-bloat, not a glm breakage. A choking lane should not veto a substantive 2-0 PASS.

## Changes

`apply_panel_rule` (over the SCORING lanes only), preserving the existing semantics:
- **quorum = min(2, panel size)**: a multi-member panel needs ≥2 readable voices (a degraded 3-panel with one readable lane can't certify on a single voice); a deliberate 1-member smoke still needs only its one voice.
- any BLOCK → REVISE; ≥2 REVISE → REVISE; passes outnumber dissent → PASS; a tie is safety-first REVISE.
- non-scoring lanes are named in the rationale (`non-scoring (abstained): <labels>`) — transparent, never silent.

**Phantom-pass prevention (codex finding 1) is preserved differently:** a garbled lane is not counted as a pass (it abstains), and the quorum blocks certifying on too few real voices.

## Verification

- `tests/test_plan_gate_panel.py` reconciled to the new behavior + non-scoring/quorum cases added. 41 pass.
- kimi-gate on the diff: PASS (0 blocking).

## Open Items

None. Operator-approved (2026-06-24) as a robustness fix. Follow-ups (not blocking): coerce glm harder to the fence, or post-process its verdict from prose. Primary mitigation: keep plan docs tight (the final spec, not accumulated revision history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC