### PR TITLE
fix(slop-sweep): clean the 6 pre-existing silent-except findings (pre10)

### DIFF
--- a/scripts/benchmark/export_routing_matrix.py
+++ b/scripts/benchmark/export_routing_matrix.py
@@ -25,9 +25,12 @@ from __future__ import annotations
 import argparse
 import csv
 import glob
+import logging
 import statistics
 from collections import defaultdict
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 import yaml
 
@@ -115,8 +118,8 @@ def aggregate():
                             cells[key]["costs"].append(c)
                     except ValueError:
                         pass
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("skipping %s during routing-matrix aggregation: %s", f, exc)
     return cells
 
 

--- a/scripts/ci_lint_patterns.py
+++ b/scripts/ci_lint_patterns.py
@@ -3,12 +3,16 @@
 
 Pattern A — silent exception:
   `except Exception:` or bare `except:` immediately followed by `pass`
-  with no log or re-raise. Whitelist: `# noqa: vnx-silent-except`.
+  with no log or re-raise. Whitelist: a PLAIN marker comment on the `except`
+  line containing `vnx-silent-except` (e.g. `# vnx-silent-except: <reason>`).
+  Do NOT use the `# noqa:` prefix — Ruff rejects `# noqa: vnx-silent-except`
+  as an invalid directive; this gate only substring-matches the token.
 
 Pattern B — non-atomic state write:
   `open(path, "w"|"wb")` where path matches state file patterns,
   without os.replace / tempfile / state_writer in the following 10 lines.
-  Whitelist: `# noqa: vnx-atomic-write`.
+  Whitelist: a plain marker comment containing `vnx-atomic-write`
+  (e.g. `# vnx-atomic-write: <reason>`) — not the Ruff-rejected `# noqa:` form.
 
 Exit codes:
   0 = clean (no findings)
@@ -139,7 +143,17 @@ def collect_files_from_dirs(root: Path) -> list[str]:
         if not target.is_dir():
             continue
         for dirpath, dirs, files in os.walk(target):
-            dirs[:] = [d for d in dirs if d not in ("__pycache__", ".venv", "node_modules")]
+            parts = Path(dirpath).parts
+            # Skip vendored/cache dirs, and the benchmark task SEEDS under
+            # field-tests/ — those are PLANTED fixtures (deliberate anti-patterns
+            # reviewer-models must find); a suppression marker there would tip the
+            # answer. Path-component match (not substring) so `field-tests-old/seed`
+            # is NOT skipped. Real harness `runners/` + `verify.py` stay linted.
+            dirs[:] = [
+                d for d in dirs
+                if d not in ("__pycache__", ".venv", "node_modules")
+                and not (d == "seed" and "field-tests" in parts)
+            ]
             for f in files:
                 if f.endswith(".py"):
                     result.append(os.path.join(dirpath, f))
@@ -166,9 +180,9 @@ def _print_findings(findings: list[Finding]) -> None:
     print("  A = silent exception (except + pass, no log/re-raise)")
     print("  B = non-atomic state write (open(path,'w') without os.replace)")
     print()
