### PR TITLE
fix(exit-classifier): restore stderr classification + decision-tree + retry semantics (hardening A1)

### DIFF
--- a/docs/contracts/HEADLESS_RUN_CONTRACT.md
+++ b/docs/contracts/HEADLESS_RUN_CONTRACT.md
@@ -249,6 +249,17 @@ Classification is applied in order (first match wins):
 7. **Stderr contains prompt/input error patterns** -> `prompt_error`
 8. **Exit code != 0 with no matching pattern** -> `unknown`
 
+**Retryability refinements (2026-06-26).** Two stderr cases override their class
+default because a blind auto-retry cannot fix them and only wastes API
+calls/tokens:
+
+- **Context / token-limit exceeded** -> `prompt_error` (NOT `tool_failure`). It
+  is an input-size problem; re-running the same oversized prompt fails again.
+  Operator action: reduce the prompt.
+- **Auth errors (401 / 403)** -> `tool_failure` class (it is an API error) but
+  **non-retryable**. Operator action: rotate credentials, then retry. The
+  per-pattern `retryable=False` flag overrides the `tool_failure` class default.
+
 ### 4.3 Classification Evidence
 
 Each failure classification MUST record:

--- a/scripts/lib/exit_classifier.py
+++ b/scripts/lib/exit_classifier.py
@@ -10,7 +10,8 @@ Failure classes:
   TOOL_FAIL    — transient tool/network error (retryable)
   INFRA_FAIL   — infrastructure problem: binary missing, OOM, etc.
   NO_OUTPUT    — subprocess produced no output (hung or crashed silently)
-  INTERRUPTED  — terminated by a signal (SIGTERM, SIGKILL, etc.)
+  INTERRUPTED  — terminated by a graceful/user signal (SIGINT, SIGTERM, SIGHUP).
+                 SIGKILL(-9) is NOT interrupted — it falls through (usually OOM/infra).
   PROMPT_ERR   — prompt rejected by the CLI (not retryable)
   UNKNOWN      — unrecognised exit condition
 
@@ -20,7 +21,7 @@ BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -49,40 +50,92 @@ _OPERATOR_HINTS = {
     FC_UNKNOWN: "Unknown failure. Check exit code and stderr for clues.",
 }
 
-# Retryable by default per failure class
+# Retryable by default per failure class (HEADLESS_RUN_CONTRACT.md §4.1).
+# INTERRUPTED is retryable (a SIGINT/SIGTERM is a transient/manual stop); UNKNOWN
+# is NOT retryable (do not blindly re-run an unclassified failure).
 _RETRYABLE = {
     FC_SUCCESS: False,
     FC_TIMEOUT: True,
     FC_TOOL_FAIL: True,
     FC_INFRA_FAIL: True,
     FC_NO_OUTPUT: True,
-    FC_INTERRUPTED: False,
+    FC_INTERRUPTED: True,
     FC_PROMPT_ERR: False,
-    FC_UNKNOWN: True,
+    FC_UNKNOWN: False,
 }
 
 # Stderr patterns → (failure_class, reason, retryable)
 # Checked in order; first match wins.
