### PR TITLE
feat(intelligence): model-agnostic LLM tagger + DeepSeek lane (build-step 3b)

### DIFF
--- a/scripts/lib/classifier_providers/base.py
+++ b/scripts/lib/classifier_providers/base.py
@@ -138,4 +138,7 @@ def get_provider(name: Optional[str] = None) -> ClassifierProvider:
     if key == "codex":
         from .codex_provider import CodexProvider
         return CodexProvider()
+    if key == "deepseek":
+        from .deepseek_provider import DeepSeekProvider
+        return DeepSeekProvider()
     raise ValueError(f"unknown classifier provider: {key}")

--- a/scripts/lib/classifier_providers/deepseek_provider.py
+++ b/scripts/lib/classifier_providers/deepseek_provider.py
@@ -1,0 +1,113 @@
+"""DeepSeek classifier provider via the claude-CLI harness (key-auth).
+
+Runs `claude --print` with ANTHROPIC_BASE_URL pointed at DeepSeek's
+Anthropic-compatible endpoint and ANTHROPIC_API_KEY = the operator's own
+DEEPSEEK_API_KEY. This is the sanctioned key-auth path per the provider
+constraint `deepseek-harness-subscription-blocked`: own-key + hardening
+(CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1, MCP off) routes all inference to
+DeepSeek with zero calls to api.anthropic.com. It is BLOCKED to ride the
+production OAuth subscription (no own key) — hence the explicit DEEPSEEK_API_KEY
+requirement in is_available().
+
+Cheap (DeepSeek-Flash ~$0.14/$0.28 per MTok) and model-agnostic: the model is
+selectable via VNX_DEEPSEEK_CLASSIFIER_MODEL.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from .base import ClassifierProvider, ClassifierResult, parse_json_block
+
+_DEFAULT_MODEL = "deepseek-v4-flash"
+_DEFAULT_TIMEOUT = 60
+_DEFAULT_FLAT_COST_USD = 0.0005
+_DEEPSEEK_ANTHROPIC_BASE_URL = "https://api.deepseek.com/anthropic"
+
+
+class DeepSeekProvider(ClassifierProvider):
+    """Run classification via the DeepSeek harness lane (own-key, hardened)."""
+
+    name = "deepseek"
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        flat_cost_usd: Optional[float] = None,
+    ) -> None:
+        self.model = model or os.environ.get("VNX_DEEPSEEK_CLASSIFIER_MODEL", _DEFAULT_MODEL)
+        self.timeout_seconds = int(
+            timeout_seconds
+            if timeout_seconds is not None
+            else os.environ.get("VNX_DEEPSEEK_CLASSIFIER_TIMEOUT", _DEFAULT_TIMEOUT)
+        )
+        try:
+            self.flat_cost_usd = float(
+                flat_cost_usd
+                if flat_cost_usd is not None
+                else os.environ.get("VNX_DEEPSEEK_CLASSIFIER_FLAT_COST_USD", _DEFAULT_FLAT_COST_USD)
+            )
+        except (TypeError, ValueError):
+            self.flat_cost_usd = _DEFAULT_FLAT_COST_USD
+
+    def is_available(self) -> bool:
+        # Requires the claude CLI AND the operator's own DeepSeek key (never the
+        # production OAuth subscription — constraint deepseek-harness-subscription-blocked).
+        return shutil.which("claude") is not None and bool(os.environ.get("DEEPSEEK_API_KEY"))
+
+    def _harness_env(self) -> dict:
+        env = dict(os.environ)
+        env["ANTHROPIC_BASE_URL"] = _DEEPSEEK_ANTHROPIC_BASE_URL
+        env["ANTHROPIC_API_KEY"] = os.environ.get("DEEPSEEK_API_KEY", "")
+        # Hardening: kill non-essential traffic + telemetry so 0 calls reach
+        # api.anthropic.com (the measured-safe configuration in the constraint doc).
+        env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+        return env
+
+    def classify(self, prompt: str, _max_tokens: int = 1500) -> ClassifierResult:
+        cmd = [
+            "claude", "--print", "--model", self.model,
+            "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}',
+        ]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                env=self._harness_env(),
+            )
+        except FileNotFoundError as exc:
+            return ClassifierResult(
+                raw_response="", parsed_json=None, cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name, error=f"claude CLI not found: {exc}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ClassifierResult(
+                raw_response="", parsed_json=None, cost_usd=0.0,
+                latency_ms=int((time.monotonic() - start) * 1000),
+                provider=self.name, error=f"timeout after {self.timeout_seconds}s: {exc}",
+            )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if proc.returncode != 0:
+            return ClassifierResult(
+                raw_response=proc.stdout or "", parsed_json=None, cost_usd=0.0,
+                latency_ms=latency_ms, provider=self.name,
+                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
+            )
+        raw = proc.stdout or ""
+        return ClassifierResult(
+            raw_response=raw,
+            parsed_json=parse_json_block(raw),
+            cost_usd=self.flat_cost_usd,
+            latency_ms=latency_ms,
+            provider=self.name,
+            extra={"model": self.model, "lane": "deepseek-harness"},
+        )

--- a/scripts/lib/vnx_tagger.py
+++ b/scripts/lib/vnx_tagger.py
@@ -1,0 +1,116 @@
+"""Model-agnostic LLM tagger over the VNX closed tag vocabulary (build-step 3b).
+
+Layers an optional LLM tagging pass on top of the deterministic
+vnx_tag_vocabulary.derive_tags() floor. The model is selected via env
+(VNX_TAGGER_PROVIDER, default "deepseek" — the cheap key-auth DeepSeek-Flash
+harness lane), so the tagging/review model is swappable without code changes.
+Output is validated against the closed vocabulary (snap-to-vocab) so an
+off-vocabulary value can never enter the matching layer.
+
+Opt-in via VNX_TAGGER_ENABLED=1 (it makes an LLM call). Fail-silent: any error
+returns [], so callers degrade to the deterministic floor and never break.
+
+NOTE: this is a CAPABILITY, intentionally NOT wired into the per-dispatch hot
+selection path (that would add LLM latency to every dispatch). It is meant for
+persist-time pattern tagging or a scout pre-pass, where one call enriches many
+later matches.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Optional
+
+try:
+    from vnx_tag_vocabulary import (
+        VNX_COMPONENTS,
+        VNX_DOMAINS,
+        VNX_INTENTS,
+        derive_tags,
+        validate_tags,
+    )
+except ImportError:  # pragma: no cover - path fallback
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from vnx_tag_vocabulary import (
+        VNX_COMPONENTS,
+        VNX_DOMAINS,
+        VNX_INTENTS,
+        derive_tags,
+        validate_tags,
+    )
+
+ENV_ENABLED = "VNX_TAGGER_ENABLED"
+ENV_PROVIDER = "VNX_TAGGER_PROVIDER"
+_DEFAULT_PROVIDER = "deepseek"
+_MAX_TAGS = 6
+
+
+def is_enabled() -> bool:
+    return os.environ.get(ENV_ENABLED, "0") == "1"
+
+
+def get_tagger_provider_name() -> str:
+    return (os.environ.get(ENV_PROVIDER) or _DEFAULT_PROVIDER).strip().lower()
+
+
+def _build_prompt(text: str, paths: Optional[List[str]]) -> str:
+    domains = ", ".join(sorted(VNX_DOMAINS))
+    intents = ", ".join(sorted(VNX_INTENTS))
+    components = ", ".join(sorted(VNX_COMPONENTS))
+    paths_str = ", ".join(paths or []) or "(none)"
+    return (
+        "You are a strict classifier for the VNX Orchestration codebase. Assign "
+        "tags to the work described below, choosing ONLY from the closed vocabulary. "
+        "Do not invent tags. Pick the most relevant (at most "
+        f"{_MAX_TAGS}).\n\n"
+        f"DOMAIN (the subsystem): {domains}\n"
+        f"INTENT (what the work is): {intents}\n"
+        f"COMPONENT (cross-cutting concern): {components}\n\n"
+        f"FILES: {paths_str}\n"
+        f"WORK: {text}\n\n"
+        'Return ONLY a JSON object: {"tags": ["...", "..."]} with values drawn '
+        "from the vocabulary above. No prose."
+    )
+
+
+def llm_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:
+    """Return validated VNX tags from the configured LLM, or [] on any failure.
+
+    Honours VNX_TAGGER_ENABLED (opt-in) and VNX_TAGGER_PROVIDER (model-agnostic).
+    """
+    if not is_enabled() or not (text or paths):
+        return []
+    try:
+        from classifier_providers import get_provider
+        provider = get_provider(get_tagger_provider_name())
+        if not provider.is_available():
+            return []
+        result = provider.classify(_build_prompt(text or "", paths), _max_tokens=200)
+        if result.error:
+            return []
+        data = result.parsed_json
+        if data is None and result.raw_response:
+            try:
+                data = json.loads(result.raw_response)
+            except (json.JSONDecodeError, TypeError):
+                data = None
+        if not isinstance(data, dict):
+            return []
+        return validate_tags(list(data.get("tags", []))[: _MAX_TAGS * 2])
+    except Exception:
+        # Fail-silent: callers fall back to the deterministic floor.
+        return []
+
+
+def enrich_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:
+    """Deterministic tags + (when enabled) validated LLM tags, deduplicated.
+
+    The deterministic derive_tags() is always the floor; the LLM only adds.
+    """
+    tags = list(derive_tags(text, paths))
+    for t in llm_tags(text, paths):
+        if t not in tags:
+            tags.append(t)
+    return tags

