### PR TITLE
fix(report-findings): self-heal drifted table before index creation (D-A3)

### DIFF
--- a/scripts/lib/report_findings_migration.py
+++ b/scripts/lib/report_findings_migration.py
@@ -39,9 +39,52 @@ CREATE INDEX IF NOT EXISTS idx_report_findings_dispatch
     ON report_findings (dispatch_id);
 """
 
+# Canonical non-PK columns, in CREATE TABLE order, with an ALTER-safe type.
+# Kept in sync with the CREATE TABLE above. Used to self-heal a drifted
+# pre-existing table before the indexes are (re)created. `extracted_at` is
+# added WITHOUT its CURRENT_TIMESTAMP default because SQLite's ALTER TABLE
+# ADD COLUMN rejects non-constant defaults; rows created through the normal
+# CREATE TABLE path still get the default.
+_EXPECTED_COLUMNS: list[tuple[str, str]] = [
+    ("report_path", "TEXT"),
+    ("report_date", "TIMESTAMP"),
+    ("terminal", "TEXT"),
+    ("task_type", "TEXT"),
+    ("patterns_found", "INTEGER"),
+    ("antipatterns_found", "INTEGER"),
+    ("prevention_rules_found", "INTEGER"),
+    ("tags_found", "TEXT"),
+    ("summary", "TEXT"),
+    ("age_category", "TEXT"),
+    ("extracted_at", "TIMESTAMP"),
+    ("dispatch_id", "TEXT"),
+]
+
+
+def _self_heal_drifted_columns(conn: sqlite3.Connection) -> None:
+    """Add any canonical columns missing from a pre-existing report_findings table.
+
+    A table left behind by an older schema can lack columns the current
+    indexes reference (notably ``extracted_at``). Without this, the
+    ``CREATE INDEX ... (extracted_at DESC)`` below raises
+    ``OperationalError: no such column: extracted_at`` and the whole
+    self-healing migration crashes. Columns are added nullable (additive,
+    no rebuild, no data loss).
+    """
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(report_findings)")}
+    for name, col_type in _EXPECTED_COLUMNS:
+        if name not in existing:
+            conn.execute(
+                f"ALTER TABLE report_findings ADD COLUMN {name} {col_type}"
+            )
+
 
 def ensure_report_findings_table(conn: sqlite3.Connection) -> bool:
     """Create report_findings table + indexes if they do not exist. Idempotent.
+
+    If the table already exists but has drifted (missing columns the indexes
+    reference), the missing columns are added before the indexes are created,
+    so a drifted-but-populated table self-heals instead of crashing.
 
     Returns True if the table was freshly created, False if it already existed.
     """
@@ -51,6 +94,8 @@ def ensure_report_findings_table(conn: sqlite3.Connection) -> bool:
         ).fetchone()
         is not None
     )
+    if existed:
+        _self_heal_drifted_columns(conn)
     conn.executescript(_MIGRATION_SQL)
     conn.commit()
     return not existed

--- a/tests/test_report_findings_migration.py
+++ b/tests/test_report_findings_migration.py
@@ -190,3 +190,69 @@ def test_pre_existing_full_schema_table_survives():
     result = ensure_report_findings_table(conn)
     assert result is False
     assert _table_exists(conn)
+
+
+# ── drifted pre-existing table self-heals (D-A3) ────────────────────────────────
+
+def _drifted_table_missing_extracted_at(conn: sqlite3.Connection) -> None:
+    """Create a report_findings table that predates the extracted_at column."""
+    conn.executescript(
+        """
+        CREATE TABLE report_findings (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            report_path  TEXT NOT NULL,
+            terminal     TEXT,
+            summary      TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO report_findings (report_path, terminal, summary) "
+        "VALUES ('r/old.md', 'T1', 'pre-drift row')"
+    )
+    conn.commit()
+
+
+def test_drifted_table_missing_extracted_at_does_not_crash():
+    """A populated table missing extracted_at must self-heal, not crash on CREATE INDEX."""
+    conn = _fresh_conn()
+    _drifted_table_missing_extracted_at(conn)
+
+    # Pre-condition: the index column is genuinely absent.
+    cols_before = {r[1] for r in conn.execute("PRAGMA table_info(report_findings)")}
+    assert "extracted_at" not in cols_before
+
+    # Must not raise OperationalError: no such column: extracted_at.
+    result = ensure_report_findings_table(conn)
+    assert result is False  # table already existed
+
+    cols_after = {r[1] for r in conn.execute("PRAGMA table_info(report_findings)")}
+    # Self-healed: the missing canonical columns were added.
+    for expected in (
+        "extracted_at", "dispatch_id", "report_date", "task_type",
+        "patterns_found", "antipatterns_found", "prevention_rules_found",
+        "tags_found", "age_category",
+    ):
+        assert expected in cols_after, f"{expected} not self-healed onto drifted table"
+
+    # The extracted_at index now exists (it was the crash site).
+    assert "idx_report_findings_extracted" in _indexes(conn)
+
+    # Pre-drift data is preserved (additive ALTER, no rebuild).
+    row = conn.execute(
+        "SELECT report_path, terminal, summary, extracted_at FROM report_findings"
+    ).fetchone()
+    assert row[0] == "r/old.md"
+    assert row[1] == "T1"
+    assert row[3] is None  # nullable backfill — no CURRENT_TIMESTAMP default on ALTER
+
+
+def test_drifted_table_self_heal_is_idempotent():
+    """Running the self-heal twice on a drifted table is a no-op the second time."""
+    conn = _fresh_conn()
+    _drifted_table_missing_extracted_at(conn)
+    ensure_report_findings_table(conn)
+    # Second call: table now complete; must not raise duplicate-column.
+    result = ensure_report_findings_table(conn)
+    assert result is False
+    assert "idx_report_findings_extracted" in _indexes(conn)


### PR DESCRIPTION
## Summary

Hardening sprint D-A3. `ensure_report_findings_table` runs `CREATE INDEX ... (extracted_at DESC)` on a pre-existing table. On a **drifted** table (created by an older schema missing `extracted_at`) the index creation raised `OperationalError: no such column: extracted_at` and crashed the self-healing migration — exactly when self-heal was needed (the nightly pipeline's Phase 3 calls this before its first SELECT on `report_findings`).

## Changes

- `scripts/lib/report_findings_migration.py`:
  - `_EXPECTED_COLUMNS` — canonical non-PK columns + ALTER-safe types, in sync with the CREATE TABLE. `extracted_at` is typed **without** its `CURRENT_TIMESTAMP` default (SQLite `ALTER ADD COLUMN` rejects non-constant defaults; rows via the normal CREATE path still get the default).
  - `_self_heal_drifted_columns(conn)` — ALTER-adds missing canonical columns (nullable, additive, no rebuild, no data loss).
  - `ensure_report_findings_table` calls the self-heal before `executescript` when the table already existed.
- `tests/test_report_findings_migration.py`: `test_drifted_table_missing_extracted_at_does_not_crash` + `test_drifted_table_self_heal_is_idempotent`.

## Scope

Crash-fix only. The ADR-007 `project_id` + composite-key retrofit on `report_findings` is a separate, **deferred POST-1.0** tenant-stamping migration (nullable-add → backfill via resolve_init → UNIQUE-composite rebuild; must not default to `vnx-dev`).

## Verification

- `pytest tests/test_report_findings_migration.py tests/test_report_findings_schema.py` → 15 passed (incl. `test_link_sessions_dispatches_full_main` + the 2 new drifted-table tests).
- **kimi-diff-gate: PASS (0 blocking, 0 advisory).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)