+# Signal numbers classified as INTERRUPTED — graceful/user terminations only.
+# SIGKILL (9) and other signals are NOT here: they fall through to stderr/UNKNOWN
+# (a SIGKILL is usually an OOM-killer or hard infra kill, not a user interrupt).
+# Contract: HEADLESS_RUN_CONTRACT.md §4.1.
+_INTERRUPT_SIGNALS: frozenset[int] = frozenset({1, 2, 15})  # SIGHUP, SIGINT, SIGTERM
+
+# stderr → failure-class patterns, evaluated first-match-wins. ORDER MATTERS:
+# INFRA before TOOL before PROMPT, so a line matching both ("Permission denied,
+# API error" → INFRA) resolves to the more-fundamental class (§4.2).
 _STDERR_PATTERNS: list[tuple[re.Pattern, str, str, bool]] = [
+    # --- INFRA_FAIL: host / binary / resource (infra beats tool) ---
     (
-        re.compile(r"rate.limit|429|too many requests", re.IGNORECASE),
-        FC_TOOL_FAIL, "API rate limit or HTTP 429 detected in stderr", True,
+        re.compile(r"command not found", re.IGNORECASE),
+        FC_INFRA_FAIL, "CLI binary missing / command not found", True,
+    ),
+    (
+        re.compile(r"permission denied|EACCES", re.IGNORECASE),
+        FC_INFRA_FAIL, "Permission denied", True,
+    ),
+    (
+        re.compile(r"no space left|disk full|ENOSPC", re.IGNORECASE),
+        FC_INFRA_FAIL, "Disk full / no space left on device", True,
+    ),
+    (
+        re.compile(r"out.of.memory|\bOOM\b|cannot.allocate|\bkilled\b", re.IGNORECASE),
+        FC_INFRA_FAIL, "Out-of-memory or resource exhaustion", True,
+    ),
+    # --- TOOL_FAIL: transient API / network ---
+    (
+        re.compile(r"rate.limit|\b429\b|too many requests", re.IGNORECASE),
+        FC_TOOL_FAIL, "API rate limit or HTTP 429", True,
+    ),
+    (
+        re.compile(r"api error|model overloaded|\b50[0-9]\b|service unavailable", re.IGNORECASE),
+        FC_TOOL_FAIL, "API/service error (5xx / overloaded)", True,
+    ),
+    (
+        # Auth is a tool/API error but NON-retryable: a blind retry won't fix a
+        # 401/403 without credential rotation and just burns tokens/API calls.
+        re.compile(r"\b401\b|\b403\b|unauthorized|forbidden", re.IGNORECASE),
+        FC_TOOL_FAIL, "Auth error (401/403) — rotate credentials (non-retryable)", False,
     ),
     (
         re.compile(r"connection.refused|connection.reset|connection.error|network.error|ECONNREFUSED", re.IGNORECASE),
-        FC_TOOL_FAIL, "Network/connection error detected in stderr", True,
+        FC_TOOL_FAIL, "Network/connection error", True,
     ),
     (
-        re.compile(r"timeout|timed.out", re.IGNORECASE),
-        FC_TOOL_FAIL, "Timeout keyword in stderr", True,
+        # A timeout keyword in stderr WITHOUT the timed_out flag (the flag is
+        # caught earlier as TIMEOUT); keep it retryable to preserve auto-recovery.
+        re.compile(r"\btimeout\b|timed.out|deadline exceeded", re.IGNORECASE),
+        FC_TOOL_FAIL, "Timeout/deadline keyword in stderr", True,
+    ),
+    # --- PROMPT_ERR: non-retryable input problem ---
+    (
+        # Context/token-limit is an input-size problem, not a transient tool error:
+        # re-running the same oversized prompt fails again → PROMPT_ERR (fix the prompt).
+        re.compile(r"context.length|context.window|token.limit", re.IGNORECASE),
+        FC_PROMPT_ERR, "Context/token limit exceeded — reduce prompt size", False,
     ),
     (
-        re.compile(r"invalid.prompt|bad.prompt|prompt.error|malformed.prompt", re.IGNORECASE),
-        FC_PROMPT_ERR, "Invalid or malformed prompt rejected by CLI", False,
+        re.compile(r"invalid.prompt|bad.prompt|prompt.error|malformed.prompt|prompt too long", re.IGNORECASE),
+        FC_PROMPT_ERR, "Invalid / malformed / oversized prompt rejected by CLI", False,
     ),
     (
-        re.compile(r"out.of.memory|OOM|killed|cannot.allocate", re.IGNORECASE),
-        FC_INFRA_FAIL, "Out-of-memory or resource exhaustion detected in stderr", True,
+        re.compile(r"malformed json|invalid json", re.IGNORECASE),
+        FC_PROMPT_ERR, "Malformed JSON input", False,
+    ),
+    (
+        re.compile(r"schema validation|schema error", re.IGNORECASE),
+        FC_PROMPT_ERR, "Schema validation error on input", False,
     ),
 ]
 
@@ -117,25 +170,38 @@ def classify_exit(
 ) -> ClassificationResult:
     """Classify a headless subprocess exit into a named failure class.
 
-    Priority order (first match wins):
-      1. binary_not_found → INFRA_FAIL
-      2. no_output_detected → NO_OUTPUT
-      3. timed_out → TIMEOUT
-      4. exit_code < 0 → INTERRUPTED (signal termination)
-      5. exit_code == 0 → SUCCESS
-      6. stderr pattern match → class from pattern table
+    Priority order (first match wins) — HEADLESS_RUN_CONTRACT.md §4.2:
+      1. exit_code == 0 → SUCCESS (a clean exit wins over any flag/stderr)
+      2. timed_out → TIMEOUT (beats signals, binary_not_found and stderr)
+      3. no_output_detected → NO_OUTPUT
+      4. exit_code < 0 with signal in _INTERRUPT_SIGNALS → INTERRUPTED
+         (SIGKILL/-9 and other signals fall through — usually OOM/infra, not a user interrupt)
+      5. binary_not_found → INFRA_FAIL
+      6. stderr pattern match → class from pattern table (INFRA > TOOL > PROMPT)
       7. fallback → UNKNOWN
     """
     stderr_tail = (stderr or "")[-500:].strip()
