### PR TITLE
fix(doctor): tolerate missing VNX_INTELLIGENCE_DIR on partial setup (D-A5)

### DIFF
--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -119,7 +119,12 @@ def check_path_resolution(paths: Dict[str, str]) -> List[CheckResult]:
     results = []
     project_root = Path(paths["PROJECT_ROOT"])
     canonical_root = Path(paths.get("VNX_CANONICAL_ROOT", paths["VNX_HOME"]))
-    intelligence_dir = Path(paths["VNX_INTELLIGENCE_DIR"])
+    # Tolerate a partial paths dict (e.g. vnx_doctor run on a bare project before
+    # full init): fall back to the canonical derivation rather than KeyError-ing.
+    # Mirrors vnx_paths.py: VNX_INTELLIGENCE_DIR = canonical_root / ".vnx-intelligence".
+    intelligence_dir = Path(
+        paths.get("VNX_INTELLIGENCE_DIR") or (canonical_root / ".vnx-intelligence")
+    )
 
     if project_root.is_dir():
         results.append(CheckResult("path", PASS, f"Runtime root: {project_root}"))

--- a/tests/test_vnx_doctor.py
+++ b/tests/test_vnx_doctor.py
@@ -264,8 +264,21 @@ class TestWriteAccess:
 class TestPathResolution:
     def test_project_root_valid(self, vnx_env):
         results = check_path_resolution(vnx_env)
-        root_check = [r for r in results if "Project root" in r.message]
+        root_check = [r for r in results if "Runtime root" in r.message]
         assert root_check[0].status == PASS
+
+    def test_missing_intelligence_dir_falls_back_without_crash(self, tmp_path):
+        """A paths dict without VNX_INTELLIGENCE_DIR must not KeyError; it falls
+        back to the canonical <canonical_root>/.vnx-intelligence derivation."""
+        partial = {
+            "PROJECT_ROOT": str(tmp_path),
+            "VNX_HOME": str(tmp_path / "vnx"),
+            # VNX_INTELLIGENCE_DIR intentionally omitted
+        }
+        results = check_path_resolution(partial)  # must not raise
+        intel = [r for r in results if "Intelligence dir" in r.message]
+        assert intel, "Intelligence dir check missing"
+        assert ".vnx-intelligence" in intel[0].message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardening sprint D-A5. `check_path_resolution` hard-subscripted `paths["VNX_INTELLIGENCE_DIR"]` (vnx_doctor.py:122), so running the doctor on a partial/bare project (a paths dict without that key) raised `KeyError` and crashed instead of reporting failures.

## Changes

- `scripts/vnx_doctor.py`: `intelligence_dir = Path(paths.get("VNX_INTELLIGENCE_DIR") or (canonical_root / ".vnx-intelligence"))` — the canonical fallback mirrors `vnx_paths.py`. (This is the only missing-key crash in the partial-setup path; all other subscripted keys are present there.)
- `tests/test_vnx_doctor.py`:
  - `test_project_root_valid` — match the current "Runtime root" message (stale "Project root", D-TESTS cluster-4).
  - new `test_missing_intelligence_dir_falls_back_without_crash` — covers the fallback branch directly.

## Verification

- `pytest tests/test_vnx_doctor.py` → **27 passed** (target `test_doctor_does_not_crash_on_partial_setup` now passes; previously the suite had 1 pre-existing stale failure).
- **kimi-diff-gate (production change): PASS, 0 blocking.** The added coverage test addresses the gate's own advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)