### PR TITLE
feat(intelligence): deterministic VNX tag vocabulary for matching (build-step 3a)

### DIFF
--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -65,6 +65,12 @@ except ImportError:
     _sys.path.insert(0, str(Path(__file__).resolve().parent))
     from project_scope import current_project_id, project_filter_enabled
 
+try:
+    from vnx_tag_vocabulary import derive_tags as _derive_tags
+except ImportError:
+    def _derive_tags(text, paths=None):  # type: ignore[misc]
+        return []
+
 # Direct injection source table: (item_class, cumulative_drop_order)
 _DIRECT_SOURCES = [
     ("prior_round_finding", ["prior_round_finding"]),
@@ -117,9 +123,18 @@ def _recency_decay(last_seen) -> float:
 
 
 def _relevance_score(item, query_scope) -> float:
-    """Composite relevance score for rank-then-budget."""
+    """Composite relevance score for rank-then-budget.
+
+    tag_overlap counts the item's tags (its own scope_tags plus deterministically
+    derived VNX domain/intent/component tags from its title+content) against the
+    query scope, so matching is by intent + subsystem, not just file-path overlap.
+    """
     conf = float(getattr(item, "confidence", 0.0) or 0.0)
-    overlap = len(set(getattr(item, "scope_tags", None) or []) & set(query_scope or []))
+    item_tags = set(getattr(item, "scope_tags", None) or [])
+    item_tags |= set(_derive_tags(
+        f"{getattr(item, 'title', '')} {getattr(item, 'content', '')}"
+    ))
+    overlap = len(item_tags & set(query_scope or []))
     recency = _recency_decay(getattr(item, "last_seen", ""))
     weight = _CLASS_WEIGHT.get(getattr(item, "item_class", ""), 1.0)
     return conf * (1.0 + overlap) * recency * weight
@@ -227,11 +242,19 @@ class IntelligenceSelector:
         }
 
         if _rank_then_budget_enabled():
-            # Unified rank-then-budget over standard + direct candidates.
+            # Unified rank-then-budget over standard + direct candidates. The query
+            # scope is enriched with deterministic VNX domain/intent/component tags
+            # so tag_overlap matches on intent + subsystem (not just file paths).
+            # Kept local to this opt-in branch so the legacy DB-query scope is
+            # unchanged.
+            query_tags = list(effective_scope)
+            for tag in _derive_tags(instruction_text, paths):
+                if tag not in query_tags:
+                    query_tags.append(tag)
             pool = list(selected) + [
                 direct[c] for c, _ in _DIRECT_SOURCES if direct.get(c) is not None
             ]
-            selected = self._rank_then_budget(pool, suppressed, effective_scope)
+            selected = self._rank_then_budget(pool, suppressed, query_tags)
         else:
             # Legacy default: class-priority eviction, direct items appended last.
             selected = self._enforce_payload_limit(selected, suppressed, list(reversed(ITEM_CLASS_PRIORITY)))