+    sig = abs(exit_code) if (exit_code is not None and exit_code < 0) else None
 
-    if binary_not_found:
+    if exit_code == 0:
         return ClassificationResult(
-            failure_class=FC_INFRA_FAIL,
-            retryable=_RETRYABLE[FC_INFRA_FAIL],
+            failure_class=FC_SUCCESS,
+            retryable=_RETRYABLE[FC_SUCCESS],
+            exit_code=0,
+            stderr_tail=stderr_tail,
+            classification_reason="Subprocess exited with code 0",
+            operator_hint=_OPERATOR_HINTS[FC_SUCCESS],
+        )
+
+    if timed_out:
+        return ClassificationResult(
+            failure_class=FC_TIMEOUT,
+            retryable=_RETRYABLE[FC_TIMEOUT],
+            signal=sig,
             exit_code=exit_code,
             stderr_tail=stderr_tail,
-            classification_reason="CLI binary not found in PATH",
-            operator_hint=_OPERATOR_HINTS[FC_INFRA_FAIL],
+            classification_reason="Subprocess exceeded its configured timeout",
+            operator_hint=_OPERATOR_HINTS[FC_TIMEOUT],
         )
 
     if no_output_detected:
@@ -148,18 +214,7 @@ def classify_exit(
             operator_hint=_OPERATOR_HINTS[FC_NO_OUTPUT],
         )
 
