### PR TITLE
test: fix stale-test clusters from the hardening sprint (D-TESTS)

### DIFF
--- a/tests/test_adr007_dispatches_repair.py
+++ b/tests/test_adr007_dispatches_repair.py
@@ -722,7 +722,8 @@ def test_run_repairs_then_walks_to_head(tmp_path: Path, monkeypatch: pytest.Monk
     assert mfs._has_composite_unique(conn, _dispatch_cols(conn)) is True
     assert mfs._has_solo_dispatch_id_unique(conn, _dispatch_cols(conn)) is False
     assert "ux_solo_did" not in _unique_index_names(conn)
-    assert schema_migration_user_version(conn) == 30
+    # Head moved 30 -> 31 when migration 0031 (runtime tenant FK repair) landed.
+    assert schema_migration_user_version(conn) == 31
     conn.close()
 
 

--- a/tests/test_adr_indexer.py
+++ b/tests/test_adr_indexer.py
@@ -83,16 +83,23 @@ def _write_adr(adr_dir: Path, num: str, title: str, context_files: str,
 class TestAdrIndexLoad(unittest.TestCase):
 
     def test_load_index_from_adr_dir(self):
-        """Loads all 14 ADRs from the real docs/governance/decisions/ directory."""
+        """Loads every ADR from the real docs/governance/decisions/ directory.
+
+        Counts the live ADR-*.md files rather than hardcoding a number, so adding
+        a new ADR does not break this test.
+        """
         if not _REAL_ADR_DIR.is_dir():
             self.skipTest("real ADR dir not available")
 
+        expected = len(list(_REAL_ADR_DIR.glob("ADR-*.md")))
+        self.assertGreater(expected, 0, "no ADR files found in the real ADR dir")
+
         index, mtimes = _scan_adrs(_REAL_ADR_DIR)
 
-        self.assertEqual(len(index.entries), 14, (
-            f"Expected 14 ADRs, got {len(index.entries)}: {sorted(index.entries.keys())}"
+        self.assertEqual(len(index.entries), expected, (
+            f"Expected {expected} ADRs, got {len(index.entries)}: {sorted(index.entries.keys())}"
         ))
-        self.assertEqual(len(mtimes), 14)
+        self.assertEqual(len(mtimes), expected)
 
     def test_load_index_empty_dir(self):
         """Loading from an empty directory yields no entries."""

--- a/tests/test_api_intelligence.py
+++ b/tests/test_api_intelligence.py
@@ -37,14 +37,16 @@ def _make_db(tmp_path: Path) -> Path:
             confidence_score REAL,
             category TEXT,
             usage_count INTEGER,
-            last_used TEXT
+            last_used TEXT,
+            project_id TEXT DEFAULT 'vnx-dev'
         );
         CREATE TABLE antipatterns (
             id INTEGER PRIMARY KEY,
             title TEXT,
             severity TEXT,
             occurrence_count INTEGER,
-            last_seen TEXT
+            last_seen TEXT,
+            project_id TEXT DEFAULT 'vnx-dev'
         );
         CREATE TABLE coordination_events (
             id INTEGER PRIMARY KEY,
@@ -95,7 +97,9 @@ class TestPatternsEndpoint:
         db_path = _make_db(tmp_path)
         con = sqlite3.connect(str(db_path))
         con.execute(
-            "INSERT INTO success_patterns VALUES (1, 'Test Pattern', 0.85, 'crawler', 3, '2026-01-01')"
+            "INSERT INTO success_patterns "
+            "(id, title, confidence_score, category, usage_count, last_used) "
+            "VALUES (1, 'Test Pattern', 0.85, 'crawler', 3, '2026-01-01')"
         )
         con.commit()
         con.close()
@@ -114,7 +118,9 @@ class TestPatternsEndpoint:
         db_path = _make_db(tmp_path)
         con = sqlite3.connect(str(db_path))
         con.execute(
-            "INSERT INTO antipatterns VALUES (1, 'Bad Pattern', 'medium', 5, '2026-01-01')"
+            "INSERT INTO antipatterns "
+            "(id, title, severity, occurrence_count, last_seen) "
+            "VALUES (1, 'Bad Pattern', 'medium', 5, '2026-01-01')"
         )
         con.commit()
         con.close()
@@ -141,7 +147,9 @@ class TestPatternsEndpoint:
         con = sqlite3.connect(str(db_path))
         for i in range(10):
             con.execute(
-                "INSERT INTO success_patterns VALUES (?, ?, 0.5, 'cat', 1, NULL)",
+                "INSERT INTO success_patterns "
+                "(id, title, confidence_score, category, usage_count, last_used) "
+                "VALUES (?, ?, 0.5, 'cat', 1, NULL)",
                 (i + 1, f"Pattern {i}"),
             )
         con.commit()

--- a/tests/test_headless_smoke.py
+++ b/tests/test_headless_smoke.py
@@ -129,7 +129,10 @@ class TestSmokeSuccess(_SmokeTestCase):
         result = classify_exit(exit_code=0)
         self.assertEqual(result.failure_class, SUCCESS)
         self.assertFalse(result.retryable)
-        self.assertEqual(result.operator_hint, "")
+        self.assertEqual(
+            result.operator_hint,
+            "Run completed successfully. Check output artifact for results.",
+        )
 
     def test_success_inspection(self):
         """Operator can inspect a succeeded run."""
@@ -144,7 +147,7 @@ class TestSmokeSuccess(_SmokeTestCase):
 
         run = self.registry.get(run.run_id)
         line = format_run_line(run)
-        self.assertIn("[+]", line)
+        self.assertIn("[✓]", line)
         self.assertIn("succeeded", line)
 
         detail = format_run_detail(run)
@@ -196,12 +199,12 @@ class TestSmokeTimeout(_SmokeTestCase):
 
         run = self.registry.get(run.run_id)
         line = format_run_line(run)
-        self.assertIn("[X]", line)
+        self.assertIn("[✗]", line)
         self.assertIn("TIMEOUT", line)
 
         detail = format_run_detail(run)
         self.assertIn("TIMEOUT", detail)
-        self.assertIn("Timed out", detail)
+        self.assertIn("Failure Class : TIMEOUT", detail)
 
 
 class TestSmokeNoOutputHang(_SmokeTestCase):
@@ -266,7 +269,7 @@ class TestSmokeNoOutputHang(_SmokeTestCase):
         run = self.registry.get(run.run_id)
         detail = format_run_detail(run)
         self.assertIn("NO_OUTPUT", detail)
-        self.assertIn("No output (hang)", detail)
+        self.assertIn("Failure Class : NO_OUTPUT", detail)
 
 
 class TestSmokeInterrupted(_SmokeTestCase):
@@ -321,7 +324,7 @@ class TestSmokeInterrupted(_SmokeTestCase):
         run = self.registry.get(run.run_id)
         detail = format_run_detail(run)
         self.assertIn("INTERRUPTED", detail)
-        self.assertIn("Interrupted (signal)", detail)
+        self.assertIn("Failure Class : INTERRUPTED", detail)
 
 
 class TestSmokeOperatorSummary(_SmokeTestCase):
@@ -355,18 +358,17 @@ class TestSmokeOperatorSummary(_SmokeTestCase):
         self.assertEqual(summary.active_count, 1)
         self.assertEqual(summary.succeeded_count, 1)
         self.assertEqual(summary.failed_count, 1)
-        self.assertEqual(summary.status_label, "ACTIVE")
         self.assertEqual(summary.failure_class_counts.get("TIMEOUT"), 1)
 
         text = format_health_summary(summary)
-        self.assertIn("ACTIVE", text)
+        self.assertIn("Active      : 1", text)
         self.assertIn("TIMEOUT", text)
 
     def test_summary_idle(self):
         """Health summary shows IDLE when no runs exist."""
         summary = build_health_summary(self.registry)
-        self.assertEqual(summary.status_label, "IDLE")
         self.assertEqual(summary.total_runs, 0)
+        self.assertEqual(summary.active_count, 0)
 
     def test_list_runs_active_filter(self):
         """list_runs with show_active returns only running runs."""
@@ -389,7 +391,7 @@ class TestSmokeOperatorSummary(_SmokeTestCase):
 
         lines = list_runs(self.registry, show_failed=True)
         self.assertEqual(len(lines), 1)
-        self.assertIn("[X]", lines[0])
+        self.assertIn("[✗]", lines[0])
         self.assertIn("TOOL_FAIL", lines[0])
 
 

--- a/tests/test_intelligence_pipeline_e2e.py
+++ b/tests/test_intelligence_pipeline_e2e.py
@@ -29,6 +29,7 @@ def _create_test_db(db_path: Path) -> sqlite3.Connection:
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS success_patterns (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
             pattern_type TEXT NOT NULL,
             category TEXT NOT NULL,
             title TEXT NOT NULL,
@@ -44,11 +45,14 @@ def _create_test_db(db_path: Path) -> sqlite3.Connection:
             source_dispatch_ids TEXT,
             source_receipts TEXT,
             first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
-            last_used DATETIME
+            last_used DATETIME,
+            valid_from DATETIME DEFAULT CURRENT_TIMESTAMP,
+            valid_until DATETIME
         );
 
         CREATE TABLE IF NOT EXISTS antipatterns (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
             pattern_type TEXT NOT NULL,
             category TEXT NOT NULL,
             title TEXT NOT NULL,
@@ -62,11 +66,14 @@ def _create_test_db(db_path: Path) -> sqlite3.Connection:
             severity TEXT DEFAULT 'medium',
             source_dispatch_ids TEXT,
             first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
-            last_seen DATETIME
+            last_seen DATETIME,
+            valid_from DATETIME DEFAULT CURRENT_TIMESTAMP,
+            valid_until DATETIME
         );
 
         CREATE TABLE IF NOT EXISTS prevention_rules (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
             tag_combination TEXT NOT NULL,
             rule_type TEXT NOT NULL,
             description TEXT NOT NULL,
@@ -74,7 +81,10 @@ def _create_test_db(db_path: Path) -> sqlite3.Connection:
             confidence REAL DEFAULT 0.0,
             created_at TEXT NOT NULL,
             triggered_count INTEGER DEFAULT 0,
-            last_triggered TEXT
+            last_triggered TEXT,
+            source_dispatch_id TEXT,
+            valid_from DATETIME DEFAULT CURRENT_TIMESTAMP,
+            valid_until DATETIME
         );
 
         CREATE TABLE IF NOT EXISTS pattern_usage (

--- a/tests/test_log_artifacts.py
+++ b/tests/test_log_artifacts.py
@@ -56,6 +56,8 @@ class TestLogArtifactCreation(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="Hello world",
             stderr="",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         self.assertTrue(path.exists())
         self.assertEqual(path.name, "run-001.log")
@@ -70,6 +72,8 @@ class TestLogArtifactCreation(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="output",
             stderr="",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         self.assertTrue(nested_dir.exists())
 
@@ -86,12 +90,14 @@ class TestLogArtifactHeader(_TmpDirTestCase):
             started_at="2026-03-30T12:00:00.000Z",
             stdout="",
             stderr="",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
-        self.assertIn("run_id:       run-hdr-1", content)
-        self.assertIn("dispatch_id:  d-hdr-1", content)
-        self.assertIn("target_type:  headless_codex_cli", content)
-        self.assertIn("started_at:   2026-03-30T12:00:00.000Z", content)
+        self.assertIn("Run ID       : run-hdr-1", content)
+        self.assertIn("Dispatch ID  : d-hdr-1", content)
+        self.assertIn("Target Type  : headless_codex_cli", content)
+        self.assertIn("Started At   : 2026-03-30T12:00:00.000Z", content)
         self.assertIn("VNX HEADLESS RUN LOG", content)
 
 
@@ -106,6 +112,8 @@ class TestLogArtifactStdoutStderr(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="Analysis complete: module uses layered architecture",
             stderr="",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
         self.assertIn("STDOUT", content)
@@ -120,6 +128,8 @@ class TestLogArtifactStdoutStderr(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="",
             stderr="Error: context limit exceeded",
+            exit_code=1,
+            duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
         self.assertIn("STDERR", content)
@@ -134,9 +144,11 @@ class TestLogArtifactStdoutStderr(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="",
             stderr="",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
-        self.assertIn("(no stdout)", content)
+        self.assertIn("(no output)", content)
         self.assertIn("(no stderr)", content)
 
     def test_both_stdout_and_stderr_delimited(self):
@@ -149,6 +161,8 @@ class TestLogArtifactStdoutStderr(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="good output",
             stderr="warning output",
+            exit_code=0,
+            duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
         stdout_pos = content.index("STDOUT")
@@ -171,14 +185,13 @@ class TestLogArtifactFooter(_TmpDirTestCase):
             stderr="",
             exit_code=0,
             duration_seconds=42.5,
-            completed_at="2026-03-30T10:00:42.500Z",
         )
         content = path.read_text(encoding="utf-8")
         self.assertIn("RUN OUTCOME", content)
-        self.assertIn("exit_code:        0", content)
-        self.assertIn("failure_class:    N/A", content)
-        self.assertIn("duration_seconds: 42.5", content)
-        self.assertIn("completed_at:     2026-03-30T10:00:42.500Z", content)
+        self.assertIn("Exit Code    : 0", content)
+        self.assertIn("Failure Class: SUCCESS", content)
+        self.assertIn("Duration     : 42.5s", content)
+        self.assertIn("Status       : SUCCEEDED", content)
 
     def test_footer_with_failure(self):
         path = write_log_artifact(
@@ -194,11 +207,11 @@ class TestLogArtifactFooter(_TmpDirTestCase):
             duration_seconds=5.2,
         )
         content = path.read_text(encoding="utf-8")
-        self.assertIn("exit_code:        1", content)
-        self.assertIn("failure_class:    TOOL_FAIL", content)
-        self.assertIn("duration_seconds: 5.2", content)
+        self.assertIn("Exit Code    : 1", content)
+        self.assertIn("Failure Class: TOOL_FAIL", content)
+        self.assertIn("Duration     : 5.2s", content)
 
-    def test_footer_defaults_na_for_missing(self):
+    def test_footer_placeholders_for_unknown_outcome(self):
         path = write_log_artifact(
             artifact_dir=self.artifact_dir,
             run_id="run-foot-3",
@@ -207,11 +220,13 @@ class TestLogArtifactFooter(_TmpDirTestCase):
             started_at="2026-03-30T10:00:00.000Z",
             stdout="",
             stderr="",
+            exit_code=None,
+            duration_seconds=0.0,
         )
         content = path.read_text(encoding="utf-8")
-        self.assertIn("exit_code:        N/A", content)
-        self.assertIn("failure_class:    N/A", content)
-        self.assertIn("duration_seconds: N/A", content)
+        self.assertIn("Exit Code    : —", content)
+        self.assertIn("Failure Class: UNKNOWN", content)
+        self.assertIn("Duration     : 0.0s", content)
 
 
 # ============================================================================
@@ -252,7 +267,7 @@ class TestOutputArtifact(_TmpDirTestCase):
             run_id="run-oa-4",
             stdout="content",
         )
-        self.assertEqual(path.name, "run-oa-4.output.txt")
+        self.assertEqual(path.name, "run-oa-4.out")
 
 
 # ============================================================================

--- a/tests/test_proposals_api.py
+++ b/tests/test_proposals_api.py
@@ -36,14 +36,16 @@ def _make_db(tmp_path: Path) -> Path:
             confidence_score REAL,
             category TEXT,
             usage_count INTEGER,
-            last_used TEXT
+            last_used TEXT,
+            project_id TEXT DEFAULT 'vnx-dev'
         );
         CREATE TABLE antipatterns (
             id INTEGER PRIMARY KEY,
             title TEXT,
             severity TEXT,
             occurrence_count INTEGER,
-            last_seen TEXT
+            last_seen TEXT,
+            project_id TEXT DEFAULT 'vnx-dev'
         );
         """
     )
@@ -274,9 +276,9 @@ class TestConfidenceTrends:
     def test_success_patterns_aggregated_by_date(self, tmp_path):
         db_path = _make_db(tmp_path)
         con = sqlite3.connect(str(db_path))
-        con.execute("INSERT INTO success_patterns VALUES (1, 'P1', 0.8, 'cat', 1, '2026-04-10')")
-        con.execute("INSERT INTO success_patterns VALUES (2, 'P2', 0.6, 'cat', 1, '2026-04-10')")
-        con.execute("INSERT INTO success_patterns VALUES (3, 'P3', 0.9, 'cat', 1, '2026-04-11')")
+        con.execute("INSERT INTO success_patterns (id, title, confidence_score, category, usage_count, last_used) VALUES (1, 'P1', 0.8, 'cat', 1, '2026-04-10')")
+        con.execute("INSERT INTO success_patterns (id, title, confidence_score, category, usage_count, last_used) VALUES (2, 'P2', 0.6, 'cat', 1, '2026-04-10')")
+        con.execute("INSERT INTO success_patterns (id, title, confidence_score, category, usage_count, last_used) VALUES (3, 'P3', 0.9, 'cat', 1, '2026-04-11')")
         con.commit()
         con.close()
 
@@ -295,7 +297,7 @@ class TestConfidenceTrends:
     def test_antipatterns_included_in_trends(self, tmp_path):
         db_path = _make_db(tmp_path)
         con = sqlite3.connect(str(db_path))
-        con.execute("INSERT INTO antipatterns VALUES (1, 'AP1', 'high', 3, '2026-04-12')")
+        con.execute("INSERT INTO antipatterns (id, title, severity, occurrence_count, last_seen) VALUES (1, 'AP1', 'high', 3, '2026-04-12')")
         con.commit()
         con.close()
 
@@ -312,7 +314,7 @@ class TestConfidenceTrends:
     def test_trend_entry_has_required_fields(self, tmp_path):
         db_path = _make_db(tmp_path)
         con = sqlite3.connect(str(db_path))
-        con.execute("INSERT INTO success_patterns VALUES (1, 'P1', 0.7, 'cat', 1, '2026-04-13')")
+        con.execute("INSERT INTO success_patterns (id, title, confidence_score, category, usage_count, last_used) VALUES (1, 'P1', 0.7, 'cat', 1, '2026-04-13')")
         con.commit()
         con.close()
 

--- a/tests/test_wrapper_removal_as09.py
+++ b/tests/test_wrapper_removal_as09.py
@@ -10,11 +10,16 @@ VNX_ROOT = TESTS_DIR.parent
 SCRIPTS_DIR = VNX_ROOT / "scripts"
 
 
-def test_dispatch_ack_watcher_invokes_ack_monitor_directly():
-    content = (SCRIPTS_DIR / "dispatch_ack_watcher.sh").read_text(encoding="utf-8")
-    assert "heartbeat_ack_monitor_wrapper.py" not in content
-    assert "heartbeat_ack_monitor.py" in content
-    assert "--stdin" in content
+def test_heartbeat_ack_monitor_wrapper_removed():
+    """AS-09 removed the wrapper indirection. The dispatch_ack_watcher.sh shim was
+    itself later deleted (cb174793), so the durable invariant is simply that the
+    wrapper module no longer exists and the monitor it wrapped still does."""
+    assert not (SCRIPTS_DIR / "heartbeat_ack_monitor_wrapper.py").exists(), (
+        "heartbeat_ack_monitor_wrapper.py should be gone (AS-09 wrapper removal)"
+    )
+    assert (SCRIPTS_DIR / "heartbeat_ack_monitor.py").exists(), (
+        "heartbeat_ack_monitor.py (the direct target) should exist"
+    )
 
 
 def test_pr_queue_completion_attempt_inlines_event_logging():


### PR DESCRIPTION
## Summary

Test-only. Fixes the stale-test clusters from the 1.0 hardening sprint — production evolved, these tests carried outdated expectations/fixtures. Each was verified as genuinely stale (not a masked bug). Clusters 3 (selector symbols) and 4 (doctor) were already fixed in D-A4/D-A5; this covers 1, 2, 5, 8, 9.

## Changes

- **cluster-1** (`test_api_intelligence`, `test_proposals_api`): `_make_db` lacked `project_id` (the API now `SELECT project_id, ...`) → add column + convert positional inserts to explicit-column form.
- **cluster-2** (`test_intelligence_pipeline_e2e`): fixture schema missing F54 `valid_from`/`valid_until` + `source_dispatch_id` + `project_id` that `persist_to_intelligence_db`/`ingest_approved_rules` now write → INSERT failed → 0 rows. Added them.
- **cluster-5** (`test_adr007_dispatches_repair`): migration head walked 30→31 (0031 landed) → update the version assertion.
- **cluster-8** (`test_log_artifacts`, `test_headless_smoke`): cb174793 renamed CLI glyphs (`[+]`→`[✓]`, `[X]`→`[✗]`), failure-class labels (`No output (hang)`→`NO_OUTPUT`), output messages; `write_log_artifact()` gained required `exit_code`/`duration_seconds` and dropped `completed_at`; `HealthSummary.status_label` removed. Tests aligned to current production output.
- **cluster-9** (`test_adr_indexer`, `test_wrapper_removal_as09`): ADR count now counts live `ADR-*.md` (was hardcoded 14, robust to future ADRs); the removed-shim test asserts the wrapper module's absence (its `dispatch_ack_watcher.sh` was deleted in cb174793).

## Verification

- **127 passed** across the 7 fixed files; `test_adr007` 66 passed.
- **kimi-diff-gate: PASS (0 blocking).**
- Test-only diff — no production code touched.

## Out of scope

`test_adr007_dispatches_repair::test_all_functions_within_70_lines_gate_counter` is a **pre-existing** failure (5 long migration functions exceed the 70-line gate) — real code debt, not a stale test. Left untouched; candidate POST-1.0 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)