### PR TITLE
fix(learning-loop): revive proposal-tier on the real receipt stream (D-LEARN)

### DIFF
--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -28,6 +28,18 @@ except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
 
+# Failure statuses sampled from the governed receipt stream when mining for
+# recurring failure patterns. Keep in sync with check_active_drain.FAILURE_STATUSES,
+# weekly_digest._FAILURE_STATUSES, receipt_classifier._FAILURE_STATUSES, and
+# payload.FAILURE_STATUSES (gate-F2). "timeout" is included here (unlike the
+# confidence-scoring set in payload.py): a recurring task_timeout is a legitimate
+# failure to learn a prevention rule from — generate_prevention_suggestion has a
+# dedicated 'timeout' branch.
+_FAILURE_STATUSES = frozenset(
+    {"failed", "failure", "error", "blocked", "timeout", "contract_invalid"}
+)
+
+
 def _to_aware_utc(dt: Optional[datetime]) -> Optional[datetime]:
     """Normalize a datetime to timezone-aware UTC, handling naive datetimes gracefully."""
     if dt is None:
@@ -35,6 +47,27 @@ def _to_aware_utc(dt: Optional[datetime]) -> Optional[datetime]:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
+
+
+def _parse_receipt_timestamp(value) -> Optional[datetime]:
+    """Parse a receipt timestamp string to tz-aware UTC, or None if unparseable.
+
+    Handles both ISO forms seen in t0_receipts.ndjson:
+      "2026-05-07T08:31:55.295343+00:00" and "2026-06-26T12:51:47Z".
+    """
+    if not value or not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return _to_aware_utc(datetime.fromisoformat(raw))
+    except ValueError:
+        # Fall back to a date-only prefix (day-granularity window).
+        try:
+            return _to_aware_utc(datetime.fromisoformat(raw[:10]))
+        except ValueError:
+            return None
 
 
 @dataclass
@@ -62,7 +95,11 @@ class LearningLoop:
         self.vnx_path = Path(paths["VNX_HOME"])
         state_dir = Path(paths["VNX_STATE_DIR"]).expanduser().resolve()
         self.db_path = state_dir / "quality_intelligence.db"
-        self.receipts_path = self.vnx_path / "terminals" / "file_bus" / "receipts"
+        # Mine failures from the governed receipt stream (the single NDJSON the
+        # receipt processor writes), not the long-gone terminals/file_bus/receipts
+        # directory — that path never existed under the central store, which is why
+        # the proposal tier never produced a single pending_rules.json.
+        self.receipts_path = state_dir / "t0_receipts.ndjson"
         self.archive_path = state_dir / "archive" / "patterns"
 
         # Create archive directory if it doesn't exist
@@ -290,44 +327,97 @@ class LearningLoop:
             log.debug("Failed to commit ignored_count updates: %s", e)
 
     def extract_failure_patterns(self, start_time: datetime = None) -> List[Dict]:
-        """Extract new failure patterns from recent terminal errors"""
+        """Extract recurring failure patterns from the governed receipt stream.
+
+        Reads the single ``t0_receipts.ndjson`` line by line, keeps receipts whose
+        ``status`` is a failure status (``_FAILURE_STATUSES``) inside the time
+        window, and projects each onto the failure dict consumed downstream by
+        ``generate_prevention_rules`` / ``persist_to_intelligence_db``
+        (keys: task / terminal / agent / error / timestamp).
+        """
         if not start_time:
             start_time = datetime.now(timezone.utc) - timedelta(hours=24)
         else:
             start_time = _to_aware_utc(start_time)
 
-        failure_patterns = []
+        failure_patterns: List[Dict] = []
 
-        # Scan receipts for failures and extract patterns
-        for receipt_file in self.receipts_path.glob("*.ndjson"):
-            if receipt_file.stat().st_mtime < start_time.timestamp():
-                continue
+        if not self.receipts_path.exists():
+            return failure_patterns
 
