### PR TITLE
fix(tenant-stamp): dispatch-tier fail-closed resolver + ADR-007 amendment (PR-1)

### DIFF
--- a/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+++ b/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
@@ -111,6 +111,53 @@ applying the in-place rebuild against a live DB (quiesce, verified backup,
 preflight + dry-run, postflight `integrity_check`, restore-on-failure) is in
 `docs/MIGRATION_GUIDE.md` (PRD §7.2, human-gated).
 
+## Amendment 2026-06-24 — QI-write-tier fail-closed (operator-signed)
+
+The original **Decision** (§Decision), **Column rule** (Decision rule 1), and
+**Rejected sentinel** consequence stated that every tenant-scoped table
+*declares* `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` and that new code
+*SHOULD NOT* rely on the default. Field experience (the `mission-control`
+re-stamp contamination, [[mc-autonomous-release-and-store-tenant-contamination]])
+showed *SHOULD NOT* is too weak for the live QI write path: a writer that
+silently degrades to `vnx-dev` on an unresolved tenant re-contaminates a
+non-vnx-dev store on every write. This amendment **supersedes** those clauses
+for the **QI-write-tier** (`dispatch_metadata`, `adrs`):
+
+1. **Fresh schema carries NO default.** `schemas/quality_intelligence.sql`
+   declares `project_id TEXT NOT NULL` (no `DEFAULT 'vnx-dev'`) for
+   `dispatch_metadata` and `adrs`. A conformance test asserts absence via
+   `PRAGMA table_info` on a store built through the production init entrypoint.
+
+2. **Writers MUST resolve fail-closed.** Every QI-write-tier writer resolves the
+   tenant via `project_scope.resolve_stamp_project_id` (store-derived from the
+   DB path; env only when no db_path). An unresolvable tenant (no source /
+   source conflict / invalid id) raises `TenantUnresolved`; the writer logs at
+   ERROR (`tenant_stamp_skip` + `skip_metrics.ndjson`) and **skips** the write
+   rather than stamping a guessed default. This reverses the prior #907 fail-open
+   resolver semantics on purpose — completing the arc #859 began on the runtime
+   tier ("never a silent `vnx-dev` default").
+
+3. **Legacy column-add migrations may keep an inert transient default.** A
+   `ALTER TABLE … ADD COLUMN project_id … NOT NULL` requires a literal default
+   under SQLite (`quality_db_init.py:783`); that default is inert because (a) it
+   only runs on legacy stores via the column-absent guard, and (b) the bootstrap
+   self-heal (`run_qi_three_phase_migration`, Phase 3, dynamic
+   `enumerate_project_id_tables`) re-stamps and drops the default for any
+   non-vnx-dev store.
+
+4. **NDJSON cost log stays best-effort.** `provider_costs.emit_provider_cost` is
+   an append-only receipt log, not a central-DB table, so the DEFAULT-ban does
+   not bind it; it must never skip an event (cost-audit = no data-loss) and
+   stamps a store-derived pid best-effort.
+
+5. **Acknowledged temporary exceptions:** the self-learning/intelligence-tier
+   writers (`success_patterns`, `intelligence_injections`; PR-2,
+   `pre10-tenant-intel-tier`) and the runtime-coordination tier keep the legacy
+   default until their own follow-up migrations.
+
+Composite-key rule (Decision rule 2) is unchanged and verified present:
+`dispatch_metadata UNIQUE(project_id, dispatch_id)`, `adrs PK(adr_id, project_id)`.
+
 ## Cross-references
 
 - ADR-009 — Schema-first migrations via PRAGMA introspection (the implementation discipline that keeps this ADR enforceable across future migrations)