--- a/tests/test_vnx_tagger.py
+++ b/tests/test_vnx_tagger.py
@@ -1,0 +1,112 @@
+"""Tests for the model-agnostic VNX LLM tagger (build-step 3b).
+
+No real LLM calls — the classifier provider is mocked.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+import vnx_tagger  # noqa: E402
+from classifier_providers.base import ClassifierResult, get_provider  # noqa: E402
+
+
+class _FakeProvider:
+    name = "fake"
+
+    def __init__(self, parsed=None, error=None, available=True):
+        self._parsed = parsed
+        self._error = error
+        self._available = available
+
+    def is_available(self):
+        return self._available
+
+    def classify(self, prompt, _max_tokens=1500):
+        return ClassifierResult(
+            raw_response="", parsed_json=self._parsed, cost_usd=0.0,
+            latency_ms=1, provider=self.name, error=self._error,
+        )
+
+
+def test_default_disabled(monkeypatch):
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+    assert vnx_tagger.is_enabled() is False
+    assert vnx_tagger.llm_tags("fix a dispatch bug", ["x.py"]) == []
+
+
+def test_provider_name_default_and_override(monkeypatch):
+    monkeypatch.delenv("VNX_TAGGER_PROVIDER", raising=False)
+    assert vnx_tagger.get_tagger_provider_name() == "deepseek"
+    monkeypatch.setenv("VNX_TAGGER_PROVIDER", "ollama")
+    assert vnx_tagger.get_tagger_provider_name() == "ollama"
+
+
+def test_llm_tags_validated_against_vocab(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    fake = _FakeProvider(parsed={"tags": ["dispatch", "bogus_tag", "fix_bug"]})
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: fake)
+    tags = vnx_tagger.llm_tags("fix the dispatch lane", ["scripts/lib/dispatch_cli.py"])
+    assert "dispatch" in tags and "fix_bug" in tags
+    assert "bogus_tag" not in tags  # off-vocab snapped out
+
+
+def test_llm_tags_fail_silent_on_error(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    monkeypatch.setattr("classifier_providers.get_provider",
+                        lambda name=None: _FakeProvider(error="boom"))
+    assert vnx_tagger.llm_tags("x", ["y.py"]) == []
+
+
+def test_llm_tags_empty_when_provider_unavailable(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    monkeypatch.setattr("classifier_providers.get_provider",
+                        lambda name=None: _FakeProvider(available=False))
+    assert vnx_tagger.llm_tags("x", ["y.py"]) == []
+
+
+def test_enrich_combines_deterministic_and_llm(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    # LLM adds 'harden'; deterministic floor already finds dispatch/fix_bug.
+    fake = _FakeProvider(parsed={"tags": ["harden"]})
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: fake)
+    tags = vnx_tagger.enrich_tags("fix a dispatch bug", ["scripts/lib/dispatch_cli.py"])
+    assert "dispatch" in tags  # deterministic
+    assert "harden" in tags    # llm-added
+    assert tags.count("dispatch") == 1  # deduped
+
+
+def test_enrich_is_deterministic_floor_when_disabled(monkeypatch):
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+    from vnx_tag_vocabulary import derive_tags
+    text, paths = "migrate the schema project_id", ["schemas/x.sql"]
+    assert vnx_tagger.enrich_tags(text, paths) == derive_tags(text, paths)
+
+
+# --- DeepSeek provider registration + safety -------------------------------
+
+def test_deepseek_provider_registered():
+    from classifier_providers.deepseek_provider import DeepSeekProvider
+    prov = get_provider("deepseek")
+    assert isinstance(prov, DeepSeekProvider)
+    assert prov.name == "deepseek"
+
+
+def test_deepseek_requires_own_key(monkeypatch):
+    from classifier_providers.deepseek_provider import DeepSeekProvider
+    prov = DeepSeekProvider()
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    # Without the own key it is unavailable (never rides the OAuth subscription).
+    assert prov.is_available() is False
+
+
+def test_deepseek_harness_env_points_at_deepseek(monkeypatch):
+    from classifier_providers.deepseek_provider import DeepSeekProvider
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    env = DeepSeekProvider()._harness_env()
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.deepseek.com/anthropic"
+    assert env["ANTHROPIC_API_KEY"] == "sk-test"
+    assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"


### PR DESCRIPTION
## Summary

Build-step 3b. A **model-agnostic** LLM tagger layered on the deterministic `vnx_tag_vocabulary` floor (3a). The model is selected via env (`VNX_TAGGER_PROVIDER`, default `"deepseek"`) — the **"review model in env"** so it's swappable without code changes. Output is validated against the closed VNX vocabulary (snap-to-vocab). Opt-in (`VNX_TAGGER_ENABLED=1`), fail-silent (degrades to the deterministic floor).

## Changes

- `classifier_providers/deepseek_provider.py` (new): `DeepSeekProvider` via the **sanctioned key-auth harness lane** (`claude --print` + `ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic` + own `DEEPSEEK_API_KEY` + hardening), per `deepseek-harness-subscription-blocked`. `is_available()` requires the own key — never the OAuth subscription.
- `classifier_providers.base.get_provider`: registered the `deepseek` lane.
- `scripts/lib/vnx_tagger.py` (new): `llm_tags` (validated, fail-silent), `enrich_tags` (deterministic floor + LLM). **Intentionally not** wired into the per-dispatch hot path (avoids per-dispatch LLM latency — a capability for persist-time/scout use).

## Verification

- **17 tagger/vocab + 206 classifier-regression tests pass** (mocked provider — no real LLM calls): default-disabled, env model-agnosticism, snap-to-vocab, fail-silent on error/unavailable, enrich = floor + LLM deduped, DeepSeek registration + own-key requirement + harness-env endpoint.
- **kimi-gate: PASS (0 blocking).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)