-            try:
-                with open(receipt_file, 'r') as f:
-                    for line in f:
-                        try:
-                            receipt = json.loads(line.strip())
+        try:
+            with open(self.receipts_path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        receipt = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
 
-                            # Check for error indicators
-                            if receipt.get('outcome') == 'error' or 'error' in str(receipt.get('terminal_response', '')).lower():
-                                # Extract failure context
-                                failure_pattern = {
-                                    'task': receipt.get('task_description', ''),
-                                    'terminal': receipt.get('terminal', ''),
-                                    'agent': receipt.get('agent', ''),
-                                    'error': self.extract_error_message(receipt.get('terminal_response', '')),
-                                    'timestamp': receipt.get('timestamp', datetime.now().isoformat())
-                                }
-                                failure_patterns.append(failure_pattern)
+                    status = str(receipt.get("status", "")).lower()
+                    if status not in _FAILURE_STATUSES:
+                        continue
 
-                        except json.JSONDecodeError:
-                            continue
+                    # Window filter on the receipt timestamp. Drop records we
+                    # cannot place in time so a full historical stream does not
+                    # over-produce against the >=2 recurrence threshold.
+                    ts_raw = receipt.get("timestamp")
+                    ts_dt = _parse_receipt_timestamp(ts_raw)
+                    if ts_dt is None or ts_dt < start_time:
+                        continue
 
-            except Exception as e:
-                print(f"⚠️ Error extracting failure patterns: {e}")
+                    failure_patterns.append({
+                        "task": str(receipt.get("task_id") or receipt.get("task_description") or ""),
+                        "terminal": str(receipt.get("terminal") or receipt.get("terminal_id") or ""),
+                        "agent": str(receipt.get("provider") or receipt.get("model") or ""),
+                        "error": self._failure_error_message(receipt),
+                        "timestamp": ts_raw or datetime.now(timezone.utc).isoformat(),
+                    })
+
+        except OSError as e:
+            print(f"⚠️ Error reading receipt stream {self.receipts_path}: {e}")
 
         return failure_patterns
+
+    def _failure_error_message(self, receipt: Dict) -> str:
+        """Derive a stable error string from a failure receipt.
+
+        Prefers the structured ``failure_reason`` (e.g. "Exhausted 3 retries"),
+        then summarizes ``contract_violations`` for contract-invalid receipts,
+        and finally falls back to scanning any free-text error field.
+        """
+        reason = receipt.get("failure_reason")
+        if reason:
+            return str(reason)[:200]
+
+        status = str(receipt.get("status", "")).lower()
+        if status == "contract_invalid":
+            violations = receipt.get("contract_violations")
+            summary = self._summarize_contract_violations(violations)
+            if summary:
+                return summary[:200]
+
+        for field in ("error", "message", "detail", "terminal_response"):
+            text = receipt.get(field)
+            if isinstance(text, str) and text.strip():
+                return self.extract_error_message(text)
+
+        return "Unknown error"
+
+    @staticmethod
+    def _summarize_contract_violations(violations) -> str:
+        """Render contract_violations (a list of missing headings) into a key."""
+        if isinstance(violations, list) and violations:
+            items = [str(v) for v in violations if str(v).strip()]
+            if items:
+                return "Contract violations: " + ", ".join(items)
+        elif isinstance(violations, dict) and violations:
+            return "Contract violations: " + ", ".join(sorted(str(k) for k in violations))
+        elif isinstance(violations, str) and violations.strip():
+            return "Contract violations: " + violations.strip()
+        return ""
 
     def extract_error_message(self, response: str) -> str:
         """Extract error message from terminal response"""

--- a/tests/test_learning_loop_proposal_tier.py
+++ b/tests/test_learning_loop_proposal_tier.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""D-LEARN: proposal-tier revival tests.
+
+The self-learning proposal tier was dormant because
+``LearningLoop.extract_failure_patterns`` scanned a directory
+(``terminals/file_bus/receipts``) that never existed under the central store, and
+it matched on the legacy ``outcome``/``terminal_response`` fields that the
+governed receipt stream does not carry. After the fix it reads the single
+``<VNX_STATE_DIR>/t0_receipts.ndjson`` line by line and matches on ``status``.
+
+These tests prove:
+  1. ``receipts_path`` is wired to the real ``t0_receipts.ndjson``.
+  2. Failures are mined from the real receipt schema (status / failure_reason).
+  3. The time window excludes stale failures.
+  4. End-to-end: >=2 matching failures emit a pending rule to pending_rules.json
+     (operator-gated, G-L1 — never auto-activated).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+def _now_iso(offset_hours: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=offset_hours)).isoformat()
+
+
+def _write_receipts(path: Path, receipts: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in receipts) + "\n", encoding="utf-8"
+    )
+
+
+class _FakePaths:
+    def __init__(self, state_dir: Path, vnx_home: Path):
+        self._d = {
+            "VNX_STATE_DIR": str(state_dir),
+            "VNX_HOME": str(vnx_home),
+            "VNX_DATA_DIR": str(state_dir.parent),
+        }
+
+    def __getitem__(self, k):
+        return self._d[k]
+
+    def get(self, k, default=None):
+        return self._d.get(k, default)
+
+
+@pytest.fixture
+def loop_env(tmp_path):
+    """Build a LearningLoop bound to a tmp state dir via a patched ensure_env."""
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = _FakePaths(state_dir, vnx_home)
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+def test_receipts_path_points_at_t0_receipts(loop_env):
+    """The fix: receipts_path is the governed NDJSON stream, not file_bus dir."""
+    loop, state_dir = loop_env
+    assert loop.receipts_path == state_dir / "t0_receipts.ndjson"
+
+
+def test_extract_mines_real_receipt_schema(loop_env):
+    """Failures are matched on status (+ failure_reason), not legacy outcome."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "terminal": "T1",
+                "provider": "claude_code",
+                "dispatch_id": "d-1",
+                "timestamp": _now_iso(-1),
+            },
+            {
+                "status": "success",
+                "terminal": "T1",
+                "dispatch_id": "d-ok",
+                "timestamp": _now_iso(-1),
+            },
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+
+    assert len(failures) == 1
+    f = failures[0]
+    assert f["error"] == "Exhausted 3 retries"
+    assert f["terminal"] == "T1"
+    assert f["agent"] == "claude_code"
+
+
+def test_contract_invalid_violations_summarized(loop_env):
+    """contract_invalid receipts derive an error from contract_violations."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "contract_invalid",
+                "contract_violations": ["## Changes", "## Verification"],
+                "terminal_id": "plan-gate",
+                "dispatch_id": "d-c1",
+                "timestamp": _now_iso(-1),
+            }
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+
+    assert len(failures) == 1
+    assert "## Changes" in failures[0]["error"]
+    assert failures[0]["terminal"] == "plan-gate"
+
+
+def test_time_window_excludes_stale_failures(loop_env):
+    """A failure older than the window is not mined."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "terminal": "T1",
+                "provider": "claude_code",
+                "dispatch_id": "d-old",
+                "timestamp": _now_iso(-72),  # 3 days ago
+            }
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(hours=24)
+    )
+
+    assert failures == []
+
+
+def test_proposal_tier_emits_pending_rule(loop_env):
+    """End-to-end: >=2 matching failures queue an operator-gated pending rule."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "terminal": "T1",
+                "provider": "claude_code",
+                "dispatch_id": "d-1",
+                "timestamp": _now_iso(-2),
+            },
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "terminal": "T1",
+                "provider": "claude_code",
+                "dispatch_id": "d-2",
+                "timestamp": _now_iso(-1),
+            },
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+    rules = loop.generate_prevention_rules(failures)
+    assert len(rules) >= 1, "two identical failures should form a recurring rule"
+
+    loop.update_terminal_constraints(rules)
+
+    pending_path = state_dir / "pending_rules.json"
+    assert pending_path.exists(), "proposal tier must write pending_rules.json"
+    data = json.loads(pending_path.read_text(encoding="utf-8"))
+    pending = data.get("pending_rules", [])
+    assert len(pending) >= 1
+    assert all(r["status"] == "pending" for r in pending), "G-L1: never auto-active"
+    assert pending[0]["source"] == "learning_loop"
+
+
+def test_single_failure_does_not_emit_rule(loop_env):
+    """A lone failure (count < 2) does not reach the recurrence threshold."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "terminal": "T1",
+                "provider": "claude_code",
+                "dispatch_id": "d-1",
+                "timestamp": _now_iso(-1),
+            }
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+    rules = loop.generate_prevention_rules(failures)
+    assert rules == []
+
+
+def test_missing_receipts_file_is_safe(loop_env):
+    """No receipt stream → no crash, empty result."""
+    loop, state_dir = loop_env
+    # No t0_receipts.ndjson written.
+    assert not (state_dir / "t0_receipts.ndjson").exists()
+    assert loop.extract_failure_patterns() == []


### PR DESCRIPTION
## Summary

Revives the dormant self-learning **proposal tier** (hardening sprint D-LEARN).

`LearningLoop.extract_failure_patterns` scanned `VNX_HOME/terminals/file_bus/receipts/` — a directory that **never existed** under the central store — and matched on the legacy `outcome`/`terminal_response` fields the governed receipt stream does not carry. Result: it never mined a single failure and never produced `pending_rules.json`. Both tiers of the self-learning loop were effectively dead.

This points the miner at the real `<VNX_STATE_DIR>/t0_receipts.ndjson` and rewrites it to match the actual receipt schema.

## Changes

- **`scripts/learning_loop.py`**
  - `__init__`: `receipts_path` → `<VNX_STATE_DIR>/t0_receipts.ndjson` (was the non-existent `terminals/file_bus/receipts` dir).
  - `extract_failure_patterns`: dir-glob over `outcome`/`terminal_response` → single-file NDJSON line-iteration filtered on `status in _FAILURE_STATUSES` + a timestamp window. Unplaceable records are dropped so a full historical stream can't over-produce against the `>=2` recurrence threshold. Downstream failure-dict contract (`task`/`terminal`/`agent`/`error`/`timestamp`) unchanged.
  - New `_failure_error_message` (prefers `failure_reason`, then a `contract_violations` summary, then free-text fallback) + `_summarize_contract_violations`.
  - New module-level `_FAILURE_STATUSES` (gate-F2 sync set, incl. `timeout`) and `_parse_receipt_timestamp` (handles both `Z` and `+00:00` ISO forms).
- **`tests/test_learning_loop_proposal_tier.py`** (new): path wiring, real-schema mining, contract-violation summary, time-window exclusion, end-to-end pending-rule emit (G-L1 `pending`, never auto-active), single-failure non-emission, missing-file safety.

## Scope / deferrals

- **Proposal tier only.** Auto-tier `source_dispatch_ids` backfill stays deferred to `self-improve-loop-v2` — receipts carry only `dispatch_id`, no pattern-join-key, so reconstruction is impossible without v2 outcome-grounding.
- Output is operator-gated (`pending_rules.json`, status `pending`); nothing auto-activates (G-L1).

## Verification

- `pytest` on the proposal-tier + full learning suite → **118 passed**.
- Live smoke against the real `t0_receipts.ndjson`: 3747 failures mined (30-day window) → 51 candidate rules (top groups: contract-violations, `tmux_receipt_deadline_exceeded`, `Exhausted 3 retries`). Daily cycle default window is 24h.
- **kimi-diff-gate: PASS, 0 blocking findings.**
- `ci_lint_patterns.py --scan-stdin`: EXIT=0. `ruff` on changed lines: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)