--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -517,7 +517,7 @@ VALUES ('8.0.5-session-model', 'Add session_model column to session_analytics fo
 CREATE TABLE IF NOT EXISTS dispatch_metadata (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     dispatch_id TEXT NOT NULL,
-    project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+    project_id TEXT NOT NULL,  -- ADR-007 amendment 2026-06-24: NO default; writers fail-closed via resolve_stamp_project_id
     terminal TEXT NOT NULL,
     track TEXT NOT NULL,
     provider TEXT,
@@ -681,7 +681,7 @@ INSERT OR IGNORE INTO schema_meta(key, value) VALUES ('schema_version', '0');
 
 CREATE TABLE IF NOT EXISTS adrs (
     adr_id              TEXT    NOT NULL,
-    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    project_id          TEXT    NOT NULL,  -- ADR-007 amendment 2026-06-24: NO default; index_adrs fail-closed
     status              TEXT    NOT NULL,
     title               TEXT    NOT NULL,
     decision_summary    TEXT    NOT NULL,

--- a/scripts/backfill_dispatch_metadata.py
+++ b/scripts/backfill_dispatch_metadata.py
@@ -46,9 +46,8 @@ if str(LIB_DIR) not in sys.path:
 
 try:
     from vnx_paths import ensure_env
-    from project_scope import current_project_id
 except Exception as exc:
-    raise SystemExit(f"backfill_dispatch_metadata: failed to load vnx_paths / project_scope: {exc}")
+    raise SystemExit(f"backfill_dispatch_metadata: failed to load vnx_paths: {exc}")
 
 # ---------------------------------------------------------------------------
 # Canonical status vocabulary (#837 — keep in sync with check_active_drain,
@@ -442,7 +441,14 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     receipts_file = Path(args.receipts_file) if args.receipts_file else state_dir / "t0_receipts.ndjson"
     db_path = Path(args.db_path) if args.db_path else state_dir / "quality_intelligence.db"
-    project_id = args.project_id or current_project_id()
+    # Fail-closed tenant resolve: explicit --project-id, else store-derived from
+    # db_path. Refuse to backfill under a guessed 'vnx-dev' on a non-vnx-dev store.
+    try:
+        from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+        project_id = resolve_stamp_project_id(explicit=args.project_id or None, db_path=db_path)
+    except TenantUnresolved as exc:
+        print(f"ERROR: tenant_stamp_skip backfill_dispatch_metadata db_path={db_path} reason={exc}", file=sys.stderr)
+        return 1
 
     if not receipts_file.exists():
         print(f"ERROR: receipts file not found: {receipts_file}", file=sys.stderr)

--- a/scripts/index_adrs.py
+++ b/scripts/index_adrs.py
@@ -27,10 +27,7 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
-_DEFAULT_PROJECT_ID = "vnx-dev"
-
-
-def _parse_adr(file_path: Path, project_id: str = _DEFAULT_PROJECT_ID) -> dict:
+def _parse_adr(file_path: Path, project_id: str) -> dict:
     stem = file_path.stem  # e.g. ADR-007-multitenant-project-id-stamping
     parts = stem.split("-")
     adr_id = f"{parts[0]}-{parts[1]}"  # ADR-007
@@ -178,7 +175,7 @@ def index_adrs(
     db_path: Path,
     adr_dir: Path,
     events_file: Path,
-    project_id: str = _DEFAULT_PROJECT_ID,
+    project_id: str,
 ) -> dict:
     """Index all ADR-*.md files from adr_dir into db_path.
 
@@ -229,7 +226,15 @@ def main() -> None:
     if not adr_dir.exists():
         raise SystemExit(f"ADR directory not found: {adr_dir}")
 
-    result = index_adrs(db_path, adr_dir, events_file)
+    # Fail-closed: stamp adrs with the store's owning tenant (derived from db_path),
+    # never a guessed 'vnx-dev' on a non-vnx-dev store.
+    from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+    try:
+        project_id = resolve_stamp_project_id(db_path=db_path)
+    except TenantUnresolved as exc:
+        raise SystemExit(f"index_adrs: tenant unresolved for {db_path} ({exc}); refusing to stamp adrs")
+
+    result = index_adrs(db_path, adr_dir, events_file, project_id=project_id)
     print(
         f"ADR indexing complete: {result['indexed']} indexed, "
         f"{result['skipped']} skipped, {result['total']} total"

--- a/scripts/intelligence_backfill.py
+++ b/scripts/intelligence_backfill.py
@@ -135,6 +135,22 @@ def backfill_dispatch_metadata() -> int:
     if not PROCESSED_DIR.exists() or not DB_PATH.exists():
         return 0
 
+    # Fail-closed tenant resolve (ADR-007 amendment clause 2: QI-write-tier
+    # writers MUST use resolve_stamp_project_id, never a silent 'vnx-dev'
+    # fallback). Refuse the whole backfill if the owning tenant is unresolvable
+    # rather than stamp a contaminating default. Stamped on every INSERT (the
+    # column is NOT NULL with no default) and used to project-scope the UPDATE.
+    from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+    try:
+        project_id = resolve_stamp_project_id(db_path=DB_PATH)
+    except TenantUnresolved as exc:
+        print(
+            f"ERROR: tenant_stamp_skip intelligence_backfill db_path={DB_PATH} "
+            f"reason={exc} — refusing to backfill under a guessed default",
+            file=sys.stderr,
+        )
+        return 0
+
     conn = sqlite3.connect(str(DB_PATH))
     now = datetime.now(timezone.utc).isoformat()
     inserted = 0
@@ -172,17 +188,18 @@ def backfill_dispatch_metadata() -> int:
                 if outcome:
                     conn.execute(
                         "UPDATE dispatch_metadata SET outcome_status = COALESCE(outcome_status, ?), "
-                        "completed_at = COALESCE(completed_at, ?) WHERE dispatch_id = ?",
-                        (outcome, timestamp, dispatch_id),
+                        "completed_at = COALESCE(completed_at, ?) "
+                        "WHERE dispatch_id = ? AND project_id = ?",
+                        (outcome, timestamp, dispatch_id, project_id),
                     )
                 continue
 
             conn.execute(
                 "INSERT INTO dispatch_metadata "
-                "(dispatch_id, terminal, track, gate, dispatched_at, completed_at, outcome_status) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "(dispatch_id, terminal, track, gate, dispatched_at, completed_at, outcome_status, project_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (dispatch_id, terminal, track, gate, timestamp,
-                 timestamp if outcome else None, outcome),
+                 timestamp if outcome else None, outcome, project_id),
             )
             inserted += 1
 

--- a/scripts/lib/codex_wrapper.py
+++ b/scripts/lib/codex_wrapper.py
@@ -11,7 +11,6 @@ No Anthropic SDK, no LiteLLM, no direct API calls.
 from __future__ import annotations
 
 import logging
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -70,7 +69,6 @@ def codex_exec(
     """
     from provider_costs import emit_provider_cost, _compute_cost_from_rates  # noqa: PLC0415
 
-    effective_project_id = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
     cmd = ["codex", "exec", "--json", "--model", model]
 
     try:
@@ -106,7 +104,7 @@ def codex_exec(
         output_tokens=output_tokens,
         cost_usd_estimate=cost_usd,
         dispatch_id=dispatch_id,
-        project_id=effective_project_id,
+        project_id=project_id,  # forward caller pid; emit resolves env fallback (best-effort)
         metadata={"billing_mode": "subscription"} if is_flat else None,
     )
 

--- a/scripts/lib/dispatch_metadata_db.py
+++ b/scripts/lib/dispatch_metadata_db.py
@@ -51,38 +51,55 @@ def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
 
 
 def _resolve_project_id(explicit: Optional[str], db_path: Optional[Path] = None) -> str:
-    """Resolve the project_id to stamp on a dispatch_metadata row.
+    """Resolve the project_id to stamp on a ``dispatch_metadata`` row — fail-closed.
 
-    Order: explicit arg → ambient project_scope → the OWNING store (derived from
-    ``db_path``) → VNX_PROJECT_ID env → 'vnx-dev'.
+    Delegates to :func:`project_scope.resolve_stamp_project_id`, the single
+    store-derived resolver: the OWNING store (derived from ``db_path``'s
+    ``~/.vnx-data/<pid>/state/`` layout) is authoritative, so a write to a
+    non-vnx-dev store (e.g. mission-control) stamps THAT tenant — never the bare
+    ``vnx-dev`` literal.
 
-    The store-derived step (``resolve_init_project_id``) is the tenant-correctness
-    fix: it anchors on the DB file's ``~/.vnx-data/<pid>/state/`` path layout, so a
-    write to a non-vnx-dev store (e.g. mission-control) stamps THAT tenant instead
-    of the bare literal 'vnx-dev'. A genuine source-conflict (path vs marker vs env
-    disagree) is logged and degrades to the env default rather than crashing the
-    write — never silently mis-stamps without a trace.
+    Raises :class:`project_scope.TenantUnresolved` when no tenant can be
+    resolved (no source / source conflict / invalid id). This REVERSES the prior
+    #907 fail-open semantics (degrade-to-env / keep-vnx-dev) on purpose: the
+    QI-write-tier is fail-closed per the ADR-007 amendment (2026-06-24). The sole
+    caller, :func:`upsert_dispatch_provider_row`, catches it and skips the write.
     """
-    if explicit:
-        return explicit
+    from project_scope import resolve_stamp_project_id  # noqa: PLC0415
+    return resolve_stamp_project_id(explicit, db_path)
+
+
+def _log_tenant_stamp_skip(
+    db_path: Path, dispatch_id: str, terminal: str, exc: Exception
+) -> None:
+    """Record a fail-closed dispatch_metadata skip — observable, not silent.
+
+    Logs at ERROR with the diagnostic fields and bumps a counter event in
+    ``<db_dir>/skip_metrics.ndjson``. The metric path anchors on the DB file's
+    own directory (NOT ``~/.vnx-data/<pid>/state``) precisely because the pid is
+    what failed to resolve — the db dir always exists and needs no tenant.
+    """
+    logger.error(
+        "tenant_stamp_skip: refused dispatch_metadata write (fail-closed) — "
+        "db_path=%s dispatch_id=%s terminal=%s conflicting_sources=%s",
+        db_path, dispatch_id, terminal or "?", exc,
+    )
     try:
-        from project_scope import current_project_id  # noqa: PLC0415
-        pid = current_project_id()
-        if pid:
-            return pid
-    except Exception:  # noqa: BLE001 — project_scope is optional in some contexts
-        logger.debug("project_scope unavailable; trying store-derived project_id", exc_info=True)
-    if db_path is not None:
-        try:
-            from project_id_migration import resolve_init_project_id  # noqa: PLC0415
-            return resolve_init_project_id(Path(db_path))
-        except RuntimeError as exc:
-            # Conflicting tenant sources — surface it; do not crash the write.
-            logger.warning("dispatch_metadata project_id resolution conflict for %s: %s", db_path, exc)
-        except Exception:  # noqa: BLE001 — resolver optional; fall through to env default
-            logger.debug("store-derived project_id unavailable; falling back to env", exc_info=True)
-    import os  # noqa: PLC0415
-    return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+        from state_writer import append_locked  # noqa: PLC0415
+        append_locked(
+            Path(db_path).parent / "skip_metrics.ndjson",
+            {
+                "event_type": "tenant_stamp_skip",
+                "table": "dispatch_metadata",
+                "db_path": str(db_path),
+                "dispatch_id": dispatch_id,
+                "terminal": terminal or None,
+                "reason": str(exc),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception:  # noqa: BLE001 — the metric is best-effort; the ERROR log is the contract
+        logger.debug("skip_metrics append failed (non-fatal)", exc_info=True)
 
 
 def upsert_dispatch_provider_row(
@@ -129,7 +146,6 @@ def upsert_dispatch_provider_row(
 
     now_iso = datetime.now(timezone.utc).isoformat()
     completed_at = now_iso if outcome_status else None
-    resolved_project_id = _resolve_project_id(project_id, db_path)
 
     conn = None
     try:
@@ -140,6 +156,18 @@ def upsert_dispatch_provider_row(
         has_report_path = _has_column(conn, "dispatch_metadata", "outcome_report_path")
         has_outcome = _has_column(conn, "dispatch_metadata", "outcome_status")
         has_completed = _has_column(conn, "dispatch_metadata", "completed_at")
+
+        # Tenant-stamp only when the column exists (old column-less stores are
+        # left untouched). Fail-closed: an unresolvable tenant logs + skips the
+        # write rather than stamping a contaminating 'vnx-dev' default.
+        resolved_project_id = None
+        if has_project:
+            from project_scope import TenantUnresolved  # noqa: PLC0415
+            try:
+                resolved_project_id = _resolve_project_id(project_id, db_path)
+            except TenantUnresolved as exc:
+                _log_tenant_stamp_skip(db_path, dispatch_id, terminal, exc)
+                return False
 
         # --- create-if-absent (never clobber a richer dispatcher-written row) ---
         insert_cols = ["dispatch_id", "terminal", "track", "role", "gate", "pr_id", "dispatched_at"]

--- a/scripts/lib/gemini_wrapper.py
+++ b/scripts/lib/gemini_wrapper.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -84,7 +83,6 @@ def gemini_exec(
     """
     from provider_costs import emit_provider_cost, _compute_cost_from_rates  # noqa: PLC0415
 
-    effective_project_id = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
     cmd = ["gemini", "--model", model, "--output-format", "stream-json"]
 
     try:
@@ -120,7 +118,7 @@ def gemini_exec(
         output_tokens=output_tokens,
         cost_usd_estimate=cost_usd,
         dispatch_id=dispatch_id,
-        project_id=effective_project_id,
+        project_id=project_id,  # forward caller pid; emit resolves env fallback (best-effort)
         metadata={"billing_mode": "subscription"} if is_flat else None,
     )
 

--- a/scripts/lib/kimi_wrapper.py
+++ b/scripts/lib/kimi_wrapper.py
@@ -87,7 +87,6 @@ def kimi_exec(
     """
     from provider_costs import emit_provider_cost  # noqa: PLC0415
 
-    effective_project_id = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
     cmd = ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p", prompt]
     if model and model != DEFAULT_KIMI_MODEL:
         cmd.extend(["-m", model])
@@ -131,7 +130,7 @@ def kimi_exec(
         output_tokens=output_tokens,
         cost_usd_estimate=None,
         dispatch_id=dispatch_id,
-        project_id=effective_project_id,
+        project_id=project_id,  # forward caller pid; emit resolves env fallback (best-effort)
         metadata={"billing_mode": "subscription"},
     )
 

--- a/scripts/lib/project_id_migration.py
+++ b/scripts/lib/project_id_migration.py
@@ -93,7 +93,7 @@ def _read_marker_from_path(db_path: Path) -> Optional[str]:
     return None
 
 
-def resolve_init_project_id(db_path: Path) -> str:
+def resolve_init_project_id(db_path: Path, strict: bool = False) -> str:
     """Resolve the owning project_id for an init-time ADD COLUMN backfill.
 
     Anchor: the resolved DB file path (not cwd).  Resolution order:
@@ -104,12 +104,17 @@ def resolve_init_project_id(db_path: Path) -> str:
     All present sources must agree — any conflict raises RuntimeError
     (fail-closed: the real contamination guard).
 
-    No sources at all → defaults to 'vnx-dev' with a logging.warning.
-    Rationale: real non-vnx-dev central stores always carry their pid in
-    the path (source 1) so they never reach this default.  Only contextless
-    callers (tests, fresh default installs) reach it, and 'vnx-dev' is the
-    correct legacy default for those.  This restores backward-compat without
-    reintroducing contamination.
+    ``strict`` (default ``False``): when no source resolves, the legacy
+    behavior returns ``'vnx-dev'`` with a warning (backward-compat for
+    init-backfill callers). When ``strict=True`` — the QI-write-tier stamp
+    path (:func:`project_scope.resolve_stamp_project_id`) — a total absence
+    raises :class:`project_scope.TenantUnresolved` instead, so the caller
+    refuses to stamp a guessed default. Source conflicts and invalid ids
+    raise ``RuntimeError`` regardless of ``strict`` (the stamp resolver casts
+    those to ``TenantUnresolved``).
+
+    Rationale (non-strict default): real non-vnx-dev central stores always
+    carry their pid in the path (source 1) so they never reach the default.
 
     ADR-007 compliance: callers may invoke this and pass the returned value
     as ``default_project_id`` to ``run_runtime_coordination_migration`` /
@@ -135,6 +140,14 @@ def resolve_init_project_id(db_path: Path) -> str:
             "All sources must agree. Resolve the conflict before running init."
         )
     if not distinct:
+        if strict:
+            # QI-write-tier stamp path: refuse to guess a default — fail-closed.
+            from project_scope import TenantUnresolved  # noqa: PLC0415 — function-local: avoids a project_scope↔project_id_migration import cycle
+            raise TenantUnresolved(
+                "resolve_init_project_id(strict=True): no project_id source for "
+                f"db_path {db_path!r} (no .vnx-data path layout, no .vnx-project-id "
+                "marker, VNX_PROJECT_ID unset). Refusing to stamp a guessed default."
+            )
         log.warning(
             "resolve_init_project_id: no project_id source found (no .vnx-data path "
             "layout, no .vnx-project-id marker walking up from '%s', VNX_PROJECT_ID "

--- a/scripts/lib/project_scope.py
+++ b/scripts/lib/project_scope.py
@@ -67,6 +67,73 @@ def current_project_id() -> str:
     return _validate(raw)
 
 
+class TenantUnresolved(RuntimeError):
+    """No authoritative project_id could be resolved for a write that MUST be
+    tenant-stamped.
+
+    Fail-closed contract (ADR-007 amendment 2026-06-24, QI-write-tier): callers
+    in the DB-table write regime (``dispatch_metadata``, ``adrs``) catch this,
+    log at ERROR + skip the write — they never stamp a contaminating ``vnx-dev``
+    default onto a non-vnx-dev store. Unlike :func:`current_project_id`, which
+    degrades to ``'vnx-dev'`` on an unset env, this path refuses to guess.
+    """
+
+
+def resolve_stamp_project_id(
+    explicit: str | None = None, db_path: "str | Path | None" = None
+) -> str:
+    """Resolve the project_id to STAMP on a tenant-scoped DB-table write, fail-closed.
+
+    NEVER silently defaults to ``vnx-dev``: an unresolvable tenant raises
+    :class:`TenantUnresolved` so the caller can refuse the contaminating write.
+
+    Precedence:
+      (a) ``explicit`` (non-empty, valid) → use it.
+      (b) ``db_path`` given → :func:`project_id_migration.resolve_init_project_id`
+          with ``strict=True`` is TERMINAL. That resolver weighs
+          {db-path layout, ``.vnx-project-id`` marker, ``VNX_PROJECT_ID`` env}
+          as co-sources that must AGREE — a lone env source IS the value (not a
+          conflict); a source mismatch or (under strict) a total absence raises.
+          A ``RuntimeError`` (source conflict / invalid id) is CAST to
+          ``TenantUnresolved``. No separate env step runs after ``db_path``.
+      (c) no ``db_path`` → ``VNX_PROJECT_ID`` env (non-empty, valid) → use it.
+      (d) otherwise → ``raise TenantUnresolved``.
+
+    ``Path.resolve()`` inside the resolver may raise ``OSError`` on a
+    non-existent parent; that is caught and converted to ``TenantUnresolved``
+    so an IO error never leaks to the fail-closed caller.
+    """
+    if explicit:
+        try:
+            return _validate(explicit)
+        except ValueError as exc:
+            raise TenantUnresolved(f"explicit project_id invalid: {exc}") from exc
+
+    if db_path is not None:
+        try:
+            from project_id_migration import resolve_init_project_id  # noqa: PLC0415
+            return resolve_init_project_id(Path(db_path), strict=True)
+        except TenantUnresolved:
+            raise  # already the fail-closed type — do not double-wrap
+        except (RuntimeError, OSError) as exc:
+            # RuntimeError: source conflict or invalid resolved id.
+            # OSError: Path.resolve() on a non-existent parent.
+            raise TenantUnresolved(
+                f"tenant unresolved for db_path {db_path!r}: {exc}"
+            ) from exc
+
+    raw = os.environ.get(ENV_VAR)
+    if raw:
+        try:
+            return _validate(raw)
+        except ValueError as exc:
+            raise TenantUnresolved(f"VNX_PROJECT_ID invalid: {exc}") from exc
+
+    raise TenantUnresolved(
+        "no project_id source: no explicit arg, no db_path, and VNX_PROJECT_ID unset"
+    )
+
+
 def project_filter_enabled() -> bool:
     """Return True when per-project filtering should be applied to reads.
 

--- a/scripts/lib/provider_costs.py
+++ b/scripts/lib/provider_costs.py
@@ -157,7 +157,7 @@ def emit_provider_cost(
     output_tokens: int | None,
     cost_usd_estimate: float | None,
     dispatch_id: str | None = None,
-    project_id: str = "vnx-dev",
+    project_id: str = "",
     metadata: dict | None = None,
 ) -> None:
     """Append a provider cost NDJSON event to .vnx-data/events/provider_costs.ndjson.
@@ -166,6 +166,14 @@ def emit_provider_cost(
     ADR-007: project_id stamped on every event.
 
     Raises OSError/IOError on write failure — no silent except.
+
+    Tenant resolution (best-effort, NOT fail-closed): the cost log is an
+    append-only NDJSON receipt, not a central-DB table, so the ADR-007
+    DEFAULT-ban does not bind it and it must NEVER skip an event (cost-audit =
+    no data-loss). Callers that hold a store ``db_path`` (provider_dispatch,
+    recovery) pass a store-derived pid explicitly; absent that, this falls back
+    to the env (then ``vnx-dev``). The ``if not project_id`` trigger treats
+    ``None`` and ``""`` identically.
     """
     effective_project_id = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
     timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -413,7 +413,8 @@ def _record_provider_metadata(
             pr_id=getattr(args, "pr_id", None),
             outcome_status=status,
             report_path=str(report_path),
-            project_id=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+            # No project_id kwarg: upsert resolves it store-derived from db_path
+            # (fail-closed). Passing the env-literal here would short-circuit that.
         )
     except Exception as exc:  # noqa: BLE001 — metadata logging is non-fatal
         logger.warning(
@@ -504,6 +505,15 @@ def _emit_governance(
 
     # ADR-005: emit cost event BEFORE receipt/report writes. Raises on failure — fail-loud.
     from provider_costs import emit_provider_cost  # noqa: PLC0415
+    # Best-effort store-derived pid (NDJSON cost log is outside the fail-closed
+    # regime — it must never skip): resolve from the store db_path; on an
+    # unresolved tenant, log and let emit fall back to env (no data-loss).
+    _cost_pid = ""
+    try:
+        from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+        _cost_pid = resolve_stamp_project_id(db_path=Path(state_dir) / "quality_intelligence.db")
+    except TenantUnresolved as _pid_exc:
+        logger.warning("cost-event project_id unresolved from store; emit falls back to env: %s", _pid_exc)
     emit_provider_cost(
         provider=provider,
         model=model_used,
@@ -511,7 +521,7 @@ def _emit_governance(
         output_tokens=token_usage.get("output") if token_usage else None,
         cost_usd_estimate=cost_usd,
         dispatch_id=args.dispatch_id,
-        project_id=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+        project_id=_cost_pid,
     )
 
     # Provider-aware self-learning: stamp a dispatch_metadata row so EVERY governed
@@ -1793,7 +1803,7 @@ def _dispatch_local_gemma(args: argparse.Namespace) -> int:
         role=getattr(args, "role", None),
         deadline_seconds=300,
         dispatch_id=args.dispatch_id,
-        project_id=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+        # project_id dropped: spawn_local_gemma does not consume it (inert kwarg).
     )
     end_time = datetime.now(timezone.utc)
 

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -163,7 +163,16 @@ def _handle_success(
 
     # ADR-005: emit cost event BEFORE receipt write. Raises on failure — fail-loud.
     from provider_costs import emit_provider_cost  # noqa: PLC0415
-    import os as _os  # noqa: PLC0415
+    # Best-effort store-derived pid (NDJSON cost log never skips); on an
+    # unresolved tenant, fall back to emit's env default — no data-loss.
+    _cost_pid = ""
+    try:
+        from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+        _cost_pid = resolve_stamp_project_id(
+            db_path=_sd._default_state_dir() / "quality_intelligence.db"
+        )
+    except TenantUnresolved:
+        pass  # emit falls back to env; cost-audit must not lose the event
     emit_provider_cost(
         provider="claude",
         model=model or "sonnet",
@@ -171,7 +180,7 @@ def _handle_success(
         output_tokens=token_usage.get("output") if token_usage else None,
         cost_usd_estimate=cost_usd,
         dispatch_id=dispatch_id,
-        project_id=_os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+        project_id=_cost_pid,
     )
 
     _sd._ensure_unified_report(dispatch_id, terminal_id, "done")

--- a/scripts/log_dispatch_metadata.py
+++ b/scripts/log_dispatch_metadata.py
@@ -16,7 +16,6 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 try:
     from vnx_paths import ensure_env
-    from project_scope import current_project_id
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
@@ -76,7 +75,25 @@ def main():
     # INSERT OR IGNORE: only inserts when the row is new so existing provider/model
     # values are never deleted by a REPLACE. dispatched_at is set on first insert only.
     # A follow-up UPDATE keeps all other dispatch fields current on re-calls.
-    project_id_val = current_project_id()
+    #
+    # Tenant-stamp fail-closed (this tmux-lane is the live MC contamination source):
+    # resolve the owning tenant store-derived from DB_PATH; if unresolvable, log +
+    # skip rather than stamp a contaminating 'vnx-dev' default. Only the
+    # project_id-column path needs it (old column-less stores skip stamping).
+    has_project = _has_column(conn, "dispatch_metadata", "project_id")
+    project_id_val = None
+    if has_project:
+        try:
+            from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+            project_id_val = resolve_stamp_project_id(db_path=DB_PATH)
+        except TenantUnresolved as exc:
+            print(
+                "ERROR: tenant_stamp_skip log_dispatch_metadata "
+                f"db_path={DB_PATH} dispatch_id={args.dispatch_id} "
+                f"terminal={args.terminal} reason={exc}",
+                file=sys.stderr,
+            )
+            return 1
     now_iso = datetime.utcnow().isoformat()
     _dispatch_vals = (
         args.role or None,
@@ -93,7 +110,7 @@ def main():
         args.target_open_items,
     )
 
-    if _has_column(conn, "dispatch_metadata", "project_id"):
+    if has_project:
         cur.execute("""
             INSERT OR IGNORE INTO dispatch_metadata (
                 dispatch_id, terminal, track, role, skill_name, gate,
@@ -144,7 +161,7 @@ def main():
     # land via migration v21/v23 (GAP 2); older DBs simply skip them. COALESCE keeps
     # any real value already stamped by provider_dispatch; only fills NULL.
     # ADR-007: scope by project_id when present to prevent cross-tenant overwrite.
-    has_project = _has_column(conn, "dispatch_metadata", "project_id")
+    # (has_project already resolved above for the fail-closed tenant stamp.)
     if args.provider and _has_column(conn, "dispatch_metadata", "provider"):
         if has_project:
             cur.execute(

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -514,7 +514,7 @@ def _migrate_v19(conn: sqlite3.Connection) -> None:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS adrs (
                 adr_id              TEXT    NOT NULL,
-                project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+                project_id          TEXT    NOT NULL,  -- ADR-007 amendment 2026-06-24: NO default (CREATE, not ALTER); index_adrs fail-closed always stamps project_id
                 status              TEXT    NOT NULL,
                 title               TEXT    NOT NULL,
                 decision_summary    TEXT    NOT NULL,

--- a/tests/test_codex_wrapper.py
+++ b/tests/test_codex_wrapper.py
@@ -81,13 +81,15 @@ class TestCodexExec:
         assert result == expected_stdout
 
     def test_emit_called_with_correct_provider(self, monkeypatch):
-        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
-
+        # Post-2026-06-24: the wrapper forwards the caller's project_id verbatim;
+        # the env fallback now lives in emit_provider_cost (best-effort), not here.
         with patch("codex_wrapper.subprocess.run", return_value=_make_run_result(stdout=_CODEX_NDJSON_NO_TOKENS)), \
              patch("provider_costs.emit_provider_cost") as mock_emit, \
              patch("provider_costs._compute_cost_from_rates", return_value=(0.001, False)):
 
-            codex_wrapper.codex_exec("test prompt", model="gpt-5.5", dispatch_id="d-003")
+            codex_wrapper.codex_exec(
+                "test prompt", model="gpt-5.5", dispatch_id="d-003", project_id="test-proj"
+            )
 
         mock_emit.assert_called_once()
         call_kwargs = mock_emit.call_args.kwargs

--- a/tests/test_dispatch_metadata_provider_migration.py
+++ b/tests/test_dispatch_metadata_provider_migration.py
@@ -435,6 +435,9 @@ def test_log_dispatch_metadata_no_clobber_existing_provider_model():
         env = os.environ.copy()
         env["VNX_STATE_DIR"] = str(db_path.parent)
         env["VNX_DATA_DIR"] = tmpdir
+        # tmp store has no .vnx-data/<pid>/state path layout; give the fail-closed
+        # tenant resolver an explicit source so log_dispatch_metadata can stamp.
+        env["VNX_PROJECT_ID"] = "vnx-dev"
 
         # Invoke log_dispatch_metadata WITHOUT --provider / --model (defaults to empty).
         result = subprocess.run(

--- a/tests/test_dispatch_metadata_resolver.py
+++ b/tests/test_dispatch_metadata_resolver.py
@@ -3,8 +3,15 @@
 dispatch_metadata_db._resolve_project_id used to fall back to a bare literal
 'vnx-dev', so a dispatch write to a non-vnx-dev store (e.g. mission-control)
 re-stamped the WRONG tenant on every write (the live re-contamination source
-behind the QI tenant-stamping bug). It now derives the owning tenant from the
-store's own DB-path layout (resolve_init_project_id), fail-closed.
+behind the QI tenant-stamping bug).
+
+As of the 2026-06-24 ADR-007 amendment it delegates to
+``project_scope.resolve_stamp_project_id`` and is FAIL-CLOSED: it derives the
+owning tenant from the store's own DB-path layout and RAISES
+``TenantUnresolved`` when no tenant can be resolved (no source / source
+conflict / invalid id) — reversing the prior #907 fail-OPEN (degrade-to-env)
+semantics on purpose. The sole caller (``upsert_dispatch_provider_row``)
+catches it and skips the write rather than stamping a guessed default.
 """
 
 from __future__ import annotations
@@ -12,11 +19,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
 if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
 
 import dispatch_metadata_db as dmd  # noqa: E402
+import project_scope  # noqa: E402 — reference TenantUnresolved via the module (survives importlib.reload in test_project_scope_filesystem)
 
 
 def _store_db(tmp_path: Path, pid: str) -> Path:
@@ -32,34 +42,30 @@ def test_explicit_wins(tmp_path):
 
 def test_store_path_resolves_owning_tenant_not_vnx_dev(tmp_path, monkeypatch):
     # The core fix: a write to mission-control's store stamps mission-control,
-    # NOT the literal 'vnx-dev'. Clear ambient sources so only the path speaks.
+    # NOT the literal 'vnx-dev'. Clear ambient env so only the path speaks.
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
-    # project_scope must not short-circuit: force it unavailable.
-    monkeypatch.setitem(sys.modules, "project_scope", None)
     db = _store_db(tmp_path, "mission-control")
     assert dmd._resolve_project_id(None, db) == "mission-control"
 
 
 def test_vnx_dev_store_still_resolves_vnx_dev(tmp_path, monkeypatch):
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
-    monkeypatch.setitem(sys.modules, "project_scope", None)
     db = _store_db(tmp_path, "vnx-dev")
     assert dmd._resolve_project_id(None, db) == "vnx-dev"
 
 
-def test_source_conflict_does_not_crash_and_falls_back(tmp_path, monkeypatch):
-    # Path says mission-control, env says something else → resolve_init_project_id
-    # raises (fail-closed contamination guard). The write path must NOT crash; it
-    # logs and degrades to the env default.
+def test_source_conflict_raises_tenant_unresolved(tmp_path, monkeypatch):
+    # Path says mission-control, env disagrees → fail-CLOSED: raise (the cast
+    # of resolve_init_project_id's RuntimeError to TenantUnresolved). The caller
+    # skips the write; it must NOT silently degrade to the wrong env tenant.
     monkeypatch.setenv("VNX_PROJECT_ID", "conflicting-proj")
-    monkeypatch.setitem(sys.modules, "project_scope", None)
     db = _store_db(tmp_path, "mission-control")
-    result = dmd._resolve_project_id(None, db)
-    assert result == "conflicting-proj"  # degraded to env, no exception
+    with pytest.raises(project_scope.TenantUnresolved):
+        dmd._resolve_project_id(None, db)
 
 
-def test_contextless_keeps_vnx_dev_default(tmp_path, monkeypatch):
+def test_contextless_raises_tenant_unresolved(tmp_path, monkeypatch):
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
-    monkeypatch.setitem(sys.modules, "project_scope", None)
-    # No db_path, no env, no project_scope → backward-compat 'vnx-dev'.
-    assert dmd._resolve_project_id(None, None) == "vnx-dev"
+    # No db_path, no env → fail-CLOSED: raise rather than stamp a guessed 'vnx-dev'.
+    with pytest.raises(project_scope.TenantUnresolved):
+        dmd._resolve_project_id(None, None)

--- a/tests/test_gemini_wrapper.py
+++ b/tests/test_gemini_wrapper.py
@@ -80,13 +80,15 @@ class TestGeminiExec:
         assert result == expected
 
     def test_emit_called_with_correct_provider(self, monkeypatch):
-        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
-
+        # Post-2026-06-24: the wrapper forwards the caller's project_id verbatim;
+        # the env fallback now lives in emit_provider_cost (best-effort), not here.
         with patch("gemini_wrapper.subprocess.run", return_value=_make_run_result()), \
              patch("provider_costs.emit_provider_cost") as mock_emit, \
              patch("provider_costs._compute_cost_from_rates", return_value=(0.002, False)):
 
-            gemini_wrapper.gemini_exec("prompt", model="gemini-2.5-pro", dispatch_id="d-g003")
+            gemini_wrapper.gemini_exec(
+                "prompt", model="gemini-2.5-pro", dispatch_id="d-g003", project_id="test-proj"
+            )
 
         mock_emit.assert_called_once()
         kwargs = mock_emit.call_args.kwargs
@@ -94,6 +96,19 @@ class TestGeminiExec:
         assert kwargs["model"] == "gemini-2.5-pro"
         assert kwargs["dispatch_id"] == "d-g003"
         assert kwargs["project_id"] == "test-proj"
+
+    def test_forwards_none_project_id_when_caller_omits_it(self, monkeypatch):
+        # No project_id passed → wrapper forwards None; emit applies its own env
+        # fallback (the cost log is best-effort, never skips). The wrapper itself
+        # no longer resolves env.
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        with patch("gemini_wrapper.subprocess.run", return_value=_make_run_result()), \
+             patch("provider_costs.emit_provider_cost") as mock_emit, \
+             patch("provider_costs._compute_cost_from_rates", return_value=(0.002, False)):
+
+            gemini_wrapper.gemini_exec("prompt", model="gemini-2.5-pro", dispatch_id="d-g004")
+
+        assert mock_emit.call_args.kwargs["project_id"] is None
 
     def test_emit_cost_reflects_computed_value(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")

--- a/tests/test_index_adrs.py
+++ b/tests/test_index_adrs.py
@@ -77,27 +77,27 @@ def _write_adr(tmp_path: Path, filename: str, content: str) -> Path:
 class TestAdrParser:
     def test_adr_id_extracted(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         assert adr["adr_id"] == "ADR-007"
 
     def test_status_extracted(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         assert adr["status"] == "Accepted"
 
     def test_title_extracted(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         assert "Multi-tenant" in adr["title"]
 
     def test_decision_summary_populated(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         assert "project_id" in adr["decision_summary"]
 
     def test_binding_rules_json_list(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         rules = json.loads(adr["binding_rules"])
         assert isinstance(rules, list)
         assert len(rules) >= 1
@@ -105,7 +105,7 @@ class TestAdrParser:
 
     def test_source_hash_16_chars(self, tmp_path):
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
-        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md")
+        adr = _parse_adr(adr_dir / "ADR-007-multitenant.md", project_id="test-proj")
         assert len(adr["source_hash"]) == 16
 
     def test_project_id_stamped(self, tmp_path):
@@ -120,7 +120,7 @@ class TestIndexAdrs:
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
         events_file = tmp_path / "events" / "adr_index.ndjson"
 
-        result = index_adrs(db_path, adr_dir, events_file)
+        result = index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
         assert result["indexed"] == 1
         assert result["total"] == 1
 
@@ -134,8 +134,8 @@ class TestIndexAdrs:
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
         events_file = tmp_path / "events" / "adr_index.ndjson"
 
-        index_adrs(db_path, adr_dir, events_file)
-        result2 = index_adrs(db_path, adr_dir, events_file)
+        index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
+        result2 = index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
         assert result2["indexed"] == 0
         assert result2["skipped"] == 1
 
@@ -144,7 +144,7 @@ class TestIndexAdrs:
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
         events_file = tmp_path / "events" / "adr_index.ndjson"
 
-        index_adrs(db_path, adr_dir, events_file)
+        index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
         assert events_file.exists()
         lines = [l for l in events_file.read_text().splitlines() if l.strip()]
         assert len(lines) >= 1
@@ -158,7 +158,7 @@ class TestIndexAdrs:
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
         events_file = tmp_path / "events" / "adr_index.ndjson"
 
-        index_adrs(db_path, adr_dir, events_file)
+        index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
         lines = [l for l in events_file.read_text().splitlines() if l.strip()]
         event = json.loads(lines[0])
         # record_id must be a 64-char hex sha256
@@ -171,19 +171,19 @@ class TestIndexAdrs:
 
         with mock.patch("builtins.open", side_effect=OSError("disk full")):
             with pytest.raises(OSError, match="disk full"):
-                index_adrs(db_path, adr_dir, events_file)
+                index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
 
     def test_changed_content_reindexed(self, tmp_path):
         db_path = _setup_db(tmp_path)
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
         events_file = tmp_path / "events" / "adr_index.ndjson"
 
-        index_adrs(db_path, adr_dir, events_file)
+        index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
 
         # Modify the ADR
         (adr_dir / "ADR-007-multitenant.md").write_text(
             _FIXTURE_ADR + "\n\n## Additional notes\n\nUpdated content.\n",
             encoding="utf-8",
         )
-        result2 = index_adrs(db_path, adr_dir, events_file)
+        result2 = index_adrs(db_path, adr_dir, events_file, project_id="test-proj")
         assert result2["indexed"] == 1

--- a/tests/test_intelligence_fixes.py
+++ b/tests/test_intelligence_fixes.py
@@ -103,8 +103,8 @@ class TestIntelligencePersist:
 
         conn = sqlite3.connect(str(db_path))
         conn.execute(
-            "INSERT INTO dispatch_metadata (dispatch_id, terminal, track) VALUES (?, ?, ?)",
-            ("d-003", "T1", "A"),
+            "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, project_id) VALUES (?, ?, ?, ?)",
+            ("d-003", "T1", "A", "vnx-dev"),
         )
         conn.commit()
         conn.close()

--- a/tests/test_provider_aware_intelligence.py
+++ b/tests/test_provider_aware_intelligence.py
@@ -38,7 +38,9 @@ from dispatch_metadata_db import upsert_dispatch_provider_row  # noqa: E402
 
 
 def _bootstrap_db(tmp_path: Path) -> Path:
-    db = tmp_path / "state" / "quality_intelligence.db"
+    # Canonical ~/.vnx-data/<pid>/state/ layout so the fail-closed tenant resolver
+    # derives the owning project_id from the path (no env/marker needed).
+    db = tmp_path / ".vnx-data" / "vnx-dev" / "state" / "quality_intelligence.db"
     db.parent.mkdir(parents=True, exist_ok=True)
     assert quality_db_init.bootstrap_qi_db(db, _REPO / "schemas" / "quality_intelligence.sql")
     return db
@@ -177,8 +179,8 @@ def test_upsert_does_not_clobber_existing_richer_row(tmp_path):
     db = _bootstrap_db(tmp_path)
     conn = sqlite3.connect(str(db))
     conn.execute(
-        "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, role, gate) "
-        "VALUES ('d-2', 'T1', 'A', 'frontend-architect', 'codex_gate')"
+        "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, role, gate, project_id) "
+        "VALUES ('d-2', 'T1', 'A', 'frontend-architect', 'codex_gate', 'vnx-dev')"
     )
     conn.commit(); conn.close()
     # Upsert with provider; role/gate already set must be preserved (COALESCE)

--- a/tests/test_resolve_stamp_project_id.py
+++ b/tests/test_resolve_stamp_project_id.py
@@ -1,0 +1,118 @@
+"""tests/test_resolve_stamp_project_id.py — fail-closed tenant stamp resolver.
+
+Covers ``project_scope.resolve_stamp_project_id`` and the ``strict`` mode added
+to ``project_id_migration.resolve_init_project_id`` (ADR-007 amendment
+2026-06-24, QI-write-tier fail-closed). The resolver NEVER silently defaults to
+``vnx-dev``: an unresolvable tenant raises ``TenantUnresolved`` so DB-table
+writers can refuse the contaminating write.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+# Reference project_scope members through the module object (NOT `from project_scope
+# import ...`) so we stay correct across importlib.reload(project_scope) done by
+# test_project_scope_filesystem: reload mutates the module in place, so
+# `project_scope.TenantUnresolved` is always the class the runtime currently raises.
+import project_scope  # noqa: E402
+import project_id_migration as pim  # noqa: E402
+
+
+def resolve_stamp_project_id(*a, **k):
+    return project_scope.resolve_stamp_project_id(*a, **k)
+
+
+def _store_db(tmp_path: Path, pid: str) -> Path:
+    """A DB path with the canonical ~/.vnx-data/<pid>/state/ layout."""
+    d = tmp_path / ".vnx-data" / pid / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "quality_intelligence.db"
+
+
+# --- resolve_stamp_project_id precedence ------------------------------------
+
+def test_explicit_wins(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_PROJECT_ID", "env-proj")
+    # explicit beats env AND a conflicting store path.
+    assert resolve_stamp_project_id("seocrawler-v2", _store_db(tmp_path, "mission-control")) == "seocrawler-v2"
+
+
+def test_db_path_resolves_owning_tenant(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    assert resolve_stamp_project_id(db_path=_store_db(tmp_path, "mission-control")) == "mission-control"
+
+
+def test_vnx_dev_store_resolves_vnx_dev(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    assert resolve_stamp_project_id(db_path=_store_db(tmp_path, "vnx-dev")) == "vnx-dev"
+
+
+def test_env_only_when_no_db_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_PROJECT_ID", "mission-control")
+    assert resolve_stamp_project_id() == "mission-control"
+
+
+def test_empty_env_is_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_PROJECT_ID", "")
+    with pytest.raises(project_scope.TenantUnresolved):
+        resolve_stamp_project_id()
+
+
+def test_no_source_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    with pytest.raises(project_scope.TenantUnresolved):
+        resolve_stamp_project_id()
+
+
+def test_invalid_explicit_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    with pytest.raises(project_scope.TenantUnresolved):
+        resolve_stamp_project_id("Bad_ID")
+
+
+def test_invalid_env_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_PROJECT_ID", "Bad_ID")
+    with pytest.raises(project_scope.TenantUnresolved):
+        resolve_stamp_project_id()
+
+
+def test_path_env_conflict_raises_cast(tmp_path, monkeypatch):
+    # db_path says mission-control, env says vnx-dev → resolve_init raises
+    # RuntimeError; resolve_stamp_project_id casts it to TenantUnresolved.
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    with pytest.raises(project_scope.TenantUnresolved):
+        resolve_stamp_project_id(db_path=_store_db(tmp_path, "mission-control"))
+
+
+def test_non_layout_db_path_with_env_resolves_env(tmp_path, monkeypatch):
+    # A db_path with NO .vnx-data/<pid>/state layout and NO marker: env is the
+    # lone co-source inside resolve_init → it IS the value (not a conflict).
+    monkeypatch.setenv("VNX_PROJECT_ID", "mission-control")
+    bare = tmp_path / "loose" / "quality_intelligence.db"
+    bare.parent.mkdir(parents=True, exist_ok=True)
+    assert resolve_stamp_project_id(db_path=bare) == "mission-control"
+
+
+# --- resolve_init_project_id strict mode ------------------------------------
+
+def test_strict_true_no_source_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    bare = tmp_path / "loose" / "quality_intelligence.db"
+    bare.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(project_scope.TenantUnresolved):
+        pim.resolve_init_project_id(bare, strict=True)
+
+
+def test_strict_false_no_source_keeps_vnx_dev(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    bare = tmp_path / "loose" / "quality_intelligence.db"
+    bare.parent.mkdir(parents=True, exist_ok=True)
+    assert pim.resolve_init_project_id(bare, strict=False) == "vnx-dev"

--- a/tests/test_schema_init_view_ordering.py
+++ b/tests/test_schema_init_view_ordering.py
@@ -424,8 +424,8 @@ class TestAlreadyCurrentDbBootstrap:
 
         conn = sqlite3.connect(str(db))
         conn.execute(
-            "INSERT INTO dispatch_metadata (dispatch_id, terminal, track) "
-            "VALUES ('idempotent-test-dispatch', 'T1', 'A')"
+            "INSERT INTO dispatch_metadata (dispatch_id, terminal, track, project_id) "
+            "VALUES ('idempotent-test-dispatch', 'T1', 'A', 'vnx-dev')"
         )
         conn.commit()
         conn.close()

--- a/tests/test_tenant_stamp_fail_closed.py
+++ b/tests/test_tenant_stamp_fail_closed.py
@@ -1,0 +1,114 @@
+"""tests/test_tenant_stamp_fail_closed.py — QI-write-tier fail-closed guarantees.
+
+Two contracts from the ADR-007 amendment (2026-06-24):
+
+1. Conformance (anti-revert): on a store built through the PRODUCTION init
+   entrypoint (``bootstrap_qi_db`` → full migration chain), ``dispatch_metadata``
+   and ``adrs`` carry ``project_id NOT NULL`` with NO ``DEFAULT 'vnx-dev'`` —
+   verified via ``PRAGMA table_info`` on the runtime DB, not just .sql text.
+
+2. Skip-observability: when the owning tenant cannot be resolved,
+   ``upsert_dispatch_provider_row`` logs ``tenant_stamp_skip`` (with db_path,
+   dispatch_id, terminal, reason), writes a ``skip_metrics.ndjson`` event next
+   to the DB, and returns ``False`` — it never stamps a contaminating default.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_LIB = _REPO / "scripts" / "lib"
+_SCRIPTS = _REPO / "scripts"
+for _p in (_LIB, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import quality_db_init  # noqa: E402
+from dispatch_metadata_db import upsert_dispatch_provider_row  # noqa: E402
+
+
+def _pragma_project_id(db: Path, table: str) -> dict:
+    conn = sqlite3.connect(str(db))
+    try:
+        for cid, name, ctype, notnull, dflt, pk in conn.execute(f"PRAGMA table_info({table})"):
+            if name == "project_id":
+                return {"notnull": notnull, "default": dflt}
+    finally:
+        conn.close()
+    raise AssertionError(f"{table}.project_id column not found")
+
+
+def _fresh_store(tmp_path: Path) -> Path:
+    db = tmp_path / ".vnx-data" / "vnx-dev" / "state" / "quality_intelligence.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    assert quality_db_init.bootstrap_qi_db(db, _REPO / "schemas" / "quality_intelligence.sql")
+    return db
+
+
+def test_dispatch_metadata_project_id_not_null_no_default(tmp_path):
+    db = _fresh_store(tmp_path)
+    col = _pragma_project_id(db, "dispatch_metadata")
+    assert col["notnull"] == 1
+    assert col["default"] is None, f"DEFAULT must be dropped, got {col['default']!r}"
+
+
+def test_adrs_project_id_not_null_no_default(tmp_path):
+    db = _fresh_store(tmp_path)
+    col = _pragma_project_id(db, "adrs")
+    assert col["notnull"] == 1
+    assert col["default"] is None, f"DEFAULT must be dropped, got {col['default']!r}"
+
+
+def test_upsert_stamps_owning_tenant_from_path(tmp_path):
+    # Canonical mission-control store: upsert resolves the owning tenant from the
+    # path layout and stamps mission-control, not a guessed 'vnx-dev'.
+    db = tmp_path / ".vnx-data" / "mission-control" / "state" / "quality_intelligence.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    assert quality_db_init.bootstrap_qi_db(db, _REPO / "schemas" / "quality_intelligence.sql")
+    ok = upsert_dispatch_provider_row(db, dispatch_id="d-1", terminal="T1", provider="codex")
+    assert ok
+    conn = sqlite3.connect(str(db))
+    try:
+        pid = conn.execute("SELECT project_id FROM dispatch_metadata WHERE dispatch_id='d-1'").fetchone()[0]
+    finally:
+        conn.close()
+    assert pid == "mission-control"
+
+
+def test_upsert_skips_and_logs_when_tenant_unresolved(tmp_path, monkeypatch, caplog):
+    # A bare store path (no .vnx-data layout, no marker) with env unset: the
+    # tenant is unresolvable → upsert skips, logs tenant_stamp_skip, writes the
+    # skip metric next to the DB, and returns False (no contaminating stamp).
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    db = tmp_path / "loose" / "quality_intelligence.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    assert quality_db_init.bootstrap_qi_db(db, _REPO / "schemas" / "quality_intelligence.sql")
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = upsert_dispatch_provider_row(db, dispatch_id="d-skip", terminal="T7", provider="codex")
+    assert ok is False
+
+    # ERROR log carries the diagnostic fields.
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "tenant_stamp_skip" in msg
+    assert "d-skip" in msg and "T7" in msg and str(db) in msg
+
+    # No row was written (no contaminating stamp).
+    conn = sqlite3.connect(str(db))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM dispatch_metadata WHERE dispatch_id='d-skip'").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    # skip_metrics.ndjson recorded next to the DB (fallback path: db dir, not <pid>).
+    metric = db.parent / "skip_metrics.ndjson"
+    assert metric.exists()
+    ev = json.loads(metric.read_text().splitlines()[-1])
+    assert ev["event_type"] == "tenant_stamp_skip"
+    assert ev["dispatch_id"] == "d-skip"
+    assert ev["table"] == "dispatch_metadata"


### PR DESCRIPTION
## What

Fixes the live multi-tenant contamination of the QI write-tier (the last 1.0 gate-blocker). The `dispatch_metadata` resolver called `current_project_id()` before store-derivation, so an unset `VNX_PROJECT_ID` silently stamped `vnx-dev` on a non-vnx-dev store (mission-control) on every write — re-contaminating it after each init-heal. The tmux lane (`log_dispatch_metadata`) hit the same masking bug and is the live MC source.

**PR-1 of 2** (dispatch-tier). PR-2 = intelligence-tier (`success_patterns`, `intelligence_injections`), tracked `pre10-tenant-intel-tier`, not gate-blocking.

## Design — fail-closed = refuse the contaminating row, not crash the dispatch

- New `project_scope.resolve_stamp_project_id` + `TenantUnresolved`: store-derived (db_path authoritative), env only when no db_path, raises on no-source / source-conflict / invalid-id (RuntimeError + OSError cast). `strict` mode on `resolve_init_project_id` (function-local import, no cycle).
- DB-table writers (`dispatch_metadata`, `adrs`) catch `TenantUnresolved` → log `tenant_stamp_skip` (db_path, dispatch_id, terminal, sources) + `skip_metrics.ndjson` next to the DB → skip the write. **Reverses the #907 fail-open resolver semantics on purpose** (the 2 resolver tests are the only consumers; revised).
- NDJSON cost emitter stays **outside** fail-closed (append-only receipt, never skips); its db_path callers supply a store-derived pid best-effort.
- `.sql` drops `DEFAULT 'vnx-dev'` on `dispatch_metadata` + `adrs`; the `ALTER ADD COLUMN` at `quality_db_init:783` stays (SQLite load-bearing, inert — Phase-3 enforces NO default for non-vnx-dev).
- **ADR-007 additive amendment** (operator-signed) supersedes the Column rule for the QI-write-tier.

## Verification

- 145 tenant-stamping tests green (new `test_resolve_stamp_project_id` + `test_tenant_stamp_fail_closed` PRAGMA-conformance/skip-observability, plus revised blast-radius).
- **Zero new failures vs origin/main** (isolated worktree baseline: clean main has 41 pre-existing failures; this branch has the identical 41).
- No Anthropic SDK (ADR-003); `migration_linter` OK; `ci_lint_patterns.py` clean.
- **kimi-gate: PASS** (0 blocking; round 1 caught a real ADR-clause-2 violation in `intelligence_backfill` — fixed).

## Process

Plan-gate cleared via operator-override after 10 rounds (design unanimously sound across rounds 5-10; gate diverged on build-tier inventory; glm flaking). Audit event `track_plan_gate_operator_override` emitted. The ADR-007 amendment is **operator-gated — pending Vincent's sign-off before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)