### PR TITLE
fix(intelligence): render direct-injection classes to the worker (render-gap)

### DIFF
--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -390,4 +390,16 @@ def format_intelligence_items(items: list) -> str:
         for item in by_class["recent_comparable"]:
             parts.append(f"- **{item.title}**: {item.content}")
         parts.append("")
+    # Direct-injection classes carry a fully-formatted markdown section in
+    # item.content (code anchors as file:line pointers, ADRs, schema sections,
+    # operator memories, prior-round findings). They are selected + budgeted by
+    # IntelligenceSelector but were previously never rendered here — emit their
+    # content verbatim so the worker actually receives them.
+    for cls in ("prior_round_finding", "adr_relevant", "schema_section",
+                "code_anchor", "operator_memory"):
+        for item in by_class.get(cls, []):
+            content = (getattr(item, "content", "") or "").rstrip()
+            if content:
+                parts.append(content)
+                parts.append("")
     return "\n".join(parts)

--- a/scripts/lib/intelligence_sources/_models.py
+++ b/scripts/lib/intelligence_sources/_models.py
@@ -34,6 +34,16 @@ def _format_items_markdown(items: List[IntelligenceItem]) -> str:
         for item in by_class["recent_comparable"]:
             parts.append(f"- **{item.title}**: {item.content}")
         parts.append("")
+    # Direct-injection classes carry a fully-formatted markdown section in
+    # item.content; emit it verbatim so they reach the worker (they were
+    # selected + budgeted but previously dropped at render).
+    for cls in ("prior_round_finding", "adr_relevant", "schema_section",
+                "code_anchor", "operator_memory"):
+        for item in by_class.get(cls, []):
+            content = (item.content or "").rstrip()
+            if content:
+                parts.append(content)
+                parts.append("")
     return "\n".join(parts)
 
 

--- a/tests/test_intelligence_injection.py
+++ b/tests/test_intelligence_injection.py
@@ -96,6 +96,41 @@ class TestFormatIntelligenceItems:
         section = intelligence_injection.format_intelligence_items([])
         assert section == ""
 
+    def test_direct_injection_classes_render_their_content(self):
+        """Regression: direct-injection classes (code_anchor, adr_relevant,
+        schema_section, operator_memory, prior_round_finding) were selected and
+        budgeted but never rendered — their content must now reach the worker."""
+        items = [
+            _make_item("code_anchor", "Code anchors",
+                       "## CODE ANCHORS\n- `scripts/x.py:10-20` (matched: foo)"),
+            _make_item("adr_relevant", "ADRs",
+                       "## ADRS\n- ADR-007: tenant project_id"),
+            _make_item("prior_round_finding", "Prior",
+                       "## PRIOR FINDINGS\n- missing UNIQUE on dispatch_metadata"),
+            _make_item("operator_memory", "Memory",
+                       "## OPERATOR MEMORY\n- release stale leases first"),
+            _make_item("schema_section", "Schema",
+                       "## SCHEMA\nCREATE TABLE dispatches (...)"),
+        ]
+        section = intelligence_injection.format_intelligence_items(items)
+        assert "scripts/x.py:10-20" in section, "code_anchor pointer not rendered"
+        assert "ADR-007" in section
+        assert "missing UNIQUE on dispatch_metadata" in section
+        assert "release stale leases first" in section
+        assert "CREATE TABLE dispatches" in section
+
+    def test_direct_and_standard_classes_both_render(self):
+        """A mix of standard + direct classes must render both."""
+        items = [
+            _make_item("proven_pattern", "PP", "do this"),
+            _make_item("code_anchor", "Code anchors",
+                       "## CODE ANCHORS\n- `scripts/y.py:1-5`"),
+        ]
+        section = intelligence_injection.format_intelligence_items(items)
+        assert "Proven success patterns" in section
+        assert "do this" in section
+        assert "scripts/y.py:1-5" in section
+
 
 # ---------------------------------------------------------------------------
 # fetch_intelligence_section


### PR DESCRIPTION
## Summary

The dispatch-injection renderer `format_intelligence_items` (the real path, via `fetch_intelligence_section`) — and the selector's `_format_items_markdown` — only emitted three classes: `failure_prevention`, `proven_pattern`, `recent_comparable`. **Every direct-injection class — `code_anchor` (incl. the D-A4 file:line pointers), `adr_relevant`, `schema_section`, `operator_memory`, `prior_round_finding` — was selected, budgeted, and audited by `IntelligenceSelector`, then silently dropped before reaching the worker.** Code-anchor grounding + ADR injection were effectively dead in production.

Surfaced by the multi-model intelligence-layer design research (DeepSeek + Codex grounded in the code; a web agent flagged it), then verified directly.

## Fix

Emit each direct-injection item's `.content` verbatim (it's already a complete markdown section) after the three standard classes, in **both** renderers. Order: prior_round_finding, adr_relevant, schema_section, code_anchor, operator_memory.

## Verification

- `pytest tests/test_intelligence_injection.py tests/test_intelligence_selector.py tests/test_code_anchor_finder.py` → **119 passed** (incl. 2 new regression tests proving the 5 direct classes render + direct/standard coexist).
- **kimi-diff-gate: PASS (0 blocking).** silent-except EXIT=0; ruff clean.

## Why it matters

This is the keystone (build-step 0) for the POST-1.0 intelligence program — without it, D-A4 and everything downstream is invisible to workers. Full design synthesis (GLM-5.2/Kimi-2.7/DeepSeek-V4/Codex research): `claudedocs/2026-06-26-intelligence-layer-design-research-SYNTHESIS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)