--- a/scripts/lib/vnx_tag_vocabulary.py
+++ b/scripts/lib/vnx_tag_vocabulary.py
@@ -1,0 +1,95 @@
+"""VNX tag vocabulary — a closed, faceted tag taxonomy for intelligence matching.
+
+The existing docs/intelligence/TAG_TAXONOMY.md is SEOcrawler-flavoured
+(crawler/storage/api components). This module is the VNX-specific closed
+vocabulary the design research recommended: three flat, independent facets
+(domain / intent / component) used to match injected intelligence to a dispatch
+by intent + subsystem, not just file-path overlap.
+
+`derive_tags()` is the DETERMINISTIC floor (keyword/path → closed-vocab tags, no
+LLM). A later model-agnostic LLM enrichment (build-step 3b) layers on top: it
+will use the classifier_providers.get_provider() factory with the model selected
+via an env var (VNX_TAGGER_MODEL / VNX_TAGGER_PROVIDER, defaulting to a cheap
+key-auth lane such as DeepSeek-Flash), so the tagging/review model is swappable
+in env without code changes. The LLM output is validated against this same closed
+vocabulary (reject/snap off-vocab), so the deterministic and LLM paths share one
+SSOT.
+"""
+from __future__ import annotations
+
+from typing import Dict, FrozenSet, List, Optional
+
+# --- Facet A: DOMAIN — the subsystem the work touches ---------------------
+_DOMAIN_KEYWORDS: Dict[str, List[str]] = {
+    "dispatch": ["dispatch", "lane", "door", "tmux", "worker", "worktree"],
+    "intelligence": ["intelligence", "pattern", "anchor", "inject", "selector", "doc_relevant"],
+    "receipts_audit": ["receipt", "ndjson", "audit", "t0_receipts", "provenance"],
+    "governance_gates": ["gate", "govern", "phantom", "permit", "first-pass"],
+    "providers_routing": ["provider", "kimi", "glm", "deepseek", "codex", "gemini", "routing", "litellm", "openrouter"],
+    "schema_migrations": ["schema", "migration", "migrate", "alter table", "user_version", "sqlite"],
+    "tenant_project_id": ["project_id", "tenant", "adr-007", "multitenant"],
+    "tests_harness": ["pytest", "fixture", "harness", "test_"],
+    "docs": ["docs/", "readme", "changelog", "documentation", "manifesto"],
+    "dashboard_ui": ["dashboard", ".tsx", ".html", " css", " ui"],
+    "benchmark": ["benchmark", "bench"],
+    "learning_loop": ["learning_loop", "self-learning", "pending_rules", "confidence"],
+}
+
+# --- Facet B: INTENT — what the work is -----------------------------------
+_INTENT_KEYWORDS: Dict[str, List[str]] = {
+    "fix_bug": ["fix", "bug", "crash", "broken", "regression", "no such"],
+    "implement_feature": ["implement", "feature", "introduce", "add a", "add the"],
+    "refactor": ["refactor", "extract", "rename", "cleanup", "simplify", "deduplicate"],
+    "add_test": ["add test", "coverage", "regression test", "unit test"],
+    "harden": ["harden", "fail-closed", "fail closed", "guard", "robust", "edge case"],
+    "migrate_schema": ["migrat", "rebuild", "alter table", "composite key"],
+    "wire_integration": ["wire", "integrate", "hook up", "plumb"],
+    "review_audit": ["review", "audit", "verify", "validate"],
+    "document": ["document", "write docs", "changelog", "readme"],
+    "investigate_rootcause": ["investigate", "root cause", "diagnose", "debug"],
+}
+
+# --- Facet C: COMPONENT — cross-cutting concerns --------------------------
+_COMPONENT_KEYWORDS: Dict[str, List[str]] = {
+    "fail_closed": ["fail-closed", "fail closed", "fail_closed", "abort on"],
+    "idempotency": ["idempotent", "idempotency"],
+    "concurrency_lease": ["lease", "concurren", "race condition", "deadlock", "savepoint", "lock"],
+    "project_id_stamping": ["project_id", "stamp", "tenant"],
+    "cli_subprocess": ["subprocess", "claude -p", "popen", "console-script"],
+    "ndjson_contract": ["ndjson", "receipt contract", "report contract", "report_body_contract"],
+    "fts5": ["fts5", "code_snippets", "full-text"],
+    "provider_constraint": ["constraint", "no-sdk", "kimi-via-cli", "headless-block", "no anthropic sdk"],
+}
+
+_FACETS = (_DOMAIN_KEYWORDS, _INTENT_KEYWORDS, _COMPONENT_KEYWORDS)
+
+VNX_DOMAINS: FrozenSet[str] = frozenset(_DOMAIN_KEYWORDS)
+VNX_INTENTS: FrozenSet[str] = frozenset(_INTENT_KEYWORDS)
+VNX_COMPONENTS: FrozenSet[str] = frozenset(_COMPONENT_KEYWORDS)
+VNX_TAG_VOCABULARY: FrozenSet[str] = VNX_DOMAINS | VNX_INTENTS | VNX_COMPONENTS
+
+
+def derive_tags(text: Optional[str], paths: Optional[List[str]] = None) -> List[str]:
+    """Deterministically derive closed-vocabulary tags from free text + file paths.
+
+    A keyword/path scan only — no LLM. Returns canonical tags (a subset of
+    VNX_TAG_VOCABULARY), deduplicated, in facet order (domain, intent, component).
+    """
+    haystack = (text or "").lower()
+    if paths:
+        haystack += " " + " ".join(str(p).lower() for p in paths)
+    tags: List[str] = []
+    for facet in _FACETS:
+        for tag, keywords in facet.items():
+            if tag not in tags and any(kw in haystack for kw in keywords):
+                tags.append(tag)
+    return tags
+
+
+def validate_tags(tags: Optional[List[str]]) -> List[str]:
+    """Keep only tags that are in the closed vocabulary (snap-to-vocab).
+
+    Used to validate LLM-assigned tags (build-step 3b) against the SSOT so an
+    off-vocabulary value can never enter the matching layer.
+    """
+    return [t for t in (tags or []) if t in VNX_TAG_VOCABULARY]