-    if timed_out:
-        return ClassificationResult(
-            failure_class=FC_TIMEOUT,
-            retryable=_RETRYABLE[FC_TIMEOUT],
-            exit_code=exit_code,
-            stderr_tail=stderr_tail,
-            classification_reason="Subprocess exceeded its configured timeout",
-            operator_hint=_OPERATOR_HINTS[FC_TIMEOUT],
-        )
-
-    if exit_code is not None and exit_code < 0:
-        sig = abs(exit_code)
+    if sig is not None and sig in _INTERRUPT_SIGNALS:
         return ClassificationResult(
             failure_class=FC_INTERRUPTED,
             retryable=_RETRYABLE[FC_INTERRUPTED],
@@ -170,23 +225,24 @@ def classify_exit(
             operator_hint=_OPERATOR_HINTS[FC_INTERRUPTED],
         )
 
-    if exit_code == 0:
+    if binary_not_found:
         return ClassificationResult(
-            failure_class=FC_SUCCESS,
-            retryable=_RETRYABLE[FC_SUCCESS],
-            exit_code=0,
+            failure_class=FC_INFRA_FAIL,
+            retryable=_RETRYABLE[FC_INFRA_FAIL],
+            exit_code=exit_code,
             stderr_tail=stderr_tail,
-            classification_reason="Subprocess exited with code 0",
-            operator_hint=_OPERATOR_HINTS[FC_SUCCESS],
+            classification_reason="CLI binary not found in PATH",
+            operator_hint=_OPERATOR_HINTS[FC_INFRA_FAIL],
         )
 
-    # Stderr pattern matching
+    # Stderr pattern matching (INFRA > TOOL > PROMPT, first-match-wins).
     if stderr:
         for pattern, fc, reason, retryable in _STDERR_PATTERNS:
             if pattern.search(stderr):
                 return ClassificationResult(
                     failure_class=fc,
                     retryable=retryable,
+                    signal=sig,
                     exit_code=exit_code,
                     stderr_tail=stderr_tail,
                     classification_reason=reason,
@@ -196,6 +252,7 @@ def classify_exit(
     return ClassificationResult(
         failure_class=FC_UNKNOWN,
         retryable=_RETRYABLE[FC_UNKNOWN],
+        signal=sig,
         exit_code=exit_code,
         stderr_tail=stderr_tail,
         classification_reason=f"Unrecognised failure: exit_code={exit_code}",

--- a/tests/test_exit_classifier.py
+++ b/tests/test_exit_classifier.py
@@ -22,7 +22,6 @@ if SCRIPTS_LIB not in sys.path:
 
 from exit_classifier import (
     classify_exit,
-    ClassificationResult,
     FC_SUCCESS as SUCCESS,
     FC_TIMEOUT as TIMEOUT,
     FC_NO_OUTPUT as NO_OUTPUT,
@@ -146,9 +145,12 @@ class TestToolFailClassification(unittest.TestCase):
         result = classify_exit(exit_code=1, stderr="Error 429: Too Many Requests")
         self.assertEqual(result.failure_class, TOOL_FAIL)
 
-    def test_context_limit(self):
-        result = classify_exit(exit_code=1, stderr="context length exceeded")
+    def test_auth_error_not_retryable(self):
+        """Auth (401/403) is a tool/API error but must NOT be retried blindly
+        (credential rotation needed) — a retry just burns tokens."""
+        result = classify_exit(exit_code=1, stderr="401 Unauthorized")
         self.assertEqual(result.failure_class, TOOL_FAIL)
+        self.assertFalse(result.retryable)
 
     def test_connection_refused(self):
         result = classify_exit(exit_code=1, stderr="connection refused")
@@ -158,15 +160,25 @@ class TestToolFailClassification(unittest.TestCase):
         result = classify_exit(exit_code=1, stderr="503 Service Unavailable")
         self.assertEqual(result.failure_class, TOOL_FAIL)
 
-    def test_auth_error(self):
-        result = classify_exit(exit_code=1, stderr="401 Unauthorized")
+    def test_timeout_keyword_in_stderr_retryable(self):
+        """A timeout keyword in stderr (without the timed_out flag) stays a
+        retryable TOOL_FAIL — preserves auto-recovery coverage."""
+        result = classify_exit(exit_code=1, stderr="upstream request timeout")
         self.assertEqual(result.failure_class, TOOL_FAIL)
+        self.assertTrue(result.retryable)
 
 
 class TestPromptErrClassification(unittest.TestCase):
 
     def test_invalid_prompt(self):
         result = classify_exit(exit_code=1, stderr="Error: invalid prompt format")
+        self.assertEqual(result.failure_class, PROMPT_ERR)
+        self.assertFalse(result.retryable)
+
+    def test_context_limit_is_prompt_err_not_retryable(self):
+        """Context/token-limit is an input-size problem, not a transient tool
+        error: re-running the same oversized prompt fails again."""
+        result = classify_exit(exit_code=1, stderr="context length exceeded")
         self.assertEqual(result.failure_class, PROMPT_ERR)
         self.assertFalse(result.retryable)
 


### PR DESCRIPTION
## What

A dead-code purge (`cb174793`) gutted `exit_classifier`: `_STDERR_PATTERNS` dropped to 5, the INFRA>TOOL>PROMPT ordering was lost, the decision-tree priority was wrong, and `_RETRYABLE` inverted INTERRUPTED/UNKNOWN. These values persist into `coordination_events` + dispatch-transition metadata, so the regression **corrupted the governed audit trail and retry behaviour**. First deliverable of the 1.0 hardening sprint (A1, highest priority).

## Restored to HEADLESS_RUN_CONTRACT §4 (existing tests are the SSOT)

- **`_STDERR_PATTERNS`**: full set, ordered INFRA (command-not-found / permission / disk-full / OOM) > TOOL (rate-limit/429 / api-error/5xx / connection / timeout-keyword) > PROMPT (invalid/too-long prompt / malformed-json / schema-validation), so `"Permission denied, API error"` → INFRA.
- **decision tree (§4.2, exact order)**: `exit_code==0` → `timed_out` → `no_output` → signal-interrupted → `binary_not_found` → stderr → unknown.
- **SIGKILL (§4.1)**: `_INTERRUPT_SIGNALS = {SIGHUP, SIGINT, SIGTERM}`; SIGKILL(-9) falls through (usually OOM/infra, not a user interrupt).
- **`_RETRYABLE`**: INTERRUPTED retryable=True, UNKNOWN retryable=False.

## Contract refinement (operator-approved)

A blind auto-retry cannot fix these and only wastes tokens:
- **context/token-limit** → `PROMPT_ERR` non-retryable (input-size problem).
- **auth (401/403)** → `TOOL_FAIL` class but non-retryable (rotate credentials).

§4.2 documents both; tests updated to lock them.

## Verification

- `tests/test_exit_classifier.py`: **41/41 green** (all 8 classes + decision-tree ordering + evidence + the new retry-semantics tests).
- kimi-gate: **PASS** (0 blocking; round-1/2 caught the §4.2 order + the retry-semantics, both fixed). No consumer change needed — `classify_exit` output is the contract surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)