-    print("To suppress a specific line add the appropriate noqa comment:")
-    print("  # noqa: vnx-silent-except")
-    print("  # noqa: vnx-atomic-write")
+    print("To suppress a line, add a PLAIN marker comment on it (NOT a # noqa: directive — Ruff rejects that):")
+    print("  # vnx-silent-except: <reason>")
+    print("  # vnx-atomic-write: <reason>")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/lib/tenant_stamping.py
+++ b/scripts/lib/tenant_stamping.py
@@ -757,7 +757,7 @@ def run_phase1_ddl(
         except Exception:
             try:
                 conn.execute("ROLLBACK")
-            except Exception:
+            except Exception:  # vnx-silent-except: rollback best-effort
                 pass
             raise
     finally:
@@ -868,7 +868,7 @@ def run_phase2_restamp(
         except Exception:
             try:
                 conn.execute("ROLLBACK")
-            except Exception:
+            except Exception:  # vnx-silent-except: rollback best-effort
                 pass
             raise
     finally:
@@ -1110,7 +1110,7 @@ def run_phase3_enforce(
         except Exception:
             try:
                 conn.execute("ROLLBACK")
-            except Exception:
+            except Exception:  # vnx-silent-except: rollback best-effort
                 pass
             raise
     finally:

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -3021,7 +3021,7 @@ def run(project_root: Path | None = None) -> None:
         if conn is not None:
             try:
                 conn.rollback()
-            except Exception:
+            except Exception:  # vnx-silent-except: rollback best-effort
                 pass
         raise
     finally:

--- a/tests/test_ci_lint_patterns.py
+++ b/tests/test_ci_lint_patterns.py
@@ -171,3 +171,80 @@ def test_files_from_stdin_skips_blanks_and_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
     result = lint.main(["--files-from-stdin"])
     assert result == 0
+
+
+# --- pre10-slop-sweep anti-revert (2026-06-25) ---------------------------------
+# These guard the slop-sweep: the full repo scan stays clean, the field-tests
+# seed-exclude stays narrow, the plain-marker convention works, and the 4
+# rollback sites keep re-raising (the marker must never hide a real swallow).
+
+import ast
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def test_full_scan_repo_clean():
+    # The real default full-scan (scripts/ + dashboard/) must be finding-free.
+    # Fails the moment anyone reintroduces a silent-except or drops a marker.
+    assert lint.main([]) == 0
+
+
+def test_field_tests_seeds_excluded_runners_kept():
+    files = lint.collect_files_from_dirs(_REPO)
+    seed_under_ft = [
+        f for f in files
+        if "seed" in Path(f).parts and "field-tests" in Path(f).parts
+    ]
+    assert not seed_under_ft, f"field-tests seeds must be excluded, got: {seed_under_ft[:3]}"
+    # ...but the real harness code under field-tests stays linted.
+    runners = [f for f in files if "field-tests" in Path(f).parts and "runners" in Path(f).parts]
+    assert runners, "field-tests/runners/ harness scripts must remain in scope"
+
+
+def test_seed_outside_field_tests_still_scanned(tmp_path, monkeypatch):
+    # A production `seed/` dir NOT under field-tests must NOT be excluded.
+    seed = tmp_path / "scripts" / "seed"
+    seed.mkdir(parents=True)
+    (seed / "mod.py").write_text("x = 1\n")
+    monkeypatch.setattr(lint, "_SCAN_DIRS", ("scripts",))
+    files = lint.collect_files_from_dirs(tmp_path)
+    assert str(seed / "mod.py") in files, "non-field-tests seed/ must stay scanned"
+
+
+def test_plain_marker_suppresses(tmp_path):
+    # The Ruff-safe plain marker (no `# noqa:` prefix) suppresses Pattern A.
+    path = _write(
+        tmp_path,
+        "ok_plain.py",
+        "try:\n    pass\nexcept Exception:  # vnx-silent-except: justified\n    pass\n",
+    )
+    findings = lint.scan_file(path)
+    assert not any(f.pattern == "A" for f in findings), f"plain marker must suppress, got: {findings}"
+
+
+def _outer_handlers_of_passonly_swallows(filepath: Path):
+    """AST/block-scoped: every pass-only except nested inside another handler
+    (the rollback-best-effort pattern) -> return its ENCLOSING handler."""
+    tree = ast.parse(filepath.read_text())
+    parents = {c: p for p in ast.walk(tree) for c in ast.iter_child_nodes(p)}
+    outers = []
+    for h in ast.walk(tree):
+        if isinstance(h, ast.ExceptHandler) and len(h.body) == 1 and isinstance(h.body[0], ast.Pass):
+            p = parents.get(h)
+            while p is not None and not isinstance(p, ast.ExceptHandler):
+                p = parents.get(p)
+            if p is not None:
+                outers.append(p)
+    return outers
+
+
+def test_rollback_sites_still_reraise():
+    # AST, not line-proximity: each marked rollback-swallow lives inside an outer
+    # handler that re-raises the original error. Drop the `raise` -> this fails.
+    expected = {"scripts/lib/tenant_stamping.py": 3, "scripts/migrate_future_system.py": 1}
+    for rel, count in expected.items():
+        outers = _outer_handlers_of_passonly_swallows(_REPO / rel)
+        assert len(outers) >= count, f"{rel}: expected >= {count} rollback patterns, got {len(outers)}"
+        for oh in outers:
+            assert any(isinstance(n, ast.Raise) for n in oh.body), \
+                f"{rel}: an outer rollback handler does not re-raise (silent swallow!)"


### PR DESCRIPTION
## What

The full-scan `ci_lint_patterns.py` was **EXIT=1 with 6 Pattern-A silent-except findings** (NEW slop is already CI-gated via `--scan-stdin` on added lines; this clears the pre-existing debt so the full scan is clean). Surgical per-site — no blanket suppression. Last gate-blocking item before the 1.0 PyPI ship.

## The 6 findings, classified

- **4 legitimate rollback-best-effort-then-reraise** (`tenant_stamping.py:760/871/1113`, `migrate_future_system.py:3024`): the original error always re-raises; only a *secondary* rollback failure is swallowed (correct — a rollback error must not mask the real one). Marked with the plain `# vnx-silent-except: rollback best-effort` comment — **not** `# noqa:` (Ruff rejects that as an invalid directive; the gate substring-matches the token).
- **1 benchmark seed fixture** (`field-tests/.../seed/seoaudit/crawl_queue.py`): a *planted* bug for the t5 review benchmark — a marker would tip reviewer-models. `collect_files_from_dirs` now **path-component-excludes `seed/` dirs under field-tests only** (runners/ + verify.py graders stay linted; a production `seed/` elsewhere stays scanned).
- **1 real bug-hider** (`export_routing_matrix.py:118`): the outer `except: pass` silently dropped whole CSV files → now logs via `logging.warning` (control-flow identical: it was the last statement in the per-file loop).

Also updates the lint's own self-docs (docstring + help text) to the plain-marker convention so contributors don't apply the Ruff-rejected `# noqa:` form.

## Verification

- Full-scan `ci_lint_patterns.py`: **EXIT=0** (was EXIT=1/6 findings).
- 5 anti-revert tests added to `tests/test_ci_lint_patterns.py`: full-scan EXIT=0, seed-exclude narrow (runners kept, non-field-tests seed still scanned), plain-marker suppresses, and an **AST/block-scoped** check that all 4 rollback sites still re-raise.
- 100 changed-module tests green; no new failures vs origin/main.
- Plan-gate: PASS (2/3, converged on quorum over 5 rounds, no override). kimi-gate: PASS (0 blocking). No ADR/schema touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)