### PR TITLE
fix(schema): declare dispatches.output_ref/output_kind in the base schema (D-A2)

### DIFF
--- a/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
+++ b/schemas/migrations/0027_planning_horizon_and_deliverable_view.sql
@@ -9,11 +9,13 @@
 --         claudedocs/PLANNING-OBJECT-MODEL-SYNTHESIS-2026-06-01.md
 --
 -- Pre-migration state (v24-v26): tracks has no `horizon`; dispatches may or
---          may not carry output_ref/output_kind (added by structural-doctor on
---          live DBs, absent on fresh DBs that only have the 0024 schema).
---          A preflight hook in migrate_future_system.py idempotently adds
---          output_ref + output_kind (+ backfill from pr_ref) before this SQL
---          runs, so the deliverables VIEW always sees those columns.
+--          may not carry output_ref/output_kind. Fresh DBs now declare both in
+--          the base runtime_coordination.sql CREATE TABLE (the schema SSOT, so
+--          the schema-drift guard passes); legacy DBs got them from the
+--          structural-doctor. Either way, a preflight hook in
+--          migrate_future_system.py idempotently adds output_ref + output_kind
+--          (+ backfill from pr_ref) before this SQL runs when they are still
+--          absent, so the deliverables VIEW always sees those columns.
 -- Post-migration state (v27): tracks.horizon TEXT CHECK(now|next|later);
 --          deliverables VIEW (GROUP BY project_id, output_ref).
 --

--- a/schemas/runtime_coordination.sql
+++ b/schemas/runtime_coordination.sql
@@ -48,6 +48,13 @@ CREATE TABLE IF NOT EXISTS dispatches (
     track           TEXT,
     priority        TEXT    DEFAULT 'P2',
     pr_ref          TEXT,
+    -- Pluggable output identity (NO-NODE deliverable model). A deliverable is
+    -- the GROUP BY over dispatches sharing one output_ref; migration 0027's
+    -- deliverables VIEW reads these. Declared here so the schema is the SSOT;
+    -- the idempotent preflight (_ensure_dispatches_output_columns) still adds
+    -- them to legacy DBs created before they existed.
+    output_ref      TEXT,
+    output_kind     TEXT,
     gate            TEXT,
     attempt_count   INTEGER NOT NULL DEFAULT 0,
     bundle_path     TEXT,


### PR DESCRIPTION
## Summary

Closes a schema-code drift (hardening sprint D-A2). `dispatches.output_ref` and `dispatches.output_kind` were referenced by `migrate_future_system.py`, `vnx_structural_doctor.py`, and migration 0027's deliverables VIEW, but **never declared in any `.sql`** — they existed only via the Python preflight `_ensure_dispatches_output_columns` and the structural doctor. `test_runtime_coordination_schema_drift` flagged this (RED on 4 references).

Declares both columns in the canonical `dispatches` CREATE TABLE so the schema is the SSOT.

## Changes

- `schemas/runtime_coordination.sql` — add `output_ref TEXT` + `output_kind TEXT` to the `dispatches` CREATE TABLE (the base schema applied to fresh DBs).
- `schemas/migrations/0027_planning_horizon_and_deliverable_view.sql` — header comment updated to reflect the base-schema declaration; preflight remains for legacy DBs.

## Why this placement

- **Not a bare `ALTER` in 0027**: it would duplicate-collide with the idempotent preflight on live DBs that already carry the columns (the exact reason the preflight exists, per the 0027 header).
- **Not in `runtime_coordination_v10.sql`**: that's an immutable versioned snapshot, and its `CREATE TABLE IF NOT EXISTS` is a fresh-install no-op (the base creates the table) — redundant and governance-questionable. (An earlier draft touched it; reverted after the kimi-gate flagged it.)
- The idempotent preflight stays as the legacy-DB upgrade path; on fresh DBs it now no-ops the add.

## Verification

- `test_runtime_coordination_schema_drift` → **GREEN** (was RED).
- `test_migrate_0027_planning_horizon` → 11 passed (fixtures build `dispatches` inline + exercise the runtime preflight — unaffected).
- dispatches-touching suites + broader sweep (`structural_doctor`/`migrate_future`/`planning_cli`/`coordination`) → 133 passed.
- Fresh `init_schema` smoke: base + v2..v10 chain applies cleanly, `dispatches` carries both columns, no duplicate-column.
- **kimi-diff-gate: PASS (0 blocking, 0 advisory).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)