### PR TITLE
feat(intelligence): junction-grounded confidence updates (build-step 4)

### DIFF
--- a/scripts/lib/intelligence_persist.py
+++ b/scripts/lib/intelligence_persist.py
@@ -15,10 +15,11 @@ Tables written:
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from project_scope import current_project_id
@@ -38,6 +39,104 @@ def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
         if name == column:
             return True
     return False
+
+
+def _has_table(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        return conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone() is not None
+    except sqlite3.Error:
+        return False
+
+
+def _outcome_grounding_v2_enabled() -> bool:
+    """Opt-in flag for junction-grounded confidence updates (default OFF).
+
+    When unset, ``update_confidence_from_outcome`` keeps its legacy
+    ``source_dispatch_ids`` substring join byte-for-byte. When ``=1`` and the
+    ``dispatch_pattern_offered`` junction exists, the precise per-dispatch
+    offered↔pattern linkage grounds confidence instead. Governance-critical
+    path (runs on every completion receipt) — gated for a deliberate rollout.
+    """
+    return os.environ.get("VNX_OUTCOME_GROUNDING_V2", "0") == "1"
+
+
+def _legacy_source_id_rows(
+    conn: sqlite3.Connection,
+    dispatch_id: str,
+    project_id: str,
+    sp_has_project: bool,
+) -> list:
+    """Legacy join: success_patterns whose source_dispatch_ids contains dispatch_id."""
+    if sp_has_project:
+        return conn.execute(
+            "SELECT id, confidence_score, usage_count, title FROM success_patterns "
+            "WHERE source_dispatch_ids LIKE ? AND project_id = ?",
+            (f"%{dispatch_id}%", project_id),
+        ).fetchall()
+    return conn.execute(
+        "SELECT id, confidence_score, usage_count, title FROM success_patterns "
+        "WHERE source_dispatch_ids LIKE ?",
+        (f"%{dispatch_id}%",),
+    ).fetchall()
+
+
+def _junction_grounded_rows(
+    conn: sqlite3.Connection,
+    dispatch_id: str,
+    project_id: str,
+    sp_has_project: bool,
+) -> list:
+    """Precise join: success_patterns OFFERED for this dispatch via the junction.
+
+    ``dispatch_pattern_offered`` is the per-dispatch offering junction (PK
+    ``(dispatch_id, pattern_id)``), written atomically alongside
+    ``source_dispatch_ids`` at injection time. Joining on the stable
+    ``intel_sp_<id>`` pattern-id convention gives an exact offered↔pattern
+    linkage — no substring false positives, no source_dispatch_ids 20-entry cap.
+    Tenant-scoped on BOTH sides when the project_id column is present so a
+    cross-tenant pattern_id/id collision cannot leak a confidence update.
+    """
+    from confidence_reconcile import SUCCESS_PATTERN_PREFIX
+
+    params: list = [SUCCESS_PATTERN_PREFIX]  # binds the JOIN's (? || sp.id)
+    where_parts = ["dpo.dispatch_id = ?"]
+    params.append(dispatch_id)
+    if sp_has_project:
+        where_parts.append("sp.project_id = ?")
+        params.append(project_id)
+    if _has_column(conn, "dispatch_pattern_offered", "project_id"):
+        where_parts.append("dpo.project_id = ?")
+        params.append(project_id)
+    sql = (
+        "SELECT DISTINCT sp.id, sp.confidence_score, sp.usage_count, sp.title "
+        "FROM success_patterns sp "
+        "JOIN dispatch_pattern_offered dpo ON dpo.pattern_id = (? || sp.id) "
+        "WHERE " + " AND ".join(where_parts)
+    )
+    return conn.execute(sql, params).fetchall()
+
+
+def _resolve_grounded_patterns(
+    conn: sqlite3.Connection,
+    dispatch_id: str,
+    project_id: str,
+    sp_has_project: bool,
+) -> Tuple[list, str]:
+    """Return (success_pattern rows offered for this dispatch, grounding_source).
+
+    With ``VNX_OUTCOME_GROUNDING_V2`` and the junction present, the junction is
+    authoritative ('junction'); otherwise the legacy substring join is used
+    ('source_dispatch_ids'). The junction and source_dispatch_ids are co-written
+    in one transaction at injection, so "junction present" implies it is the
+    complete, precise set — the legacy join only remains for pre-junction DBs
+    and the flag-off default.
+    """
+    if _outcome_grounding_v2_enabled() and _has_table(conn, "dispatch_pattern_offered"):
+        return _junction_grounded_rows(conn, dispatch_id, project_id, sp_has_project), "junction"
+    return _legacy_source_id_rows(conn, dispatch_id, project_id, sp_has_project), "source_dispatch_ids"
 
 
 def persist_signals_to_db(
@@ -279,12 +378,17 @@ def update_confidence_from_outcome(
     success_count or failure_count on the matching pattern_usage row, then
     the new Beta posterior is written back to success_patterns.confidence_score.
 
-    Linkage is via success_patterns.source_dispatch_ids (JSON array).
-    pattern_usage rows are matched / created using the stable
-    "intel_sp_<id>" id convention so the daily reconcile and the
-    per-dispatch update read and write the same row.
+    Linkage from a dispatch to the patterns it grounds is resolved by
+    ``_resolve_grounded_patterns``: with ``VNX_OUTCOME_GROUNDING_V2=1`` the
+    ``dispatch_pattern_offered`` junction (precise per-dispatch offered↔pattern
+    linkage) is authoritative; otherwise the legacy ``source_dispatch_ids``
+    substring join is used (default, byte-identical to the prior behaviour).
+    pattern_usage rows are matched / created using the stable "intel_sp_<id>"
+    id convention so the daily reconcile and the per-dispatch update read and
+    write the same row.
 
-    A confidence_events row is written for audit/learning-summary queries.
+    A confidence_events row is written for audit/learning-summary queries; its
+    ``grounding_source`` records which linkage produced the event.
 
     Args:
         db_path:     Path to quality_intelligence.db.
@@ -313,18 +417,9 @@ def update_confidence_from_outcome(
     ce_has_project = _has_column(conn, "confidence_events", "project_id")
 
     try:
-        if sp_has_project:
-            rows = conn.execute(
-                "SELECT id, confidence_score, usage_count, title FROM success_patterns "
-                "WHERE source_dispatch_ids LIKE ? AND project_id = ?",
-                (f"%{dispatch_id}%", project_id),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT id, confidence_score, usage_count, title FROM success_patterns "
-                "WHERE source_dispatch_ids LIKE ?",
-                (f"%{dispatch_id}%",),
-            ).fetchall()
+        rows, grounding_source = _resolve_grounded_patterns(
+            conn, dispatch_id, project_id, sp_has_project
+        )
 
         is_success = status == "success"
 
@@ -396,26 +491,26 @@ def update_confidence_from_outcome(
                 )
                 decayed += 1
 
-        # Record a confidence_events audit row (best-effort — table may not exist yet)
+        # Record a confidence_events audit row (best-effort — table/columns may
+        # not exist yet on older DBs). Columns are appended only when present so
+        # the same insert works across every migration level.
         try:
+            ce_cols = ["dispatch_id", "terminal", "outcome", "patterns_boosted",
+                       "patterns_decayed", "confidence_change", "occurred_at"]
+            ce_vals: list = [dispatch_id, terminal, status, boosted, decayed,
+                             round(net_change, 4), now]
             if ce_has_project:
-                conn.execute(
-                    "INSERT INTO confidence_events "
-                    "(dispatch_id, terminal, outcome, patterns_boosted, patterns_decayed, "
-                    " confidence_change, occurred_at, project_id) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (dispatch_id, terminal, status, boosted, decayed,
-                     round(net_change, 4), now, project_id),
-                )
-            else:
-                conn.execute(
-                    "INSERT INTO confidence_events "
-                    "(dispatch_id, terminal, outcome, patterns_boosted, patterns_decayed, "
-                    " confidence_change, occurred_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (dispatch_id, terminal, status, boosted, decayed,
-                     round(net_change, 4), now),
-                )
+                ce_cols.append("project_id")
+                ce_vals.append(project_id)
+            if _has_column(conn, "confidence_events", "grounding_source"):
+                ce_cols.append("grounding_source")
+                ce_vals.append(grounding_source)
+            placeholders = ", ".join("?" for _ in ce_vals)
+            conn.execute(
+                f"INSERT INTO confidence_events ({', '.join(ce_cols)}) "
+                f"VALUES ({placeholders})",
+                ce_vals,
+            )
         except sqlite3.OperationalError:
             pass  # Table not yet migrated in older DBs
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -25,7 +25,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 23
+HIGHEST_QI_VERSION = 24
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -949,6 +949,27 @@ def _migrate_v23(conn: sqlite3.Connection) -> None:
         log('INFO', 'Migrated dispatch_metadata: added model column (GAP 2, v23)')
 
 
+def _migrate_v24(conn: sqlite3.Connection) -> None:
+    """V24: grounding_source column on confidence_events (outcome-grounding v2).
+
+    Records HOW a per-dispatch confidence event was grounded — ``'junction'``
+    (the ``dispatch_pattern_offered`` precise per-dispatch linkage) or
+    ``'source_dispatch_ids'`` (the legacy substring join) — so the self-learning
+    auto-tier and audit queries can tell precisely-grounded outcomes apart from
+    the legacy-grounded ones. Additive nullable column; existing rows read NULL.
+    ALTER TABLE only (no rebuild). confidence_events is created by _migrate_v11,
+    which runs first; the existence guard is cheap insurance for partial DBs.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='confidence_events'"
+    ).fetchone():
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(confidence_events)").fetchall()}
+    if "grounding_source" not in cols:
+        conn.execute("ALTER TABLE confidence_events ADD COLUMN grounding_source TEXT")
+        log('INFO', 'Migrated confidence_events: added grounding_source column (outcome-grounding v2, v24)')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -974,6 +995,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     21: _migrate_v21,
     22: _migrate_v22,
     23: _migrate_v23,
+    24: _migrate_v24,
 }
 
 

--- a/tests/test_outcome_grounding_v2.py
+++ b/tests/test_outcome_grounding_v2.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Tests for outcome-grounding v2: junction-grounded confidence updates.
+
+Dispatch-ID: 20260626-outcome-grounding-v2
+
+Step 4 collapses the universal receipt-append confidence path onto the
+``dispatch_pattern_offered`` junction (the precise per-dispatch offered↔pattern
+linkage), gated by ``VNX_OUTCOME_GROUNDING_V2`` (default OFF → legacy
+``source_dispatch_ids`` substring join, byte-identical).
+
+Covers:
+- junction grounds a pattern even when source_dispatch_ids is empty (the gap the
+  legacy join could not close)
+- flag OFF keeps the legacy substring behaviour exactly
+- flag ON falls back to the legacy join when the junction table is absent
+- grounding_source is recorded on the confidence_events audit row
+- failure decays via the junction
+- tenant isolation: a junction join never crosses project_id
+- non-pattern junction rows (code_anchor etc.) are ignored
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from intelligence_persist import update_confidence_from_outcome  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Schema fixtures
+# ---------------------------------------------------------------------------
+
+_SCHEMA_BASE = """
+CREATE TABLE IF NOT EXISTS success_patterns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pattern_type TEXT NOT NULL,
+    category TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    pattern_data TEXT NOT NULL,
+    confidence_score REAL DEFAULT 0.0,
+    usage_count INTEGER DEFAULT 0,
+    source_dispatch_ids TEXT,
+    first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used DATETIME{sp_project}
+);
+
+CREATE TABLE IF NOT EXISTS pattern_usage (
+    pattern_id TEXT PRIMARY KEY,
+    pattern_title TEXT NOT NULL,
+    pattern_hash TEXT NOT NULL,
+    used_count INTEGER DEFAULT 0,
+    ignored_count INTEGER DEFAULT 0,
+    success_count INTEGER DEFAULT 0,
+    failure_count INTEGER DEFAULT 0,
+    last_used TIMESTAMP,
+    last_offered TIMESTAMP,
+    confidence REAL DEFAULT 1.0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS confidence_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    terminal TEXT,
+    outcome TEXT NOT NULL,
+    patterns_boosted INTEGER DEFAULT 0,
+    patterns_decayed INTEGER DEFAULT 0,
+    confidence_change REAL NOT NULL,
+    occurred_at TEXT NOT NULL,
+    grounding_source TEXT
+);
+"""
+
+_JUNCTION_DDL = """
+CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+    dispatch_id   TEXT NOT NULL,
+    pattern_id    TEXT NOT NULL,
+    pattern_title TEXT NOT NULL,
+    offered_at    TEXT NOT NULL{dpo_project},
+    PRIMARY KEY (dispatch_id, pattern_id)
+);
+"""
+
+
+def _make_db(tmp_path: Path, *, junction: bool = True, project_id: bool = False) -> Path:
+    db = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        _SCHEMA_BASE.format(
+            sp_project=",\n    project_id TEXT NOT NULL DEFAULT 'vnx-dev'" if project_id else ""
+        )
+    )
+    if junction:
+        conn.executescript(
+            _JUNCTION_DDL.format(
+                dpo_project=",\n    project_id TEXT NOT NULL DEFAULT 'vnx-dev'" if project_id else ""
+            )
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _insert_pattern(
+    db: Path,
+    *,
+    source_dispatch_ids,
+    confidence: float = 0.5,
+    title: str = "Test pattern",
+    project_id: str = None,
+) -> int:
+    conn = sqlite3.connect(str(db))
+    src = json.dumps(source_dispatch_ids) if source_dispatch_ids is not None else None
+    if project_id is not None:
+        cur = conn.execute(
+            "INSERT INTO success_patterns "
+            "(pattern_type, category, title, description, pattern_data, "
+            " confidence_score, usage_count, source_dispatch_ids, project_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("approach", "governance", title, "desc", "{}", confidence, 1, src, project_id),
+        )
+    else:
+        cur = conn.execute(
+            "INSERT INTO success_patterns "
+            "(pattern_type, category, title, description, pattern_data, "
+            " confidence_score, usage_count, source_dispatch_ids) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("approach", "governance", title, "desc", "{}", confidence, 1, src),
+        )
+    row_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return row_id
+
+
+def _offer(db: Path, dispatch_id: str, pattern_id: str, title: str = "Test pattern", project_id: str = None) -> None:
+    conn = sqlite3.connect(str(db))
+    if project_id is not None:
+        conn.execute(
+            "INSERT INTO dispatch_pattern_offered "
+            "(dispatch_id, pattern_id, pattern_title, offered_at, project_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (dispatch_id, pattern_id, title, "2026-06-26T00:00:00+00:00", project_id),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO dispatch_pattern_offered "
+            "(dispatch_id, pattern_id, pattern_title, offered_at) "
+            "VALUES (?, ?, ?, ?)",
+            (dispatch_id, pattern_id, title, "2026-06-26T00:00:00+00:00"),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _confidence(db: Path, sp_id: int) -> float:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT confidence_score FROM success_patterns WHERE id = ?", (sp_id,)
+    ).fetchone()
+    conn.close()
+    return float(row[0])
+
+
+def _event_grounding(db: Path, dispatch_id: str) -> str:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT grounding_source FROM confidence_events WHERE dispatch_id = ? "
+        "ORDER BY id DESC LIMIT 1",
+        (dispatch_id,),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+@pytest.fixture
+def grounding_on(monkeypatch):
+    monkeypatch.setenv("VNX_OUTCOME_GROUNDING_V2", "1")
+
+
+@pytest.fixture
+def grounding_off(monkeypatch):
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. Junction grounds even when source_dispatch_ids is empty (the core gap)
+# ---------------------------------------------------------------------------
+
+def test_junction_grounds_with_empty_source_dispatch_ids(tmp_path, grounding_on):
+    db = _make_db(tmp_path)
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5)
+    _offer(db, "D-1", f"intel_sp_{sp_id}")
+
+    result = update_confidence_from_outcome(db, "D-1", "T1", "success")
+
+    assert result == {"boosted": 1, "decayed": 0}
+    # Beta first success → (1+1)/(1+0+2) = 2/3
+    assert abs(_confidence(db, sp_id) - 2 / 3) < 1e-4
+    assert _event_grounding(db, "D-1") == "junction"
+
+
+# ---------------------------------------------------------------------------
+# 2. Flag OFF keeps the legacy substring behaviour (junction ignored)
+# ---------------------------------------------------------------------------
+
+def test_flag_off_ignores_junction(tmp_path, grounding_off):
+    db = _make_db(tmp_path)
+    # Pattern is OFFERED in the junction but NOT stamped into source_dispatch_ids.
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5)
+    _offer(db, "D-1", f"intel_sp_{sp_id}")
+
+    result = update_confidence_from_outcome(db, "D-1", "T1", "success")
+
+    # Legacy LIKE on empty source_dispatch_ids finds nothing → no grounding.
+    assert result == {"boosted": 0, "decayed": 0}
+    assert abs(_confidence(db, sp_id) - 0.5) < 1e-9
+    assert _event_grounding(db, "D-1") == "source_dispatch_ids"
+
+
+# ---------------------------------------------------------------------------
+# 3. Flag ON falls back to legacy when the junction table is absent
+# ---------------------------------------------------------------------------
+
+def test_flag_on_falls_back_to_legacy_without_junction(tmp_path, grounding_on):
+    db = _make_db(tmp_path, junction=False)
+    sp_id = _insert_pattern(db, source_dispatch_ids=["D-1"], confidence=0.5)
+
+    result = update_confidence_from_outcome(db, "D-1", "T1", "success")
+
+    assert result == {"boosted": 1, "decayed": 0}
+    assert abs(_confidence(db, sp_id) - 2 / 3) < 1e-4
+    assert _event_grounding(db, "D-1") == "source_dispatch_ids"
+
+
+# ---------------------------------------------------------------------------
+# 4. Failure decays via the junction
+# ---------------------------------------------------------------------------
+
+def test_junction_failure_decays(tmp_path, grounding_on):
+    db = _make_db(tmp_path)
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.7)
+    _offer(db, "D-9", f"intel_sp_{sp_id}")
+
+    result = update_confidence_from_outcome(db, "D-9", "T1", "failure")
+
+    assert result == {"boosted": 0, "decayed": 1}
+    # Beta first failure → (0+1)/(0+1+2) = 1/3
+    assert abs(_confidence(db, sp_id) - 1 / 3) < 1e-4
+    assert _event_grounding(db, "D-9") == "junction"
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-pattern junction rows (code_anchor etc.) are ignored
+# ---------------------------------------------------------------------------
+
+def test_non_pattern_junction_rows_ignored(tmp_path, grounding_on):
+    db = _make_db(tmp_path)
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5)
+    _offer(db, "D-2", f"intel_sp_{sp_id}")
+    # A code-anchor / doc pointer offered to the same dispatch — not a pattern.
+    _offer(db, "D-2", "code_anchor_foo_bar", title="some/file.py:10")
+    _offer(db, "D-2", "intel_ap_99", title="an antipattern, not a success pattern")
+
+    result = update_confidence_from_outcome(db, "D-2", "T1", "success")
+
+    # Only the single success-pattern grounds; the others do not resolve to a row.
+    assert result == {"boosted": 1, "decayed": 0}
+
+
+# ---------------------------------------------------------------------------
+# 6. Junction offered once → updated exactly once (DISTINCT)
+# ---------------------------------------------------------------------------
+
+def test_junction_offered_once_updates_once(tmp_path, grounding_on):
+    db = _make_db(tmp_path)
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5)
+    _offer(db, "D-3", f"intel_sp_{sp_id}")
+
+    result = update_confidence_from_outcome(db, "D-3", "T1", "success")
+
+    assert result["boosted"] == 1  # not 2, even though source_dispatch_ids also empty
+    conn = sqlite3.connect(str(db))
+    n_events = conn.execute(
+        "SELECT COUNT(*) FROM confidence_events WHERE dispatch_id = ?", ("D-3",)
+    ).fetchone()[0]
+    conn.close()
+    assert n_events == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Tenant isolation: the junction join never crosses project_id
+# ---------------------------------------------------------------------------
+
+def test_junction_tenant_isolation(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_OUTCOME_GROUNDING_V2", "1")
+    monkeypatch.setenv("VNX_PROJECT_ID", "proj-a")
+    db = _make_db(tmp_path, project_id=True)
+
+    sp_a = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5, project_id="proj-a")
+    sp_b = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5, project_id="proj-b")
+    # Same dispatch_id, both projects stamp a junction row (id-collision scenario).
+    _offer(db, "D-T", f"intel_sp_{sp_a}", project_id="proj-a")
+    _offer(db, "D-T", f"intel_sp_{sp_b}", project_id="proj-b")
+
+    result = update_confidence_from_outcome(db, "D-T", "T1", "success")
+
+    # Only proj-a's pattern is grounded; proj-b is untouched.
+    assert result == {"boosted": 1, "decayed": 0}
+    assert abs(_confidence(db, sp_a) - 2 / 3) < 1e-4
+    assert abs(_confidence(db, sp_b) - 0.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 8. grounding_source omitted gracefully when the column is absent (old DB)
+# ---------------------------------------------------------------------------
+
+def test_grounding_source_column_absent_is_graceful(tmp_path, grounding_on):
+    db = _make_db(tmp_path)
+    # Drop the grounding_source column scenario: rebuild confidence_events without it.
+    conn = sqlite3.connect(str(db))
+    conn.execute("DROP TABLE confidence_events")
+    conn.execute(
+        "CREATE TABLE confidence_events ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL, terminal TEXT,"
+        " outcome TEXT NOT NULL, patterns_boosted INTEGER DEFAULT 0,"
+        " patterns_decayed INTEGER DEFAULT 0, confidence_change REAL NOT NULL,"
+        " occurred_at TEXT NOT NULL)"
+    )
+    conn.commit()
+    conn.close()
+    sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5)
+    _offer(db, "D-4", f"intel_sp_{sp_id}")
+
+    # Must not raise even though grounding_source has nowhere to go.
+    result = update_confidence_from_outcome(db, "D-4", "T1", "success")
+    assert result == {"boosted": 1, "decayed": 0}
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT outcome, patterns_boosted FROM confidence_events WHERE dispatch_id = ?",
+        ("D-4",),
+    ).fetchone()
+    conn.close()
+    assert row == ("success", 1)


### PR DESCRIPTION
## Summary

Intelligence build-step 4 (outcome-grounding). Collapses the **universal receipt-append confidence path** onto the `dispatch_pattern_offered` junction.

`intelligence_persist.update_confidence_from_outcome` runs on **every completion receipt** (via `append_receipt_internals/payload.py::_update_confidence_from_receipt`). It previously linked a dispatch to its patterns through a weak `source_dispatch_ids LIKE '%dispatch_id%'` substring join — prone to false positives, and capped at the last 20 ids per pattern. This wires it to the **precise per-dispatch `dispatch_pattern_offered` junction** (exact offered↔pattern linkage on the stable `intel_sp_<id>` convention), tenant-scoped on both sides, and records the grounding method on the `confidence_events` audit row so the self-learning auto-tier can tell precisely-grounded outcomes apart.

Same junction the subprocess-lane feedback loop already uses (`pattern_confidence._update_pattern_confidence`) — this brings the universal path to parity.

## Behaviour / safety

- **Opt-in, default OFF.** `VNX_OUTCOME_GROUNDING_V2=1` activates the junction join. Unset → **byte-identical** legacy `source_dispatch_ids` behaviour. Governance-critical path (touches confidence on every receipt), so the rollout is deliberate.
- **Junction authoritative when present** (flag ON); legacy join remains only as a compatibility shim for pre-junction DBs / flag-off. Junction and `source_dispatch_ids` are co-written in one transaction at injection, so "junction present" implies it is the complete, precise set.
- **Tenant-safe:** join filters `sp.project_id` **and** `dpo.project_id` when present (ADR-007); a cross-tenant id collision cannot leak a confidence update.
- **Fail-closed-not-crash** preserved (existing try/except + rollback). Idempotent within a call (junction PK + `SELECT DISTINCT`).
- Beta(success+1, failure+1) smoothing and `pattern_usage` linkage unchanged.

## Changes

- `scripts/lib/intelligence_persist.py` — `_resolve_grounded_patterns` (+ `_junction_grounded_rows`, `_legacy_source_id_rows`, `_has_table`, `_outcome_grounding_v2_enabled`); dynamic `confidence_events` insert that appends `grounding_source` when the column exists.
- `scripts/quality_db_init.py` — `_migrate_v24` (additive nullable `grounding_source TEXT`, existence-guarded, ALTER-only, idempotent); `HIGHEST_QI_VERSION` 23 → 24.
- `tests/test_outcome_grounding_v2.py` — 8 tests (junction grounds with empty `source_dispatch_ids`, flag-OFF legacy parity, junction-absent fallback, failure decay, non-pattern rows ignored, single-update DISTINCT, tenant isolation, absent-column grace).

## Verification

- New tests: 8 passed. Fresh-DB bootstrap reaches `user_version=24` with the new column, idempotent re-bootstrap.
- Regression green on `test_feedback_loop`, `test_success_patterns_multitenant`, `test_schema_idempotency`, `test_failure_decay_*`, `test_schema_versioning`, `test_migration_phase1_project_id`, `test_project_id_migration`, `test_payload_exception_handling`, `test_intelligence_recency`.
- kimi-diff-gate: **PASS** (0 blocking).
- 3 unrelated pre-existing failures confirmed on `origin/main` with this diff stashed (env/live-DB dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)