### PR TITLE
feat(intelligence): doc_relevant source — inject doc-section pointers (build-step 2)

### DIFF
--- a/scripts/doc_section_extractor.py
+++ b/scripts/doc_section_extractor.py
@@ -6,7 +6,8 @@ Purpose: Extract high-quality documentation sections from markdown files
          and populate FTS5 search database alongside code snippets.
 
 Configurable via VNX_DOCS_DIRS environment variable (comma-separated paths,
-relative to PROJECT_ROOT or absolute). Feature is inactive when not configured.
+relative to PROJECT_ROOT or absolute). When unset, defaults to the project's
+own docs/ directory; set VNX_DOCS_DIRS="" to disable doc indexing.
 """
 
 import hashlib
@@ -98,10 +99,19 @@ def log(level: str, message: str):
 
 
 def _resolve_docs_dirs() -> List[Path]:
-    """Resolve documentation directories from VNX_DOCS_DIRS env var."""
-    raw = os.environ.get("VNX_DOCS_DIRS", "")
-    if not raw:
-        return []
+    """Resolve documentation directories from VNX_DOCS_DIRS env var.
+
+    When VNX_DOCS_DIRS is UNSET, defaults to the project's own ``docs/`` directory
+    so the project's functional/technical docs are indexed for the doc_relevant
+    intelligence source without operator config. An EXPLICIT empty value
+    (VNX_DOCS_DIRS="") disables doc indexing.
+    """
+    raw = os.environ.get("VNX_DOCS_DIRS")
+    if raw is None:
+        default_docs = PROJECT_ROOT / "docs"
+        return [default_docs] if default_docs.is_dir() else []
+    if not raw.strip():
+        return []  # explicit empty → doc indexing disabled
     dirs = []
     for entry in raw.split(","):
         p = Path(entry.strip())

--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -396,7 +396,7 @@ def format_intelligence_items(items: list) -> str:
     # IntelligenceSelector but were previously never rendered here — emit their
     # content verbatim so the worker actually receives them.
     for cls in ("prior_round_finding", "adr_relevant", "schema_section",
-                "code_anchor", "operator_memory"):
+                "code_anchor", "doc_relevant", "operator_memory"):
         for item in by_class.get(cls, []):
             content = (getattr(item, "content", "") or "").rstrip()
             if content:

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -33,6 +33,7 @@ from intelligence_sources import (  # noqa: F401  (re-exported for backward comp
     query_proven_patterns, query_failure_prevention, query_recent_comparable,
     build_adr_item, build_schema_section_item,
     build_code_anchor_item, build_operator_memory_item, build_prior_round_item,
+    build_doc_relevant_item,
     record_injection_audit, record_pattern_usage,
 )
 from intelligence_sources import stamp_source_dispatch_ids as _stamp
@@ -69,8 +70,9 @@ _DIRECT_SOURCES = [
     ("prior_round_finding", ["prior_round_finding"]),
     ("adr_relevant",        ["prior_round_finding", "adr_relevant"]),
     ("code_anchor",         ["prior_round_finding", "adr_relevant", "code_anchor"]),
-    ("operator_memory",     ["prior_round_finding", "adr_relevant", "code_anchor", "operator_memory"]),
-    ("schema_section",      ["prior_round_finding", "adr_relevant", "code_anchor", "operator_memory", "schema_section"]),
+    ("doc_relevant",        ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant"]),
+    ("operator_memory",     ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant", "operator_memory"]),
+    ("schema_section",      ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant", "operator_memory", "schema_section"]),
 ]
 
 # Build-step 1: rank-then-budget (opt-in via VNX_INTEL_RANK_THEN_BUDGET=1).
@@ -85,6 +87,7 @@ _CLASS_WEIGHT: Dict[str, float] = {
     "proven_pattern": 1.2,
     "adr_relevant": 1.1,
     "schema_section": 1.1,
+    "doc_relevant": 1.0,
     "code_anchor": 1.0,
     "operator_memory": 1.0,
     "recent_comparable": 0.8,
@@ -218,6 +221,7 @@ class IntelligenceSelector:
             "prior_round_finding": build_prior_round_item(pr_id or "", paths, now_ts) if pr_id else None,
             "adr_relevant": build_adr_item(dispatch_id, paths, now_ts) if paths else None,
             "code_anchor": build_code_anchor_item(dispatch_id, paths, instruction_text or "", now_ts) if (paths and instruction_text) else None,
+            "doc_relevant": build_doc_relevant_item(self._get_quality_db(), dispatch_id, paths, instruction_text or "", now_ts) if (paths or instruction_text) else None,
             "operator_memory": build_operator_memory_item(dispatch_id, skill_name, paths, instruction_text or "", now_ts) if (skill_name or paths or instruction_text) else None,
             "schema_section": build_schema_section_item(dispatch_id, paths, instruction_text or "", now_ts) if (paths or instruction_text) else None,
         }

--- a/scripts/lib/intelligence_sources/__init__.py
+++ b/scripts/lib/intelligence_sources/__init__.py
@@ -49,6 +49,7 @@ from .failure_prevention import query_failure_prevention
 from .recent_comparable import query_recent_comparable
 from .adr_relevant import build_adr_item, build_schema_section_item
 from .code_anchor import build_code_anchor_item, build_operator_memory_item, build_prior_round_item
+from .doc_relevant import build_doc_relevant_item
 
 __all__ = [
     "CONFIDENCE_THRESHOLDS", "EVIDENCE_THRESHOLDS", "GOVERNANCE_CONFIDENCE_PENALTY",
@@ -69,4 +70,5 @@ __all__ = [
     "query_proven_patterns", "query_failure_prevention", "query_recent_comparable",
     "build_adr_item", "build_schema_section_item",
     "build_code_anchor_item", "build_operator_memory_item", "build_prior_round_item",
+    "build_doc_relevant_item",
 ]

--- a/scripts/lib/intelligence_sources/_common.py
+++ b/scripts/lib/intelligence_sources/_common.py
@@ -40,6 +40,7 @@ _DIRECT_INJECTION_CLASSES = frozenset({
     "adr_relevant",
     "operator_memory",
     "schema_section",
+    "doc_relevant",
 })
 
 CONFIDENCE_THRESHOLDS = {

--- a/scripts/lib/intelligence_sources/_models.py
+++ b/scripts/lib/intelligence_sources/_models.py
@@ -38,7 +38,7 @@ def _format_items_markdown(items: List[IntelligenceItem]) -> str:
     # item.content; emit it verbatim so they reach the worker (they were
     # selected + budgeted but previously dropped at render).
     for cls in ("prior_round_finding", "adr_relevant", "schema_section",
-                "code_anchor", "operator_memory"):
+                "code_anchor", "doc_relevant", "operator_memory"):
         for item in by_class.get(cls, []):
             content = (item.content or "").rstrip()
             if content:

--- a/scripts/lib/intelligence_sources/doc_relevant.py
+++ b/scripts/lib/intelligence_sources/doc_relevant.py
@@ -1,0 +1,136 @@
+"""doc_relevant source — inject POINTERS to relevant documentation sections.
+
+Queries the markdown sections that ``doc_section_extractor`` indexes into the
+``code_snippets`` FTS5 table (language='markdown'), matched to the dispatch's
+instruction terms + touched-file stems, and injects compact ``file:line — heading``
+pointers — never doc bodies. The worker (or a scout) opens the referenced range.
+This reuses the code-anchor pointer pattern so docs survive the payload budget.
+
+The selector passes its quality_intelligence.db connection (unlike the file-based
+adr/code-anchor indexers, the doc index lives in the DB).
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+from ._common import (
+    PATTERN_CATEGORY_CODE,
+    IntelligenceItem,
+)
+
+try:
+    import code_anchor_finder as _code_anchor_finder
+except ImportError:
+    _code_anchor_finder = None  # type: ignore[assignment]
+
+MAX_DOC_SECTIONS = 5
+_MAX_QUERY_TOKENS = 12
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{3,}")
+
+
+def _extract_terms(instruction_text: str) -> List[str]:
+    """Reuse the code-anchor term extractor when available; fall back to a simple
+    identifier scan."""
+    if _code_anchor_finder is not None:
+        return _code_anchor_finder.extract_terms(instruction_text or "")
+    seen: set = set()
+    out: List[str] = []
+    for m in _IDENT_RE.finditer(instruction_text or ""):
+        tok = m.group(0)
+        if tok not in seen:
+            seen.add(tok)
+            out.append(tok)
+    return out
+
+
+def _fts5_match_expr(tokens: List[str]) -> str:
+    """Build an OR-of-quoted-terms FTS5 MATCH expression (capped)."""
+    safe = []
+    for t in tokens[:_MAX_QUERY_TOKENS]:
+        cleaned = t.replace('"', "").strip()
+        if cleaned:
+            safe.append(f'"{cleaned}"')
+    return " OR ".join(safe)
+
+
+def fetch_relevant_doc_sections(
+    conn: "Optional[sqlite3.Connection]",
+    dispatch_paths: Optional[List[str]],
+    instruction_text: str,
+    limit: int = MAX_DOC_SECTIONS,
+) -> List[tuple]:
+    """Return up to ``limit`` (title, file_path, line_range) doc-section pointers
+    from the markdown FTS5 index, ranked by FTS5 relevance. Empty on any error or
+    when nothing matches."""
+    if conn is None:
+        return []
+    terms = _extract_terms(instruction_text)
+    path_stems = [Path(p).stem for p in (dispatch_paths or []) if p]
+    tokens = [t for t in (terms + path_stems) if t]
+    if not tokens:
+        return []
+    match_expr = _fts5_match_expr(tokens)
+    if not match_expr:
+        return []
+    try:
+        rows = conn.execute(
+            "SELECT title, file_path, line_range FROM code_snippets "
+            "WHERE language = 'markdown' AND code_snippets MATCH ? "
+            "ORDER BY rank LIMIT ?",
+            (match_expr, limit),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [tuple(r) for r in rows]
+
+
+def format_doc_refs(sections: List[tuple]) -> str:
+    """Compact pointer format: ``file:line — heading``. No doc bodies."""
+    if not sections:
+        return ""
+    lines = [
+        "## RELEVANT DOCS (pointers — open the section before deciding)",
+        "",
+        "> Pointers to the live docs, not copies. Open each range; re-read the "
+        "file if it looks stale.",
+        "",
+    ]
+    for title, file_path, line_range in sections:
+        lines.append(f"- `{file_path}:{line_range}` — {title}")
+    return "\n".join(lines)
+
+
+def build_doc_relevant_item(
+    conn: "Optional[sqlite3.Connection]",
+    dispatch_id: str,
+    dispatch_paths: Optional[List[str]],
+    instruction_text: str,
+    now_ts: str,
+) -> Optional[IntelligenceItem]:
+    """Return a doc_relevant IntelligenceItem, or None when nothing matches.
+
+    Queries the markdown FTS5 index for sections relevant to the dispatch and
+    injects them as compact file:line pointers.
+    """
+    if conn is None or not (dispatch_paths or instruction_text):
+        return None
+    sections = fetch_relevant_doc_sections(conn, dispatch_paths, instruction_text or "")
+    if not sections:
+        return None
+    return IntelligenceItem(
+        item_id=f"intel_doc_{dispatch_id}",
+        item_class="doc_relevant",
+        title=f"Relevant docs ({len(sections)} sections)",
+        content=format_doc_refs(sections),
+        confidence=1.0,
+        evidence_count=len(sections),
+        last_seen=now_ts,
+        scope_tags=[],
+        source_refs=[f"{fp}:{lr}" for _, fp, lr in sections],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )

--- a/tests/test_doc_relevant.py
+++ b/tests/test_doc_relevant.py
@@ -1,0 +1,127 @@
+"""Tests for the doc_relevant intelligence source (build-step 2).
+
+Queries the markdown sections doc_section_extractor indexes into code_snippets
+FTS5 and injects compact file:line pointers (not bodies).
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "scripts"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+from intelligence_sources import doc_relevant  # noqa: E402
+
+
+_FTS5_COLS = (
+    "title, description, code, file_path, line_range, tags, language, "
+    "framework, dependencies, quality_score, usage_count, last_updated"
+)
+
+
+def _make_db(sections: list[dict]) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        f"CREATE VIRTUAL TABLE code_snippets USING fts5({_FTS5_COLS}, "
+        "tokenize = 'porter unicode61')"
+    )
+    for s in sections:
+        conn.execute(
+            "INSERT INTO code_snippets "
+            "(title, description, code, file_path, line_range, tags, language, "
+            " framework, dependencies, quality_score, usage_count, last_updated) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                s["title"], s.get("description", ""), s.get("code", ""),
+                s["file_path"], s["line_range"], s.get("tags", ""),
+                s.get("language", "markdown"), "", "", "80", "0", "now",
+            ),
+        )
+    conn.commit()
+    return conn
+
+
+_DOCS = [
+    {"title": "Lane selection", "file_path": "docs/core/DISPATCH_RULES.md",
+     "line_range": "112-130", "code": "Two lanes ship on main; the door selects the lane for dispatch routing.",
+     "language": "markdown"},
+    {"title": "Receipt format", "file_path": "docs/core/11_RECEIPT_FORMAT.md",
+     "line_range": "1-40", "code": "NDJSON receipts carry the governance audit trail.",
+     "language": "markdown"},
+    {"title": "A python helper", "file_path": "scripts/x.py",
+     "line_range": "1-10", "code": "def dispatch(): pass",
+     "language": "python"},  # not markdown — must never match
+]
+
+
+def test_fetch_matches_markdown_only():
+    conn = _make_db(_DOCS)
+    rows = doc_relevant.fetch_relevant_doc_sections(
+        conn, ["scripts/foo.py"], "edit the dispatch routing lane selection"
+    )
+    conn.close()
+    paths = {r[1] for r in rows}
+    assert "docs/core/DISPATCH_RULES.md" in paths
+    assert "scripts/x.py" not in paths  # python row never returned
+
+
+def test_fetch_no_match_returns_empty():
+    conn = _make_db(_DOCS)
+    rows = doc_relevant.fetch_relevant_doc_sections(conn, [], "zzzznomatchterm")
+    conn.close()
+    assert rows == []
+
+
+def test_fetch_none_conn_safe():
+    assert doc_relevant.fetch_relevant_doc_sections(None, ["a.py"], "x") == []
+
+
+def test_format_doc_refs_are_pointers_not_bodies():
+    sections = [("Lane selection", "docs/core/DISPATCH_RULES.md", "112-130")]
+    out = doc_relevant.format_doc_refs(sections)
+    assert "docs/core/DISPATCH_RULES.md:112-130" in out
+    assert "Lane selection" in out
+    # No body content injected — only the pointer + heading.
+    assert "Two lanes ship" not in out
+
+
+def test_build_item():
+    conn = _make_db(_DOCS)
+    item = doc_relevant.build_doc_relevant_item(
+        conn, "d-1", ["scripts/foo.py"], "dispatch routing lane selection", "now"
+    )
+    conn.close()
+    assert item is not None
+    assert item.item_class == "doc_relevant"
+    assert item.confidence == 1.0
+    assert "docs/core/DISPATCH_RULES.md:112-130" in item.content
+    assert any("DISPATCH_RULES.md" in ref for ref in item.source_refs)
+
+
+def test_build_item_none_when_no_match():
+    conn = _make_db(_DOCS)
+    item = doc_relevant.build_doc_relevant_item(conn, "d-2", [], "zzzznomatch", "now")
+    conn.close()
+    assert item is None
+
+
+def test_doc_relevant_in_direct_injection_set():
+    from intelligence_sources._common import _DIRECT_INJECTION_CLASSES
+    assert "doc_relevant" in _DIRECT_INJECTION_CLASSES
+
+
+def test_doc_relevant_renders_to_worker():
+    """Regression: doc_relevant content must reach the worker via the renderer."""
+    from intelligence_injection import format_intelligence_items
+    from intelligence_sources._common import IntelligenceItem
+    item = IntelligenceItem(
+        item_id="doc", item_class="doc_relevant", title="docs",
+        content="## RELEVANT DOCS\n- `docs/core/DISPATCH_RULES.md:112-130` — Lane selection",
+        confidence=1.0, evidence_count=1, last_seen="now", scope_tags=[],
+    )
+    section = format_intelligence_items([item])
+    assert "docs/core/DISPATCH_RULES.md:112-130" in section

--- a/tests/test_doc_section_extractor.py
+++ b/tests/test_doc_section_extractor.py
@@ -234,10 +234,18 @@ def test_docs_dirs_from_env(tmp_path, monkeypatch):
     assert dirs[0] == docs_dir
 
 
-def test_docs_dirs_empty_when_unset(monkeypatch):
+def test_docs_dirs_defaults_to_project_docs_when_unset(monkeypatch):
+    """Unset VNX_DOCS_DIRS now defaults to the project's docs/ (so the project's
+    own docs are indexed for the doc_relevant source without operator config)."""
     monkeypatch.delenv("VNX_DOCS_DIRS", raising=False)
     dirs = _resolve_docs_dirs()
-    assert dirs == []
+    assert any(p.name == "docs" for p in dirs), dirs
+
+
+def test_docs_dirs_empty_when_explicitly_blank(monkeypatch):
+    """An explicit empty value disables doc indexing."""
+    monkeypatch.setenv("VNX_DOCS_DIRS", "")
+    assert _resolve_docs_dirs() == []
 
 
 # ── Full Pipeline E2E Test ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Build-step 2 of the POST-1.0 intelligence program. A **`doc_relevant`** direct-injection source that surfaces the project's functional/technical docs as **pointers**. It queries the markdown sections `doc_section_extractor` already indexes into the `code_snippets` FTS5 table (`language='markdown'`), matched to the dispatch's instruction terms + touched-file stems, and injects compact `file:line — heading` pointers (never bodies) — reusing the code-anchor pointer pattern so docs survive the budget and the worker opens the live section.

The multi-model research (DeepSeek, code-grounded) found this index infra **already exists** — this is the **query layer + wiring**, not a new indexer.

## Changes

- `scripts/lib/intelligence_sources/doc_relevant.py` (new): `fetch_relevant_doc_sections` (FTS5 MATCH, markdown-only, ranked), `format_doc_refs`, `build_doc_relevant_item`.
- `doc_section_extractor._resolve_docs_dirs` defaults to the project's `docs/` when `VNX_DOCS_DIRS` is **unset** (explicit `""` disables) → the nightly pipeline (phase 1c, already wired) indexes VNX's own docs with no operator config.
- Wired into the selector: `_DIRECT_INJECTION_CLASSES`, `_DIRECT_SOURCES`, `_CLASS_WEIGHT`, the `direct` dict (built with the quality-DB connection), both render loops; re-exported.

## Verification

- **134 passed** incl. 8 new `doc_relevant` tests (markdown-only match, no-match→None, pointer-not-body, build_item, direct-set membership, render-to-worker) + the updated extractor contract tests.
- **kimi-gate: PASS (0 blocking)** after fixing the broken-contract test + stale docstring it flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)