--- a/tests/test_vnx_tag_vocabulary.py
+++ b/tests/test_vnx_tag_vocabulary.py
@@ -1,0 +1,69 @@
+"""Tests for the VNX tag vocabulary (build-step 3a, deterministic tagging)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+from vnx_tag_vocabulary import (  # noqa: E402
+    VNX_TAG_VOCABULARY,
+    VNX_DOMAINS,
+    VNX_INTENTS,
+    VNX_COMPONENTS,
+    derive_tags,
+    validate_tags,
+)
+
+
+def test_facets_are_disjoint_and_unioned():
+    assert VNX_TAG_VOCABULARY == VNX_DOMAINS | VNX_INTENTS | VNX_COMPONENTS
+    assert VNX_DOMAINS and VNX_INTENTS and VNX_COMPONENTS
+
+
+def test_derive_maps_dispatch_bug():
+    tags = derive_tags("fix a bug in the dispatch lane routing", ["scripts/lib/dispatch_cli.py"])
+    assert "dispatch" in tags
+    assert "fix_bug" in tags
+    # everything returned is in the closed vocabulary
+    assert all(t in VNX_TAG_VOCABULARY for t in tags)
+
+
+def test_derive_maps_schema_migration():
+    tags = derive_tags("migrate the schema, add composite project_id key", ["schemas/x.sql"])
+    assert "schema_migrations" in tags
+    assert "migrate_schema" in tags
+    assert "project_id_stamping" in tags
+
+
+def test_derive_empty_on_no_match():
+    assert derive_tags("zzz qqq", []) == []
+    assert derive_tags("", None) == []
+
+
+def test_derive_dedups_and_is_facet_ordered():
+    tags = derive_tags("dispatch dispatch fix fix", [])
+    assert tags.count("dispatch") == 1
+    # domain tag appears before intent tag (facet order)
+    assert tags.index("dispatch") < tags.index("fix_bug")
+
+
+def test_validate_snaps_to_vocabulary():
+    assert validate_tags(["dispatch", "bogus_tag", "fix_bug", ""]) == ["dispatch", "fix_bug"]
+    assert validate_tags(None) == []
+
+
+def test_tag_overlap_boosts_relevance_score():
+    """The selector's rank score must rise when query tags match the item's
+    derived tags (intent/subsystem matching, not just file paths)."""
+    from intelligence_selector import _relevance_score
+    from intelligence_sources._common import IntelligenceItem
+    item = IntelligenceItem(
+        item_id="i", item_class="proven_pattern", title="dispatch lane fix",
+        content="how to fix dispatch routing", confidence=0.8, evidence_count=2,
+        last_seen="2026-06-26T00:00:00Z", scope_tags=[],
+    )
+    matched = _relevance_score(item, ["dispatch", "fix_bug"])
+    unmatched = _relevance_score(item, ["benchmark"])
+    assert matched > unmatched


### PR DESCRIPTION
## Summary

Build-step 3a. A closed, faceted **VNX tag vocabulary** (domain / intent / component) + deterministic derivation, feeding the `tag_overlap` that rank-then-budget (step 1) already scores — so injected intelligence matches a dispatch by **intent + subsystem**, not just file-path overlap. **No LLM** (avoids the `claude-headless` provider constraint).

Per the lane decision (deterministic now, DeepSeek after, model-agnostic): the LLM enrichment (3b) will use `classifier_providers.get_provider()` with the model selected via env (`VNX_TAGGER_MODEL`, default a cheap key-auth lane like DeepSeek-Flash), validated against this same closed vocabulary.

## Changes

- `scripts/lib/vnx_tag_vocabulary.py` (new): the VNX closed vocab + `derive_tags(text, paths)` (keyword/path → tags) + `validate_tags` (snap-to-vocab for the future LLM path).
- `intelligence_selector`: `_relevance_score` counts the item's derived tags against the query scope; the query scope is enriched with `derive_tags(instruction, paths)`. **Both isolated to the opt-in rank-then-budget branch** (legacy DB-query scope unchanged).

## Verification

- **84 tests pass** incl. 7 new vocab tests (derivation, dedup/facet-order, snap-to-vocab, tag_overlap → relevance boost). Default path unchanged.
- **kimi-gate: PASS (0 blocking).** The existing SEOcrawler `TAG_TAXONOMY.md` is superseded by this VNX SSOT for matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)